### PR TITLE
Workspace panel UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 packages/*/node_modules/
 frontend/playwright-report/
 frontend/test-results/
+frontend/tests/demo/screenshots/
 .idea/
 .vscode/
 tmp/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "bun run check && bunx tsc --noEmit -p ./tsconfig.json",
     "test": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "demo-workspace": "playwright test --config tests/demo/playwright-demo.config.ts"
   },
   "dependencies": {
     "@middleman/ui": "workspace:*",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -610,18 +610,20 @@
             activePlatformHost={getEmbedActivePlatformHost()}
             onSelectPR={(n) => {
               if ("platformHost" in route) {
-                softPinnedKey = detailKey(
-                  route.platformHost, route.owner, route.name, n,
-                );
                 navigate(
                   `/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}/${n}`,
                 );
-                emitWorkspaceCommand("softPinPR", {
-                  host: route.platformHost,
-                  owner: route.owner,
-                  name: route.name,
-                  number: n,
-                });
+                if (!panelHardPinned) {
+                  softPinnedKey = detailKey(
+                    route.platformHost, route.owner, route.name, n,
+                  );
+                  emitWorkspaceCommand("softPinPR", {
+                    host: route.platformHost,
+                    owner: route.owner,
+                    name: route.name,
+                    number: n,
+                  });
+                }
               }
             }}
             onBack={() => {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -76,26 +76,43 @@
 
   let stores = $state<StoreInstances | undefined>();
   let appReady = $state(false);
-  let panelSoftPinned = $state(false);
+  let softPinnedKey = $state<string | null>(null);
   let panelHardPinned = $state(false);
 
-  // Sync pin state from route transitions. Hard-pin is sticky
-  // (cleared only by explicit unpin). Soft-pin syncs from URL
-  // and clears when the panel navigates away from detail.
+  function detailKey(
+    host: string, owner: string, name: string, n: number,
+  ): string {
+    return `${host}/${owner}/${name}/${n}`;
+  }
+
+  // Derive current detail route key for pin matching.
+  const currentDetailKey = $derived.by(() => {
+    const r = getRoute();
+    if (
+      r.page === "workspaces-panel" &&
+      r.view === "detail" &&
+      "platformHost" in r
+    ) {
+      return detailKey(r.platformHost, r.owner, r.name, r.number);
+    }
+    return null;
+  });
+
+  // Hard-pin is sticky (cleared only by explicit unpin).
+  // Soft-pin from URL sets softPinnedKey for the current route.
   $effect(() => {
     const r = getRoute();
-    if (r.page !== "workspaces-panel") {
-      panelSoftPinned = false;
-      return;
-    }
+    if (r.page !== "workspaces-panel") return;
     if ("pin" in r && r.pin === "hard") {
       panelHardPinned = true;
     }
-    if ("pin" in r && r.pin === "soft") {
-      panelSoftPinned = true;
-    }
-    if (r.page === "workspaces-panel" && r.view !== "detail") {
-      panelSoftPinned = false;
+    if (
+      "pin" in r && r.pin === "soft" &&
+      r.view === "detail" && "platformHost" in r
+    ) {
+      softPinnedKey = detailKey(
+        r.platformHost, r.owner, r.name, r.number,
+      );
     }
   });
 
@@ -579,7 +596,9 @@
         {@const route = getRoute()}
         {#if route.page === "workspaces-panel"}
           {@const isPinned =
-            panelHardPinned || panelSoftPinned}
+            panelHardPinned ||
+            (softPinnedKey != null &&
+              softPinnedKey === currentDetailKey)}
           <WorkspacePanelView
             view={route.view}
             {isPinned}
@@ -591,7 +610,9 @@
             activePlatformHost={getEmbedActivePlatformHost()}
             onSelectPR={(n) => {
               if ("platformHost" in route) {
-                panelSoftPinned = true;
+                softPinnedKey = detailKey(
+                  route.platformHost, route.owner, route.name, n,
+                );
                 navigate(
                   `/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}/${n}`,
                 );
@@ -605,7 +626,7 @@
             }}
             onBack={() => {
               if ("platformHost" in route) {
-                panelSoftPinned = false;
+                softPinnedKey = null;
                 navigate(
                   `/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}`,
                 );
@@ -628,7 +649,7 @@
               });
             }}
             onUnpin={() => {
-              panelSoftPinned = false;
+              softPinnedKey = null;
               panelHardPinned = false;
               emitWorkspaceCommand("unpinPanelContext", {});
             }}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -79,15 +79,23 @@
   let panelSoftPinned = $state(false);
   let panelHardPinned = $state(false);
 
-  // Detect hard-pin from URL; cleared only by explicit unpin.
+  // Sync pin state from route transitions. Hard-pin is sticky
+  // (cleared only by explicit unpin). Soft-pin syncs from URL
+  // and clears when the panel navigates away from detail.
   $effect(() => {
     const r = getRoute();
-    if (
-      r.page === "workspaces-panel" &&
-      "pin" in r &&
-      r.pin === "hard"
-    ) {
+    if (r.page !== "workspaces-panel") {
+      panelSoftPinned = false;
+      return;
+    }
+    if ("pin" in r && r.pin === "hard") {
       panelHardPinned = true;
+    }
+    if ("pin" in r && r.pin === "soft") {
+      panelSoftPinned = true;
+    }
+    if (r.page === "workspaces-panel" && r.view !== "detail") {
+      panelSoftPinned = false;
     }
   });
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -76,6 +76,20 @@
 
   let stores = $state<StoreInstances | undefined>();
   let appReady = $state(false);
+  let panelSoftPinned = $state(false);
+  let panelHardPinned = $state(false);
+
+  // Detect hard-pin from URL; cleared only by explicit unpin.
+  $effect(() => {
+    const r = getRoute();
+    if (
+      r.page === "workspaces-panel" &&
+      "pin" in r &&
+      r.pin === "hard"
+    ) {
+      panelHardPinned = true;
+    }
+  });
 
   onMount(() => {
     initTheme();
@@ -556,8 +570,11 @@
       {:else if getPage() === "workspaces-panel"}
         {@const route = getRoute()}
         {#if route.page === "workspaces-panel"}
+          {@const isPinned =
+            panelHardPinned || panelSoftPinned}
           <WorkspacePanelView
             view={route.view}
+            {isPinned}
             platformHost={"platformHost" in route ? route.platformHost : undefined}
             owner={"owner" in route ? route.owner : undefined}
             name={"name" in route ? route.name : undefined}
@@ -566,12 +583,25 @@
             activePlatformHost={getEmbedActivePlatformHost()}
             onSelectPR={(n) => {
               if ("platformHost" in route) {
-                navigate(`/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}/${n}`);
+                panelSoftPinned = true;
+                navigate(
+                  `/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}/${n}`,
+                );
+                emitWorkspaceCommand("softPinPR", {
+                  host: route.platformHost,
+                  owner: route.owner,
+                  name: route.name,
+                  number: n,
+                });
               }
             }}
             onBack={() => {
               if ("platformHost" in route) {
-                navigate(`/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}`);
+                panelSoftPinned = false;
+                navigate(
+                  `/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}`,
+                );
+                emitWorkspaceCommand("clearSoftPin", {});
               }
             }}
             onCreateWorktree={(n) => {
@@ -583,6 +613,22 @@
                   platformHost: route.platformHost,
                 });
               }
+            }}
+            onNavigateWorktree={(key) => {
+              emitWorkspaceCommand("navigateWorktree", {
+                worktreeKey: key,
+              });
+            }}
+            onUnpin={() => {
+              panelSoftPinned = false;
+              panelHardPinned = false;
+              emitWorkspaceCommand("unpinPanelContext", {});
+            }}
+            onRefresh={() => {
+              emitWorkspaceCommand("refreshPulls", {});
+            }}
+            onRevealHostSettings={() => {
+              emitWorkspaceCommand("revealHostSettings", {});
             }}
           />
         {/if}

--- a/frontend/src/lib/stores/embed-config.svelte.ts
+++ b/frontend/src/lib/stores/embed-config.svelte.ts
@@ -241,15 +241,17 @@ export function initWorkspaceBridge(): void {
     const changingHost =
       "hostKey" in selection &&
       selection.hostKey !== config.workspace.selectedHostKey;
+    const updated = { ...config.workspace };
     if ("hostKey" in selection) {
-      config.workspace.selectedHostKey = selection.hostKey ?? null;
+      updated.selectedHostKey = selection.hostKey ?? null;
     }
     if ("worktreeKey" in selection) {
-      config.workspace.selectedWorktreeKey =
+      updated.selectedWorktreeKey =
         selection.worktreeKey ?? null;
     } else if (changingHost) {
-      config.workspace.selectedWorktreeKey = null;
+      updated.selectedWorktreeKey = null;
     }
+    config.workspace = updated;
     window.__middleman_notify_config_changed?.();
   };
   window.__middleman_update_host_state = (
@@ -260,16 +262,22 @@ export function initWorkspaceBridge(): void {
     },
   ) => {
     const config = window.__middleman_config;
-    const host = config?.workspace?.hosts.find(
+    if (!config?.workspace) return;
+    const hostIdx = config.workspace.hosts.findIndex(
       (h) => h.key === hostKey,
     );
-    if (!host) return;
+    if (hostIdx < 0) return;
+    const host = config.workspace.hosts[hostIdx]!;
+    const updated = { ...host };
     if ("connectionState" in patch) {
-      host.connectionState = patch.connectionState!;
+      updated.connectionState = patch.connectionState!;
     }
     if ("resources" in patch) {
-      host.resources = patch.resources ?? null;
+      updated.resources = patch.resources ?? null;
     }
+    const hosts = [...config.workspace.hosts];
+    hosts[hostIdx] = updated;
+    config.workspace = { ...config.workspace, hosts };
     window.__middleman_notify_config_changed?.();
   };
 }

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -2,7 +2,15 @@ export type Route =
   | { page: "activity" }
   | { page: "workspaces" }
   | { page: "workspaces-panel"; view: "list"; platformHost: string; owner: string; name: string }
-  | { page: "workspaces-panel"; view: "detail"; platformHost: string; owner: string; name: string; number: number }
+  | {
+      page: "workspaces-panel";
+      view: "detail";
+      platformHost: string;
+      owner: string;
+      name: string;
+      number: number;
+      pin?: "soft" | "hard";
+    }
   | { page: "workspaces-panel"; view: "empty"; emptyReason: string }
   | { page: "pulls"; view: "list" | "board"; selected?: { owner: string; name: string; number: number }; tab?: "files" }
   | { page: "issues"; selected?: { owner: string; name: string; number: number } }
@@ -94,6 +102,8 @@ function parseRoute(fullPath: string): Route {
       /^\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/,
     );
     if (detail) {
+      const params = new URLSearchParams(search);
+      const pin = params.get("pin");
       return {
         page: "workspaces-panel",
         view: "detail",
@@ -101,6 +111,9 @@ function parseRoute(fullPath: string): Route {
         owner: detail[2]!,
         name: detail[3]!,
         number: parseInt(detail[4]!, 10),
+        ...(pin === "soft" || pin === "hard"
+          ? { pin }
+          : {}),
       };
     }
     const list = rest.match(

--- a/frontend/tests/demo/playwright-demo.config.ts
+++ b/frontend/tests/demo/playwright-demo.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "off",
+    screenshot: "off",
+  },
+  webServer: {
+    command:
+      "bun run dev --host 127.0.0.1 --port 4173 --strictPort",
+    port: 4173,
+    cwd: "../..",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "demo",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 360, height: 640 },
+      },
+    },
+  ],
+});

--- a/frontend/tests/demo/playwright-demo.config.ts
+++ b/frontend/tests/demo/playwright-demo.config.ts
@@ -1,4 +1,12 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig, devices } from "@playwright/test";
+
+const frontendDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
 
 export default defineConfig({
   testDir: ".",
@@ -13,7 +21,7 @@ export default defineConfig({
     command:
       "bun run dev --host 127.0.0.1 --port 4173 --strictPort",
     port: 4173,
-    cwd: "../..",
+    cwd: frontendDir,
     reuseExistingServer: true,
     timeout: 120_000,
   },

--- a/frontend/tests/demo/workspace-screenshots.spec.ts
+++ b/frontend/tests/demo/workspace-screenshots.spec.ts
@@ -2,8 +2,8 @@
  * Workspace panel demo / screenshot harness.
  *
  * Usage:
- *   bun run demo:workspace            # headless, saves PNGs
- *   bun run demo:workspace --headed   # opens browser for visual inspection
+ *   bun run demo-workspace            # headless, saves PNGs
+ *   bun run demo-workspace --headed   # opens browser for visual inspection
  *
  * Screenshots land in frontend/tests/demo/screenshots/
  */
