### PR TITLE
Fix copy button reliability and improve visual feedback

### DIFF
--- a/frontend/src/lib/components/detail/EventTimeline.svelte
+++ b/frontend/src/lib/components/detail/EventTimeline.svelte
@@ -2,6 +2,7 @@
   import type { PREvent } from "../../api/types.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { timeAgo } from "../../utils/time.js";
+  import { copyToClipboard } from "../../utils/clipboard.js";
 
   interface Props {
     events: PREvent[];
@@ -31,7 +32,8 @@
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   function copyText(id: string, text: string): void {
-    void navigator.clipboard.writeText(text).then(() => {
+    void copyToClipboard(text).then((ok) => {
+      if (!ok) return;
       copiedId = id;
       if (copyTimeout !== null) clearTimeout(copyTimeout);
       copyTimeout = setTimeout(() => {
@@ -75,6 +77,7 @@
             <div class="event-body-wrap">
               <button
                 class="copy-icon-btn"
+                class:copied={copiedId === String(event.ID)}
                 onclick={() => copyText(String(event.ID), event.Body)}
                 title={copiedId === String(event.ID) ? "Copied!" : "Copy to clipboard"}
               >
@@ -234,6 +237,12 @@
 
   .copy-icon-btn:active {
     transform: scale(0.92);
+  }
+
+  .copy-icon-btn.copied {
+    opacity: 1;
+    color: var(--accent-green);
+    background: color-mix(in srgb, var(--accent-green) 12%, transparent);
   }
 
   @media (hover: none) {

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -11,6 +11,7 @@
   import type { IssueLabel } from "../../api/types.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { timeAgo } from "../../utils/time.js";
+  import { copyToClipboard } from "../../utils/clipboard.js";
   import EventTimeline from "./EventTimeline.svelte";
   import IssueCommentBox from "./IssueCommentBox.svelte";
 
@@ -32,7 +33,8 @@
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   function copyBody(text: string): void {
-    void navigator.clipboard.writeText(text).then(() => {
+    void copyToClipboard(text).then((ok) => {
+      if (!ok) return;
       copied = true;
       if (copyTimeout !== null) clearTimeout(copyTimeout);
       copyTimeout = setTimeout(() => {
@@ -141,6 +143,7 @@
           <div class="inset-box-wrap">
             <button
               class="copy-icon-btn"
+              class:copied
               onclick={() => copyBody(issue.Body)}
               title={copied ? "Copied!" : "Copy to clipboard"}
             >
@@ -363,6 +366,12 @@
 
   .copy-icon-btn:active {
     transform: scale(0.92);
+  }
+
+  .copy-icon-btn.copied {
+    opacity: 1;
+    color: var(--accent-green);
+    background: color-mix(in srgb, var(--accent-green) 12%, transparent);
   }
 
   @media (hover: none) {

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -14,6 +14,7 @@
   import type { CICheck, KanbanStatus } from "../../api/types.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { timeAgo } from "../../utils/time.js";
+  import { copyToClipboard } from "../../utils/clipboard.js";
   import EventTimeline from "./EventTimeline.svelte";
   import CommentBox from "./CommentBox.svelte";
   import ApproveButton from "./ApproveButton.svelte";
@@ -38,7 +39,8 @@
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
   function copyBody(text: string): void {
-    void navigator.clipboard.writeText(text).then(() => {
+    void copyToClipboard(text).then((ok) => {
+      if (!ok) return;
       copied = true;
       if (copyTimeout !== null) clearTimeout(copyTimeout);
       copyTimeout = setTimeout(() => {
@@ -308,6 +310,7 @@
           <div class="inset-box-wrap">
             <button
               class="copy-icon-btn"
+              class:copied
               onclick={() => copyBody(pr.Body)}
               title={copied ? "Copied!" : "Copy to clipboard"}
             >
@@ -670,6 +673,12 @@
 
   .copy-icon-btn:active {
     transform: scale(0.92);
+  }
+
+  .copy-icon-btn.copied {
+    opacity: 1;
+    color: var(--accent-green);
+    background: color-mix(in srgb, var(--accent-green) 12%, transparent);
   }
 
   @media (hover: none) {

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,0 +1,30 @@
+/**
+ * Copy text to clipboard with fallback for when the async
+ * Clipboard API fails (e.g. document not focused, permissions).
+ * Returns true on success, false on failure.
+ */
+export function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard) {
+    return navigator.clipboard
+      .writeText(text)
+      .then(() => true)
+      .catch(() => fallbackCopy(text));
+  }
+  return Promise.resolve(fallbackCopy(text));
+}
+
+function fallbackCopy(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `execCommand('copy')` fallback for when the async Clipboard API fails (e.g. document loses focus between click and write)
- Extract shared `copyToClipboard()` utility used by PullDetail, IssueDetail, and EventTimeline
- Show green highlight on the copy button when copy succeeds for clearer visual feedback