### PR TITLE
[codex] add ready for review action

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -93,6 +93,17 @@ export async function approvePR(
   );
 }
 
+export async function markPRReadyForReview(
+  owner: string,
+  name: string,
+  number: number,
+): Promise<void> {
+  await request(
+    `/repos/${owner}/${name}/pulls/${number}/ready-for-review`,
+    { method: "POST" },
+  );
+}
+
 export interface MergeParams {
   commit_title: string;
   commit_message: string;

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -18,6 +18,7 @@
   import CommentBox from "./CommentBox.svelte";
   import ApproveButton from "./ApproveButton.svelte";
   import MergeModal from "./MergeModal.svelte";
+  import ReadyForReviewButton from "./ReadyForReviewButton.svelte";
 
   interface Props {
     owner: string;
@@ -247,6 +248,9 @@
       <!-- Approve / Merge actions (open PRs only) -->
       {#if pr.State === "open"}
         <div class="actions-row">
+          {#if pr.IsDraft}
+            <ReadyForReviewButton {owner} {name} {number} />
+          {/if}
           <ApproveButton {owner} {name} {number} />
           {#if repoSettings}
             <button

--- a/frontend/src/lib/components/detail/ReadyForReviewButton.svelte
+++ b/frontend/src/lib/components/detail/ReadyForReviewButton.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import { markPRReadyForReview } from "../../api/client.js";
+  import { loadDetail } from "../../stores/detail.svelte.js";
+  import { loadPulls } from "../../stores/pulls.svelte.js";
+
+  interface Props {
+    owner: string;
+    name: string;
+    number: number;
+  }
+
+  const { owner, name, number }: Props = $props();
+
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+
+  async function handleReadyForReview(): Promise<void> {
+    submitting = true;
+    error = null;
+    try {
+      await markPRReadyForReview(owner, name, number);
+      await loadDetail(owner, name, number);
+      await loadPulls();
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="ready-section">
+  <button
+    class="btn btn--ready"
+    onclick={() => void handleReadyForReview()}
+    disabled={submitting}
+  >
+    {submitting ? "Publishing…" : "Ready for review"}
+  </button>
+  {#if error}
+    <p class="ready-error">{error}</p>
+  {/if}
+</div>
+
+<style>
+  .ready-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .ready-error {
+    font-size: 12px;
+    color: var(--accent-red);
+  }
+
+  .btn {
+    font-size: 13px;
+    font-weight: 500;
+    padding: 6px 14px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: opacity 0.1s;
+  }
+
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn--ready {
+    background: color-mix(
+      in srgb, var(--accent-blue) 10%, transparent
+    );
+    color: var(--accent-blue);
+    border: 1px solid color-mix(
+      in srgb, var(--accent-blue) 30%, transparent
+    );
+  }
+
+  .btn--ready:hover:not(:disabled) {
+    background: color-mix(
+      in srgb, var(--accent-blue) 18%, transparent
+    );
+  }
+</style>

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -22,6 +22,7 @@ type Client interface {
 	CreateIssueComment(ctx context.Context, owner, repo string, number int, body string) (*gh.IssueComment, error)
 	GetRepository(ctx context.Context, owner, repo string) (*gh.Repository, error)
 	CreateReview(ctx context.Context, owner, repo string, number int, event string, body string) (*gh.PullRequestReview, error)
+	MarkPullRequestReadyForReview(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error)
 	MergePullRequest(ctx context.Context, owner, repo string, number int, commitTitle, commitMessage, method string) (*gh.PullRequestMergeResult, error)
 }
 
@@ -242,6 +243,32 @@ func (c *liveClient) CreateReview(
 		)
 	}
 	return review, nil
+}
+
+func (c *liveClient) MarkPullRequestReadyForReview(
+	ctx context.Context, owner, repo string, number int,
+) (*gh.PullRequest, error) {
+	req, err := c.gh.NewRequest(
+		"POST",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/ready_for_review", owner, repo, number),
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"building ready-for-review request for %s/%s#%d: %w",
+			owner, repo, number, err,
+		)
+	}
+
+	pr := new(gh.PullRequest)
+	if _, err := c.gh.Do(ctx, req, pr); err != nil {
+		return nil, fmt.Errorf(
+			"marking %s/%s#%d ready for review: %w",
+			owner, repo, number, err,
+		)
+	}
+
+	return pr, nil
 }
 
 func (c *liveClient) MergePullRequest(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -25,12 +25,12 @@ func openTestDB(t *testing.T) *db.DB {
 
 // mockClient implements Client with configurable canned responses.
 type mockClient struct {
-	openPRs    []*gh.PullRequest
-	singlePR   *gh.PullRequest
-	comments   []*gh.IssueComment
-	reviews    []*gh.PullRequestReview
-	commits    []*gh.RepositoryCommit
-	ciStatus   *gh.CombinedStatus
+	openPRs  []*gh.PullRequest
+	singlePR *gh.PullRequest
+	comments []*gh.IssueComment
+	reviews  []*gh.PullRequestReview
+	commits  []*gh.RepositoryCommit
+	ciStatus *gh.CombinedStatus
 }
 
 func (m *mockClient) ListOpenPullRequests(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
@@ -96,6 +96,13 @@ func (m *mockClient) CreateReview(
 	id := int64(1)
 	state := "APPROVED"
 	return &gh.PullRequestReview{ID: &id, State: &state}, nil
+}
+
+func (m *mockClient) MarkPullRequestReadyForReview(
+	_ context.Context, _, _ string, number int,
+) (*gh.PullRequest, error) {
+	draft := false
+	return &gh.PullRequest{Number: &number, Draft: &draft}, nil
 }
 
 func (m *mockClient) MergePullRequest(

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -133,9 +133,9 @@ func (s *Server) handleGetPull(w http.ResponseWriter, r *http.Request) {
 // --- PUT /api/v1/repos/{owner}/{name}/pulls/{number}/state ---
 
 var validKanbanStates = map[string]bool{
-	"new":           true,
-	"reviewing":     true,
-	"waiting":       true,
+	"new":            true,
+	"reviewing":      true,
+	"waiting":        true,
 	"awaiting_merge": true,
 }
 
@@ -302,10 +302,10 @@ func (s *Server) handleListIssues(w http.ResponseWriter, r *http.Request) {
 // --- /api/v1/repos/{owner}/{name}/issues/{number} ---
 
 type issueDetailResponse struct {
-	Issue     *db.Issue        `json:"issue"`
-	Events    []db.IssueEvent  `json:"events"`
-	RepoOwner string           `json:"repo_owner"`
-	RepoName  string           `json:"repo_name"`
+	Issue     *db.Issue       `json:"issue"`
+	Events    []db.IssueEvent `json:"events"`
+	RepoOwner string          `json:"repo_owner"`
+	RepoName  string          `json:"repo_name"`
 }
 
 func (s *Server) handleGetIssue(w http.ResponseWriter, r *http.Request) {
@@ -543,6 +543,34 @@ func (s *Server) handleApprovePR(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "approved"})
+}
+
+// --- POST /api/v1/repos/{owner}/{name}/pulls/{number}/ready-for-review ---
+
+func (s *Server) handleReadyForReview(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+	number, err := strconv.Atoi(r.PathValue("number"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid PR number")
+		return
+	}
+
+	pr, err := s.gh.MarkPullRequestReadyForReview(r.Context(), owner, name, number)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "GitHub API error: "+err.Error())
+		return
+	}
+
+	repoObj, err := s.db.GetRepoByOwnerName(r.Context(), owner, name)
+	if err == nil && repoObj != nil {
+		normalized := ghclient.NormalizePR(repoObj.ID, pr)
+		if prID, upsertErr := s.db.UpsertPullRequest(r.Context(), normalized); upsertErr == nil {
+			_ = s.db.EnsureKanbanState(r.Context(), prID)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ready_for_review"})
 }
 
 // --- POST /api/v1/repos/{owner}/{name}/pulls/{number}/merge ---

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -16,7 +16,10 @@ import (
 )
 
 // mockGH implements ghclient.Client for testing.
-type mockGH struct{}
+type mockGH struct {
+	getPullRequestFn     func(context.Context, string, string, int) (*gh.PullRequest, error)
+	markReadyForReviewFn func(context.Context, string, string, int) (*gh.PullRequest, error)
+}
 
 func (m *mockGH) ListOpenPullRequests(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
 	return nil, nil
@@ -31,6 +34,9 @@ func (m *mockGH) GetIssue(_ context.Context, _, _ string, _ int) (*gh.Issue, err
 }
 
 func (m *mockGH) GetPullRequest(_ context.Context, _, _ string, _ int) (*gh.PullRequest, error) {
+	if m.getPullRequestFn != nil {
+		return m.getPullRequestFn(context.Background(), "", "", 0)
+	}
 	return nil, nil
 }
 
@@ -86,6 +92,16 @@ func (m *mockGH) CreateReview(
 	id := int64(99)
 	state := "APPROVED"
 	return &gh.PullRequestReview{ID: &id, State: &state}, nil
+}
+
+func (m *mockGH) MarkPullRequestReadyForReview(
+	ctx context.Context, owner, repo string, number int,
+) (*gh.PullRequest, error) {
+	if m.markReadyForReviewFn != nil {
+		return m.markReadyForReviewFn(ctx, owner, repo, number)
+	}
+	draft := false
+	return &gh.PullRequest{Number: &number, Draft: &draft}, nil
 }
 
 func (m *mockGH) MergePullRequest(
@@ -313,3 +329,90 @@ func TestHandleSyncStatus(t *testing.T) {
 	}
 }
 
+func TestHandleReadyForReview(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	mock := &mockGH{
+		markReadyForReviewFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(1001)
+			title := "Ready PR"
+			state := "open"
+			url := "https://github.com/acme/widget/pull/1"
+			author := "octocat"
+			draft := false
+			now := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				Title:     &title,
+				State:     &state,
+				HTMLURL:   &url,
+				Draft:     &draft,
+				CreatedAt: &now,
+				UpdatedAt: &now,
+				User:      &gh.User{Login: &author},
+				Head:      &gh.PullRequestBranch{Ref: gh.Ptr("feature")},
+				Base:      &gh.PullRequestBranch{Ref: gh.Ptr("main")},
+			}, nil
+		},
+	}
+	syncer := ghclient.NewSyncer(mock, database, nil, time.Minute)
+	srv := New(database, mock, syncer, nil)
+
+	repoID, err := database.UpsertRepo(context.Background(), "acme", "widget")
+	if err != nil {
+		t.Fatalf("upsert repo: %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	prID, err := database.UpsertPullRequest(context.Background(), &db.PullRequest{
+		RepoID:         repoID,
+		GitHubID:       1001,
+		Number:         1,
+		URL:            "https://github.com/acme/widget/pull/1",
+		Title:          "Ready PR",
+		Author:         "octocat",
+		State:          "open",
+		IsDraft:        true,
+		Body:           "",
+		HeadBranch:     "feature",
+		BaseBranch:     "main",
+		Additions:      0,
+		Deletions:      0,
+		CommentCount:   0,
+		ReviewDecision: "",
+		CIStatus:       "",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	if err != nil {
+		t.Fatalf("upsert pull request: %v", err)
+	}
+	if err := database.EnsureKanbanState(context.Background(), prID); err != nil {
+		t.Fatalf("ensure kanban state: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos/acme/widget/pulls/1/ready-for-review", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	pr, err := database.GetPullRequest(context.Background(), "acme", "widget", 1)
+	if err != nil {
+		t.Fatalf("get pull request: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected PR to exist")
+	}
+	if pr.IsDraft {
+		t.Fatal("expected PR to no longer be draft")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,6 +42,7 @@ func New(database *db.DB, gh ghclient.Client, syncer *ghclient.Syncer, frontend 
 	s.mux.HandleFunc("GET /api/v1/repos", s.handleListRepos)
 	s.mux.HandleFunc("GET /api/v1/repos/{owner}/{name}", s.handleGetRepo)
 	s.mux.HandleFunc("POST /api/v1/repos/{owner}/{name}/pulls/{number}/approve", s.handleApprovePR)
+	s.mux.HandleFunc("POST /api/v1/repos/{owner}/{name}/pulls/{number}/ready-for-review", s.handleReadyForReview)
 	s.mux.HandleFunc("POST /api/v1/repos/{owner}/{name}/pulls/{number}/merge", s.handleMergePR)
 	s.mux.HandleFunc("POST /api/v1/sync", s.handleTriggerSync)
 	s.mux.HandleFunc("GET /api/v1/sync/status", s.handleSyncStatus)


### PR DESCRIPTION
## Summary
- add a backend endpoint and GitHub client support to mark draft pull requests ready for review
- update the local PR record immediately after the GitHub transition so the UI stops showing the PR as draft without waiting for the next background sync
- add a draft-only action in the PR detail view to move a PR out of draft mode from the dashboard

## Why
The UI already surfaces draft pull requests, but there was no way to take the next step and make them ready for review. That forced users back to GitHub for a core PR lifecycle action.

## Validation
- `GOCACHE=/tmp/go-build go test ./...`
