### PR TITLE
fix: refresh edited GitHub comments during sync

### DIFF
--- a/frontend/tests/e2e-full/activity-filters.spec.ts
+++ b/frontend/tests/e2e-full/activity-filters.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
 
 // The e2e server seeds the Activity config with view_mode: "flat"
 // and time_range: "7d", so the flat table renders by default.
@@ -181,17 +182,27 @@ test.describe("activity feed filters", () => {
 });
 
 test.describe("activity UTC timestamp presentation", () => {
+  let isolatedServer: IsolatedE2EServer;
+
+  test.beforeAll(async () => {
+    isolatedServer = await startIsolatedE2EServer();
+  });
+
+  test.afterAll(async () => {
+    await isolatedServer.stop();
+  });
+
   test.beforeEach(async ({ page }) => {
     await page.addInitScript((offsetMs) => {
       const originalNow = Date.now.bind(Date);
       Date.now = () => originalNow() + offsetMs;
     }, 2 * 24 * 60 * 60 * 1000);
-    await page.goto("/");
+    await page.goto(isolatedServer.info.base_url);
     await waitForTable(page);
   });
 
   test("activity API timestamps stay UTC and render as local dates", async ({ page }) => {
-    await page.goto("/");
+    await page.goto(isolatedServer.info.base_url);
     await waitForTable(page);
     await page.locator(".seg-btn", { hasText: "30d" }).click();
     await expect(page.locator(".activity-row").first()).toBeVisible();

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -872,9 +872,10 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 
 // --- Events ---
 
-// UpsertMREvents bulk-inserts events after normalizing CreatedAt to UTC. When a
-// duplicate dedupe key is seen again, the conflict path refreshes created_at so
-// legacy local-offset rows are repaired during normal sync.
+// UpsertMREvents bulk-inserts events after normalizing CreatedAt to UTC.
+// When a duplicate dedupe key is seen again, the conflict path refreshes
+// mutable fields so edited events and legacy local-offset timestamps are
+// repaired during normal sync.
 func (d *DB) UpsertMREvents(ctx context.Context, events []MREvent) error {
 	if len(events) == 0 {
 		return nil
@@ -1646,8 +1647,8 @@ func (d *DB) UpdateBackfillCursor(
 // --- Issue Events ---
 
 // UpsertIssueEvents bulk-inserts issue events after normalizing CreatedAt to
-// UTC. Duplicate keys rewrite created_at so repeat syncs repair older local
-// timestamp encodings instead of preserving them forever.
+// UTC. Duplicate keys refresh mutable fields so edited events and older local
+// timestamp encodings are repaired during normal sync.
 func (d *DB) UpsertIssueEvents(ctx context.Context, events []IssueEvent) error {
 	if len(events) == 0 {
 		return nil
@@ -1659,14 +1660,14 @@ func (d *DB) UpsertIssueEvents(ctx context.Context, events []IssueEvent) error {
 			     metadata_json, created_at, dedupe_key)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(dedupe_key) DO UPDATE SET
-			    issue_id      = excluded.issue_id,
-			    platform_id   = excluded.platform_id,
-			    event_type    = excluded.event_type,
-			    author        = excluded.author,
-			    summary       = excluded.summary,
-			    body          = excluded.body,
-			    metadata_json = excluded.metadata_json,
-			    created_at    = excluded.created_at`)
+			    issue_id       = excluded.issue_id,
+			    platform_id    = excluded.platform_id,
+			    event_type     = excluded.event_type,
+			    author         = excluded.author,
+			    summary        = excluded.summary,
+			    body           = excluded.body,
+			    metadata_json  = excluded.metadata_json,
+			    created_at     = excluded.created_at`)
 		if err != nil {
 			return fmt.Errorf("prepare upsert issue events: %w", err)
 		}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -935,6 +935,31 @@ func (d *DB) DeleteMissingMRCommentEvents(
 	return nil
 }
 
+// GetMRLatestNonCommentEventTime returns the most recent created_at across
+// non-comment events (reviews, commits, force pushes) for a merge request.
+// Returns zero time when no such events exist. The comment-only refresh
+// paths use this to avoid regressing last_activity_at to a comment-derived
+// value when reviews or commits with a newer timestamp are already stored.
+func (d *DB) GetMRLatestNonCommentEventTime(ctx context.Context, mrID int64) (time.Time, error) {
+	var createdAt sql.NullString
+	err := d.ro.QueryRowContext(ctx, `
+		SELECT MAX(created_at) FROM middleman_mr_events
+		WHERE merge_request_id = ? AND event_type != 'issue_comment'`,
+		mrID,
+	).Scan(&createdAt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("query latest non-comment mr event: %w", err)
+	}
+	if !createdAt.Valid {
+		return time.Time{}, nil
+	}
+	t, err := parseDBTime(createdAt.String)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse latest non-comment mr event time %q: %w", createdAt.String, err)
+	}
+	return t, nil
+}
+
 // ListMREvents returns all events for a merge request ordered by created_at DESC.
 func (d *DB) ListMREvents(ctx context.Context, mrID int64) ([]MREvent, error) {
 	rows, err := d.ro.QueryContext(ctx, `

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1074,6 +1074,12 @@ type MRDerivedFields struct {
 	LastActivityAt time.Time
 }
 
+// IssueDerivedFields holds computed fields that are refreshed after fetching issue events.
+type IssueDerivedFields struct {
+	CommentCount   int
+	LastActivityAt time.Time
+}
+
 // UpdateMRTitleBody updates only the title, body, updated_at, and
 // last_activity_at fields. last_activity_at is set to
 // MAX(existing, updatedAt) to preserve correct list ordering.
@@ -1113,6 +1119,26 @@ func (d *DB) UpdateMRDerivedFields(
 	)
 	if err != nil {
 		return fmt.Errorf("update mr derived fields: %w", err)
+	}
+	return nil
+}
+
+// UpdateIssueDerivedFields writes computed fields back to the issues row.
+func (d *DB) UpdateIssueDerivedFields(
+	ctx context.Context,
+	repoID int64,
+	number int,
+	fields IssueDerivedFields,
+) error {
+	_, err := d.rw.ExecContext(ctx, `
+		UPDATE middleman_issues
+		SET comment_count = ?, last_activity_at = ?
+		WHERE repo_id = ? AND number = ?`,
+		fields.CommentCount, fields.LastActivityAt,
+		repoID, number,
+	)
+	if err != nil {
+		return fmt.Errorf("update issue derived fields: %w", err)
 	}
 	return nil
 }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -913,6 +913,28 @@ func (d *DB) UpsertMREvents(ctx context.Context, events []MREvent) error {
 	})
 }
 
+// DeleteMissingMRCommentEvents removes issue_comment rows for a PR whose
+// dedupe keys are absent from the latest GitHub comment list.
+func (d *DB) DeleteMissingMRCommentEvents(
+	ctx context.Context,
+	mrID int64,
+	dedupeKeys []string,
+) error {
+	query := `DELETE FROM middleman_mr_events
+		WHERE merge_request_id = ? AND event_type = 'issue_comment'`
+	args := []any{mrID}
+	if len(dedupeKeys) > 0 {
+		query += ` AND dedupe_key NOT IN (` + sqlPlaceholders(len(dedupeKeys)) + `)`
+		for _, key := range dedupeKeys {
+			args = append(args, key)
+		}
+	}
+	if _, err := d.rw.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("delete missing mr comment events: %w", err)
+	}
+	return nil
+}
+
 // ListMREvents returns all events for a merge request ordered by created_at DESC.
 func (d *DB) ListMREvents(ctx context.Context, mrID int64) ([]MREvent, error) {
 	rows, err := d.ro.QueryContext(ctx, `
@@ -1686,6 +1708,28 @@ func (d *DB) UpsertIssueEvents(ctx context.Context, events []IssueEvent) error {
 		}
 		return nil
 	})
+}
+
+// DeleteMissingIssueCommentEvents removes issue_comment rows for an issue whose
+// dedupe keys are absent from the latest GitHub comment list.
+func (d *DB) DeleteMissingIssueCommentEvents(
+	ctx context.Context,
+	issueID int64,
+	dedupeKeys []string,
+) error {
+	query := `DELETE FROM middleman_issue_events
+		WHERE issue_id = ? AND event_type = 'issue_comment'`
+	args := []any{issueID}
+	if len(dedupeKeys) > 0 {
+		query += ` AND dedupe_key NOT IN (` + sqlPlaceholders(len(dedupeKeys)) + `)`
+		for _, key := range dedupeKeys {
+			args = append(args, key)
+		}
+	}
+	if _, err := d.rw.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("delete missing issue comment events: %w", err)
+	}
+	return nil
 }
 
 // ListIssueEvents returns all events for an issue ordered by created_at DESC.

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -279,6 +279,92 @@ func TestCascadeDeleteRepo(t *testing.T) {
 	assert.Equal(0, count)
 }
 
+func TestUpsertMREventsUpdatesExistingEventBody(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+	base := baseTime()
+
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mrID := insertTestMR(t, d, repoID, 1, "edited comment", base)
+	platformID := int64(101)
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		PlatformID:     &platformID,
+		EventType:      "issue_comment",
+		Author:         "alice",
+		Body:           "original body",
+		CreatedAt:      base,
+		DedupeKey:      "comment-101",
+	}}))
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		PlatformID:     &platformID,
+		EventType:      "issue_comment",
+		Author:         "alice",
+		Body:           "edited body",
+		CreatedAt:      base,
+		DedupeKey:      "comment-101",
+	}}))
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("edited body", events[0].Body)
+}
+
+func TestUpsertIssueEventsUpdatesExistingEventBody(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+	base := baseTime()
+
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	issueID, err := d.UpsertIssue(ctx, &Issue{
+		RepoID:         repoID,
+		PlatformID:     201,
+		Number:         1,
+		URL:            "https://github.com/acme/widget/issues/1",
+		Title:          "edited issue comment",
+		Author:         "alice",
+		State:          "open",
+		CreatedAt:      base,
+		UpdatedAt:      base,
+		LastActivityAt: base,
+	})
+	require.NoError(err)
+	platformID := int64(202)
+
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID:    issueID,
+		PlatformID: &platformID,
+		EventType:  "issue_comment",
+		Author:     "alice",
+		Body:       "original body",
+		CreatedAt:  base,
+		DedupeKey:  "issue-comment-202",
+	}}))
+
+	require.NoError(d.UpsertIssueEvents(ctx, []IssueEvent{{
+		IssueID:    issueID,
+		PlatformID: &platformID,
+		EventType:  "issue_comment",
+		Author:     "alice",
+		Body:       "edited body",
+		CreatedAt:  base,
+		DedupeKey:  "issue-comment-202",
+	}}))
+
+	events, err := d.ListIssueEvents(ctx, issueID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("edited body", events[0].Body)
+}
+
 func TestUpsertAndListRepos(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -39,6 +39,7 @@ type Client interface {
 	ListOpenIssues(ctx context.Context, owner, repo string) ([]*gh.Issue, error)
 	GetIssue(ctx context.Context, owner, repo string, number int) (*gh.Issue, error)
 	ListIssueComments(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error)
+	ListIssueCommentsIfChanged(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error)
 	ListReviews(ctx context.Context, owner, repo string, number int) ([]*gh.PullRequestReview, error)
 	ListCommits(ctx context.Context, owner, repo string, number int) ([]*gh.RepositoryCommit, error)
 	ListForcePushEvents(ctx context.Context, owner, repo string, number int) ([]ForcePushEvent, error)
@@ -58,7 +59,8 @@ type Client interface {
 	// InvalidateListETagsForRepo drops cached conditional-GET
 	// validators for the given repo's list endpoints so the next
 	// list call issues an unconditional fetch. The endpoints
-	// parameter selects which caches to clear ("pulls", "issues").
+	// parameter selects which caches to clear ("pulls", "issues",
+	// "comments").
 	// If empty, both are cleared. Used to recover from a
 	// partial-failure sync.
 	InvalidateListETagsForRepo(owner, repo string, endpoints ...string)
@@ -432,6 +434,18 @@ func (c *liveClient) GetUser(ctx context.Context, login string) (*gh.User, error
 }
 
 func (c *liveClient) ListIssueComments(
+	ctx context.Context, owner, repo string, number int,
+) ([]*gh.IssueComment, error) {
+	return c.listIssueComments(withBypassETag(ctx), owner, repo, number)
+}
+
+func (c *liveClient) ListIssueCommentsIfChanged(
+	ctx context.Context, owner, repo string, number int,
+) ([]*gh.IssueComment, error) {
+	return c.listIssueComments(ctx, owner, repo, number)
+}
+
+func (c *liveClient) listIssueComments(
 	ctx context.Context, owner, repo string, number int,
 ) ([]*gh.IssueComment, error) {
 	opts := &gh.IssueListCommentsOptions{

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -60,9 +60,9 @@ type Client interface {
 	// validators for the given repo's list endpoints so the next
 	// list call issues an unconditional fetch. The endpoints
 	// parameter selects which caches to clear ("pulls", "issues",
-	// "comments").
-	// If empty, both are cleared. Used to recover from a
-	// partial-failure sync.
+	// "comments"); passing no endpoints clears every supported
+	// repo-scoped list path. Used to recover from a partial-failure
+	// sync.
 	InvalidateListETagsForRepo(owner, repo string, endpoints ...string)
 }
 
@@ -129,15 +129,13 @@ type liveClient struct {
 }
 
 // InvalidateListETagsForRepo evicts cached ETag entries for the repo's
-// list endpoints. Pass "pulls" and/or "issues" to scope the
-// invalidation; if no endpoints are given, both are cleared.
-// Safe to call when the transport is nil (tests).
+// list endpoints. Pass any combination of "pulls", "issues", and
+// "comments" to scope the invalidation; omitting endpoints clears
+// every supported repo-scoped list path. Safe to call when the
+// transport is nil (tests).
 func (c *liveClient) InvalidateListETagsForRepo(owner, repo string, endpoints ...string) {
 	if c.etag == nil {
 		return
-	}
-	if len(endpoints) == 0 {
-		endpoints = []string{"pulls", "issues"}
 	}
 	c.etag.invalidateRepo(owner, repo, endpoints...)
 }

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	urlpkg "net/url"
@@ -15,12 +16,16 @@ import (
 
 const etagTTL = 30 * time.Minute
 
-// etagEligiblePath matches list endpoints that return a collection
+// etagEligibleListPath matches list endpoints that return a collection
 // ETag. Supports both github.com (`/repos/{owner}/{name}/{pulls,issues}`)
 // and GitHub Enterprise (`/api/v3/repos/...`), since GHE clients route
 // through the same RoundTripper.
-var etagEligiblePath = regexp.MustCompile(
+var etagEligibleListPath = regexp.MustCompile(
 	`^(?:/api/v3)?/repos/[^/]+/[^/]+/(pulls|issues)$`,
+)
+
+var etagEligibleCommentPath = regexp.MustCompile(
+	`^(?:/api/v3)?/repos/[^/]+/[^/]+/issues/[0-9]+/comments$`,
 )
 
 type etagEntry struct {
@@ -33,6 +38,12 @@ type etagTransport struct {
 	cache sync.Map // URL string -> etagEntry
 }
 
+type bypassETagKey struct{}
+
+func withBypassETag(ctx context.Context) context.Context {
+	return context.WithValue(ctx, bypassETagKey{}, true)
+}
+
 func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req == nil || req.URL == nil {
 		return nil, errors.New("nil request")
@@ -40,6 +51,9 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Gate: only GET requests to allowlisted endpoints
 	if req.Method != http.MethodGet || !isETagEligible(req.URL.Path) {
+		return t.base.RoundTrip(req)
+	}
+	if bypass, _ := req.Context().Value(bypassETagKey{}).(bool); bypass {
 		return t.base.RoundTrip(req)
 	}
 
@@ -90,7 +104,8 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func isETagEligible(path string) bool {
-	return etagEligiblePath.MatchString(path)
+	return etagEligibleListPath.MatchString(path) ||
+		etagEligibleCommentPath.MatchString(path)
 }
 
 func hasLinkNext(resp *http.Response) bool {
@@ -110,10 +125,6 @@ func hasLinkNext(resp *http.Response) bool {
 func (t *etagTransport) invalidateRepo(owner, name string, endpoints ...string) {
 	base := "/repos/" + owner + "/" + name + "/"
 	gheBase := "/api/v3/repos/" + owner + "/" + name + "/"
-	var prefixes []string
-	for _, ep := range endpoints {
-		prefixes = append(prefixes, base+ep, gheBase+ep)
-	}
 	t.cache.Range(func(k, _ any) bool {
 		urlStr, ok := k.(string)
 		if !ok {
@@ -123,11 +134,35 @@ func (t *etagTransport) invalidateRepo(owner, name string, endpoints ...string) 
 		if err != nil {
 			return true
 		}
-		if slices.Contains(prefixes, parsed.Path) {
+		if matchesInvalidateEndpoint(parsed.Path, base, gheBase, endpoints) {
 			t.cache.Delete(k)
 		}
 		return true
 	})
+}
+
+func matchesInvalidateEndpoint(path, base, gheBase string, endpoints []string) bool {
+	var exactPrefixes []string
+	for _, ep := range endpoints {
+		switch ep {
+		case "comments":
+			if isCommentListPath(path, base, gheBase) {
+				return true
+			}
+		default:
+			exactPrefixes = append(exactPrefixes, base+ep, gheBase+ep)
+		}
+	}
+	return slices.Contains(exactPrefixes, path)
+}
+
+func isCommentListPath(path, base, gheBase string) bool {
+	for _, prefix := range []string{base + "issues/", gheBase + "issues/"} {
+		if strings.HasPrefix(path, prefix) && strings.HasSuffix(path, "/comments") {
+			return true
+		}
+	}
+	return false
 }
 
 // IsNotModified returns true if the error represents a 304 Not Modified

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -118,8 +118,9 @@ func hasLinkNext(resp *http.Response) bool {
 }
 
 // invalidateRepo drops cached ETag entries for the given repo's list
-// endpoints. The endpoints parameter controls which to invalidate:
-// "pulls", "issues", or both. Used by the sync engine to force an
+// endpoints. The endpoints parameter selects which to invalidate —
+// "pulls", "issues", or "comments" — and an empty slice clears every
+// supported repo-scoped list path. Used by the sync engine to force an
 // unconditional refetch after a partial failure so the next cycle
 // re-applies per-item state that the previous cycle failed to persist.
 func (t *etagTransport) invalidateRepo(owner, name string, endpoints ...string) {
@@ -142,6 +143,14 @@ func (t *etagTransport) invalidateRepo(owner, name string, endpoints ...string) 
 }
 
 func matchesInvalidateEndpoint(path, base, gheBase string, endpoints []string) bool {
+	if len(endpoints) == 0 {
+		// Empty means invalidate every supported repo-scoped list path
+		// so callers can recover from partial-failure syncs without
+		// needing to enumerate every endpoint we cache.
+		return path == base+"pulls" || path == gheBase+"pulls" ||
+			path == base+"issues" || path == gheBase+"issues" ||
+			isCommentListPath(path, base, gheBase)
+	}
 	var exactPrefixes []string
 	for _, ep := range endpoints {
 		switch ep {

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -560,6 +560,30 @@ func TestETagTransport_InvalidateRepo(t *testing.T) {
 		_, ok = et.cache.Load("https://ghe.example.com/api/v3/repos/o/n/pulls")
 		assert.True(ok, "issues-only should preserve GHE pulls cache")
 	})
+
+	t.Run("empty endpoints clears every supported path", func(t *testing.T) {
+		et := &etagTransport{}
+		now := time.Now()
+		et.cache.Store("https://api.github.com/repos/o/n/pulls", etagEntry{etag: `"1"`, cachedAt: now})
+		et.cache.Store("https://api.github.com/repos/o/n/issues", etagEntry{etag: `"2"`, cachedAt: now})
+		et.cache.Store("https://api.github.com/repos/o/n/issues/7/comments", etagEntry{etag: `"3"`, cachedAt: now})
+		et.cache.Store("https://ghe.example.com/api/v3/repos/o/n/issues/9/comments", etagEntry{etag: `"4"`, cachedAt: now})
+		et.cache.Store("https://api.github.com/repos/other/other/pulls", etagEntry{etag: `"5"`, cachedAt: now})
+
+		et.invalidateRepo("o", "n")
+
+		for _, u := range []string{
+			"https://api.github.com/repos/o/n/pulls",
+			"https://api.github.com/repos/o/n/issues",
+			"https://api.github.com/repos/o/n/issues/7/comments",
+			"https://ghe.example.com/api/v3/repos/o/n/issues/9/comments",
+		} {
+			_, ok := et.cache.Load(u)
+			assert.Falsef(ok, "empty endpoints should drop %s", u)
+		}
+		_, ok := et.cache.Load("https://api.github.com/repos/other/other/pulls")
+		assert.True(ok, "empty endpoints must not touch unrelated repos")
+	})
 }
 
 func TestIsNotModified(t *testing.T) {

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -358,7 +358,6 @@ func TestETagTransport_DetailEndpointBypassesCache(t *testing.T) {
 		"https://api.github.com/repos/o/n/pulls/123",
 		"https://api.github.com/repos/o/n/pulls/123/files",
 		"https://api.github.com/repos/o/n/issues/456",
-		"https://api.github.com/repos/o/n/issues/456/comments",
 	} {
 		req, _ := http.NewRequest("GET", url, nil)
 		_, err := et.RoundTrip(req)
@@ -366,6 +365,34 @@ func TestETagTransport_DetailEndpointBypassesCache(t *testing.T) {
 		_, ok := et.cache.Load(url)
 		assert.False(t, ok, "%s should not be cached", url)
 	}
+}
+
+func TestETagTransport_IssueCommentsUseCache(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	url := "https://api.github.com/repos/o/n/issues/456/comments"
+	et := &etagTransport{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Empty(r.Header.Get("If-None-Match"))
+		rec := httptest.NewRecorder()
+		rec.Header().Set("ETag", `"comment-etag"`)
+		rec.WriteHeader(200)
+		return rec.Result(), nil
+	})}
+
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	_, err := et.RoundTrip(req)
+	require.NoError(err)
+
+	et.base = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(`"comment-etag"`, r.Header.Get("If-None-Match"))
+		rec := httptest.NewRecorder()
+		rec.WriteHeader(http.StatusNotModified)
+		return rec.Result(), nil
+	})
+	req2, _ := http.NewRequest(http.MethodGet, url, nil)
+	_, err = et.RoundTrip(req2)
+	require.NoError(err)
 }
 
 // TestETagTransport_304DoesNotExtendCacheLifetime verifies that

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -189,6 +189,20 @@ type Syncer struct {
 	runCtx    context.Context
 	runCancel context.CancelFunc
 	runCtxMu  sync.Mutex
+
+	commentRefreshMu         sync.Mutex
+	pendingPRCommentSyncs    []queuedPRCommentSync
+	pendingIssueCommentSyncs []queuedIssueCommentSync
+}
+
+type queuedPRCommentSync struct {
+	repo   RepoRef
+	number int
+}
+
+type queuedIssueCommentSync struct {
+	repo   RepoRef
+	number int
 }
 
 // ensureRunCtx lazily initializes runCtx/runCancel. Safe to call
@@ -1015,6 +1029,7 @@ func (s *Syncer) runOnce(
 		Progress: fmt.Sprintf("0/%d", total),
 	})
 	slog.Info("sync started", "repos", total)
+	s.resetPendingCommentSyncs()
 
 	workers := min(max(int(s.parallelism.Load()), 1), total)
 
@@ -1121,6 +1136,10 @@ dispatch:
 			}
 			s.runBackfillDiscovery(ctx, host, repos)
 		}
+	}
+
+	if !canceled.Load() && ctx.Err() == nil {
+		s.drainPendingCommentSyncs(ctx, eligibleHosts)
 	}
 
 	// Use a latched flag (set by the dispatch loop and workers at
@@ -1489,7 +1508,7 @@ func (s *Syncer) indexUpsertMR(
 	if existing != nil &&
 		existing.DetailFetchedAt != nil &&
 		existing.UpdatedAt.Equal(normalized.UpdatedAt) {
-		s.refreshPRCommentsForItem(ctx, client, repo, existing)
+		s.queuePRCommentSync(repo, existing.Number)
 	}
 
 	return nil
@@ -1585,6 +1604,111 @@ func (s *Syncer) refreshIssueCommentsForItem(
 			"number", issue.Number,
 			"err", err,
 		)
+	}
+}
+
+func (s *Syncer) resetPendingCommentSyncs() {
+	s.commentRefreshMu.Lock()
+	defer s.commentRefreshMu.Unlock()
+	s.pendingPRCommentSyncs = nil
+	s.pendingIssueCommentSyncs = nil
+}
+
+func (s *Syncer) queuePRCommentSync(repo RepoRef, number int) {
+	s.commentRefreshMu.Lock()
+	defer s.commentRefreshMu.Unlock()
+	s.pendingPRCommentSyncs = append(s.pendingPRCommentSyncs, queuedPRCommentSync{
+		repo:   repo,
+		number: number,
+	})
+}
+
+func (s *Syncer) queueIssueCommentSync(repo RepoRef, number int) {
+	s.commentRefreshMu.Lock()
+	defer s.commentRefreshMu.Unlock()
+	s.pendingIssueCommentSyncs = append(s.pendingIssueCommentSyncs, queuedIssueCommentSync{
+		repo:   repo,
+		number: number,
+	})
+}
+
+func (s *Syncer) drainPendingCommentSyncs(
+	ctx context.Context,
+	eligibleHosts map[string]bool,
+) {
+	s.commentRefreshMu.Lock()
+	prs := append([]queuedPRCommentSync(nil), s.pendingPRCommentSyncs...)
+	issues := append([]queuedIssueCommentSync(nil), s.pendingIssueCommentSyncs...)
+	s.pendingPRCommentSyncs = nil
+	s.pendingIssueCommentSyncs = nil
+	s.commentRefreshMu.Unlock()
+
+	for _, item := range prs {
+		if ctx.Err() != nil {
+			return
+		}
+		host := item.repo.PlatformHost
+		if host == "" {
+			host = "github.com"
+		}
+		if !eligibleHosts[host] {
+			continue
+		}
+		client, err := s.clientFor(item.repo)
+		if err != nil {
+			slog.Warn("comment refresh: resolve client failed",
+				"repo", item.repo.Owner+"/"+item.repo.Name,
+				"number", item.number,
+				"err", err,
+			)
+			continue
+		}
+		pr, err := s.db.GetMergeRequest(
+			ctx, item.repo.Owner, item.repo.Name, item.number,
+		)
+		if err != nil {
+			slog.Warn("comment refresh: get PR failed",
+				"repo", item.repo.Owner+"/"+item.repo.Name,
+				"number", item.number,
+				"err", err,
+			)
+			continue
+		}
+		s.refreshPRCommentsForItem(ctx, client, item.repo, pr)
+	}
+
+	for _, item := range issues {
+		if ctx.Err() != nil {
+			return
+		}
+		host := item.repo.PlatformHost
+		if host == "" {
+			host = "github.com"
+		}
+		if !eligibleHosts[host] {
+			continue
+		}
+		client, err := s.clientFor(item.repo)
+		if err != nil {
+			slog.Warn("comment refresh: resolve client failed",
+				"repo", item.repo.Owner+"/"+item.repo.Name,
+				"number", item.number,
+				"err", err,
+			)
+			continue
+		}
+		issue, err := s.db.GetIssue(
+			ctx, item.repo.Owner, item.repo.Name, item.number,
+		)
+		if err != nil {
+			slog.Warn("comment refresh: get issue failed",
+				"repo", item.repo.Owner+"/"+item.repo.Name,
+				"number", item.number,
+				"err", err,
+			)
+			continue
+		}
+		s.refreshIssueCommentsForItem(ctx, client, item.repo, issue)
 	}
 }
 
@@ -2761,7 +2885,7 @@ func (s *Syncer) syncOpenIssue(
 
 	if !needsTimeline {
 		if existing != nil && existing.DetailFetchedAt != nil {
-			s.refreshIssueCommentsForItem(ctx, client, repo, existing)
+			s.queueIssueCommentSync(repo, existing.Number)
 		}
 		return nil
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1667,36 +1667,19 @@ func (s *Syncer) syncOpenIssueFromBulk(
 	}
 
 	if bulk.CommentsComplete {
-		// Events from bulk data — skip REST ListIssueComments.
-		var events []db.IssueEvent
-		for _, c := range bulk.Comments {
-			events = append(events, NormalizeIssueCommentEvent(issueID, c))
-		}
-		if len(events) > 0 {
-			if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
-				return fmt.Errorf(
-					"upsert issue events for #%d: %w", number, err,
-				)
-			}
-		}
-		// Update last activity from bulk comment timestamps.
-		// comment_count was already written by UpsertIssue using
-		// normalized.CommentCount (GraphQL's authoritative
-		// Comments.TotalCount), so don't overwrite it here.
-		lastActivity := normalized.UpdatedAt
-		for _, c := range bulk.Comments {
-			if c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity) {
-				lastActivity = c.UpdatedAt.Time
-			}
-		}
-		_, err = s.db.WriteDB().ExecContext(ctx,
-			`UPDATE middleman_issues SET last_activity_at = ?
-			 WHERE id = ?`,
-			lastActivity, issueID,
-		)
-		if err != nil {
+		if err := s.replaceIssueCommentEvents(ctx, issueID, bulk.Comments); err != nil {
 			return fmt.Errorf(
-				"update issue #%d last_activity_at: %w", number, err,
+				"replace issue comment events for #%d: %w", number, err,
+			)
+		}
+		if err := s.db.UpdateIssueDerivedFields(
+			ctx, repoID, number, db.IssueDerivedFields{
+				CommentCount:   normalized.CommentCount,
+				LastActivityAt: computeIssueCommentLastActivity(bulk.Issue, bulk.Comments),
+			},
+		); err != nil {
+			return fmt.Errorf(
+				"update issue #%d derived fields: %w", number, err,
 			)
 		}
 
@@ -1862,12 +1845,17 @@ func (s *Syncer) syncOpenMRFromBulk(
 	for _, c := range bulk.Commits {
 		events = append(events, NormalizeCommitEvent(mrID, c))
 	}
-	if len(events) > 0 {
-		if err := s.db.UpsertMREvents(ctx, events); err != nil {
+	if bulk.CommentsComplete {
+		if err := s.replacePRCommentEvents(ctx, mrID, bulk.Comments); err != nil {
 			return fmt.Errorf(
-				"upsert events for MR #%d: %w", number, err,
+				"replace comment events for MR #%d: %w", number, err,
 			)
 		}
+	}
+	if err := s.db.UpsertMREvents(ctx, events); err != nil {
+		return fmt.Errorf(
+			"upsert events for MR #%d: %w", number, err,
+		)
 	}
 
 	// CI status — only write if complete (don't write
@@ -2302,6 +2290,9 @@ func (s *Syncer) refreshTimeline(
 		events = append(events, NormalizeForcePushEvent(mrID, fp))
 	}
 
+	if err := s.replacePRCommentEvents(ctx, mrID, comments); err != nil {
+		return fmt.Errorf("replace comment events for MR #%d: %w", number, err)
+	}
 	if err := s.db.UpsertMREvents(ctx, events); err != nil {
 		return fmt.Errorf("upsert events for MR #%d: %w", number, err)
 	}
@@ -2412,6 +2403,101 @@ func computeLastActivity(
 		}
 	}
 	return latest
+}
+
+func computePRCommentRefreshLastActivity(
+	pr *db.MergeRequest,
+	comments []*gh.IssueComment,
+) time.Time {
+	latest := pr.UpdatedAt
+	if latest.IsZero() || pr.CreatedAt.After(latest) {
+		latest = pr.CreatedAt
+	}
+	for _, c := range comments {
+		switch {
+		case c.UpdatedAt != nil && c.UpdatedAt.After(latest):
+			latest = c.UpdatedAt.Time
+		case c.CreatedAt != nil && c.CreatedAt.After(latest):
+			latest = c.CreatedAt.Time
+		}
+	}
+	return latest
+}
+
+func computeIssueCommentLastActivity(
+	ghIssue *gh.Issue,
+	comments []*gh.IssueComment,
+) time.Time {
+	var latest time.Time
+	if ghIssue != nil {
+		if ghIssue.UpdatedAt != nil {
+			latest = ghIssue.UpdatedAt.Time
+		}
+		if latest.IsZero() && ghIssue.CreatedAt != nil {
+			latest = ghIssue.CreatedAt.Time
+		}
+	}
+	for _, c := range comments {
+		switch {
+		case c.UpdatedAt != nil && c.UpdatedAt.After(latest):
+			latest = c.UpdatedAt.Time
+		case c.CreatedAt != nil && c.CreatedAt.After(latest):
+			latest = c.CreatedAt.Time
+		}
+	}
+	return latest
+}
+
+func computeIssueCommentRefreshLastActivity(
+	issue *db.Issue,
+	comments []*gh.IssueComment,
+) time.Time {
+	return computeIssueCommentLastActivity(&gh.Issue{
+		CreatedAt: &gh.Timestamp{Time: issue.CreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: issue.UpdatedAt},
+	}, comments)
+}
+
+func (s *Syncer) replacePRCommentEvents(
+	ctx context.Context,
+	mrID int64,
+	comments []*gh.IssueComment,
+) error {
+	events := make([]db.MREvent, 0, len(comments))
+	dedupeKeys := make([]string, 0, len(comments))
+	for _, c := range comments {
+		event := NormalizeCommentEvent(mrID, c)
+		events = append(events, event)
+		dedupeKeys = append(dedupeKeys, event.DedupeKey)
+	}
+	if err := s.db.DeleteMissingMRCommentEvents(ctx, mrID, dedupeKeys); err != nil {
+		return fmt.Errorf("delete missing mr comment events: %w", err)
+	}
+	if err := s.db.UpsertMREvents(ctx, events); err != nil {
+		return fmt.Errorf("upsert mr comment events: %w", err)
+	}
+	return nil
+}
+
+func (s *Syncer) replaceIssueCommentEvents(
+	ctx context.Context,
+	issueID int64,
+	comments []*gh.IssueComment,
+) error {
+	events := make([]db.IssueEvent, 0, len(comments))
+	dedupeKeys := make([]string, 0, len(comments))
+	for _, c := range comments {
+		event := NormalizeIssueCommentEvent(issueID, c)
+		events = append(events, event)
+		dedupeKeys = append(dedupeKeys, event.DedupeKey)
+	}
+	if err := s.db.DeleteMissingIssueCommentEvents(ctx, issueID, dedupeKeys); err != nil {
+		return fmt.Errorf("delete missing issue comment events: %w", err)
+	}
+	if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
+		return fmt.Errorf("upsert issue comment events: %w", err)
+	}
+	return nil
 }
 
 // resolveDisplayName returns the GitHub display name for a
@@ -2593,28 +2679,13 @@ func (s *Syncer) refreshIssueTimeline(
 		)
 	}
 
-	var events []db.IssueEvent
-	for _, c := range comments {
-		events = append(events, NormalizeIssueCommentEvent(issueID, c))
-	}
-
-	if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
+	if err := s.replaceIssueCommentEvents(ctx, issueID, comments); err != nil {
 		return fmt.Errorf(
-			"upsert issue events for #%d: %w", number, err,
+			"replace issue events for #%d: %w", number, err,
 		)
 	}
 
-	var lastActivity time.Time
-	if ghIssue.UpdatedAt != nil {
-		lastActivity = ghIssue.UpdatedAt.Time
-	} else if ghIssue.CreatedAt != nil {
-		lastActivity = ghIssue.CreatedAt.Time
-	}
-	for _, c := range comments {
-		if c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity) {
-			lastActivity = c.UpdatedAt.Time
-		}
-	}
+	lastActivity := computeIssueCommentLastActivity(ghIssue, comments)
 
 	_, err = s.db.WriteDB().ExecContext(ctx,
 		`UPDATE middleman_issues SET comment_count = ?, last_activity_at = ?
@@ -2762,37 +2833,14 @@ func (s *Syncer) persistPRComments(
 	pr *db.MergeRequest,
 	comments []*gh.IssueComment,
 ) error {
-	var events []db.MREvent
-	var dedupeKeys []string
-	for _, c := range comments {
-		event := NormalizeCommentEvent(pr.ID, c)
-		events = append(events, event)
-		dedupeKeys = append(dedupeKeys, event.DedupeKey)
-	}
-	if err := s.db.DeleteMissingMRCommentEvents(ctx, pr.ID, dedupeKeys); err != nil {
-		return fmt.Errorf("delete missing mr comment events: %w", err)
-	}
-	if err := s.db.UpsertMREvents(ctx, events); err != nil {
-		return fmt.Errorf("upsert events: %w", err)
-	}
-
-	lastActivity := pr.LastActivityAt
-	if pr.UpdatedAt.After(lastActivity) {
-		lastActivity = pr.UpdatedAt
-	}
-	for _, c := range comments {
-		switch {
-		case c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity):
-			lastActivity = c.UpdatedAt.Time
-		case c.CreatedAt != nil && c.CreatedAt.After(lastActivity):
-			lastActivity = c.CreatedAt.Time
-		}
+	if err := s.replacePRCommentEvents(ctx, pr.ID, comments); err != nil {
+		return fmt.Errorf("replace PR comment events: %w", err)
 	}
 
 	return s.db.UpdateMRDerivedFields(ctx, pr.RepoID, pr.Number, db.MRDerivedFields{
 		ReviewDecision: pr.ReviewDecision,
 		CommentCount:   len(comments),
-		LastActivityAt: lastActivity,
+		LastActivityAt: computePRCommentRefreshLastActivity(pr, comments),
 	})
 }
 
@@ -2801,36 +2849,13 @@ func (s *Syncer) persistIssueComments(
 	issue *db.Issue,
 	comments []*gh.IssueComment,
 ) error {
-	var events []db.IssueEvent
-	var dedupeKeys []string
-	for _, c := range comments {
-		event := NormalizeIssueCommentEvent(issue.ID, c)
-		events = append(events, event)
-		dedupeKeys = append(dedupeKeys, event.DedupeKey)
-	}
-	if err := s.db.DeleteMissingIssueCommentEvents(ctx, issue.ID, dedupeKeys); err != nil {
-		return fmt.Errorf("delete missing issue comment events: %w", err)
-	}
-	if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
-		return fmt.Errorf("upsert issue events: %w", err)
-	}
-
-	lastActivity := issue.LastActivityAt
-	if issue.UpdatedAt.After(lastActivity) {
-		lastActivity = issue.UpdatedAt
-	}
-	for _, c := range comments {
-		switch {
-		case c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity):
-			lastActivity = c.UpdatedAt.Time
-		case c.CreatedAt != nil && c.CreatedAt.After(lastActivity):
-			lastActivity = c.CreatedAt.Time
-		}
+	if err := s.replaceIssueCommentEvents(ctx, issue.ID, comments); err != nil {
+		return fmt.Errorf("replace issue comment events: %w", err)
 	}
 
 	return s.db.UpdateIssueDerivedFields(ctx, issue.RepoID, issue.Number, db.IssueDerivedFields{
 		CommentCount:   len(comments),
-		LastActivityAt: lastActivity,
+		LastActivityAt: computeIssueCommentRefreshLastActivity(issue, comments),
 	})
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2828,15 +2828,10 @@ func (s *Syncer) persistIssueComments(
 		}
 	}
 
-	_, err := s.db.WriteDB().ExecContext(ctx,
-		`UPDATE middleman_issues SET comment_count = ?, last_activity_at = ?
-		 WHERE id = ?`,
-		len(comments), lastActivity, issue.ID,
-	)
-	if err != nil {
-		return fmt.Errorf("update issue comment fields: %w", err)
-	}
-	return nil
+	return s.db.UpdateIssueDerivedFields(ctx, issue.RepoID, issue.Number, db.IssueDerivedFields{
+		CommentCount:   len(comments),
+		LastActivityAt: lastActivity,
+	})
 }
 
 func (s *Syncer) fetchAndUpdateClosedIssue(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2104,11 +2104,24 @@ func (s *Syncer) syncOpenMRFromBulk(
 	// a full REST fetch. Derived fields from truncated data would
 	// overwrite correct values with partial counts.
 	if bulk.CommentsComplete {
+		lastActivity := computeLastActivity(bulk.PR, bulk.Comments, nil, nil)
+		// When reviews/commits are truncated this cycle, any stored
+		// review/commit/force-push event with a newer timestamp must
+		// still win so the dashboard ordering doesn't regress.
+		nonCommentLatest, nErr := s.db.GetMRLatestNonCommentEventTime(ctx, mrID)
+		if nErr != nil {
+			slog.Warn("latest non-comment event lookup failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number, "err", nErr,
+			)
+		} else if nonCommentLatest.After(lastActivity) {
+			lastActivity = nonCommentLatest
+		}
 		if err := s.db.UpdateMRDerivedFields(
 			ctx, repoID, number, db.MRDerivedFields{
 				ReviewDecision: normalized.ReviewDecision,
 				CommentCount:   len(bulk.Comments),
-				LastActivityAt: computeLastActivity(bulk.PR, bulk.Comments, nil, nil),
+				LastActivityAt: lastActivity,
 			},
 		); err != nil {
 			slog.Warn("update comment-derived fields failed",
@@ -2638,13 +2651,22 @@ func computeLastActivity(
 	return latest
 }
 
+// computePRCommentRefreshLastActivity derives last_activity_at for a
+// comment-only refresh. nonCommentLatest should be the most recent
+// timestamp among stored review/commit/force-push events so a refresh
+// that only sees comments can't regress activity captured by those
+// events when GitHub's PR.UpdatedAt is stale.
 func computePRCommentRefreshLastActivity(
 	pr *db.MergeRequest,
 	comments []*gh.IssueComment,
+	nonCommentLatest time.Time,
 ) time.Time {
 	latest := pr.UpdatedAt
 	if latest.IsZero() || pr.CreatedAt.After(latest) {
 		latest = pr.CreatedAt
+	}
+	if nonCommentLatest.After(latest) {
+		latest = nonCommentLatest
 	}
 	for _, c := range comments {
 		switch {
@@ -3019,10 +3041,15 @@ func (s *Syncer) persistPRComments(
 		return fmt.Errorf("replace PR comment events: %w", err)
 	}
 
+	nonCommentLatest, err := s.db.GetMRLatestNonCommentEventTime(ctx, pr.ID)
+	if err != nil {
+		return fmt.Errorf("latest non-comment event for PR #%d: %w", pr.Number, err)
+	}
+
 	return s.db.UpdateMRDerivedFields(ctx, pr.RepoID, pr.Number, db.MRDerivedFields{
 		ReviewDecision: pr.ReviewDecision,
 		CommentCount:   len(comments),
-		LastActivityAt: computePRCommentRefreshLastActivity(pr, comments),
+		LastActivityAt: computePRCommentRefreshLastActivity(pr, comments, nonCommentLatest),
 	})
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1352,9 +1352,11 @@ func (s *Syncer) indexSyncRepo(
 	ghIssues, issueListErr := client.ListOpenIssues(
 		ctx, repo.Owner, repo.Name,
 	)
+	issueListUnchanged := false
 	if issueListErr != nil {
 		if IsNotModified(issueListErr) {
 			// 304: open issue list unchanged, skip.
+			issueListUnchanged = true
 		} else {
 			slog.Error("list open issues failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -1407,6 +1409,13 @@ func (s *Syncer) indexSyncRepo(
 	} else {
 		// Clean pass — drop any leftover flag from a prior cycle.
 		s.clearRepoFailed(repo)
+	}
+
+	if prListUnchanged && failedScope&failMR == 0 {
+		s.refreshRepoPRComments(ctx, repo)
+	}
+	if issueListUnchanged && failedScope&failIssues == 0 {
+		s.refreshRepoIssueComments(ctx, repo)
 	}
 
 	return nil
@@ -2613,6 +2622,209 @@ func (s *Syncer) refreshIssueTimeline(
 		len(comments), lastActivity, issueID,
 	)
 	return err
+}
+
+func (s *Syncer) refreshRepoPRComments(
+	ctx context.Context,
+	repo RepoRef,
+) {
+	prs, err := s.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{
+		RepoOwner: repo.Owner,
+		RepoName:  repo.Name,
+		State:     "open",
+	})
+	if err != nil {
+		slog.Warn("comment refresh: list open PRs failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"err", err,
+		)
+		return
+	}
+
+	client, err := s.clientFor(repo)
+	if err != nil {
+		slog.Warn("comment refresh: resolve client failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"err", err,
+		)
+		return
+	}
+
+	for i := range prs {
+		if ctx.Err() != nil {
+			return
+		}
+		pr := &prs[i]
+		if pr.DetailFetchedAt == nil {
+			continue
+		}
+		if !s.canSpendCommentRefresh(repo.PlatformHost) {
+			return
+		}
+		comments, err := client.ListIssueCommentsIfChanged(
+			ctx, repo.Owner, repo.Name, pr.Number,
+		)
+		if err != nil {
+			if IsNotModified(err) {
+				continue
+			}
+			slog.Warn("comment refresh: list PR comments failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", pr.Number,
+				"err", err,
+			)
+			continue
+		}
+		if err := s.persistPRComments(ctx, pr, comments); err != nil {
+			client.InvalidateListETagsForRepo(repo.Owner, repo.Name, "comments")
+			slog.Warn("comment refresh: persist PR comments failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", pr.Number,
+				"err", err,
+			)
+		}
+	}
+}
+
+func (s *Syncer) refreshRepoIssueComments(
+	ctx context.Context,
+	repo RepoRef,
+) {
+	issues, err := s.db.ListIssues(ctx, db.ListIssuesOpts{
+		RepoOwner: repo.Owner,
+		RepoName:  repo.Name,
+		State:     "open",
+	})
+	if err != nil {
+		slog.Warn("comment refresh: list open issues failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"err", err,
+		)
+		return
+	}
+
+	client, err := s.clientFor(repo)
+	if err != nil {
+		slog.Warn("comment refresh: resolve client failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"err", err,
+		)
+		return
+	}
+
+	for i := range issues {
+		if ctx.Err() != nil {
+			return
+		}
+		issue := &issues[i]
+		if issue.DetailFetchedAt == nil {
+			continue
+		}
+		if !s.canSpendCommentRefresh(repo.PlatformHost) {
+			return
+		}
+		comments, err := client.ListIssueCommentsIfChanged(
+			ctx, repo.Owner, repo.Name, issue.Number,
+		)
+		if err != nil {
+			if IsNotModified(err) {
+				continue
+			}
+			slog.Warn("comment refresh: list issue comments failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", issue.Number,
+				"err", err,
+			)
+			continue
+		}
+		if err := s.persistIssueComments(ctx, issue, comments); err != nil {
+			client.InvalidateListETagsForRepo(repo.Owner, repo.Name, "comments")
+			slog.Warn("comment refresh: persist issue comments failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", issue.Number,
+				"err", err,
+			)
+		}
+	}
+}
+
+func (s *Syncer) canSpendCommentRefresh(platformHost string) bool {
+	host := platformHost
+	if host == "" {
+		host = "github.com"
+	}
+	budget := s.budgets[host]
+	return budget == nil || budget.CanSpend(1)
+}
+
+func (s *Syncer) persistPRComments(
+	ctx context.Context,
+	pr *db.MergeRequest,
+	comments []*gh.IssueComment,
+) error {
+	var events []db.MREvent
+	for _, c := range comments {
+		events = append(events, NormalizeCommentEvent(pr.ID, c))
+	}
+	if err := s.db.UpsertMREvents(ctx, events); err != nil {
+		return fmt.Errorf("upsert events: %w", err)
+	}
+
+	lastActivity := pr.LastActivityAt
+	if pr.UpdatedAt.After(lastActivity) {
+		lastActivity = pr.UpdatedAt
+	}
+	for _, c := range comments {
+		switch {
+		case c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity):
+			lastActivity = c.UpdatedAt.Time
+		case c.CreatedAt != nil && c.CreatedAt.After(lastActivity):
+			lastActivity = c.CreatedAt.Time
+		}
+	}
+
+	return s.db.UpdateMRDerivedFields(ctx, pr.RepoID, pr.Number, db.MRDerivedFields{
+		ReviewDecision: pr.ReviewDecision,
+		CommentCount:   len(comments),
+		LastActivityAt: lastActivity,
+	})
+}
+
+func (s *Syncer) persistIssueComments(
+	ctx context.Context,
+	issue *db.Issue,
+	comments []*gh.IssueComment,
+) error {
+	var events []db.IssueEvent
+	for _, c := range comments {
+		events = append(events, NormalizeIssueCommentEvent(issue.ID, c))
+	}
+	if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
+		return fmt.Errorf("upsert issue events: %w", err)
+	}
+
+	lastActivity := issue.LastActivityAt
+	if issue.UpdatedAt.After(lastActivity) {
+		lastActivity = issue.UpdatedAt
+	}
+	for _, c := range comments {
+		switch {
+		case c.UpdatedAt != nil && c.UpdatedAt.After(lastActivity):
+			lastActivity = c.UpdatedAt.Time
+		case c.CreatedAt != nil && c.CreatedAt.After(lastActivity):
+			lastActivity = c.CreatedAt.Time
+		}
+	}
+
+	_, err := s.db.WriteDB().ExecContext(ctx,
+		`UPDATE middleman_issues SET comment_count = ?, last_activity_at = ?
+		 WHERE id = ?`,
+		len(comments), lastActivity, issue.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update issue comment fields: %w", err)
+	}
+	return nil
 }
 
 func (s *Syncer) fetchAndUpdateClosedIssue(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2763,8 +2763,14 @@ func (s *Syncer) persistPRComments(
 	comments []*gh.IssueComment,
 ) error {
 	var events []db.MREvent
+	var dedupeKeys []string
 	for _, c := range comments {
-		events = append(events, NormalizeCommentEvent(pr.ID, c))
+		event := NormalizeCommentEvent(pr.ID, c)
+		events = append(events, event)
+		dedupeKeys = append(dedupeKeys, event.DedupeKey)
+	}
+	if err := s.db.DeleteMissingMRCommentEvents(ctx, pr.ID, dedupeKeys); err != nil {
+		return fmt.Errorf("delete missing mr comment events: %w", err)
 	}
 	if err := s.db.UpsertMREvents(ctx, events); err != nil {
 		return fmt.Errorf("upsert events: %w", err)
@@ -2796,8 +2802,14 @@ func (s *Syncer) persistIssueComments(
 	comments []*gh.IssueComment,
 ) error {
 	var events []db.IssueEvent
+	var dedupeKeys []string
 	for _, c := range comments {
-		events = append(events, NormalizeIssueCommentEvent(issue.ID, c))
+		event := NormalizeIssueCommentEvent(issue.ID, c)
+		events = append(events, event)
+		dedupeKeys = append(dedupeKeys, event.DedupeKey)
+	}
+	if err := s.db.DeleteMissingIssueCommentEvents(ctx, issue.ID, dedupeKeys); err != nil {
+		return fmt.Errorf("delete missing issue comment events: %w", err)
 	}
 	if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
 		return fmt.Errorf("upsert issue events: %w", err)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1885,6 +1885,21 @@ func (s *Syncer) syncOpenMRFromBulk(
 	// DetailFetchedAt stale so the detail drain picks them up for
 	// a full REST fetch. Derived fields from truncated data would
 	// overwrite correct values with partial counts.
+	if bulk.CommentsComplete {
+		if err := s.db.UpdateMRDerivedFields(
+			ctx, repoID, number, db.MRDerivedFields{
+				ReviewDecision: normalized.ReviewDecision,
+				CommentCount:   len(bulk.Comments),
+				LastActivityAt: computeLastActivity(bulk.PR, bulk.Comments, nil, nil),
+			},
+		); err != nil {
+			slog.Warn("update comment-derived fields failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number, "err", err,
+			)
+		}
+	}
+
 	allComplete := bulk.CommentsComplete &&
 		bulk.ReviewsComplete &&
 		bulk.CommitsComplete &&

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1311,7 +1311,7 @@ func (s *Syncer) indexSyncRepo(
 
 			for _, ghPR := range ghPRs {
 				if err := s.indexUpsertMR(
-					ctx, repo, repoID, ghPR,
+					ctx, client, repo, repoID, ghPR,
 				); err != nil {
 					slog.Error("index upsert MR failed",
 						"repo", repo.Owner+"/"+repo.Name,
@@ -1390,7 +1390,7 @@ func (s *Syncer) indexSyncRepo(
 		if !graphQLIssuesDone {
 			// REST fallback using already-fetched ghIssues.
 			if err := s.syncIssuesFromList(
-				ctx, repo, repoID, ghIssues, forceIssues,
+				ctx, client, repo, repoID, ghIssues, forceIssues,
 			); err != nil {
 				slog.Error("REST issue sync failed",
 					"repo", repo.Owner+"/"+repo.Name,
@@ -1427,6 +1427,7 @@ func (s *Syncer) indexSyncRepo(
 // mergeable_state) from the existing DB row.
 func (s *Syncer) indexUpsertMR(
 	ctx context.Context,
+	client Client,
 	repo RepoRef,
 	repoID int64,
 	ghPR *gh.PullRequest,
@@ -1458,16 +1459,10 @@ func (s *Syncer) indexUpsertMR(
 		if host == "" {
 			host = "github.com"
 		}
-		client, clientErr := s.clientFor(repo)
-		if clientErr == nil {
-			if name, ok := s.resolveDisplayName(
-				ctx, client, host, normalized.Author,
-			); ok {
-				normalized.AuthorDisplayName = name
-			} else if existing != nil {
-				normalized.AuthorDisplayName =
-					existing.AuthorDisplayName
-			}
+		if name, ok := s.resolveDisplayName(
+			ctx, client, host, normalized.Author,
+		); ok {
+			normalized.AuthorDisplayName = name
 		} else if existing != nil {
 			normalized.AuthorDisplayName =
 				existing.AuthorDisplayName
@@ -1491,7 +1486,106 @@ func (s *Syncer) indexUpsertMR(
 		)
 	}
 
+	if existing != nil &&
+		existing.DetailFetchedAt != nil &&
+		existing.UpdatedAt.Equal(normalized.UpdatedAt) {
+		s.refreshPRCommentsForItem(ctx, client, repo, existing)
+	}
+
 	return nil
+}
+
+const largeCommentThreadThreshold = 100
+
+func (s *Syncer) listCommentsForRefresh(
+	ctx context.Context,
+	client Client,
+	repo RepoRef,
+	number int,
+	knownCount int,
+) ([]*gh.IssueComment, error) {
+	if knownCount >= largeCommentThreadThreshold {
+		return client.ListIssueComments(
+			ctx, repo.Owner, repo.Name, number,
+		)
+	}
+	return client.ListIssueCommentsIfChanged(
+		ctx, repo.Owner, repo.Name, number,
+	)
+}
+
+func (s *Syncer) refreshPRCommentsForItem(
+	ctx context.Context,
+	client Client,
+	repo RepoRef,
+	pr *db.MergeRequest,
+) {
+	if pr == nil || pr.DetailFetchedAt == nil {
+		return
+	}
+	if !s.canSpendCommentRefresh(repo.PlatformHost) {
+		return
+	}
+
+	comments, err := s.listCommentsForRefresh(
+		ctx, client, repo, pr.Number, pr.CommentCount,
+	)
+	if err != nil {
+		if IsNotModified(err) {
+			return
+		}
+		slog.Warn("comment refresh: list PR comments failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"number", pr.Number,
+			"err", err,
+		)
+		return
+	}
+	if err := s.persistPRComments(ctx, pr, comments); err != nil {
+		client.InvalidateListETagsForRepo(repo.Owner, repo.Name, "comments")
+		slog.Warn("comment refresh: persist PR comments failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"number", pr.Number,
+			"err", err,
+		)
+	}
+}
+
+func (s *Syncer) refreshIssueCommentsForItem(
+	ctx context.Context,
+	client Client,
+	repo RepoRef,
+	issue *db.Issue,
+) {
+	if issue == nil || issue.DetailFetchedAt == nil {
+		return
+	}
+	if !s.canSpendCommentRefresh(repo.PlatformHost) {
+		return
+	}
+
+	comments, err := s.listCommentsForRefresh(
+		ctx, client, repo, issue.Number, issue.CommentCount,
+	)
+	if err != nil {
+		if IsNotModified(err) {
+			return
+		}
+		slog.Warn("comment refresh: list issue comments failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"number", issue.Number,
+			"err", err,
+		)
+		return
+	}
+	if err := s.persistIssueComments(ctx, issue, comments); err != nil {
+		client.InvalidateListETagsForRepo(repo.Owner, repo.Name, "comments")
+		slog.Warn("comment refresh: persist issue comments failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"number", issue.Number,
+			"err", err,
+		)
+	}
 }
 
 // doSyncRepoGraphQL processes bulk GraphQL results for a repo.
@@ -2582,6 +2676,7 @@ func (s *Syncer) resolveDisplayName(
 // via the REST path. Handles per-issue upsert and closure detection.
 func (s *Syncer) syncIssuesFromList(
 	ctx context.Context,
+	client Client,
 	repo RepoRef,
 	repoID int64,
 	ghIssues []*gh.Issue,
@@ -2594,7 +2689,7 @@ func (s *Syncer) syncIssuesFromList(
 
 	var hadItemFailure bool
 	for _, ghIssue := range ghIssues {
-		if err := s.syncOpenIssue(ctx, repo, repoID, ghIssue, forceRefresh); err != nil {
+		if err := s.syncOpenIssue(ctx, client, repo, repoID, ghIssue, forceRefresh); err != nil {
 			slog.Error("sync issue failed",
 				"repo", repo.Owner+"/"+repo.Name,
 				"number", ghIssue.GetNumber(),
@@ -2631,6 +2726,7 @@ func (s *Syncer) syncIssuesFromList(
 
 func (s *Syncer) syncOpenIssue(
 	ctx context.Context,
+	client Client,
 	repo RepoRef,
 	repoID int64,
 	ghIssue *gh.Issue,
@@ -2664,6 +2760,9 @@ func (s *Syncer) syncOpenIssue(
 	}
 
 	if !needsTimeline {
+		if existing != nil && existing.DetailFetchedAt != nil {
+			s.refreshIssueCommentsForItem(ctx, client, repo, existing)
+		}
 		return nil
 	}
 
@@ -2740,35 +2839,7 @@ func (s *Syncer) refreshRepoPRComments(
 		if ctx.Err() != nil {
 			return
 		}
-		pr := &prs[i]
-		if pr.DetailFetchedAt == nil {
-			continue
-		}
-		if !s.canSpendCommentRefresh(repo.PlatformHost) {
-			return
-		}
-		comments, err := client.ListIssueCommentsIfChanged(
-			ctx, repo.Owner, repo.Name, pr.Number,
-		)
-		if err != nil {
-			if IsNotModified(err) {
-				continue
-			}
-			slog.Warn("comment refresh: list PR comments failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"number", pr.Number,
-				"err", err,
-			)
-			continue
-		}
-		if err := s.persistPRComments(ctx, pr, comments); err != nil {
-			client.InvalidateListETagsForRepo(repo.Owner, repo.Name, "comments")
-			slog.Warn("comment refresh: persist PR comments failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"number", pr.Number,
-				"err", err,
-			)
-		}
+		s.refreshPRCommentsForItem(ctx, client, repo, &prs[i])
 	}
 }
 
@@ -2802,35 +2873,7 @@ func (s *Syncer) refreshRepoIssueComments(
 		if ctx.Err() != nil {
 			return
 		}
-		issue := &issues[i]
-		if issue.DetailFetchedAt == nil {
-			continue
-		}
-		if !s.canSpendCommentRefresh(repo.PlatformHost) {
-			return
-		}
-		comments, err := client.ListIssueCommentsIfChanged(
-			ctx, repo.Owner, repo.Name, issue.Number,
-		)
-		if err != nil {
-			if IsNotModified(err) {
-				continue
-			}
-			slog.Warn("comment refresh: list issue comments failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"number", issue.Number,
-				"err", err,
-			)
-			continue
-		}
-		if err := s.persistIssueComments(ctx, issue, comments); err != nil {
-			client.InvalidateListETagsForRepo(repo.Owner, repo.Name, "comments")
-			slog.Warn("comment refresh: persist issue comments failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"number", issue.Number,
-				"err", err,
-			)
-		}
+		s.refreshIssueCommentsForItem(ctx, client, repo, &issues[i])
 	}
 }
 

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4386,6 +4386,7 @@ func TestSyncerRemovesDeletedPRCommentWhenPRListIsUnchanged(t *testing.T) {
 	events, err = d.ListMREvents(ctx, mr.ID)
 	require.NoError(err)
 	assert.Empty(events)
+	assert.Equal(now.UTC(), mr.LastActivityAt.UTC())
 }
 
 func TestSyncerRemovesDeletedIssueCommentWhenIssueListIsUnchanged(t *testing.T) {
@@ -4458,6 +4459,339 @@ func TestSyncerRemovesDeletedIssueCommentWhenIssueListIsUnchanged(t *testing.T) 
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal(0, issue.CommentCount)
+
+	events, err = d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	assert.Empty(events)
+	assert.Equal(now.UTC(), issue.LastActivityAt.UTC())
+}
+
+func TestFetchMRDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC)
+	firstUpdatedAt := now
+	secondUpdatedAt := now.Add(time.Minute)
+	commentID := int64(7101)
+	commentAuthor := "reviewer"
+	commentBody := "full refresh comment"
+	commentTime := now.Add(2 * time.Minute)
+
+	fetches := 0
+	mc := &mockClient{
+		comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			Body:      &commentBody,
+			User:      &gh.User{Login: &commentAuthor},
+			CreatedAt: makeTimestamp(commentTime),
+			UpdatedAt: makeTimestamp(commentTime),
+		}},
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			require.Equal(1, number)
+			fetches++
+			if fetches == 1 {
+				return buildOpenPR(1, firstUpdatedAt), nil
+			}
+			return buildOpenPR(1, secondUpdatedAt), nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	_, err = syncer.fetchMRDetail(
+		ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, 1, false,
+	)
+	require.NoError(err)
+
+	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.Equal(1, mr.CommentCount)
+	assert.Equal(commentTime.UTC(), mr.LastActivityAt.UTC())
+
+	events, err := d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+
+	mc.comments = []*gh.IssueComment{}
+
+	_, err = syncer.fetchMRDetail(
+		ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, 1, false,
+	)
+	require.NoError(err)
+
+	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(0, mr.CommentCount)
+	assert.Equal(secondUpdatedAt.UTC(), mr.LastActivityAt.UTC())
+
+	events, err = d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	assert.Empty(events)
+}
+
+func TestFetchIssueDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC)
+	firstUpdatedAt := now
+	secondUpdatedAt := now.Add(time.Minute)
+	issueID := int64(820)
+	issueNumber := 8
+	issueTitle := "full refresh issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/8"
+	commentID := int64(821)
+	commentAuthor := "reviewer"
+	commentBody := "full refresh issue comment"
+	commentTime := now.Add(2 * time.Minute)
+
+	fetches := 0
+	mc := &mockClient{
+		comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			Body:      &commentBody,
+			User:      &gh.User{Login: &commentAuthor},
+			CreatedAt: makeTimestamp(commentTime),
+			UpdatedAt: makeTimestamp(commentTime),
+		}},
+		getIssueFn: func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+			require.Equal(issueNumber, number)
+			fetches++
+			updatedAt := firstUpdatedAt
+			if fetches > 1 {
+				updatedAt = secondUpdatedAt
+			}
+			return &gh.Issue{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				CreatedAt: makeTimestamp(now),
+				UpdatedAt: makeTimestamp(updatedAt),
+			}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	_, err = syncer.fetchIssueDetail(
+		ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, issueNumber,
+	)
+	require.NoError(err)
+
+	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue)
+	require.Equal(1, issue.CommentCount)
+	assert.Equal(commentTime.UTC(), issue.LastActivityAt.UTC())
+
+	events, err := d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+
+	mc.comments = []*gh.IssueComment{}
+
+	_, err = syncer.fetchIssueDetail(
+		ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID, issueNumber,
+	)
+	require.NoError(err)
+
+	issue, err = d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.Equal(0, issue.CommentCount)
+	assert.Equal(secondUpdatedAt.UTC(), issue.LastActivityAt.UTC())
+
+	events, err = d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	assert.Empty(events)
+}
+
+func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 3, 12, 0, 0, 0, time.UTC)
+	firstUpdatedAt := now
+	secondUpdatedAt := now.Add(time.Minute)
+	commentID := int64(9101)
+	commentAuthor := "reviewer"
+	commentBody := "bulk PR comment"
+	commentTime := gh.Timestamp{Time: now.Add(2 * time.Minute)}
+
+	commentTotal := 1
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}},
+		d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+
+	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
+		PR: buildOpenPR(1, firstUpdatedAt),
+		Comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			Body:      &commentBody,
+			User:      &gh.User{Login: &commentAuthor},
+			CreatedAt: &commentTime,
+			UpdatedAt: &commentTime,
+		}},
+		CommentsComplete: true,
+		ReviewsComplete:  true,
+		CommitsComplete:  true,
+		CIComplete:       true,
+	}, false)
+	require.NoError(err)
+
+	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.Equal(1, mr.CommentCount)
+	assert.Equal(commentTime.UTC(), mr.LastActivityAt.UTC())
+
+	events, err := d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+
+	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
+		PR:               buildOpenPR(1, secondUpdatedAt),
+		Comments:         []*gh.IssueComment{},
+		CommentsComplete: true,
+		ReviewsComplete:  true,
+		CommitsComplete:  true,
+		CIComplete:       true,
+	}, false)
+	require.NoError(err)
+
+	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(0, mr.CommentCount)
+	assert.Equal(secondUpdatedAt.UTC(), mr.LastActivityAt.UTC())
+
+	events, err = d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	assert.Empty(events)
+	_ = commentTotal
+}
+
+func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 3, 12, 0, 0, 0, time.UTC)
+	firstUpdatedAt := gh.Timestamp{Time: now}
+	secondUpdatedAt := gh.Timestamp{Time: now.Add(time.Minute)}
+	issueID := int64(9201)
+	issueNumber := 9
+	issueTitle := "bulk issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/9"
+	issueAuthor := "alice"
+	commentID := int64(9202)
+	commentAuthor := "reviewer"
+	commentBody := "bulk issue comment"
+	commentTime := gh.Timestamp{Time: now.Add(2 * time.Minute)}
+	commentTotal := 1
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}},
+		d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+
+	err = syncer.syncOpenIssueFromBulk(ctx, repo, repoID, &BulkIssue{
+		Issue: &gh.Issue{
+			ID:        &issueID,
+			Number:    &issueNumber,
+			Title:     &issueTitle,
+			State:     &issueState,
+			HTMLURL:   &issueURL,
+			Comments:  &commentTotal,
+			User:      &gh.User{Login: &issueAuthor},
+			CreatedAt: &firstUpdatedAt,
+			UpdatedAt: &firstUpdatedAt,
+		},
+		Comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			Body:      &commentBody,
+			User:      &gh.User{Login: &commentAuthor},
+			CreatedAt: &commentTime,
+			UpdatedAt: &commentTime,
+		}},
+		CommentsComplete: true,
+	})
+	require.NoError(err)
+
+	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue)
+	require.Equal(1, issue.CommentCount)
+	assert.Equal(commentTime.UTC(), issue.LastActivityAt.UTC())
+
+	events, err := d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+
+	zeroComments := 0
+	err = syncer.syncOpenIssueFromBulk(ctx, repo, repoID, &BulkIssue{
+		Issue: &gh.Issue{
+			ID:        &issueID,
+			Number:    &issueNumber,
+			Title:     &issueTitle,
+			State:     &issueState,
+			HTMLURL:   &issueURL,
+			Comments:  &zeroComments,
+			User:      &gh.User{Login: &issueAuthor},
+			CreatedAt: &firstUpdatedAt,
+			UpdatedAt: &secondUpdatedAt,
+		},
+		Comments:         []*gh.IssueComment{},
+		CommentsComplete: true,
+	})
+	require.NoError(err)
+
+	issue, err = d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.Equal(0, issue.CommentCount)
+	assert.Equal(secondUpdatedAt.UTC(), issue.LastActivityAt.UTC())
 
 	events, err = d.ListIssueEvents(ctx, issue.ID)
 	require.NoError(err)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -43,35 +43,38 @@ func testBudget(limit int) map[string]*SyncBudget {
 
 // mockClient implements Client with configurable canned responses.
 type mockClient struct {
-	budget                  *SyncBudget // optional: simulates transport counting
-	openPRs                 []*gh.PullRequest
-	openIssues              []*gh.Issue
-	listOpenPRsErr          error
-	listOpenIssuesErr       error
-	singlePR                *gh.PullRequest
-	getRepositoryFn         func(context.Context, string, string) (*gh.Repository, error)
-	getPullRequestFn        func(context.Context, string, string, int) (*gh.PullRequest, error)
-	getIssueFn              func(context.Context, string, string, int) (*gh.Issue, error)
-	getUserFn               func(context.Context, string) (*gh.User, error)
-	listReposByOwnerFn      func(context.Context, string) ([]*gh.Repository, error)
-	listOpenPRsFn           func(context.Context, string, string) ([]*gh.PullRequest, error)
-	listPullRequestsPageFn  func(context.Context, string, string, string, int) ([]*gh.PullRequest, bool, error)
-	listIssuesPageFn        func(context.Context, string, string, string, int) ([]*gh.Issue, bool, error)
-	comments                []*gh.IssueComment
-	reviews                 []*gh.PullRequestReview
-	commits                 []*gh.RepositoryCommit
-	forcePushEvents         []ForcePushEvent
-	forcePushEventsErr      error
-	ciStatus                *gh.CombinedStatus
-	checkRuns               []*gh.CheckRun
-	workflowRuns            []*gh.WorkflowRun
-	approveWorkflowRunFn    func(context.Context, string, string, int64) error
-	listOpenPRsCalled       bool
-	getUserCalls            atomic.Int32
-	getCombinedCalls        atomic.Int32
-	invalidateCalls         atomic.Int32
-	listIssueCommentsCalled atomic.Int32
-	listIssueCommentsErr    error
+	budget                          *SyncBudget // optional: simulates transport counting
+	openPRs                         []*gh.PullRequest
+	openIssues                      []*gh.Issue
+	listOpenPRsErr                  error
+	listOpenIssuesErr               error
+	singlePR                        *gh.PullRequest
+	getRepositoryFn                 func(context.Context, string, string) (*gh.Repository, error)
+	getPullRequestFn                func(context.Context, string, string, int) (*gh.PullRequest, error)
+	getIssueFn                      func(context.Context, string, string, int) (*gh.Issue, error)
+	getUserFn                       func(context.Context, string) (*gh.User, error)
+	listReposByOwnerFn              func(context.Context, string) ([]*gh.Repository, error)
+	listOpenPRsFn                   func(context.Context, string, string) ([]*gh.PullRequest, error)
+	listPullRequestsPageFn          func(context.Context, string, string, string, int) ([]*gh.PullRequest, bool, error)
+	listIssuesPageFn                func(context.Context, string, string, string, int) ([]*gh.Issue, bool, error)
+	comments                        []*gh.IssueComment
+	reviews                         []*gh.PullRequestReview
+	commits                         []*gh.RepositoryCommit
+	forcePushEvents                 []ForcePushEvent
+	forcePushEventsErr              error
+	ciStatus                        *gh.CombinedStatus
+	checkRuns                       []*gh.CheckRun
+	workflowRuns                    []*gh.WorkflowRun
+	approveWorkflowRunFn            func(context.Context, string, string, int64) error
+	listOpenPRsCalled               bool
+	getUserCalls                    atomic.Int32
+	getCombinedCalls                atomic.Int32
+	invalidateCalls                 atomic.Int32
+	listIssueCommentsCalled         atomic.Int32
+	listIssueCommentsIfChangedCalls atomic.Int32
+	listIssueCommentsErr            error
+	listIssueCommentsFn             func(context.Context, string, string, int) ([]*gh.IssueComment, error)
+	listIssueCommentsIfChangedFn    func(context.Context, string, string, int) ([]*gh.IssueComment, error)
 }
 
 func (m *mockClient) trackCall() {
@@ -153,9 +156,12 @@ func (m *mockClient) GetPullRequest(
 	return nil, nil
 }
 
-func (m *mockClient) ListIssueComments(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+func (m *mockClient) ListIssueComments(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error) {
 	m.trackCall()
 	m.listIssueCommentsCalled.Add(1)
+	if m.listIssueCommentsFn != nil {
+		return m.listIssueCommentsFn(ctx, owner, repo, number)
+	}
 	if m.listIssueCommentsErr != nil {
 		return nil, m.listIssueCommentsErr
 	}
@@ -165,6 +171,10 @@ func (m *mockClient) ListIssueComments(_ context.Context, _, _ string, _ int) ([
 func (m *mockClient) ListIssueCommentsIfChanged(
 	ctx context.Context, owner, repo string, number int,
 ) ([]*gh.IssueComment, error) {
+	m.listIssueCommentsIfChangedCalls.Add(1)
+	if m.listIssueCommentsIfChangedFn != nil {
+		return m.listIssueCommentsIfChangedFn(ctx, owner, repo, number)
+	}
 	if m.listIssueCommentsErr != nil {
 		return nil, m.listIssueCommentsErr
 	}
@@ -5658,6 +5668,108 @@ func TestSyncRepoGraphQLIssuesFullFlow(t *testing.T) {
 
 	// GraphQL path skipped REST ListIssueComments.
 	assert.Equal(int32(0), mock.listIssueCommentsCalled.Load())
+}
+
+func TestRefreshRepoPRCommentsUsesFullFetchForLargeThreads(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	detailFetchedAt := now.Add(time.Minute)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      101,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "Large thread",
+		Author:          "alice",
+		State:           "open",
+		CommentCount:    100,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+
+	mock := &mockClient{
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			require.Equal(1, number)
+			return []*gh.IssueComment{}, nil
+		},
+		listIssueCommentsIfChangedFn: func(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+			require.FailNow("conditional comment refresh should not be used for 100+ comment PRs")
+			return nil, nil
+		},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	syncer.refreshRepoPRComments(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"})
+
+	assert.Equal(int32(1), mock.listIssueCommentsCalled.Load())
+	assert.Equal(int32(0), mock.listIssueCommentsIfChangedCalls.Load())
+}
+
+func TestRefreshRepoIssueCommentsUsesFullFetchForLargeThreads(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	detailFetchedAt := now.Add(time.Minute)
+	_, err = d.UpsertIssue(ctx, &db.Issue{
+		RepoID:          repoID,
+		PlatformID:      201,
+		Number:          2,
+		URL:             "https://github.com/owner/repo/issues/2",
+		Title:           "Large thread issue",
+		Author:          "bob",
+		State:           "open",
+		CommentCount:    100,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+
+	mock := &mockClient{
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			require.Equal(2, number)
+			return []*gh.IssueComment{}, nil
+		},
+		listIssueCommentsIfChangedFn: func(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+			require.FailNow("conditional comment refresh should not be used for 100+ comment issues")
+			return nil, nil
+		},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	syncer.refreshRepoIssueComments(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"})
+
+	assert.Equal(int32(1), mock.listIssueCommentsCalled.Load())
+	assert.Equal(int32(0), mock.listIssueCommentsIfChangedCalls.Load())
 }
 
 func TestSyncerGQLRateTrackers(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4319,6 +4319,151 @@ func TestSyncerRefreshesEditedPRCommentWhenPRListIsUnchanged(t *testing.T) {
 	assert.Equal("edited body", events[0].Body)
 }
 
+func TestSyncerRemovesDeletedPRCommentWhenPRListIsUnchanged(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	commentID := int64(7002)
+	commentUser := "reviewer"
+	commentBody := "to be deleted"
+	commentTime := now.Add(2 * time.Minute)
+
+	mc := &mockClient{
+		openIssues: []*gh.Issue{},
+		comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			Body:      &commentBody,
+			User:      &gh.User{Login: &commentUser},
+			CreatedAt: makeTimestamp(commentTime),
+			UpdatedAt: makeTimestamp(commentTime),
+		}},
+	}
+	mc.getPullRequestFn = func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+		require.Equal(1, number)
+		return buildOpenPR(1, now), nil
+	}
+	prListCalls := 0
+	mc.listOpenPRsFn = func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+		prListCalls++
+		if prListCalls == 1 {
+			return []*gh.PullRequest{buildOpenPR(1, now)}, nil
+		}
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, testBudget(10000),
+	)
+
+	syncer.RunOnce(ctx)
+
+	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.Equal(1, mr.CommentCount)
+
+	events, err := d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+
+	mc.comments = []*gh.IssueComment{}
+
+	syncer.RunOnce(ctx)
+
+	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(0, mr.CommentCount)
+
+	events, err = d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	assert.Empty(events)
+}
+
+func TestSyncerRemovesDeletedIssueCommentWhenIssueListIsUnchanged(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	issueID := int64(801)
+	issueNumber := 8
+	issueTitle := "edited issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/8"
+	openIssue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &issueTitle,
+		State:     &issueState,
+		HTMLURL:   &issueURL,
+		CreatedAt: makeTimestamp(now),
+		UpdatedAt: makeTimestamp(now),
+	}
+
+	commentID := int64(810)
+	commentUser := "reviewer"
+	commentBody := "issue comment"
+	commentTime := now.Add(2 * time.Minute)
+
+	mc := &partialFailureMock{}
+	mc.openPRs = []*gh.PullRequest{}
+	mc.openIssues = []*gh.Issue{openIssue}
+	mc.comments = []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &commentBody,
+		User:      &gh.User{Login: &commentUser},
+		CreatedAt: makeTimestamp(commentTime),
+		UpdatedAt: makeTimestamp(commentTime),
+	}}
+	mc.listOpenPRsErr = notModifiedErr()
+	mc.getIssueFn = func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+		require.Equal(issueNumber, number)
+		return openIssue, nil
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, testBudget(10000),
+	)
+
+	syncer.RunOnce(ctx)
+
+	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue)
+	require.Equal(1, issue.CommentCount)
+
+	events, err := d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+
+	mc.comments = []*gh.IssueComment{}
+	mc.issuesCached = true
+
+	syncer.RunOnce(ctx)
+
+	issue, err = d.GetIssue(ctx, "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.Equal(0, issue.CommentCount)
+
+	events, err = d.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	assert.Empty(events)
+}
+
 func TestSyncRepoGraphQLIssues(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -162,6 +162,18 @@ func (m *mockClient) ListIssueComments(_ context.Context, _, _ string, _ int) ([
 	return m.comments, nil
 }
 
+func (m *mockClient) ListIssueCommentsIfChanged(
+	ctx context.Context, owner, repo string, number int,
+) ([]*gh.IssueComment, error) {
+	if m.listIssueCommentsErr != nil {
+		return nil, m.listIssueCommentsErr
+	}
+	if m.comments == nil {
+		return nil, notModifiedErr()
+	}
+	return m.ListIssueComments(ctx, owner, repo, number)
+}
+
 func (m *mockClient) ListReviews(_ context.Context, _, _ string, _ int) ([]*gh.PullRequestReview, error) {
 	m.trackCall()
 	return m.reviews, nil
@@ -3828,6 +3840,18 @@ func (m *partialFailureMock) ListIssueComments(_ context.Context, _, _ string, _
 	return m.comments, nil
 }
 
+func (m *partialFailureMock) ListIssueCommentsIfChanged(
+	ctx context.Context, owner, repo string, number int,
+) ([]*gh.IssueComment, error) {
+	if m.listIssueCommentsErr != nil {
+		return nil, m.listIssueCommentsErr
+	}
+	if m.comments == nil {
+		return nil, notModifiedErr()
+	}
+	return m.ListIssueComments(ctx, owner, repo, number)
+}
+
 func (m *partialFailureMock) ListReviews(_ context.Context, _, _ string, _ int) ([]*gh.PullRequestReview, error) {
 	if m.listReviewsErr != nil {
 		return nil, m.listReviewsErr
@@ -4216,6 +4240,83 @@ func TestSyncerMRDetailFailureRetries(t *testing.T) {
 	events, err = d.ListMREvents(ctx, mr.ID)
 	require.NoError(err)
 	assert.NotEmpty(events, "review event should be persisted after detail retry")
+}
+
+func TestSyncerRefreshesEditedPRCommentWhenPRListIsUnchanged(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	commentID := int64(7001)
+	commentUser := "reviewer"
+	commentBody := "original body"
+	commentUpdatedAt := now.Add(2 * time.Minute)
+
+	mc := &mockClient{
+		openIssues: []*gh.Issue{},
+		comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			Body:      &commentBody,
+			User:      &gh.User{Login: &commentUser},
+			CreatedAt: makeTimestamp(commentUpdatedAt),
+			UpdatedAt: makeTimestamp(commentUpdatedAt),
+		}},
+	}
+	mc.getPullRequestFn = func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+		require.Equal(1, number)
+		return buildOpenPR(1, now), nil
+	}
+	prListCalls := 0
+	mc.listOpenPRsFn = func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+		prListCalls++
+		if prListCalls == 1 {
+			return []*gh.PullRequest{buildOpenPR(1, now)}, nil
+		}
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, testBudget(10000),
+	)
+
+	syncer.RunOnce(ctx)
+
+	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+
+	events, err := d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("original body", events[0].Body)
+
+	editedBody := "edited body"
+	editedAt := now.Add(4 * time.Minute)
+	mc.comments = []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &editedBody,
+		User:      &gh.User{Login: &commentUser},
+		CreatedAt: makeTimestamp(commentUpdatedAt),
+		UpdatedAt: makeTimestamp(editedAt),
+	}}
+
+	syncer.RunOnce(ctx)
+
+	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+
+	events, err = d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("edited body", events[0].Body)
 }
 
 func TestSyncRepoGraphQLIssues(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5670,6 +5670,37 @@ func TestSyncRepoGraphQLIssuesFullFlow(t *testing.T) {
 	assert.Equal(int32(0), mock.listIssueCommentsCalled.Load())
 }
 
+// TestComputePRCommentRefreshLastActivity_PreservesNonCommentEvents
+// guards the comment-only refresh path against regressing a PR whose
+// latest activity came from a review, commit, or force push — data
+// the comment list can't see. The non-comment timestamp is supplied
+// by the caller from the DB's stored events.
+func TestComputePRCommentRefreshLastActivity_PreservesNonCommentEvents(t *testing.T) {
+	assert := Assert.New(t)
+
+	created := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	updated := created.Add(1 * time.Hour)
+	commentAt := created.Add(2 * time.Hour)
+	reviewAt := created.Add(3 * time.Hour)
+
+	pr := &db.MergeRequest{CreatedAt: created, UpdatedAt: updated}
+	comments := []*gh.IssueComment{{
+		CreatedAt: &gh.Timestamp{Time: commentAt},
+		UpdatedAt: &gh.Timestamp{Time: commentAt},
+	}}
+
+	assert.Equal(reviewAt, computePRCommentRefreshLastActivity(pr, comments, reviewAt),
+		"stored non-comment event activity must win over comment timestamp")
+
+	newerComment := reviewAt.Add(30 * time.Minute)
+	comments[0].UpdatedAt = &gh.Timestamp{Time: newerComment}
+	assert.Equal(newerComment, computePRCommentRefreshLastActivity(pr, comments, reviewAt),
+		"a strictly newer comment should advance activity past stored events")
+
+	assert.Equal(updated, computePRCommentRefreshLastActivity(pr, nil, time.Time{}),
+		"no comments and no stored events should fall back to PR UpdatedAt")
+}
+
 func TestRefreshRepoPRCommentsUsesFullFetchForLargeThreads(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5772,6 +5772,107 @@ func TestRefreshRepoIssueCommentsUsesFullFetchForLargeThreads(t *testing.T) {
 	assert.Equal(int32(0), mock.listIssueCommentsIfChangedCalls.Load())
 }
 
+func TestDeferredCommentRefreshYieldsBudgetToDetailDrain(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	budget := testBudget(11)
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+
+	pr1UpdatedAt := now.Add(-10 * time.Minute)
+	detailFetchedAt := now.Add(-5 * time.Minute)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1001,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "Large unchanged thread",
+		Author:          "alice",
+		State:           "open",
+		CommentCount:    100,
+		HeadBranch:      "feature/large-thread",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "1111111",
+		PlatformBaseSHA: "aaaaaaa",
+		CreatedAt:       pr1UpdatedAt,
+		UpdatedAt:       pr1UpdatedAt,
+		LastActivityAt:  pr1UpdatedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	pr2ID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1002,
+		Number:          2,
+		URL:             "https://github.com/owner/repo/pull/2",
+		Title:           "Needs detail drain",
+		Author:          "alice",
+		State:           "open",
+		CommentCount:    0,
+		HeadBranch:      "feature/detail-drain",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "2222222",
+		PlatformBaseSHA: "aaaaaaa",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+	require.NoError(d.EnsureKanbanState(ctx, pr2ID))
+
+	var commentCalls []int
+	mc := &mockClient{
+		budget: budget["github.com"],
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			require.Equal(2, number)
+			return &gh.PullRequest{
+				ID:        new(int64(1002)),
+				Number:    new(2),
+				Title:     new("Needs detail drain"),
+				State:     new("open"),
+				HTMLURL:   new("https://github.com/owner/repo/pull/2"),
+				User:      &gh.User{Login: new("alice")},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				Head:      &gh.PullRequestBranch{Ref: new("feature/detail-drain"), SHA: new("2222222")},
+				Base:      &gh.PullRequestBranch{Ref: new("main"), SHA: new("aaaaaaa")},
+			}, nil
+		},
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			commentCalls = append(commentCalls, number)
+			return []*gh.IssueComment{}, nil
+		},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		ciStatus: &gh.CombinedStatus{State: new("success")},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, budget,
+	)
+
+	syncer.queuePRCommentSync(repo, 1)
+	budget["github.com"].Spend(3)
+	syncer.drainDetailQueue(ctx, map[string]bool{"github.com": true})
+	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
+
+	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 2)
+	require.NoError(err)
+	require.NotNil(pr)
+	assert.NotNil(pr.DetailFetchedAt,
+		"detail drain should win before unchanged large-thread refresh")
+	assert.Equal([]int{2}, commentCalls,
+		"only the detail-drain PR should spend the remaining budget")
+}
+
 func TestSyncerGQLRateTrackers(t *testing.T) {
 	assert := Assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4705,6 +4705,77 @@ func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *test
 	_ = commentTotal
 }
 
+func TestSyncOpenMRFromBulkUpdatesCommentFieldsWhenOnlyCommentsAreComplete(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 3, 13, 0, 0, 0, time.UTC)
+	firstUpdatedAt := now
+	secondUpdatedAt := now.Add(time.Minute)
+	commentID := int64(9301)
+	commentAuthor := "reviewer"
+	commentBody := "partial bulk PR comment"
+	commentTime := gh.Timestamp{Time: now.Add(2 * time.Minute)}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}},
+		d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+
+	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
+		PR: buildOpenPR(1, firstUpdatedAt),
+		Comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			Body:      &commentBody,
+			User:      &gh.User{Login: &commentAuthor},
+			CreatedAt: &commentTime,
+			UpdatedAt: &commentTime,
+		}},
+		CommentsComplete: true,
+		ReviewsComplete:  false,
+		CommitsComplete:  false,
+		CIComplete:       false,
+	}, false)
+	require.NoError(err)
+
+	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(1, mr.CommentCount)
+	assert.Equal(commentTime.UTC(), mr.LastActivityAt.UTC())
+
+	events, err := d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+
+	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
+		PR:               buildOpenPR(1, secondUpdatedAt),
+		Comments:         []*gh.IssueComment{},
+		CommentsComplete: true,
+		ReviewsComplete:  false,
+		CommitsComplete:  false,
+		CIComplete:       false,
+	}, false)
+	require.NoError(err)
+
+	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(0, mr.CommentCount)
+	assert.Equal(secondUpdatedAt.UTC(), mr.LastActivityAt.UTC())
+
+	events, err = d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	assert.Empty(events)
+}
+
 func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3727,6 +3727,162 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 	require.Empty(*secondResp.JSON200.Events)
 }
 
+func TestE2EPRDetailRemovesDeletedCommentWhenAnotherPRChanges(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 12, 15, 0, 0, 0, time.UTC)
+	targetNumber := 160
+	targetID := int64(160000)
+	targetTitle := "Target PR keeps stale comment"
+	targetURL := "https://github.com/acme/widget/pull/160"
+	otherNumber := 161
+	otherID := int64(161000)
+	otherTitle := "Other PR changes"
+	otherURL := "https://github.com/acme/widget/pull/161"
+	prState := "open"
+	headRef := "feature/comments"
+	headSHA := "deadbeef"
+	baseRef := "main"
+	commentID := int64(9050)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	targetCommentBody := "target comment"
+	targetComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &targetCommentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+	otherUpdatedAt := now
+
+	prListCalls := 0
+	mock := &mockGH{
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return nil, nil
+		},
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			prListCalls++
+			if prListCalls > 1 {
+				otherUpdatedAt = now.Add(5 * time.Minute)
+			}
+			return []*gh.PullRequest{
+				{
+					ID:        &targetID,
+					Number:    &targetNumber,
+					Title:     &targetTitle,
+					HTMLURL:   &targetURL,
+					State:     &prState,
+					UpdatedAt: &gh.Timestamp{Time: now},
+					CreatedAt: &gh.Timestamp{Time: now},
+					Head:      &gh.PullRequestBranch{Ref: &headRef, SHA: &headSHA},
+					Base:      &gh.PullRequestBranch{Ref: &baseRef},
+				},
+				{
+					ID:        &otherID,
+					Number:    &otherNumber,
+					Title:     &otherTitle,
+					HTMLURL:   &otherURL,
+					State:     &prState,
+					UpdatedAt: &gh.Timestamp{Time: otherUpdatedAt},
+					CreatedAt: &gh.Timestamp{Time: now},
+					Head:      &gh.PullRequestBranch{Ref: &headRef, SHA: &headSHA},
+					Base:      &gh.PullRequestBranch{Ref: &baseRef},
+				},
+			}, nil
+		},
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			switch number {
+			case targetNumber:
+				return &gh.PullRequest{
+					ID:        &targetID,
+					Number:    &targetNumber,
+					Title:     &targetTitle,
+					HTMLURL:   &targetURL,
+					State:     &prState,
+					UpdatedAt: &gh.Timestamp{Time: now},
+					CreatedAt: &gh.Timestamp{Time: now},
+					Head:      &gh.PullRequestBranch{Ref: &headRef, SHA: &headSHA},
+					Base:      &gh.PullRequestBranch{Ref: &baseRef},
+				}, nil
+			case otherNumber:
+				return &gh.PullRequest{
+					ID:        &otherID,
+					Number:    &otherNumber,
+					Title:     &otherTitle,
+					HTMLURL:   &otherURL,
+					State:     &prState,
+					UpdatedAt: &gh.Timestamp{Time: otherUpdatedAt},
+					CreatedAt: &gh.Timestamp{Time: now},
+					Head:      &gh.PullRequestBranch{Ref: &headRef, SHA: &headSHA},
+					Base:      &gh.PullRequestBranch{Ref: &baseRef},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected pull request %d", number)
+			}
+		},
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			if number == targetNumber {
+				return targetComments, nil
+			}
+			return []*gh.IssueComment{}, nil
+		},
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(targetNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.MergeRequest.CommentCount)
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("target comment", (*firstResp.JSON200.Events)[0].Body)
+
+	targetComments = []*gh.IssueComment{}
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(targetNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.MergeRequest.CommentCount)
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
+}
+
 func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -3963,6 +4119,153 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.
 	require.NotNil(secondResp.JSON200)
 	require.Equal(int64(0), secondResp.JSON200.Issue.CommentCount)
 	require.Equal(now.UTC(), secondResp.JSON200.Issue.LastActivityAt.UTC())
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
+}
+
+func TestE2EIssueDetailRemovesDeletedCommentWhenAnotherIssueChanges(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 12, 16, 0, 0, 0, time.UTC)
+	targetNumber := 161
+	targetID := int64(161000)
+	targetTitle := "Target issue keeps stale comment"
+	targetURL := "https://github.com/acme/widget/issues/161"
+	otherNumber := 162
+	otherID := int64(162000)
+	otherTitle := "Other issue changes"
+	otherURL := "https://github.com/acme/widget/issues/162"
+	issueState := "open"
+	commentID := int64(9060)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	targetCommentBody := "target issue comment"
+	targetComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &targetCommentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+	otherUpdatedAt := now
+
+	issueListCalls := 0
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			issueListCalls++
+			if issueListCalls > 1 {
+				otherUpdatedAt = now.Add(5 * time.Minute)
+			}
+			return []*gh.Issue{
+				{
+					ID:        &targetID,
+					Number:    &targetNumber,
+					Title:     &targetTitle,
+					State:     &issueState,
+					HTMLURL:   &targetURL,
+					UpdatedAt: &gh.Timestamp{Time: now},
+					CreatedAt: &gh.Timestamp{Time: now},
+				},
+				{
+					ID:        &otherID,
+					Number:    &otherNumber,
+					Title:     &otherTitle,
+					State:     &issueState,
+					HTMLURL:   &otherURL,
+					UpdatedAt: &gh.Timestamp{Time: otherUpdatedAt},
+					CreatedAt: &gh.Timestamp{Time: now},
+				},
+			}, nil
+		},
+		getIssueFn: func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+			switch number {
+			case targetNumber:
+				return &gh.Issue{
+					ID:        &targetID,
+					Number:    &targetNumber,
+					Title:     &targetTitle,
+					State:     &issueState,
+					HTMLURL:   &targetURL,
+					UpdatedAt: &gh.Timestamp{Time: now},
+					CreatedAt: &gh.Timestamp{Time: now},
+				}, nil
+			case otherNumber:
+				return &gh.Issue{
+					ID:        &otherID,
+					Number:    &otherNumber,
+					Title:     &otherTitle,
+					State:     &issueState,
+					HTMLURL:   &otherURL,
+					UpdatedAt: &gh.Timestamp{Time: otherUpdatedAt},
+					CreatedAt: &gh.Timestamp{Time: now},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected issue %d", number)
+			}
+		},
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			if number == targetNumber {
+				return targetComments, nil
+			}
+			return []*gh.IssueComment{}, nil
+		},
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(targetNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.Issue.CommentCount)
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("target issue comment", (*firstResp.JSON200.Events)[0].Body)
+
+	targetComments = []*gh.IssueComment{}
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(targetNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.Issue.CommentCount)
 	require.NotNil(secondResp.JSON200.Events)
 	require.Empty(*secondResp.JSON200.Events)
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3594,6 +3594,128 @@ func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
 	assert.Equal("edited body", (*secondResp.JSON200.Events)[0].Body)
 }
 
+func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 12, 14, 0, 0, 0, time.UTC)
+	issueNumber := 161
+	issueID := int64(161000)
+	issueTitle := "Edited issue comment refresh"
+	issueState := "open"
+	issueURL := "https://github.com/acme/widget/issues/161"
+	commentID := int64(9011)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	commentBody := "original issue body"
+
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+		getIssueFn: func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+			require.Equal(issueNumber, number)
+			return &gh.Issue{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+			}, nil
+		},
+	}
+	issueListCalls := 0
+	mock.listOpenIssuesFn = func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+		issueListCalls++
+		if issueListCalls == 1 {
+			return []*gh.Issue{{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+			}}, nil
+		}
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+	mockComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &commentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+	mock.listIssueCommentsFn = func(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+		return mockComments, nil
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("original issue body", (*firstResp.JSON200.Events)[0].Body)
+
+	editedBody := "edited issue body"
+	mockComments = []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &editedBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: now.Add(4 * time.Minute)},
+	}}
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.NotNil(secondResp.JSON200.Events)
+	require.Len(*secondResp.JSON200.Events, 1)
+	assert.Equal("edited issue body", (*secondResp.JSON200.Events)[0].Body)
+}
+
 func make422Error() error {
 	return &gh.ErrorResponse{
 		Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3967,6 +3967,344 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.
 	require.Empty(*secondResp.JSON200.Events)
 }
 
+func TestE2EPRDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	prNumber := 170
+	prID := int64(170000)
+	prTitle := "Full refresh deleted comment"
+	prState := "open"
+	prURL := "https://github.com/acme/widget/pull/170"
+	headRef := "feature/full-refresh-delete"
+	headSHA := "feedface"
+	baseRef := "main"
+	commentID := int64(9101)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	commentBody := "comment removed on full refresh"
+	currentUpdatedAt := now
+	currentComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &commentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+
+	mock := &mockGH{
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return nil, nil
+		},
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			require.Equal(prNumber, number)
+			return &gh.PullRequest{
+				ID:        &prID,
+				Number:    &prNumber,
+				Title:     &prTitle,
+				HTMLURL:   &prURL,
+				State:     &prState,
+				UpdatedAt: &gh.Timestamp{Time: currentUpdatedAt},
+				CreatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref: &headRef,
+					SHA: &headSHA,
+				},
+				Base: &gh.PullRequestBranch{
+					Ref: &baseRef,
+				},
+			}, nil
+		},
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			require.Equal(prNumber, number)
+			return currentComments, nil
+		},
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	require.NoError(srv.syncer.SyncMR(ctx, "acme", "widget", prNumber))
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.MergeRequest.CommentCount)
+	require.Equal(commentCreatedAt.UTC(), firstResp.JSON200.MergeRequest.LastActivityAt.UTC())
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("comment removed on full refresh", (*firstResp.JSON200.Events)[0].Body)
+
+	currentUpdatedAt = now.Add(time.Minute)
+	currentComments = []*gh.IssueComment{}
+
+	require.NoError(srv.syncer.SyncMR(ctx, "acme", "widget", prNumber))
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.MergeRequest.CommentCount)
+	require.Equal(currentUpdatedAt.UTC(), secondResp.JSON200.MergeRequest.LastActivityAt.UTC())
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
+}
+
+func TestE2EIssueDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	issueNumber := 171
+	issueID := int64(171000)
+	issueTitle := "Full refresh deleted issue comment"
+	issueState := "open"
+	issueURL := "https://github.com/acme/widget/issues/171"
+	commentID := int64(9111)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	commentBody := "issue comment removed on full refresh"
+	currentUpdatedAt := now
+	currentComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &commentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+		getIssueFn: func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+			require.Equal(issueNumber, number)
+			return &gh.Issue{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				UpdatedAt: &gh.Timestamp{Time: currentUpdatedAt},
+				CreatedAt: &gh.Timestamp{Time: now},
+			}, nil
+		},
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			require.Equal(issueNumber, number)
+			return currentComments, nil
+		},
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	require.NoError(srv.syncer.SyncIssue(ctx, "acme", "widget", issueNumber))
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.Issue.CommentCount)
+	require.Equal(commentCreatedAt.UTC(), firstResp.JSON200.Issue.LastActivityAt.UTC())
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("issue comment removed on full refresh", (*firstResp.JSON200.Events)[0].Body)
+
+	currentUpdatedAt = now.Add(time.Minute)
+	currentComments = []*gh.IssueComment{}
+
+	require.NoError(srv.syncer.SyncIssue(ctx, "acme", "widget", issueNumber))
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.Issue.CommentCount)
+	require.Equal(currentUpdatedAt.UTC(), secondResp.JSON200.Issue.LastActivityAt.UTC())
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
+}
+
+func TestE2EIssueDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 13, 11, 0, 0, 0, time.UTC)
+	firstUpdatedAt := now.Format(time.RFC3339)
+	secondUpdatedAt := now.Add(time.Minute).Format(time.RFC3339)
+	currentUpdatedAt := firstUpdatedAt
+	currentCommentJSON := `{"totalCount":1,"nodes":[{"databaseId":9122,"author":{"login":"commenter"},"body":"bulk comment removed","createdAt":"` + firstUpdatedAt + `","updatedAt":"` + firstUpdatedAt + `"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}`
+
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if bytes.Contains(body, []byte("pullRequests")) {
+			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequests":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+			return
+		}
+		resp := `{"data":{"repository":{"issues":{"nodes":[{
+			"databaseId":171100,
+			"number":172,
+			"title":"Bulk deleted comment issue",
+			"state":"OPEN",
+			"body":"GraphQL bulk issue",
+			"url":"https://github.com/acme/widget/issues/172",
+			"author":{"login":"heidi"},
+			"createdAt":"` + firstUpdatedAt + `",
+			"updatedAt":"` + currentUpdatedAt + `",
+			"closedAt":null,
+			"labels":{"nodes":[]},
+			"comments":` + currentCommentJSON + `
+		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer gqlSrv.Close()
+
+	issueID := int64(171100)
+	issueNumber := 172
+	issueTitle := "Bulk deleted comment issue"
+	issueState := "open"
+	issueURL := "https://github.com/acme/widget/issues/172"
+	issueAuthor := "heidi"
+	issueTime := gh.Timestamp{Time: now}
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return []*gh.Issue{{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				User:      &gh.User{Login: &issueAuthor},
+				CreatedAt: &issueTime,
+				UpdatedAt: &issueTime,
+			}}, nil
+		},
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	gqlClient := githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client())
+	syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcherWithClient(gqlClient, nil),
+	})
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.Issue.CommentCount)
+	require.Equal(now.UTC(), firstResp.JSON200.Issue.LastActivityAt.UTC())
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("bulk comment removed", (*firstResp.JSON200.Events)[0].Body)
+
+	currentUpdatedAt = secondUpdatedAt
+	currentCommentJSON = `{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}`
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.Issue.CommentCount)
+	require.Equal(now.Add(time.Minute).UTC(), secondResp.JSON200.Issue.LastActivityAt.UTC())
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
+}
+
 func make422Error() error {
 	return &gh.ErrorResponse{
 		Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3594,6 +3594,137 @@ func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
 	assert.Equal("edited body", (*secondResp.JSON200.Events)[0].Body)
 }
 
+func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 12, 14, 0, 0, 0, time.UTC)
+	prNumber := 160
+	prID := int64(160000)
+	prTitle := "Deleted comment refresh"
+	prState := "open"
+	prURL := "https://github.com/acme/widget/pull/160"
+	headRef := "feature/deleted-comment"
+	headSHA := "deadbeef"
+	baseRef := "main"
+	commentID := int64(9001)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	commentBody := "body to remove"
+
+	mock := &mockGH{
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return nil, nil
+		},
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			require.Equal(prNumber, number)
+			return &gh.PullRequest{
+				ID:        &prID,
+				Number:    &prNumber,
+				Title:     &prTitle,
+				HTMLURL:   &prURL,
+				State:     &prState,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref: &headRef,
+					SHA: &headSHA,
+				},
+				Base: &gh.PullRequestBranch{
+					Ref: &baseRef,
+				},
+			}, nil
+		},
+	}
+	prListCalls := 0
+	mock.listOpenPullRequestsFn = func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+		prListCalls++
+		if prListCalls == 1 {
+			return []*gh.PullRequest{{
+				ID:        &prID,
+				Number:    &prNumber,
+				Title:     &prTitle,
+				HTMLURL:   &prURL,
+				State:     &prState,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref: &headRef,
+					SHA: &headSHA,
+				},
+				Base: &gh.PullRequestBranch{
+					Ref: &baseRef,
+				},
+			}}, nil
+		}
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+	mockComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &commentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+	mock.listIssueCommentsFn = func(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+		return mockComments, nil
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.MergeRequest.CommentCount)
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("body to remove", (*firstResp.JSON200.Events)[0].Body)
+
+	mockComments = []*gh.IssueComment{}
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.MergeRequest.CommentCount)
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
+}
+
 func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -3714,6 +3845,122 @@ func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
 	require.NotNil(secondResp.JSON200.Events)
 	require.Len(*secondResp.JSON200.Events, 1)
 	assert.Equal("edited issue body", (*secondResp.JSON200.Events)[0].Body)
+}
+
+func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 12, 14, 0, 0, 0, time.UTC)
+	issueNumber := 161
+	issueID := int64(161000)
+	issueTitle := "Deleted issue comment refresh"
+	issueState := "open"
+	issueURL := "https://github.com/acme/widget/issues/161"
+	commentID := int64(9011)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	commentBody := "issue body to remove"
+
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+		getIssueFn: func(_ context.Context, _, _ string, number int) (*gh.Issue, error) {
+			require.Equal(issueNumber, number)
+			return &gh.Issue{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+			}, nil
+		},
+	}
+	issueListCalls := 0
+	mock.listOpenIssuesFn = func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+		issueListCalls++
+		if issueListCalls == 1 {
+			return []*gh.Issue{{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+			}}, nil
+		}
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+	mockComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &commentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+	mock.listIssueCommentsFn = func(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+		return mockComments, nil
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.Issue.CommentCount)
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("issue body to remove", (*firstResp.JSON200.Events)[0].Body)
+
+	mockComments = []*gh.IssueComment{}
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.Issue.CommentCount)
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
 }
 
 func make422Error() error {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3706,6 +3706,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 	require.Equal(http.StatusOK, firstResp.StatusCode())
 	require.NotNil(firstResp.JSON200)
 	require.Equal(int64(1), firstResp.JSON200.MergeRequest.CommentCount)
+	require.Equal(commentCreatedAt.UTC(), firstResp.JSON200.MergeRequest.LastActivityAt.UTC())
 	require.NotNil(firstResp.JSON200.Events)
 	require.Len(*firstResp.JSON200.Events, 1)
 	assert.Equal("body to remove", (*firstResp.JSON200.Events)[0].Body)
@@ -3721,6 +3722,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 	require.Equal(http.StatusOK, secondResp.StatusCode())
 	require.NotNil(secondResp.JSON200)
 	require.Equal(int64(0), secondResp.JSON200.MergeRequest.CommentCount)
+	require.Equal(now.UTC(), secondResp.JSON200.MergeRequest.LastActivityAt.UTC())
 	require.NotNil(secondResp.JSON200.Events)
 	require.Empty(*secondResp.JSON200.Events)
 }
