### PR TITLE
fix: render CI checks as inline collapse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: cd frontend && bunx playwright install --with-deps chromium
 
       - name: Run frontend e2e UTC coverage
-        run: cd frontend && bun run test:e2e --config playwright-e2e.config.ts --grep "UTC timestamp"
+        run: cd frontend && bun run test:e2e --config playwright-e2e.config.ts --project=chromium --grep "UTC timestamp"
 
       - name: Run tests
         run: go test ./... -v -shuffle=on

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -353,6 +353,7 @@ func patchFixturePRSHAs(fc *testutil.FixtureClient, owner, repo string, number i
 	}
 
 	repoKey := fmt.Sprintf("%s/%s", owner, repo)
+	oldHeadSHA := ""
 	patch := func(prs []*gh.PullRequest) {
 		for _, pr := range prs {
 			if pr.GetNumber() != number {
@@ -364,6 +365,9 @@ func patchFixturePRSHAs(fc *testutil.FixtureClient, owner, repo string, number i
 			if pr.Base == nil {
 				pr.Base = &gh.PullRequestBranch{}
 			}
+			if oldHeadSHA == "" {
+				oldHeadSHA = pr.Head.GetSHA()
+			}
 			pr.Head.SHA = &headSHA
 			pr.Base.SHA = &baseSHA
 		}
@@ -371,4 +375,16 @@ func patchFixturePRSHAs(fc *testutil.FixtureClient, owner, repo string, number i
 
 	patch(fc.OpenPRs[repoKey])
 	patch(fc.PRs[repoKey])
+
+	if oldHeadSHA == "" || oldHeadSHA == headSHA {
+		return
+	}
+	oldRefKey := fmt.Sprintf("%s/%s@%s", owner, repo, oldHeadSHA)
+	newRefKey := fmt.Sprintf("%s/%s@%s", owner, repo, headSHA)
+	if combined, ok := fc.CombinedStatuses[oldRefKey]; ok {
+		fc.CombinedStatuses[newRefKey] = combined
+	}
+	if runs, ok := fc.CheckRuns[oldRefKey]; ok {
+		fc.CheckRuns[newRefKey] = runs
+	}
 }

--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -25,12 +25,28 @@ export default defineConfig({
       },
     },
     {
+      name: "firefox",
+      testIgnore: /roborev/,
+      use: {
+        ...devices["Desktop Firefox"],
+      },
+    },
+    {
       name: "roborev",
       testMatch: /roborev/,
       fullyParallel: false,
       workers: 1,
       use: {
         ...devices["Desktop Chrome"],
+      },
+    },
+    {
+      name: "roborev-firefox",
+      testMatch: /roborev/,
+      fullyParallel: false,
+      workers: 1,
+      use: {
+        ...devices["Desktop Firefox"],
       },
     },
   ],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -24,5 +24,11 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
       },
     },