@@ -12,15 +12,6 @@ import { expect, test } from "@playwright/test";
 import { mockApi } from "../e2e/support/mockApi";
 
 const SCREENSHOT_DIR = "tests/demo/screenshots";
-
-function _embedConfig(
-  host: string | null = "github.com",
-) {
-  return {
-    embed: { activePlatformHost: host },
-    onWorkspaceCommand: () => ({ ok: true }),
-  };
-}
 
 test.beforeEach(async ({ page }) => {
   await mockApi(page);

--- a/frontend/tests/demo/workspace-screenshots.spec.ts
+++ b/frontend/tests/demo/workspace-screenshots.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Workspace panel demo / screenshot harness.
+ *
+ * Usage:
+ *   bun run demo:workspace            # headless, saves PNGs
+ *   bun run demo:workspace --headed   # opens browser for visual inspection
+ *
+ * Screenshots land in frontend/tests/demo/screenshots/
+ */
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "../e2e/support/mockApi";
+
+const SCREENSHOT_DIR = "tests/demo/screenshots";
+
+function _embedConfig(
+  host: string | null = "github.com",
+) {
+  return {
+    embed: { activePlatformHost: host },
+    onWorkspaceCommand: () => ({ ok: true }),
+  };
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("01 - empty: no selection", async ({ page }) => {
+  await page.goto("/workspaces/panel/empty/noSelection");
+  await expect(
+    page.getByText("Select a worktree"),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `${SCREENSHOT_DIR}/01-empty-no-selection.png`,
+    fullPage: true,
+  });
+});
+
+test(
+  "02 - empty: no platform repo",
+  async ({ page }) => {
+    await page.goto(
+      "/workspaces/panel/empty/noPlatformRepo",
+    );
+    await expect(
+      page.getByText("no linked repository"),
+    ).toBeVisible();
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/02-empty-no-platform-repo.png`,
+      fullPage: true,
+    });
+  },
+);
+
+test("03 - starting up (null host)", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: { activePlatformHost: null },
+    };
+  });
+  await page.goto(
+    "/workspaces/panel/github.com/acme/widgets",
+  );
+  await expect(
+    page.getByText("starting up"),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `${SCREENSHOT_DIR}/03-starting-up.png`,
+    fullPage: true,
+  });
+});
+
+test(
+  "04 - non-primary host degraded",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/example.com/wesm/other-repo",
+    );
+    await expect(
+      page.getByTestId("non-primary-state"),
+    ).toBeVisible();
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/04-non-primary-host.png`,
+      fullPage: true,
+    });
+  },
+);
+
+test("05 - PR list view", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: { activePlatformHost: "github.com" },
+      onWorkspaceCommand: () => ({ ok: true }),
+    };
+  });
+  await page.goto(
+    "/workspaces/panel/github.com/acme/widgets",
+  );
+  await expect(
+    page.getByText("acme/widgets"),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Add browser regression coverage"),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `${SCREENSHOT_DIR}/05-list-view.png`,
+    fullPage: true,
+  });
+});
+
+test(
+  "06 - PR list with worktree chip hover",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: () => ({ ok: true }),
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets",
+    );
+    const row = page
+      .locator(".panel-pr-item")
+      .filter({ hasText: "Refactor theme system" });
+    await row.hover();
+    await expect(row.locator(".wt-chip")).toBeVisible();
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/06-list-worktree-chip.png`,
+      fullPage: true,
+    });
+  },
+);
+
+test("07 - PR detail view", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: { activePlatformHost: "github.com" },
+      onWorkspaceCommand: () => ({ ok: true }),
+    };
+  });
+  await page.goto(
+    "/workspaces/panel/github.com/acme/widgets/42",
+  );
+  await expect(
+    page.getByText(
+      "#42 Add browser regression coverage",
+    ),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `${SCREENSHOT_DIR}/07-detail-view.png`,
+    fullPage: true,
+  });
+});
+
+test(
+  "08 - detail pinned with Unpin button",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: () => ({ ok: true }),
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets/42?pin=hard",
+    );
+    await expect(
+      page.locator("button.panel-unpin-btn"),
+    ).toBeVisible();
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/08-detail-pinned.png`,
+      fullPage: true,
+    });
+  },
+);
+
+test("09 - detail not found", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: { activePlatformHost: "github.com" },
+      onWorkspaceCommand: () => ({ ok: true }),
+    };
+  });
+  await page.goto(
+    "/workspaces/panel/github.com/acme/widgets/999",
+  );
+  await expect(
+    page.getByTestId("detail-not-found"),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `${SCREENSHOT_DIR}/09-detail-not-found.png`,
+    fullPage: true,
+  });
+});

