### PR TITLE
fix: update activity feed on PR merge

### DIFF
--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -1,4 +1,4 @@
-import type { QuerySerializerOptions } from "openapi-fetch";
+import type { ClientOptions, QuerySerializerOptions } from "openapi-fetch";
 
 import { createAPIClient } from "./generated/client.js";
 import type { components } from "./generated/schema.js";
@@ -14,30 +14,31 @@ export const querySerializer: QuerySerializerOptions = {
   },
 };
 
+type FetchFn = NonNullable<ClientOptions["fetch"]>;
+
 // Wraps fetch to ensure Content-Type: application/json on all
 // mutation requests, required by the server's CSRF protection.
-function csrfFetch(
-  inner: typeof globalThis.fetch = globalThis.fetch,
-): typeof globalThis.fetch {
-  return (input, init) => {
-    const method = init?.method?.toUpperCase() ?? "GET";
+function csrfFetch(inner: FetchFn): FetchFn {
+  return (input: Request) => {
+    const method = input.method.toUpperCase();
     if (method !== "GET" && method !== "HEAD") {
-      const headers = new Headers(init?.headers);
-      if (!headers.has("Content-Type")) {
+      if (!input.headers.has("Content-Type")) {
+        const headers = new Headers(input.headers);
         headers.set("Content-Type", "application/json");
+        return inner(new Request(input, { headers }));
       }
-      return inner(input, { ...init, headers });
     }
-    return inner(input, init);
+    return inner(input);
   };
 }
 
 export function createRuntimeClient(
-  fetch?: typeof globalThis.fetch,
+  fetch?: FetchFn,
   clientBaseURL = baseUrl,
 ) {
+  const inner = fetch ?? globalThis.fetch.bind(globalThis);
   return createAPIClient(clientBaseURL, {
-    fetch: csrfFetch(fetch ?? globalThis.fetch),
+    fetch: csrfFetch(inner as FetchFn),
     querySerializer,
   });
 }

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -364,6 +364,7 @@
             showMergeModal = false;
             void loadDetail(owner, name, number);
             void loadPulls();
+            void loadActivity();
           }}
         />
       {/if}

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -26,7 +26,10 @@ let searchQuery = $state<string | undefined>(undefined);
 let timeRange = $state<TimeRange>("7d");
 let viewMode = $state<ViewMode>("flat");
 let pollHandle: ReturnType<typeof setInterval> | null = null;
+let pollInFlight = false;
 let requestVersion = 0;
+let pollCount = 0;
+const FULL_REFRESH_EVERY = 4; // full reload every 4th poll (~60s)
 
 let hideClosedMerged = $state(false);
 let hideBots = $state(false);
@@ -192,12 +195,65 @@ export async function loadActivity(): Promise<void> {
   }
 }
 
+/**
+ * Silent background refresh — merges updated item_state from the
+ * server into the existing list without replacing it, so the user's
+ * scroll depth and any items beyond the server's response cap are
+ * preserved. Does not advance requestVersion so it never disrupts a
+ * foreground loadActivity().
+ */
+async function refreshActivity(): Promise<void> {
+  const versionAtStart = requestVersion;
+  try {
+    const { data, error: requestError } = await client.GET(
+      "/activity",
+      { params: { query: buildParams() } },
+    );
+    if (requestError || versionAtStart !== requestVersion) return;
+    const fresh = data?.items ?? [];
+    if (fresh.length === 0) return;
+    // Only update item_state on existing items — new item insertion
+    // is handled by the cursor-based poll path to avoid gaps.
+    const freshById = new Map(fresh.map((it) => [it.id, it]));
+    items = items.map((it) => {
+      const updated = freshById.get(it.id);
+      if (updated && updated.item_state !== it.item_state) {
+        return { ...it, item_state: updated.item_state };
+      }
+      return it;
+    });
+  } catch {
+    // silent
+  }
+}
+
 /** Poll for new items since the newest displayed item. */
 async function pollNewItems(): Promise<void> {
+  if (pollInFlight) return;
+  pollInFlight = true;
+  try {
+    await doPoll();
+  } finally {
+    pollInFlight = false;
+  }
+}
+
+async function doPoll(): Promise<void> {
+  // Skip polling while a foreground load is in flight to avoid
+  // using a stale cursor with potentially new filter/time params.
+  if (loading) return;
+  pollCount++;
   if (items.length === 0) {
     await loadActivity();
     return;
   }
+  // Periodically do a full refresh to pick up state changes
+  // (e.g. merged/closed) on existing items.
+  if (pollCount % FULL_REFRESH_EVERY === 0) {
+    await refreshActivity();
+    return;
+  }
+  const versionAtStart = requestVersion;
   try {
     const params = buildParams();
     params.after = items[0]!.cursor;
@@ -207,6 +263,7 @@ async function pollNewItems(): Promise<void> {
     if (requestError) {
       throw new Error(apiErrorMessage(requestError, "failed to poll activity"));
     }
+    if (versionAtStart !== requestVersion) return;
     const resp = data;
     if (!resp) {
       return;
@@ -227,6 +284,7 @@ async function pollNewItems(): Promise<void> {
   } catch {
     // Silent poll failure
   }
+  if (versionAtStart !== requestVersion) return;
   // Prune items older than the current window.
   const cutoff = new Date(Date.now() - RANGE_MS[timeRange]);
   items = items.filter((it) => new Date(it.created_at) >= cutoff);


### PR DESCRIPTION
## Summary

- Reload activity feed when a PR is merged from the detail drawer (the close/reopen handler already did this, merge was missing it)
- Add periodic silent full refresh (~60s) to activity polling so item state changes (merged, closed) on existing items are picked up without a page reload
- Fix pre-existing type errors: fetch signature mismatch in runtime client, `exactOptionalPropertyTypes` violations in pulls/issues stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)