### PR TITLE
Collapsible PR/issue sidebar with expand strip

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -8,11 +8,6 @@
   import {
     isDark, toggleTheme, isThemeToggleVisible,
   } from "../../stores/theme.svelte.js";
-  import {
-    isSidebarCollapsed,
-    toggleSidebar,
-    isSidebarToggleEnabled,
-  } from "../../stores/sidebar.svelte.js";
 
   const stores = getStores();
   const { sync } = stores;
@@ -27,21 +22,6 @@
 
 <header class="app-header">
   <div class="header-left">
-    {#if isSidebarCollapsed() && isSidebarToggleEnabled()}
-      <button
-        class="sidebar-toggle"
-        onclick={toggleSidebar}
-        title="Expand sidebar"
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16"
-          fill="none" stroke="currentColor" stroke-width="1.5">
-          <rect x="1" y="1" width="14" height="14" rx="2" />
-          <line x1="6" y1="1" x2="6" y2="15" />
-          <polyline points="8,6 10,8 8,10"
-            stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
-    {/if}
     <span class="logo">middleman</span>
     {#if !getUIConfig().hideRepoSelector}
       <RepoTypeahead
@@ -253,20 +233,5 @@
     margin-left: 4px;
     vertical-align: middle;
     opacity: 0.6;
-  }
-
-  .sidebar-toggle {
-    width: 26px;
-    height: 26px;
-    border-radius: var(--radius-sm);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-  }
-
-  .sidebar-toggle:hover {
-    background: var(--bg-surface-hover);
-    color: var(--text-primary);
   }
 </style>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -15,7 +15,8 @@
   } from "../../stores/sidebar.svelte.js";
 
   const hasSidebarStrip = $derived(
-    getPage() === "pulls" || getPage() === "issues",
+    getPage() === "issues"
+    || (getPage() === "pulls" && getView() === "list"),
   );
 
   const stores = getStores();

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -8,6 +8,15 @@
   import {
     isDark, toggleTheme, isThemeToggleVisible,
   } from "../../stores/theme.svelte.js";
+  import {
+    isSidebarCollapsed,
+    toggleSidebar,
+    isSidebarToggleEnabled,
+  } from "../../stores/sidebar.svelte.js";
+
+  const hasSidebarStrip = $derived(
+    getPage() === "pulls" || getPage() === "issues",
+  );
 
   const stores = getStores();
   const { sync } = stores;
@@ -22,6 +31,21 @@
 
 <header class="app-header">
   <div class="header-left">