--- a/frontend/tests/e2e/support/mockApi.ts
+++ b/frontend/tests/e2e/support/mockApi.ts
@@ -63,6 +63,42 @@ const pulls = [
     platform_host: "example.com",
     worktree_links: [],
   },
+  {
+    ID: 3,
+    RepoID: 1,
+    GitHubID: 301,
+    Number: 55,
+    URL: "https://github.com/acme/widgets/pull/55",
+    Title: "Refactor theme system",
+    Author: "luisa",
+    State: "open",
+    IsDraft: false,
+    Body: "Consolidates theme tokens.",
+    HeadBranch: "refactor/theme",
+    BaseBranch: "main",
+    Additions: 80,
+    Deletions: 40,
+    CommentCount: 0,
+    ReviewDecision: "",
+    CIStatus: "pending",
+    CIChecksJSON: "[]",
+    CreatedAt: "2026-03-29T14:00:00Z",
+    UpdatedAt: "2026-03-30T14:00:00Z",
+    LastActivityAt: "2026-03-30T14:00:00Z",
+    MergedAt: null,
+    ClosedAt: null,
+    KanbanStatus: "new",
+    Starred: false,
+    repo_owner: "acme",
+    repo_name: "widgets",
+    platform_host: "github.com",
+    worktree_links: [
+      {
+        worktree_key: "projects/theme-rework",
+        worktree_branch: "refactor/theme",
+      },
+    ],
+  },
 ];
 
 const issues = [
@@ -151,6 +187,38 @@ export async function mockApi(page: Page): Promise<void> {
 
     if (method === "GET" && pathname === "/api/v1/pulls") {
       await fulfillJson(route, pulls);
+      return;
+    }
+
+    const singlePrMatch = pathname.match(
+      /^\/api\/v1\/repos\/([^/]+)\/([^/]+)\/pulls\/(\d+)$/,
+    );
+    if (method === "GET" && singlePrMatch) {
+      const prOwner = singlePrMatch[1];
+      const prName = singlePrMatch[2];
+      const prNumber = parseInt(singlePrMatch[3]!, 10);
+      const pr = pulls.find(
+        (p) =>
+          p.repo_owner === prOwner &&
+          p.repo_name === prName &&
+          p.Number === prNumber,
+      );
+      if (pr) {
+        await fulfillJson(route, {
+          merge_request: pr,
+          repo_owner: pr.repo_owner,
+          repo_name: pr.repo_name,
+          detail_loaded: true,
+          detail_fetched_at: "2026-03-30T14:00:00Z",
+          worktree_links: pr.worktree_links,
+        });
+      } else {
+        await fulfillJson(
+          route,
+          { error: "Not found" },
+          404,
+        );
+      }
       return;
     }
 

--- a/frontend/tests/e2e/theme-toggle.spec.ts
+++ b/frontend/tests/e2e/theme-toggle.spec.ts
@@ -11,13 +11,19 @@ test("renders mocked frontend data", async ({ page }) => {
 
   await expect(page.getByText("Add browser regression coverage")).toBeVisible();
   await expect(page.getByText("acme/widgets")).toBeVisible();
-  await expect(page.getByText("1 PRs")).toBeVisible();
-  await expect(page.getByText("1 repos")).toBeVisible();
+  await expect(
+    page.getByRole("contentinfo").getByText("3 PRs"),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("contentinfo").getByText("1 repos"),
+  ).toBeVisible();
 
   await page.getByRole("button", { name: "Issues" }).click();
 
   await expect(page.getByText("Theme toggle does not stick")).toBeVisible();
-  await expect(page.getByText("1 issues")).toBeVisible();
+  await expect(
+    page.getByRole("contentinfo").getByText("1 issues"),
+  ).toBeVisible();
 });
 
 test("toggles dark mode from the header control", async ({ page }) => {

--- a/frontend/tests/e2e/workspaces-panel.spec.ts
+++ b/frontend/tests/e2e/workspaces-panel.spec.ts
@@ -278,6 +278,122 @@ test(
 );
 
 test(
+  "panel detail fallback fetches via single-PR endpoint",
+  async ({ page }) => {
+    // Mock a single-PR endpoint for a closed PR not in /pulls
+    await page.route(
+      "**/api/v1/repos/acme/widgets/pulls/100",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            merge_request: {
+              ID: 100,
+              Number: 100,
+              Title: "Closed feature",
+              Author: "alice",
+              State: "closed",
+              repo_owner: "acme",
+              repo_name: "widgets",
+              worktree_links: [],
+            },
+            repo_owner: "acme",
+            repo_name: "widgets",
+            detail_loaded: true,
+            detail_fetched_at: "2026-04-10T00:00:00Z",
+            worktree_links: [],
+          }),
+        });
+      },
+    );
+
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: () => ({ ok: true }),
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets/100",
+    );
+
+    // Should render the fallback-fetched PR detail
+    await expect(
+      page.getByText("Closed feature"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("#100"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "panel detail Refresh retries single-PR fetch after miss",
+  async ({ page }) => {
+    let fetchCount = 0;
+    await page.route(
+      "**/api/v1/repos/acme/widgets/pulls/200",
+      async (route) => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          await route.fulfill({
+            status: 404,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "Not found" }),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              merge_request: {
+                ID: 200,
+                Number: 200,
+                Title: "Late-synced PR",
+                Author: "bob",
+                State: "open",
+                repo_owner: "acme",
+                repo_name: "widgets",
+                worktree_links: [],
+              },
+              repo_owner: "acme",
+              repo_name: "widgets",
+              detail_loaded: true,
+              detail_fetched_at: "2026-04-10T00:00:00Z",
+              worktree_links: [],
+            }),
+          });
+        }
+      },
+    );
+
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: () => ({ ok: true }),
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets/200",
+    );
+
+    // First fetch returns 404 — shows not-found
+    await expect(
+      page.getByTestId("detail-not-found"),
+    ).toBeVisible();
+
+    // Click Refresh — resets dedup guard and retries
+    await page.getByRole("button", { name: "Refresh" }).click();
+
+    // Second fetch returns PR — shows detail
+    await expect(
+      page.getByText("Late-synced PR"),
+    ).toBeVisible();
+  },
+);
+
+test(
   "panel select PR emits softPinPR and shows Unpin",
   async ({ page }) => {
     await page.addInitScript(() => {

--- a/frontend/tests/e2e/workspaces-panel.spec.ts
+++ b/frontend/tests/e2e/workspaces-panel.spec.ts
@@ -43,7 +43,7 @@ test(
       };
     });
     await page.goto(
-      "/workspaces/panel/example.com/wesm/ghosthub",
+      "/workspaces/panel/example.com/wesm/other-repo",
     );
     await expect(
       page.getByTestId("non-primary-state"),
@@ -60,7 +60,7 @@ test(
       };
     });
     await page.goto(
-      "/workspaces/panel/github.com/wesm/ghosthub",
+      "/workspaces/panel/github.com/wesm/other-repo",
     );
     await expect(
       page.getByText("starting up"),
@@ -250,14 +250,14 @@ test(
 );
 
 test(
-  "panel detail not-found when PR missing from store",
+  "panel detail not-found keeps Back button and shows Refresh",
   async ({ page }) => {
     await page.addInitScript(() => {
       window.__middleman_config = {
         embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: () => ({ ok: true }),
       };
     });
-    // PR #999 is not in the mock fixture
     await page.goto(
       "/workspaces/panel/github.com/acme/widgets/999",
     );
@@ -271,5 +271,265 @@ test(
     await expect(
       page.getByRole("button", { name: "Back to list" }),
     ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Refresh" }),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "panel select PR emits softPinPR and shows Unpin",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: (
+          cmd: string,
+          payload: Record<string, unknown>,
+        ) => {
+          (window as Record<string, unknown>).__workspace_commands ??= [];
+          (
+            (window as Record<string, unknown>).__workspace_commands as unknown[]
+          ).push({ cmd, payload });
+          return { ok: true };
+        },
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets",
+    );
+
+    const row = page
+      .locator(".panel-pr-item")
+      .filter({ hasText: "Add browser regression coverage" });
+    await row.click();
+
+    await expect(page).toHaveURL(
+      /\/workspaces\/panel\/github\.com\/acme\/widgets\/42$/,
+    );
+
+    // softPinPR command emitted
+    const cmds = await page.evaluate(
+      () => (window as Record<string, unknown>).__workspace_commands as
+        { cmd: string; payload: Record<string, unknown> }[],
+    );
+    const softPin = cmds.find((c) => c.cmd === "softPinPR");
+    expect(softPin).toBeTruthy();
+    expect(softPin!.payload).toMatchObject({
+      host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+    });
+
+    // Unpin button visible
+    await expect(
+      page.locator("button.panel-unpin-btn"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "panel Unpin button emits unpinPanelContext",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: (
+          cmd: string,
+          payload: Record<string, unknown>,
+        ) => {
+          (window as Record<string, unknown>).__last_cmd = {
+            cmd,
+            payload,
+          };
+          return { ok: true };
+        },
+      };
+    });
+    // Navigate to list first, then click a PR to get soft-pinned
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets",
+    );
+    const row = page
+      .locator(".panel-pr-item")
+      .filter({ hasText: "Add browser regression coverage" });
+    await row.click();
+
+    const unpin = page.locator("button.panel-unpin-btn");
+    await expect(unpin).toBeVisible();
+    await unpin.click();
+
+    const cmd = await page.evaluate(
+      () => (window as Record<string, unknown>).__last_cmd as
+        { cmd: string },
+    );
+    expect(cmd.cmd).toBe("unpinPanelContext");
+
+    // Unpin button should disappear
+    await expect(unpin).not.toBeVisible();
+  },
+);
+
+test(
+  "panel back emits clearSoftPin",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: (
+          cmd: string,
+          payload: Record<string, unknown>,
+        ) => {
+          (window as Record<string, unknown>).__last_cmd = {
+            cmd,
+            payload,
+          };
+          return { ok: true };
+        },
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets",
+    );
+    await page
+      .locator(".panel-pr-item")
+      .filter({ hasText: "Add browser regression coverage" })
+      .click();
+
+    await page
+      .getByRole("button", { name: "Back to list" })
+      .click();
+
+    const cmd = await page.evaluate(
+      () => (window as Record<string, unknown>).__last_cmd as
+        { cmd: string },
+    );
+    expect(cmd.cmd).toBe("clearSoftPin");
+    await expect(page).toHaveURL(
+      /\/workspaces\/panel\/github\.com\/acme\/widgets$/,
+    );
+  },
+);
+
+test(
+  "panel hard-pin preserved across back navigation",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: () => ({ ok: true }),
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets/42?pin=hard",
+    );
+
+    // Unpin visible on hard-pinned detail
+    await expect(
+      page.locator("button.panel-unpin-btn"),
+    ).toBeVisible();
+
+    // Go back to list
+    await page
+      .getByRole("button", { name: "Back to list" })
+      .click();
+
+    // Click another PR — should still be pinned
+    const row = page
+      .locator(".panel-pr-item")
+      .filter({ hasText: "Refactor theme system" });
+    await row.click();
+
+    await expect(
+      page.locator("button.panel-unpin-btn"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "panel worktree chip emits navigateWorktree",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: (
+          cmd: string,
+          payload: Record<string, unknown>,
+        ) => {
+          (window as Record<string, unknown>).__last_cmd = {
+            cmd,
+            payload,
+          };
+          return { ok: true };
+        },
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets",
+    );
+
+    const row = page
+      .locator(".panel-pr-item")
+      .filter({ hasText: "Refactor theme system" });
+    await row.hover();
+
+    const chip = row.locator("button.wt-chip");
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveText("theme-rework");
+    await chip.click();
+
+    const cmd = await page.evaluate(
+      () => (window as Record<string, unknown>).__last_cmd as
+        { cmd: string; payload: Record<string, unknown> },
+    );
+    expect(cmd.cmd).toBe("navigateWorktree");
+    expect(cmd.payload.worktreeKey).toBe(
+      "projects/theme-rework",
+    );
+
+    // Should stay on list (chip click stops propagation)
+    await expect(page).toHaveURL(
+      /\/workspaces\/panel\/github\.com\/acme\/widgets$/,
+    );
+  },
+);
+
+test(
+  "panel non-primary state shows both hosts and Reveal button",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: (
+          cmd: string,
+        ) => {
+          (window as Record<string, unknown>).__last_cmd = {
+            cmd,
+          };
+          return { ok: true };
+        },
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/example.com/wesm/other-repo",
+    );
+
+    const state = page.getByTestId("non-primary-state");
+    await expect(state).toBeVisible();
+    await expect(state).toContainText("example.com");
+    await expect(state).toContainText("github.com");
+
+    const reveal = page.getByRole("button", {
+      name: "Reveal in Host Settings",
+    });
+    await expect(reveal).toBeVisible();
+    await reveal.click();
+
+    const cmd = await page.evaluate(
+      () => (window as Record<string, unknown>).__last_cmd as
+        { cmd: string },
+    );
+    expect(cmd.cmd).toBe("revealHostSettings");
   },
 );

