### PR TITLE
feat: show head/base branch in PR detail header

### DIFF
--- a/frontend/tests/e2e-full/pr-detail-branches.spec.ts
+++ b/frontend/tests/e2e-full/pr-detail-branches.spec.ts
@@ -1,40 +1,34 @@
-import { expect, test, type Page } from "@playwright/test";
-
-async function openFirstPR(page: Page): Promise<void> {
-  await page.goto("/pulls");
-  await page.locator(".pull-item").first()
-    .waitFor({ state: "visible", timeout: 10_000 });
-  await page.locator(".pull-item").first().click();
-  await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 10_000 });
-}
+import { expect, test } from "@playwright/test";
 
 test.describe("PR detail branch info", () => {
   test("shows head and base branch in meta-row", async ({ page }) => {
-    await openFirstPR(page);
+    await page.goto("/pulls/acme/widgets/1");
+    await page.locator(".pull-detail")
+      .waitFor({ state: "visible", timeout: 10_000 });
 
     const metaBranch = page.locator(".meta-branch");
     await expect(metaBranch).toBeVisible();
 
-    // Branch names render inside .branch-name spans
-    const branchNames = metaBranch.locator(".branch-name");
-    await expect(branchNames).toHaveCount(2);
+    const branchBtns = metaBranch.locator(".branch-name-btn");
+    await expect(branchBtns).toHaveCount(2);
 
-    // Head branch (first) and base branch (second) should be non-empty
-    await expect(branchNames.first()).not.toBeEmpty();
-    await expect(branchNames.last()).not.toBeEmpty();
+    await expect(branchBtns.first()).not.toBeEmpty();
+    await expect(branchBtns.last()).not.toBeEmpty();
 
-    // Arrow separator present
     const arrow = metaBranch.locator(".branch-arrow");
     await expect(arrow).toBeVisible();
   });
 
   test("branch names match seeded fixture data", async ({ page }) => {
-    await openFirstPR(page);
+    await page.goto("/pulls/acme/widgets/1");
+    await page.locator(".pull-detail")
+      .waitFor({ state: "visible", timeout: 10_000 });
 
-    const branchNames = page.locator(".meta-branch .branch-name");
-
-    // First seeded open PR (widgets#1) has HeadBranch: "feature/caching", BaseBranch: "main"
-    await expect(branchNames.first()).toHaveText("feature/caching");
-    await expect(branchNames.last()).toHaveText("main");
+    const branchBtns = page.locator(
+      ".meta-branch .branch-name-btn",
+    );
+    await expect(branchBtns.first())
+      .toHaveText("feature/caching");
+    await expect(branchBtns.last()).toHaveText("main");
   });
 });

--- a/frontend/tests/e2e-full/pr-detail-branches.spec.ts
+++ b/frontend/tests/e2e-full/pr-detail-branches.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function openFirstPR(page: Page): Promise<void> {
+  await page.goto("/pulls");
+  await page.locator(".pull-item").first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await page.locator(".pull-item").first().click();
+  await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 10_000 });
+}
+
+test.describe("PR detail branch info", () => {
+  test("shows head and base branch in meta-row", async ({ page }) => {
+    await openFirstPR(page);
+
+    const metaBranch = page.locator(".meta-branch");
+    await expect(metaBranch).toBeVisible();
+
+    // Branch names render inside .branch-name spans
+    const branchNames = metaBranch.locator(".branch-name");
+    await expect(branchNames).toHaveCount(2);
+
+    // Head branch (first) and base branch (second) should be non-empty
+    await expect(branchNames.first()).not.toBeEmpty();
+    await expect(branchNames.last()).not.toBeEmpty();
+
+    // Arrow separator present
+    const arrow = metaBranch.locator(".branch-arrow");
+    await expect(arrow).toBeVisible();
+  });
+
+  test("branch names match seeded fixture data", async ({ page }) => {
+    await openFirstPR(page);
+
+    const branchNames = page.locator(".meta-branch .branch-name");
+
+    // First seeded open PR (widgets#1) has HeadBranch: "feature/caching", BaseBranch: "main"
+    await expect(branchNames.first()).toHaveText("feature/caching");
+    await expect(branchNames.last()).toHaveText("main");
+  });
+});

