### PR TITLE
Read frontend dev proxy target from config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,11 @@ air-install:
 
 # Run Go server in dev mode with live reload and API artifact refresh (use alongside `make frontend-dev`)
 dev: ensure-embed-dir check-air
-	"$(AIR_BIN)" -c .air.toml -- $(ARGS)
+	@if [ -n "$(MIDDLEMAN_CONFIG)" ]; then \
+		"$(AIR_BIN)" -c .air.toml -- -config "$(MIDDLEMAN_CONFIG)" $(ARGS); \
+	else \
+		"$(AIR_BIN)" -c .air.toml -- $(ARGS); \
+	fi
 
 # Run tests
 test: ensure-embed-dir
@@ -196,10 +200,10 @@ help:
 	@echo "  install        - Build and install to ~/.local/bin or GOPATH"
 	@echo "  air-install    - Install air live reload tool"
 	@echo ""
-	@echo "  dev            - Run Go server with air live reload and API artifact refresh"
+	@echo "  dev            - Run Go server with air live reload and API artifact refresh (honors MIDDLEMAN_CONFIG)"
 	@echo "  frontend       - Build frontend SPA"
-	@echo "  frontend-dev   - Install deps and run Vite dev server, logging to tmp/logs/frontend-dev.log"
-	@echo "  frontend-dev-bun - Install deps with Bun and run Vite dev server"
+	@echo "  frontend-dev   - Install deps and run Vite dev server, logging to tmp/logs/frontend-dev.log (honors MIDDLEMAN_CONFIG)"
+	@echo "  frontend-dev-bun - Install deps with Bun and run Vite dev server (honors MIDDLEMAN_CONFIG)"
 	@echo "  frontend-check - Run TS/Svelte lint and typecheck for frontend and packages/ui"
 	@echo "  api-generate   - Regenerate checked-in OpenAPI and TS schema"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ Compose behavior:
 - Stores SQLite state in Docker volume as `/data/middleman.db` via `data_dir = "/data"`
 - Exposes backend on `http://127.0.0.1:18090` and frontend dev server on `http://127.0.0.1:15173`
 
