### PR TITLE
feat(ui): highlight Svelte files in diff view

### DIFF
--- a/packages/ui/src/utils/highlight.ts
+++ b/packages/ui/src/utils/highlight.ts
@@ -5,7 +5,7 @@ let highlighterPromise: Promise<Highlighter> | null = null;
 const LANGS = [
   "go", "typescript", "javascript", "tsx", "jsx", "python", "rust", "json",
   "yaml", "markdown", "sql", "shellscript", "css", "html", "toml",
-  "dockerfile", "makefile",
+  "dockerfile", "makefile", "svelte",
 ];
 
 function getHighlighter(): Promise<Highlighter> {
@@ -23,7 +23,7 @@ const EXT_TO_LANG: Record<string, string> = {
   jsx: "jsx", py: "python", rs: "rust", json: "json",
   yaml: "yaml", yml: "yaml", md: "markdown", sql: "sql",
   sh: "shellscript", bash: "shellscript", css: "css", html: "html",
-  toml: "toml", mk: "makefile",
+  toml: "toml", mk: "makefile", svelte: "svelte",
 };
 
 const BASENAME_TO_LANG: Record<string, string> = {


### PR DESCRIPTION
## Summary

The diff view already syntax-highlights file contents with Shiki, but `.svelte` files were rendered as plain text because the Svelte grammar was never registered and the extension had no entry in the language map. This change adds both, so Svelte components inside a PR diff now get the same per-token coloring as Go, TypeScript, Python, and the other supported languages.

- Add `svelte` to the list of grammars loaded into the Shiki highlighter in `packages/ui/src/utils/highlight.ts`.
- Map the `.svelte` extension to the `svelte` language so `langFromPath()` returns it for files like `App.svelte` or `lib/components/Button.svelte`.

The Svelte grammar ships with the bundled `shiki` package already in `dependencies`, so no new packages are required.