### PR TITLE
Support MIDDLEMAN_HOME env var

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,10 +53,17 @@ type Config struct {
 }
 
 func DefaultConfigPath() string {
-	return filepath.Join(homeDir(), ".config", "middleman", "config.toml")
+	return filepath.Join(baseDir(), "config.toml")
 }
 
 func DefaultDataDir() string {
+	return baseDir()
+}
+
+func baseDir() string {
+	if d := os.Getenv("MIDDLEMAN_HOME"); d != "" {
+		return d
+	}
 	return filepath.Join(homeDir(), ".config", "middleman")
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,6 +172,29 @@ func TestGitHubTokenReturnsEmptyWhenGHCliUnavailable(t *testing.T) {
 	Assert.Empty(t, cfg.GitHubToken())
 }
 
+func TestMiddlemanHomeOverridesDefaultPaths(t *testing.T) {
+	assert := Assert.New(t)
+	t.Setenv("MIDDLEMAN_HOME", "/tmp/middleman-test")
+
+	assert.Equal(
+		"/tmp/middleman-test/config.toml",
+		DefaultConfigPath(),
+	)
+	assert.Equal("/tmp/middleman-test", DefaultDataDir())
+}
+
+func TestDefaultPathsWithoutMiddlemanHome(t *testing.T) {
+	assert := Assert.New(t)
+	t.Setenv("MIDDLEMAN_HOME", "")
+	t.Setenv("HOME", "/fakehome")
+
+	assert.Equal(
+		"/fakehome/.config/middleman/config.toml",
+		DefaultConfigPath(),
+	)
+	assert.Equal("/fakehome/.config/middleman", DefaultDataDir())
+}
+
 func TestDBPath(t *testing.T) {
 	cfg := &Config{DataDir: "/tmp/middleman-test"}
 	expected := "/tmp/middleman-test/middleman.db"


### PR DESCRIPTION
## Summary
- When `MIDDLEMAN_HOME` is set, use it as the base directory for config and data instead of `~/.config/middleman`
- Allows `export MIDDLEMAN_HOME=/tmp/middleman-test` to relocate all middleman state
- Falls back to existing `~/.config/middleman` when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)