### PR TITLE
fix: extend diff line backgrounds to full scroll width

### DIFF
--- a/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
+++ b/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
@@ -79,10 +79,11 @@ test.describe("diff highlight backgrounds on horizontal scroll", () => {
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
-    // Wait for syntax highlighting on add/delete lines specifically — highlighting
-    // is incremental so a context line span appearing doesn't guarantee the
-    // add/delete rows this test asserts on are ready.
+    // Wait for syntax highlighting on both add and delete lines — highlighting
+    // is incremental so we need both row types ready before asserting widths.
     await page.locator(".diff-line--add .code span[style]").first()
+      .waitFor({ state: "attached", timeout: 10_000 });
+    await page.locator(".diff-line--del .code span[style]").first()
       .waitFor({ state: "attached", timeout: 10_000 });
 
     const fileContent = page.locator(".file-content").first();

--- a/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
+++ b/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
@@ -79,8 +79,10 @@ test.describe("diff highlight backgrounds on horizontal scroll", () => {
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
-    // Wait for syntax highlighting: token spans get style attributes with --dc/--lc.
-    await page.locator(".diff-line .code span[style]").first()
+    // Wait for syntax highlighting on add/delete lines specifically — highlighting
+    // is incremental so a context line span appearing doesn't guarantee the
+    // add/delete rows this test asserts on are ready.
+    await page.locator(".diff-line--add .code span[style]").first()
       .waitFor({ state: "attached", timeout: 10_000 });
 
     const fileContent = page.locator(".file-content").first();

--- a/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
+++ b/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
@@ -79,28 +79,20 @@ test.describe("diff highlight backgrounds on horizontal scroll", () => {
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
-    // Wait for syntax highlighting to finish.
-    await page.waitForTimeout(1000);
+    // Wait for syntax highlighting: token spans get style attributes with --dc/--lc.
+    await page.locator(".diff-line .code span[style]").first()
+      .waitFor({ state: "attached", timeout: 10_000 });
 
-    // Screenshot before scroll.
-    await page.screenshot({
-      path: "test-results/diff-highlight-before-scroll.png",
-      fullPage: false,
-    });
-
-    // Scroll the diff area to the right.
     const fileContent = page.locator(".file-content").first();
+
+    // Scroll the diff area to the right and wait for scroll to settle.
     await fileContent.evaluate((el) => { el.scrollLeft = 300; });
-    await page.waitForTimeout(300);
+    await expect.poll(
+      () => fileContent.evaluate((el) => el.scrollLeft),
+      { timeout: 2_000 },
+    ).toBeGreaterThan(0);
 
-    // Screenshot after scroll — backgrounds should be contiguous.
-    await page.screenshot({
-      path: "test-results/diff-highlight-after-scroll.png",
-      fullPage: false,
-    });
-
-    // Verify add/delete lines have backgrounds that extend to the scroll width.
-    // Check that the .file-rows wrapper is wider than .file-content's visible width.
+    // Verify .file-rows wrapper is wider than the visible container.
     const widths = await fileContent.evaluate((el) => {
       const rows = el.querySelector(".file-rows");
       return {
@@ -109,10 +101,28 @@ test.describe("diff highlight backgrounds on horizontal scroll", () => {
         rowsWidth: rows ? rows.getBoundingClientRect().width : 0,
       };
     });
-
-    // file-rows should be at least as wide as the scroll area (allow sub-pixel rounding).
-    expect(widths.rowsWidth).toBeGreaterThanOrEqual(widths.scrollWidth - 1);
-    // Scroll width should exceed container (long lines).
     expect(widths.scrollWidth).toBeGreaterThan(widths.containerWidth);
+    expect(widths.rowsWidth).toBeGreaterThanOrEqual(widths.scrollWidth - 1);
+
+    // Verify individual add/delete rows match the file-rows width (backgrounds
+    // extend to the full scroll width, not just the viewport).
+    const rowWidths = await fileContent.evaluate((el) => {
+      const rows = el.querySelector(".file-rows");
+      if (!rows) return { rowsWidth: 0, addWidths: [] as number[], delWidths: [] as number[] };
+      const rw = rows.getBoundingClientRect().width;
+      const adds = [...el.querySelectorAll(".diff-line--add")].map(
+        (r) => r.getBoundingClientRect().width,
+      );
+      const dels = [...el.querySelectorAll(".diff-line--del")].map(
+        (r) => r.getBoundingClientRect().width,
+      );
+      return { rowsWidth: rw, addWidths: adds, delWidths: dels };
+    });
+
+    expect(rowWidths.addWidths.length).toBeGreaterThan(0);
+    expect(rowWidths.delWidths.length).toBeGreaterThan(0);
+    for (const w of [...rowWidths.addWidths, ...rowWidths.delWidths]) {
+      expect(w).toBeGreaterThanOrEqual(rowWidths.rowsWidth - 1);
+    }
   });
 });

--- a/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
+++ b/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "@playwright/test";
+import type { DiffResult, FilesResult } from "@middleman/ui/api/types";
+
+// Fixture with long lines that force horizontal scroll.
+const longLineDiff: DiffResult = {
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: ".github/workflows/ci.yml",
+      old_path: ".github/workflows/ci.yml",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 8,
+      deletions: 4,
+      hunks: [
+        {
+          old_start: 10,
+          old_count: 12,
+          new_start: 10,
+          new_count: 16,
+          section: "jobs",
+          lines: [
+            { type: "context", content: "jobs:", old_num: 10, new_num: 10 },
+            { type: "context", content: "  test:", old_num: 11, new_num: 11 },
+            { type: "context", content: "    runs-on: ubuntu-latest", old_num: 12, new_num: 12 },
+            { type: "delete", content: "    name: Run tests", old_num: 13 },
+            { type: "add", content: "    name: Run tests with cross-browser coverage on multiple platforms and architectures", new_num: 13 },
+            { type: "context", content: "    steps:", old_num: 14, new_num: 14 },
+            { type: "delete", content: "      - run: go test ./...", old_num: 15 },
+            { type: "add", content: "      - run: go build -o ./cmd/e2e-server/e2e-server ./cmd/e2e-server && playwright test --config playwright-e2e.config.ts --project=chromium --grep \"UTC timestamp\"", new_num: 15 },
+            { type: "add", content: "      - run: playwright test --config playwright-e2e.config.ts --project=chromium --reporter=html --output=test-results/cross-browser-coverage", new_num: 16 },
+            { type: "context", content: "  coverage:", old_num: 16, new_num: 17 },
+            { type: "context", content: "    runs-on: ubuntu-latest", old_num: 17, new_num: 18 },
+            { type: "delete", content: "      - run: go test -coverprofile=coverage.out ./...", old_num: 18 },
+            { type: "delete", content: "      - run: go tool cover -html=coverage.out", old_num: 19 },
+            { type: "add", content: "      - run: go test -coverprofile=coverage.out -covermode=atomic -race -shuffle=on -timeout=300s ./internal/... ./cmd/... 2>&1 | tee test-output.log", new_num: 19 },
+            { type: "add", content: "      - run: go tool cover -html=coverage.out -o coverage-report.html && upload-artifact coverage-report.html coverage.out test-output.log", new_num: 20 },
+            { type: "add", content: "      - run: playwright install --with-deps ${{ matrix.browser }} && playwright test --config playwright-e2e.config.ts --project=${{ matrix.browser }}", new_num: 21 },
+            { type: "context", content: "    strategy:", old_num: 20, new_num: 22 },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function filesFromDiff(fixture: DiffResult): FilesResult {
+  return {
+    stale: fixture.stale,
+    files: fixture.files.map((f) => ({
+      ...f,
+      additions: 0,
+      deletions: 0,
+      hunks: [],
+    })),
+  };
+}
+
+test.describe("diff highlight backgrounds on horizontal scroll", () => {
+  test("line backgrounds extend to full scroll width", async ({ page }) => {
+    await page.route("**/api/v1/repos/acme/widgets/pulls/1/files", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(filesFromDiff(longLineDiff)),
+      });
+    });
+    await page.route("**/api/v1/repos/acme/widgets/pulls/1/diff*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(longLineDiff),
+      });
+    });
+
+    await page.goto("/pulls/acme/widgets/1/files");
+    await page.locator(".diff-file").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    // Wait for syntax highlighting to finish.
+    await page.waitForTimeout(1000);
+
+    // Screenshot before scroll.
+    await page.screenshot({
+      path: "test-results/diff-highlight-before-scroll.png",
+      fullPage: false,
+    });
+
+    // Scroll the diff area to the right.
+    const fileContent = page.locator(".file-content").first();
+    await fileContent.evaluate((el) => { el.scrollLeft = 300; });
+    await page.waitForTimeout(300);
+
+    // Screenshot after scroll — backgrounds should be contiguous.
+    await page.screenshot({
+      path: "test-results/diff-highlight-after-scroll.png",
+      fullPage: false,
+    });
+
+    // Verify add/delete lines have backgrounds that extend to the scroll width.
+    // Check that the .file-rows wrapper is wider than .file-content's visible width.
+    const widths = await fileContent.evaluate((el) => {
+      const rows = el.querySelector(".file-rows");
+      return {
+        containerWidth: el.clientWidth,
+        scrollWidth: el.scrollWidth,
+        rowsWidth: rows ? rows.getBoundingClientRect().width : 0,
+      };
+    });
+
+    // file-rows should be at least as wide as the scroll area (allow sub-pixel rounding).
+    expect(widths.rowsWidth).toBeGreaterThanOrEqual(widths.scrollWidth - 1);
+    // Scroll width should exceed container (long lines).
+    expect(widths.scrollWidth).toBeGreaterThan(widths.containerWidth);
+  });
+});

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -192,29 +192,31 @@
       {#if renderedFile.is_binary}
         <div class="binary-notice">Binary file changed</div>
       {:else}
-        {#each renderedFile.hunks as hunk, hunkIdx}
-          {#if hunkIdx > 0}
-            {@const gap = computeCollapsedLines(renderedFile.hunks, hunkIdx)}
-            {#if gap > 0}
-              <CollapsedRegion lineCount={gap} />
+        <div class="file-rows">
+          {#each renderedFile.hunks as hunk, hunkIdx}
+            {#if hunkIdx > 0}
+              {@const gap = computeCollapsedLines(renderedFile.hunks, hunkIdx)}
+              {#if gap > 0}
+                <CollapsedRegion lineCount={gap} />
+              {/if}
             {/if}
-          {/if}
-          <div class="hunk-header">
-            <span class="hunk-gutter"></span>
-            <span class="hunk-gutter"></span>
-            <span class="hunk-text">@@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@{hunk.section ? ` ${hunk.section}` : ""}</span>
-          </div>
-          {#each hunk.lines as line, lineIdx}
-            <DiffLineComponent
-              type={line.type}
-              content={line.content}
-              {...(line.old_num != null ? { oldNum: line.old_num } : {})}
-              {...(line.new_num != null ? { newNum: line.new_num } : {})}
-              {...(line.no_newline ? { noNewline: line.no_newline } : {})}
-              tokens={getTokens(hunkIdx, lineIdx)}
-            />
+            <div class="hunk-header">
+              <span class="hunk-gutter"></span>
+              <span class="hunk-gutter"></span>
+              <span class="hunk-text">@@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@{hunk.section ? ` ${hunk.section}` : ""}</span>
+            </div>
+            {#each hunk.lines as line, lineIdx}
+              <DiffLineComponent
+                type={line.type}
+                content={line.content}
+                {...(line.old_num != null ? { oldNum: line.old_num } : {})}
+                {...(line.new_num != null ? { newNum: line.new_num } : {})}
+                {...(line.no_newline ? { noNewline: line.no_newline } : {})}
+                tokens={getTokens(hunkIdx, lineIdx)}
+              />
+            {/each}
           {/each}
-        {/each}
+        </div>
       {/if}
     </div>
   {/if}
@@ -298,6 +300,11 @@
 
   .file-content {
     overflow-x: auto;
+  }
+
+  .file-rows {
+    min-width: 100%;
+    width: max-content;
   }
 
   .binary-notice {

--- a/packages/ui/src/components/diff/DiffLine.svelte
+++ b/packages/ui/src/components/diff/DiffLine.svelte
@@ -96,8 +96,7 @@
   }
 
   .code {
-    flex: 1;
-    min-width: 0;
+    flex: 1 0 auto;
     margin: 0;
     padding: 0 8px 0 4px;
     font-family: var(--font-mono);
@@ -105,7 +104,6 @@
     line-height: 20px;
     color: var(--diff-text);
     white-space: pre;
-    overflow-x: visible;
     background: transparent;
     border: none;
   }


### PR DESCRIPTION
## Summary

- Diff line add/delete backgrounds now extend to the full horizontal scroll width instead of stopping at the viewport edge
- Added e2e test verifying individual row widths match the scroll container after horizontal scroll