### PR TITLE
Normalize repo names in config: strip .git, parse GitHub URLs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,6 +33,94 @@ type Repo struct {
 
 func (r Repo) FullName() string {
 	return r.Owner + "/" + r.Name
+}
+
+// normalize cleans up a Repo entry, extracting owner/name from
+// GitHub URLs or SSH addresses if the user pasted one into either
+// field. It also strips a trailing .git suffix.
+func (r *Repo) normalize() error {
+	// Check if either field contains a full GitHub URL or SSH
+	// address. If so, extract owner/name from it.
+	for _, raw := range []string{r.Owner, r.Name} {
+		owner, name, err := parseGitHubRef(raw)
+		if err != nil {
+			return err
+		}
+		if owner != "" {
+			r.Owner = owner
+			r.Name = name
+			return nil
+		}
+	}
+
+	r.Name = strings.TrimSuffix(r.Name, ".git")
+	if r.Owner == "" || r.Name == "" {
+		return errors.New("must have owner and name")
+	}
+	return nil
+}
+
+// parseGitHubRef extracts owner and repo name from a GitHub URL or
+// SSH address. Returns ("", "", nil) when the input is not a GitHub
+// ref at all, or a non-nil error when it looks like a GitHub ref but
+// is malformed (e.g. missing the repo name).
+func parseGitHubRef(raw string) (owner, name string, err error) {
+	raw = strings.TrimSpace(raw)
+	var path string
+	switch {
+	case strings.HasPrefix(raw, "ssh://"):
+		// URI-style SSH: ssh://git@github.com[:port]/owner/repo
+		p, isGitHub, err := parseSSHURI(raw)
+		if err != nil {
+			return "", "", err
+		}
+		if !isGitHub {
+			return "", "", nil
+		}
+		path = p
+	default:
+		if m := ghSCPRe.FindStringSubmatch(raw); m != nil {
+			path = m[1]
+		} else if m := ghSchemeRe.FindStringSubmatch(raw); m != nil {
+			path = m[1]
+		} else if m := ghBareRe.FindStringSubmatch(raw); m != nil {
+			path = m[1]
+		} else {
+			return "", "", nil
+		}
+	}
+	path = cleanPath(path)
+	parts := strings.SplitN(path, "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf(
+			"incomplete GitHub reference %q: expected owner/repo", raw,
+		)
+	}
+	return parts[0], parts[1], nil
+}
+
+// parseSSHURI parses ssh:// URIs. Returns (path, true, nil) when
+// the host is github.com, or ("", false, nil) when it is not.
+func parseSSHURI(raw string) (string, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid SSH URI %q: %w", raw, err)
+	}
+	if u.Hostname() != "github.com" {
+		return "", false, nil
+	}
+	return strings.TrimPrefix(u.Path, "/"), true, nil
+}
+
+// cleanPath strips query strings, fragments, trailing slashes,
+// and an optional .git suffix from a GitHub ref path.
+func cleanPath(path string) string {
+	if idx := strings.IndexAny(path, "?#"); idx != -1 {
+		path = path[:idx]
+	}
+	path = strings.TrimRight(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	return path
 }
 
 type Activity struct {
@@ -212,9 +301,9 @@ func Load(path string) (*Config, error) {
 }
 
 func (c *Config) Validate() error {
-	for i, r := range c.Repos {
-		if r.Owner == "" || r.Name == "" {
-			return fmt.Errorf("config: repos[%d] must have owner and name", i)
+	for i := range c.Repos {
+		if err := c.Repos[i].normalize(); err != nil {
+			return fmt.Errorf("config: repos[%d]: %w", i, err)
 		}
 	}
 
@@ -263,7 +352,16 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-var validBasePathRe = regexp.MustCompile(`^/([a-zA-Z0-9._~-]+/)*$`)
+var (
+	validBasePathRe = regexp.MustCompile(`^/([a-zA-Z0-9._~-]+/)*$`)
+	// With scheme: optional path so https://github.com is caught.
+	ghSchemeRe = regexp.MustCompile(`^https?://github\.com(?:/(.*))?$`)
+	// Without scheme: require / so bare "github.com" (a valid repo
+	// name) is not falsely matched.
+	ghBareRe = regexp.MustCompile(`^github\.com/(.*)$`)
+	// SCP-style only (git@github.com:path); ssh:// URIs use net/url.
+	ghSCPRe = regexp.MustCompile(`^[^@]+@github\.com:(.*)$`)
+)
 
 func (c *Config) SyncDuration() time.Duration {
 	d, _ := time.ParseDuration(c.SyncInterval)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -89,6 +90,16 @@ func TestLoadRepoMissingFields(t *testing.T) {
 	path := writeConfig(t, `
 [[repos]]
 owner = "a"
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+}
+
+func TestLoadRepoNameDotGitOnly(t *testing.T) {
+	path := writeConfig(t, `
+[[repos]]
+owner = "a"
+name = ".git"
 `)
 	_, err := Load(path)
 	require.Error(t, err)
@@ -261,6 +272,225 @@ time_range = "1y"
 `)
 	_, err := Load(path)
 	require.Error(t, err)
+}
+
+func TestLoadNormalizesRepoNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		owner     string
+		repoName  string
+		wantOwner string
+		wantName  string
+	}{
+		{
+			name:      "strips .git suffix",
+			owner:     "apache",
+			repoName:  "arrow.git",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "HTTPS URL in name",
+			owner:     "ignored",
+			repoName:  "https://github.com/apache/arrow",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "HTTPS URL with .git in name",
+			owner:     "ignored",
+			repoName:  "https://github.com/apache/arrow.git",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "SSH URL in name",
+			owner:     "ignored",
+			repoName:  "git@github.com:apache/arrow.git",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "SSH URL without .git in name",
+			owner:     "ignored",
+			repoName:  "git@github.com:apache/arrow",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "SSH URI-style URL",
+			owner:     "ignored",
+			repoName:  "ssh://git@github.com/apache/arrow.git",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "SSH URI-style with port",
+			owner:     "ignored",
+			repoName:  "ssh://git@github.com:22/apache/arrow.git",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "SSH URI-style non-github host",
+			owner:     "myorg",
+			repoName:  "ssh://git@gitlab.com/apache/arrow.git",
+			wantOwner: "myorg",
+			wantName:  "ssh://git@gitlab.com/apache/arrow",
+		},
+		{
+			name:      "bare github.com path in name",
+			owner:     "ignored",
+			repoName:  "github.com/apache/arrow",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "HTTPS URL in owner",
+			owner:     "https://github.com/apache/arrow.git",
+			repoName:  "ignored",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "plain owner and name unchanged",
+			owner:     "apache",
+			repoName:  "arrow",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "URL with query string",
+			owner:     "ignored",
+			repoName:  "https://github.com/apache/arrow?tab=readme",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "URL with fragment",
+			owner:     "ignored",
+			repoName:  "https://github.com/apache/arrow#readme",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "URL with trailing slash",
+			owner:     "ignored",
+			repoName:  "https://github.com/apache/arrow/",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "URL with .git and trailing slash",
+			owner:     "ignored",
+			repoName:  "https://github.com/apache/arrow.git/",
+			wantOwner: "apache",
+			wantName:  "arrow",
+		},
+		{
+			name:      "repo literally named github.com",
+			owner:     "acme",
+			repoName:  "github.com",
+			wantOwner: "acme",
+			wantName:  "github.com",
+		},
+		{
+			name:      "non-github HTTPS host not parsed",
+			owner:     "ignored",
+			repoName:  "https://notgithub.com/apache/arrow",
+			wantOwner: "ignored",
+			wantName:  "https://notgithub.com/apache/arrow",
+		},
+		{
+			name:      "non-github SSH host not parsed",
+			owner:     "ignored",
+			repoName:  "git@notgithub.com:apache/arrow.git",
+			wantOwner: "ignored",
+			wantName:  "git@notgithub.com:apache/arrow",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			cfg := fmt.Sprintf(`
+[[repos]]
+owner = %q
+name = %q
+`, tt.owner, tt.repoName)
+			path := writeConfig(t, cfg)
+			got, err := Load(path)
+			require.NoError(t, err)
+			assert.Equal(tt.wantOwner, got.Repos[0].Owner)
+			assert.Equal(tt.wantName, got.Repos[0].Name)
+		})
+	}
+}
+
+func TestLoadRejectsMalformedGitHubRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		owner    string
+		repoName string
+	}{
+		{
+			name:     "HTTPS URL missing repo",
+			owner:    "ignored",
+			repoName: "https://github.com/apache/",
+		},
+		{
+			name:     "HTTPS URL owner only",
+			owner:    "ignored",
+			repoName: "https://github.com/apache",
+		},
+		{
+			name:     "SSH URL missing repo",
+			owner:    "ignored",
+			repoName: "git@github.com:apache",
+		},
+		{
+			name:     "bare HTTPS prefix",
+			owner:    "ignored",
+			repoName: "https://github.com/",
+		},
+		{
+			name:     "bare github.com slash",
+			owner:    "ignored",
+			repoName: "github.com/",
+		},
+		{
+			name:     "bare SSH prefix",
+			owner:    "ignored",
+			repoName: "git@github.com:",
+		},
+		{
+			name:     "HTTPS host only no slash",
+			owner:    "ignored",
+			repoName: "https://github.com",
+		},
+		{
+			name:     "SSH URI bare host",
+			owner:    "ignored",
+			repoName: "ssh://git@github.com",
+		},
+		{
+			name:     "SSH URI bare host with port",
+			owner:    "ignored",
+			repoName: "ssh://git@github.com:22",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := fmt.Sprintf(`
+[[repos]]
+owner = %q
+name = %q
+`, tt.owner, tt.repoName)
+			path := writeConfig(t, cfg)
+			_, err := Load(path)
+			require.Error(t, err)
+			Assert.Contains(t, err.Error(), "incomplete GitHub reference")
+		})
+	}
 }
 
 func TestSaveRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary
- Strip `.git` suffix from repo names during config validation
- Parse full GitHub URLs (HTTPS, SSH, bare `github.com/` paths) pasted into either the owner or name field, extracting the correct owner/name pair

Closes #36