### PR TITLE
[codex] fix manual sync status updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS := -X main.version=$(VERSION) \
 
 LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 
-.PHONY: ensure-embed-dir build build-release install frontend frontend-dev dev \
+.PHONY: ensure-embed-dir build build-release install frontend frontend-dev frontend-dev-bun dev \
         test test-short vet lint tidy clean help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
@@ -54,6 +54,10 @@ frontend:
 # Run Vite dev server (use alongside `make dev`)
 frontend-dev:
 	cd frontend && npm run dev
+
+# Run Vite dev server with Bun (use alongside `make dev`)
+frontend-dev-bun:
+	cd frontend && bun install && bun run dev
 
 # Run Go server in dev mode (no embedded frontend)
 dev: ensure-embed-dir
@@ -99,6 +103,7 @@ help:
 	@echo "  dev            - Run Go server (use with frontend-dev)"
 	@echo "  frontend       - Build frontend SPA"
 	@echo "  frontend-dev   - Run Vite dev server"
+	@echo "  frontend-dev-bun - Install deps with Bun and run Vite dev server"
 	@echo ""
 	@echo "  test           - Run all tests"
 	@echo "  test-short     - Run fast tests only"

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -43,8 +43,29 @@ export async function refreshSyncStatus(): Promise<void> {
 }
 
 export async function triggerSync(): Promise<void> {
-  await apiTriggerSync();
-  await refreshSyncStatus();
+  const previous = status;
+
+  status = {
+    running: true,
+    last_run_at: previous?.last_run_at ?? "",
+    last_error: "",
+  };
+  wasRunning = true;
+  adjustPollingSpeed(true);
+
+  try {
+    await apiTriggerSync();
+    await refreshSyncStatus();
+  } catch (err) {
+    status = {
+      running: false,
+      last_run_at: previous?.last_run_at ?? "",
+      last_error: err instanceof Error ? err.message : "failed to trigger sync",
+    };
+    wasRunning = false;
+    adjustPollingSpeed(false);
+    throw err;
+  }
 }
 
 let currentIntervalMs = 30_000;

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -617,7 +618,7 @@ func (s *Server) handleListRepos(w http.ResponseWriter, r *http.Request) {
 // --- POST /api/v1/sync ---
 
 func (s *Server) handleTriggerSync(w http.ResponseWriter, r *http.Request) {
-	go s.syncer.RunOnce(r.Context())
+	go s.syncer.RunOnce(context.WithoutCancel(r.Context()))
 	w.WriteHeader(http.StatusAccepted)
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -313,3 +313,43 @@ func TestHandleSyncStatus(t *testing.T) {
 	}
 }
 
+func TestHandleTriggerSyncIgnoresRequestCancellation(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	mock := &mockGH{}
+	syncer := ghclient.NewSyncer(mock, database, []ghclient.RepoRef{{
+		Owner: "acme",
+		Name:  "widget",
+	}}, time.Minute)
+	srv := New(database, mock, syncer, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync", nil).WithContext(ctx)
+	cancel()
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		repos, err := database.ListRepos(context.Background())
+		if err != nil {
+			t.Fatalf("list repos: %v", err)
+		}
+		if len(repos) == 1 && repos[0].Owner == "acme" && repos[0].Name == "widget" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("expected sync to complete despite request context cancellation")
+}


### PR DESCRIPTION
## Summary
- keep manual syncs running after the trigger request ends instead of inheriting a canceled request context
- update the frontend sync store immediately when the user clicks Sync so the UI shows active state and trigger failures right away
- add a Bun-based frontend dev target that installs deps before launching Vite

## Why
Manual syncs were being launched with the HTTP request context, so clicking the Sync button could cancel the work as soon as the request completed. The frontend also stayed visually idle until the next polling interval, which made the action feel broken.

## Validation
- `GOCACHE=/tmp/go-build go test ./internal/server`
