### PR TITLE
fix: reject reused migration numbers

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -43,7 +43,13 @@ func (d *DB) init() error {
 		return fmt.Errorf("enable WAL: %w", err)
 	}
 
-	return runMigrations(d.rw)
+	if err := runMigrations(d.rw); err != nil {
+		return err
+	}
+	if err := d.repairLegacyTimestampStorage(context.Background()); err != nil {
+		return fmt.Errorf("repair legacy timestamp storage: %w", err)
+	}
+	return nil
 }
 
 // Close closes both database connections.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/wesm/middleman/internal/db/dbupgrade"
 	_ "modernc.org/sqlite"
 )
 
@@ -43,10 +44,16 @@ func (d *DB) init() error {
 		return fmt.Errorf("enable WAL: %w", err)
 	}
 
-	if err := runMigrations(d.rw); err != nil {
+	startVersion, err := runMigrations(d.rw)
+	if err != nil {
 		return err
 	}
-	if err := d.repairLegacyTimestampStorage(context.Background()); err != nil {
+	if !dbupgrade.NeedsLegacyTimestampRepair(startVersion) {
+		return nil
+	}
+	if err := d.Tx(context.Background(), func(tx *sql.Tx) error {
+		return dbupgrade.RepairLegacyTimestamps(context.Background(), tx)
+	}); err != nil {
 		return fmt.Errorf("repair legacy timestamp storage: %w", err)
 	}
 	return nil

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 
@@ -498,6 +499,134 @@ func TestOpenCasefoldsDuplicateRepositoryRows(t *testing.T) {
 	err = d.ReadDB().QueryRow(`SELECT COUNT(*) FROM pragma_foreign_key_check`).Scan(&foreignKeyViolations)
 	require.NoError(err)
 	require.Zero(foreignKeyViolations)
+}
+
+func TestOpenRepairsLegacyTimestampStorage(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.db")
+	ctx := context.Background()
+
+	d, err := Open(path)
+	require.NoError(err)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(err)
+	mrID, err := d.UpsertMergeRequest(ctx, &MergeRequest{
+		RepoID:            repoID,
+		PlatformID:        101,
+		Number:            1,
+		URL:               "https://github.com/acme/widget/pull/1",
+		Title:             "Legacy PR",
+		Author:            "octocat",
+		AuthorDisplayName: "octocat",
+		State:             "open",
+		HeadBranch:        "feature",
+		BaseBranch:        "main",
+		CreatedAt:         time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:         time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		LastActivityAt:    time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(err)
+	issueID, err := d.UpsertIssue(ctx, &Issue{
+		RepoID:         repoID,
+		PlatformID:     201,
+		Number:         2,
+		URL:            "https://github.com/acme/widget/issues/2",
+		Title:          "Legacy issue",
+		Author:         "octocat",
+		State:          "open",
+		CreatedAt:      time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		LastActivityAt: time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "issue_comment",
+		Author:         "reviewer",
+		Body:           "legacy comment",
+		CreatedAt:      time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		DedupeKey:      "comment-1",
+	}}))
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID:   issueID,
+		EventType: "issue_comment",
+		Author:    "reporter",
+		Body:      "legacy issue comment",
+		CreatedAt: time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		DedupeKey: "issue-comment-1",
+	}}))
+	require.NoError(d.Close())
+
+	raw, err := sql.Open("sqlite", path)
+	require.NoError(err)
+	_, err = raw.ExecContext(ctx, `
+		UPDATE middleman_merge_requests
+		SET created_at = ?, updated_at = ?, last_activity_at = ?
+		WHERE repo_id = ? AND number = ?`,
+		"2026-04-11 08:00:00 -0400 EDT",
+		"2026-04-11 08:00:00 -0400 EDT",
+		"2026-04-11 09:00:00 -0400 EDT",
+		repoID,
+		1,
+	)
+	require.NoError(err)
+	_, err = raw.ExecContext(ctx, `
+		UPDATE middleman_issues
+		SET created_at = ?, updated_at = ?, last_activity_at = ?
+		WHERE repo_id = ? AND number = ?`,
+		"2026-04-11 08:30:00 -0400 EDT",
+		"2026-04-11 08:30:00 -0400 EDT",
+		"2026-04-11 09:30:00 -0400 EDT",
+		repoID,
+		2,
+	)
+	require.NoError(err)
+	_, err = raw.ExecContext(ctx,
+		`UPDATE middleman_mr_events SET created_at = ? WHERE dedupe_key = ?`,
+		"2026-04-11 08:00:00 -0400 EDT",
+		"comment-1",
+	)
+	require.NoError(err)
+	_, err = raw.ExecContext(ctx,
+		`UPDATE middleman_issue_events SET created_at = ? WHERE dedupe_key = ?`,
+		"2026-04-11 09:00:00 -0400 EDT",
+		"issue-comment-1",
+	)
+	require.NoError(err)
+	require.NoError(raw.Close())
+
+	reopened, err := Open(path)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(reopened.Close()) })
+
+	rows, err := reopened.ReadDB().QueryContext(ctx, `
+		SELECT created_at FROM middleman_merge_requests
+		UNION ALL
+		SELECT updated_at FROM middleman_merge_requests
+		UNION ALL
+		SELECT last_activity_at FROM middleman_merge_requests
+		UNION ALL
+		SELECT created_at FROM middleman_issues
+		UNION ALL
+		SELECT updated_at FROM middleman_issues
+		UNION ALL
+		SELECT last_activity_at FROM middleman_issues
+		UNION ALL
+		SELECT created_at FROM middleman_mr_events
+		UNION ALL
+		SELECT created_at FROM middleman_issue_events`)
+	require.NoError(err)
+	defer rows.Close()
+
+	for rows.Next() {
+		var value string
+		require.NoError(rows.Scan(&value))
+		require.NotContains(value, "EDT")
+		require.NotContains(value, "-0400")
+	}
+	require.NoError(rows.Err())
 }
 
 func TestOpenRejectsUnsupportedLegacySchemaVersion(t *testing.T) {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -595,6 +595,23 @@ func TestOpenRepairsLegacyTimestampStorage(t *testing.T) {
 		"issue-comment-1",
 	)
 	require.NoError(err)
+	_, err = raw.ExecContext(ctx, `
+		UPDATE middleman_repos
+		SET last_sync_started_at = ?, last_sync_completed_at = ?,
+		    backfill_pr_completed_at = ?, backfill_issue_completed_at = ?
+		WHERE id = ?`,
+		"2026-04-11 07:00:00 -0400 EDT",
+		"2026-04-11 07:30:00 -0400 EDT",
+		"2026-04-11 08:00:00 -0400 EDT",
+		"2026-04-11 08:30:00 -0400 EDT",
+		repoID,
+	)
+	require.NoError(err)
+	_, err = raw.ExecContext(ctx,
+		`UPDATE schema_migrations SET version = ?, dirty = FALSE`,
+		9,
+	)
+	require.NoError(err)
 	require.NoError(raw.Close())
 
 	reopened, err := Open(path)
@@ -602,6 +619,14 @@ func TestOpenRepairsLegacyTimestampStorage(t *testing.T) {
 	t.Cleanup(func() { require.NoError(reopened.Close()) })
 
 	rows, err := reopened.ReadDB().QueryContext(ctx, `
+		SELECT last_sync_started_at FROM middleman_repos
+		UNION ALL
+		SELECT last_sync_completed_at FROM middleman_repos
+		UNION ALL
+		SELECT backfill_pr_completed_at FROM middleman_repos
+		UNION ALL
+		SELECT backfill_issue_completed_at FROM middleman_repos
+		UNION ALL
 		SELECT created_at FROM middleman_merge_requests
 		UNION ALL
 		SELECT updated_at FROM middleman_merge_requests
@@ -627,6 +652,109 @@ func TestOpenRepairsLegacyTimestampStorage(t *testing.T) {
 		require.NotContains(value, "-0400")
 	}
 	require.NoError(rows.Err())
+
+	var firstPass []string
+	rows, err = reopened.ReadDB().QueryContext(ctx, `
+		SELECT last_sync_started_at FROM middleman_repos
+		UNION ALL
+		SELECT last_sync_completed_at FROM middleman_repos
+		UNION ALL
+		SELECT backfill_pr_completed_at FROM middleman_repos
+		UNION ALL
+		SELECT backfill_issue_completed_at FROM middleman_repos`)
+	require.NoError(err)
+	defer rows.Close()
+	for rows.Next() {
+		var value string
+		require.NoError(rows.Scan(&value))
+		firstPass = append(firstPass, value)
+	}
+	require.NoError(rows.Err())
+
+	require.NoError(reopened.Close())
+	reopened, err = Open(path)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(reopened.Close()) })
+
+	var secondPass []string
+	rows, err = reopened.ReadDB().QueryContext(ctx, `
+		SELECT last_sync_started_at FROM middleman_repos
+		UNION ALL
+		SELECT last_sync_completed_at FROM middleman_repos
+		UNION ALL
+		SELECT backfill_pr_completed_at FROM middleman_repos
+		UNION ALL
+		SELECT backfill_issue_completed_at FROM middleman_repos`)
+	require.NoError(err)
+	defer rows.Close()
+	for rows.Next() {
+		var value string
+		require.NoError(rows.Scan(&value))
+		secondPass = append(secondPass, value)
+	}
+	require.NoError(rows.Err())
+	require.Equal(firstPass, secondPass)
+}
+
+func TestRepoTimestampWritesStoreUTC(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(err)
+
+	//nolint:forbidigo // Test fixture intentionally uses a non-UTC zone to verify normalization.
+	edt := time.FixedZone("EDT", -4*60*60)
+	startedAt := time.Date(2026, 4, 11, 8, 0, 0, 0, edt)
+	completedAt := time.Date(2026, 4, 11, 8, 30, 0, 0, edt)
+	backfillPRCompletedAt := time.Date(2026, 4, 11, 9, 0, 0, 0, edt)
+	backfillIssueCompletedAt := time.Date(2026, 4, 11, 9, 30, 0, 0, edt)
+
+	require.NoError(d.UpdateRepoSyncStarted(ctx, repoID, startedAt))
+	require.NoError(d.UpdateRepoSyncCompleted(ctx, repoID, completedAt, ""))
+	require.NoError(d.UpdateBackfillCursor(
+		ctx,
+		repoID,
+		1, true, &backfillPRCompletedAt,
+		2, true, &backfillIssueCompletedAt,
+	))
+
+	rows, err := d.ReadDB().QueryContext(ctx, `
+		SELECT last_sync_started_at FROM middleman_repos WHERE id = ?
+		UNION ALL
+		SELECT last_sync_completed_at FROM middleman_repos WHERE id = ?
+		UNION ALL
+		SELECT backfill_pr_completed_at FROM middleman_repos WHERE id = ?
+		UNION ALL
+		SELECT backfill_issue_completed_at FROM middleman_repos WHERE id = ?`,
+		repoID, repoID, repoID, repoID,
+	)
+	require.NoError(err)
+	defer rows.Close()
+	for rows.Next() {
+		var value string
+		require.NoError(rows.Scan(&value))
+		require.NotContains(value, "EDT")
+		require.NotContains(value, "-0400")
+	}
+	require.NoError(rows.Err())
+
+	repo, err := d.GetRepoByID(ctx, repoID)
+	require.NoError(err)
+	require.NotNil(repo)
+	require.NotNil(repo.LastSyncStartedAt)
+	require.NotNil(repo.LastSyncCompletedAt)
+	require.NotNil(repo.BackfillPRCompletedAt)
+	require.NotNil(repo.BackfillIssueCompletedAt)
+	require.Equal(time.UTC, repo.LastSyncStartedAt.Location())
+	require.Equal(time.UTC, repo.LastSyncCompletedAt.Location())
+	require.Equal(time.UTC, repo.BackfillPRCompletedAt.Location())
+	require.Equal(time.UTC, repo.BackfillIssueCompletedAt.Location())
+	require.Equal(startedAt.UTC(), *repo.LastSyncStartedAt)
+	require.Equal(completedAt.UTC(), *repo.LastSyncCompletedAt)
+	require.Equal(backfillPRCompletedAt.UTC(), *repo.BackfillPRCompletedAt)
+	require.Equal(backfillIssueCompletedAt.UTC(), *repo.BackfillIssueCompletedAt)
 }
 
 func TestOpenRejectsUnsupportedLegacySchemaVersion(t *testing.T) {

--- a/internal/db/dbupgrade/legacy_timestamps.go
+++ b/internal/db/dbupgrade/legacy_timestamps.go
@@ -1,0 +1,126 @@
+package dbupgrade
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	migratedb "github.com/golang-migrate/migrate/v4/database"
+)
+
+const LegacyTimestampRepairSchemaVersion = 10
+
+func NeedsLegacyTimestampRepair(startVersion int) bool {
+	if startVersion == migratedb.NilVersion {
+		return false
+	}
+	return startVersion < LegacyTimestampRepairSchemaVersion
+}
+
+func RepairLegacyTimestamps(
+	ctx context.Context, tx *sql.Tx,
+) error {
+	repairs := []struct {
+		table  string
+		column string
+	}{
+		{table: "middleman_repos", column: "created_at"},
+		{table: "middleman_repos", column: "last_sync_started_at"},
+		{table: "middleman_repos", column: "last_sync_completed_at"},
+		{table: "middleman_repos", column: "backfill_pr_completed_at"},
+		{table: "middleman_repos", column: "backfill_issue_completed_at"},
+		{table: "middleman_merge_requests", column: "created_at"},
+		{table: "middleman_merge_requests", column: "updated_at"},
+		{table: "middleman_merge_requests", column: "last_activity_at"},
+		{table: "middleman_merge_requests", column: "merged_at"},
+		{table: "middleman_merge_requests", column: "closed_at"},
+		{table: "middleman_merge_requests", column: "detail_fetched_at"},
+		{table: "middleman_issues", column: "created_at"},
+		{table: "middleman_issues", column: "updated_at"},
+		{table: "middleman_issues", column: "last_activity_at"},
+		{table: "middleman_issues", column: "closed_at"},
+		{table: "middleman_issues", column: "detail_fetched_at"},
+		{table: "middleman_mr_events", column: "created_at"},
+		{table: "middleman_issue_events", column: "created_at"},
+	}
+
+	for _, repair := range repairs {
+		if err := repairTimestampColumn(
+			ctx, tx, repair.table, repair.column,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func repairTimestampColumn(
+	ctx context.Context, tx *sql.Tx, table, column string,
+) error {
+	query := fmt.Sprintf(
+		`SELECT rowid, %s FROM %s WHERE %s IS NOT NULL`,
+		column, table, column,
+	)
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("query %s.%s timestamps: %w", table, column, err)
+	}
+	defer rows.Close()
+
+	type repairRow struct {
+		rowID int64
+		value time.Time
+	}
+
+	var repairs []repairRow
+	for rows.Next() {
+		var rowID int64
+		var raw string
+		if err := rows.Scan(&rowID, &raw); err != nil {
+			return fmt.Errorf("scan %s.%s timestamp: %w", table, column, err)
+		}
+		parsed, err := parseStoredTimestamp(raw)
+		if err != nil {
+			return fmt.Errorf("parse %s.%s row %d timestamp %q: %w", table, column, rowID, raw, err)
+		}
+		if raw == canonicalUTCDatabaseString(parsed) {
+			continue
+		}
+		repairs = append(repairs, repairRow{rowID: rowID, value: parsed.UTC()})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate %s.%s timestamps: %w", table, column, err)
+	}
+
+	update := fmt.Sprintf(`UPDATE %s SET %s = ? WHERE rowid = ?`, table, column)
+	for _, repair := range repairs {
+		if _, err := tx.ExecContext(ctx, update, repair.value, repair.rowID); err != nil {
+			return fmt.Errorf("update %s.%s row %d timestamp: %w", table, column, repair.rowID, err)
+		}
+	}
+	return nil
+}
+
+func canonicalUTCDatabaseString(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+var storedTimestampLayouts = []string{
+	"2006-01-02 15:04:05 +0000 UTC",
+	"2006-01-02 15:04:05 -0700 -0700",
+	"2006-01-02 15:04:05 -0700 MST",
+	"2006-01-02T15:04:05Z",
+	time.RFC3339,
+	time.RFC3339Nano,
+	"2006-01-02 15:04:05",
+}
+
+func parseStoredTimestamp(raw string) (time.Time, error) {
+	for _, layout := range storedTimestampLayouts {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognized time format: %q", raw)
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -26,31 +26,32 @@ const (
 //go:embed migrations/*.sql
 var migrationFiles embed.FS
 
-func runMigrations(rw *sql.DB) error {
+func runMigrations(rw *sql.DB) (int, error) {
 	sourceDriver, err := iofs.New(migrationFiles, "migrations")
 	if err != nil {
-		return fmt.Errorf("load embedded migrations: %w", err)
+		return migratedb.NilVersion, fmt.Errorf("load embedded migrations: %w", err)
 	}
 
 	databaseDriver, err := migratesqlite.WithInstance(rw, &migratesqlite.Config{
 		MigrationsTable: migrationTableName,
 	})
 	if err != nil {
-		return wrapMigrationError(fmt.Errorf("open migration driver: %w", err))
+		return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("open migration driver: %w", err))
 	}
 
 	version, dirty, err := databaseDriver.Version()
 	if err != nil {
-		return wrapMigrationError(fmt.Errorf("read migration version: %w", err))
+		return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("read migration version: %w", err))
 	}
+	startVersion := version
 
 	latest, err := latestMigrationVersion()
 	if err != nil {
-		return fmt.Errorf("read embedded migration versions: %w", err)
+		return migratedb.NilVersion, fmt.Errorf("read embedded migration versions: %w", err)
 	}
 
 	if version > latest {
-		return fmt.Errorf(
+		return migratedb.NilVersion, fmt.Errorf(
 			"middleman schema version %d is newer than this binary "+
 				"(expects %d); upgrade middleman",
 			version, latest,
@@ -58,40 +59,41 @@ func runMigrations(rw *sql.DB) error {
 	}
 
 	if dirty {
-		return wrapMigrationError(fmt.Errorf("database is in a dirty migration state"))
+		return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("database is in a dirty migration state"))
 	}
 
 	if version == migratedb.NilVersion {
 		legacyVersion, hasLegacyVersion, err := readLegacySchemaVersion(rw)
 		if err != nil {
-			return wrapMigrationError(fmt.Errorf("read legacy schema version: %w", err))
+			return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("read legacy schema version: %w", err))
 		}
 
 		switch {
 		case hasLegacyVersion:
 			if !hasMiddlemanTables(rw) {
-				return wrapMigrationError(
+				return migratedb.NilVersion, wrapMigrationError(
 					fmt.Errorf("legacy database schema version metadata exists without middleman tables"),
 				)
 			}
 			if legacyVersion > latestLegacySchemaVersion {
-				return fmt.Errorf(
+				return migratedb.NilVersion, fmt.Errorf(
 					"middleman schema version %d is newer than this binary "+
 						"(expects %d); upgrade middleman",
 					legacyVersion, latestLegacySchemaVersion,
 				)
 			}
 			if legacyVersion < firstLegacySchemaVersion {
-				return wrapMigrationError(
+				return migratedb.NilVersion, wrapMigrationError(
 					fmt.Errorf("legacy database schema version %d is invalid", legacyVersion),
 				)
 			}
 			if err := databaseDriver.SetVersion(legacyVersion, false); err != nil {
-				return wrapMigrationError(fmt.Errorf("seed legacy migration version: %w", err))
+				return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("seed legacy migration version: %w", err))
 			}
+			startVersion = legacyVersion
 
 		case hasMiddlemanTables(rw):
-			return wrapMigrationError(
+			return migratedb.NilVersion, wrapMigrationError(
 				fmt.Errorf("legacy database is missing schema version metadata"),
 			)
 		}
@@ -99,27 +101,27 @@ func runMigrations(rw *sql.DB) error {
 
 	m, err := migrate.NewWithInstance("iofs", sourceDriver, "sqlite", databaseDriver)
 	if err != nil {
-		return wrapMigrationError(fmt.Errorf("create migrator: %w", err))
+		return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("create migrator: %w", err))
 	}
 
 	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		return wrapMigrationError(fmt.Errorf("apply migrations: %w", err))
+		return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("apply migrations: %w", err))
 	}
 
 	version, dirty, err = databaseDriver.Version()
 	if err != nil {
-		return wrapMigrationError(fmt.Errorf("read migration version after update: %w", err))
+		return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("read migration version after update: %w", err))
 	}
 	if dirty {
-		return wrapMigrationError(fmt.Errorf("database is in a dirty migration state"))
+		return migratedb.NilVersion, wrapMigrationError(fmt.Errorf("database is in a dirty migration state"))
 	}
 	if version != latest {
-		return wrapMigrationError(
+		return migratedb.NilVersion, wrapMigrationError(
 			fmt.Errorf("database ended at migration version %d, expected %d", version, latest),
 		)
 	}
 
-	return nil
+	return startVersion, nil
 }
 
 func latestMigrationVersion() (int, error) {

--- a/internal/db/migrations/000010_timestamp_repair_gate.down.sql
+++ b/internal/db/migrations/000010_timestamp_repair_gate.down.sql
@@ -1,0 +1,1 @@
+-- Version gate rollback for the one-time legacy timestamp repair.

--- a/internal/db/migrations/000010_timestamp_repair_gate.up.sql
+++ b/internal/db/migrations/000010_timestamp_repair_gate.up.sql
@@ -1,0 +1,2 @@
+-- Version gate for the one-time legacy timestamp repair that runs from Go
+-- immediately after upgrading databases from schema versions below 10.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -586,9 +586,12 @@ func (d *DB) UpdateRepoSettings(
 
 // --- Merge Requests ---
 
-// UpsertMergeRequest inserts or updates a merge request, returning its internal ID.
+// UpsertMergeRequest inserts or updates a merge request, returning its internal
+// ID. Before writing, all timestamp fields are normalized to UTC so the raw
+// SQLite DATETIME text stays comparable in SQL.
 // On conflict (repo_id, number), stale snapshots are ignored wholesale.
 func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, error) {
+	canonicalizeMergeRequestTimestamps(mr)
 	_, err := d.rw.ExecContext(ctx, `
 		INSERT INTO middleman_merge_requests
 		    (repo_id, platform_id, number, url, title, author, author_display_name,
@@ -867,7 +870,9 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 
 // --- Events ---
 
-// UpsertMREvents bulk-inserts events, ignoring duplicates per merge request.
+// UpsertMREvents bulk-inserts events after normalizing CreatedAt to UTC. When a
+// duplicate dedupe key is seen again, the conflict path refreshes created_at so
+// legacy local-offset rows are repaired during normal sync.
 func (d *DB) UpsertMREvents(ctx context.Context, events []MREvent) error {
 	if len(events) == 0 {
 		return nil
@@ -878,7 +883,14 @@ func (d *DB) UpsertMREvents(ctx context.Context, events []MREvent) error {
 			    (merge_request_id, platform_id, event_type, author, summary, body,
 			     metadata_json, created_at, dedupe_key)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(merge_request_id, dedupe_key) DO NOTHING`)
+			ON CONFLICT(merge_request_id, dedupe_key) DO UPDATE SET
+			    platform_id   = excluded.platform_id,
+			    event_type    = excluded.event_type,
+			    author        = excluded.author,
+			    summary       = excluded.summary,
+			    body          = excluded.body,
+			    metadata_json = excluded.metadata_json,
+			    created_at    = excluded.created_at`)
 		if err != nil {
 			return fmt.Errorf("prepare upsert mr events: %w", err)
 		}
@@ -886,6 +898,7 @@ func (d *DB) UpsertMREvents(ctx context.Context, events []MREvent) error {
 
 		for i := range events {
 			e := &events[i]
+			canonicalizeMREventTimestamps(e)
 			if _, err := stmt.ExecContext(ctx,
 				e.MergeRequestID, e.PlatformID, e.EventType, e.Author, e.Summary, e.Body,
 				e.MetadataJSON, e.CreatedAt, e.DedupeKey,
@@ -1231,9 +1244,12 @@ func (d *DB) UpdateMRState(
 
 // --- Issues ---
 
-// UpsertIssue inserts or updates an issue, returning its internal ID.
+// UpsertIssue inserts or updates an issue, returning its internal ID. Before
+// writing, all timestamp fields are normalized to UTC so SQL ordering/filtering
+// operates on a consistent storage representation.
 // On conflict (repo_id, number), stale snapshots are ignored wholesale.
 func (d *DB) UpsertIssue(ctx context.Context, issue *Issue) (int64, error) {
+	canonicalizeIssueTimestamps(issue)
 	_, err := d.rw.ExecContext(ctx, `
 		INSERT INTO middleman_issues
 		    (repo_id, platform_id, number, url, title, author, state,
@@ -1622,7 +1638,9 @@ func (d *DB) UpdateBackfillCursor(
 
 // --- Issue Events ---
 
-// UpsertIssueEvents bulk-inserts issue events, ignoring duplicates by dedupe_key.
+// UpsertIssueEvents bulk-inserts issue events after normalizing CreatedAt to
+// UTC. Duplicate keys rewrite created_at so repeat syncs repair older local
+// timestamp encodings instead of preserving them forever.
 func (d *DB) UpsertIssueEvents(ctx context.Context, events []IssueEvent) error {
 	if len(events) == 0 {
 		return nil
@@ -1633,7 +1651,15 @@ func (d *DB) UpsertIssueEvents(ctx context.Context, events []IssueEvent) error {
 			    (issue_id, platform_id, event_type, author, summary, body,
 			     metadata_json, created_at, dedupe_key)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(dedupe_key) DO NOTHING`)
+			ON CONFLICT(dedupe_key) DO UPDATE SET
+			    issue_id      = excluded.issue_id,
+			    platform_id   = excluded.platform_id,
+			    event_type    = excluded.event_type,
+			    author        = excluded.author,
+			    summary       = excluded.summary,
+			    body          = excluded.body,
+			    metadata_json = excluded.metadata_json,
+			    created_at    = excluded.created_at`)
 		if err != nil {
 			return fmt.Errorf("prepare upsert issue events: %w", err)
 		}
@@ -1641,6 +1667,7 @@ func (d *DB) UpsertIssueEvents(ctx context.Context, events []IssueEvent) error {
 
 		for i := range events {
 			e := &events[i]
+			canonicalizeIssueEventTimestamps(e)
 			if _, err := stmt.ExecContext(ctx,
 				e.IssueID, e.PlatformID, e.EventType, e.Author,
 				e.Summary, e.Body, e.MetadataJSON, e.CreatedAt,

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -452,6 +452,7 @@ func (d *DB) ListRepos(ctx context.Context) ([]Repo, error) {
 
 // UpdateRepoSyncStarted records the time a sync began.
 func (d *DB) UpdateRepoSyncStarted(ctx context.Context, id int64, t time.Time) error {
+	t = canonicalUTCTime(t)
 	_, err := d.rw.ExecContext(ctx,
 		`UPDATE middleman_repos SET last_sync_started_at = ? WHERE id = ?`, t, id,
 	)
@@ -463,6 +464,7 @@ func (d *DB) UpdateRepoSyncStarted(ctx context.Context, id int64, t time.Time) e
 
 // UpdateRepoSyncCompleted records the time and optional error a sync finished.
 func (d *DB) UpdateRepoSyncCompleted(ctx context.Context, id int64, t time.Time, syncErr string) error {
+	t = canonicalUTCTime(t)
 	_, err := d.rw.ExecContext(ctx,
 		`UPDATE middleman_repos SET last_sync_completed_at = ?, last_sync_error = ? WHERE id = ?`,
 		t, syncErr, id,
@@ -1617,6 +1619,11 @@ func (d *DB) UpdateBackfillCursor(
 	issuePage int, issueComplete bool,
 	issueCompletedAt *time.Time,
 ) error {
+	repo := &Repo{
+		BackfillPRCompletedAt:    prCompletedAt,
+		BackfillIssueCompletedAt: issueCompletedAt,
+	}
+	canonicalizeRepoTimestamps(repo)
 	_, err := d.rw.ExecContext(ctx, `
 		UPDATE middleman_repos
 		SET backfill_pr_page = ?,
@@ -1626,8 +1633,8 @@ func (d *DB) UpdateBackfillCursor(
 		    backfill_issue_complete = ?,
 		    backfill_issue_completed_at = ?
 		WHERE id = ?`,
-		prPage, prComplete, prCompletedAt,
-		issuePage, issueComplete, issueCompletedAt,
+		prPage, prComplete, repo.BackfillPRCompletedAt,
+		issuePage, issueComplete, repo.BackfillIssueCompletedAt,
 		repoID,
 	)
 	if err != nil {

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -174,8 +174,11 @@ func (d *DB) ListActivity(
 	return items, rows.Err()
 }
 
-// dbTimeLayouts lists formats the modernc.org/sqlite driver may
-// produce for DATETIME columns, ordered by likelihood.
+// dbTimeLayouts lists timestamp encodings that may already exist in SQLite.
+// Middleman now writes UTC timestamps consistently, but older databases may
+// still contain local-offset strings from earlier builds or SQLite-built
+// values from migrations/defaults. The parser accepts both so read paths and
+// startup repair can recover the original instant before normalizing to UTC.
 var dbTimeLayouts = []string{
 	"2006-01-02 15:04:05 +0000 UTC",
 	"2006-01-02 15:04:05 -0700 -0700",

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -308,3 +308,107 @@ func TestParseDBTime(t *testing.T) {
 		assert.Error(err)
 	})
 }
+
+func TestUpsertMREventsRewritesLegacyCreatedAtOnConflict(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+	base := baseTime()
+	repoID := insertTestRepo(t, d, "alice", "alpha")
+	prID := insertTestMR(t, d, repoID, 1, "Rewrite timestamps", base)
+
+	_, err := d.WriteDB().ExecContext(ctx, `
+		INSERT INTO middleman_mr_events
+		    (merge_request_id, platform_id, event_type, author, summary, body,
+		     metadata_json, created_at, dedupe_key)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		prID,
+		101,
+		"issue_comment",
+		"reviewer",
+		"",
+		"legacy row",
+		"",
+		"2026-04-11 08:00:00 -0400 EDT",
+		"comment-legacy",
+	)
+	require.NoError(err)
+
+	canonical := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+	err = d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: prID,
+		EventType:      "issue_comment",
+		Author:         "reviewer",
+		Body:           "rewritten",
+		CreatedAt:      canonical,
+		DedupeKey:      "comment-legacy",
+	}})
+	require.NoError(err)
+
+	var raw string
+	err = d.ReadDB().QueryRowContext(ctx,
+		`SELECT created_at FROM middleman_mr_events WHERE merge_request_id = ? AND dedupe_key = ?`,
+		prID,
+		"comment-legacy",
+	).Scan(&raw)
+	require.NoError(err)
+	require.NotContains(raw, "EDT")
+	require.NotContains(raw, "-0400")
+
+	events, err := d.ListMREvents(ctx, prID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal(canonical, events[0].CreatedAt)
+}
+
+func TestUpsertIssueEventsRewritesLegacyCreatedAtOnConflict(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+	base := baseTime()
+	repoID := insertTestRepo(t, d, "alice", "alpha")
+	issueID := insertTestIssue(t, d, repoID, 7, "Rewrite timestamps", base)
+
+	_, err := d.WriteDB().ExecContext(ctx, `
+		INSERT INTO middleman_issue_events
+		    (issue_id, platform_id, event_type, author, summary, body,
+		     metadata_json, created_at, dedupe_key)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		issueID,
+		202,
+		"issue_comment",
+		"reporter",
+		"",
+		"legacy row",
+		"",
+		"2026-04-11 09:00:00 -0400 EDT",
+		"issue-comment-legacy",
+	)
+	require.NoError(err)
+
+	canonical := time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC)
+	err = d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID:   issueID,
+		EventType: "issue_comment",
+		Author:    "reporter",
+		Body:      "rewritten",
+		CreatedAt: canonical,
+		DedupeKey: "issue-comment-legacy",
+	}})
+	require.NoError(err)
+
+	var raw string
+	err = d.ReadDB().QueryRowContext(ctx,
+		`SELECT created_at FROM middleman_issue_events WHERE issue_id = ? AND dedupe_key = ?`,
+		issueID,
+		"issue-comment-legacy",
+	).Scan(&raw)
+	require.NoError(err)
+	require.NotContains(raw, "EDT")
+	require.NotContains(raw, "-0400")
+
+	events, err := d.ListIssueEvents(ctx, issueID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal(canonical, events[0].CreatedAt)
+}

--- a/internal/db/timestamps.go
+++ b/internal/db/timestamps.go
@@ -1,0 +1,153 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// canonicalUTCTime converts application timestamps to UTC before they cross
+// the SQLite write boundary. This keeps raw text storage stable so SQL
+// ordering/filtering on DATETIME columns reflects the actual instant.
+func canonicalUTCTime(t time.Time) time.Time {
+	if t.IsZero() {
+		return t
+	}
+	return t.UTC()
+}
+
+func canonicalUTCTimePtr(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	utc := canonicalUTCTime(*t)
+	return &utc
+}
+
+// canonicalizeMergeRequestTimestamps enforces the repo-wide contract that PR
+// timestamps are stored in UTC, even if the caller constructed local-zone
+// fixtures or legacy values upstream.
+func canonicalizeMergeRequestTimestamps(mr *MergeRequest) {
+	if mr == nil {
+		return
+	}
+	mr.CreatedAt = canonicalUTCTime(mr.CreatedAt)
+	mr.UpdatedAt = canonicalUTCTime(mr.UpdatedAt)
+	mr.LastActivityAt = canonicalUTCTime(mr.LastActivityAt)
+	mr.MergedAt = canonicalUTCTimePtr(mr.MergedAt)
+	mr.ClosedAt = canonicalUTCTimePtr(mr.ClosedAt)
+	mr.DetailFetchedAt = canonicalUTCTimePtr(mr.DetailFetchedAt)
+}
+
+// canonicalizeIssueTimestamps applies the same UTC storage contract to issue
+// timestamps before insert/update statements execute.
+func canonicalizeIssueTimestamps(issue *Issue) {
+	if issue == nil {
+		return
+	}
+	issue.CreatedAt = canonicalUTCTime(issue.CreatedAt)
+	issue.UpdatedAt = canonicalUTCTime(issue.UpdatedAt)
+	issue.LastActivityAt = canonicalUTCTime(issue.LastActivityAt)
+	issue.ClosedAt = canonicalUTCTimePtr(issue.ClosedAt)
+	issue.DetailFetchedAt = canonicalUTCTimePtr(issue.DetailFetchedAt)
+}
+
+// canonicalizeMREventTimestamps normalizes event times before activity rows
+// reach SQLite so raw created_at text stays chronologically sortable.
+func canonicalizeMREventTimestamps(event *MREvent) {
+	if event == nil {
+		return
+	}
+	event.CreatedAt = canonicalUTCTime(event.CreatedAt)
+}
+
+// canonicalizeIssueEventTimestamps normalizes issue activity timestamps before
+// they are persisted.
+func canonicalizeIssueEventTimestamps(event *IssueEvent) {
+	if event == nil {
+		return
+	}
+	event.CreatedAt = canonicalUTCTime(event.CreatedAt)
+}
+
+// repairLegacyTimestampStorage rewrites legacy offset-based timestamps into
+// UTC on startup. This is intentionally idempotent: reopening a database keeps
+// the same instants but refreshes the raw DATETIME text so SQL comparisons no
+// longer depend on mixed local/UTC encodings.
+func (d *DB) repairLegacyTimestampStorage(ctx context.Context) error {
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		repairs := []struct {
+			table  string
+			column string
+		}{
+			{table: "middleman_merge_requests", column: "created_at"},
+			{table: "middleman_merge_requests", column: "updated_at"},
+			{table: "middleman_merge_requests", column: "last_activity_at"},
+			{table: "middleman_merge_requests", column: "merged_at"},
+			{table: "middleman_merge_requests", column: "closed_at"},
+			{table: "middleman_merge_requests", column: "detail_fetched_at"},
+			{table: "middleman_issues", column: "created_at"},
+			{table: "middleman_issues", column: "updated_at"},
+			{table: "middleman_issues", column: "last_activity_at"},
+			{table: "middleman_issues", column: "closed_at"},
+			{table: "middleman_issues", column: "detail_fetched_at"},
+			{table: "middleman_mr_events", column: "created_at"},
+			{table: "middleman_issue_events", column: "created_at"},
+		}
+
+		for _, repair := range repairs {
+			if err := repairTimestampColumn(ctx, tx, repair.table, repair.column); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// repairTimestampColumn reparses one timestamp column and writes the same
+// instant back in UTC. It operates on rowid so the helper works across all
+// timestamp-bearing tables without needing per-table primary-key logic.
+func repairTimestampColumn(
+	ctx context.Context, tx *sql.Tx, table, column string,
+) error {
+	query := fmt.Sprintf(
+		`SELECT rowid, %s FROM %s WHERE %s IS NOT NULL`,
+		column, table, column,
+	)
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("query %s.%s timestamps: %w", table, column, err)
+	}
+	defer rows.Close()
+
+	type repairRow struct {
+		rowID int64
+		value time.Time
+	}
+
+	var repairs []repairRow
+	for rows.Next() {
+		var rowID int64
+		var raw string
+		if err := rows.Scan(&rowID, &raw); err != nil {
+			return fmt.Errorf("scan %s.%s timestamp: %w", table, column, err)
+		}
+		parsed, err := parseDBTime(raw)
+		if err != nil {
+			return fmt.Errorf("parse %s.%s row %d timestamp %q: %w", table, column, rowID, raw, err)
+		}
+		repairs = append(repairs, repairRow{rowID: rowID, value: parsed.UTC()})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate %s.%s timestamps: %w", table, column, err)
+	}
+
+	update := fmt.Sprintf(`UPDATE %s SET %s = ? WHERE rowid = ?`, table, column)
+	for _, repair := range repairs {
+		if _, err := tx.ExecContext(ctx, update, repair.value, repair.rowID); err != nil {
+			return fmt.Errorf("update %s.%s row %d timestamp: %w", table, column, repair.rowID, err)
+		}
+	}
+	return nil
+}

--- a/internal/db/timestamps.go
+++ b/internal/db/timestamps.go
@@ -1,11 +1,6 @@
 package db
 
-import (
-	"context"
-	"database/sql"
-	"fmt"
-	"time"
-)
+import "time"
 
 // canonicalUTCTime converts application timestamps to UTC before they cross
 // the SQLite write boundary. This keeps raw text storage stable so SQL
@@ -23,6 +18,19 @@ func canonicalUTCTimePtr(t *time.Time) *time.Time {
 	}
 	utc := canonicalUTCTime(*t)
 	return &utc
+}
+
+// canonicalizeRepoTimestamps enforces UTC storage for repo metadata timestamps
+// before update statements persist sync/backfill progress.
+func canonicalizeRepoTimestamps(repo *Repo) {
+	if repo == nil {
+		return
+	}
+	repo.CreatedAt = canonicalUTCTime(repo.CreatedAt)
+	repo.LastSyncStartedAt = canonicalUTCTimePtr(repo.LastSyncStartedAt)
+	repo.LastSyncCompletedAt = canonicalUTCTimePtr(repo.LastSyncCompletedAt)
+	repo.BackfillPRCompletedAt = canonicalUTCTimePtr(repo.BackfillPRCompletedAt)
+	repo.BackfillIssueCompletedAt = canonicalUTCTimePtr(repo.BackfillIssueCompletedAt)
 }
 
 // canonicalizeMergeRequestTimestamps enforces the repo-wide contract that PR
@@ -69,85 +77,4 @@ func canonicalizeIssueEventTimestamps(event *IssueEvent) {
 		return
 	}
 	event.CreatedAt = canonicalUTCTime(event.CreatedAt)
-}
-
-// repairLegacyTimestampStorage rewrites legacy offset-based timestamps into
-// UTC on startup. This is intentionally idempotent: reopening a database keeps
-// the same instants but refreshes the raw DATETIME text so SQL comparisons no
-// longer depend on mixed local/UTC encodings.
-func (d *DB) repairLegacyTimestampStorage(ctx context.Context) error {
-	return d.Tx(ctx, func(tx *sql.Tx) error {
-		repairs := []struct {
-			table  string
-			column string
-		}{
-			{table: "middleman_merge_requests", column: "created_at"},
-			{table: "middleman_merge_requests", column: "updated_at"},
-			{table: "middleman_merge_requests", column: "last_activity_at"},
-			{table: "middleman_merge_requests", column: "merged_at"},
-			{table: "middleman_merge_requests", column: "closed_at"},
-			{table: "middleman_merge_requests", column: "detail_fetched_at"},
-			{table: "middleman_issues", column: "created_at"},
-			{table: "middleman_issues", column: "updated_at"},
-			{table: "middleman_issues", column: "last_activity_at"},
-			{table: "middleman_issues", column: "closed_at"},
-			{table: "middleman_issues", column: "detail_fetched_at"},
-			{table: "middleman_mr_events", column: "created_at"},
-			{table: "middleman_issue_events", column: "created_at"},
-		}
-
-		for _, repair := range repairs {
-			if err := repairTimestampColumn(ctx, tx, repair.table, repair.column); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-}
-
-// repairTimestampColumn reparses one timestamp column and writes the same
-// instant back in UTC. It operates on rowid so the helper works across all
-// timestamp-bearing tables without needing per-table primary-key logic.
-func repairTimestampColumn(
-	ctx context.Context, tx *sql.Tx, table, column string,
-) error {
-	query := fmt.Sprintf(
-		`SELECT rowid, %s FROM %s WHERE %s IS NOT NULL`,
-		column, table, column,
-	)
-	rows, err := tx.QueryContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("query %s.%s timestamps: %w", table, column, err)
-	}
-	defer rows.Close()
-
-	type repairRow struct {
-		rowID int64
-		value time.Time
-	}
-
-	var repairs []repairRow
-	for rows.Next() {
-		var rowID int64
-		var raw string
-		if err := rows.Scan(&rowID, &raw); err != nil {
-			return fmt.Errorf("scan %s.%s timestamp: %w", table, column, err)
-		}
-		parsed, err := parseDBTime(raw)
-		if err != nil {
-			return fmt.Errorf("parse %s.%s row %d timestamp %q: %w", table, column, rowID, raw, err)
-		}
-		repairs = append(repairs, repairRow{rowID: rowID, value: parsed.UTC()})
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate %s.%s timestamps: %w", table, column, err)
-	}
-
-	update := fmt.Sprintf(`UPDATE %s SET %s = ? WHERE rowid = ?`, table, column)
-	for _, repair := range repairs {
-		if _, err := tx.ExecContext(ctx, update, repair.value, repair.rowID); err != nil {
-			return fmt.Errorf("update %s.%s row %d timestamp: %w", table, column, repair.rowID, err)
-		}
-	}
-	return nil
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4596,6 +4596,11 @@ func TestAPIActivityStartupRepairsLegacyTimestampStorage(t *testing.T) {
 		"comment-issue-legacy",
 	)
 	require.NoError(err)
+	_, err = raw.ExecContext(ctx,
+		`UPDATE schema_migrations SET version = ?, dirty = FALSE`,
+		9,
+	)
+	require.NoError(err)
 	require.NoError(raw.Close())
 
 	reopened, err := db.Open(path)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4486,8 +4486,9 @@ func TestAPIActivityReturnsUTCCreatedAt(t *testing.T) {
 	client := setupTestClient(t, srv)
 	prID := seedPR(t, database, "acme", "widget", 1)
 	ctx := context.Background()
+	createdAtUTC := time.Now().UTC().Add(-2 * time.Hour).Round(time.Second)
 	//nolint:forbidigo // Test fixture intentionally uses a non-UTC timestamp to verify UTC normalization.
-	createdAt := time.Date(2026, 4, 11, 12, 0, 0, 0, time.FixedZone("EDT", -4*60*60))
+	createdAt := createdAtUTC.In(time.FixedZone("EDT", -4*60*60))
 
 	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
 		MergeRequestID: prID,
@@ -4498,7 +4499,7 @@ func TestAPIActivityReturnsUTCCreatedAt(t *testing.T) {
 		DedupeKey:      "comment-utc-created-at",
 	}}))
 
-	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
+	since := createdAtUTC.Add(-time.Hour).Format(time.RFC3339)
 	resp, err := client.HTTP.GetActivityWithResponse(
 		ctx, &generated.GetActivityParams{Since: &since},
 	)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -260,6 +261,25 @@ func (m *mockGH) InvalidateListETagsForRepo(_, _ string, _ ...string) {}
 func setupTestServer(t *testing.T) (*Server, *db.DB) {
 	t.Helper()
 	return setupTestServerWithMock(t, &mockGH{})
+}
+
+func setupTestServerWithDatabase(
+	t *testing.T, database *db.DB, repos []ghclient.RepoRef,
+) *Server {
+	t.Helper()
+
+	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": &mockGH{}}, database, nil, repos, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := New(
+		database, syncer, nil, "/",
+		nil, ServerOptions{},
+	)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return srv
 }
 
 func setupTestServerWithMock(t *testing.T, mock *mockGH) (*Server, *db.DB) {
@@ -4500,6 +4520,121 @@ func TestAPIActivityReturnsUTCCreatedAt(t *testing.T) {
 	assertRFC3339UTC(t, commentItem.CreatedAt, createdAt)
 	assert.Equal("reviewer", commentItem.Author)
 	assert.Equal("comment", commentItem.ActivityType)
+}
+
+func TestAPIActivityStartupRepairsLegacyTimestampStorage(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	setTestLocalEDT(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	database, err := db.Open(path)
+	require.NoError(err)
+
+	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(err)
+	prID, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:            repoID,
+		PlatformID:        101,
+		Number:            1,
+		URL:               "https://github.com/acme/widget/pull/1",
+		Title:             "Legacy PR",
+		Author:            "octocat",
+		AuthorDisplayName: "octocat",
+		State:             "open",
+		HeadBranch:        "feature",
+		BaseBranch:        "main",
+		CreatedAt:         time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:         time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		LastActivityAt:    time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(err)
+	issueID, err := database.UpsertIssue(ctx, &db.Issue{
+		RepoID:         repoID,
+		PlatformID:     201,
+		Number:         2,
+		URL:            "https://github.com/acme/widget/issues/2",
+		Title:          "Legacy issue",
+		Author:         "octocat",
+		State:          "open",
+		CreatedAt:      time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		LastActivityAt: time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(err)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: prID,
+		EventType:      "issue_comment",
+		Author:         "pr-reviewer",
+		Body:           "PR comment",
+		CreatedAt:      time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC),
+		DedupeKey:      "comment-pr-legacy",
+	}}))
+	require.NoError(database.UpsertIssueEvents(ctx, []db.IssueEvent{{
+		IssueID:   issueID,
+		EventType: "issue_comment",
+		Author:    "issue-reporter",
+		Body:      "Issue comment",
+		CreatedAt: time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		DedupeKey: "comment-issue-legacy",
+	}}))
+	require.NoError(database.Close())
+
+	raw, err := sql.Open("sqlite", path)
+	require.NoError(err)
+	_, err = raw.ExecContext(ctx,
+		`UPDATE middleman_mr_events SET created_at = ? WHERE dedupe_key = ?`,
+		"2026-04-11 08:00:00 -0400 EDT",
+		"comment-pr-legacy",
+	)
+	require.NoError(err)
+	_, err = raw.ExecContext(ctx,
+		`UPDATE middleman_issue_events SET created_at = ? WHERE dedupe_key = ?`,
+		"2026-04-11 09:00:00 -0400 EDT",
+		"comment-issue-legacy",
+	)
+	require.NoError(err)
+	require.NoError(raw.Close())
+
+	reopened, err := db.Open(path)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(reopened.Close()) })
+
+	srv := setupTestServerWithDatabase(t, reopened, defaultTestRepos)
+	client := setupTestClient(t, srv)
+
+	since := "2026-04-11T11:30:00Z"
+	resp, err := client.HTTP.GetActivityWithResponse(
+		ctx, &generated.GetActivityParams{Since: &since},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Items)
+	commentItems := make([]generated.ActivityItemResponse, 0, 2)
+	for _, item := range *resp.JSON200.Items {
+		if item.ActivityType == "comment" {
+			commentItems = append(commentItems, item)
+		}
+	}
+	require.Len(commentItems, 2)
+	assert.Equal("issue-reporter", commentItems[0].Author)
+	assert.Equal("pr-reviewer", commentItems[1].Author)
+	assertRFC3339UTC(t, commentItems[0].CreatedAt, time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC))
+	assertRFC3339UTC(t, commentItems[1].CreatedAt, time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC))
+
+	since = "2026-04-11T12:30:00Z"
+	resp, err = client.HTTP.GetActivityWithResponse(
+		ctx, &generated.GetActivityParams{Since: &since},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Items)
+	require.Len(*resp.JSON200.Items, 1)
+	assert.Equal("issue-reporter", (*resp.JSON200.Items)[0].Author)
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -97,6 +97,10 @@ func validateStarredRequest(body starredRequest) bool {
 	return body.ItemType == "pr" || body.ItemType == "issue"
 }
 
+// formatUTCRFC3339 is the server's API boundary formatter for timestamps.
+// Handlers pass absolute instants through this helper so JSON always leaves
+// middleman as explicit UTC RFC3339, regardless of how a test or caller
+// constructed the original time.Time.
 func formatUTCRFC3339(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/wesm/middleman/internal/apiclient/generated"
 	"github.com/wesm/middleman/internal/config"
 	"github.com/wesm/middleman/internal/db"
-	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/gitclone"
+	ghclient "github.com/wesm/middleman/internal/github"
 )
 
 // writeTmuxRecorder creates an executable fake-tmux script at a
@@ -208,6 +208,7 @@ func setupWrapperServerWithScript(
 
 func TestTmuxWrapperNewSession(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 	client, _, record := setupWrapperServer(t)
 	ctx := context.Background()
 
@@ -220,15 +221,14 @@ func TestTmuxWrapperNewSession(t *testing.T) {
 			MrNumber:     1,
 		},
 	)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
-	require.NotNil(t, createResp.JSON202)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
 
 	// Workspace setup runs asynchronously. Poll the record file
 	// until the new-session invocation shows up, up to ~5s.
 	var argvs [][]string
 	require.Eventually(
-		t,
 		func() bool {
 			argvs = readTmuxRecord(t, record)
 			for _, argv := range argvs {
@@ -251,7 +251,7 @@ func TestTmuxWrapperNewSession(t *testing.T) {
 	}
 
 	// "wrap" prefix, then "new-session -d -s <id> -c <path> <shell> -l"
-	require.GreaterOrEqual(t, len(newSession), 9)
+	require.GreaterOrEqual(len(newSession), 9)
 	assert.Equal("wrap", newSession[0])
 	assert.Equal("new-session", newSession[1])
 	assert.Equal("-d", newSession[2])
@@ -265,6 +265,7 @@ func TestTmuxWrapperNewSession(t *testing.T) {
 
 func TestTmuxWrapperAttachSession(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 	client, baseURL, record := setupWrapperServer(t)
 	ctx := context.Background()
 
@@ -277,14 +278,13 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 			MrNumber:     1,
 		},
 	)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
-	require.NotNil(t, createResp.JSON202)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
 	wsID := createResp.JSON202.Id
 
 	// Poll for status == "ready".
 	require.Eventually(
-		t,
 		func() bool {
 			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
 				ctx, wsID,
@@ -307,11 +307,11 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 	)
 	defer dialCancel()
 	u, err := url.Parse(wsURL)
-	require.NoError(t, err)
+	require.NoError(err)
 	conn, httpResp, err := websocket.Dial(
 		dialCtx, u.String(), nil,
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 	if httpResp != nil && httpResp.Body != nil {
 		httpResp.Body.Close()
 	}
@@ -340,8 +340,8 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 			break
 		}
 	}
-	require.NotNil(t, attach, "attach-session argv not recorded")
-	require.Len(t, attach, 4)
+	require.NotNil(attach, "attach-session argv not recorded")
+	require.Len(attach, 4)
 	assert.Equal("wrap", attach[0])
 	assert.Equal("attach-session", attach[1])
 	assert.Equal("-t", attach[2])
@@ -355,15 +355,16 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 // collapsing them.
 func TestReadTmuxRecordPreservesEmptyArgs(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 	path := filepath.Join(t.TempDir(), "record")
 
 	// First record: 3 args with an interior empty ("a", "", "b").
 	// Second record: 2 args with a trailing empty ("x", "").
 	body := "3\x00a\x00\x00b\x00" + "2\x00x\x00\x00"
-	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	require.NoError(os.WriteFile(path, []byte(body), 0o644))
 
 	argvs := readTmuxRecord(t, path)
-	require.Len(t, argvs, 2)
+	require.Len(argvs, 2)
 	assert.Equal([]string{"a", "", "b"}, argvs[0])
 	assert.Equal([]string{"x", ""}, argvs[1])
 }
@@ -374,6 +375,7 @@ func TestReadTmuxRecordPreservesEmptyArgs(t *testing.T) {
 // together they cover all three tmux verbs that cross the HTTP boundary.
 func TestTmuxWrapperKillSession(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 	client, _, record := setupWrapperServer(t)
 	ctx := context.Background()
 
@@ -386,15 +388,14 @@ func TestTmuxWrapperKillSession(t *testing.T) {
 			MrNumber:     1,
 		},
 	)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
-	require.NotNil(t, createResp.JSON202)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
 	wsID := createResp.JSON202.Id
 
 	// Poll for status == "ready" before deleting so the tmux
 	// session is known to exist from the manager's perspective.
 	require.Eventually(
-		t,
 		func() bool {
 			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
 				ctx, wsID,
@@ -411,8 +412,8 @@ func TestTmuxWrapperKillSession(t *testing.T) {
 	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
 		ctx, wsID, &generated.DeleteWorkspaceParams{Force: &force},
 	)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusNoContent, delResp.StatusCode())
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, delResp.StatusCode())
 
 	// The recorded argv should contain a kill-session invocation
 	// with our "wrap" prefix.
@@ -423,8 +424,8 @@ func TestTmuxWrapperKillSession(t *testing.T) {
 			break
 		}
 	}
-	require.NotNil(t, kill, "kill-session argv not recorded")
-	require.Len(t, kill, 4)
+	require.NotNil(kill, "kill-session argv not recorded")
+	require.Len(kill, 4)
 	assert.Equal("wrap", kill[0])
 	assert.Equal("kill-session", kill[1])
 	assert.Equal("-t", kill[2])

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -375,6 +375,7 @@ func TestManagerDeleteUsesTmuxPrefix(t *testing.T) {
 
 func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 
 	// Script: "has-session" emits tmux's canonical "can't find
 	// session" stderr and exits 1 (so isTmuxSessionAbsent classifies
@@ -392,7 +393,7 @@ func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 		`  fi` + "\n" +
 		"done\n" +
 		"exit 0\n"
-	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 	t.Setenv("TMUX_RECORD", record)
 
 	d := openTestDB(t)
@@ -400,10 +401,10 @@ func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 	mgr.SetTmuxCommand([]string{script})
 
 	ctx := context.Background()
-	require.NoError(t, mgr.EnsureTmux(ctx, "sess-B", "/tmp/cwd"))
+	require.NoError(mgr.EnsureTmux(ctx, "sess-B", "/tmp/cwd"))
 
 	argvs := readRecorderArgv(t, record)
-	require.Len(t, argvs, 2)
+	require.Len(argvs, 2)
 	assert.Equal(
 		[]string{"has-session", "-t", "sess-B"},
 		argvs[0],
@@ -411,7 +412,7 @@ func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 	// new-session argv: "new-session -d -s sess-B -c /tmp/cwd <shell> -l"
 	// We check the prefix up to the shell; the shell resolves per
 	// runtime so just assert it is non-empty and ends with "-l".
-	require.GreaterOrEqual(t, len(argvs[1]), 8)
+	require.GreaterOrEqual(len(argvs[1]), 8)
 	assert.Equal("new-session", argvs[1][0])
 	assert.Equal("-d", argvs[1][1])
 	assert.Equal("-s", argvs[1][2])
@@ -429,15 +430,16 @@ func TestManagerEnsureTmuxCreatesSessionOnMiss(t *testing.T) {
 // collapsing them.
 func TestReadRecorderArgvPreservesEmptyArgs(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 	path := filepath.Join(t.TempDir(), "record")
 
 	// First record: 3 args with an interior empty ("a", "", "b").
 	// Second record: 2 args with a trailing empty ("x", "").
 	body := "3\x00a\x00\x00b\x00" + "2\x00x\x00\x00"
-	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	require.NoError(os.WriteFile(path, []byte(body), 0o644))
 
 	argvs := readRecorderArgv(t, path)
-	require.Len(t, argvs, 2)
+	require.Len(argvs, 2)
 	assert.Equal([]string{"a", "", "b"}, argvs[0])
 	assert.Equal([]string{"x", ""}, argvs[1])
 }
@@ -450,6 +452,7 @@ func TestReadRecorderArgvPreservesEmptyArgs(t *testing.T) {
 // same broken wrapper and the error would only surface on the second
 // exec, masking the real cause.
 func TestManagerEnsureTmuxPropagatesBinaryError(t *testing.T) {
+	require := require.New(t)
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
 	// Path that cannot possibly exist — exec returns a non-exit
@@ -459,8 +462,8 @@ func TestManagerEnsureTmuxPropagatesBinaryError(t *testing.T) {
 	)
 
 	err := mgr.EnsureTmux(context.Background(), "sess-X", "/tmp")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "tmux has-session")
+	require.Error(err)
+	require.Contains(err.Error(), "tmux has-session")
 }
 
 // TestManagerEnsureTmuxPropagatesNon1ExitCode pins down the
@@ -472,20 +475,21 @@ func TestManagerEnsureTmuxPropagatesBinaryError(t *testing.T) {
 // because the old check matched any *exec.ExitError. Now it must
 // propagate to the caller so misconfiguration surfaces cleanly.
 func TestManagerEnsureTmuxPropagatesNon1ExitCode(t *testing.T) {
+	require := require.New(t)
 	dir := t.TempDir()
 	script := filepath.Join(dir, "fake-tmux")
 	// exit 127 mimics "command not found" — a common wrapper failure
 	// signal that is NOT tmux's own "session missing" response.
 	body := "#!/bin/sh\nexit 127\n"
-	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script})
 
 	err := mgr.EnsureTmux(context.Background(), "sess-Y", "/tmp")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "tmux has-session")
+	require.Error(err)
+	require.Contains(err.Error(), "tmux has-session")
 }
 
 // TestManagerEnsureTmuxPropagatesExit1NonTmuxError covers the
@@ -496,19 +500,20 @@ func TestManagerEnsureTmuxPropagatesNon1ExitCode(t *testing.T) {
 // absent" would mask the wrapper bug by immediately trying
 // new-session through the same broken wrapper.
 func TestManagerEnsureTmuxPropagatesExit1NonTmuxError(t *testing.T) {
+	require := require.New(t)
 	dir := t.TempDir()
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\necho 'wrapper blew up' >&2\nexit 1\n"
-	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script})
 
 	err := mgr.EnsureTmux(context.Background(), "sess-Q", "/tmp")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "tmux has-session")
-	require.Contains(t, err.Error(), "wrapper blew up")
+	require.Error(err)
+	require.Contains(err.Error(), "tmux has-session")
+	require.Contains(err.Error(), "wrapper blew up")
 }
 
 // TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout pins down the
@@ -518,20 +523,21 @@ func TestManagerEnsureTmuxPropagatesExit1NonTmuxError(t *testing.T) {
 // unrelated reasons) must NOT be treated as session-absent — only
 // stderr carries the authoritative tmux signal.
 func TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout(t *testing.T) {
+	require := require.New(t)
 	dir := t.TempDir()
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
 		`echo "can't find session: sim"` + "\n" + // stdout only
 		`echo "real failure" >&2` + "\n" +
 		"exit 1\n"
-	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script})
 
 	err := mgr.EnsureTmux(context.Background(), "sess-R", "/tmp")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "tmux has-session")
-	require.Contains(t, err.Error(), "real failure")
+	require.Error(err)
+	require.Contains(err.Error(), "tmux has-session")
+	require.Contains(err.Error(), "real failure")
 }

--- a/packages/ui/src/utils/time.ts
+++ b/packages/ui/src/utils/time.ts
@@ -1,7 +1,28 @@
+/**
+ * Timestamp helpers for API data.
+ *
+ * Contract:
+ * - The backend stores and emits absolute instants in UTC.
+ * - These helpers preserve the instant when parsing.
+ * - Local timezone conversion is presentation-only and must stay in explicit
+ *   UI formatting helpers such as `localDateLabel()`.
+ */
+
+/**
+ * Parses an API timestamp into a JavaScript Date without changing the instant.
+ *
+ * API payloads are expected to be UTC RFC3339 strings, but JavaScript will
+ * also preserve the instant for older offset-formatted strings when tests
+ * exercise legacy data.
+ */
 export function parseAPITimestamp(dateStr: string): Date {
   return new Date(dateStr);
 }
 
+/**
+ * Returns a relative label for an API timestamp while keeping calculations in
+ * absolute time. This must not introduce any local timezone formatting.
+ */
 export function timeAgo(dateStr: string): string {
   const diffMs = Date.now() - parseAPITimestamp(dateStr).getTime();
   const diffMin = Math.floor(diffMs / 60_000);
@@ -14,6 +35,14 @@ export function timeAgo(dateStr: string): string {
   return `${Math.floor(days / 30)}mo ago`;
 }
 
+/**
+ * Converts an API timestamp to a local calendar label for display.
+ *
+ * This is one of the intentionally small number of places where frontend code
+ * is allowed to apply the browser's local timezone. Callers that only need
+ * ordering, filtering, or relative-time math should use `parseAPITimestamp()`
+ * instead so they stay on the original UTC instant.
+ */
 export function localDateLabel(dateStr: string): string {
   return parseAPITimestamp(dateStr).toLocaleDateString();
 }

--- a/tools/migrationhistorycheck/main.go
+++ b/tools/migrationhistorycheck/main.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -40,16 +42,31 @@ func run(stderr io.Writer) int {
 		return 1
 	}
 
-	violations := changedMainBranchMigrations(baseRef, migrationDir, diff)
-	if len(violations) == 0 {
+	changedViolations := changedMainBranchMigrations(baseRef, migrationDir, diff)
+	duplicateViolations, err := duplicateMigrationNumberViolations(baseRef, migrationDir, diff)
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to verify migration numbers: %v\n", err)
+		return 1
+	}
+
+	if len(changedViolations) == 0 && len(duplicateViolations) == 0 {
 		return 0
 	}
 
-	fmt.Fprintf(stderr, "Refusing to commit edits to migrations that already exist on %s.\n\n", baseRef)
-	fmt.Fprintln(stderr, "Migrations are append-only once they land on main. Add a new numbered migration instead.")
-	fmt.Fprintln(stderr, "\nBlocked files:")
-	for _, path := range violations {
-		fmt.Fprintf(stderr, "  %s\n", path)
+	fmt.Fprintln(stderr, "Refusing to commit staged migration history changes.")
+	if len(changedViolations) > 0 {
+		fmt.Fprintf(stderr, "\nEdits to migrations that already exist on %s are not allowed.\n", baseRef)
+		fmt.Fprintln(stderr, "Migrations are append-only once they land on main. Add a new numbered migration instead.")
+		fmt.Fprintln(stderr, "\nBlocked files:")
+		for _, path := range changedViolations {
+			fmt.Fprintf(stderr, "  %s\n", path)
+		}
+	}
+	if len(duplicateViolations) > 0 {
+		fmt.Fprintln(stderr, "\nEach migration number may identify only one migration. Found duplicate migration number assignments:")
+		for _, violation := range duplicateViolations {
+			fmt.Fprintf(stderr, "  %s: %s\n", violation.number, strings.Join(violation.names, ", "))
+		}
 	}
 	return 1
 }
@@ -91,6 +108,135 @@ func changedPaths(fields []string) []string {
 		return paths[1:]
 	}
 	return paths[:1]
+}
+
+type duplicateNumberViolation struct {
+	number string
+	names  []string
+}
+
+func duplicateMigrationNumberViolations(baseRef, migrationDir, diff string) ([]duplicateNumberViolation, error) {
+	baseByNumber, err := migrationNamesByNumberOnRef(baseRef, migrationDir)
+	if err != nil {
+		return nil, err
+	}
+
+	stagedByNumber := map[string]map[string]struct{}{}
+	for _, path := range stagedMigrationPaths(diff, migrationDir) {
+		number, name, ok := migrationIdentityFromPath(path)
+		if !ok {
+			continue
+		}
+		if _, exists := stagedByNumber[number]; !exists {
+			stagedByNumber[number] = map[string]struct{}{}
+		}
+		stagedByNumber[number][name] = struct{}{}
+	}
+
+	var violations []duplicateNumberViolation
+	for number, stagedNames := range stagedByNumber {
+		allNames := map[string]struct{}{}
+		for name := range baseByNumber[number] {
+			allNames[name] = struct{}{}
+		}
+		for name := range stagedNames {
+			allNames[name] = struct{}{}
+		}
+		if len(allNames) <= 1 {
+			continue
+		}
+
+		names := sortedKeys(allNames)
+		violations = append(violations, duplicateNumberViolation{
+			number: number,
+			names:  names,
+		})
+	}
+
+	slices.SortFunc(violations, func(a, b duplicateNumberViolation) int {
+		return strings.Compare(a.number, b.number)
+	})
+	return violations, nil
+}
+
+func migrationNamesByNumberOnRef(ref, migrationDir string) (map[string]map[string]struct{}, error) {
+	output, err := git("ls-tree", "-r", "--name-only", ref, "--", migrationDir)
+	if err != nil {
+		return nil, err
+	}
+
+	byNumber := map[string]map[string]struct{}{}
+	for line := range strings.SplitSeq(output, "\n") {
+		number, name, ok := migrationIdentityFromPath(line)
+		if !ok {
+			continue
+		}
+		if _, exists := byNumber[number]; !exists {
+			byNumber[number] = map[string]struct{}{}
+		}
+		byNumber[number][name] = struct{}{}
+	}
+	return byNumber, nil
+}
+
+func stagedMigrationPaths(diff, migrationDir string) []string {
+	var paths []string
+	for line := range strings.SplitSeq(diff, "\n") {
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+
+		path, ok := stagedPath(fields)
+		if !ok || !strings.HasPrefix(path, migrationDir+"/") {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func stagedPath(fields []string) (string, bool) {
+	status := fields[0]
+	paths := fields[1:]
+	if len(paths) == 0 || strings.HasPrefix(status, "D") {
+		return "", false
+	}
+	if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
+		return paths[len(paths)-1], true
+	}
+	return paths[0], true
+}
+
+func migrationIdentityFromPath(path string) (string, string, bool) {
+	base := filepath.Base(path)
+	switch {
+	case strings.HasSuffix(base, ".up.sql"):
+		base = strings.TrimSuffix(base, ".up.sql")
+	case strings.HasSuffix(base, ".down.sql"):
+		base = strings.TrimSuffix(base, ".down.sql")
+	default:
+		return "", "", false
+	}
+
+	number, _, ok := strings.Cut(base, "_")
+	if !ok || number == "" {
+		return "", "", false
+	}
+	return number, base, true
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func getenvDefault(key, fallback string) string {

--- a/tools/migrationhistorycheck/main_test.go
+++ b/tools/migrationhistorycheck/main_test.go
@@ -26,6 +26,31 @@ func TestAllowsNewMigration(t *testing.T) {
 	assert.Empty(t, stderr.String())
 }
 
+func TestBlocksNewMigrationWhenNumberAlreadyExistsOnMain(t *testing.T) {
+	assert := assert.New(t)
+	isolateGitEnvironment(t)
+	repo := initRepoWithMainMigration(t)
+	t.Chdir(repo)
+	t.Setenv("MIDDLEMAN_MIGRATION_BASE_REF", "main")
+
+	gitCommand(t, "checkout", "main")
+	writeFile(t, repo, "internal/db/migrations/000002_main_name.up.sql", "main up\n")
+	writeFile(t, repo, "internal/db/migrations/000002_main_name.down.sql", "main down\n")
+	gitCommand(t, "add", "internal/db/migrations/000002_main_name.up.sql", "internal/db/migrations/000002_main_name.down.sql")
+	gitCommand(t, "commit", "-qm", "add main migration")
+	gitCommand(t, "checkout", "feature")
+	writeFile(t, repo, "internal/db/migrations/000002_branch_name.up.sql", "new up\n")
+	writeFile(t, repo, "internal/db/migrations/000002_branch_name.down.sql", "new down\n")
+	gitCommand(t, "add", "internal/db/migrations/000002_branch_name.up.sql", "internal/db/migrations/000002_branch_name.down.sql")
+
+	var stderr bytes.Buffer
+	assert.Equal(1, run(&stderr))
+	assert.Contains(stderr.String(), "duplicate migration number")
+	assert.Contains(stderr.String(), "000002")
+	assert.Contains(stderr.String(), "000002_branch_name")
+	assert.Contains(stderr.String(), "000002_main_name")
+}
+
 func TestBlocksMainBranchMigrationEdit(t *testing.T) {
 	isolateGitEnvironment(t)
 	repo := initRepoWithMainMigration(t)
@@ -37,7 +62,7 @@ func TestBlocksMainBranchMigrationEdit(t *testing.T) {
 
 	var stderr bytes.Buffer
 	assert.Equal(t, 1, run(&stderr))
-	assert.Contains(t, stderr.String(), "Refusing to commit edits to migrations")
+	assert.Contains(t, stderr.String(), "Refusing to commit staged migration history changes")
 	assert.Contains(t, stderr.String(), "internal/db/migrations/000001_init.up.sql")
 }
 


### PR DESCRIPTION
- reject staged migrations when their numeric prefix is already assigned to a different migration on the base ref
- cover the stale-branch collision case where another branch already landed the same migration number