### PR TITLE
Fix SSE connection error on page reload

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -79,11 +79,19 @@
         appReady = true;
       },
     });
+    const onBeforeUnload = () => {
+      stores?.events.disconnect();
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
     return () => {
       cancelStartup();
       cleanupTheme();
       cleanupContainer();
       cleanupItemRefs();
+      window.removeEventListener(
+        "beforeunload",
+        onBeforeUnload,
+      );
     };
   });
 

--- a/frontend/src/lib/stores/diff-scope.test.ts
+++ b/frontend/src/lib/stores/diff-scope.test.ts
@@ -58,7 +58,7 @@ describe("diff store scope", () => {
     await store.loadCommits();
 
     expect(store.getCommits()).toHaveLength(3);
-    expect(store.getCommits()![0].sha).toBe("sha3");
+    expect(store.getCommits()![0]!.sha).toBe("sha3");
   });
 
   it("loadCommits is a no-op if already loaded", async () => {
@@ -212,8 +212,8 @@ describe("diff store scope", () => {
     store.selectCommit("sha2");
 
     await vi.waitFor(() => {
-      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
-      const url = lastCall[0] as string;
+      const lastCall = mockFetch.mock.calls.at(-1);
+      const url = lastCall![0] as string;
       expect(url).toContain("commit=sha2");
     });
   });
@@ -229,8 +229,8 @@ describe("diff store scope", () => {
     store.selectRange("sha1", "sha3");
 
     await vi.waitFor(() => {
-      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
-      const url = lastCall[0] as string;
+      const lastCall = mockFetch.mock.calls.at(-1);
+      const url = lastCall![0] as string;
       expect(url).toContain("from=sha1");
       expect(url).toContain("to=sha3");
     });

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -116,7 +116,6 @@ describe("createDiffStore loadDiff", () => {
   });
 
   it("aborts in-flight requests when switching PRs", async () => {
-    const filesA = makeFilesResult(["a.ts"]);
     const diffB = makeDiffResult(["b.ts"]);
     const filesB = makeFilesResult(["b.ts"]);
 
@@ -161,7 +160,7 @@ describe("createDiffStore loadDiff", () => {
     const store = createDiffStore({ getBasePath: () => "/" });
 
     // Start loading PR A (will hang).
-    const loadA = store.loadDiff("owner", "repo", 1);
+    void store.loadDiff("owner", "repo", 1);
 
     // Switch to PR B — should abort PR A.
     await store.loadDiff("owner", "repo", 2);

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -489,13 +489,14 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       return;
     }
     if (commits.length === 0) return;
-    if (scope.kind === "head") {
-      selectCommit(commits[0].sha);
-    } else if (scope.kind === "commit") {
-      const idx = commits.findIndex((c) => c.sha === scope.sha);
-      if (idx < commits.length - 1) selectCommit(commits[idx + 1].sha);
+    const s = scope;
+    if (s.kind === "head") {
+      selectCommit(commits[0]!.sha);
+    } else if (s.kind === "commit") {
+      const idx = commits.findIndex((c) => c.sha === s.sha);
+      if (idx < commits.length - 1) selectCommit(commits[idx + 1]!.sha);
     } else {
-      selectCommit(scope.fromSha);
+      selectCommit(s.fromSha);
     }
   }
 
@@ -505,17 +506,18 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       return;
     }
     if (commits.length === 0) return;
-    if (scope.kind === "head") {
+    const s = scope;
+    if (s.kind === "head") {
       return;
-    } else if (scope.kind === "commit") {
-      const idx = commits.findIndex((c) => c.sha === scope.sha);
+    } else if (s.kind === "commit") {
+      const idx = commits.findIndex((c) => c.sha === s.sha);
       if (idx > 0) {
-        selectCommit(commits[idx - 1].sha);
+        selectCommit(commits[idx - 1]!.sha);
       } else {
         resetToHead();
       }
     } else {
-      selectCommit(scope.toSha);
+      selectCommit(s.toSha);
     }
   }
 


### PR DESCRIPTION
## Summary
- Close EventSource via `beforeunload` listener before the browser tears down the page on reload, preventing "connection was interrupted" errors
- Fix pre-existing TypeScript errors in diff store (`$state` union narrowing, array index assertions)
- Fix lint errors in diff test files (unused variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)