### PR TITLE
Add project filter to kanban board

### DIFF
--- a/frontend/src/lib/components/kanban/KanbanBoard.svelte
+++ b/frontend/src/lib/components/kanban/KanbanBoard.svelte
@@ -22,7 +22,6 @@
 
   onDestroy(() => {
     if (refreshHandle !== null) clearInterval(refreshHandle);
-    setFilterRepo(undefined);
     void loadPulls();
   });
 


### PR DESCRIPTION
## Summary
- Add repo filter dropdown to the kanban board view, reusing the existing RepoTypeahead component
- Filter state is shared with the sidebar pull list so it persists across view switches

Generated with [Claude Code](https://claude.ai/code)