### PR TITLE
Surface real GitHub merge errors

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -347,6 +347,94 @@ func TestAPIMergePRNetworkErrorReturns502(t *testing.T) {
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
+	require.Contains(string(resp.Body), "connection refused")
+}
+
+func TestAPIMergePR422ForwardsGitHubMessage(t *testing.T) {
+	require := require.New(t)
+
+	mock := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, _ int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+				Message:  "Required status check is failing",
+			}
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
+		context.Background(), "acme", "widget", 1,
+		generated.MergePRInputBody{
+			CommitTitle:   "title",
+			CommitMessage: "msg",
+			Method:        "squash",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusUnprocessableEntity, resp.StatusCode())
+	require.Contains(string(resp.Body), "Required status check is failing")
+}
+
+func TestAPIMergePR403ForwardsGitHubMessage(t *testing.T) {
+	require := require.New(t)
+
+	mock := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, _ int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+				Message:  "Resource not accessible by integration",
+			}
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
+		context.Background(), "acme", "widget", 1,
+		generated.MergePRInputBody{
+			CommitTitle:   "title",
+			CommitMessage: "msg",
+			Method:        "squash",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusForbidden, resp.StatusCode())
+	require.Contains(string(resp.Body), "Resource not accessible by integration")
+}
+
+func TestAPIMergePR5xxReturns502WithGitHubMessage(t *testing.T) {
+	require := require.New(t)
+
+	mock := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, _ int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusServiceUnavailable},
+				Message:  "Service unavailable",
+			}
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
+		context.Background(), "acme", "widget", 1,
+		generated.MergePRInputBody{
+			CommitTitle:   "title",
+			CommitMessage: "msg",
+			Method:        "squash",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusBadGateway, resp.StatusCode())
+	require.Contains(string(resp.Body), "Service unavailable")
 }
 
 func TestAPIClientConstruction(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -669,18 +669,37 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 	)
 	if err != nil {
 		var ghErr *gh.ErrorResponse
-		if errors.As(err, &ghErr) &&
-			(ghErr.Response.StatusCode == 405 || ghErr.Response.StatusCode == 409) {
-			go func() {
-				if syncErr := s.syncer.SyncMR(
-					context.WithoutCancel(ctx), input.Owner, input.Name, input.Number,
-				); syncErr != nil {
-					slog.Warn("background sync after merge failure", "err", syncErr)
-				}
-			}()
-			return nil, huma.Error409Conflict(ghErr.Message)
+		if errors.As(err, &ghErr) {
+			slog.Warn("github merge failed",
+				"owner", input.Owner, "repo", input.Name,
+				"number", input.Number, "method", input.Body.Method,
+				"status", ghErr.Response.StatusCode,
+				"message", ghErr.Message)
+
+			if ghErr.Response.StatusCode == http.StatusMethodNotAllowed ||
+				ghErr.Response.StatusCode == http.StatusConflict {
+				go func() {
+					if syncErr := s.syncer.SyncMR(
+						context.WithoutCancel(ctx), input.Owner, input.Name, input.Number,
+					); syncErr != nil {
+						slog.Warn("background sync after merge failure", "err", syncErr)
+					}
+				}()
+				return nil, huma.Error409Conflict(ghErr.Message)
+			}
+
+			// Forward 4xx GitHub errors as-is so the user sees the real cause
+			// (e.g. 422 validation, 403 forbidden). 5xx becomes 502.
+			if ghErr.Response.StatusCode >= 400 && ghErr.Response.StatusCode < 500 {
+				return nil, huma.NewError(ghErr.Response.StatusCode, ghErr.Message)
+			}
+			return nil, huma.Error502BadGateway("GitHub: " + ghErr.Message)
 		}
-		return nil, huma.Error502BadGateway("GitHub merge error")
+		slog.Warn("github merge transport error",
+			"owner", input.Owner, "repo", input.Name,
+			"number", input.Number, "method", input.Body.Method,
+			"err", err)
+		return nil, huma.Error502BadGateway("GitHub merge error: " + err.Error())
 	}
 
 	repoObj, _ := s.db.GetRepoByOwnerName(ctx, input.Owner, input.Name)


### PR DESCRIPTION
- Merge failures now show GitHub's actual error message instead of a generic "GitHub merge error"
- Server logs every merge failure with owner, repo, number, status, and GitHub's message
- 4xx responses forwarded with original status; 5xx wrapped as 502
- Transport errors return 502 with the underlying error string