### PR TITLE
Deduplicate CI checks by latest run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -78,6 +83,9 @@ jobs:
         run: cd frontend && bun run test
 
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MIDDLEMAN_LIVE_GITHUB_TESTS: "1"
         run: go test ./... -v -shuffle=on
 
       - name: Run integration tests (git-dependent)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,11 @@ on:
   workflow_dispatch:
 
 permissions:
+  checks: read
   contents: read
   issues: read
   pull-requests: read
+  statuses: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -86,7 +87,7 @@ jobs:
         run: go test ./... -v -shuffle=on
 
       - name: Run live GraphQL validation
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MIDDLEMAN_LIVE_GITHUB_TESTS: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,14 @@ jobs:
         run: cd frontend && bun run test
 
       - name: Run tests
+        run: go test ./... -v -shuffle=on
+
+      - name: Run live GraphQL validation
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MIDDLEMAN_LIVE_GITHUB_TESTS: "1"
-        run: go test ./... -v -shuffle=on
+        run: go test ./internal/github -run TestLiveGraphQLQueriesValidateAgainstGitHub -shuffle=on
 
       - name: Run integration tests (git-dependent)
         run: go test -tags integration ./... -v -shuffle=on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ make vet        # go vet
 - All tests use `t.TempDir()` for temp directories
 - Tests should be fast and isolated
 - Do not run tests with `-v` (especially `go test`) — default output has enough signal to debug failures, and verbose output wastes tokens. Only use `-v` if the user asks for it or a failure genuinely needs the extra detail
+- For GraphQL query changes, follow `context/testing.md` and enable `MIDDLEMAN_LIVE_GITHUB_TESTS=1` to validate query shape against GitHub's live GraphQL API
 
 ## Build Requirements
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -1,0 +1,15 @@
+# Testing
+
+## Live GraphQL validation
+
+GraphQL query shape changes must be validated against GitHub's live GraphQL API before they are merged. The local test suite includes a gated live test:
+
+```sh
+MIDDLEMAN_LIVE_GITHUB_TESTS=1 go test ./internal/github -run TestLiveGraphQLQueriesValidateAgainstGitHub -shuffle=on
+```
+
+The test uses `MIDDLEMAN_GITHUB_TOKEN` first, then `GITHUB_TOKEN`. It intentionally skips unless `MIDDLEMAN_LIVE_GITHUB_TESTS=1` is set because live validation consumes GitHub GraphQL rate limit and requires network access.
+
+When changing structs, fields, aliases, fragments, pagination arguments, or nested selections used by `internal/github/graphql.go`, enable `MIDDLEMAN_LIVE_GITHUB_TESTS=1` and run the live validation test in addition to the normal Go tests.
+
+CI enables `MIDDLEMAN_LIVE_GITHUB_TESTS=1` for the main Go test job using the workflow `GITHUB_TOKEN`, so schema drift is caught automatically in pull requests.

--- a/context/testing.md
+++ b/context/testing.md
@@ -12,4 +12,4 @@ The test uses `MIDDLEMAN_GITHUB_TOKEN` first, then `GITHUB_TOKEN`. It intentiona
 
 When changing structs, fields, aliases, fragments, pagination arguments, or nested selections used by `internal/github/graphql.go`, enable `MIDDLEMAN_LIVE_GITHUB_TESTS=1` and run the live validation test in addition to the normal Go tests.
 
-CI runs the live GraphQL validation as a separate Go test step using the workflow `GITHUB_TOKEN` only in trusted contexts, such as pushes to `main` and same-repository pull requests. The general pull request Go test step does not receive a GitHub token.
+CI runs the live GraphQL validation as a separate Go test step using the workflow `GITHUB_TOKEN` only in trusted contexts, such as pushes to `main`, manual `workflow_dispatch` runs, and same-repository pull requests. The general pull request Go test step does not receive a GitHub token.

--- a/context/testing.md
+++ b/context/testing.md
@@ -12,4 +12,4 @@ The test uses `MIDDLEMAN_GITHUB_TOKEN` first, then `GITHUB_TOKEN`. It intentiona
 
 When changing structs, fields, aliases, fragments, pagination arguments, or nested selections used by `internal/github/graphql.go`, enable `MIDDLEMAN_LIVE_GITHUB_TESTS=1` and run the live validation test in addition to the normal Go tests.
 
