### PR TITLE
GraphQL issue sync with ETag-gated REST fallback

### DIFF
--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -116,6 +116,36 @@ type gqlCommit struct {
 	}
 }
 
+type gqlIssueQuery struct {
+	Repository struct {
+		Issues struct {
+			Nodes    []gqlIssue
+			PageInfo pageInfo
+		} `graphql:"issues(first: $pageSize, states: OPEN, after: $cursor)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+type gqlIssue struct {
+	DatabaseId int64 `graphql:"databaseId"`
+	Number     int
+	Title      string
+	State      string
+	Body       string
+	URL        string `graphql:"url"`
+	Author     struct{ Login string }
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	ClosedAt   *time.Time
+	Labels     struct {
+		Nodes []gqlLabel
+	} `graphql:"labels(first: 100)"`
+	Comments struct {
+		TotalCount int
+		Nodes      []gqlComment
+		PageInfo   pageInfo
+	} `graphql:"comments(first: 100)"`
+}
+
 type gqlLabel struct {
 	Name        string
 	Color       string
@@ -207,6 +237,40 @@ func adaptPR(gql *gqlPR) *gh.PullRequest {
 	}
 
 	return pr
+}
+
+func adaptIssue(gql *gqlIssue) *gh.Issue {
+	state := stateToREST(gql.State)
+	issue := &gh.Issue{
+		ID:       new(gql.DatabaseId),
+		Number:   new(gql.Number),
+		Title:    new(gql.Title),
+		State:    new(state),
+		Body:     new(gql.Body),
+		HTMLURL:  new(gql.URL),
+		Comments: new(gql.Comments.TotalCount),
+		User:     &gh.User{Login: new(gql.Author.Login)},
+	}
+
+	created := gh.Timestamp{Time: gql.CreatedAt}
+	updated := gh.Timestamp{Time: gql.UpdatedAt}
+	issue.CreatedAt = &created
+	issue.UpdatedAt = &updated
+
+	if gql.ClosedAt != nil {
+		t := gh.Timestamp{Time: *gql.ClosedAt}
+		issue.ClosedAt = &t
+	}
+	for _, l := range gql.Labels.Nodes {
+		issue.Labels = append(issue.Labels, &gh.Label{
+			Name:        new(l.Name),
+			Color:       new(l.Color),
+			Description: new(l.Description),
+			Default:     new(l.IsDefault),
+		})
+	}
+
+	return issue
 }
 
 func stateToREST(graphqlState string) string {
@@ -320,9 +384,19 @@ func toLower(s string) string {
 
 // --- Bulk result types ---
 
-// RepoBulkResult holds all open PRs fetched via GraphQL for a repo.
+// RepoBulkResult holds all open PRs and issues fetched via GraphQL for a repo.
 type RepoBulkResult struct {
 	PullRequests []BulkPR
+	Issues       []BulkIssue
+}
+
+// BulkIssue holds an issue and its nested comments from a single
+// GraphQL query. CommentsComplete indicates whether the comments
+// connection was fully paginated.
+type BulkIssue struct {
+	Issue            *gh.Issue
+	Comments         []*gh.IssueComment
+	CommentsComplete bool
 }
 
 // BulkPR holds a PR and its nested data from a single GraphQL query.
@@ -340,6 +414,19 @@ type BulkPR struct {
 	ReviewsComplete  bool
 	CommitsComplete  bool
 	CIComplete       bool
+}
+
+func convertGQLIssue(gql *gqlIssue) BulkIssue {
+	bulk := BulkIssue{
+		Issue:            adaptIssue(gql),
+		CommentsComplete: !gql.Comments.PageInfo.HasNextPage,
+	}
+
+	for i := range gql.Comments.Nodes {
+		bulk.Comments = append(bulk.Comments, adaptComment(&gql.Comments.Nodes[i]))
+	}
+
+	return bulk
 }
 
 // --- GraphQL rate transport ---
@@ -430,6 +517,18 @@ func NewGraphQLFetcher(
 	}
 }
 
+// NewGraphQLFetcherWithClient wraps a pre-built githubv4.Client as a
+// GraphQLFetcher. Used by tests that need to point the fetcher at a
+// mock HTTP backend.
+func NewGraphQLFetcherWithClient(
+	client *githubv4.Client, rateTracker *RateTracker,
+) *GraphQLFetcher {
+	return &GraphQLFetcher{
+		client:      client,
+		rateTracker: rateTracker,
+	}
+}
+
 func (g *GraphQLFetcher) ShouldBackoff() (bool, time.Duration) {
 	if g.rateTracker == nil {
 		return false, 0
@@ -484,6 +583,57 @@ func (g *GraphQLFetcher) fetchRepoPRsWithPageSize(
 	for i := range gqlPRs {
 		bulk := convertGQLPR(&gqlPRs[i])
 		result.PullRequests = append(result.PullRequests, bulk)
+	}
+	return result, nil
+}
+
+func (g *GraphQLFetcher) FetchRepoIssues(
+	ctx context.Context, owner, name string,
+) (*RepoBulkResult, error) {
+	result, err := g.fetchRepoIssuesWithPageSize(
+		ctx, owner, name, topLevelPageSize,
+	)
+	if err != nil {
+		slog.Warn("GraphQL issue query failed, retrying with smaller page",
+			"owner", owner, "name", name,
+			"err", err, "retryPageSize", retryPageSize,
+		)
+		result, err = g.fetchRepoIssuesWithPageSize(
+			ctx, owner, name, retryPageSize,
+		)
+	}
+	return result, err
+}
+
+func (g *GraphQLFetcher) fetchRepoIssuesWithPageSize(
+	ctx context.Context, owner, name string, pageSize int,
+) (*RepoBulkResult, error) {
+	gqlIssues, err := fetchAllPages(ctx, func(
+		ctx context.Context, cursor *string,
+	) ([]gqlIssue, pageInfo, error) {
+		var q gqlIssueQuery
+		vars := map[string]any{
+			"owner":    githubv4.String(owner),
+			"name":     githubv4.String(name),
+			"pageSize": githubv4.Int(pageSize),
+			"cursor":   cursorVar(cursor),
+		}
+		if err := g.client.Query(ctx, &q, vars); err != nil {
+			return nil, pageInfo{}, err
+		}
+		return q.Repository.Issues.Nodes,
+			q.Repository.Issues.PageInfo, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &RepoBulkResult{
+		Issues: make([]BulkIssue, 0, len(gqlIssues)),
+	}
+	for i := range gqlIssues {
+		bulk := convertGQLIssue(&gqlIssues[i])
+		result.Issues = append(result.Issues, bulk)
 	}
 	return result, nil
 }

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -293,6 +293,112 @@ func TestAdaptPRNilFields(t *testing.T) {
 	assert.False(pr.GetMerged())
 }
 
+func TestAdaptIssue(t *testing.T) {
+	assert := Assert.New(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	closed := now.Add(-time.Hour)
+
+	gql := gqlIssue{
+		DatabaseId: 99999,
+		Number:     10,
+		Title:      "Bug report",
+		State:      "OPEN",
+		Body:       "Something broke",
+		URL:        "https://github.com/o/r/issues/10",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	gql.Author.Login = "alice"
+	gql.Labels.Nodes = []gqlLabel{
+		{Name: "bug", Color: "d73a4a", Description: "Something broken", IsDefault: false},
+	}
+	gql.Comments.Nodes = []gqlComment{
+		{DatabaseId: 501, Body: "I see this too", CreatedAt: now, UpdatedAt: now},
+	}
+	gql.Comments.Nodes[0].Author.Login = "bob"
+
+	issue := adaptIssue(&gql)
+
+	assert.Equal(int64(99999), issue.GetID())
+	assert.Equal(10, issue.GetNumber())
+	assert.Equal("Bug report", issue.GetTitle())
+	assert.Equal("open", issue.GetState())
+	assert.Equal("Something broke", issue.GetBody())
+	assert.Equal("https://github.com/o/r/issues/10", issue.GetHTMLURL())
+	assert.Equal("alice", issue.GetUser().GetLogin())
+	require.Len(t, issue.Labels, 1)
+	assert.Equal("bug", issue.Labels[0].GetName())
+	assert.Equal("d73a4a", issue.Labels[0].GetColor())
+	assert.Nil(issue.ClosedAt)
+	// Comments.TotalCount should map to issue comment count, not len(Nodes).
+	assert.Equal(0, issue.GetComments())
+
+	// TotalCount > len(Nodes): server has more comments than page returned.
+	gql.Comments.TotalCount = 42
+	issue = adaptIssue(&gql)
+	assert.Equal(42, issue.GetComments())
+
+	// Test closed state
+	gql.State = "CLOSED"
+	gql.ClosedAt = &closed
+	issue = adaptIssue(&gql)
+	assert.Equal("closed", issue.GetState())
+	require.NotNil(t, issue.ClosedAt)
+	assert.Equal(closed, issue.ClosedAt.Time)
+}
+
+func TestAdaptIssueNilFields(t *testing.T) {
+	assert := Assert.New(t)
+
+	gql := gqlIssue{
+		Number:    1,
+		Title:     "minimal",
+		State:     "OPEN",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	// Author empty, no labels, no ClosedAt
+	issue := adaptIssue(&gql)
+	assert.Empty(issue.GetUser().GetLogin())
+	assert.Nil(issue.ClosedAt)
+	assert.Empty(issue.Labels)
+}
+
+func TestConvertGQLIssue(t *testing.T) {
+	assert := Assert.New(t)
+
+	now := time.Now()
+	gql := gqlIssue{
+		DatabaseId: 1,
+		Number:     5,
+		Title:      "test",
+		State:      "OPEN",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	gql.Author.Login = "user"
+
+	// All complete (no next page)
+	bulk := convertGQLIssue(&gql)
+	assert.True(bulk.CommentsComplete)
+	assert.NotNil(bulk.Issue)
+	assert.Equal(5, bulk.Issue.GetNumber())
+	assert.Empty(bulk.Comments)
+
+	// Add comments with next page
+	gql.Comments.Nodes = []gqlComment{
+		{DatabaseId: 100, Body: "hello", CreatedAt: now, UpdatedAt: now},
+	}
+	gql.Comments.Nodes[0].Author.Login = "commenter"
+	gql.Comments.PageInfo.HasNextPage = true
+
+	bulk = convertGQLIssue(&gql)
+	assert.False(bulk.CommentsComplete)
+	require.Len(t, bulk.Comments, 1)
+	assert.Equal("hello", bulk.Comments[0].GetBody())
+}
+
 func TestStateConversion(t *testing.T) {
 	assert := Assert.New(t)
 	assert.Equal("open", stateToREST("OPEN"))

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1304,16 +1304,57 @@ func (s *Syncer) indexSyncRepo(
 		}
 	}
 
-	// Index issues (list-only, no detail).
-	// Issues have an independent etag, so this still runs even when the
-	// PR list returned 304.
-	if err := s.indexSyncIssues(
-		ctx, repo, repoID, forceIssues,
-	); err != nil {
-		slog.Error("index sync issues failed",
-			"repo", repo.Owner+"/"+repo.Name, "err", err,
-		)
-		failedScope |= failIssues
+	// Index issues — ETag-gated, with GraphQL when available.
+	// Same structure as PR sync: REST list first (ETag gate),
+	// then GraphQL if available, REST fallback if not.
+	ghIssues, issueListErr := client.ListOpenIssues(
+		ctx, repo.Owner, repo.Name,
+	)
+	if issueListErr != nil {
+		if IsNotModified(issueListErr) {
+			// 304: open issue list unchanged, skip.
+		} else {
+			slog.Error("list open issues failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"err", issueListErr,
+			)
+			failedScope |= failIssues
+		}
+	} else {
+		graphQLIssuesDone := false
+		if fetcher := s.fetcherFor(repo); fetcher != nil {
+			if backoff, _ := fetcher.ShouldBackoff(); !backoff {
+				issueResult, gqlErr := fetcher.FetchRepoIssues(
+					ctx, repo.Owner, repo.Name,
+				)
+				if gqlErr != nil {
+					slog.Warn("GraphQL issue fetch failed, falling back to REST",
+						"repo", repo.Owner+"/"+repo.Name,
+						"err", gqlErr,
+					)
+				} else {
+					if err := s.doSyncRepoGraphQLIssues(
+						ctx, repo, repoID, issueResult,
+					); err != nil {
+						failedScope |= failIssues
+					}
+					graphQLIssuesDone = true
+				}
+			}
+		}
+
+		if !graphQLIssuesDone {
+			// REST fallback using already-fetched ghIssues.
+			if err := s.syncIssuesFromList(
+				ctx, repo, repoID, ghIssues, forceIssues,
+			); err != nil {
+				slog.Error("REST issue sync failed",
+					"repo", repo.Owner+"/"+repo.Name,
+					"err", err,
+				)
+				failedScope |= failIssues
+			}
+		}
 	}
 
 	if failedScope != 0 {
@@ -1445,6 +1486,196 @@ func (s *Syncer) doSyncRepoGraphQL(
 	if failedScope != 0 {
 		return fmt.Errorf("GraphQL sync had partial failures")
 	}
+	return nil
+}
+
+// doSyncRepoGraphQLIssues processes bulk GraphQL results for issues.
+func (s *Syncer) doSyncRepoGraphQLIssues(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	result *RepoBulkResult,
+) error {
+	var failedScope failScope
+	stillOpen := make(map[int]bool, len(result.Issues))
+
+	for i := range result.Issues {
+		bulk := &result.Issues[i]
+		number := bulk.Issue.GetNumber()
+		stillOpen[number] = true
+
+		if err := s.syncOpenIssueFromBulk(
+			ctx, repo, repoID, bulk,
+		); err != nil {
+			slog.Error("GraphQL sync issue failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
+			failedScope |= failIssues
+		}
+	}
+
+	// Detect closed issues — same as REST path.
+	closedNumbers, err := s.db.GetPreviouslyOpenIssueNumbers(
+		ctx, repoID, stillOpen,
+	)
+	if err != nil {
+		return fmt.Errorf("get previously open issues: %w", err)
+	}
+	for _, number := range closedNumbers {
+		if err := s.fetchAndUpdateClosedIssue(
+			ctx, repo, repoID, number,
+		); err != nil {
+			slog.Error("update closed issue failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
+			failedScope |= failIssues
+		}
+	}
+
+	if failedScope != 0 {
+		return fmt.Errorf("GraphQL issue sync had partial failures")
+	}
+	return nil
+}
+
+// syncOpenIssueFromBulk processes a single issue from GraphQL bulk
+// results. Uses pre-fetched data instead of per-issue REST calls.
+func (s *Syncer) syncOpenIssueFromBulk(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	bulk *BulkIssue,
+) error {
+	number := bulk.Issue.GetNumber()
+	normalized := NormalizeIssue(repoID, bulk.Issue)
+
+	// Preserve derived fields that NormalizeIssue doesn't populate
+	// from bulk data. Without this, upsert overwrites them with
+	// zero values.
+	existing, err := s.db.GetIssueByRepoIDAndNumber(
+		ctx, repoID, number,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"get existing issue #%d: %w", number, err,
+		)
+	}
+	if existing != nil {
+		// Only preserve DetailFetchedAt when comments are complete.
+		// When incomplete, clear it so the detail drain re-queues
+		// this issue if the REST fallback fails.
+		if bulk.CommentsComplete {
+			normalized.DetailFetchedAt = existing.DetailFetchedAt
+		}
+		// CommentCount comes from GraphQL Comments.TotalCount via
+		// adaptIssue, so trust the fresh GraphQL value.
+	}
+
+	issueID, err := s.db.UpsertIssue(ctx, normalized)
+	if err != nil {
+		return fmt.Errorf("upsert issue #%d: %w", number, err)
+	}
+
+	// UpsertIssue uses COALESCE to preserve existing detail_fetched_at,
+	// so passing nil doesn't clear it. When comments are incomplete,
+	// explicitly clear it so the detail drain re-queues this issue
+	// if the REST fallback fails.
+	if !bulk.CommentsComplete {
+		_, err = s.db.WriteDB().ExecContext(ctx,
+			`UPDATE middleman_issues SET detail_fetched_at = NULL WHERE id = ?`,
+			issueID,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"clear detail_fetched_at for issue #%d: %w", number, err,
+			)
+		}
+	}
+
+	if err := s.replaceIssueLabels(
+		ctx, repoID, issueID, normalized.Labels,
+	); err != nil {
+		return fmt.Errorf(
+			"persist labels for issue #%d: %w", number, err,
+		)
+	}
+
+	if bulk.CommentsComplete {
+		// Events from bulk data — skip REST ListIssueComments.
+		var events []db.IssueEvent
+		for _, c := range bulk.Comments {
+			events = append(events, NormalizeIssueCommentEvent(issueID, c))
+		}
+		if len(events) > 0 {
+			if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
+				return fmt.Errorf(
+					"upsert issue events for #%d: %w", number, err,
+				)
+			}
+		}
+		// Update last activity from bulk comment timestamps.
+		// comment_count was already written by UpsertIssue using
+		// normalized.CommentCount (GraphQL's authoritative
+		// Comments.TotalCount), so don't overwrite it here.
+		lastActivity := normalized.UpdatedAt
+		for _, c := range bulk.Comments {
+			if c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity) {
+				lastActivity = c.UpdatedAt.Time
+			}
+		}
+		_, err = s.db.WriteDB().ExecContext(ctx,
+			`UPDATE middleman_issues SET last_activity_at = ?
+			 WHERE id = ?`,
+			lastActivity, issueID,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"update issue #%d last_activity_at: %w", number, err,
+			)
+		}
+
+		// Mark detail as fetched so the detail drain doesn't
+		// re-queue this issue for REST detail fetches.
+		host := repo.PlatformHost
+		if host == "" {
+			host = "github.com"
+		}
+		if err := s.db.UpdateIssueDetailFetched(
+			ctx, host, repo.Owner, repo.Name, number,
+		); err != nil {
+			slog.Warn("mark GraphQL issue detail fetched failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number, "err", err,
+			)
+		}
+	} else {
+		// Comments truncated — fall back to REST.
+		if err := s.refreshIssueTimeline(
+			ctx, repo, issueID, bulk.Issue,
+		); err != nil {
+			return fmt.Errorf(
+				"refresh timeline for issue #%d: %w", number, err,
+			)
+		}
+		// REST fallback succeeded — mark detail as fetched.
+		host := repo.PlatformHost
+		if host == "" {
+			host = "github.com"
+		}
+		if err := s.db.UpdateIssueDetailFetched(
+			ctx, host, repo.Owner, repo.Name, number,
+		); err != nil {
+			slog.Warn("mark issue detail fetched after REST fallback failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number, "err", err,
+			)
+		}
+	}
+
 	return nil
 }
 
@@ -2155,27 +2386,15 @@ func (s *Syncer) resolveDisplayName(
 
 // --- Issue sync ---
 
-// indexSyncIssues syncs issues from list endpoint data and
-// refreshes timeline when data changed or forceRefresh is set.
-// Issues have no separate detail phase, so timeline refresh
-// happens inline here via syncOpenIssue.
-func (s *Syncer) indexSyncIssues(
-	ctx context.Context, repo RepoRef, repoID int64, forceRefresh bool,
+// syncIssuesFromList processes a pre-fetched list of open issues
+// via the REST path. Handles per-issue upsert and closure detection.
+func (s *Syncer) syncIssuesFromList(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	ghIssues []*gh.Issue,
+	forceRefresh bool,
 ) error {
-	client := s.clientFor(repo)
-	ghIssues, err := client.ListOpenIssues(
-		ctx, repo.Owner, repo.Name,
-	)
-	if err != nil {
-		// 304: open issue list unchanged since the previous sync.
-		// No issue opened, closed, or modified. Skip per-issue
-		// upserts and closure detection.
-		if IsNotModified(err) {
-			return nil
-		}
-		return fmt.Errorf("list open issues: %w", err)
-	}
-
 	stillOpen := make(map[int]bool, len(ghIssues))
 	for _, issue := range ghIssues {
 		stillOpen[issue.GetNumber()] = true
@@ -2193,7 +2412,6 @@ func (s *Syncer) indexSyncIssues(
 		}
 	}
 
-	// Detect closed issues and fetch final state.
 	closedNumbers, err := s.db.GetPreviouslyOpenIssueNumbers(
 		ctx, repoID, stillOpen,
 	)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v84/github"
+	"github.com/shurcooL/githubv4"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/db"
@@ -62,10 +64,12 @@ type mockClient struct {
 	checkRuns              []*gh.CheckRun
 	workflowRuns           []*gh.WorkflowRun
 	approveWorkflowRunFn   func(context.Context, string, string, int64) error
-	listOpenPRsCalled      bool
-	getUserCalls           atomic.Int32
-	getCombinedCalls       atomic.Int32
-	invalidateCalls        atomic.Int32
+	listOpenPRsCalled          bool
+	getUserCalls               atomic.Int32
+	getCombinedCalls           atomic.Int32
+	invalidateCalls            atomic.Int32
+	listIssueCommentsCalled    atomic.Int32
+	listIssueCommentsErr       error
 }
 
 func (m *mockClient) trackCall() {
@@ -139,6 +143,10 @@ func (m *mockClient) GetPullRequest(
 
 func (m *mockClient) ListIssueComments(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
 	m.trackCall()
+	m.listIssueCommentsCalled.Add(1)
+	if m.listIssueCommentsErr != nil {
+		return nil, m.listIssueCommentsErr
+	}
 	return m.comments, nil
 }
 
@@ -3923,6 +3931,95 @@ func TestSyncerMRDetailFailureRetries(t *testing.T) {
 	assert.NotEmpty(events, "review event should be persisted after detail retry")
 }
 
+func TestSyncRepoGraphQLIssues(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	mock := &mockClient{}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	issueID := int64(10000)
+	issueNumber := 10
+	issueTitle := "Bug report"
+	issueState := "open"
+	issueBody := "Something broke"
+	issueURL := "https://github.com/owner/repo/issues/10"
+	issueAuthor := "alice"
+	commentID := int64(501)
+	commentBody := "I see this too"
+	commentLogin := "bob"
+	commentTime := gh.Timestamp{Time: now}
+	// TotalCount (5) deliberately > len(nodes) (1). Proves the sync
+	// uses GraphQL's TotalCount, not node length.
+	issueCommentTotal := 5
+	result := &RepoBulkResult{
+		Issues: []BulkIssue{
+			{
+				Issue: &gh.Issue{
+					ID:        &issueID,
+					Number:    &issueNumber,
+					Title:     &issueTitle,
+					State:     &issueState,
+					Body:      &issueBody,
+					HTMLURL:   &issueURL,
+					Comments:  &issueCommentTotal,
+					User:      &gh.User{Login: &issueAuthor},
+					CreatedAt: &commentTime,
+					UpdatedAt: &commentTime,
+				},
+				Comments: []*gh.IssueComment{
+					{
+						ID:        &commentID,
+						Body:      &commentBody,
+						User:      &gh.User{Login: &commentLogin},
+						CreatedAt: &commentTime,
+						UpdatedAt: &commentTime,
+					},
+				},
+				CommentsComplete: true,
+			},
+		},
+	}
+
+	err = syncer.doSyncRepoGraphQLIssues(ctx,
+		RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, result,
+	)
+	require.NoError(t, err)
+
+	// Verify issue in DB.
+	issue, err := d.GetIssue(ctx, "owner", "repo", 10)
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.Equal("Bug report", issue.Title)
+	assert.Equal("alice", issue.Author)
+	assert.Equal("open", issue.State)
+	// Count comes from GraphQL TotalCount (5), not len(Nodes) (1).
+	assert.Equal(5, issue.CommentCount)
+
+	// Verify comment event.
+	events, err := d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Len(events, 1)
+	assert.Equal("I see this too", events[0].Body)
+
+	// Comments were complete — ListIssueComments should NOT be called.
+	assert.Equal(int32(0), mock.listIssueCommentsCalled.Load())
+
+	// detail_fetched_at should be set for complete bulk issues.
+	assert.NotNil(issue.DetailFetchedAt)
+}
+
 // blockingCtxMockClient blocks in ListOpenPullRequests until either
 // the provided channel is closed or the ctx is canceled. Unlike
 // blockingMockClient (which ignores ctx), this variant is used by
@@ -4151,4 +4248,474 @@ func TestResolveDisplayName_CachesSuccessfulEmptyName(t *testing.T) {
 	assert.Empty(name2)
 	assert.True(ok2, "cached empty name must remain ok=true")
 	assert.Equal(1, callCount, "GetUser should not be called again for cached success")
+}
+
+func TestSyncRepoGraphQLIssuesCommentsIncomplete(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	commentTime := gh.Timestamp{Time: now}
+
+	commentID := int64(777)
+	commentBody := "REST comment"
+	commentLogin := "carol"
+
+	mock := &mockClient{
+		comments: []*gh.IssueComment{
+			{
+				ID:        &commentID,
+				Body:      &commentBody,
+				User:      &gh.User{Login: &commentLogin},
+				CreatedAt: &commentTime,
+				UpdatedAt: &commentTime,
+			},
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	issueID := int64(20000)
+	issueNumber := 20
+	issueTitle := "Lots of comments"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/20"
+	issueLogin := "dave"
+	result := &RepoBulkResult{
+		Issues: []BulkIssue{
+			{
+				Issue: &gh.Issue{
+					ID:        &issueID,
+					Number:    &issueNumber,
+					Title:     &issueTitle,
+					State:     &issueState,
+					HTMLURL:   &issueURL,
+					User:      &gh.User{Login: &issueLogin},
+					CreatedAt: &commentTime,
+					UpdatedAt: &commentTime,
+				},
+				CommentsComplete: false,
+			},
+		},
+	}
+
+	err = syncer.doSyncRepoGraphQLIssues(ctx,
+		RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, result,
+	)
+	require.NoError(t, err)
+
+	// REST fallback should have been called
+	assert.Equal(int32(1), mock.listIssueCommentsCalled.Load())
+
+	// Verify the REST comment landed
+	issue, err := d.GetIssue(ctx, "owner", "repo", 20)
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+
+	events, err := d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Len(events, 1)
+	assert.Equal("REST comment", events[0].Body)
+}
+
+func TestSyncRepoGraphQLIssuesClosureDetection(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Pre-seed an open issue that will not appear in GraphQL results
+	_, err = d.UpsertIssue(ctx, &db.Issue{
+		RepoID:         repoID,
+		PlatformID:     30000,
+		Number:         30,
+		URL:            "https://github.com/owner/repo/issues/30",
+		Title:          "Will be closed",
+		Author:         "eve",
+		State:          "open",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(t, err)
+
+	closedAt := gh.Timestamp{Time: now}
+	closedState := "closed"
+	closedIssueID := int64(30000)
+	closedNumber := 30
+	closedTitle := "Will be closed"
+
+	mock := &mockClient{
+		getIssueFn: func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+			if number == 30 {
+				return &gh.Issue{
+					ID:       &closedIssueID,
+					Number:   &closedNumber,
+					Title:    &closedTitle,
+					State:    &closedState,
+					ClosedAt: &closedAt,
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected issue %d", number)
+		},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	// GraphQL returns no issues (issue #30 was closed)
+	result := &RepoBulkResult{Issues: []BulkIssue{}}
+
+	err = syncer.doSyncRepoGraphQLIssues(ctx,
+		RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, result,
+	)
+	require.NoError(t, err)
+
+	// Issue should now be closed
+	issue, err := d.GetIssue(ctx, "owner", "repo", 30)
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.Equal("closed", issue.State)
+	assert.NotNil(issue.ClosedAt)
+}
+
+func TestSyncRepoGraphQLIssuesPreservesExistingFields(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	fetchedAt := now.Add(-time.Hour)
+
+	// Pre-seed issue with existing derived fields
+	_, err = d.UpsertIssue(ctx, &db.Issue{
+		RepoID:          repoID,
+		PlatformID:      40000,
+		Number:          40,
+		URL:             "https://github.com/owner/repo/issues/40",
+		Title:           "Existing issue",
+		Author:          "frank",
+		State:           "open",
+		CommentCount:    5,
+		DetailFetchedAt: &fetchedAt,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(t, err)
+
+	commentTime := gh.Timestamp{Time: now}
+	mock := &mockClient{}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	// GraphQL returns the same issue with no comments (incomplete)
+	issueID := int64(40000)
+	issueNumber := 40
+	issueTitle := "Existing issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/40"
+	issueLogin := "frank"
+	result := &RepoBulkResult{
+		Issues: []BulkIssue{
+			{
+				Issue: &gh.Issue{
+					ID:        &issueID,
+					Number:    &issueNumber,
+					Title:     &issueTitle,
+					State:     &issueState,
+					HTMLURL:   &issueURL,
+					User:      &gh.User{Login: &issueLogin},
+					CreatedAt: &commentTime,
+					UpdatedAt: &commentTime,
+				},
+				CommentsComplete: false,
+			},
+		},
+	}
+
+	err = syncer.doSyncRepoGraphQLIssues(ctx,
+		RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, result,
+	)
+	require.NoError(t, err)
+
+	// DetailFetchedAt is cleared before REST fallback, then re-set
+	// after successful refreshIssueTimeline. CommentCount is updated
+	// by the REST fallback (0 comments returned by the mock).
+	issue, err := d.GetIssue(ctx, "owner", "repo", 40)
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.NotNil(issue.DetailFetchedAt)
+	assert.Equal(0, issue.CommentCount)
+}
+
+func TestSyncRepoGraphQLIssuesClearsDetailFetchedAtOnFailedFallback(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	fetchedAt := now.Add(-time.Hour)
+
+	// Pre-seed issue with non-nil DetailFetchedAt (previously fetched).
+	_, err = d.UpsertIssue(ctx, &db.Issue{
+		RepoID:          repoID,
+		PlatformID:      45000,
+		Number:          45,
+		URL:             "https://github.com/owner/repo/issues/45",
+		Title:           "Previously fetched",
+		Author:          "grace",
+		State:           "open",
+		CommentCount:    3,
+		DetailFetchedAt: &fetchedAt,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(t, err)
+
+	commentTime := gh.Timestamp{Time: now}
+	mock := &mockClient{
+		listIssueCommentsErr: fmt.Errorf("transient API failure"),
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	issueID := int64(45000)
+	issueNumber := 45
+	issueTitle := "Previously fetched"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/45"
+	issueLogin := "grace"
+	result := &RepoBulkResult{
+		Issues: []BulkIssue{
+			{
+				Issue: &gh.Issue{
+					ID:        &issueID,
+					Number:    &issueNumber,
+					Title:     &issueTitle,
+					State:     &issueState,
+					HTMLURL:   &issueURL,
+					User:      &gh.User{Login: &issueLogin},
+					CreatedAt: &commentTime,
+					UpdatedAt: &commentTime,
+				},
+				CommentsComplete: false, // triggers REST fallback
+			},
+		},
+	}
+
+	// REST fallback will fail due to listIssueCommentsErr.
+	err = syncer.doSyncRepoGraphQLIssues(ctx,
+		RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, result,
+	)
+	// Partial failure expected.
+	require.Error(t, err)
+
+	// DetailFetchedAt must be nil so the detail drain re-queues this issue.
+	issue, err := d.GetIssue(ctx, "owner", "repo", 45)
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.Nil(issue.DetailFetchedAt)
+}
+
+func TestSyncRepoGraphQLIssuesFallbackToREST(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	issueTime := makeTimestamp(now)
+	issueID := int64(50000)
+	issueNumber := 50
+	issueTitle := "REST issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/50"
+	issueLogin := "grace"
+
+	ghIssue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &issueTitle,
+		State:     &issueState,
+		HTMLURL:   &issueURL,
+		User:      &gh.User{Login: &issueLogin},
+		CreatedAt: issueTime,
+		UpdatedAt: issueTime,
+	}
+
+	mock := &mockClient{
+		listOpenPRsErr: notModifiedErr(),
+		openIssues:     []*gh.Issue{ghIssue},
+		getIssueFn: func(_ context.Context, _, _ string, _ int) (*gh.Issue, error) {
+			return ghIssue, nil
+		},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	// Configure a GraphQL fetcher that returns errors. The HTTP server
+	// responds with a GraphQL error, so FetchRepoIssues fails and the
+	// sync engine falls back to REST using the already-fetched issue list.
+	errSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"server error"}]}`))
+	}))
+	defer errSrv.Close()
+	gqlClient := githubv4.NewEnterpriseClient(errSrv.URL, errSrv.Client())
+	syncer.SetFetchers(map[string]*GraphQLFetcher{
+		"github.com": {client: gqlClient},
+	})
+
+	syncer.RunOnce(ctx)
+
+	issue, err := d.GetIssue(ctx, "owner", "repo", 50)
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.Equal("REST issue", issue.Title)
+	assert.Equal("grace", issue.Author)
+}
+
+// TestSyncRepoGraphQLIssuesFullFlow exercises the full GraphQL issue
+// sync path end-to-end: real GraphQLFetcher with a real HTTP backend
+// returning canned JSON, through JSON parsing → gqlIssue adapter →
+// NormalizeIssue → UpsertIssue. Validates that struct tags, adapter
+// mapping, and the full data flow work together.
+func TestSyncRepoGraphQLIssuesFullFlow(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+
+	// GraphQL server responds with canned issue data. The request
+	// body distinguishes PR queries from issue queries; respond with
+	// empty PRs and a single issue.
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if bytes.Contains(body, []byte("pullRequests")) {
+			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+			return
+		}
+		resp := `{"data":{"repository":{"issues":{"nodes":[{
+			"databaseId":70000,
+			"number":70,
+			"title":"Full flow issue",
+			"state":"OPEN",
+			"body":"End to end test",
+			"url":"https://github.com/owner/repo/issues/70",
+			"author":{"login":"heidi"},
+			"createdAt":"` + now + `",
+			"updatedAt":"` + now + `",
+			"closedAt":null,
+			"labels":{"nodes":[{"name":"bug","color":"d73a4a","description":"","isDefault":false}]},
+			"comments":{"totalCount":1,"nodes":[{"databaseId":701,"author":{"login":"commenter"},"body":"Full flow comment","createdAt":"` + now + `","updatedAt":"` + now + `"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer gqlSrv.Close()
+
+	// REST mock: returns the same issue in list (for ETag gate pass),
+	// and also lists PRs as 304 to focus on issues.
+	issueID := int64(70000)
+	issueNumber := 70
+	issueTitle := "Full flow issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/70"
+	issueLogin := "heidi"
+	issueTime := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	ghIssue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &issueTitle,
+		State:     &issueState,
+		HTMLURL:   &issueURL,
+		User:      &gh.User{Login: &issueLogin},
+		CreatedAt: &issueTime,
+		UpdatedAt: &issueTime,
+	}
+	mock := &mockClient{
+		listOpenPRsErr: notModifiedErr(),
+		openIssues:     []*gh.Issue{ghIssue},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	gqlClient := githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client())
+	syncer.SetFetchers(map[string]*GraphQLFetcher{
+		"github.com": {client: gqlClient},
+	})
+
+	syncer.RunOnce(ctx)
+
+	// Verify issue persisted with GraphQL data.
+	issue, err := d.GetIssue(ctx, "owner", "repo", 70)
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.Equal("Full flow issue", issue.Title)
+	assert.Equal("heidi", issue.Author)
+	assert.Equal("open", issue.State)
+	assert.Equal("End to end test", issue.Body)
+	assert.Equal(1, issue.CommentCount)
+	assert.NotNil(issue.DetailFetchedAt)
+
+	// Labels persisted from GraphQL.
+	require.Len(t, issue.Labels, 1)
+	assert.Equal("bug", issue.Labels[0].Name)
+
+	// Comment events persisted from GraphQL bulk (no REST fallback).
+	events, err := d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal("Full flow comment", events[0].Body)
+	assert.Equal("commenter", events[0].Author)
+
+	// GraphQL path skipped REST ListIssueComments.
+	assert.Equal(int32(0), mock.listIssueCommentsCalled.Load())
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v84/github"
+	"github.com/shurcooL/githubv4"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/apiclient"
@@ -36,16 +38,25 @@ type mockGH struct {
 	listWorkflowRunsForHeadFn func(context.Context, string, string, string) ([]*gh.WorkflowRun, error)
 	approveWorkflowRunFn      func(context.Context, string, string, int64) error
 	listOpenPullRequestsFn    func(context.Context, string, string) ([]*gh.PullRequest, error)
+	listOpenPRsErr            error
+	listOpenIssuesFn          func(context.Context, string, string) ([]*gh.Issue, error)
+	listIssueCommentsErr      error
 }
 
 func (m *mockGH) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
 	if m.listOpenPullRequestsFn != nil {
 		return m.listOpenPullRequestsFn(ctx, owner, repo)
 	}
+	if m.listOpenPRsErr != nil {
+		return nil, m.listOpenPRsErr
+	}
 	return nil, nil
 }
 
-func (m *mockGH) ListOpenIssues(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+func (m *mockGH) ListOpenIssues(ctx context.Context, owner, repo string) ([]*gh.Issue, error) {
+	if m.listOpenIssuesFn != nil {
+		return m.listOpenIssuesFn(ctx, owner, repo)
+	}
 	return nil, nil
 }
 
@@ -70,6 +81,9 @@ func (m *mockGH) GetPullRequest(ctx context.Context, owner, repo string, number 
 func (m *mockGH) ListIssueComments(
 	_ context.Context, _, _ string, _ int,
 ) ([]*gh.IssueComment, error) {
+	if m.listIssueCommentsErr != nil {
+		return nil, m.listIssueCommentsErr
+	}
 	return nil, nil
 }
 
@@ -2478,6 +2492,297 @@ func TestAPIGetIssueIncludesLabels(t *testing.T) {
 		Color:       "d73a4a",
 		IsDefault:   true,
 	}}, *resp.JSON200.Issue.Labels)
+}
+
+// TestAPIIssueDataFromGraphQLSync verifies the API correctly serves
+// issue data that was persisted by the GraphQL sync path. The sync
+// path itself (GraphQL fetch → normalize → DB upsert) is tested in
+// internal/github/sync_test.go; this test covers the DB → API layer.
+func TestAPIIssueDataFromGraphQLSync(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	mock := &mockGH{}
+	srv, database := setupTestServerWithMock(t, mock)
+	client := setupTestClient(t, srv)
+
+	// Seed DB directly — same shape as GraphQL sync output.
+	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	issueID, err := database.UpsertIssue(ctx, &db.Issue{
+		RepoID:         repoID,
+		PlatformID:     60000,
+		Number:         60,
+		URL:            "https://github.com/acme/widget/issues/60",
+		Title:          "GraphQL synced issue",
+		Author:         "testuser",
+		State:          "open",
+		Body:           "Synced via GraphQL",
+		CommentCount:   1,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(t, err)
+
+	// Add a label
+	require.NoError(t, database.ReplaceIssueLabels(ctx, repoID, issueID, []db.Label{
+		{PlatformID: 1, Name: "bug", Color: "d73a4a", UpdatedAt: now},
+	}))
+
+	// Add a comment event
+	require.NoError(t, database.UpsertIssueEvents(ctx, []db.IssueEvent{
+		{
+			IssueID:   issueID,
+			EventType: "issue_comment",
+			Author:    "commenter",
+			Body:      "I can reproduce",
+			CreatedAt: now,
+			DedupeKey: "issue-comment-601",
+		},
+	}))
+
+	// Verify via ListIssues API
+	resp, err := client.HTTP.ListIssuesWithResponse(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode())
+	require.NotNil(t, resp.JSON200)
+	require.Len(t, *resp.JSON200, 1)
+
+	apiIssue := (*resp.JSON200)[0]
+	assert.Equal(int64(60), apiIssue.Number)
+	assert.Equal("GraphQL synced issue", apiIssue.Title)
+	assert.Equal("testuser", apiIssue.Author)
+	assert.Equal("open", apiIssue.State)
+	require.NotNil(t, apiIssue.Labels)
+	require.Len(t, *apiIssue.Labels, 1)
+	assert.Equal("bug", (*apiIssue.Labels)[0].Name)
+
+	// Verify via GetIssue API
+	detailResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", 60,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 200, detailResp.StatusCode())
+	require.NotNil(t, detailResp.JSON200)
+	assert.Equal("Synced via GraphQL", detailResp.JSON200.Issue.Body)
+	assert.Equal(int64(1), detailResp.JSON200.Issue.CommentCount)
+}
+
+// TestE2EGraphQLIssueSyncThroughAPI is a full-stack test that runs the
+// real GraphQL issue sync path against a mocked GraphQL HTTP backend
+// with real SQLite, then verifies the resulting issue data through
+// the HTTP API. Exercises: GraphQL HTTP → adapter → NormalizeIssue →
+// UpsertIssue → HTTP API handler → JSON response.
+func TestE2EGraphQLIssueSyncThroughAPI(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+
+	// Mock GraphQL backend returning a single issue with a label
+	// and a comment.
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if bytes.Contains(body, []byte("pullRequests")) {
+			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+			return
+		}
+		resp := `{"data":{"repository":{"issues":{"nodes":[{
+			"databaseId":80000,
+			"number":80,
+			"title":"Full stack GraphQL issue",
+			"state":"OPEN",
+			"body":"Synced through the HTTP API",
+			"url":"https://github.com/acme/widget/issues/80",
+			"author":{"login":"ivy"},
+			"createdAt":"` + now + `",
+			"updatedAt":"` + now + `",
+			"closedAt":null,
+			"labels":{"nodes":[{"name":"bug","color":"d73a4a","description":"","isDefault":false}]},
+			"comments":{"totalCount":1,"nodes":[{"databaseId":801,"author":{"login":"judy"},"body":"full stack comment","createdAt":"` + now + `","updatedAt":"` + now + `"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer gqlSrv.Close()
+
+	// REST mock: PR list returns 304 (skip PR sync), issue list
+	// returns minimal data to pass the ETag gate so GraphQL runs.
+	issueID := int64(80000)
+	issueNumber := 80
+	issueTitle := "Full stack GraphQL issue"
+	issueState := "open"
+	issueURL := "https://github.com/acme/widget/issues/80"
+	issueLogin := "ivy"
+	issueTime := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	mock := &mockGH{
+		listOpenPRsErr: &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		},
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return []*gh.Issue{{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				User:      &gh.User{Login: &issueLogin},
+				CreatedAt: &issueTime,
+				UpdatedAt: &issueTime,
+			}}, nil
+		},
+	}
+	srv, _ := setupTestServerWithMock(t, mock)
+
+	// Wire a real GraphQLFetcher pointing at the mock GraphQL server
+	// into the syncer.
+	gqlClient := githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client())
+	srv.syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcherWithClient(gqlClient, nil),
+	})
+
+	// Trigger the real sync pipeline.
+	srv.syncer.RunOnce(ctx)
+
+	// Verify through the HTTP API that issue data flowed end-to-end.
+	client := setupTestClient(t, srv)
+
+	listResp, err := client.HTTP.ListIssuesWithResponse(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, listResp.StatusCode())
+	require.NotNil(t, listResp.JSON200)
+	require.Len(t, *listResp.JSON200, 1)
+
+	apiIssue := (*listResp.JSON200)[0]
+	assert.Equal(int64(80), apiIssue.Number)
+	assert.Equal("Full stack GraphQL issue", apiIssue.Title)
+	assert.Equal("ivy", apiIssue.Author)
+	assert.Equal("open", apiIssue.State)
+	require.NotNil(t, apiIssue.Labels)
+	require.Len(t, *apiIssue.Labels, 1)
+	assert.Equal("bug", (*apiIssue.Labels)[0].Name)
+
+	detailResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", 80,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 200, detailResp.StatusCode())
+	require.NotNil(t, detailResp.JSON200)
+	assert.Equal("Synced through the HTTP API", detailResp.JSON200.Issue.Body)
+	assert.Equal(int64(1), detailResp.JSON200.Issue.CommentCount)
+}
+
+// TestE2EGraphQLIssueSyncTrustsTotalCount pre-seeds an issue with a
+// stale CommentCount, runs a real GraphQL sync with truncated
+// comments (totalCount > nodes, HasNextPage=true), and forces the
+// REST fallback to fail. The only remaining count in the DB is
+// whatever UpsertIssue wrote from NormalizeIssue — which must be
+// GraphQL's TotalCount, not the stale existing.CommentCount.
+// Regression test for the "preserve existing.CommentCount" overwrite.
+func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+
+	// GraphQL: totalCount=42, HasNextPage=true → CommentsComplete=false.
+	// REST ListIssueComments will error. Stale DB count is 5.
+	// Post-sync count must be 42 (fresh GraphQL TotalCount), not 5.
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		if bytes.Contains(body, []byte("pullRequests")) {
+			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+			return
+		}
+		resp := `{"data":{"repository":{"issues":{"nodes":[{
+			"databaseId":90000,
+			"number":90,
+			"title":"Stale count issue",
+			"state":"OPEN",
+			"body":"GraphQL count must win",
+			"url":"https://github.com/acme/widget/issues/90",
+			"author":{"login":"kate"},
+			"createdAt":"` + now + `",
+			"updatedAt":"` + now + `",
+			"closedAt":null,
+			"labels":{"nodes":[]},
+			"comments":{"totalCount":42,"nodes":[{"databaseId":901,"author":{"login":"leo"},"body":"one","createdAt":"` + now + `","updatedAt":"` + now + `"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor1"}}
+		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer gqlSrv.Close()
+
+	issueID := int64(90000)
+	issueNumber := 90
+	issueTitle := "Stale count issue"
+	issueState := "open"
+	issueURL := "https://github.com/acme/widget/issues/90"
+	issueLogin := "kate"
+	issueTime := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	mock := &mockGH{
+		listOpenPRsErr: &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		},
+		listIssueCommentsErr: fmt.Errorf("transient comments failure"),
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return []*gh.Issue{{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				User:      &gh.User{Login: &issueLogin},
+				CreatedAt: &issueTime,
+				UpdatedAt: &issueTime,
+			}}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+
+	// Pre-seed DB with a stale CommentCount (5). REST fallback fails,
+	// so UpsertIssue's value is what survives. With the bug, it's 5.
+	// Without the bug, it's TotalCount=42.
+	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(t, err)
+	stale := time.Now().UTC().Truncate(time.Second)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID:         repoID,
+		PlatformID:     90000,
+		Number:         90,
+		URL:            issueURL,
+		Title:          issueTitle,
+		Author:         issueLogin,
+		State:          "open",
+		CommentCount:   5, // stale
+		CreatedAt:      stale,
+		UpdatedAt:      stale,
+		LastActivityAt: stale,
+	})
+	require.NoError(t, err)
+
+	gqlClient := githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client())
+	srv.syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcherWithClient(gqlClient, nil),
+	})
+
+	srv.syncer.RunOnce(ctx)
+
+	// API must expose GraphQL TotalCount (42), not stale DB (5).
+	// With the preservation bug, count would remain 5.
+	client := setupTestClient(t, srv)
+	detailResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", 90,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 200, detailResp.StatusCode())
+	require.NotNil(t, detailResp.JSON200)
+	assert.Equal(int64(42), detailResp.JSON200.Issue.CommentCount)
 }
 
 func make422Error() error {


### PR DESCRIPTION
## Summary

- Fetch open issues via GitHub GraphQL API v4, matching existing PR GraphQL path
- ETag-gated REST fallback: REST list first (cheap 304 check), GraphQL when available, REST processing as fallback
- Bulk comment import from GraphQL when comments fit in single page, REST `ListIssueComments` fallback when truncated
- Closure detection via DB diff + individual REST fetches (same pattern as PRs)
- Set `detail_fetched_at` for complete bulk issues to prevent unnecessary REST re-queuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)