+### Custom config file
+
+Use custom config file for both processes with shared env override:
+
+```sh
+MIDDLEMAN_CONFIG=/path/to/config.toml make dev
+MIDDLEMAN_CONFIG=/path/to/config.toml make frontend-dev
+```
+
 Other targets:
 
 ```sh

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "dompurify": "3.3.3",
+        "js-toml": "^1.0.3",
         "marked": "17.0.5",
         "openapi-fetch": "^0.17.0",
         "shiki": "^4.0.2",
@@ -88,6 +89,18 @@
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/runtime-corejs3": ["@babel/runtime-corejs3@7.29.2", "", { "dependencies": { "core-js-pure": "^3.48.0" } }, "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.2.0", "", { "dependencies": { "@chevrotain/gast": "11.2.0", "@chevrotain/types": "11.2.0", "lodash-es": "4.17.23" } }, "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@11.2.0", "", { "dependencies": { "@chevrotain/types": "11.2.0", "lodash-es": "4.17.23" } }, "sha512-c+KoD6eSI1xjAZZoNUW+V0l13UEn+a4ShmUrjIKs1BeEWCji0Kwhmqn5FSx1K4BhWL7IQKlV7wLR4r8lLArORQ=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@11.2.0", "", {}, "sha512-lG73pBFqbXODTbXhdZwv0oyUaI+3Irm+uOv5/W79lI3g5hasYaJnVJOm3H2NkhA0Ef4XLBU4Scr7TJDJwgFkAw=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.2.0", "", {}, "sha512-vBMSj/lz/LqolbGQEHB0tlpW5BnljHVtp+kzjQfQU+5BtGMTuZCPVgaAjtKvQYXnHb/8i/02Kii00y0tsuwfsw=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@11.2.0", "", {}, "sha512-+7whECg4yNWHottjvr2To2BRxL4XJVjIyyv5J4+bJ0iMOVU8j/8n1qPDLZS/90W/BObDR8VNL46lFbzY/Hosmw=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -457,6 +470,8 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "chevrotain": ["chevrotain@11.2.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.2.0", "@chevrotain/gast": "11.2.0", "@chevrotain/regexp-to-ast": "11.2.0", "@chevrotain/types": "11.2.0", "@chevrotain/utils": "11.2.0", "lodash-es": "4.17.23" } }, "sha512-mHCHTxM51nCklUw9RzRVc0DLjAh/SAUPM4k/zMInlTIo25ldWXOZoPt7XEIk/LwoT4lFVmJcu9g5MHtx371x3A=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
@@ -464,6 +479,8 @@
     "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "core-js-pure": ["core-js-pure@3.49.0", "", {}, "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
@@ -589,6 +606,8 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "js-toml": ["js-toml@1.0.3", "", { "dependencies": { "chevrotain": "^11.1.1", "xregexp": "^5.1.2" } }, "sha512-sgyRKshBUSPIlUrbVXYQHReVZUXKHTldaW+Fj7KSan21vgnmMpuAAo00rBvm7W4HQrvZSvv186wNHlIjMPYC/A=="],
+
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
@@ -636,6 +655,8 @@
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
@@ -926,6 +947,8 @@
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "xregexp": ["xregexp@5.1.2", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.9" } }, "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw=="],
 
     "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "dompurify": "3.3.3",
+    "js-toml": "^1.0.3",
     "marked": "17.0.5",
     "openapi-fetch": "^0.17.0",
     "shiki": "^4.0.2"

--- a/frontend/src/lib/dev/apiProxyTarget.test.ts
+++ b/frontend/src/lib/dev/apiProxyTarget.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  defaultDevApiUrl,
+  resolveDevApiUrl,
+} from "./apiProxyTarget";
+
+describe("resolveDevApiUrl", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    tempDirs.length = 0;
+  });
+
+  it("prefers MIDDLEMAN_API_URL when present", () => {
+    expect(
+      resolveDevApiUrl({
+        HOME: "/ignored",
+        MIDDLEMAN_API_URL: "http://127.0.0.1:9123/custom",
+      }),
+    ).toBe("http://127.0.0.1:9123/custom");
+  });
+
+  it("reads host, port, and base path from MIDDLEMAN_HOME config", () => {
+    const middlemanHome = makeTempDir();
+    writeConfig(
+      middlemanHome,
+      `
+host = "127.0.0.1"
+port = 9123
+base_path = "/middleman/"
+`,
+    );
+
+    expect(
+      resolveDevApiUrl({
+        HOME: "/ignored",
+        MIDDLEMAN_HOME: middlemanHome,
+      }),
+    ).toBe("http://127.0.0.1:9123/middleman");
+  });
+
+  it("falls back to the default config path under HOME", () => {
+    const home = makeTempDir();
+    writeConfig(
+      path.join(home, ".config", "middleman"),
+      `
+port = 9234
+`,
+    );
+
+    expect(
+      resolveDevApiUrl({
+        HOME: home,
+      }),
+    ).toBe("http://127.0.0.1:9234");
+  });
+
+  it("falls back to the default URL when config cannot be read", () => {
+    expect(
+      resolveDevApiUrl({
+        HOME: "/missing-home",
+      }),
+    ).toBe(defaultDevApiUrl);
+  });
+
+  it("formats IPv6 loopback hosts correctly", () => {
+    const middlemanHome = makeTempDir();
+    writeConfig(
+      middlemanHome,
+      `
+host = "::1"
+port = 9345
+`,
+    );
+
+    expect(
+      resolveDevApiUrl({
+        HOME: "/ignored",
+        MIDDLEMAN_HOME: middlemanHome,
+      }),
+    ).toBe("http://[::1]:9345");
+  });
+
+  function makeTempDir(): string {
+    const dir = path.join(
+      os.tmpdir(),
+      `middleman-api-proxy-target-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function writeConfig(baseDir: string, content: string): void {
+    mkdirSync(baseDir, { recursive: true });
+    writeFileSync(path.join(baseDir, "config.toml"), content.trimStart(), "utf8");
+  }
+});

