### PR TITLE
Update middleman roborev review guidance

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -28,4 +28,9 @@ Do not downgrade missing e2e coverage because of a claim that this repo
 lacks browser testing infrastructure. middleman already has Playwright
 e2e coverage, and many required e2e tests here are API plus SQLite
 full-stack tests rather than purely browser concerns.
+
+middleman targets Go 1.26, where the built-in new accepts expression
+operands such as new(expr). Do not flag new(expr) usage as invalid,
+suspicious, or something that must be rewritten through a temporary
+variable solely because older Go versions did not allow it.
 """

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -33,4 +33,7 @@ middleman targets Go 1.26, where the built-in new accepts expression
 operands such as new(expr). Do not flag new(expr) usage as invalid,
 suspicious, or something that must be rewritten through a temporary
 variable solely because older Go versions did not allow it.
+
+Disregard findings whose only substance is that the code does not
+compile or type-check. middleman has static tests for that already.
 """

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,5 +1,4 @@
-[review]
-guidelines = """
+review_guidelines = """
 middleman is a local-first, single-user tool that binds to loopback
 (127.0.0.1) by default. There is no multi-user authentication or
 session management by design. All API endpoints -- including mutation
@@ -14,4 +13,19 @@ decision, not a missing feature.
 The root-level middleman package (middleman.go) is the embedding API.
 It does not have a stable API and can be changed arbitrarily until it
 stabilizes. Do not flag breaking changes to its exported surface.
+
+End-to-end tests are non-negotiable in this repository. Major features,
+bug fixes, refactors, and user-visible changes affecting API behavior,
+data flow, or maintainer workflows require e2e coverage that exercises
+the full stack with the real HTTP API and SQLite database.
+
+Treat missing required e2e coverage as at least MEDIUM severity.
+Treat it as HIGH severity when the uncovered change affects core
+maintainer actions, regression-prone flows, or bug fixes where the lack
+of an e2e test could allow a user-visible breakage to ship.
+
+Do not downgrade missing e2e coverage because of a claim that this repo
+lacks browser testing infrastructure. middleman already has Playwright
+e2e coverage, and many required e2e tests here are API plus SQLite
+full-stack tests rather than purely browser concerns.
 """


### PR DESCRIPTION
## Summary
- switch middleman's repo-level roborev config to the current `review_guidelines` key so roborev actually loads it
- tell roborev to treat missing required e2e coverage as at least medium severity, and not to down-rank it based on bogus lack-of-framework claims
- document middleman's Go 1.26 `new(expr)` usage and ignore compile-only findings that static checks already cover