### PR TITLE
test: stabilize e2e startup and stale diff coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,9 @@ tmp/
 .claude/skills/
 cmd/e2e-server/e2e-server
 cmd/e2e-server/e2e-server.exe
+/e2e-server
+/e2e-server.exe
 .claude/worktrees/
 .claude/settings.local.json
 .superset
-e2e-server
 frontend/src/lib/api/generated/

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -2,16 +2,20 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
+	gh "github.com/google/go-github/v84/github"
 	"github.com/wesm/middleman/internal/config"
 	"github.com/wesm/middleman/internal/db"
 	ghclient "github.com/wesm/middleman/internal/github"
@@ -21,20 +25,31 @@ import (
 )
 
 func main() {
-	port := flag.Int("port", 4174, "port to listen on")
+	port := flag.Int("port", 0, "port to listen on (0 selects a random free port)")
 	roborev := flag.String(
 		"roborev", "",
 		"roborev daemon endpoint (enables proxy)",
 	)
+	serverInfoFile := flag.String(
+		"server-info-file", "",
+		"path to write discovered server port info as JSON",
+	)
 	flag.Parse()
 
-	if err := run(*port, *roborev); err != nil {
+	if err := run(*port, *roborev, *serverInfoFile); err != nil {
 		slog.Error("fatal", "err", err)
 		os.Exit(1)
 	}
 }
 
-func run(port int, roborevEndpoint string) error {
+type e2eServerInfo struct {
+	Host    string `json:"host"`
+	Port    int    `json:"port"`
+	BaseURL string `json:"base_url"`
+	PID     int    `json:"pid"`
+}
+
+func run(port int, roborevEndpoint, serverInfoFile string) error {
 	tmpDir, err := os.MkdirTemp("", "middleman-e2e-*")
 	if err != nil {
 		return fmt.Errorf("create temp dir: %w", err)
@@ -81,18 +96,7 @@ func run(port int, roborevEndpoint string) error {
 	}
 
 	fc := result.FixtureClient()
-
-	// Patch the fixture client's PR for acme/widgets#1 with the real
-	// SHAs from the test repo. Without this, the detail store's
-	// background sync (POST /repos/.../pulls/1/sync) would upsert the
-	// PR with empty platform SHAs, overwriting what SetupDiffRepo set.
-	for _, pr := range fc.OpenPRs["acme/widgets"] {
-		if pr.GetNumber() == 1 {
-			pr.Head.SHA = &diffRepo.HeadSHA
-			pr.Base.SHA = &diffRepo.BaseSHA
-			break
-		}
-	}
+	patchFixturePRSHAs(fc, "acme", "widgets", 1, diffRepo.HeadSHA, diffRepo.BaseSHA)
 
 	repos := make([]ghclient.RepoRef, len(cfg.Repos))
 	for i, r := range cfg.Repos {
@@ -115,13 +119,40 @@ func run(port int, roborevEndpoint string) error {
 	// incomplete fixture client data. The syncer only needs to exist
 	// for Status() and IsTrackedRepo() calls.
 
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	slog.Info(fmt.Sprintf("starting e2e server at http://%s", addr))
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	defer listener.Close()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return fmt.Errorf("unexpected listener addr type %T", listener.Addr())
+	}
+
+	info := e2eServerInfo{
+		Host:    "127.0.0.1",
+		Port:    tcpAddr.Port,
+		BaseURL: fmt.Sprintf("http://127.0.0.1:%d", tcpAddr.Port),
+		PID:     os.Getpid(),
+	}
+	if err := writeServerInfoFile(serverInfoFile, info); err != nil {
+		return fmt.Errorf("write server info file: %w", err)
+	}
+	defer cleanupServerInfoFile(serverInfoFile)
+
+	slog.Info(fmt.Sprintf("starting e2e server at %s", info.BaseURL))
+
+	httpServer := &http.Server{
+		Handler:     srv,
+		ReadTimeout: 15 * time.Second,
+		IdleTimeout: 60 * time.Second,
+	}
 
 	errCh := make(chan error, 1)
 	go func() {
-		if listenErr := srv.ListenAndServe(addr); !errors.Is(listenErr, http.ErrServerClosed) {
-			errCh <- listenErr
+		if serveErr := httpServer.Serve(listener); !errors.Is(serveErr, http.ErrServerClosed) {
+			errCh <- serveErr
 		}
 	}()
 
@@ -132,4 +163,62 @@ func run(port int, roborevEndpoint string) error {
 	case err := <-errCh:
 		return fmt.Errorf("server: %w", err)
 	}
+}
+
+func cleanupServerInfoFile(path string) {
+	if path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		slog.Warn("cleanup server info file failed", "path", path, "err", err)
+	}
+}
+
+func writeServerInfoFile(path string, info e2eServerInfo) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir server info dir: %w", err)
+	}
+
+	content, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("marshal server info: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, append(content, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write temp server info file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename server info file: %w", err)
+	}
+	return nil
+}
+
+func patchFixturePRSHAs(fc *testutil.FixtureClient, owner, repo string, number int, headSHA, baseSHA string) {
+	if fc == nil {
+		return
+	}
+
+	repoKey := fmt.Sprintf("%s/%s", owner, repo)
+	patch := func(prs []*gh.PullRequest) {
+		for _, pr := range prs {
+			if pr.GetNumber() != number {
+				continue
+			}
+			if pr.Head == nil {
+				pr.Head = &gh.PullRequestBranch{}
+			}
+			if pr.Base == nil {
+				pr.Base = &gh.PullRequestBranch{}
+			}
+			pr.Head.SHA = &headSHA
+			pr.Base.SHA = &baseSHA
+		}
+	}
+
+	patch(fc.OpenPRs[repoKey])
+	patch(fc.PRs[repoKey])
 }

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -220,5 +220,4 @@ func patchFixturePRSHAs(fc *testutil.FixtureClient, owner, repo string, number i
 	}
 
 	patch(fc.OpenPRs[repoKey])
-	patch(fc.PRs[repoKey])
 }

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -43,13 +43,8 @@ func TestCleanupServerInfoFileRemovesFile(t *testing.T) {
 	assert.ErrorIs(err, os.ErrNotExist)
 }
 
-func TestPatchFixturePRSHAsUpdatesOpenAndAllPRs(t *testing.T) {
+func TestPatchFixturePRSHAsUpdatesOpenPRs(t *testing.T) {
 	openPR := &gh.PullRequest{
-		Number: new(1),
-		Head:   &gh.PullRequestBranch{},
-		Base:   &gh.PullRequestBranch{},
-	}
-	allPR := &gh.PullRequest{
 		Number: new(1),
 		Head:   &gh.PullRequestBranch{},
 		Base:   &gh.PullRequestBranch{},
@@ -58,9 +53,6 @@ func TestPatchFixturePRSHAsUpdatesOpenAndAllPRs(t *testing.T) {
 		OpenPRs: map[string][]*gh.PullRequest{
 			"acme/widgets": {openPR},
 		},
-		PRs: map[string][]*gh.PullRequest{
-			"acme/widgets": {allPR},
-		},
 	}
 
 	patchFixturePRSHAs(fc, "acme", "widgets", 1, "head-sha", "base-sha")
@@ -68,6 +60,4 @@ func TestPatchFixturePRSHAsUpdatesOpenAndAllPRs(t *testing.T) {
 	assert := Assert.New(t)
 	assert.Equal("head-sha", openPR.GetHead().GetSHA())
 	assert.Equal("base-sha", openPR.GetBase().GetSHA())
-	assert.Equal("head-sha", allPR.GetHead().GetSHA())
-	assert.Equal("base-sha", allPR.GetBase().GetSHA())
 }

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gh "github.com/google/go-github/v84/github"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/testutil"
+)
+
+func TestWriteServerInfoFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "server-info.json")
+	info := e2eServerInfo{
+		Host:    "127.0.0.1",
+		Port:    43123,
+		BaseURL: "http://127.0.0.1:43123",
+		PID:     4242,
+	}
+
+	require.NoError(t, writeServerInfoFile(path, info))
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var got e2eServerInfo
+	require.NoError(t, json.Unmarshal(content, &got))
+	assert := Assert.New(t)
+	assert.Equal(info, got)
+}
+
+func TestCleanupServerInfoFileRemovesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "server-info.json")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+
+	cleanupServerInfoFile(path)
+
+	_, err := os.Stat(path)
+	assert := Assert.New(t)
+	assert.ErrorIs(err, os.ErrNotExist)
+}
+
+func TestPatchFixturePRSHAsUpdatesOpenAndAllPRs(t *testing.T) {
+	openPR := &gh.PullRequest{
+		Number: new(1),
+		Head:   &gh.PullRequestBranch{},
+		Base:   &gh.PullRequestBranch{},
+	}
+	allPR := &gh.PullRequest{
+		Number: new(1),
+		Head:   &gh.PullRequestBranch{},
+		Base:   &gh.PullRequestBranch{},
+	}
+	fc := &testutil.FixtureClient{
+		OpenPRs: map[string][]*gh.PullRequest{
+			"acme/widgets": {openPR},
+		},
+		PRs: map[string][]*gh.PullRequest{
+			"acme/widgets": {allPR},
+		},
+	}
+
+	patchFixturePRSHAs(fc, "acme", "widgets", 1, "head-sha", "base-sha")
+
+	assert := Assert.New(t)
+	assert.Equal("head-sha", openPR.GetHead().GetSHA())
+	assert.Equal("base-sha", openPR.GetBase().GetSHA())
+	assert.Equal("head-sha", allPR.GetHead().GetSHA())
+	assert.Equal("base-sha", allPR.GetBase().GetSHA())
+}

--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
+import { ensureE2EServer } from "./tests/e2e-full/support/e2eServer";
 
