### PR TITLE
workspace: add standalone /workspaces/sidebar route

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
     FocusListView,
     WorkspacesView,
     WorkspacePanelView,
+    WorkspaceSidebarView,
   } from "@middleman/ui";
   import type { StoreInstances } from "@middleman/ui";
   import type { ActivityItem } from "@middleman/ui/api/types";
@@ -82,45 +83,6 @@
 
   let stores = $state<StoreInstances | undefined>();
   let appReady = $state(false);
-  let softPinnedKey = $state<string | null>(null);
-  let panelHardPinned = $state(false);
-
-  function detailKey(
-    host: string, owner: string, name: string, n: number,
-  ): string {
-    return `${host}/${owner}/${name}/${n}`;
-  }
-
-  // Derive current detail route key for pin matching.
-  const currentDetailKey = $derived.by(() => {
-    const r = getRoute();
-    if (
-      r.page === "workspaces-panel" &&
-      r.view === "detail" &&
-      "platformHost" in r
-    ) {
-      return detailKey(r.platformHost, r.owner, r.name, r.number);
-    }
-    return null;
-  });
-
-  // Hard-pin is sticky (cleared only by explicit unpin).
-  // Soft-pin from URL sets softPinnedKey for the current route.
-  $effect(() => {
-    const r = getRoute();
-    if (r.page !== "workspaces-panel") return;
-    if ("pin" in r && r.pin === "hard") {
-      panelHardPinned = true;
-    }
-    if (
-      "pin" in r && r.pin === "soft" &&
-      r.view === "detail" && "platformHost" in r
-    ) {
-      softPinnedKey = detailKey(
-        r.platformHost, r.owner, r.name, r.number,
-      );
-    }
-  });
 
   onMount(() => {
     initTheme();
@@ -363,6 +325,7 @@
     if (page === "reviews") return;
     if (page === "workspaces") return;
     if (page === "workspaces-panel") return;
+    if (page === "workspaces-sidebar") return;
 
     if (page === "activity") {
       if (
@@ -536,6 +499,25 @@
         {/if}
       </main>
     {/if}
+  {:else if getPage() === "workspaces-sidebar"}
+    {@const r = getRoute()}
+    {#if r.page === "workspaces-sidebar"}
+      <FlashBanner />
+      <main class="focus-layout">
+        <WorkspaceSidebarView
+          platformHost={r.platformHost}
+          owner={r.owner}
+          name={r.name}
+          number={r.number}
+          branch={r.branch}
+          tab={r.tab}
+          basePath={getBasePath()}
+          activePlatformHost={getEmbedActivePlatformHost()}
+          navigate={(path) => navigate(path)}
+          onWorkspaceCommand={emitWorkspaceCommand}
+        />
+      </main>
+    {/if}
   {:else}
     {#if !isHeaderHidden()}
       <AppHeader />
@@ -600,13 +582,8 @@
       {:else if getPage() === "workspaces-panel"}
         {@const route = getRoute()}
         {#if route.page === "workspaces-panel"}
-          {@const isPinned =
-            panelHardPinned ||
-            (softPinnedKey != null &&
-              softPinnedKey === currentDetailKey)}
           <WorkspacePanelView
             view={route.view}
-            {isPinned}
             platformHost={"platformHost" in route ? route.platformHost : undefined}
             owner={"owner" in route ? route.owner : undefined}
             name={"name" in route ? route.name : undefined}
@@ -624,26 +601,13 @@
                 navigate(
                   `/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}/${n}`,
                 );
-                if (!panelHardPinned) {
-                  softPinnedKey = detailKey(
-                    route.platformHost, route.owner, route.name, n,
-                  );
-                  emitWorkspaceCommand("softPinPR", {
-                    host: route.platformHost,
-                    owner: route.owner,
-                    name: route.name,
-                    number: n,
-                  });
-                }
               }
             }}
             onBack={() => {
               if ("platformHost" in route) {
-                softPinnedKey = null;
                 navigate(
                   `/workspaces/panel/${route.platformHost}/${route.owner}/${route.name}`,
                 );
-                emitWorkspaceCommand("clearSoftPin", {});
               }
             }}
             onCreateWorktree={(n) => {
@@ -660,11 +624,6 @@
               emitWorkspaceCommand("navigateWorktree", {
                 worktreeKey: key,
               });
-            }}
-            onUnpin={() => {
-              softPinnedKey = null;
-              panelHardPinned = false;
-              emitWorkspaceCommand("unpinPanelContext", {});
             }}
             onRefresh={() => {
               emitWorkspaceCommand("refreshPulls", {});

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -10,9 +10,17 @@ export type Route =
       owner: string;
       name: string;
       number: number;
-      pin?: "soft" | "hard";
     }
   | { page: "workspaces-panel"; view: "empty"; emptyReason: string }
+  | {
+      page: "workspaces-sidebar";
+      platformHost: string;
+      owner: string;
+      name: string;
+      number: number;
+      branch?: string;
+      tab?: "pr" | "reviews";
+    }
   | { page: "pulls"; view: "list" | "board"; selected?: { owner: string; name: string; number: number }; tab?: "files" }
   | { page: "issues"; selected?: { owner: string; name: string; number: number } }
   | { page: "settings" }
@@ -93,6 +101,30 @@ function parseRoute(fullPath: string): Route {
   if (path === "/design-system") {
     return { page: "design-system" };
   }
+  if (path.startsWith("/workspaces/sidebar/")) {
+    const tail = path.slice("/workspaces/sidebar/".length);
+    const parts = tail.split("/");
+    if (parts.length === 4) {
+      const [platformHost, owner, name, numberStr] = parts as [
+        string, string, string, string,
+      ];
+      if (platformHost && owner && name && /^\d+$/.test(numberStr)) {
+        const number = Number.parseInt(numberStr, 10);
+        const sp = new URLSearchParams(search);
+        const branch = sp.get("branch") ?? undefined;
+        const tabRaw = sp.get("tab");
+        const tab =
+          tabRaw === "pr" || tabRaw === "reviews" ? tabRaw : undefined;
+        const r: Route = {
+          page: "workspaces-sidebar",
+          platformHost, owner, name, number,
+        };
+        if (branch) r.branch = branch;
+        if (tab) r.tab = tab;
+        return r;
+      }
+    }
+  }
   if (path.startsWith("/workspaces/panel")) {
     const rest = path.slice("/workspaces/panel".length);
     if (rest.startsWith("/empty/")) {
@@ -107,8 +139,6 @@ function parseRoute(fullPath: string): Route {
       /^\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/,
     );
     if (detail) {
-      const params = new URLSearchParams(search);
-      const pin = params.get("pin");
       return {
         page: "workspaces-panel",
         view: "detail",
@@ -116,9 +146,6 @@ function parseRoute(fullPath: string): Route {
         owner: detail[2]!,
         name: detail[3]!,
         number: parseInt(detail[4]!, 10),
-        ...(pin === "soft" || pin === "hard"
-          ? { pin }
-          : {}),
       };
     }
     const list = rest.match(
@@ -209,7 +236,8 @@ export function getRoute(): Route {
 }
 
 export function getPage():
-  "activity" | "design-system" | "pulls" | "issues" | "settings" | "focus" | "reviews" | "workspaces" | "workspaces-panel" | "terminal" {
+  "activity" | "design-system" | "pulls" | "issues" | "settings" | "focus" | "reviews"
+  | "workspaces" | "workspaces-panel" | "workspaces-sidebar" | "terminal" {
   return route.page;
 }
 
@@ -259,6 +287,7 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
   } else if (
     r.page === "workspaces" ||
     r.page === "workspaces-panel" ||
+    r.page === "workspaces-sidebar" ||
     r.page === "terminal"
   ) {
     navType = "workspaces";
@@ -271,7 +300,7 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
   const event: MiddlemanNavigateEvent = {
     type: navType,
     focus,
-    view: stripBase(window.location.pathname),
+    view: stripBase(window.location.pathname) + window.location.search,
   };
 
   if (r.page === "focus" && "owner" in r) {
@@ -321,6 +350,12 @@ export function replaceUrl(path: string): void {
   history.replaceState(null, "", fullPath);
   route = parseRoute(fullPath);
   fireRouteChange(route);
+}
+
+export function isWorkspaceSidebarRoute(
+  r: Route = route,
+): r is Route & { page: "workspaces-sidebar" } {
+  return r.page === "workspaces-sidebar";
 }
 
 // Listen for browser back/forward.

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -188,3 +188,103 @@ describe("router navigation events", () => {
     expect(payload.view).toBe("/design-system");
   });
 });
+
+describe("router /workspaces/sidebar route", () => {
+  beforeEach(() => {
+    navigate("/pulls");
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { __middleman_config?: unknown })
+      .__middleman_config;
+    (window as unknown as {
+      __middleman_notify_config_changed?: () => void;
+    }).__middleman_notify_config_changed?.();
+  });
+
+  it("parses /workspaces/sidebar/:host/:owner/:name/:number", () => {
+    navigate("/workspaces/sidebar/github.com/acme/widgets/42");
+    expect(getRoute()).toEqual({
+      page: "workspaces-sidebar",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+    });
+  });
+
+  it("parses branch and tab query params", () => {
+    navigate(
+      "/workspaces/sidebar/github.com/acme/widgets/42"
+        + "?branch=feat/x&tab=reviews",
+    );
+    expect(getRoute()).toEqual({
+      page: "workspaces-sidebar",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+      branch: "feat/x",
+      tab: "reviews",
+    });
+  });
+
+  it("ignores unknown tab values", () => {
+    navigate(
+      "/workspaces/sidebar/github.com/acme/widgets/42?tab=bogus",
+    );
+    const route = getRoute();
+    expect(route.page).toBe("workspaces-sidebar");
+    expect((route as { tab?: string }).tab).toBeUndefined();
+  });
+
+  it("falls back to /workspaces on malformed paths", () => {
+    navigate("/workspaces/sidebar/github.com/acme/widgets");
+    expect(getRoute()).toEqual({ page: "workspaces" });
+  });
+
+  it("rejects non-digit number segments", () => {
+    navigate("/workspaces/sidebar/github.com/acme/widgets/42abc");
+    expect(getRoute()).toEqual({ page: "workspaces" });
+  });
+
+  it("getPage returns workspaces-sidebar", () => {
+    navigate("/workspaces/sidebar/github.com/acme/widgets/42");
+    expect(getPage()).toBe("workspaces-sidebar");
+  });
+
+  it("fires onNavigate with workspaces type", () => {
+    const spy = vi.fn();
+    (window as unknown as { __middleman_config?: unknown })
+      .__middleman_config = { onNavigate: spy };
+    (window as unknown as {
+      __middleman_notify_config_changed?: () => void;
+    }).__middleman_notify_config_changed?.();
+
+    navigate("/workspaces/sidebar/github.com/acme/widgets/42");
+
+    expect(spy).toHaveBeenCalled();
+    const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.type).toBe("workspaces");
+  });
+
+  it("includes query string in onNavigate view", () => {
+    const spy = vi.fn();
+    (window as unknown as { __middleman_config?: unknown })
+      .__middleman_config = { onNavigate: spy };
+    (window as unknown as {
+      __middleman_notify_config_changed?: () => void;
+    }).__middleman_notify_config_changed?.();
+
+    navigate(
+      "/workspaces/sidebar/github.com/acme/widgets/42"
+        + "?branch=feat/x&tab=reviews",
+    );
+
+    const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.view).toBe(
+      "/workspaces/sidebar/github.com/acme/widgets/42"
+        + "?branch=feat/x&tab=reviews",
+    );
+  });
+});

--- a/frontend/tests/demo/workspace-screenshots.spec.ts
+++ b/frontend/tests/demo/workspace-screenshots.spec.ts
@@ -150,28 +150,6 @@ test("07 - PR detail view", async ({ page }) => {
   });
 });
 
-test(
-  "08 - detail pinned with Unpin button",
-  async ({ page }) => {
-    await page.addInitScript(() => {
-      window.__middleman_config = {
-        embed: { activePlatformHost: "github.com" },
-        onWorkspaceCommand: () => ({ ok: true }),
-      };
-    });
-    await page.goto(
-      "/workspaces/panel/github.com/acme/widgets/42?pin=hard",
-    );
-    await expect(
-      page.locator("button.panel-unpin-btn"),
-    ).toBeVisible();
-    await page.screenshot({
-      path: `${SCREENSHOT_DIR}/08-detail-pinned.png`,
-      fullPage: true,
-    });
-  },
-);
-
 test("09 - detail not found", async ({ page }) => {
   await page.addInitScript(() => {
     window.__middleman_config = {

--- a/frontend/tests/e2e/workspace-sidebar-route.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar-route.spec.ts
@@ -1,0 +1,396 @@
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+async function mockPR(
+  page: import("@playwright/test").Page,
+  owner: string,
+  name: string,
+  number: number,
+  title: string,
+): Promise<void> {
+  await page.route(
+    `**/api/v1/repos/${owner}/${name}/pulls/${number}`,
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          merge_request: {
+            ID: 1,
+            RepoID: 1,
+            GitHubID: 101,
+            Number: number,
+            URL: `https://github.com/${owner}/${name}/pull/${number}`,
+            Title: title,
+            Author: "marius",
+            State: "open",
+            IsDraft: false,
+            Body: "Test PR body",
+            HeadBranch: "feature/x",
+            BaseBranch: "main",
+            Additions: 10,
+            Deletions: 2,
+            CommentCount: 0,
+            ReviewDecision: "",
+            CIStatus: "success",
+            CIChecksJSON: "[]",
+            CreatedAt: "2026-04-10T12:00:00Z",
+            UpdatedAt: "2026-04-10T12:00:00Z",
+            LastActivityAt: "2026-04-10T12:00:00Z",
+            MergedAt: null,
+            ClosedAt: null,
+            KanbanStatus: "new",
+            Starred: false,
+            repo_owner: owner,
+            repo_name: name,
+            platform_host: "github.com",
+            worktree_links: [],
+          },
+          repo_owner: owner,
+          repo_name: name,
+          detail_loaded: true,
+          detail_fetched_at: "2026-04-10T12:00:00Z",
+          worktree_links: [],
+        }),
+      }),
+  );
+}
+
+async function mockRoborev(
+  page: import("@playwright/test").Page,
+  rootPath: string | null,
+  basePrefix: string = "",
+): Promise<void> {
+  // Match only the app-relative Roborev path at the configured
+  // prefix. If WorkspaceSidebarView builds a malformed base (e.g.
+  // "//api/roborev" from an unnormalized "/") or omits the subpath
+  // prefix, the request will not match and the test will fail —
+  // which is the intended regression guard.
+  const apiPath = `${basePrefix}/api/roborev/`;
+  await page.route(
+    (url) => url.pathname.startsWith(apiPath),
+    async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname.endsWith("/api/repos")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            repos: rootPath
+              ? [{ name: "widgets", root_path: rootPath, count: 0 }]
+              : [],
+            total_count: rootPath ? 1 : 0,
+          }),
+        });
+        return;
+      }
+      if (url.pathname.includes("/api/jobs")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            jobs: [],
+            has_more: false,
+            stats: { done: 0, closed: 0, open: 0 },
+          }),
+        });
+        return;
+      }
+      if (url.pathname.endsWith("/status")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ status: "ok" }),
+        });
+        return;
+      }
+      if (url.pathname.includes("/stream/events")) {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: "",
+        });
+        return;
+      }
+      await route.fulfill({ status: 404 });
+    },
+  );
+}
+
+async function injectPrimaryHost(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: { activePlatformHost: "github.com" },
+    };
+  });
+}
+
+test(
+  "sidebar route loads PR tab with full PullDetail",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x",
+    );
+    await expect(
+      page.locator(".detail-title", { hasText: "Add thing" }),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "switching to Reviews tab resolves repo and renders JobTable",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x",
+    );
+    await page
+      .locator(".seg-btn", { hasText: "Reviews" })
+      .click();
+    await expect(page.getByText("No jobs found")).toBeVisible();
+  },
+);
+
+test("?tab=reviews initializes on the Reviews tab", async ({ page }) => {
+  await injectPrimaryHost(page);
+  await mockPR(page, "acme", "widgets", 42, "Add thing");
+  await mockRoborev(page, "/home/user/acme/widgets");
+  await page.goto(
+    "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x&tab=reviews",
+  );
+  await expect(page.getByText("No jobs found")).toBeVisible();
+});
+
+test(
+  "branch omitted with number > 0: Reviews empty, PR tab works",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto("/workspaces/sidebar/github.com/acme/widgets/42");
+    await expect(
+      page.locator(".detail-title", { hasText: "Add thing" }),
+    ).toBeVisible();
+    await page
+      .locator(".seg-btn", { hasText: "Reviews" })
+      .click();
+    await expect(page.getByText("No jobs found")).toBeVisible();
+  },
+);
+
+test(
+  "number=0 renders 'No linked PR' on PR tab",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto("/workspaces/sidebar/github.com/acme/widgets/0");
+    await expect(page.getByText("No linked PR")).toBeVisible();
+  },
+);
+
+test(
+  "startup state shows when activePlatformHost is null",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: null },
+      };
+    });
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x",
+    );
+    await expect(page.getByTestId("startup-state")).toBeVisible();
+  },
+);
+
+test(
+  "URL tab param changes sync the active segment",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x&tab=pr",
+    );
+    await expect(
+      page.locator(".detail-title", { hasText: "Add thing" }),
+    ).toBeVisible();
+    const prBtn = page.locator(".seg-btn", { hasText: "PR" });
+    const reviewsBtn = page.locator(".seg-btn", { hasText: "Reviews" });
+    await expect(prBtn).toHaveClass(/active/);
+    await expect(reviewsBtn).not.toHaveClass(/active/);
+
+    await page.evaluate(() => {
+      history.pushState(
+        null,
+        "",
+        "/workspaces/sidebar/github.com/acme/widgets/42"
+          + "?branch=feat/x&tab=reviews",
+      );
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    await expect(reviewsBtn).toHaveClass(/active/);
+    await expect(prBtn).not.toHaveClass(/active/);
+    await expect(page.getByText("No jobs found")).toBeVisible();
+  },
+);
+
+test(
+  "non-primary host state shows 'Reveal in Host Settings'",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+      };
+    });
+    await page.goto(
+      "/workspaces/sidebar/example.com/acme/widgets/42?branch=feat/x",
+    );
+    await expect(page.getByTestId("non-primary-state")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Reveal in Host Settings" }),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "clicking a segment pushes history so Back restores the previous tab",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x&tab=pr",
+    );
+    const prBtn = page.locator(".seg-btn", { hasText: "PR" });
+    const reviewsBtn = page.locator(".seg-btn", { hasText: "Reviews" });
+    await expect(prBtn).toHaveClass(/active/);
+
+    await reviewsBtn.click();
+    await expect(reviewsBtn).toHaveClass(/active/);
+    await expect(page).toHaveURL(/tab=reviews/);
+
+    await page.goBack();
+    await expect(prBtn).toHaveClass(/active/);
+    await expect(page).toHaveURL(/tab=pr/);
+  },
+);
+
+test(
+  "sidebar route renders without global AppHeader or StatusBar",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x",
+    );
+    await expect(
+      page.locator(".detail-title", { hasText: "Add thing" }),
+    ).toBeVisible();
+    await expect(page.locator(".app-header")).toHaveCount(0);
+    await expect(page.locator(".status-bar")).toHaveCount(0);
+  },
+);
+
+test(
+  "flash banner renders on sidebar route when a flash is triggered",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x",
+    );
+    await expect(
+      page.locator(".detail-title", { hasText: "Add thing" }),
+    ).toBeVisible();
+    await expect(page.locator(".flash-banner")).toHaveCount(0);
+
+    await page.evaluate(async () => {
+      const mod = await import(
+        "/src/lib/stores/flash.svelte.ts"
+      );
+      mod.showFlash("Simulated sidebar error", 10_000);
+    });
+
+    await expect(page.locator(".flash-banner")).toBeVisible();
+    await expect(
+      page.locator(".flash-banner"),
+    ).toContainText("Simulated sidebar error");
+  },
+);
+
+test(
+  "list-navigation keys do not navigate away from sidebar route",
+  async ({ page }) => {
+    await injectPrimaryHost(page);
+    await mockPR(page, "acme", "widgets", 42, "Add thing");
+    await mockRoborev(page, "/home/user/acme/widgets");
+    await page.goto(
+      "/workspaces/sidebar/github.com/acme/widgets/42?branch=feat/x",
+    );
+    await expect(
+      page.locator(".detail-title", { hasText: "Add thing" }),
+    ).toBeVisible();
+
+    for (const key of ["j", "k", "Escape", "1", "2"]) {
+      await page.keyboard.press(key);
+    }
+
+    const pathname = await page.evaluate(() => window.location.pathname);
+    expect(pathname).toMatch(/^\/workspaces\/sidebar\//);
+  },
+);
+
+test(
+  "prefixed base path routes Roborev requests through the prefix",
+  async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__BASE_PATH__ = "/middleman/";
+      window.__middleman_config = {
+        embed: { activePlatformHost: "github.com" },
+      };
+    });
+    const roborevUrls: string[] = [];
+    page.on("request", (req) => {
+      const url = new URL(req.url());
+      if (req.resourceType() === "xhr" || req.resourceType() === "fetch") {
+        if (url.pathname.includes("/api/roborev/")) {
+          roborevUrls.push(url.pathname);
+        }
+      }
+    });
+    await page.route("**/middleman/api/v1/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "{}",
+      }),
+    );
+    await mockRoborev(page, "/home/user/acme/widgets", "/middleman");
+
+    await page.goto(
+      "/middleman/workspaces/sidebar/github.com/acme/widgets/42"
+        + "?branch=feat/x&tab=reviews",
+    );
+    await expect(page.getByText("No jobs found")).toBeVisible();
+
+    expect(roborevUrls.length).toBeGreaterThan(0);
+    for (const pathname of roborevUrls) {
+      expect(pathname).toMatch(/^\/middleman\/api\/roborev\//);
+    }
+  },
+);

