### PR TITLE
test: run with -shuffle=on and drop -count=1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,13 @@ jobs:
         run: cd frontend && bun run test:e2e --config playwright-e2e.config.ts --grep "UTC timestamp"
 
       - name: Run tests
-        run: go test ./... -v -count=1
+        run: go test ./... -v -shuffle=on
 
       - name: Run integration tests (git-dependent)
-        run: go test -tags integration ./... -v -count=1
+        run: go test -tags integration ./... -v -shuffle=on
 
       - name: Run tests (race detector)
-        run: go test -race ./... -count=1
+        run: go test -race ./... -shuffle=on
 
   build:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,9 @@ make vet        # go vet
 
 ### Test Guidelines
 
+- Always pass `-shuffle=on` when invoking `go test` directly (e.g. `go test ./internal/db -run TestFoo -shuffle=on`). The `make test` and `make test-short` targets already set it. Shuffled ordering catches hidden test-to-test coupling
+- Do not pass `-count=1` to `go test`. `-count=1` is the default and specifying it wastes tokens and disables the build cache unnecessarily. Omit the flag. If a genuine need to bypass cache arises, confirm with the user first
+- Only pass `-count=N` when `N > 1` (e.g. `-count=10` for flake hunting)
 - Table-driven tests for Go code
 - Use `testify` consistently in Go tests; prefer `require` for setup/preconditions and `assert` for non-blocking checks
 - When a test function has more than 3 assertions, create a local helper with `assert := Assert.New(t)` and use the helper methods for the rest of the checks

--- a/Makefile
+++ b/Makefile
@@ -116,15 +116,15 @@ dev: ensure-embed-dir check-air
 
 # Run tests
 test: ensure-embed-dir
-	go test ./... -v -count=1
+	go test ./... -v -shuffle=on
 
 # Run fast tests only
 test-short: ensure-embed-dir
-	go test ./... -short -count=1
+	go test ./... -short -shuffle=on
 
 # Run integration tests that execute real git commands (excluded from test-short)
 test-integration: ensure-embed-dir
