### PR TITLE
fix: add cross-browser (reduces some flaky e2e tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
       - name: Build e2e server
         run: GOFLAGS=-buildvcs=false go build -o ./cmd/e2e-server/e2e-server ./cmd/e2e-server
 
-      - name: Install Playwright browser
-        run: cd frontend && bunx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: cd frontend && bunx playwright install --with-deps chromium firefox webkit
 
       - name: Run frontend e2e UTC coverage
-        run: cd frontend && bun run test:e2e --config playwright-e2e.config.ts --project=chromium --grep "UTC timestamp"
+        run: cd frontend && bun run test:e2e --config playwright-e2e.config.ts --grep "UTC timestamp"
 
       - name: Run tests
         run: go test ./... -v -shuffle=on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    name: e2e (${{ matrix.browser }})
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -131,11 +136,19 @@ jobs:
       - name: Build E2E server
         run: go build -o ./cmd/e2e-server/e2e-server ./cmd/e2e-server
 
-      - name: Install Playwright browsers
-        run: cd frontend && bunx playwright install --with-deps chromium
+      - name: Install Playwright browser
+        run: cd frontend && bunx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run E2E tests
-        run: cd frontend && bun run playwright test --config=playwright-e2e.config.ts --project=chromium
+        run: cd frontend && bun run playwright test --config=playwright-e2e.config.ts --project=${{ matrix.browser }}
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: e2e-report-${{ matrix.browser }}
+          path: frontend/playwright-report/
+          retention-days: 7
 
   e2e-roborev:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,18 +69,6 @@ jobs:
       - name: Run frontend unit tests
         run: cd frontend && bun run test
 
-      - name: Build frontend assets for e2e
-        run: make frontend
-
-      - name: Build e2e server
-        run: GOFLAGS=-buildvcs=false go build -o ./cmd/e2e-server/e2e-server ./cmd/e2e-server
-
-      - name: Install Playwright browsers
-        run: cd frontend && bunx playwright install --with-deps chromium firefox webkit
-
-      - name: Run frontend e2e UTC coverage
-        run: cd frontend && bun run test:e2e --config playwright-e2e.config.ts --grep "UTC timestamp"
-
       - name: Run tests
         run: go test ./... -v -shuffle=on
 

--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -32,6 +32,13 @@ export default defineConfig({
       },
     },
     {
+      name: "webkit",
+      testIgnore: /roborev/,
+      use: {
+        ...devices["Desktop Safari"],
+      },
+    },
+    {
       name: "roborev",
       testMatch: /roborev/,
       fullyParallel: false,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,5 +30,11 @@ export default defineConfig({
         ...devices["Desktop Firefox"],
       },
     },
+    {
+      name: "webkit",
+      use: {
+        ...devices["Desktop Safari"],
+      },
+    },
   ],
 });