--- a/frontend/tests/e2e/workspaces-panel.spec.ts
+++ b/frontend/tests/e2e/workspaces-panel.spec.ts
@@ -394,6 +394,83 @@ test(
 );
 
 test(
+  "panel detail shows error state on server failure",
+  async ({ page }) => {
+    await page.route(
+      "**/api/v1/repos/acme/widgets/pulls/500",
+      async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Internal error" }),
+        });
+      },
+    );
+
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: () => ({ ok: true }),
+      };
+    });
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets/500",
+    );
+
+    await expect(
+      page.getByTestId("detail-error"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Failed to load PR #500"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Retry" }),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "panel hard-pin skips softPinPR on select",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+        onWorkspaceCommand: (
+          cmd: string,
+          payload: Record<string, unknown>,
+        ) => {
+          (window as Record<string, unknown>).__workspace_commands ??= [];
+          (
+            (window as Record<string, unknown>).__workspace_commands as unknown[]
+          ).push({ cmd, payload });
+          return { ok: true };
+        },
+      };
+    });
+    // Start hard-pinned, go back, then select a PR
+    await page.goto(
+      "/workspaces/panel/github.com/acme/widgets/42?pin=hard",
+    );
+    await page
+      .getByRole("button", { name: "Back to list" })
+      .click();
+    await page
+      .locator(".panel-pr-item")
+      .filter({ hasText: "Refactor theme system" })
+      .click();
+
+    const cmds = await page.evaluate(
+      () => (window as Record<string, unknown>).__workspace_commands as
+        { cmd: string }[] | undefined,
+    );
+    const softPins = (cmds ?? []).filter(
+      (c) => c.cmd === "softPinPR",
+    );
+    expect(softPins).toHaveLength(0);
+  },
+);
+
+test(
   "panel select PR emits softPinPR and shows Unpin",
   async ({ page }) => {
     await page.addInitScript(() => {

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -7,6 +7,8 @@ const testWorkspaceData: WorkspaceData = {
     key: "local",
     label: "Local",
     connectionState: "connected",
+    transport: "local",
+    platform: "macOS",
     projects: [{
       key: "proj-1",
       name: "test-project",
@@ -72,6 +74,9 @@ test("workspaces route renders empty state", async ({ page }) => {
 });
 
 test("AppHeader shows Workspaces tab", async ({ page }) => {
+  await page.addInitScript((d) => {
+    window.__middleman_config = { workspace: d };
+  }, testWorkspaceData);
   await page.goto("/pulls");
   await expect(
     page.getByRole("button", { name: "Workspaces" }),
@@ -81,6 +86,9 @@ test("AppHeader shows Workspaces tab", async ({ page }) => {
 test(
   "Workspaces tab navigates to /workspaces",
   async ({ page }) => {
+    await page.addInitScript((d) => {
+      window.__middleman_config = { workspace: d };
+    }, testWorkspaceData);
     await page.goto("/pulls");
     await page
       .getByRole("button", { name: "Workspaces" })
@@ -114,7 +122,7 @@ test(
       page.locator(".project-name", { hasText: "test-project" }),
     ).toBeVisible();
     await expect(
-      page.getByText("feature-auth"),
+      page.getByText("Add auth middleware"),
     ).toBeVisible();
   },
 );
@@ -155,7 +163,7 @@ test(
       page.locator(".project-name", { hasText: "test-project" }),
     ).toBeVisible();
     await expect(
-      page.getByText("feature-auth"),
+      page.getByText("Add auth middleware"),
     ).toBeVisible();
   },
 );
@@ -255,7 +263,7 @@ test(
 
     const row = page
       .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
+      .filter({ hasText: "Add auth middleware" });
     await expect(row).toBeVisible();
     await row.click();
 
@@ -276,7 +284,7 @@ test(
 
     const row = page
       .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
+      .filter({ hasText: "Add auth middleware" });
     await expect(row).toBeVisible();
     await row.click({ button: "right" });
 
@@ -301,7 +309,7 @@ test(
 
     const row = page
       .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
+      .filter({ hasText: "Add auth middleware" });
     await expect(row).toBeVisible();
     await row.click({ button: "right" });
 
@@ -431,10 +439,10 @@ test(
     await expect(selectedRow).toBeVisible();
     await expect(selectedRow).toHaveClass(/selected/);
 
-    // wt-2 ("feature-auth") should NOT be selected
+    // wt-2 (renders as "Add auth middleware") should NOT be selected
     const otherRow = page
       .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
+      .filter({ hasText: "Add auth middleware" });
     await expect(otherRow).toBeVisible();
     await expect(otherRow).not.toHaveClass(/selected/);
   },
@@ -448,7 +456,7 @@ test(
     }, testWorkspaceData);
     await page.goto("/workspaces");
 
-    const worktreeRow = page.getByText("feature-auth");
+    const worktreeRow = page.getByText("Add auth middleware");
     await expect(worktreeRow).toBeVisible();
 
     // Collapse by clicking project header
@@ -533,10 +541,10 @@ test(
       });
     });
 
-    // wt-2 ("feature-auth") should now be selected
+    // wt-2 (renders as "Add auth middleware") should now be selected
     const selectedRow = page
       .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
+      .filter({ hasText: "Add auth middleware" });
     await expect(selectedRow).toHaveClass(/selected/);
   },
 );
@@ -704,7 +712,7 @@ test(
 
     const row = page
       .locator(".worktree-row")
-      .filter({ hasText: "feature-auth" });
+      .filter({ hasText: "Add auth middleware" });
     await expect(row).toBeVisible();
     await row.click();
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "workspaces": ["frontend", "packages/*"]
+  "workspaces": ["frontend", "packages/*"],
+  "scripts": {
+    "demo-workspace": "bun run --cwd frontend demo-workspace"
+  }
 }

--- a/packages/ui/src/components/workspace/WorkspacePanelPRItem.svelte
+++ b/packages/ui/src/components/workspace/WorkspacePanelPRItem.svelte
@@ -5,10 +5,15 @@
     pull: PullRequest;
     onSelect: (number: number) => void;
     onCreateWorktree: (number: number) => void;
+    onNavigateWorktree: (worktreeKey: string) => void;
   }
 
-  const { pull, onSelect, onCreateWorktree }: Props =
-    $props();
+  const {
+    pull,
+    onSelect,
+    onCreateWorktree,
+    onNavigateWorktree,
+  }: Props = $props();
 
   type PRState = "open" | "draft" | "closed" | "merged";
 
@@ -28,10 +33,6 @@
 
   const hasWorktree = $derived(
     (pull.worktree_links?.length ?? 0) > 0,
-  );
-
-  const linkedBranch = $derived(
-    pull.worktree_links?.[0]?.worktree_branch ?? null,
   );
 
   function handleCreateClick(e: MouseEvent): void {
@@ -62,11 +63,20 @@
     <span class="state-pill state-pill--{prState}">
       {stateLabel[prState]}
     </span>
-    {#if hasWorktree && linkedBranch}
-      <span class="linked-branch" title="Linked: {linkedBranch}">
-        {linkedBranch}
-      </span>
-    {:else if !hasWorktree && pull.State === "open"}
+    {#if hasWorktree}
+      {#each pull.worktree_links ?? [] as link (link.worktree_key)}
+        <button
+          class="wt-chip"
+          onclick={(e) => {
+            e.stopPropagation();
+            onNavigateWorktree(link.worktree_key);
+          }}
+          title="Open worktree: {link.worktree_key}"
+        >
+          {link.worktree_key.split("/").pop()}
+        </button>
+      {/each}
+    {:else if pull.State === "open"}
       <button
         class="create-wt-btn"
         onclick={handleCreateClick}
@@ -167,14 +177,25 @@
     color: var(--accent-purple);
   }
 
-  .linked-branch {
-    font-family: var(--font-mono, monospace);
+  .wt-chip {
     font-size: 10px;
-    color: var(--accent-teal, var(--accent-green));
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 0;
+    padding: 1px 5px;
+    border: 1px solid var(--border-muted);
+    border-radius: 3px;
+    background: var(--bg-inset);
+    color: var(--text-muted);
+    cursor: pointer;
+    visibility: hidden;
+  }
+
+  .panel-pr-item:hover .wt-chip,
+  .panel-pr-item:focus-within .wt-chip {
+    visibility: visible;
+  }
+
+  .wt-chip:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
   }
 
   .create-wt-btn {

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -286,6 +286,36 @@ export function createPullsStore(opts: PullsStoreOptions) {
     await loadPulls();
   }
 
+  async function fetchSinglePull(
+    owner: string,
+    name: string,
+    number: number,
+  ): Promise<PullRequest | null> {
+    try {
+      const { data, error } = await apiClient.GET(
+        "/repos/{owner}/{name}/pulls/{number}",
+        {
+          params: {
+            path: { owner, name, number },
+          },
+        },
+      );
+      if (error || !data) return null;
+      const mr = data.merge_request;
+      return {
+        ...mr,
+        platform_host: "",
+        repo_owner: data.repo_owner,
+        repo_name: data.repo_name,
+        detail_loaded: data.detail_loaded,
+        detail_fetched_at: data.detail_fetched_at,
+        worktree_links: data.worktree_links,
+      } as PullRequest;
+    } catch {
+      return null;
+    }
+  }
+
   async function loadPulls(
     params?: PullsParams,
   ): Promise<void> {
@@ -343,6 +373,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     optimisticKanbanUpdate,
     togglePRStar,
     loadPulls,
+    fetchSinglePull,
   };
 }
 

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -1,6 +1,11 @@
 import type { KanbanStatus, PullRequest } from "../api/types.js";
 import type { MiddlemanClient } from "../types.js";
 
+export type FetchPullResult =
+  | { status: "found"; pull: PullRequest }
+  | { status: "not-found" }
+  | { status: "error"; message: string };
+
 type PullsParams = {
   repo?: string;
   state?: string;
@@ -290,9 +295,9 @@ export function createPullsStore(opts: PullsStoreOptions) {
     owner: string,
     name: string,
     number: number,
-  ): Promise<PullRequest | null> {
+  ): Promise<FetchPullResult> {
     try {
-      const { data, error } = await apiClient.GET(
+      const { data, error, response } = await apiClient.GET(
         "/repos/{owner}/{name}/pulls/{number}",
         {
           params: {
@@ -300,19 +305,35 @@ export function createPullsStore(opts: PullsStoreOptions) {
           },
         },
       );
-      if (error || !data) return null;
+      if (error || !data) {
+        if (response?.status === 404) {
+          return { status: "not-found" };
+        }
+        return {
+          status: "error",
+          message: `API returned ${response?.status ?? "unknown"}`,
+        };
+      }
       const mr = data.merge_request;
       return {
-        ...mr,
-        platform_host: "",
-        repo_owner: data.repo_owner,
-        repo_name: data.repo_name,
-        detail_loaded: data.detail_loaded,
-        detail_fetched_at: data.detail_fetched_at,
-        worktree_links: data.worktree_links,
-      } as PullRequest;
-    } catch {
-      return null;
+        status: "found",
+        pull: {
+          ...mr,
+          platform_host: "",
+          repo_owner: data.repo_owner,
+          repo_name: data.repo_name,
+          detail_loaded: data.detail_loaded,
+          detail_fetched_at: data.detail_fetched_at,
+          worktree_links: data.worktree_links,
+        } as PullRequest,
+      };
+    } catch (err) {
+      return {
+        status: "error",
+        message: err instanceof Error
+          ? err.message
+          : "network error",
+      };
     }
   }
 

--- a/packages/ui/src/views/WorkspacePanelView.svelte
+++ b/packages/ui/src/views/WorkspacePanelView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getStores } from "../context.js";
+  import type { PullRequest } from "../api/types.js";
   import WorkspacePanelPRItem
     from "../components/workspace/WorkspacePanelPRItem.svelte";
 
@@ -7,6 +8,7 @@
 
   interface Props {
     view: "list" | "detail" | "empty";
+    isPinned?: boolean | undefined;
     platformHost?: string | undefined;
     owner?: string | undefined;
     name?: string | undefined;
@@ -16,10 +18,15 @@
     onSelectPR: (number: number) => void;
     onBack: () => void;
     onCreateWorktree: (number: number) => void;
+    onNavigateWorktree: (worktreeKey: string) => void;
+    onUnpin?: (() => void) | undefined;
+    onRefresh?: () => void;
+    onRevealHostSettings?: () => void;
   }
 
   let {
     view,
+    isPinned = false,
     platformHost,
     owner,
     name,
@@ -29,6 +36,10 @@
     onSelectPR,
     onBack,
     onCreateWorktree,
+    onNavigateWorktree,
+    onUnpin,
+    onRefresh,
+    onRevealHostSettings,
   }: Props = $props();
 
   const filteredPulls = $derived.by(() => {
@@ -57,6 +68,38 @@
     platformHost !== undefined &&
     platformHost !== activePlatformHost,
   );
+
+  let fetchedPull = $state<PullRequest | null>(null);
+  let fetchingPull = $state(false);
+  let lastFetchedNumber = $state<number | null>(null);
+
+  $effect(() => {
+    if (view !== "detail" || !number || !owner || !name) {
+      fetchedPull = null;
+      lastFetchedNumber = null;
+      return;
+    }
+    if (selectedPull) return;
+    if (number === lastFetchedNumber) return;
+
+    lastFetchedNumber = number;
+    fetchingPull = true;
+    const n = number;
+    pulls.fetchSinglePull(owner, name, n).then((pr) => {
+      if (n === number) {
+        fetchedPull = pr;
+        fetchingPull = false;
+      }
+    });
+  });
+
+  const resolvedPull = $derived(selectedPull ?? fetchedPull);
+
+  function handleDetailRefresh(): void {
+    lastFetchedNumber = null;
+    fetchedPull = null;
+    onRefresh?.();
+  }
 </script>
 
 <div class="workspace-panel">
@@ -75,9 +118,20 @@
   {:else if isNonPrimary}
     <div class="panel-empty" data-testid="non-primary-state">
       <p>
-        This repository is on a different platform host
-        ({platformHost}).
+        This worktree's repository is on
+        <strong>{platformHost}</strong>.
       </p>
+      <p class="panel-muted">
+        Pull request data is only available for repositories
+        on the active host
+        ({activePlatformHost}).
+      </p>
+      {#if onRevealHostSettings}
+        <button
+          class="panel-action-btn"
+          onclick={onRevealHostSettings}
+        >Reveal in Host Settings</button>
+      {/if}
     </div>
   {:else if view === "detail"}
     <div class="panel-detail">
@@ -97,27 +151,42 @@
             />
           </svg>
         </button>
-        {#if selectedPull}
+        {#if isPinned}
+          <button
+            class="panel-unpin-btn"
+            onclick={onUnpin}
+            title="Unpin and follow selection"
+          >Unpin</button>
+        {/if}
+        {#if resolvedPull}
           <span class="detail-title">
-            #{selectedPull.Number} {selectedPull.Title}
+            #{resolvedPull.Number} {resolvedPull.Title}
           </span>
+        {:else if number}
+          <span class="detail-title">PR #{number}</span>
         {/if}
       </div>
       <div class="detail-body">
-        {#if selectedPull}
-          {#if selectedPull.Body}
-            <p class="body-text">{selectedPull.Body}</p>
+        {#if resolvedPull}
+          {#if resolvedPull.Body}
+            <p class="body-text">{resolvedPull.Body}</p>
           {:else}
             <p class="body-empty">No description provided.</p>
           {/if}
-        {:else if pulls.isLoading()}
-          <p class="body-empty" data-testid="detail-loading">
-            Loading...
-          </p>
+        {:else if fetchingPull}
+          <div class="detail-body-empty" data-testid="detail-loading">
+            <p>Loading PR #{number}...</p>
+          </div>
         {:else}
-          <p class="body-empty" data-testid="detail-not-found">
-            Pull request #{number} not found.
-          </p>
+          <div class="detail-body-empty" data-testid="detail-not-found">
+            <p>PR #{number} was not found.</p>
+            {#if onRefresh}
+              <button
+                class="panel-action-btn"
+                onclick={handleDetailRefresh}
+              >Refresh</button>
+            {/if}
+          </div>
         {/if}
       </div>
     </div>
@@ -131,17 +200,26 @@
       </div>
       <div class="list-body">
         {#if pulls.isLoading() && filteredPulls.length === 0}
-          <p class="panel-empty-text">Loading...</p>
-        {:else if filteredPulls.length === 0}
           <p class="panel-empty-text">
-            No pull requests found.
+            Loading pull requests...
           </p>
+        {:else if filteredPulls.length === 0}
+          <div class="panel-empty-state">
+            <p>No open pull requests for {owner}/{name}.</p>
+            {#if onRefresh}
+              <button
+                class="panel-action-btn"
+                onclick={onRefresh}
+              >Refresh</button>
+            {/if}
+          </div>
         {:else}
           {#each filteredPulls as pr (pr.ID)}
             <WorkspacePanelPRItem
               pull={pr}
               onSelect={onSelectPR}
               {onCreateWorktree}
+              {onNavigateWorktree}
             />
           {/each}
         {/if}
@@ -161,8 +239,10 @@
 
   .panel-empty {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 4px;
     flex: 1;
     padding: 16px;
     color: var(--text-muted);
@@ -205,6 +285,22 @@
     color: var(--text-primary);
   }
 
+  .panel-unpin-btn {
+    font-size: 11px;
+    padding: 2px 6px;
+    border: 1px solid var(--border-muted);
+    border-radius: 4px;
+    background: var(--bg-inset);
+    color: var(--text-muted);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .panel-unpin-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
   .detail-title {
     font-size: 12px;
     font-weight: 600;
@@ -219,6 +315,20 @@
     flex: 1;
     overflow-y: auto;
     padding: 12px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .detail-body-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    flex: 1;
+    color: var(--text-muted);
+    font-size: 13px;
+    text-align: center;
   }
 
   .body-text {
@@ -283,5 +393,36 @@
     font-size: 13px;
     color: var(--text-muted);
     text-align: center;
+  }
+
+  .panel-empty-state {
+    padding: 24px 16px;
+    font-size: 13px;
+    color: var(--text-muted);
+    text-align: center;
+  }
+
+  .panel-muted {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 4px;
+  }
+
+  .panel-action-btn {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
+  }
+
+  .panel-action-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
   }
 </style>

--- a/packages/ui/src/views/WorkspacePanelView.svelte
+++ b/packages/ui/src/views/WorkspacePanelView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getStores } from "../context.js";
   import type { PullRequest } from "../api/types.js";
+  import type { FetchPullResult } from "../stores/pulls.svelte.js";
   import WorkspacePanelPRItem
     from "../components/workspace/WorkspacePanelPRItem.svelte";
 
@@ -69,7 +70,7 @@
     platformHost !== activePlatformHost,
   );
 
-  let fetchedPull = $state<PullRequest | null>(null);
+  let fetchResult = $state<FetchPullResult | null>(null);
   let fetchingPull = $state(false);
   let lastFetchKey = $state<string | null>(null);
 
@@ -83,7 +84,7 @@
   $effect(() => {
     const key = fetchKey();
     if (view !== "detail" || !key || !number || !owner || !name) {
-      fetchedPull = null;
+      fetchResult = null;
       lastFetchKey = null;
       return;
     }
@@ -93,19 +94,25 @@
     lastFetchKey = key;
     fetchingPull = true;
     const capturedKey = key;
-    pulls.fetchSinglePull(owner, name, number).then((pr) => {
+    pulls.fetchSinglePull(owner, name, number).then((r) => {
       if (capturedKey === fetchKey()) {
-        fetchedPull = pr;
+        fetchResult = r;
         fetchingPull = false;
       }
     });
   });
 
+  const fetchedPull = $derived(
+    fetchResult?.status === "found" ? fetchResult.pull : null,
+  );
+  const fetchError = $derived(
+    fetchResult?.status === "error" ? fetchResult.message : null,
+  );
   const resolvedPull = $derived(selectedPull ?? fetchedPull);
 
   function handleDetailRefresh(): void {
     lastFetchKey = null;
-    fetchedPull = null;
+    fetchResult = null;
     onRefresh?.();
   }
 </script>
@@ -184,6 +191,17 @@
         {:else if fetchingPull}
           <div class="detail-body-empty" data-testid="detail-loading">
             <p>Loading PR #{number}...</p>
+          </div>
+        {:else if fetchError}
+          <div class="detail-body-empty" data-testid="detail-error">
+            <p>Failed to load PR #{number}.</p>
+            <p class="error-hint">{fetchError}</p>
+            {#if onRefresh}
+              <button
+                class="panel-action-btn"
+                onclick={handleDetailRefresh}
+              >Retry</button>
+            {/if}
           </div>
         {:else}
           <div class="detail-body-empty" data-testid="detail-not-found">
@@ -351,6 +369,12 @@
     font-size: 13px;
     color: var(--text-muted);
     font-style: italic;
+  }
+
+  .error-hint {
+    font-size: 11px;
+    color: var(--accent-red);
+    margin-top: 2px;
   }
 
   .panel-list {

--- a/packages/ui/src/views/WorkspacePanelView.svelte
+++ b/packages/ui/src/views/WorkspacePanelView.svelte
@@ -71,22 +71,30 @@
 
   let fetchedPull = $state<PullRequest | null>(null);
   let fetchingPull = $state(false);
-  let lastFetchedNumber = $state<number | null>(null);
+  let lastFetchKey = $state<string | null>(null);
+
+  function fetchKey(): string | null {
+    if (!platformHost || !owner || !name || !number) {
+      return null;
+    }
+    return `${platformHost}/${owner}/${name}/${number}`;
+  }
 
   $effect(() => {
-    if (view !== "detail" || !number || !owner || !name) {
+    const key = fetchKey();
+    if (view !== "detail" || !key || !number || !owner || !name) {
       fetchedPull = null;
-      lastFetchedNumber = null;
+      lastFetchKey = null;
       return;
     }
     if (selectedPull) return;
-    if (number === lastFetchedNumber) return;
+    if (key === lastFetchKey) return;
 
-    lastFetchedNumber = number;
+    lastFetchKey = key;
     fetchingPull = true;
-    const n = number;
-    pulls.fetchSinglePull(owner, name, n).then((pr) => {
-      if (n === number) {
+    const capturedKey = key;
+    pulls.fetchSinglePull(owner, name, number).then((pr) => {
+      if (capturedKey === fetchKey()) {
         fetchedPull = pr;
         fetchingPull = false;
       }
@@ -96,7 +104,7 @@
   const resolvedPull = $derived(selectedPull ?? fetchedPull);
 
   function handleDetailRefresh(): void {
-    lastFetchedNumber = null;
+    lastFetchKey = null;
     fetchedPull = null;
     onRefresh?.();
   }


### PR DESCRIPTION
## Summary

- Panel navigation emits workspace commands (softPinPR, clearSoftPin, unpinPanelContext, navigateWorktree, refreshPulls, revealHostSettings) instead of relying solely on URL routing
- Unpin button in detail header lets user release pin and return to selection-driven routing
- Worktree chips on list rows replace single linked-branch label; clicking navigates to worktree
- Loading, empty, and not-found panel states with Back/Unpin controls always accessible
- Non-primary host state explains the mismatch and offers Reveal in Host Settings
- Hard-pin state (`?pin=hard`) preserved across back navigation
- Worktree chips keyboard-accessible via focus-within
- Detail Refresh retries single-PR fetch
- E2e coverage for pin/unpin flows, worktree chips, non-primary Reveal, not-found Back button

🤖 Generated with [Claude Code](https://claude.com/claude-code)