### PR TITLE
feat: configurable tmux launch command

### DIFF
--- a/docs/superpowers/plans/2026-04-16-configurable-tmux-command.md
+++ b/docs/superpowers/plans/2026-04-16-configurable-tmux-command.md
@@ -1,0 +1,1445 @@
+# Configurable tmux Launch Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow operators to prefix every tmux invocation middleman makes with a configured command (e.g. `systemd-run --user --scope tmux`) so the tmux session can run under different permissions than a hardened middleman systemd service.
+
+**Architecture:** Add an optional `[tmux] command = [...]` TOML section loaded into `*config.Config`. A nil-safe `TmuxCommand()` helper returns the prefix (default `["tmux"]`). The prefix is threaded into `workspace.Manager` and `terminal.Handler` via `newServer`. The four existing tmux call sites (`new-session`, `has-session`, `kill-session`, `attach-session`) all route through the prefix. Default behavior is preserved bit-for-bit when the setting is unset.
+
+**Tech Stack:** Go 1.26, BurntSushi/toml, testify, coder/websocket, creack/pty.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-configurable-tmux-command-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/server/tmux_wrapper_test.go` — e2e tests that wire a recording script into `tmux.command` and assert argv for new-session and attach-session paths.
+
+**Modify:**
+- `internal/config/config.go` — add `Tmux` type, `Config.Tmux` field, `TmuxCommand()` method, validation case.
+- `internal/config/config_test.go` — add parsing, defensive-copy, and validation tests.
+- `internal/workspace/manager.go` — add `tmuxCmd []string` field + `SetTmuxCommand` setter; convert `EnsureTmux`, `TmuxSessionExists`, `newTmuxSession` to methods on `*Manager`; update `Setup` and `Delete` call sites to use the prefix.
+- `internal/workspace/manager_test.go` — recording-script unit test for all three workspace-side tmux call sites.
+- `internal/terminal/handler.go` — add `TmuxCommand []string` field; call `h.Workspaces.EnsureTmux` instead of the package function; build the attach-session `exec.Cmd` from the prefix.
+- `internal/server/server.go` — in `newServer`, populate `workspaces.SetTmuxCommand(cfg.TmuxCommand())` and the terminal handler's `TmuxCommand` from `cfg.TmuxCommand()`.
+
+**Field naming convention (used throughout this plan):**
+- `workspace.Manager.tmuxCmd` (unexported, set via `SetTmuxCommand`)
+- `terminal.Handler.TmuxCommand` (exported, set at struct-literal construction)
+
+Both are `[]string`. The asymmetry (exported vs unexported) mirrors existing patterns: `Manager` uses setter methods (`SetClones`), while `Handler` uses struct-literal construction (`&terminal.Handler{Workspaces: s.workspaces}`).
+
+---
+
+## Task 1: Add Tmux config type, helper, and validation
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Test: `internal/config/config_test.go`
+
+- [ ] **Step 1.1: Write failing parsing test**
+
+Append to `internal/config/config_test.go`:
+
+```go
+func TestLoadTmuxCommand(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[tmux]
+command = ["systemd-run", "--user", "--scope", "tmux"]
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "--scope", "tmux"},
+		cfg.Tmux.Command,
+	)
+}
+
+func TestLoadTmuxCommandOmitted(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, ``)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(cfg.Tmux.Command)
+	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+}
+
+func TestLoadTmuxCommandEmptyArray(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[tmux]
+command = []
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+}
+```
+
+- [ ] **Step 1.2: Run parsing tests to verify they fail**
+
+Run: `go test ./internal/config -run TestLoadTmux -shuffle=on`
+Expected: FAIL — `cfg.Tmux.Command` and `cfg.TmuxCommand()` do not exist yet.
+
+- [ ] **Step 1.3: Add the `Tmux` struct, `Config.Tmux` field, and `TmuxCommand()` method**
+
+Edit `internal/config/config.go`. Add near the other config sub-structs (`Activity`, `Roborev`):
+
+```go
+type Tmux struct {
+	Command []string `toml:"command,omitempty"`
+}
+```
+
+Add to the `Config` struct (alongside `Activity` and `Roborev`):
+
+```go
+type Config struct {
+	// ... existing fields ...
+	Activity          Activity `toml:"activity"`
+	Roborev           Roborev  `toml:"roborev"`
+	Tmux              Tmux     `toml:"tmux"`
+}
+```
+
+Add the helper method below the existing `Config` methods (next to `RoborevEndpoint`):
+
+```go
+// TmuxCommand returns the command + argv prefix used to invoke
+// tmux. Defaults to ["tmux"] when c is nil or the setting is
+// unconfigured. The returned slice is a copy, safe to append to.
+func (c *Config) TmuxCommand() []string {
+	if c == nil || len(c.Tmux.Command) == 0 {
+		return []string{"tmux"}
+	}
+	return append([]string(nil), c.Tmux.Command...)
+}
+```
+
+- [ ] **Step 1.4: Run parsing tests to verify they pass**
+
+Run: `go test ./internal/config -run TestLoadTmux -shuffle=on`
+Expected: PASS (3 tests).
+
+- [ ] **Step 1.5: Write failing defensive-copy test**
+
+Append to `internal/config/config_test.go`:
+
+```go
+func TestTmuxCommandDefensiveCopy(t *testing.T) {
+	assert := Assert.New(t)
+	cfg := &Config{Tmux: Tmux{
+		Command: []string{"tmux"},
+	}}
+	first := cfg.TmuxCommand()
+	first[0] = "hacked"
+	second := cfg.TmuxCommand()
+	assert.Equal([]string{"tmux"}, second)
+}
+
+func TestTmuxCommandNilReceiver(t *testing.T) {
+	assert := Assert.New(t)
+	var cfg *Config
+	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+}
+```
+
+- [ ] **Step 1.6: Run the two new tests to verify they pass**
+
+Run: `go test ./internal/config -run "TestTmuxCommand" -shuffle=on`
+Expected: PASS (2 tests). The `TmuxCommand()` implementation added in step 1.3 already satisfies both (the nil-guard handles `TestTmuxCommandNilReceiver`, the `append([]string(nil), ...)` handles `TestTmuxCommandDefensiveCopy`).
+
+- [ ] **Step 1.7: Write failing validation tests**
+
+The rule: the first element must contain non-whitespace after `strings.TrimSpace`. An empty string fails (TOML lets you write `[""]`), and a whitespace-only string fails too (`exec("   ")` would otherwise produce a confusing shell-level error at first workspace create instead of a clean config-load validation message). Append to `internal/config/config_test.go`:
+
+```go
+func TestLoadTmuxCommandRejectsEmptyFirstElement(t *testing.T) {
+	path := writeConfig(t, `
+[tmux]
+command = ["", "extra"]
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(),
+		`config: invalid tmux.command`,
+	)
+}
+
+func TestLoadTmuxCommandRejectsWhitespaceFirstElement(t *testing.T) {
+	path := writeConfig(t, `
+[tmux]
+command = ["   ", "extra"]
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(),
+		`config: invalid tmux.command`,
+	)
+}
+```
+
+- [ ] **Step 1.8: Run validation tests to verify they fail**
+
+Run: `go test ./internal/config -run TestLoadTmuxCommandRejects -shuffle=on`
+Expected: FAIL — no validation exists; the config loads without error for both cases.
+
+- [ ] **Step 1.9: Add validation in `Config.Validate`**
+
+Edit `internal/config/config.go`. In the `Validate` method, add a new block alongside the other validation checks (e.g. just before `return nil`):
+
+```go
+if len(c.Tmux.Command) > 0 &&
+	strings.TrimSpace(c.Tmux.Command[0]) == "" {
+	return fmt.Errorf(
+		"config: invalid tmux.command: first element must be non-empty",
+	)
+}
+```
+
+`strings` is already imported in `config.go`.
+
+- [ ] **Step 1.10: Run validation test to verify it passes**
+
+Run: `go test ./internal/config -run TestLoadTmuxCommandRejects -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 1.11: Write failing round-trip test for `Save()` preserving `[tmux]`**
+
+`(*Config).Save` serializes via an internal `configFile` struct that enumerates a subset of fields. Without adding `Tmux` to it, every settings-UI action (`PUT /settings`, `POST /repos`, `DELETE /repos`) silently strips the operator's wrapper configuration from disk. Guard this with a test that saves and reloads:
+
+Append to `internal/config/config_test.go`:
+
+```go
+func TestSavePreservesTmuxCommand(t *testing.T) {
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := &Config{
+		SyncInterval:   "5m",
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Host:           "127.0.0.1",
+		Port:           8091,
+		DataDir:        dir,
+		Activity:       Activity{ViewMode: "threaded", TimeRange: "7d"},
+		Tmux: Tmux{
+			Command: []string{"systemd-run", "--user", "--scope", "tmux"},
+		},
+	}
+	require.NoError(t, cfg.Save(path))
+
+	reloaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "--scope", "tmux"},
+		reloaded.Tmux.Command,
+	)
+}
+```
+
+- [ ] **Step 1.12: Run the round-trip test to verify it fails**
+
+Run: `go test ./internal/config -run TestSavePreservesTmux -shuffle=on`
+Expected: FAIL — `configFile` does not include `Tmux`, so `Save()` drops the section and `reloaded.Tmux.Command` is empty.
+
+- [ ] **Step 1.13: Extend `configFile` and `Save()` to round-trip the Tmux section**
+
+Edit `internal/config/config.go`. Update the `configFile` struct to include the new field:
+
+```go
+// configFile is the subset of Config written to disk.
+type configFile struct {
+	SyncInterval      string   `toml:"sync_interval"`
+	GitHubTokenEnv    string   `toml:"github_token_env"`
+	Host              string   `toml:"host"`
+	Port              int      `toml:"port"`
+	SyncBudgetPerHour int      `toml:"sync_budget_per_hour,omitempty"`
+	BasePath          string   `toml:"base_path,omitempty"`
+	DataDir           string   `toml:"data_dir,omitempty"`
+	Repos             []Repo   `toml:"repos"`
+	Activity          Activity `toml:"activity"`
+	Roborev           Roborev  `toml:"roborev,omitempty"`
+	Tmux              Tmux     `toml:"tmux,omitempty"`
+}
+```
+
+In `(*Config).Save`, populate the new field by adding one assignment inside the `configFile{...}` literal, right after `Roborev: c.Roborev,`:
+
+```go
+	f := configFile{
+		SyncInterval:   c.SyncInterval,
+		GitHubTokenEnv: c.GitHubTokenEnv,
+		Host:           c.Host,
+		Port:           c.Port,
+		Repos:          c.Repos,
+		Activity:       c.Activity,
+		Roborev:        c.Roborev,
+		Tmux:           c.Tmux,
+	}
+```
+
+The existing conditional assignments below (`SyncBudgetPerHour`, `BasePath`, `DataDir`) stay unchanged.
+
+- [ ] **Step 1.14: Run the round-trip test to verify it passes**
+
+Run: `go test ./internal/config -run TestSavePreservesTmux -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 1.15: Run the full config package tests to confirm no regressions**
+
+Run: `go test ./internal/config -shuffle=on`
+Expected: PASS (all tests).
+
+- [ ] **Step 1.16: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): add tmux.command prefix with nil-safe helper"
+```
+
+---
+
+## Task 2: Thread tmuxCmd through `workspace.Manager`
+
+**Files:**
+- Modify: `internal/workspace/manager.go`
+- Test: `internal/workspace/manager_test.go`
+
+**Summary of code changes in this task:**
+- Add a `tmuxCmd []string` field to `Manager`.
+- Add a `SetTmuxCommand([]string)` setter mirroring `SetClones`.
+- Add a method `Manager.tmuxExec(ctx, extra ...string) *exec.Cmd` that builds the full argv (prefix + extra) and returns an `*exec.Cmd`, defaulting to `["tmux"]` when `m.tmuxCmd` is nil/empty. Returning `*exec.Cmd` (rather than a `[]string` callers index) keeps the first-argument access inside the helper so NilAway can prove safety.
+- Add a package helper `runBuiltCmd(*exec.Cmd) error` that runs a pre-built command and wraps failures with the combined output (replaces the previous `runCmd` path, which is no longer needed).
+- Add method versions of `EnsureTmux`, `tmuxSessionExists`, `newTmuxSession`, and `killTmuxSession` on `*Manager` that use the prefix. `tmuxSessionExists` returns `(bool, error)`, and a package helper `isTmuxSessionAbsent(stderr []byte, err error) bool` encodes the "session absent" contract: exit code 1 **and** stderr containing `can't find session` or `no server running`. Every other failure propagates via `EnsureTmux` as `"tmux has-session: %w"`.
+- `tmuxSessionExists` must capture stdout and stderr into **separate** `bytes.Buffer`s (not `CombinedOutput`) so stdout content cannot spoof the tmux-absent signal.
+- Update `Setup` (internal call site of `newTmuxSession`) and `Delete` (kill-session call) to use the new methods.
+- **Keep the existing package-level `EnsureTmux`, `TmuxSessionExists`, and `newTmuxSession` functions untouched** in Task 2 — they are still called by `internal/terminal/handler.go:77`. Task 3 switches the terminal handler to the method form and removes the package functions at that point, so every commit on this branch builds cleanly and tests pass.
+
+- [ ] **Step 2.1: Add the recording-script helper and write the failing test**
+
+Append to `internal/workspace/manager_test.go`:
+
+```go
+// writeRecorderScript creates an executable shell script at a
+// fresh path under t.TempDir() that appends the count and each
+// argument, NUL-delimited, to TMUX_RECORD. Returns the script path
+// and the record file path.
+func writeRecorderScript(t *testing.T) (scriptPath, recordPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	recordPath = filepath.Join(dir, "record")
+	scriptPath = filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", recordPath)
+	return scriptPath, recordPath
+}
+
+// readRecorderArgv reads the NUL-delimited record file and returns
+// each recorded invocation as a []string. Each invocation is stored
+// as "<argc>\0<arg0>\0<arg1>...\0".
+//
+// The parser must be robust against two realities:
+//   - Interior empty args (argc > 0 but one of the args is "") are
+//     meaningful — the NUL framing exists precisely to preserve
+//     them. Don't skip them.
+//   - Async tests poll this file while the recorder is still
+//     writing; if the last record is mid-write (argc parsed but
+//     args not all flushed yet, or argc itself not yet a valid
+//     integer), stop cleanly rather than panic. The next poll will
+//     see a complete record.
+func readRecorderArgv(t *testing.T, path string) [][]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+	// Split without TrimRight — TrimRight would nuke trailing empty
+	// args. A flushed stream always ends with a trailing \0 so
+	// Split produces one trailing empty element; strip exactly one.
+	parts := strings.Split(string(data), "\x00")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	var out [][]string
+	for i := 0; i < len(parts); {
+		n, err := strconv.Atoi(parts[i])
+		if err != nil {
+			// Mid-write; next poll will see it.
+			break
+		}
+		if i+1+n > len(parts) {
+			// argc parsed but args not all on disk yet.
+			break
+		}
+		i++
+		argv := parts[i : i+n]
+		out = append(out, argv)
+		i += n
+	}
+	return out
+}
+
+func TestManagerEnsureTmuxHasSessionPrefix(t *testing.T) {
+	assert := Assert.New(t)
+
+	script, record := writeRecorderScript(t)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+
+	ctx := context.Background()
+
+	// Script exits 0 for every invocation, so EnsureTmux observes
+	// "session exists" after the has-session call and returns
+	// without running new-session.
+	require.NoError(t, mgr.EnsureTmux(ctx, "sess-A", t.TempDir()))
+
+	argvs := readRecorderArgv(t, record)
+	require.Len(t, argvs, 1)
+	assert.Equal(
+		[]string{"wrap", "has-session", "-t", "sess-A"},
+		argvs[0],
+	)
+}
+
+func TestManagerDeleteUsesTmuxPrefix(t *testing.T) {
+	assert := Assert.New(t)
+
+	script, record := writeRecorderScript(t)
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+
+	ctx := context.Background()
+	ws, err := mgr.Create(ctx, "github.com", "acme", "widget", 42)
+	require.NoError(t, err)
+
+	// force=true skips the dirty-files check. m.clones is nil, so
+	// Delete takes the clones==nil short-circuit after killing the
+	// tmux session — no git operations are required.
+	_, err = mgr.Delete(ctx, ws.ID, true)
+	require.NoError(t, err)
+
+	// Delete invokes exactly one tmux command on this path
+	// (kill-session). It ignores the exit code because the session
+	// may not exist, but our script exits 0 so the invocation is
+	// still recorded.
+	argvs := readRecorderArgv(t, record)
+	require.Len(t, argvs, 1)
+	assert.Equal(
+		[]string{"wrap", "kill-session", "-t", ws.TmuxSession},
+		argvs[0],
+	)
+}
+
+func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
+	assert := Assert.New(t)
+
+	// Script: "has-session" emits tmux's canonical "can't find
+	// session" stderr and exits 1 (so isTmuxSessionAbsent classifies
+	// it as session-missing rather than wrapper failure); everything
+	// else succeeds, so EnsureTmux calls newTmuxSession.
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then` + "\n" +
+		`    echo "can't find session: sim" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+
+	ctx := context.Background()
+	require.NoError(t, mgr.EnsureTmux(ctx, "sess-B", "/tmp/cwd"))
+
+	argvs := readRecorderArgv(t, record)
+	require.Len(t, argvs, 2)
+	assert.Equal(
+		[]string{"has-session", "-t", "sess-B"},
+		argvs[0],
+	)
+	// new-session argv: "new-session -d -s sess-B -c /tmp/cwd <shell> -l"
+	// We check the prefix up to the shell; the shell resolves per
+	// runtime so just assert it is non-empty and ends with "-l".
+	require.GreaterOrEqual(t, len(argvs[1]), 8)
+	assert.Equal("new-session", argvs[1][0])
+	assert.Equal("-d", argvs[1][1])
+	assert.Equal("-s", argvs[1][2])
+	assert.Equal("sess-B", argvs[1][3])
+	assert.Equal("-c", argvs[1][4])
+	assert.Equal("/tmp/cwd", argvs[1][5])
+	assert.NotEmpty(argvs[1][6])
+	assert.Equal("-l", argvs[1][7])
+}
+```
+
+Add these imports to `internal/workspace/manager_test.go` if not present:
+
+```go
+"os"
+"strconv"
+"strings"
+```
+
+- [ ] **Step 2.2: Run the new tests to verify they fail**
+
+Run: `go test ./internal/workspace -run 'TestManager(EnsureTmux|DeleteUsesTmux)' -shuffle=on`
+Expected: FAIL — `mgr.SetTmuxCommand` does not exist yet, and the method forms of `EnsureTmux` / the internal `killTmuxSession` have not been added, so `TestManagerDeleteUsesTmuxPrefix` cannot reach the prefix via the Delete code path.
+
+- [ ] **Step 2.3: Add the `tmuxCmd` field and `SetTmuxCommand` setter**
+
+Edit `internal/workspace/manager.go`. Add to the `Manager` struct:
+
+```go
+type Manager struct {
+	db          *db.DB
+	worktreeDir string
+	clones      *gitclone.Manager
+	tmuxCmd     []string
+}
+```
+
+Add below `SetClones`:
+
+```go
+// SetTmuxCommand sets the command + argv prefix for every tmux
+// invocation the manager issues. When nil/empty, the manager uses
+// ["tmux"] — preserving today's behavior.
+func (m *Manager) SetTmuxCommand(cmd []string) {
+	m.tmuxCmd = append([]string(nil), cmd...)
+}
+
+// tmuxExec builds an *exec.Cmd for a tmux invocation: the
+// configured prefix + extra args. Defaults to ["tmux"] when
+// unconfigured. Returning the *exec.Cmd directly (rather than a
+// []string that callers index) keeps the first-element access
+// inside this function where the branch structure makes it
+// statically safe — NilAway cannot prove safety through an indexed
+// slice return.
+func (m *Manager) tmuxExec(
+	ctx context.Context, extra ...string,
+) *exec.Cmd {
+	if len(m.tmuxCmd) == 0 {
+		return exec.CommandContext(ctx, "tmux", extra...)
+	}
+	args := make([]string, 0, len(m.tmuxCmd)-1+len(extra))
+	args = append(args, m.tmuxCmd[1:]...)
+	args = append(args, extra...)
+	return exec.CommandContext(ctx, m.tmuxCmd[0], args...)
+}
+```
+
+Also add a package-level helper for running the pre-built command
+(replaces the old `runCmd(ctx, dir, name, args...)` path; the two
+callers that used it in this file now route through `tmuxExec`):
+
+```go
+// runBuiltCmd runs a pre-built exec.Cmd and wraps any failure with
+// the combined output. Used for tmux invocations whose *exec.Cmd is
+// assembled by tmuxExec so argv[0] access stays inside that helper.
+func runBuiltCmd(cmd *exec.Cmd) error {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf(
+			"%w: %s", err, strings.TrimSpace(string(out)),
+		)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2.4: Add method forms, keep the package functions, and migrate internal callers**
+
+Edit `internal/workspace/manager.go`. **Do not delete** the package-level `EnsureTmux`, `TmuxSessionExists`, or `newTmuxSession`. They stay until Task 3, when the last external caller (`internal/terminal/handler.go`) migrates and Task 3 removes them.
+
+**Add** a method form of `EnsureTmux` on `*Manager`. Method and package function coexist; both remain exported. The method uses the configured prefix and propagates non-absent errors:
+
+```go
+// EnsureTmux creates a tmux session if it does not already exist,
+// using the manager's configured tmux command prefix. Errors from
+// has-session that are not tmux's canonical "session missing"
+// signal propagate — a broken wrapper should surface here rather
+// than be masked by a subsequent new-session through the same
+// wrapper.
+func (m *Manager) EnsureTmux(
+	ctx context.Context, session, cwd string,
+) error {
+	exists, err := m.tmuxSessionExists(ctx, session)
+	if err != nil {
+		return fmt.Errorf("tmux has-session: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	return m.newTmuxSession(ctx, session, cwd)
+}
+```
+
+**Add** a method form of `newTmuxSession` on `*Manager`. The existing package-level `newTmuxSession` stays; the method lives alongside it with a different (method) signature so there is no name clash:
+
+```go
+func (m *Manager) newTmuxSession(
+	ctx context.Context, session, cwd string,
+) error {
+	shell := userLoginShell()
+	cmd := m.tmuxExec(
+		ctx,
+		"new-session", "-d",
+		"-s", session,
+		"-c", cwd,
+		shell, "-l",
+	)
+	return runBuiltCmd(cmd)
+}
+```
+
+**Add** an unexported method `tmuxSessionExists` on `*Manager`. It returns `(bool, error)` — the boolean answers "is the session there" only when the command actually told us, and any other failure becomes the error. Stdout and stderr are captured **separately** so the absent-session stderr-only match is not fooled by a wrapper emitting the phrase on stdout. The existing exported package function `TmuxSessionExists` stays:
+
+```go
+// tmuxSessionExists runs `tmux has-session` and distinguishes a
+// genuine "session absent" signal from a wrapper/binary failure.
+// See isTmuxSessionAbsent for the exact contract.
+func (m *Manager) tmuxSessionExists(
+	ctx context.Context, session string,
+) (bool, error) {
+	cmd := m.tmuxExec(ctx, "has-session", "-t", session)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	if isTmuxSessionAbsent(stderr.Bytes(), err) {
+		return false, nil
+	}
+	msg := strings.TrimSpace(stderr.String())
+	if msg == "" {
+		msg = strings.TrimSpace(stdout.String())
+	}
+	return false, fmt.Errorf("%w: %s", err, msg)
+}
+
+// isTmuxSessionAbsent reports whether a has-session failure is
+// tmux's documented "session does not exist" signal. Must be both
+// exit code 1 AND one of tmux's specific stderr phrases. Plain
+// exit 1 is a common generic wrapper/shell failure code, and
+// stdout content is not load-bearing — a wrapper could emit
+// anything there for unrelated reasons.
+func isTmuxSessionAbsent(stderr []byte, err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		return false
+	}
+	msg := string(stderr)
+	return strings.Contains(msg, "can't find session") ||
+		strings.Contains(msg, "no server running")
+}
+```
+
+Add `"bytes"` and `"errors"` to `internal/workspace/manager.go` imports if not already present.
+
+**Add** an unexported method `killTmuxSession` on `*Manager` (no existing package equivalent):
+
+```go
+// killTmuxSession kills a tmux session via the manager's prefix.
+// Errors are returned rather than logged — callers decide whether
+// to ignore them (Delete ignores; tests assert).
+func (m *Manager) killTmuxSession(
+	ctx context.Context, session string,
+) error {
+	return runBuiltCmd(m.tmuxExec(ctx, "kill-session", "-t", session))
+}
+```
+
+**Update** `Setup` — switch its internal call from the package-level `newTmuxSession` to the method. Change:
+
+```go
+	err = newTmuxSession(ctx, ws.TmuxSession, ws.WorktreePath)
+```
+
+to:
+
+```go
+	err = m.newTmuxSession(ctx, ws.TmuxSession, ws.WorktreePath)
+```
+
+**Update** `Delete` — switch its inline `runCmd(..., "tmux", "kill-session", ...)` to the method. Change:
+
+```go
+	// Kill tmux session (ignore errors -- session may not exist).
+	_ = runCmd(
+		ctx, "",
+		"tmux", "kill-session", "-t", ws.TmuxSession,
+	)
+```
+
+to:
+
+```go
+	// Kill tmux session (ignore errors -- session may not exist).
+	_ = m.killTmuxSession(ctx, ws.TmuxSession)
+```
+
+After this step, both forms coexist:
+- Methods on `*Manager` (prefix-aware) — used by `Setup`, `Delete`, and the new tests.
+- Package-level `EnsureTmux`, `TmuxSessionExists`, `newTmuxSession` — still hard-coded to `"tmux"`, still called only by `internal/terminal/handler.go:77` until Task 3 migrates it.
+
+- [ ] **Step 2.5: Run workspace tests to verify the new tests pass**
+
+Run: `go test ./internal/workspace -run 'TestManager(EnsureTmux|DeleteUsesTmux)' -shuffle=on`
+Expected: PASS (3 tests: `TestManagerEnsureTmuxHasSessionPrefix`, `TestManagerEnsureTmuxCreatesSessionOnMiss`, `TestManagerDeleteUsesTmuxPrefix`).
+
+- [ ] **Step 2.6: Run full workspace package tests to confirm no regressions**
+
+Run: `go test ./internal/workspace -shuffle=on`
+Expected: PASS — the package-level functions still exist and existing tests (which don't call them directly) continue to work.
+
+- [ ] **Step 2.7: Build the whole module to confirm no cross-package break**
+
+Run: `go build ./...`
+Expected: success. `terminal/handler.go` still compiles because `workspace.EnsureTmux` (the package function) is untouched in this task.
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add internal/workspace/manager.go internal/workspace/manager_test.go
+git commit -m "feat(workspace): thread tmux command prefix through Manager"
+```
+
+---
+
+## Task 3: Thread tmux command prefix through `terminal.Handler` and retire package-level tmux helpers
+
+**Files:**
+- Modify: `internal/terminal/handler.go`
+- Modify: `internal/workspace/manager.go`
+
+No new test file — the attach-session path is covered by the server-level e2e in Task 5. Existing `handler_test.go` cases (workspace-not-found, workspace-not-ready) do not reach the `attach-session` exec and remain passing unchanged.
+
+This task also removes the now-unused package-level `EnsureTmux`, `TmuxSessionExists`, and `newTmuxSession` functions that Task 2 intentionally left in place for bisectability. Once the terminal handler switches to `h.Workspaces.EnsureTmux`, nothing outside the `workspace` package references them, and `Manager.newTmuxSession` (method) replaces the internal package function.
+
+- [ ] **Step 3.1: Add the `TmuxCommand` field to `Handler`**
+
+Edit `internal/terminal/handler.go`. Update the `Handler` struct:
+
+```go
+// Handler serves WebSocket connections that bridge a
+// PTY-attached tmux session to the browser.
+type Handler struct {
+	Workspaces  *workspace.Manager
+	TmuxCommand []string
+}
+```
+
+- [ ] **Step 3.2: Switch to `h.Workspaces.EnsureTmux` and build attach from the prefix**
+
+Edit `internal/terminal/handler.go`. Locate the block:
+
+```go
+	if tmuxErr := workspace.EnsureTmux(
+		ctx, ws.TmuxSession, ws.WorktreePath,
+	); tmuxErr != nil {
+		slog.Error("ensure tmux", "err", tmuxErr)
+		conn.Close(
+			websocket.StatusInternalError,
+			"failed to start tmux",
+		)
+		return
+	}
+
+	cmd := exec.CommandContext(
+		ctx, "tmux", "attach-session", "-t", ws.TmuxSession,
+	)
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+```
+
+Replace with:
+
+```go
+	if tmuxErr := h.Workspaces.EnsureTmux(
+		ctx, ws.TmuxSession, ws.WorktreePath,
+	); tmuxErr != nil {
+		slog.Error("ensure tmux", "err", tmuxErr)
+		conn.Close(
+			websocket.StatusInternalError,
+			"failed to start tmux",
+		)
+		return
+	}
+
+	prefix := h.TmuxCommand
+	if len(prefix) == 0 {
+		prefix = []string{"tmux"}
+	}
+	argv := make([]string, 0, len(prefix)+3)
+	argv = append(argv, prefix...)
+	argv = append(argv, "attach-session", "-t", ws.TmuxSession)
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+```
+
+- [ ] **Step 3.3: Remove the now-unused package-level tmux functions**
+
+Edit `internal/workspace/manager.go`. Delete the package-level `EnsureTmux`, `TmuxSessionExists`, and `newTmuxSession` functions that Task 2 preserved. With the terminal handler now calling `h.Workspaces.EnsureTmux`, these have no remaining callers. The method forms on `*Manager` stay.
+
+- [ ] **Step 3.4: Run full terminal and workspace package tests to confirm no regressions**
+
+Run: `go test ./internal/terminal ./internal/workspace -shuffle=on`
+Expected: PASS — existing handler tests (not-found, not-ready) short-circuit before `EnsureTmux` and `attach-session`; workspace tests use only the exported method API.
+
+- [ ] **Step 3.5: Build the whole module to confirm nothing else referenced the removed functions**
+
+Run: `go build ./...`
+Expected: success. If build fails with "undefined: workspace.EnsureTmux" (or similar), search for any missed caller with `grep -rn "workspace\.EnsureTmux\|workspace\.TmuxSessionExists" internal/` and migrate it to the method form.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add internal/terminal/handler.go internal/workspace/manager.go
+git commit -m "feat(terminal): use workspace.Manager.EnsureTmux and configurable attach prefix"
+```
+
+---
+
+## Task 4: Wire `cfg.TmuxCommand()` in `newServer`
+
+**Files:**
+- Modify: `internal/server/server.go`
+
+- [ ] **Step 4.1: Populate both the manager and the handler from `cfg`**
+
+Edit `internal/server/server.go`. Locate the block around line 290-303 (inside `newServer`):
+
+```go
+	if options.WorktreeDir != "" {
+		s.workspaces = workspace.NewManager(database, options.WorktreeDir)
+		if clones != nil {
+			s.workspaces.SetClones(clones)
+		}
+	}
+
+	if s.workspaces != nil {
+		termHandler := &terminal.Handler{Workspaces: s.workspaces}
+		mux.Handle(
+			"GET /api/v1/workspaces/{id}/terminal",
+			termHandler,
+		)
+	}
+```
+
+Replace with:
+
+```go
+	if options.WorktreeDir != "" {
+		s.workspaces = workspace.NewManager(database, options.WorktreeDir)
+		s.workspaces.SetTmuxCommand(cfg.TmuxCommand())
+		if clones != nil {
+			s.workspaces.SetClones(clones)
+		}
+	}
+
+	if s.workspaces != nil {
+		termHandler := &terminal.Handler{
+			Workspaces:  s.workspaces,
+			TmuxCommand: cfg.TmuxCommand(),
+		}
+		mux.Handle(
+			"GET /api/v1/workspaces/{id}/terminal",
+			termHandler,
+		)
+	}
+```
+
+`cfg.TmuxCommand()` is nil-safe (from Task 1), so this works whether `cfg` is nil or populated. Two calls intentionally produce two independent copies so the manager and handler each own their slice.
+
+- [ ] **Step 4.2: Run server tests to confirm no regressions**
+
+Run: `go test ./internal/server -shuffle=on`
+Expected: PASS — all existing tests pass with the default `["tmux"]` prefix because `cfg.TmuxCommand()` returns `["tmux"]` for nil cfg and for cfg without a `[tmux]` section.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add internal/server/server.go
+git commit -m "feat(server): wire tmux.command config into workspace and terminal"
+```
+
+---
+
+## Task 5: Server-level e2e — happy-path tmux verbs
+
+**Files:**
+- Create: `internal/server/tmux_wrapper_test.go`
+
+Cover the three happy-path tmux verbs that cross the HTTP boundary with a recording script standing in for the real `tmux` binary:
+
+- `new-session` via `POST /api/v1/workspaces`
+- `attach-session` via the terminal WebSocket
+  (`GET /api/v1/workspaces/{id}/terminal`)
+- `kill-session` via `DELETE /api/v1/workspaces/{id}`
+
+The non-GET routes need a `Content-Type: application/json` header even when the body is absent (the server's CSRF guard rejects bare `DELETE` otherwise). The e2e helper wraps `http.DefaultTransport` with a `roundTripFunc` that adds the header on every non-GET request.
+
+Task 6 extends this file with the wrapper-failure surface tests; Task 7 adds the Save-round-trip test in `internal/server/settings_test.go`. Splitting into three commits keeps each reviewable and lets a bisect land on the exact stage that broke.
+
+- [ ] **Step 5.1: Add the new-session e2e test**
+
+Task 5 follows Tasks 1-4 which have already wired the prefix end-to-end, so this test is expected to PASS on first run. We add it not for TDD but as a regression gate: if a future edit breaks the wiring at any of the four layers, this test fails loudly at the HTTP boundary.
+
+Create `internal/server/tmux_wrapper_test.go`:
+
+```go
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wesm/middleman/internal/apiclient"
+	"github.com/wesm/middleman/internal/apiclient/generated"
+	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/db"
+	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/gitclone"
+)
+
+// writeTmuxRecorder creates an executable fake-tmux script at a
+// fresh temp path. The script appends NUL-delimited argv to
+// record. It exits 1 when invoked as "has-session" (so EnsureTmux
+// proceeds to new-session), 0 otherwise. Returns the script path
+// and the record path.
+func writeTmuxRecorder(t *testing.T) (script, record string) {
+	t.Helper()
+	dir := t.TempDir()
+	record = filepath.Join(dir, "record")
+	script = filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then exit 1; fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+	return script, record
+}
+
+func readTmuxRecord(t *testing.T, path string) [][]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	parts := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	var out [][]string
+	for i := 0; i < len(parts); {
+		if parts[i] == "" {
+			i++
+			continue
+		}
+		n, err := strconv.Atoi(parts[i])
+		require.NoError(t, err)
+		i++
+		argv := parts[i : i+n]
+		out = append(out, argv)
+		i += n
+	}
+	return out
+}
+
+// setupWrapperServer constructs a full server wired with a
+// recording-script tmux command, a bare repo, and a seeded PR.
+// Returns a generated API client pointed at the httptest server,
+// the httptest baseURL (needed for WebSocket dialing), and the
+// record-file path.
+func setupWrapperServer(t *testing.T) (client *apiclient.Client, baseURL, record string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("e2e tests skipped in short mode")
+	}
+
+	script, record := writeTmuxRecorder(t)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	bareDir := filepath.Join(dir, "clones")
+	require.NoError(t, os.MkdirAll(bareDir, 0o755))
+	bare := filepath.Join(
+		bareDir, "github.com", "acme", "widget.git",
+	)
+	tmpWork := filepath.Join(dir, "work")
+	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	runGit(t, dir, "clone", bare, tmpWork)
+	runGit(t, tmpWork, "config", "user.email", "test@test.com")
+	runGit(t, tmpWork, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpWork, "base.txt"),
+		[]byte("base\n"), 0o644,
+	))
+	runGit(t, tmpWork, "add", ".")
+	runGit(t, tmpWork, "commit", "-m", "base commit")
+	runGit(t, tmpWork, "push", "origin", "main")
+	runGit(t, tmpWork, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpWork, "new.txt"),
+		[]byte("new\n"), 0o644,
+	))
+	runGit(t, tmpWork, "add", ".")
+	runGit(t, tmpWork, "commit", "-m", "feature commit")
+	runGit(t, tmpWork, "push", "origin", "feature")
+
+	clones := gitclone.New(bareDir, nil)
+	worktreeDir := filepath.Join(dir, "worktrees")
+
+	repos := []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+	}
+	mock := &mockGH{}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, repos, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	cfg := &config.Config{
+		Tmux: config.Tmux{
+			Command: []string{script, "wrap"},
+		},
+	}
+	srv := New(database, syncer, nil, "/", cfg, ServerOptions{
+		Clones:      clones,
+		WorktreeDir: worktreeDir,
+	})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	seedPR(t, database, "acme", "widget", 1)
+
+	// Real listener — WebSocket Dial needs a real TCP endpoint.
+	// The generated API client also points at this URL rather than
+	// the in-process roundtripper used elsewhere, because we cannot
+	// split HTTP and WebSocket transports per-request.
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err = apiclient.NewWithHTTPClient(ts.URL, http.DefaultClient)
+	require.NoError(t, err)
+
+	return client, ts.URL, record
+}
+
+func TestTmuxWrapperNewSession(t *testing.T) {
+	assert := Assert.New(t)
+	client, _, record := setupWrapperServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(t, createResp.JSON202)
+
+	// Workspace setup runs asynchronously. Poll the record file
+	// until the new-session invocation shows up, up to ~5s.
+	var argvs [][]string
+	require.Eventually(
+		t,
+		func() bool {
+			argvs = readTmuxRecord(t, record)
+			for _, argv := range argvs {
+				if len(argv) >= 2 && argv[1] == "new-session" {
+					return true
+				}
+			}
+			return false
+		},
+		5*time.Second, 50*time.Millisecond,
+		"new-session argv not recorded",
+	)
+
+	var newSession []string
+	for _, argv := range argvs {
+		if len(argv) >= 2 && argv[1] == "new-session" {
+			newSession = argv
+			break
+		}
+	}
+
+	// "wrap" prefix, then "new-session -d -s <id> -c <path> <shell> -l"
+	require.GreaterOrEqual(t, len(newSession), 9)
+	assert.Equal("wrap", newSession[0])
+	assert.Equal("new-session", newSession[1])
+	assert.Equal("-d", newSession[2])
+	assert.Equal("-s", newSession[3])
+	assert.NotEmpty(newSession[4])
+	assert.Equal("-c", newSession[5])
+	assert.NotEmpty(newSession[6])
+	assert.NotEmpty(newSession[7])
+	assert.Equal("-l", newSession[8])
+}
+```
+
+- [ ] **Step 5.2: Run new-session e2e and confirm it passes**
+
+Run: `go test ./internal/server -run TestTmuxWrapperNewSession -shuffle=on`
+Expected: PASS — Tasks 1-4 wired the prefix end-to-end; this e2e confirms the wiring.
+
+If it FAILS, inspect the recorded argv via `cat $record` (where `$record` is in a `t.TempDir()` — use `t.Logf` in the test if needed). Common causes: missing `SetTmuxCommand` call in Task 4, prefix not reaching `newTmuxSession` in Task 2, `cfg` arriving as a non-nil with empty `Tmux.Command` (still works, just yields `["tmux"]`).
+
+- [ ] **Step 5.3: Add the attach-session e2e test**
+
+Same caveat as step 5.1: this test guards the attach-session wiring rather than driving TDD. It is expected to PASS on first run.
+
+Append to `internal/server/tmux_wrapper_test.go`:
+
+```go
+func TestTmuxWrapperAttachSession(t *testing.T) {
+	assert := Assert.New(t)
+	client, baseURL, record := setupWrapperServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(t, createResp.JSON202)
+	wsID := createResp.JSON202.Id
+
+	// Poll for status == "ready".
+	require.Eventually(
+		t,
+		func() bool {
+			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+				ctx, wsID,
+			)
+			if getErr != nil || getResp.JSON200 == nil {
+				return false
+			}
+			return getResp.JSON200.Status == "ready"
+		},
+		5*time.Second, 50*time.Millisecond,
+	)
+
+	// Connect to the WebSocket terminal endpoint using the
+	// httptest baseURL (the generated client cannot upgrade to
+	// WebSocket, so we dial directly with coder/websocket).
+	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) +
+		"/api/v1/workspaces/" + wsID + "/terminal"
+	dialCtx, dialCancel := context.WithTimeout(
+		ctx, 3*time.Second,
+	)
+	defer dialCancel()
+	u, err := url.Parse(wsURL)
+	require.NoError(t, err)
+	conn, httpResp, err := websocket.Dial(
+		dialCtx, u.String(), nil,
+	)
+	require.NoError(t, err)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	// The recording script exits 0 immediately, so the PTY
+	// closes and the handler sends an "exited" message. Read
+	// until the connection closes or 3s elapses.
+	readCtx, readCancel := context.WithTimeout(
+		ctx, 3*time.Second,
+	)
+	defer readCancel()
+	for {
+		_, _, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+	}
+
+	// The recorded argv should contain an attach-session invocation
+	// with our "wrap" prefix.
+	var attach []string
+	for _, argv := range readTmuxRecord(t, record) {
+		if len(argv) >= 2 && argv[1] == "attach-session" {
+			attach = argv
+			break
+		}
+	}
+	require.NotNil(t, attach, "attach-session argv not recorded")
+	require.Len(t, attach, 4)
+	assert.Equal("wrap", attach[0])
+	assert.Equal("attach-session", attach[1])
+	assert.Equal("-t", attach[2])
+	assert.NotEmpty(attach[3])
+}
+```
+
+- [ ] **Step 5.4: Run attach-session e2e and confirm it passes**
+
+Run: `go test ./internal/server -run TestTmuxWrapperAttachSession -shuffle=on`
+Expected: PASS — the attach path uses `h.TmuxCommand` wired in Task 4.
+
+If it FAILS with a timeout waiting for `status == "ready"`, the likely cause is that workspace Setup is erroring out — inspect the recorded argv with `t.Logf("%#v", readTmuxRecord(t, record))` and check whether the recording script is being called as expected. If it FAILS on the WebSocket dial, confirm the httptest server URL and the ws:// scheme conversion.
+
+- [ ] **Step 5.5: Add the kill-session e2e test**
+
+DELETE without a body is rejected by the server's CSRF guard as 415 Unsupported Media Type unless the client sends `Content-Type: application/json`. Wrap the HTTP transport used by the generated client with a `roundTripFunc` that injects the header on non-GET requests, and add a test that creates a workspace, waits for ready, then DELETEs it and asserts the wrapper reached `kill-session`:
+
+```go
+func TestTmuxWrapperKillSession(t *testing.T) {
+	assert := Assert.New(t)
+	client, _, record := setupWrapperServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(t, err)
+	wsID := createResp.JSON202.Id
+
+	require.Eventually(t, func() bool {
+		r, _ := client.HTTP.GetWorkspacesByIdWithResponse(ctx, wsID)
+		return r != nil && r.JSON200 != nil && r.JSON200.Status == "ready"
+	}, 5*time.Second, 50*time.Millisecond)
+
+	force := true
+	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, wsID, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, delResp.StatusCode())
+
+	var kill []string
+	for _, argv := range readTmuxRecord(t, record) {
+		if len(argv) >= 2 && argv[1] == "kill-session" {
+			kill = argv
+			break
+		}
+	}
+	require.NotNil(t, kill, "kill-session argv not recorded")
+	require.Len(t, kill, 4)
+	assert.Equal("wrap", kill[0])
+	assert.Equal("kill-session", kill[1])
+}
+```
+
+`setupWrapperServer` must set up the `Content-Type`-injecting transport when building the `apiclient`. Example wrapper:
+
+```go
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+httpClient := &http.Client{
+	Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet && req.Header.Get("Content-Type") == "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		return http.DefaultTransport.RoundTrip(req)
+	}),
+}
+client, err := apiclient.NewWithHTTPClient(ts.URL, httpClient)
+```
+
+Run: `go test ./internal/server -run TestTmuxWrapperKillSession -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 5.6: Run full server package tests to confirm no regressions**
+
+Run: `go test ./internal/server -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add internal/server/tmux_wrapper_test.go
+git commit -m "test(server): happy-path e2e for wrapped tmux verbs"
+```
+
+---
+
+## Task 6: Server-level e2e — has-session wrapper-failure surface
+
+**Files:**
+- Modify: `internal/server/tmux_wrapper_test.go`
+
+Task 5 proved the happy-path prefix reaches every verb. This task proves the has-session failure contract holds at the HTTP layer: a wrapper failing has-session in any of the three non-absent shapes must close the attach WebSocket with `websocket.StatusInternalError` rather than silently proceeding to `new-session` through the same broken wrapper.
+
+- [ ] **Step 6.1: Add the shared attach-failure helper**
+
+Append to `internal/server/tmux_wrapper_test.go`:
+
+```go
+// attachWebsocketAndExpectInternalError writes scriptBody to a
+// fake-tmux in t.TempDir(), sets $TMUX_RECORD, wires the server
+// via setupWrapperServerWithScript, creates a workspace, waits for
+// ready, dials the terminal WebSocket, and asserts conn.Read
+// returns a CloseError with websocket.StatusInternalError.
+func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
+	t.Helper()
+	// ... write script, env, server setup, Create, wait for ready,
+	// Dial ws://.../terminal, conn.Read — expect
+	// websocket.CloseStatus(err) == websocket.StatusInternalError.
+}
+```
+
+- [ ] **Step 6.2: Add one test per failure shape**
+
+Each test body supplies a `#!/bin/sh` script that succeeds on new-session (so Setup finishes) but fails has-session in exactly one of the three shapes the contract must surface:
+
+- `TestTmuxWrapperAttachSurfacesWrapperFailure` — has-session exits 127 (non-1 ExitCode, wrapper ENOEXEC-style).
+- `TestTmuxWrapperAttachSurfacesExit1Failure` — has-session prints `"wrapper failed"` to stderr and exits 1 (exit 1 without tmux's canonical stderr).
+- `TestTmuxWrapperAttachIgnoresAbsencePhraseOnStdout` — has-session prints `"can't find session: sim"` to stdout, prints an unrelated line to stderr, exits 1 (tmux phrase routed to stdout — must not trigger the absent-session branch).
+
+Each test calls `attachWebsocketAndExpectInternalError(t, body)`.
+
+Run: `go test ./internal/server -run "TestTmuxWrapperAttach(SurfacesWrapperFailure|SurfacesExit1Failure|IgnoresAbsencePhraseOnStdout)" -shuffle=on`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6.3: Run full server package tests**
+
+Run: `go test ./internal/server -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add internal/server/tmux_wrapper_test.go
+git commit -m "test(server): wrapper-failure surface at attach WebSocket"
+```
+
+---
+
+## Task 7: Server-level e2e — `[tmux]` preserved across settings save
+
+**Files:**
+- Modify: `internal/server/settings_test.go`
+
+A single mutation route regression-gates the entire Save path — all three mutation handlers (`PUT /api/v1/settings`, `POST /api/v1/repos`, `DELETE /api/v1/repos`) call the same `(*Config).Save`. `PUT /api/v1/settings` has the smallest request body and is the cheapest canary.
+
+- [ ] **Step 7.1: Add the preservation test**
+
+Append to `internal/server/settings_test.go`:
+
+```go
+func TestHandleUpdateSettingsPreservesTmuxCommand(t *testing.T) {
+	srv, _, cfgPath := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+[[repos]]
+owner = "acme"
+name = "widget"
+[tmux]
+command = ["systemd-run", "--user", "--scope", "tmux"]
+`, &mockGH{})
+
+	body := updateSettingsRequest{Activity: config.Activity{
+		ViewMode:  "threaded",
+		TimeRange: "30d",
+	}}
+	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", body)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	reloaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"systemd-run", "--user", "--scope", "tmux"},
+		reloaded.Tmux.Command,
+	)
+}
+```
+
+Run: `go test ./internal/server -run TestHandleUpdateSettingsPreservesTmuxCommand -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 7.2: Run the whole suite as a final gate**
+
+Run: `make test`
+Expected: PASS.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add internal/server/settings_test.go
+git commit -m "test(server): settings save preserves [tmux] section"
+```
+
+---
+
+## Completion checklist
+
+After Task 7, the branch should:
+- Add a `[tmux] command = [...]` config section parsed by BurntSushi/toml, with validation rejecting an empty or whitespace-only first element.
+- Round-trip `[tmux]` through `(*Config).Save` — every settings mutation route (`PUT /api/v1/settings`, `POST /api/v1/repos`, `DELETE /api/v1/repos`) shares this path, so `[tmux]` is not silently erased by any of them.
+- Thread the prefix through `workspace.Manager` and `terminal.Handler` via `newServer`.
+- Change every one of the four tmux exec call sites to use the prefix.
+- Enforce the has-session failure contract: only `exit 1 + stderr containing "can't find session" or "no server running"` is treated as session-absent. Wrapper misconfiguration (exec errors, other exit codes, exit 1 without the stderr match, or the tmux phrase only on stdout) propagates through `EnsureTmux` as `"tmux has-session: %w"`.
+- Leave default behavior (`["tmux"]`) unchanged when the config is omitted.
+- Cover the new behavior with unit tests (`internal/config`, `internal/workspace`) and full-stack e2e tests (`internal/server`) including the wrapper-failure surface at the terminal WebSocket layer.
+
+Run `make test` as the final verification. Once green, hand back to the user for review.

--- a/docs/superpowers/specs/2026-04-16-configurable-tmux-command-design.md
+++ b/docs/superpowers/specs/2026-04-16-configurable-tmux-command-design.md
@@ -1,0 +1,471 @@
+# Configurable tmux Launch Command
+
+## Problem
+
+middleman shells out to `tmux` at four call sites to create, query,
+attach to, and kill per-workspace tmux sessions. The command name is
+hard-coded to the literal string `"tmux"` everywhere. Operators who
+run middleman under a hardened systemd unit (tight sandboxing,
+restricted namespaces, read-only paths, etc.) have no way to launch
+the tmux session under a different set of permissions than the
+middleman service itself.
+
+The motivating use case is `systemd-run --user --scope tmux ...`,
+which moves the tmux server into its own transient scope so it is
+not bound by the middleman service's sandboxing. Without this, the
+only options are to loosen sandboxing on the whole service or to
+disable the workspace terminal feature.
+
+## Goals
+
+- Let operators prefix every `tmux` invocation with an arbitrary
+  command + argv prefix (e.g. `systemd-run --user --scope tmux`).
+- Keep existing behavior bit-for-bit when the setting is unset.
+- Apply consistently across all four call sites. No per-site knobs.
+
+## Non-goals
+
+- No per-workspace override.
+- No templating, no env-var interpolation, no shell parsing.
+- No change to the arguments middleman passes after the tmux binary
+  (e.g. `new-session -d -s ... -c ...`). Only the command + argv
+  prefix is configurable.
+- No runtime reconfiguration. The command is read once at startup;
+  editing `tmux.command` in `config.toml` requires a middleman
+  restart to take effect on the live process. Settings-API writes
+  (`PUT /settings`, `POST /repos`, `DELETE /repos`) preserve the
+  `[tmux]` section on disk but do not reload the running server.
+- No changes to the settings API or UI. `tmux.command` is a
+  file-only setting, edited by operators who are configuring a
+  hardened systemd unit. A misconfigured wrapper breaks the
+  workspace feature and should require a deliberate config-file
+  edit + restart.
+- No README entry, no `middleman config` subcommand output, no CLI
+  help text beyond what the sample stanza below provides. The
+  feature is a last-resort escape hatch for a specific sandboxing
+  scenario, not a general-purpose knob — matching how the
+  internal-only `[roborev]` section is handled today.
+
+## Operator reference
+
+The one supported configuration shape, to be copy-pasted into
+`~/.config/middleman/config.toml` (or wherever the operator keeps
+it):
+
+```toml
+# tmux launch command wrapper (optional). Configure ONLY when
+# middleman runs under a sandbox that prevents tmux from creating
+# its server, e.g. a hardened systemd unit. The first element is
+# exec'd; remaining elements are its leading arguments. Include the
+# tmux binary somewhere in this list (conventionally last).
+# middleman does NOT append "tmux" — the config must provide it.
+#
+# Changes take effect on middleman restart.
+[tmux]
+command = ["systemd-run", "--user", "--scope", "tmux"]
+```
+
+This spec is the operator-facing reference. The project has no
+shipped CHANGELOG or release-notes artifact; discovery is through
+the PR description on merge and this spec in the repo, which are
+the same surface operators already use to find the `[roborev]`
+section.
+
+## Trust model
+
+`tmux.command` is arbitrary local process execution: whatever the
+first element of the array names gets exec'd on every workspace
+operation. The configuration is trusted operator input on the same
+footing as `github_token_env` or `data_dir` — it must come from a
+`config.toml` the operator controls. Environments that ingest a
+`config.toml` from an untrusted source (e.g. a shared multi-tenant
+directory or a user-uploaded file) must not enable this setting,
+because a malicious value turns every workspace create, terminal
+attach, and workspace delete into arbitrary code execution under
+the middleman process's credentials. Middleman makes no defense
+against this case — the validation only checks structural shape,
+not identity or safety of the binary.
+
+## Design
+
+### Config
+
+A new optional `[tmux]` section in `config.toml`:
+
+```toml
+[tmux]
+command = ["systemd-run", "--user", "--scope", "tmux"]
+```
+
+- `command` is a TOML array of strings representing the **full
+  argv** that replaces middleman's conceptual `"tmux"` slot. The
+  first element is exec'd; the remaining elements are that
+  process's leading arguments. middleman then appends its own
+  subcommand argv (`new-session ...`, `has-session ...`, etc.)
+  after the configured array.
+- The operator is required to include the `tmux` binary somewhere
+  in `command` (typically as the last element). middleman does
+  **not** append `tmux` on its own. A configuration like
+  `["systemd-run", "--user", "--scope"]` (without `tmux`) is
+  unsupported — the wrapper would see `new-session` as its
+  subcommand and fail to exec anything useful. Validation does
+  not detect this form because there is no reliable heuristic; the
+  failure surfaces at the first workspace create.
+- When `[tmux]` is omitted or `command` is an empty array, the
+  effective value is `["tmux"]`, preserving today's behavior.
+
+### Go types
+
+In `internal/config/config.go`:
+
+```go
+type Tmux struct {
+    Command []string `toml:"command,omitempty"`
+}
+
+type Config struct {
+    // ... existing fields ...
+    Tmux Tmux `toml:"tmux"`
+}
+```
+
+Only a `toml` tag — `Tmux.Command` is not exposed via the settings
+API, matching how the internal-only `Roborev` subsection is tagged.
+
+Add a helper on `*Config`:
+
+```go
+// TmuxCommand returns the command + argv prefix used to invoke
+// tmux. Defaults to ["tmux"] when c is nil or the setting is
+// unconfigured.
+func (c *Config) TmuxCommand() []string {
+    if c == nil || len(c.Tmux.Command) == 0 {
+        return []string{"tmux"}
+    }
+    return append([]string(nil), c.Tmux.Command...)
+}
+```
+
+The helper is nil-safe because the server constructor chain
+(`server.New` and `server.NewWithConfig` both route through
+`newServer`) commonly runs with `cfg == nil` in tests — many
+existing tests in `internal/server` pass `nil` for cfg while still
+exercising the workspace/terminal paths (`api_test.go:4887`
+wires up workspaces with `cfg == nil`). The helper returns a copy
+so callers can safely `append` without mutating the config.
+
+### Validation
+
+In `Config.Validate`:
+
+- If `Tmux.Command` is set (non-nil) and non-empty, the first
+  element must contain non-whitespace after `strings.TrimSpace`.
+  Reject both `""` and whitespace-only values (`"   "`) with a
+  clear error. A whitespace-only executable would otherwise sneak
+  past a plain `== ""` check and fail with a confusing shell-level
+  error at first workspace create.
+- An empty or missing array is valid (uses default).
+
+Config validation only checks structure. It does not stat the
+executable or confirm it is on PATH — a missing binary surfaces
+at runtime when middleman first tries to create a workspace, with
+the existing exec error path. This matches how middleman currently
+treats `tmux` itself.
+
+### Call-site changes
+
+All four call sites that currently hard-code `"tmux"` switch to
+using the configured prefix. The arguments after the prefix are
+unchanged.
+
+1. `internal/workspace/manager.go` `newTmuxSession` — creates the
+   detached session.
+2. `internal/workspace/manager.go` `TmuxSessionExists` — runs
+   `has-session`.
+3. `internal/workspace/manager.go` `Delete` — runs `kill-session`.
+4. `internal/terminal/handler.go` `ServeHTTP` — runs
+   `attach-session` under a PTY.
+
+`workspace.Manager` gains a `tmuxCmd []string` field set at
+construction. `terminal.Handler` gains an equivalent field. Both
+are populated from `cfg.TmuxCommand()` inside `newServer`
+(`internal/server/server.go`), which both `server.New` and
+`server.NewWithConfig` route through and which is where the
+`workspace.Manager` and `terminal.Handler` are constructed today.
+`cfg` is already available there, so no plumbing through
+`ServerOptions` is required. Because `TmuxCommand()` is nil-safe,
+the call is `cfg.TmuxCommand()` without a guard — tests that pass
+`cfg == nil` will receive the default `["tmux"]` prefix.
+Field visibility should mirror each type's existing construction
+convention rather than being forced to match across types:
+`workspace.Manager` already takes dependencies via setter methods
+(`SetClones`), so the tmux field is unexported with a
+`SetTmuxCommand` setter; `terminal.Handler` is populated via a
+struct literal in `newServer` (`&terminal.Handler{Workspaces: ...}`),
+so the tmux field is exported. The asymmetry is load-bearing — it
+keeps both types consistent with their existing call sites — and
+is not something the implementer needs to "pick."
+
+Because `EnsureTmux` and `TmuxSessionExists` are currently
+package-level functions, they become methods on `*Manager` (or take
+an explicit command prefix) so they can reach the configured
+command. The terminal handler calls `Manager.EnsureTmux` through
+its existing `*workspace.Manager` dependency rather than the
+package-level function.
+
+### has-session failure handling
+
+Wrapping tmux adds a second exec layer to every call, which forces
+a contract the unwrapped code could leave implicit: when
+`has-session` fails, is it tmux saying "session missing" or the
+wrapper saying "I could not run tmux at all"? The answer decides
+whether `EnsureTmux` falls through to `new-session` (correct for
+session-missing) or surfaces the error (correct for every other
+failure — a broken wrapper will fail new-session the same way and
+the user sees a misleading error about the second call instead of
+the first).
+
+The heuristic `tmuxSessionExists` uses, top to bottom:
+
+- If the command runs and exits 0, the session exists — return
+  `(true, nil)`.
+- If exec itself fails (binary missing, ENOENT, context cancelled),
+  the error is not an `*exec.ExitError`. Propagate it — the caller
+  cannot safely assume "session missing" when the wrapper or binary
+  could not run.
+- If it is an `*exec.ExitError` with exit code != 1, propagate the
+  error. tmux's `has-session` exits 1 specifically when the target
+  session is absent; other exit codes (127 "command not found", 203
+  "exec failed", 126 "permission denied", etc.) signal wrapper
+  misconfiguration, not a missing tmux session.
+- If it is an `*exec.ExitError` with exit code 1, inspect **stderr
+  only** (stdout is not load-bearing — a wrapper may emit anything
+  there). If stderr contains either `can't find session` or
+  `no server running`, the session is genuinely absent — return
+  `(false, nil)`. Otherwise propagate as an error.
+
+Consequences:
+
+- `tmuxSessionExists` returns `(bool, error)`. The old
+  `runCmd(...) == nil` boolean collapses the distinction above and
+  is insufficient.
+- `cmd.Stdout` and `cmd.Stderr` must be captured into separate
+  buffers so the heuristic can look at stderr alone. `CombinedOutput`
+  merges them and lets stdout content spoof the session-absent
+  signal.
+- `EnsureTmux` wraps the non-absent error as `"tmux has-session: %w"`
+  so the error message identifies which call surfaced the
+  misconfiguration.
+
+Assumption: tmux's stderr phrases `can't find session` and
+`no server running` have been stable across multiple major tmux
+releases and are the observable contract we pin against.
+Environments running a heavily patched tmux fork that renames
+these messages must either reconfigure the wrapper to translate
+them, or accept that middleman will surface the non-match as a
+wrapper-failure error and refuse to create sessions. This
+trade-off sits on the operator's side; middleman does not try to
+recover from an unknown tmux.
+
+### Wrapper requirements
+
+Operators writing a wrapper must ensure it:
+
+- Forwards argv unchanged from the wrapper's own arguments onward.
+  middleman appends tmux's subcommand (`new-session`, `has-session`,
+  etc.) after the configured argv, and a wrapper that rewrites
+  these loses the tmux verb.
+- Preserves stdio for `attach-session`. The terminal handler runs
+  `attach-session` under a PTY via `creack/pty.StartWithSize`; a
+  wrapper that daemonizes, redirects stdio, or detaches before
+  tmux takes over breaks interactive attach even when the
+  non-interactive verbs (`new-session -d`, `has-session`,
+  `kill-session`) still work.
+- Exits with the child process's status for non-attach verbs, or at
+  least preserves tmux's exit-1-for-missing-session behavior.
+  Wrappers that remap exit codes will confuse the has-session
+  heuristic.
+- Does not buffer or rewrite stderr. The session-absent heuristic
+  matches tmux's stderr phrases verbatim; a wrapper that captures
+  stderr and re-emits it on stdout (or translates the message)
+  defeats the match.
+
+`systemd-run --user --scope tmux` is the motivating example and
+meets all four requirements on paper: it inherits stdio, runs tmux
+in the foreground, and forwards exit codes. The automated tests
+exercise synthetic shell wrappers and a recording binary, not
+`systemd-run` itself — operators deploying this wrapper should
+validate the full attach path manually on their target host before
+relying on it. Small `sh` wrappers that only `exec tmux "$@"`
+(optionally after `exec systemd-run --user --scope`) are equally
+fine and are the simplest way to narrow the scope of what the
+wrapper does before handing off to tmux.
+
+### Operator-facing failure surface
+
+When the wrapper is misconfigured, the failure needs to be visible
+to the operator without a deep dive into source. The surfaces:
+
+- `EnsureTmux` errors are logged via `slog.Error("ensure tmux",
+  "err", ...)` inside `terminal.Handler.ServeHTTP` before the
+  connection closes.
+- The WebSocket terminal connection closes with
+  `websocket.StatusInternalError` (1011) and reason `"failed to
+  start tmux"`. A browser client observing the close frame knows
+  the session could not start.
+- Workspace setup (`new-session` through the wrapper) surfaces the
+  same `exec.ExitError` wrapping through the existing workspace
+  `error` status; the UI already shows that state.
+
+These are existing channels; no new logging or error types are
+introduced. The design ensures misconfiguration reaches them
+promptly rather than being silently retried as "session absent."
+
+Assembling the exec call is a one-liner — prefix + args, pass to
+`exec.CommandContext`. Either inline it at each call site or
+extract an exported helper that both `workspace` and `terminal`
+can import. Sketch of an exported form:
+
+```go
+// TmuxExec returns an *exec.Cmd for `<prefix...> <args...>`.
+// The helper makes a defensive copy of prefix so the caller may
+// reuse it.
+func TmuxExec(ctx context.Context, prefix []string, args ...string) *exec.Cmd {
+    full := append(append([]string(nil), prefix...), args...)
+    return exec.CommandContext(ctx, full[0], full[1:]...)
+}
+```
+
+If inlined instead, the terminal handler still needs to set
+`cmd.Env` after construction — the helper only builds the command,
+it does not manage env or attach PTYs.
+
+### Behavior when wrapper is set
+
+Example with `command = ["systemd-run", "--user", "--scope", "tmux"]`:
+
+| site | existing argv | new argv |
+|------|---------------|----------|
+| new-session | `tmux new-session -d -s S -c C shell -l` | `systemd-run --user --scope tmux new-session -d -s S -c C shell -l` |
+| has-session | `tmux has-session -t S` | `systemd-run --user --scope tmux has-session -t S` |
+| kill-session | `tmux kill-session -t S` | `systemd-run --user --scope tmux kill-session -t S` |
+| attach-session | `tmux attach-session -t S` | `systemd-run --user --scope tmux attach-session -t S` |
+
+Operators who only want the server (new-session) wrapped can point
+`command` at a small script that discriminates on `$1 == "new-session"`
+and execs `tmux` directly otherwise. This keeps middleman's wiring
+simple.
+
+## Testing
+
+E2E and unit coverage live in the existing packages:
+
+1. `internal/config` — table-driven test: omitted `[tmux]`,
+   explicit empty array, single-element `["tmux"]`, multi-element
+   wrapper, invalid empty-first-element (expect error), invalid
+   whitespace-only first-element (expect error).
+2. `internal/config` — `TmuxCommand()` returns a defensive copy
+   (mutating the result must not affect the config). Nil-receiver
+   returns the default `["tmux"]`.
+3. `internal/config` — `Save` round-trip: a config with a
+   populated `[tmux]` section reloads with the same slice.
+4. `internal/workspace` — with a fake prefix that points at a test
+   helper binary (or a shell script written to `t.TempDir()`),
+   assert that `newTmuxSession`, `tmuxSessionExists`, and
+   `Delete`'s kill-session path invoke the prefix + expected argv.
+   Additionally, pin down the `has-session` failure contract with
+   four cases: binary missing (non-ExitError propagates), exit code
+   != 1 (propagates), exit 1 with non-tmux stderr (propagates),
+   exit 1 with the tmux phrase on stdout only (propagates — not
+   session-absent). Verify argv via a recording binary that writes
+   NUL-delimited argv to a file.
+5. `internal/server` e2e — spin up the full HTTP server with a
+   config that sets `tmux.command` to a recording script. Cover:
+   - Create a workspace via the API, assert the recorded argv
+     matches the prefix + `new-session ...`.
+   - Dial the `/api/v1/workspaces/{id}/terminal` WebSocket and
+     assert the recorded argv for the `attach-session` invocation
+     matches `prefix + attach-session -t <session>`.
+   - Delete the workspace via the API, assert the recorded argv
+     matches the prefix + `kill-session -t <session>`.
+   - Wrapper-failure surface: a `has-session` script that fails
+     (exit != 1, exit 1 with non-tmux stderr, or exit 1 with the
+     tmux phrase on stdout only) must close the attach WebSocket
+     with `websocket.StatusInternalError` rather than silently
+     proceeding to `new-session` through the same broken wrapper.
+   - One settings mutation path (`PUT /api/v1/settings` is the
+     cheapest) must preserve the `[tmux]` section across the
+     handler's `(*Config).Save` round-trip. All three mutation
+     routes (`PUT /settings`, `POST /repos`, `DELETE /repos`) use
+     the same `Save` implementation; one e2e is enough to regression-
+     gate the mechanism.
+6. Default-path coverage — existing workspace/terminal tests
+   continue to pass without any config change, confirming the
+   no-wrapper default is unchanged.
+
+The recording helper must record argv unambiguously — a naive
+`echo "$@"` collapses whitespace and cannot distinguish empty
+arguments from absent ones. Use NUL-delimited output so the test
+can recover the exact argv:
+
+```sh
+#!/bin/sh
+# Appends "<argc>\0<arg0>\0<arg1>\0...\0" per invocation.
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+```
+
+The test reads `$TMUX_RECORD`, splits on NUL, and compares against
+the expected argv slice. A tiny Go helper built with `go test -c`
+is equally acceptable (and avoids the shell entirely), but the
+shell form is enough and matches existing test doubles in the
+project.
+
+## Success criteria
+
+The work is complete when all of the following hold:
+
+- Default-path parity: with no `[tmux]` section in `config.toml`,
+  every tmux exec middleman issues is byte-for-byte identical to
+  today's invocation. Existing tests pass unchanged.
+- Wrapper-path coverage at every call site: with
+  `tmux.command = [prefix...]` set, `new-session`, `has-session`,
+  `kill-session`, and `attach-session` all run as
+  `<prefix...> <original argv...>`.
+- has-session failure contract (see "has-session failure handling"
+  above) holds: only `exit code 1 + stderr containing "can't find
+  session" or "no server running"` is treated as session-absent.
+  All other failure modes (non-ExitError, other exit codes, exit 1
+  without the stderr match) propagate so wrapper misconfiguration
+  surfaces on the first call.
+- Save-round-trip: `(*Config).Save` preserves the `[tmux]` section
+  rather than silently erasing it on the next write. All three
+  settings-UI mutation routes (`PUT /api/v1/settings`,
+  `POST /api/v1/repos`, `DELETE /api/v1/repos`) call the same
+  `Save`, so one e2e on any of them regression-gates the
+  mechanism.
+- Validation: a `tmux.command` whose first element is empty or
+  whitespace-only fails config load with a clear error.
+- Nil-cfg safety: server constructors (`server.New` with `cfg ==
+  nil`, common in tests) continue to work with the default
+  `["tmux"]` prefix.
+- Required e2e coverage: `internal/server` has end-to-end tests
+  that drive the real HTTP stack with a recording script wired as
+  `tmux.command` and assert the prefix reaches `new-session`
+  (via `POST /api/v1/workspaces`), `attach-session` (via
+  `GET /api/v1/workspaces/{id}/terminal` WebSocket), and
+  `kill-session` (via `DELETE /api/v1/workspaces/{id}`). The
+  attach path also has coverage for the wrapper-failure surface
+  (WebSocket closes with `StatusInternalError` when has-session
+  fails for non-absent reasons).
+
+## Rollout
+
+No migration, no feature flag. Behavior is identical for anyone
+who does not set `tmux.command`.
+
+The change is staged across several bisectable commits — one per
+package layer (config, workspace manager, terminal handler,
+server wiring) plus the e2e suite — so each commit builds and
+tests cleanly in isolation. The commit count is an implementation
+detail of the staged plan; see `docs/superpowers/plans/` for the
+concrete sequencing.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,10 @@ type Roborev struct {
 	Endpoint string `toml:"endpoint,omitempty"`
 }
 
