### PR TITLE
fix: let repo typeahead dropdown grow wider than trigger

### DIFF
--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -229,7 +229,10 @@
     position: absolute;
     top: 100%;
     left: 0;
-    right: 0;
+    right: auto;
+    min-width: 100%;
+    width: max-content;
+    max-width: min(520px, 90vw);
     margin-top: 2px;
     max-height: 50vh;
     overflow-y: auto;


### PR DESCRIPTION
The repo selector dropdown in the top header was pinned to the trigger's width via `left: 0; right: 0` on the `.typeahead-list`, so long `owner/name` values got truncated with ellipsis.

The open list now floats off the trigger's left edge only, with `min-width: 100%; width: max-content; max-width: min(520px, 90vw)` so it grows to fit the longest repo name without running off narrow viewports. The trigger/input stay compact.

![repo-dropdown-fixed.png](https://github.com/user-attachments/assets/7c4e85dd-c8ae-49a5-8117-430e3a03da4d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)