### PR TITLE
fix: sort CI checks by casefolded name

### DIFF
--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -23,9 +23,12 @@ test.describe("CI dropdown", () => {
     expect(checksBox!.y).toBeGreaterThan(chipBox!.y + chipBox!.height);
     expect(additionsChipBox!.height).toBeLessThan(40);
 
-    await expect(detail.locator(".ci-check").first()).toContainText("build");
-    await expect(detail.locator(".ci-check").nth(1)).toContainText("test");
-    await expect(detail.locator(".ci-check").nth(2)).toContainText("lint");
+    await expect(detail.locator(".ci-name")).toHaveText([
+      "build",
+      "lint",
+      "roborev",
+      "test",
+    ]);
     const roborevRow = detail.locator(".ci-check", { hasText: "roborev" });
     await expect(roborevRow).toHaveCount(1);
     expect(

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -287,9 +287,9 @@ func TestNormalizeBulkCI(t *testing.T) {
 
 	checks := normalizeBulkCI(bulk)
 	require.Len(t, checks, 2)
-	assert.Equal("test", checks[0].Name)
+	assert.Equal("ci/lint", checks[0].Name)
 	assert.Equal("completed", checks[0].Status)
-	assert.Equal("ci/lint", checks[1].Name)
+	assert.Equal("test", checks[1].Name)
 	assert.Equal("completed", checks[1].Status)
 }
 
@@ -452,4 +452,30 @@ func TestNormalizeBulkCIPendingStatus(t *testing.T) {
 	assert.Equal("ci/deploy", checks[0].Name)
 	assert.Equal("in_progress", checks[0].Status)
 	assert.Empty(checks[0].Conclusion)
+}
+
+func TestNormalizeBulkCI_SortsByCasefoldedName(t *testing.T) {
+	assert := Assert.New(t)
+
+	buildName := "build"
+	zebraName := "Zebra"
+	alphaContext := "alpha"
+	statusCompleted := "completed"
+	conclusionSuccess := "success"
+	stateSuccess := "success"
+
+	checks := normalizeBulkCI(&BulkPR{
+		CheckRuns: []*gh.CheckRun{
+			{Name: &buildName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+			{Name: &zebraName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+		},
+		Statuses: []*gh.RepoStatus{
+			{Context: &alphaContext, State: &stateSuccess},
+		},
+	})
+	require.Len(t, checks, 3)
+
+	assert.Equal("alpha", checks[0].Name)
+	assert.Equal("build", checks[1].Name)
+	assert.Equal("Zebra", checks[2].Name)
 }

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -263,6 +264,7 @@ func NormalizeCheckRuns(runs []*gh.CheckRun) string {
 			App:        appName(r),
 		})
 	}
+	sortCIChecksByName(checks)
 	b, err := json.Marshal(checks)
 	if err != nil {
 		return ""
@@ -309,11 +311,23 @@ func NormalizeCIChecks(
 	if len(checks) == 0 {
 		return ""
 	}
+	sortCIChecksByName(checks)
 	b, err := json.Marshal(checks)
 	if err != nil {
 		return ""
 	}
 	return string(b)
+}
+
+func sortCIChecksByName(checks []db.CICheck) {
+	sort.SliceStable(checks, func(i, j int) bool {
+		leftFolded := strings.ToLower(checks[i].Name)
+		rightFolded := strings.ToLower(checks[j].Name)
+		if leftFolded != rightFolded {
+			return leftFolded < rightFolded
+		}
+		return checks[i].Name < checks[j].Name
+	})
 }
 
 func shortSHA(sha string) string {

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -479,6 +479,33 @@ func TestNormalizeCIChecks_ExpectedAndPendingStatus(t *testing.T) {
 	assert.Empty(checks[1].Conclusion)
 }
 
+func TestNormalizeCIChecks_SortsByCasefoldedName(t *testing.T) {
+	assert := Assert.New(t)
+
+	buildName := "build"
+	zebraName := "Zebra"
+	alphaName := "alpha"
+	statusCompleted := "completed"
+	conclusionSuccess := "success"
+
+	raw := NormalizeCIChecks([]*gh.CheckRun{
+		{Name: &buildName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+		{Name: &zebraName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+		{Name: &alphaName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+	}, nil)
+	require.NotEmpty(t, raw)
+
+	var checks []struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &checks))
+	require.Len(t, checks, 3)
+
+	assert.Equal("alpha", checks[0].Name)
+	assert.Equal("build", checks[1].Name)
+	assert.Equal("Zebra", checks[2].Name)
+}
+
 func TestDeriveReviewDecision_Empty(t *testing.T) {
 	result := DeriveReviewDecision(nil)
 	Assert.Empty(t, result)

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -479,6 +479,33 @@ func TestNormalizeCIChecks_ExpectedAndPendingStatus(t *testing.T) {
 	assert.Empty(checks[1].Conclusion)
 }
 
+func TestNormalizeCheckRuns_SortsByCasefoldedName(t *testing.T) {
+	assert := Assert.New(t)
+
+	buildName := "build"
+	zebraName := "Zebra"
+	alphaName := "alpha"
+	statusCompleted := "completed"
+	conclusionSuccess := "success"
+
+	raw := NormalizeCheckRuns([]*gh.CheckRun{
+		{Name: &buildName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+		{Name: &zebraName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+		{Name: &alphaName, Status: &statusCompleted, Conclusion: &conclusionSuccess},
+	})
+	require.NotEmpty(t, raw)
+
+	var checks []struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &checks))
+	require.Len(t, checks, 3)
+
+	assert.Equal("alpha", checks[0].Name)
+	assert.Equal("build", checks[1].Name)
+	assert.Equal("Zebra", checks[2].Name)
+}
+
 func TestNormalizeCIChecks_SortsByCasefoldedName(t *testing.T) {
 	assert := Assert.New(t)
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -122,9 +122,9 @@ const defaultParallelism = 4
 // does not suppress a real retry for hours. The size bound is
 // well above any realistic author set for a fixed repo list.
 const (
-	displayNameCacheSize   = 1024
-	displayNameSuccessTTL  = 24 * time.Hour
-	displayNameFailureTTL  = 15 * time.Minute
+	displayNameCacheSize  = 1024
+	displayNameSuccessTTL = 24 * time.Hour
+	displayNameFailureTTL = 15 * time.Minute
 )
 
 // Syncer periodically pulls PR data from GitHub into SQLite.
@@ -159,9 +159,9 @@ type Syncer struct {
 	// handles profile-name changes without an explicit flush.
 	displayNames     *displayNameCache
 	displayNameGroup singleflight.Group // dedups concurrent GetUser calls
-	onMRSynced         func(owner, name string, mr *db.MergeRequest)
-	onSyncCompleted    func(results []RepoSyncResult)
-	onStatusChange     func(status *SyncStatus)
+	onMRSynced       func(owner, name string, mr *db.MergeRequest)
+	onSyncCompleted  func(results []RepoSyncResult)
+	onStatusChange   func(status *SyncStatus)
 	// statusMu serializes publishStatus so worker goroutines
 	// can't interleave updates and deliver out-of-order snapshots
 	// to SSE subscribers.
@@ -1984,6 +1984,7 @@ func normalizeBulkCI(bulk *BulkPR) []db.CICheck {
 			App:        s.GetContext(),
 		})
 	}
+	sortCIChecksByName(checks)
 	return checks
 }
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -51,13 +51,6 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			App:        "GitHub Actions",
 		},
 		{
-			Name:       "test",
-			Status:     "completed",
-			Conclusion: "success",
-			URL:        "https://github.com/acme/widgets/actions/runs/1/job/2",
-			App:        "GitHub Actions",
-		},
-		{
 			Name:       "lint",
 			Status:     "completed",
 			Conclusion: "success",
@@ -70,6 +63,13 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			Conclusion: "",
 			URL:        "",
 			App:        "roborev",
+		},
+		{
+			Name:       "test",
+			Status:     "completed",
+			Conclusion: "success",
+			URL:        "https://github.com/acme/widgets/actions/runs/1/job/2",
+			App:        "GitHub Actions",
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
- sort CI checks case-insensitively before persisting CI check lists
- cover mixed-case ordering in normalization and bulk GraphQL tests