### PR TITLE
Fix bot user display name 404 warnings

### DIFF
--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -432,10 +432,15 @@ func loginOrEmpty(u *gh.User) string {
 	return u.GetLogin()
 }
 
-// nameOrEmpty returns the GitHub display name for a user, or "" if unavailable.
+// nameOrEmpty returns the GitHub display name for a user, or "" if
+// unavailable. Bot accounts (Type == "Bot") use their login as display name
+// since they have no user-facing name on the GitHub API.
 func nameOrEmpty(u *gh.User) string {
 	if u == nil {
 		return ""
+	}
+	if u.GetType() == "Bot" {
+		return u.GetLogin()
 	}
 	return sanitizeDisplayName(u.GetName())
 }

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -519,3 +519,62 @@ func TestDeriveReviewDecision_LatestStatePerUser(t *testing.T) {
 	result := DeriveReviewDecision(reviews)
 	Assert.Equal(t, "approved", result)
 }
+
+func TestNormalizePR_BotUserDisplayName(t *testing.T) {
+	assert := Assert.New(t)
+	ghPR := &gh.PullRequest{
+		ID:     new(int64(3003)),
+		Number: new(7),
+		State:  new("open"),
+		User: &gh.User{
+			Login: new("renovate[bot]"),
+			Type:  new("Bot"),
+		},
+	}
+
+	pr := NormalizePR(1, ghPR)
+
+	assert.Equal("renovate[bot]", pr.Author)
+	assert.Equal("renovate[bot]", pr.AuthorDisplayName,
+		"bot users should get login as display name")
+}
+
+func TestNameOrEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		user *gh.User
+		want string
+	}{
+		{
+			name: "nil user",
+			user: nil,
+			want: "",
+		},
+		{
+			name: "regular user with name",
+			user: &gh.User{Login: new("alice"), Name: new("Alice Smith")},
+			want: "Alice Smith",
+		},
+		{
+			name: "regular user without name",
+			user: &gh.User{Login: new("alice")},
+			want: "",
+		},
+		{
+			name: "bot user returns login",
+			user: &gh.User{Login: new("dependabot[bot]"), Type: new("Bot")},
+			want: "dependabot[bot]",
+		},
+		{
+			name: "bot user with name still returns login",
+			user: &gh.User{Login: new("mybot[bot]"), Type: new("Bot"), Name: new("My Bot")},
+			want: "mybot[bot]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Assert.Equal(t, tt.want, nameOrEmpty(tt.user))
+		})
+	}
+}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2123,7 +2123,7 @@ func (s *Syncer) resolveDisplayName(
 		if err != nil {
 			return "", err
 		}
-		resolved := sanitizeDisplayName(user.GetName())
+		resolved := nameOrEmpty(user)
 		s.displayNamesMu.Lock()
 		s.displayNames[key] = resolved
 		s.displayNamesMu.Unlock()

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -2087,6 +2088,9 @@ func computeLastActivity(
 // callers can preserve existing data. Uses an in-memory cache across
 // a sync run plus singleflight dedup so concurrent workers racing on
 // the same author only trigger one GetUser call.
+//
+// Bot logins (ending with "[bot]") are returned as-is since bot accounts
+// have no display name on the GitHub API.
 func (s *Syncer) resolveDisplayName(
 	ctx context.Context, client Client, host, login string,
 ) (string, bool) {
@@ -2095,7 +2099,13 @@ func (s *Syncer) resolveDisplayName(
 	name, ok := s.displayNames[key]
 	s.displayNamesMu.Unlock()
 	if ok {
-		return name, true
+		return name, name != ""
+	}
+	if strings.HasSuffix(login, "[bot]") {
+		s.displayNamesMu.Lock()
+		s.displayNames[key] = login
+		s.displayNamesMu.Unlock()
+		return login, true
 	}
 
 	v, err, _ := s.displayNameGroup.Do(key, func() (any, error) {
@@ -2123,6 +2133,7 @@ func (s *Syncer) resolveDisplayName(
 		slog.Warn("get user display name failed",
 			"login", login, "err", err,
 		)
+		s.displayNames[key] = ""
 		return "", false
 	}
 	return v.(string), true

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2104,6 +2104,9 @@ func (s *Syncer) resolveDisplayName(
 ) (string, bool) {
 	key := host + "\x00" + login
 	s.displayNamesMu.Lock()
+	if s.displayNames == nil {
+		s.displayNames = make(map[string]displayNameResult)
+	}
 	cached, ok := s.displayNames[key]
 	s.displayNamesMu.Unlock()
 	if ok {
@@ -2838,13 +2841,14 @@ func (s *Syncer) syncMRWithHost(
 	normalized := NormalizePR(repoID, ghPR)
 
 	if normalized.Author != "" && normalized.AuthorDisplayName == "" {
-		existing, _ := s.db.GetMergeRequest(ctx, owner, name, number)
-		if existing != nil && existing.AuthorDisplayName != "" {
-			normalized.AuthorDisplayName = existing.AuthorDisplayName
+		// Resolve directly instead of using s.resolveDisplayName to
+		// preserve existing display names on failure.
+		if displayName, ok := s.resolveDisplayName(ctx, client, host, normalized.Author); ok {
+			normalized.AuthorDisplayName = displayName
 		} else {
-			user, userErr := client.GetUser(ctx, normalized.Author)
-			if userErr == nil {
-				normalized.AuthorDisplayName = sanitizeDisplayName(user.GetName())
+			existing, _ := s.db.GetMergeRequest(ctx, owner, name, number)
+			if existing != nil {
+				normalized.AuthorDisplayName = existing.AuthorDisplayName
 			}
 		}
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -116,6 +116,14 @@ type WatchedMR struct {
 // per-host GitHub rate limit / abuse-detection thresholds.
 const defaultParallelism = 4
 
+// displayNameResult caches a resolved display name along with whether
+// the lookup succeeded, so empty names from real users are not confused
+// with failed lookups.
+type displayNameResult struct {
+	name string
+	ok   bool
+}
+
 // Syncer periodically pulls PR data from GitHub into SQLite.
 type Syncer struct {
 	clients       map[string]Client // host -> client
@@ -142,7 +150,7 @@ type Syncer struct {
 	stopped            bool                 // guarded by lifecycleMu
 	nextSyncAfter      map[string]time.Time // host -> next eligible background sync time
 	nextWatchSyncAfter map[string]time.Time // host -> next eligible watch-sync time
-	displayNames       map[string]string    // "host\x00login" -> display name, per sync run
+	displayNames       map[string]displayNameResult // "host\x00login" -> resolved name, per sync run
 	displayNamesMu     sync.Mutex
 	displayNameGroup   singleflight.Group // dedups concurrent GetUser calls
 	onMRSynced         func(owner, name string, mr *db.MergeRequest)
@@ -970,7 +978,7 @@ func (s *Syncer) RunOnce(ctx context.Context) {
 		Progress: fmt.Sprintf("0/%d", total),
 	})
 	s.displayNamesMu.Lock()
-	s.displayNames = make(map[string]string)
+	s.displayNames = make(map[string]displayNameResult)
 	s.displayNamesMu.Unlock()
 	slog.Info("sync started", "repos", total)
 
@@ -2096,14 +2104,14 @@ func (s *Syncer) resolveDisplayName(
 ) (string, bool) {
 	key := host + "\x00" + login
 	s.displayNamesMu.Lock()
-	name, ok := s.displayNames[key]
+	cached, ok := s.displayNames[key]
 	s.displayNamesMu.Unlock()
 	if ok {
-		return name, name != ""
+		return cached.name, cached.ok
 	}
 	if strings.HasSuffix(login, "[bot]") {
 		s.displayNamesMu.Lock()
-		s.displayNames[key] = login
+		s.displayNames[key] = displayNameResult{name: login, ok: true}
 		s.displayNamesMu.Unlock()
 		return login, true
 	}
@@ -2121,22 +2129,25 @@ func (s *Syncer) resolveDisplayName(
 
 		user, err := client.GetUser(ctx, login)
 		if err != nil {
-			return "", err
+			return displayNameResult{}, err
 		}
-		resolved := nameOrEmpty(user)
+		result := displayNameResult{name: nameOrEmpty(user), ok: true}
 		s.displayNamesMu.Lock()
-		s.displayNames[key] = resolved
+		s.displayNames[key] = result
 		s.displayNamesMu.Unlock()
-		return resolved, nil
+		return result, nil
 	})
 	if err != nil {
 		slog.Warn("get user display name failed",
 			"login", login, "err", err,
 		)
-		s.displayNames[key] = ""
+		s.displayNamesMu.Lock()
+		s.displayNames[key] = displayNameResult{ok: false}
+		s.displayNamesMu.Unlock()
 		return "", false
 	}
-	return v.(string), true
+	result := v.(displayNameResult)
+	return result.name, result.ok
 }
 
 // --- Issue sync ---

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4005,7 +4005,7 @@ func TestResolveDisplayName(t *testing.T) {
 				map[string]Client{"github.com": mc}, nil, nil, nil,
 				time.Minute, nil, nil,
 			)
-			syncer.displayNames = make(map[string]string)
+			syncer.displayNames = make(map[string]displayNameResult)
 
 			name, ok := syncer.resolveDisplayName(ctx, mc, "github.com", tt.login)
 			assert.Equal(tt.wantName, name)
@@ -4030,7 +4030,7 @@ func TestResolveDisplayName_CachesNegativeResult(t *testing.T) {
 		map[string]Client{"github.com": mc}, nil, nil, nil,
 		time.Minute, nil, nil,
 	)
-	syncer.displayNames = make(map[string]string)
+	syncer.displayNames = make(map[string]displayNameResult)
 
 	// First call: hits API, returns failure.
 	name1, ok1 := syncer.resolveDisplayName(ctx, mc, "github.com", "renovate")

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4044,3 +4044,33 @@ func TestResolveDisplayName_CachesNegativeResult(t *testing.T) {
 	assert.False(ok2)
 	assert.Equal(1, callCount, "GetUser should not be called again for cached failure")
 }
+
+func TestResolveDisplayName_CachesSuccessfulEmptyName(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	callCount := 0
+	mc := &mockClient{
+		getUserFn: func(_ context.Context, login string) (*gh.User, error) {
+			callCount++
+			return &gh.User{Login: &login}, nil // no display name
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, nil, nil, nil,
+		time.Minute, nil, nil,
+	)
+	syncer.displayNames = make(map[string]displayNameResult)
+
+	// First call: hits API, succeeds with empty name.
+	name1, ok1 := syncer.resolveDisplayName(ctx, mc, "github.com", "no-profile")
+	assert.Equal("", name1)
+	assert.True(ok1, "successful lookup of empty name should return ok=true")
+	assert.Equal(1, callCount)
+
+	// Second call: cache hit must still return ok=true, not flip to false.
+	name2, ok2 := syncer.resolveDisplayName(ctx, mc, "github.com", "no-profile")
+	assert.Equal("", name2)
+	assert.True(ok2, "cached empty name must remain ok=true")
+	assert.Equal(1, callCount, "GetUser should not be called again for cached success")
+}

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -49,6 +49,7 @@ type mockClient struct {
 	singlePR               *gh.PullRequest
 	getPullRequestFn       func(context.Context, string, string, int) (*gh.PullRequest, error)
 	getIssueFn             func(context.Context, string, string, int) (*gh.Issue, error)
+	getUserFn              func(context.Context, string) (*gh.User, error)
 	listOpenPRsFn          func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listPullRequestsPageFn func(context.Context, string, string, string, int) ([]*gh.PullRequest, bool, error)
 	listIssuesPageFn       func(context.Context, string, string, string, int) ([]*gh.Issue, bool, error)
@@ -107,9 +108,12 @@ func (m *mockClient) GetIssue(
 	return nil, nil
 }
 
-func (m *mockClient) GetUser(_ context.Context, login string) (*gh.User, error) {
+func (m *mockClient) GetUser(ctx context.Context, login string) (*gh.User, error) {
 	m.trackCall()
 	m.getUserCalls.Add(1)
+	if m.getUserFn != nil {
+		return m.getUserFn(ctx, login)
+	}
 	name := "Display " + login
 	return &gh.User{Login: &login, Name: &name}, nil
 }
@@ -3922,4 +3926,121 @@ func TestSyncerStopCancelsTriggerRun(t *testing.T) {
 		close(release) // unblock the mock so the test can tear down
 		require.FailNow("Stop did not return after ctx cancellation")
 	}
+}
+
+func TestResolveDisplayName(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		login         string
+		getUserFn     func(context.Context, string) (*gh.User, error)
+		wantName      string
+		wantOK        bool
+		wantAPICalled bool
+	}{
+		{
+			name:  "regular user with display name",
+			login: "alice",
+			getUserFn: func(_ context.Context, login string) (*gh.User, error) {
+				name := "Alice Smith"
+				return &gh.User{Login: &login, Name: &name}, nil
+			},
+			wantName:      "Alice Smith",
+			wantOK:        true,
+			wantAPICalled: true,
+		},
+		{
+			name:  "regular user without display name",
+			login: "bob",
+			getUserFn: func(_ context.Context, login string) (*gh.User, error) {
+				return &gh.User{Login: &login}, nil
+			},
+			wantName:      "",
+			wantOK:        true,
+			wantAPICalled: true,
+		},
+		{
+			name:  "bot login skips API call",
+			login: "renovate[bot]",
+			getUserFn: func(_ context.Context, _ string) (*gh.User, error) {
+				return nil, nil
+			},
+			wantName:      "renovate[bot]",
+			wantOK:        true,
+			wantAPICalled: false,
+		},
+		{
+			name:  "API-returned bot uses login as display name",
+			login: "ci-helper",
+			getUserFn: func(_ context.Context, login string) (*gh.User, error) {
+				botType := "Bot"
+				return &gh.User{Login: &login, Type: &botType}, nil
+			},
+			wantName:      "ci-helper",
+			wantOK:        true,
+			wantAPICalled: true,
+		},
+		{
+			name:  "user not found returns false",
+			login: "ghost",
+			getUserFn: func(_ context.Context, _ string) (*gh.User, error) {
+				return nil, fmt.Errorf("GET https://api.github.com/users/ghost: 404 Not Found")
+			},
+			wantName:      "",
+			wantOK:        false,
+			wantAPICalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			apiCalled := false
+			mc := &mockClient{getUserFn: func(ctx context.Context, login string) (*gh.User, error) {
+				apiCalled = true
+				return tt.getUserFn(ctx, login)
+			}}
+			syncer := NewSyncer(
+				map[string]Client{"github.com": mc}, nil, nil, nil,
+				time.Minute, nil, nil,
+			)
+			syncer.displayNames = make(map[string]string)
+
+			name, ok := syncer.resolveDisplayName(ctx, mc, "github.com", tt.login)
+			assert.Equal(tt.wantName, name)
+			assert.Equal(tt.wantOK, ok)
+			assert.Equal(tt.wantAPICalled, apiCalled, "GetUser call expectation")
+		})
+	}
+}
+
+func TestResolveDisplayName_CachesNegativeResult(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	callCount := 0
+	mc := &mockClient{
+		getUserFn: func(_ context.Context, _ string) (*gh.User, error) {
+			callCount++
+			return nil, fmt.Errorf("404 Not Found")
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, nil, nil, nil,
+		time.Minute, nil, nil,
+	)
+	syncer.displayNames = make(map[string]string)
+
+	// First call: hits API, returns failure.
+	name1, ok1 := syncer.resolveDisplayName(ctx, mc, "github.com", "renovate")
+	assert.Equal("", name1)
+	assert.False(ok1)
+	assert.Equal(1, callCount)
+
+	// Second call: should use cache, no additional API call.
+	name2, ok2 := syncer.resolveDisplayName(ctx, mc, "github.com", "renovate")
+	assert.Equal("", name2)
+	assert.False(ok2)
+	assert.Equal(1, callCount, "GetUser should not be called again for cached failure")
 }

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4034,13 +4034,13 @@ func TestResolveDisplayName_CachesNegativeResult(t *testing.T) {
 
 	// First call: hits API, returns failure.
 	name1, ok1 := syncer.resolveDisplayName(ctx, mc, "github.com", "renovate")
-	assert.Equal("", name1)
+	assert.Empty(name1)
 	assert.False(ok1)
 	assert.Equal(1, callCount)
 
 	// Second call: should use cache, no additional API call.
 	name2, ok2 := syncer.resolveDisplayName(ctx, mc, "github.com", "renovate")
-	assert.Equal("", name2)
+	assert.Empty(name2)
 	assert.False(ok2)
 	assert.Equal(1, callCount, "GetUser should not be called again for cached failure")
 }
@@ -4064,13 +4064,13 @@ func TestResolveDisplayName_CachesSuccessfulEmptyName(t *testing.T) {
 
 	// First call: hits API, succeeds with empty name.
 	name1, ok1 := syncer.resolveDisplayName(ctx, mc, "github.com", "no-profile")
-	assert.Equal("", name1)
+	assert.Empty(name1)
 	assert.True(ok1, "successful lookup of empty name should return ok=true")
 	assert.Equal(1, callCount)
 
 	// Second call: cache hit must still return ok=true, not flip to false.
 	name2, ok2 := syncer.resolveDisplayName(ctx, mc, "github.com", "no-profile")
-	assert.Equal("", name2)
+	assert.Empty(name2)
 	assert.True(ok2, "cached empty name must remain ok=true")
 	assert.Equal(1, callCount, "GetUser should not be called again for cached success")
 }


### PR DESCRIPTION
## Summary

- Bot accounts (GitHub type "Bot") now use their login as display name instead of attempting a `/users/{login}` API call that 404s
- Failed user lookups are cached within a sync run to prevent repeated warnings
- Bot-type detection is consistent between normalize and resolve paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)