--- a/frontend/tests/e2e/workspaces-panel.spec.ts
+++ b/frontend/tests/e2e/workspaces-panel.spec.ts
@@ -473,62 +473,12 @@ test(
 );
 
 test(
-  "panel hard-pin skips softPinPR on select",
+  "panel select PR navigates to detail",
   async ({ page }) => {
     await page.addInitScript(() => {
       window.__middleman_config = {
         embed: { activePlatformHost: "github.com" },
-        onWorkspaceCommand: (
-          cmd: string,
-          payload: Record<string, unknown>,
-        ) => {
-          (window as Record<string, unknown>).__workspace_commands ??= [];
-          (
-            (window as Record<string, unknown>).__workspace_commands as unknown[]
-          ).push({ cmd, payload });
-          return { ok: true };
-        },
-      };
-    });
-    // Start hard-pinned, go back, then select a PR
-    await page.goto(
-      "/workspaces/panel/github.com/acme/widgets/42?pin=hard",
-    );
-    await page
-      .getByRole("button", { name: "Back to list" })
-      .click();
-    await page
-      .locator(".panel-pr-item")
-      .filter({ hasText: "Refactor theme system" })
-      .click();
-
-    const cmds = await page.evaluate(
-      () => (window as Record<string, unknown>).__workspace_commands as
-        { cmd: string }[] | undefined,
-    );
-    const softPins = (cmds ?? []).filter(
-      (c) => c.cmd === "softPinPR",
-    );
-    expect(softPins).toHaveLength(0);
-  },
-);
-
-test(
-  "panel select PR emits softPinPR and shows Unpin",
-  async ({ page }) => {
-    await page.addInitScript(() => {
-      window.__middleman_config = {
-        embed: { activePlatformHost: "github.com" },
-        onWorkspaceCommand: (
-          cmd: string,
-          payload: Record<string, unknown>,
-        ) => {
-          (window as Record<string, unknown>).__workspace_commands ??= [];
-          (
-            (window as Record<string, unknown>).__workspace_commands as unknown[]
-          ).push({ cmd, payload });
-          return { ok: true };
-        },
+        onWorkspaceCommand: () => ({ ok: true }),
       };
     });
     await page.goto(
@@ -543,86 +493,16 @@ test(
     await expect(page).toHaveURL(
       /\/workspaces\/panel\/github\.com\/acme\/widgets\/42$/,
     );
-
-    // softPinPR command emitted
-    const cmds = await page.evaluate(
-      () => (window as Record<string, unknown>).__workspace_commands as
-        { cmd: string; payload: Record<string, unknown> }[],
-    );
-    const softPin = cmds.find((c) => c.cmd === "softPinPR");
-    expect(softPin).toBeTruthy();
-    expect(softPin!.payload).toMatchObject({
-      host: "github.com",
-      owner: "acme",
-      name: "widgets",
-      number: 42,
-    });
-
-    // Unpin button visible
-    await expect(
-      page.locator("button.panel-unpin-btn"),
-    ).toBeVisible();
   },
 );
 
 test(
-  "panel Unpin button emits unpinPanelContext",
+  "panel back returns to list",
   async ({ page }) => {
     await page.addInitScript(() => {
       window.__middleman_config = {
         embed: { activePlatformHost: "github.com" },
-        onWorkspaceCommand: (
-          cmd: string,
-          payload: Record<string, unknown>,
-        ) => {
-          (window as Record<string, unknown>).__last_cmd = {
-            cmd,
-            payload,
-          };
-          return { ok: true };
-        },
-      };
-    });
-    // Navigate to list first, then click a PR to get soft-pinned
-    await page.goto(
-      "/workspaces/panel/github.com/acme/widgets",
-    );
-    const row = page
-      .locator(".panel-pr-item")
-      .filter({ hasText: "Add browser regression coverage" });
-    await row.click();
-
-    const unpin = page.locator("button.panel-unpin-btn");
-    await expect(unpin).toBeVisible();
-    await unpin.click();
-
-    const cmd = await page.evaluate(
-      () => (window as Record<string, unknown>).__last_cmd as
-        { cmd: string },
-    );
-    expect(cmd.cmd).toBe("unpinPanelContext");
-
-    // Unpin button should disappear
-    await expect(unpin).not.toBeVisible();
-  },
-);
-
-test(
-  "panel back emits clearSoftPin",
-  async ({ page }) => {
-    await page.addInitScript(() => {
-      window.__middleman_config = {
-        embed: { activePlatformHost: "github.com" },
-        onWorkspaceCommand: (
-          cmd: string,
-          payload: Record<string, unknown>,
-        ) => {
-          (window as Record<string, unknown>).__last_cmd = {
-            cmd,
-            payload,
-          };
-          return { ok: true };
-        },
+        onWorkspaceCommand: () => ({ ok: true }),
       };
     });
     await page.goto(
@@ -637,49 +517,9 @@ test(
       .getByRole("button", { name: "Back to list" })
       .click();
 
-    const cmd = await page.evaluate(
-      () => (window as Record<string, unknown>).__last_cmd as
-        { cmd: string },
-    );
-    expect(cmd.cmd).toBe("clearSoftPin");
     await expect(page).toHaveURL(
       /\/workspaces\/panel\/github\.com\/acme\/widgets$/,
     );
-  },
-);
-
-test(
-  "panel hard-pin preserved across back navigation",
-  async ({ page }) => {
-    await page.addInitScript(() => {
-      window.__middleman_config = {
-        embed: { activePlatformHost: "github.com" },
-        onWorkspaceCommand: () => ({ ok: true }),
-      };
-    });
-    await page.goto(
-      "/workspaces/panel/github.com/acme/widgets/42?pin=hard",
-    );
-
-    // Unpin visible on hard-pinned detail
-    await expect(
-      page.locator("button.panel-unpin-btn"),
-    ).toBeVisible();
-
-    // Go back to list
-    await page
-      .getByRole("button", { name: "Back to list" })
-      .click();
-
-    // Click another PR — should still be pinned
-    const row = page
-      .locator(".panel-pr-item")
-      .filter({ hasText: "Refactor theme system" });
-    await row.click();
-
-    await expect(
-      page.locator("button.panel-unpin-btn"),
-    ).toBeVisible();
   },
 );
 

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -200,45 +200,6 @@ test(
 );
 
 test(
-  "clicking PR badge emits pinLinkedPR command",
-  async ({ page }) => {
-    await page.addInitScript((data) => {
-      window.__middleman_config = {
-        workspace: data,
-        onWorkspaceCommand: (
-          cmd: string,
-          payload: Record<string, unknown>,
-        ) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
-          (window as Record<string, any>).__last_workspace_command = {
-            cmd,
-            payload,
-          };
-          return { ok: true };
-        },
-      };
-    }, testWorkspaceData);
-
-    await page.goto("/workspaces");
-
-    const prBadge = page.locator("button.pr-badge").first();
-    await expect(prBadge).toBeVisible();
-    await prBadge.click();
-
-    const command = await page.evaluate(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only window property
-      () => (window as Record<string, any>).__last_workspace_command,
-    );
-    expect(command).toBeTruthy();
-    expect(command.cmd).toBe("pinLinkedPR");
-    expect(command.payload.hostKey).toBe("local");
-    expect(command.payload.projectKey).toBe("proj-1");
-    expect(command.payload.worktreeKey).toBe("wt-2");
-    expect(command.payload.prNumber).toBe(42);
-  },
-);
-
-test(
   "navigateToRoute bridge method works",
   async ({ page }) => {
     await page.goto("/pulls");
@@ -304,6 +265,28 @@ test(
     expect(command.payload.worktreeKey).toBe("wt-2");
     expect(command.payload.hostKey).toBe("local");
     expect(command.payload.projectKey).toBe("proj-1");
+  },
+);
+
+test(
+  "linked-PR badge is non-interactive and omits pin menu item",
+  async ({ page }) => {
+    await injectWithCallback(page, testWorkspaceData);
+    await page.goto("/workspaces");
+
+    const badge = page.locator(".pr-badge").filter({ hasText: "#42" });
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveJSProperty("tagName", "SPAN");
+
+    await badge.click();
+    const afterBadgeClick = await getLastCommand(page);
+    expect(afterBadgeClick).toBeFalsy();
+
+    const row = page
+      .locator(".worktree-row")
+      .filter({ hasText: "Add auth middleware" });
+    await row.click({ button: "right" });
+    await expect(page.getByText("Pin linked PR")).toHaveCount(0);
   },
 );
 

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -253,6 +253,7 @@ func setupWrapperServerWithScriptAndDBAndServer(
 }
 
 func TestTmuxWrapperNewSession(t *testing.T) {
+	require := require.New(t)
 	assert := Assert.New(t)
 	require := require.New(t)
 	client, _, record := setupWrapperServer(t)
@@ -733,6 +734,7 @@ func TestWorkspaceShutdownCancellationDoesNotPersistAfterDeadlineBudgetExhausted
 }
 
 func TestTmuxWrapperAttachSession(t *testing.T) {
+	require := require.New(t)
 	assert := Assert.New(t)
 	require := require.New(t)
 	client, baseURL, record := setupWrapperServer(t)
@@ -843,6 +845,7 @@ func TestReadTmuxRecordPreservesEmptyArgs(t *testing.T) {
 // This complements TestTmuxWrapperNewSession and TestTmuxWrapperAttachSession —
 // together they cover all three tmux verbs that cross the HTTP boundary.
 func TestTmuxWrapperKillSession(t *testing.T) {
+	require := require.New(t)
 	assert := Assert.New(t)
 	require := require.New(t)
 	client, _, record := setupWrapperServer(t)

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -255,7 +255,6 @@ func setupWrapperServerWithScriptAndDBAndServer(
 func TestTmuxWrapperNewSession(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
-	require := require.New(t)
 	client, _, record := setupWrapperServer(t)
 	ctx := context.Background()
 
@@ -736,7 +735,6 @@ func TestWorkspaceShutdownCancellationDoesNotPersistAfterDeadlineBudgetExhausted
 func TestTmuxWrapperAttachSession(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
-	require := require.New(t)
 	client, baseURL, record := setupWrapperServer(t)
 	ctx := context.Background()
 
@@ -847,7 +845,6 @@ func TestReadTmuxRecordPreservesEmptyArgs(t *testing.T) {
 func TestTmuxWrapperKillSession(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
-	require := require.New(t)
 	client, _, record := setupWrapperServer(t)
 	ctx := context.Background()
 

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -614,6 +614,7 @@ func TestManagerDeleteUsesTmuxPrefix(t *testing.T) {
 }
 
 func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
+	require := require.New(t)
 	assert := Assert.New(t)
 	require := require.New(t)
 

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -616,7 +616,6 @@ func TestManagerDeleteUsesTmuxPrefix(t *testing.T) {
 func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
-	require := require.New(t)
 
 	// Script: "has-session" emits tmux's canonical "can't find
 	// session" stderr and exits 1 (so isTmuxSessionAbsent classifies

--- a/packages/ui/src/components/workspace/WorktreeRow.svelte
+++ b/packages/ui/src/components/workspace/WorktreeRow.svelte
@@ -159,18 +159,12 @@
     {#if worktree.linkedPR || worktree.diff || showBranch}
       <span class="meta-row">
         {#if worktree.linkedPR}
-          <button
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <span
             class="pr-badge pr-{worktree.linkedPR.state}"
-            title="Pin PR #{worktree.linkedPR.number}"
-            onclick={(e: MouseEvent) => {
-              e.stopPropagation();
-              onCommand("pinLinkedPR", {
-                hostKey,
-                projectKey,
-                worktreeKey: worktree.key,
-                prNumber: worktree.linkedPR!.number,
-              });
-            }}
+            title="PR #{worktree.linkedPR.number}"
+            onclick={(e: MouseEvent) => e.stopPropagation()}
           >
             #{worktree.linkedPR.number} {worktree.linkedPR.state.toUpperCase()}
             {#if worktree.linkedPR.checksStatus === "success"}
@@ -208,7 +202,7 @@
                 />
               </svg>
             {/if}
-          </button>
+          </span>
         {/if}
 
         {#if worktree.diff}
@@ -241,16 +235,6 @@
     >
       Open session
     </button>
-    {#if worktree.linkedPR}
-      <button
-        class="menu-item"
-        onclick={() => menuAction("pinLinkedPR", {
-          prNumber: worktree.linkedPR?.number,
-        })}
-      >
-        Pin linked PR
-      </button>
-    {/if}
     <button
       class="menu-item menu-item--danger"
       onclick={() => menuAction("deleteWorktree")}
@@ -423,9 +407,7 @@
     background: none;
     border: none;
     padding: 1px 6px;
-    cursor: pointer;
     border-radius: 3px;
-    transition: opacity 0.1s;
   }
 
   .pr-open {
@@ -454,10 +436,6 @@
     background: color-mix(
       in srgb, var(--text-muted) 12%, transparent
     );
-  }
-
-  .pr-badge:hover {
-    opacity: 0.75;
   }
 
   .checks-icon {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -116,6 +116,9 @@ export {
   default as WorkspacePanelView,
 } from "./views/WorkspacePanelView.svelte";
 export {
+  default as WorkspaceSidebarView,
+} from "./views/WorkspaceSidebarView.svelte";
+export {
   default as ActionButton,
 } from "./components/shared/ActionButton.svelte";
 export {

--- a/packages/ui/src/views/WorkspaceSidebarView.svelte
+++ b/packages/ui/src/views/WorkspaceSidebarView.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+  // Import-pattern: takes `activePlatformHost`, `navigate`, and
+  // `onWorkspaceCommand` as callback props — mirrors
+  // WorkspacePanelView.svelte. `packages/ui` must not cross-import
+  // frontend/src helpers, so the App.svelte consumer wires the
+  // concrete implementations (navigate from router, workspace
+  // commands from embed-config). `navigate` uses pushState so tab
+  // switches are restorable via browser back/forward.
+  import WorkspaceRightSidebar
+    from "../components/workspace/WorkspaceRightSidebar.svelte";
+
+  type Tab = "pr" | "reviews";
+
+  interface Props {
+    platformHost: string;
+    owner: string;
+    name: string;
+    number: number;
+    branch?: string | undefined;
+    tab?: Tab | undefined;
+    basePath: string;
+    activePlatformHost: string | null;
+    navigate: (path: string) => void;
+    onWorkspaceCommand: (
+      command: string,
+      payload: Record<string, unknown>,
+    ) => void;
+  }
+
+  let {
+    platformHost,
+    owner,
+    name,
+    number,
+    branch = "",
+    tab,
+    basePath,
+    activePlatformHost,
+    navigate,
+    onWorkspaceCommand,
+  }: Props = $props();
+
+  const TAB_KEY = "middleman-workspace-sidebar-tab";
+
+  function storedTab(): Tab {
+    const v = localStorage.getItem(TAB_KEY);
+    return v === "reviews" ? "reviews" : "pr";
+  }
+
+  const activeTab: Tab = $derived(
+    tab === "pr" || tab === "reviews" ? tab : storedTab(),
+  );
+
+  $effect(() => {
+    localStorage.setItem(TAB_KEY, activeTab);
+  });
+
+  const bp = $derived(basePath.replace(/\/$/, ""));
+
+  const isNonPrimary = $derived(
+    activePlatformHost !== null
+      && platformHost !== activePlatformHost,
+  );
+
+  const headerTitle = $derived(
+    number > 0
+      ? `${owner}/${name} #${number}`
+      : `${owner}/${name}`,
+  );
+
+  function rebuildURL(next: Tab): string {
+    const base =
+      `/workspaces/sidebar/${platformHost}`
+      + `/${owner}/${name}/${number}`;
+    const params = new URLSearchParams();
+    if (branch) params.set("branch", branch);
+    params.set("tab", next);
+    return `${base}?${params.toString()}`;
+  }
+
+  function handleSegment(next: Tab): void {
+    if (next === activeTab) return;
+    navigate(rebuildURL(next));
+  }
+
+  function handleRevealHostSettings(): void {
+    onWorkspaceCommand("revealHostSettings", {});
+  }
+</script>
+
+<div class="workspace-sidebar-view">
+  <div class="header-bar">
+    <div class="header-left">
+      <span class="header-name">{headerTitle}</span>
+      {#if branch}
+        <code class="header-branch">{branch}</code>
+      {/if}
+    </div>
+    <div class="header-right">
+      <div class="seg-control">
+        <button
+          class="seg-btn"
+          class:active={activeTab === "pr"}
+          onclick={() => handleSegment("pr")}
+        >
+          PR
+        </button>
+        <button
+          class="seg-btn"
+          class:active={activeTab === "reviews"}
+          onclick={() => handleSegment("reviews")}
+        >
+          Reviews
+        </button>
+      </div>
+    </div>
+  </div>
+  <div class="body">
+    {#if activePlatformHost === null}
+      <div class="state-message" data-testid="startup-state">
+        Middleman is starting up...
+      </div>
+    {:else if isNonPrimary}
+      <div class="state-message" data-testid="non-primary-state">
+        <p>
+          This worktree's repository is on
+          <strong>{platformHost}</strong>.
+        </p>
+        <p class="state-muted">
+          Pull request data is only available for repositories
+          on the active host ({activePlatformHost}).
+        </p>
+        <button
+          class="state-action-btn"
+          onclick={handleRevealHostSettings}
+        >Reveal in Host Settings</button>
+      </div>
+    {:else}
+      <WorkspaceRightSidebar
+        {activeTab}
+        repoOwner={owner}
+        repoName={name}
+        mrNumber={number}
+        branch={branch ?? ""}
+        roborevBaseUrl={bp + "/api/roborev"}
+      />
+    {/if}
+  </div>
+</div>
+
+<style>
+  .workspace-sidebar-view {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    background: var(--bg-primary);
+  }
+
+  .header-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 14px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-default);
+    gap: 12px;
+    flex-shrink: 0;
+  }
+
+  .header-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    overflow: hidden;
+  }
+
+  .header-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .header-branch {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-muted);
+    background: var(--bg-inset);
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .seg-control {
+    display: flex;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .seg-btn {
+    padding: 3px 10px;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+  }
+
+  .seg-btn:first-child {
+    border-right: 1px solid var(--border-default);
+  }
+
+  .seg-btn:hover {
+    color: var(--text-secondary);
+    background: var(--bg-surface-hover);
+  }
+
+  .seg-btn.active {
+    background: var(--accent-blue);
+    color: #fff;
+  }
+
+  .body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    min-height: 0;
+  }
+
+  .state-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    flex: 1;
+    padding: 16px;
+    color: var(--text-muted);
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .state-muted {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 4px;
+  }
+
+  .state-action-btn {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
+  }
+
+  .state-action-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+</style>


### PR DESCRIPTION
## Summary

- New `/workspaces/sidebar/<host>/<owner>/<repo>/<number>` route with a WorkspaceSidebarView rendering PR detail and Roborev reviews in a PR/Reviews segmented control
- Tab state is URL-driven (back/forward and external `replaceUrl` track the segment), with localStorage fallback when the `tab` query param is absent
- Degraded-state guards for startup (no active platform host yet) and non-primary hosts (with a Reveal in Host Settings action)
- `roborevBaseUrl` is now base-path-normalized so subpath deployments (`/<prefix>/api/roborev/...`) work correctly
- `workspaces-sidebar` is short-circuited in the App keydown guard so `j`/`k`/`Escape`/`1`/`2` stay on the sidebar route
- Worktree linked-PR badge is now non-interactive display text; the Pin linked PR context-menu action is removed
- Router unit tests for the new route, and e2e coverage for PR/Reviews rendering, URL-driven tab changes, keyboard guard, subpath base path, startup / non-primary states, and post-change linked-PR behavior

### PR tab

![sidebar-pr-tab.png](https://github.com/user-attachments/assets/beac8b7f-6114-4288-b46b-0e45fc188067)

### Reviews tab

![sidebar-reviews-tab.png](https://github.com/user-attachments/assets/9e16a0e4-1b10-4480-83aa-5acc88f82acb)