### PR TITLE
fix: bypass cooldown for user-triggered sync runs

### DIFF
--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -452,13 +452,14 @@ func (s *Syncer) fetcherFor(repo RepoRef) *GraphQLFetcher {
 	return s.fetchers[host]
 }
 
-// TriggerRun kicks off a non-blocking RunOnce on the Syncer's
-// wait group so callers can request an ad-hoc sync without
-// blocking the caller. The run participates in the Syncer's
-// lifecycle: Stop cancels the merged context so any in-flight
-// GitHub call unblocks, then waits for the goroutine to exit.
-// The caller's ctx is honored too, so per-request deadlines still
-// apply.
+// TriggerRun kicks off a non-blocking ad-hoc sync on the Syncer's
+// wait group so callers can request an immediate run without
+// blocking the caller. Ad-hoc runs bypass the normal nextSyncAfter
+// cadence gate, but still respect hard rate-limit pauses and the
+// syncer's lifecycle: Stop cancels the merged context so any
+// in-flight GitHub call unblocks, then waits for the goroutine to
+// exit. The caller's ctx is honored too, so per-request deadlines
+// still apply.
 func (s *Syncer) TriggerRun(ctx context.Context) {
 	s.lifecycleMu.Lock()
 	if s.stopped {
@@ -472,7 +473,7 @@ func (s *Syncer) TriggerRun(ctx context.Context) {
 	go func() {
 		defer s.wg.Done()
 		defer cancel()
-		s.RunOnce(merged)
+		s.runOnce(merged, true)
 	}()
 }
 
@@ -975,6 +976,13 @@ func (s *Syncer) publishMonotonicProgress(
 // per-host GitHub rate limit and abuse-detection thresholds happy
 // while still capturing most of the wall-clock win on network I/O.
 func (s *Syncer) RunOnce(ctx context.Context) {
+	s.runOnce(ctx, false)
+}
+
+func (s *Syncer) runOnce(
+	ctx context.Context,
+	bypassNextSyncAfter bool,
+) {
 	if !s.running.CompareAndSwap(false, true) {
 		return
 	}
@@ -1024,9 +1032,11 @@ func (s *Syncer) RunOnce(ctx context.Context) {
 		}
 		repoHosts[i] = host
 	}
-	eligibleHosts := s.hostEligibility(
-		repoHosts, s.nextSyncAfter,
-	)
+	nextAfter := s.nextSyncAfter
+	if bypassNextSyncAfter {
+		nextAfter = nil
+	}
+	eligibleHosts := s.hostEligibility(repoHosts, nextAfter)
 
 	var (
 		completed atomic.Int32

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1789,6 +1790,68 @@ func TestAPITriggerSyncIgnoresRequestCancellation(t *testing.T) {
 	}
 
 	Assert.Fail(t, "expected sync to complete despite request context cancellation")
+}
+
+func TestAPITriggerSyncBypassesNextSyncAfter(t *testing.T) {
+	require := require.New(t)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	var listCalls atomic.Int32
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(
+			_ context.Context, _, _ string,
+		) ([]*gh.PullRequest, error) {
+			listCalls.Add(1)
+			return nil, nil
+		},
+	}
+	trackers := map[string]*ghclient.RateTracker{
+		"github.com": ghclient.NewRateTracker(
+			database, "github.com", "rest",
+		),
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Owner:        "acme",
+			Name:         "widget",
+			PlatformHost: "github.com",
+		}},
+		time.Minute,
+		trackers,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	// Seed the host cooldown window exactly like a recent background sync.
+	syncer.RunOnce(context.Background())
+	require.Equal(int32(1), listCalls.Load())
+
+	client := setupTestClient(t, srv)
+	resp, err := client.HTTP.TriggerSyncWithResponse(
+		context.Background(),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, resp.StatusCode())
+
+	require.Eventually(func() bool {
+		return listCalls.Load() == 2
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestAPIReadyForReview(t *testing.T) {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -166,6 +166,86 @@ func TestHandleAddRepo(t *testing.T) {
 	require.Len(t, cfg2.Repos, 2)
 }
 
+func TestHandleAddRepoTriggersImmediateSyncDuringCooldown(t *testing.T) {
+	require := require.New(t)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	require.NoError(os.WriteFile(cfgPath, []byte(`
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`), 0o644))
+
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+
+	mock := &mockGH{}
+	trackers := map[string]*ghclient.RateTracker{
+		"github.com": ghclient.NewRateTracker(
+			database, "github.com", "rest",
+		),
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Owner:        "acme",
+			Name:         "widget",
+			PlatformHost: "github.com",
+		}},
+		time.Minute,
+		trackers,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := NewWithConfig(
+		database, syncer, nil, nil, cfg, cfgPath,
+		ServerOptions{},
+	)
+
+	// Prime nextSyncAfter so the add-repo trigger exercises the same
+	// cooldown path as a user clicking Sync right after a recent sync.
+	syncer.RunOnce(context.Background())
+
+	rr := doJSON(
+		t, srv, http.MethodPost, "/api/v1/repos",
+		map[string]string{
+			"owner": "other-org",
+			"name":  "other-repo",
+		},
+	)
+	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
+
+	require.Eventually(func() bool {
+		repos, err := database.ListRepos(context.Background())
+		if err != nil {
+			return false
+		}
+		if len(repos) != 2 {
+			return false
+		}
+		for _, repo := range repos {
+			if repo.Owner == "other-org" &&
+				repo.Name == "other-repo" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
 func TestHandleAddRepoDuplicate(t *testing.T) {
 	srv, _, _ := setupTestServerWithConfig(t)
 

--- a/internal/server/sync_cooldown_e2e_test.go
+++ b/internal/server/sync_cooldown_e2e_test.go
@@ -1,0 +1,278 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/db"
+	ghclient "github.com/wesm/middleman/internal/github"
+)
+
+func TestTriggerSyncE2EBypassesCooldown(t *testing.T) {
+	require := require.New(t)
+
+	baseURL, client, database := startSyncCooldownE2EServer(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, &mockGH{})
+
+	status, body := postJSON(
+		t, client, baseURL+"/api/v1/sync", nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+
+	first := waitForRepoSynced(t, database, "acme", "widget", nil)
+	require.NotNil(first.LastSyncCompletedAt)
+
+	time.Sleep(10 * time.Millisecond)
+
+	status, body = postJSON(
+		t, client, baseURL+"/api/v1/sync", nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+
+	second := waitForRepoSynced(
+		t, database, "acme", "widget", first.LastSyncCompletedAt,
+	)
+	require.NotNil(second.LastSyncCompletedAt)
+}
+
+func TestAddRepoE2ETriggersImmediateSyncDuringCooldown(t *testing.T) {
+	require := require.New(t)
+
+	baseURL, client, database := startSyncCooldownE2EServer(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, &mockGH{})
+
+	status, body := postJSON(
+		t, client, baseURL+"/api/v1/sync", nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+	waitForRepoSynced(t, database, "acme", "widget", nil)
+
+	status, body = postJSON(t, client, baseURL+"/api/v1/repos", map[string]string{
+		"owner": "other-org",
+		"name":  "other-repo",
+	})
+	require.Equal(http.StatusCreated, status, body)
+
+	added := waitForRepoSynced(
+		t, database, "other-org", "other-repo", nil,
+	)
+	require.NotNil(added.LastSyncCompletedAt)
+}
+
+func TestRefreshRepoE2ETriggersImmediateSyncDuringCooldown(t *testing.T) {
+	require := require.New(t)
+
+	var includeRefreshRepo atomic.Bool
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			repos := []*gh.Repository{{
+				Name:     new("middleman"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}}
+			if includeRefreshRepo.Load() {
+				repos = append(repos, &gh.Repository{
+					Name:     new("review-bot"),
+					Owner:    &gh.User{Login: new(owner)},
+					Archived: new(false),
+				})
+			}
+			return repos, nil
+		},
+	}
+
+	baseURL, client, database := startSyncCooldownE2EServer(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8090
+
+[[repos]]
+owner = "roborev-dev"
+name = "*"
+`, mock)
+
+	status, body := postJSON(
+		t, client, baseURL+"/api/v1/sync", nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+	waitForRepoSynced(t, database, "roborev-dev", "middleman", nil)
+
+	includeRefreshRepo.Store(true)
+
+	status, body = postJSON(
+		t, client,
+		baseURL+"/api/v1/repos/roborev-dev/%2A/refresh",
+		nil,
+	)
+	require.Equal(http.StatusOK, status, body)
+
+	refreshed := waitForRepoSynced(
+		t, database, "roborev-dev", "review-bot", nil,
+	)
+	require.NotNil(refreshed.LastSyncCompletedAt)
+}
+
+func startSyncCooldownE2EServer(
+	t *testing.T,
+	cfgContent string,
+	mock *mockGH,
+) (string, *http.Client, *db.DB) {
+	t.Helper()
+	require := require.New(t)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	require.NoError(os.WriteFile(cfgPath, []byte(cfgContent), 0o644))
+
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+
+	clients := map[string]ghclient.Client{"github.com": mock}
+	resolved := ghclient.ResolveConfiguredRepos(
+		context.Background(), clients, cfg.Repos,
+	)
+	trackers := map[string]*ghclient.RateTracker{
+		"github.com": ghclient.NewRateTracker(
+			database, "github.com", "rest",
+		),
+	}
+	syncer := ghclient.NewSyncer(
+		clients, database, nil, resolved.Expanded,
+		time.Minute, trackers, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := NewWithConfig(
+		database, syncer, nil, nil, cfg, cfgPath,
+		ServerOptions{},
+	)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(ln)
+	}()
+
+	baseURL := "http://" + ln.Addr().String()
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	require.Eventually(func() bool {
+		resp, err := client.Get(baseURL + "/api/v1/version")
+		if err != nil {
+			return false
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 10*time.Millisecond)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+		select {
+		case err := <-serveErr:
+			require.ErrorIs(err, http.ErrServerClosed)
+		case <-time.After(5 * time.Second):
+			require.FailNow("server did not stop")
+		}
+	})
+
+	return baseURL, client, database
+}
+
+func postJSON(
+	t *testing.T,
+	client *http.Client,
+	url string,
+	body any,
+) (int, string) {
+	t.Helper()
+	require := require.New(t)
+
+	var payload io.Reader = http.NoBody
+	if body != nil {
+		buf, err := json.Marshal(body)
+		require.NoError(err)
+		payload = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, payload)
+	require.NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	return resp.StatusCode, string(respBody)
+}
+
+func waitForRepoSynced(
+	t *testing.T,
+	database *db.DB,
+	owner, name string,
+	after *time.Time,
+) *db.Repo {
+	t.Helper()
+	require := require.New(t)
+
+	var repo *db.Repo
+	require.Eventually(func() bool {
+		got, err := database.GetRepoByOwnerName(
+			context.Background(), owner, name,
+		)
+		if err != nil || got == nil || got.LastSyncCompletedAt == nil {
+			return false
+		}
+		if after != nil &&
+			!got.LastSyncCompletedAt.After(*after) {
+			return false
+		}
+		repo = got
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+
+	return repo
+}


### PR DESCRIPTION
- bypass cadence cooldown for user-triggered sync runs while still respecting hard rate-limit pauses
- add regression coverage for manual sync and add-repo immediate sync behavior