--- a/frontend/tests/e2e-full/activity-filters.spec.ts
+++ b/frontend/tests/e2e-full/activity-filters.spec.ts
@@ -191,7 +191,7 @@ test.describe("activity UTC timestamp presentation", () => {
   });
 
   test("activity API timestamps stay UTC and render as local dates", async ({ page }) => {
-    await page.reload();
+    await page.goto("/");
     await waitForTable(page);
     await page.locator(".seg-btn", { hasText: "30d" }).click();
     await expect(page.locator(".activity-row").first()).toBeVisible();

--- a/frontend/tests/e2e-full/collapsible-repos.spec.ts
+++ b/frontend/tests/e2e-full/collapsible-repos.spec.ts
@@ -24,14 +24,13 @@ function toolsHeader(page: Page) {
 
 test.describe("collapsible repo groups", () => {
   test.beforeEach(async ({ page }) => {
-    // Clear collapse state so every test starts expanded.
-    // localStorage can only be touched after the first goto.
-    await page.goto("/pulls");
-    await page.evaluate(() => {
+    // Clear collapse state before app bootstrap so each test starts expanded
+    // without relying on WebKit reload stability in CI.
+    await page.addInitScript(() => {
       localStorage.removeItem("middleman:collapsedRepos:pulls");
       localStorage.removeItem("middleman:collapsedRepos:issues");
     });
-    await page.reload();
+    await page.goto("/pulls");
     await waitForPullList(page);
   });
 
@@ -84,11 +83,14 @@ test.describe("collapsible repo groups", () => {
     await widgetsHeader(page).click();
     await expect(widgetsHeader(page)).toHaveAttribute("aria-expanded", "false");
 
-    await page.reload();
-    await waitForPullList(page);
+    const refreshedPage = await page.context().newPage();
+    await refreshedPage.goto("/pulls");
+    await waitForPullList(refreshedPage);
 
-    await expect(widgetsHeader(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(page.locator(".pull-item")).toHaveCount(4);
+    await expect(widgetsHeader(refreshedPage)).toHaveAttribute("aria-expanded", "false");
+    await expect(refreshedPage.locator(".pull-item")).toHaveCount(4);
+
+    await refreshedPage.close();
   });
 
   test("collapse is independent across pulls and issues surfaces", async ({ page }) => {
@@ -125,11 +127,14 @@ test.describe("collapsible repo groups", () => {
     await expect(widgetsHeader(page)).toHaveAttribute("aria-expanded", "true");
     await expect(page.locator(".issue-item")).toHaveCount(4);
 
-    // Collapse again and reload.
+    // Collapse again and verify persisted state in a fresh page.
     await widgetsHeader(page).click();
-    await page.reload();
-    await waitForIssueList(page);
-    await expect(widgetsHeader(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(page.locator(".issue-item")).toHaveCount(1);
+    const refreshedPage = await page.context().newPage();
+    await refreshedPage.goto("/issues");
+    await waitForIssueList(refreshedPage);
+    await expect(widgetsHeader(refreshedPage)).toHaveAttribute("aria-expanded", "false");
+    await expect(refreshedPage.locator(".issue-item")).toHaveCount(1);
+
+    await refreshedPage.close();
   });
 });

--- a/frontend/tests/e2e-full/comment-editor.spec.ts
+++ b/frontend/tests/e2e-full/comment-editor.spec.ts
@@ -107,10 +107,11 @@ test.describe("comment editor autocomplete", () => {
     await editor.click();
     await page.keyboard.type("<script>alert('x')</script> @a");
 
-    await expect(
-      page.locator(".comment-editor-option").filter({ hasText: "@alice" }),
-    ).toBeVisible({ timeout: 10_000 });
-    await editor.press("Enter");
+    const aliceOption = page
+      .locator(".comment-editor-option")
+      .filter({ hasText: "@alice" });
+    await expect(aliceOption).toBeVisible({ timeout: 10_000 });
+    await aliceOption.dispatchEvent("pointerdown");
     await expect(editor).toContainText("@alice");
 
     const submit = detail.locator(".submit-btn");

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -16,10 +16,17 @@ async function waitForIssueList(page: Page): Promise<void> {
 
 test.describe("grouping toggle", () => {
   test.beforeEach(async ({ page }) => {
-    // Clear localStorage to start with default (By Repo).
+    // Clear persisted grouping once before first app bootstrap so tests start
+    // in default grouped mode without relying on WebKit reload stability.
+    await page.addInitScript(() => {
+      if (sessionStorage.getItem("middleman:test:grouping:init") === "1") {
+        return;
+      }
+      localStorage.removeItem("middleman:groupingMode");
+      localStorage.removeItem("middleman:groupByRepo");
+      sessionStorage.setItem("middleman:test:grouping:init", "1");
+    });
     await page.goto("/pulls");
-    await page.evaluate(() => localStorage.removeItem("middleman:groupByRepo"));
-    await page.reload();
     await waitForPullList(page);
   });
 
@@ -51,13 +58,16 @@ test.describe("grouping toggle", () => {
     await page.locator(".group-btn", { hasText: "All" }).click();
     await expect(page.locator(".repo-header")).toHaveCount(0, { timeout: 5_000 });
 
-    // Reload the page.
-    await page.reload();
-    await waitForPullList(page);
+    // Verify persisted state in a fresh page in same browser context.
+    const refreshedPage = await page.context().newPage();
+    await refreshedPage.goto("/pulls");
+    await waitForPullList(refreshedPage);
 
     // Should still be ungrouped.
-    await expect(page.locator(".repo-header")).toHaveCount(0);
-    await expect(page.locator(".repo-badge").first()).toBeVisible();
+    await expect(refreshedPage.locator(".repo-header")).toHaveCount(0);
+    await expect(refreshedPage.locator(".repo-badge").first()).toBeVisible();
+
+    await refreshedPage.close();
   });
 
   test("toggle syncs from PRs to issues", async ({ page }) => {

--- a/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
+++ b/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
@@ -6,6 +6,12 @@ type PullRef = {
   number: number;
 };
 
+type IssueRef = {
+  owner: string;
+  repo: string;
+  number: number;
+};
+
 async function fetchPullDetail(
   page: import("@playwright/test").Page,
   pull: PullRef,
@@ -16,15 +22,43 @@ async function fetchPullDetail(
   }, pull);
 }
 
-async function fetchIssueDetail(page: import("@playwright/test").Page, number: number) {
-  return page.evaluate(async (issueNumber) => {
-    const response = await fetch(`/api/v1/repos/acme/widgets/issues/${issueNumber}`);
+async function fetchIssueDetail(
+  page: import("@playwright/test").Page,
+  issue: IssueRef,
+) {
+  return page.evaluate(async ({ owner, repo, number }) => {
+    const response = await fetch(`/api/v1/repos/${owner}/${repo}/issues/${number}`);
     return response.json();
-  }, number);
+  }, issue);
 }
 
 function widgetsPull(number: number): PullRef {
   return { owner: "acme", repo: "widgets", number };
+}
+
+function widgetsIssue(number: number): IssueRef {
+  return { owner: "acme", repo: "widgets", number };
+}
+
+function toolsPull(number: number): PullRef {
+  return { owner: "acme", repo: "tools", number };
+}
+
+function toolsIssue(number: number): IssueRef {
+  return { owner: "acme", repo: "tools", number };
+}
+
+function closeReopenPullTarget(browserName: string): PullRef {
+  switch (browserName) {
+    case "chromium":
+      return widgetsPull(6);
+    case "firefox":
+      return widgetsPull(2);
+    case "webkit":
+      return toolsPull(10);
+    default:
+      return widgetsPull(6);
+  }
 }
 
 function mergeTarget(browserName: string): PullRef {
@@ -34,9 +68,22 @@ function mergeTarget(browserName: string): PullRef {
     case "firefox":
       return widgetsPull(1);
     case "webkit":
-      return { owner: "acme", repo: "tools", number: 1 };
+      return toolsPull(1);
     default:
       return widgetsPull(7);
+  }
+}
+
+function closeReopenIssueTarget(browserName: string): IssueRef {
+  switch (browserName) {
+    case "chromium":
+      return widgetsIssue(11);
+    case "firefox":
+      return widgetsIssue(10);
+    case "webkit":
+      return toolsIssue(5);
+    default:
+      return widgetsIssue(11);
   }
 }
 
@@ -46,21 +93,23 @@ function expectUTCString(value: string | null): void {
 }
 
 test.describe("UTC maintainer flows", () => {
-  test("closing and reopening a pull request keeps API timestamps canonical UTC", async ({ page }) => {
-    await page.goto("/pulls/acme/widgets/6");
+  test("closing and reopening a pull request keeps API timestamps canonical UTC", async ({ page, browserName }) => {
+    const pull = closeReopenPullTarget(browserName);
+
+    await page.goto(`/pulls/${pull.owner}/${pull.repo}/${pull.number}`);
     await expect(page.locator(".btn--close")).toBeVisible();
 
     await page.locator(".btn--close").click();
     await expect(page.locator(".btn--reopen")).toBeVisible();
 
-    const closed = await fetchPullDetail(page, widgetsPull(6));
+    const closed = await fetchPullDetail(page, pull);
     expect(closed.merge_request.State).toBe("closed");
     expectUTCString(closed.merge_request.ClosedAt);
 
     await page.locator(".btn--reopen").click();
     await expect(page.locator(".btn--close")).toBeVisible();
 
-    const reopened = await fetchPullDetail(page, widgetsPull(6));
+    const reopened = await fetchPullDetail(page, pull);
     expect(reopened.merge_request.State).toBe("open");
     expect(reopened.merge_request.ClosedAt).toBeNull();
   });
@@ -83,21 +132,23 @@ test.describe("UTC maintainer flows", () => {
     expectUTCString(merged.merge_request.MergedAt);
   });
 
-  test("closing and reopening an issue keeps API timestamps canonical UTC", async ({ page }) => {
-    await page.goto("/issues/acme/widgets/11");
+  test("closing and reopening an issue keeps API timestamps canonical UTC", async ({ page, browserName }) => {
+    const issue = closeReopenIssueTarget(browserName);
+
+    await page.goto(`/issues/${issue.owner}/${issue.repo}/${issue.number}`);
     await expect(page.locator(".btn--close")).toBeVisible();
 
     await page.locator(".btn--close").click();
     await expect(page.locator(".btn--reopen")).toBeVisible();
 
-    const closed = await fetchIssueDetail(page, 11);
+    const closed = await fetchIssueDetail(page, issue);
     expect(closed.issue.State).toBe("closed");
     expectUTCString(closed.issue.ClosedAt);
 
     await page.locator(".btn--reopen").click();
     await expect(page.locator(".btn--close")).toBeVisible();
 
-    const reopened = await fetchIssueDetail(page, 11);
+    const reopened = await fetchIssueDetail(page, issue);
     expect(reopened.issue.State).toBe("open");
     expect(reopened.issue.ClosedAt).toBeNull();
   });

--- a/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
+++ b/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
@@ -1,10 +1,19 @@
 import { expect, test } from "@playwright/test";
 
-async function fetchPullDetail(page: import("@playwright/test").Page, number: number) {
-  return page.evaluate(async (prNumber) => {
-    const response = await fetch(`/api/v1/repos/acme/widgets/pulls/${prNumber}`);
+type PullRef = {
+  owner: string;
+  repo: string;
+  number: number;
+};
+
+async function fetchPullDetail(
+  page: import("@playwright/test").Page,
+  pull: PullRef,
+) {
+  return page.evaluate(async ({ owner, repo, number }) => {
+    const response = await fetch(`/api/v1/repos/${owner}/${repo}/pulls/${number}`);
     return response.json();
-  }, number);
+  }, pull);
 }
 
 async function fetchIssueDetail(page: import("@playwright/test").Page, number: number) {
@@ -12,6 +21,23 @@ async function fetchIssueDetail(page: import("@playwright/test").Page, number: n
     const response = await fetch(`/api/v1/repos/acme/widgets/issues/${issueNumber}`);
     return response.json();
   }, number);
+}
+
+function widgetsPull(number: number): PullRef {
+  return { owner: "acme", repo: "widgets", number };
+}
+
+function mergeTarget(browserName: string): PullRef {
+  switch (browserName) {
+    case "chromium":
+      return widgetsPull(7);
+    case "firefox":
+      return widgetsPull(1);
+    case "webkit":
+      return { owner: "acme", repo: "tools", number: 1 };
+    default:
+      return widgetsPull(7);
+  }
 }
 
 function expectUTCString(value: string | null): void {
@@ -27,20 +53,22 @@ test.describe("UTC maintainer flows", () => {
     await page.locator(".btn--close").click();
     await expect(page.locator(".btn--reopen")).toBeVisible();
 
-    const closed = await fetchPullDetail(page, 6);
+    const closed = await fetchPullDetail(page, widgetsPull(6));
     expect(closed.merge_request.State).toBe("closed");
     expectUTCString(closed.merge_request.ClosedAt);
 
     await page.locator(".btn--reopen").click();
     await expect(page.locator(".btn--close")).toBeVisible();
 
-    const reopened = await fetchPullDetail(page, 6);
+    const reopened = await fetchPullDetail(page, widgetsPull(6));
     expect(reopened.merge_request.State).toBe("open");
     expect(reopened.merge_request.ClosedAt).toBeNull();
   });
 
-  test("merging a pull request stores UTC timestamps and updates the detail view", async ({ page }) => {
-    await page.goto("/pulls/acme/widgets/7");
+  test("merging a pull request stores UTC timestamps and updates the detail view", async ({ page, browserName }) => {
+    const pull = mergeTarget(browserName);
+
+    await page.goto(`/pulls/${pull.owner}/${pull.repo}/${pull.number}`);
     await expect(page.locator(".btn--merge")).toBeVisible();
 
     await page.locator(".btn--merge").click();
@@ -49,7 +77,7 @@ test.describe("UTC maintainer flows", () => {
 
     await expect(page.locator(".chip.chip--purple")).toHaveText("Merged");
 
-    const merged = await fetchPullDetail(page, 7);
+    const merged = await fetchPullDetail(page, pull);
     expect(merged.merge_request.State).toBe("merged");
     expectUTCString(merged.merge_request.ClosedAt);
     expectUTCString(merged.merge_request.MergedAt);


### PR DESCRIPTION
- install Firefox and WebKit for UTC browser coverage in CI
- add WebKit projects to Playwright configs alongside Chromium and Firefox
- isolate cross-browser UTC merge tests so browser projects do not race on shared fixture PR state