@@ -3944,6 +3946,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.
 	require.Equal(http.StatusOK, firstResp.StatusCode())
 	require.NotNil(firstResp.JSON200)
 	require.Equal(int64(1), firstResp.JSON200.Issue.CommentCount)
+	require.Equal(commentCreatedAt.UTC(), firstResp.JSON200.Issue.LastActivityAt.UTC())
 	require.NotNil(firstResp.JSON200.Events)
 	require.Len(*firstResp.JSON200.Events, 1)
 	assert.Equal("issue body to remove", (*firstResp.JSON200.Events)[0].Body)
@@ -3959,6 +3962,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.
 	require.Equal(http.StatusOK, secondResp.StatusCode())
 	require.NotNil(secondResp.JSON200)
 	require.Equal(int64(0), secondResp.JSON200.Issue.CommentCount)
+	require.Equal(now.UTC(), secondResp.JSON200.Issue.LastActivityAt.UTC())
 	require.NotNil(secondResp.JSON200.Events)
 	require.Empty(*secondResp.JSON200.Events)
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4608,6 +4608,130 @@ func TestE2EIssueDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 	require.Empty(*secondResp.JSON200.Events)
 }
 
+func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 13, 11, 30, 0, 0, time.UTC)
+	firstUpdatedAt := now.Format(time.RFC3339)
+	secondUpdatedAt := now.Add(time.Minute).Format(time.RFC3339)
+	commentCreatedAt := now.Add(2 * time.Minute).Format(time.RFC3339)
+	currentUpdatedAt := firstUpdatedAt
+	currentCommentsJSON := `{"nodes":[{"databaseId":9222,"author":{"login":"commenter"},"body":"bulk PR comment removed","createdAt":"` + commentCreatedAt + `","updatedAt":"` + commentCreatedAt + `"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}`
+
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if bytes.Contains(body, []byte("pullRequests")) {
+			resp := `{"data":{"repository":{"pullRequests":{"nodes":[{
+				"databaseId":172100,
+				"number":173,
+				"title":"Bulk deleted comment PR",
+				"state":"OPEN",
+				"isDraft":false,
+				"body":"GraphQL bulk PR",
+				"url":"https://github.com/acme/widget/pull/173",
+				"author":{"login":"heidi"},
+				"createdAt":"` + firstUpdatedAt + `",
+				"updatedAt":"` + currentUpdatedAt + `",
+				"mergedAt":null,
+				"closedAt":null,
+				"additions":1,
+				"deletions":0,
+				"mergeable":"MERGEABLE",
+				"reviewDecision":"",
+				"headRefName":"feature/bulk-pr",
+				"baseRefName":"main",
+				"headRefOid":"deadbeef",
+				"baseRefOid":"feedface",
+				"headRepository":{"url":"https://github.com/acme/widget"},
+				"labels":{"nodes":[]},
+				"comments":` + currentCommentsJSON + `,
+				"reviews":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"review-cursor"}},
+				"allCommits":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"commit-cursor"}},
+				"lastCommit":{"nodes":[]}
+			}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`
+			_, _ = w.Write([]byte(resp))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+	}))
+	defer gqlSrv.Close()
+
+	prID := int64(172100)
+	prNumber := 173
+	prTitle := "Bulk deleted comment PR"
+	prState := "open"
+	prURL := "https://github.com/acme/widget/pull/173"
+	headRef := "feature/bulk-pr"
+	headSHA := "deadbeef"
+	baseRef := "main"
+	prTime := gh.Timestamp{Time: now}
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			updatedAt, parseErr := time.Parse(time.RFC3339, currentUpdatedAt)
+			require.NoError(parseErr)
+			updatedStamp := gh.Timestamp{Time: updatedAt}
+			return []*gh.PullRequest{{
+				ID:        &prID,
+				Number:    &prNumber,
+				Title:     &prTitle,
+				State:     &prState,
+				HTMLURL:   &prURL,
+				User:      &gh.User{Login: new("heidi")},
+				CreatedAt: &prTime,
+				UpdatedAt: &updatedStamp,
+				Head:      &gh.PullRequestBranch{Ref: &headRef, SHA: &headSHA},
+				Base:      &gh.PullRequestBranch{Ref: &baseRef},
+			}}, nil
+		},
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+	}
+
+	srv, _ := setupTestServerWithMock(t, mock)
+	gqlClient := githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client())
+	srv.syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcherWithClient(gqlClient, nil),
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.Equal(int64(1), firstResp.JSON200.MergeRequest.CommentCount)
+	require.Equal(now.Add(2*time.Minute).UTC(), firstResp.JSON200.MergeRequest.LastActivityAt.UTC())
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("bulk PR comment removed", (*firstResp.JSON200.Events)[0].Body)
+
+	currentUpdatedAt = secondUpdatedAt
+	currentCommentsJSON = `{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}`
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.Equal(int64(0), secondResp.JSON200.MergeRequest.CommentCount)
+	require.Equal(now.Add(time.Minute).UTC(), secondResp.JSON200.MergeRequest.LastActivityAt.UTC())
+	require.NotNil(secondResp.JSON200.Events)
+	require.Empty(*secondResp.JSON200.Events)
+}
+
 func make422Error() error {
 	return &gh.ErrorResponse{
 		Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -47,6 +47,7 @@ type mockGH struct {
 	listOpenPullRequestsFn    func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listOpenPRsErr            error
 	listOpenIssuesFn          func(context.Context, string, string) ([]*gh.Issue, error)
+	listIssueCommentsFn       func(context.Context, string, string, int) ([]*gh.IssueComment, error)
 	listIssueCommentsErr      error
 }
 
@@ -98,12 +99,26 @@ func (m *mockGH) GetPullRequest(ctx context.Context, owner, repo string, number 
 }
 
 func (m *mockGH) ListIssueComments(
-	_ context.Context, _, _ string, _ int,
+	ctx context.Context, owner, repo string, number int,
 ) ([]*gh.IssueComment, error) {
+	if m.listIssueCommentsFn != nil {
+		return m.listIssueCommentsFn(ctx, owner, repo, number)
+	}
 	if m.listIssueCommentsErr != nil {
 		return nil, m.listIssueCommentsErr
 	}
 	return nil, nil
+}
+
+func (m *mockGH) ListIssueCommentsIfChanged(
+	ctx context.Context, owner, repo string, number int,
+) ([]*gh.IssueComment, error) {
+	if m.listIssueCommentsFn == nil && m.listIssueCommentsErr == nil {
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+	return m.ListIssueComments(ctx, owner, repo, number)
 }
 
 func (m *mockGH) ListReviews(
@@ -3440,6 +3455,143 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 	require.Equal(200, detailResp.StatusCode())
 	require.NotNil(detailResp.JSON200)
 	assert.Equal(int64(42), detailResp.JSON200.Issue.CommentCount)
+}
+
+func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	now := time.Date(2026, 4, 12, 14, 0, 0, 0, time.UTC)
+	prNumber := 160
+	prID := int64(160000)
+	prTitle := "Edited comment refresh"
+	prState := "open"
+	prURL := "https://github.com/acme/widget/pull/160"
+	headRef := "feature/edited-comment"
+	headSHA := "deadbeef"
+	baseRef := "main"
+	commentID := int64(9001)
+	commentAuthor := "reviewer"
+	commentCreatedAt := now.Add(2 * time.Minute)
+	commentBody := "original body"
+
+	mock := &mockGH{
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return nil, nil
+		},
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			require.Equal(prNumber, number)
+			return &gh.PullRequest{
+				ID:        &prID,
+				Number:    &prNumber,
+				Title:     &prTitle,
+				HTMLURL:   &prURL,
+				State:     &prState,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref: &headRef,
+					SHA: &headSHA,
+				},
+				Base: &gh.PullRequestBranch{
+					Ref: &baseRef,
+				},
+			}, nil
+		},
+	}
+	prListCalls := 0
+	mock.listOpenPullRequestsFn = func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+		prListCalls++
+		if prListCalls == 1 {
+			return []*gh.PullRequest{{
+				ID:        &prID,
+				Number:    &prNumber,
+				Title:     &prTitle,
+				HTMLURL:   &prURL,
+				State:     &prState,
+				UpdatedAt: &gh.Timestamp{Time: now},
+				CreatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref: &headRef,
+					SHA: &headSHA,
+				},
+				Base: &gh.PullRequestBranch{
+					Ref: &baseRef,
+				},
+			}}, nil
+		}
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+	mockComments := []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &commentBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: commentCreatedAt},
+	}}
+	mock.listIssueCommentsFn = func(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+		return mockComments, nil
+	}
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	require.NotNil(firstResp.JSON200.Events)
+	require.Len(*firstResp.JSON200.Events, 1)
+	assert.Equal("original body", (*firstResp.JSON200.Events)[0].Body)
+
+	editedBody := "edited body"
+	mockComments = []*gh.IssueComment{{
+		ID:        &commentID,
+		Body:      &editedBody,
+		User:      &gh.User{Login: &commentAuthor},
+		CreatedAt: &gh.Timestamp{Time: commentCreatedAt},
+		UpdatedAt: &gh.Timestamp{Time: now.Add(4 * time.Minute)},
+	}}
+
+	srv.syncer.RunOnce(ctx)
+
+	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	require.NotNil(secondResp.JSON200.Events)
+	require.Len(*secondResp.JSON200.Events, 1)
+	assert.Equal("edited body", (*secondResp.JSON200.Events)[0].Body)
 }
 
 func make422Error() error {

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -461,11 +461,12 @@ func TestTmuxWrapperAttachSurfacesWrapperFailure(t *testing.T) {
 func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 	t.Helper()
 	assert := Assert.New(t)
+	require := require.New(t)
 
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	script := filepath.Join(dir, "fake-tmux")
-	require.NoError(t, os.WriteFile(script, []byte(scriptBody), 0o755))
+	require.NoError(os.WriteFile(script, []byte(scriptBody), 0o755))
 	t.Setenv("TMUX_RECORD", record)
 
 	client, baseURL := setupWrapperServerWithScript(t, script)
@@ -480,13 +481,12 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 			MrNumber:     1,
 		},
 	)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusAccepted, createResp.StatusCode())
