### PR TITLE
Add configurable terminal font family

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -111,7 +111,11 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 	}
 
 	cfg := &config.Config{
-		BasePath: "/",
+		SyncInterval:   "5m",
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Host:           "127.0.0.1",
+		Port:           8091,
+		BasePath:       "/",
 		Repos: []config.Repo{
 			{Owner: "acme", Name: "widgets"},
 			{Owner: "acme", Name: "tools"},

--- a/frontend/src/Provider.test.ts
+++ b/frontend/src/Provider.test.ts
@@ -100,8 +100,12 @@ vi.mock("@middleman/ui/stores/grouping", () => ({
 
 vi.mock("@middleman/ui/stores/settings", () => ({
   createSettingsStore: () => ({
-    getSettings: () => null,
-    loadSettings: vi.fn(),
+    getConfiguredRepos: () => [],
+    setConfiguredRepos: vi.fn(),
+    getTerminalFontFamily: () => "",
+    setTerminalFontFamily: vi.fn(),
+    hasConfiguredRepos: () => false,
+    isSettingsLoaded: () => true,
   }),
 }));
 

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -10,7 +10,10 @@ export async function getSettings(): Promise<Settings> {
 }
 
 export async function updateSettings(
-  settings: { activity: Settings["activity"] },
+  settings: {
+    activity?: Settings["activity"];
+    terminal?: Settings["terminal"];
+  },
 ): Promise<Settings> {
   const res = await fetch(`${BASE}/settings`, {
     method: "PUT",

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -6,6 +6,7 @@
   import SettingsSection from "./SettingsSection.svelte";
   import RepoSettings from "./RepoSettings.svelte";
   import ActivitySettings from "./ActivitySettings.svelte";
+  import TerminalSettings from "./TerminalSettings.svelte";
 
   const { settings: settingsStore } = getStores();
 
@@ -21,6 +22,9 @@
     try {
       settings = await getSettings();
       settingsStore.setConfiguredRepos(settings.repos);
+      settingsStore.setTerminalFontFamily(
+        settings.terminal.font_family,
+      );
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -43,6 +47,18 @@
 
     <SettingsSection title="Activity feed defaults">
       <ActivitySettings activity={settings.activity} onUpdate={(activity) => { settings = { ...settings!, activity }; }} />
+    </SettingsSection>
+
+    <SettingsSection title="Workspace terminal">
+      <TerminalSettings
+        terminal={settings.terminal}
+        onUpdate={(terminal) => {
+          settings = { ...settings!, terminal };
+          settingsStore.setTerminalFontFamily(
+            terminal.font_family,
+          );
+        }}
+      />
     </SettingsSection>
   {/if}
 </div>

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { getStores } from "@middleman/ui";
+  import type { TerminalSettings as TerminalSettingsType } from "@middleman/ui/api/types";
+  import { updateSettings } from "../../api/settings.js";
+
+  import { isEmbedded } from "../../stores/embed-config.svelte.js";
+
+  interface Props {
+    terminal: TerminalSettingsType;
+    onUpdate: (terminal: TerminalSettingsType) => void;
+  }
+
+  let { terminal, onUpdate }: Props = $props();
+
+  const { settings: settingsStore } = getStores();
+  const embedded = isEmbedded();
+
+  let saving = $state(false);
+  let draft = $state("");
+
+  function normalizeFontFamily(value: string): string {
+    return value.trim();
+  }
+
+  const currentFontFamily = $derived(terminal.font_family);
+  const normalizedDraft = $derived(normalizeFontFamily(draft));
+  const isDirty = $derived(
+    normalizedDraft !== currentFontFamily,
+  );
+  const canSave = $derived(
+    !saving && isDirty,
+  );
+
+  onMount(() => {
+    draft = terminal.font_family;
+  });
+
+  async function save(): Promise<void> {
+    if (embedded) return;
+    draft = normalizedDraft;
+    if (normalizedDraft === currentFontFamily) return;
+
+    saving = true;
+    try {
+      const settings = await updateSettings({
+        terminal: {
+          font_family: normalizedDraft,
+        },
+      });
+      draft = settings.terminal.font_family;
+      onUpdate(settings.terminal);
+      settingsStore.setTerminalFontFamily(
+        settings.terminal.font_family,
+      );
+    } catch (err) {
+      draft = currentFontFamily;
+      console.warn("Failed to save terminal settings:", err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function reset(): void {
+    draft = "";
+    void save();
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void save();
+    } else if (event.key === "Escape") {
+      draft = currentFontFamily;
+    }
+  }
+</script>
+
+<div class="terminal-settings">
+  <label class="font-field" for="terminal-font-family">
+    <span class="setting-label">Monospace font family</span>
+    <input
+      id="terminal-font-family"
+      class="font-input"
+      type="text"
+      bind:value={draft}
+      placeholder='"JetBrains Mono", "SF Mono", Menlo, Consolas, monospace'
+      disabled={saving}
+      onkeydown={handleKeydown}
+    />
+  </label>
+
+  <div class="setting-actions">
+    <p class="setting-help">
+      Leave blank to use the app default monospace stack.
+    </p>
+    <div class="button-row">
+      <button
+        class="save-btn"
+        type="button"
+        disabled={!canSave}
+        onclick={() => void save()}
+      >
+        {saving ? "Saving..." : "Save"}
+      </button>
+      <button
+        class="reset-btn"
+        type="button"
+        disabled={saving || !currentFontFamily}
+        onclick={reset}
+      >
+        Reset
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .terminal-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .font-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .setting-label {
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+
+  .font-input {
+    width: 100%;
+    font-family: var(--font-mono);
+  }
+
+  .setting-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .button-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .setting-help {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .save-btn,
+  .reset-btn {
+    padding: 5px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    border-radius: var(--radius-sm);
+    transition: background 0.12s, color 0.12s, opacity 0.12s,
+      border-color 0.12s;
+  }
+
+  .save-btn {
+    color: white;
+    background: var(--accent-blue);
+  }
+
+  .save-btn:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .save-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .reset-btn {
+    color: var(--text-secondary);
+    border: 1px solid var(--border-muted);
+  }
+
+  .reset-btn:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .reset-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/src/lib/components/settings/TerminalSettings.test.ts
+++ b/frontend/src/lib/components/settings/TerminalSettings.test.ts
@@ -1,0 +1,93 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const {
+  mockSetTerminalFontFamily,
+  mockUpdateSettings,
+} = vi.hoisted(() => ({
+  mockSetTerminalFontFamily: vi.fn(),
+  mockUpdateSettings: vi.fn(),
+}));
+
+vi.mock("@middleman/ui", () => ({
+  getStores: () => ({
+    settings: {
+      setTerminalFontFamily: mockSetTerminalFontFamily,
+    },
+  }),
+}));
+
+vi.mock("../../api/settings.js", () => ({
+  updateSettings: mockUpdateSettings,
+}));
+
+vi.mock("../../stores/embed-config.svelte.js", () => ({
+  isEmbedded: () => false,
+}));
+
+import TerminalSettings from "./TerminalSettings.svelte";
+
+describe("TerminalSettings", () => {
+  afterEach(() => {
+    cleanup();
+    mockSetTerminalFontFamily.mockReset();
+    mockUpdateSettings.mockReset();
+  });
+
+  it("enables save after editing and persists the font family", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        font_family: "\"Iosevka Term\", monospace",
+      },
+    });
+    const onUpdate = vi.fn();
+
+    render(TerminalSettings, {
+      props: {
+        terminal: { font_family: "" },
+        onUpdate,
+      },
+    });
+
+    const input = screen.getByLabelText("Monospace font family");
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    await fireEvent.input(input, {
+      target: { value: "\"Iosevka Term\", monospace" },
+    });
+
+    await waitFor(() => {
+      expect(
+        (saveButton as HTMLButtonElement).disabled,
+      ).toBe(false);
+    });
+
+    await fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        terminal: {
+          font_family: "\"Iosevka Term\", monospace",
+        },
+      });
+    });
+    expect(onUpdate).toHaveBeenCalledWith({
+      font_family: "\"Iosevka Term\", monospace",
+    });
+    expect(mockSetTerminalFontFamily).toHaveBeenCalledWith(
+      "\"Iosevka Term\", monospace",
+    );
+  });
+});

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { getStores } from "@middleman/ui";
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import { WebglAddon } from "@xterm/addon-webgl";
   import "@xterm/xterm/css/xterm.css";
 
   const { workspaceId }: { workspaceId: string } = $props();
+  const { settings: settingsStore } = getStores();
 
   const basePath = (window.__BASE_PATH__ ?? "/").replace(/\/$/, "");
 
@@ -22,6 +24,22 @@
   const encoder = new TextEncoder();
 
   const MAX_RECONNECT_DELAY = 30000;
+
+  function defaultTerminalFontFamily(): string {
+    const rootFontFamily = getComputedStyle(
+      document.documentElement,
+    )
+      .getPropertyValue("--font-mono")
+      .trim();
+    return rootFontFamily || "monospace";
+  }
+
+  const terminalFontFamily = $derived.by(() => {
+    const configured = settingsStore
+      .getTerminalFontFamily()
+      .trim();
+    return configured || defaultTerminalFontFamily();
+  });
 
   function buildWsUrl(cols: number, rows: number): string {
     const proto = location.protocol === "https:" ? "wss" : "ws";
@@ -142,6 +160,12 @@
     }
   }
 
+  $effect(() => {
+    if (!terminal) return;
+    terminal.options.fontFamily = terminalFontFamily;
+    fitAddon?.fit();
+  });
+
   onMount(() => {
     const term = new Terminal({
       theme: {
@@ -150,7 +174,7 @@
         cursor: "#58a6ff",
       },
       cursorBlink: true,
-      fontFamily: "monospace",
+      fontFamily: terminalFontFamily,
       fontSize: 14,
     });
     terminal = term;

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -1,0 +1,101 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFit = vi.fn();
+const mockOpen = vi.fn();
+const mockLoadAddon = vi.fn();
+const mockOnData = vi.fn();
+const mockOnBinary = vi.fn();
+const mockDispose = vi.fn();
+const terminalCtor = vi.fn();
+
+let configuredFontFamily = "";
+
+vi.mock("@middleman/ui", () => ({
+  getStores: () => ({
+    settings: {
+      getTerminalFontFamily: () => configuredFontFamily,
+    },
+  }),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation((options) => {
+    terminalCtor(options);
+    return {
+      cols: 80,
+      rows: 24,
+      open: mockOpen,
+      loadAddon: mockLoadAddon,
+      onData: mockOnData,
+      onBinary: mockOnBinary,
+      dispose: mockDispose,
+      write: vi.fn(),
+      options: { ...options },
+    };
+  }),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: mockFit,
+  })),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({})),
+}));
+
+import TerminalPane from "./TerminalPane.svelte";
+
+describe("TerminalPane", () => {
+  beforeEach(() => {
+    configuredFontFamily = "";
+    terminalCtor.mockReset();
+    mockFit.mockReset();
+    mockOpen.mockReset();
+    mockLoadAddon.mockReset();
+    mockOnData.mockReset();
+    mockOnBinary.mockReset();
+    mockDispose.mockReset();
+
+    vi.stubGlobal("ResizeObserver", class {
+      observe(): void {}
+      disconnect(): void {}
+    });
+
+    vi.stubGlobal("WebSocket", class {
+      static OPEN = 1;
+      readyState = 1;
+      binaryType = "arraybuffer";
+      onopen: (() => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      constructor(_: string) {}
+
+      send(): void {}
+      close(): void {}
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the configured settings font family for xterm", () => {
+    configuredFontFamily = "\"Fira Code\", monospace";
+
+    render(TerminalPane, {
+      props: { workspaceId: "ws-123" },
+    });
+
+    expect(terminalCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fontFamily: "\"Fira Code\", monospace",
+      }),
+    );
+  });
+});

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -7,6 +7,7 @@ function makeStores(): StoreInstances {
   return {
     settings: {
       setConfiguredRepos: vi.fn(),
+      setTerminalFontFamily: vi.fn(),
     },
     activity: {
       hydrateDefaults: vi.fn(),
@@ -34,13 +35,15 @@ function makeSettings(): Settings {
   return {
     repos: [],
     activity: {
-      item_types: [],
-      event_types: [],
-      authored_by_me: false,
-      assigned_or_mentioned: false,
-      include_bots: false,
+      view_mode: "threaded",
+      time_range: "7d",
+      hide_closed: false,
+      hide_bots: false,
     },
-  } as unknown as Settings;
+    terminal: {
+      font_family: "\"Fira Code\", monospace",
+    },
+  };
 }
 
 async function flushMicrotasks(): Promise<void> {
@@ -63,6 +66,9 @@ describe("runAppStartup", () => {
 
     expect(stores.settings.setConfiguredRepos).toHaveBeenCalledWith(
       settings.repos,
+    );
+    expect(stores.settings.setTerminalFontFamily).toHaveBeenCalledWith(
+      settings.terminal.font_family,
     );
     expect(stores.activity.hydrateDefaults).toHaveBeenCalledWith(
       settings.activity,
@@ -93,6 +99,7 @@ describe("runAppStartup", () => {
     await flushMicrotasks();
 
     expect(stores.settings.setConfiguredRepos).not.toHaveBeenCalled();
+    expect(stores.settings.setTerminalFontFamily).not.toHaveBeenCalled();
     expect(stores.activity.hydrateDefaults).not.toHaveBeenCalled();
     expect(onReady).not.toHaveBeenCalled();
     expect(stores.sync.startPolling).not.toHaveBeenCalled();
@@ -116,6 +123,7 @@ describe("runAppStartup", () => {
 
     expect(warn).toHaveBeenCalled();
     expect(stores.settings.setConfiguredRepos).not.toHaveBeenCalled();
+    expect(stores.settings.setTerminalFontFamily).not.toHaveBeenCalled();
     expect(onReady).toHaveBeenCalledTimes(1);
     expect(stores.sync.startPolling).toHaveBeenCalledTimes(1);
     expect(stores.events.connect).toHaveBeenCalledTimes(1);

--- a/frontend/src/lib/utils/appStartup.ts
+++ b/frontend/src/lib/utils/appStartup.ts
@@ -28,6 +28,9 @@ export function runAppStartup(deps: AppStartupDeps): () => void {
       const stores = deps.getStores();
       if (stores) {
         stores.settings.setConfiguredRepos(settings.repos);
+        stores.settings.setTerminalFontFamily(
+          settings.terminal.font_family,
+        );
         stores.activity.hydrateDefaults(settings.activity);
       }
     } catch (err) {

--- a/frontend/tests/e2e-full/settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/settings-terminal-font.spec.ts
@@ -1,0 +1,71 @@
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+} from "@playwright/test";
+import {
+  startIsolatedE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
+
+let isolatedServer: IsolatedE2EServer | undefined;
+let api: APIRequestContext | undefined;
+
+test.beforeAll(async () => {
+  isolatedServer = await startIsolatedE2EServer();
+  api = await playwrightRequest.newContext({
+    baseURL: isolatedServer.info.base_url,
+  });
+});
+
+test.afterAll(async () => {
+  await api?.dispose();
+  await isolatedServer?.stop();
+});
+
+test("settings saves and reloads the workspace terminal font family", async ({
+  page,
+}) => {
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
+
+  const input = page.getByLabel("Monospace font family");
+  const saveButton = page.getByRole("button", { name: "Save" });
+  await expect(input).toHaveValue("");
+
+  await input.click();
+  await input.pressSequentially(
+    "\"Iosevka Term\", monospace",
+  );
+  await expect(saveButton).toBeEnabled();
+  const saveResponsePromise = page.waitForResponse((response) =>
+    response.url().endsWith("/api/v1/settings") &&
+    response.request().method() === "PUT"
+  );
+  await saveButton.click();
+  const saveResponse = await saveResponsePromise;
+  const saveBody = await saveResponse.text();
+  expect(
+    saveResponse.status(),
+    `PUT /api/v1/settings failed: ${saveBody}`,
+  ).toBe(200);
+
+  await expect.poll(async () => {
+    if (!api) {
+      throw new Error("settings terminal API context not initialized");
+    }
+    const response = await api.get("/api/v1/settings");
+    const settings = await response.json() as {
+      terminal: { font_family: string };
+    };
+    return settings.terminal.font_family;
+  }).toBe("\"Iosevka Term\", monospace");
+
+  await page.reload();
+  await page.locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await expect(page.getByLabel("Monospace font family"))
+    .toHaveValue("\"Iosevka Term\", monospace");
+});

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,6 +165,10 @@ type Activity struct {
 	HideBots   bool   `toml:"hide_bots" json:"hide_bots"`
 }
 
+type Terminal struct {
+	FontFamily string `toml:"font_family,omitempty" json:"font_family"`
+}
+
 type Roborev struct {
 	Endpoint string `toml:"endpoint,omitempty"`
 }
@@ -183,6 +187,7 @@ type Config struct {
 	SyncBudgetPerHour int      `toml:"sync_budget_per_hour"`
 	Repos             []Repo   `toml:"repos"`
 	Activity          Activity `toml:"activity"`
+	Terminal          Terminal `toml:"terminal"`
 	Roborev           Roborev  `toml:"roborev"`
 	Tmux              Tmux     `toml:"tmux"`
 }
@@ -445,6 +450,8 @@ func (c *Config) Validate() error {
 		)
 	}
 
+	c.Terminal.FontFamily = strings.TrimSpace(c.Terminal.FontFamily)
+
 	if len(c.Tmux.Command) > 0 &&
 		strings.TrimSpace(c.Tmux.Command[0]) == "" {
 		return fmt.Errorf(
@@ -530,6 +537,7 @@ type configFile struct {
 	DataDir           string   `toml:"data_dir,omitempty"`
 	Repos             []Repo   `toml:"repos"`
 	Activity          Activity `toml:"activity"`
+	Terminal          Terminal `toml:"terminal,omitempty"`
 	Roborev           Roborev  `toml:"roborev,omitempty"`
 	Tmux              Tmux     `toml:"tmux,omitempty"`
 }
@@ -543,6 +551,7 @@ func (c *Config) Save(path string) error {
 		Port:           c.Port,
 		Repos:          c.Repos,
 		Activity:       c.Activity,
+		Terminal:       c.Terminal,
 		Roborev:        c.Roborev,
 		Tmux:           c.Tmux,
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -831,6 +831,28 @@ endpoint = "http://custom:9999"
 	assert.Equal("http://custom:9999", cfg2.RoborevEndpoint())
 }
 
+func TestTerminalConfigRoundTrip(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[[repos]]
+owner = "a"
+name = "b"
+
+[terminal]
+font_family = '  "Iosevka Term", monospace  '
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal("\"Iosevka Term\", monospace", cfg.Terminal.FontFamily)
+
+	savePath := filepath.Join(t.TempDir(), "saved.toml")
+	require.NoError(t, cfg.Save(savePath))
+
+	cfg2, err := Load(savePath)
+	require.NoError(t, err)
+	assert.Equal("\"Iosevka Term\", monospace", cfg2.Terminal.FontFamily)
+}
+
 func TestSyncBudgetPerHour(t *testing.T) {
 	t.Run("default is 500 when not set", func(t *testing.T) {
 		path := writeConfig(t, `

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -15,10 +15,12 @@ import (
 type settingsResponse struct {
 	Repos    []ghclient.ConfiguredRepoStatus `json:"repos"`
 	Activity config.Activity                 `json:"activity"`
+	Terminal config.Terminal                 `json:"terminal"`
 }
 
 type updateSettingsRequest struct {
-	Activity config.Activity `json:"activity"`
+	Activity *config.Activity `json:"activity,omitempty"`
+	Terminal *config.Terminal `json:"terminal,omitempty"`
 }
 
 func (s *Server) configuredClients(
@@ -45,6 +47,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	s.cfgMu.Lock()
 	repos := append([]config.Repo(nil), s.cfg.Repos...)
 	activity := s.cfg.Activity
+	terminal := s.cfg.Terminal
 	s.cfgMu.Unlock()
 
 	tracked := s.syncer.TrackedRepos()
@@ -62,6 +65,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	return settingsResponse{
 		Repos:    configured,
 		Activity: activity,
+		Terminal: terminal,
 	}
 }
 
@@ -260,25 +264,32 @@ func (s *Server) handleUpdateSettings(
 		return
 	}
 
-	candidate := body.Activity
-	if candidate.ViewMode == "" {
-		candidate.ViewMode = "threaded"
-	}
-	if candidate.TimeRange == "" {
-		candidate.TimeRange = "7d"
-	}
-
 	s.cfgMu.Lock()
-	prev := s.cfg.Activity
-	s.cfg.Activity = candidate
+	prevActivity := s.cfg.Activity
+	prevTerminal := s.cfg.Terminal
+	if body.Activity != nil {
+		candidate := *body.Activity
+		if candidate.ViewMode == "" {
+			candidate.ViewMode = "threaded"
+		}
+		if candidate.TimeRange == "" {
+			candidate.TimeRange = "7d"
+		}
+		s.cfg.Activity = candidate
+	}
+	if body.Terminal != nil {
+		s.cfg.Terminal = *body.Terminal
+	}
 	if err := s.cfg.Validate(); err != nil {
-		s.cfg.Activity = prev
+		s.cfg.Activity = prevActivity
+		s.cfg.Terminal = prevTerminal
 		s.cfgMu.Unlock()
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
-		s.cfg.Activity = prev
+		s.cfg.Activity = prevActivity
+		s.cfg.Terminal = prevTerminal
 		s.cfgMu.Unlock()
 		writeError(w, http.StatusInternalServerError,
 			"save config: "+err.Error())

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -103,19 +103,25 @@ func TestHandleGetSettings(t *testing.T) {
 	assert.Equal("acme", resp.Repos[0].Owner)
 	assert.Equal(1, resp.Repos[0].MatchedRepoCount)
 	assert.Equal("threaded", resp.Activity.ViewMode)
+	assert.Empty(resp.Terminal.FontFamily)
 }
 
 func TestHandleUpdateSettings(t *testing.T) {
 	assert := Assert.New(t)
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
+	activity := config.Activity{
+		ViewMode:   "threaded",
+		TimeRange:  "30d",
+		HideClosed: true,
+		HideBots:   true,
+	}
+	terminal := config.Terminal{
+		FontFamily: "\"Fira Code\", monospace",
+	}
 	body := updateSettingsRequest{
-		Activity: config.Activity{
-			ViewMode:   "threaded",
-			TimeRange:  "30d",
-			HideClosed: true,
-			HideBots:   true,
-		},
+		Activity: &activity,
+		Terminal: &terminal,
 	}
 	rr := doJSON(
 		t, srv, http.MethodPut, "/api/v1/settings", body,
@@ -127,16 +133,57 @@ func TestHandleUpdateSettings(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("threaded", cfg2.Activity.ViewMode)
 	assert.Equal("30d", cfg2.Activity.TimeRange)
+	assert.Equal("\"Fira Code\", monospace", cfg2.Terminal.FontFamily)
+}
+
+func TestHandleUpdateTerminalSettingsPreservesActivity(t *testing.T) {
+	assert := Assert.New(t)
+	srv, _, cfgPath := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[activity]
+view_mode = "flat"
+time_range = "30d"
+hide_closed = true
+hide_bots = true
+`, &mockGH{})
+
+	terminal := config.Terminal{
+		FontFamily: "\"Iosevka Term\", monospace",
+	}
+	body := updateSettingsRequest{
+		Terminal: &terminal,
+	}
+	rr := doJSON(
+		t, srv, http.MethodPut, "/api/v1/settings", body,
+	)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	cfg2, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal("flat", cfg2.Activity.ViewMode)
+	assert.Equal("30d", cfg2.Activity.TimeRange)
+	assert.True(cfg2.Activity.HideClosed)
+	assert.True(cfg2.Activity.HideBots)
+	assert.Equal("\"Iosevka Term\", monospace", cfg2.Terminal.FontFamily)
 }
 
 func TestHandleUpdateSettingsInvalid(t *testing.T) {
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
+	activity := config.Activity{
+		ViewMode:  "kanban",
+		TimeRange: "7d",
+	}
 	body := updateSettingsRequest{
-		Activity: config.Activity{
-			ViewMode:  "kanban",
-			TimeRange: "7d",
-		},
+		Activity: &activity,
 	}
 	rr := doJSON(
 		t, srv, http.MethodPut, "/api/v1/settings", body,
@@ -325,7 +372,7 @@ func TestGetSettingsWithoutPersistence(t *testing.T) {
 
 	// Mutations should be rejected (no cfgPath).
 	mutRR := doJSON(t, srv, http.MethodPut, "/api/v1/settings",
-		updateSettingsRequest{Activity: cfg.Activity})
+		updateSettingsRequest{Activity: &cfg.Activity})
 	assert.Equal(http.StatusNotFound, mutRR.Code)
 
 	addRR := doJSON(t, srv, http.MethodPost, "/api/v1/repos",
@@ -704,7 +751,7 @@ func TestAddRepoDoesNotDropConcurrentActivityChange(t *testing.T) {
 	rr := doJSON(
 		t, srv, http.MethodPut, "/api/v1/settings",
 		updateSettingsRequest{
-			Activity: config.Activity{
+			Activity: &config.Activity{
 				ViewMode:  "threaded",
 				TimeRange: "30d",
 			},
@@ -836,7 +883,7 @@ command = ["systemd-run", "--user", "--scope", "tmux"]
 `, &mockGH{})
 
 	body := updateSettingsRequest{
-		Activity: config.Activity{
+		Activity: &config.Activity{
 			ViewMode:  "threaded",
 			TimeRange: "30d",
 		},

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -48,6 +48,10 @@ export interface ActivitySettings {
   hide_bots: boolean;
 }
 
+export interface TerminalSettings {
+  font_family: string;
+}
+
 export interface ConfigRepo {
   owner: string;
   name: string;
@@ -58,6 +62,7 @@ export interface ConfigRepo {
 export interface Settings {
   repos: ConfigRepo[];
   activity: ActivitySettings;
+  terminal: TerminalSettings;
 }
 
 export interface DiffResult {

--- a/packages/ui/src/stores/settings.svelte.ts
+++ b/packages/ui/src/stores/settings.svelte.ts
@@ -1,7 +1,11 @@
-import type { ConfigRepo } from "../api/types.js";
+import type {
+  ConfigRepo,
+  TerminalSettings,
+} from "../api/types.js";
 
 export function createSettingsStore() {
   let repos = $state<ConfigRepo[]>([]);
+  let terminalFontFamily = $state("");
   let loaded = $state(false);
 
   function getConfiguredRepos(): ConfigRepo[] {
@@ -11,6 +15,16 @@ export function createSettingsStore() {
   function setConfiguredRepos(r: ConfigRepo[]): void {
     repos = r ?? [];
     loaded = true;
+  }
+
+  function getTerminalFontFamily(): string {
+    return terminalFontFamily;
+  }
+
+  function setTerminalFontFamily(
+    fontFamily: TerminalSettings["font_family"] | null | undefined,
+  ): void {
+    terminalFontFamily = fontFamily ?? "";
   }
 
   function hasConfiguredRepos(): boolean {
@@ -24,6 +38,8 @@ export function createSettingsStore() {
   return {
     getConfiguredRepos,
     setConfiguredRepos,
+    getTerminalFontFamily,
+    setTerminalFontFamily,
     hasConfiguredRepos,
     isSettingsLoaded,
   };


### PR DESCRIPTION
## Summary
- Add a new `terminal.font_family` setting to persist the workspace monospace font in config and the settings API.
- Wire the saved font family into the app startup flow and xterm initialization so the terminal picks it up automatically.
- Add settings UI for editing, saving, and resetting the terminal font family.
- Cover the new behavior with config, server, frontend unit, and end-to-end tests.

## Testing
- `go test ./internal/config ./internal/server -shuffle=on`
- `bun test frontend/src/lib/components/settings/TerminalSettings.test.ts frontend/src/lib/components/terminal/TerminalPane.test.ts frontend/src/lib/utils/appStartup.test.ts frontend/src/Provider.test.ts`
- `bun test frontend/tests/e2e-full/settings-terminal-font.spec.ts`
- Not run: full repository test suite