### PR TITLE
Add resizable sidebar

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -31,6 +31,8 @@
   } from "./lib/stores/theme.svelte.js";
   import {
     isSidebarCollapsed,
+    getSidebarWidth,
+    setSidebarWidth,
     toggleSidebar,
     isSidebarToggleEnabled,
     initSidebar,
@@ -68,7 +70,7 @@
     isHeaderHidden,
     isStatusBarHidden,
     getInitialRoute,
-    getSidebarWidth,
+    getSidebarWidth as getEmbeddedSidebarWidth,
     emitLayoutChanged,
     getEmbedActivePlatformHost,
     getEmbedHoverCardsEnabled,
@@ -292,6 +294,14 @@
   function closeDrawer(): void {
     drawerItem = null;
     updateDrawerURL(null);
+  }
+
+  function handleSidebarResize(width: number): void {
+    setSidebarWidth(width);
+    emitLayoutChanged({
+      sidebar: { width },
+      pinnedPanel: { width: 0, visible: false },
+    });
   }
 
   function navigateToSelectedPR(): void {
@@ -577,6 +587,8 @@
             {selectedPR}
             {detailTab}
             isSidebarCollapsed={isSidebarCollapsed()}
+            sidebarWidth={getSidebarWidth()}
+            onSidebarResize={handleSidebarResize}
           />
         {/if}
       {:else if getPage() === "issues"}
@@ -585,6 +597,8 @@
         <IssueListView
           {selectedIssue}
           isSidebarCollapsed={isSidebarCollapsed()}
+          sidebarWidth={getSidebarWidth()}
+          onSidebarResize={handleSidebarResize}
         />
       {:else if getPage() === "reviews"}
         {@const route = getRoute()}
@@ -670,7 +684,7 @@
             workspaceData={getWorkspaceData()}
             hoverCardsEnabled={getEmbedHoverCardsEnabled()}
             onCommand={emitWorkspaceCommand}
-            sidebarWidth={getSidebarWidth()}
+            sidebarWidth={getEmbeddedSidebarWidth()}
             onSidebarResize={(width) => emitLayoutChanged({
               sidebar: { width },
               pinnedPanel: { width: 0, visible: false },

--- a/frontend/src/lib/stores/sidebar.svelte.test.ts
+++ b/frontend/src/lib/stores/sidebar.svelte.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   isSidebarCollapsed,
+  getSidebarWidth,
+  setSidebarWidth,
   toggleSidebar,
   isSidebarToggleEnabled,
   initSidebar,
@@ -12,6 +14,7 @@ const win = window as any;
 afterEach(() => {
   delete win.__middleman_config;
   try { localStorage.removeItem("middleman-sidebar"); } catch { /* noop */ }
+  try { localStorage.removeItem("middleman-sidebar-width"); } catch { /* noop */ }
 });
 
 describe("standalone mode", () => {
@@ -39,6 +42,20 @@ describe("standalone mode", () => {
     expect(
       localStorage.getItem("middleman-sidebar"),
     ).toBe("collapsed");
+  });
+
+  it("starts with the default width", () => {
+    initSidebar();
+    expect(getSidebarWidth()).toBe(340);
+  });
+
+  it("persists a resized width", () => {
+    initSidebar();
+    setSidebarWidth(420);
+    expect(getSidebarWidth()).toBe(420);
+    expect(
+      localStorage.getItem("middleman-sidebar-width"),
+    ).toBe("420");
   });
 });
 
@@ -68,6 +85,15 @@ describe("embedded mode — embedder owns sidebar", () => {
     win.__middleman_notify_config_changed?.();
     initSidebar();
     expect(isSidebarToggleEnabled()).toBe(false);
+  });
+
+  it("uses the embedded width when provided", () => {
+    win.__middleman_config = {
+      embed: { sidebarWidth: 410 },
+    };
+    win.__middleman_notify_config_changed?.();
+    initSidebar();
+    expect(getSidebarWidth()).toBe(410);
   });
 });
 

--- a/frontend/src/lib/stores/sidebar.svelte.ts
+++ b/frontend/src/lib/stores/sidebar.svelte.ts
@@ -1,13 +1,28 @@
-import { getUIConfig } from "./embed-config.svelte.js";
+import {
+  getUIConfig,
+  getSidebarWidth as getEmbeddedSidebarWidth,
+} from "./embed-config.svelte.js";
 
 const STORAGE_KEY = "middleman-sidebar";
+const WIDTH_STORAGE_KEY = "middleman-sidebar-width";
+const DEFAULT_WIDTH = 340;
+const MIN_WIDTH = 200;
+const MAX_WIDTH = 600;
 
 let collapsed = $state(false);
+let width = $state(DEFAULT_WIDTH);
 // When the container enters narrow mode, we force-collapse the sidebar.
 // narrowCollapsed forces closed; narrowOpened forces open (user override).
 // Both are cleared when leaving narrow mode.
 let narrowCollapsed = $state(false);
 let narrowOpened = $state(false);
+
+function clampWidth(value: number): number {
+  return Math.max(
+    MIN_WIDTH,
+    Math.min(MAX_WIDTH, Math.round(value)),
+  );
+}
 
 function loadPersisted(): boolean {
   try {
@@ -15,6 +30,22 @@ function loadPersisted(): boolean {
   } catch {
     return false;
   }
+}
+
+function loadPersistedWidth(): number {
+  try {
+    const raw = localStorage.getItem(WIDTH_STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_WIDTH;
+    }
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) {
+      return clampWidth(parsed);
+    }
+  } catch {
+    // Storage blocked
+  }
+  return DEFAULT_WIDTH;
 }
 
 function persist(value: boolean): void {
@@ -29,12 +60,30 @@ function persist(value: boolean): void {
   }
 }
 
+function persistWidth(value: number): void {
+  try {
+    localStorage.setItem(
+      WIDTH_STORAGE_KEY,
+      String(clampWidth(value)),
+    );
+  } catch {
+    // Storage blocked
+  }
+}
+
 export function initSidebar(): void {
   const ui = getUIConfig();
   if (ui.sidebarCollapsed !== undefined) {
     collapsed = ui.sidebarCollapsed;
   } else {
     collapsed = loadPersisted();
+  }
+
+  const embeddedWidth = getEmbeddedSidebarWidth();
+  if (embeddedWidth !== undefined) {
+    width = clampWidth(embeddedWidth);
+  } else {
+    width = loadPersistedWidth();
   }
 }
 
@@ -64,6 +113,17 @@ export function toggleSidebar(): void {
 
 export function setSidebarCollapsed(value: boolean): void {
   collapsed = value;
+}
+
+export function getSidebarWidth(): number {
+  return width;
+}
+
+export function setSidebarWidth(value: number): void {
+  width = clampWidth(value);
+  if (getEmbeddedSidebarWidth() === undefined) {
+    persistWidth(width);
+  }
 }
 
 export function setNarrowOverride(narrow: boolean): void {

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -804,24 +804,24 @@ test.describe("PR list tabs", () => {
 
     await page.goto("/pulls/acme/widgets/1");
 
-    // Wait for the PRListView tab bar (scoped to .detail-area) to
+    // Wait for the PRListView tab bar (scoped to .main-area) to
     // render.
-    await page.locator(".detail-area .detail-tabs").first()
+    await page.locator(".main-area .detail-tabs").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
     // Exactly one tab bar is present inside the outer PRListView
     // container. If PullDetail ever stops respecting hideTabs, a
-    // second .detail-tabs element would show up inside .detail-area.
-    await expect(page.locator(".detail-area .detail-tabs")).toHaveCount(1);
+    // second .detail-tabs element would show up inside .main-area.
+    await expect(page.locator(".main-area .detail-tabs")).toHaveCount(1);
     await expect(
       page.locator(
-        ".detail-area .detail-tabs .detail-tab",
+        ".main-area .detail-tabs .detail-tab",
         { hasText: "Conversation" },
       ),
     ).toHaveCount(1);
     await expect(
       page.locator(
-        ".detail-area .detail-tabs .detail-tab",
+        ".main-area .detail-tabs .detail-tab",
         { hasText: "Files changed" },
       ),
     ).toHaveCount(1);
@@ -829,21 +829,21 @@ test.describe("PR list tabs", () => {
     // Clicking Files changed in the outer tab bar updates the URL to
     // the /files sub-route.
     await page.locator(
-      ".detail-area .detail-tabs .detail-tab",
+      ".main-area .detail-tabs .detail-tab",
       { hasText: "Files changed" },
     ).click();
     await expect(page).toHaveURL(/\/pulls\/acme\/widgets\/1\/files$/);
     await expect(page.locator(".diff-view")).toBeVisible();
-    await expect(page.locator(".detail-area .detail-tabs")).toHaveCount(1);
+    await expect(page.locator(".main-area .detail-tabs")).toHaveCount(1);
 
     // Clicking Conversation routes back and keeps the tab bar
     // singular.
     await page.locator(
-      ".detail-area .detail-tabs .detail-tab",
+      ".main-area .detail-tabs .detail-tab",
       { hasText: "Conversation" },
     ).click();
     await expect(page).toHaveURL(/\/pulls\/acme\/widgets\/1$/);
-    await expect(page.locator(".detail-area .detail-tabs")).toHaveCount(1);
+    await expect(page.locator(".main-area .detail-tabs")).toHaveCount(1);
   });
 
   test("direct load of /pulls/:owner/:name/:number/files renders the diff with a single tab bar", async ({ page }) => {
@@ -855,14 +855,14 @@ test.describe("PR list tabs", () => {
 
     await page.goto("/pulls/acme/widgets/1/files");
 
-    await page.locator(".detail-area .detail-tabs").first()
+    await page.locator(".main-area .detail-tabs").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
-    await expect(page.locator(".detail-area .detail-tabs")).toHaveCount(1);
+    await expect(page.locator(".main-area .detail-tabs")).toHaveCount(1);
     await expect(page.locator(".diff-view")).toBeVisible();
     await expect(
       page.locator(
-        ".detail-area .detail-tabs .detail-tab--active",
+        ".main-area .detail-tabs .detail-tab--active",
         { hasText: "Files changed" },
       ),
     ).toHaveCount(1);

--- a/frontend/tests/e2e-full/embedded-config.spec.ts
+++ b/frontend/tests/e2e-full/embedded-config.spec.ts
@@ -5,6 +5,12 @@ async function waitForPRList(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function sidebarWidth(page: Page): Promise<number> {
+  return Math.round(await page.locator(".sidebar").first().evaluate((node) =>
+    node.getBoundingClientRect().width
+  ));
+}
+
 test.describe("embedded config", () => {
   test("hides sync button when hideSync is true", async ({ page }) => {
     await page.addInitScript(() => {
@@ -54,6 +60,22 @@ test.describe("embedded config", () => {
     await expect(
       page.locator("button[title='Toggle theme']"),
     ).not.toBeAttached();
+  });
+
+  test("host sidebarWidth overrides persisted width on pulls", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("middleman-sidebar-width", "520");
+      window.__middleman_config = { embed: { sidebarWidth: 410 } };
+    });
+    await page.goto("/pulls");
+    await waitForPRList(page);
+
+    await expect.poll(async () => sidebarWidth(page)).toBe(410);
+
+    await page.reload();
+    await waitForPRList(page);
+
+    await expect.poll(async () => sidebarWidth(page)).toBe(410);
   });
 
   test("settings page is blocked in embedded mode", async ({ page }) => {

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -56,7 +56,7 @@ test.describe("issue list view", () => {
       .first()
       .click();
 
-    // IssueListView renders IssueDetail into .detail-area, where
+    // IssueListView renders IssueDetail into .main-area, where
     // .issue-detail is the designated internal scroll container.
     const issueDetail = page.locator(".issue-detail");
     await expect(issueDetail).toBeVisible();
@@ -98,9 +98,9 @@ test.describe("issue list view", () => {
 
     // Centering check: .issue-detail has max-width 800px and
     // margin-inline: auto. Compare its horizontal center against the
-    // center of its parent .detail-area container (the PR list view
+    // center of its parent .main-area container (the PR list view
     // has a sidebar, so the viewport center is not relevant).
-    const detailArea = page.locator(".detail-area");
+    const detailArea = page.locator(".main-area");
     const areaBox = await detailArea.boundingBox();
     const detailBox = await issueDetail.boundingBox();
     expect(areaBox).not.toBeNull();

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -10,6 +10,58 @@ async function waitForIssueList(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function sidebarWidth(sidebar: ReturnType<Page["locator"]>): Promise<number> {
+  return Math.round(await sidebar.evaluate((node) =>
+    node.getBoundingClientRect().width
+  ));
+}
+
+async function dragResizeHandle(
+  page: Page,
+  handle: ReturnType<Page["locator"]>,
+  deltaX: number,
+): Promise<void> {
+  const box = await handle.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) {
+    throw new Error("resize handle missing");
+  }
+
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    box.x + box.width / 2 + deltaX,
+    box.y + box.height / 2,
+    { steps: 10 },
+  );
+  await page.mouse.up();
+}
+
+async function expectResizedSidebar(
+  page: Page,
+  path: string,
+  waitForList: (page: Page) => Promise<void>,
+): Promise<void> {
+  await page.goto(path);
+  await waitForList(page);
+
+  const sidebar = page.locator(".sidebar").first();
+  const handle = page.locator(".resize-handle");
+
+  expect(await sidebarWidth(sidebar)).toBe(340);
+
+  await dragResizeHandle(page, handle, 80);
+
+  await expect.poll(async () => sidebarWidth(sidebar)).toBe(420);
+
+  await page.reload();
+  await waitForList(page);
+
+  await expect.poll(async () =>
+    sidebarWidth(page.locator(".sidebar").first())
+  ).toBe(420);
+}
+
 test.describe("collapsible sidebar", () => {
   test("collapse and expand via strip on pulls", async ({ page }) => {
     await page.goto("/pulls");
@@ -92,5 +144,13 @@ test.describe("collapsible sidebar", () => {
     // Press again to expand.
     await page.keyboard.press(`${modifier}+[`);
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
+  });
+
+  test("sidebar can be resized on pulls and keeps the new width after reload", async ({ page }) => {
+    await expectResizedSidebar(page, "/pulls", waitForPRList);
+  });
+
+  test("sidebar can be resized on issues and keeps the new width after reload", async ({ page }) => {
+    await expectResizedSidebar(page, "/issues", waitForIssueList);
   });
 });

--- a/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
+++ b/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
@@ -37,8 +37,12 @@
     onExpand = undefined,
   }: Props = $props();
 
+  // svelte-ignore state_referenced_locally
+  // eslint-disable-next-line svelte/prefer-writable-derived -- $derived.writable not in svelte 5.55
+  let committedWidth = $state(sidebarWidth);
+  $effect(() => { committedWidth = sidebarWidth; });
   let dragWidth: number | null = $state(null);
-  let currentWidth = $derived(dragWidth ?? sidebarWidth);
+  let currentWidth = $derived(dragWidth ?? committedWidth);
 
   function startResize(event: MouseEvent): void {
     event.preventDefault();
@@ -58,7 +62,9 @@
     function onUp(): void {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
-      onSidebarResize?.(currentWidth);
+      const finalWidth = currentWidth;
+      onSidebarResize?.(finalWidth);
+      committedWidth = finalWidth;
       dragWidth = null;
     }
 
@@ -97,8 +103,6 @@
         </svg>
       </button>
     </aside>
-  {:else if !hideSidebar && !sidebarOnly}
-    <aside class="sidebar sidebar--collapsed"></aside>
   {/if}
 
   {#if hasMain}

--- a/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
+++ b/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
@@ -37,7 +37,8 @@
     onExpand = undefined,
   }: Props = $props();
 
-  let currentWidth = $derived(sidebarWidth);
+  let dragWidth: number | null = $state(null);
+  let currentWidth = $derived(dragWidth ?? sidebarWidth);
 
   function startResize(event: MouseEvent): void {
     event.preventDefault();
@@ -45,7 +46,7 @@
     const startWidth = currentWidth;
 
     function onMove(moveEvent: MouseEvent): void {
-      currentWidth = Math.max(
+      dragWidth = Math.max(
         minSidebarWidth,
         Math.min(
           maxSidebarWidth,
@@ -58,6 +59,7 @@
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
       onSidebarResize?.(currentWidth);
+      dragWidth = null;
     }
 
     window.addEventListener("mousemove", onMove);

--- a/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
+++ b/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    children?: Snippet | undefined;
+    sidebar: Snippet;
+    trailing?: Snippet | undefined;
+    isCollapsed?: boolean;
+    hideSidebar?: boolean;
+    sidebarWidth?: number;
+    sidebarOnly?: boolean;
+    hasMain?: boolean;
+    showCollapsedStrip?: boolean;
+    mainEmpty?: boolean;
+    mainOverflow?: "auto" | "hidden";
+    minSidebarWidth?: number;
+    maxSidebarWidth?: number;
+    onSidebarResize?: ((width: number) => void) | undefined;
+    onExpand?: (() => void) | undefined;
+  }
+
+  let {
+    children = undefined,
+    sidebar,
+    trailing = undefined,
+    isCollapsed = false,
+    hideSidebar = false,
+    sidebarWidth = 340,
+    sidebarOnly = false,
+    hasMain = true,
+    showCollapsedStrip = false,
+    mainEmpty = false,
+    mainOverflow = "auto",
+    minSidebarWidth = 200,
+    maxSidebarWidth = 600,
+    onSidebarResize = undefined,
+    onExpand = undefined,
+  }: Props = $props();
+
+  let currentWidth = $derived(sidebarWidth);
+
+  function startResize(event: MouseEvent): void {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = currentWidth;
+
+    function onMove(moveEvent: MouseEvent): void {
+      currentWidth = Math.max(
+        minSidebarWidth,
+        Math.min(
+          maxSidebarWidth,
+          startWidth + moveEvent.clientX - startX,
+        ),
+      );
+    }
+
+    function onUp(): void {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      onSidebarResize?.(currentWidth);
+    }
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+</script>
+
+<div class="list-layout">
+  {#if !isCollapsed}
+    <aside
+      class="sidebar"
+      style={`width: ${sidebarOnly || !hasMain ? "100%" : `${currentWidth}px`}`}
+    >
+      {@render sidebar()}
+    </aside>
+    {#if !sidebarOnly && hasMain}
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div
+        class="resize-handle"
+        role="separator"
+        aria-label="Resize sidebar"
+        aria-orientation="vertical"
+        onmousedown={startResize}
+      ></div>
+    {/if}
+  {:else if !hideSidebar && showCollapsedStrip}
+    <aside class="sidebar sidebar--collapsed">
+      <button class="expand-btn" onclick={onExpand} title="Expand sidebar">
+        <svg width="14" height="14" viewBox="0 0 16 16"
+          fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="1" y="1" width="14" height="14" rx="2" />
+          <line x1="6" y1="1" x2="6" y2="15" />
+          <polyline points="8,6 10,8 8,10"
+            stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
+    </aside>
+  {:else if !hideSidebar && !sidebarOnly}
+    <aside class="sidebar sidebar--collapsed"></aside>
+  {/if}
+
+  {#if hasMain}
+    <section
+      class="main-area"
+      class:main-area--empty={mainEmpty}
+      class:main-area--hidden={mainOverflow === "hidden"}
+    >
+      {#if children}
+        {@render children()}
+      {/if}
+    </section>
+  {/if}
+
+  {#if trailing}
+    {@render trailing()}
+  {/if}
+</div>
+
+<style>
+  .list-layout {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .sidebar {
+    width: 340px;
+    flex-shrink: 0;
+    background: var(--bg-surface);
+    border-right: 1px solid var(--border-default);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sidebar--collapsed {
+    width: 28px;
+    align-items: center;
+    padding-top: 6px;
+  }
+
+  .expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .expand-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+  }
+
+  .resize-handle {
+    width: 4px;
+    cursor: col-resize;
+    background: var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .resize-handle:hover {
+    background: var(--accent-blue);
+  }
+
+  .main-area {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+    background: var(--bg-primary);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .main-area--empty {
+    align-items: center;
+    justify-content: center;
+  }
+
+  .main-area--hidden {
+    overflow: hidden;
+  }
+</style>

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getSidebar } from "../context.js";
+  import CollapsibleResizableSidebar from "../components/shared/CollapsibleResizableSidebar.svelte";
   import IssueList
     from "../components/sidebar/IssueList.svelte";
   import IssueDetail
@@ -15,106 +16,47 @@
     } | null;
     isSidebarCollapsed?: boolean;
     hideSidebar?: boolean;
+    sidebarWidth?: number;
+    onSidebarResize?: (width: number) => void;
   }
 
   let {
     selectedIssue = null,
     isSidebarCollapsed = false,
     hideSidebar = false,
+    sidebarWidth = 340,
+    onSidebarResize,
   }: Props = $props();
 </script>
 
-<div class="list-layout">
-  {#if !isSidebarCollapsed}
-    <aside class="sidebar">
-      <IssueList />
-    </aside>
-  {:else if !hideSidebar && isSidebarToggleEnabled()}
-    <aside class="sidebar sidebar--collapsed">
-      <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
-        <svg width="14" height="14" viewBox="0 0 16 16"
-          fill="none" stroke="currentColor" stroke-width="1.5">
-          <rect x="1" y="1" width="14" height="14" rx="2" />
-          <line x1="6" y1="1" x2="6" y2="15" />
-          <polyline points="8,6 10,8 8,10"
-            stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
-    </aside>
+<CollapsibleResizableSidebar
+  isCollapsed={isSidebarCollapsed}
+  {hideSidebar}
+  {sidebarWidth}
+  {onSidebarResize}
+  showCollapsedStrip={isSidebarToggleEnabled()}
+  onExpand={toggleSidebar}
+  mainEmpty={selectedIssue === null}
+>
+  {#snippet sidebar()}
+    <IssueList />
+  {/snippet}
+
+  {#if selectedIssue !== null}
+    <IssueDetail
+      owner={selectedIssue.owner}
+      name={selectedIssue.name}
+      number={selectedIssue.number}
+    />
+  {:else}
+    <div class="placeholder-content">
+      <p class="placeholder-text">Select an issue</p>
+      <p class="placeholder-hint">j/k to navigate</p>
+    </div>
   {/if}
-  <section
-    class="detail-area"
-    class:detail-area--empty={selectedIssue === null}
-  >
-    {#if selectedIssue !== null}
-      <IssueDetail
-        owner={selectedIssue.owner}
-        name={selectedIssue.name}
-        number={selectedIssue.number}
-      />
-    {:else}
-      <div class="placeholder-content">
-        <p class="placeholder-text">Select an issue</p>
-        <p class="placeholder-hint">j/k to navigate</p>
-      </div>
-    {/if}
-  </section>
-</div>
+</CollapsibleResizableSidebar>
 
 <style>
-  .list-layout {
-    display: flex;
-    flex: 1;
-    overflow: hidden;
-  }
-
-  .sidebar {
-    width: 340px;
-    flex-shrink: 0;
-    background: var(--bg-surface);
-    border-right: 1px solid var(--border-default);
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .sidebar--collapsed {
-    width: 28px;
-    border-right: 1px solid var(--border-default);
-    align-items: center;
-    padding-top: 6px;
-  }
-
-  .expand-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: color 0.1s, background 0.1s;
-  }
-
-  .expand-btn:hover {
-    color: var(--text-primary);
-    background: var(--bg-surface-hover);
-  }
-
-  .detail-area {
-    flex: 1;
-    overflow-y: auto;
-    background: var(--bg-primary);
-    display: flex;
-    flex-direction: column;
-  }
-
-  .detail-area--empty {
-    align-items: center;
-    justify-content: center;
-  }
-
   .placeholder-content {
     text-align: center;
   }

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -2,8 +2,7 @@
   import {
     getNavigate, getSidebar,
   } from "../context.js";
-
-  const { isSidebarToggleEnabled, toggleSidebar } = getSidebar();
+  import CollapsibleResizableSidebar from "../components/shared/CollapsibleResizableSidebar.svelte";
   import PullList from "../components/sidebar/PullList.svelte";
   import PullDetail
     from "../components/detail/PullDetail.svelte";
@@ -11,6 +10,7 @@
   import StackSidebar
     from "../components/detail/StackSidebar.svelte";
 
+  const { isSidebarToggleEnabled, toggleSidebar } = getSidebar();
   const navigate = getNavigate();
 
   interface Props {
@@ -22,6 +22,8 @@
     detailTab?: "conversation" | "files";
     isSidebarCollapsed?: boolean;
     hideSidebar?: boolean;
+    sidebarWidth?: number;
+    onSidebarResize?: (width: number) => void;
   }
 
   let {
@@ -29,138 +31,88 @@
     detailTab = "conversation",
     isSidebarCollapsed = false,
     hideSidebar = false,
+    sidebarWidth = 340,
+    onSidebarResize,
   }: Props = $props();
 </script>
 
-<div class="list-layout">
-  {#if !isSidebarCollapsed}
-    <aside class="sidebar">
-      <PullList getDetailTab={() => detailTab} />
-    </aside>
-  {:else if !hideSidebar && isSidebarToggleEnabled()}
-    <aside class="sidebar sidebar--collapsed">
-      <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
-        <svg width="14" height="14" viewBox="0 0 16 16"
-          fill="none" stroke="currentColor" stroke-width="1.5">
-          <rect x="1" y="1" width="14" height="14" rx="2" />
-          <line x1="6" y1="1" x2="6" y2="15" />
-          <polyline points="8,6 10,8 8,10"
-            stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
+<CollapsibleResizableSidebar
+  isCollapsed={isSidebarCollapsed}
+  {hideSidebar}
+  {sidebarWidth}
+  {onSidebarResize}
+  showCollapsedStrip={isSidebarToggleEnabled()}
+  onExpand={toggleSidebar}
+  mainEmpty={selectedPR === null}
+>
+  {#snippet sidebar()}
+    <PullList getDetailTab={() => detailTab} />
+  {/snippet}
+
+  {#if selectedPR !== null}
+    <div class="detail-tabs">
+      <button
+        class="detail-tab"
+        class:detail-tab--active={detailTab === "conversation"}
+        onclick={() => navigate(
+          `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`,
+        )}
+      >
+        Conversation
       </button>
-    </aside>
-  {/if}
-  <section
-    class="detail-area"
-    class:detail-area--empty={selectedPR === null}
-  >
-    {#if selectedPR !== null}
-      <div class="detail-tabs">
-        <button
-          class="detail-tab"
-          class:detail-tab--active={detailTab === "conversation"}
-          onclick={() => navigate(
-            `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`,
-          )}
-        >
-          Conversation
-        </button>
-        <button
-          class="detail-tab"
-          class:detail-tab--active={detailTab === "files"}
-          onclick={() => navigate(
-            `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}/files`,
-          )}
-        >
-          Files changed
-        </button>
-      </div>
-      {#if detailTab === "files"}
-        {#key `${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`}
-          <DiffView
-            owner={selectedPR.owner}
-            name={selectedPR.name}
-            number={selectedPR.number}
-          />
-        {/key}
-      {:else}
-        <PullDetail
+      <button
+        class="detail-tab"
+        class:detail-tab--active={detailTab === "files"}
+        onclick={() => navigate(
+          `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}/files`,
+        )}
+      >
+        Files changed
+      </button>
+    </div>
+    {#if detailTab === "files"}
+      {#key `${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`}
+        <DiffView
           owner={selectedPR.owner}
           name={selectedPR.name}
           number={selectedPR.number}
-          hideTabs={true}
         />
-      {/if}
+      {/key}
     {:else}
-      <div class="placeholder-content">
-        <p class="placeholder-text">Select a PR</p>
-        <p class="placeholder-hint">
-          j/k to navigate &middot; 1/2 to switch views
-        </p>
-      </div>
+      <PullDetail
+        owner={selectedPR.owner}
+        name={selectedPR.name}
+        number={selectedPR.number}
+        hideTabs={true}
+      />
     {/if}
-  </section>
-  {#if selectedPR !== null}
-    <StackSidebar
-      owner={selectedPR.owner}
-      name={selectedPR.name}
-      number={selectedPR.number}
-    />
+  {:else}
+    <div class="placeholder-content">
+      <p class="placeholder-text">Select a PR</p>
+      <p class="placeholder-hint">
+        j/k to navigate &middot; 1/2 to switch views
+      </p>
+    </div>
   {/if}
-</div>
+
+  {#snippet trailing()}
+    {#if selectedPR !== null}
+      <StackSidebar
+        owner={selectedPR.owner}
+        name={selectedPR.name}
+        number={selectedPR.number}
+      />
+    {/if}
+  {/snippet}
+</CollapsibleResizableSidebar>
 
 <style>
-  .list-layout {
+  .detail-tabs {
     display: flex;
-    flex: 1;
-    overflow: hidden;
-  }
-
-  .sidebar {
-    width: 340px;
-    flex-shrink: 0;
+    gap: 0;
+    border-bottom: 1px solid var(--border-default);
     background: var(--bg-surface);
-    border-right: 1px solid var(--border-default);
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .sidebar--collapsed {
-    width: 28px;
-    border-right: 1px solid var(--border-default);
-    align-items: center;
-    padding-top: 6px;
-  }
-
-  .expand-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: color 0.1s, background 0.1s;
-  }
-
-  .expand-btn:hover {
-    color: var(--text-primary);
-    background: var(--bg-surface-hover);
-  }
-
-  .detail-area {
-    flex: 1;
-    overflow-y: auto;
-    background: var(--bg-primary);
-    display: flex;
-    flex-direction: column;
-  }
-
-  .detail-area--empty {
-    align-items: center;
-    justify-content: center;
+    flex-shrink: 0;
   }
 
   .placeholder-content {
@@ -177,14 +129,6 @@
     font-size: 11px;
     margin-top: 8px;
     opacity: 0.7;
-  }
-
-  .detail-tabs {
-    display: flex;
-    gap: 0;
-    border-bottom: 1px solid var(--border-default);
-    background: var(--bg-surface);
-    flex-shrink: 0;
   }
 
   .detail-tab {

--- a/packages/ui/src/views/WorkspacesView.svelte
+++ b/packages/ui/src/views/WorkspacesView.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-  import WorkspaceSidebar from "../components/workspace/WorkspaceSidebar.svelte";
+  import type { Snippet } from "svelte";
   import type {
     WorkspaceData,
     WorkspaceDetailContext,
     WorkspaceProject,
     WorkspaceWorktree,
   } from "../api/types.js";
-  import type { Snippet } from "svelte";
+  import CollapsibleResizableSidebar from "../components/shared/CollapsibleResizableSidebar.svelte";
+  import WorkspaceSidebar from "../components/workspace/WorkspaceSidebar.svelte";
 
   interface Props {
     workspaceData: WorkspaceData | undefined;
@@ -28,14 +29,6 @@
     sidebarWidth,
     onSidebarResize,
   }: Props = $props();
-
-  let currentWidth = $state(280);
-
-  $effect(() => {
-    if (sidebarWidth != null) {
-      currentWidth = sidebarWidth;
-    }
-  });
 
   const detailContext: WorkspaceDetailContext = $derived.by(
     () => {
@@ -72,85 +65,40 @@
       "/" +
       (detailContext.worktree?.key ?? ""),
   );
-
-  function startResize(e: MouseEvent): void {
-    e.preventDefault();
-    const startX = e.clientX;
-    const startW = currentWidth;
-
-    function onMove(ev: MouseEvent): void {
-      currentWidth = Math.max(
-        200,
-        Math.min(600, startW + ev.clientX - startX),
-      );
-    }
-
-    function onUp(): void {
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
-      onSidebarResize?.(currentWidth);
-    }
-
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onUp);
-  }
 </script>
 
-<div class="workspaces-view">
-  {#if workspaceData}
-    <div
-      class="sidebar-pane"
-      style="width: {detailSnippet
-        ? currentWidth + 'px'
-        : '100%'}"
-    >
-      <WorkspaceSidebar {workspaceData} {hoverCardsEnabled} {onCommand} />
-    </div>
+{#if workspaceData}
+  {@const resolvedWorkspaceData = workspaceData}
+  <CollapsibleResizableSidebar
+    sidebarWidth={sidebarWidth ?? 280}
+    onSidebarResize={onSidebarResize}
+    sidebarOnly={detailSnippet == null}
+    hasMain={detailSnippet != null}
+    mainOverflow="hidden"
+  >
+    {#snippet sidebar()}
+      <WorkspaceSidebar
+        workspaceData={resolvedWorkspaceData}
+        {hoverCardsEnabled}
+        {onCommand}
+      />
+    {/snippet}
 
     {#if detailSnippet}
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="resize-handle"
-        onmousedown={startResize}
-      ></div>
       <div class="detail-pane">
         {#key snippetKey}
           {@render detailSnippet(detailContext)}
         {/key}
       </div>
     {/if}
-  {:else}
-    <div class="workspaces-empty">
-      <p>No workspace data available.</p>
-    </div>
-  {/if}
-</div>
+  </CollapsibleResizableSidebar>
+{:else}
+  <div class="workspaces-empty">
+    <p>No workspace data available.</p>
+  </div>
+{/if}
 
 <style>
-  .workspaces-view {
-    flex: 1;
-    display: flex;
-    overflow: hidden;
-    background: var(--bg-primary);
-  }
-
-  .sidebar-pane {
-    flex-shrink: 0;
-    overflow: hidden;
-    display: flex;
-  }
-
-  .resize-handle {
-    width: 4px;
-    cursor: col-resize;
-    background: var(--border-muted);
-    flex-shrink: 0;
-  }
-
-  .resize-handle:hover {
-    background: var(--accent-blue);
-  }
-
   .detail-pane {
     flex: 1;
     min-width: 0;

--- a/skills/capture-playwright/SKILL.md
+++ b/skills/capture-playwright/SKILL.md
@@ -39,7 +39,7 @@ const videoPath = await page.video()?.path();
 
 5. **Stop here by default.** Report the local artifact path to the user. Only proceed to upload if the user explicitly requests it.
 
-6. **If the user approves upload**, confirm the target PR or issue number first. Never upload without attaching to a specific PR or issue. Upload the file with `gh image`, then immediately attach it to the PR or issue via a comment — `gh image` alone does not bind the upload to any target:
+6. **If the user approves upload**, confirm the target PR or issue number first. Never upload without attaching to a specific PR or issue. Upload the file with `gh image` (the command prints a markdown snippet whose links already point at the uploaded content), then immediately attach it to the PR or issue via a comment — `gh image` alone does not bind the upload to any target:
 
 ```bash
 # Upload and capture the markdown link
@@ -52,6 +52,10 @@ gh issue comment <number> --repo owner/repo --body "$IMAGE_MD"
 ```
 
 **`gh image --repo owner/repo <file>` alone is insufficient** — it uploads without binding to a PR or issue. Always follow up with a comment command to attach.
+
+For screenshots, the emitted markdown can usually be pasted as-is.
+
+For videos, `gh image` may still emit image-style markdown like `![demo.webm](...)`. GitHub PR descriptions and comments do not reliably inline `.webm` attachments from that syntax, so normalize it to a plain link such as `[demo.webm](...)` or `Video: https://...` before pasting into a PR description or comment.
 
 If video upload is rejected, keep the local video file, say that `gh image` appears image-only in this environment, and ask whether a screenshot link or a different upload path is preferred.
 
@@ -80,4 +84,5 @@ Tell the user to sign in to GitHub in Chrome, Brave, Edge, or Chromium on that m
 Return:
 - the local artifact path (always)
 - if uploaded: the markdown link(s) printed by `gh image` and the target PR/issue
+- for video uploads, the normalized plain-link form to paste into a PR description or comment
 - a brief note if video upload had to fall back to screenshots or another path


### PR DESCRIPTION
## Summary
- add a drag handle so the PR and issue sidebars can be resized
- persist standalone sidebar width across reloads while preserving embed-provided widths
- add focused unit and e2e coverage for resize behavior and persistence

Validated with `make frontend-check frontend`, `bunx vitest run src/lib/stores/sidebar.svelte.test.ts`, and `bunx playwright test -c playwright-e2e.config.ts tests/e2e-full/sidebar-collapse.spec.ts`.

## Video
[resizable-sidebar-demo.webm](https://github.com/user-attachments/assets/97c18909-39b1-477f-a835-060a30afe7a2)