+type Tmux struct {
+	Command []string `toml:"command,omitempty"`
+}
+
 type Config struct {
 	SyncInterval      string   `toml:"sync_interval"`
 	GitHubTokenEnv    string   `toml:"github_token_env"`
@@ -180,6 +184,7 @@ type Config struct {
 	Repos             []Repo   `toml:"repos"`
 	Activity          Activity `toml:"activity"`
 	Roborev           Roborev  `toml:"roborev"`
+	Tmux              Tmux     `toml:"tmux"`
 }
 
 func DefaultConfigPath() string {
@@ -440,6 +445,13 @@ func (c *Config) Validate() error {
 		)
 	}
 
+	if len(c.Tmux.Command) > 0 &&
+		strings.TrimSpace(c.Tmux.Command[0]) == "" {
+		return fmt.Errorf(
+			"config: invalid tmux.command: first element must be non-empty",
+		)
+	}
+
 	return nil
 }
 
@@ -497,6 +509,16 @@ func (c *Config) RoborevEndpoint() string {
 	return "http://127.0.0.1:7373"
 }
 
+// TmuxCommand returns the command + argv prefix used to invoke
+// tmux. Defaults to ["tmux"] when c is nil or the setting is
+// unconfigured. The returned slice is a copy, safe to append to.
+func (c *Config) TmuxCommand() []string {
+	if c == nil || len(c.Tmux.Command) == 0 {
+		return []string{"tmux"}
+	}
+	return append([]string(nil), c.Tmux.Command...)
+}
+
 // configFile is the subset of Config written to disk.
 type configFile struct {
 	SyncInterval      string   `toml:"sync_interval"`
@@ -509,6 +531,7 @@ type configFile struct {
 	Repos             []Repo   `toml:"repos"`
 	Activity          Activity `toml:"activity"`
 	Roborev           Roborev  `toml:"roborev,omitempty"`
+	Tmux              Tmux     `toml:"tmux,omitempty"`
 }
 
 // Save writes the current config to the given path.
@@ -521,6 +544,7 @@ func (c *Config) Save(path string) error {
 		Repos:          c.Repos,
 		Activity:       c.Activity,
 		Roborev:        c.Roborev,
+		Tmux:           c.Tmux,
 	}
 	if c.SyncBudgetPerHour != defaultSyncBudgetPerHour {
 		f.SyncBudgetPerHour = c.SyncBudgetPerHour

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -893,3 +893,110 @@ func TestRoborevEndpointDefault(t *testing.T) {
 		t, "http://127.0.0.1:7373", cfg.RoborevEndpoint(),
 	)
 }
+
+func TestLoadTmuxCommand(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[tmux]
+command = ["systemd-run", "--user", "--scope", "tmux"]
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "--scope", "tmux"},
+		cfg.Tmux.Command,
+	)
+}
+
+func TestLoadTmuxCommandOmitted(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, ``)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(cfg.Tmux.Command)
+	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+}
+
+func TestLoadTmuxCommandEmptyArray(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[tmux]
+command = []
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+}
+
+func TestTmuxCommandDefensiveCopy(t *testing.T) {
+	assert := Assert.New(t)
+	cfg := &Config{Tmux: Tmux{
+		Command: []string{"tmux"},
+	}}
+	first := cfg.TmuxCommand()
+	first[0] = "hacked"
+	second := cfg.TmuxCommand()
+	assert.Equal([]string{"tmux"}, second)
+}
+
+func TestTmuxCommandNilReceiver(t *testing.T) {
+	assert := Assert.New(t)
+	var cfg *Config
+	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+}
+
+func TestLoadTmuxCommandRejectsEmptyFirstElement(t *testing.T) {
+	path := writeConfig(t, `
+[tmux]
+command = ["", "extra"]
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(),
+		`config: invalid tmux.command`,
+	)
+}
+
+// TestLoadTmuxCommandRejectsWhitespaceFirstElement covers the
+// whitespace-only case: "   " would sneak past a plain == "" check
+// and exec("   ") fails with a confusing shell-level error rather
+// than the config-load validation message operators actually want.
+func TestLoadTmuxCommandRejectsWhitespaceFirstElement(t *testing.T) {
+	path := writeConfig(t, `
+[tmux]
+command = ["   ", "extra"]
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(),
+		`config: invalid tmux.command`,
+	)
+}
+
+func TestSavePreservesTmuxCommand(t *testing.T) {
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := &Config{
+		SyncInterval:   "5m",
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Host:           "127.0.0.1",
+		Port:           8091,
+		DataDir:        dir,
+		Activity:       Activity{ViewMode: "threaded", TimeRange: "7d"},
+		Tmux: Tmux{
+			Command: []string{"systemd-run", "--user", "--scope", "tmux"},
+		},
+	}
+	require.NoError(t, cfg.Save(path))
+
+	reloaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "--scope", "tmux"},
+		reloaded.Tmux.Command,
+	)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -289,13 +289,17 @@ func newServer(
 
 	if options.WorktreeDir != "" {
 		s.workspaces = workspace.NewManager(database, options.WorktreeDir)
+		s.workspaces.SetTmuxCommand(cfg.TmuxCommand())
 		if clones != nil {
 			s.workspaces.SetClones(clones)
 		}
 	}
 
 	if s.workspaces != nil {
-		termHandler := &terminal.Handler{Workspaces: s.workspaces}
+		termHandler := &terminal.Handler{
+			Workspaces:  s.workspaces,
+			TmuxCommand: cfg.TmuxCommand(),
+		}
 		mux.Handle(
 			"GET /api/v1/workspaces/{id}/terminal",
 			termHandler,

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -812,3 +812,44 @@ name = "*"
 	assert.False(srv.syncer.IsTrackedRepo("roborev-dev", "middleman"),
 		"deleted repo resurrected by concurrent refresh")
 }
+
+// TestHandleUpdateSettingsPreservesTmuxCommand drives a real
+// settings-mutation HTTP call against a config that has a [tmux]
+// section on disk, then reloads the config and asserts the Tmux
+// command array survived the Save round-trip. This pins down the
+// operator-visible contract: mutating activity settings (or any
+// other field the UI touches) must not silently erase tmux.command.
+func TestHandleUpdateSettingsPreservesTmuxCommand(t *testing.T) {
+	assert := Assert.New(t)
+	srv, _, cfgPath := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[tmux]
+command = ["systemd-run", "--user", "--scope", "tmux"]
+`, &mockGH{})
+
+	body := updateSettingsRequest{
+		Activity: config.Activity{
+			ViewMode:  "threaded",
+			TimeRange: "30d",
+		},
+	}
+	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", body)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	reloaded, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "--scope", "tmux"},
+		reloaded.Tmux.Command,
+	)
+	// Sanity: the mutation actually took effect, so Save did write.
+	assert.Equal("30d", reloaded.Activity.TimeRange)
+}

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -1,0 +1,432 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wesm/middleman/internal/apiclient"
+	"github.com/wesm/middleman/internal/apiclient/generated"
+	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/db"
+	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/gitclone"
+)
+
+// writeTmuxRecorder creates an executable fake-tmux script at a
+// fresh temp path. The script appends NUL-delimited argv to
+// record. For has-session it emits tmux's "can't find session"
+// stderr and exits 1 (so EnsureTmux's isTmuxSessionAbsent check
+// sees the canonical signal and proceeds to new-session); all
+// other invocations exit 0. Returns the script path and the record
+// path.
+func writeTmuxRecorder(t *testing.T) (script, record string) {
+	t.Helper()
+	dir := t.TempDir()
+	record = filepath.Join(dir, "record")
+	script = filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then` + "\n" +
+		`    echo "can't find session: sim" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+	return script, record
+}
+
+func readTmuxRecord(t *testing.T, path string) [][]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+	// Split on NUL. Each record is "<argc>\0<arg0>\0<arg1>\0...\0",
+	// so a flushed stream always ends with a trailing \0 and Split
+	// produces a final empty element after it. Strip exactly one
+	// trailing empty so we don't mistake it for part of the next
+	// record. Interior empty elements are real args (the NUL framing
+	// exists to preserve them) and must NOT be skipped.
+	parts := strings.Split(string(data), "\x00")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	var out [][]string
+	for i := 0; i < len(parts); {
+		n, err := strconv.Atoi(parts[i])
+		if err != nil {
+			// Trailing record is mid-write: argc isn't a valid
+			// integer yet. Stop; the next poll will see the full
+			// record once the recorder script flushes.
+			break
+		}
+		if i+1+n > len(parts) {
+			// argc is parsed but not all args are on disk yet.
+			// Same treatment: defer to the next poll.
+			break
+		}
+		i++
+		argv := parts[i : i+n]
+		out = append(out, argv)
+		i += n
+	}
+	return out
+}
+
+// setupWrapperServer constructs a full server wired with a
+// recording-script tmux command, a bare repo, and a seeded PR.
+// Returns a generated API client pointed at the httptest server,
+// the httptest baseURL (needed for WebSocket dialing), and the
+// record-file path.
+func setupWrapperServer(t *testing.T) (client *apiclient.Client, baseURL, record string) {
+	t.Helper()
+	script, record := writeTmuxRecorder(t)
+	client, baseURL = setupWrapperServerWithScript(t, script)
+	return client, baseURL, record
+}
+
+// setupWrapperServerWithScript is setupWrapperServer parameterized
+// by the tmux-command path. Tests that want a non-default wrapper
+// (e.g. one that fails has-session with a non-1 exit code) write
+// their own script first and call this helper instead.
+func setupWrapperServerWithScript(
+	t *testing.T, script string,
+) (client *apiclient.Client, baseURL string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("e2e tests skipped in short mode")
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	bareDir := filepath.Join(dir, "clones")
+	require.NoError(t, os.MkdirAll(bareDir, 0o755))
+	bare := filepath.Join(
+		bareDir, "github.com", "acme", "widget.git",
+	)
+	tmpWork := filepath.Join(dir, "work")
+	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	runGit(t, dir, "clone", bare, tmpWork)
+	runGit(t, tmpWork, "config", "user.email", "test@test.com")
+	runGit(t, tmpWork, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpWork, "base.txt"),
+		[]byte("base\n"), 0o644,
+	))
+	runGit(t, tmpWork, "add", ".")
+	runGit(t, tmpWork, "commit", "-m", "base commit")
+	runGit(t, tmpWork, "push", "origin", "main")
+	runGit(t, tmpWork, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpWork, "new.txt"),
+		[]byte("new\n"), 0o644,
+	))
+	runGit(t, tmpWork, "add", ".")
+	runGit(t, tmpWork, "commit", "-m", "feature commit")
+	runGit(t, tmpWork, "push", "origin", "feature")
+
+	// Point bare origin at itself so EnsureClone fetch works.
+	runGit(t, bare, "remote", "add", "origin", bare)
+
+	clones := gitclone.New(bareDir, nil)
+	worktreeDir := filepath.Join(dir, "worktrees")
+
+	repos := []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+	}
+	mock := &mockGH{}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, repos, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	cfg := &config.Config{
+		Tmux: config.Tmux{
+			Command: []string{script, "wrap"},
+		},
+	}
+	srv := New(database, syncer, nil, "/", cfg, ServerOptions{
+		Clones:      clones,
+		WorktreeDir: worktreeDir,
+	})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	seedPR(t, database, "acme", "widget", 1)
+
+	// Real listener — WebSocket Dial needs a real TCP endpoint.
+	// The generated API client also points at this URL rather than
+	// the in-process roundtripper used elsewhere, because we cannot
+	// split HTTP and WebSocket transports per-request.
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// Wrap the underlying TCP transport with the same Content-Type
+	// shim setupTestClient uses — the server's CSRF check rejects
+	// non-GET requests without Content-Type (e.g. DELETE with no
+	// body) as 415 Unsupported Media Type. The shim runs in addition
+	// to the normal transport, which still reaches the httptest
+	// server over TCP so WebSocket upgrades continue to work.
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet && req.Header.Get("Content-Type") == "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	}
+	client, err = apiclient.NewWithHTTPClient(ts.URL, httpClient)
+	require.NoError(t, err)
+
+	return client, ts.URL
+}
+
+func TestTmuxWrapperNewSession(t *testing.T) {
+	assert := Assert.New(t)
+	client, _, record := setupWrapperServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(t, createResp.JSON202)
+
+	// Workspace setup runs asynchronously. Poll the record file
+	// until the new-session invocation shows up, up to ~5s.
+	var argvs [][]string
+	require.Eventually(
+		t,
+		func() bool {
+			argvs = readTmuxRecord(t, record)
+			for _, argv := range argvs {
+				if len(argv) >= 2 && argv[1] == "new-session" {
+					return true
+				}
+			}
+			return false
+		},
+		5*time.Second, 50*time.Millisecond,
+		"new-session argv not recorded",
+	)
+
+	var newSession []string
+	for _, argv := range argvs {
+		if len(argv) >= 2 && argv[1] == "new-session" {
+			newSession = argv
+			break
+		}
+	}
+
+	// "wrap" prefix, then "new-session -d -s <id> -c <path> <shell> -l"
+	require.GreaterOrEqual(t, len(newSession), 9)
+	assert.Equal("wrap", newSession[0])
+	assert.Equal("new-session", newSession[1])
+	assert.Equal("-d", newSession[2])
+	assert.Equal("-s", newSession[3])
+	assert.NotEmpty(newSession[4])
+	assert.Equal("-c", newSession[5])
+	assert.NotEmpty(newSession[6])
+	assert.NotEmpty(newSession[7])
+	assert.Equal("-l", newSession[8])
+}
+
+func TestTmuxWrapperAttachSession(t *testing.T) {
+	assert := Assert.New(t)
+	client, baseURL, record := setupWrapperServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(t, createResp.JSON202)
+	wsID := createResp.JSON202.Id
+
+	// Poll for status == "ready".
+	require.Eventually(
+		t,
+		func() bool {
+			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+				ctx, wsID,
+			)
+			if getErr != nil || getResp.JSON200 == nil {
+				return false
+			}
+			return getResp.JSON200.Status == "ready"
+		},
+		5*time.Second, 50*time.Millisecond,
+	)
+
+	// Connect to the WebSocket terminal endpoint using the
+	// httptest baseURL (the generated client cannot upgrade to
+	// WebSocket, so we dial directly with coder/websocket).
+	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) +
+		"/api/v1/workspaces/" + wsID + "/terminal"
+	dialCtx, dialCancel := context.WithTimeout(
+		ctx, 3*time.Second,
+	)
+	defer dialCancel()
+	u, err := url.Parse(wsURL)
+	require.NoError(t, err)
+	conn, httpResp, err := websocket.Dial(
+		dialCtx, u.String(), nil,
+	)
+	require.NoError(t, err)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	// The recording script exits 0 immediately, so the PTY
+	// closes and the handler sends an "exited" message. Read
+	// until the connection closes or 3s elapses.
+	readCtx, readCancel := context.WithTimeout(
+		ctx, 3*time.Second,
+	)
+	defer readCancel()
+	for {
+		_, _, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+	}
+
+	// The recorded argv should contain an attach-session invocation
+	// with our "wrap" prefix.
+	var attach []string
+	for _, argv := range readTmuxRecord(t, record) {
+		if len(argv) >= 2 && argv[1] == "attach-session" {
+			attach = argv
+			break
+		}
+	}
+	require.NotNil(t, attach, "attach-session argv not recorded")
+	require.Len(t, attach, 4)
+	assert.Equal("wrap", attach[0])
+	assert.Equal("attach-session", attach[1])
+	assert.Equal("-t", attach[2])
+	assert.NotEmpty(attach[3])
+}
+
+// TestReadTmuxRecordPreservesEmptyArgs pins down the parser's
+// empty-arg handling. The NUL-delimited record format was chosen to
+// round-trip argv with empty-string elements unambiguously; the
+// parser must keep interior and trailing empties rather than
+// collapsing them.
+func TestReadTmuxRecordPreservesEmptyArgs(t *testing.T) {
+	assert := Assert.New(t)
+	path := filepath.Join(t.TempDir(), "record")
+
+	// First record: 3 args with an interior empty ("a", "", "b").
+	// Second record: 2 args with a trailing empty ("x", "").
+	body := "3\x00a\x00\x00b\x00" + "2\x00x\x00\x00"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+
+	argvs := readTmuxRecord(t, path)
+	require.Len(t, argvs, 2)
+	assert.Equal([]string{"a", "", "b"}, argvs[0])
+	assert.Equal([]string{"x", ""}, argvs[1])
+}
+
+// TestTmuxWrapperKillSession proves the configured tmux.command
+// prefix reaches the kill-session exec issued by DELETE /workspaces/{id}.
+// This complements TestTmuxWrapperNewSession and TestTmuxWrapperAttachSession —
+// together they cover all three tmux verbs that cross the HTTP boundary.
+func TestTmuxWrapperKillSession(t *testing.T) {
+	assert := Assert.New(t)
+	client, _, record := setupWrapperServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(t, createResp.JSON202)
+	wsID := createResp.JSON202.Id
+
+	// Poll for status == "ready" before deleting so the tmux
+	// session is known to exist from the manager's perspective.
+	require.Eventually(
+		t,
+		func() bool {
+			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+				ctx, wsID,
+			)
+			if getErr != nil || getResp.JSON200 == nil {
+				return false
+			}
+			return getResp.JSON200.Status == "ready"
+		},
+		5*time.Second, 50*time.Millisecond,
+	)
+
+	force := true
+	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, wsID, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, delResp.StatusCode())
+
+	// The recorded argv should contain a kill-session invocation
+	// with our "wrap" prefix.
+	var kill []string
+	for _, argv := range readTmuxRecord(t, record) {
+		if len(argv) >= 2 && argv[1] == "kill-session" {
+			kill = argv
+			break
+		}
+	}
+	require.NotNil(t, kill, "kill-session argv not recorded")
+	require.Len(t, kill, 4)
+	assert.Equal("wrap", kill[0])
+	assert.Equal("kill-session", kill[1])
+	assert.Equal("-t", kill[2])
+	assert.NotEmpty(kill[3])
+}

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -430,3 +430,139 @@ func TestTmuxWrapperKillSession(t *testing.T) {
 	assert.Equal("-t", kill[2])
 	assert.NotEmpty(kill[3])
 }
+
+// TestTmuxWrapperAttachSurfacesWrapperFailure exercises the
+// error-propagation path end-to-end. Workspace setup uses a wrapper
+// that succeeds for new-session (so the workspace reaches "ready")
+// but fails has-session with exit code 127 — the kind of exit a
+// broken wrapper like systemd-run would produce. Under the old
+// boolean-only tmuxSessionExists, this silently passed through as
+// "session absent" and the bug hid behind a confusing new-session
+// failure. With the bool/error split plus the exit-code-1 carve-out,
+// the terminal handler sees the error and closes the WebSocket with
+// StatusInternalError.
+func TestTmuxWrapperAttachSurfacesWrapperFailure(t *testing.T) {
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then exit 127; fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	attachWebsocketAndExpectInternalError(t, body)
+}
+
+// attachWebsocketAndExpectInternalError drives the end-to-end
+// attach path with a custom fake-tmux script, asserting the
+// WebSocket is closed by the handler with StatusInternalError
+// rather than attaching to a session. Callers provide the script
+// body; the helper handles server setup, workspace creation,
+// ready-polling, dial, and close-status assertion.
+func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
+	t.Helper()
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	require.NoError(t, os.WriteFile(script, []byte(scriptBody), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	client, baseURL := setupWrapperServerWithScript(t, script)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(t, createResp.JSON202)
+	wsID := createResp.JSON202.Id
+
+	require.Eventually(
+		t,
+		func() bool {
+			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+				ctx, wsID,
+			)
+			if getErr != nil || getResp.JSON200 == nil {
+				return false
+			}
+			return getResp.JSON200.Status == "ready"
+		},
+		5*time.Second, 50*time.Millisecond,
+	)
+
+	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) +
+		"/api/v1/workspaces/" + wsID + "/terminal"
+	dialCtx, dialCancel := context.WithTimeout(
+		ctx, 3*time.Second,
+	)
+	defer dialCancel()
+	u, err := url.Parse(wsURL)
+	require.NoError(t, err)
+	conn, httpResp, err := websocket.Dial(
+		dialCtx, u.String(), nil,
+	)
+	require.NoError(t, err)
+	if httpResp != nil && httpResp.Body != nil {
+		httpResp.Body.Close()
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	readCtx, readCancel := context.WithTimeout(
+		ctx, 3*time.Second,
+	)
+	defer readCancel()
+	_, _, readErr := conn.Read(readCtx)
+	require.Error(t, readErr)
+	assert.Equal(
+		websocket.StatusInternalError,
+		websocket.CloseStatus(readErr),
+	)
+}
+
+// TestTmuxWrapperAttachSurfacesExit1Failure covers the second half
+// of the session-absent heuristic at the HTTP layer: exit code 1
+// without tmux's "can't find session" or "no server running"
+// stderr must be treated as a real wrapper failure, not as
+// "session absent, please create one." This is the common case the
+// reviewer flagged — shell wrappers often exit 1 for their own
+// generic errors.
+func TestTmuxWrapperAttachSurfacesExit1Failure(t *testing.T) {
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then` + "\n" +
+		`    echo "wrapper failed" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	attachWebsocketAndExpectInternalError(t, body)
+}
+
+// TestTmuxWrapperAttachIgnoresAbsencePhraseOnStdout verifies that
+// the absent-session heuristic is stderr-only at the HTTP layer:
+// a wrapper that exits 1 with the tmux phrase on stdout (and an
+// unrelated stderr message) must surface as an error, not as
+// "session absent." Pairs with the unit-level
+// TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout.
+func TestTmuxWrapperAttachIgnoresAbsencePhraseOnStdout(t *testing.T) {
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then` + "\n" +
+		`    echo "can't find session: sim"` + "\n" + // stdout only
+		`    echo "real failure" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	attachWebsocketAndExpectInternalError(t, body)
+}

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -21,7 +21,8 @@ import (
 // Handler serves WebSocket connections that bridge a
 // PTY-attached tmux session to the browser.
 type Handler struct {
-	Workspaces *workspace.Manager
+	Workspaces  *workspace.Manager
+	TmuxCommand []string
 }
 
 type controlMsg struct {
@@ -74,7 +75,7 @@ func (h *Handler) ServeHTTP(
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	if tmuxErr := workspace.EnsureTmux(
+	if tmuxErr := h.Workspaces.EnsureTmux(
 		ctx, ws.TmuxSession, ws.WorktreePath,
 	); tmuxErr != nil {
 		slog.Error("ensure tmux", "err", tmuxErr)
@@ -85,9 +86,14 @@ func (h *Handler) ServeHTTP(
 		return
 	}
 
-	cmd := exec.CommandContext(
-		ctx, "tmux", "attach-session", "-t", ws.TmuxSession,
-	)
+	prefix := h.TmuxCommand
+	if len(prefix) == 0 {
+		prefix = []string{"tmux"}
+	}
+	argv := make([]string, 0, len(prefix)+3)
+	argv = append(argv, prefix...)
+	argv = append(argv, "attach-session", "-t", ws.TmuxSession)
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 
 	winSize := &pty.Winsize{

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -457,66 +457,6 @@ func runBuiltCmd(cmd *exec.Cmd) error {
 	return nil
 }
 
-// runCmd executes an arbitrary command. If dir is non-empty it
-// sets the working directory. Retained only for the package-level
-// tmux functions below, which exist so internal/terminal/handler.go
-// still compiles before Task 3 migrates it to the method form.
-func runCmd(
-	ctx context.Context, dir string, name string, args ...string,
-) error {
-	cmd := exec.CommandContext(ctx, name, args...)
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf(
-			"%w: %s", err, strings.TrimSpace(string(out)),
-		)
-	}
-	return nil
-}
-
-// EnsureTmux creates a tmux session if it does not already exist.
-// Package-level retained until Task 3 migrates terminal.Handler to
-// the method form; deleted at that point.
-func EnsureTmux(
-	ctx context.Context, session, cwd string,
-) error {
-	if TmuxSessionExists(ctx, session) {
-		return nil
-	}
-	return packageNewTmuxSession(ctx, session, cwd)
-}
-
-// TmuxSessionExists checks whether a tmux session exists.
-// Package-level retained until Task 3.
-func TmuxSessionExists(
-	ctx context.Context, session string,
-) bool {
-	err := runCmd(
-		ctx, "",
-		"tmux", "has-session", "-t", session,
-	)
-	return err == nil
-}
-
-// packageNewTmuxSession is the pre-refactor new-session exec
-// kept only for the package-level EnsureTmux above. Task 3 deletes
-// both along with the terminal-handler migration.
-func packageNewTmuxSession(
-	ctx context.Context, session, cwd string,
-) error {
-	shell := userLoginShell()
-	return runCmd(
-		ctx, "",
-		"tmux", "new-session", "-d",
-		"-s", session,
-		"-c", cwd,
-		shell, "-l",
-	)
-}
-
 // dirtyFiles returns the list of uncommitted files in a worktree.
 func dirtyFiles(
 	ctx context.Context, worktreePath string,

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -22,6 +23,7 @@ type Manager struct {
 	db          *db.DB
 	worktreeDir string
 	clones      *gitclone.Manager
+	tmuxCmd     []string
 }
 
 // NewManager creates a Manager that stores worktrees under
@@ -39,6 +41,32 @@ func NewManager(
 // operations. Called after the clone manager is initialized.
 func (m *Manager) SetClones(clones *gitclone.Manager) {
 	m.clones = clones
+}
+
+// SetTmuxCommand sets the command + argv prefix for every tmux
+// invocation the manager issues. When nil/empty, the manager uses
+// ["tmux"] — preserving today's behavior.
+func (m *Manager) SetTmuxCommand(cmd []string) {
+	m.tmuxCmd = append([]string(nil), cmd...)
+}
+
+// tmuxExec builds an *exec.Cmd for a tmux invocation: the
+// configured prefix + extra args. Defaults to ["tmux"] when
+// unconfigured. Returning the *exec.Cmd directly (rather than a
+// []string that callers index) keeps the first-element access
+// inside this function where the branch structure makes it
+// statically safe — NilAway cannot prove safety through an indexed
+// slice return.
+func (m *Manager) tmuxExec(
+	ctx context.Context, extra ...string,
+) *exec.Cmd {
+	if len(m.tmuxCmd) == 0 {
+		return exec.CommandContext(ctx, "tmux", extra...)
+	}
+	args := make([]string, 0, len(m.tmuxCmd)-1+len(extra))
+	args = append(args, m.tmuxCmd[1:]...)
+	args = append(args, extra...)
+	return exec.CommandContext(ctx, m.tmuxCmd[0], args...)
 }
 
 // Create validates inputs, inserts a workspace row with status
@@ -154,7 +182,7 @@ func (m *Manager) Setup(
 		return fmt.Errorf("git worktree add: %w", err)
 	}
 
-	err = newTmuxSession(ctx, ws.TmuxSession, ws.WorktreePath)
+	err = m.newTmuxSession(ctx, ws.TmuxSession, ws.WorktreePath)
 	if err != nil {
 		m.rollbackWorktree(ctx, cloneDir, ws)
 		m.setError(ctx, ws.ID, err)
@@ -199,10 +227,7 @@ func (m *Manager) Delete(
 	}
 
 	// Kill tmux session (ignore errors -- session may not exist).
-	_ = runCmd(
-		ctx, "",
-		"tmux", "kill-session", "-t", ws.TmuxSession,
-	)
+	_ = m.killTmuxSession(ctx, ws.TmuxSession)
 
 	if m.clones == nil {
 		return nil, m.db.DeleteWorkspace(ctx, ws.ID)
@@ -263,31 +288,94 @@ func (m *Manager) ListSummaries(
 	return m.db.ListWorkspaceSummaries(ctx)
 }
 
-// EnsureTmux creates a tmux session if it does not already exist.
-func EnsureTmux(
+// EnsureTmux creates a tmux session if it does not already exist,
+// using the manager's configured tmux command prefix.
+func (m *Manager) EnsureTmux(
 	ctx context.Context, session, cwd string,
 ) error {
-	if TmuxSessionExists(ctx, session) {
+	exists, err := m.tmuxSessionExists(ctx, session)
+	if err != nil {
+		return fmt.Errorf("tmux has-session: %w", err)
+	}
+	if exists {
 		return nil
 	}
-	return newTmuxSession(ctx, session, cwd)
+	return m.newTmuxSession(ctx, session, cwd)
 }
 
-// newTmuxSession creates a detached tmux session that runs
-// the user's default login shell. Without an explicit shell
-// command, tmux uses its default-shell which may not source
-// the user's shell profile (.zshrc, .bashrc, etc.).
-func newTmuxSession(
+func (m *Manager) newTmuxSession(
 	ctx context.Context, session, cwd string,
 ) error {
 	shell := userLoginShell()
-	return runCmd(
-		ctx, "",
-		"tmux", "new-session", "-d",
+	cmd := m.tmuxExec(
+		ctx,
+		"new-session", "-d",
 		"-s", session,
 		"-c", cwd,
 		shell, "-l",
 	)
+	return runBuiltCmd(cmd)
+}
+
+// tmuxSessionExists runs `tmux has-session` and distinguishes a
+// genuine "session absent" signal from a wrapper/binary failure.
+// tmux reports session-absent by exiting 1 with one of two
+// well-known stderr messages:
+//
+//	can't find session: <name>
+//	no server running on <socket>
+//
+// Stdout and stderr are captured separately so a wrapper that
+// happens to emit those phrases on stdout for unrelated reasons
+// cannot masquerade as session-absent. Any other failure — missing
+// binary (non-ExitError), wrapper exit codes other than 1, or
+// exit-1 without the canonical stderr — propagates so
+// misconfiguration surfaces instead of silently falling through to
+// new-session through the same broken wrapper.
+func (m *Manager) tmuxSessionExists(
+	ctx context.Context, session string,
+) (bool, error) {
+	cmd := m.tmuxExec(ctx, "has-session", "-t", session)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	if isTmuxSessionAbsent(stderr.Bytes(), err) {
+		return false, nil
+	}
+	msg := strings.TrimSpace(stderr.String())
+	if msg == "" {
+		msg = strings.TrimSpace(stdout.String())
+	}
+	return false, fmt.Errorf("%w: %s", err, msg)
+}
+
+// isTmuxSessionAbsent reports whether a has-session failure is
+// tmux's documented "session does not exist" signal. Must be both
+// exit code 1 AND one of tmux's specific stderr phrases. Plain
+// exit 1 is a common generic wrapper/shell failure code, and
+// stdout content is not load-bearing — a wrapper could emit
+// anything there for unrelated reasons.
+func isTmuxSessionAbsent(stderr []byte, err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		return false
+	}
+	msg := string(stderr)
+	return strings.Contains(msg, "can't find session") ||
+		strings.Contains(msg, "no server running")
+}
+
+// killTmuxSession kills a tmux session via the manager's prefix.
+// Errors are returned rather than logged — callers decide whether
+// to ignore them (Delete ignores; tests assert).
+func (m *Manager) killTmuxSession(
+	ctx context.Context, session string,
+) error {
+	return runBuiltCmd(m.tmuxExec(ctx, "kill-session", "-t", session))
 }
 
 // userLoginShell resolves the current user's login shell from
@@ -340,17 +428,6 @@ func shellFromPasswdLine(line string) string {
 	return shell
 }
 
-// TmuxSessionExists checks whether a tmux session exists.
-func TmuxSessionExists(
-	ctx context.Context, session string,
-) bool {
-	err := runCmd(
-		ctx, "",
-		"tmux", "has-session", "-t", session,
-	)
-	return err == nil
-}
-
 // runGit executes a git command in dir and returns combined
 // output on error.
 func runGit(ctx context.Context, dir string, args ...string) error {
@@ -367,8 +444,23 @@ func runGit(ctx context.Context, dir string, args ...string) error {
 	return nil
 }
 
+// runBuiltCmd runs a pre-built exec.Cmd and wraps any failure with
+// the combined output. Used for tmux invocations whose *exec.Cmd is
+// assembled by tmuxExec so argv[0] access stays inside that helper.
+func runBuiltCmd(cmd *exec.Cmd) error {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf(
+			"%w: %s", err, strings.TrimSpace(string(out)),
+		)
+	}
+	return nil
+}
+
 // runCmd executes an arbitrary command. If dir is non-empty it
-// sets the working directory.
+// sets the working directory. Retained only for the package-level
+// tmux functions below, which exist so internal/terminal/handler.go
+// still compiles before Task 3 migrates it to the method form.
 func runCmd(
 	ctx context.Context, dir string, name string, args ...string,
 ) error {
@@ -383,6 +475,46 @@ func runCmd(
 		)
 	}
 	return nil
+}
+
+// EnsureTmux creates a tmux session if it does not already exist.
+// Package-level retained until Task 3 migrates terminal.Handler to
+// the method form; deleted at that point.
+func EnsureTmux(
+	ctx context.Context, session, cwd string,
+) error {
+	if TmuxSessionExists(ctx, session) {
+		return nil
+	}
+	return packageNewTmuxSession(ctx, session, cwd)
+}
+
+// TmuxSessionExists checks whether a tmux session exists.
+// Package-level retained until Task 3.
+func TmuxSessionExists(
+	ctx context.Context, session string,
+) bool {
+	err := runCmd(
+		ctx, "",
+		"tmux", "has-session", "-t", session,
+	)
+	return err == nil
+}
+
+// packageNewTmuxSession is the pre-refactor new-session exec
+// kept only for the package-level EnsureTmux above. Task 3 deletes
+// both along with the terminal-handler migration.
+func packageNewTmuxSession(
+	ctx context.Context, session, cwd string,
+) error {
+	shell := userLoginShell()
+	return runCmd(
+		ctx, "",
+		"tmux", "new-session", "-d",
+		"-s", session,
+		"-c", cwd,
+		shell, "-l",
+	)
 }
 
 // dirtyFiles returns the list of uncommitted files in a worktree.

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2,7 +2,10 @@ package workspace
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -263,4 +266,272 @@ func TestShellFromPasswdLine(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// writeRecorderScript creates an executable shell script at a
+// fresh path under t.TempDir() that appends the count and each
+// argument, NUL-delimited, to TMUX_RECORD. Returns the script path
+// and the record file path.
+func writeRecorderScript(t *testing.T) (scriptPath, recordPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	recordPath = filepath.Join(dir, "record")
+	scriptPath = filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", recordPath)
+	return scriptPath, recordPath
+}
+
+// readRecorderArgv reads the NUL-delimited record file and returns
+// each recorded invocation as a []string. Each invocation is stored
+// as "<argc>\0<arg0>\0<arg1>...\0", so this reads argc then slurps
+// that many args per invocation.
+func readRecorderArgv(t *testing.T, path string) [][]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	// Split on NUL. Each record is "<argc>\0<arg0>\0<arg1>\0...\0",
+	// so the flushed stream always ends with a trailing \0 and Split
+	// produces a final empty element after it. Strip exactly one
+	// trailing empty so we don't mistake it for part of the next
+	// record. Interior empty elements are real args (the NUL framing
+	// exists to preserve them) and must NOT be skipped.
+	parts := strings.Split(string(data), "\x00")
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	var out [][]string
+	for i := 0; i < len(parts); {
+		n, err := strconv.Atoi(parts[i])
+		require.NoError(t, err)
+		i++
+		argv := parts[i : i+n]
+		out = append(out, argv)
+		i += n
+	}
+	return out
+}
+
+func TestManagerEnsureTmuxHasSessionPrefix(t *testing.T) {
+	assert := Assert.New(t)
+
+	script, record := writeRecorderScript(t)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+
+	ctx := context.Background()
+
+	// Script exits 0 for every invocation, so EnsureTmux observes
+	// "session exists" after the has-session call and returns
+	// without running new-session.
+	require.NoError(t, mgr.EnsureTmux(ctx, "sess-A", t.TempDir()))
+
+	argvs := readRecorderArgv(t, record)
+	require.Len(t, argvs, 1)
+	assert.Equal(
+		[]string{"wrap", "has-session", "-t", "sess-A"},
+		argvs[0],
+	)
+}
+
+func TestManagerDeleteUsesTmuxPrefix(t *testing.T) {
+	assert := Assert.New(t)
+
+	script, record := writeRecorderScript(t)
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+
+	ctx := context.Background()
+	ws, err := mgr.Create(ctx, "github.com", "acme", "widget", 42)
+	require.NoError(t, err)
+
+	// force=true skips the dirty-files check. m.clones is nil, so
+	// Delete takes the clones==nil short-circuit after killing the
+	// tmux session — no git operations are required.
+	_, err = mgr.Delete(ctx, ws.ID, true)
+	require.NoError(t, err)
+
+	// Delete invokes exactly one tmux command on this path
+	// (kill-session). It ignores the exit code because the session
+	// may not exist, but our script exits 0 so the invocation is
+	// still recorded.
+	argvs := readRecorderArgv(t, record)
+	require.Len(t, argvs, 1)
+	assert.Equal(
+		[]string{"wrap", "kill-session", "-t", ws.TmuxSession},
+		argvs[0],
+	)
+}
+
+func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
+	assert := Assert.New(t)
+
+	// Script: "has-session" emits tmux's canonical "can't find
+	// session" stderr and exits 1 (so isTmuxSessionAbsent classifies
+	// it as session-missing rather than wrapper failure); everything
+	// else succeeds, so EnsureTmux calls newTmuxSession.
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then` + "\n" +
+		`    echo "can't find session: sim" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+
+	ctx := context.Background()
+	require.NoError(t, mgr.EnsureTmux(ctx, "sess-B", "/tmp/cwd"))
+
+	argvs := readRecorderArgv(t, record)
+	require.Len(t, argvs, 2)
+	assert.Equal(
+		[]string{"has-session", "-t", "sess-B"},
+		argvs[0],
+	)
+	// new-session argv: "new-session -d -s sess-B -c /tmp/cwd <shell> -l"
+	// We check the prefix up to the shell; the shell resolves per
+	// runtime so just assert it is non-empty and ends with "-l".
+	require.GreaterOrEqual(t, len(argvs[1]), 8)
+	assert.Equal("new-session", argvs[1][0])
+	assert.Equal("-d", argvs[1][1])
+	assert.Equal("-s", argvs[1][2])
+	assert.Equal("sess-B", argvs[1][3])
+	assert.Equal("-c", argvs[1][4])
+	assert.Equal("/tmp/cwd", argvs[1][5])
+	assert.NotEmpty(argvs[1][6])
+	assert.Equal("-l", argvs[1][7])
+}
+
+// TestReadRecorderArgvPreservesEmptyArgs pins down the parser's
+// empty-arg handling. The NUL-delimited record format was chosen to
+// round-trip argv with empty-string elements unambiguously; the
+// parser must keep interior and trailing empties rather than
+// collapsing them.
+func TestReadRecorderArgvPreservesEmptyArgs(t *testing.T) {
+	assert := Assert.New(t)
+	path := filepath.Join(t.TempDir(), "record")
+
+	// First record: 3 args with an interior empty ("a", "", "b").
+	// Second record: 2 args with a trailing empty ("x", "").
+	body := "3\x00a\x00\x00b\x00" + "2\x00x\x00\x00"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+
+	argvs := readRecorderArgv(t, path)
+	require.Len(t, argvs, 2)
+	assert.Equal([]string{"a", "", "b"}, argvs[0])
+	assert.Equal([]string{"x", ""}, argvs[1])
+}
+
+// TestManagerEnsureTmuxPropagatesBinaryError verifies that a wrapper
+// misconfiguration (binary not on disk) surfaces as an error rather
+// than being silently conflated with "session does not exist, please
+// create one." The previous boolean-only tmuxSessionExists swallowed
+// this case — EnsureTmux would proceed to run new-session with the
+// same broken wrapper and the error would only surface on the second
+// exec, masking the real cause.
+func TestManagerEnsureTmuxPropagatesBinaryError(t *testing.T) {
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	// Path that cannot possibly exist — exec returns a non-exit
+	// error (ENOENT), not an *exec.ExitError.
+	mgr.SetTmuxCommand(
+		[]string{filepath.Join(t.TempDir(), "does-not-exist")},
+	)
+
+	err := mgr.EnsureTmux(context.Background(), "sess-X", "/tmp")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tmux has-session")
+}
+
+// TestManagerEnsureTmuxPropagatesNon1ExitCode pins down the
+// exit-code-1 carve-out in tmuxSessionExists. tmux's has-session
+// exits 1 specifically when the session is not found; wrappers that
+// fail for their own reasons typically exit with other codes (127
+// "command not found", 203 "exec failed", etc.). A wrapper exiting
+// with a non-1 code used to be silently treated as "session absent"
+// because the old check matched any *exec.ExitError. Now it must
+// propagate to the caller so misconfiguration surfaces cleanly.
+func TestManagerEnsureTmuxPropagatesNon1ExitCode(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-tmux")
+	// exit 127 mimics "command not found" — a common wrapper failure
+	// signal that is NOT tmux's own "session missing" response.
+	body := "#!/bin/sh\nexit 127\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+
+	err := mgr.EnsureTmux(context.Background(), "sess-Y", "/tmp")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tmux has-session")
+}
+
+// TestManagerEnsureTmuxPropagatesExit1NonTmuxError covers the
+// second half of the session-absent heuristic: exit code 1 alone is
+// not enough, the output must match tmux's canonical "session
+// missing" phrases too. Many real wrappers and shell scripts use
+// exit 1 as a generic failure signal — treating that as "session
+// absent" would mask the wrapper bug by immediately trying
+// new-session through the same broken wrapper.
+func TestManagerEnsureTmuxPropagatesExit1NonTmuxError(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\necho 'wrapper blew up' >&2\nexit 1\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+
+	err := mgr.EnsureTmux(context.Background(), "sess-Q", "/tmp")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tmux has-session")
+	require.Contains(t, err.Error(), "wrapper blew up")
+}
+
+// TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout pins down the
+// stdout vs. stderr distinction. A wrapper that exits 1 with the
+// tmux phrase on stdout (e.g. one that mirrors stderr to stdout for
+// logging, or a script that coincidentally prints the phrase for
+// unrelated reasons) must NOT be treated as session-absent — only
+// stderr carries the authoritative tmux signal.
+func TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`echo "can't find session: sim"` + "\n" + // stdout only
+		`echo "real failure" >&2` + "\n" +
+		"exit 1\n"
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+
+	err := mgr.EnsureTmux(context.Background(), "sess-R", "/tmp")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tmux has-session")
+	require.Contains(t, err.Error(), "real failure")
 }


### PR DESCRIPTION
## Summary

- New optional `[tmux] command = [...]` TOML section. Operators can prefix every `tmux` invocation middleman makes with a configured argv (e.g. `["systemd-run", "--user", "--scope", "tmux"]`) so the tmux session runs under different permissions than a hardened middleman systemd service.
- Threaded through all four call sites: `new-session` (workspace create), `has-session` + `new-session` (terminal ensure), `attach-session` (terminal WebSocket), `kill-session` (workspace delete).
- Default behavior is bit-for-bit identical when `[tmux]` is unset — `Config.TmuxCommand()` returns `["tmux"]` for nil cfg and for cfg without a `[tmux]` section.
- Save round-trip: `(*Config).Save` now preserves `[tmux]` so settings-UI actions (`PUT /settings`, `POST /repos`, `DELETE /repos`) don't silently strip operator config.
- Full-stack e2e tests drive real HTTP + WebSocket against `httptest.NewServer` with a recording-script fake-tmux, asserting the prefix reaches all three user-visible verbs.

## Test plan

- [ ] `make test` — full suite passes
- [ ] `nix run nixpkgs#go -- test ./internal/server -run TestTmuxWrapper -shuffle=on -count=5` — new e2e tests stable
- [ ] Manual: set `command = ["systemd-run", "--user", "--scope", "tmux"]`, create a workspace, confirm the tmux server lives in its own transient scope via `systemctl --user list-units --type=scope`