### PR TITLE
fix: reinstall stack-sync hook on StartSync after StopSync

### DIFF
--- a/middleman.go
+++ b/middleman.go
@@ -183,15 +183,18 @@ type Instance struct {
 	// SetOnSyncCompleted. Separate from cancelSync so ad-hoc syncs via
 	// TriggerRun before StartSync still run detection, and so StopSync
 	// can cancel hook work regardless of how callers parent their ctx.
-	// Read/written only from inside stopOnce.Do in StopSync.
+	// Read/written only from inside cancelHookOnce.Do in StopSync.
 	cancelHook context.CancelFunc
-	// stopOnce ensures the StopSync body runs exactly once even under
-	// concurrent calls from StopSync and Close. Without it, the
-	// cancelHook check/call/reset sequence has a TOCTOU window that
-	// can panic on a nil dereference if two callers race.
-	stopOnce sync.Once
-	stopMu   sync.Mutex
-	closed   bool
+	// cancelHookOnce serializes the cancelHook check/call/reset
+	// sequence in StopSync so concurrent callers cannot race into a
+	// nil-dereference TOCTOU window. It intentionally does NOT cover
+	// i.syncer.Stop(): Syncer.Stop is designed to be called multiple
+	// times and waits up to stopGracePeriod on every call, so a
+	// subsequent Close after a StopSync that hit the grace-period
+	// timeout can still re-wait for lingering sync work.
+	cancelHookOnce sync.Once
+	stopMu         sync.Mutex
+	closed         bool
 }
 
 // New creates a middleman Instance from the given options.
