### PR TITLE
feat: support globbed repo settings

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -66,6 +67,8 @@ type e2eServerInfo struct {
 	PID     int    `json:"pid"`
 }
 
+type globRefreshContextKey struct{}
+
 // run starts the e2e server and blocks until ctx is canceled or the
 // HTTP server errors out. Tests call it directly with a cancellable
 // context; main() wires it to SIGINT/SIGTERM.
@@ -108,10 +111,12 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 	}
 
 	cfg := &config.Config{
+		BasePath: "/",
 		Repos: []config.Repo{
 			{Owner: "acme", Name: "widgets"},
 			{Owner: "acme", Name: "tools"},
 			{Owner: "acme", Name: "archived"},
+			{Owner: "roborev-dev", Name: "*"},
 		},
 		Activity: config.Activity{
 			ViewMode:  "flat",
@@ -120,13 +125,58 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 	}
 
 	cfg.Roborev.Endpoint = roborevEndpoint
+	cfgPath := filepath.Join(tmpDir, "config.toml")
+	if err := cfg.Save(cfgPath); err != nil {
+		return fmt.Errorf("save e2e config: %w", err)
+	}
 
 	fc := result.FixtureClient()
+	fc.ListRepositoriesByOwnerFn = func(
+		ctx context.Context, owner string,
+	) ([]*gh.Repository, error) {
+		if owner != "roborev-dev" {
+			return fc.ReposByOwner[owner], nil
+		}
+
+		repos := []*gh.Repository{
+			{
+				Name:     new("middleman"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			},
+			{
+				Name:     new("worker"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			},
+			{
+				Name:     new("archived"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(true),
+			},
+		}
+		if includeRefreshRepo, _ := ctx.Value(globRefreshContextKey{}).(bool); includeRefreshRepo {
+			repos = append(repos, &gh.Repository{
+				Name:     new("review-bot"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			})
+		}
+		return repos, nil
+	}
 	patchFixturePRSHAs(fc, "acme", "widgets", 1, diffRepo.HeadSHA, diffRepo.BaseSHA)
 
-	repos := make([]ghclient.RepoRef, len(cfg.Repos))
-	for i, r := range cfg.Repos {
-		repos[i] = ghclient.RepoRef{Owner: r.Owner, Name: r.Name, PlatformHost: "github.com"}
+	startupResolved := ghclient.ResolveConfiguredRepos(
+		ctx,
+		map[string]ghclient.Client{"github.com": fc},
+		cfg.Repos,
+	)
+	for _, repo := range startupResolved.Expanded {
+		if _, err := database.UpsertRepo(
+			ctx, repo.PlatformHost, repo.Owner, repo.Name,
+		); err != nil {
+			return fmt.Errorf("seed startup repo %s/%s: %w", repo.Owner, repo.Name, err)
+		}
 	}
 
 	rt := ghclient.NewRateTracker(database, "github.com", "rest")
@@ -149,7 +199,7 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": fc},
-		database, diffRepo.Manager, repos, time.Hour,
+		database, diffRepo.Manager, startupResolved.Expanded, time.Hour,
 		map[string]*ghclient.RateTracker{"github.com": rt},
 		map[string]*ghclient.SyncBudget{"github.com": budget},
 	)
@@ -163,8 +213,19 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 		return fmt.Errorf("load frontend assets: %w", err)
 	}
 
-	srv := server.New(database, syncer, assets, "/", cfg, server.ServerOptions{
-		Clones: diffRepo.Manager,
+	srv := server.NewWithConfig(
+		database, syncer, diffRepo.Manager, assets, cfg, cfgPath,
+		server.ServerOptions{Clones: diffRepo.Manager},
+	)
+	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost &&
+			strings.Contains(r.URL.Path, "/api/v1/repos/roborev-dev/") &&
+			strings.HasSuffix(r.URL.Path, "/refresh") {
+			r = r.WithContext(
+				context.WithValue(r.Context(), globRefreshContextKey{}, true),
+			)
+		}
+		srv.ServeHTTP(w, r)
 	})
 
 	// Do not start the syncer's background loop. The seeded DB is the
@@ -197,7 +258,7 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 	slog.Info(fmt.Sprintf("starting e2e server at %s", info.BaseURL))
 
 	httpServer := &http.Server{
-		Handler:     srv,
+		Handler:     rootHandler,
 		ReadTimeout: 15 * time.Second,
 		IdleTimeout: 60 * time.Second,
 	}

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -137,14 +139,9 @@ func run(configPath string) error {
 		cloneTokens[host] = token
 	}
 
-	repos := make([]ghclient.RepoRef, len(cfg.Repos))
-	for i, r := range cfg.Repos {
-		repos[i] = ghclient.RepoRef{
-			Owner:        r.Owner,
-			Name:         r.Name,
-			PlatformHost: r.PlatformHostOrDefault(),
-		}
-	}
+	repos := resolveStartupRepos(
+		context.Background(), cfg, clients, database,
+	)
 
 	cloneMgr := gitclone.New(
 		filepath.Join(cfg.DataDir, "clones"), cloneTokens,
@@ -244,4 +241,93 @@ func run(configPath string) error {
 	case err := <-errCh:
 		return fmt.Errorf("server: %w", err)
 	}
+}
+
+func resolveStartupRepos(
+	ctx context.Context,
+	cfg *config.Config,
+	clients map[string]ghclient.Client,
+	database *db.DB,
+) []ghclient.RepoRef {
+	seen := make(map[string]struct{})
+	repos := make([]ghclient.RepoRef, 0, len(cfg.Repos))
+	for _, raw := range cfg.Repos {
+		_, expanded, err := ghclient.ResolveConfiguredRepo(
+			ctx, clients, raw,
+		)
+		if err != nil {
+			slog.Warn("resolve configured repo", "err", err)
+			if raw.HasNameGlob() {
+				expanded = fallbackGlobFromDB(
+					ctx, database, raw,
+				)
+			} else {
+				expanded = []ghclient.RepoRef{{
+					Owner:        raw.Owner,
+					Name:         raw.Name,
+					PlatformHost: raw.PlatformHostOrDefault(),
+				}}
+			}
+		}
+		for _, repo := range expanded {
+			key := strings.ToLower(repo.PlatformHost) + "\x00" +
+				strings.ToLower(repo.Owner) + "\x00" +
+				strings.ToLower(repo.Name)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			repos = append(repos, repo)
+		}
+	}
+	return repos
+}
+
+// fallbackGlobFromDB returns repos from the database that match
+// the glob config entry, preserving previously tracked matches
+// when GitHub is unreachable at startup.
+func fallbackGlobFromDB(
+	ctx context.Context,
+	database *db.DB,
+	raw config.Repo,
+) []ghclient.RepoRef {
+	if database == nil {
+		return nil
+	}
+	dbRepos, err := database.ListRepos(ctx)
+	if err != nil {
+		slog.Warn("fallback glob from db", "err", err)
+		return nil
+	}
+	host := raw.PlatformHostOrDefault()
+	var matches []ghclient.RepoRef
+	for _, r := range dbRepos {
+		dbHost := r.PlatformHost
+		if dbHost == "" {
+			dbHost = "github.com"
+		}
+		if !strings.EqualFold(dbHost, host) ||
+			!strings.EqualFold(r.Owner, raw.Owner) {
+			continue
+		}
+		matched, _ := path.Match(
+			strings.ToLower(raw.Name),
+			strings.ToLower(r.Name),
+		)
+		if matched {
+			matches = append(matches, ghclient.RepoRef{
+				Owner:        r.Owner,
+				Name:         r.Name,
+				PlatformHost: dbHost,
+			})
+		}
+	}
+	if len(matches) > 0 {
+		slog.Info(
+			"using DB-persisted repos for offline glob",
+			"pattern", raw.Owner+"/"+raw.Name,
+			"count", len(matches),
+		)
+	}
+	return matches
 }

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	gh "github.com/google/go-github/v84/github"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/db"
+	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/server"
+	"github.com/wesm/middleman/internal/testutil"
+)
+
+func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
+	assert := Assert.New(t)
+	cfg := &config.Config{
+		Repos: []config.Repo{{Owner: "roborev-dev", Name: "*"}},
+	}
+	client := &testutil.FixtureClient{
+		ReposByOwner: map[string][]*gh.Repository{
+			"roborev-dev": {
+				{
+					Name:     new("middleman"),
+					Archived: new(false),
+				},
+				{
+					Name:     new("archived"),
+					Archived: new(true),
+				},
+			},
+		},
+	}
+
+	repos := resolveStartupRepos(
+		context.Background(),
+		cfg,
+		map[string]ghclient.Client{"github.com": client},
+		nil,
+	)
+
+	assert.Equal([]ghclient.RepoRef{{
+		Owner:        "roborev-dev",
+		Name:         "middleman",
+		PlatformHost: "github.com",
+	}}, repos)
+}
+
+func TestResolveStartupReposKeepsExactReposWhenResolutionFails(t *testing.T) {
+	assert := Assert.New(t)
+	cfg := &config.Config{
+		Repos: []config.Repo{{Owner: "roborev-dev", Name: "middleman"}},
+	}
+
+	repos := resolveStartupRepos(
+		context.Background(),
+		cfg,
+		map[string]ghclient.Client{},
+		nil,
+	)
+
+	assert.Equal([]ghclient.RepoRef{{
+		Owner:        "roborev-dev",
+		Name:         "middleman",
+		PlatformHost: "github.com",
+	}}, repos)
+}
+
+func TestResolveStartupReposFallsBackToDBForOfflineGlobs(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	_, err = database.UpsertRepo(ctx, "github.com", "acme", "widgets")
+	require.NoError(err)
+	_, err = database.UpsertRepo(ctx, "github.com", "acme", "tools")
+	require.NoError(err)
+
+	cfg := &config.Config{
+		Repos: []config.Repo{{Owner: "acme", Name: "*"}},
+	}
+
+	repos := resolveStartupRepos(
+		ctx, cfg, map[string]ghclient.Client{}, database,
+	)
+
+	assert.Len(repos, 2)
+	names := make([]string, len(repos))
+	for i, r := range repos {
+		names[i] = r.Name
+	}
+	assert.ElementsMatch([]string{"widgets", "tools"}, names)
+}
+
+func TestStartupFallbackKeepsPersistedGlobMatchesInAPIs(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	_, err = database.UpsertRepo(
+		context.Background(), "github.com", "roborev-dev", "middleman",
+	)
+	require.NoError(err)
+	_, err = database.UpsertRepo(
+		context.Background(), "github.com", "roborev-dev", "worker",
+	)
+	require.NoError(err)
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfg := &config.Config{
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Host:           "127.0.0.1",
+		Port:           8090,
+		BasePath:       "/",
+		DataDir:        dir,
+		Repos: []config.Repo{
+			{Owner: "roborev-dev", Name: "*"},
+		},
+		Activity: config.Activity{
+			ViewMode:  "flat",
+			TimeRange: "7d",
+		},
+	}
+	require.NoError(cfg.Save(cfgPath))
+
+	client := &testutil.FixtureClient{
+		ListRepositoriesByOwnerFn: func(
+			context.Context, string,
+		) ([]*gh.Repository, error) {
+			return nil, errors.New("offline")
+		},
+	}
+	repos := resolveStartupRepos(
+		context.Background(),
+		cfg,
+		map[string]ghclient.Client{"github.com": client},
+		database,
+	)
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": client},
+		database, nil, repos, 0, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := server.NewWithConfig(
+		database, syncer, nil, nil, cfg, cfgPath,
+		server.ServerOptions{},
+	)
+
+	reposReq := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	reposRR := httptest.NewRecorder()
+	srv.ServeHTTP(reposRR, reposReq)
+	require.Equal(http.StatusOK, reposRR.Code, reposRR.Body.String())
+
+	var listed []struct {
+		Owner string `json:"owner"`
+		Name  string `json:"name"`
+	}
+	require.NoError(json.NewDecoder(reposRR.Body).Decode(&listed))
+	require.Len(listed, 2)
+	assert.ElementsMatch([]string{"middleman", "worker"}, []string{
+		listed[0].Name,
+		listed[1].Name,
+	})
+
+	settingsReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	settingsRR := httptest.NewRecorder()
+	srv.ServeHTTP(settingsRR, settingsReq)
+	require.Equal(http.StatusOK, settingsRR.Code, settingsRR.Body.String())
+
+	var settings struct {
+		Repos []struct {
+			Owner            string `json:"owner"`
+			Name             string `json:"name"`
+			MatchedRepoCount int    `json:"matched_repo_count"`
+		} `json:"repos"`
+	}
+	require.NoError(json.NewDecoder(settingsRR.Body).Decode(&settings))
+	require.Len(settings.Repos, 1)
+	assert.Equal("roborev-dev", settings.Repos[0].Owner)
+	assert.Equal("*", settings.Repos[0].Name)
+	assert.Equal(2, settings.Repos[0].MatchedRepoCount)
+}

--- a/frontend/src/lib/api/settings.test.ts
+++ b/frontend/src/lib/api/settings.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { removeRepo } from "./settings.js";
+
+describe("settings api", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi.fn(),
+    }));
+  });
+
+  it("encodes repo names for delete requests", async () => {
+    await removeRepo("acme", "widgets-?");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/v1/repos/acme/widgets-%3F",
+      { method: "DELETE", headers: { "Content-Type": "application/json" } },
+    );
+  });
+});

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -24,7 +24,7 @@ export async function updateSettings(
 export async function addRepo(
   owner: string,
   name: string,
-): Promise<{ owner: string; name: string }> {
+): Promise<Settings> {
   const res = await fetch(`${BASE}/repos`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -34,7 +34,7 @@ export async function addRepo(
     const text = await res.text().catch(() => res.statusText);
     throw new Error(text);
   }
-  return res.json();
+  return res.json() as Promise<Settings>;
 }
 
 export async function removeRepo(
@@ -42,11 +42,26 @@ export async function removeRepo(
   name: string,
 ): Promise<void> {
   const res = await fetch(
-    `${BASE}/repos/${owner}/${name}`,
+    `${BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
     { method: "DELETE", headers: { "Content-Type": "application/json" } },
   );
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);
     throw new Error(text);
   }
+}
+
+export async function refreshRepo(
+  owner: string,
+  name: string,
+): Promise<Settings> {
+  const res = await fetch(
+    `${BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/refresh`,
+    { method: "POST", headers: { "Content-Type": "application/json" } },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(text);
+  }
+  return res.json() as Promise<Settings>;
 }

--- a/frontend/src/lib/components/settings/RepoSettings.svelte
+++ b/frontend/src/lib/components/settings/RepoSettings.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getStores } from "@middleman/ui";
   import type { ConfigRepo } from "@middleman/ui/api/types";
-  import { addRepo, removeRepo, getSettings } from "../../api/settings.js";
+  import { addRepo, removeRepo, getSettings, refreshRepo } from "../../api/settings.js";
 
   const { sync } = getStores();
 
@@ -20,6 +20,8 @@
   let addError = $state<string | null>(null);
   let confirmingRemove = $state<string | null>(null);
   let removeError = $state<string | null>(null);
+  let refreshingByKey = $state<Record<string, boolean>>({});
+  let refreshErrors = $state<Record<string, string>>({});
 
   async function handleAdd(): Promise<void> {
     if (embedded) return;
@@ -33,9 +35,8 @@
     adding = true;
     addError = null;
     try {
-      await addRepo(parts[0], parts[1]);
+      const settings = await addRepo(parts[0], parts[1]);
       inputValue = "";
-      const settings = await getSettings();
       onUpdate(settings.repos);
       void sync.refreshSyncStatus();
     } catch (err) {
@@ -56,8 +57,35 @@
       confirmingRemove = null;
       const settings = await getSettings();
       onUpdate(settings.repos);
+      void sync.refreshSyncStatus();
     } catch (err) {
       removeError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  async function handleRefresh(
+    owner: string,
+    name: string,
+  ): Promise<void> {
+    if (embedded) return;
+    const key = `${owner}/${name}`;
+    refreshingByKey = { ...refreshingByKey, [key]: true };
+    if (refreshErrors[key]) {
+      const nextErrors = { ...refreshErrors };
+      delete nextErrors[key];
+      refreshErrors = nextErrors;
+    }
+    try {
+      const settings = await refreshRepo(owner, name);
+      onUpdate(settings.repos);
+      void sync.refreshSyncStatus();
+    } catch (err) {
+      refreshErrors = {
+        ...refreshErrors,
+        [key]: err instanceof Error ? err.message : String(err),
+      };
+    } finally {
+      refreshingByKey = { ...refreshingByKey, [key]: false };
     }
   }
 
@@ -73,7 +101,17 @@
   {#each repos as repo (`${repo.owner}/${repo.name}`)}
     {@const key = `${repo.owner}/${repo.name}`}
     <div class="repo-row">
-      <span class="repo-name">{repo.owner}/{repo.name}</span>
+      <div class="repo-main">
+        <span class="repo-name">
+          {repo.owner}/{repo.name}
+          {#if repo.is_glob}
+            <span class="repo-count">({repo.matched_repo_count})</span>
+          {/if}
+        </span>
+        {#if refreshErrors[key]}
+          <div class="error-msg row-error">{refreshErrors[key]}</div>
+        {/if}
+      </div>
       {#if confirmingRemove === key}
         <span class="confirm-prompt">
           Remove?
@@ -81,11 +119,30 @@
           <button class="confirm-btn confirm-no" onclick={() => { confirmingRemove = null; removeError = null; }}>No</button>
         </span>
       {:else}
-        <button
-          class="remove-btn"
-          title={`Remove ${key}`}
-          onclick={() => { confirmingRemove = key; removeError = null; }}
-        >&times;</button>
+        <div class="repo-actions">
+          {#if repo.is_glob}
+            <button
+              class="refresh-btn"
+              onclick={() => void handleRefresh(repo.owner, repo.name)}
+              disabled={Boolean(refreshingByKey[key])}
+            >
+              {refreshingByKey[key] ? "Refreshing..." : "Refresh"}
+            </button>
+          {/if}
+          <button
+            class="remove-btn"
+            title={`Remove ${key}`}
+            onclick={() => {
+              confirmingRemove = key;
+              removeError = null;
+              if (refreshErrors[key]) {
+                const nextErrors = { ...refreshErrors };
+                delete nextErrors[key];
+                refreshErrors = nextErrors;
+              }
+            }}
+          >&times;</button>
+        </div>
       {/if}
     </div>
   {/each}
@@ -111,9 +168,22 @@
   .repo-row {
     display: flex; align-items: center; justify-content: space-between;
     padding: 8px 0; border-bottom: 1px solid var(--border-muted);
+    gap: 12px;
   }
   .repo-row:last-child { border-bottom: none; }
+  .repo-main { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
   .repo-name { font-size: 13px; color: var(--text-primary); font-weight: 500; }
+  .repo-count { color: var(--text-muted); margin-left: 4px; }
+  .repo-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+  .refresh-btn {
+    padding: 4px 10px; font-size: 12px; font-weight: 500;
+    color: var(--accent-blue); border: 1px solid color-mix(in srgb, var(--accent-blue) 35%, var(--border-muted));
+    border-radius: var(--radius-sm); transition: background 0.12s, opacity 0.12s;
+  }
+  .refresh-btn:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+  }
+  .refresh-btn:disabled { opacity: 0.5; cursor: not-allowed; }
   .remove-btn {
     font-size: 16px; color: var(--text-muted); padding: 2px 6px;
     border-radius: var(--radius-sm); line-height: 1; transition: color 0.1s, background 0.1s;
@@ -141,4 +211,5 @@
   .add-btn:hover:not(:disabled) { opacity: 0.9; }
   .add-btn:disabled { opacity: 0.5; cursor: not-allowed; }
   .error-msg { font-size: 12px; color: var(--accent-red); padding: 4px 0; }
+  .row-error { padding: 0; }
 </style>

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockRefreshSyncStatus = vi.fn();
+
+vi.mock("@middleman/ui", () => ({
+  getStores: () => ({
+    sync: {
+      refreshSyncStatus: mockRefreshSyncStatus,
+    },
+  }),
+}));
+
+vi.mock("../../api/settings.js", () => ({
+  addRepo: vi.fn(),
+  removeRepo: vi.fn(),
+  getSettings: vi.fn(),
+  refreshRepo: vi.fn(),
+}));
+
+vi.mock("../../stores/embed-config.svelte.js", () => ({
+  isEmbedded: () => false,
+}));
+
+import RepoSettings from "./RepoSettings.svelte";
+
+describe("RepoSettings", () => {
+  afterEach(() => {
+    cleanup();
+    mockRefreshSyncStatus.mockReset();
+  });
+
+  it("renders the glob count and refresh action", () => {
+    render(RepoSettings, {
+      props: {
+        repos: [{
+          owner: "roborev-dev",
+          name: "*",
+          is_glob: true,
+          matched_repo_count: 2,
+        }],
+        onUpdate: vi.fn(),
+      },
+    });
+
+    expect(screen.getByText((_, element) => element?.textContent === "roborev-dev/* (2)")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeTruthy();
+  });
+});

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -1,0 +1,59 @@
+import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
+import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+
+type RepoSummary = {
+  Owner: string;
+  Name: string;
+};
+
+let isolatedServer: IsolatedE2EServer;
+let api: APIRequestContext;
+
+test.beforeAll(async () => {
+  isolatedServer = await startIsolatedE2EServer();
+  api = await playwrightRequest.newContext({
+    baseURL: isolatedServer.info.base_url,
+  });
+});
+
+test.afterAll(async () => {
+  await api.dispose();
+  await isolatedServer.stop();
+});
+
+test("settings shows glob match counts and refresh updates tracked repos", async ({ page }) => {
+  await page.goto(`${isolatedServer.info.base_url}/settings`);
+
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+
+  const row = page.locator(".repo-row", { hasText: "roborev-dev/*" });
+  await expect(row).toContainText("roborev-dev/*");
+  await expect(row).toContainText("(2)");
+  await expect.poll(async () => {
+    const response = await api.get("/api/v1/repos");
+    const repos = await response.json() as RepoSummary[];
+    return repos
+      .filter((repo) => repo.Owner === "roborev-dev")
+      .map((repo) => repo.Name)
+      .sort()
+      .join(",");
+  }).toBe("middleman,worker");
+
+  await row.getByRole("button", { name: "Refresh" }).click();
+
+  await expect(row).toContainText("(3)");
+  await expect.poll(async () => {
+    const response = await api.get("/api/v1/repos");
+    const repos = await response.json() as RepoSummary[];
+    return repos
+      .filter((repo) => repo.Owner === "roborev-dev")
+      .map((repo) => repo.Name)
+      .sort()
+      .join(",");
+  }).toBe("middleman,review-bot,worker");
+
+  await page.screenshot({
+    path: "test-results/settings-globs-pr.png",
+    fullPage: true,
+  });
+});

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -15,6 +15,11 @@ export type E2EServerInfo = {
   pid: number;
 };
 
+export type IsolatedE2EServer = {
+  info: E2EServerInfo;
+  stop: () => Promise<void>;
+};
+
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../../..");
 const serverInfoDir = mkdtempSync(path.join(os.tmpdir(), "middleman-e2e-"));
@@ -115,6 +120,34 @@ async function removeServerInfo(filePath: string): Promise<void> {
   await rm(filePath, { force: true });
 }
 
+async function spawnServer(infoFile: string): Promise<{
+  child: ChildProcess;
+  info: E2EServerInfo;
+}> {
+  const args = [
+    "run",
+    "./cmd/e2e-server",
+    "-port",
+    "0",
+    "-server-info-file",
+    infoFile,
+  ];
+  if (process.env.ROBOREV_ENDPOINT) {
+    args.push("-roborev", process.env.ROBOREV_ENDPOINT);
+  }
+
+  const child = spawn("go", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  return {
+    child,
+    info: await waitForServerInfo(infoFile, child),
+  };
+}
+
 export function cleanupManagedServerProcess(
   child: ManagedChildLike | null = managedChild,
   infoFile: string | undefined = process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE,
@@ -155,27 +188,12 @@ function installCleanup(infoFile: string): void {
 }
 
 async function startManagedServer(): Promise<E2EServerInfo> {
-  const args = [
-    "run",
-    "./cmd/e2e-server",
-    "-port",
-    "0",
-    "-server-info-file",
-    serverInfoFile,
-  ];
-  if (process.env.ROBOREV_ENDPOINT) {
-    args.push("-roborev", process.env.ROBOREV_ENDPOINT);
-  }
-
-  managedChild = spawn("go", args, {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: process.env,
-  });
+  const started = await spawnServer(serverInfoFile);
+  managedChild = started.child;
 
   installCleanup(serverInfoFile);
 
-  const info = await waitForServerInfo(serverInfoFile, managedChild);
+  const info = started.info;
   process.env.PLAYWRIGHT_E2E_BASE_URL = info.base_url;
   process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE = serverInfoFile;
   process.env[ownedServerEnvVar] = "1";
@@ -232,4 +250,19 @@ export async function stopE2EServer(): Promise<void> {
   delete process.env[ownedServerEnvVar];
   delete process.env.PLAYWRIGHT_E2E_SERVER_INFO_FILE;
   delete process.env.PLAYWRIGHT_E2E_BASE_URL;
+}
+
+export async function startIsolatedE2EServer(): Promise<IsolatedE2EServer> {
+  const isolatedInfoDir = mkdtempSync(path.join(os.tmpdir(), "middleman-e2e-"));
+  const isolatedInfoFile = path.join(isolatedInfoDir, "server-info.json");
+  const started = await spawnServer(isolatedInfoFile);
+
+  return {
+    info: started.info,
+    stop: async () => {
+      cleanupManagedServerProcess(started.child, isolatedInfoFile);
+      await removeServerInfo(isolatedInfoFile);
+      await rm(isolatedInfoDir, { force: true, recursive: true });
+    },
+  };
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ func (r Repo) FullName() string {
 	return r.Owner + "/" + r.Name
 }
 
+func (r Repo) HasNameGlob() bool {
+	return strings.ContainsAny(r.Name, "*?[")
+}
+
 // PlatformHostOrDefault returns the configured platform host,
 // defaulting to "github.com" when empty.
 func (r Repo) PlatformHostOrDefault() string {
@@ -82,6 +86,10 @@ func (r *Repo) normalize() error {
 		return errors.New("must have owner and name")
 	}
 	return nil
+}
+
+func (r Repo) ownerHasGlob() bool {
+	return strings.ContainsAny(r.Owner, "*?[")
 }
 
 // parseGitHubRef extracts owner and repo name from a GitHub URL or
@@ -336,6 +344,11 @@ func Load(path string) (*Config, error) {
 
 func (c *Config) Validate() error {
 	for i := range c.Repos {
+		if c.Repos[i].ownerHasGlob() {
+			return fmt.Errorf(
+				"config: repos[%d]: glob syntax in owner is not supported", i,
+			)
+		}
 		if err := c.Repos[i].normalize(); err != nil {
 			return fmt.Errorf("config: repos[%d]: %w", i, err)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,6 +105,38 @@ name = ".git"
 	require.Error(t, err)
 }
 
+func TestLoadRejectsGlobInOwner(t *testing.T) {
+	path := writeConfig(t, `
+[[repos]]
+owner = "acme-*"
+name = "widgets"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "glob syntax in owner")
+}
+
+func TestLoadRejectsGlobInOwnerBeforeGitHubRefNormalization(t *testing.T) {
+	path := writeConfig(t, `
+[[repos]]
+owner = "acme-*"
+name = "https://github.com/acme/widgets"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "glob syntax in owner")
+}
+
+func TestRepoHasNameGlob(t *testing.T) {
+	assert := Assert.New(t)
+
+	assert.False((&Repo{Owner: "acme", Name: "widgets"}).HasNameGlob())
+	assert.True((&Repo{Owner: "acme", Name: "widgets-*"}).HasNameGlob())
+	assert.True((&Repo{Owner: "acme", Name: "widgets-?"}).HasNameGlob())
+}
+
 func TestGitHubToken(t *testing.T) {
 	t.Setenv("TEST_GH_TOKEN", "secret123")
 	cfg := &Config{GitHubTokenEnv: "TEST_GH_TOKEN"}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error)
 	GetPullRequest(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error)
 	GetUser(ctx context.Context, login string) (*gh.User, error)
+	ListRepositoriesByOwner(ctx context.Context, owner string) ([]*gh.Repository, error)
 	ListOpenIssues(ctx context.Context, owner, repo string) ([]*gh.Issue, error)
 	GetIssue(ctx context.Context, owner, repo string, number int) (*gh.Issue, error)
 	ListIssueComments(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error)
@@ -236,6 +237,54 @@ func (c *liveClient) ListOpenIssues(
 		}
 	}
 	return all, nil
+}
+
+func (c *liveClient) ListRepositoriesByOwner(
+	ctx context.Context, owner string,
+) ([]*gh.Repository, error) {
+	orgRepos, err := collectPages(
+		ctx,
+		func(opts *gh.ListOptions) ([]*gh.Repository, *gh.Response, error) {
+			page, resp, err := c.gh.Repositories.ListByOrg(
+				ctx, owner, &gh.RepositoryListByOrgOptions{
+					Type:        "all",
+					ListOptions: *opts,
+				},
+			)
+			if err != nil {
+				return nil, resp, err
+			}
+			return page, resp, nil
+		},
+		c.trackRate,
+	)
+	if err == nil {
+		return orgRepos, nil
+	}
+
+	userRepos, userErr := collectPages(
+		ctx,
+		func(opts *gh.ListOptions) ([]*gh.Repository, *gh.Response, error) {
+			page, resp, err := c.gh.Repositories.ListByUser(
+				ctx, owner, &gh.RepositoryListByUserOptions{
+					Type:        "owner",
+					ListOptions: *opts,
+				},
+			)
+			if err != nil {
+				return nil, resp, err
+			}
+			return page, resp, nil
+		},
+		c.trackRate,
+	)
+	if userErr != nil {
+		return nil, fmt.Errorf(
+			"listing repositories for %s: org=%v user=%w",
+			owner, err, userErr,
+		)
+	}
+	return userRepos, nil
 }
 
 func (c *liveClient) GetIssue(

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -1,0 +1,216 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/wesm/middleman/internal/config"
+)
+
+var ErrConfiguredRepoArchived = errors.New("configured repo archived")
+
+func canonicalRepoName(name string) string {
+	return strings.ToLower(name)
+}
+
+func canonicalRepoPattern(pattern string) string {
+	return strings.ToLower(pattern)
+}
+
+type ConfiguredRepoStatus struct {
+	Owner            string `json:"owner"`
+	Name             string `json:"name"`
+	IsGlob           bool   `json:"is_glob"`
+	MatchedRepoCount int    `json:"matched_repo_count"`
+}
+
+type ResolveConfiguredReposResult struct {
+	Configured []ConfiguredRepoStatus
+	Expanded   []RepoRef
+	Warnings   []error
+}
+
+func FallbackConfiguredRepoRefs(
+	previous []RepoRef,
+	raw config.Repo,
+) []RepoRef {
+	host := raw.PlatformHostOrDefault()
+	if !raw.HasNameGlob() {
+		for _, repo := range previous {
+			if sameConfiguredRepoHost(repo.PlatformHost, host) &&
+				strings.EqualFold(repo.Owner, raw.Owner) &&
+				strings.EqualFold(repo.Name, raw.Name) {
+				return []RepoRef{repo}
+			}
+		}
+		return []RepoRef{{
+			Owner:        raw.Owner,
+			Name:         raw.Name,
+			PlatformHost: host,
+		}}
+	}
+
+	fallback := make([]RepoRef, 0)
+	for _, repo := range previous {
+		if !sameConfiguredRepoHost(repo.PlatformHost, host) ||
+			!strings.EqualFold(repo.Owner, raw.Owner) {
+			continue
+		}
+		matched, err := path.Match(
+			canonicalRepoPattern(raw.Name),
+			canonicalRepoName(repo.Name),
+		)
+		if err != nil || !matched {
+			continue
+		}
+		fallback = append(fallback, repo)
+	}
+	return fallback
+}
+
+func ResolveConfiguredRepos(
+	ctx context.Context,
+	clients map[string]Client,
+	repos []config.Repo,
+) ResolveConfiguredReposResult {
+	seen := make(map[string]struct{})
+	result := ResolveConfiguredReposResult{
+		Configured: make([]ConfiguredRepoStatus, 0, len(repos)),
+	}
+
+	for _, raw := range repos {
+		status, expanded, err := resolveConfiguredRepo(
+			ctx, clients, raw,
+		)
+		if err != nil {
+			status.MatchedRepoCount = 0
+			result.Warnings = append(result.Warnings, err)
+		}
+		result.Configured = append(result.Configured, status)
+		for _, repo := range expanded {
+			appendExpandedRepo(&result.Expanded, seen, repo)
+		}
+	}
+
+	return result
+}
+
+func ResolveConfiguredRepo(
+	ctx context.Context,
+	clients map[string]Client,
+	repo config.Repo,
+) (ConfiguredRepoStatus, []RepoRef, error) {
+	return resolveConfiguredRepo(ctx, clients, repo)
+}
+
+func resolveConfiguredRepo(
+	ctx context.Context,
+	clients map[string]Client,
+	raw config.Repo,
+) (ConfiguredRepoStatus, []RepoRef, error) {
+	status := ConfiguredRepoStatus{
+		Owner:  raw.Owner,
+		Name:   raw.Name,
+		IsGlob: raw.HasNameGlob(),
+	}
+	host := raw.PlatformHostOrDefault()
+	client, ok := clients[host]
+	if !ok {
+		return status, nil, fmt.Errorf(
+			"no client configured for host %s", host,
+		)
+	}
+
+	if !status.IsGlob {
+		repo, err := client.GetRepository(ctx, raw.Owner, raw.Name)
+		if err != nil {
+			return status, nil, fmt.Errorf(
+				"resolve configured repo %s/%s: %w",
+				raw.Owner, raw.Name, err,
+			)
+		}
+		if repo.GetArchived() {
+			return status, nil, fmt.Errorf(
+				"%w: %s/%s",
+				ErrConfiguredRepoArchived, raw.Owner, raw.Name,
+			)
+		}
+		canonicalOwner := repo.GetOwner().GetLogin()
+		if canonicalOwner == "" {
+			canonicalOwner = raw.Owner
+		}
+		status.MatchedRepoCount = 1
+		return status, []RepoRef{{
+			Owner:        canonicalOwner,
+			Name:         repo.GetName(),
+			PlatformHost: host,
+		}}, nil
+	}
+
+	repos, err := client.ListRepositoriesByOwner(ctx, raw.Owner)
+	if err != nil {
+		return status, nil, fmt.Errorf(
+			"resolve configured repo glob %s/%s: %w",
+			raw.Owner, raw.Name, err,
+		)
+	}
+
+	matches := make([]RepoRef, 0, len(repos))
+	for _, repo := range repos {
+		if repo.GetArchived() {
+			continue
+		}
+		matched, err := path.Match(
+			canonicalRepoName(raw.Name),
+			canonicalRepoName(repo.GetName()),
+		)
+		if err != nil {
+			return status, nil, fmt.Errorf(
+				"invalid repo glob %s/%s: %w",
+				raw.Owner, raw.Name, err,
+			)
+		}
+		if !matched {
+			continue
+		}
+		canonicalOwner := repo.GetOwner().GetLogin()
+		if canonicalOwner == "" {
+			canonicalOwner = raw.Owner
+		}
+		matches = append(matches, RepoRef{
+			Owner:        canonicalOwner,
+			Name:         repo.GetName(),
+			PlatformHost: host,
+		})
+	}
+	status.MatchedRepoCount = len(matches)
+	return status, matches, nil
+}
+
+func appendExpandedRepo(
+	dst *[]RepoRef,
+	seen map[string]struct{},
+	repo RepoRef,
+) {
+	key := strings.ToLower(repo.PlatformHost) + "\x00" +
+		strings.ToLower(repo.Owner) + "\x00" +
+		strings.ToLower(repo.Name)
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+	*dst = append(*dst, repo)
+}
+
+func sameConfiguredRepoHost(left, right string) bool {
+	if left == "" {
+		left = "github.com"
+	}
+	if right == "" {
+		right = "github.com"
+	}
+	return strings.EqualFold(left, right)
+}

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -1,0 +1,186 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gh "github.com/google/go-github/v84/github"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/config"
+)
+
+func TestResolveConfiguredRepos_ExpandsGlobAndSkipsArchived(t *testing.T) {
+	assert := Assert.New(t)
+	client := &mockClient{
+		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("widgets"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					Name:     new("widgets-api"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					Name:     new("widgets-legacy"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(true),
+				},
+			}, nil
+		},
+	}
+
+	result := ResolveConfiguredRepos(
+		context.Background(),
+		map[string]Client{"github.com": client},
+		[]config.Repo{{Owner: "acme", Name: "widgets-*"}},
+	)
+
+	require.Len(t, result.Configured, 1)
+	assert.Equal(1, result.Configured[0].MatchedRepoCount)
+	assert.Equal([]RepoRef{{
+		Owner:        "acme",
+		Name:         "widgets-api",
+		PlatformHost: "github.com",
+	}}, result.Expanded)
+}
+
+func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
+	assert := Assert.New(t)
+	client := &mockClient{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}, nil
+		},
+		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("widgets"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					Name:     new("widgets-api"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+			}, nil
+		},
+	}
+
+	result := ResolveConfiguredRepos(
+		context.Background(),
+		map[string]Client{"github.com": client},
+		[]config.Repo{
+			{Owner: "acme", Name: "widgets"},
+			{Owner: "acme", Name: "widgets*"},
+		},
+	)
+
+	assert.Len(result.Expanded, 2)
+	assert.ElementsMatch([]RepoRef{
+		{Owner: "acme", Name: "widgets", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widgets-api", PlatformHost: "github.com"},
+	}, result.Expanded)
+}
+
+func TestResolveConfiguredRepos_DeduplicatesOwnerCase(t *testing.T) {
+	assert := Assert.New(t)
+	client := &mockClient{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new("acme")},
+				Archived: new(false),
+			}, nil
+		},
+		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("widgets"),
+					Owner:    &gh.User{Login: new("acme")},
+					Archived: new(false),
+				},
+			}, nil
+		},
+	}
+
+	result := ResolveConfiguredRepos(
+		context.Background(),
+		map[string]Client{"github.com": client},
+		[]config.Repo{
+			{Owner: "Acme", Name: "widgets"},
+			{Owner: "acme", Name: "widgets*"},
+		},
+	)
+
+	assert.Equal([]RepoRef{{
+		Owner:        "acme",
+		Name:         "widgets",
+		PlatformHost: "github.com",
+	}}, result.Expanded)
+}
+
+func TestResolveConfiguredRepos_ReportsZeroCountOnStartupWarning(t *testing.T) {
+	assert := Assert.New(t)
+	client := &mockClient{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return nil, errors.New("boom")
+		},
+	}
+
+	result := ResolveConfiguredRepos(
+		context.Background(),
+		map[string]Client{"github.com": client},
+		[]config.Repo{{Owner: "acme", Name: "widgets-*"}},
+	)
+
+	require.Len(t, result.Configured, 1)
+	assert.True(result.Configured[0].IsGlob)
+	assert.Equal(0, result.Configured[0].MatchedRepoCount)
+	assert.Empty(result.Expanded)
+	assert.Len(result.Warnings, 1)
+}
+
+func TestResolveConfiguredRepos_MatchesRepoNamesCaseInsensitively(t *testing.T) {
+	assert := Assert.New(t)
+	client := &mockClient{
+		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("Widget-API"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+			}, nil
+		},
+	}
+
+	result := ResolveConfiguredRepos(
+		context.Background(),
+		map[string]Client{"github.com": client},
+		[]config.Repo{{Owner: "acme", Name: "widget-*"}},
+	)
+
+	require.Len(t, result.Configured, 1)
+	assert.Equal(1, result.Configured[0].MatchedRepoCount)
+	assert.Equal([]RepoRef{{
+		Owner:        "acme",
+		Name:         "Widget-API",
+		PlatformHost: "github.com",
+	}}, result.Expanded)
+}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -147,9 +147,9 @@ type Syncer struct {
 	// lifecycleMu serializes TriggerRun registration with Stop so
 	// no wg.Add can happen after Stop begins wg.Wait.
 	lifecycleMu        sync.Mutex
-	stopped            bool                 // guarded by lifecycleMu
-	nextSyncAfter      map[string]time.Time // host -> next eligible background sync time
-	nextWatchSyncAfter map[string]time.Time // host -> next eligible watch-sync time
+	stopped            bool                         // guarded by lifecycleMu
+	nextSyncAfter      map[string]time.Time         // host -> next eligible background sync time
+	nextWatchSyncAfter map[string]time.Time         // host -> next eligible watch-sync time
 	displayNames       map[string]displayNameResult // "host\x00login" -> resolved name, per sync run
 	displayNamesMu     sync.Mutex
 	displayNameGroup   singleflight.Group // dedups concurrent GetUser calls
@@ -497,7 +497,8 @@ func (s *Syncer) ClientForRepo(
 	s.reposMu.Lock()
 	defer s.reposMu.Unlock()
 	for _, r := range s.repos {
-		if r.Owner == owner && r.Name == name {
+		if strings.EqualFold(r.Owner, owner) &&
+			strings.EqualFold(r.Name, name) {
 			return s.clientFor(r), nil
 		}
 	}
@@ -523,7 +524,8 @@ func (s *Syncer) ClientForHost(
 // owner/name. Returns "github.com" if not found.
 func (s *Syncer) hostFor(owner, name string) string {
 	for _, r := range s.repos {
-		if r.Owner == owner && r.Name == name {
+		if strings.EqualFold(r.Owner, owner) &&
+			strings.EqualFold(r.Name, name) {
 			if r.PlatformHost != "" {
 				return r.PlatformHost
 			}
@@ -2996,11 +2998,22 @@ func (s *Syncer) IsTrackedRepo(owner, name string) bool {
 	repos := s.repos
 	s.reposMu.Unlock()
 	for _, r := range repos {
-		if r.Owner == owner && r.Name == name {
+		if strings.EqualFold(r.Owner, owner) &&
+			strings.EqualFold(r.Name, name) {
 			return true
 		}
 	}
 	return false
+}
+
+// TrackedRepos returns a snapshot of the tracked repositories.
+func (s *Syncer) TrackedRepos() []RepoRef {
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
+
+	repos := make([]RepoRef, len(s.repos))
+	copy(repos, s.repos)
+	return repos
 }
 
 // isTrackedRepoOnHost checks whether the given repo on a specific host
@@ -3018,11 +3031,19 @@ func (s *Syncer) isTrackedRepoOnHost(owner, name, host string) bool {
 		if rHost == "" {
 			rHost = "github.com"
 		}
-		if r.Owner == owner && r.Name == name && rHost == host {
+		if strings.EqualFold(r.Owner, owner) &&
+			strings.EqualFold(r.Name, name) &&
+			strings.EqualFold(rHost, host) {
 			return true
 		}
 	}
 	return false
+}
+
+// IsTrackedRepoOnHost checks whether the given repo on a specific host
+// is in the configured list.
+func (s *Syncer) IsTrackedRepoOnHost(owner, name, host string) bool {
+	return s.isTrackedRepoOnHost(owner, name, host)
 }
 
 // SyncMR fetches fresh data for a single MR from GitHub and updates the DB.
@@ -3287,6 +3308,12 @@ func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID 
 	ghPR, err := client.GetPullRequest(ctx, repo.Owner, repo.Name, number)
 	if err != nil {
 		return fmt.Errorf("get closed PR #%d: %w", number, err)
+	}
+	if ghPR == nil {
+		return fmt.Errorf(
+			"get closed PR #%d: client returned nil pull request",
+			number,
+		)
 	}
 
 	state := ghPR.GetState()

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -49,9 +49,11 @@ type mockClient struct {
 	listOpenPRsErr          error
 	listOpenIssuesErr       error
 	singlePR                *gh.PullRequest
+	getRepositoryFn         func(context.Context, string, string) (*gh.Repository, error)
 	getPullRequestFn        func(context.Context, string, string, int) (*gh.PullRequest, error)
 	getIssueFn              func(context.Context, string, string, int) (*gh.Issue, error)
 	getUserFn               func(context.Context, string) (*gh.User, error)
+	listReposByOwnerFn      func(context.Context, string) ([]*gh.Repository, error)
 	listOpenPRsFn           func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listPullRequestsPageFn  func(context.Context, string, string, string, int) ([]*gh.PullRequest, bool, error)
 	listIssuesPageFn        func(context.Context, string, string, string, int) ([]*gh.Issue, bool, error)
@@ -120,6 +122,16 @@ func (m *mockClient) GetUser(ctx context.Context, login string) (*gh.User, error
 	}
 	name := "Display " + login
 	return &gh.User{Login: &login, Name: &name}, nil
+}
+
+func (m *mockClient) ListRepositoriesByOwner(
+	ctx context.Context, owner string,
+) ([]*gh.Repository, error) {
+	m.trackCall()
+	if m.listReposByOwnerFn != nil {
+		return m.listReposByOwnerFn(ctx, owner)
+	}
+	return nil, nil
 }
 
 func (m *mockClient) GetPullRequest(
@@ -201,9 +213,12 @@ func (m *mockClient) CreateIssueComment(
 }
 
 func (m *mockClient) GetRepository(
-	_ context.Context, _, _ string,
+	ctx context.Context, owner, repo string,
 ) (*gh.Repository, error) {
 	m.trackCall()
+	if m.getRepositoryFn != nil {
+		return m.getRepositoryFn(ctx, owner, repo)
+	}
 	return &gh.Repository{}, nil
 }
 
@@ -1576,9 +1591,24 @@ func TestIsTrackedRepo(t *testing.T) {
 	}, time.Minute, nil, nil)
 
 	assert.True(syncer.IsTrackedRepo("acme", "widget"))
+	assert.True(syncer.IsTrackedRepo("Acme", "Widget"))
 	assert.True(syncer.IsTrackedRepo("corp", "lib"))
 	assert.False(syncer.IsTrackedRepo("acme", "other"))
 	assert.False(syncer.IsTrackedRepo("nobody", "widget"))
+}
+
+func TestClientForRepoMatchesCaseInsensitively(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	mc := &mockClient{}
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, database, nil, []RepoRef{
+		{Owner: "Acme", Name: "Widget", PlatformHost: "github.com"},
+	}, time.Minute, nil, nil)
+
+	client, err := syncer.ClientForRepo("acme", "widget")
+	require.NoError(err)
+	require.Same(mc, client)
 }
 
 func TestSyncItemByNumber_Issue(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -30,6 +30,7 @@ import (
 
 // mockGH implements ghclient.Client for testing.
 type mockGH struct {
+	getRepositoryFn           func(context.Context, string, string) (*gh.Repository, error)
 	getPullRequestFn          func(context.Context, string, string, int) (*gh.PullRequest, error)
 	getIssueFn                func(context.Context, string, string, int) (*gh.Issue, error)
 	markReadyForReviewFn      func(context.Context, string, string, int) (*gh.PullRequest, error)
@@ -38,6 +39,7 @@ type mockGH struct {
 	mergePullRequestFn        func(context.Context, string, string, int, string, string, string) (*gh.PullRequestMergeResult, error)
 	listWorkflowRunsForHeadFn func(context.Context, string, string, string) ([]*gh.WorkflowRun, error)
 	approveWorkflowRunFn      func(context.Context, string, string, int64) error
+	listReposByOwnerFn        func(context.Context, string) ([]*gh.Repository, error)
 	listOpenPullRequestsFn    func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listOpenPRsErr            error
 	listOpenIssuesFn          func(context.Context, string, string) ([]*gh.Issue, error)
@@ -70,6 +72,15 @@ func (m *mockGH) GetIssue(ctx context.Context, owner, repo string, number int) (
 
 func (m *mockGH) GetUser(_ context.Context, login string) (*gh.User, error) {
 	return &gh.User{Login: &login}, nil
+}
+
+func (m *mockGH) ListRepositoriesByOwner(
+	ctx context.Context, owner string,
+) ([]*gh.Repository, error) {
+	if m.listReposByOwnerFn != nil {
+		return m.listReposByOwnerFn(ctx, owner)
+	}
+	return nil, nil
 }
 
 func (m *mockGH) GetPullRequest(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
@@ -147,9 +158,16 @@ func (m *mockGH) CreateIssueComment(
 }
 
 func (m *mockGH) GetRepository(
-	_ context.Context, _, _ string,
+	ctx context.Context, owner, repo string,
 ) (*gh.Repository, error) {
-	return &gh.Repository{}, nil
+	if m.getRepositoryFn != nil {
+		return m.getRepositoryFn(ctx, owner, repo)
+	}
+	return &gh.Repository{
+		Name:     &repo,
+		Owner:    &gh.User{Login: &owner},
+		Archived: new(false),
+	}, nil
 }
 
 func (m *mockGH) CreateReview(
@@ -1581,6 +1599,33 @@ func TestAPIListRepos(t *testing.T) {
 	require.Equal("widget", (*resp.JSON200)[0].Name)
 }
 
+func TestAPIPostPrCommentAllowsMixedCaseTrackedRepo(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(
+		t,
+		&mockGH{},
+		[]ghclient.RepoRef{{
+			Owner:        "Acme",
+			Name:         "widget",
+			PlatformHost: "github.com",
+		}},
+	)
+	client := setupTestClient(t, srv)
+
+	seedPR(t, database, "acme", "widget", 7)
+
+	resp, err := client.HTTP.PostPrCommentWithResponse(
+		context.Background(),
+		"acme",
+		"widget",
+		7,
+		generated.PostPrCommentJSONRequestBody{Body: "looks good"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusCreated, resp.StatusCode())
+	require.NotNil(resp.JSON201)
+}
+
 func TestAPICommentAutocomplete(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -2691,7 +2736,8 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 	assert := Assert.New(t)
 	ctx := context.Background()
 
-	now := time.Now().UTC().Truncate(time.Second).Format(time.RFC3339)
+	now := time.Date(2026, 4, 12, 14, 0, 0, 0, time.UTC)
+	nowRFC3339 := now.Format(time.RFC3339)
 
 	// GraphQL: totalCount=42, HasNextPage=true → CommentsComplete=false.
 	// REST ListIssueComments will error. Stale DB count is 5.
@@ -2712,11 +2758,11 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 			"body":"GraphQL count must win",
 			"url":"https://github.com/acme/widget/issues/90",
 			"author":{"login":"kate"},
-			"createdAt":"` + now + `",
-			"updatedAt":"` + now + `",
+			"createdAt":"` + nowRFC3339 + `",
+			"updatedAt":"` + nowRFC3339 + `",
 			"closedAt":null,
 			"labels":{"nodes":[]},
-			"comments":{"totalCount":42,"nodes":[{"databaseId":901,"author":{"login":"leo"},"body":"one","createdAt":"` + now + `","updatedAt":"` + now + `"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor1"}}
+			"comments":{"totalCount":42,"nodes":[{"databaseId":901,"author":{"login":"leo"},"body":"one","createdAt":"` + nowRFC3339 + `","updatedAt":"` + nowRFC3339 + `"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor1"}}
 		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`
 		_, _ = w.Write([]byte(resp))
 	}))
@@ -2728,7 +2774,7 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 	issueState := "open"
 	issueURL := "https://github.com/acme/widget/issues/90"
 	issueLogin := "kate"
-	issueTime := gh.Timestamp{Time: time.Now().UTC().Truncate(time.Second)}
+	issueTime := gh.Timestamp{Time: now}
 	mock := &mockGH{
 		listOpenPRsErr: &gh.ErrorResponse{
 			Response: &http.Response{StatusCode: http.StatusNotModified},
@@ -2763,7 +2809,7 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 	// — a test-only flake, not a production bug.
 	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
 	require.NoError(err)
-	stale := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
+	stale := now.Add(-time.Second)
 	_, err = database.UpsertIssue(ctx, &db.Issue{
 		RepoID:         repoID,
 		PlatformID:     90000,

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -36,8 +36,8 @@ func buildRepoLookup(repos []db.Repo) map[int64]db.Repo {
 }
 
 // lookupRepoMap fetches repos and returns an ID-keyed map. When config is
-// available, only configured repos are included so that removed repos are
-// filtered out of list responses.
+// available, only currently tracked repos are included so that removed repos
+// are filtered out of list responses.
 func (s *Server) lookupRepoMap(ctx context.Context) (map[int64]db.Repo, error) {
 	repos, err := s.db.ListRepos(ctx)
 	if err != nil {
@@ -49,18 +49,11 @@ func (s *Server) lookupRepoMap(ctx context.Context) (map[int64]db.Repo, error) {
 	return buildRepoLookup(repos), nil
 }
 
-// filterConfiguredRepos returns only repos that are in the config.
+// filterConfiguredRepos returns only repos that are currently tracked.
 func (s *Server) filterConfiguredRepos(repos []db.Repo) []db.Repo {
-	s.cfgMu.Lock()
-	configured := make(map[string]bool, len(s.cfg.Repos))
-	for _, cr := range s.cfg.Repos {
-		configured[cr.Owner+"/"+cr.Name] = true
-	}
-	s.cfgMu.Unlock()
-
 	filtered := make([]db.Repo, 0, len(repos))
 	for _, r := range repos {
-		if configured[r.Owner+"/"+r.Name] {
+		if s.syncer.IsTrackedRepoOnHost(r.Owner, r.Name, r.PlatformHost) {
 			filtered = append(filtered, r)
 		}
 	}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1355,16 +1355,9 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 	}
 
 	if s.cfg != nil {
-		s.cfgMu.Lock()
-		configured := make(map[string]bool, len(s.cfg.Repos))
-		for _, cr := range s.cfg.Repos {
-			configured[cr.Owner+"/"+cr.Name] = true
-		}
-		s.cfgMu.Unlock()
-
 		filtered := items[:0]
 		for _, it := range items {
-			if configured[it.RepoOwner+"/"+it.RepoName] {
+			if s.syncer.IsTrackedRepo(it.RepoOwner, it.RepoName) {
 				filtered = append(filtered, it)
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -255,6 +255,7 @@ func newServer(
 	mux.HandleFunc("GET /api/v1/settings", s.handleGetSettings)
 	mux.HandleFunc("PUT /api/v1/settings", s.handleUpdateSettings)
 	mux.HandleFunc("POST /api/v1/repos", s.handleAddRepo)
+	mux.HandleFunc("POST /api/v1/repos/{owner}/{name}/refresh", s.handleRefreshRepo)
 	mux.HandleFunc("DELETE /api/v1/repos/{owner}/{name}", s.handleDeleteRepo)
 	mux.HandleFunc("GET /api/v1/events", s.handleSSE)
 

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -3,19 +3,234 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"path"
+	"strings"
 
 	"github.com/wesm/middleman/internal/config"
 	ghclient "github.com/wesm/middleman/internal/github"
 )
 
 type settingsResponse struct {
-	Repos    []config.Repo   `json:"repos"`
-	Activity config.Activity `json:"activity"`
+	Repos    []ghclient.ConfiguredRepoStatus `json:"repos"`
+	Activity config.Activity                 `json:"activity"`
 }
 
 type updateSettingsRequest struct {
 	Activity config.Activity `json:"activity"`
+}
+
+func (s *Server) configuredClients(
+	repos []config.Repo,
+) map[string]ghclient.Client {
+	clients := make(map[string]ghclient.Client)
+	for _, repo := range repos {
+		host := repo.PlatformHostOrDefault()
+		if _, ok := clients[host]; ok {
+			continue
+		}
+		client, err := s.syncer.ClientForHost(host)
+		if err != nil {
+			continue
+		}
+		clients[host] = client
+	}
+	return clients
+}
+
+// buildLocalSettingsResponse builds the settings response from
+// in-memory state (syncer tracked repos) without calling GitHub.
+func (s *Server) buildLocalSettingsResponse() settingsResponse {
+	s.cfgMu.Lock()
+	repos := append([]config.Repo(nil), s.cfg.Repos...)
+	activity := s.cfg.Activity
+	s.cfgMu.Unlock()
+
+	tracked := s.syncer.TrackedRepos()
+	configured := make(
+		[]ghclient.ConfiguredRepoStatus, len(repos),
+	)
+	for i, raw := range repos {
+		configured[i] = ghclient.ConfiguredRepoStatus{
+			Owner:            raw.Owner,
+			Name:             raw.Name,
+			IsGlob:           raw.HasNameGlob(),
+			MatchedRepoCount: matchedRepoCount(raw, tracked),
+		}
+	}
+	return settingsResponse{
+		Repos:    configured,
+		Activity: activity,
+	}
+}
+
+func matchedRepoCount(
+	raw config.Repo, tracked []ghclient.RepoRef,
+) int {
+	host := raw.PlatformHostOrDefault()
+	count := 0
+	for _, repo := range tracked {
+		if !samePlatformHost(repo.PlatformHost, host) ||
+			!strings.EqualFold(repo.Owner, raw.Owner) {
+			continue
+		}
+		if raw.HasNameGlob() {
+			matched, _ := path.Match(
+				strings.ToLower(raw.Name),
+				strings.ToLower(repo.Name),
+			)
+			if matched {
+				count++
+			}
+		} else if strings.EqualFold(repo.Name, raw.Name) {
+			count++
+		}
+	}
+	return count
+}
+
+// mergeTrackedRepos adds repos to the syncer's tracked set,
+// deduplicating by host/owner/name.
+func (s *Server) mergeTrackedRepos(add []ghclient.RepoRef) {
+	current := s.syncer.TrackedRepos()
+	seen := make(map[string]struct{}, len(current))
+	for _, r := range current {
+		key := strings.ToLower(r.PlatformHost) + "\x00" +
+			strings.ToLower(r.Owner) + "\x00" +
+			strings.ToLower(r.Name)
+		seen[key] = struct{}{}
+	}
+	for _, r := range add {
+		key := strings.ToLower(r.PlatformHost) + "\x00" +
+			strings.ToLower(r.Owner) + "\x00" +
+			strings.ToLower(r.Name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		current = append(current, r)
+	}
+	s.syncer.SetRepos(current)
+}
+
+// replaceGlobRepos removes repos that only match the refreshed
+// glob entry, preserves repos still matched by other config
+// entries, then adds the newly resolved matches.
+func (s *Server) replaceGlobRepos(
+	raw config.Repo,
+	expanded []ghclient.RepoRef,
+	configured []config.Repo,
+) {
+	current := s.syncer.TrackedRepos()
+	kept := make([]ghclient.RepoRef, 0, len(current))
+	seen := make(map[string]struct{}, len(current)+len(expanded))
+	for _, repo := range current {
+		if repoMatchesConfig(repo, raw) &&
+			!repoMatchesOtherConfig(repo, raw, configured) {
+			continue
+		}
+		appendTrackedRepo(&kept, seen, repo)
+	}
+	for _, repo := range expanded {
+		appendTrackedRepo(&kept, seen, repo)
+	}
+	s.syncer.SetRepos(kept)
+}
+
+// removeConfigRepos keeps only tracked repos that match at
+// least one of the remaining config entries.
+func (s *Server) removeConfigRepos(
+	remaining []config.Repo,
+) {
+	current := s.syncer.TrackedRepos()
+	kept := make([]ghclient.RepoRef, 0, len(current))
+	for _, repo := range current {
+		for _, raw := range remaining {
+			if repoMatchesConfig(repo, raw) {
+				kept = append(kept, repo)
+				break
+			}
+		}
+	}
+	s.syncer.SetRepos(kept)
+}
+
+func repoMatchesOtherConfig(
+	repo ghclient.RepoRef,
+	target config.Repo,
+	configured []config.Repo,
+) bool {
+	for _, raw := range configured {
+		if sameConfiguredRepo(raw, target) {
+			continue
+		}
+		if repoMatchesConfig(repo, raw) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameConfiguredRepo(left, right config.Repo) bool {
+	return samePlatformHost(
+		left.PlatformHostOrDefault(),
+		right.PlatformHostOrDefault(),
+	) &&
+		strings.EqualFold(left.Owner, right.Owner) &&
+		strings.EqualFold(left.Name, right.Name)
+}
+
+func repoMatchesConfig(
+	repo ghclient.RepoRef, raw config.Repo,
+) bool {
+	host := raw.PlatformHostOrDefault()
+	if !samePlatformHost(repo.PlatformHost, host) ||
+		!strings.EqualFold(repo.Owner, raw.Owner) {
+		return false
+	}
+	if raw.HasNameGlob() {
+		matched, _ := path.Match(
+			strings.ToLower(raw.Name),
+			strings.ToLower(repo.Name),
+		)
+		return matched
+	}
+	return strings.EqualFold(repo.Name, raw.Name)
+}
+
+func appendTrackedRepo(
+	dst *[]ghclient.RepoRef,
+	seen map[string]struct{},
+	repo ghclient.RepoRef,
+) {
+	key := strings.ToLower(repo.PlatformHost) + "\x00" +
+		strings.ToLower(repo.Owner) + "\x00" +
+		strings.ToLower(repo.Name)
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+	*dst = append(*dst, repo)
+}
+
+func samePlatformHost(left, right string) bool {
+	if left == "" {
+		left = "github.com"
+	}
+	if right == "" {
+		right = "github.com"
+	}
+	return strings.EqualFold(left, right)
+}
+
+func classifyResolveError(err error) (int, string) {
+	switch {
+	case errors.Is(err, ghclient.ErrConfiguredRepoArchived):
+		return http.StatusBadRequest, err.Error()
+	default:
+		return http.StatusBadGateway, "GitHub API error: " + err.Error()
+	}
 }
 
 func (s *Server) handleGetSettings(
@@ -27,16 +242,7 @@ func (s *Server) handleGetSettings(
 		return
 	}
 
-	s.cfgMu.Lock()
-	repos := make([]config.Repo, len(s.cfg.Repos))
-	copy(repos, s.cfg.Repos)
-	activity := s.cfg.Activity
-	s.cfgMu.Unlock()
-
-	writeJSON(w, http.StatusOK, settingsResponse{
-		Repos:    repos,
-		Activity: activity,
-	})
+	writeJSON(w, http.StatusOK, s.buildLocalSettingsResponse())
 }
 
 func (s *Server) handleUpdateSettings(
@@ -63,26 +269,24 @@ func (s *Server) handleUpdateSettings(
 	}
 
 	s.cfgMu.Lock()
-	defer s.cfgMu.Unlock()
-
 	prev := s.cfg.Activity
 	s.cfg.Activity = candidate
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Activity = prev
+		s.cfgMu.Unlock()
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Activity = prev
+		s.cfgMu.Unlock()
 		writeError(w, http.StatusInternalServerError,
 			"save config: "+err.Error())
 		return
 	}
+	s.cfgMu.Unlock()
 
-	writeJSON(w, http.StatusOK, settingsResponse{
-		Repos:    s.cfg.Repos,
-		Activity: s.cfg.Activity,
-	})
+	writeJSON(w, http.StatusOK, s.buildLocalSettingsResponse())
 }
 
 func (s *Server) handleAddRepo(
@@ -108,54 +312,132 @@ func (s *Server) handleAddRepo(
 		return
 	}
 
-	s.cfgMu.Lock()
-	defer s.cfgMu.Unlock()
+	newRepo := config.Repo{Owner: body.Owner, Name: body.Name}
 
+	// Pre-check (racy but gives a fast 400 before the GitHub call).
+	s.cfgMu.Lock()
 	for _, rp := range s.cfg.Repos {
 		if rp.Owner == body.Owner && rp.Name == body.Name {
+			s.cfgMu.Unlock()
 			writeError(w, http.StatusBadRequest,
 				body.Owner+"/"+body.Name+" is already configured")
 			return
 		}
 	}
+	allRepos := append(
+		append([]config.Repo(nil), s.cfg.Repos...), newRepo,
+	)
+	s.cfgMu.Unlock()
 
-	ghClient, clientErr := s.syncer.ClientForHost("github.com")
-	if clientErr != nil {
-		writeError(w, http.StatusServiceUnavailable,
-			"no GitHub client available")
+	_, expanded, err := ghclient.ResolveConfiguredRepo(
+		r.Context(), s.configuredClients(allRepos), newRepo,
+	)
+	if err != nil {
+		status, msg := classifyResolveError(err)
+		writeError(w, status, msg)
 		return
 	}
-	if _, err := ghClient.GetRepository(
-		r.Context(), body.Owner, body.Name,
-	); err != nil {
-		writeError(w, http.StatusBadGateway,
-			"GitHub API error: "+err.Error())
+
+	// Re-acquire lock and apply the addition to current state
+	// so concurrent activity/settings changes are not lost.
+	s.cfgMu.Lock()
+	for _, rp := range s.cfg.Repos {
+		if rp.Owner == body.Owner && rp.Name == body.Name {
+			s.cfgMu.Unlock()
+			writeError(w, http.StatusBadRequest,
+				body.Owner+"/"+body.Name+" is already configured")
+			return
+		}
+	}
+	s.cfg.Repos = append(s.cfg.Repos, newRepo)
+	if err := s.cfg.Validate(); err != nil {
+		s.cfg.Repos = s.cfg.Repos[:len(s.cfg.Repos)-1]
+		s.cfgMu.Unlock()
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-
-	s.cfg.Repos = append(s.cfg.Repos,
-		config.Repo{Owner: body.Owner, Name: body.Name})
-
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Repos = s.cfg.Repos[:len(s.cfg.Repos)-1]
+		s.cfgMu.Unlock()
 		writeError(w, http.StatusInternalServerError,
 			"save config: "+err.Error())
 		return
 	}
+	s.mergeTrackedRepos(expanded)
+	s.cfgMu.Unlock()
 
-	refs := make([]ghclient.RepoRef, len(s.cfg.Repos))
-	for i, rp := range s.cfg.Repos {
-		refs[i] = ghclient.RepoRef{
-			Owner:        rp.Owner,
-			Name:         rp.Name,
-			PlatformHost: rp.PlatformHostOrDefault(),
+	s.syncer.TriggerRun(context.WithoutCancel(r.Context()))
+	writeJSON(w, http.StatusCreated, s.buildLocalSettingsResponse())
+}
+
+func (s *Server) handleRefreshRepo(
+	w http.ResponseWriter, r *http.Request,
+) {
+	if s.cfgPath == "" {
+		writeError(w, http.StatusNotFound,
+			"settings not available")
+		return
+	}
+
+	owner := r.PathValue("owner")
+	name := r.PathValue("name")
+
+	s.cfgMu.Lock()
+	repos := append([]config.Repo(nil), s.cfg.Repos...)
+	s.cfgMu.Unlock()
+
+	var target *config.Repo
+	for i := range repos {
+		if repos[i].Owner == owner && repos[i].Name == name {
+			target = &repos[i]
+			break
 		}
 	}
-	s.syncer.SetRepos(refs)
-	s.syncer.TriggerRun(context.WithoutCancel(r.Context()))
+	if target == nil {
+		writeError(w, http.StatusNotFound,
+			owner+"/"+name+" is not configured")
+		return
+	}
+	if !target.HasNameGlob() {
+		writeError(w, http.StatusBadRequest,
+			"refresh is only supported for glob patterns")
+		return
+	}
 
-	writeJSON(w, http.StatusCreated,
-		config.Repo{Owner: body.Owner, Name: body.Name})
+	_, expanded, err := ghclient.ResolveConfiguredRepo(
+		r.Context(), s.configuredClients(repos), *target,
+	)
+	if err != nil {
+		status, msg := classifyResolveError(err)
+		writeError(w, status, msg)
+		return
+	}
+
+	// Re-acquire cfgMu and verify the target glob still exists
+	// in the config before applying the resolved matches.
+	// Without this, a concurrent DELETE on the same glob
+	// could run between the unlock above and the helper below,
+	// and the stale expansion would resurrect removed repos.
+	s.cfgMu.Lock()
+	stillExists := false
+	currentRepos := append([]config.Repo(nil), s.cfg.Repos...)
+	for _, rp := range currentRepos {
+		if rp.Owner == owner && rp.Name == name {
+			stillExists = true
+			break
+		}
+	}
+	if !stillExists {
+		s.cfgMu.Unlock()
+		writeError(w, http.StatusNotFound,
+			owner+"/"+name+" is no longer configured")
+		return
+	}
+	s.replaceGlobRepos(*target, expanded, currentRepos)
+	s.cfgMu.Unlock()
+
+	s.syncer.TriggerRun(context.WithoutCancel(r.Context()))
+	writeJSON(w, http.StatusOK, s.buildLocalSettingsResponse())
 }
 
 func (s *Server) handleDeleteRepo(
@@ -171,8 +453,6 @@ func (s *Server) handleDeleteRepo(
 	name := r.PathValue("name")
 
 	s.cfgMu.Lock()
-	defer s.cfgMu.Unlock()
-
 	idx := -1
 	for i, rp := range s.cfg.Repos {
 		if rp.Owner == owner && rp.Name == name {
@@ -181,35 +461,25 @@ func (s *Server) handleDeleteRepo(
 		}
 	}
 	if idx == -1 {
+		s.cfgMu.Unlock()
 		writeError(w, http.StatusNotFound,
 			owner+"/"+name+" is not configured")
 		return
 	}
 
-	removed := s.cfg.Repos[idx]
+	prev := append([]config.Repo(nil), s.cfg.Repos...)
 	s.cfg.Repos = append(
 		s.cfg.Repos[:idx], s.cfg.Repos[idx+1:]...,
 	)
-
 	if err := s.cfg.Save(s.cfgPath); err != nil {
-		s.cfg.Repos = append(
-			s.cfg.Repos[:idx],
-			append([]config.Repo{removed}, s.cfg.Repos[idx:]...)...,
-		)
+		s.cfg.Repos = prev
+		s.cfgMu.Unlock()
 		writeError(w, http.StatusInternalServerError,
 			"save config: "+err.Error())
 		return
 	}
-
-	refs := make([]ghclient.RepoRef, len(s.cfg.Repos))
-	for i, rp := range s.cfg.Repos {
-		refs[i] = ghclient.RepoRef{
-			Owner:        rp.Owner,
-			Name:         rp.Name,
-			PlatformHost: rp.PlatformHostOrDefault(),
-		}
-	}
-	s.syncer.SetRepos(refs)
+	s.removeConfigRepos(s.cfg.Repos)
+	s.cfgMu.Unlock()
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -2,14 +2,18 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	gh "github.com/google/go-github/v84/github"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/config"
@@ -20,14 +24,7 @@ import (
 func setupTestServerWithConfig(
 	t *testing.T,
 ) (*Server, *db.DB, string) {
-	t.Helper()
-
-	dir := t.TempDir()
-	database, err := db.Open(filepath.Join(dir, "test.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
-
-	cfgContent := `
+	return setupTestServerWithConfigContent(t, `
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
@@ -36,7 +33,20 @@ port = 8090
 [[repos]]
 owner = "acme"
 name = "widget"
-`
+`, &mockGH{})
+}
+
+func setupTestServerWithConfigContent(
+	t *testing.T,
+	cfgContent string,
+	mock *mockGH,
+) (*Server, *db.DB, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
 	cfgPath := filepath.Join(dir, "config.toml")
 	err = os.WriteFile(cfgPath, []byte(cfgContent), 0o644)
 	require.NoError(t, err)
@@ -44,9 +54,13 @@ name = "widget"
 	cfg, err := config.Load(cfgPath)
 	require.NoError(t, err)
 
-	mock := &mockGH{}
+	clients := map[string]ghclient.Client{"github.com": mock}
+	resolved := ghclient.ResolveConfiguredRepos(
+		context.Background(), clients, cfg.Repos,
+	)
 	syncer := ghclient.NewSyncer(
-		map[string]ghclient.Client{"github.com": mock}, database, nil, nil, time.Minute, nil, nil,
+		clients, database, nil, resolved.Expanded,
+		time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
 	srv := NewWithConfig(
@@ -87,6 +101,7 @@ func TestHandleGetSettings(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Repos, 1)
 	assert.Equal("acme", resp.Repos[0].Owner)
+	assert.Equal(1, resp.Repos[0].MatchedRepoCount)
 	assert.Equal("threaded", resp.Activity.ViewMode)
 }
 
@@ -254,4 +269,466 @@ func TestHandleDeleteLastRepo(t *testing.T) {
 	cfg2, err := config.Load(cfgPath)
 	require.NoError(t, err)
 	Assert.Empty(t, cfg2.Repos)
+}
+
+func TestHandleGetSettingsIncludesGlobCounts(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("middleman"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					Name:     new("globber"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					Name:     new("archived"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(true),
+				},
+			}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "roborev-dev"
+name = "*"
+`, mock)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp settingsResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp.Repos, 1)
+	assert.Equal("roborev-dev", resp.Repos[0].Owner)
+	assert.Equal("*", resp.Repos[0].Name)
+	assert.True(resp.Repos[0].IsGlob)
+	assert.Equal(2, resp.Repos[0].MatchedRepoCount)
+}
+
+func TestHandleRefreshRepoRebuildsExpandedSyncSet(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("middleman"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					Name:     new("globber"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+				{
+					Name:     new("archived"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(true),
+				},
+			}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "roborev-dev"
+name = "*"
+`, mock)
+
+	rr := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/repos/roborev-dev/*/refresh", nil,
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp settingsResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(2, resp.Repos[0].MatchedRepoCount)
+	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "middleman"))
+	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "globber"))
+	assert.False(srv.syncer.IsTrackedRepo("roborev-dev", "archived"))
+}
+
+func TestHandleRefreshRepoKeepsReposMatchedByOtherConfigEntries(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("middleman"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+			}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "roborev-dev"
+name = "*"
+
+[[repos]]
+owner = "roborev-dev"
+name = "worker"
+`, mock)
+
+	rr := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/repos/roborev-dev/*/refresh", nil,
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp settingsResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp.Repos, 2)
+	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "middleman"))
+	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "worker"))
+}
+
+func TestHandleDeleteRepoRebuildsExpandedSetFromRemainingPatterns(t *testing.T) {
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				Name:     new(repo),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{
+				{
+					Name:     new("middleman"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				},
+			}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "roborev-dev"
+name = "*"
+
+[[repos]]
+owner = "roborev-dev"
+name = "tools"
+`, mock)
+
+	rr := doJSON(
+		t, srv, http.MethodDelete,
+		"/api/v1/repos/roborev-dev/*", nil,
+	)
+	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
+	Assert.True(t, srv.syncer.IsTrackedRepo("roborev-dev", "tools"))
+	Assert.False(t, srv.syncer.IsTrackedRepo("roborev-dev", "middleman"))
+}
+
+func TestRefreshRepoPreservesExistingWhenResolutionFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	fail := true
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			if fail {
+				return nil, errors.New("boom")
+			}
+			return []*gh.Repository{{
+				Name:     new("middleman"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "roborev-dev"
+name = "*"
+`, mock)
+	// Prime the syncer with a previously resolved match so we can
+	// verify it survives a failed refresh.
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:        "roborev-dev",
+		Name:         "middleman",
+		PlatformHost: "github.com",
+	}})
+
+	rr := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/repos/roborev-dev/*/refresh", nil,
+	)
+	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
+	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "middleman"))
+}
+
+func TestGetSettingsDoesNotCallGitHub(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, _, _ string,
+		) (*gh.Repository, error) {
+			require.FailNow("GET /settings must not call GetRepository")
+			return nil, nil
+		},
+		listReposByOwnerFn: func(
+			_ context.Context, _ string,
+		) ([]*gh.Repository, error) {
+			require.FailNow("GET /settings must not call ListRepositoriesByOwner")
+			return nil, nil
+		},
+	}
+	// Build the server directly (bypass setup helper) to avoid
+	// its startup call to ResolveConfiguredRepos, which would
+	// trip the failing mock during seeding.
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+	cfgPath := filepath.Join(dir, "config.toml")
+	require.NoError(os.WriteFile(cfgPath, []byte(`
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`), 0o644))
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+
+	clients := map[string]ghclient.Client{"github.com": mock}
+	syncer := ghclient.NewSyncer(
+		clients, database, nil,
+		[]ghclient.RepoRef{{
+			Owner: "acme", Name: "widget",
+			PlatformHost: "github.com",
+		}},
+		time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := NewWithConfig(
+		database, syncer, nil, nil, cfg, cfgPath,
+		ServerOptions{},
+	)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp settingsResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp.Repos, 1)
+	assert.Equal(1, resp.Repos[0].MatchedRepoCount)
+}
+
+func TestGlobMatchingIsCaseInsensitive(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:     new("Widget-API"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "acme"
+name = "Widget-*"
+`, mock)
+
+	rr := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/repos/acme/Widget-*/refresh", nil,
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.True(srv.syncer.IsTrackedRepo("acme", "Widget-API"))
+}
+
+func TestAddRepoDoesNotDropConcurrentActivityChange(t *testing.T) {
+	// Pre-check for the race fix: handleAddRepo must not
+	// overwrite a concurrent handleUpdateSettings change.
+	// The setup mutates s.cfg.Activity after the add's
+	// pre-check but before its save, then verifies the
+	// activity change survives in both memory and on disk.
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, _, cfgPath := setupTestServerWithConfig(t)
+
+	// Change activity via the update handler.
+	rr := doJSON(
+		t, srv, http.MethodPut, "/api/v1/settings",
+		updateSettingsRequest{
+			Activity: config.Activity{
+				ViewMode:  "threaded",
+				TimeRange: "30d",
+			},
+		},
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	// Add a new repo; handler should preserve activity.
+	addRR := doJSON(
+		t, srv, http.MethodPost, "/api/v1/repos",
+		map[string]string{
+			"owner": "other-org", "name": "other-repo",
+		},
+	)
+	require.Equal(http.StatusCreated, addRR.Code, addRR.Body.String())
+
+	cfg2, err := config.Load(cfgPath)
+	require.NoError(err)
+	assert.Equal("30d", cfg2.Activity.TimeRange)
+	assert.Len(cfg2.Repos, 2)
+}
+
+// TestConcurrentRefreshAndDeleteDoesNotResurrect exercises the
+// race where a refresh of a glob is in-flight (blocked on the
+// GitHub call) while a DELETE removes that glob. Before the fix
+// the refresh would apply its stale expansion after the delete
+// and re-add the removed repos to the syncer's tracked set.
+func TestConcurrentRefreshAndDeleteDoesNotResurrect(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var calls atomic.Int32
+	ghBlocked := make(chan struct{}, 1)
+	ghUnblock := make(chan struct{})
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			// The setup helper resolves the glob once at
+			// server construction; block only on the second
+			// call (the refresh request under test).
+			if calls.Add(1) == 2 {
+				ghBlocked <- struct{}{}
+				<-ghUnblock
+			}
+			return []*gh.Repository{{
+				Name:     new("middleman"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "roborev-dev"
+name = "*"
+`, mock)
+	require.True(srv.syncer.IsTrackedRepo("roborev-dev", "middleman"))
+
+	refreshDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		// Inline the request (no testify helpers) so the
+		// linter does not flag assertions inside the goroutine.
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/api/v1/repos/roborev-dev/*/refresh", nil,
+		)
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		refreshDone <- rr
+	}()
+
+	select {
+	case <-ghBlocked:
+	case <-time.After(5 * time.Second):
+		require.FailNow("refresh did not reach the GH mock")
+	}
+
+	delRR := doJSON(
+		t, srv, http.MethodDelete,
+		"/api/v1/repos/roborev-dev/*", nil,
+	)
+	require.Equal(http.StatusNoContent, delRR.Code, delRR.Body.String())
+	require.False(srv.syncer.IsTrackedRepo("roborev-dev", "middleman"))
+
+	close(ghUnblock)
+	var refreshRR *httptest.ResponseRecorder
+	select {
+	case refreshRR = <-refreshDone:
+	case <-time.After(5 * time.Second):
+		require.FailNow("refresh did not complete")
+	}
+	// Refresh should observe that the glob no longer exists
+	// and report 404 rather than applying its stale expansion.
+	assert.Equal(http.StatusNotFound, refreshRR.Code, refreshRR.Body.String())
+
+	// The deleted repo must not have reappeared after the
+	// refresh completed.
+	assert.False(srv.syncer.IsTrackedRepo("roborev-dev", "middleman"),
+		"deleted repo resurrected by concurrent refresh")
 }

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -16,24 +16,27 @@ var errFixtureReadOnly = errors.New("fixture client: mutation not supported")
 // FixtureClient is a ghclient.Client implementation for E2E tests. It serves
 // seeded PRs and issues from the list methods and stubs out everything else.
 type FixtureClient struct {
-	OpenPRs    map[string][]*gh.PullRequest
-	PRs        map[string][]*gh.PullRequest
-	OpenIssues map[string][]*gh.Issue
-	Issues     map[string][]*gh.Issue
-	Comments   map[string][]*gh.IssueComment
-	mu         sync.Mutex
-	nextID     int64
+	OpenPRs                   map[string][]*gh.PullRequest
+	PRs                       map[string][]*gh.PullRequest
+	OpenIssues                map[string][]*gh.Issue
+	Issues                    map[string][]*gh.Issue
+	Comments                  map[string][]*gh.IssueComment
+	ReposByOwner              map[string][]*gh.Repository
+	ListRepositoriesByOwnerFn func(context.Context, string) ([]*gh.Repository, error)
+	mu                        sync.Mutex
+	nextID                    int64
 }
 
 // NewFixtureClient returns a FixtureClient with empty fixture maps.
 func NewFixtureClient() ghclient.Client {
 	return &FixtureClient{
-		OpenPRs:    make(map[string][]*gh.PullRequest),
-		PRs:        make(map[string][]*gh.PullRequest),
-		OpenIssues: make(map[string][]*gh.Issue),
-		Issues:     make(map[string][]*gh.Issue),
-		Comments:   make(map[string][]*gh.IssueComment),
-		nextID:     10_000,
+		OpenPRs:      make(map[string][]*gh.PullRequest),
+		PRs:          make(map[string][]*gh.PullRequest),
+		OpenIssues:   make(map[string][]*gh.Issue),
+		Issues:       make(map[string][]*gh.Issue),
+		Comments:     make(map[string][]*gh.IssueComment),
+		ReposByOwner: make(map[string][]*gh.Repository),
+		nextID:       10_000,
 	}
 }
 
@@ -64,10 +67,31 @@ func (c *FixtureClient) GetUser(_ context.Context, login string) (*gh.User, erro
 	return &gh.User{Login: &login}, nil
 }
 
+func (c *FixtureClient) ListRepositoriesByOwner(
+	ctx context.Context, owner string,
+) ([]*gh.Repository, error) {
+	if c.ListRepositoriesByOwnerFn != nil {
+		return c.ListRepositoriesByOwnerFn(ctx, owner)
+	}
+	repos := c.ReposByOwner[owner]
+	if len(repos) == 0 {
+		return nil, nil
+	}
+	out := make([]*gh.Repository, len(repos))
+	copy(out, repos)
+	return out, nil
+}
+
 // GetRepository returns a repository with all merge methods enabled.
-func (c *FixtureClient) GetRepository(_ context.Context, _, _ string) (*gh.Repository, error) {
+func (c *FixtureClient) GetRepository(
+	_ context.Context, owner, repo string,
+) (*gh.Repository, error) {
 	t := true
+	archived := repo == "archived"
 	return &gh.Repository{
+		Name:             &repo,
+		Owner:            &gh.User{Login: &owner},
+		Archived:         &archived,
 		AllowSquashMerge: &t,
 		AllowMergeCommit: &t,
 		AllowRebaseMerge: &t,

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -51,6 +51,8 @@ export interface ActivitySettings {
 export interface ConfigRepo {
   owner: string;
   name: string;
+  is_glob: boolean;
+  matched_repo_count: number;
 }
 
 export interface Settings {


### PR DESCRIPTION
## Summary
- support repo glob patterns in settings and startup, limited to the repo-name segment
- exclude archived matches, show matched counts in settings, and add a manual refresh action for glob entries
- add full-stack coverage for the settings glob flow and include a settings screenshot

## Screenshot
![settings-globs-pr.png](https://github.com/user-attachments/assets/807d117b-5d95-4aa2-8098-8c637891da78)