### PR TITLE
Fix activity feed 500 from UNION ALL type affinity loss

### DIFF
--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -147,18 +147,47 @@ func (d *DB) ListActivity(
 	var items []ActivityItem
 	for rows.Next() {
 		var it ActivityItem
+		var createdAtStr string
 		if err := rows.Scan(
 			&it.ActivityType, &it.Source, &it.SourceID,
 			&it.RepoOwner, &it.RepoName,
 			&it.ItemType, &it.ItemNumber, &it.ItemTitle,
 			&it.ItemURL, &it.ItemState, &it.Author,
-			&it.CreatedAt, &it.BodyPreview,
+			&createdAtStr, &it.BodyPreview,
 		); err != nil {
 			return nil, fmt.Errorf("scan activity item: %w", err)
 		}
+		t, err := parseDBTime(createdAtStr)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse activity created_at %q: %w",
+				createdAtStr, err)
+		}
+		it.CreatedAt = t
 		items = append(items, it)
 	}
 	return items, rows.Err()
+}
+
+// dbTimeLayouts lists formats the modernc.org/sqlite driver may
+// produce for DATETIME columns, ordered by likelihood.
+var dbTimeLayouts = []string{
+	"2006-01-02 15:04:05 +0000 UTC",
+	"2006-01-02 15:04:05 -0700 -0700",
+	"2006-01-02 15:04:05 -0700 MST",
+	"2006-01-02T15:04:05Z",
+	time.RFC3339,
+	time.RFC3339Nano,
+	"2006-01-02 15:04:05",
+}
+
+func parseDBTime(s string) (time.Time, error) {
+	for _, layout := range dbTimeLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized time format: %q", s)
 }
 
 // EncodeCursor encodes a sort position into an opaque cursor string.

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -240,3 +240,61 @@ func TestListActivity(t *testing.T) {
 
 	_ = prID2
 }
+
+func TestParseDBTime(t *testing.T) {
+	assert := Assert.New(t)
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			name:  "go time.String format",
+			input: "2026-04-09 21:27:11 +0000 UTC",
+			want:  time.Date(2026, 4, 9, 21, 27, 11, 0, time.UTC),
+		},
+		{
+			name:  "ISO 8601 UTC",
+			input: "2026-04-09T21:27:11Z",
+			want:  time.Date(2026, 4, 9, 21, 27, 11, 0, time.UTC),
+		},
+		{
+			name:  "RFC3339 with offset",
+			input: "2026-04-09T21:27:11+00:00",
+			want:  time.Date(2026, 4, 9, 21, 27, 11, 0, time.UTC),
+		},
+		{
+			name:  "RFC3339Nano",
+			input: "2026-04-09T21:27:11.123456Z",
+			want:  time.Date(2026, 4, 9, 21, 27, 11, 123456000, time.UTC),
+		},
+		{
+			name:  "local tz with repeated numeric offset",
+			input: "2026-04-10 18:48:35 -0400 -0400",
+			want:  time.Date(2026, 4, 10, 22, 48, 35, 0, time.UTC),
+		},
+		{
+			name:  "local tz with named zone",
+			input: "2026-04-10 18:48:35 -0400 EDT",
+			want:  time.Date(2026, 4, 10, 22, 48, 35, 0, time.UTC),
+		},
+		{
+			name:  "bare datetime",
+			input: "2026-04-09 21:27:11",
+			want:  time.Date(2026, 4, 9, 21, 27, 11, 0, time.UTC),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDBTime(tc.input)
+			require.NoError(t, err)
+			assert.True(tc.want.Equal(got),
+				"want %v, got %v", tc.want, got)
+		})
+	}
+
+	t.Run("invalid format returns error", func(t *testing.T) {
+		_, err := parseDBTime("not-a-date")
+		assert.Error(err)
+	})
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2811,3 +2811,35 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 	require.Equal(http.StatusOK, resp.StatusCode())
 	require.NotNil(resp.JSON200)
 }
+
+func TestAPIListActivity(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+
+	prID := seedPR(t, database, "acme", "widget", 1)
+	ctx := context.Background()
+
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{
+		{
+			MergeRequestID: prID,
+			EventType:      "issue_comment",
+			Author:         "reviewer",
+			Body:           "Looks good",
+			CreatedAt:      time.Now().UTC(),
+			DedupeKey:      "comment-1",
+		},
+	}))
+
+	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
+	resp, err := client.HTTP.GetActivityWithResponse(
+		ctx, &generated.GetActivityParams{Since: &since},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Items)
+	assert.NotEmpty(*resp.JSON200.Items,
+		"activity feed should contain PR and comment items")
+}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1258,6 +1258,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 
 	items, err := s.db.ListActivity(ctx, opts)
 	if err != nil {
+		slog.Error("list activity failed", "err", err)
 		return nil, huma.Error500InternalServerError("list activity failed")
 	}
 


### PR DESCRIPTION
## Summary

- Fix 500 on `/activity` endpoint: SQLite UNION ALL strips column type affinity, causing `created_at` to arrive as `string` instead of `time.Time` from the modernc.org/sqlite driver. Scan as string and parse with known layouts.
- Add error logging to activity handler (was silently swallowing the DB error)
- Add `TestParseDBTime` covering all observed datetime formats including local timezone variants
- Add `TestAPIListActivity` HTTP-level test to prevent regression