--- a/frontend/src/lib/dev/apiProxyTarget.test.ts
+++ b/frontend/src/lib/dev/apiProxyTarget.test.ts
@@ -44,6 +44,39 @@ base_path = "/middleman/"
     ).toBe("http://127.0.0.1:9123/middleman");
   });
 
+  it("prefers explicit MIDDLEMAN_CONFIG over MIDDLEMAN_HOME and HOME defaults", () => {
+    const home = makeTempDir();
+    const middlemanHome = makeTempDir();
+    const explicitConfigPath = path.join(makeTempDir(), "custom.toml");
+
+    writeConfig(
+      path.join(home, ".config", "middleman"),
+      `
+port = 9234
+`,
+    );
+    writeConfig(
+      middlemanHome,
+      `
+port = 9345
+`,
+    );
+    writeConfigFile(
+      explicitConfigPath,
+      `
+port = 9456
+`,
+    );
+
+    const env = {
+      HOME: home,
+      MIDDLEMAN_HOME: middlemanHome,
+      MIDDLEMAN_CONFIG: explicitConfigPath,
+    };
+
+    expect(resolveDevApiUrl(env)).toBe("http://127.0.0.1:9456");
+  });
+
   it("falls back to the default config path under HOME", () => {
     const home = makeTempDir();
     writeConfig(
@@ -58,6 +91,25 @@ port = 9234
         HOME: home,
       }),
     ).toBe("http://127.0.0.1:9234");
+  });
+
+  it("parses full TOML syntax used by backend config", () => {
+    const middlemanHome = makeTempDir();
+    writeConfig(
+      middlemanHome,
+      `
+host = '::1'
+port = 9_456
+base_path = '/middleman/'
+`,
+    );
+
+    expect(
+      resolveDevApiUrl({
+        HOME: "/ignored",
+        MIDDLEMAN_HOME: middlemanHome,
+      }),
+    ).toBe("http://[::1]:9456/middleman");
   });
 
   it("falls back to the default URL when config cannot be read", () => {
@@ -97,7 +149,11 @@ port = 9345
   }
 
   function writeConfig(baseDir: string, content: string): void {
-    mkdirSync(baseDir, { recursive: true });
-    writeFileSync(path.join(baseDir, "config.toml"), content.trimStart(), "utf8");
+    writeConfigFile(path.join(baseDir, "config.toml"), content);
+  }
+
+  function writeConfigFile(filePath: string, content: string): void {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content.trimStart(), "utf8");
   }
 });