--- a/frontend/tests/e2e-full/pr-detail-branches.spec.ts
+++ b/frontend/tests/e2e-full/pr-detail-branches.spec.ts
@@ -21,9 +21,11 @@ test.describe("PR detail branch info", () => {
   });
 
   test("click branch shows copied feedback", async ({
-    page, context,
+    page, context, browserName,
   }) => {
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    if (browserName === "chromium") {
+      await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    }
 
     const headBtn = page.locator(
       ".meta-branch .branch-name-btn",

--- a/frontend/tests/e2e-full/pr-detail-branches.spec.ts
+++ b/frontend/tests/e2e-full/pr-detail-branches.spec.ts
@@ -1,17 +1,18 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("PR detail branch info", () => {
-  test("shows head and base branch in meta-row", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto("/pulls/acme/widgets/1");
     await page.locator(".pull-detail")
       .waitFor({ state: "visible", timeout: 10_000 });
+  });
 
+  test("shows head and base branch buttons", async ({ page }) => {
     const metaBranch = page.locator(".meta-branch");
     await expect(metaBranch).toBeVisible();
 
     const branchBtns = metaBranch.locator(".branch-name-btn");
     await expect(branchBtns).toHaveCount(2);
-
     await expect(branchBtns.first()).not.toBeEmpty();
     await expect(branchBtns.last()).not.toBeEmpty();
 
@@ -19,16 +20,21 @@ test.describe("PR detail branch info", () => {
     await expect(arrow).toBeVisible();
   });
 
-  test("branch names match seeded fixture data", async ({ page }) => {
-    await page.goto("/pulls/acme/widgets/1");
-    await page.locator(".pull-detail")
-      .waitFor({ state: "visible", timeout: 10_000 });
+  test("click branch shows copied feedback", async ({
+    page, context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
-    const branchBtns = page.locator(
+    const headBtn = page.locator(
       ".meta-branch .branch-name-btn",
+    ).first();
+    await expect(headBtn).toHaveAttribute(
+      "title", "Click to copy",
     );
-    await expect(branchBtns.first())
-      .toHaveText("feature/caching");
-    await expect(branchBtns.last()).toHaveText("main");
+
+    await headBtn.click();
+
+    await expect(headBtn).toHaveClass(/branch-name-btn--copied/);
+    await expect(headBtn).toHaveAttribute("title", "Copied!");
   });
 });

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -709,6 +709,24 @@ func TestAPIGetPull(t *testing.T) {
 	require.Equal("widget", resp.JSON200.RepoName)
 }
 
+func TestAPIGetPullIncludesBranches(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	mr := resp.JSON200.MergeRequest
+	require.NotNil(mr)
+	require.Equal("feature", mr.HeadBranch)
+	require.Equal("main", mr.BaseBranch)
+}
+
 func TestAPIGetPullIncludesLabels(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -296,6 +296,17 @@
         <span class="meta-item">{pr.Author}</span>
         <span class="meta-sep">·</span>
         <span class="meta-item">{timeAgo(pr.CreatedAt)}</span>
+        {#if pr.HeadBranch}
+          <span class="meta-sep">·</span>
+          <span class="meta-branch">
+            <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
+            </svg>
+            <span class="branch-name">{pr.HeadBranch}</span>
+            <span class="branch-arrow">&rarr;</span>
+            <span class="branch-name">{pr.BaseBranch}</span>
+          </span>
+        {/if}
         {#if detailStore.isDetailSyncing()}
           <span class="meta-sep">·</span>
           <span class="sync-indicator" title="Syncing from GitHub">
@@ -306,17 +317,6 @@
           </span>
         {/if}
       </div>
-
-      {#if pr.HeadBranch}
-        <div class="branch-row">
-          <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
-          </svg>
-          <span class="branch-name">{pr.HeadBranch}</span>
-          <span class="branch-arrow">&rarr;</span>
-          <span class="branch-name">{pr.BaseBranch}</span>
-        </div>
-      {/if}
 
       <!-- Chips row -->
       <div class="chips-row">
@@ -752,10 +752,10 @@
     to { transform: rotate(360deg); }
   }
 
-  .branch-row {
-    display: flex;
+  .meta-branch {
+    display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: 3px;
     font-size: 12px;
   }
 

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -307,6 +307,17 @@
         {/if}
       </div>
 
+      {#if pr.HeadBranch}
+        <div class="branch-row">
+          <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
+          </svg>
+          <span class="branch-name">{pr.HeadBranch}</span>
+          <span class="branch-arrow">&rarr;</span>
+          <span class="branch-name">{pr.BaseBranch}</span>
+        </div>
+      {/if}
+
       <!-- Chips row -->
       <div class="chips-row">
         {#if pr.State === "merged"}
@@ -739,6 +750,28 @@
 
   @keyframes spin {
     to { transform: rotate(360deg); }
+  }
+
+  .branch-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+  }
+
+  .branch-icon {
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .branch-name {
+    color: var(--text-secondary);
+    font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+    font-size: 11.5px;
+  }
+
+  .branch-arrow {
+    color: var(--text-muted);
   }
 
   .chips-row {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -793,6 +793,7 @@
   }
 
   .branch-name-btn {
+    position: relative;
     color: var(--text-secondary);
     font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
     font-size: 11.5px;
@@ -801,7 +802,7 @@
     padding: 1px 4px;
     border-radius: 3px;
     cursor: pointer;
-    transition: background 0.1s, color 0.1s;
+    transition: background 0.15s, color 0.15s;
   }
 
   .branch-name-btn:hover {
@@ -811,6 +812,39 @@
 
   .branch-name-btn--copied {
     color: var(--accent-green);
+    background: color-mix(
+      in srgb, var(--accent-green) 10%, transparent
+    );
+  }
+
+  .branch-name-btn--copied::after {
+    content: "Copied!";
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    font-family: inherit;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: #fff;
+    background: var(--accent-green);
+    padding: 2px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+    pointer-events: none;
+    animation: copied-pop 0.2s ease-out;
+  }
+
+  @keyframes copied-pop {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
   }
 
   .branch-arrow {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -59,6 +59,24 @@
     });
   }
 
+  let copiedBranch = $state<string | null>(null);
+  let branchCopyTimeout: ReturnType<typeof setTimeout> | null
+    = null;
+
+  function copyBranch(text: string): void {
+    void copyToClipboard(text).then((ok) => {
+      if (!ok) return;
+      copiedBranch = text;
+      if (branchCopyTimeout !== null) {
+        clearTimeout(branchCopyTimeout);
+      }
+      branchCopyTimeout = setTimeout(() => {
+        copiedBranch = null;
+        branchCopyTimeout = null;
+      }, 1500);
+    });
+  }
+
   async function refreshPulls(): Promise<void> {
     if (onPullsRefresh) {
       await onPullsRefresh();
@@ -302,9 +320,19 @@
             <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
               <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
             </svg>
-            <span class="branch-name">{pr.HeadBranch}</span>
+            <button
+              class="branch-name-btn"
+              class:branch-name-btn--copied={copiedBranch === pr.HeadBranch}
+              title={copiedBranch === pr.HeadBranch ? "Copied!" : "Click to copy"}
+              onclick={() => copyBranch(pr.HeadBranch)}
+            >{pr.HeadBranch}</button>
             <span class="branch-arrow">&rarr;</span>
-            <span class="branch-name">{pr.BaseBranch}</span>
+            <button
+              class="branch-name-btn"
+              class:branch-name-btn--copied={copiedBranch === pr.BaseBranch}
+              title={copiedBranch === pr.BaseBranch ? "Copied!" : "Click to copy"}
+              onclick={() => copyBranch(pr.BaseBranch)}
+            >{pr.BaseBranch}</button>
           </span>
         {/if}
         {#if detailStore.isDetailSyncing()}
@@ -764,10 +792,25 @@
     flex-shrink: 0;
   }
 
-  .branch-name {
+  .branch-name-btn {
     color: var(--text-secondary);
     font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
     font-size: 11.5px;
+    background: none;
+    border: none;
+    padding: 1px 4px;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s;
+  }
+
+  .branch-name-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .branch-name-btn--copied {
+    color: var(--accent-green);
   }
 
   .branch-arrow {


### PR DESCRIPTION
## Summary

- Show head and base branch names inline in the PR detail meta-row (e.g. `fix-auth → main`)
- Git-branch icon prefix, monospace branch names, arrow separator
- Only renders when head branch data is available

![pr-detail.png](https://github.com/user-attachments/assets/4bba49b7-8f74-4e3e-ba40-cd9e691f14f3)