### PR TITLE
Add embedding action hooks for host-provided PR and issue actions

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -201,3 +201,21 @@ a.item-ref {
 a.item-ref:hover {
   text-decoration: underline;
 }
+
+/* Embedding action buttons (used in PR and issue detail views) */
+.btn--embedding-action {
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.btn--embedding-action:hover {
+  background: var(--accent-blue, #1f6feb);
+  color: #fff;
+  border-color: var(--accent-blue, #1f6feb);
+}

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -18,6 +18,7 @@
   import { copyToClipboard } from "../../utils/clipboard.js";
   import EventTimeline from "./EventTimeline.svelte";
   import IssueCommentBox from "./IssueCommentBox.svelte";
+  import { getIssueActions, invokeAction } from "../../utils/embedding-hooks.svelte.js";
 
   interface Props {
     owner: string;
@@ -221,6 +222,14 @@
             {stateSubmitting ? "Reopening..." : "Reopen issue"}
           </button>
         {/if}
+        {#each getIssueActions() as action (action.id)}
+          <button
+            class="btn--embedding-action"
+            onclick={() => invokeAction(action, { owner, name, number })}
+          >
+            {action.label}
+          </button>
+        {/each}
         {#if stateError}
           <span class="action-error">{stateError}</span>
         {/if}

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -22,6 +22,7 @@
   import ApproveButton from "./ApproveButton.svelte";
   import MergeModal from "./MergeModal.svelte";
   import ReadyForReviewButton from "./ReadyForReviewButton.svelte";
+  import { getPullRequestActions, invokeAction } from "../../utils/embedding-hooks.svelte.js";
 
   interface Props {
     owner: string;
@@ -362,6 +363,19 @@
           {#if stateError}
             <span class="action-error">{stateError}</span>
           {/if}
+        </div>
+      {/if}
+
+      {#if getPullRequestActions().length > 0}
+        <div class="actions-row">
+          {#each getPullRequestActions() as action (action.id)}
+            <button
+              class="btn--embedding-action"
+              onclick={() => invokeAction(action, { owner, name, number })}
+            >
+              {action.label}
+            </button>
+          {/each}
         </div>
       {/if}
 

--- a/frontend/src/lib/utils/embedding-hooks.svelte.test.ts
+++ b/frontend/src/lib/utils/embedding-hooks.svelte.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getPullRequestActions,
+  getIssueActions,
+  invokeAction,
+} from "./embedding-hooks.svelte.js";
+import type { ActionHook } from "./embedding-hooks.svelte.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const win = window as any;
+
+afterEach(() => {
+  win.__middleman_hooks = null;
+});
+
+describe("getPullRequestActions", () => {
+  it("returns empty array when no hooks registered", () => {
+    expect(getPullRequestActions()).toEqual([]);
+  });
+
+  it("returns PR actions from registered hooks", () => {
+    const handler = vi.fn();
+    win.__middleman_hooks = {
+      actions: {
+        pullRequest: [{ id: "pr1", label: "Test", handler }],
+      },
+    };
+    const actions = getPullRequestActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]!.id).toBe("pr1");
+    expect(actions[0]!.label).toBe("Test");
+  });
+});
+
+describe("lazy read without notify", () => {
+  it("picks up hooks set after import without calling notify", () => {
+    win.__middleman_hooks = {
+      actions: {
+        pullRequest: [{ id: "lazy-pr", label: "Lazy PR", handler: vi.fn() }],
+        issue: [{ id: "lazy-iss", label: "Lazy Issue", handler: vi.fn() }],
+      },
+    };
+    expect(getPullRequestActions()).toHaveLength(1);
+    expect(getPullRequestActions()[0]!.id).toBe("lazy-pr");
+    expect(getIssueActions()).toHaveLength(1);
+    expect(getIssueActions()[0]!.id).toBe("lazy-iss");
+  });
+
+  it("picks up replaced hooks without calling notify", () => {
+    win.__middleman_hooks = {
+      actions: { pullRequest: [{ id: "v1", label: "V1", handler: vi.fn() }] },
+    };
+    win.__middleman_hooks = {
+      actions: { pullRequest: [{ id: "v2", label: "V2", handler: vi.fn() }] },
+    };
+    expect(getPullRequestActions()[0]!.id).toBe("v2");
+  });
+});
+
+describe("getIssueActions", () => {
+  it("returns empty array when no hooks registered", () => {
+    expect(getIssueActions()).toEqual([]);
+  });
+
+  it("returns issue actions from registered hooks", () => {
+    const handler = vi.fn();
+    win.__middleman_hooks = {
+      actions: {
+        issue: [{ id: "iss1", label: "Issue Action", handler }],
+      },
+    };
+    const actions = getIssueActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]!.id).toBe("iss1");
+  });
+
+  it("picks up in-place mutation via manual notify", () => {
+    const hooks = { actions: { issue: [] as ActionHook[] } };
+    win.__middleman_hooks = hooks;
+    expect(getIssueActions()).toHaveLength(0);
+    hooks.actions.issue.push({ id: "mut", label: "Mutated", handler: vi.fn() });
+    win.__middleman_notify_hooks_changed();
+    expect(getIssueActions()).toHaveLength(1);
+    expect(getIssueActions()[0]!.id).toBe("mut");
+  });
+});
+
+describe("invokeAction", () => {
+  it("passes correct context to handler", () => {
+    const handler = vi.fn();
+    const action: ActionHook = { id: "a", label: "A", handler };
+    invokeAction(action, { owner: "org", name: "repo", number: 42 });
+    expect(handler).toHaveBeenCalledWith({
+      owner: "org",
+      name: "repo",
+      number: 42,
+    });
+  });
+
+  it("catches sync errors from handler", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const action: ActionHook = {
+      id: "b",
+      label: "B",
+      handler: () => { throw new Error("boom"); },
+    };
+    invokeAction(action, { owner: "o", name: "n", number: 1 });
+    expect(spy).toHaveBeenCalledWith(
+      "Embedding action error:",
+      expect.any(Error),
+    );
+    spy.mockRestore();
+  });
+
+  it("catches async errors from handler", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const action: ActionHook = {
+      id: "c",
+      label: "C",
+      handler: () => Promise.reject(new Error("async boom")),
+    };
+    invokeAction(action, { owner: "o", name: "n", number: 1 });
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(
+        "Embedding action error:",
+        expect.any(Error),
+      );
+    });
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/lib/utils/embedding-hooks.svelte.ts
+++ b/frontend/src/lib/utils/embedding-hooks.svelte.ts
@@ -1,0 +1,82 @@
+export interface EmbeddingHooks {
+  actions?: {
+    pullRequest?: ActionHook[];
+    issue?: ActionHook[];
+  };
+}
+
+export interface ActionHook {
+  id: string;
+  label: string;
+  handler: (context: ActionContext) => void | Promise<void>;
+}
+
+export interface ActionContext {
+  owner: string;
+  name: string;
+  number: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _hooksValue: EmbeddingHooks | null = (window as any).__middleman_hooks ?? null;
+let _generation = $state(0);
+let _intercepted = false;
+
+// Intercept assignments to window.__middleman_hooks so setting the
+// property automatically triggers Svelte reactivity. Only install the
+// interceptor when the property is absent or a plain data property.
+const desc = Object.getOwnPropertyDescriptor(window, "__middleman_hooks");
+if (!desc || (!desc.get && !desc.set && desc.configurable)) {
+  Object.defineProperty(window, "__middleman_hooks", {
+    get() { return _hooksValue; },
+    set(val: EmbeddingHooks | null) {
+      _hooksValue = val;
+      _generation++;
+    },
+    configurable: true,
+    enumerable: true,
+  });
+  _intercepted = true;
+}
+
+// Manual notify for hosts that mutate the hooks object in-place,
+// or when the setter could not be installed.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).__middleman_notify_hooks_changed = () => {
+  if (!_intercepted) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _hooksValue = (window as any).__middleman_hooks ?? null;
+  }
+  _generation++;
+};
+
+function currentHooks(): EmbeddingHooks | null {
+  void _generation; // reactive dependency
+  if (!_intercepted) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _hooksValue = (window as any).__middleman_hooks ?? null;
+  }
+  return _hooksValue;
+}
+
+export function getPullRequestActions(): ActionHook[] {
+  return currentHooks()?.actions?.pullRequest ?? [];
+}
+
+export function getIssueActions(): ActionHook[] {
+  return currentHooks()?.actions?.issue ?? [];
+}
+
+export function invokeAction(
+  action: ActionHook,
+  context: ActionContext,
+): void {
+  try {
+    const result = action.handler(context);
+    Promise.resolve(result).catch((err: unknown) => {
+      console.error("Embedding action error:", err);
+    });
+  } catch (err) {
+    console.error("Embedding action error:", err);
+  }
+}


### PR DESCRIPTION
## Summary

- Embedding hosts can register action buttons in PR and issue detail views via `window.__middleman_hooks`
- Hooks are read live from window on every access for backward compatibility; `window.__middleman_notify_hooks_changed()` triggers reactive re-renders
- Handler invocations are wrapped in try/catch with async error isolation
- Shared `.btn--embedding-action` styles in `app.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)