@@ -418,19 +421,25 @@ func (i *Instance) StartSync(ctx context.Context) {
 // StopSync stops the periodic GitHub sync. This operation is
 // terminal: the underlying Syncer permanently refuses further
 // Start or TriggerRun calls after Stop, so callers that need to
-// resume sync must create a new Instance. Safe to call
-// concurrently: stopOnce guarantees the body runs exactly once.
+// resume sync must create a new Instance.
+//
+// Safe to call concurrently. The cancelHook check/call/reset is
+// protected by cancelHookOnce so only the first caller cancels
+// the stack-detection context. i.syncer.Stop() runs on every
+// call by design: Syncer.Stop waits up to stopGracePeriod on
+// each call, so a Close() following a StopSync() that hit the
+// grace-period timeout can still re-wait for lingering work
+// rather than closing the database out from under it.
 func (i *Instance) StopSync() {
-	i.stopOnce.Do(func() {
-		// Cancel any in-flight stack-detection pass before stopping
-		// the syncer so the hook does not continue after StopSync
-		// returns.
+	// Cancel any in-flight stack-detection pass before stopping the
+	// syncer so the hook does not continue after StopSync returns.
+	i.cancelHookOnce.Do(func() {
 		if i.cancelHook != nil {
 			i.cancelHook()
 			i.cancelHook = nil
 		}
-		i.syncer.Stop()
 	})
+	i.syncer.Stop()
 }
 
 // Close stops sync and closes the database. Safe to call

--- a/middleman.go
+++ b/middleman.go
@@ -184,13 +184,8 @@ type Instance struct {
 	// TriggerRun before StartSync still run detection, and so StopSync
 	// can cancel hook work regardless of how callers parent their ctx.
 	cancelHook context.CancelFunc
-	// installHook reinstalls the sync-completion hook with a fresh
-	// context. Called from the constructor and from StartSync after
-	// StopSync has canceled the previous context, so restarted syncs
-	// keep running stack detection.
-	installHook func(ctx context.Context)
-	stopMu      sync.Mutex
-	closed      bool
+	stopMu     sync.Mutex
+	closed     bool
 }
 
 // New creates a middleman Instance from the given options.
@@ -372,16 +367,13 @@ func New(opts Options) (*Instance, error) {
 			cb(out)
 		}
 	}
-	installHook := func(ctx context.Context) {
-		syncer.SetOnSyncCompleted(
-			stacks.SyncCompletedHook(ctx, database, embedNext),
-		)
-	}
-
 	// Install the stacks hook eagerly so ad-hoc syncs triggered
-	// before StartSync still run detection.
+	// before StartSync still run detection. The hook context is
+	// canceled by StopSync, which is a terminal operation.
 	hookCtx, cancelHook := context.WithCancel(context.Background())
-	installHook(hookCtx)
+	syncer.SetOnSyncCompleted(
+		stacks.SyncCompletedHook(hookCtx, database, embedNext),
+	)
 
 	srv := server.New(
 		database, syncer, frontend,
@@ -393,11 +385,10 @@ func New(opts Options) (*Instance, error) {
 	)
 
 	return &Instance{
-		db:          database,
-		server:      srv,
-		syncer:      syncer,
-		cancelHook:  cancelHook,
-		installHook: installHook,
+		db:         database,
+		server:     srv,
+		syncer:     syncer,
+		cancelHook: cancelHook,
 	}, nil
 }
 
@@ -408,26 +399,23 @@ func (i *Instance) Handler() http.Handler {
 
 // StartSync begins periodic GitHub sync in the background.
 // The context is used for cancellation during Close.
+//
+// StartSync must be called at most once per Instance. Once
+// StopSync (or Close) has stopped the syncer, the underlying
+// Syncer cannot be restarted — a subsequent StartSync call is a
+// silent no-op. Construct a new Instance if sync must run again.
 func (i *Instance) StartSync(ctx context.Context) {
-	// Reinstall the sync-completion hook with a fresh context if
-	// StopSync canceled the previous one, so restarted syncs keep
-	// running stack detection.
-	if i.cancelHook == nil && i.installHook != nil {
-		hookCtx, cancelHook := context.WithCancel(
-			context.Background(),
-		)
-		i.cancelHook = cancelHook
-		i.installHook(hookCtx)
-	}
 	ctx, i.cancelSync = context.WithCancel(ctx)
 	i.syncer.Start(ctx)
 }
 
-// StopSync stops the periodic GitHub sync.
+// StopSync stops the periodic GitHub sync. This operation is
+// terminal: the underlying Syncer permanently refuses further
+// Start or TriggerRun calls after Stop, so callers that need to
+// resume sync must create a new Instance.
 func (i *Instance) StopSync() {
 	// Cancel any in-flight stack-detection pass before stopping the
 	// syncer so the hook does not continue after StopSync returns.
-	// The hook is reinstalled on the next StartSync.
 	if i.cancelHook != nil {
 		i.cancelHook()
 		i.cancelHook = nil

--- a/middleman.go
+++ b/middleman.go
@@ -180,13 +180,17 @@ type Instance struct {
 	syncer     *ghclient.Syncer
 	cancelSync context.CancelFunc
 	// cancelHook aborts any in-flight stack-detection pass triggered by
-	// SetOnSyncCompleted. Separate from cancelSync so the hook context
-	// spans the entire Instance lifetime (including ad-hoc syncs via
-	// TriggerRun before StartSync), and so StopSync can cancel hook
-	// work even when callers started sync with context.Background().
+	// SetOnSyncCompleted. Separate from cancelSync so ad-hoc syncs via
+	// TriggerRun before StartSync still run detection, and so StopSync
+	// can cancel hook work regardless of how callers parent their ctx.
 	cancelHook context.CancelFunc
-	stopMu     sync.Mutex
-	closed     bool
+	// installHook reinstalls the sync-completion hook with a fresh
+	// context. Called from the constructor and from StartSync after
+	// StopSync has canceled the previous context, so restarted syncs
+	// keep running stack detection.
+	installHook func(ctx context.Context)
+	stopMu      sync.Mutex
+	closed      bool
 }
 
 // New creates a middleman Instance from the given options.
@@ -368,12 +372,16 @@ func New(opts Options) (*Instance, error) {
 			cb(out)
 		}
 	}
-	// Install the stacks hook eagerly with an instance-lifetime context.
-	// This ensures ad-hoc syncs (TriggerRun) triggered before StartSync
-	// still run detection, and makes detection cancelable from both
-	// StopSync and Close regardless of how callers parent their ctx.
+	installHook := func(ctx context.Context) {
+		syncer.SetOnSyncCompleted(
+			stacks.SyncCompletedHook(ctx, database, embedNext),
+		)
+	}
+
+	// Install the stacks hook eagerly so ad-hoc syncs triggered
+	// before StartSync still run detection.
 	hookCtx, cancelHook := context.WithCancel(context.Background())
-	syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(hookCtx, database, embedNext))
+	installHook(hookCtx)
 
 	srv := server.New(
 		database, syncer, frontend,
@@ -385,10 +393,11 @@ func New(opts Options) (*Instance, error) {
 	)
 
 	return &Instance{
-		db:         database,
-		server:     srv,
-		syncer:     syncer,
-		cancelHook: cancelHook,
+		db:          database,
+		server:      srv,
+		syncer:      syncer,
+		cancelHook:  cancelHook,
+		installHook: installHook,
 	}, nil
 }
 
@@ -400,16 +409,28 @@ func (i *Instance) Handler() http.Handler {
 // StartSync begins periodic GitHub sync in the background.
 // The context is used for cancellation during Close.
 func (i *Instance) StartSync(ctx context.Context) {
+	// Reinstall the sync-completion hook with a fresh context if
+	// StopSync canceled the previous one, so restarted syncs keep
+	// running stack detection.
+	if i.cancelHook == nil && i.installHook != nil {
+		hookCtx, cancelHook := context.WithCancel(
+			context.Background(),
+		)
+		i.cancelHook = cancelHook
+		i.installHook(hookCtx)
+	}
 	ctx, i.cancelSync = context.WithCancel(ctx)
 	i.syncer.Start(ctx)
 }
 
 // StopSync stops the periodic GitHub sync.
 func (i *Instance) StopSync() {
-	// Cancel any in-flight stack-detection pass before stopping the syncer
-	// so the hook does not continue after StopSync returns.
+	// Cancel any in-flight stack-detection pass before stopping the
+	// syncer so the hook does not continue after StopSync returns.
+	// The hook is reinstalled on the next StartSync.
 	if i.cancelHook != nil {
 		i.cancelHook()
+		i.cancelHook = nil
 	}
 	i.syncer.Stop()
 }

--- a/middleman.go
+++ b/middleman.go
@@ -183,9 +183,15 @@ type Instance struct {
 	// SetOnSyncCompleted. Separate from cancelSync so ad-hoc syncs via
 	// TriggerRun before StartSync still run detection, and so StopSync
 	// can cancel hook work regardless of how callers parent their ctx.
+	// Read/written only from inside stopOnce.Do in StopSync.
 	cancelHook context.CancelFunc
-	stopMu     sync.Mutex
-	closed     bool
+	// stopOnce ensures the StopSync body runs exactly once even under
+	// concurrent calls from StopSync and Close. Without it, the
+	// cancelHook check/call/reset sequence has a TOCTOU window that
+	// can panic on a nil dereference if two callers race.
+	stopOnce sync.Once
+	stopMu   sync.Mutex
+	closed   bool
 }
 
 // New creates a middleman Instance from the given options.
@@ -412,15 +418,19 @@ func (i *Instance) StartSync(ctx context.Context) {
 // StopSync stops the periodic GitHub sync. This operation is
 // terminal: the underlying Syncer permanently refuses further
 // Start or TriggerRun calls after Stop, so callers that need to
-// resume sync must create a new Instance.
+// resume sync must create a new Instance. Safe to call
+// concurrently: stopOnce guarantees the body runs exactly once.
 func (i *Instance) StopSync() {
-	// Cancel any in-flight stack-detection pass before stopping the
-	// syncer so the hook does not continue after StopSync returns.
-	if i.cancelHook != nil {
-		i.cancelHook()
-		i.cancelHook = nil
-	}
-	i.syncer.Stop()
+	i.stopOnce.Do(func() {
+		// Cancel any in-flight stack-detection pass before stopping
+		// the syncer so the hook does not continue after StopSync
+		// returns.
+		if i.cancelHook != nil {
+			i.cancelHook()
+			i.cancelHook = nil
+		}
+		i.syncer.Stop()
+	})
 }
 
 // Close stops sync and closes the database. Safe to call

--- a/middleman_test.go
+++ b/middleman_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -384,4 +385,42 @@ func TestStartSyncAfterStopSyncIsTerminal(t *testing.T) {
 	// sequence.
 	req.NoError(inst.Close())
 	req.NoError(inst.Close())
+}
+
+// TestStopSyncConcurrent pins the concurrency contract of StopSync:
+// multiple callers racing into StopSync must not panic on a nil
+// cancelHook dereference. Before stopOnce was added, the
+// check/call/reset sequence had a TOCTOU window — caller A could
+// observe cancelHook != nil, caller B could then nil it, and caller
+// A would dereference nil. Under -race this test also verifies no
+// data race exists on the field.
+func TestStopSyncConcurrent(t *testing.T) {
+	frontend := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body>app</body></html>`),
+		},
+	}
+
+	req := require.New(t)
+	inst, err := New(Options{
+		Token:   "test-token",
+		DataDir: t.TempDir(),
+		Assets:  frontend,
+	})
+	req.NoError(err)
+	t.Cleanup(func() { _ = inst.Close() })
+
+	const workers = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			inst.StopSync()
+		}()
+	}
+	close(start)
+	wg.Wait()
 }

--- a/middleman_test.go
+++ b/middleman_test.go
@@ -345,3 +345,43 @@ func TestStopSyncCancelsStackHook(t *testing.T) {
 	// Close must still succeed after StopSync.
 	require.NoError(t, inst.Close())
 }
+
+// TestStartSyncAfterStopSyncIsTerminal pins the documented contract of
+// StopSync: once the Syncer is stopped, a subsequent StartSync is a
+// silent no-op — it must not resurrect the hook, must not start a new
+// background sync goroutine, and must not panic. A previous attempt at
+// fixing a hook-lifecycle bug reinstalled the hook on StartSync, which
+// only looked like a restart: the underlying Syncer.Start already
+// no-ops once stopped, so the reinstalled hook never fired. This test
+// prevents that half-working restart path from coming back.
+func TestStartSyncAfterStopSyncIsTerminal(t *testing.T) {
+	frontend := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body>app</body></html>`),
+		},
+	}
+
+	req := require.New(t)
+	inst, err := New(Options{
+		Token:   "test-token",
+		DataDir: t.TempDir(),
+		Assets:  frontend,
+	})
+	req.NoError(err)
+	t.Cleanup(func() { _ = inst.Close() })
+
+	req.NotNil(inst.cancelHook, "hook must be installed by New")
+	inst.StopSync()
+	req.Nil(inst.cancelHook, "StopSync must cancel and clear the hook")
+
+	// StartSync after StopSync must not reinstall the hook and must
+	// not panic. The Syncer underneath is already permanently stopped
+	// (Start/TriggerRun both no-op once stopped=true).
+	inst.StartSync(t.Context())
+	req.Nil(inst.cancelHook, "StartSync must not resurrect the hook after StopSync")
+
+	// Close remains idempotent and safe after a StopSync/StartSync
+	// sequence.
+	req.NoError(inst.Close())
+	req.NoError(inst.Close())
+}


### PR DESCRIPTION
## Summary
- Track the stack-sync hook installer on the `Instance` so ad-hoc syncs after a `StopSync`/`StartSync` cycle re-run stack detection.
- Rebuild the hook context on each `StartSync` since the prior context was canceled by `StopSync`.

## Test plan
- [ ] Regression test for `StopSync`/`StartSync` cycle (pending, see review follow-up)