### PR TITLE
Set up prek hooks and golangci-lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
     - ineffassign
     - staticcheck
     - unused
-    - gosimple
+    - modernize
   settings:
     govet:
       disable:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ LDFLAGS := -X main.version=$(VERSION) \
 
 LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 
-.PHONY: ensure-embed-dir build build-release install frontend frontend-dev dev \
-        test test-short vet lint tidy clean help
+.PHONY: ensure-embed-dir build build-release install frontend frontend-dev \
+        frontend-check dev test test-short vet lint tidy clean help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -54,6 +54,10 @@ frontend:
 # Run Vite dev server (use alongside `make dev`)
 frontend-dev:
 	cd frontend && npm run dev
+
+# Run frontend type checks
+frontend-check:
+	cd frontend && npm run check
 
 # Run Go server in dev mode (no embedded frontend)
 dev: ensure-embed-dir

--- a/README.md
+++ b/README.md
@@ -70,10 +70,22 @@ Other targets:
 
 ```
 make build          # Production binary with embedded frontend
+make frontend-check # Svelte / TypeScript checks
 make test           # Run all Go tests
 make lint           # golangci-lint
 make install        # Install to ~/.local/bin
 ```
+
+To enable local git hooks with `prek`:
+
+```sh
+brew install prek
+brew install golangci-lint
+prek install
+prek run --all-files
+```
+
+The repo hook config lives in `prek.toml`. Go commits run `gofmt`, `golangci-lint --fix`, and `make test-short`; frontend commits run `make frontend-check`. Install frontend dependencies once with `npm --prefix frontend install` if you have not already done so.
 
 ## License
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -62,7 +62,7 @@ func (d *DB) migrate() {
 		"ALTER TABLE repos ADD COLUMN allow_rebase_merge INTEGER NOT NULL DEFAULT 1",
 	}
 	for _, m := range migrations {
-		d.rw.Exec(m) // Ignore errors — column may already exist
+		_, _ = d.rw.Exec(m) // Ignore errors — column may already exist
 	}
 }
 