+    {
+      name: "firefox",
+      use: {
+        ...devices["Desktop Firefox"],
+      },
+    },
   ],
 });

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -1,23 +1,35 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("CI dropdown", () => {
-  test("expanded CI checks remain visible", async ({ page }) => {
+  test("expanded CI checks stay below chip without stretching sibling chips", async ({ page }) => {
     await page.goto("/pulls/acme/widgets/1");
 
-    const chip = page.getByRole("button", { name: /CI:\s*success/i });
+    const detail = page.locator(".pull-detail");
+    const chip = detail.getByRole("button", { name: /CI:\s*(success|pending)/i });
     await chip.waitFor({ state: "visible", timeout: 10_000 });
+    const chipBox = await chip.boundingBox();
     await chip.click();
 
-    const checks = page.locator(".ci-checks");
+    const checks = detail.locator(".ci-checks");
     await expect(checks).toBeVisible();
-    await expect(page.locator(".ci-check")).toHaveCount(3);
+    await expect(detail.locator(".ci-check")).toHaveCount(4);
 
-    const box = await checks.boundingBox();
-    expect(box).not.toBeNull();
-    expect(box!.height).toBeGreaterThan(30);
+    const checksBox = await checks.boundingBox();
+    const additionsChipBox = await detail.locator(".chip--muted").boundingBox();
 
-    await expect(page.locator(".ci-check").first()).toContainText("build");
-    await expect(page.locator(".ci-check").nth(1)).toContainText("test");
-    await expect(page.locator(".ci-check").nth(2)).toContainText("lint");
+    expect(chipBox).not.toBeNull();
+    expect(checksBox).not.toBeNull();
+    expect(additionsChipBox).not.toBeNull();
+    expect(checksBox!.y).toBeGreaterThan(chipBox!.y + chipBox!.height);
+    expect(additionsChipBox!.height).toBeLessThan(40);
+
+    await expect(detail.locator(".ci-check").first()).toContainText("build");
+    await expect(detail.locator(".ci-check").nth(1)).toContainText("test");
+    await expect(detail.locator(".ci-check").nth(2)).toContainText("lint");
+    const roborevRow = detail.locator(".ci-check", { hasText: "roborev" });
+    await expect(roborevRow).toHaveCount(1);
+    expect(
+      await roborevRow.evaluate((node) => node.tagName),
+    ).not.toBe("A");
   });
 });

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("CI dropdown", () => {
+  test("expanded CI checks remain visible", async ({ page }) => {
+    await page.goto("/pulls/acme/widgets/1");
+
+    const chip = page.getByRole("button", { name: /CI:\s*success/i });
+    await chip.waitFor({ state: "visible", timeout: 10_000 });
+    await chip.click();
+
+    const checks = page.locator(".ci-checks");
+    await expect(checks).toBeVisible();
+    await expect(page.locator(".ci-check")).toHaveCount(3);
+
+    const box = await checks.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.height).toBeGreaterThan(30);
+
+    await expect(page.locator(".ci-check").first()).toContainText("build");
+    await expect(page.locator(".ci-check").nth(1)).toContainText("test");
+    await expect(page.locator(".ci-check").nth(2)).toContainText("lint");
+  });
+});

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -22,6 +22,8 @@ type FixtureClient struct {
 	Issues                    map[string][]*gh.Issue
 	Comments                  map[string][]*gh.IssueComment
 	ReposByOwner              map[string][]*gh.Repository
+	CombinedStatuses          map[string]*gh.CombinedStatus
+	CheckRuns                 map[string][]*gh.CheckRun
 	ListRepositoriesByOwnerFn func(context.Context, string) ([]*gh.Repository, error)
 	mu                        sync.Mutex
 	nextID                    int64
@@ -30,13 +32,15 @@ type FixtureClient struct {
 // NewFixtureClient returns a FixtureClient with empty fixture maps.
 func NewFixtureClient() ghclient.Client {
 	return &FixtureClient{
-		OpenPRs:      make(map[string][]*gh.PullRequest),
-		PRs:          make(map[string][]*gh.PullRequest),
-		OpenIssues:   make(map[string][]*gh.Issue),
-		Issues:       make(map[string][]*gh.Issue),
-		Comments:     make(map[string][]*gh.IssueComment),
-		ReposByOwner: make(map[string][]*gh.Repository),
-		nextID:       10_000,
+		OpenPRs:          make(map[string][]*gh.PullRequest),
+		PRs:              make(map[string][]*gh.PullRequest),
+		OpenIssues:       make(map[string][]*gh.Issue),
+		Issues:           make(map[string][]*gh.Issue),
+		Comments:         make(map[string][]*gh.IssueComment),
+		ReposByOwner:     make(map[string][]*gh.Repository),
+		CombinedStatuses: make(map[string]*gh.CombinedStatus),
+		CheckRuns:        make(map[string][]*gh.CheckRun),
+		nextID:           10_000,
 	}
 }
 
@@ -46,6 +50,10 @@ func repoKey(owner, repo string) string {
 
 func issueKey(owner, repo string, number int) string {
 	return fmt.Sprintf("%s/%s#%d", owner, repo, number)
+}
+
+func refKey(owner, repo, ref string) string {
+	return fmt.Sprintf("%s/%s@%s", owner, repo, ref)
 }
 
 // ListOpenPullRequests returns the seeded open PRs for the given repo.
@@ -178,18 +186,24 @@ func (c *FixtureClient) ListForcePushEvents(
 	return nil, nil
 }
 
-// GetCombinedStatus returns nil (read-only stub).
+// GetCombinedStatus returns a seeded combined status by repo/ref.
 func (c *FixtureClient) GetCombinedStatus(
-	_ context.Context, _, _, _ string,
+	_ context.Context, owner, repo, ref string,
 ) (*gh.CombinedStatus, error) {
-	return nil, nil
+	return c.CombinedStatuses[refKey(owner, repo, ref)], nil
 }
 
-// ListCheckRunsForRef returns nil (read-only stub).
+// ListCheckRunsForRef returns seeded check runs by repo/ref.
 func (c *FixtureClient) ListCheckRunsForRef(
-	_ context.Context, _, _, _ string,
+	_ context.Context, owner, repo, ref string,
 ) ([]*gh.CheckRun, error) {
-	return nil, nil
+	runs := c.CheckRuns[refKey(owner, repo, ref)]
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	out := make([]*gh.CheckRun, len(runs))
+	copy(out, runs)
+	return out, nil
 }
 
 // ListWorkflowRunsForHeadSHA returns nil (read-only stub).

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -64,6 +64,13 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			URL:        "https://github.com/acme/widgets/actions/runs/1/job/3",
 			App:        "GitHub Actions",
 		},
+		{
+			Name:       "roborev",
+			Status:     "in_progress",
+			Conclusion: "",
+			URL:        "",
+			App:        "roborev",
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal widgets#1 ci checks: %w", err)
@@ -689,6 +696,13 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 							Conclusion: new("success"),
 							HTMLURL:    new("https://github.com/acme/widgets/actions/runs/1/job/3"),
 							App:        &gh.App{Name: new("GitHub Actions")},
+						},
+						{
+							Name:       new("roborev"),
+							Status:     new("in_progress"),
+							Conclusion: new(""),
+							HTMLURL:    new(""),
+							App:        &gh.App{Name: new("roborev")},
 						},
 					},
 				},

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -39,6 +40,35 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	// --- Pull Requests ---
 
+	const widgetsPR1HeadSHA = "1111111111111111111111111111111111111111"
+
+	ciChecksJSON, err := json.Marshal([]db.CICheck{
+		{
+			Name:       "build",
+			Status:     "completed",
+			Conclusion: "success",
+			URL:        "https://github.com/acme/widgets/actions/runs/1/job/1",
+			App:        "GitHub Actions",
+		},
+		{
+			Name:       "test",
+			Status:     "completed",
+			Conclusion: "success",
+			URL:        "https://github.com/acme/widgets/actions/runs/1/job/2",
+			App:        "GitHub Actions",
+		},
+		{
+			Name:       "lint",
+			Status:     "completed",
+			Conclusion: "success",
+			URL:        "https://github.com/acme/widgets/actions/runs/1/job/3",
+			App:        "GitHub Actions",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal widgets#1 ci checks: %w", err)
+	}
+
 	// widgets#1: open, alice, has reviews+comments+4 commits
 	w1Created := now.Add(-10 * 24 * time.Hour)
 	w1ID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
@@ -55,6 +85,8 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Additions:         240,
 		Deletions:         30,
 		CommentCount:      3,
+		CIStatus:          "success",
+		CIChecksJSON:      string(ciChecksJSON),
 		CreatedAt:         w1Created,
 		UpdatedAt:         now.Add(-2 * time.Hour),
 		LastActivityAt:    now.Add(-2 * time.Hour),
@@ -569,7 +601,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	openPRs := map[string][]*gh.PullRequest{
 		"acme/widgets": {
-			setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30),
+			setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1006, 6, "WIP: new dashboard layout", "carol", "open", true, "", w6Created, now.Add(-12*time.Hour)), 150, 40),
 			setPRStats(buildGHPR("acme", "widgets", 1007, 7, "Bump lodash from 4.17.20 to 4.17.21", "dependabot[bot]", "open", false, "", w7Created, now.Add(-6*time.Hour)), 1, 1),
@@ -581,7 +613,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	allPRs := map[string][]*gh.PullRequest{
 		"acme/widgets": {
-			setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30),
+			setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1003, 3, "Upgrade dependency versions", "carol", "merged", false, "", now.Add(-10*24*time.Hour), w3Merged), 80, 80),
 			setPRStats(buildGHPR("acme", "widgets", 1004, 4, "Refactor storage backend", "alice", "merged", false, "", now.Add(-30*24*time.Hour), w4Merged), 420, 310),
@@ -630,7 +662,37 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 				OpenIssues: openIssues,
 				Issues:     allIssues,
 				Comments:   make(map[string][]*gh.IssueComment),
-				nextID:     10_000,
+				CombinedStatuses: map[string]*gh.CombinedStatus{
+					refKey("acme", "widgets", widgetsPR1HeadSHA): {
+						State: new("success"),
+					},
+				},
+				CheckRuns: map[string][]*gh.CheckRun{
+					refKey("acme", "widgets", widgetsPR1HeadSHA): {
+						{
+							Name:       new("build"),
+							Status:     new("completed"),
+							Conclusion: new("success"),
+							HTMLURL:    new("https://github.com/acme/widgets/actions/runs/1/job/1"),
+							App:        &gh.App{Name: new("GitHub Actions")},
+						},
+						{
+							Name:       new("test"),
+							Status:     new("completed"),
+							Conclusion: new("success"),
+							HTMLURL:    new("https://github.com/acme/widgets/actions/runs/1/job/2"),
+							App:        &gh.App{Name: new("GitHub Actions")},
+						},
+						{
+							Name:       new("lint"),
+							Status:     new("completed"),
+							Conclusion: new("success"),
+							HTMLURL:    new("https://github.com/acme/widgets/actions/runs/1/job/3"),
+							App:        &gh.App{Name: new("GitHub Actions")},
+						},
+					},
+				},
+				nextID: 10_000,
 			}
 		},
 	}