-CI enables `MIDDLEMAN_LIVE_GITHUB_TESTS=1` for the main Go test job using the workflow `GITHUB_TOKEN`, so schema drift is caught automatically in pull requests.
+CI runs the live GraphQL validation as a separate Go test step using the workflow `GITHUB_TOKEN` only in trusted contexts, such as pushes to `main` and same-repository pull requests. The general pull request Go test step does not receive a GitHub token.

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -160,11 +160,13 @@ type gqlCheckContext struct {
 }
 
 type gqlCheckRunFields struct {
-	Name       string
-	Status     string
-	Conclusion string
-	DetailsURL string `graphql:"detailsUrl"`
-	CheckSuite struct {
+	Name        string
+	Status      string
+	Conclusion  string
+	DetailsURL  string `graphql:"detailsUrl"`
+	StartedAt   *time.Time
+	CompletedAt *time.Time
+	CheckSuite  struct {
 		App struct {
 			Name string
 		}
@@ -353,12 +355,14 @@ func splitCheckContexts(contexts []gqlCheckContext) ([]*gh.CheckRun, []*gh.RepoS
 func adaptCheckRun(gql *gqlCheckRunFields) *gh.CheckRun {
 	url := sanitizeURL(gql.DetailsURL)
 	return &gh.CheckRun{
-		Name:       new(gql.Name),
-		Status:     new(toLower(gql.Status)),
-		Conclusion: new(toLower(gql.Conclusion)),
-		HTMLURL:    new(url),
-		DetailsURL: new(gql.DetailsURL),
-		App:        &gh.App{Name: new(gql.CheckSuite.App.Name)},
+		Name:        new(gql.Name),
+		Status:      new(toLower(gql.Status)),
+		Conclusion:  new(toLower(gql.Conclusion)),
+		HTMLURL:     new(url),
+		DetailsURL:  new(gql.DetailsURL),
+		StartedAt:   ghTimestampPtr(gql.StartedAt),
+		CompletedAt: ghTimestampPtr(gql.CompletedAt),
+		App:         &gh.App{Name: new(gql.CheckSuite.App.Name)},
 	}
 }
 
@@ -380,6 +384,13 @@ func toLower(s string) string {
 		b[i] = c
 	}
 	return string(b)
+}
+
+func ghTimestampPtr(t *time.Time) *gh.Timestamp {
+	if t == nil {
+		return nil
+	}
+	return &gh.Timestamp{Time: *t}
 }
 
 // --- Bulk result types ---

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -164,6 +164,7 @@ type gqlCheckRunFields struct {
 	Status      string
 	Conclusion  string
 	DetailsURL  string `graphql:"detailsUrl"`
+	CreatedAt   *time.Time
 	StartedAt   *time.Time
 	CompletedAt *time.Time
 	CheckSuite  struct {
@@ -362,6 +363,7 @@ func adaptCheckRun(gql *gqlCheckRunFields) *gh.CheckRun {
 		DetailsURL:  new(gql.DetailsURL),
 		StartedAt:   ghTimestampPtr(gql.StartedAt),
 		CompletedAt: ghTimestampPtr(gql.CompletedAt),
+		CheckSuite:  &gh.CheckSuite{CreatedAt: ghTimestampPtr(gql.CreatedAt)},
 		App:         &gh.App{Name: new(gql.CheckSuite.App.Name)},
 	}
 }

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -164,11 +164,11 @@ type gqlCheckRunFields struct {
 	Status      string
 	Conclusion  string
 	DetailsURL  string `graphql:"detailsUrl"`
-	CreatedAt   *time.Time
 	StartedAt   *time.Time
 	CompletedAt *time.Time
 	CheckSuite  struct {
-		App struct {
+		CreatedAt *time.Time
+		App       struct {
 			Name string
 		}
 	}
@@ -363,7 +363,7 @@ func adaptCheckRun(gql *gqlCheckRunFields) *gh.CheckRun {
 		DetailsURL:  new(gql.DetailsURL),
 		StartedAt:   ghTimestampPtr(gql.StartedAt),
 		CompletedAt: ghTimestampPtr(gql.CompletedAt),
-		CheckSuite:  &gh.CheckSuite{CreatedAt: ghTimestampPtr(gql.CreatedAt)},
+		CheckSuite:  &gh.CheckSuite{CreatedAt: ghTimestampPtr(gql.CheckSuite.CreatedAt)},
 		App:         &gh.App{Name: new(gql.CheckSuite.App.Name)},
 	}
 }

--- a/internal/github/graphql_live_test.go
+++ b/internal/github/graphql_live_test.go
@@ -1,0 +1,44 @@
+package github
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/require"
+)
+
+const liveGraphQLTestsEnv = "MIDDLEMAN_LIVE_GITHUB_TESTS"
+
+func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
+	if os.Getenv(liveGraphQLTestsEnv) != "1" {
+		t.Skipf("set %s=1 to validate GraphQL queries against GitHub", liveGraphQLTestsEnv)
+	}
+
+	token := os.Getenv("MIDDLEMAN_GITHUB_TOKEN")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	require.NotEmpty(t, token, "set MIDDLEMAN_GITHUB_TOKEN or GITHUB_TOKEN")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	fetcher := NewGraphQLFetcher(token, "github.com", nil, nil)
+
+	var prQuery gqlPRQuery
+	vars := map[string]any{
+		"owner":    githubv4.String("wesm"),
+		"name":     githubv4.String("middleman"),
+		"pageSize": githubv4.Int(1),
+		"cursor":   (*githubv4.String)(nil),
+	}
+	err := fetcher.client.Query(ctx, &prQuery, vars)
+	require.NoError(t, err, "bulk PR GraphQL query should validate against GitHub")
+
+	var issueQuery gqlIssueQuery
+	err = fetcher.client.Query(ctx, &issueQuery, vars)
+	require.NoError(t, err, "bulk issue GraphQL query should validate against GitHub")
+}

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -127,6 +127,7 @@ func TestAdaptCommit(t *testing.T) {
 func TestAdaptCheckContext(t *testing.T) {
 	assert := Assert.New(t)
 
+	now := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
 	contexts := []gqlCheckContext{
 		{
 			Typename: "CheckRun",
@@ -135,6 +136,7 @@ func TestAdaptCheckContext(t *testing.T) {
 				Status:     "COMPLETED",
 				Conclusion: "SUCCESS",
 				DetailsURL: "https://example.com/1",
+				CreatedAt:  &now,
 			},
 		},
 		{
@@ -155,6 +157,8 @@ func TestAdaptCheckContext(t *testing.T) {
 	assert.Equal("completed", checks[0].GetStatus())
 	assert.Equal("success", checks[0].GetConclusion())
 	assert.Equal("GitHub Actions", checks[0].GetApp().GetName())
+	require.NotNil(t, checks[0].GetCheckSuite().CreatedAt)
+	assert.True(checks[0].GetCheckSuite().CreatedAt.Time.Equal(now))
 
 	require.Len(t, statuses, 1)
 	assert.Equal("ci/lint", statuses[0].GetContext())

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -479,3 +479,37 @@ func TestNormalizeBulkCI_SortsByCasefoldedName(t *testing.T) {
 	assert.Equal("build", checks[1].Name)
 	assert.Equal("Zebra", checks[2].Name)
 }
+
+func TestNormalizeBulkCI_LatestCheckRunPerNameWins(t *testing.T) {
+	assert := Assert.New(t)
+
+	older := gh.Timestamp{Time: time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)}
+	newer := gh.Timestamp{Time: older.Add(10 * time.Minute)}
+	buildName := "build"
+	statusCompleted := "completed"
+	conclusionFailure := "failure"
+	conclusionSuccess := "success"
+
+	checks := normalizeBulkCI(&BulkPR{
+		CheckRuns: []*gh.CheckRun{
+			{
+				ID:          new(int64(100)),
+				Name:        &buildName,
+				Status:      &statusCompleted,
+				Conclusion:  &conclusionFailure,
+				CompletedAt: &older,
+			},
+			{
+				ID:          new(int64(101)),
+				Name:        &buildName,
+				Status:      &statusCompleted,
+				Conclusion:  &conclusionSuccess,
+				CompletedAt: &newer,
+			},
+		},
+	})
+
+	require.Len(t, checks, 1)
+	assert.Equal("build", checks[0].Name)
+	assert.Equal("success", checks[0].Conclusion)
+}

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -136,7 +136,6 @@ func TestAdaptCheckContext(t *testing.T) {
 				Status:     "COMPLETED",
 				Conclusion: "SUCCESS",
 				DetailsURL: "https://example.com/1",
-				CreatedAt:  &now,
 			},
 		},
 		{
@@ -148,6 +147,7 @@ func TestAdaptCheckContext(t *testing.T) {
 			},
 		},
 	}
+	contexts[0].CheckRun.CheckSuite.CreatedAt = &now
 	contexts[0].CheckRun.CheckSuite.App.Name = "GitHub Actions"
 
 	checks, statuses := splitCheckContexts(contexts)

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -183,46 +183,26 @@ func DeriveOverallCIStatus(
 	runs []*gh.CheckRun,
 	combined *gh.CombinedStatus,
 ) string {
-	hasAny := false
-	hasPending := false
-	hasFailed := false
-
-	for _, r := range runs {
-		hasAny = true
-		if r.GetStatus() != "completed" {
-			hasPending = true
-			continue
-		}
-		switch r.GetConclusion() {
-		case "success", "neutral", "skipped":
-			// OK — not a failure.
-		default:
-			hasFailed = true
-		}
+	status := deriveCIStatusFromChecks(normalizeCIChecks(
+		runs,
+		combinedStatuses(combined),
+	))
+	if combined == nil || combined.GetTotalCount() == 0 {
+		return status
 	}
-
-	// Use GitHub's pre-aggregated State rather than iterating
-	// combined.Statuses, which may be truncated by pagination.
-	if combined != nil && combined.GetTotalCount() > 0 {
-		hasAny = true
-		switch combined.GetState() {
-		case "pending":
-			hasPending = true
-		case "failure", "error":
-			hasFailed = true
-		}
-	}
-
-	if !hasAny {
-		return ""
-	}
-	if hasFailed {
+	switch combined.GetState() {
+	case "failure", "error":
 		return "failure"
+	case "pending":
+		if status != "failure" {
+			return "pending"
+		}
+	case "success":
+		if status == "" {
+			return "success"
+		}
 	}
-	if hasPending {
-		return "pending"
-	}
-	return "success"
+	return status
 }
 
 // DeriveReviewDecision computes the aggregate review decision from a list of
@@ -260,20 +240,10 @@ func DeriveReviewDecision(reviews []*gh.PullRequestReview) string {
 
 // NormalizeCheckRuns converts GitHub check runs to a JSON string of CICheck objects.
 func NormalizeCheckRuns(runs []*gh.CheckRun) string {
-	if len(runs) == 0 {
+	checks := normalizeCIChecks(runs, nil)
+	if len(checks) == 0 {
 		return ""
 	}
-	checks := make([]db.CICheck, 0, len(runs))
-	for _, r := range runs {
-		checks = append(checks, db.CICheck{
-			Name:       r.GetName(),
-			Status:     r.GetStatus(),
-			Conclusion: r.GetConclusion(),
-			URL:        r.GetHTMLURL(),
-			App:        appName(r),
-		})
-	}
-	sortCIChecksByName(checks)
 	b, err := json.Marshal(checks)
 	if err != nil {
 		return ""
@@ -289,43 +259,140 @@ func NormalizeCIChecks(
 	runs []*gh.CheckRun,
 	combined *gh.CombinedStatus,
 ) string {
-	var checks []db.CICheck
-	for _, r := range runs {
-		checks = append(checks, db.CICheck{
-			Name:       r.GetName(),
-			Status:     r.GetStatus(),
-			Conclusion: r.GetConclusion(),
-			URL:        r.GetHTMLURL(),
-			App:        appName(r),
-		})
-	}
-	if combined != nil {
-		for _, s := range combined.Statuses {
-			// Map commit status state to check run status/conclusion.
-			status := "completed"
-			conclusion := s.GetState()
-			if conclusion == "pending" || conclusion == "expected" {
-				status = "in_progress"
-				conclusion = ""
-			}
-			checks = append(checks, db.CICheck{
-				Name:       s.GetContext(),
-				Status:     status,
-				Conclusion: conclusion,
-				URL:        sanitizeURL(s.GetTargetURL()),
-				App:        s.GetContext(),
-			})
-		}
-	}
+	checks := normalizeCIChecks(runs, combinedStatuses(combined))
 	if len(checks) == 0 {
 		return ""
 	}
-	sortCIChecksByName(checks)
 	b, err := json.Marshal(checks)
 	if err != nil {
 		return ""
 	}
 	return string(b)
+}
+
+type ciCheckCandidate struct {
+	check db.CICheck
+	name  string
+	at    time.Time
+	id    int64
+	order int
+}
+
+func normalizeCIChecks(runs []*gh.CheckRun, statuses []*gh.RepoStatus) []db.CICheck {
+	candidates := make([]ciCheckCandidate, 0, len(runs)+len(statuses))
+	for _, r := range runs {
+		candidates = append(candidates, ciCheckCandidate{
+			check: db.CICheck{
+				Name:       r.GetName(),
+				Status:     r.GetStatus(),
+				Conclusion: r.GetConclusion(),
+				URL:        r.GetHTMLURL(),
+				App:        appName(r),
+			},
+			name:  r.GetName(),
+			at:    checkRunRecency(r),
+			id:    r.GetID(),
+			order: len(candidates),
+		})
+	}
+	for _, s := range statuses {
+		candidates = append(candidates, ciCheckCandidate{
+			check: db.CICheck{
+				Name:       s.GetContext(),
+				Status:     repoStatusCheckState(s),
+				Conclusion: repoStatusConclusion(s),
+				URL:        sanitizeURL(s.GetTargetURL()),
+				App:        s.GetContext(),
+			},
+			name:  s.GetContext(),
+			at:    repoStatusRecency(s),
+			id:    s.GetID(),
+			order: len(candidates),
+		})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	byName := make(map[string]ciCheckCandidate, len(candidates))
+	orderedKeys := make([]string, 0, len(candidates))
+	checks := make([]db.CICheck, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.name == "" {
+			checks = append(checks, candidate.check)
+			continue
+		}
+		existing, ok := byName[candidate.name]
+		if !ok {
+			orderedKeys = append(orderedKeys, candidate.name)
+			byName[candidate.name] = candidate
+			continue
+		}
+		if ciCheckCandidateIsNewer(existing, candidate) {
+			byName[candidate.name] = candidate
+		}
+	}
+	for _, key := range orderedKeys {
+		checks = append(checks, byName[key].check)
+	}
+	sortCIChecksByName(checks)
+	return checks
+}
+
+func ciCheckCandidateIsNewer(existing, candidate ciCheckCandidate) bool {
+	if existing.at.IsZero() != candidate.at.IsZero() {
+		return existing.at.IsZero()
+	}
+	if !existing.at.Equal(candidate.at) {
+		return candidate.at.After(existing.at)
+	}
+	if existing.id != candidate.id {
+		return candidate.id > existing.id
+	}
+	return candidate.order > existing.order
+}
+
+func combinedStatuses(combined *gh.CombinedStatus) []*gh.RepoStatus {
+	if combined == nil {
+		return nil
+	}
+	return combined.Statuses
+}
+
+func checkRunRecency(r *gh.CheckRun) time.Time {
+	completedAt := r.GetCompletedAt().Time
+	if !completedAt.IsZero() {
+		return completedAt
+	}
+	return r.GetStartedAt().Time
+}
+
+func repoStatusRecency(s *gh.RepoStatus) time.Time {
+	updatedAt := s.GetUpdatedAt().Time
+	if !updatedAt.IsZero() {
+		return updatedAt
+	}
+	return s.GetCreatedAt().Time
+}
+
+func repoStatusCheckState(s *gh.RepoStatus) string {
+	switch s.GetState() {
+	case "pending", "expected":
+		return "in_progress"
+	default:
+		return "completed"
+	}
+}
+
+func repoStatusConclusion(s *gh.RepoStatus) string {
+	switch s.GetState() {
+	case "pending", "expected":
+		return ""
+	case "failure", "error":
+		return "failure"
+	default:
+		return s.GetState()
+	}
 }
 
 func sortCIChecksByName(checks []db.CICheck) {

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -360,19 +360,26 @@ func combinedStatuses(combined *gh.CombinedStatus) []*gh.RepoStatus {
 }
 
 func checkRunRecency(r *gh.CheckRun) time.Time {
-	completedAt := r.GetCompletedAt().Time
+	completedAt := timestampTime(r.CompletedAt)
 	if !completedAt.IsZero() {
 		return completedAt
 	}
-	return r.GetStartedAt().Time
+	return timestampTime(r.StartedAt)
 }
 
 func repoStatusRecency(s *gh.RepoStatus) time.Time {
-	updatedAt := s.GetUpdatedAt().Time
+	updatedAt := timestampTime(s.UpdatedAt)
 	if !updatedAt.IsZero() {
 		return updatedAt
 	}
-	return s.GetCreatedAt().Time
+	return timestampTime(s.CreatedAt)
+}
+
+func timestampTime(t *gh.Timestamp) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return t.Time
 }
 
 func repoStatusCheckState(s *gh.RepoStatus) string {

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -273,6 +273,7 @@ func NormalizeCIChecks(
 type ciCheckCandidate struct {
 	check db.CICheck
 	name  string
+	key   string
 	at    time.Time
 	id    int64
 	order int
@@ -290,6 +291,7 @@ func normalizeCIChecks(runs []*gh.CheckRun, statuses []*gh.RepoStatus) []db.CICh
 				App:        appName(r),
 			},
 			name:  r.GetName(),
+			key:   checkRunDedupeKey(r),
 			at:    checkRunRecency(r),
 			id:    r.GetID(),
 			order: len(candidates),
@@ -305,6 +307,7 @@ func normalizeCIChecks(runs []*gh.CheckRun, statuses []*gh.RepoStatus) []db.CICh
 				App:        s.GetContext(),
 			},
 			name:  s.GetContext(),
+			key:   repoStatusDedupeKey(s),
 			at:    repoStatusRecency(s),
 			id:    s.GetID(),
 			order: len(candidates),
@@ -318,18 +321,18 @@ func normalizeCIChecks(runs []*gh.CheckRun, statuses []*gh.RepoStatus) []db.CICh
 	orderedKeys := make([]string, 0, len(candidates))
 	checks := make([]db.CICheck, 0, len(candidates))
 	for _, candidate := range candidates {
-		if candidate.name == "" {
+		if candidate.key == "" {
 			checks = append(checks, candidate.check)
 			continue
 		}
-		existing, ok := byName[candidate.name]
+		existing, ok := byName[candidate.key]
 		if !ok {
-			orderedKeys = append(orderedKeys, candidate.name)
-			byName[candidate.name] = candidate
+			orderedKeys = append(orderedKeys, candidate.key)
+			byName[candidate.key] = candidate
 			continue
 		}
 		if ciCheckCandidateIsNewer(existing, candidate) {
-			byName[candidate.name] = candidate
+			byName[candidate.key] = candidate
 		}
 	}
 	for _, key := range orderedKeys {
@@ -364,7 +367,30 @@ func checkRunRecency(r *gh.CheckRun) time.Time {
 	if !completedAt.IsZero() {
 		return completedAt
 	}
-	return timestampTime(r.StartedAt)
+	startedAt := timestampTime(r.StartedAt)
+	if !startedAt.IsZero() {
+		return startedAt
+	}
+	if suite := r.GetCheckSuite(); suite != nil {
+		return timestampTime(suite.CreatedAt)
+	}
+	return time.Time{}
+}
+
+func checkRunDedupeKey(r *gh.CheckRun) string {
+	name := r.GetName()
+	if name == "" {
+		return ""
+	}
+	return "check-run\x00" + appName(r) + "\x00" + name
+}
+
+func repoStatusDedupeKey(s *gh.RepoStatus) string {
+	context := s.GetContext()
+	if context == "" {
+		return ""
+	}
+	return "status\x00" + context
 }
 
 func repoStatusRecency(s *gh.RepoStatus) time.Time {

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -527,6 +527,71 @@ func TestNormalizeCheckRuns_SortsByCasefoldedName(t *testing.T) {
 	assert.Equal("Zebra", checks[2].Name)
 }
 
+func TestNormalizeCIChecks_LatestCheckRunPerNameWins(t *testing.T) {
+	assert := Assert.New(t)
+
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	name := "build"
+	statusCompleted := "completed"
+	conclusionFailure := "failure"
+	conclusionSuccess := "success"
+
+	raw := NormalizeCIChecks([]*gh.CheckRun{
+		{
+			ID:          new(int64(100)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionFailure,
+			CompletedAt: ghTimestamp(older),
+		},
+		{
+			ID:          new(int64(101)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionSuccess,
+			CompletedAt: ghTimestamp(newer),
+		},
+	}, nil)
+	require.NotEmpty(t, raw)
+
+	var checks []db.CICheck
+	require.NoError(t, json.Unmarshal([]byte(raw), &checks))
+	require.Len(t, checks, 1)
+
+	assert.Equal("build", checks[0].Name)
+	assert.Equal("completed", checks[0].Status)
+	assert.Equal("success", checks[0].Conclusion)
+}
+
+func TestDeriveOverallCIStatus_LatestCheckRunPerNameWins(t *testing.T) {
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	name := "build"
+	statusCompleted := "completed"
+	conclusionFailure := "failure"
+	conclusionSuccess := "success"
+
+	result := DeriveOverallCIStatus([]*gh.CheckRun{
+		{
+			ID:          new(int64(100)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionFailure,
+			CompletedAt: ghTimestamp(older),
+		},
+		{
+			ID:          new(int64(101)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionSuccess,
+			CompletedAt: ghTimestamp(newer),
+		},
+	}, nil)
+
+	Assert.Equal(t, "success", result)
+}
+
 func TestNormalizeCIChecks_SortsByCasefoldedName(t *testing.T) {
 	assert := Assert.New(t)
 

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -564,6 +564,82 @@ func TestNormalizeCIChecks_LatestCheckRunPerNameWins(t *testing.T) {
 	assert.Equal("success", checks[0].Conclusion)
 }
 
+func TestNormalizeCIChecks_CheckRunMissingCompletedAtFallsBackToStartedAt(t *testing.T) {
+	assert := Assert.New(t)
+
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	name := "build"
+	statusCompleted := "completed"
+	statusInProgress := "in_progress"
+	conclusionFailure := "failure"
+
+	raw := NormalizeCIChecks([]*gh.CheckRun{
+		{
+			ID:          new(int64(100)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionFailure,
+			CompletedAt: ghTimestamp(older),
+			StartedAt:   ghTimestamp(older.Add(-2 * time.Minute)),
+		},
+		{
+			ID:        new(int64(101)),
+			Name:      &name,
+			Status:    &statusInProgress,
+			StartedAt: ghTimestamp(newer),
+		},
+	}, nil)
+	require.NotEmpty(t, raw)
+
+	var checks []db.CICheck
+	require.NoError(t, json.Unmarshal([]byte(raw), &checks))
+	require.Len(t, checks, 1)
+
+	assert.Equal("build", checks[0].Name)
+	assert.Equal("in_progress", checks[0].Status)
+	assert.Empty(checks[0].Conclusion)
+}
+
+func TestNormalizeCIChecks_StatusMissingUpdatedAtFallsBackToCreatedAt(t *testing.T) {
+	assert := Assert.New(t)
+
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	context := "roborev"
+	oldState := "success"
+	newState := "failure"
+
+	raw := NormalizeCIChecks(nil, &gh.CombinedStatus{
+		TotalCount: new(2),
+		State:      &newState,
+		Statuses: []*gh.RepoStatus{
+			{
+				ID:        new(int64(100)),
+				Context:   &context,
+				State:     &oldState,
+				UpdatedAt: ghTimestamp(older),
+				CreatedAt: ghTimestamp(older.Add(-2 * time.Minute)),
+			},
+			{
+				ID:        new(int64(101)),
+				Context:   &context,
+				State:     &newState,
+				CreatedAt: ghTimestamp(newer),
+			},
+		},
+	})
+	require.NotEmpty(t, raw)
+
+	var checks []db.CICheck
+	require.NoError(t, json.Unmarshal([]byte(raw), &checks))
+	require.Len(t, checks, 1)
+
+	assert.Equal("roborev", checks[0].Name)
+	assert.Equal("completed", checks[0].Status)
+	assert.Equal("failure", checks[0].Conclusion)
+}
+
 func TestDeriveOverallCIStatus_LatestCheckRunPerNameWins(t *testing.T) {
 	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
 	newer := older.Add(10 * time.Minute)

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -601,6 +601,101 @@ func TestNormalizeCIChecks_CheckRunMissingCompletedAtFallsBackToStartedAt(t *tes
 	assert.Empty(checks[0].Conclusion)
 }
 
+func TestNormalizeCIChecks_CheckRunMissingStartedAtFallsBackToCreatedAt(t *testing.T) {
+	assert := Assert.New(t)
+
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	name := "build"
+	statusQueued := "queued"
+	statusCompleted := "completed"
+	conclusionSuccess := "success"
+
+	raw := NormalizeCIChecks([]*gh.CheckRun{
+		{
+			ID:          new(int64(100)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionSuccess,
+			CompletedAt: ghTimestamp(older),
+			CheckSuite:  &gh.CheckSuite{CreatedAt: ghTimestamp(older.Add(-2 * time.Minute))},
+		},
+		{
+			ID:         new(int64(101)),
+			Name:       &name,
+			Status:     &statusQueued,
+			CheckSuite: &gh.CheckSuite{CreatedAt: ghTimestamp(newer)},
+		},
+	}, nil)
+	require.NotEmpty(t, raw)
+
+	var checks []db.CICheck
+	require.NoError(t, json.Unmarshal([]byte(raw), &checks))
+	require.Len(t, checks, 1)
+
+	assert.Equal("build", checks[0].Name)
+	assert.Equal("queued", checks[0].Status)
+	assert.Empty(checks[0].Conclusion)
+}
+
+func TestNormalizeCIChecks_DeduplicatesBySourceAwareKey(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	name := "build"
+	statusCompleted := "completed"
+	conclusionFailure := "failure"
+	conclusionSuccess := "success"
+	conclusionNeutral := "neutral"
+	appOne := "GitHub Actions"
+	appTwo := "Buildkite"
+
+	raw := NormalizeCIChecks([]*gh.CheckRun{
+		{
+			ID:          new(int64(100)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionFailure,
+			CompletedAt: ghTimestamp(older),
+			App:         &gh.App{Name: &appOne},
+		},
+		{
+			ID:          new(int64(101)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionSuccess,
+			CompletedAt: ghTimestamp(newer),
+			App:         &gh.App{Name: &appOne},
+		},
+		{
+			ID:          new(int64(102)),
+			Name:        &name,
+			Status:      &statusCompleted,
+			Conclusion:  &conclusionNeutral,
+			CompletedAt: ghTimestamp(older),
+			App:         &gh.App{Name: &appTwo},
+		},
+	}, nil)
+	require.NotEmpty(raw)
+
+	var checks []db.CICheck
+	require.NoError(json.Unmarshal([]byte(raw), &checks))
+	require.Len(checks, 2)
+
+	byApp := make(map[string]db.CICheck, len(checks))
+	for _, check := range checks {
+		byApp[check.App] = check
+	}
+	require.Contains(byApp, "Buildkite")
+	require.Contains(byApp, "GitHub Actions")
+	assert.Equal("build", byApp["Buildkite"].Name)
+	assert.Equal("neutral", byApp["Buildkite"].Conclusion)
+	assert.Equal("build", byApp["GitHub Actions"].Name)
+	assert.Equal("success", byApp["GitHub Actions"].Conclusion)
+}
+
 func TestNormalizeCIChecks_StatusMissingUpdatedAtFallsBackToCreatedAt(t *testing.T) {
 	assert := Assert.New(t)
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2219,38 +2219,7 @@ func deriveCIStatusFromChecks(checks []db.CICheck) string {
 // normalizeBulkCI converts GraphQL check runs and statuses to
 // the db.CICheck slice format used by the rest of the codebase.
 func normalizeBulkCI(bulk *BulkPR) []db.CICheck {
-	var checks []db.CICheck
-	for _, cr := range bulk.CheckRuns {
-		checks = append(checks, db.CICheck{
-			Name:       cr.GetName(),
-			Status:     cr.GetStatus(),
-			Conclusion: cr.GetConclusion(),
-			URL:        cr.GetHTMLURL(),
-			App:        cr.GetApp().GetName(),
-		})
-	}
-	for _, s := range bulk.Statuses {
-		// Mirror NormalizeCIChecks: pending → in_progress with
-		// empty conclusion; failure/error → failure.
-		status := "completed"
-		conclusion := s.GetState()
-		switch conclusion {
-		case "pending", "expected":
-			status = "in_progress"
-			conclusion = ""
-		case "failure", "error":
-			conclusion = "failure"
-		}
-		checks = append(checks, db.CICheck{
-			Name:       s.GetContext(),
-			Status:     status,
-			Conclusion: conclusion,
-			URL:        sanitizeURL(s.GetTargetURL()),
-			App:        s.GetContext(),
-		})
-	}
-	sortCIChecksByName(checks)
-	return checks
+	return normalizeCIChecks(bulk.CheckRuns, bulk.Statuses)
 }
 
 // fetchMRDetail performs a full detail fetch for a single MR:

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -45,6 +45,8 @@ type mockGH struct {
 	approveWorkflowRunFn      func(context.Context, string, string, int64) error
 	listReposByOwnerFn        func(context.Context, string) ([]*gh.Repository, error)
 	listOpenPullRequestsFn    func(context.Context, string, string) ([]*gh.PullRequest, error)
+	listCheckRunsForRefFn     func(context.Context, string, string, string) ([]*gh.CheckRun, error)
+	getCombinedStatusFn       func(context.Context, string, string, string) (*gh.CombinedStatus, error)
 	listOpenPRsErr            error
 	listOpenIssuesFn          func(context.Context, string, string) ([]*gh.Issue, error)
 	listIssueCommentsFn       func(context.Context, string, string, int) ([]*gh.IssueComment, error)
@@ -140,14 +142,20 @@ func (m *mockGH) ListForcePushEvents(
 }
 
 func (m *mockGH) GetCombinedStatus(
-	_ context.Context, _, _, _ string,
+	ctx context.Context, owner, repo, ref string,
 ) (*gh.CombinedStatus, error) {
+	if m.getCombinedStatusFn != nil {
+		return m.getCombinedStatusFn(ctx, owner, repo, ref)
+	}
 	return nil, nil
 }
 
 func (m *mockGH) ListCheckRunsForRef(
-	_ context.Context, _, _, _ string,
+	ctx context.Context, owner, repo, ref string,
 ) ([]*gh.CheckRun, error) {
+	if m.listCheckRunsForRefFn != nil {
+		return m.listCheckRunsForRefFn(ctx, owner, repo, ref)
+	}
 	return nil, nil
 }
 
@@ -6577,6 +6585,125 @@ func TestDisplayNameCacheE2E(t *testing.T) {
 	rr2 := doJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
 	require.Equal(http.StatusOK, rr2.Code)
 	require.Contains(rr2.Body.String(), `"AuthorDisplayName":"Alice Smith"`)
+}
+
+func TestCICheckDedupLatestRunWinsE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	prID := int64(1001)
+	prNumber := 1
+	prTitle := "check dedupe"
+	prState := "open"
+	prURL := "https://github.com/acme/widget/pull/1"
+	prBody := ""
+	prAuthor := "alice"
+	headRef := "feature/check-dedupe"
+	baseRef := "main"
+	headSHA := "abc123"
+	baseSHA := "def456"
+	headCloneURL := "https://github.com/acme/widget.git"
+	checkName := "build"
+	checkStatus := "completed"
+	oldConclusion := "failure"
+	newConclusion := "success"
+	oldCheckURL := "https://github.com/acme/widget/actions/runs/1"
+	newCheckURL := "https://github.com/acme/widget/actions/runs/2"
+	combinedTotal := 1
+	combinedState := "success"
+
+	pr := &gh.PullRequest{
+		ID:        &prID,
+		Number:    &prNumber,
+		Title:     &prTitle,
+		State:     &prState,
+		HTMLURL:   &prURL,
+		Body:      &prBody,
+		User:      &gh.User{Login: &prAuthor},
+		CreatedAt: &gh.Timestamp{Time: older},
+		UpdatedAt: &gh.Timestamp{Time: newer},
+		Head: &gh.PullRequestBranch{
+			Ref: &headRef,
+			SHA: &headSHA,
+			Repo: &gh.Repository{
+				CloneURL: &headCloneURL,
+			},
+		},
+		Base: &gh.PullRequestBranch{
+			Ref: &baseRef,
+			SHA: &baseSHA,
+		},
+	}
+
+	mock := &mockGH{
+		getPullRequestFn: func(
+			_ context.Context, _, _ string, _ int,
+		) (*gh.PullRequest, error) {
+			return pr, nil
+		},
+		listCheckRunsForRefFn: func(
+			_ context.Context, owner, repo, ref string,
+		) ([]*gh.CheckRun, error) {
+			require.Equal("acme", owner)
+			require.Equal("widget", repo)
+			require.Equal(headSHA, ref)
+			return []*gh.CheckRun{
+				{
+					ID:          new(int64(10)),
+					Name:        &checkName,
+					Status:      &checkStatus,
+					Conclusion:  &oldConclusion,
+					CompletedAt: &gh.Timestamp{Time: older},
+					HTMLURL:     &oldCheckURL,
+				},
+				{
+					ID:          new(int64(11)),
+					Name:        &checkName,
+					Status:      &checkStatus,
+					Conclusion:  &newConclusion,
+					CompletedAt: &gh.Timestamp{Time: newer},
+					HTMLURL:     &newCheckURL,
+				},
+			}, nil
+		},
+		getCombinedStatusFn: func(
+			_ context.Context, owner, repo, ref string,
+		) (*gh.CombinedStatus, error) {
+			require.Equal("acme", owner)
+			require.Equal("widget", repo)
+			require.Equal(headSHA, ref)
+			return &gh.CombinedStatus{
+				TotalCount: &combinedTotal,
+				State:      &combinedState,
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	client := setupTestClient(t, srv)
+	seedPR(t, database, "acme", "widget", prNumber)
+
+	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
+		context.Background(), "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.MergeRequest)
+	require.Equal("success", resp.JSON200.MergeRequest.CIStatus)
+
+	var checks []db.CICheck
+	require.NoError(json.Unmarshal(
+		[]byte(resp.JSON200.MergeRequest.CIChecksJSON),
+		&checks,
+	))
+	require.Len(checks, 1)
+	assert.Equal("build", checks[0].Name)
+	assert.Equal("completed", checks[0].Status)
+	assert.Equal("success", checks[0].Conclusion)
+	assert.Equal(newCheckURL, checks[0].URL)
 }
 
 // setupTestServerWithWorkspaces creates a test server wired with

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4740,6 +4740,126 @@ func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 	require.Empty(*secondResp.JSON200.Events)
 }
 
+func TestE2EGraphQLBulkSyncKeepsNewestCICheckBySuiteCreatedAt(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	older := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(10 * time.Minute)
+	prUpdatedAt := newer.Add(time.Minute)
+	prID := int64(173100)
+	prNumber := 174
+	prTitle := "GraphQL check dedupe"
+	prState := "open"
+	prURL := "https://github.com/acme/widget/pull/174"
+	prAuthor := "alice"
+	headRef := "feature/graphql-check-dedupe"
+	baseRef := "main"
+	headSHA := "abc123"
+	baseSHA := "def456"
+	checkName := "build"
+	oldCheckURL := "https://ci.example.com/runs/old"
+	newCheckURL := "https://ci.example.com/runs/new"
+
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if bytes.Contains(body, []byte("pullRequests")) {
+			resp := `{"data":{"repository":{"pullRequests":{"nodes":[{
+				"databaseId":173100,
+				"number":174,
+				"title":"GraphQL check dedupe",
+				"state":"OPEN",
+				"isDraft":false,
+				"body":"",
+				"url":"https://github.com/acme/widget/pull/174",
+				"author":{"login":"alice"},
+				"createdAt":"` + older.Format(time.RFC3339) + `",
+				"updatedAt":"` + prUpdatedAt.Format(time.RFC3339) + `",
+				"mergedAt":null,
+				"closedAt":null,
+				"additions":1,
+				"deletions":0,
+				"mergeable":"MERGEABLE",
+				"reviewDecision":"",
+				"headRefName":"feature/graphql-check-dedupe",
+				"baseRefName":"main",
+				"headRefOid":"abc123",
+				"baseRefOid":"def456",
+				"headRepository":{"url":"https://github.com/acme/widget"},
+				"labels":{"nodes":[]},
+				"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+				"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+				"allCommits":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+				"lastCommit":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[
+					{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"FAILURE","detailsUrl":"https://ci.example.com/runs/old","startedAt":null,"completedAt":null,"checkSuite":{"createdAt":"` + older.Format(time.RFC3339) + `","app":{"name":"GitHub Actions"}}},
+					{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"SUCCESS","detailsUrl":"https://ci.example.com/runs/new","startedAt":null,"completedAt":null,"checkSuite":{"createdAt":"` + newer.Format(time.RFC3339) + `","app":{"name":"GitHub Actions"}}}
+				],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}]}
+			}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`
+			_, _ = w.Write([]byte(resp))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+	}))
+	defer gqlSrv.Close()
+
+	prTime := gh.Timestamp{Time: prUpdatedAt}
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return []*gh.PullRequest{{
+				ID:        &prID,
+				Number:    &prNumber,
+				Title:     &prTitle,
+				State:     &prState,
+				HTMLURL:   &prURL,
+				User:      &gh.User{Login: &prAuthor},
+				CreatedAt: &gh.Timestamp{Time: older},
+				UpdatedAt: &prTime,
+				Head:      &gh.PullRequestBranch{Ref: &headRef, SHA: &headSHA},
+				Base:      &gh.PullRequestBranch{Ref: &baseRef, SHA: &baseSHA},
+			}}, nil
+		},
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+	}
+
+	srv, _ := setupTestServerWithMock(t, mock)
+	gqlClient := githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client())
+	srv.syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcherWithClient(gqlClient, nil),
+	})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		ctx, "acme", "widget", int64(prNumber),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.MergeRequest)
+	require.Equal("success", resp.JSON200.MergeRequest.CIStatus)
+
+	var checks []db.CICheck
+	require.NoError(json.Unmarshal(
+		[]byte(resp.JSON200.MergeRequest.CIChecksJSON),
+		&checks,
+	))
+	require.Len(checks, 1)
+	assert.Equal(checkName, checks[0].Name)
+	assert.Equal("completed", checks[0].Status)
+	assert.Equal("success", checks[0].Conclusion)
+	assert.Equal(newCheckURL, checks[0].URL)
+	assert.Equal("GitHub Actions", checks[0].App)
+	assert.NotEqual(oldCheckURL, checks[0].URL)
+}
+
 func make422Error() error {
 	return &gh.ErrorResponse{
 		Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},


### PR DESCRIPTION
## Summary
- Prefer the newest CI check result when multiple runs share the same name.
- Carry check run timestamps through GraphQL normalization so recency can be determined reliably.
- Share the deduplication logic across GraphQL sync, bulk sync, and status derivation paths.
- Add coverage for normalization, status derivation, GraphQL mapping, and an end-to-end sync case.

## Testing
- `go test ./internal/github -run 'TestNormalize|TestDeriveOverallCIStatus|TestNormalizeBulkCI' -shuffle=on`
- `go test ./internal/server -run TestCICheckDedupLatestRunWinsE2E -shuffle=on`
- Not run: full repository test suite