### PR TITLE
Fix activity feed layout: margins and Type column

### DIFF
--- a/frontend/src/lib/components/ActivityFeed.svelte
+++ b/frontend/src/lib/components/ActivityFeed.svelte
@@ -290,6 +290,7 @@
   .table-container {
     flex: 1;
     overflow-y: auto;
+    padding: 0 16px;
   }
 
   .activity-table {
@@ -324,7 +325,7 @@
     text-overflow: ellipsis;
   }
 
-  .col-type { width: 76px; }
+  .col-type { width: 90px; overflow: visible; }
   .col-repo { width: 160px; }
   .col-item { width: auto; }
   .col-author { width: 130px; }


### PR DESCRIPTION
## Summary
- Add 16px side padding to the table container so rows don't run to the edge
- Widen Type column from 76px to 90px and prevent text truncation so "New Issue" badge is fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)