### PR TITLE
docs: avoid running tests with -v

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ make vet        # go vet
 - Use `openTestDB(t)` helper for database tests
 - All tests use `t.TempDir()` for temp directories
 - Tests should be fast and isolated
+- Do not run tests with `-v` (especially `go test`) — default output has enough signal to debug failures, and verbose output wastes tokens. Only use `-v` if the user asks for it or a failure genuinely needs the extra detail
 
 ## Build Requirements
 


### PR DESCRIPTION
Add rule to project CLAUDE.md discouraging `-v` on test runs — default output has enough signal for most failures and verbose output wastes agent tokens.