-const server = `../cmd/e2e-server/e2e-server${process.platform === "win32" ? ".exe" : ""}`;
+const serverInfo = await ensureE2EServer();
 
 export default defineConfig({
   testDir: "./tests/e2e-full",
@@ -11,17 +12,10 @@ export default defineConfig({
     timeout: 5_000,
   },
   use: {
-    baseURL: "http://127.0.0.1:4174",
+    baseURL: serverInfo.base_url,
     trace: "on-first-retry",
   },
-  webServer: {
-    command: process.env.ROBOREV_ENDPOINT
-      ? `${server} -port 4174 -roborev ${process.env.ROBOREV_ENDPOINT}`
-      : `${server} -port 4174`,
-    port: 4174,
-    reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
-  },
+  globalTeardown: "./tests/e2e-full/support/e2eServerTeardown.ts",
   projects: [
     {
       name: "chromium",

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { readFile, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { stopE2EServer } from "../../../tests/e2e-full/support/e2eServer";
+import * as e2eServerModule from "../../../tests/e2e-full/support/e2eServer";
+
+const { stopE2EServer } = e2eServerModule;
 
 const originalEnv = { ...process.env };
 
@@ -20,6 +23,117 @@ async function fileExists(filePath: string): Promise<boolean> {
 afterEach(() => {
   vi.restoreAllMocks();
   process.env = { ...originalEnv };
+});
+
+describe("waitForServerInfo", () => {
+  it("waits until the reported base URL accepts connections", async () => {
+    const waitForServerInfo = (
+      e2eServerModule as {
+        waitForServerInfo?: (
+          filePath: string,
+          child: { exitCode: number | null },
+        ) => Promise<{
+          host: string;
+          port: number;
+          base_url: string;
+          pid: number;
+        }>;
+      }
+    ).waitForServerInfo;
+
+    expect(waitForServerInfo).toBeTypeOf("function");
+    if (!waitForServerInfo) {
+      return;
+    }
+
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const infoFile = path.join(dir, "server-info.json");
+    const readyAt = Date.now() + 150;
+    const server = createServer((_req, res) => {
+      if (Date.now() < readyAt) {
+        res.writeHead(503, { "content-type": "text/plain" });
+        res.end("not ready");
+        return;
+      }
+
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+
+    const port = await new Promise<number>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("server did not bind a TCP port"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+
+    writeFileSync(
+      infoFile,
+      JSON.stringify({
+        host: "127.0.0.1",
+        port,
+        base_url: `http://127.0.0.1:${port}`,
+        pid: 99999,
+      }),
+    );
+
+    const startedAt = Date.now();
+    const info = await waitForServerInfo(infoFile, { exitCode: null });
+
+    expect(info.base_url).toBe(`http://127.0.0.1:${port}`);
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+});
+
+describe("cleanupManagedServerProcess", () => {
+  it("kills the real server pid from server-info instead of the wrapper pid", () => {
+    const cleanupManagedServerProcess = (
+      e2eServerModule as {
+        cleanupManagedServerProcess?: (
+          managedChild?: { pid?: number; exitCode: number | null } | null,
+        ) => void;
+      }
+    ).cleanupManagedServerProcess;
+
+    expect(cleanupManagedServerProcess).toBeTypeOf("function");
+    if (!cleanupManagedServerProcess) {
+      return;
+    }
+
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const infoFile = path.join(dir, "server-info.json");
+    writeFileSync(
+      infoFile,
+      JSON.stringify({
+        host: "127.0.0.1",
+        port: 1234,
+        base_url: "http://127.0.0.1:1234",
+        pid: 99999,
+      }),
+    );
+    process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = infoFile;
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    cleanupManagedServerProcess({ pid: 11111, exitCode: null });
+
+    expect(killSpy).toHaveBeenCalledWith(99999, "SIGTERM");
+    expect(killSpy).not.toHaveBeenCalledWith(11111, "SIGTERM");
+  });
 });
 
 describe("stopE2EServer", () => {

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -100,6 +100,70 @@ describe("waitForServerInfo", () => {
 });
 
 describe("getReusableServerInfo", () => {
+  it("accepts a reachable server even when the response is slower than the poll interval", async () => {
+    const getReusableServerInfo = (
+      e2eServerModule as {
+        getReusableServerInfo?: (filePath: string) => Promise<{
+          host: string;
+          port: number;
+          base_url: string;
+          pid: number;
+        } | null>;
+      }
+    ).getReusableServerInfo;
+
+    expect(getReusableServerInfo).toBeTypeOf("function");
+    if (!getReusableServerInfo) {
+      return;
+    }
+
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const infoFile = path.join(dir, "server-info.json");
+    const server = createServer(async (_req, res) => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+
+    const port = await new Promise<number>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("server did not bind a TCP port"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+
+    writeFileSync(
+      infoFile,
+      JSON.stringify({
+        host: "127.0.0.1",
+        port,
+        base_url: `http://127.0.0.1:${port}`,
+        pid: 99999,
+      }),
+    );
+
+    await expect(getReusableServerInfo(infoFile)).resolves.toEqual({
+      host: "127.0.0.1",
+      port,
+      base_url: `http://127.0.0.1:${port}`,
+      pid: 99999,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
   it("ignores stale server info when the recorded base URL is unreachable", async () => {
     const getReusableServerInfo = (
       e2eServerModule as {

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { stopE2EServer } from "../../../tests/e2e-full/support/e2eServer";
+
+const originalEnv = { ...process.env };
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env = { ...originalEnv };
+});
+
+describe("stopE2EServer", () => {
+  it("does not kill or delete externally managed server resources", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const infoFile = path.join(dir, "server-info.json");
+    const siblingFile = path.join(dir, "keep.txt");
+    writeFileSync(
+      infoFile,
+      JSON.stringify({
+        host: "127.0.0.1",
+        port: 1234,
+        base_url: "http://127.0.0.1:1234",
+        pid: 99999,
+      }),
+    );
+    writeFileSync(siblingFile, "keep");
+
+    process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = infoFile;
+    process.env.PLAYWRIGHT_E2E_BASE_URL = "http://127.0.0.1:1234";
+    delete process.env.PLAYWRIGHT_E2E_SERVER_OWNED;
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await stopE2EServer();
+
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(await fileExists(infoFile)).toBe(true);
+    expect(await readFile(siblingFile, "utf8")).toBe("keep");
+  });
+
+  it("only tears down resources created by this helper", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const infoFile = path.join(dir, "server-info.json");
+    const siblingFile = path.join(dir, "keep.txt");
+    writeFileSync(
+      infoFile,
+      JSON.stringify({
+        host: "127.0.0.1",
+        port: 1234,
+        base_url: "http://127.0.0.1:1234",
+        pid: 99999,
+      }),
+    );
+    writeFileSync(siblingFile, "keep");
+
+    process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = infoFile;
+    process.env.PLAYWRIGHT_E2E_BASE_URL = "http://127.0.0.1:1234";
+    process.env.PLAYWRIGHT_E2E_SERVER_OWNED = "1";
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    await stopE2EServer();
+
+    expect(killSpy).toHaveBeenCalledWith(99999, "SIGTERM");
+    expect(await fileExists(infoFile)).toBe(false);
+    expect(await readFile(siblingFile, "utf8")).toBe("keep");
+    expect(process.env.PLAYWRIGHT_E2E_SERVER_OWNED).toBeUndefined();
+    expect(process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE).toBeUndefined();
+    expect(process.env.PLAYWRIGHT_E2E_BASE_URL).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -99,6 +99,66 @@ describe("waitForServerInfo", () => {
   });
 });
 
+describe("getReusableServerInfo", () => {
+  it("ignores stale server info when the recorded base URL is unreachable", async () => {
+    const getReusableServerInfo = (
+      e2eServerModule as {
+        getReusableServerInfo?: (filePath: string) => Promise<{
+          host: string;
+          port: number;
+          base_url: string;
+          pid: number;
+        } | null>;
+      }
+    ).getReusableServerInfo;
+
+    expect(getReusableServerInfo).toBeTypeOf("function");
+    if (!getReusableServerInfo) {
+      return;
+    }
+
+    const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
+    const infoFile = path.join(dir, "server-info.json");
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+
+    const port = await new Promise<number>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("server did not bind a TCP port"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+    writeFileSync(
+      infoFile,
+      JSON.stringify({
+        host: "127.0.0.1",
+        port,
+        base_url: `http://127.0.0.1:${port}`,
+        pid: 99999,
+      }),
+    );
+
+    await expect(getReusableServerInfo(infoFile)).resolves.toBeNull();
+  });
+});
+
 describe("cleanupManagedServerProcess", () => {
   it("kills the real server pid from server-info instead of the wrapper pid", () => {
     const cleanupManagedServerProcess = (

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -21,6 +21,7 @@ const serverInfoDir = mkdtempSync(path.join(os.tmpdir(), "middleman-e2e-"));
 const serverInfoFile = path.join(serverInfoDir, "server-info.json");
 const startupTimeoutMs = 30_000;
 const pollIntervalMs = 100;
+const reachabilityTimeoutMs = 1_000;
 const ownedServerEnvVar = "PLAYWRIGHT_E2E_SERVER_OWNED";
 
 type ManagedChildLike = {
@@ -57,7 +58,7 @@ async function isServerReachable(baseURL: string): Promise<boolean> {
     const url = new URL(baseURL);
     const request = (url.protocol === "https:" ? httpsRequest : httpRequest)(
       url,
-      { method: "GET", timeout: pollIntervalMs },
+      { method: "GET", timeout: reachabilityTimeoutMs },
       (response) => {
         response.resume();
         resolve(

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -77,6 +77,19 @@ async function isServerReachable(baseURL: string): Promise<boolean> {
   });
 }
 
+export async function getReusableServerInfo(
+  filePath: string,
+): Promise<E2EServerInfo | null> {
+  const info = await readServerInfo(filePath);
+  if (!info) {
+    return null;
+  }
+  if (!(await isServerReachable(info.base_url))) {
+    return null;
+  }
+  return info;
+}
+
 export async function waitForServerInfo(
   filePath: string,
   child: Pick<ManagedChildLike, "exitCode">,
@@ -140,6 +153,34 @@ function installCleanup(infoFile: string): void {
   });
 }
 
+async function startManagedServer(): Promise<E2EServerInfo> {
+  const args = [
+    "run",
+    "./cmd/e2e-server",
+    "-port",
+    "0",
+    "-server-info-file",
+    serverInfoFile,
+  ];
+  if (process.env.ROBOREV_ENDPOINT) {
+    args.push("-roborev", process.env.ROBOREV_ENDPOINT);
+  }
+
+  managedChild = spawn("go", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  installCleanup(serverInfoFile);
+
+  const info = await waitForServerInfo(serverInfoFile, managedChild);
+  process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;
+  process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = serverInfoFile;
+  process.env[ownedServerEnvVar] = "1";
+  return info;
+}
+
 export async function ensureE2EServer(): Promise<E2EServerInfo> {
   if (serverPromise) {
     return await serverPromise;
@@ -150,45 +191,21 @@ export async function ensureE2EServer(): Promise<E2EServerInfo> {
   if (existingBaseURL && existingInfoFile) {
     delete process.env[ownedServerEnvVar];
     serverPromise = (async () => {
-      const info = await readServerInfo(existingInfoFile);
-      if (!info) {
-        throw new Error(
-          `failed to read existing e2e server info file ${existingInfoFile}`,
-        );
+      const info = await getReusableServerInfo(existingInfoFile);
+      if (info) {
+        process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;
+        process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = existingInfoFile;
+        return info;
       }
-      return info;
+
+      delete process.env.PLAYWRIGHT_E2E_BASE_URL;
+      delete process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE;
+      return await startManagedServer();
     })();
     return await serverPromise;
   }
 
-  serverPromise = (async () => {
-    const args = [
-      "run",
-      "./cmd/e2e-server",
-      "-port",
-      "0",
-      "-server-info-file",
-      serverInfoFile,
-    ];
-    if (process.env.ROBOREV_ENDPOINT) {
-      args.push("-roborev", process.env.ROBOREV_ENDPOINT);
-    }
-
-    managedChild = spawn("go", args, {
-      cwd: repoRoot,
-      stdio: "inherit",
-      env: process.env,
-    });
-
-    installCleanup(serverInfoFile);
-
-    const info = await waitForServerInfo(serverInfoFile, managedChild);
-    process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;
-    process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = serverInfoFile;
-    process.env[ownedServerEnvVar] = "1";
-    return info;
-  })();
-
+  serverPromise = startManagedServer();
   return await serverPromise;
 }
 

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -1,0 +1,156 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export type E2EServerInfo = {
+  host: string;
+  port: number;
+  base_url: string;
+  pid: number;
+};
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../../..");
+const serverInfoDir = mkdtempSync(path.join(os.tmpdir(), "middleman-e2e-"));
+const serverInfoFile = path.join(serverInfoDir, "server-info.json");
+const startupTimeoutMs = 30_000;
+const pollIntervalMs = 100;
+
+let serverPromise: Promise<E2EServerInfo> | null = null;
+let managedChild: ChildProcess | null = null;
+let cleanupInstalled = false;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readServerInfo(filePath: string): Promise<E2EServerInfo | null> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8")) as E2EServerInfo;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForServerInfo(
+  filePath: string,
+  child: ChildProcess,
+): Promise<E2EServerInfo> {
+  const deadline = Date.now() + startupTimeoutMs;
+  while (Date.now() < deadline) {
+    const info = await readServerInfo(filePath);
+    if (info) {
+      return info;
+    }
+    if (child.exitCode !== null) {
+      throw new Error(
+        `e2e server exited with code ${child.exitCode} before writing ${filePath}`,
+      );
+    }
+    await delay(pollIntervalMs);
+  }
+  throw new Error(`timed out waiting for e2e server info file ${filePath}`);
+}
+
+async function removeServerInfo(filePath: string): Promise<void> {
+  await rm(path.dirname(filePath), { recursive: true, force: true });
+}
+
+function installCleanup(): void {
+  if (cleanupInstalled) {
+    return;
+  }
+  cleanupInstalled = true;
+
+  const cleanup = () => {
+    if (managedChild?.pid && managedChild.exitCode === null) {
+      try {
+        process.kill(managedChild.pid, "SIGTERM");
+      } catch {
+        // Process already exited.
+      }
+    }
+  };
+
+  process.once("exit", cleanup);
+  process.once("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.once("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+}
+
+export async function ensureE2EServer(): Promise<E2EServerInfo> {
+  if (serverPromise) {
+    return await serverPromise;
+  }
+
+  const existingBaseURL = process.env.PLAYWRIGHT_E2E_BASE_URL;
+  const existingInfoFile = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE;
+  if (existingBaseURL && existingInfoFile) {
+    serverPromise = (async () => {
+      const info = await readServerInfo(existingInfoFile);
+      if (!info) {
+        throw new Error(
+          `failed to read existing e2e server info file ${existingInfoFile}`,
+        );
+      }
+      return info;
+    })();
+    return await serverPromise;
+  }
+
+  serverPromise = (async () => {
+    const args = [
+      "run",
+      "./cmd/e2e-server",
+      "-port",
+      "0",
+      "-server-info-file",
+      serverInfoFile,
+    ];
+    if (process.env.ROBOREV_ENDPOINT) {
+      args.push("-roborev", process.env.ROBOREV_ENDPOINT);
+    }
+
+    managedChild = spawn("go", args, {
+      cwd: repoRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    installCleanup();
+
+    const info = await waitForServerInfo(serverInfoFile, managedChild);
+    process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;
+    process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = serverInfoFile;
+    return info;
+  })();
+
+  return await serverPromise;
+}
+
+export async function stopE2EServer(): Promise<void> {
+  const filePath = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE;
+  if (!filePath) {
+    return;
+  }
+
+  const info = await readServerInfo(filePath);
+  if (info?.pid) {
+    try {
+      process.kill(info.pid, "SIGTERM");
+    } catch {
+      // Process already exited.
+    }
+  }
+
+  await removeServerInfo(filePath);
+}

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -19,6 +19,7 @@ const serverInfoDir = mkdtempSync(path.join(os.tmpdir(), "middleman-e2e-"));
 const serverInfoFile = path.join(serverInfoDir, "server-info.json");
 const startupTimeoutMs = 30_000;
 const pollIntervalMs = 100;
+const ownedServerEnvVar = "PLAYWRIGHT_E2E_SERVER_OWNED";
 
 let serverPromise: Promise<E2EServerInfo> | null = null;
 let managedChild: ChildProcess | null = null;
@@ -57,7 +58,7 @@ async function waitForServerInfo(
 }
 
 async function removeServerInfo(filePath: string): Promise<void> {
-  await rm(path.dirname(filePath), { recursive: true, force: true });
+  await rm(filePath, { force: true });
 }
 
 function installCleanup(): void {
@@ -95,6 +96,7 @@ export async function ensureE2EServer(): Promise<E2EServerInfo> {
   const existingBaseURL = process.env.PLAYWRIGHT_E2E_BASE_URL;
   const existingInfoFile = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE;
   if (existingBaseURL && existingInfoFile) {
+    delete process.env[ownedServerEnvVar];
     serverPromise = (async () => {
       const info = await readServerInfo(existingInfoFile);
       if (!info) {
@@ -131,6 +133,7 @@ export async function ensureE2EServer(): Promise<E2EServerInfo> {
     const info = await waitForServerInfo(serverInfoFile, managedChild);
     process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;
     process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = serverInfoFile;
+    process.env[ownedServerEnvVar] = "1";
     return info;
   })();
 
@@ -140,6 +143,9 @@ export async function ensureE2EServer(): Promise<E2EServerInfo> {
 export async function stopE2EServer(): Promise<void> {
   const filePath = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE;
   if (!filePath) {
+    return;
+  }
+  if (process.env[ownedServerEnvVar] !== "1") {
     return;
   }
 
@@ -153,4 +159,7 @@ export async function stopE2EServer(): Promise<void> {
   }
 
   await removeServerInfo(filePath);
+  delete process.env[ownedServerEnvVar];
+  delete process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE;
+  delete process.env.PLAYWRIGHT_E2E_BASE_URL;
 }

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -37,44 +39,89 @@ async function readServerInfo(filePath: string): Promise<E2EServerInfo | null> {
   }
 }
 
-async function waitForServerInfo(
+function readServerInfoSync(filePath: string): E2EServerInfo | null {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8")) as E2EServerInfo;
+  } catch {
+    return null;
+  }
+}
+
+async function isServerReachable(baseURL: string): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const url = new URL(baseURL);
+    const request = (url.protocol === "https:" ? httpsRequest : httpRequest)(
+      url,
+      { method: "GET", timeout: pollIntervalMs },
+      (response) => {
+        response.resume();
+        resolve(
+          (response.statusCode ?? 0) >= 200 && (response.statusCode ?? 0) < 300,
+        );
+      },
+    );
+
+    request.on("error", () => {
+      resolve(false);
+    });
+    request.on("timeout", () => {
+      request.destroy();
+      resolve(false);
+    });
+    request.end();
+  });
+}
+
+export async function waitForServerInfo(
   filePath: string,
-  child: ChildProcess,
+  child: { exitCode: number | null },
 ): Promise<E2EServerInfo> {
   const deadline = Date.now() + startupTimeoutMs;
   while (Date.now() < deadline) {
     const info = await readServerInfo(filePath);
-    if (info) {
+    if (info && (await isServerReachable(info.base_url))) {
       return info;
     }
     if (child.exitCode !== null) {
       throw new Error(
-        `e2e server exited with code ${child.exitCode} before writing ${filePath}`,
+        `e2e server exited with code ${child.exitCode} before becoming ready from ${filePath}`,
       );
     }
     await delay(pollIntervalMs);
   }
-  throw new Error(`timed out waiting for e2e server info file ${filePath}`);
+  throw new Error(`timed out waiting for ready e2e server from ${filePath}`);
 }
 
 async function removeServerInfo(filePath: string): Promise<void> {
   await rm(filePath, { force: true });
 }
 
-function installCleanup(): void {
+export function cleanupManagedServerProcess(
+  child: { pid?: number; exitCode: number | null } | null = managedChild,
+  infoFile: string | undefined = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE,
+): void {
+  const serverPID = infoFile ? readServerInfoSync(infoFile)?.pid : undefined;
+  const fallbackPID = child?.exitCode === null ? child.pid : undefined;
+  const pid = serverPID ?? fallbackPID;
+  if (!pid) {
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // Process already exited.
+  }
+}
+
+function installCleanup(infoFile: string): void {
   if (cleanupInstalled) {
     return;
   }
   cleanupInstalled = true;
 
   const cleanup = () => {
-    if (managedChild?.pid && managedChild.exitCode === null) {
-      try {
-        process.kill(managedChild.pid, "SIGTERM");
-      } catch {
-        // Process already exited.
-      }
-    }
+    cleanupManagedServerProcess(managedChild, infoFile);
   };
 
   process.once("exit", cleanup);
@@ -128,7 +175,7 @@ export async function ensureE2EServer(): Promise<E2EServerInfo> {
       env: process.env,
     });
 
-    installCleanup();
+    installCleanup(serverInfoFile);
 
     const info = await waitForServerInfo(serverInfoFile, managedChild);
     process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -23,6 +23,11 @@ const startupTimeoutMs = 30_000;
 const pollIntervalMs = 100;
 const ownedServerEnvVar = "PLAYWRIGHT_E2E_SERVER_OWNED";
 
+type ManagedChildLike = {
+  pid?: number | undefined;
+  exitCode: number | null;
+};
+
 let serverPromise: Promise<E2EServerInfo> | null = null;
 let managedChild: ChildProcess | null = null;
 let cleanupInstalled = false;
@@ -74,7 +79,7 @@ async function isServerReachable(baseURL: string): Promise<boolean> {
 
 export async function waitForServerInfo(
   filePath: string,
-  child: { exitCode: number | null },
+  child: Pick<ManagedChildLike, "exitCode">,
 ): Promise<E2EServerInfo> {
   const deadline = Date.now() + startupTimeoutMs;
   while (Date.now() < deadline) {
@@ -97,7 +102,7 @@ async function removeServerInfo(filePath: string): Promise<void> {
 }
 
 export function cleanupManagedServerProcess(
-  child: { pid?: number; exitCode: number | null } | null = managedChild,
+  child: ManagedChildLike | null = managedChild,
   infoFile: string | undefined = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE,
 ): void {
   const serverPID = infoFile ? readServerInfoSync(infoFile)?.pid : undefined;

--- a/frontend/tests/e2e-full/support/e2eServerTeardown.ts
+++ b/frontend/tests/e2e-full/support/e2eServerTeardown.ts
@@ -1,0 +1,5 @@
+import { stopE2EServer } from "./e2eServer";
+
+export default async function globalTeardown(): Promise<void> {
+  await stopE2EServer();
+}

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -1,61 +1,69 @@
 import { expect, test } from "@playwright/test";
+import type { WorkspaceData } from "@middleman/ui/api/types";
 
 import { mockApi } from "./support/mockApi";
 
-const testWorkspaceData = {
-  hosts: [{
-    key: "local",
-    label: "Local",
-    connectionState: "connected",
-    projects: [{
-      key: "proj-1",
-      name: "test-project",
-      kind: "repository",
-      repoKind: "STANDARD",
-      defaultBranch: "main",
-      platformRepo: "acme/test-project",
-      worktrees: [
+const testWorkspaceData: WorkspaceData = {
+  hosts: [
+    {
+      key: "local",
+      label: "Local",
+      connectionState: "connected",
+      projects: [
         {
-          key: "wt-1",
-          name: "main",
-          branch: "main",
-          isPrimary: true,
-          isHidden: false,
-          isStale: false,
-          sessionBackend: "local",
-          linkedPR: null,
-          activity: { state: "idle", lastOutputAt: null },
-          diff: null,
-        },
-        {
-          key: "wt-2",
-          name: "feature-auth",
-          branch: "feature/auth",
-          isPrimary: false,
-          isHidden: false,
-          isStale: false,
-          sessionBackend: "local",
-          linkedPR: {
-            number: 42,
-            title: "Add auth middleware",
-            state: "open",
-            checksStatus: "success",
-            updatedAt: "2026-04-10T12:00:00Z",
-          },
-          activity: {
-            state: "active",
-            lastOutputAt: "2026-04-10T12:00:00Z",
-          },
-          diff: { added: 45, removed: 12 },
+          key: "proj-1",
+          name: "test-project",
+          kind: "repository",
+          repoKind: "STANDARD",
+          defaultBranch: "main",
+          platformRepo: "acme/test-project",
+          worktrees: [
+            {
+              key: "wt-1",
+              name: "main",
+              branch: "main",
+              isPrimary: true,
+              isHidden: false,
+              isStale: false,
+              sessionBackend: "local",
+              linkedPR: null,
+              activity: { state: "idle", lastOutputAt: null },
+              diff: null,
+            },
+            {
+              key: "wt-2",
+              name: "feature-auth",
+              branch: "feature/auth",
+              isPrimary: false,
+              isHidden: false,
+              isStale: false,
+              sessionBackend: "local",
+              linkedPR: {
+                number: 42,
+                title: "Add auth middleware",
+                state: "open",
+                checksStatus: "success",
+                updatedAt: "2026-04-10T12:00:00Z",
+              },
+              activity: {
+                state: "active",
+                lastOutputAt: "2026-04-10T12:00:00Z",
+              },
+              diff: { added: 45, removed: 12 },
+            },
+          ],
         },
       ],
-    }],
-    sessions: [],
-    resources: null,
-  }],
+      sessions: [],
+      resources: null,
+    },
+  ],
   selectedWorktreeKey: "wt-1",
   selectedHostKey: "local",
 };
+
+const primaryHost = testWorkspaceData.hosts[0]!;
+const primaryProject = primaryHost.projects[0]!;
 
 test.beforeEach(async ({ page }) => {
   await mockApi(page);
@@ -63,134 +71,101 @@ test.beforeEach(async ({ page }) => {
 
 test("workspaces route renders empty state", async ({ page }) => {
   await page.goto("/workspaces");
-  await expect(
-    page.getByText("No workspace data available"),
-  ).toBeVisible();
+  await expect(page.getByText("No workspace data available")).toBeVisible();
 });
 
 test("AppHeader shows Workspaces tab", async ({ page }) => {
   await page.goto("/pulls");
-  await expect(
-    page.getByRole("button", { name: "Workspaces" }),
-  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Workspaces" })).toBeVisible();
 });
 
-test(
-  "Workspaces tab navigates to /workspaces",
-  async ({ page }) => {
-    await page.goto("/pulls");
-    await page
-      .getByRole("button", { name: "Workspaces" })
-      .click();
-    await expect(page).toHaveURL(/\/workspaces/);
-  },
-);
+test("Workspaces tab navigates to /workspaces", async ({ page }) => {
+  await page.goto("/pulls");
+  await page.getByRole("button", { name: "Workspaces" }).click();
+  await expect(page).toHaveURL(/\/workspaces/);
+});
 
-test(
-  "hideHeader suppresses AppHeader",
-  async ({ page }) => {
-    await page.addInitScript(() => {
-      window.__middleman_config = {
-        embed: { hideHeader: true },
-      };
-    });
-    await page.goto("/workspaces");
-    await expect(page.locator("header.app-header")).toHaveCount(0);
-  },
-);
+test("hideHeader suppresses AppHeader", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: { hideHeader: true },
+    };
+  });
+  await page.goto("/workspaces");
+  await expect(page.locator("header.app-header")).toHaveCount(0);
+});
 
-test(
-  "workspace data injection renders sidebar",
-  async ({ page }) => {
-    const data = testWorkspaceData;
-    await page.addInitScript((d) => {
-      window.__middleman_config = { workspace: d };
-    }, data);
-    await page.goto("/workspaces");
-    await expect(
-      page.locator(".project-name", { hasText: "test-project" }),
-    ).toBeVisible();
-    await expect(
-      page.getByText("feature-auth"),
-    ).toBeVisible();
-  },
-);
+test("workspace data injection renders sidebar", async ({ page }) => {
+  const data = testWorkspaceData;
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, data);
+  await page.goto("/workspaces");
+  await expect(
+    page.locator(".project-name", { hasText: "test-project" }),
+  ).toBeVisible();
+  await expect(page.getByText("feature-auth")).toBeVisible();
+});
 
-test(
-  "bridge update method renders workspace data",
-  async ({ page }) => {
-    // Start with embedded config but no workspace data
-    await page.addInitScript(() => {
-      window.__middleman_config = {};
-    });
-    await page.goto("/workspaces");
-    await expect(
-      page.getByText("No workspace data available"),
-    ).toBeVisible();
+test("bridge update method renders workspace data", async ({ page }) => {
+  // Start with embedded config but no workspace data
+  await page.addInitScript(() => {
+    window.__middleman_config = {};
+  });
+  await page.goto("/workspaces");
+  await expect(page.getByText("No workspace data available")).toBeVisible();
 
-    const data = testWorkspaceData;
-    await page.evaluate((d) => {
-      window.__middleman_update_workspace?.(d as WorkspaceData);
-    }, data);
+  const data = testWorkspaceData;
+  await page.evaluate((d) => {
+    window.__middleman_update_workspace?.(d as WorkspaceData);
+  }, data);
 
-    await expect(
-      page.locator(".project-name", { hasText: "test-project" }),
-    ).toBeVisible();
-    await expect(
-      page.getByText("feature-auth"),
-    ).toBeVisible();
-  },
-);
+  await expect(
+    page.locator(".project-name", { hasText: "test-project" }),
+  ).toBeVisible();
+  await expect(page.getByText("feature-auth")).toBeVisible();
+});
 
-test(
-  "clicking PR badge emits pinLinkedPR command",
-  async ({ page }) => {
-    await page.addInitScript((data) => {
-      window.__middleman_config = {
-        workspace: data,
-        onWorkspaceCommand: (
-          cmd: string,
-          payload: Record<string, unknown>,
-        ) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
-          (window as Record<string, any>).__last_workspace_command = {
-            cmd,
-            payload,
-          };
-          return { ok: true };
-        },
-      };
-    }, testWorkspaceData);
+test("clicking PR badge emits pinLinkedPR command", async ({ page }) => {
+  await page.addInitScript((data) => {
+    window.__middleman_config = {
+      workspace: data,
+      onWorkspaceCommand: (cmd: string, payload: Record<string, unknown>) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
+        (window as Record<string, any>).__last_workspace_command = {
+          cmd,
+          payload,
+        };
+        return { ok: true };
+      },
+    };
+  }, testWorkspaceData);
 
-    await page.goto("/workspaces");
+  await page.goto("/workspaces");
 
-    const prBadge = page.locator("button.pr-badge").first();
-    await expect(prBadge).toBeVisible();
-    await prBadge.click();
+  const prBadge = page.locator("button.pr-badge").first();
+  await expect(prBadge).toBeVisible();
+  await prBadge.click();
 
-    const command = await page.evaluate(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
-      () => (window as Record<string, any>).__last_workspace_command,
-    );
-    expect(command).toBeTruthy();
-    expect(command.cmd).toBe("pinLinkedPR");
-    expect(command.payload.hostKey).toBe("local");
-    expect(command.payload.projectKey).toBe("proj-1");
-    expect(command.payload.worktreeKey).toBe("wt-2");
-    expect(command.payload.prNumber).toBe(42);
-  },
-);
+  const command = await page.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
+    () => (window as Record<string, any>).__last_workspace_command,
+  );
+  expect(command).toBeTruthy();
+  expect(command.cmd).toBe("pinLinkedPR");
+  expect(command.payload.hostKey).toBe("local");
+  expect(command.payload.projectKey).toBe("proj-1");
+  expect(command.payload.worktreeKey).toBe("wt-2");
+  expect(command.payload.prNumber).toBe(42);
+});
 
-test(
-  "navigateToRoute bridge method works",
-  async ({ page }) => {
-    await page.goto("/pulls");
-    await page.evaluate(() => {
-      window.__middleman_navigate_to_route?.("/workspaces");
-    });
-    await expect(page).toHaveURL(/\/workspaces/);
-  },
-);
+test("navigateToRoute bridge method works", async ({ page }) => {
+  await page.goto("/pulls");
+  await page.evaluate(() => {
+    window.__middleman_navigate_to_route?.("/workspaces");
+  });
+  await expect(page).toHaveURL(/\/workspaces/);
+});
 
 // --- New sidebar interaction tests ---
 
@@ -200,15 +175,12 @@ test(
  */
 async function injectWithCallback(
   page: import("@playwright/test").Page,
-  data: typeof testWorkspaceData,
+  data: WorkspaceData,
 ): Promise<void> {
   await page.addInitScript((d) => {
     window.__middleman_config = {
       workspace: d,
-      onWorkspaceCommand: (
-        cmd: string,
-        payload: Record<string, unknown>,
-      ) => {
+      onWorkspaceCommand: (cmd: string, payload: Record<string, unknown>) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
         (window as Record<string, any>).__last_workspace_command = {
           cmd,
@@ -229,558 +201,486 @@ async function getLastCommand(
   );
 }
 
-test(
-  "clicking worktree row emits selectWorktree",
-  async ({ page }) => {
-    await injectWithCallback(page, testWorkspaceData);
-    await page.goto("/workspaces");
+test("clicking worktree row emits selectWorktree", async ({ page }) => {
+  await injectWithCallback(page, testWorkspaceData);
+  await page.goto("/workspaces");
 
-    const row = page
-      .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
-    await expect(row).toBeVisible();
-    await row.click();
+  const row = page.locator(".worktree-row").filter({ hasText: "feature-auth" });
+  await expect(row).toBeVisible();
+  await row.click();
 
-    const command = await getLastCommand(page);
-    expect(command).toBeTruthy();
-    expect(command.cmd).toBe("selectWorktree");
-    expect(command.payload.worktreeKey).toBe("wt-2");
-    expect(command.payload.hostKey).toBe("local");
-    expect(command.payload.projectKey).toBe("proj-1");
-  },
-);
+  const command = await getLastCommand(page);
+  expect(command).toBeTruthy();
+  expect(command.cmd).toBe("selectWorktree");
+  expect(command.payload.worktreeKey).toBe("wt-2");
+  expect(command.payload.hostKey).toBe("local");
+  expect(command.payload.projectKey).toBe("proj-1");
+});
 
-test(
-  "worktree context menu: deleteWorktree",
-  async ({ page }) => {
-    await injectWithCallback(page, testWorkspaceData);
-    await page.goto("/workspaces");
+test("worktree context menu: deleteWorktree", async ({ page }) => {
+  await injectWithCallback(page, testWorkspaceData);
+  await page.goto("/workspaces");
 
-    const row = page
-      .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
-    await expect(row).toBeVisible();
-    await row.click({ button: "right" });
+  const row = page.locator(".worktree-row").filter({ hasText: "feature-auth" });
+  await expect(row).toBeVisible();
+  await row.click({ button: "right" });
 
-    const menuItem = page.getByText("Delete worktree");
-    await expect(menuItem).toBeVisible();
-    await menuItem.click();
+  const menuItem = page.getByText("Delete worktree");
+  await expect(menuItem).toBeVisible();
+  await menuItem.click();
 
-    const command = await getLastCommand(page);
-    expect(command).toBeTruthy();
-    expect(command.cmd).toBe("deleteWorktree");
-    expect(command.payload.hostKey).toBe("local");
-    expect(command.payload.projectKey).toBe("proj-1");
-    expect(command.payload.worktreeKey).toBe("wt-2");
-  },
-);
+  const command = await getLastCommand(page);
+  expect(command).toBeTruthy();
+  expect(command.cmd).toBe("deleteWorktree");
+  expect(command.payload.hostKey).toBe("local");
+  expect(command.payload.projectKey).toBe("proj-1");
+  expect(command.payload.worktreeKey).toBe("wt-2");
+});
 
-test(
-  "worktree context menu: setWorktreeHidden",
-  async ({ page }) => {
-    await injectWithCallback(page, testWorkspaceData);
-    await page.goto("/workspaces");
+test("worktree context menu: setWorktreeHidden", async ({ page }) => {
+  await injectWithCallback(page, testWorkspaceData);
+  await page.goto("/workspaces");
 
-    const row = page
-      .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
-    await expect(row).toBeVisible();
-    await row.click({ button: "right" });
+  const row = page.locator(".worktree-row").filter({ hasText: "feature-auth" });
+  await expect(row).toBeVisible();
+  await row.click({ button: "right" });
 
-    // wt-2 has isHidden: false, so menu shows "Hide worktree"
-    const menuItem = page.getByText("Hide worktree");
-    await expect(menuItem).toBeVisible();
-    await menuItem.click();
+  // wt-2 has isHidden: false, so menu shows "Hide worktree"
+  const menuItem = page.getByText("Hide worktree");
+  await expect(menuItem).toBeVisible();
+  await menuItem.click();
 
-    const command = await getLastCommand(page);
-    expect(command).toBeTruthy();
-    expect(command.cmd).toBe("setWorktreeHidden");
-    expect(command.payload.hostKey).toBe("local");
-    expect(command.payload.projectKey).toBe("proj-1");
-    expect(command.payload.worktreeKey).toBe("wt-2");
-    expect(command.payload.hidden).toBe(true);
-  },
-);
+  const command = await getLastCommand(page);
+  expect(command).toBeTruthy();
+  expect(command.cmd).toBe("setWorktreeHidden");
+  expect(command.payload.hostKey).toBe("local");
+  expect(command.payload.projectKey).toBe("proj-1");
+  expect(command.payload.worktreeKey).toBe("wt-2");
+  expect(command.payload.hidden).toBe(true);
+});
 
-test(
-  "activity state dot colors match activity state",
-  async ({ page }) => {
-    const activityData = {
-      ...testWorkspaceData,
-      hosts: [{
-        ...testWorkspaceData.hosts[0],
-        projects: [{
-          ...testWorkspaceData.hosts[0].projects[0],
-          worktrees: [
-            {
-              key: "wt-idle",
-              name: "idle-wt",
-              branch: "idle",
-              isPrimary: false,
-              isHidden: false,
-              isStale: false,
-              sessionBackend: "local",
-              linkedPR: null,
-              activity: { state: "idle", lastOutputAt: null },
-              diff: null,
-            },
-            {
-              key: "wt-active",
-              name: "active-wt",
-              branch: "active",
-              isPrimary: false,
-              isHidden: false,
-              isStale: false,
-              sessionBackend: "local",
-              linkedPR: null,
-              activity: {
-                state: "active",
-                lastOutputAt: "2026-04-10T12:00:00Z",
+test("activity state dot colors match activity state", async ({ page }) => {
+  const activityData: WorkspaceData = {
+    ...testWorkspaceData,
+    hosts: [
+      {
+        ...primaryHost,
+        projects: [
+          {
+            ...primaryProject,
+            worktrees: [
+              {
+                key: "wt-idle",
+                name: "idle-wt",
+                branch: "idle",
+                isPrimary: false,
+                isHidden: false,
+                isStale: false,
+                sessionBackend: "local",
+                linkedPR: null,
+                activity: { state: "idle", lastOutputAt: null },
+                diff: null,
               },
-              diff: null,
-            },
-            {
-              key: "wt-running",
-              name: "running-wt",
-              branch: "running",
-              isPrimary: false,
-              isHidden: false,
-              isStale: false,
-              sessionBackend: "local",
-              linkedPR: null,
-              activity: {
-                state: "running",
-                lastOutputAt: "2026-04-10T12:00:00Z",
+              {
+                key: "wt-active",
+                name: "active-wt",
+                branch: "active",
+                isPrimary: false,
+                isHidden: false,
+                isStale: false,
+                sessionBackend: "local",
+                linkedPR: null,
+                activity: {
+                  state: "active",
+                  lastOutputAt: "2026-04-10T12:00:00Z",
+                },
+                diff: null,
               },
-              diff: null,
-            },
-            {
-              key: "wt-attention",
-              name: "attention-wt",
-              branch: "attention",
-              isPrimary: false,
-              isHidden: false,
-              isStale: false,
-              sessionBackend: "local",
-              linkedPR: null,
-              activity: {
-                state: "needsAttention",
-                lastOutputAt: "2026-04-10T12:00:00Z",
+              {
+                key: "wt-running",
+                name: "running-wt",
+                branch: "running",
+                isPrimary: false,
+                isHidden: false,
+                isStale: false,
+                sessionBackend: "local",
+                linkedPR: null,
+                activity: {
+                  state: "running",
+                  lastOutputAt: "2026-04-10T12:00:00Z",
+                },
+                diff: null,
               },
-              diff: null,
-            },
-          ],
-        }],
-      }],
-    };
-
-    await page.addInitScript((d) => {
-      window.__middleman_config = { workspace: d };
-    }, activityData);
-    await page.goto("/workspaces");
-
-    const expected: [string, string][] = [
-      ["idle-wt", "var(--text-muted)"],
-      ["active-wt", "var(--accent-green)"],
-      ["running-wt", "var(--accent-blue)"],
-      ["attention-wt", "var(--accent-amber)"],
-    ];
-
-    for (const [name, cssVar] of expected) {
-      const dot = page
-        .locator(".worktree-row")
-        .filter({ hasText: name })
-        .locator(".activity-dot");
-      await expect(dot).toBeVisible();
-      const style = await dot.getAttribute("style");
-      expect(style).toContain(`background: ${cssVar}`);
-    }
-  },
-);
-
-test(
-  "selected worktree row has .selected class",
-  async ({ page }) => {
-    await page.addInitScript((d) => {
-      window.__middleman_config = { workspace: d };
-    }, testWorkspaceData);
-    await page.goto("/workspaces");
-
-    // wt-1 ("main") is selectedWorktreeKey
-    const selectedRow = page
-      .locator(".worktree-row")
-      .filter({ hasText: "main" });
-    await expect(selectedRow).toBeVisible();
-    await expect(selectedRow).toHaveClass(/selected/);
-
-    // wt-2 ("feature-auth") should NOT be selected
-    const otherRow = page
-      .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
-    await expect(otherRow).toBeVisible();
-    await expect(otherRow).not.toHaveClass(/selected/);
-  },
-);
-
-test(
-  "project collapse and expand toggles worktree rows",
-  async ({ page }) => {
-    await page.addInitScript((d) => {
-      window.__middleman_config = { workspace: d };
-    }, testWorkspaceData);
-    await page.goto("/workspaces");
-
-    const worktreeRow = page.getByText("feature-auth");
-    await expect(worktreeRow).toBeVisible();
-
-    // Collapse by clicking project header
-    const header = page.locator(".project-header").first();
-    await header.click();
-    await expect(worktreeRow).not.toBeVisible();
-
-    // Expand again
-    await header.click();
-    await expect(worktreeRow).toBeVisible();
-  },
-);
-
-test(
-  "Add Repository button emits addRepository command",
-  async ({ page }) => {
-    await injectWithCallback(page, testWorkspaceData);
-    await page.goto("/workspaces");
-
-    const addBtn = page.locator("button.add-repo-btn");
-    await expect(addBtn).toBeVisible();
-    await addBtn.click();
-
-    const command = await getLastCommand(page);
-    expect(command).toBeTruthy();
-    expect(command.cmd).toBe("addRepository");
-    expect(command.payload).toEqual({ hostKey: "local" });
-  },
-);
-
-test(
-  "disconnected host shows retry and emits retryHost",
-  async ({ page }) => {
-    const multiHostData = {
-      ...testWorkspaceData,
-      hosts: [
-        testWorkspaceData.hosts[0],
-        {
-          key: "remote",
-          label: "Build Server",
-          connectionState: "disconnected" as const,
-          projects: [],
-          sessions: [],
-          resources: null,
-        },
-      ],
-    };
-
-    await injectWithCallback(page, multiHostData);
-    await page.goto("/workspaces");
-
-    // Host switcher should be visible with two hosts
-    const remoteBtns = page
-      .locator(".host-btn")
-      .filter({ hasText: "Build Server" });
-    await expect(remoteBtns).toBeVisible();
-
-    // Disconnected host should have a Retry button
-    const retryBtn = remoteBtns.locator(".retry-btn");
-    await expect(retryBtn).toBeVisible();
-    await retryBtn.click();
-
-    const command = await getLastCommand(page);
-    expect(command).toBeTruthy();
-    expect(command.cmd).toBe("retryHost");
-    expect(command.payload).toEqual({ hostKey: "remote" });
-  },
-);
-
-test(
-  "update_selection sets both host and worktree atomically",
-  async ({ page }) => {
-    await page.addInitScript((d) => {
-      window.__middleman_config = { workspace: d };
-    }, testWorkspaceData);
-    await page.goto("/workspaces");
-
-    await page.evaluate(() => {
-      window.__middleman_update_selection?.({
-        hostKey: "local",
-        worktreeKey: "wt-2",
-      });
-    });
-
-    // wt-2 ("feature-auth") should now be selected
-    const selectedRow = page
-      .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
-    await expect(selectedRow).toHaveClass(/selected/);
-  },
-);
-
-test(
-  "update_selection changing host clears worktree",
-  async ({ page }) => {
-    await page.addInitScript((d) => {
-      window.__middleman_config = { workspace: d };
-    }, testWorkspaceData);
-    await page.goto("/workspaces");
-
-    // Verify wt-1 starts selected
-    const mainRow = page
-      .locator(".worktree-row")
-      .filter({ hasText: "main" });
-    await expect(mainRow).toHaveClass(/selected/);
-
-    // Change host without providing worktreeKey
-    await page.evaluate(() => {
-      window.__middleman_update_selection?.({
-        hostKey: "other",
-      });
-    });
-
-    // No worktree should be selected now
-    const selectedRows = page.locator(".worktree-row.selected");
-    await expect(selectedRows).toHaveCount(0);
-  },
-);
-
-test(
-  "update_host_state shows disconnected banner",
-  async ({ page }) => {
-    await page.addInitScript((d) => {
-      window.__middleman_config = { workspace: d };
-    }, testWorkspaceData);
-    await page.goto("/workspaces");
-
-    // Host starts connected — no status banner
-    await expect(
-      page.locator(".single-host-status"),
-    ).toHaveCount(0);
-
-    // Patch host to disconnected
-    await page.evaluate(() => {
-      window.__middleman_update_host_state?.(
-        "local",
-        { connectionState: "disconnected" },
-      );
-    });
-
-    await expect(
-      page.locator(".single-host-status"),
-    ).toBeVisible();
-  },
-);
-
-test(
-  "set_repo_filter bridge sets and clears filter",
-  async ({ page }) => {
-    await page.goto("/pulls");
-
-    await page.evaluate(() => {
-      window.__middleman_set_repo_filter?.({
-        owner: "acme",
-        name: "backend",
-      });
-    });
-
-    const repo = await page.evaluate(() => {
-      return localStorage.getItem("middleman-filter-repo");
-    });
-    expect(repo).toBe("acme/backend");
-
-    await page.evaluate(() => {
-      window.__middleman_set_repo_filter?.(null);
-    });
-
-    const cleared = await page.evaluate(() => {
-      return localStorage.getItem("middleman-filter-repo");
-    });
-    expect(cleared).toBeNull();
-  },
-);
-
-test(
-  "embed.initialRoute navigates on mount",
-  async ({ page }) => {
-    await page.addInitScript(() => {
-      window.__middleman_config = {
-        embed: { initialRoute: "/workspaces" },
-      };
-    });
-
-    await page.goto("/");
-
-    await expect(page).toHaveURL(/\/workspaces/);
-    await expect(
-      page.getByText("No workspace data available"),
-    ).toBeVisible();
-  },
-);
-
-test(
-  "WorkspacesView sidebar-only mode still works",
-  async ({ page }) => {
-    await page.addInitScript((data) => {
-      window.__middleman_config = {
-        workspace: data,
-        onWorkspaceCommand: () => ({ ok: true }),
-        embed: { sidebarWidth: 300 },
-      };
-    }, testWorkspaceData);
-
-    await page.goto("/workspaces");
-
-    await expect(
-      page.locator(".worktree-row"),
-    ).toHaveCount(2);
-    // No resize handle in sidebar-only mode
-    await expect(
-      page.locator(".resize-handle"),
-    ).toHaveCount(0);
-  },
-);
-
-test(
-  "onWorkspaceCommand returning CommandResult works without error",
-  async ({ page }) => {
-    await page.addInitScript((data) => {
-      window.__middleman_config = {
-        workspace: data,
-        onWorkspaceCommand: (
-          cmd: string,
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          payload: Record<string, unknown>,
-        ) => {
-          if (cmd === "selectWorktree") {
-            return { ok: true };
-          }
-          return { ok: false, message: "unknown" };
-        },
-      };
-    }, testWorkspaceData);
-
-    await page.goto("/workspaces");
-
-    const row = page
-      .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
-    await expect(row).toBeVisible();
-    await row.click();
-
-    // Verify no console errors from the command handler
-    const errors: string[] = [];
-    page.on("pageerror", (err) => errors.push(err.message));
-
-    // Click another row to trigger a second command
-    const mainRow = page
-      .locator(".worktree-row")
-      .filter({ hasText: "main" });
-    await mainRow.click();
-
-    expect(errors).toHaveLength(0);
-  },
-);
-
-test(
-  "empty hosts renders without error",
-  async ({ page }) => {
-    const emptyData = {
-      hosts: [],
-      selectedWorktreeKey: null,
-      selectedHostKey: null,
-    };
-    await page.addInitScript((data) => {
-      window.__middleman_config = {
-        workspace: data,
-        onWorkspaceCommand: () => ({ ok: true }),
-      };
-    }, emptyData);
-
-    const errors: string[] = [];
-    page.on("pageerror", (err) => errors.push(err.message));
-
-    await page.goto("/workspaces");
-
-    // Should not crash — renders the sidebar container
-    // with no projects, sessions, or host switcher
-    await expect(
-      page.locator(".workspace-sidebar"),
-    ).toBeVisible();
-    expect(errors).toHaveLength(0);
-  },
-);
-
-test(
-  "hidden worktrees emit commands with parent keys",
-  async ({ page }) => {
-    const dataWithHidden = {
-      ...testWorkspaceData,
-      hosts: [{
-        ...testWorkspaceData.hosts[0],
-        projects: [{
-          ...testWorkspaceData.hosts[0]!.projects[0],
-          worktrees: [
-            ...testWorkspaceData.hosts[0]!.projects[0]!.worktrees,
-            {
-              key: "wt-hidden",
-              name: "hidden-branch",
-              branch: "hidden/branch",
-              isPrimary: false,
-              isHidden: true,
-              isStale: false,
-              sessionBackend: null,
-              linkedPR: null,
-              activity: {
-                state: "idle" as const,
-                lastOutputAt: null,
+              {
+                key: "wt-attention",
+                name: "attention-wt",
+                branch: "attention",
+                isPrimary: false,
+                isHidden: false,
+                isStale: false,
+                sessionBackend: "local",
+                linkedPR: null,
+                activity: {
+                  state: "needsAttention",
+                  lastOutputAt: "2026-04-10T12:00:00Z",
+                },
+                diff: null,
               },
-              diff: null,
-            },
-          ],
-        }],
-      }],
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, activityData);
+  await page.goto("/workspaces");
+
+  const expected: [string, string][] = [
+    ["idle-wt", "var(--text-muted)"],
+    ["active-wt", "var(--accent-green)"],
+    ["running-wt", "var(--accent-blue)"],
+    ["attention-wt", "var(--accent-amber)"],
+  ];
+
+  for (const [name, cssVar] of expected) {
+    const dot = page
+      .locator(".worktree-row")
+      .filter({ hasText: name })
+      .locator(".activity-dot");
+    await expect(dot).toBeVisible();
+    const style = await dot.getAttribute("style");
+    expect(style).toContain(`background: ${cssVar}`);
+  }
+});
+
+test("selected worktree row has .selected class", async ({ page }) => {
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, testWorkspaceData);
+  await page.goto("/workspaces");
+
+  // wt-1 ("main") is selectedWorktreeKey
+  const selectedRow = page.locator(".worktree-row").filter({ hasText: "main" });
+  await expect(selectedRow).toBeVisible();
+  await expect(selectedRow).toHaveClass(/selected/);
+
+  // wt-2 ("feature-auth") should NOT be selected
+  const otherRow = page
+    .locator(".worktree-row")
+    .filter({ hasText: "feature-auth" });
+  await expect(otherRow).toBeVisible();
+  await expect(otherRow).not.toHaveClass(/selected/);
+});
+
+test("project collapse and expand toggles worktree rows", async ({ page }) => {
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, testWorkspaceData);
+  await page.goto("/workspaces");
+
+  const worktreeRow = page.getByText("feature-auth");
+  await expect(worktreeRow).toBeVisible();
+
+  // Collapse by clicking project header
+  const header = page.locator(".project-header").first();
+  await header.click();
+  await expect(worktreeRow).not.toBeVisible();
+
+  // Expand again
+  await header.click();
+  await expect(worktreeRow).toBeVisible();
+});
+
+test("Add Repository button emits addRepository command", async ({ page }) => {
+  await injectWithCallback(page, testWorkspaceData);
+  await page.goto("/workspaces");
+
+  const addBtn = page.locator("button.add-repo-btn");
+  await expect(addBtn).toBeVisible();
+  await addBtn.click();
+
+  const command = await getLastCommand(page);
+  expect(command).toBeTruthy();
+  expect(command.cmd).toBe("addRepository");
+  expect(command.payload).toEqual({ hostKey: "local" });
+});
+
+test("disconnected host shows retry and emits retryHost", async ({ page }) => {
+  const multiHostData: WorkspaceData = {
+    ...testWorkspaceData,
+    hosts: [
+      primaryHost,
+      {
+        key: "remote",
+        label: "Build Server",
+        connectionState: "disconnected" as const,
+        projects: [],
+        sessions: [],
+        resources: null,
+      },
+    ],
+  };
+
+  await injectWithCallback(page, multiHostData);
+  await page.goto("/workspaces");
+
+  // Host switcher should be visible with two hosts
+  const remoteBtns = page
+    .locator(".host-btn")
+    .filter({ hasText: "Build Server" });
+  await expect(remoteBtns).toBeVisible();
+
+  // Disconnected host should have a Retry button
+  const retryBtn = remoteBtns.locator(".retry-btn");
+  await expect(retryBtn).toBeVisible();
+  await retryBtn.click();
+
+  const command = await getLastCommand(page);
+  expect(command).toBeTruthy();
+  expect(command.cmd).toBe("retryHost");
+  expect(command.payload).toEqual({ hostKey: "remote" });
+});
+
+test("update_selection sets both host and worktree atomically", async ({
+  page,
+}) => {
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, testWorkspaceData);
+  await page.goto("/workspaces");
+
+  await page.evaluate(() => {
+    window.__middleman_update_selection?.({
+      hostKey: "local",
+      worktreeKey: "wt-2",
+    });
+  });
+
+  // wt-2 ("feature-auth") should now be selected
+  const selectedRow = page
+    .locator(".worktree-row")
+    .filter({ hasText: "feature-auth" });
+  await expect(selectedRow).toHaveClass(/selected/);
+});
+
+test("update_selection changing host clears worktree", async ({ page }) => {
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, testWorkspaceData);
+  await page.goto("/workspaces");
+
+  // Verify wt-1 starts selected
+  const mainRow = page.locator(".worktree-row").filter({ hasText: "main" });
+  await expect(mainRow).toHaveClass(/selected/);
+
+  // Change host without providing worktreeKey
+  await page.evaluate(() => {
+    window.__middleman_update_selection?.({
+      hostKey: "other",
+    });
+  });
+
+  // No worktree should be selected now
+  const selectedRows = page.locator(".worktree-row.selected");
+  await expect(selectedRows).toHaveCount(0);
+});
+
+test("update_host_state shows disconnected banner", async ({ page }) => {
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, testWorkspaceData);
+  await page.goto("/workspaces");
+
+  // Host starts connected — no status banner
+  await expect(page.locator(".single-host-status")).toHaveCount(0);
+
+  // Patch host to disconnected
+  await page.evaluate(() => {
+    window.__middleman_update_host_state?.("local", {
+      connectionState: "disconnected",
+    });
+  });
+
+  await expect(page.locator(".single-host-status")).toBeVisible();
+});
+
+test("set_repo_filter bridge sets and clears filter", async ({ page }) => {
+  await page.goto("/pulls");
+
+  await page.evaluate(() => {
+    window.__middleman_set_repo_filter?.({
+      owner: "acme",
+      name: "backend",
+    });
+  });
+
+  const repo = await page.evaluate(() => {
+    return localStorage.getItem("middleman-filter-repo");
+  });
+  expect(repo).toBe("acme/backend");
+
+  await page.evaluate(() => {
+    window.__middleman_set_repo_filter?.(null);
+  });
+
+  const cleared = await page.evaluate(() => {
+    return localStorage.getItem("middleman-filter-repo");
+  });
+  expect(cleared).toBeNull();
+});
+
+test("embed.initialRoute navigates on mount", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: { initialRoute: "/workspaces" },
     };
-    await page.addInitScript((data) => {
-      window.__middleman_config = {
-        workspace: data,
-        onWorkspaceCommand: (
-          _cmd: string,
-          payload: Record<string, unknown>,
-        ) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
-          (window as Record<string, any>).__lastPayload =
-            payload;
+  });
+
+  await page.goto("/");
+
+  await expect(page).toHaveURL(/\/workspaces/);
+  await expect(page.getByText("No workspace data available")).toBeVisible();
+});
+
+test("WorkspacesView sidebar-only mode still works", async ({ page }) => {
+  await page.addInitScript((data) => {
+    window.__middleman_config = {
+      workspace: data,
+      onWorkspaceCommand: () => ({ ok: true }),
+      embed: { sidebarWidth: 300 },
+    };
+  }, testWorkspaceData);
+
+  await page.goto("/workspaces");
+
+  await expect(page.locator(".worktree-row")).toHaveCount(2);
+  // No resize handle in sidebar-only mode
+  await expect(page.locator(".resize-handle")).toHaveCount(0);
+});
+
+test("onWorkspaceCommand returning CommandResult works without error", async ({
+  page,
+}) => {
+  await page.addInitScript((data) => {
+    window.__middleman_config = {
+      workspace: data,
+      onWorkspaceCommand: (
+        cmd: string,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        payload: Record<string, unknown>,
+      ) => {
+        if (cmd === "selectWorktree") {
           return { ok: true };
-        },
-      };
-    }, dataWithHidden);
+        }
+        return { ok: false, message: "unknown" };
+      },
+    };
+  }, testWorkspaceData);
 
-    await page.goto("/workspaces");
+  await page.goto("/workspaces");
 
-    // Expand hidden worktrees
-    await page
-      .getByRole("button", { name: /show 1 hidden/i })
-      .click();
+  const row = page.locator(".worktree-row").filter({ hasText: "feature-auth" });
+  await expect(row).toBeVisible();
+  await row.click();
 
-    // Click the hidden worktree row
-    const hiddenRow = page
-      .locator(".worktree-row")
-      .filter({ hasText: "hidden-branch" });
-    await hiddenRow.click();
+  // Verify no console errors from the command handler
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(err.message));
 
-    const payload = await page.evaluate(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
-      () => (window as Record<string, any>).__lastPayload,
-    );
-    expect(payload).toBeTruthy();
-    expect(payload.hostKey).toBe("local");
-    expect(payload.projectKey).toBe("proj-1");
-    expect(payload.worktreeKey).toBe("wt-hidden");
-  },
-);
+  // Click another row to trigger a second command
+  const mainRow = page.locator(".worktree-row").filter({ hasText: "main" });
+  await mainRow.click();
+
+  expect(errors).toHaveLength(0);
+});
+
+test("empty hosts renders without error", async ({ page }) => {
+  const emptyData: WorkspaceData = {
+    hosts: [],
+    selectedWorktreeKey: null,
+    selectedHostKey: null,
+  };
+  await page.addInitScript((data) => {
+    window.__middleman_config = {
+      workspace: data,
+      onWorkspaceCommand: () => ({ ok: true }),
+    };
+  }, emptyData);
+
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(err.message));
+
+  await page.goto("/workspaces");
+
+  // Should not crash — renders the sidebar container
+  // with no projects, sessions, or host switcher
+  await expect(page.locator(".workspace-sidebar")).toBeVisible();
+  expect(errors).toHaveLength(0);
+});
+
+test("hidden worktrees emit commands with parent keys", async ({ page }) => {
+  const dataWithHidden: WorkspaceData = {
+    ...testWorkspaceData,
+    hosts: [
+      {
+        ...primaryHost,
+        projects: [
+          {
+            ...primaryProject,
+            worktrees: [
+              ...primaryProject.worktrees,
+              {
+                key: "wt-hidden",
+                name: "hidden-branch",
+                branch: "hidden/branch",
+                isPrimary: false,
+                isHidden: true,
+                isStale: false,
+                sessionBackend: null,
+                linkedPR: null,
+                activity: {
+                  state: "idle" as const,
+                  lastOutputAt: null,
+                },
+                diff: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  await page.addInitScript((data) => {
+    window.__middleman_config = {
+      workspace: data,
+      onWorkspaceCommand: (_cmd: string, payload: Record<string, unknown>) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+        (window as Record<string, any>).__lastPayload = payload;
+        return { ok: true };
+      },
+    };
+  }, dataWithHidden);
+
+  await page.goto("/workspaces");
+
+  // Expand hidden worktrees
+  await page.getByRole("button", { name: /show 1 hidden/i }).click();
+
+  // Click the hidden worktree row
+  const hiddenRow = page
+    .locator(".worktree-row")
+    .filter({ hasText: "hidden-branch" });
+  await hiddenRow.click();
+
+  const payload = await page.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+    () => (window as Record<string, any>).__lastPayload,
+  );
+  expect(payload).toBeTruthy();
+  expect(payload.hostKey).toBe("local");
+  expect(payload.projectKey).toBe("proj-1");
+  expect(payload.worktreeKey).toBe("wt-hidden");
+});

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -601,7 +601,10 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		    title                = excluded.title,
 		    author               = excluded.author,
 		    author_display_name  = excluded.author_display_name,
-		    state                = excluded.state,
+		    state                = CASE
+		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.state
+		                               ELSE middleman_merge_requests.state
+		                             END,
 		    is_draft             = excluded.is_draft,
 		    body                 = excluded.body,
 		    head_branch          = excluded.head_branch,
@@ -617,10 +620,22 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		    ci_checks_json       = excluded.ci_checks_json,
 		    detail_fetched_at    = COALESCE(middleman_merge_requests.detail_fetched_at, excluded.detail_fetched_at),
 		    ci_had_pending       = middleman_merge_requests.ci_had_pending,
-		    updated_at           = excluded.updated_at,
-		    last_activity_at     = excluded.last_activity_at,
-		    merged_at            = excluded.merged_at,
-		    closed_at            = excluded.closed_at,
+		    updated_at           = CASE
+		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.updated_at
+		                               ELSE middleman_merge_requests.updated_at
+		                             END,
+		    last_activity_at     = CASE
+		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.last_activity_at
+		                               ELSE middleman_merge_requests.last_activity_at
+		                             END,
+		    merged_at            = CASE
+		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.merged_at
+		                               ELSE middleman_merge_requests.merged_at
+		                             END,
+		    closed_at            = CASE
+		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.closed_at
+		                               ELSE middleman_merge_requests.closed_at
+		                             END,
 		    mergeable_state      = excluded.mergeable_state`,
 		mr.RepoID, mr.PlatformID, mr.Number, mr.URL, mr.Title,
 		mr.Author, mr.AuthorDisplayName,
@@ -1210,14 +1225,26 @@ func (d *DB) UpsertIssue(ctx context.Context, issue *Issue) (int64, error) {
 		    url               = excluded.url,
 		    title             = excluded.title,
 		    author            = excluded.author,
-		    state             = excluded.state,
+		    state             = CASE
+		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.state
+		                            ELSE middleman_issues.state
+		                          END,
 		    body              = excluded.body,
 		    comment_count     = excluded.comment_count,
 		    labels_json       = excluded.labels_json,
 		    detail_fetched_at = COALESCE(middleman_issues.detail_fetched_at, excluded.detail_fetched_at),
-		    updated_at        = excluded.updated_at,
-		    last_activity_at  = excluded.last_activity_at,
-		    closed_at         = excluded.closed_at`,
+		    updated_at        = CASE
+		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.updated_at
+		                            ELSE middleman_issues.updated_at
+		                          END,
+		    last_activity_at  = CASE
+		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.last_activity_at
+		                            ELSE middleman_issues.last_activity_at
+		                          END,
+		    closed_at         = CASE
+		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.closed_at
+		                            ELSE middleman_issues.closed_at
+		                          END`,
 		issue.RepoID, issue.PlatformID, issue.Number, issue.URL,
 		issue.Title, issue.Author, issue.State,
 		issue.Body, issue.CommentCount, issue.LabelsJSON,

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -581,7 +581,7 @@ func (d *DB) UpdateRepoSettings(
 // --- Merge Requests ---
 
 // UpsertMergeRequest inserts or updates a merge request, returning its internal ID.
-// On conflict (repo_id, number) all fields except created_at are updated.
+// On conflict (repo_id, number), stale snapshots are ignored wholesale.
 func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, error) {
 	_, err := d.rw.ExecContext(ctx, `
 		INSERT INTO middleman_merge_requests
@@ -601,14 +601,8 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		    title                = excluded.title,
 		    author               = excluded.author,
 		    author_display_name  = excluded.author_display_name,
-		    state                = CASE
-		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.state
-		                               ELSE middleman_merge_requests.state
-		                             END,
-		    is_draft             = CASE
-		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.is_draft
-		                               ELSE middleman_merge_requests.is_draft
-		                             END,
+		    state                = excluded.state,
+		    is_draft             = excluded.is_draft,
 		    body                 = excluded.body,
 		    head_branch          = excluded.head_branch,
 		    base_branch          = excluded.base_branch,
@@ -623,23 +617,12 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		    ci_checks_json       = excluded.ci_checks_json,
 		    detail_fetched_at    = COALESCE(middleman_merge_requests.detail_fetched_at, excluded.detail_fetched_at),
 		    ci_had_pending       = middleman_merge_requests.ci_had_pending,
-		    updated_at           = CASE
-		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.updated_at
-		                               ELSE middleman_merge_requests.updated_at
-		                             END,
-		    last_activity_at     = CASE
-		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.last_activity_at
-		                               ELSE middleman_merge_requests.last_activity_at
-		                             END,
-		    merged_at            = CASE
-		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.merged_at
-		                               ELSE middleman_merge_requests.merged_at
-		                             END,
-		    closed_at            = CASE
-		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.closed_at
-		                               ELSE middleman_merge_requests.closed_at
-		                             END,
-		    mergeable_state      = excluded.mergeable_state`,
+		    updated_at           = excluded.updated_at,
+		    last_activity_at     = excluded.last_activity_at,
+		    merged_at            = excluded.merged_at,
+		    closed_at            = excluded.closed_at,
+		    mergeable_state      = excluded.mergeable_state
+		WHERE excluded.updated_at >= middleman_merge_requests.updated_at`,
 		mr.RepoID, mr.PlatformID, mr.Number, mr.URL, mr.Title,
 		mr.Author, mr.AuthorDisplayName,
 		mr.State, mr.IsDraft, mr.Body, mr.HeadBranch, mr.BaseBranch,
@@ -1216,6 +1199,7 @@ func (d *DB) UpdateMRState(
 // --- Issues ---
 
 // UpsertIssue inserts or updates an issue, returning its internal ID.
+// On conflict (repo_id, number), stale snapshots are ignored wholesale.
 func (d *DB) UpsertIssue(ctx context.Context, issue *Issue) (int64, error) {
 	_, err := d.rw.ExecContext(ctx, `
 		INSERT INTO middleman_issues
@@ -1228,26 +1212,15 @@ func (d *DB) UpsertIssue(ctx context.Context, issue *Issue) (int64, error) {
 		    url               = excluded.url,
 		    title             = excluded.title,
 		    author            = excluded.author,
-		    state             = CASE
-		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.state
-		                            ELSE middleman_issues.state
-		                          END,
+		    state             = excluded.state,
 		    body              = excluded.body,
 		    comment_count     = excluded.comment_count,
 		    labels_json       = excluded.labels_json,
 		    detail_fetched_at = COALESCE(middleman_issues.detail_fetched_at, excluded.detail_fetched_at),
-		    updated_at        = CASE
-		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.updated_at
-		                            ELSE middleman_issues.updated_at
-		                          END,
-		    last_activity_at  = CASE
-		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.last_activity_at
-		                            ELSE middleman_issues.last_activity_at
-		                          END,
-		    closed_at         = CASE
-		                            WHEN excluded.updated_at >= middleman_issues.updated_at THEN excluded.closed_at
-		                            ELSE middleman_issues.closed_at
-		                          END`,
+		    updated_at        = excluded.updated_at,
+		    last_activity_at  = excluded.last_activity_at,
+		    closed_at         = excluded.closed_at
+		WHERE excluded.updated_at >= middleman_issues.updated_at`,
 		issue.RepoID, issue.PlatformID, issue.Number, issue.URL,
 		issue.Title, issue.Author, issue.State,
 		issue.Body, issue.CommentCount, issue.LabelsJSON,

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -605,7 +605,10 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.state
 		                               ELSE middleman_merge_requests.state
 		                             END,
-		    is_draft             = excluded.is_draft,
+		    is_draft             = CASE
+		                               WHEN excluded.updated_at >= middleman_merge_requests.updated_at THEN excluded.is_draft
+		                               ELSE middleman_merge_requests.is_draft
+		                             END,
 		    body                 = excluded.body,
 		    head_branch          = excluded.head_branch,
 		    base_branch          = excluded.base_branch,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1904,6 +1904,180 @@ func TestAPIReopenIssue(t *testing.T) {
 	require.Nil(issue.ClosedAt, "closed_at should be cleared on reopen")
 }
 
+func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	staleUpdatedAt := time.Date(2026, 4, 12, 1, 0, 0, 0, time.UTC)
+	syncStarted := make(chan struct{}, 1)
+	releaseSync := make(chan struct{})
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
+			syncStarted <- struct{}{}
+			<-releaseSync
+
+			id := int64(101)
+			state := "open"
+			title := "stale sync"
+			url := "https://github.com/acme/widget/pull/1"
+			author := "alice"
+			headSHA := "abc123"
+			baseSHA := "def456"
+			featureRef := "feature"
+			mainRef := "main"
+			createdAt := gh.Timestamp{Time: staleUpdatedAt.Add(-time.Hour)}
+			updatedAt := gh.Timestamp{Time: staleUpdatedAt}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+				Head:      &gh.PullRequestBranch{SHA: &headSHA, Ref: &featureRef},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &mainRef},
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	syncDone := make(chan *generated.PostReposByOwnerByNamePullsByNumberSyncResponse, 1)
+	syncErr := make(chan error, 1)
+	go func() {
+		resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
+			context.Background(), "acme", "widget", 1,
+		)
+		if err != nil {
+			syncErr <- err
+			return
+		}
+		syncDone <- resp
+	}()
+
+	<-syncStarted
+
+	resp, err := client.HTTP.SetPrGithubStateWithResponse(
+		context.Background(), "acme", "widget", 1,
+		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+
+	closedPR, err := database.GetMergeRequest(context.Background(), "acme", "widget", 1)
+	require.NoError(err)
+	require.Equal("closed", closedPR.State)
+	require.NotNil(closedPR.ClosedAt)
+
+	close(releaseSync)
+
+	completed := false
+	select {
+	case err := <-syncErr:
+		require.NoError(err)
+		completed = true
+	case resp := <-syncDone:
+		require.Equal(http.StatusOK, resp.StatusCode())
+		completed = true
+	case <-time.After(5 * time.Second):
+	}
+	require.True(completed, "timed out waiting for stale PR sync")
+
+	finalPR, err := database.GetMergeRequest(context.Background(), "acme", "widget", 1)
+	require.NoError(err)
+	assert.Equal("closed", finalPR.State)
+	assert.NotNil(finalPR.ClosedAt)
+	assert.True(finalPR.UpdatedAt.After(staleUpdatedAt))
+}
+
+func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	staleUpdatedAt := time.Date(2026, 4, 12, 1, 0, 0, 0, time.UTC)
+	syncStarted := make(chan struct{}, 1)
+	releaseSync := make(chan struct{})
+	mock := &mockGH{
+		getIssueFn: func(_ context.Context, owner, repo string, number int) (*gh.Issue, error) {
+			syncStarted <- struct{}{}
+			<-releaseSync
+
+			id := int64(202)
+			state := "open"
+			title := "stale issue sync"
+			url := "https://github.com/acme/widget/issues/5"
+			author := "alice"
+			createdAt := gh.Timestamp{Time: staleUpdatedAt.Add(-time.Hour)}
+			updatedAt := gh.Timestamp{Time: staleUpdatedAt}
+			return &gh.Issue{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedIssue(t, database, "acme", "widget", 5, "open")
+	client := setupTestClient(t, srv)
+
+	syncDone := make(chan *generated.PostReposByOwnerByNameIssuesByNumberSyncResponse, 1)
+	syncErr := make(chan error, 1)
+	go func() {
+		resp, err := client.HTTP.PostReposByOwnerByNameIssuesByNumberSyncWithResponse(
+			context.Background(), "acme", "widget", 5,
+		)
+		if err != nil {
+			syncErr <- err
+			return
+		}
+		syncDone <- resp
+	}()
+
+	<-syncStarted
+
+	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
+		context.Background(), "acme", "widget", 5,
+		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+
+	closedIssue, err := database.GetIssue(context.Background(), "acme", "widget", 5)
+	require.NoError(err)
+	require.Equal("closed", closedIssue.State)
+	require.NotNil(closedIssue.ClosedAt)
+
+	close(releaseSync)
+
+	completed := false
+	select {
+	case err := <-syncErr:
+		require.NoError(err)
+		completed = true
+	case resp := <-syncDone:
+		require.Equal(http.StatusOK, resp.StatusCode())
+		completed = true
+	case <-time.After(5 * time.Second):
+	}
+	require.True(completed, "timed out waiting for stale issue sync")
+
+	finalIssue, err := database.GetIssue(context.Background(), "acme", "widget", 5)
+	require.NoError(err)
+	assert.Equal("closed", finalIssue.State)
+	assert.NotNil(finalIssue.ClosedAt)
+	assert.True(finalIssue.UpdatedAt.After(staleUpdatedAt))
+}
+
 func TestAPIListPullsStateFilter(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1991,6 +1991,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 	require.NoError(err)
 	assert.Equal("closed", finalPR.State)
 	assert.NotNil(finalPR.ClosedAt)
+	assert.Equal("Test PR #1", finalPR.Title)
 	assert.True(finalPR.UpdatedAt.After(staleUpdatedAt))
 }
 
@@ -2137,6 +2138,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 	finalPR, err := database.GetMergeRequest(context.Background(), "acme", "widget", 1)
 	require.NoError(err)
 	assert.False(finalPR.IsDraft)
+	assert.Equal("ready for review", finalPR.Title)
 	assert.True(finalPR.UpdatedAt.Equal(readyUpdatedAt))
 }
 
@@ -2221,6 +2223,7 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 	require.NoError(err)
 	assert.Equal("closed", finalIssue.State)
 	assert.NotNil(finalIssue.ClosedAt)
+	assert.Equal("Test Issue", finalIssue.Title)
 	assert.True(finalIssue.UpdatedAt.After(staleUpdatedAt))
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1994,6 +1994,152 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 	assert.True(finalPR.UpdatedAt.After(staleUpdatedAt))
 }
 
+func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	staleUpdatedAt := time.Date(2026, 4, 12, 1, 0, 0, 0, time.UTC)
+	readyUpdatedAt := staleUpdatedAt.Add(30 * time.Minute)
+	syncStarted := make(chan struct{}, 1)
+	releaseSync := make(chan struct{})
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
+			syncStarted <- struct{}{}
+			<-releaseSync
+
+			id := int64(101)
+			state := "open"
+			title := "stale sync"
+			url := "https://github.com/acme/widget/pull/1"
+			author := "alice"
+			draft := true
+			headSHA := "abc123"
+			baseSHA := "def456"
+			featureRef := "feature"
+			mainRef := "main"
+			createdAt := gh.Timestamp{Time: staleUpdatedAt.Add(-time.Hour)}
+			updatedAt := gh.Timestamp{Time: staleUpdatedAt}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				Draft:     &draft,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+				Head:      &gh.PullRequestBranch{SHA: &headSHA, Ref: &featureRef},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &mainRef},
+			}, nil
+		},
+		markReadyForReviewFn: func(_ context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
+			id := int64(101)
+			state := "open"
+			title := "ready for review"
+			url := "https://github.com/acme/widget/pull/1"
+			author := "alice"
+			draft := false
+			headSHA := "abc123"
+			baseSHA := "def456"
+			featureRef := "feature"
+			mainRef := "main"
+			createdAt := gh.Timestamp{Time: staleUpdatedAt.Add(-time.Hour)}
+			updatedAt := gh.Timestamp{Time: readyUpdatedAt}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				Draft:     &draft,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+				Head:      &gh.PullRequestBranch{SHA: &headSHA, Ref: &featureRef},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &mainRef},
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	client := setupTestClient(t, srv)
+
+	repoID, err := database.UpsertRepo(context.Background(), "github.com", "acme", "widget")
+	require.NoError(err)
+
+	prID, err := database.UpsertMergeRequest(context.Background(), &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      101,
+		Number:          1,
+		URL:             "https://github.com/acme/widget/pull/1",
+		Title:           "draft PR",
+		Author:          "alice",
+		State:           "open",
+		IsDraft:         true,
+		Body:            "",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123",
+		PlatformBaseSHA: "def456",
+		Additions:       0,
+		Deletions:       0,
+		CommentCount:    0,
+		ReviewDecision:  "",
+		CIStatus:        "",
+		CreatedAt:       staleUpdatedAt.Add(-time.Hour),
+		UpdatedAt:       staleUpdatedAt.Add(-time.Minute),
+		LastActivityAt:  staleUpdatedAt.Add(-time.Minute),
+	})
+	require.NoError(err)
+	require.NoError(database.EnsureKanbanState(context.Background(), prID))
+
+	syncDone := make(chan *generated.PostReposByOwnerByNamePullsByNumberSyncResponse, 1)
+	syncErr := make(chan error, 1)
+	go func() {
+		resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
+			context.Background(), "acme", "widget", 1,
+		)
+		if err != nil {
+			syncErr <- err
+			return
+		}
+		syncDone <- resp
+	}()
+
+	<-syncStarted
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+
+	readyPR, err := database.GetMergeRequest(context.Background(), "acme", "widget", 1)
+	require.NoError(err)
+	require.False(readyPR.IsDraft)
+	assert.True(readyPR.UpdatedAt.Equal(readyUpdatedAt))
+
+	close(releaseSync)
+
+	completed := false
+	select {
+	case err := <-syncErr:
+		require.NoError(err)
+		completed = true
+	case resp := <-syncDone:
+		require.Equal(http.StatusOK, resp.StatusCode())
+		completed = true
+	case <-time.After(5 * time.Second):
+	}
+	require.True(completed, "timed out waiting for stale draft sync")
+
+	finalPR, err := database.GetMergeRequest(context.Background(), "acme", "widget", 1)
+	require.NoError(err)
+	assert.False(finalPR.IsDraft)
+	assert.True(finalPR.UpdatedAt.Equal(readyUpdatedAt))
+}
+
 func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -99,3 +99,81 @@ export interface CommitInfo {
   author_name: string;
   authored_at: string;
 }
+
+export interface WorkspaceHost {
+  key: string;
+  label: string;
+  connectionState:
+    | "connected"
+    | "connecting"
+    | "disconnected"
+    | "error";
+  projects: WorkspaceProject[];
+  sessions: WorkspaceSession[];
+  resources: WorkspaceResources | null;
+}
+
+export interface WorkspaceProject {
+  key: string;
+  name: string;
+  kind: "repository" | "scratch";
+  repoKind: string;
+  defaultBranch: string;
+  platformRepo: string | null;
+  worktrees: WorkspaceWorktree[];
+}
+
+export interface WorkspaceWorktree {
+  key: string;
+  name: string;
+  branch: string;
+  isPrimary: boolean;
+  isHidden: boolean;
+  isStale: boolean;
+  sessionBackend: string | null;
+  linkedPR: WorkspaceLinkedPR | null;
+  activity: WorkspaceActivity;
+  diff: WorkspaceDiff | null;
+}
+
+export interface WorkspaceLinkedPR {
+  number: number;
+  title: string;
+  state: "open" | "closed" | "merged";
+  checksStatus: string | null;
+  updatedAt: string | null;
+}
+
+export interface WorkspaceActivity {
+  state: "idle" | "active" | "running" | "needsAttention";
+  lastOutputAt: string | null;
+}
+
+export interface WorkspaceDiff {
+  added: number;
+  removed: number;
+}
+
+export interface WorkspaceSession {
+  key: string;
+  name: string;
+  worktreeKey: string | null;
+  isHidden: boolean;
+}
+
+export interface WorkspaceResources {
+  cpuPercent: number;
+  residentMB: number;
+}
+
+export interface WorkspaceData {
+  hosts: WorkspaceHost[];
+  selectedWorktreeKey: string | null;
+  selectedHostKey: string | null;
+}
+
+export interface WorkspaceDetailContext {
+  worktree: WorkspaceWorktree | null;
+  project: WorkspaceProject | null;
+  host: WorkspaceHost | null;
+}

--- a/packages/ui/src/components/workspace/ProjectSection.svelte
+++ b/packages/ui/src/components/workspace/ProjectSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { WorkspaceProject } from "../../api/types.js";
   import WorktreeRow from "./WorktreeRow.svelte";
 
   interface Props {

--- a/packages/ui/src/components/workspace/ResourceFooter.svelte
+++ b/packages/ui/src/components/workspace/ResourceFooter.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { WorkspaceResources } from "../../api/types.js";
+
   interface Props {
     resources: WorkspaceResources | null;
   }

--- a/packages/ui/src/components/workspace/SessionSection.svelte
+++ b/packages/ui/src/components/workspace/SessionSection.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { WorkspaceSession } from "../../api/types.js";
+
   interface Props {
     sessions: WorkspaceSession[];
     onCommand: (

--- a/packages/ui/src/components/workspace/WorkspaceSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceSidebar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { WorkspaceData } from "../../api/types.js";
   import ProjectSection from "./ProjectSection.svelte";
   import SessionSection from "./SessionSection.svelte";
   import ResourceFooter from "./ResourceFooter.svelte";

--- a/packages/ui/src/components/workspace/WorktreeRow.svelte
+++ b/packages/ui/src/components/workspace/WorktreeRow.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+  import type {
+    WorkspaceActivity,
+    WorkspaceLinkedPR,
+    WorkspaceWorktree,
+  } from "../../api/types.js";
+
   interface Props {
     worktree: WorkspaceWorktree;
     hostKey: string;

--- a/packages/ui/src/views/WorkspacesView.svelte
+++ b/packages/ui/src/views/WorkspacesView.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import WorkspaceSidebar from "../components/workspace/WorkspaceSidebar.svelte";
+  import type {
+    WorkspaceData,
+    WorkspaceDetailContext,
+    WorkspaceProject,
+    WorkspaceWorktree,
+  } from "../api/types.js";
   import type { Snippet } from "svelte";
 
   interface Props {


### PR DESCRIPTION
- Stacked on #113
- Stabilize Playwright e2e startup by using a random server port with a server-info handoff
- Clean up e2e server metadata on shutdown and tighten ignore rules for local binaries
- Preserve fixture PR SHAs across background syncs so git-backed diff tests stay non-stale