### PR TITLE
Context audit: nil guards, race fixes, ctx plumbing, display-name cache

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -263,6 +263,24 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 		IdleTimeout: 60 * time.Second,
 	}
 
+	// Drain HTTP handlers and bg goroutines before DB close.
+	// LIFO ordering: this runs after stop() but before the
+	// deferred database.Close above. srv.Shutdown closes the
+	// hub so SSE handlers exit, then drains bg goroutines;
+	// httpServer.Shutdown drains in-flight HTTP handlers.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 10*time.Second,
+		)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("server shutdown", "err", err)
+		}
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("http shutdown", "err", err)
+		}
+	}()
+
 	errCh := make(chan error, 1)
 	go func() {
 		if serveErr := httpServer.Serve(listener); !errors.Is(serveErr, http.ErrServerClosed) {
@@ -274,15 +292,20 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 	select {
 	case <-ctx.Done():
 		slog.Info("shutting down")
+		// Trigger Shutdown so Serve unblocks (the defer is a
+		// safety net for other exit paths and is idempotent).
 		shutdownCtx, cancel := context.WithTimeout(
-			context.Background(), 5*time.Second,
+			context.Background(), 10*time.Second,
 		)
 		defer cancel()
-		if shutdownErr := httpServer.Shutdown(shutdownCtx); shutdownErr != nil {
-			slog.Warn("http shutdown error", "err", shutdownErr)
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("server shutdown", "err", err)
 		}
-		// Drain any late error from Serve before returning so the
-		// goroutine does not outlive the function.
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("http shutdown", "err", err)
+		}
+		// Drain errCh so a real Serve failure (not
+		// ErrServerClosed) is surfaced instead of swallowed.
 		if serveErr, ok := <-errCh; ok {
 			return fmt.Errorf("server: %w", serveErr)
 		}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -352,8 +352,8 @@ func (d *DB) loadLabelsForIssues(ctx context.Context, ids []int64) (map[int64][]
 // PurgeOtherHosts deletes all data for platform hosts other
 // than keepHost. Deletes in FK-dependency order so it works
 // on existing DBs where CASCADE may not be retrofitted.
-func (d *DB) PurgeOtherHosts(keepHost string) error {
-	return d.Tx(context.Background(), func(tx *sql.Tx) error {
+func (d *DB) PurgeOtherHosts(ctx context.Context, keepHost string) error {
+	return d.Tx(ctx, func(tx *sql.Tx) error {
 		queries := []string{
 			`DELETE FROM middleman_starred_items WHERE repo_id IN (SELECT id FROM middleman_repos WHERE platform_host != ?)`,
 			`DELETE FROM middleman_mr_worktree_links WHERE merge_request_id IN (SELECT id FROM middleman_merge_requests WHERE repo_id IN (SELECT id FROM middleman_repos WHERE platform_host != ?))`,
@@ -366,7 +366,7 @@ func (d *DB) PurgeOtherHosts(keepHost string) error {
 			`DELETE FROM middleman_rate_limits WHERE platform_host != ?`,
 		}
 		for _, q := range queries {
-			if _, err := tx.Exec(q, keepHost); err != nil {
+			if _, err := tx.ExecContext(ctx, q, keepHost); err != nil {
 				return err
 			}
 		}
@@ -1897,9 +1897,11 @@ func (d *DB) GetRateLimit(
 // SetWorktreeLinks replaces all worktree links atomically.
 // The existing rows are deleted and the provided links are
 // inserted in a single transaction.
-func (d *DB) SetWorktreeLinks(links []WorktreeLink) error {
-	return d.Tx(context.Background(), func(tx *sql.Tx) error {
-		if _, err := tx.Exec(
+func (d *DB) SetWorktreeLinks(
+	ctx context.Context, links []WorktreeLink,
+) error {
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx,
 			`DELETE FROM middleman_mr_worktree_links`,
 		); err != nil {
 			return fmt.Errorf("delete worktree links: %w", err)
@@ -1907,7 +1909,7 @@ func (d *DB) SetWorktreeLinks(links []WorktreeLink) error {
 		if len(links) == 0 {
 			return nil
 		}
-		stmt, err := tx.Prepare(`
+		stmt, err := tx.PrepareContext(ctx, `
 			INSERT INTO middleman_mr_worktree_links
 			    (merge_request_id, worktree_key,
 			     worktree_path, worktree_branch, linked_at)
@@ -1920,7 +1922,7 @@ func (d *DB) SetWorktreeLinks(links []WorktreeLink) error {
 		defer stmt.Close()
 		for i := range links {
 			l := &links[i]
-			if _, err := stmt.Exec(
+			if _, err := stmt.ExecContext(ctx,
 				l.MergeRequestID, l.WorktreeKey,
 				l.WorktreePath, l.WorktreeBranch,
 				l.LinkedAt.UTC().Format(time.RFC3339),
@@ -1938,9 +1940,9 @@ func (d *DB) SetWorktreeLinks(links []WorktreeLink) error {
 // GetWorktreeLinksForMR returns worktree links for a
 // specific merge request.
 func (d *DB) GetWorktreeLinksForMR(
-	mergeRequestID int64,
+	ctx context.Context, mergeRequestID int64,
 ) ([]WorktreeLink, error) {
-	rows, err := d.ro.Query(`
+	rows, err := d.ro.QueryContext(ctx, `
 		SELECT id, merge_request_id, worktree_key,
 		       worktree_path, worktree_branch, linked_at
 		FROM middleman_mr_worktree_links
@@ -1961,7 +1963,7 @@ func (d *DB) GetWorktreeLinksForMR(
 // given merge request IDs. IDs are batched to stay within
 // SQLite's bind-parameter limit.
 func (d *DB) GetWorktreeLinksForMRs(
-	mrIDs []int64,
+	ctx context.Context, mrIDs []int64,
 ) ([]WorktreeLink, error) {
 	if len(mrIDs) == 0 {
 		return nil, nil
@@ -1984,7 +1986,7 @@ func (d *DB) GetWorktreeLinksForMRs(
 			WHERE merge_request_id IN (` +
 			strings.Join(placeholders, ",") + `)
 			ORDER BY linked_at DESC`
-		rows, err := d.ro.Query(query, args...)
+		rows, err := d.ro.QueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"get worktree links for MRs: %w", err,
@@ -2002,8 +2004,10 @@ func (d *DB) GetWorktreeLinksForMRs(
 
 // GetAllWorktreeLinks returns all worktree links ordered
 // by linked_at DESC.
-func (d *DB) GetAllWorktreeLinks() ([]WorktreeLink, error) {
-	rows, err := d.ro.Query(`
+func (d *DB) GetAllWorktreeLinks(
+	ctx context.Context,
+) ([]WorktreeLink, error) {
+	rows, err := d.ro.QueryContext(ctx, `
 		SELECT id, merge_request_id, worktree_key,
 		       worktree_path, worktree_branch, linked_at
 		FROM middleman_mr_worktree_links

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -110,7 +110,7 @@ func TestPurgeOtherHosts(t *testing.T) {
 	}))
 
 	// Insert worktree links for both MRs.
-	require.NoError(d.SetWorktreeLinks([]WorktreeLink{
+	require.NoError(d.SetWorktreeLinks(ctx, []WorktreeLink{
 		{
 			MergeRequestID: ghMRID,
 			WorktreeKey:    "wt-gh",
@@ -136,7 +136,7 @@ func TestPurgeOtherHosts(t *testing.T) {
 	))
 
 	// Purge all hosts except github.com.
-	require.NoError(d.PurgeOtherHosts("github.com"))
+	require.NoError(d.PurgeOtherHosts(ctx, "github.com"))
 
 	// github.com data should remain.
 	repos, err := d.ListRepos(ctx)
@@ -156,7 +156,7 @@ func TestPurgeOtherHosts(t *testing.T) {
 	assert.Len(ghEvents, 1)
 
 	// github.com worktree links should remain.
-	ghLinks, err := d.GetWorktreeLinksForMR(ghMRID)
+	ghLinks, err := d.GetWorktreeLinksForMR(ctx, ghMRID)
 	require.NoError(err)
 	assert.Len(ghLinks, 1)
 
@@ -1269,6 +1269,7 @@ func TestSetWorktreeLinks(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	d := openTestDB(t)
+	ctx := context.Background()
 
 	repoID := insertTestRepo(t, d, "o", "r")
 	mrID1 := insertTestMR(t, d, repoID, 1, "pr1", baseTime())
@@ -1279,9 +1280,9 @@ func TestSetWorktreeLinks(t *testing.T) {
 		{MergeRequestID: mrID1, WorktreeKey: "wt-1", WorktreePath: "/tmp/wt1", WorktreeBranch: "feature-1", LinkedAt: now},
 		{MergeRequestID: mrID2, WorktreeKey: "wt-2", WorktreePath: "/tmp/wt2", WorktreeBranch: "feature-2", LinkedAt: now.Add(time.Hour)},
 	}
-	require.NoError(d.SetWorktreeLinks(links))
+	require.NoError(d.SetWorktreeLinks(ctx, links))
 
-	all, err := d.GetAllWorktreeLinks()
+	all, err := d.GetAllWorktreeLinks(ctx)
 	require.NoError(err)
 	require.Len(all, 2)
 	// Newest first.
@@ -1294,9 +1295,9 @@ func TestSetWorktreeLinks(t *testing.T) {
 	replacement := []WorktreeLink{
 		{MergeRequestID: mrID1, WorktreeKey: "wt-3", WorktreePath: "/tmp/wt3", WorktreeBranch: "hotfix", LinkedAt: now},
 	}
-	require.NoError(d.SetWorktreeLinks(replacement))
+	require.NoError(d.SetWorktreeLinks(ctx, replacement))
 
-	all2, err := d.GetAllWorktreeLinks()
+	all2, err := d.GetAllWorktreeLinks(ctx)
 	require.NoError(err)
 	require.Len(all2, 1)
 	assert.Equal("wt-3", all2[0].WorktreeKey)
@@ -1306,6 +1307,7 @@ func TestGetWorktreeLinksForMR(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	d := openTestDB(t)
+	ctx := context.Background()
 
 	repoID := insertTestRepo(t, d, "o", "r")
 	mrID1 := insertTestMR(t, d, repoID, 1, "pr1", baseTime())
@@ -1316,15 +1318,15 @@ func TestGetWorktreeLinksForMR(t *testing.T) {
 		{MergeRequestID: mrID1, WorktreeKey: "wt-a", LinkedAt: now},
 		{MergeRequestID: mrID2, WorktreeKey: "wt-b", LinkedAt: now},
 	}
-	require.NoError(d.SetWorktreeLinks(links))
+	require.NoError(d.SetWorktreeLinks(ctx, links))
 
-	forMR1, err := d.GetWorktreeLinksForMR(mrID1)
+	forMR1, err := d.GetWorktreeLinksForMR(ctx, mrID1)
 	require.NoError(err)
 	require.Len(forMR1, 1)
 	assert.Equal("wt-a", forMR1[0].WorktreeKey)
 
 	// Empty when no links for a given MR.
-	forMR999, err := d.GetWorktreeLinksForMR(999)
+	forMR999, err := d.GetWorktreeLinksForMR(ctx, 999)
 	require.NoError(err)
 	assert.Empty(forMR999)
 }
@@ -1429,9 +1431,9 @@ func TestWorktreeLinksCascadeOnMRDelete(t *testing.T) {
 	links := []WorktreeLink{
 		{MergeRequestID: mrID, WorktreeKey: "wt-del", LinkedAt: baseTime()},
 	}
-	require.NoError(d.SetWorktreeLinks(links))
+	require.NoError(d.SetWorktreeLinks(ctx, links))
 
-	all, err := d.GetAllWorktreeLinks()
+	all, err := d.GetAllWorktreeLinks(ctx)
 	require.NoError(err)
 	require.Len(all, 1)
 
@@ -1440,7 +1442,34 @@ func TestWorktreeLinksCascadeOnMRDelete(t *testing.T) {
 		`DELETE FROM middleman_merge_requests WHERE id = ?`, mrID)
 	require.NoError(err)
 
-	after, err := d.GetAllWorktreeLinks()
+	after, err := d.GetAllWorktreeLinks(ctx)
 	require.NoError(err)
 	require.Empty(after)
+}
+
+// TestWorktreeAndPurgeRespectCanceledContext verifies a
+// pre-canceled context aborts the database/sql call rather
+// than running the query. Locks in the cancellation guarantee
+// the ctx plumbing added for worktree-link and purge queries.
+func TestWorktreeAndPurgeRespectCanceledContext(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := d.PurgeOtherHosts(canceled, "github.com")
+	require.ErrorIs(err, context.Canceled)
+
+	err = d.SetWorktreeLinks(canceled, nil)
+	require.ErrorIs(err, context.Canceled)
+
+	_, err = d.GetWorktreeLinksForMR(canceled, 1)
+	require.ErrorIs(err, context.Canceled)
+
+	_, err = d.GetWorktreeLinksForMRs(canceled, []int64{1, 2})
+	require.ErrorIs(err, context.Canceled)
+
+	_, err = d.GetAllWorktreeLinks(canceled)
+	require.ErrorIs(err, context.Canceled)
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -521,8 +521,10 @@ func (s *Syncer) ClientForHost(
 }
 
 // hostFor returns the platform host for a repo identified by
-// owner/name. Returns "github.com" if not found.
+// owner/name. Returns "github.com" if not found. Thread-safe.
 func (s *Syncer) hostFor(owner, name string) string {
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
 	for _, r := range s.repos {
 		if strings.EqualFold(r.Owner, owner) &&
 			strings.EqualFold(r.Name, name) {
@@ -538,8 +540,6 @@ func (s *Syncer) hostFor(owner, name string) string {
 // HostForRepo returns the platform host for a tracked repo.
 // Thread-safe.
 func (s *Syncer) HostForRepo(owner, name string) string {
-	s.reposMu.Lock()
-	defer s.reposMu.Unlock()
 	return s.hostFor(owner, name)
 }
 
@@ -2522,7 +2522,12 @@ func (s *Syncer) refreshIssueTimeline(
 		)
 	}
 
-	lastActivity := ghIssue.UpdatedAt.Time
+	var lastActivity time.Time
+	if ghIssue.UpdatedAt != nil {
+		lastActivity = ghIssue.UpdatedAt.Time
+	} else if ghIssue.CreatedAt != nil {
+		lastActivity = ghIssue.CreatedAt.Time
+	}
 	for _, c := range comments {
 		if c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity) {
 			lastActivity = c.UpdatedAt.Time

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -606,6 +606,201 @@ func TestSyncIssueReplacesLabelsOnResync(t *testing.T) {
 	require.Equal(int64(802), stored.Labels[0].PlatformID)
 }
 
+// TestSyncIssueNilUpdatedAt verifies refreshIssueTimeline
+// tolerates a GitHub issue whose updated_at is null. Before
+// the nil guard this panicked the sync goroutine when GitHub
+// occasionally returned missing timestamps.
+func TestSyncIssueNilUpdatedAt(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 4, 12, 0, 0, 0, time.UTC)
+	issueNumber := 7
+	issueTitle := "no updated_at"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/7"
+	issueBody := ""
+	issueID := int64(900007)
+	issue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &issueTitle,
+		State:     &issueState,
+		HTMLURL:   &issueURL,
+		Body:      &issueBody,
+		CreatedAt: makeTimestamp(now),
+		UpdatedAt: nil, // the case under test
+	}
+
+	commentID := int64(9001)
+	commentBody := "later comment"
+	commentURL := "https://github.com/owner/repo/issues/7#issuecomment-9001"
+	commentTime := now.Add(2 * time.Hour)
+	commentAuthor := "alice"
+	comment := &gh.IssueComment{
+		ID:        &commentID,
+		Body:      &commentBody,
+		HTMLURL:   &commentURL,
+		CreatedAt: makeTimestamp(commentTime),
+		UpdatedAt: makeTimestamp(commentTime),
+		User:      &gh.User{Login: &commentAuthor},
+	}
+
+	mc := &mockClient{
+		getIssueFn: func(
+			context.Context, string, string, int,
+		) (*gh.Issue, error) {
+			return issue, nil
+		},
+		comments: []*gh.IssueComment{comment},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{
+			Owner:        "owner",
+			Name:         "repo",
+			PlatformHost: "github.com",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	// Must not panic and must succeed.
+	require.NoError(
+		syncer.SyncIssue(ctx, "owner", "repo", issueNumber),
+	)
+
+	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(stored)
+	// last_activity_at should track the comment timestamp
+	// even though the issue had no updated_at.
+	assert.Equal(commentTime.UTC(), stored.LastActivityAt.UTC())
+}
+
+// TestSyncIssueNilUpdatedAtNoComments verifies the CreatedAt
+// fallback when UpdatedAt is nil and there are no comments.
+// Without the fallback, lastActivity would be zero time and
+// the issue would sort incorrectly in activity views.
+func TestSyncIssueNilUpdatedAtNoComments(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	created := time.Date(2024, 6, 4, 12, 0, 0, 0, time.UTC)
+	issueNumber := 8
+	issueTitle := "no updated_at, no comments"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/8"
+	issueBody := ""
+	issueID := int64(900008)
+	issue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &issueTitle,
+		State:     &issueState,
+		HTMLURL:   &issueURL,
+		Body:      &issueBody,
+		CreatedAt: makeTimestamp(created),
+		UpdatedAt: nil,
+	}
+
+	mc := &mockClient{
+		getIssueFn: func(
+			context.Context, string, string, int,
+		) (*gh.Issue, error) {
+			return issue, nil
+		},
+		comments: []*gh.IssueComment{},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{
+			Owner:        "owner",
+			Name:         "repo",
+			PlatformHost: "github.com",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	require.NoError(
+		syncer.SyncIssue(ctx, "owner", "repo", issueNumber),
+	)
+
+	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(created.UTC(), stored.LastActivityAt.UTC(),
+		"lastActivity should fall back to CreatedAt, not zero time")
+}
+
+// TestHostForConcurrentSetRepos verifies that concurrent
+// SetRepos calls don't race with hostFor readers. Run under
+// go test -race to catch regressions in the reposMu locking
+// inside hostFor. Readers exercise all three hostFor return
+// paths (tracked-with-host, tracked-with-empty-host, not-found)
+// so a future refactor that reintroduces unsynchronized access
+// on any branch is caught.
+func TestHostForConcurrentSetRepos(t *testing.T) {
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}}, nil, nil,
+		[]RepoRef{{Owner: "o", Name: "r", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer: rotate between three shapes so readers see each
+	// hostFor branch at some point in the run.
+	wg.Go(func() {
+		withHost := []RepoRef{
+			{Owner: "o", Name: "r", PlatformHost: "ghe.example.com"},
+			{Owner: "o2", Name: "r2", PlatformHost: "github.com"},
+		}
+		emptyHost := []RepoRef{
+			{Owner: "o", Name: "r", PlatformHost: ""},
+		}
+		orig := []RepoRef{
+			{Owner: "o", Name: "r", PlatformHost: "github.com"},
+		}
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			syncer.SetRepos(withHost)
+			syncer.SetRepos(emptyHost)
+			syncer.SetRepos(orig)
+		}
+	})
+
+	// Readers: hit every unlocked hostFor caller, including
+	// the not-found branch (ghost/missing) and the empty-host
+	// branch driven by the writer's emptyHost state.
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = syncer.HostForRepo("o", "r")
+				_ = syncer.HostForRepo("ghost", "missing")
+				_ = syncer.IsTrackedRepo("o", "r")
+			}
+		})
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
 func TestSyncIgnoresForcePushFetchFailures(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2421,6 +2421,68 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 	assert.True(finalIssue.UpdatedAt.After(staleUpdatedAt))
 }
 
+// TestAPISyncIssueNilUpdatedAtFallsBackToCreatedAt drives the full
+// HTTP handler -> syncer -> SQLite path with a GitHub response that
+// has updated_at: null, and verifies last_activity_at falls back to
+// created_at via the nil guard in refreshIssueTimeline. The sync_test
+// unit tests cover the same logic at the syncer layer; this test
+// covers the request path users actually hit in production.
+func TestAPISyncIssueNilUpdatedAtFallsBackToCreatedAt(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	createdAt := time.Date(2025, 3, 14, 9, 0, 0, 0, time.UTC)
+	mock := &mockGH{
+		getIssueFn: func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+			id := int64(9999)
+			state := "open"
+			title := "nil updated_at"
+			url := "https://github.com/acme/widget/issues/9"
+			author := "alice"
+			createdTs := gh.Timestamp{Time: createdAt}
+			return &gh.Issue{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &createdTs,
+				UpdatedAt: nil,
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedIssue(t, database, "acme", "widget", 9, "open")
+	client := setupTestClient(t, srv)
+
+	// Before the nil guard, refreshIssueTimeline panicked on
+	// ghIssue.UpdatedAt.Time and the handler returned 502.
+	syncResp, err := client.HTTP.PostReposByOwnerByNameIssuesByNumberSyncWithResponse(
+		ctx, "acme", "widget", 9,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, syncResp.StatusCode())
+	require.NotNil(syncResp.JSON200)
+	// LastActivityAt must equal CreatedAt, not Go's zero time.
+	// Without the fallback, activity-ordered views would sort
+	// this issue at 0001-01-01 instead of its creation date.
+	assert.False(syncResp.JSON200.Issue.LastActivityAt.IsZero())
+	assert.Equal(createdAt, syncResp.JSON200.Issue.LastActivityAt.UTC())
+
+	// Verify the persisted value round-trips through the read
+	// endpoint so the storage -> serializer path is covered.
+	getResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", 9,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, getResp.StatusCode())
+	require.NotNil(getResp.JSON200)
+	assert.Equal(createdAt, getResp.JSON200.Issue.LastActivityAt.UTC())
+}
+
 func TestAPIListPullsStateFilter(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3162,15 +3162,17 @@ func TestMRListIncludesWorktreeLinks(t *testing.T) {
 	prID := seedPR(t, database, "acme", "widget", 1)
 
 	now := time.Now().UTC().Truncate(time.Second)
-	require.NoError(database.SetWorktreeLinks([]db.WorktreeLink{
-		{
-			MergeRequestID: prID,
-			WorktreeKey:    "wt-abc",
-			WorktreePath:   "/tmp/wt",
-			WorktreeBranch: "feature",
-			LinkedAt:       now,
-		},
-	}))
+	require.NoError(database.SetWorktreeLinks(
+		context.Background(),
+		[]db.WorktreeLink{
+			{
+				MergeRequestID: prID,
+				WorktreeKey:    "wt-abc",
+				WorktreePath:   "/tmp/wt",
+				WorktreeBranch: "feature",
+				LinkedAt:       now,
+			},
+		}))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/pulls", nil)
 	rr := httptest.NewRecorder()
@@ -3190,14 +3192,16 @@ func TestMRDetailIncludesWorktreeLinks(t *testing.T) {
 	prID := seedPR(t, database, "acme", "widget", 1)
 
 	now := time.Now().UTC().Truncate(time.Second)
-	require.NoError(database.SetWorktreeLinks([]db.WorktreeLink{
-		{
-			MergeRequestID: prID,
-			WorktreeKey:    "wt-detail",
-			WorktreePath:   "/tmp/detail",
-			LinkedAt:       now,
-		},
-	}))
+	require.NoError(database.SetWorktreeLinks(
+		context.Background(),
+		[]db.WorktreeLink{
+			{
+				MergeRequestID: prID,
+				WorktreeKey:    "wt-detail",
+				WorktreePath:   "/tmp/detail",
+				LinkedAt:       now,
+			},
+		}))
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/repos/acme/widget/pulls/1", nil)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -370,7 +370,7 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 	for i, mr := range mrs {
 		mrIDs[i] = mr.ID
 	}
-	links, err := s.db.GetWorktreeLinksForMRs(mrIDs)
+	links, err := s.db.GetWorktreeLinksForMRs(ctx, mrIDs)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("load worktree links failed")
 	}
@@ -433,7 +433,7 @@ func (s *Server) buildPullDetailResponse(
 		events = []db.MREvent{}
 	}
 
-	dbLinks, err := s.db.GetWorktreeLinksForMR(mr.ID)
+	dbLinks, err := s.db.GetWorktreeLinksForMR(ctx, mr.ID)
 	if err != nil {
 		return mergeRequestDetailResponse{}, huma.Error500InternalServerError(
 			"load worktree links failed",

--- a/middleman.go
+++ b/middleman.go
@@ -61,9 +61,11 @@ func uniqueHosts(repos []Repo) []string {
 }
 
 // resolveHostTokens builds a map of host -> token. When
-// resolveToken is set it is called once per host; otherwise
-// staticToken is used for all hosts.
+// resolveToken is set it is called once per host with ctx;
+// otherwise staticToken is used for all hosts. ctx lets
+// callers bound slow or hung token providers.
 func resolveHostTokens(
+	ctx context.Context,
 	hosts []string,
 	staticToken string,
 	resolveToken func(ctx context.Context, host string) (string, error),
@@ -71,9 +73,7 @@ func resolveHostTokens(
 	tokens := make(map[string]string, len(hosts))
 	for _, host := range hosts {
 		if resolveToken != nil {
-			tok, err := resolveToken(
-				context.Background(), host,
-			)
+			tok, err := resolveToken(ctx, host)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"middleman: resolve token for %s: %w",
@@ -197,10 +197,31 @@ type Instance struct {
 	closed         bool
 }
 
-// New creates a middleman Instance from the given options.
+// New creates a middleman Instance from the given options. It
+// wraps NewWithContext with context.Background(); callers that
+// need to bound or cancel a slow ResolveToken callback should
+// use NewWithContext directly.
+//
 // Either Token or ResolveToken must yield a non-empty token.
 // Either DBPath or DataDir must be provided.
 func New(opts Options) (*Instance, error) {
+	return NewWithContext(context.Background(), opts)
+}
+
+// NewWithContext creates a middleman Instance from the given
+// options. The provided ctx is used for ResolveToken lookups
+// during initialization so hosts that depend on a slow secret
+// store can bound it. A nil ctx is treated as
+// context.Background() to preserve the panic-free contract of
+// the older New(opts) entry point. ctx is not retained past
+// New; runtime sync cancellation is controlled by StartSync /
+// Close.
+func NewWithContext(
+	ctx context.Context, opts Options,
+) (*Instance, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	// DB path: prefer explicit DBPath over DataDir-derived.
 	dbPath := opts.DBPath
 	if dbPath == "" {
@@ -232,7 +253,7 @@ func New(opts Options) (*Instance, error) {
 
 	// Build per-host tokens.
 	hostTokens, err := resolveHostTokens(
-		hosts, opts.Token, opts.ResolveToken,
+		ctx, hosts, opts.Token, opts.ResolveToken,
 	)
 	if err != nil {
 		return nil, err
@@ -461,9 +482,27 @@ func (i *Instance) Close() error {
 }
 
 // PurgeOtherHosts deletes all data for platform hosts other
-// than keepHost.
+// than keepHost. Uses context.Background(); callers that need
+// to bound a long-running purge should call
+// PurgeOtherHostsWithContext instead.
 func (inst *Instance) PurgeOtherHosts(keepHost string) error {
-	return inst.db.PurgeOtherHosts(keepHost)
+	return inst.PurgeOtherHostsWithContext(
+		context.Background(), keepHost,
+	)
+}
+
+// PurgeOtherHostsWithContext deletes all data for platform
+// hosts other than keepHost under the given ctx. A nil ctx is
+// treated as context.Background() so callers that previously
+// used the context-less API do not hit database/sql's nil-ctx
+// panic.
+func (inst *Instance) PurgeOtherHostsWithContext(
+	ctx context.Context, keepHost string,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return inst.db.PurgeOtherHosts(ctx, keepHost)
 }
 
 // SetWatchedMRs sets the list of merge requests to sync on a
@@ -473,10 +512,27 @@ func (inst *Instance) SetWatchedMRs(mrs []WatchedMR) {
 }
 
 // SetWorktreeLinks replaces all worktree links atomically.
+// Uses context.Background(); callers that need cancellation
+// should call SetWorktreeLinksWithContext.
 func (inst *Instance) SetWorktreeLinks(
 	links []WorktreeLink,
 ) error {
-	return inst.db.SetWorktreeLinks(links)
+	return inst.SetWorktreeLinksWithContext(
+		context.Background(), links,
+	)
+}
+
+// SetWorktreeLinksWithContext replaces all worktree links
+// atomically under the given ctx. A nil ctx is treated as
+// context.Background() so callers that previously used the
+// context-less API do not hit database/sql's nil-ctx panic.
+func (inst *Instance) SetWorktreeLinksWithContext(
+	ctx context.Context, links []WorktreeLink,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return inst.db.SetWorktreeLinks(ctx, links)
 }
 
 // SetActiveWorktree sets the key of the currently focused worktree.

--- a/middleman_test.go
+++ b/middleman_test.go
@@ -216,6 +216,59 @@ func TestNewResolveTokenError(t *testing.T) {
 	Assert.Contains(t, err.Error(), "auth failed")
 }
 
+// TestNewWithContextCancelsResolveToken verifies NewWithContext
+// propagates the caller's ctx to ResolveToken so a slow or hung
+// token provider can be bounded.
+func TestNewWithContextCancelsResolveToken(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	_, err := NewWithContext(ctx, Options{
+		ResolveToken: func(
+			resolveCtx context.Context, _ string,
+		) (string, error) {
+			// Observe cancellation and propagate it.
+			return "", resolveCtx.Err()
+		},
+		DataDir: t.TempDir(),
+		Repos:   []Repo{{Owner: "t", Name: "r"}},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestNewWithContextNilCtx verifies a nil ctx is treated as
+// context.Background() so ResolveToken callbacks that call
+// ctx.Err() / ctx.Done() / context.WithTimeout(ctx, ...) do not
+// panic. Regression test for the old New(opts) contract.
+func TestNewWithContextNilCtx(t *testing.T) {
+	dir := t.TempDir()
+	var observed context.Context
+	//nolint:staticcheck // intentional: verifying nil-ctx normalization
+	inst, err := NewWithContext(nil, Options{
+		ResolveToken: func(
+			resolveCtx context.Context, _ string,
+		) (string, error) {
+			observed = resolveCtx
+			// Exercise ctx methods that would panic on a
+			// nil ctx: Err, Done, WithTimeout.
+			_ = resolveCtx.Err()
+			_ = resolveCtx.Done()
+			c, cancel := context.WithTimeout(
+				resolveCtx, time.Second,
+			)
+			cancel()
+			_ = c
+			return "tok", nil
+		},
+		DataDir: dir,
+		Repos:   []Repo{{Owner: "t", Name: "r"}},
+	})
+	require.NoError(t, err)
+	defer inst.Close()
+	require.NotNil(t, observed)
+	require.NoError(t, observed.Err())
+}
+
 func TestNewResolveTokenOverridesStatic(t *testing.T) {
 	dir := t.TempDir()
 	inst, err := New(Options{
@@ -423,4 +476,36 @@ func TestStopSyncConcurrent(t *testing.T) {
 	}
 	close(start)
 	wg.Wait()
+}
+
+// TestInstancePurgeOtherHostsWithContextNilCtx verifies a nil
+// ctx is normalized to context.Background() at the API
+// boundary so database/sql does not panic.
+func TestInstancePurgeOtherHostsWithContextNilCtx(t *testing.T) {
+	inst, err := New(Options{
+		Token:   "test-token",
+		DataDir: t.TempDir(),
+		Repos:   []Repo{{Owner: "t", Name: "r"}},
+	})
+	require.NoError(t, err)
+	defer inst.Close()
+
+	//nolint:staticcheck // intentional: verifying nil-ctx normalization
+	require.NoError(t, inst.PurgeOtherHostsWithContext(nil, "github.com"))
+}
+
+// TestInstanceSetWorktreeLinksWithContextNilCtx verifies a nil
+// ctx is normalized to context.Background() at the API
+// boundary so database/sql does not panic.
+func TestInstanceSetWorktreeLinksWithContextNilCtx(t *testing.T) {
+	inst, err := New(Options{
+		Token:   "test-token",
+		DataDir: t.TempDir(),
+		Repos:   []Repo{{Owner: "t", Name: "r"}},
+	})
+	require.NoError(t, err)
+	defer inst.Close()
+
+	//nolint:staticcheck // intentional: verifying nil-ctx normalization
+	require.NoError(t, inst.SetWorktreeLinksWithContext(nil, nil))
 }


### PR DESCRIPTION
## Summary

- Guard nil `ghIssue.UpdatedAt` in `refreshIssueTimeline` to prevent sync-goroutine panic
- Add `NewWithContext` for cancellable embedder token resolution; normalize nil ctx to `context.Background()`
- Lock `reposMu` inside `hostFor` so handler-triggered `SyncMR`/`SyncIssue`/`SyncItemByNumber` don't race `SetRepos`
- Thread `context.Context` through worktree-link and purge DB methods so handler cancellation propagates to SQL; add `*WithContext` Instance shims with nil-ctx normalization
- Wire `srv.Shutdown` + errCh drain in `cmd/e2e-server` to match the production binary's graceful shutdown

Generated with [Claude Code](https://claude.com/claude-code)