+    {#if isSidebarCollapsed() && isSidebarToggleEnabled() && !hasSidebarStrip}
+      <button
+        class="sidebar-toggle"
+        onclick={toggleSidebar}
+        title="Expand sidebar"
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16"
+          fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="1" y="1" width="14" height="14" rx="2" />
+          <line x1="6" y1="1" x2="6" y2="15" />
+          <polyline points="8,6 10,8 8,10"
+            stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
+    {/if}
     <span class="logo">middleman</span>
     {#if !getUIConfig().hideRepoSelector}
       <RepoTypeahead
@@ -221,6 +245,21 @@
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
     background: var(--bg-surface);
+    color: var(--text-primary);
+  }
+
+  .sidebar-toggle {
+    width: 26px;
+    height: 26px;
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+  }
+
+  .sidebar-toggle:hover {
+    background: var(--bg-surface-hover);
     color: var(--text-primary);
   }
 

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -5,8 +5,13 @@ async function waitForPRList(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function waitForIssueList(page: Page): Promise<void> {
+  await page.locator(".issue-item").first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
 test.describe("collapsible sidebar", () => {
-  test("collapse and expand via buttons", async ({ page }) => {
+  test("collapse and expand via strip on pulls", async ({ page }) => {
     await page.goto("/pulls");
     await waitForPRList(page);
 
@@ -25,6 +30,51 @@ test.describe("collapsible sidebar", () => {
     // Click the expand button to restore the sidebar.
     await expandBtn.click();
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
+  });
+
+  test("collapse and expand via strip on issues", async ({ page }) => {
+    await page.goto("/issues");
+    await waitForIssueList(page);
+
+    const sidebar = page.locator(".sidebar");
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
+
+    await sidebar.locator(".sidebar-toggle").click();
+    await expect(sidebar).toHaveClass(/sidebar--collapsed/);
+
+    const expandBtn = sidebar.locator(".expand-btn");
+    await expect(expandBtn).toBeVisible();
+
+    await expandBtn.click();
+    await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
+  });
+
+  test("header expand on non-list route after collapsing", async ({ page }) => {
+    await page.goto("/pulls");
+    await waitForPRList(page);
+
+    // Collapse sidebar on list view.
+    const sidebar = page.locator(".sidebar");
+    await sidebar.locator(".sidebar-toggle").click();
+    await expect(sidebar).toHaveClass(/sidebar--collapsed/);
+
+    // Navigate to board view (no sidebar strip).
+    await page.goto("/pulls/board");
+    await page.waitForTimeout(300);
+
+    // Header expand button should be visible.
+    const headerToggle = page.locator(".app-header .sidebar-toggle");
+    await expect(headerToggle).toBeVisible();
+
+    // Click it to expand.
+    await headerToggle.click();
+
+    // Navigate back to list view and verify sidebar is expanded.
+    await page.goto("/pulls");
+    await waitForPRList(page);
+    const restoredSidebar = page.locator(".sidebar");
+    await expect(restoredSidebar).not.toHaveClass(/sidebar--collapsed/);
   });
 
   test("keyboard shortcut toggles sidebar", async ({ page }) => {

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -61,7 +61,7 @@ test.describe("collapsible sidebar", () => {
 
     // Navigate to board view (no sidebar strip).
     await page.goto("/pulls/board");
-    await page.waitForTimeout(300);
+    await expect(page).toHaveURL(/\/pulls\/board$/);
 
     // Header expand button should be visible.
     const headerToggle = page.locator(".app-header .sidebar-toggle");

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -18,12 +18,12 @@ test.describe("collapsible sidebar", () => {
     await sidebar.locator(".sidebar-toggle").click();
     await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
-    // The expand button should now appear in the header.
-    const headerToggle = page.locator(".app-header .sidebar-toggle");
-    await expect(headerToggle).toBeVisible();
+    // The expand button should now appear in the collapsed strip.
+    const expandBtn = sidebar.locator(".expand-btn");
+    await expect(expandBtn).toBeVisible();
 
-    // Click the header expand button to restore the sidebar.
-    await headerToggle.click();
+    // Click the expand button to restore the sidebar.
+    await expandBtn.click();
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
   });
 

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -209,8 +209,23 @@
     background: var(--bg-surface);
   }
 
-  .filter-bar :global(.sidebar-toggle) {
+  .sidebar-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
     margin-left: auto;
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .sidebar-toggle:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
   }
 
   .search-bar {
@@ -450,7 +465,6 @@
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
-    margin-left: auto;
   }
   .group-btn {
     font-size: 11px;

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -328,8 +328,23 @@
     background: var(--bg-surface);
   }
 
-  .filter-bar :global(.sidebar-toggle) {
+  .sidebar-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
     margin-left: auto;
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .sidebar-toggle:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
   }
 
   .search-bar {
@@ -594,7 +609,6 @@
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
-    margin-left: auto;
   }
   .group-btn {
     font-size: 11px;

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+  import { getSidebar } from "../context.js";
   import IssueList
     from "../components/sidebar/IssueList.svelte";
   import IssueDetail
     from "../components/detail/IssueDetail.svelte";
+
+  const { isSidebarToggleEnabled, toggleSidebar } = getSidebar();
 
   interface Props {
     selectedIssue?: {

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -29,19 +29,17 @@
     <aside class="sidebar">
       <IssueList />
     </aside>
-  {:else if !hideSidebar}
+  {:else if !hideSidebar && isSidebarToggleEnabled()}
     <aside class="sidebar sidebar--collapsed">
-      {#if isSidebarToggleEnabled()}
-        <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
-          <svg width="14" height="14" viewBox="0 0 16 16"
-            fill="none" stroke="currentColor" stroke-width="1.5">
-            <rect x="1" y="1" width="14" height="14" rx="2" />
-            <line x1="6" y1="1" x2="6" y2="15" />
-            <polyline points="8,6 10,8 8,10"
-              stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </button>
-      {/if}
+      <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
+        <svg width="14" height="14" viewBox="0 0 16 16"
+          fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="1" y="1" width="14" height="14" rx="2" />
+          <line x1="6" y1="1" x2="6" y2="15" />
+          <polyline points="8,6 10,8 8,10"
+            stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
     </aside>
   {/if}
   <section

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -27,7 +27,19 @@
       <IssueList />
     </aside>
   {:else if !hideSidebar}
-    <aside class="sidebar sidebar--collapsed"></aside>
+    <aside class="sidebar sidebar--collapsed">
+      {#if isSidebarToggleEnabled()}
+        <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
+          <svg width="14" height="14" viewBox="0 0 16 16"
+            fill="none" stroke="currentColor" stroke-width="1.5">
+            <rect x="1" y="1" width="14" height="14" rx="2" />
+            <line x1="6" y1="1" x2="6" y2="15" />
+            <polyline points="8,6 10,8 8,10"
+              stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+      {/if}
+    </aside>
   {/if}
   <section
     class="detail-area"
@@ -66,9 +78,27 @@
   }
 
   .sidebar--collapsed {
-    width: 0;
-    overflow: hidden;
-    border-right: none;
+    width: 28px;
+    border-right: 1px solid var(--border-default);
+    align-items: center;
+    padding-top: 6px;
+  }
+
+  .expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .expand-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
   }
 
   .detail-area {

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import {
-    getNavigate,
+    getNavigate, getSidebar,
   } from "../context.js";
+
+  const { isSidebarToggleEnabled, toggleSidebar } = getSidebar();
   import PullList from "../components/sidebar/PullList.svelte";
   import PullDetail
     from "../components/detail/PullDetail.svelte";

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -36,7 +36,19 @@
       <PullList getDetailTab={() => detailTab} />
     </aside>
   {:else if !hideSidebar}
-    <aside class="sidebar sidebar--collapsed"></aside>
+    <aside class="sidebar sidebar--collapsed">
+      {#if isSidebarToggleEnabled()}
+        <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
+          <svg width="14" height="14" viewBox="0 0 16 16"
+            fill="none" stroke="currentColor" stroke-width="1.5">
+            <rect x="1" y="1" width="14" height="14" rx="2" />
+            <line x1="6" y1="1" x2="6" y2="15" />
+            <polyline points="8,6 10,8 8,10"
+              stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+      {/if}
+    </aside>
   {/if}
   <section
     class="detail-area"
@@ -115,9 +127,27 @@
   }
 
   .sidebar--collapsed {
-    width: 0;
-    overflow: hidden;
-    border-right: none;
+    width: 28px;
+    border-right: 1px solid var(--border-default);
+    align-items: center;
+    padding-top: 6px;
+  }
+
+  .expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .expand-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
   }
 
   .detail-area {

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -37,19 +37,17 @@
     <aside class="sidebar">
       <PullList getDetailTab={() => detailTab} />
     </aside>
-  {:else if !hideSidebar}
+  {:else if !hideSidebar && isSidebarToggleEnabled()}
     <aside class="sidebar sidebar--collapsed">
-      {#if isSidebarToggleEnabled()}
-        <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
-          <svg width="14" height="14" viewBox="0 0 16 16"
-            fill="none" stroke="currentColor" stroke-width="1.5">
-            <rect x="1" y="1" width="14" height="14" rx="2" />
-            <line x1="6" y1="1" x2="6" y2="15" />
-            <polyline points="8,6 10,8 8,10"
-              stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </button>
-      {/if}
+      <button class="expand-btn" onclick={toggleSidebar} title="Expand sidebar">
+        <svg width="14" height="14" viewBox="0 0 16 16"
+          fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="1" y="1" width="14" height="14" rx="2" />
+          <line x1="6" y1="1" x2="6" y2="15" />
+          <polyline points="8,6 10,8 8,10"
+            stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
     </aside>
   {/if}
   <section


### PR DESCRIPTION
## Summary

- Fix sidebar collapse button being clipped in the filter bar (missing explicit sizing / flex-shrink)
- Add 28px expand strip with chevron when sidebar is collapsed (both PR and issue views)
- Remove redundant header expand button in favor of the sidebar strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)