@@ -671,6 +733,14 @@ func buildGHPR(
 func setPRStats(pr *gh.PullRequest, additions, deletions int) *gh.PullRequest {
 	pr.Additions = &additions
 	pr.Deletions = &deletions
+	return pr
+}
+
+func setPRHeadSHA(pr *gh.PullRequest, sha string) *gh.PullRequest {
+	if pr.Head == nil {
+		pr.Head = &gh.PullRequestBranch{}
+	}
+	pr.Head.SHA = &sha
 	return pr
 }
 

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -93,6 +93,33 @@
             {#if failedChecks.length > 0}
               <div class="ci-section-label ci-section-label--red">Failed ({failedChecks.length})</div>
               {#each failedChecks as check}
+                {#if check.url}
+                  <a
+                    class="ci-check"
+                    href={check.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+                    <span class="ci-name">{check.name}</span>
+                    {#if check.app}
+                      <span class="ci-app">{check.app}</span>
+                    {/if}
+                    <span class="ci-arrow">→</span>
+                  </a>
+                {:else}
+                  <div class="ci-check ci-check--static">
+                    <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+                    <span class="ci-name">{check.name}</span>
+                    {#if check.app}
+                      <span class="ci-app">{check.app}</span>
+                    {/if}
+                  </div>
+                {/if}
+              {/each}
+            {/if}
+            {#each nonFailedChecks as check}
+              {#if check.url}
                 <a
                   class="ci-check"
                   href={check.url}
@@ -106,22 +133,15 @@
                   {/if}
                   <span class="ci-arrow">→</span>
                 </a>
-              {/each}
-            {/if}
-            {#each nonFailedChecks as check}
-              <a
-                class="ci-check"
-                href={check.url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-                <span class="ci-name">{check.name}</span>
-                {#if check.app}
-                  <span class="ci-app">{check.app}</span>
-                {/if}
-                <span class="ci-arrow">→</span>
-              </a>
+              {:else}
+                <div class="ci-check ci-check--static">
+                  <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+                  <span class="ci-name">{check.name}</span>
+                  {#if check.app}
+                    <span class="ci-app">{check.app}</span>
+                  {/if}
+                </div>
+              {/if}
             {/each}
           </div>
         {/if}
@@ -200,6 +220,14 @@
   .ci-check:hover {
     background: var(--bg-surface-hover);
     text-decoration: none;
+  }
+
+  .ci-check--static {
+    cursor: default;
+  }
+
+  .ci-check--static:hover {
+    background: transparent;
   }
 
   .ci-check + .ci-check {

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import type { CICheck } from "../../api/types.js";
+
+  interface Props {
+    status: string;
+    checksJSON: string;
+    detailLoaded: boolean;
+    detailSyncing: boolean;
+  }
+
+  let {
+    status,
+    checksJSON,
+    detailLoaded,
+    detailSyncing,
+  }: Props = $props();
+
+  let expanded = $state(false);
+
+  const checks = $derived(parseCIChecks(checksJSON));
+  const failedChecks = $derived(
+    checks.filter((check) => check.conclusion === "failure"),
+  );
+  const nonFailedChecks = $derived(
+    checks.filter((check) => check.conclusion !== "failure"),
+  );
+  const hasCI = $derived(Boolean(status || checks.length > 0));
+
+  function parseCIChecks(json: string): CICheck[] {
+    if (!json) return [];
+    try {
+      return JSON.parse(json) as CICheck[];
+    } catch {
+      return [];
+    }
+  }
+
+  function checkIcon(check: CICheck): string {
+    if (check.status !== "completed") return "◦";
+    if (check.conclusion === "success") return "✓";
+    if (check.conclusion === "failure") return "✗";
+    if (check.conclusion === "skipped" || check.conclusion === "neutral") {
+      return "–";
+    }
+    return "?";
+  }
+
+  function checkColor(check: CICheck): string {
+    if (check.status !== "completed") return "var(--accent-amber)";
+    if (check.conclusion === "success") return "var(--accent-green)";
+    if (check.conclusion === "failure") return "var(--accent-red)";
+    return "var(--text-muted)";
+  }
+
+  function chipColor(chipStatus: string): string {
+    if (chipStatus === "success") return "chip--green";
+    if (chipStatus === "failure" || chipStatus === "error") return "chip--red";
+    if (chipStatus === "pending") return "chip--amber";
+    return "chip--muted";
+  }
+</script>
+
+{#if hasCI}
+  <button
+    class="chip chip--clickable {chipColor(status)}"
+    onclick={() => { expanded = !expanded; }}
+    title={expanded ? "Collapse CI checks" : "Expand CI checks"}
+  >
+    CI: {status || "unknown"}
+    {#if checks.length > 0}
+      ({checks.length})
+    {/if}
+    <span class="chip-chevron" class:chip-chevron--open={expanded}>▾</span>
+  </button>
+
+  {#if expanded}
+    {#if !detailLoaded}
+      {#if detailSyncing}
+        <div class="loading-placeholder">
+          <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
+          </svg>
+          Loading checks...
+        </div>
+      {:else}
+        <div class="loading-placeholder">Detail not yet loaded</div>
+      {/if}
+    {:else if checks.length > 0}
+      <div class="ci-checks">
+        {#if failedChecks.length > 0}
+          <div class="ci-section-label ci-section-label--red">Failed ({failedChecks.length})</div>
+          {#each failedChecks as check}
+            <a
+              class="ci-check"
+              href={check.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+              <span class="ci-name">{check.name}</span>
+              {#if check.app}
+                <span class="ci-app">{check.app}</span>
+              {/if}
+              <span class="ci-arrow">→</span>
+            </a>
+          {/each}
+        {/if}
+        {#each nonFailedChecks as check}
+          <a
+            class="ci-check"
+            href={check.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+            <span class="ci-name">{check.name}</span>
+            {#if check.app}
+              <span class="ci-app">{check.app}</span>
+            {/if}
+            <span class="ci-arrow">→</span>
+          </a>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+{/if}
+
+<style>
+  .chip--clickable {
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: opacity 0.1s;
+  }
+
+  .chip--clickable:hover {
+    opacity: 0.8;
+  }
+
+  .chip-chevron {
+    font-size: 10px;
+    transition: transform 0.15s;
+  }
+
+  .chip-chevron--open {
+    transform: rotate(180deg);
+  }
+
+  .ci-checks {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  .ci-section-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 6px 12px 4px;
+    color: var(--text-muted);
+  }
+
+  .ci-section-label--red {
+    color: var(--accent-red);
+  }
+
+  .ci-check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .ci-check:hover {
+    background: var(--bg-surface-hover);
+    text-decoration: none;
+  }
+
+  .ci-check + .ci-check {
+    border-top: 1px solid var(--border-muted);
+  }
+
+  .ci-icon {
+    font-weight: 700;
+    font-size: 13px;
+    flex-shrink: 0;
+    width: 16px;
+    text-align: center;
+  }
+
+  .ci-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ci-app {
+    font-size: 10px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .ci-arrow {
+    color: var(--text-muted);
+    flex-shrink: 0;
+    font-size: 12px;
+  }
+
+  .loading-placeholder {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .sync-spinner {
+    animation: spin 0.9s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+</style>

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -61,71 +61,80 @@
 </script>
 
 {#if hasCI}
-  <button
-    class="chip chip--clickable {chipColor(status)}"
-    onclick={() => { expanded = !expanded; }}
-    title={expanded ? "Collapse CI checks" : "Expand CI checks"}
-  >
-    CI: {status || "unknown"}
-    {#if checks.length > 0}
-      ({checks.length})
-    {/if}
-    <span class="chip-chevron" class:chip-chevron--open={expanded}>▾</span>
-  </button>
-
-  {#if expanded}
-    {#if !detailLoaded}
-      {#if detailSyncing}
-        <div class="loading-placeholder">
-          <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">
-            <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
-          </svg>
-          Loading checks...
-        </div>
-      {:else}
-        <div class="loading-placeholder">Detail not yet loaded</div>
+  <div class="ci-status">
+    <button
+      class="chip chip--clickable {chipColor(status)}"
+      onclick={() => { expanded = !expanded; }}
+      title={expanded ? "Collapse CI checks" : "Expand CI checks"}
+      aria-expanded={expanded}
+    >
+      CI: {status || "unknown"}
+      {#if checks.length > 0}
+        ({checks.length})
       {/if}
-    {:else if checks.length > 0}
-      <div class="ci-checks">
-        {#if failedChecks.length > 0}
-          <div class="ci-section-label ci-section-label--red">Failed ({failedChecks.length})</div>
-          {#each failedChecks as check}
-            <a
-              class="ci-check"
-              href={check.url}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-              <span class="ci-name">{check.name}</span>
-              {#if check.app}
-                <span class="ci-app">{check.app}</span>
-              {/if}
-              <span class="ci-arrow">→</span>
-            </a>
-          {/each}
-        {/if}
-        {#each nonFailedChecks as check}
-          <a
-            class="ci-check"
-            href={check.url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-            <span class="ci-name">{check.name}</span>
-            {#if check.app}
-              <span class="ci-app">{check.app}</span>
+      <span class="chip-chevron" class:chip-chevron--open={expanded}>▾</span>
+    </button>
+
+    {#if expanded}
+      <div class="ci-collapse">
+        {#if !detailLoaded}
+          {#if detailSyncing}
+            <div class="loading-placeholder">
+              <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">
+                <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
+              </svg>
+              Loading checks...
+            </div>
+          {:else}
+            <div class="loading-placeholder">Detail not yet loaded</div>
+          {/if}
+        {:else if checks.length > 0}
+          <div class="ci-checks">
+            {#if failedChecks.length > 0}
+              <div class="ci-section-label ci-section-label--red">Failed ({failedChecks.length})</div>
+              {#each failedChecks as check}
+                <a
+                  class="ci-check"
+                  href={check.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+                  <span class="ci-name">{check.name}</span>
+                  {#if check.app}
+                    <span class="ci-app">{check.app}</span>
+                  {/if}
+                  <span class="ci-arrow">→</span>
+                </a>
+              {/each}
             {/if}
-            <span class="ci-arrow">→</span>
-          </a>
-        {/each}
+            {#each nonFailedChecks as check}
+              <a
+                class="ci-check"
+                href={check.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+                <span class="ci-name">{check.name}</span>
+                {#if check.app}
+                  <span class="ci-app">{check.app}</span>
+                {/if}
+                <span class="ci-arrow">→</span>
+              </a>
+            {/each}
+          </div>
+        {/if}
       </div>
     {/if}
-  {/if}
+  </div>
 {/if}
 
 <style>
+  .ci-status {
+    display: contents;
+  }
+
   .chip--clickable {
     cursor: pointer;
     display: inline-flex;
@@ -147,14 +156,22 @@
     transform: rotate(180deg);
   }
 
+  .ci-collapse {
+    flex-basis: 100%;
+    width: 100%;
+    min-width: 0;
+    margin-top: 6px;
+  }
+
   .ci-checks {
     display: flex;
     flex-direction: column;
     background: var(--bg-inset);
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-md);
-    overflow: hidden;
+    overflow: auto;
     flex-shrink: 0;
+    max-height: min(320px, 50vh);
   }
 
   .ci-section-label {
@@ -223,6 +240,11 @@
     gap: 8px;
     color: var(--text-muted);
     font-size: 12px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    padding: 10px 12px;
+    white-space: nowrap;
   }
 
   .sync-spinner {

--- a/packages/ui/src/components/detail/CIStatus.test.ts
+++ b/packages/ui/src/components/detail/CIStatus.test.ts
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import CIStatus from "./CIStatus.svelte";
+
+describe("CIStatus", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders expanded CI checks when chip is clicked", async () => {
+    render(CIStatus, {
+      props: {
+        status: "success",
+        checksJSON: JSON.stringify([
+          {
+            name: "build",
+            status: "completed",
+            conclusion: "success",
+            url: "https://example.com/build",
+            app: "GitHub Actions",
+          },
+          {
+            name: "test",
+            status: "completed",
+            conclusion: "success",
+            url: "https://example.com/test",
+            app: "GitHub Actions",
+          },
+          {
+            name: "lint",
+            status: "completed",
+            conclusion: "success",
+            url: "https://example.com/lint",
+            app: "GitHub Actions",
+          },
+        ]),
+        detailLoaded: true,
+        detailSyncing: false,
+      },
+    });
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /CI:\s*success \(3\)/i }),
+    );
+
+    expect(screen.getByText("build")).toBeTruthy();
+    expect(screen.getByText("test")).toBeTruthy();
+    expect(screen.getByText("lint")).toBeTruthy();
+    expect(document.querySelectorAll(".ci-check")).toHaveLength(3);
+  });
+});

--- a/packages/ui/src/components/detail/CIStatus.test.ts
+++ b/packages/ui/src/components/detail/CIStatus.test.ts
@@ -33,6 +33,13 @@ describe("CIStatus", () => {
             url: "https://example.com/lint",
             app: "GitHub Actions",
           },
+          {
+            name: "roborev",
+            status: "in_progress",
+            conclusion: "",
+            url: "",
+            app: "roborev",
+          },
         ]),
         detailLoaded: true,
         detailSyncing: false,
@@ -40,12 +47,15 @@ describe("CIStatus", () => {
     });
 
     await fireEvent.click(
-      screen.getByRole("button", { name: /CI:\s*success \(3\)/i }),
+      screen.getByRole("button", { name: /CI:\s*success \(4\)/i }),
     );
 
     expect(screen.getByText("build")).toBeTruthy();
     expect(screen.getByText("test")).toBeTruthy();
     expect(screen.getByText("lint")).toBeTruthy();
-    expect(document.querySelectorAll(".ci-check")).toHaveLength(3);
+    expect(document.querySelectorAll(".ci-name")).toHaveLength(4);
+    expect(document.querySelectorAll(".ci-check")).toHaveLength(4);
+    expect(document.querySelectorAll("a.ci-check")).toHaveLength(3);
+    expect(document.querySelector(".ci-check--static")).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { CICheck, KanbanStatus } from "../../api/types.js";
+  import type { KanbanStatus } from "../../api/types.js";
   import { getStores, getClient, getActions, getUIConfig } from "../../context.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { timeAgo } from "../../utils/time.js";
@@ -13,6 +13,7 @@
   import GitHubLabels from "../shared/GitHubLabels.svelte";
   import DiffView from "../diff/DiffView.svelte";
   import DiffSidebar from "../diff/DiffSidebar.svelte";
+  import CIStatus from "./CIStatus.svelte";
 
   const { detail: detailStore, pulls, activity } = getStores();
   const client = getClient();
@@ -116,36 +117,9 @@
     }).catch(() => {});
   });
 
-  let ciExpanded = $state(false);
   const workflowApproval = $derived(
     detailStore.getDetail()?.workflow_approval,
   );
-  const checks = $derived(parseCIChecks(detailStore.getDetail()?.merge_request?.CIChecksJSON ?? ""));
-  const failedChecks = $derived(checks.filter(c => c.conclusion === "failure"));
-
-  function parseCIChecks(json: string): CICheck[] {
-    if (!json) return [];
-    try {
-      return JSON.parse(json) as CICheck[];
-    } catch {
-      return [];
-    }
-  }
-
-  function checkIcon(c: CICheck): string {
-    if (c.status !== "completed") return "◦";
-    if (c.conclusion === "success") return "✓";
-    if (c.conclusion === "failure") return "✗";
-    if (c.conclusion === "skipped" || c.conclusion === "neutral") return "–";
-    return "?";
-  }
-
-  function checkColor(c: CICheck): string {
-    if (c.status !== "completed") return "var(--accent-amber)";
-    if (c.conclusion === "success") return "var(--accent-green)";
-    if (c.conclusion === "failure") return "var(--accent-red)";
-    return "var(--text-muted)";
-  }
 
   const kanbanOptions: { value: KanbanStatus; label: string }[] = [
     { value: "new", label: "New" },
@@ -153,13 +127,6 @@
     { value: "waiting", label: "Waiting" },
     { value: "awaiting_merge", label: "Awaiting Merge" },
   ];
-
-  function ciColor(status: string): string {
-    if (status === "success") return "chip--green";
-    if (status === "failure" || status === "error") return "chip--red";
-    if (status === "pending") return "chip--amber";
-    return "chip--muted";
-  }
 
   function reviewColor(decision: string): string {
     if (decision === "APPROVED") return "chip--green";
@@ -310,19 +277,12 @@
         {:else}
           <span class="chip chip--green">Open</span>
         {/if}
-        {#if pr.CIStatus || checks.length > 0}
-          <button
-            class="chip chip--clickable {ciColor(pr.CIStatus)}"
-            onclick={() => { ciExpanded = !ciExpanded; }}
-            title={ciExpanded ? "Collapse CI checks" : "Expand CI checks"}
-          >
-            CI: {pr.CIStatus || "unknown"}
-            {#if checks.length > 0}
-              ({checks.length})
-            {/if}
-            <span class="chip-chevron" class:chip-chevron--open={ciExpanded}>▾</span>
-          </button>
-        {/if}
+        <CIStatus
+          status={pr.CIStatus}
+          checksJSON={pr.CIChecksJSON}
+          detailLoaded={detailStore.getDetailLoaded()}
+          detailSyncing={detailStore.isDetailSyncing()}
+        />
         {#if pr.ReviewDecision}
           <span class="chip {reviewColor(pr.ReviewDecision)}">{pr.ReviewDecision.replace(/_/g, " ")}</span>
         {/if}
@@ -336,58 +296,6 @@
 
       {#if labels.length > 0}
         <GitHubLabels {labels} mode="full" />
-      {/if}
-
-      <!-- Expanded CI checks -->
-      {#if ciExpanded}
-        {#if !detailStore.getDetailLoaded()}
-          {#if detailStore.isDetailSyncing()}
-            <div class="loading-placeholder">
-              <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">
-                <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
-              </svg>
-              Loading checks...
-            </div>
-          {:else}
-            <div class="loading-placeholder">Detail not yet loaded</div>
-          {/if}
-        {:else if checks.length > 0}
-          <div class="ci-checks">
-            {#if failedChecks.length > 0}
-              <div class="ci-section-label ci-section-label--red">Failed ({failedChecks.length})</div>
-              {#each failedChecks as check}
-                <a
-                  class="ci-check"
-                  href={check.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-                  <span class="ci-name">{check.name}</span>
-                  {#if check.app}
-                    <span class="ci-app">{check.app}</span>
-                  {/if}
-                  <span class="ci-arrow">→</span>
-                </a>
-              {/each}
-            {/if}
-            {#each checks.filter(c => c.conclusion !== "failure") as check}
-              <a
-                class="ci-check"
-                href={check.url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-                <span class="ci-name">{check.name}</span>
-                {#if check.app}
-                  <span class="ci-app">{check.app}</span>
-                {/if}
-                <span class="ci-arrow">→</span>
-              </a>
-            {/each}
-          </div>
-        {/if}
       {/if}
 
       <!-- Kanban state -->
@@ -817,85 +725,6 @@
       transparent
     );
     color: var(--accent-teal, var(--accent-green));
-  }
-
-  .chip--clickable {
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    transition: opacity 0.1s;
-  }
-  .chip--clickable:hover {
-    opacity: 0.8;
-  }
-  .chip-chevron {
-    font-size: 10px;
-    transition: transform 0.15s;
-  }
-  .chip-chevron--open {
-    transform: rotate(180deg);
-  }
-
-  .ci-checks {
-    display: flex;
-    flex-direction: column;
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
-    overflow: hidden;
-  }
-  .ci-section-label {
-    font-size: 10px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    padding: 6px 12px 4px;
-    color: var(--text-muted);
-  }
-  .ci-section-label--red {
-    color: var(--accent-red);
-  }
-  .ci-check {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 12px;
-    font-size: 12px;
-    color: var(--text-primary);
-    text-decoration: none;
-    transition: background 0.08s;
-  }
-  .ci-check:hover {
-    background: var(--bg-surface-hover);
-    text-decoration: none;
-  }
-  .ci-check + .ci-check {
-    border-top: 1px solid var(--border-muted);
-  }
-  .ci-icon {
-    font-weight: 700;
-    font-size: 13px;
-    flex-shrink: 0;
-    width: 16px;
-    text-align: center;
-  }
-  .ci-name {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .ci-app {
-    font-size: 10px;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-  .ci-arrow {
-    color: var(--text-muted);
-    flex-shrink: 0;
-    font-size: 12px;
   }
 
   .kanban-row {


### PR DESCRIPTION
- render CI status details as inline collapse under status chips
- keep CI checks from stretching sibling chips in pull detail
- avoid self-links for CI checks when no target URL is available