--- a/frontend/src/lib/dev/apiProxyTarget.ts
+++ b/frontend/src/lib/dev/apiProxyTarget.ts
@@ -1,0 +1,178 @@
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const defaultHost = "127.0.0.1";
+const defaultPort = 8091;
+
+export const defaultDevApiUrl = `http://${defaultHost}:${defaultPort}`;
+
+export interface DevEnv {
+  HOME?: string;
+  MIDDLEMAN_API_URL?: string;
+  MIDDLEMAN_HOME?: string;
+}
+
+interface MiddlemanConfigFields {
+  basePath?: string;
+  host?: string;
+  port?: number;
+}
+
+export function resolveDevApiUrl(env: DevEnv = process.env): string {
+  const override = env.MIDDLEMAN_API_URL?.trim();
+  if (override) {
+    return override;
+  }
+
+  try {
+    const configText = readFileSync(resolveConfigPath(env), "utf8");
+    return buildDevApiUrl(parseConfig(configText));
+  } catch {
+    return defaultDevApiUrl;
+  }
+}
+
+function resolveConfigPath(env: DevEnv): string {
+  const middlemanHome = env.MIDDLEMAN_HOME?.trim();
+  if (middlemanHome) {
+    return path.join(middlemanHome, "config.toml");
+  }
+
+  const home = env.HOME?.trim() || os.homedir();
+  return path.join(home, ".config", "middleman", "config.toml");
+}
+
+function buildDevApiUrl(config: MiddlemanConfigFields): string {
+  const host = normalizeHost(config.host);
+  const port = normalizePort(config.port);
+  const basePath = normalizeBasePath(config.basePath);
+  const url = new URL(`http://${formatHostForUrl(host)}:${port}`);
+
+  if (basePath) {
+    url.pathname = `${basePath}/`;
+    return `${url.origin}${basePath}`;
+  }
+
+  return url.origin;
+}
+
+function normalizeHost(host: string | undefined): string {
+  const value = host?.trim();
+  return value || defaultHost;
+}
+
+function normalizePort(port: number | undefined): number {
+  if (typeof port !== "number" || !Number.isInteger(port)) {
+    return defaultPort;
+  }
+  if (port < 1 || port > 65535) {
+    return defaultPort;
+  }
+  return port;
+}
+
+function normalizeBasePath(basePath: string | undefined): string {
+  const value = basePath?.trim();
+  if (!value || value === "/") {
+    return "";
+  }
+
+  return `/${value.replace(/^\/+|\/+$/g, "")}`;
+}
+
+function formatHostForUrl(host: string): string {
+  if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) {
+    return `[${host}]`;
+  }
+  return host;
+}
+
+function parseConfig(configText: string): MiddlemanConfigFields {
+  const config: MiddlemanConfigFields = {};
+
+  for (const rawLine of configText.split(/\r?\n/u)) {
+    const line = stripComments(rawLine).trim();
+    if (!line) {
+      continue;
+    }
+
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$/u);
+    if (!match) {
+      continue;
+    }
+
+    const key = match[1];
+    const rawValue = match[2];
+    if (!key || !rawValue) {
+      continue;
+    }
+
+    switch (key) {
+      case "host": {
+        const host = parseTomlString(rawValue);
+        if (host !== undefined) {
+          config.host = host;
+        }
+        break;
+      }
+      case "base_path": {
+        const basePath = parseTomlString(rawValue);
+        if (basePath !== undefined) {
+          config.basePath = basePath;
+        }
+        break;
+      }
+      case "port": {
+        const port = parseTomlInteger(rawValue);
+        if (port !== undefined) {
+          config.port = port;
+        }
+        break;
+      }
+    }
+  }
+
+  return config;
+}
+
+function stripComments(line: string): string {
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"' && !escaped) {
+      inString = !inString;
+    } else if (char === "#" && !inString) {
+      return line.slice(0, i);
+    }
+
+    escaped = char === "\\" && !escaped;
+    if (char !== "\\") {
+      escaped = false;
+    }
+  }
+
+  return line;
+}
+
+function parseTomlString(value: string): string | undefined {
+  const match = value.trim().match(/^"((?:[^"\\]|\\.)*)"$/u);
+  if (!match) {
+    return undefined;
+  }
+
+  return JSON.parse(`"${match[1]}"`) as string;
+}
+
+function parseTomlInteger(value: string): number | undefined {
+  const match = value.trim().match(/^[+-]?\d+$/u);
+  if (!match) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(match[0], 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}

--- a/frontend/src/lib/dev/apiProxyTarget.ts
+++ b/frontend/src/lib/dev/apiProxyTarget.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { load as loadToml } from "js-toml";
 
 const defaultHost = "127.0.0.1";
 const defaultPort = 8091;
@@ -10,6 +11,7 @@ export const defaultDevApiUrl = `http://${defaultHost}:${defaultPort}`;
 export interface DevEnv {
   HOME?: string;
   MIDDLEMAN_API_URL?: string;
+  MIDDLEMAN_CONFIG?: string;
   MIDDLEMAN_HOME?: string;
 }
 
@@ -34,6 +36,11 @@ export function resolveDevApiUrl(env: DevEnv = process.env): string {
 }
 
 function resolveConfigPath(env: DevEnv): string {
+  const explicitConfigPath = env.MIDDLEMAN_CONFIG?.trim();
+  if (explicitConfigPath) {
+    return explicitConfigPath;
+  }
+
   const middlemanHome = env.MIDDLEMAN_HOME?.trim();
   if (middlemanHome) {
     return path.join(middlemanHome, "config.toml");
@@ -89,90 +96,43 @@ function formatHostForUrl(host: string): string {
 }
 
 function parseConfig(configText: string): MiddlemanConfigFields {
-  const config: MiddlemanConfigFields = {};
+  const config = loadToml(configText) as Record<string, unknown>;
+  const parsed: MiddlemanConfigFields = {};
 
-  for (const rawLine of configText.split(/\r?\n/u)) {
-    const line = stripComments(rawLine).trim();
-    if (!line) {
-      continue;
-    }
-
-    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$/u);
-    if (!match) {
-      continue;
-    }
-
-    const key = match[1];
-    const rawValue = match[2];
-    if (!key || !rawValue) {
-      continue;
-    }
-
-    switch (key) {
-      case "host": {
-        const host = parseTomlString(rawValue);
-        if (host !== undefined) {
-          config.host = host;
-        }
-        break;
-      }
-      case "base_path": {
-        const basePath = parseTomlString(rawValue);
-        if (basePath !== undefined) {
-          config.basePath = basePath;
-        }
-        break;
-      }
-      case "port": {
-        const port = parseTomlInteger(rawValue);
-        if (port !== undefined) {
-          config.port = port;
-        }
-        break;
-      }
-    }
+  const host = parseStringField(config.host);
+  if (host !== undefined) {
+    parsed.host = host;
   }
 
-  return config;
+  const basePath = parseStringField(config.base_path);
+  if (basePath !== undefined) {
+    parsed.basePath = basePath;
+  }
+
+  const port = parseIntegerField(config.port);
+  if (port !== undefined) {
+    parsed.port = port;
+  }
+
+  return parsed;
 }
 
-function stripComments(line: string): string {
-  let inString = false;
-  let escaped = false;
-
-  for (let i = 0; i < line.length; i += 1) {
-    const char = line[i];
-
-    if (char === '"' && !escaped) {
-      inString = !inString;
-    } else if (char === "#" && !inString) {
-      return line.slice(0, i);
-    }
-
-    escaped = char === "\\" && !escaped;
-    if (char !== "\\") {
-      escaped = false;
-    }
-  }
-
-  return line;
+function parseStringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
-function parseTomlString(value: string): string | undefined {
-  const match = value.trim().match(/^"((?:[^"\\]|\\.)*)"$/u);
-  if (!match) {
-    return undefined;
+function parseIntegerField(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value;
   }
 
-  return JSON.parse(`"${match[1]}"`) as string;
-}
-
-function parseTomlInteger(value: string): number | undefined {
-  const match = value.trim().match(/^[+-]?\d+$/u);
-  if (!match) {
-    return undefined;
+  if (
+    typeof value === "bigint" &&
+    value >= BigInt(Number.MIN_SAFE_INTEGER) &&
+    value <= BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    return Number(value);
   }
 
-  const parsed = Number.parseInt(match[0], 10);
-  return Number.isNaN(parsed) ? undefined : parsed;
+  return undefined;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,12 +4,13 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { svelteTesting } from "@testing-library/svelte/vite";
 import { searchForWorkspaceRoot, type UserConfig } from "vite";
 import type { InlineConfig } from "vitest/node";
+import { resolveDevApiUrl } from "./src/lib/dev/apiProxyTarget";
 import { healthcheckPlugin } from "./src/lib/dev/healthcheckPlugin";
 
 const require = createRequire(import.meta.url);
 const testingLibrarySvelteEntry = require.resolve("@testing-library/svelte");
 
-const apiUrl = process.env.MIDDLEMAN_API_URL ?? "http://127.0.0.1:8091";
+const apiUrl = resolveDevApiUrl();
 const workspaceRoot = searchForWorkspaceRoot(process.cwd());
 const uiPkg = path.resolve(process.cwd(), "../packages/ui");
 const uiIndex = path.resolve(process.cwd(), "../packages/ui/src/index.ts");


### PR DESCRIPTION
- Read the Vite dev proxy target from the same middleman config that `make dev` uses.
- Honor `MIDDLEMAN_API_URL` overrides and support configured `host`, `port`, and `base_path` values.
- Add regression coverage for config lookup, fallback behavior, and IPv6 formatting.

Validation: `bun run test -- src/lib/dev/apiProxyTarget.test.ts`, `bun run typecheck`, `bun run build`