### PR TITLE
[codex] add gh auth token fallback

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -103,7 +105,20 @@ func (c *Config) SyncDuration() time.Duration {
 }
 
 func (c *Config) GitHubToken() string {
-	return os.Getenv(c.GitHubTokenEnv)
+	if token := os.Getenv(c.GitHubTokenEnv); token != "" {
+		return token
+	}
+	return ghAuthToken()
+}
+
+var execCommand = exec.Command
+
+func ghAuthToken() string {
+	out, err := execCommand("gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func (c *Config) ListenAddr() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -124,6 +124,48 @@ func TestGitHubToken(t *testing.T) {
 	}
 }
 
+func TestGitHubTokenFallsBackToGHCli(t *testing.T) {
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\necho gh-secret\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", dir)
+	t.Setenv("TEST_GH_TOKEN", "")
+
+	cfg := &Config{GitHubTokenEnv: "TEST_GH_TOKEN"}
+	if got := cfg.GitHubToken(); got != "gh-secret" {
+		t.Fatalf("expected gh-secret, got %q", got)
+	}
+}
+
+func TestGitHubTokenPrefersEnvVarOverGHCli(t *testing.T) {
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\necho gh-secret\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", dir)
+	t.Setenv("TEST_GH_TOKEN", "secret123")
+
+	cfg := &Config{GitHubTokenEnv: "TEST_GH_TOKEN"}
+	if got := cfg.GitHubToken(); got != "secret123" {
+		t.Fatalf("expected secret123, got %q", got)
+	}
+}
+
+func TestGitHubTokenReturnsEmptyWhenGHCliUnavailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("TEST_GH_TOKEN", "")
+
+	cfg := &Config{GitHubTokenEnv: "TEST_GH_TOKEN"}
+	if got := cfg.GitHubToken(); got != "" {
+		t.Fatalf("expected empty token, got %q", got)
+	}
+}
+
 func TestDBPath(t *testing.T) {
 	cfg := &Config{DataDir: "/tmp/middleman-test"}
 	expected := "/tmp/middleman-test/middleman.db"


### PR DESCRIPTION
## Summary
- fall back to `gh auth token` when the configured GitHub token env var is empty
- keep env var token precedence unchanged when it is set
- add config tests covering env precedence, CLI fallback, and unavailable `gh`

## Why
Middleman currently hard-fails unless a token is exported in the configured environment variable. This change lets local `gh` authentication satisfy that requirement without changing existing env-based behavior.

## Validation
- `GOCACHE=/tmp/go-build go test ./...`
