### PR TITLE
server: graceful Shutdown for HTTP listener and background goroutines

### DIFF
--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/wesm/middleman/internal/config"
 	"github.com/wesm/middleman/internal/db"
@@ -174,6 +175,21 @@ func run(configPath string) error {
 		database, syncer, cloneMgr, assets,
 		cfg, configPath, server.ServerOptions{},
 	)
+
+	// Drain HTTP-handler-spawned background goroutines (and stop
+	// the HTTP listener) before DB close. LIFO ordering of defers
+	// below runs this after stop()/syncer.Stop and before the
+	// deferred database.Close, so the DB stays open for in-flight
+	// requests and the mergePR post-failure refresh.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 10*time.Second,
+		)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("server shutdown", "err", err)
+		}
+	}()
 
 	// Wire status callback and prime the SSE event hub so clients
 	// can show live sync state without polling.

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -176,21 +176,6 @@ func run(configPath string) error {
 		cfg, configPath, server.ServerOptions{},
 	)
 
-	// Drain HTTP-handler-spawned background goroutines (and stop
-	// the HTTP listener) before DB close. LIFO ordering of defers
-	// below runs this after stop()/syncer.Stop and before the
-	// deferred database.Close, so the DB stays open for in-flight
-	// requests and the mergePR post-failure refresh.
-	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(
-			context.Background(), 10*time.Second,
-		)
-		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			slog.Warn("server shutdown", "err", err)
-		}
-	}()
-
 	// Wire status callback and prime the SSE event hub so clients
 	// can show live sync state without polling.
 	syncer.SetOnStatusChange(func(status *ghclient.SyncStatus) {
@@ -220,6 +205,21 @@ func run(configPath string) error {
 	syncer.Start(ctx)
 	defer syncer.Stop()
 	defer stop()
+
+	// srv.Shutdown MUST be the last-registered defer so LIFO runs
+	// it FIRST on return: close the HTTP listener (and SSE hub)
+	// before syncer.Stop blocks for up to 30 s, otherwise the
+	// process keeps serving requests against a syncer that is
+	// already winding down.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 10*time.Second,
+		)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("server shutdown", "err", err)
+		}
+	}()
 
 	displayVersion := version
 	if version == "dev" && commit != "unknown" {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -241,6 +241,13 @@ func setupTestServerWithRepos(
 		database, syncer, nil, "/",
 		nil, ServerOptions{},
 	)
+	// Registered after the DB cleanup so LIFO ordering runs Shutdown
+	// first and lets background goroutines finish before DB close.
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
 	return srv, database
 }
 
