### PR TITLE
Add workspaces tab with embed workspace API

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,6 +8,7 @@
     KanbanBoardView,
     ReviewsView,
     FocusListView,
+    WorkspacesView,
   } from "@middleman/ui";
   import type { StoreInstances } from "@middleman/ui";
   import type { ActivityItem } from "@middleman/ui/api/types";
@@ -58,6 +59,13 @@
     getIssueActions,
     getActiveWorktreeKey,
     invokeAction,
+    getWorkspaceData,
+    emitWorkspaceCommand,
+    initWorkspaceBridge,
+    isHeaderHidden,
+    getInitialRoute,
+    getSidebarWidth,
+    emitLayoutChanged,
   } from "./lib/stores/embed-config.svelte.js";
   import { getSettings } from "./lib/api/settings.js";
 
@@ -67,6 +75,11 @@
   onMount(() => {
     initTheme();
     initSidebar();
+    initWorkspaceBridge();
+    const initialRoute = getInitialRoute();
+    if (initialRoute) {
+      replaceUrl(initialRoute);
+    }
     const ui = getUIConfig();
     applyConfigRepo(ui.repo, ui.hideRepoSelector);
     const appEl = document.getElementById("app")!;
@@ -284,6 +297,7 @@
     const page = getPage();
     if (page === "settings") return;
     if (page === "reviews") return;
+    if (page === "workspaces") return;
 
     if (page === "activity") {
       if (
@@ -458,7 +472,9 @@
       </main>
     {/if}
   {:else}
-    <AppHeader />
+    {#if !isHeaderHidden()}
+      <AppHeader />
+    {/if}
     <FlashBanner />
 
     <main class="app-main">
@@ -526,6 +542,16 @@
         {:else}
           <ReviewsView />
         {/if}
+      {:else if getPage() === "workspaces"}
+        <WorkspacesView
+          workspaceData={getWorkspaceData()}
+          onCommand={emitWorkspaceCommand}
+          sidebarWidth={getSidebarWidth()}
+          onSidebarResize={(width) => emitLayoutChanged({
+            sidebar: { width },
+            pinnedPanel: { width: 0, visible: false },
+          })}
+        />
       {/if}
     </main>
 

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -3,7 +3,7 @@
   import { getPage, getView, navigate } from "../../stores/router.svelte.ts";
   import RepoTypeahead from "../RepoTypeahead.svelte";
   import { getGlobalRepo, setGlobalRepo } from "../../stores/filter.svelte.js";
-  import { isEmbedded, getUIConfig } from "../../stores/embed-config.svelte.js";
+  import { isEmbedded, getUIConfig, getWorkspaceData } from "../../stores/embed-config.svelte.js";
   import { isNarrow } from "../../stores/container.svelte.js";
   import {
     isDark, toggleTheme, isThemeToggleVisible,
@@ -72,7 +72,9 @@
         <option value="issues">Issues</option>
         <option value="board">Board</option>
         <option value="reviews">Reviews</option>
-        <option value="workspaces">Workspaces</option>
+        {#if getWorkspaceData()}
+          <option value="workspaces">Workspaces</option>
+        {/if}
         {#if !isEmbedded() && getPage() === "settings"}
           <option value="settings">Settings</option>
         {/if}
@@ -99,11 +101,13 @@
             <span class="daemon-indicator" title="Daemon unavailable"></span>
           {/if}
         </button>
-        <button
-          class="view-tab"
-          class:active={getPage() === "workspaces"}
-          onclick={() => navigate("/workspaces")}
-        >Workspaces</button>
+        {#if getWorkspaceData()}
+          <button
+            class="view-tab"
+            class:active={getPage() === "workspaces"}
+            onclick={() => navigate("/workspaces")}
+          >Workspaces</button>
+        {/if}
       </div>
     {/if}
   </nav>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -63,6 +63,7 @@
           else if (v === "issues") navigate("/issues");
           else if (v === "board") navigate("/pulls/board");
           else if (v === "reviews") navigate("/reviews");
+          else if (v === "workspaces") navigate("/workspaces");
           else if (v === "settings") navigate("/settings");
         }}
       >
@@ -71,6 +72,7 @@
         <option value="issues">Issues</option>
         <option value="board">Board</option>
         <option value="reviews">Reviews</option>
+        <option value="workspaces">Workspaces</option>
         {#if !isEmbedded() && getPage() === "settings"}
           <option value="settings">Settings</option>
         {/if}
@@ -97,6 +99,11 @@
             <span class="daemon-indicator" title="Daemon unavailable"></span>
           {/if}
         </button>
+        <button
+          class="view-tab"
+          class:active={getPage() === "workspaces"}
+          onclick={() => navigate("/workspaces")}
+        >Workspaces</button>
       </div>
     {/if}
   </nav>

--- a/frontend/src/lib/stores/embed-config.svelte.ts
+++ b/frontend/src/lib/stores/embed-config.svelte.ts
@@ -1,3 +1,14 @@
+import { setGlobalRepo } from "../stores/filter.svelte.js";
+
+// Bridge: repo filter (module-scope, not workspace-specific)
+window.__middleman_set_repo_filter = (
+  repo: { owner: string; name: string } | null,
+) => {
+  setGlobalRepo(
+    repo ? `${repo.owner}/${repo.name}` : undefined,
+  );
+};
+
 export interface ActionHook {
   id: string;
   label: string;
@@ -43,6 +54,10 @@ window.__middleman_notify_config_changed = () => {
 
 export function isEmbedded(): boolean {
   return readConfig() !== undefined;
+}
+
+export function isHeaderHidden(): boolean {
+  return readConfig()?.embed?.hideHeader === true;
 }
 
 export function getThemeMode():
@@ -118,4 +133,125 @@ export function invokeAction(
   } catch (err) {
     console.error("Embedding action error:", err);
   }
+}
+
+export function getInitialRoute(): string | undefined {
+  return readConfig()?.embed?.initialRoute;
+}
+
+export function getSidebarWidth(): number | undefined {
+  return readConfig()?.embed?.sidebarWidth;
+}
+
+export function getOnLayoutChanged():
+  MiddlemanConfig["onLayoutChanged"] | undefined {
+  return readConfig()?.onLayoutChanged;
+}
+
+let layoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+export function emitLayoutChanged(layout: {
+  sidebar: { width: number };
+  pinnedPanel: { width: number; visible: boolean };
+}): void {
+  clearTimeout(layoutTimer);
+  layoutTimer = setTimeout(() => {
+    const handler = getOnLayoutChanged();
+    if (handler) {
+      try {
+        handler(layout);
+      } catch (e) {
+        console.error("[middleman] onLayoutChanged error:", e);
+      }
+    }
+  }, 150);
+}
+
+export function getWorkspaceData():
+  WorkspaceData | undefined {
+  return readConfig()?.workspace;
+}
+
+export function getOnWorkspaceCommand():
+  WorkspaceCommandHandler | undefined {
+  return readConfig()?.onWorkspaceCommand;
+}
+
+export async function emitWorkspaceCommand(
+  command: string,
+  payload: Record<string, unknown>,
+): Promise<CommandResult> {
+  const handler = getOnWorkspaceCommand();
+  if (!handler) {
+    return { ok: true };
+  }
+  try {
+    const result = await handler(command, payload);
+    if (result && typeof result === "object" && "ok" in result) {
+      return result;
+    }
+    return { ok: true };
+  } catch (e) {
+    const message =
+      e instanceof Error ? e.message : String(e);
+    console.error(
+      `[middleman] workspace command "${command}" failed:`,
+      e,
+    );
+    return { ok: false, message };
+  }
+}
+
+export function initWorkspaceBridge(): void {
+  window.__middleman_update_workspace = (
+    data: WorkspaceData,
+  ) => {
+    const config = window.__middleman_config;
+    if (config) {
+      config.workspace = data;
+      window.__middleman_notify_config_changed?.();
+    }
+  };
+  window.__middleman_update_selection = (
+    selection: {
+      hostKey?: string | null;
+      worktreeKey?: string | null;
+    },
+  ) => {
+    const config = window.__middleman_config;
+    if (!config?.workspace) return;
+    const changingHost =
+      "hostKey" in selection &&
+      selection.hostKey !== config.workspace.selectedHostKey;
+    if ("hostKey" in selection) {
+      config.workspace.selectedHostKey = selection.hostKey ?? null;
+    }
+    if ("worktreeKey" in selection) {
+      config.workspace.selectedWorktreeKey =
+        selection.worktreeKey ?? null;
+    } else if (changingHost) {
+      config.workspace.selectedWorktreeKey = null;
+    }
+    window.__middleman_notify_config_changed?.();
+  };
+  window.__middleman_update_host_state = (
+    hostKey: string,
+    patch: {
+      connectionState?: WorkspaceHost["connectionState"];
+      resources?: WorkspaceResources | null;
+    },
+  ) => {
+    const config = window.__middleman_config;
+    const host = config?.workspace?.hosts.find(
+      (h) => h.key === hostKey,
+    );
+    if (!host) return;
+    if ("connectionState" in patch) {
+      host.connectionState = patch.connectionState!;
+    }
+    if ("resources" in patch) {
+      host.resources = patch.resources ?? null;
+    }
+    window.__middleman_notify_config_changed?.();
+  };
 }

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -1,5 +1,6 @@
 export type Route =
   | { page: "activity" }
+  | { page: "workspaces" }
   | { page: "pulls"; view: "list" | "board"; selected?: { owner: string; name: string; number: number } }
   | { page: "pulls"; view: "diff"; owner: string; name: string; number: number }
   | { page: "issues"; selected?: { owner: string; name: string; number: number } }
@@ -121,6 +122,9 @@ function parseRoute(fullPath: string): Route {
     }
     return { page: "reviews" };
   }
+  if (path === "/workspaces" || path.startsWith("/workspaces/")) {
+    return { page: "workspaces" };
+  }
   return { page: "activity" };
 }
 
@@ -139,7 +143,7 @@ export function getRoute(): Route {
 }
 
 export function getPage():
-  "activity" | "pulls" | "issues" | "settings" | "focus" | "reviews" {
+  "activity" | "pulls" | "issues" | "settings" | "focus" | "reviews" | "workspaces" {
   return route.page;
 }
 
@@ -186,6 +190,8 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
     navType = "issue";
   } else if (r.page === "reviews") {
     navType = "reviews";
+  } else if (r.page === "workspaces") {
+    navType = "workspaces";
   } else {
     navType = r.page as "activity";
   }
@@ -259,6 +265,13 @@ if (typeof window !== "undefined") {
     );
     fireRouteChange(route);
   });
+}
+
+// Expose imperative navigation for the host embedder.
+if (typeof window !== "undefined") {
+  window.__middleman_navigate_to_route = (route: string) => {
+    navigate(route);
+  };
 }
 
 // --- detail tab derived from route ---

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -51,6 +51,17 @@ interface MiddlemanConfig {
     pullRequest?: ActionHookDef[];
     issue?: ActionHookDef[];
   };
+  workspace?: WorkspaceData;
+  onWorkspaceCommand?: WorkspaceCommandHandler;
+  embed?: {
+    hideHeader?: boolean;
+    initialRoute?: string;
+    sidebarWidth?: number;
+  };
+  onLayoutChanged?: (layout: {
+    sidebar: { width: number };
+    pinnedPanel: { width: number; visible: boolean };
+  }) => void;
   onNavigate?: (event: MiddlemanNavigateEvent) => void;
   onRouteChange?: (event: MiddlemanNavigateEvent) => void;
 }
@@ -67,8 +78,98 @@ interface ActionHookDef {
   }) => void | Promise<void>;
 }
 
+interface WorkspaceHost {
+  key: string;
+  label: string;
+  connectionState:
+    | "connected"
+    | "connecting"
+    | "disconnected"
+    | "error";
+  projects: WorkspaceProject[];
+  sessions: WorkspaceSession[];
+  resources: WorkspaceResources | null;
+}
+
+interface WorkspaceProject {
+  key: string;
+  name: string;
+  kind: "repository" | "scratch";
+  repoKind: string;
+  defaultBranch: string;
+  platformRepo: string | null;
+  worktrees: WorkspaceWorktree[];
+}
+
+interface WorkspaceWorktree {
+  key: string;
+  name: string;
+  branch: string;
+  isPrimary: boolean;
+  isHidden: boolean;
+  isStale: boolean;
+  sessionBackend: string | null;
+  linkedPR: WorkspaceLinkedPR | null;
+  activity: WorkspaceActivity;
+  diff: WorkspaceDiff | null;
+}
+
+interface WorkspaceLinkedPR {
+  number: number;
+  title: string;
+  state: "open" | "closed" | "merged";
+  checksStatus: string | null;
+  updatedAt: string | null;
+}
+
+interface WorkspaceActivity {
+  state: "idle" | "active" | "running" | "needsAttention";
+  lastOutputAt: string | null;
+}
+
+interface WorkspaceDiff {
+  added: number;
+  removed: number;
+}
+
+interface WorkspaceSession {
+  key: string;
+  name: string;
+  worktreeKey: string | null;
+  isHidden: boolean;
+}
+
+interface WorkspaceResources {
+  cpuPercent: number;
+  residentMB: number;
+}
+
+interface WorkspaceData {
+  hosts: WorkspaceHost[];
+  selectedWorktreeKey: string | null;
+  selectedHostKey: string | null;
+}
+
+interface CommandResult {
+  ok: boolean;
+  message?: string;
+}
+
+interface WorkspaceCommandHandler {
+  (
+    command: string,
+    payload: Record<string, unknown>,
+  ): CommandResult | Promise<CommandResult>;
+}
+
+interface WorkspaceDetailContext {
+  worktree: WorkspaceWorktree | null;
+  project: WorkspaceProject | null;
+  host: WorkspaceHost | null;
+}
+
 interface MiddlemanNavigateEvent {
-  type: "pull" | "issue" | "activity" | "board" | "reviews";
+  type: "pull" | "issue" | "activity" | "board" | "reviews" | "workspaces";
   owner?: string;
   name?: string;
   number?: number;
@@ -82,5 +183,22 @@ interface Window {
   __BASE_PATH__?: string;
   __middleman_config?: MiddlemanConfig;
   __middleman_notify_config_changed?: () => void;
-
+  __middleman_update_workspace?: (data: WorkspaceData) => void;
+  __middleman_navigate_to_route?: (route: string) => void;
+  __middleman_set_repo_filter?: (
+    repo: { owner: string; name: string } | null,
+  ) => void;
+  __middleman_update_selection?: (
+    selection: {
+      hostKey?: string | null;
+      worktreeKey?: string | null;
+    },
+  ) => void;
+  __middleman_update_host_state?: (
+    hostKey: string,
+    patch: {
+      connectionState?: WorkspaceHost["connectionState"];
+      resources?: WorkspaceResources | null;
+    },
+  ) => void;
 }

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -1,0 +1,786 @@
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+const testWorkspaceData = {
+  hosts: [{
+    key: "local",
+    label: "Local",
+    connectionState: "connected",
+    projects: [{
+      key: "proj-1",
+      name: "test-project",
+      kind: "repository",
+      repoKind: "STANDARD",
+      defaultBranch: "main",
+      platformRepo: "acme/test-project",
+      worktrees: [
+        {
+          key: "wt-1",
+          name: "main",
+          branch: "main",
+          isPrimary: true,
+          isHidden: false,
+          isStale: false,
+          sessionBackend: "local",
+          linkedPR: null,
+          activity: { state: "idle", lastOutputAt: null },
+          diff: null,
+        },
+        {
+          key: "wt-2",
+          name: "feature-auth",
+          branch: "feature/auth",
+          isPrimary: false,
+          isHidden: false,
+          isStale: false,
+          sessionBackend: "local",
+          linkedPR: {
+            number: 42,
+            title: "Add auth middleware",
+            state: "open",
+            checksStatus: "success",
+            updatedAt: "2026-04-10T12:00:00Z",
+          },
+          activity: {
+            state: "active",
+            lastOutputAt: "2026-04-10T12:00:00Z",
+          },
+          diff: { added: 45, removed: 12 },
+        },
+      ],
+    }],
+    sessions: [],
+    resources: null,
+  }],
+  selectedWorktreeKey: "wt-1",
+  selectedHostKey: "local",
+};
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("workspaces route renders empty state", async ({ page }) => {
+  await page.goto("/workspaces");
+  await expect(
+    page.getByText("No workspace data available"),
+  ).toBeVisible();
+});
+
+test("AppHeader shows Workspaces tab", async ({ page }) => {
+  await page.goto("/pulls");
+  await expect(
+    page.getByRole("button", { name: "Workspaces" }),
+  ).toBeVisible();
+});
+
+test(
+  "Workspaces tab navigates to /workspaces",
+  async ({ page }) => {
+    await page.goto("/pulls");
+    await page
+      .getByRole("button", { name: "Workspaces" })
+      .click();
+    await expect(page).toHaveURL(/\/workspaces/);
+  },
+);
+
+test(
+  "hideHeader suppresses AppHeader",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { hideHeader: true },
+      };
+    });
+    await page.goto("/workspaces");
+    await expect(page.locator("header.app-header")).toHaveCount(0);
+  },
+);
+
+test(
+  "workspace data injection renders sidebar",
+  async ({ page }) => {
+    const data = testWorkspaceData;
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, data);
+    await page.goto("/workspaces");
+    await expect(
+      page.locator(".project-name", { hasText: "test-project" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("feature-auth"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "bridge update method renders workspace data",
+  async ({ page }) => {
+    // Start with embedded config but no workspace data
+    await page.addInitScript(() => {
+      window.__middleman_config = {};
+    });
+    await page.goto("/workspaces");
+    await expect(
+      page.getByText("No workspace data available"),
+    ).toBeVisible();
+
+    const data = testWorkspaceData;
+    await page.evaluate((d) => {
+      window.__middleman_update_workspace?.(d as WorkspaceData);
+    }, data);
+
+    await expect(
+      page.locator(".project-name", { hasText: "test-project" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("feature-auth"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "clicking PR badge emits pinLinkedPR command",
+  async ({ page }) => {
+    await page.addInitScript((data) => {
+      window.__middleman_config = {
+        workspace: data,
+        onWorkspaceCommand: (
+          cmd: string,
+          payload: Record<string, unknown>,
+        ) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
+          (window as Record<string, any>).__last_workspace_command = {
+            cmd,
+            payload,
+          };
+          return { ok: true };
+        },
+      };
+    }, testWorkspaceData);
+
+    await page.goto("/workspaces");
+
+    const prBadge = page.locator("button.pr-badge").first();
+    await expect(prBadge).toBeVisible();
+    await prBadge.click();
+
+    const command = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
+      () => (window as Record<string, any>).__last_workspace_command,
+    );
+    expect(command).toBeTruthy();
+    expect(command.cmd).toBe("pinLinkedPR");
+    expect(command.payload.hostKey).toBe("local");
+    expect(command.payload.projectKey).toBe("proj-1");
+    expect(command.payload.worktreeKey).toBe("wt-2");
+    expect(command.payload.prNumber).toBe(42);
+  },
+);
+
+test(
+  "navigateToRoute bridge method works",
+  async ({ page }) => {
+    await page.goto("/pulls");
+    await page.evaluate(() => {
+      window.__middleman_navigate_to_route?.("/workspaces");
+    });
+    await expect(page).toHaveURL(/\/workspaces/);
+  },
+);
+
+// --- New sidebar interaction tests ---
+
+/**
+ * Helper: inject workspace data with onWorkspaceCommand callback
+ * that records the last emitted command on window.__last_workspace_command.
+ */
+async function injectWithCallback(
+  page: import("@playwright/test").Page,
+  data: typeof testWorkspaceData,
+): Promise<void> {
+  await page.addInitScript((d) => {
+    window.__middleman_config = {
+      workspace: d,
+      onWorkspaceCommand: (
+        cmd: string,
+        payload: Record<string, unknown>,
+      ) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
+        (window as Record<string, any>).__last_workspace_command = {
+          cmd,
+          payload,
+        };
+        return { ok: true };
+      },
+    };
+  }, data);
+}
+
+async function getLastCommand(
+  page: import("@playwright/test").Page,
+): Promise<{ cmd: string; payload: Record<string, unknown> }> {
+  return page.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
+    () => (window as Record<string, any>).__last_workspace_command,
+  );
+}
+
+test(
+  "clicking worktree row emits selectWorktree",
+  async ({ page }) => {
+    await injectWithCallback(page, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    const row = page
+      .locator(".worktree-row")
+      .filter({ hasText: "feature-auth" });
+    await expect(row).toBeVisible();
+    await row.click();
+
+    const command = await getLastCommand(page);
+    expect(command).toBeTruthy();
+    expect(command.cmd).toBe("selectWorktree");
+    expect(command.payload.worktreeKey).toBe("wt-2");
+    expect(command.payload.hostKey).toBe("local");
+    expect(command.payload.projectKey).toBe("proj-1");
+  },
+);
+
+test(
+  "worktree context menu: deleteWorktree",
+  async ({ page }) => {
+    await injectWithCallback(page, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    const row = page
+      .locator(".worktree-row")
+      .filter({ hasText: "feature-auth" });
+    await expect(row).toBeVisible();
+    await row.click({ button: "right" });
+
+    const menuItem = page.getByText("Delete worktree");
+    await expect(menuItem).toBeVisible();
+    await menuItem.click();
+
+    const command = await getLastCommand(page);
+    expect(command).toBeTruthy();
+    expect(command.cmd).toBe("deleteWorktree");
+    expect(command.payload.hostKey).toBe("local");
+    expect(command.payload.projectKey).toBe("proj-1");
+    expect(command.payload.worktreeKey).toBe("wt-2");
+  },
+);
+
+test(
+  "worktree context menu: setWorktreeHidden",
+  async ({ page }) => {
+    await injectWithCallback(page, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    const row = page
+      .locator(".worktree-row")
+      .filter({ hasText: "feature-auth" });
+    await expect(row).toBeVisible();
+    await row.click({ button: "right" });
+
+    // wt-2 has isHidden: false, so menu shows "Hide worktree"
+    const menuItem = page.getByText("Hide worktree");
+    await expect(menuItem).toBeVisible();
+    await menuItem.click();
+
+    const command = await getLastCommand(page);
+    expect(command).toBeTruthy();
+    expect(command.cmd).toBe("setWorktreeHidden");
+    expect(command.payload.hostKey).toBe("local");
+    expect(command.payload.projectKey).toBe("proj-1");
+    expect(command.payload.worktreeKey).toBe("wt-2");
+    expect(command.payload.hidden).toBe(true);
+  },
+);
+
+test(
+  "activity state dot colors match activity state",
+  async ({ page }) => {
+    const activityData = {
+      ...testWorkspaceData,
+      hosts: [{
+        ...testWorkspaceData.hosts[0],
+        projects: [{
+          ...testWorkspaceData.hosts[0].projects[0],
+          worktrees: [
+            {
+              key: "wt-idle",
+              name: "idle-wt",
+              branch: "idle",
+              isPrimary: false,
+              isHidden: false,
+              isStale: false,
+              sessionBackend: "local",
+              linkedPR: null,
+              activity: { state: "idle", lastOutputAt: null },
+              diff: null,
+            },
+            {
+              key: "wt-active",
+              name: "active-wt",
+              branch: "active",
+              isPrimary: false,
+              isHidden: false,
+              isStale: false,
+              sessionBackend: "local",
+              linkedPR: null,
+              activity: {
+                state: "active",
+                lastOutputAt: "2026-04-10T12:00:00Z",
+              },
+              diff: null,
+            },
+            {
+              key: "wt-running",
+              name: "running-wt",
+              branch: "running",
+              isPrimary: false,
+              isHidden: false,
+              isStale: false,
+              sessionBackend: "local",
+              linkedPR: null,
+              activity: {
+                state: "running",
+                lastOutputAt: "2026-04-10T12:00:00Z",
+              },
+              diff: null,
+            },
+            {
+              key: "wt-attention",
+              name: "attention-wt",
+              branch: "attention",
+              isPrimary: false,
+              isHidden: false,
+              isStale: false,
+              sessionBackend: "local",
+              linkedPR: null,
+              activity: {
+                state: "needsAttention",
+                lastOutputAt: "2026-04-10T12:00:00Z",
+              },
+              diff: null,
+            },
+          ],
+        }],
+      }],
+    };
+
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, activityData);
+    await page.goto("/workspaces");
+
+    const expected: [string, string][] = [
+      ["idle-wt", "var(--text-muted)"],
+      ["active-wt", "var(--accent-green)"],
+      ["running-wt", "var(--accent-blue)"],
+      ["attention-wt", "var(--accent-amber)"],
+    ];
+
+    for (const [name, cssVar] of expected) {
+      const dot = page
+        .locator(".worktree-row")
+        .filter({ hasText: name })
+        .locator(".activity-dot");
+      await expect(dot).toBeVisible();
+      const style = await dot.getAttribute("style");
+      expect(style).toContain(`background: ${cssVar}`);
+    }
+  },
+);
+
+test(
+  "selected worktree row has .selected class",
+  async ({ page }) => {
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    // wt-1 ("main") is selectedWorktreeKey
+    const selectedRow = page
+      .locator(".worktree-row")
+      .filter({ hasText: "main" });
+    await expect(selectedRow).toBeVisible();
+    await expect(selectedRow).toHaveClass(/selected/);
+
+    // wt-2 ("feature-auth") should NOT be selected
+    const otherRow = page
+      .locator(".worktree-row")
+      .filter({ hasText: "feature-auth" });
+    await expect(otherRow).toBeVisible();
+    await expect(otherRow).not.toHaveClass(/selected/);
+  },
+);
+
+test(
+  "project collapse and expand toggles worktree rows",
+  async ({ page }) => {
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    const worktreeRow = page.getByText("feature-auth");
+    await expect(worktreeRow).toBeVisible();
+
+    // Collapse by clicking project header
+    const header = page.locator(".project-header").first();
+    await header.click();
+    await expect(worktreeRow).not.toBeVisible();
+
+    // Expand again
+    await header.click();
+    await expect(worktreeRow).toBeVisible();
+  },
+);
+
+test(
+  "Add Repository button emits addRepository command",
+  async ({ page }) => {
+    await injectWithCallback(page, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    const addBtn = page.locator("button.add-repo-btn");
+    await expect(addBtn).toBeVisible();
+    await addBtn.click();
+
+    const command = await getLastCommand(page);
+    expect(command).toBeTruthy();
+    expect(command.cmd).toBe("addRepository");
+    expect(command.payload).toEqual({ hostKey: "local" });
+  },
+);
+
+test(
+  "disconnected host shows retry and emits retryHost",
+  async ({ page }) => {
+    const multiHostData = {
+      ...testWorkspaceData,
+      hosts: [
+        testWorkspaceData.hosts[0],
+        {
+          key: "remote",
+          label: "Build Server",
+          connectionState: "disconnected" as const,
+          projects: [],
+          sessions: [],
+          resources: null,
+        },
+      ],
+    };
+
+    await injectWithCallback(page, multiHostData);
+    await page.goto("/workspaces");
+
+    // Host switcher should be visible with two hosts
+    const remoteBtns = page
+      .locator(".host-btn")
+      .filter({ hasText: "Build Server" });
+    await expect(remoteBtns).toBeVisible();
+
+    // Disconnected host should have a Retry button
+    const retryBtn = remoteBtns.locator(".retry-btn");
+    await expect(retryBtn).toBeVisible();
+    await retryBtn.click();
+
+    const command = await getLastCommand(page);
+    expect(command).toBeTruthy();
+    expect(command.cmd).toBe("retryHost");
+    expect(command.payload).toEqual({ hostKey: "remote" });
+  },
+);
+
+test(
+  "update_selection sets both host and worktree atomically",
+  async ({ page }) => {
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    await page.evaluate(() => {
+      window.__middleman_update_selection?.({
+        hostKey: "local",
+        worktreeKey: "wt-2",
+      });
+    });
+
+    // wt-2 ("feature-auth") should now be selected
+    const selectedRow = page
+      .locator(".worktree-row")
+      .filter({ hasText: "feature-auth" });
+    await expect(selectedRow).toHaveClass(/selected/);
+  },
+);
+
+test(
+  "update_selection changing host clears worktree",
+  async ({ page }) => {
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    // Verify wt-1 starts selected
+    const mainRow = page
+      .locator(".worktree-row")
+      .filter({ hasText: "main" });
+    await expect(mainRow).toHaveClass(/selected/);
+
+    // Change host without providing worktreeKey
+    await page.evaluate(() => {
+      window.__middleman_update_selection?.({
+        hostKey: "other",
+      });
+    });
+
+    // No worktree should be selected now
+    const selectedRows = page.locator(".worktree-row.selected");
+    await expect(selectedRows).toHaveCount(0);
+  },
+);
+
+test(
+  "update_host_state shows disconnected banner",
+  async ({ page }) => {
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    // Host starts connected — no status banner
+    await expect(
+      page.locator(".single-host-status"),
+    ).toHaveCount(0);
+
+    // Patch host to disconnected
+    await page.evaluate(() => {
+      window.__middleman_update_host_state?.(
+        "local",
+        { connectionState: "disconnected" },
+      );
+    });
+
+    await expect(
+      page.locator(".single-host-status"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "set_repo_filter bridge sets and clears filter",
+  async ({ page }) => {
+    await page.goto("/pulls");
+
+    await page.evaluate(() => {
+      window.__middleman_set_repo_filter?.({
+        owner: "acme",
+        name: "backend",
+      });
+    });
+
+    const repo = await page.evaluate(() => {
+      return localStorage.getItem("middleman-filter-repo");
+    });
+    expect(repo).toBe("acme/backend");
+
+    await page.evaluate(() => {
+      window.__middleman_set_repo_filter?.(null);
+    });
+
+    const cleared = await page.evaluate(() => {
+      return localStorage.getItem("middleman-filter-repo");
+    });
+    expect(cleared).toBeNull();
+  },
+);
+
+test(
+  "embed.initialRoute navigates on mount",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { initialRoute: "/workspaces" },
+      };
+    });
+
+    await page.goto("/");
+
+    await expect(page).toHaveURL(/\/workspaces/);
+    await expect(
+      page.getByText("No workspace data available"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "WorkspacesView sidebar-only mode still works",
+  async ({ page }) => {
+    await page.addInitScript((data) => {
+      window.__middleman_config = {
+        workspace: data,
+        onWorkspaceCommand: () => ({ ok: true }),
+        embed: { sidebarWidth: 300 },
+      };
+    }, testWorkspaceData);
+
+    await page.goto("/workspaces");
+
+    await expect(
+      page.locator(".worktree-row"),
+    ).toHaveCount(2);
+    // No resize handle in sidebar-only mode
+    await expect(
+      page.locator(".resize-handle"),
+    ).toHaveCount(0);
+  },
+);
+
+test(
+  "onWorkspaceCommand returning CommandResult works without error",
+  async ({ page }) => {
+    await page.addInitScript((data) => {
+      window.__middleman_config = {
+        workspace: data,
+        onWorkspaceCommand: (
+          cmd: string,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          payload: Record<string, unknown>,
+        ) => {
+          if (cmd === "selectWorktree") {
+            return { ok: true };
+          }
+          return { ok: false, message: "unknown" };
+        },
+      };
+    }, testWorkspaceData);
+
+    await page.goto("/workspaces");
+
+    const row = page
+      .locator(".worktree-row")
+      .filter({ hasText: "feature-auth" });
+    await expect(row).toBeVisible();
+    await row.click();
+
+    // Verify no console errors from the command handler
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    // Click another row to trigger a second command
+    const mainRow = page
+      .locator(".worktree-row")
+      .filter({ hasText: "main" });
+    await mainRow.click();
+
+    expect(errors).toHaveLength(0);
+  },
+);
+
+test(
+  "empty hosts renders without error",
+  async ({ page }) => {
+    const emptyData = {
+      hosts: [],
+      selectedWorktreeKey: null,
+      selectedHostKey: null,
+    };
+    await page.addInitScript((data) => {
+      window.__middleman_config = {
+        workspace: data,
+        onWorkspaceCommand: () => ({ ok: true }),
+      };
+    }, emptyData);
+
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await page.goto("/workspaces");
+
+    // Should not crash — renders the sidebar container
+    // with no projects, sessions, or host switcher
+    await expect(
+      page.locator(".workspace-sidebar"),
+    ).toBeVisible();
+    expect(errors).toHaveLength(0);
+  },
+);
+
+test(
+  "hidden worktrees emit commands with parent keys",
+  async ({ page }) => {
+    const dataWithHidden = {
+      ...testWorkspaceData,
+      hosts: [{
+        ...testWorkspaceData.hosts[0],
+        projects: [{
+          ...testWorkspaceData.hosts[0]!.projects[0],
+          worktrees: [
+            ...testWorkspaceData.hosts[0]!.projects[0]!.worktrees,
+            {
+              key: "wt-hidden",
+              name: "hidden-branch",
+              branch: "hidden/branch",
+              isPrimary: false,
+              isHidden: true,
+              isStale: false,
+              sessionBackend: null,
+              linkedPR: null,
+              activity: {
+                state: "idle" as const,
+                lastOutputAt: null,
+              },
+              diff: null,
+            },
+          ],
+        }],
+      }],
+    };
+    await page.addInitScript((data) => {
+      window.__middleman_config = {
+        workspace: data,
+        onWorkspaceCommand: (
+          _cmd: string,
+          payload: Record<string, unknown>,
+        ) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+          (window as Record<string, any>).__lastPayload =
+            payload;
+          return { ok: true };
+        },
+      };
+    }, dataWithHidden);
+
+    await page.goto("/workspaces");
+
+    // Expand hidden worktrees
+    await page
+      .getByRole("button", { name: /show 1 hidden/i })
+      .click();
+
+    // Click the hidden worktree row
+    const hiddenRow = page
+      .locator(".worktree-row")
+      .filter({ hasText: "hidden-branch" });
+    await hiddenRow.click();
+
+    const payload = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only
+      () => (window as Record<string, any>).__lastPayload,
+    );
+    expect(payload).toBeTruthy();
+    expect(payload.hostKey).toBe("local");
+    expect(payload.projectKey).toBe("proj-1");
+    expect(payload.worktreeKey).toBe("wt-hidden");
+  },
+);

--- a/packages/ui/src/components/workspace/ProjectSection.svelte
+++ b/packages/ui/src/components/workspace/ProjectSection.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import WorktreeRow from "./WorktreeRow.svelte";
+
+  interface Props {
+    project: WorkspaceProject;
+    hostKey: string;
+    selectedWorktreeKey: string | null;
+    onCommand: (
+      command: string,
+      payload: Record<string, unknown>,
+    ) => void;
+  }
+
+  let {
+    project,
+    hostKey,
+    selectedWorktreeKey,
+    onCommand,
+  }: Props = $props();
+
+  const storageKey = $derived(
+    `middleman-project-${project.key}-collapsed`,
+  );
+
+  let collapsed = $state(false);
+  let showHidden = $state(false);
+  let showMenu = $state(false);
+  let menuX = $state(0);
+  let menuY = $state(0);
+
+  // Hydrate collapse state from localStorage on mount
+  $effect(() => {
+    const key = storageKey;
+    try {
+      collapsed = localStorage.getItem(key) === "true";
+    } catch {
+      // localStorage unavailable
+    }
+  });
+
+  // Persist collapse state
+  function toggleCollapsed(): void {
+    collapsed = !collapsed;
+    try {
+      localStorage.setItem(storageKey, String(collapsed));
+    } catch {
+      // localStorage unavailable
+    }
+  }
+
+  const visibleWorktrees = $derived(
+    project.worktrees.filter((w) => !w.isHidden),
+  );
+  const hiddenWorktrees = $derived(
+    project.worktrees.filter((w) => w.isHidden),
+  );
+  const hasStaleWorktrees = $derived(
+    project.worktrees.some((w) => w.isStale),
+  );
+
+  function handleHeaderContext(e: MouseEvent): void {
+    e.preventDefault();
+    e.stopPropagation();
+    menuX = e.clientX;
+    menuY = e.clientY;
+    showMenu = true;
+  }
+
+  function closeMenu(): void {
+    showMenu = false;
+  }
+
+  function menuAction(
+    command: string,
+    payload: Record<string, unknown> = {},
+  ): void {
+    onCommand(command, {
+      hostKey,
+      projectKey: project.key,
+      ...payload,
+    });
+    closeMenu();
+  }
+</script>
+
+<svelte:window onclick={showMenu ? closeMenu : undefined} oncontextmenu={showMenu ? closeMenu : undefined} />
+
+<section class="project-section">
+  <button
+    class="project-header"
+    onclick={toggleCollapsed}
+    oncontextmenu={handleHeaderContext}
+  >
+    <span class="chevron">{collapsed ? "▶" : "▼"}</span>
+    <span class="project-name">{project.name}</span>
+    {#if project.platformRepo}
+      <span class="platform-repo">{project.platformRepo}</span>
+    {/if}
+    {#if collapsed && hiddenWorktrees.length > 0}
+      <span class="hidden-count">
+        +{hiddenWorktrees.length} hidden
+      </span>
+    {/if}
+  </button>
+
+  {#if !collapsed}
+    <div class="worktree-list">
+      {#each visibleWorktrees as worktree (worktree.key)}
+        <WorktreeRow
+          {worktree}
+          {hostKey}
+          projectKey={project.key}
+          isSelected={worktree.key === selectedWorktreeKey}
+          {onCommand}
+        />
+      {/each}
+
+      {#if hiddenWorktrees.length > 0}
+        <button
+          class="hidden-toggle"
+          onclick={() => (showHidden = !showHidden)}
+        >
+          {showHidden
+            ? "Hide"
+            : `Show ${hiddenWorktrees.length} hidden`}
+        </button>
+      {/if}
+
+      {#if showHidden}
+        {#each hiddenWorktrees as worktree (worktree.key)}
+          <WorktreeRow
+            {worktree}
+            {hostKey}
+            projectKey={project.key}
+            isSelected={worktree.key === selectedWorktreeKey}
+            {onCommand}
+          />
+        {/each}
+      {/if}
+    </div>
+  {/if}
+</section>
+
+{#if showMenu}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="context-menu"
+    style="left: {menuX}px; top: {menuY}px"
+    oncontextmenu={(e) => e.preventDefault()}
+  >
+    <button
+      class="menu-item menu-item--danger"
+      onclick={() => menuAction("removeProject")}
+    >
+      Remove project
+    </button>
+    {#if hasStaleWorktrees}
+      <button
+        class="menu-item menu-item--danger"
+        onclick={() => menuAction("removeAllStaleWorktrees")}
+      >
+        Remove all stale worktrees
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .project-section {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .project-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    height: 32px;
+    padding: 0 10px;
+    text-align: left;
+    background: var(--bg-surface);
+    border: none;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .project-header:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .chevron {
+    font-size: 10px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+    width: 12px;
+  }
+
+  .project-name {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .platform-repo {
+    font-size: 11px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  .hidden-count {
+    margin-left: auto;
+    font-size: 10px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .worktree-list {
+    display: flex;
+    flex-direction: column;
+    padding-left: 8px;
+  }
+
+  .hidden-toggle {
+    display: block;
+    width: 100%;
+    padding: 4px 12px;
+    text-align: left;
+    font-size: 11px;
+    color: var(--text-muted);
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .hidden-toggle:hover {
+    color: var(--text-secondary);
+  }
+
+  .context-menu {
+    position: fixed;
+    z-index: 1000;
+    min-width: 180px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .menu-item {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    text-align: left;
+    font-size: 12px;
+    color: var(--text-primary);
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .menu-item:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .menu-item--danger {
+    color: var(--accent-red);
+  }
+</style>

--- a/packages/ui/src/components/workspace/ResourceFooter.svelte
+++ b/packages/ui/src/components/workspace/ResourceFooter.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  interface Props {
+    resources: WorkspaceResources | null;
+  }
+
+  let { resources }: Props = $props();
+</script>
+
+{#if resources}
+  <footer class="resource-footer">
+    <span class="stat">CPU {resources.cpuPercent}%</span>
+    <span class="stat">Mem {resources.residentMB}MB</span>
+  </footer>
+{/if}
+
+<style>
+  .resource-footer {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 10px;
+    height: 28px;
+    font-size: 11px;
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    border-top: 1px solid var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .stat {
+    white-space: nowrap;
+  }
+</style>

--- a/packages/ui/src/components/workspace/SessionSection.svelte
+++ b/packages/ui/src/components/workspace/SessionSection.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+  interface Props {
+    sessions: WorkspaceSession[];
+    onCommand: (
+      command: string,
+      payload: Record<string, unknown>,
+    ) => void;
+    hostKey: string;
+  }
+
+  let { sessions, onCommand, hostKey }: Props = $props();
+
+  let showHidden = $state(false);
+
+  const visibleSessions = $derived(
+    sessions.filter((s) => !s.isHidden),
+  );
+  const hiddenSessions = $derived(
+    sessions.filter((s) => s.isHidden),
+  );
+  const hasContent = $derived(
+    visibleSessions.length > 0 || hiddenSessions.length > 0,
+  );
+</script>
+
+{#if hasContent}
+  <section class="session-section">
+    <div class="section-header">Sessions</div>
+
+    {#each visibleSessions as session (session.key)}
+      <div
+        class="session-row"
+        role="button"
+        tabindex="0"
+        onclick={() =>
+          onCommand("openSession", {
+            hostKey,
+            sessionKey: session.key,
+          })}
+        onkeydown={(e: KeyboardEvent) => {
+          if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) {
+            onCommand("openSession", {
+              hostKey,
+              sessionKey: session.key,
+            });
+          }
+        }}
+      >
+        <span class="session-name">{session.name}</span>
+        {#if session.worktreeKey === null}
+          <button
+            class="hide-btn"
+            onclick={(e: MouseEvent) => {
+              e.stopPropagation();
+              onCommand("hideSession", {
+                hostKey,
+                sessionKey: session.key,
+              });
+            }}
+            title="Hide session"
+          >
+            &times;
+          </button>
+        {/if}
+      </div>
+    {/each}
+
+    {#if hiddenSessions.length > 0}
+      <button
+        class="hidden-toggle"
+        onclick={() => (showHidden = !showHidden)}
+      >
+        {showHidden
+          ? "Hide hidden sessions"
+          : `Show ${hiddenSessions.length} hidden`}
+      </button>
+    {/if}
+
+    {#if showHidden}
+      {#each hiddenSessions as session (session.key)}
+        <button
+          class="session-row session-row--hidden"
+          onclick={() =>
+            onCommand("openSession", {
+              hostKey,
+              sessionKey: session.key,
+            })}
+        >
+          <span class="session-name">{session.name}</span>
+        </button>
+      {/each}
+      <button
+        class="hidden-toggle"
+        onclick={() =>
+          onCommand("unhideAllSessions", { hostKey })}
+      >
+        Unhide all sessions
+      </button>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .session-section {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .section-header {
+    height: 32px;
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .session-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 32px;
+    padding: 0 12px;
+    text-align: left;
+    background: var(--bg-surface);
+    border: none;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .session-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .session-row--hidden {
+    opacity: 0.55;
+  }
+
+  .session-name {
+    font-size: 13px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .hide-btn {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    color: var(--text-muted);
+    background: none;
+    border: none;
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+
+  .session-row:hover .hide-btn {
+    opacity: 1;
+  }
+
+  .hide-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-inset);
+  }
+
+  .hidden-toggle {
+    display: block;
+    width: 100%;
+    padding: 4px 12px;
+    text-align: left;
+    font-size: 11px;
+    color: var(--text-muted);
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .hidden-toggle:hover {
+    color: var(--text-secondary);
+  }
+</style>

--- a/packages/ui/src/components/workspace/WorkspaceSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceSidebar.svelte
@@ -170,9 +170,11 @@
   </div>
 
   <div class="footer">
-    <button class="add-repo-btn" onclick={addRepository}>
-      Add Repository
-    </button>
+    {#if selectedHost}
+      <button class="add-repo-btn" onclick={addRepository}>
+        Add Repository
+      </button>
+    {/if}
     {#if selectedHost}
       <ResourceFooter
         resources={selectedHost.resources}

--- a/packages/ui/src/components/workspace/WorkspaceSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceSidebar.svelte
@@ -1,0 +1,314 @@
+<script lang="ts">
+  import ProjectSection from "./ProjectSection.svelte";
+  import SessionSection from "./SessionSection.svelte";
+  import ResourceFooter from "./ResourceFooter.svelte";
+
+  interface Props {
+    workspaceData: WorkspaceData;
+    onCommand: (
+      command: string,
+      payload: Record<string, unknown>,
+    ) => void;
+  }
+
+  let { workspaceData, onCommand }: Props = $props();
+
+  const selectedHost = $derived(
+    workspaceData.hosts.find(
+      (h) => h.key === workspaceData.selectedHostKey,
+    ) ?? workspaceData.hosts[0],
+  );
+
+  const repositoryProjects = $derived(
+    selectedHost?.projects.filter(
+      (p) => p.kind === "repository",
+    ) ?? [],
+  );
+
+  const scratchProjects = $derived(
+    selectedHost?.projects.filter(
+      (p) => p.kind === "scratch",
+    ) ?? [],
+  );
+
+  const multipleHosts = $derived(
+    workspaceData.hosts.length > 1,
+  );
+
+  const singleHostDisconnected = $derived(
+    !multipleHosts &&
+      selectedHost != null &&
+      selectedHost.connectionState !== "connected",
+  );
+
+  function selectHost(key: string): void {
+    onCommand("selectHost", { hostKey: key });
+  }
+
+  function retryHost(key: string): void {
+    onCommand("retryHost", { hostKey: key });
+  }
+
+
+  function addRepository(): void {
+    onCommand("addRepository", {
+      hostKey: selectedHost?.key ?? "",
+    });
+  }
+</script>
+
+<div class="workspace-sidebar">
+  {#if multipleHosts}
+    <div class="host-switcher">
+      {#each workspaceData.hosts as host (host.key)}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="host-btn"
+          class:active={host.key === selectedHost?.key}
+          onclick={() => selectHost(host.key)}
+          onkeydown={(e: KeyboardEvent) => {
+            if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) {
+              e.preventDefault();
+              selectHost(host.key);
+            }
+          }}
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="connection-dot"
+            class:connected={
+              host.connectionState === "connected"
+            }
+            class:connecting={
+              host.connectionState === "connecting"
+            }
+            class:disconnected={
+              host.connectionState === "disconnected"
+            }
+            class:error={
+              host.connectionState === "error"
+            }
+          ></span>
+          <span class="host-label">{host.label}</span>
+          {#if host.connectionState === "disconnected" || host.connectionState === "error"}
+            <button
+              class="retry-btn"
+              onclick={(e: MouseEvent) => {
+                e.stopPropagation();
+                retryHost(host.key);
+              }}
+            >
+              Retry
+            </button>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#if singleHostDisconnected && selectedHost}
+    <div class="single-host-status">
+      <span
+        class="connection-dot"
+        class:connecting={
+          selectedHost.connectionState === "connecting"
+        }
+        class:disconnected={
+          selectedHost.connectionState === "disconnected"
+        }
+        class:error={
+          selectedHost.connectionState === "error"
+        }
+      ></span>
+      <span class="status-label">
+        {selectedHost.connectionState === "connecting"
+          ? "Connecting..."
+          : selectedHost.connectionState === "error"
+            ? "Connection error"
+            : "Disconnected"}
+      </span>
+      <button
+        class="retry-btn"
+        onclick={() => retryHost(selectedHost.key)}
+      >
+        Retry
+      </button>
+    </div>
+  {/if}
+
+  <div class="scroll-area">
+    {#if selectedHost}
+      {#each scratchProjects as project (project.key)}
+        <ProjectSection
+          {project}
+          hostKey={selectedHost.key}
+          selectedWorktreeKey={
+            workspaceData.selectedWorktreeKey
+          }
+          {onCommand}
+        />
+      {/each}
+
+      {#each repositoryProjects as project (project.key)}
+        <ProjectSection
+          {project}
+          hostKey={selectedHost.key}
+          selectedWorktreeKey={
+            workspaceData.selectedWorktreeKey
+          }
+          {onCommand}
+        />
+      {/each}
+
+      <SessionSection
+        sessions={selectedHost.sessions}
+        hostKey={selectedHost.key}
+        {onCommand}
+      />
+    {/if}
+  </div>
+
+  <div class="footer">
+    <button class="add-repo-btn" onclick={addRepository}>
+      Add Repository
+    </button>
+    {#if selectedHost}
+      <ResourceFooter
+        resources={selectedHost.resources}
+      />
+    {/if}
+  </div>
+</div>
+
+<style>
+  .workspace-sidebar {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: var(--bg-primary);
+  }
+
+  .host-switcher {
+    display: flex;
+    gap: 4px;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .host-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    height: 28px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
+    transition: background 0.1s;
+    white-space: nowrap;
+  }
+
+  .host-btn:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .host-btn.active {
+    background: var(--accent-blue);
+    color: #fff;
+    border-color: var(--accent-blue);
+  }
+
+  .host-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  .single-host-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .status-label {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .connection-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--text-muted);
+  }
+
+  .connection-dot.connected {
+    background: var(--accent-green);
+  }
+
+  .connection-dot.connecting {
+    background: var(--accent-amber);
+  }
+
+  .connection-dot.disconnected {
+    background: var(--text-muted);
+  }
+
+  .connection-dot.error {
+    background: var(--accent-red);
+  }
+
+  .retry-btn {
+    flex-shrink: 0;
+    padding: 2px 8px;
+    font-size: 11px;
+    color: var(--accent-amber);
+    background: none;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
+  }
+
+  .retry-btn:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--border-muted);
+  }
+
+  .add-repo-btn {
+    display: block;
+    width: 100%;
+    padding: 8px 10px;
+    font-size: 13px;
+    color: var(--text-secondary);
+    text-align: center;
+    background: var(--bg-surface);
+    border: none;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .add-repo-btn:hover {
+    background: var(--bg-surface-hover);
+  }
+</style>

--- a/packages/ui/src/components/workspace/WorktreeRow.svelte
+++ b/packages/ui/src/components/workspace/WorktreeRow.svelte
@@ -1,0 +1,370 @@
+<script lang="ts">
+  interface Props {
+    worktree: WorkspaceWorktree;
+    hostKey: string;
+    projectKey: string;
+    isSelected: boolean;
+    onCommand: (
+      command: string,
+      payload: Record<string, unknown>,
+    ) => void;
+  }
+
+  let {
+    worktree,
+    hostKey,
+    projectKey,
+    isSelected,
+    onCommand,
+  }: Props = $props();
+
+  let showMenu = $state(false);
+  let menuX = $state(0);
+  let menuY = $state(0);
+
+  const activityColors: Record<
+    WorkspaceActivity["state"],
+    string
+  > = {
+    idle: "var(--text-muted)",
+    active: "var(--accent-green)",
+    running: "var(--accent-blue)",
+    needsAttention: "var(--accent-amber)",
+  };
+
+  const prStateColors: Record<
+    WorkspaceLinkedPR["state"],
+    string
+  > = {
+    open: "var(--accent-green)",
+    closed: "var(--accent-red)",
+    merged: "var(--accent-purple)",
+  };
+
+  function handleContextMenu(e: MouseEvent): void {
+    e.preventDefault();
+    e.stopPropagation();
+    menuX = e.clientX;
+    menuY = e.clientY;
+    showMenu = true;
+  }
+
+  function closeMenu(): void {
+    showMenu = false;
+  }
+
+  function menuAction(
+    command: string,
+    payload: Record<string, unknown> = {},
+  ): void {
+    onCommand(command, {
+      hostKey,
+      projectKey,
+      worktreeKey: worktree.key,
+      ...payload,
+    });
+    closeMenu();
+  }
+</script>
+
+<svelte:window onclick={showMenu ? closeMenu : undefined} oncontextmenu={showMenu ? closeMenu : undefined} />
+
+<div
+  class="worktree-row"
+  class:selected={isSelected}
+  class:stale={worktree.isStale}
+  role="button"
+  tabindex="0"
+  onclick={() => onCommand("selectWorktree", {
+    hostKey,
+    projectKey,
+    worktreeKey: worktree.key,
+  })}
+  onkeydown={(e) => { if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) onCommand("selectWorktree", { hostKey, projectKey, worktreeKey: worktree.key }); }}
+  oncontextmenu={handleContextMenu}
+>
+  <span
+    class="activity-dot"
+    style="background: {activityColors[worktree.activity.state]}"
+    title={worktree.activity.state}
+  ></span>
+
+  <span class="content">
+    <span class="name-row">
+      <span class="name">{worktree.name}</span>
+      <span class="branch">{worktree.branch}</span>
+    </span>
+
+    <span class="meta-row">
+      {#if worktree.linkedPR}
+        <button
+          class="pr-badge"
+          style="color: {prStateColors[worktree.linkedPR.state]}"
+          title="Pin PR #{worktree.linkedPR.number}"
+          onclick={(e: MouseEvent) => {
+            e.stopPropagation();
+            onCommand("pinLinkedPR", {
+              hostKey,
+              projectKey,
+              worktreeKey: worktree.key,
+              prNumber: worktree.linkedPR!.number,
+            });
+          }}
+        >
+          #{worktree.linkedPR.number}
+          {#if worktree.linkedPR.checksStatus === "success"}
+            <svg
+              class="checks-icon"
+              width="10"
+              height="10"
+              viewBox="0 0 16 16"
+              fill="var(--accent-green)"
+            >
+              <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/>
+            </svg>
+          {:else if worktree.linkedPR.checksStatus === "failure"}
+            <svg
+              class="checks-icon"
+              width="10"
+              height="10"
+              viewBox="0 0 16 16"
+              fill="var(--accent-red)"
+            >
+              <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/>
+            </svg>
+          {:else if worktree.linkedPR.checksStatus === "pending"}
+            <svg
+              class="checks-icon"
+              width="10"
+              height="10"
+              viewBox="0 0 16 16"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="4"
+                fill="var(--accent-amber)"
+              />
+            </svg>
+          {/if}
+        </button>
+      {/if}
+
+      {#if worktree.diff}
+        <span class="diff-summary">
+          <span class="diff-added">+{worktree.diff.added}</span>
+          <span class="diff-removed">
+            -{worktree.diff.removed}
+          </span>
+        </span>
+      {/if}
+    </span>
+  </span>
+</div>
+
+{#if showMenu}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="context-menu"
+    style="left: {menuX}px; top: {menuY}px"
+    oncontextmenu={(e) => e.preventDefault()}
+  >
+    <button
+      class="menu-item"
+      onclick={() => menuAction("openWorktreeSession")}
+    >
+      Open session
+    </button>
+    {#if worktree.linkedPR}
+      <button
+        class="menu-item"
+        onclick={() => menuAction("pinLinkedPR", {
+          prNumber: worktree.linkedPR?.number,
+        })}
+      >
+        Pin linked PR
+      </button>
+    {/if}
+    <button
+      class="menu-item menu-item--danger"
+      onclick={() => menuAction("deleteWorktree")}
+    >
+      Delete worktree
+    </button>
+    {#if worktree.isStale}
+      <button
+        class="menu-item menu-item--danger"
+        onclick={() => menuAction("removeStaleWorktree")}
+      >
+        Remove stale worktree
+      </button>
+    {/if}
+    <div class="menu-separator"></div>
+    <button
+      class="menu-item"
+      onclick={() => menuAction("setWorktreeHidden", {
+        hidden: !worktree.isHidden,
+      })}
+    >
+      {worktree.isHidden ? "Show" : "Hide"} worktree
+    </button>
+    <button
+      class="menu-item"
+      onclick={() => menuAction("setSessionBackend")}
+    >
+      Set session backend
+    </button>
+  </div>
+{/if}
+
+<style>
+  .worktree-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    height: 38px;
+    padding: 0 12px;
+    text-align: left;
+    background: var(--bg-surface);
+    border: none;
+    border-left: 3px solid transparent;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .worktree-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .worktree-row.selected {
+    background: var(--bg-inset);
+    border-left-color: var(--accent-blue);
+  }
+
+  .worktree-row.stale {
+    opacity: 0.55;
+  }
+
+  .activity-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .name-row {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .branch {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  .meta-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .pr-badge {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 11px;
+    font-weight: 600;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    border-radius: var(--radius-sm, 3px);
+    transition: opacity 0.1s;
+  }
+
+  .pr-badge:hover {
+    opacity: 0.75;
+  }
+
+  .checks-icon {
+    flex-shrink: 0;
+  }
+
+  .diff-summary {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-family: var(--font-mono);
+  }
+
+  .diff-added {
+    color: var(--accent-green);
+  }
+
+  .diff-removed {
+    color: var(--accent-red);
+  }
+
+  .context-menu {
+    position: fixed;
+    z-index: 1000;
+    min-width: 180px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: 4px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .menu-item {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    text-align: left;
+    font-size: 12px;
+    color: var(--text-primary);
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .menu-item:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .menu-item--danger {
+    color: var(--accent-red);
+  }
+
+  .menu-separator {
+    height: 1px;
+    margin: 4px 0;
+    background: var(--border-muted);
+  }
+</style>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -109,3 +109,6 @@ export {
 export {
   default as FocusListView,
 } from "./views/FocusListView.svelte";
+export {
+  default as WorkspacesView,
+} from "./views/WorkspacesView.svelte";

--- a/packages/ui/src/views/WorkspacesView.svelte
+++ b/packages/ui/src/views/WorkspacesView.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import WorkspaceSidebar from "../components/workspace/WorkspaceSidebar.svelte";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    workspaceData: WorkspaceData | undefined;
+    onCommand: (
+      command: string,
+      payload: Record<string, unknown>,
+    ) => void;
+    detailSnippet?: Snippet<[WorkspaceDetailContext]>;
+    sidebarWidth?: number | undefined;
+    onSidebarResize?: (width: number) => void;
+  }
+
+  let {
+    workspaceData,
+    onCommand,
+    detailSnippet,
+    sidebarWidth,
+    onSidebarResize,
+  }: Props = $props();
+
+  let currentWidth = $state(280);
+
+  $effect(() => {
+    if (sidebarWidth != null) {
+      currentWidth = sidebarWidth;
+    }
+  });
+
+  const detailContext: WorkspaceDetailContext = $derived.by(
+    () => {
+      if (!workspaceData) {
+        return { worktree: null, project: null, host: null };
+      }
+      const host =
+        workspaceData.hosts.find(
+          (h) => h.key === workspaceData.selectedHostKey,
+        ) ?? workspaceData.hosts[0] ?? null;
+      let project: WorkspaceProject | null = null;
+      let worktree: WorkspaceWorktree | null = null;
+      if (host && workspaceData.selectedWorktreeKey) {
+        for (const p of host.projects) {
+          const wt = p.worktrees.find(
+            (w) =>
+              w.key === workspaceData.selectedWorktreeKey,
+          );
+          if (wt) {
+            project = p;
+            worktree = wt;
+            break;
+          }
+        }
+      }
+      return { worktree, project, host };
+    },
+  );
+
+  const snippetKey = $derived(
+    (detailContext.host?.key ?? "") +
+      "/" +
+      (detailContext.project?.key ?? "") +
+      "/" +
+      (detailContext.worktree?.key ?? ""),
+  );
+
+  function startResize(e: MouseEvent): void {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = currentWidth;
+
+    function onMove(ev: MouseEvent): void {
+      currentWidth = Math.max(
+        200,
+        Math.min(600, startW + ev.clientX - startX),
+      );
+    }
+
+    function onUp(): void {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      onSidebarResize?.(currentWidth);
+    }
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+</script>
+
+<div class="workspaces-view">
+  {#if workspaceData}
+    <div
+      class="sidebar-pane"
+      style="width: {detailSnippet
+        ? currentWidth + 'px'
+        : '100%'}"
+    >
+      <WorkspaceSidebar {workspaceData} {onCommand} />
+    </div>
+
+    {#if detailSnippet}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="resize-handle"
+        onmousedown={startResize}
+      ></div>
+      <div class="detail-pane">
+        {#key snippetKey}
+          {@render detailSnippet(detailContext)}
+        {/key}
+      </div>
+    {/if}
+  {:else}
+    <div class="workspaces-empty">
+      <p>No workspace data available.</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .workspaces-view {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+    background: var(--bg-primary);
+  }
+
+  .sidebar-pane {
+    flex-shrink: 0;
+    overflow: hidden;
+    display: flex;
+  }
+
+  .resize-handle {
+    width: 4px;
+    cursor: col-resize;
+    background: var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .resize-handle:hover {
+    background: var(--accent-blue);
+  }
+
+  .detail-pane {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    display: flex;
+  }
+
+  .workspaces-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+  }
+</style>


### PR DESCRIPTION
## Summary

- New `/workspaces` route with sidebar UI for host-injected workspace data (hosts, projects, worktrees, sessions, resources)
- Embed bridge for runtime data updates: `update_workspace`, `update_selection` (atomic host+worktree), `update_host_state` (partial patch), `set_repo_filter`, `navigate_to_route`
- `CommandResult` return type on `onWorkspaceCommand` for async command tracking
- `WorkspacesView` supports sidebar-only and sidebar+detail split modes via optional Svelte snippet prop
- `embed.hideHeader`, `embed.initialRoute`, `embed.sidebarWidth`, `onLayoutChanged` config surface
- Workspaces tab only appears when workspace data is injected
- Playwright e2e coverage for all workspace features