### PR TITLE
Workspace right sidebar with PR detail and reviews

### DIFF
--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -14,6 +14,7 @@
   let fitAddon: FitAddon | null = null;
   let ws: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let restartTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectDelay = 1000;
   let resizeObserver: ResizeObserver | null = null;
   let disposed = false;
@@ -62,8 +63,9 @@
           if (msg.type === "exited") {
             exited = true;
             terminal.write(
-              "\r\n\x1b[90m[Process exited]\x1b[0m\r\n",
+              "\r\n\x1b[90m[Process exited — reconnecting...]\x1b[0m\r\n",
             );
+            scheduleSessionRestart();
           }
         } catch {
           // Non-JSON text frame; ignore.
@@ -78,6 +80,27 @@
     socket.onerror = () => {
       socket.close();
     };
+  }
+
+  function scheduleSessionRestart(): void {
+    if (disposed) return;
+    if (restartTimer) clearTimeout(restartTimer);
+    restartTimer = setTimeout(() => {
+      restartTimer = null;
+      if (disposed) return;
+      // Close stale socket so its onclose handler
+      // cannot schedule a duplicate reconnect.
+      if (ws) {
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.onmessage = null;
+        ws.close();
+        ws = null;
+      }
+      exited = false;
+      reconnectDelay = 1000;
+      connect();
+    }, 2000);
   }
 
   function scheduleReconnect(): void {
@@ -101,6 +124,10 @@
     if (reconnectTimer !== null) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
+    }
+    if (restartTimer !== null) {
+      clearTimeout(restartTimer);
+      restartTimer = null;
     }
     if (ws) {
       ws.onclose = null;

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import {
-    navigate,
-    buildItemRoute,
-  } from "../../stores/router.svelte.ts";
+  import { navigate } from "../../stores/router.svelte.ts";
   import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
   import TerminalPane from "./TerminalPane.svelte";
+  import { WorkspaceRightSidebar } from "@middleman/ui";
 
   interface Workspace {
     id: string;
@@ -38,6 +36,121 @@
     typeof setInterval
   > | null>(null);
   let eventSource = $state<EventSource | null>(null);
+
+  const SIDEBAR_TAB_KEY = "middleman-workspace-sidebar-tab";
+  const SIDEBAR_OPEN_KEY = "middleman-workspace-sidebar-open";
+  const SIDEBAR_WIDTH_KEY = "middleman-workspace-sidebar-width";
+
+  type SidebarTab = "pr" | "reviews";
+
+  function loadSidebarTab(): SidebarTab {
+    const v = localStorage.getItem(SIDEBAR_TAB_KEY);
+    return v === "reviews" ? "reviews" : "pr";
+  }
+
+  function loadSidebarOpen(): boolean {
+    return localStorage.getItem(SIDEBAR_OPEN_KEY) === "true";
+  }
+
+  const MIN_SIDEBAR_WIDTH = 280;
+  const MIN_TERMINAL_WIDTH = 300;
+  const DEFAULT_SIDEBAR_WIDTH = 640;
+
+  function loadSidebarWidth(): number {
+    const v = parseInt(
+      localStorage.getItem(SIDEBAR_WIDTH_KEY) ?? "",
+      10,
+    );
+    return Number.isFinite(v)
+      ? Math.max(MIN_SIDEBAR_WIDTH, v)
+      : DEFAULT_SIDEBAR_WIDTH;
+  }
+
+  let sidebarTab = $state<SidebarTab>(loadSidebarTab());
+  let sidebarOpen = $state(loadSidebarOpen());
+  let sidebarWidth = $state(loadSidebarWidth());
+
+  $effect(() => {
+    localStorage.setItem(SIDEBAR_TAB_KEY, sidebarTab);
+  });
+  $effect(() => {
+    localStorage.setItem(
+      SIDEBAR_OPEN_KEY,
+      String(sidebarOpen),
+    );
+  });
+  $effect(() => {
+    localStorage.setItem(
+      SIDEBAR_WIDTH_KEY,
+      String(sidebarWidth),
+    );
+  });
+
+  function handleSegmentClick(tab: SidebarTab): void {
+    if (sidebarOpen && sidebarTab === tab) {
+      sidebarOpen = false;
+    } else {
+      sidebarTab = tab;
+      sidebarOpen = true;
+    }
+  }
+
+  function toggleSidebar(): void {
+    sidebarOpen = !sidebarOpen;
+  }
+
+  let containerEl = $state<HTMLElement | null>(null);
+
+  // Clamp sidebar width to fit container when it
+  // becomes available or when the sidebar opens
+  $effect(() => {
+    if (!containerEl || !sidebarOpen) return;
+    const maxW =
+      containerEl.clientWidth - MIN_TERMINAL_WIDTH;
+    if (sidebarWidth > maxW && maxW > MIN_SIDEBAR_WIDTH) {
+      sidebarWidth = maxW;
+    }
+  });
+
+  function startSidebarResize(e: MouseEvent): void {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = sidebarWidth;
+    const maxW = containerEl
+      ? containerEl.clientWidth - MIN_TERMINAL_WIDTH
+      : 9999;
+
+    function onMove(ev: MouseEvent): void {
+      sidebarWidth = Math.max(
+        MIN_SIDEBAR_WIDTH,
+        Math.min(maxW, startW - (ev.clientX - startX)),
+      );
+    }
+
+    function onUp(): void {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    }
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  $effect(() => {
+    function onKeydown(e: KeyboardEvent): void {
+      if (
+        e.key === "]" &&
+        (e.metaKey || e.ctrlKey) &&
+        !e.defaultPrevented
+      ) {
+        e.preventDefault();
+        toggleSidebar();
+      }
+    }
+    window.addEventListener("keydown", onKeydown);
+    return () =>
+      window.removeEventListener("keydown", onKeydown);
+  });
 
   function displayName(ws: Workspace): string {
     return ws.mr_title ?? ws.mr_head_ref;
@@ -114,18 +227,6 @@
       return;
     }
     navigate("/pulls");
-  }
-
-  function navigateToPR(): void {
-    if (!workspace) return;
-    navigate(
-      buildItemRoute(
-        "pr",
-        workspace.repo_owner,
-        workspace.repo_name,
-        workspace.mr_number,
-      ),
-    );
   }
 
   onMount(() => {
@@ -243,12 +344,22 @@
           </code>
         </div>
         <div class="header-right">
-          <button
-            class="header-btn"
-            onclick={navigateToPR}
-          >
-            View PR
-          </button>
+          <div class="seg-control">
+            <button
+              class="seg-btn"
+              class:active={sidebarOpen && sidebarTab === "pr"}
+              onclick={() => handleSegmentClick("pr")}
+            >
+              PR
+            </button>
+            <button
+              class="seg-btn"
+              class:active={sidebarOpen && sidebarTab === "reviews"}
+              onclick={() => handleSegmentClick("reviews")}
+            >
+              Reviews
+            </button>
+          </div>
           <button
             class="header-btn danger"
             onclick={() => void handleDelete()}
@@ -257,8 +368,30 @@
           </button>
         </div>
       </div>
-      <div class="terminal-area">
-        <TerminalPane {workspaceId} />
+      <div class="terminal-and-sidebar" bind:this={containerEl}>
+        <div class="terminal-area">
+          <TerminalPane {workspaceId} />
+        </div>
+        {#if sidebarOpen && workspace}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="sidebar-resize-handle"
+            onmousedown={startSidebarResize}
+          ></div>
+          <div
+            class="right-sidebar"
+            style="width: {sidebarWidth}px"
+          >
+            <WorkspaceRightSidebar
+              activeTab={sidebarTab}
+              repoOwner={workspace.repo_owner}
+              repoName={workspace.repo_name}
+              mrNumber={workspace.mr_number}
+              branch={workspace.mr_head_ref}
+              roborevBaseUrl={basePath + "/api/roborev"}
+            />
+          </div>
+        {/if}
       </div>
     {/if}
   </div>
@@ -401,6 +534,60 @@
 
   .terminal-area {
     flex: 1;
+    overflow: hidden;
+  }
+
+  .seg-control {
+    display: flex;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .seg-btn {
+    padding: 3px 10px;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+  }
+
+  .seg-btn:first-child {
+    border-right: 1px solid var(--border-default);
+  }
+
+  .seg-btn:hover {
+    color: var(--text-secondary);
+    background: var(--bg-surface-hover);
+  }
+
+  .seg-btn.active {
+    background: var(--accent-blue);
+    color: #fff;
+  }
+
+  .terminal-and-sidebar {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+  }
+
+  .sidebar-resize-handle {
+    width: 4px;
+    cursor: col-resize;
+    background: var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .sidebar-resize-handle:hover {
+    background: var(--accent-blue);
+  }
+
+  .right-sidebar {
+    flex-shrink: 0;
     overflow: hidden;
   }
 </style>

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1,0 +1,654 @@
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+const testWorkspace = {
+  id: "ws-123",
+  platform_host: "github.com",
+  repo_owner: "acme",
+  repo_name: "widgets",
+  mr_number: 42,
+  mr_head_ref: "feature/auth",
+  worktree_path: "/tmp/worktrees/ws-123",
+  tmux_session: "middleman-ws-123",
+  status: "ready",
+  created_at: "2026-04-10T12:00:00Z",
+  mr_title: "Add auth middleware",
+  mr_state: "open",
+  mr_is_draft: false,
+};
+
+const roborevRepos = {
+  repos: [
+    {
+      name: "widgets",
+      root_path: "/home/dev/widgets",
+      count: 5,
+    },
+  ],
+  total_count: 1,
+};
+
+const roborevJobs = {
+  jobs: [
+    {
+      id: 1,
+      status: "done",
+      verdict: "pass",
+      agent: "code-review",
+      job_type: "review",
+      git_ref: "abc12345",
+      commit_subject: "Add auth middleware",
+      enqueued_at: "2026-04-10T12:00:00Z",
+      branch: "feature/auth",
+      repo_name: "widgets",
+      repo_id: 1,
+      agentic: false,
+      prompt_prebuilt: false,
+      retry_count: 0,
+    },
+  ],
+  has_more: false,
+  stats: { done: 1, closed: 0, open: 0 },
+};
+
+/**
+ * Mock all routes needed for terminal view tests.
+ * Registers mockApi first (catch-all), then layers
+ * workspace and roborev routes on top so they take
+ * priority (Playwright uses LIFO route matching).
+ */
+async function setupTerminalMocks(
+  page: import("@playwright/test").Page,
+  opts?: {
+    workspace?: typeof testWorkspace;
+    roborevRepos?: typeof roborevRepos;
+    roborevJobs?: typeof roborevJobs;
+  },
+): Promise<void> {
+  const ws = opts?.workspace ?? testWorkspace;
+  const rrRepos = opts?.roborevRepos ?? roborevRepos;
+  const rrJobs = opts?.roborevJobs ?? roborevJobs;
+
+  // Register catch-all first — later routes override.
+  await mockApi(page);
+
+  await page.route(
+    "**/api/v1/events",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: "",
+      });
+    },
+  );
+
+  // Register list route first, then specific route.
+  // Playwright uses LIFO matching, so the specific
+  // /workspaces/:id registered last takes priority
+  // over the list-only pattern.
+  await page.route(
+    "**/api/v1/workspaces",
+    async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ workspaces: [ws] }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200 });
+    },
+  );
+
+  await page.route(
+    `**/api/v1/workspaces/${ws.id}`,
+    async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(ws),
+        });
+        return;
+      }
+      // DELETE
+      await route.fulfill({ status: 204 });
+    },
+  );
+
+  // Route roborev API calls using a predicate to avoid
+  // matching Vite module URLs like /@fs/.../api/roborev/...
+  await page.route(
+    (url) => url.pathname.startsWith("/api/roborev/"),
+    async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname.endsWith("/api/repos")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(rrRepos),
+        });
+        return;
+      }
+      if (
+        url.pathname.endsWith("/api/jobs") ||
+        url.pathname.includes("/api/jobs?")
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(rrJobs),
+        });
+        return;
+      }
+      if (url.pathname.endsWith("/status")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ status: "ok" }),
+        });
+        return;
+      }
+      if (url.pathname.includes("/stream/events")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: "",
+        });
+        return;
+      }
+      await route.fulfill({ status: 404 });
+    },
+  );
+}
+
+// -------------------------------------------------------
+// Group 1: Toggle Behavior
+// -------------------------------------------------------
+
+test.describe("sidebar toggle behavior", () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear any persisted sidebar state before each test.
+    await page.addInitScript(() => {
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-tab",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-open",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-width",
+      );
+    });
+    await setupTerminalMocks(page);
+  });
+
+  test(
+    "segmented control visible in terminal header",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+
+      const segControl = page.locator(".seg-control");
+      await expect(segControl).toBeVisible();
+      await expect(
+        segControl.locator(".seg-btn", { hasText: "PR" }),
+      ).toBeVisible();
+      await expect(
+        segControl.locator(".seg-btn", {
+          hasText: "Reviews",
+        }),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    "clicking PR segment opens sidebar with PR content",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+
+      const prBtn = page.locator(".seg-btn", {
+        hasText: "PR",
+      });
+      await expect(prBtn).toBeVisible();
+      await prBtn.click();
+
+      // Sidebar should now be visible
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+      // PR button should be active
+      await expect(prBtn).toHaveClass(/active/);
+    },
+  );
+
+  test(
+    "clicking active segment closes sidebar",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+
+      const prBtn = page.locator(".seg-btn", {
+        hasText: "PR",
+      });
+      // Open
+      await prBtn.click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      // Click same segment again — should close
+      await prBtn.click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toHaveCount(0);
+      await expect(prBtn).not.toHaveClass(/active/);
+    },
+  );
+
+  test(
+    "clicking Reviews switches tab without closing",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+
+      const prBtn = page.locator(".seg-btn", {
+        hasText: "PR",
+      });
+      const reviewsBtn = page.locator(".seg-btn", {
+        hasText: "Reviews",
+      });
+
+      // Open PR tab
+      await prBtn.click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+      await expect(prBtn).toHaveClass(/active/);
+
+      // Switch to Reviews
+      await reviewsBtn.click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+      await expect(reviewsBtn).toHaveClass(/active/);
+      await expect(prBtn).not.toHaveClass(/active/);
+    },
+  );
+
+  test(
+    "Cmd+] toggles sidebar open and closed",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+
+      // Start closed
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toHaveCount(0);
+
+      // Open via keyboard
+      await page.keyboard.press("Meta+]");
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      // Close via keyboard
+      await page.keyboard.press("Meta+]");
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toHaveCount(0);
+    },
+  );
+});
+
+// -------------------------------------------------------
+// Group 2: Persistence
+// -------------------------------------------------------
+
+test.describe("sidebar persistence", () => {
+  // Persistence tests reload the page, so we must NOT
+  // use addInitScript (it re-runs on reload and would
+  // clear the values we want to persist). Instead we
+  // clear localStorage via evaluate after first goto.
+  test.beforeEach(async ({ page }) => {
+    await setupTerminalMocks(page);
+  });
+
+  async function clearSidebarStorage(
+    page: import("@playwright/test").Page,
+  ): Promise<void> {
+    await page.evaluate(() => {
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-tab",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-open",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-width",
+      );
+    });
+  }
+
+  test(
+    "sidebar open state persists across reload",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+      await clearSidebarStorage(page);
+
+      // Open sidebar
+      const prBtn = page.locator(".seg-btn", {
+        hasText: "PR",
+      });
+      await prBtn.click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      // Verify localStorage written
+      const stored = await page.evaluate(() =>
+        localStorage.getItem(
+          "middleman-workspace-sidebar-open",
+        ),
+      );
+      expect(stored).toBe("true");
+
+      // Reload — sidebar should still be open
+      await page.reload();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    "sidebar tab persists across reload",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+      await clearSidebarStorage(page);
+
+      // Open Reviews tab
+      const reviewsBtn = page.locator(".seg-btn", {
+        hasText: "Reviews",
+      });
+      await reviewsBtn.click();
+      await expect(reviewsBtn).toHaveClass(/active/);
+
+      // Verify localStorage
+      const tab = await page.evaluate(() =>
+        localStorage.getItem(
+          "middleman-workspace-sidebar-tab",
+        ),
+      );
+      expect(tab).toBe("reviews");
+
+      // Reload
+      await page.reload();
+      const reviewsBtnAfter = page.locator(".seg-btn", {
+        hasText: "Reviews",
+      });
+      await expect(reviewsBtnAfter).toHaveClass(/active/);
+    },
+  );
+
+  test(
+    "sidebar width persists after resize and reload",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+      await clearSidebarStorage(page);
+
+      // Open sidebar
+      await page
+        .locator(".seg-btn", { hasText: "PR" })
+        .click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      const handle = page.locator(
+        ".sidebar-resize-handle",
+      );
+      const box = await handle.boundingBox();
+      expect(box).toBeTruthy();
+
+      if (box) {
+        // Drag left to make sidebar wider
+        await page.mouse.move(
+          box.x + 2,
+          box.y + box.height / 2,
+        );
+        await page.mouse.down();
+        await page.mouse.move(
+          box.x - 100,
+          box.y + box.height / 2,
+        );
+        await page.mouse.up();
+      }
+
+      // Width should have increased from default 360
+      const width = await page.evaluate(() =>
+        localStorage.getItem(
+          "middleman-workspace-sidebar-width",
+        ),
+      );
+      expect(Number(width)).toBeGreaterThan(360);
+
+      const savedWidth = Number(width);
+
+      // Reload and check sidebar opens at saved width
+      await page.reload();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      const actualWidth = await page
+        .locator(".right-sidebar")
+        .evaluate((el) => el.offsetWidth);
+      // Allow some tolerance for rounding
+      expect(actualWidth).toBeGreaterThanOrEqual(
+        savedWidth - 2,
+      );
+      expect(actualWidth).toBeLessThanOrEqual(
+        savedWidth + 2,
+      );
+    },
+  );
+});
+
+// -------------------------------------------------------
+// Group 3: PR Tab
+// -------------------------------------------------------
+
+test.describe("sidebar PR tab", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-tab",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-open",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-width",
+      );
+    });
+    await setupTerminalMocks(page);
+  });
+
+  test(
+    "PR tab loads PR detail for workspace with linked PR",
+    async ({ page }) => {
+      await page.goto("/terminal/ws-123");
+
+      // Open PR tab
+      await page
+        .locator(".seg-btn", { hasText: "PR" })
+        .click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      // PR detail component should show PR title
+      await expect(
+        page.locator(
+          ".right-sidebar .detail-title",
+        ),
+      ).toContainText("Add browser regression coverage");
+    },
+  );
+
+  test(
+    "PR tab shows empty state when mr_number is 0",
+    async ({ page }) => {
+      const noLinkedPR = {
+        ...testWorkspace,
+        mr_number: 0,
+      };
+      // Re-setup with modified workspace
+      await setupTerminalMocks(page, {
+        workspace: noLinkedPR,
+      });
+
+      await page.goto("/terminal/ws-123");
+
+      // Open PR tab
+      await page
+        .locator(".seg-btn", { hasText: "PR" })
+        .click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      await expect(
+        page.locator(".right-sidebar .empty-state"),
+      ).toContainText("No linked PR");
+    },
+  );
+});
+
+// -------------------------------------------------------
+// Group 4: Reviews Tab
+// -------------------------------------------------------
+
+test.describe("sidebar Reviews tab", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-tab",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-open",
+      );
+      localStorage.removeItem(
+        "middleman-workspace-sidebar-width",
+      );
+    });
+  });
+
+  test(
+    "Reviews tab shows job list when roborev repo matches",
+    async ({ page }) => {
+      await setupTerminalMocks(page);
+      await page.goto("/terminal/ws-123");
+
+      // Open Reviews tab
+      await page
+        .locator(".seg-btn", { hasText: "Reviews" })
+        .click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      // Job list should render the mock job
+      await expect(
+        page.locator(
+          ".right-sidebar .job-row",
+        ),
+      ).toBeVisible();
+      await expect(
+        page.locator(".right-sidebar .job-row"),
+      ).toContainText("Add auth middleware");
+    },
+  );
+
+  test(
+    "Reviews tab shows empty state when no repo matches",
+    async ({ page }) => {
+      await setupTerminalMocks(page, {
+        roborevRepos: { repos: [], total_count: 0 },
+      });
+      await page.goto("/terminal/ws-123");
+
+      // Open Reviews tab
+      await page
+        .locator(".seg-btn", { hasText: "Reviews" })
+        .click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      // Should show empty/no-reviews message
+      await expect(
+        page.locator(".right-sidebar .empty-state"),
+      ).toContainText("No reviews");
+    },
+  );
+
+  test(
+    "branch pill shows and clears branch filter",
+    async ({ page }) => {
+      await setupTerminalMocks(page);
+      await page.goto("/terminal/ws-123");
+
+      // Open Reviews tab
+      await page
+        .locator(".seg-btn", { hasText: "Reviews" })
+        .click();
+      await expect(
+        page.locator(".right-sidebar"),
+      ).toBeVisible();
+
+      // Branch pill should show workspace branch
+      const pill = page.locator(
+        ".right-sidebar .branch-pill",
+      );
+      await expect(pill).toBeVisible();
+      await expect(pill).toContainText("feature/auth");
+
+      // Clear button removes pill
+      await pill.locator(".branch-pill-clear").click();
+      await expect(pill).not.toBeVisible();
+    },
+  );
+
+  test(
+    "selecting a job does not navigate to /reviews",
+    async ({ page }) => {
+      await setupTerminalMocks(page);
+      await page.goto("/terminal/ws-123");
+
+      // Open Reviews tab
+      await page
+        .locator(".seg-btn", { hasText: "Reviews" })
+        .click();
+      await expect(
+        page.locator(".right-sidebar .job-row"),
+      ).toBeVisible();
+
+      // Click the job row
+      await page
+        .locator(".right-sidebar .job-row")
+        .first()
+        .click();
+
+      // URL should stay on /terminal, not navigate
+      await expect(page).toHaveURL(/\/terminal\/ws-123/);
+      // Job row should get selected state
+      await expect(
+        page
+          .locator(".right-sidebar .job-row")
+          .first(),
+      ).toHaveClass(/selected/);
+    },
+  );
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -105,6 +105,7 @@ const config = {
       "/api": {
         target: apiUrl,
         changeOrigin: true,
+        ws: true,
       },
     },
   },

