### PR TITLE
fix: change middleman default ports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ CLI (middleman) → Config (TOML) → DB (SQLite)
                HTTP Server → REST API + Embedded SPA
 ```
 
-- **Server**: Huma-based HTTP server on loopback (default 127.0.0.1:8090)
+- **Server**: Huma-based HTTP server on loopback (default 127.0.0.1:8091)
 - **Storage**: SQLite with WAL mode (pure Go driver: modernc.org/sqlite)
 - **Sync**: Periodic pull from GitHub API (configurable, default 5m)
 - **Frontend**: Svelte 5 SPA embedded in the Go binary at build time
@@ -62,7 +62,7 @@ make frontend-dev   # Run Vite dev server (use alongside make dev)
 make install        # Build and install to ~/.local/bin or GOPATH
 ```
 
-For development, run `make dev` and `make frontend-dev` in parallel. Vite proxies `/api` to the Go server on :8090.
+For development, run `make dev` and `make frontend-dev` in parallel. Vite proxies `/api` to the Go server on :8091.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export MIDDLEMAN_GITHUB_TOKEN=ghp_your_token_here
 
 If you use the [GitHub CLI](https://cli.github.com/), middleman will use `gh auth token` automatically -- no env var needed.
 
-On first run, middleman creates a default config at `~/.config/middleman/config.toml` and serves the UI at **http://localhost:8090**. Add repositories from the Settings page, or edit the config file directly:
+On first run, middleman creates a default config at `~/.config/middleman/config.toml` and serves the UI at **http://localhost:8091**. Add repositories from the Settings page, or edit the config file directly:
 
 ```toml
 [[repos]]
@@ -119,7 +119,7 @@ All fields are optional. Repos can be added in the config file or through the Se
 | `sync_interval` | `"5m"` | How often to pull from GitHub |
 | `github_token_env` | `"MIDDLEMAN_GITHUB_TOKEN"` | Env var holding your token |
 | `host` | `"127.0.0.1"` | Listen address |
-| `port` | `8090` | Listen port |
+| `port` | `8091` | Listen port |
 | `base_path` | `"/"` | URL prefix for reverse proxy deployments |
 | `data_dir` | `"~/.config/middleman"` | Directory for the SQLite database |
 | `activity.view_mode` | `"threaded"` | `"flat"` or `"threaded"` |
@@ -203,8 +203,8 @@ Run the Go backend and Vite dev server in parallel:
 
 ```sh
 make air-install    # one-time: install air for live reload
-make dev            # Go server on :8090 with live reload
-make frontend-dev   # Vite on :5173, proxies /api to Go
+make dev            # Go server on :8091 with live reload
+make frontend-dev   # Vite on :5174, proxies /api to Go
 ```
 
 Other targets:

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -126,7 +126,7 @@ func TestStartupFallbackKeepsPersistedGlobMatchesInAPIs(t *testing.T) {
 	cfg := &config.Config{
 		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
 		Host:           "127.0.0.1",
-		Port:           8090,
+		Port:           8091,
 		BasePath:       "/",
 		DataDir:        dir,
 		Repos: []config.Repo{

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,7 @@ sync_interval = "5m"
 # Required scopes: repo (private repos) or public_repo (public only)
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "apache"

--- a/docs/plans/2026-04-13-default-ports-design.md
+++ b/docs/plans/2026-04-13-default-ports-design.md
@@ -1,0 +1,38 @@
+# Default ports design
+
+## Summary
+Change middleman default ports to avoid collisions with agentsview defaults and test ports.
+
+## Current overlap
+- agentsview app default: `8080`
+- agentsview Vite dev default: `5173`
+- agentsview Playwright/web server: `8090`
+- middleman app default: `8090`
+- middleman Vite dev default: `5173`
+
+## Chosen ports
+- middleman app default: `8091`
+- middleman Vite dev default: `5174`
+
+## Why
+- Avoid collision with agentsview local app and test flows.
+- Keep changes small: one-step bump from existing defaults.
+- Preserve loopback-only behavior and existing Docker/dev override ports.
+
+## Scope
+Update:
+- Go config defaults
+- default config template
+- library defaults used by embedded mode
+- Vite dev server default and API proxy fallback
+- docs and example config
+- tests asserting default port values
+
+## Non-goals
+- No Docker compose port changes
+- No reverse proxy behavior changes
+- No runtime port auto-discovery changes
+
+## Verification
+- Run relevant Go tests covering config and server settings.
+- Run frontend build/config check for Vite config validity.

--- a/docs/plans/2026-04-13-default-ports.md
+++ b/docs/plans/2026-04-13-default-ports.md
@@ -1,0 +1,209 @@
+# Default ports implementation plan
+
+> **For agentic workers:** REQUIRED: Use `/skill:orchestrator-implements` (in-session, orchestrator implements), `/skill:subagent-driven-development` (in-session, subagents implement), or `/skill:executing-plans` (parallel session) to implement this plan. Steps use checkbox syntax for tracking.
+
+**Goal:** Move middleman default app and Vite dev ports away from agentsview defaults to avoid local collisions.
+
+**Architecture:** Update port defaults at source-of-truth config points, then align docs and tests with new values. Keep runtime behavior unchanged apart from defaults: explicit config, env overrides, Docker overrides, and ephemeral test listeners still behave same.
+
+**Tech Stack:** Go, Svelte 5, Vite, Playwright, testify
+
+---
+
+### Task 1: Update backend default port sources
+
+**TDD scenario:** Modifying tested code — run existing tests first
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `middleman.go`
+- Test: `internal/config/config_test.go`
+- Test: `cmd/middleman/main_test.go`
+
+- [ ] **Step 1: Run existing backend default-port tests**
+
+Run: `go test ./internal/config ./cmd/middleman -shuffle=on`
+Expected: PASS with current `8090` defaults.
+
+- [ ] **Step 2: Update default port constants and embedded/library fallback**
+
+Set backend defaults from `8090` to `8091` in:
+
+```go
+const (
+    defaultPort = 8091
+)
+```
+
+and
+
+```go
+return &config.Config{
+    Host: "127.0.0.1",
+    Port: 8091,
+}
+```
+
+Also update default config template string in `internal/config/config.go` from:
+
+```toml
+port = 8090
+```
+
+to:
+
+```toml
+port = 8091
+```
+
+- [ ] **Step 3: Update backend tests that assert defaults**
+
+Change expected values from `8090` to `8091` in config and startup tests.
+
+- [ ] **Step 4: Run backend tests again**
+
+Run: `go test ./internal/config ./cmd/middleman -shuffle=on`
+Expected: PASS with `8091` defaults.
+
+- [ ] **Step 5: Commit**
+
+Commit message:
+
+```bash
+fix: change default backend port to 8091
+```
+
+### Task 2: Update server/config fixture expectations
+
+**TDD scenario:** Modifying tested code — run existing tests first
+
+**Files:**
+- Modify: `internal/server/settings_test.go`
+- Modify: `internal/server/roborev_proxy_test.go`
+- Modify: `internal/server/sync_cooldown_e2e_test.go`
+
+- [ ] **Step 1: Run existing server tests**
+
+Run: `go test ./internal/server -run 'TestHandleGetSettings|TestRoborevProxyForwarding|TestTriggerSyncE2EBypassesCooldown|TestAddRepoE2ETriggersImmediateSyncDuringCooldown|TestRefreshRepoE2ETriggersImmediateSyncDuringCooldown' -shuffle=on`
+Expected: PASS with current fixture configs.
+
+- [ ] **Step 2: Update fixture config snippets**
+
+Change inline TOML fixture snippets from:
+
+```toml
+port = 8090
+```
+
+to:
+
+```toml
+port = 8091
+```
+
+and any direct struct literal expectations from `8090` to `8091`.
+
+- [ ] **Step 3: Run server tests again**
+
+Run: `go test ./internal/server -run 'TestHandleGetSettings|TestRoborevProxyForwarding|TestTriggerSyncE2EBypassesCooldown|TestAddRepoE2ETriggersImmediateSyncDuringCooldown|TestRefreshRepoE2ETriggersImmediateSyncDuringCooldown' -shuffle=on`
+Expected: PASS with updated fixtures.
+
+- [ ] **Step 4: Commit**
+
+Commit message:
+
+```bash
+test: align server fixtures with new default port
+```
+
+### Task 3: Update frontend dev defaults and docs
+
+**TDD scenario:** Trivial change — use judgment
+
+**Files:**
+- Modify: `frontend/vite.config.ts`
+- Modify: `README.md`
+- Modify: `config.example.toml`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update Vite defaults**
+
+Change proxy fallback target and explicit dev port to:
+
+```ts
+const apiUrl = process.env.MIDDLEMAN_API_URL ?? "http://127.0.0.1:8091";
+
+server: {
+  port: 5174,
+  proxy: {
+    "/api": {
+      target: apiUrl,
+    },
+  },
+}
+```
+
+- [ ] **Step 2: Update user-facing docs and sample config**
+
+Change docs and examples from `8090` to `8091`, and Vite dev docs from `5173` to `5174`.
+
+- [ ] **Step 3: Verify frontend config builds**
+
+Run: `cd frontend && bun run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+Commit message:
+
+```bash
+docs: update default app and dev ports
+```
+
+### Task 4: Final verification and PR prep
+
+**TDD scenario:** Trivial change — use judgment
+
+**Files:**
+- Modify: `docs/plans/2026-04-13-default-ports-design.md`
+- Modify: `docs/plans/2026-04-13-default-ports.md`
+
+- [ ] **Step 1: Run focused full verification**
+
+Run:
+
+```bash
+go test ./internal/config ./cmd/middleman ./internal/server -shuffle=on
+cd frontend && bun run build
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Review diff**
+
+Run:
+
+```bash
+git diff --stat
+```
+
+Expected: only port-default, docs, and test-alignment changes.
+
+- [ ] **Step 3: Create final commit**
+
+Commit message:
+
+```bash
+fix: change middleman default ports
+```
+
+- [ ] **Step 4: Push branch and open PR**
+
+Run:
+
+```bash
+git push origin change-default-ports
+gh pr create --fill
+```
+
+Expected: branch pushed and PR URL returned.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,7 +9,7 @@ import { healthcheckPlugin } from "./src/lib/dev/healthcheckPlugin";
 const require = createRequire(import.meta.url);
 const testingLibrarySvelteEntry = require.resolve("@testing-library/svelte");
 
-const apiUrl = process.env.MIDDLEMAN_API_URL ?? "http://127.0.0.1:8090";
+const apiUrl = process.env.MIDDLEMAN_API_URL ?? "http://127.0.0.1:8091";
 const uiPkg = fileURLToPath(new URL("../packages/ui", import.meta.url));
 
 const config = {
@@ -27,6 +27,7 @@ const config = {
     exclude: ["@middleman/ui"],
   },
   server: {
+    port: 5174,
     fs: { allow: [".", uiPkg] },
     watch: { ignored: [`!${uiPkg}/**`, "!**/node_modules/@middleman/ui/**"] },
     proxy: {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ const (
 	defaultGitHubTokenEnv    = "MIDDLEMAN_GITHUB_TOKEN"
 	defaultSyncInterval      = "5m"
 	defaultHost              = "127.0.0.1"
-	defaultPort              = 8090
+	defaultPort              = 8091
 	defaultViewMode          = "threaded"
 	defaultTimeRange         = "7d"
 	defaultBasePath          = "/"
@@ -230,7 +230,7 @@ func EnsureDefault(path string) error {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 # Add repositories to monitor (or add them in the Settings UI).
 # [[repos]]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,7 +54,7 @@ name = "repo"
 	require.NoError(t, err)
 	assert.Equal("5m", cfg.SyncInterval)
 	assert.Equal("127.0.0.1", cfg.Host)
-	assert.Equal(8090, cfg.Port)
+	assert.Equal(8091, cfg.Port)
 }
 
 func TestLoadNoRepos(t *testing.T) {
@@ -582,7 +582,7 @@ name = "b"
 	require.NoError(t, err)
 	assert.Equal("5m", cfg2.SyncInterval)
 	assert.Equal("127.0.0.1", cfg2.Host)
-	assert.Equal(8090, cfg2.Port)
+	assert.Equal(8091, cfg2.Port)
 	assert.Equal("threaded", cfg2.Activity.ViewMode)
 	assert.Equal("7d", cfg2.Activity.TimeRange)
 }

--- a/internal/server/roborev_proxy_test.go
+++ b/internal/server/roborev_proxy_test.go
@@ -35,7 +35,7 @@ func setupTestServerWithRoborev(
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "acme"

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -28,7 +28,7 @@ func setupTestServerWithConfig(
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "acme"
@@ -179,7 +179,7 @@ func TestHandleAddRepoTriggersImmediateSyncDuringCooldown(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "acme"
@@ -297,7 +297,7 @@ func TestGetSettingsWithoutPersistence(t *testing.T) {
 		SyncInterval:   "5m",
 		GitHubTokenEnv: "UNUSED",
 		Host:           "127.0.0.1",
-		Port:           8090,
+		Port:           8091,
 		BasePath:       "/",
 		DataDir:        dir,
 		Repos: []config.Repo{
@@ -381,7 +381,7 @@ func TestHandleGetSettingsIncludesGlobCounts(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "roborev-dev"
@@ -430,7 +430,7 @@ func TestHandleRefreshRepoRebuildsExpandedSyncSet(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "roborev-dev"
@@ -480,7 +480,7 @@ func TestHandleRefreshRepoKeepsReposMatchedByOtherConfigEntries(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "roborev-dev"
@@ -531,7 +531,7 @@ func TestHandleDeleteRepoRebuildsExpandedSetFromRemainingPatterns(t *testing.T) 
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "roborev-dev"
@@ -573,7 +573,7 @@ func TestRefreshRepoPreservesExistingWhenResolutionFails(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "roborev-dev"
@@ -624,7 +624,7 @@ func TestGetSettingsDoesNotCallGitHub(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "acme"
@@ -675,7 +675,7 @@ func TestGlobMatchingIsCaseInsensitive(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "acme"
@@ -761,7 +761,7 @@ func TestConcurrentRefreshAndDeleteDoesNotResurrect(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "roborev-dev"

--- a/internal/server/sync_cooldown_e2e_test.go
+++ b/internal/server/sync_cooldown_e2e_test.go
@@ -27,7 +27,7 @@ func TestTriggerSyncE2EBypassesCooldown(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "acme"
@@ -62,7 +62,7 @@ func TestAddRepoE2ETriggersImmediateSyncDuringCooldown(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "acme"
@@ -115,7 +115,7 @@ func TestRefreshRepoE2ETriggersImmediateSyncDuringCooldown(t *testing.T) {
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
-port = 8090
+port = 8091
 
 [[repos]]
 owner = "roborev-dev"

--- a/middleman.go
+++ b/middleman.go
@@ -586,7 +586,7 @@ func buildConfig(opts Options) *config.Config {
 		SyncInterval:   interval.String(),
 		GitHubTokenEnv: "UNUSED",
 		Host:           "127.0.0.1",
-		Port:           8090,
+		Port:           8091,
 		BasePath:       basePath,
 		DataDir:        opts.DataDir,
 		Repos:          repos,


### PR DESCRIPTION
- use 8091 as default middleman app port to avoid agentsview overlap
- use 5174 for Vite dev server and point default API proxy at 8091
- align config examples, docs, and tests with new defaults