@@ -85,7 +85,7 @@ func (d *DB) Tx(ctx context.Context, fn func(tx *sql.Tx) error) error {
 		return err
 	}
 	if err := fn(tx); err != nil {
-		tx.Rollback()
+		_ = tx.Rollback()
 		return err
 	}
 	return tx.Commit()

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -96,6 +96,7 @@ func TestGetRepoByOwnerName(t *testing.T) {
 	}
 	if r == nil {
 		t.Fatal("expected repo, got nil")
+		return
 	}
 	if r.ID != id {
 		t.Errorf("ID = %d, want %d", r.ID, id)
@@ -192,6 +193,7 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected PR, got nil")
+		return
 	}
 	if got.ID != id {
 		t.Errorf("ID = %d, want %d", got.ID, id)

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -13,15 +13,15 @@ import (
 // initialized to UpdatedAt.
 func NormalizePR(repoID int64, ghPR *gh.PullRequest) *db.PullRequest {
 	pr := &db.PullRequest{
-		RepoID:   repoID,
-		GitHubID: ghPR.GetID(),
-		Number:   ghPR.GetNumber(),
-		URL:      ghPR.GetHTMLURL(),
-		Title:    ghPR.GetTitle(),
-		Author:   loginOrEmpty(ghPR.GetUser()),
-		State:    ghPR.GetState(),
-		IsDraft:  ghPR.GetDraft(),
-		Body:     ghPR.GetBody(),
+		RepoID:    repoID,
+		GitHubID:  ghPR.GetID(),
+		Number:    ghPR.GetNumber(),
+		URL:       ghPR.GetHTMLURL(),
+		Title:     ghPR.GetTitle(),
+		Author:    loginOrEmpty(ghPR.GetUser()),
+		State:     ghPR.GetState(),
+		IsDraft:   ghPR.GetDraft(),
+		Body:      ghPR.GetBody(),
 		Additions: ghPR.GetAdditions(),
 		Deletions: ghPR.GetDeletions(),
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -350,19 +350,19 @@ func computeLastActivity(
 	}
 
 	for _, c := range comments {
-		if c.UpdatedAt != nil && c.UpdatedAt.Time.After(latest) {
+		if c.UpdatedAt != nil && c.UpdatedAt.After(latest) {
 			latest = c.UpdatedAt.Time
 		}
 	}
 	for _, r := range reviews {
-		if r.SubmittedAt != nil && r.SubmittedAt.Time.After(latest) {
+		if r.SubmittedAt != nil && r.SubmittedAt.After(latest) {
 			latest = r.SubmittedAt.Time
 		}
 	}
 	for _, c := range commits {
 		if c.GetCommit() != nil && c.GetCommit().Author != nil &&
 			c.GetCommit().Author.Date != nil &&
-			c.GetCommit().Author.Date.Time.After(latest) {
+			c.GetCommit().Author.Date.After(latest) {
 			latest = c.GetCommit().Author.Date.Time
 		}
 	}
@@ -479,7 +479,7 @@ func (s *Syncer) refreshIssueTimeline(
 
 	lastActivity := ghIssue.UpdatedAt.Time
 	for _, c := range comments {
-		if c.UpdatedAt != nil && c.UpdatedAt.Time.After(lastActivity) {
+		if c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity) {
 			lastActivity = c.UpdatedAt.Time
 		}
 	}

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -25,12 +25,12 @@ func openTestDB(t *testing.T) *db.DB {
 
 // mockClient implements Client with configurable canned responses.
 type mockClient struct {
-	openPRs    []*gh.PullRequest
-	singlePR   *gh.PullRequest
-	comments   []*gh.IssueComment
-	reviews    []*gh.PullRequestReview
-	commits    []*gh.RepositoryCommit
-	ciStatus   *gh.CombinedStatus
+	openPRs  []*gh.PullRequest
+	singlePR *gh.PullRequest
+	comments []*gh.IssueComment
+	reviews  []*gh.PullRequestReview
+	commits  []*gh.RepositoryCommit
+	ciStatus *gh.CombinedStatus
 }
 
 func (m *mockClient) ListOpenPullRequests(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
@@ -180,6 +180,7 @@ func TestSyncCreatesAndUpdatesPRs(t *testing.T) {
 	}
 	if pr == nil {
 		t.Fatal("expected PR in DB, got nil")
+		return
 	}
 	if pr.Number != 1 {
 		t.Errorf("pr.Number = %d, want 1", pr.Number)
@@ -192,6 +193,7 @@ func TestSyncCreatesAndUpdatesPRs(t *testing.T) {
 	}
 	if ks == nil {
 		t.Fatal("expected kanban state, got nil")
+		return
 	}
 	if ks.Status != "new" {
 		t.Errorf("kanban status = %q, want %q", ks.Status, "new")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -133,9 +134,9 @@ func (s *Server) handleGetPull(w http.ResponseWriter, r *http.Request) {
 // --- PUT /api/v1/repos/{owner}/{name}/pulls/{number}/state ---
 
 var validKanbanStates = map[string]bool{
-	"new":           true,
-	"reviewing":     true,
-	"waiting":       true,
+	"new":            true,
+	"reviewing":      true,
+	"waiting":        true,
 	"awaiting_merge": true,
 }
 
@@ -302,10 +303,10 @@ func (s *Server) handleListIssues(w http.ResponseWriter, r *http.Request) {
 // --- /api/v1/repos/{owner}/{name}/issues/{number} ---
 
 type issueDetailResponse struct {
-	Issue     *db.Issue        `json:"issue"`
-	Events    []db.IssueEvent  `json:"events"`
-	RepoOwner string           `json:"repo_owner"`
-	RepoName  string           `json:"repo_name"`
+	Issue     *db.Issue       `json:"issue"`
+	Events    []db.IssueEvent `json:"events"`
+	RepoOwner string          `json:"repo_owner"`
+	RepoName  string          `json:"repo_name"`
 }
 
 func (s *Server) handleGetIssue(w http.ResponseWriter, r *http.Request) {
@@ -523,7 +524,10 @@ func (s *Server) handleApprovePR(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Body string `json:"body"`
 	}
-	json.NewDecoder(r.Body).Decode(&body)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err != io.EOF {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
 
 	review, err := s.gh.CreateReview(
 		r.Context(), owner, name, number, "APPROVE", body.Body,

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -247,6 +247,7 @@ func TestHandleSetKanbanState(t *testing.T) {
 	}
 	if pr == nil {
 		t.Fatal("PR not found")
+		return
 	}
 	if pr.KanbanStatus != "reviewing" {
 		t.Errorf("expected kanban status 'reviewing', got %q", pr.KanbanStatus)
@@ -312,4 +313,3 @@ func TestHandleSyncStatus(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 }
-

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,63 @@
+default_install_hook_types = ["pre-commit"]
+
+[[repos]]
+repo = "builtin"
+hooks = [
+  { id = "check-case-conflict" },
+  { id = "check-merge-conflict", args = ["--assume-in-merge"] },
+  { id = "detect-private-key" },
+  { id = "no-commit-to-branch" },
+  { id = "check-added-large-files", args = ["--maxkb=1024"] },
+  { id = "trailing-whitespace", args = ["--markdown-linebreak-ext=md"] },
+  { id = "end-of-file-fixer" },
+  { id = "check-json" },
+  { id = "check-toml" },
+  { id = "check-yaml" },
+]
+
+[[repos]]
+repo = "local"
+hooks = [
+  {
+    id = "gofmt",
+    name = "gofmt",
+    language = "system",
+    entry = "gofmt -w",
+    files = "\\.go$",
+    priority = 0,
+  },
+  {
+    id = "golangci-lint",
+    name = "golangci-lint --fix",
+    language = "system",
+    entry = "make lint",
+    files = "^(go\\.mod|go\\.sum|.*\\.go)$",
+    pass_filenames = false,
+    priority = 10,
+  },
+  {
+    id = "go-test-short",
+    name = "go test (short)",
+    language = "system",
+    entry = "make test-short",
+    files = "^(go\\.mod|go\\.sum|.*\\.go)$",
+    pass_filenames = false,
+    priority = 20,
+  },
+  {
+    id = "frontend-check",
+    name = "frontend check",
+    language = "system",
+    entry = "make frontend-check",
+    files = "^frontend/(src/.*\\.(svelte|ts)|package(-lock)?\\.json|tsconfig\\.json|vite\\.config\\.ts)$",
+    pass_filenames = false,
+    priority = 0,
+  },
+]
+
+[[repos]]
+repo = "meta"
+hooks = [
+  { id = "check-hooks-apply" },
+  { id = "check-useless-excludes" },
+]


### PR DESCRIPTION
## Summary
- add a root `prek.toml` with built-in file hygiene hooks plus `gofmt`, `golangci-lint --fix`, `make test-short`, and `make frontend-check`
- add `make frontend-check` and document local hook setup in the README
- update the golangci-lint config and fix existing lint findings so the new hook chain passes cleanly

## Testing
- `prek run --all-files`