--- a/packages/ui/src/components/workspace/SidebarJobList.svelte
+++ b/packages/ui/src/components/workspace/SidebarJobList.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import { getStores } from "../../context.js";
+  import VerdictBadge from "../roborev/VerdictBadge.svelte";
+  import type {
+    components,
+  } from "../../api/roborev/generated/schema.js";
+
+  type ReviewJob = components["schemas"]["ReviewJob"];
+
+  const stores = getStores();
+
+  const jobs = $derived(
+    stores.roborevJobs?.getJobs() ?? [],
+  );
+  const loading = $derived(
+    stores.roborevJobs?.isLoading() ?? false,
+  );
+  const selectedJobId = $derived(
+    stores.roborevJobs?.getSelectedJobId(),
+  );
+
+  function timeAgo(iso: string): string {
+    const ms = Date.now() - new Date(iso).getTime();
+    const sec = Math.floor(ms / 1000);
+    if (sec < 60) return `${sec}s`;
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}m`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h`;
+    const d = Math.floor(hr / 24);
+    return `${d}d`;
+  }
+
+  function shortRef(ref: string): string {
+    return ref.length > 8 ? ref.slice(0, 8) : ref;
+  }
+
+  function handleClick(job: ReviewJob): void {
+    if (selectedJobId === job.id) {
+      stores.roborevJobs?.deselectJob();
+    } else {
+      stores.roborevJobs?.selectJob(job.id);
+    }
+  }
+</script>
+
+<div class="sidebar-job-list">
+  {#if loading && jobs.length === 0}
+    <div class="list-empty">Loading reviews...</div>
+  {:else if jobs.length === 0}
+    <div class="list-empty">No reviews found</div>
+  {:else}
+    {#each jobs as job (job.id)}
+      <button
+        class="job-row"
+        class:selected={selectedJobId === job.id}
+        onclick={() => handleClick(job)}
+      >
+        <div class="row-top">
+          <span
+            class="status-dot status-{job.status}"
+            title={job.status}
+          ></span>
+          <span class="job-id">#{job.id}</span>
+          <span class="job-type">{job.job_type}</span>
+          <span class="job-time">
+            {timeAgo(job.enqueued_at)}
+          </span>
+        </div>
+        <div class="row-bottom">
+          {#if job.commit_subject}
+            <span class="commit-subject">
+              {job.commit_subject}
+            </span>
+          {:else}
+            <span class="commit-ref">
+              {shortRef(job.git_ref)}
+            </span>
+          {/if}
+          {#if job.status === "done" || job.verdict}
+            <VerdictBadge verdict={job.verdict} />
+          {/if}
+        </div>
+      </button>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .sidebar-job-list {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .list-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+  }
+
+  .job-row {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 8px 12px;
+    border: none;
+    border-bottom: 1px solid var(--border-muted);
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 12px;
+    width: 100%;
+  }
+
+  .job-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .job-row.selected {
+    background: color-mix(
+      in srgb, var(--accent-blue) 10%, transparent
+    );
+  }
+
+  .row-top {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .status-dot.status-queued { background: var(--review-queued); }
+  .status-dot.status-running { background: var(--review-running); }
+  .status-dot.status-done { background: var(--review-done); }
+  .status-dot.status-failed { background: var(--review-failed); }
+  .status-dot.status-canceled { background: var(--review-canceled); }
+
+  .job-id {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .job-type {
+    font-size: 11px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .job-time {
+    margin-left: auto;
+    font-size: 10px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .row-bottom {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding-left: 12px;
+  }
+
+  .commit-subject {
+    font-size: 11px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .commit-ref {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+</style>

--- a/packages/ui/src/components/workspace/SidebarStoreScope.svelte
+++ b/packages/ui/src/components/workspace/SidebarStoreScope.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+  import { STORES_KEY } from "../../context.js";
+  import type { StoreInstances } from "../../types.js";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    stores: StoreInstances;
+    children: Snippet;
+  }
+
+  let { stores, children }: Props = $props();
+
+  // svelte-ignore state_referenced_locally
+  setContext(STORES_KEY, stores);
+</script>
+
+{@render children()}

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { getStores } from "../../context.js";
+  import {
+    createRoborevClient,
+  } from "../../api/roborev/client.js";
+  import {
+    createJobsStore,
+  } from "../../stores/roborev/jobs.svelte.js";
+  import {
+    createReviewStore,
+  } from "../../stores/roborev/review.svelte.js";
+  import {
+    createLogStore,
+  } from "../../stores/roborev/log.svelte.js";
+  import type { StoreInstances } from "../../types.js";
+  import type {
+    components,
+  } from "../../api/roborev/generated/schema.js";
+  import SidebarStoreScope
+    from "./SidebarStoreScope.svelte";
+  import PullDetail
+    from "../detail/PullDetail.svelte";
+  import FilterBar
+    from "../roborev/FilterBar.svelte";
+  import DaemonStatus
+    from "../roborev/DaemonStatus.svelte";
+  import JobTable
+    from "../roborev/JobTable.svelte";
+  import ReviewDrawer
+    from "../roborev/ReviewDrawer.svelte";
+
+  type RepoWithCount =
+    components["schemas"]["RepoWithCount"];
+
+  interface Props {
+    activeTab: "pr" | "reviews";
+    repoOwner: string;
+    repoName: string;
+    mrNumber: number;
+    branch: string;
+    roborevBaseUrl: string;
+  }
+
+  let {
+    activeTab,
+    repoOwner,
+    repoName,
+    mrNumber,
+    branch,
+    roborevBaseUrl,
+  }: Props = $props();
+
+  const parentStores = getStores();
+
+  // svelte-ignore state_referenced_locally — intentional snapshot; stores are created once
+  const baseUrl = roborevBaseUrl;
+
+  // Sidebar-local roborev stores
+  const roborevClient = createRoborevClient(
+    baseUrl,
+  );
+  const sidebarJobs = createJobsStore({
+    client: roborevClient,
+    navigate: () => {},
+  });
+  const sidebarReview = createReviewStore({
+    client: roborevClient,
+  });
+  const sidebarLog = createLogStore({
+    client: roborevClient,
+    baseUrl,
+  });
+
+  // Overlay sidebar stores onto parent stores
+  const sidebarStores: StoreInstances = {
+    ...parentStores,
+    roborevJobs: sidebarJobs,
+    roborevReview: sidebarReview,
+    roborevLog: sidebarLog,
+  };
+
+  // Repo resolution state
+  let resolvedRootPath = $state<string | null>(null);
+  let repoResolutionError = $state<string | null>(
+    null,
+  );
+  let lastResolvedKey = $state("");
+  let negativeMatch = $state(false);
+
+  function repoKey(): string {
+    return `${repoOwner}/${repoName}`;
+  }
+
+  async function resolveRepo(): Promise<void> {
+    if (!repoName) {
+      resolvedRootPath = null;
+      repoResolutionError = null;
+      negativeMatch = false;
+      lastResolvedKey = "";
+      return;
+    }
+    const { data } = await roborevClient.GET(
+      "/api/repos",
+    );
+    const repos: RepoWithCount[] =
+      data?.repos ?? [];
+    const matches = repos.filter(
+      (r) =>
+        r.name.toLowerCase() ===
+        repoName.toLowerCase(),
+    );
+    if (matches.length === 0) {
+      resolvedRootPath = null;
+      repoResolutionError = null;
+      negativeMatch = true;
+      return;
+    }
+    if (matches.length === 1) {
+      resolvedRootPath = matches[0]!.root_path;
+      repoResolutionError = null;
+      negativeMatch = false;
+      lastResolvedKey = repoKey();
+      return;
+    }
+    // Multiple matches — disambiguate by owner
+    const ownerMatch = matches.filter((r) =>
+      r.root_path
+        .split("/")
+        .some(
+          (seg) =>
+            seg.toLowerCase() ===
+            repoOwner.toLowerCase(),
+        ),
+    );
+    if (ownerMatch.length === 1) {
+      resolvedRootPath = ownerMatch[0]!.root_path;
+      repoResolutionError = null;
+      negativeMatch = false;
+      lastResolvedKey = repoKey();
+      return;
+    }
+    resolvedRootPath = null;
+    repoResolutionError =
+      "Multiple repos matched \u2014 " +
+      "select one on the Reviews page";
+    negativeMatch = false;
+  }
+
+  // Resolve repo on workspace change
+  $effect(() => {
+    const key = repoKey();
+    if (key !== lastResolvedKey || negativeMatch) {
+      void resolveRepo().then(() => {
+        if (resolvedRootPath) {
+          sidebarJobs.setFilter(
+            "repo",
+            resolvedRootPath,
+          );
+          sidebarJobs.setFilter("branch", branch);
+          void sidebarJobs.loadJobs();
+        }
+      });
+    }
+  });
+
+  // Update branch filter when branch changes within
+  // the same resolved repo
+  // svelte-ignore state_referenced_locally
+  let lastBranch = $state(branch);
+  $effect(() => {
+    if (branch !== lastBranch && resolvedRootPath) {
+      lastBranch = branch;
+      sidebarJobs.setFilter("branch", branch);
+      void sidebarJobs.loadJobs();
+    }
+  });
+
+  // Sync selectedJobId → review store (mirrors
+  // ReviewsView effect #2)
+  $effect(() => {
+    const id = sidebarJobs.getSelectedJobId();
+    sidebarReview.setSelectedJobId(id);
+  });
+
+  // Reset drawer tab when job selected (mirrors
+  // ReviewsView effect #3)
+  let drawerTab = $state<
+    "review" | "log" | "prompt"
+  >("review");
+  $effect(() => {
+    const id = sidebarJobs.getSelectedJobId();
+    if (id !== undefined) {
+      drawerTab = "review";
+    }
+  });
+
+  // Re-resolve repo on daemon recovery
+  $effect(() => {
+    const available =
+      parentStores.roborevDaemon?.isAvailable() ??
+      false;
+    if (available && negativeMatch) {
+      void retryResolve();
+    }
+  });
+
+  // Re-resolve on tab activation when negative
+  $effect(() => {
+    if (activeTab === "reviews" && negativeMatch) {
+      void retryResolve();
+    }
+  });
+
+  async function retryResolve(): Promise<void> {
+    await resolveRepo();
+    if (resolvedRootPath) {
+      sidebarJobs.setFilter(
+        "repo",
+        resolvedRootPath,
+      );
+      sidebarJobs.setFilter("branch", branch);
+      void sidebarJobs.loadJobs();
+    }
+  }
+
+  // Determine if we have valid context
+  const hasRepo = $derived(
+    repoOwner !== "" && repoName !== "",
+  );
+  const hasPR = $derived(mrNumber > 0 && hasRepo);
+
+  // Connect/disconnect SSE based on daemon availability
+  let sseConnected = $state(false);
+  $effect(() => {
+    const available =
+      parentStores.roborevDaemon?.isAvailable() ??
+      false;
+    if (available && !sseConnected) {
+      sidebarJobs.connectSSE(baseUrl);
+      sseConnected = true;
+    } else if (!available && sseConnected) {
+      sidebarJobs.disconnectSSE();
+      sseConnected = false;
+    }
+  });
+
+  onDestroy(() => {
+    sidebarJobs.disconnectSSE();
+    sidebarLog.stopStreaming();
+  });
+</script>
+
+<div class="right-sidebar-content">
+  {#if activeTab === "pr"}
+    {#if hasPR}
+      <div class="pr-scroll">
+        <PullDetail
+          owner={repoOwner}
+          name={repoName}
+          number={mrNumber}
+          hideTabs={true}
+        />
+      </div>
+    {:else}
+      <div class="empty-state">No linked PR</div>
+    {/if}
+  {:else if activeTab === "reviews"}
+    {#if !hasRepo}
+      <div class="empty-state">
+        No reviews for this worktree
+      </div>
+    {:else if repoResolutionError}
+      <div class="empty-state">
+        {repoResolutionError}
+      </div>
+    {:else if resolvedRootPath === null && !negativeMatch}
+      <div class="empty-state">
+        Resolving repo...
+      </div>
+    {:else if negativeMatch}
+      <div class="empty-state">
+        No reviews for this worktree
+      </div>
+    {:else}
+      <SidebarStoreScope stores={sidebarStores}>
+        <div class="sidebar-reviews">
+          <div class="sidebar-reviews-header">
+            <FilterBar disabled={!parentStores.roborevDaemon?.isAvailable()} />
+            <DaemonStatus />
+          </div>
+          <div class="sidebar-reviews-body">
+            <div class="sidebar-reviews-table">
+              <JobTable />
+            </div>
+            <ReviewDrawer activeTab={drawerTab} />
+          </div>
+        </div>
+      </SidebarStoreScope>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .right-sidebar-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    background: var(--bg-surface);
+  }
+
+  .pr-scroll {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+    text-align: center;
+  }
+
+  .sidebar-reviews {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .sidebar-reviews-header {
+    flex-shrink: 0;
+  }
+
+  .sidebar-reviews-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .sidebar-reviews-table {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -118,3 +118,6 @@ export {
 export {
   default as ActionButton,
 } from "./components/shared/ActionButton.svelte";
+export {
+  default as WorkspaceRightSidebar,
+} from "./components/workspace/WorkspaceRightSidebar.svelte";


### PR DESCRIPTION
## Summary

- Resizable right sidebar in the workspace terminal view, toggled by a segmented `[PR | Reviews]` control in the header bar
- PR tab loads full PR detail for the worktree's linked PR
- Reviews tab shows the full roborev UI (FilterBar, JobTable, ReviewDrawer) with sidebar-local stores scoped via Svelte context override, filtered to the workspace's repo and branch
- Sidebar state (open/closed, active tab, width) persists to localStorage
- `Cmd+]` keyboard shortcut toggles the sidebar
- Auto-reconnect terminal when tmux session dies
- WebSocket proxying enabled in Vite dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)