-	require.NotNil(t, createResp.JSON202)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
 	wsID := createResp.JSON202.Id
 
 	require.Eventually(
-		t,
 		func() bool {
 			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
 				ctx, wsID,
@@ -506,11 +506,11 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 	)
 	defer dialCancel()
 	u, err := url.Parse(wsURL)
-	require.NoError(t, err)
+	require.NoError(err)
 	conn, httpResp, err := websocket.Dial(
 		dialCtx, u.String(), nil,
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 	if httpResp != nil && httpResp.Body != nil {
 		httpResp.Body.Close()
 	}
@@ -521,7 +521,7 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 	)
 	defer readCancel()
 	_, _, readErr := conn.Read(readCtx)
-	require.Error(t, readErr)
+	require.Error(readErr)
 	assert.Equal(
 		websocket.StatusInternalError,
 		websocket.CloseStatus(readErr),

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -192,6 +192,17 @@ func (c *FixtureClient) ListIssueComments(
 	return out, nil
 }
 
+func (c *FixtureClient) ListIssueCommentsIfChanged(
+	ctx context.Context, owner, repo string, number int,
+) ([]*gh.IssueComment, error) {
+	if len(c.Comments[issueKey(owner, repo, number)]) == 0 {
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotModified},
+		}
+	}
+	return c.ListIssueComments(ctx, owner, repo, number)
+}
+
 // ListReviews returns nil (read-only stub).
 func (c *FixtureClient) ListReviews(
 	_ context.Context, _, _ string, _ int,


### PR DESCRIPTION
- refresh edited PR and issue comments during background sync using conditional comment requests
- update stored comment events so edited GitHub bodies replace stale content