-	go test -tags integration ./... -v -count=1
+	go test -tags integration ./... -v -shuffle=on
 
 # Run full-stack E2E tests (Playwright against real Go server, excludes roborev)
 test-e2e: frontend

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -225,6 +225,13 @@ func setupTestServerWithRepos(
 	t.Cleanup(func() { database.Close() })
 
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, repos, time.Minute, nil, nil)
+	// Drain any TriggerRun goroutines (fired by handlers like
+	// POST /sync) before tests tear down. Registered after the DB
+	// cleanup so LIFO ordering runs Stop first: without this, a
+	// leaked goroutine from one test's handler can call time.Now
+	// concurrently with another test's setTestLocalEDT mutating
+	// time.Local, which the race detector flags under -shuffle=on.
+	t.Cleanup(syncer.Stop)
 	srv := New(
 		database, syncer, nil, "/",
 		nil, ServerOptions{},

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1004,6 +1004,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissing(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 1)
@@ -1046,6 +1047,7 @@ func TestAPIGetPullNoDiffWarningWhenSHAsPresent(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 2)
@@ -1097,6 +1099,7 @@ func TestAPIGetPullEmitsStaleDiffWarning(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 3)
@@ -1150,6 +1153,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnBaseDrift(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 4)
@@ -1206,6 +1210,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnMergedPR(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 5)
@@ -1261,6 +1266,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissingClosed(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 6)
@@ -1310,6 +1316,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnClosedPR(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 7)
@@ -1363,6 +1370,7 @@ func TestAPIGetPullNoDiffWarningOnMergedPRWithBaseDrift(t *testing.T) {
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	seedPR(t, database, "acme", "widget", 8)
@@ -1462,6 +1470,7 @@ func TestAPISyncPRSanitizesDiffFailureWarning(t *testing.T) {
 		map[string]ghclient.Client{"github.com": mock},
 		database, clones, defaultTestRepos, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
 	client := setupTestClient(t, srv)
@@ -1579,6 +1588,7 @@ func TestAPITriggerSyncIgnoresRequestCancellation(t *testing.T) {
 		database, syncer, nil, "/",
 		nil, ServerOptions{},
 	)
+	t.Cleanup(syncer.Stop)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync", nil).WithContext(ctx)
@@ -1635,6 +1645,7 @@ func TestAPIReadyForReview(t *testing.T) {
 		},
 	}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, defaultTestRepos, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
 	srv := New(
 		database, syncer, nil, "/",
 		nil, ServerOptions{},
@@ -2768,6 +2779,7 @@ func TestAPIRateLimits(t *testing.T) {
 		map[string]*ghclient.RateTracker{"github.com": rt},
 		nil,
 	)
+	t.Cleanup(syncer.Stop)
 
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	ts := httptest.NewServer(srv)
@@ -2818,6 +2830,7 @@ func TestAPISyncPRIncrementsRequestCount(t *testing.T) {
 		map[string]*ghclient.RateTracker{"github.com": rt},
 		nil,
 	)
+	t.Cleanup(syncer.Stop)
 
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	ts := httptest.NewServer(srv)
@@ -2878,6 +2891,7 @@ func TestAPIRateLimitsWithBudget(t *testing.T) {
 		map[string]*ghclient.RateTracker{"github.com": rt},
 		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(500)},
 	)
+	t.Cleanup(syncer.Stop)
 
 	// Simulate some budget spend.
 	budgets := syncer.Budgets()
@@ -3085,6 +3099,7 @@ func setupTestServerWithClones(t *testing.T) (
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, repos, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{Clones: clones})
 
 	seedPR(t, database, "acme", "widget", 1)
@@ -3231,6 +3246,7 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "rootrepo", PlatformHost: "github.com"}}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, repos, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{Clones: clones})
 
 	seedPR(t, database, "acme", "rootrepo", 1)

--- a/internal/server/basepath_test.go
+++ b/internal/server/basepath_test.go
@@ -25,6 +25,7 @@ func setupWithBasePath(t *testing.T, basePath string, frontend fs.FS) *Server {
 
 	mock := &mockGH{}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
 	return New(
 		database, syncer, frontend, basePath,
 		nil, ServerOptions{},

--- a/internal/server/embedded_test.go
+++ b/internal/server/embedded_test.go
@@ -29,6 +29,7 @@ func setupEmbeddedServer(
 
 	mock := &mockGH{}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
 	return New(
 		database,
 		syncer,

--- a/internal/server/roborev_proxy_test.go
+++ b/internal/server/roborev_proxy_test.go
@@ -57,6 +57,7 @@ endpoint = %q
 		map[string]ghclient.Client{"github.com": mock},
 		database, nil, nil, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	return NewWithConfig(
 		database, syncer, nil, nil, cfg, cfgPath,
 		ServerOptions{},

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -48,6 +48,7 @@ name = "widget"
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": mock}, database, nil, nil, time.Minute, nil, nil,
 	)
+	t.Cleanup(syncer.Stop)
 	srv := NewWithConfig(
 		database, syncer, nil, nil, cfg, cfgPath,
 		ServerOptions{},
@@ -214,6 +215,7 @@ func TestGetSettingsWithoutPersistence(t *testing.T) {
 	}
 	mock := &mockGH{}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", cfg, ServerOptions{})
 
 	// GET /settings should work (read-only).


### PR DESCRIPTION
## Summary

- Run `go test` with `-shuffle=on` in `make test`/`make test-short` and CI so test-to-test coupling fails the suite instead of hiding behind insertion order
- Drop `-count=1` everywhere; it matches the default and setting it only disables the build cache
- Document both rules in `CLAUDE.md` so agents invoking `go test` directly follow the convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)