### PR TITLE
Fix PR detail showing wrong content due to non-UTC event times

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -879,12 +879,20 @@ func (d *DB) ListMREvents(ctx context.Context, mrID int64) ([]MREvent, error) {
 	var events []MREvent
 	for rows.Next() {
 		var e MREvent
+		var createdAtStr string
 		if err := rows.Scan(
 			&e.ID, &e.MergeRequestID, &e.PlatformID, &e.EventType, &e.Author, &e.Summary,
-			&e.Body, &e.MetadataJSON, &e.CreatedAt, &e.DedupeKey,
+			&e.Body, &e.MetadataJSON, &createdAtStr, &e.DedupeKey,
 		); err != nil {
 			return nil, fmt.Errorf("scan mr event: %w", err)
 		}
+		t, err := parseDBTime(createdAtStr)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse mr event created_at %q: %w",
+				createdAtStr, err)
+		}
+		e.CreatedAt = t
 		events = append(events, e)
 	}
 	return events, rows.Err()
@@ -1591,12 +1599,20 @@ func (d *DB) ListIssueEvents(ctx context.Context, issueID int64) ([]IssueEvent, 
 	var events []IssueEvent
 	for rows.Next() {
 		var e IssueEvent
+		var createdAtStr string
 		if err := rows.Scan(
 			&e.ID, &e.IssueID, &e.PlatformID, &e.EventType, &e.Author,
-			&e.Summary, &e.Body, &e.MetadataJSON, &e.CreatedAt, &e.DedupeKey,
+			&e.Summary, &e.Body, &e.MetadataJSON, &createdAtStr, &e.DedupeKey,
 		); err != nil {
 			return nil, fmt.Errorf("scan issue event: %w", err)
 		}
+		t, err := parseDBTime(createdAtStr)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse issue event created_at %q: %w",
+				createdAtStr, err)
+		}
+		e.CreatedAt = t
 		events = append(events, e)
 	}
 	return events, rows.Err()

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -904,6 +904,52 @@ func TestMREventsDedupeIsScopedToMergeRequest(t *testing.T) {
 	assert.Equal(2, total)
 }
 
+func TestListMREventsHandlesNonUTCTimes(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID := insertTestRepo(t, d, "o", "r")
+	prID := insertTestMR(t, d, repoID, 1, "pr one", baseTime())
+
+	// Insert events with times in various non-UTC zones,
+	// reproducing the formats the sqlite driver stores.
+	edt := time.FixedZone("EDT", -4*3600)
+	cdt := time.FixedZone("CDT", -5*3600)
+	jst := time.FixedZone("JST", 9*3600)
+	zones := []struct {
+		key  string
+		zone *time.Location
+	}{
+		{"commit-utc", time.UTC},
+		{"commit-edt", edt},
+		{"commit-cdt", cdt},
+		{"commit-jst", jst},
+	}
+	var events []MREvent
+	base := baseTime()
+	for i, z := range zones {
+		events = append(events, MREvent{
+			MergeRequestID: prID,
+			EventType:      "commit",
+			Author:         "alice",
+			CreatedAt:      base.Add(time.Duration(i) * time.Hour).In(z.zone),
+			DedupeKey:      z.key,
+		})
+	}
+	require.NoError(d.UpsertMREvents(ctx, events))
+
+	got, err := d.ListMREvents(ctx, prID)
+	require.NoError(err)
+	require.Len(got, len(zones))
+
+	for _, e := range got {
+		assert.Equal(time.UTC, e.CreatedAt.Location(),
+			"event %s should be returned in UTC", e.DedupeKey)
+	}
+}
+
 func TestGetPRIDByRepoAndNumber(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -133,7 +133,7 @@ func NormalizeCommitEvent(mrID int64, c *gh.RepositoryCommit) db.MREvent {
 	if c.GetCommit() != nil {
 		event.Body = c.GetCommit().GetMessage()
 		if c.GetCommit().Author != nil && c.GetCommit().Author.Date != nil {
-			event.CreatedAt = c.GetCommit().Author.Date.Time
+			event.CreatedAt = c.GetCommit().Author.Date.UTC()
 		}
 	}
 	return event

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -234,6 +234,30 @@ func TestNormalizeForcePushEvent(t *testing.T) {
 	require.Contains(event.MetadataJSON, `"ref":"feature"`)
 }
 
+func TestNormalizeCommitEvent_CreatedAtIsUTC(t *testing.T) {
+	assert := Assert.New(t)
+	edt := time.FixedZone("EDT", -4*3600)
+	authorDate := time.Date(2024, 6, 1, 10, 30, 0, 0, edt)
+	sha := "abcdef1234567890abcdef1234567890abcdef12"
+
+	commit := &gh.RepositoryCommit{
+		SHA: &sha,
+		Commit: &gh.Commit{
+			Message: new("fix things"),
+			Author: &gh.CommitAuthor{
+				Date: &gh.Timestamp{Time: authorDate},
+				Name: new("Alice"),
+			},
+		},
+		Author: &gh.User{Login: new("alice")},
+	}
+
+	event := NormalizeCommitEvent(5, commit)
+
+	assert.Equal(time.UTC, event.CreatedAt.Location())
+	assert.True(event.CreatedAt.Equal(authorDate))
+}
+
 func TestNormalizeIssueCommentEvent(t *testing.T) {
 	assert := Assert.New(t)
 	now := time.Date(2024, 6, 7, 8, 9, 10, 0, time.UTC)

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -212,6 +212,8 @@ export function createDetailStore(
     loading = true;
     syncing = false;
     storeError = null;
+    detail = null;
+    detailLoaded = false;
     try {
       const { data, error: requestError } =
         await apiClient.GET(


### PR DESCRIPTION
## Summary

- Commit author dates from the GitHub API preserve the committer's local timezone. The SQLite driver stores these in a format it can't parse back, causing `ListMREvents` to 500 on any PR with non-UTC commit times.
- When the detail API errored, the frontend kept showing stale data from a previously loaded PR instead of an error state.
- Normalize commit event times to UTC before storage, scan event timestamps as strings with manual parsing to handle existing data, and clear stale detail in the frontend store on new loads.