@@ -2412,6 +2419,26 @@ func TestAPIClosePR422AlreadyClosed(t *testing.T) {
 
 	pr, _ := database.GetMergeRequest(context.Background(), "acme", "widget", 1)
 	require.Equal("closed", pr.State)
+}
+
+// When MarkPullRequestReadyForReview returns (nil, nil) the handler
+// must return 502 rather than claiming success with no PR payload.
+func TestAPIReadyForReview502OnNilPR(t *testing.T) {
+	require := require.New(t)
+	mock := &mockGH{
+		markReadyForReviewFn: func(_ context.Context, _, _ string, _ int) (*gh.PullRequest, error) {
+			return nil, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusBadGateway, resp.StatusCode())
 }
 
 func TestAPIClosePR422Merged(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -841,6 +841,11 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 	if err != nil {
 		return nil, huma.Error502BadGateway("GitHub API error")
 	}
+	if pr == nil {
+		// No PR payload means we cannot verify GitHub accepted the
+		// transition, so don't claim success or poison the cache.
+		return nil, huma.Error502BadGateway("GitHub API returned no pull request")
+	}
 
 	repoObj, err := s.db.GetRepoByOwnerName(ctx, input.Owner, input.Name)
 	if err == nil && repoObj != nil {
@@ -884,13 +889,13 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 
 			if ghErr.Response.StatusCode == http.StatusMethodNotAllowed ||
 				ghErr.Response.StatusCode == http.StatusConflict {
-				go func() {
+				s.runBackground(func(bgCtx context.Context) {
 					if syncErr := s.syncer.SyncMR(
-						context.WithoutCancel(ctx), input.Owner, input.Name, input.Number,
+						bgCtx, input.Owner, input.Name, input.Number,
 					); syncErr != nil {
 						slog.Warn("background sync after merge failure", "err", syncErr)
 					}
-				}()
+				})
 				return nil, huma.Error409Conflict(ghErr.Message)
 			}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -116,13 +116,14 @@ func (s *Server) runBackground(fn func(ctx context.Context)) {
 }
 
 // Shutdown stops the HTTP listener (if started via ListenAndServe
-// or Serve), cancels background goroutines' context, and blocks
-// until they finish or ctx expires. Safe to call concurrently and
-// repeatedly. Every caller drives http.Server.Shutdown with its
-// own ctx (stdlib polls idle-conn closure per call) and waits on
-// a shared drain channel, so a retry with a longer deadline
-// observes true drain for both HTTP handlers and the bg group.
-// Only the first caller sets shuttingDown and cancels bgCtx.
+// or Serve), closes the SSE event hub so streaming handlers exit,
+// cancels background goroutines' context, and blocks until they
+// finish or ctx expires. Safe to call concurrently and repeatedly.
+// Every caller drives http.Server.Shutdown with its own ctx
+// (stdlib polls idle-conn closure per call) and waits on a shared
+// drain channel, so a retry with a longer deadline observes true
+// drain for both HTTP handlers and the bg group. Only the first
+// caller closes the hub and cancels bgCtx.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.bgMu.Lock()
 	first := !s.shuttingDown
@@ -133,6 +134,14 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	drainDone := s.drainDone
 	httpSrv := s.httpSrv
 	s.bgMu.Unlock()
+
+	// Close the hub first so handleSSE subscribers can exit on
+	// their <-done select arm. Otherwise http.Server.Shutdown
+	// below would wait on SSE handlers that never return until
+	// client disconnect, hanging the shutdown until ctx expires.
+	if first && s.hub != nil {
+		s.hub.Close()
+	}
 
 	var httpErr error
 	if httpSrv != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -64,6 +67,27 @@ type Server struct {
 	activeWorktreeMu  sync.Mutex
 	activeWorktreeKey string
 	activeWorktreeSet bool
+
+	// bg tracks short-lived goroutines that HTTP handlers spawn
+	// outside of the Syncer's own wait group (e.g. mergePR's
+	// post-failure refresh). Shutdown waits on bg before the
+	// caller tears down the DB.
+	//
+	// bgMu guards shuttingDown, drainDone, and httpSrv, and
+	// serializes bg.Add against Shutdown's bg.Wait so the
+	// WaitGroup cannot observe Add racing with Wait when the
+	// counter transiently hits zero.
+	bgMu         sync.Mutex
+	bg           sync.WaitGroup
+	bgCtx        context.Context
+	bgCancel     context.CancelFunc
+	shuttingDown bool
+	// drainDone is created the first time Shutdown is called and
+	// closed when bg.Wait returns. Every caller waits on it
+	// subject to its own ctx, so a retry with a longer deadline
+	// observes true drain after an earlier caller's ctx expired.
+	drainDone chan struct{}
+	httpSrv   *http.Server
 }
 
 // Hub returns the server's SSE event hub. Callers should never
@@ -72,6 +96,67 @@ func (s *Server) Hub() *EventHub { return s.hub }
 
 // SetVersion sets the version string returned by GET /api/v1/version.
 func (s *Server) SetVersion(v string) { s.version = v }
+
+// runBackground launches fn as a tracked goroutine. fn receives a
+// context cancelled by Shutdown. If Shutdown has already started,
+// runBackground drops the task: these goroutines are best-effort
+// refreshes and starting one during drain would race with bg.Wait.
+func (s *Server) runBackground(fn func(ctx context.Context)) {
+	s.bgMu.Lock()
+	if s.shuttingDown {
+		s.bgMu.Unlock()
+		return
+	}
+	s.bg.Add(1)
+	s.bgMu.Unlock()
+	go func() {
+		defer s.bg.Done()
+		fn(s.bgCtx)
+	}()
+}
+
+// Shutdown stops the HTTP listener (if started via ListenAndServe
+// or Serve), cancels background goroutines' context, and blocks
+// until they finish or ctx expires. Safe to call concurrently and
+// repeatedly. Every caller drives http.Server.Shutdown with its
+// own ctx (stdlib polls idle-conn closure per call) and waits on
+// a shared drain channel, so a retry with a longer deadline
+// observes true drain for both HTTP handlers and the bg group.
+// Only the first caller sets shuttingDown and cancels bgCtx.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.bgMu.Lock()
+	first := !s.shuttingDown
+	if first {
+		s.shuttingDown = true
+		s.drainDone = make(chan struct{})
+	}
+	drainDone := s.drainDone
+	httpSrv := s.httpSrv
+	s.bgMu.Unlock()
+
+	var httpErr error
+	if httpSrv != nil {
+		httpErr = httpSrv.Shutdown(ctx)
+	}
+
+	if first {
+		s.bgCancel()
+		go func() {
+			s.bg.Wait()
+			close(drainDone)
+		}()
+	}
+
+	select {
+	case <-drainDone:
+		return httpErr
+	case <-ctx.Done():
+		if httpErr != nil {
+			return errors.Join(httpErr, ctx.Err())
+		}
+		return ctx.Err()
+	}
+}
 
 // SetActiveWorktreeKey sets the key of the currently
 // focused worktree. Thread-safe.
@@ -137,6 +222,7 @@ func newServer(
 ) *Server {
 	mux := http.NewServeMux()
 
+	bgCtx, bgCancel := context.WithCancel(context.Background())
 	s := &Server{
 		db:       database,
 		basePath: basePath,
@@ -146,6 +232,8 @@ func newServer(
 		cfgPath:  cfgPath,
 		options:  options,
 		hub:      NewEventHub(),
+		bgCtx:    bgCtx,
+		bgCancel: bgCancel,
 	}
 
 	api := humago.NewWithPrefix(mux, "/api/v1", apiConfig(basePath))
@@ -307,10 +395,21 @@ func checkCSRF(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-// ListenAndServe starts the HTTP server on addr.
+// ListenAndServe starts the HTTP server on addr. Returns
+// http.ErrServerClosed when stopped by Shutdown (matches net/http).
 func (s *Server) ListenAndServe(addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	return s.Serve(ln)
+}
+
+// Serve accepts HTTP connections on the provided listener. Useful
+// for tests and any caller that wants to own the listener lifetime.
+// Returns http.ErrServerClosed when stopped by Shutdown.
+func (s *Server) Serve(ln net.Listener) error {
 	srv := &http.Server{
-		Addr:        addr,
 		Handler:     s,
 		ReadTimeout: 15 * time.Second,
 		// WriteTimeout is 0 (disabled) because the roborev
@@ -320,7 +419,17 @@ func (s *Server) ListenAndServe(addr string) error {
 		// after the deadline.
 		IdleTimeout: 60 * time.Second,
 	}
-	return srv.ListenAndServe()
+
+	s.bgMu.Lock()
+	if s.shuttingDown {
+		s.bgMu.Unlock()
+		_ = ln.Close()
+		return http.ErrServerClosed
+	}
+	s.httpSrv = srv
+	s.bgMu.Unlock()
+
+	return srv.Serve(ln)
 }
 
 // handleSSE streams server events to a client. The handler subscribes

--- a/internal/server/shutdown_test.go
+++ b/internal/server/shutdown_test.go
@@ -243,3 +243,55 @@ func TestServerShutdownRetryWaitsForHTTPHandler(t *testing.T) {
 		require.FailNow(t, "Serve did not return after Shutdown")
 	}
 }
+
+// TestServerShutdownClosesSSESubscribers verifies that Shutdown
+// closes the EventHub so `handleSSE` handlers exit on their
+// <-done arm. Without this, http.Server.Shutdown would hang
+// waiting on the never-returning SSE handler until ctx timeout.
+func TestServerShutdownClosesSSESubscribers(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+
+	// Open an SSE connection and pull the first line so we know
+	// the handler is actively streaming.
+	resp, err := http.Get("http://" + addr + "/api/v1/events")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read in a goroutine so we can observe the connection close.
+	readDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		close(readDone)
+	}()
+
+	// Shutdown must complete well within ctx — if the hub is not
+	// closed, http.Server.Shutdown would hang on the SSE handler
+	// until the 2 s deadline.
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, srv.Shutdown(ctx))
+	require.Less(t, time.Since(start), time.Second,
+		"Shutdown took too long; SSE hub likely not closed")
+
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "SSE connection did not close after Shutdown")
+	}
+
+	select {
+	case e := <-serveErr:
+		require.ErrorIs(t, e, http.ErrServerClosed)
+	case <-time.After(time.Second):
+		require.FailNow(t, "Serve did not return after Shutdown")
+	}
+}

--- a/internal/server/shutdown_test.go
+++ b/internal/server/shutdown_test.go
@@ -1,0 +1,245 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestServerShutdownWaitsForBackgroundTask verifies that Shutdown
+// blocks until an in-flight runBackground task returns.
+func TestServerShutdownWaitsForBackgroundTask(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	release := make(chan struct{})
+	var finished atomic.Bool
+	srv.runBackground(func(_ context.Context) {
+		<-release
+		finished.Store(true)
+	})
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		shutdownDone <- srv.Shutdown(ctx)
+	}()
+
+	select {
+	case <-shutdownDone:
+		require.FailNow(t, "Shutdown returned before background task finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-shutdownDone)
+	require.True(t, finished.Load(), "background task should have run to completion")
+}
+
+// TestServerShutdownTimesOut verifies that Shutdown honours the
+// caller's ctx when a background task ignores its own cancellation.
+func TestServerShutdownTimesOut(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	stuck := make(chan struct{})
+	srv.runBackground(func(_ context.Context) {
+		<-stuck
+	})
+	defer close(stuck)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := srv.Shutdown(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestServerShutdownPreventsNewBackgroundTasks verifies that after
+// Shutdown starts, runBackground drops new submissions so bg.Add
+// cannot race with bg.Wait.
+func TestServerShutdownPreventsNewBackgroundTasks(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, srv.Shutdown(ctx))
+
+	var ran atomic.Bool
+	srv.runBackground(func(_ context.Context) {
+		ran.Store(true)
+	})
+
+	time.Sleep(20 * time.Millisecond)
+	require.False(t, ran.Load(), "runBackground must not spawn work after Shutdown")
+}
+
+// TestServerShutdownIsIdempotent verifies that Shutdown can be called
+// more than once without panicking on the internal WaitGroup.
+func TestServerShutdownIsIdempotent(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, srv.Shutdown(ctx))
+	require.NoError(t, srv.Shutdown(ctx))
+}
+
+// TestServerShutdownRaceNoPanic exercises runBackground concurrently
+// with Shutdown to catch WaitGroup Add/Wait races under -race.
+func TestServerShutdownRaceNoPanic(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	done := make(chan struct{})
+	go func() {
+		for range 200 {
+			srv.runBackground(func(_ context.Context) {})
+		}
+		close(done)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, srv.Shutdown(ctx))
+	<-done
+}
+
+// TestServerShutdownStopsHTTPListener verifies that Shutdown closes
+// the HTTP listener passed to Serve and that subsequent requests
+// fail fast.
+func TestServerShutdownStopsHTTPListener(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+
+	listenErrCh := make(chan error, 1)
+	go func() {
+		listenErrCh <- srv.Serve(ln)
+	}()
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get("http://" + addr + "/api/v1/version")
+		if err != nil {
+			return false
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 10*time.Millisecond, "server never accepted requests")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, srv.Shutdown(ctx))
+
+	select {
+	case listenErr := <-listenErrCh:
+		require.ErrorIs(t, listenErr, http.ErrServerClosed)
+	case <-time.After(time.Second):
+		require.FailNow(t, "Serve did not return after Shutdown")
+	}
+
+	_, err = http.Get("http://" + addr + "/api/v1/version")
+	require.Error(t, err)
+}
+
+// TestServerShutdownRetryWithLongerCtx verifies that a second
+// Shutdown call with a longer deadline can still drain background
+// work that the first call timed out waiting for.
+func TestServerShutdownRetryWithLongerCtx(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	release := make(chan struct{})
+	srv.runBackground(func(_ context.Context) {
+		<-release
+	})
+
+	shortCtx, shortCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer shortCancel()
+	err := srv.Shutdown(shortCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	close(release)
+
+	longCtx, longCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer longCancel()
+	require.NoError(t, srv.Shutdown(longCtx))
+}
+
+// TestServerShutdownRetryWaitsForHTTPHandler verifies that when the
+// first Shutdown call times out while an HTTP handler is in flight,
+// a later call with a longer deadline still invokes
+// http.Server.Shutdown and blocks until the handler drains.
+func TestServerShutdownRetryWaitsForHTTPHandler(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	srv.handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(ln)
+	}()
+
+	reqDone := make(chan struct{})
+	go func() {
+		resp, err := http.Get("http://" + addr + "/slow")
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		close(reqDone)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "slow handler never started")
+	}
+
+	shortCtx, shortCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer shortCancel()
+	err = srv.Shutdown(shortCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	longErrCh := make(chan error, 1)
+	go func() {
+		longCtx, longCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer longCancel()
+		longErrCh <- srv.Shutdown(longCtx)
+	}()
+
+	select {
+	case <-longErrCh:
+		require.FailNow(t, "second Shutdown returned before HTTP handler drained")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	<-reqDone
+	require.NoError(t, <-longErrCh)
+
+	select {
+	case e := <-serveErr:
+		require.ErrorIs(t, e, http.ErrServerClosed)
+	case <-time.After(time.Second):
+		require.FailNow(t, "Serve did not return after Shutdown")
+	}
+}


### PR DESCRIPTION
Stacked on #118.

## Summary

- Add `Server.Shutdown(ctx)` that stops the HTTP listener and drains goroutines spawned by `runBackground`. Safe to call concurrently and repeatedly; every caller drives `http.Server.Shutdown` with its own ctx so a retry with a longer deadline can observe full drain.
- Add `runBackground(fn)` guarded by a mutex + `shuttingDown` flag so `bg.Add` cannot race `bg.Wait`.
- Add `Serve(ln net.Listener)` for callers (including tests) that want to own the listener lifetime.
- Convert `mergePR`'s post-failure refresh from `go func() { ... context.WithoutCancel(ctx) ... }()` to `runBackground`, so its DB access is tied to server lifetime.
- `readyForReview` returns 502 when the GitHub client returns `(nil, nil)` instead of claiming success with no PR payload.
- Wire `srv.Shutdown` from `setupTestServerWithRepos` (LIFO drains bg work before DB close) and `cmd/middleman/main.go` (10 s budget before DB close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)