### PR TITLE
Fix workflow approval detection for fork PRs and add tooltips

### DIFF
--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -1,0 +1,42 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../packages/ui/src/context.js", () => ({
+  getClient: () => ({ POST: vi.fn() }),
+  getStores: () => ({
+    detail: { loadDetail: vi.fn() },
+    pulls: { loadPulls: vi.fn() },
+  }),
+}));
+
+import ApproveButton from "../../packages/ui/src/components/detail/ApproveButton.svelte";
+
+describe("ApproveButton tooltips", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("collapsed button title describes opening the form, not submitting", () => {
+    render(ApproveButton, {
+      props: { owner: "acme", name: "widget", number: 1 },
+    });
+
+    const trigger = screen.getByRole("button", { name: /approve/i });
+    expect(trigger.getAttribute("title")).toBe(
+      "Open the approval form to submit a code review on this pull request",
+    );
+  });
+
+  it("expanded submit button carries the actual submit-review tooltip", async () => {
+    render(ApproveButton, {
+      props: { owner: "acme", name: "widget", number: 1 },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+
+    const submit = screen.getByRole("button", { name: /^approve$/i });
+    expect(submit.getAttribute("title")).toBe(
+      "Submit an approving code review on this pull request",
+    );
+  });
+});

--- a/internal/github/workflow_approval.go
+++ b/internal/github/workflow_approval.go
@@ -1,6 +1,11 @@
 package github
 
-import gh "github.com/google/go-github/v84/github"
+import (
+	"regexp"
+	"strings"
+
+	gh "github.com/google/go-github/v84/github"
+)
 
 // WorkflowApprovalState describes whether workflow approval is needed for a PR.
 type WorkflowApprovalState struct {
@@ -10,24 +15,38 @@ type WorkflowApprovalState struct {
 	RunIDs   []int64
 }
 
-// FilterWorkflowRunsAwaitingApproval narrows action-required workflow runs down
-// to those that target the given PR. An empty run.PullRequests array is
-// treated as "association unavailable" rather than "not this PR": GitHub
-// returns an empty array for fork-triggered runs, which is precisely when
-// workflow approval is required. When the array is populated, the PR number
-// must match so we don't mis-attribute runs across two PRs that happen to
-// share a head SHA.
+// PRSource identifies a pull request's head for matching workflow runs.
+// HeadSHA is required. HeadRepoFullName ("owner/repo") and HeadRef (branch
+// name) are required to disambiguate fork-triggered runs whose pull_requests
+// array is empty; without them the filter fails closed.
+type PRSource struct {
+	Number           int
+	HeadSHA          string
+	HeadRepoFullName string
+	HeadRef          string
+}
+
+// FilterWorkflowRunsAwaitingApproval narrows action-required workflow runs to
+// those that target the given PR.
+//
+// Matching rules:
+//   - Run must be at PRSource.HeadSHA.
+//   - If the run's pull_requests array is populated (same-repo PRs), it must
+//     contain PRSource.Number.
+//   - If pull_requests is empty (fork-triggered runs), the run's head
+//     repository full name and head branch must match PRSource. Two distinct
+//     fork PRs can share a head SHA, so head SHA alone is unsafe in the
+//     approval path. If HeadRepoFullName or HeadRef is empty we fail closed.
 func FilterWorkflowRunsAwaitingApproval(
 	runs []*gh.WorkflowRun,
-	number int,
-	headSHA string,
+	pr PRSource,
 ) []*gh.WorkflowRun {
 	var filtered []*gh.WorkflowRun
 	for _, run := range runs {
-		if run.GetHeadSHA() != headSHA {
+		if run.GetHeadSHA() != pr.HeadSHA {
 			continue
 		}
-		if !workflowRunMayTargetPR(run, number) {
+		if !workflowRunMatchesPR(run, pr) {
 			continue
 		}
 		filtered = append(filtered, run)
@@ -35,16 +54,25 @@ func FilterWorkflowRunsAwaitingApproval(
 	return filtered
 }
 
-func workflowRunMayTargetPR(run *gh.WorkflowRun, number int) bool {
-	if len(run.PullRequests) == 0 {
-		return true
-	}
-	for _, pr := range run.PullRequests {
-		if pr.GetNumber() == number {
-			return true
+func workflowRunMatchesPR(run *gh.WorkflowRun, pr PRSource) bool {
+	if len(run.PullRequests) > 0 {
+		for _, runPR := range run.PullRequests {
+			if runPR.GetNumber() == pr.Number {
+				return true
+			}
 		}
+		return false
 	}
-	return false
+	if pr.HeadRepoFullName == "" || pr.HeadRef == "" {
+		return false
+	}
+	if run.GetHeadRepository().GetFullName() != pr.HeadRepoFullName {
+		return false
+	}
+	if run.GetHeadBranch() != pr.HeadRef {
+		return false
+	}
+	return true
 }
 
 // WorkflowApprovalStateFromRuns converts matched workflow runs into state.
@@ -56,4 +84,22 @@ func WorkflowApprovalStateFromRuns(runs []*gh.WorkflowRun) WorkflowApprovalState
 	state.Count = len(state.RunIDs)
 	state.Required = state.Count > 0
 	return state
+}
+
+var cloneURLPattern = regexp.MustCompile(`[/:]([\w.-]+)/([\w.-]+?)(?:\.git)?/?$`)
+
+// ParseHeadRepoFullName extracts "owner/repo" from a GitHub clone URL.
+// Accepts both HTTPS (https://host/owner/repo[.git]) and SSH
+// (git@host:owner/repo[.git]) forms. Returns empty string if the URL does
+// not match a recognized form.
+func ParseHeadRepoFullName(cloneURL string) string {
+	cloneURL = strings.TrimSpace(cloneURL)
+	if cloneURL == "" {
+		return ""
+	}
+	m := cloneURLPattern.FindStringSubmatch(cloneURL)
+	if len(m) != 3 {
+		return ""
+	}
+	return m[1] + "/" + m[2]
 }

--- a/internal/github/workflow_approval.go
+++ b/internal/github/workflow_approval.go
@@ -11,11 +11,15 @@ type WorkflowApprovalState struct {
 }
 
 // FilterWorkflowRunsAwaitingApproval narrows action-required workflow runs down
-// to those at the given PR head SHA. The run.PullRequests association is not
-// checked because GitHub returns an empty pull_requests array for fork-based
-// PRs — which is precisely when workflow approval is required.
+// to those that target the given PR. An empty run.PullRequests array is
+// treated as "association unavailable" rather than "not this PR": GitHub
+// returns an empty array for fork-triggered runs, which is precisely when
+// workflow approval is required. When the array is populated, the PR number
+// must match so we don't mis-attribute runs across two PRs that happen to
+// share a head SHA.
 func FilterWorkflowRunsAwaitingApproval(
 	runs []*gh.WorkflowRun,
+	number int,
 	headSHA string,
 ) []*gh.WorkflowRun {
 	var filtered []*gh.WorkflowRun
@@ -23,9 +27,24 @@ func FilterWorkflowRunsAwaitingApproval(
 		if run.GetHeadSHA() != headSHA {
 			continue
 		}
+		if !workflowRunMayTargetPR(run, number) {
+			continue
+		}
 		filtered = append(filtered, run)
 	}
 	return filtered
+}
+
+func workflowRunMayTargetPR(run *gh.WorkflowRun, number int) bool {
+	if len(run.PullRequests) == 0 {
+		return true
+	}
+	for _, pr := range run.PullRequests {
+		if pr.GetNumber() == number {
+			return true
+		}
+	}
+	return false
 }
 
 // WorkflowApprovalStateFromRuns converts matched workflow runs into state.

--- a/internal/github/workflow_approval.go
+++ b/internal/github/workflow_approval.go
@@ -11,18 +11,16 @@ type WorkflowApprovalState struct {
 }
 
 // FilterWorkflowRunsAwaitingApproval narrows action-required workflow runs down
-// to those that target the given PR number and head SHA.
+// to those at the given PR head SHA. The run.PullRequests association is not
+// checked because GitHub returns an empty pull_requests array for fork-based
+// PRs — which is precisely when workflow approval is required.
 func FilterWorkflowRunsAwaitingApproval(
 	runs []*gh.WorkflowRun,
-	number int,
 	headSHA string,
 ) []*gh.WorkflowRun {
 	var filtered []*gh.WorkflowRun
 	for _, run := range runs {
 		if run.GetHeadSHA() != headSHA {
-			continue
-		}
-		if !workflowRunTargetsPR(run, number) {
 			continue
 		}
 		filtered = append(filtered, run)
@@ -39,16 +37,4 @@ func WorkflowApprovalStateFromRuns(runs []*gh.WorkflowRun) WorkflowApprovalState
 	state.Count = len(state.RunIDs)
 	state.Required = state.Count > 0
 	return state
-}
-
-func workflowRunTargetsPR(run *gh.WorkflowRun, number int) bool {
-	if len(run.PullRequests) == 0 {
-		return false
-	}
-	for _, pr := range run.PullRequests {
-		if pr.GetNumber() == number {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/github/workflow_approval_test.go
+++ b/internal/github/workflow_approval_test.go
@@ -11,14 +11,17 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 	tests := []struct {
 		name    string
 		runs    []*gh.WorkflowRun
-		number  int
-		headSHA string
+		pr      PRSource
 		wantIDs []int64
 	}{
 		{
-			name:    "matches pull request event head sha and number",
-			number:  42,
-			headSHA: "abc123",
+			name: "matches pull request event head sha and number",
+			pr: PRSource{
+				Number:           42,
+				HeadSHA:          "abc123",
+				HeadRepoFullName: "acme/widget",
+				HeadRef:          "feature",
+			},
 			runs: []*gh.WorkflowRun{
 				{
 					ID:           new(int64(101)),
@@ -35,28 +38,40 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 			wantIDs: []int64{101},
 		},
 		{
-			name:    "includes fork PR runs with empty PullRequests",
-			number:  7,
-			headSHA: "abc123",
+			name: "includes fork PR runs with empty PullRequests when head repo and ref match",
+			pr: PRSource{
+				Number:           7,
+				HeadSHA:          "abc123",
+				HeadRepoFullName: "fork/widget",
+				HeadRef:          "feature",
+			},
 			runs: []*gh.WorkflowRun{
 				{
-					ID:      new(int64(201)),
-					HeadSHA: new("abc123"),
-					Event:   new("pull_request"),
+					ID:             new(int64(201)),
+					HeadSHA:        new("abc123"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("fork/widget")},
 				},
 				{
-					ID:           new(int64(202)),
-					HeadSHA:      new("abc123"),
-					Event:        new("pull_request"),
-					PullRequests: []*gh.PullRequest{},
+					ID:             new(int64(202)),
+					HeadSHA:        new("abc123"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("fork/widget")},
+					PullRequests:   []*gh.PullRequest{},
 				},
 			},
 			wantIDs: []int64{201, 202},
 		},
 		{
-			name:    "rejects populated PullRequests pointing at another PR at same SHA",
-			number:  42,
-			headSHA: "abc123",
+			name: "rejects populated PullRequests pointing at another PR at same SHA",
+			pr: PRSource{
+				Number:           42,
+				HeadSHA:          "abc123",
+				HeadRepoFullName: "acme/widget",
+				HeadRef:          "feature",
+			},
 			runs: []*gh.WorkflowRun{
 				{
 					ID:           new(int64(301)),
@@ -73,16 +88,100 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 			},
 			wantIDs: []int64{301},
 		},
+		{
+			name: "rejects fork PR run from a different fork at same head SHA",
+			pr: PRSource{
+				Number:           7,
+				HeadSHA:          "abc123",
+				HeadRepoFullName: "alice/widget",
+				HeadRef:          "feature",
+			},
+			runs: []*gh.WorkflowRun{
+				{
+					ID:             new(int64(401)),
+					HeadSHA:        new("abc123"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("alice/widget")},
+				},
+				{
+					ID:             new(int64(402)),
+					HeadSHA:        new("abc123"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("bob/widget")},
+				},
+			},
+			wantIDs: []int64{401},
+		},
+		{
+			name: "rejects fork PR run from same fork but different branch at same SHA",
+			pr: PRSource{
+				Number:           7,
+				HeadSHA:          "abc123",
+				HeadRepoFullName: "alice/widget",
+				HeadRef:          "feature",
+			},
+			runs: []*gh.WorkflowRun{
+				{
+					ID:             new(int64(501)),
+					HeadSHA:        new("abc123"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("other-branch"),
+					HeadRepository: &gh.Repository{FullName: new("alice/widget")},
+				},
+			},
+			wantIDs: []int64{},
+		},
+		{
+			name: "fails closed when head repo full name unknown and PullRequests empty",
+			pr: PRSource{
+				Number:           7,
+				HeadSHA:          "abc123",
+				HeadRepoFullName: "",
+				HeadRef:          "feature",
+			},
+			runs: []*gh.WorkflowRun{
+				{
+					ID:             new(int64(601)),
+					HeadSHA:        new("abc123"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("fork/widget")},
+				},
+			},
+			wantIDs: []int64{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FilterWorkflowRunsAwaitingApproval(tt.runs, tt.number, tt.headSHA)
+			got := FilterWorkflowRunsAwaitingApproval(tt.runs, tt.pr)
 			gotIDs := make([]int64, 0, len(got))
 			for _, run := range got {
 				gotIDs = append(gotIDs, run.GetID())
 			}
 			Assert.Equal(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestParseHeadRepoFullName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "https with .git", in: "https://github.com/cwensel/roborev.git", want: "cwensel/roborev"},
+		{name: "https without .git", in: "https://github.com/cwensel/roborev", want: "cwensel/roborev"},
+		{name: "ssh form", in: "git@github.com:cwensel/roborev.git", want: "cwensel/roborev"},
+		{name: "trailing slash", in: "https://github.com/cwensel/roborev/", want: "cwensel/roborev"},
+		{name: "empty", in: "", want: ""},
+		{name: "garbage", in: "not-a-url", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Assert.Equal(t, tt.want, ParseHeadRepoFullName(tt.in))
 		})
 	}
 }

--- a/internal/github/workflow_approval_test.go
+++ b/internal/github/workflow_approval_test.go
@@ -11,13 +11,11 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 	tests := []struct {
 		name    string
 		runs    []*gh.WorkflowRun
-		number  int
 		headSHA string
 		wantIDs []int64
 	}{
 		{
-			name:    "matches pull request event head sha and number",
-			number:  42,
+			name:    "matches runs at head sha",
 			headSHA: "abc123",
 			runs: []*gh.WorkflowRun{
 				{
@@ -27,29 +25,15 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 					PullRequests: []*gh.PullRequest{{Number: new(42)}},
 				},
 				{
-					ID:           new(int64(102)),
-					HeadSHA:      new("abc123"),
-					Event:        new("push"),
-					PullRequests: []*gh.PullRequest{{Number: new(42)}},
-				},
-				{
-					ID:           new(int64(103)),
-					HeadSHA:      new("def456"),
-					Event:        new("pull_request"),
-					PullRequests: []*gh.PullRequest{{Number: new(42)}},
-				},
-				{
-					ID:           new(int64(104)),
-					HeadSHA:      new("abc123"),
-					Event:        new("pull_request"),
-					PullRequests: []*gh.PullRequest{{Number: new(99)}},
+					ID:      new(int64(103)),
+					HeadSHA: new("def456"),
+					Event:   new("pull_request"),
 				},
 			},
-			wantIDs: []int64{101, 102},
+			wantIDs: []int64{101},
 		},
 		{
-			name:    "ignores runs without pull request association",
-			number:  7,
+			name:    "includes fork PR runs with empty PullRequests",
 			headSHA: "abc123",
 			runs: []*gh.WorkflowRun{
 				{
@@ -64,13 +48,13 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 					PullRequests: []*gh.PullRequest{},
 				},
 			},
-			wantIDs: []int64{},
+			wantIDs: []int64{201, 202},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FilterWorkflowRunsAwaitingApproval(tt.runs, tt.number, tt.headSHA)
+			got := FilterWorkflowRunsAwaitingApproval(tt.runs, tt.headSHA)
 			gotIDs := make([]int64, 0, len(got))
 			for _, run := range got {
 				gotIDs = append(gotIDs, run.GetID())

--- a/internal/github/workflow_approval_test.go
+++ b/internal/github/workflow_approval_test.go
@@ -11,11 +11,13 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 	tests := []struct {
 		name    string
 		runs    []*gh.WorkflowRun
+		number  int
 		headSHA string
 		wantIDs []int64
 	}{
 		{
-			name:    "matches runs at head sha",
+			name:    "matches pull request event head sha and number",
+			number:  42,
 			headSHA: "abc123",
 			runs: []*gh.WorkflowRun{
 				{
@@ -34,6 +36,7 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 		},
 		{
 			name:    "includes fork PR runs with empty PullRequests",
+			number:  7,
 			headSHA: "abc123",
 			runs: []*gh.WorkflowRun{
 				{
@@ -50,11 +53,31 @@ func TestFilterWorkflowRunsAwaitingApproval(t *testing.T) {
 			},
 			wantIDs: []int64{201, 202},
 		},
+		{
+			name:    "rejects populated PullRequests pointing at another PR at same SHA",
+			number:  42,
+			headSHA: "abc123",
+			runs: []*gh.WorkflowRun{
+				{
+					ID:           new(int64(301)),
+					HeadSHA:      new("abc123"),
+					Event:        new("pull_request"),
+					PullRequests: []*gh.PullRequest{{Number: new(42)}},
+				},
+				{
+					ID:           new(int64(302)),
+					HeadSHA:      new("abc123"),
+					Event:        new("pull_request"),
+					PullRequests: []*gh.PullRequest{{Number: new(99)}},
+				},
+			},
+			wantIDs: []int64{301},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FilterWorkflowRunsAwaitingApproval(tt.runs, tt.headSHA)
+			got := FilterWorkflowRunsAwaitingApproval(tt.runs, tt.number, tt.headSHA)
 			gotIDs := make([]int64, 0, len(got))
 			for _, run := range got {
 				gotIDs = append(gotIDs, run.GetID())

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1107,6 +1107,7 @@ func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
 			state := "open"
 			title := "Fork PR"
 			url := "https://github.com/acme/widget/pull/1"
+			cloneURL := "https://github.com/fork/widget.git"
 			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
 			createdAt := gh.Timestamp{Time: time.Now().UTC()}
 			return &gh.PullRequest{
@@ -1117,18 +1118,24 @@ func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
 				HTMLURL:   &url,
 				UpdatedAt: &updatedAt,
 				CreatedAt: &createdAt,
-				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
-				Base:      &gh.PullRequestBranch{Ref: new("main")},
+				Head: &gh.PullRequestBranch{
+					SHA:  &sha,
+					Ref:  new("feature"),
+					Repo: &gh.Repository{CloneURL: &cloneURL, FullName: new("fork/widget")},
+				},
+				Base: &gh.PullRequestBranch{Ref: new("main")},
 			}, nil
 		},
 		listWorkflowRunsForHeadFn: func(_ context.Context, _, _, headSHA string) ([]*gh.WorkflowRun, error) {
 			require.Equal("forkhead", headSHA)
 			return []*gh.WorkflowRun{
 				{
-					ID:           new(int64(55)),
-					HeadSHA:      new("forkhead"),
-					Event:        new("pull_request"),
-					PullRequests: []*gh.PullRequest{},
+					ID:             new(int64(55)),
+					HeadSHA:        new("forkhead"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("fork/widget")},
+					PullRequests:   []*gh.PullRequest{},
 				},
 			}, nil
 		},
@@ -1150,9 +1157,9 @@ func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
 	assert.Equal(int64(1), resp.JSON200.WorkflowApproval.Count)
 }
 
-// TestAPIApproveWorkflowsForForkPR verifies the approve endpoint also ignores
-// the pull_requests association, so a user clicking the button on a fork PR
-// actually reaches the underlying ApproveWorkflowRun call.
+// TestAPIApproveWorkflowsForForkPR verifies the approve endpoint reaches
+// ApproveWorkflowRun for a fork-triggered run when the run's head repo and
+// branch match the PR.
 func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -1164,6 +1171,7 @@ func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 			state := "open"
 			title := "Fork PR"
 			url := "https://github.com/acme/widget/pull/1"
+			cloneURL := "https://github.com/fork/widget.git"
 			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
 			createdAt := gh.Timestamp{Time: time.Now().UTC()}
 			return &gh.PullRequest{
@@ -1174,17 +1182,23 @@ func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 				HTMLURL:   &url,
 				UpdatedAt: &updatedAt,
 				CreatedAt: &createdAt,
-				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
-				Base:      &gh.PullRequestBranch{Ref: new("main")},
+				Head: &gh.PullRequestBranch{
+					SHA:  &sha,
+					Ref:  new("feature"),
+					Repo: &gh.Repository{CloneURL: &cloneURL, FullName: new("fork/widget")},
+				},
+				Base: &gh.PullRequestBranch{Ref: new("main")},
 			}, nil
 		},
 		listWorkflowRunsForHeadFn: func(_ context.Context, _, _, headSHA string) ([]*gh.WorkflowRun, error) {
 			require.Equal("forkhead", headSHA)
 			return []*gh.WorkflowRun{
 				{
-					ID:      new(int64(71)),
-					HeadSHA: new("forkhead"),
-					Event:   new("pull_request"),
+					ID:             new(int64(71)),
+					HeadSHA:        new("forkhead"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("fork/widget")},
 				},
 			}, nil
 		},
@@ -1331,6 +1345,71 @@ func TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA(t *testing.T) {
 	require.NotNil(resp.JSON200.ApprovedCount)
 	assert.EqualValues(1, *resp.JSON200.ApprovedCount)
 	assert.Equal([]int64{89}, approvedRunIDs)
+}
+
+// TestAPIApproveWorkflowsRejectsRunFromDifferentForkAtSameSHA exercises the
+// safety guarantee that two distinct forks sharing a head SHA do not
+// cross-approve. The PR's head repo is alice/widget; the run's head repo is
+// bob/widget. ApproveWorkflowRun must not be called.
+func TestAPIApproveWorkflowsRejectsRunFromDifferentForkAtSameSHA(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	approvedRunIDs := []int64{}
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(4001)
+			sha := "sharedsha"
+			state := "open"
+			title := "Alice Fork PR"
+			url := "https://github.com/acme/widget/pull/1"
+			cloneURL := "https://github.com/alice/widget.git"
+			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
+			createdAt := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Head: &gh.PullRequestBranch{
+					SHA:  &sha,
+					Ref:  new("feature"),
+					Repo: &gh.Repository{CloneURL: &cloneURL, FullName: new("alice/widget")},
+				},
+				Base: &gh.PullRequestBranch{Ref: new("main")},
+			}, nil
+		},
+		listWorkflowRunsForHeadFn: func(_ context.Context, _, _, headSHA string) ([]*gh.WorkflowRun, error) {
+			require.Equal("sharedsha", headSHA)
+			return []*gh.WorkflowRun{
+				{
+					ID:             new(int64(123)),
+					HeadSHA:        new("sharedsha"),
+					Event:          new("pull_request"),
+					HeadBranch:     new("feature"),
+					HeadRepository: &gh.Repository{FullName: new("bob/widget")},
+				},
+			}, nil
+		},
+		approveWorkflowRunFn: func(_ context.Context, _, _ string, runID int64) error {
+			approvedRunIDs = append(approvedRunIDs, runID)
+			return nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	assert.Empty(approvedRunIDs)
 }
 
 func TestAPIGetPullNotFound(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1093,6 +1093,123 @@ func TestAPIApproveWorkflowsReturnsUnderlyingApprovalErrorAfterPartialFailure(t 
 	assert.Equal("abc123", pr.PlatformHeadSHA)
 }
 
+// TestAPISyncPRIncludesWorkflowApprovalForForkPR covers the regression where
+// runs from fork-based PRs have an empty pull_requests array in GitHub's API.
+// The sync path must still flag workflow approval as required, otherwise the
+// UI never shows the approve button for the exact case it was built for.
+func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(2001)
+			sha := "forkhead"
+			state := "open"
+			title := "Fork PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
+			createdAt := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{Ref: new("main")},
+			}, nil
+		},
+		listWorkflowRunsForHeadFn: func(_ context.Context, _, _, headSHA string) ([]*gh.WorkflowRun, error) {
+			require.Equal("forkhead", headSHA)
+			return []*gh.WorkflowRun{
+				{
+					ID:           new(int64(55)),
+					HeadSHA:      new("forkhead"),
+					Event:        new("pull_request"),
+					PullRequests: []*gh.PullRequest{},
+				},
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.WorkflowApproval)
+	assert.True(resp.JSON200.WorkflowApproval.Checked)
+	assert.True(resp.JSON200.WorkflowApproval.Required)
+	assert.Equal(int64(1), resp.JSON200.WorkflowApproval.Count)
+}
+
+// TestAPIApproveWorkflowsForForkPR verifies the approve endpoint also ignores
+// the pull_requests association, so a user clicking the button on a fork PR
+// actually reaches the underlying ApproveWorkflowRun call.
+func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	approvedRunIDs := []int64{}
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(2002)
+			sha := "forkhead"
+			state := "open"
+			title := "Fork PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
+			createdAt := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{Ref: new("main")},
+			}, nil
+		},
+		listWorkflowRunsForHeadFn: func(_ context.Context, _, _, headSHA string) ([]*gh.WorkflowRun, error) {
+			require.Equal("forkhead", headSHA)
+			return []*gh.WorkflowRun{
+				{
+					ID:      new(int64(71)),
+					HeadSHA: new("forkhead"),
+					Event:   new("pull_request"),
+				},
+			}, nil
+		},
+		approveWorkflowRunFn: func(_ context.Context, _, _ string, runID int64) error {
+			approvedRunIDs = append(approvedRunIDs, runID)
+			return nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.ApprovedCount)
+	assert.Equal("approved_workflows", resp.JSON200.Status)
+	assert.EqualValues(1, *resp.JSON200.ApprovedCount)
+	assert.Equal([]int64{71}, approvedRunIDs)
+}
+
 func TestAPIGetPullNotFound(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	client := setupTestClient(t, srv)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1210,6 +1210,129 @@ func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 	assert.Equal([]int64{71}, approvedRunIDs)
 }
 
+// TestAPISyncPRIgnoresWorkflowRunsForOtherPRAtSameSHA covers the regression
+// where two PRs share a head SHA and a populated pull_requests association
+// points at the other PR. The sync path must not flag workflow approval as
+// required for the wrong PR.
+func TestAPISyncPRIgnoresWorkflowRunsForOtherPRAtSameSHA(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(3001)
+			sha := "sharedsha"
+			state := "open"
+			title := "Shared SHA PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
+			createdAt := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{Ref: new("main")},
+			}, nil
+		},
+		listWorkflowRunsForHeadFn: func(_ context.Context, _, _, headSHA string) ([]*gh.WorkflowRun, error) {
+			require.Equal("sharedsha", headSHA)
+			return []*gh.WorkflowRun{
+				{
+					ID:           new(int64(88)),
+					HeadSHA:      new("sharedsha"),
+					Event:        new("pull_request"),
+					PullRequests: []*gh.PullRequest{{Number: new(99)}},
+				},
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.WorkflowApproval)
+	assert.True(resp.JSON200.WorkflowApproval.Checked)
+	assert.False(resp.JSON200.WorkflowApproval.Required)
+	assert.Equal(int64(0), resp.JSON200.WorkflowApproval.Count)
+}
+
+// TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA verifies the approve
+// endpoint does not call ApproveWorkflowRun for runs whose pull_requests
+// association points at a different PR sharing the same head SHA.
+func TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	approvedRunIDs := []int64{}
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(3002)
+			sha := "sharedsha"
+			state := "open"
+			title := "Shared SHA PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
+			createdAt := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{Ref: new("main")},
+			}, nil
+		},
+		listWorkflowRunsForHeadFn: func(_ context.Context, _, _, headSHA string) ([]*gh.WorkflowRun, error) {
+			require.Equal("sharedsha", headSHA)
+			return []*gh.WorkflowRun{
+				{
+					ID:           new(int64(88)),
+					HeadSHA:      new("sharedsha"),
+					Event:        new("pull_request"),
+					PullRequests: []*gh.PullRequest{{Number: new(99)}},
+				},
+				{
+					ID:           new(int64(89)),
+					HeadSHA:      new("sharedsha"),
+					Event:        new("pull_request"),
+					PullRequests: []*gh.PullRequest{{Number: new(1)}},
+				},
+			}, nil
+		},
+		approveWorkflowRunFn: func(_ context.Context, _, _ string, runID int64) error {
+			approvedRunIDs = append(approvedRunIDs, runID)
+			return nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
+		context.Background(), "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.ApprovedCount)
+	assert.EqualValues(1, *resp.JSON200.ApprovedCount)
+	assert.Equal([]int64{89}, approvedRunIDs)
+}
+
 func TestAPIGetPullNotFound(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	client := setupTestClient(t, srv)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -631,7 +631,7 @@ func (s *Server) workflowApprovalState(
 	}
 
 	state := ghclient.WorkflowApprovalStateFromRuns(
-		ghclient.FilterWorkflowRunsAwaitingApproval(runs, headSHA),
+		ghclient.FilterWorkflowRunsAwaitingApproval(runs, mr.Number, headSHA),
 	)
 	return workflowApprovalResponse{
 		Checked:  state.Checked,
@@ -1051,7 +1051,7 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 	if err != nil {
 		return nil, huma.Error502BadGateway("GitHub API error")
 	}
-	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, headSHA)
+	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, input.Number, headSHA)
 
 	approvedCount := 0
 	for _, run := range pending {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -608,7 +608,7 @@ func (s *Server) workflowApprovalState(
 		return workflowApprovalResponse{}
 	}
 
-	var currentState, headSHA string
+	var currentState, headSHA, headRepoFullName, headRef string
 	if mode == workflowFull {
 		pr, prErr := client.GetPullRequest(ctx, owner, name, mr.Number)
 		if prErr != nil || pr == nil {
@@ -616,9 +616,13 @@ func (s *Server) workflowApprovalState(
 		}
 		currentState = pr.GetState()
 		headSHA = pr.GetHead().GetSHA()
+		headRepoFullName = pr.GetHead().GetRepo().GetFullName()
+		headRef = pr.GetHead().GetRef()
 	} else {
 		currentState = mr.State
 		headSHA = mr.PlatformHeadSHA
+		headRepoFullName = ghclient.ParseHeadRepoFullName(mr.HeadRepoCloneURL)
+		headRef = mr.HeadBranch
 	}
 
 	if currentState != "open" || headSHA == "" {
@@ -631,7 +635,12 @@ func (s *Server) workflowApprovalState(
 	}
 
 	state := ghclient.WorkflowApprovalStateFromRuns(
-		ghclient.FilterWorkflowRunsAwaitingApproval(runs, mr.Number, headSHA),
+		ghclient.FilterWorkflowRunsAwaitingApproval(runs, ghclient.PRSource{
+			Number:           mr.Number,
+			HeadSHA:          headSHA,
+			HeadRepoFullName: headRepoFullName,
+			HeadRef:          headRef,
+		}),
 	)
 	return workflowApprovalResponse{
 		Checked:  state.Checked,
@@ -1051,7 +1060,12 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 	if err != nil {
 		return nil, huma.Error502BadGateway("GitHub API error")
 	}
-	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, input.Number, headSHA)
+	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, ghclient.PRSource{
+		Number:           input.Number,
+		HeadSHA:          headSHA,
+		HeadRepoFullName: pr.GetHead().GetRepo().GetFullName(),
+		HeadRef:          pr.GetHead().GetRef(),
+	})
 
 	approvedCount := 0
 	for _, run := range pending {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -631,7 +631,7 @@ func (s *Server) workflowApprovalState(
 	}
 
 	state := ghclient.WorkflowApprovalStateFromRuns(
-		ghclient.FilterWorkflowRunsAwaitingApproval(runs, mr.Number, headSHA),
+		ghclient.FilterWorkflowRunsAwaitingApproval(runs, headSHA),
 	)
 	return workflowApprovalResponse{
 		Checked:  state.Checked,
@@ -1051,7 +1051,7 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 	if err != nil {
 		return nil, huma.Error502BadGateway("GitHub API error")
 	}
-	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, input.Number, headSHA)
+	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, headSHA)
 
 	approvedCount := 0
 	for _, run := range pending {

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -79,6 +79,7 @@
       onclick={() => { expanded = true; }}
       tone="success"
       surface="soft"
+      title="Submit an approving code review on this pull request"
       {size}
     >
       <svg

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -69,6 +69,7 @@
         disabled={submitting}
         tone="success"
         surface="solid"
+        title="Submit an approving code review on this pull request"
       >
         {submitting ? "Approving\u2026" : "Approve"}
       </ActionButton>
@@ -79,7 +80,7 @@
       onclick={() => { expanded = true; }}
       tone="success"
       surface="soft"
-      title="Submit an approving code review on this pull request"
+      title="Open the approval form to submit a code review on this pull request"
       {size}
     >
       <svg

--- a/packages/ui/src/components/detail/ApproveWorkflowsButton.svelte
+++ b/packages/ui/src/components/detail/ApproveWorkflowsButton.svelte
@@ -21,6 +21,8 @@
   const label = $derived(
     count > 1 ? `Approve workflows (${count})` : "Approve workflows",
   );
+  const tooltip =
+    "Approve pending GitHub Actions runs waiting on outside contributor approval";
 
   async function handleApproveWorkflows(): Promise<void> {
     submitting = true;
@@ -56,6 +58,7 @@
     disabled={submitting}
     tone="workflow"
     surface="soft"
+    title={tooltip}
     {size}
   >
     {submitting ? "Approving workflows…" : label}


### PR DESCRIPTION
## Summary

- Detect that a fork-based PR needs GitHub Actions workflow approval. The previous filter required `workflow_run.pull_requests` to contain the PR number, but GitHub returns that array empty for runs triggered from forks — exactly the case where workflow approval is required. The Approve workflows button never appeared for fork PRs and the approve endpoint was a no-op.
- When `workflow_run.pull_requests` is populated, still require it to contain the current PR number so two PRs that share a head SHA don't mis-attribute runs.
- Add `title` tooltips to both action buttons:
  - Approve (collapsed): "Open the approval form to submit a code review on this pull request"
  - Approve (expanded submit): "Submit an approving code review on this pull request"
  - Approve workflows: "Approve pending GitHub Actions runs waiting on outside contributor approval"

🤖 Generated with [Claude Code](https://claude.com/claude-code)