### PR TITLE
Restore workspace activity for launched agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,8 @@ make vet        # go vet
 - **Never amend commits** — always create new commits for fixes, never use `--amend`
 - **Never change branches** — don't create, switch, or delete branches without explicit permission
 - **Never bypass pre-commit hooks** — all commits must go through a hook-enforced Git commit path. Do not use `jj` or any other workflow to create, rewrite, or finalize commits in a way that skips the repository's Git hooks
-- Use conventional commit messages
+- Use conventional commit messages whose subject explains the reason or user-visible outcome, not just the mechanical change. Good subjects answer "why does this commit exist?" (for example, `fix: restore workspace activity for launched agents`), while vague mechanics such as `fix: run agents under tmux` are not acceptable on their own
+- Commit bodies must add any important context about the bug, regression, constraint, or tradeoff that motivated the change; do not rely on the diff to explain intent
 - Run tests before committing when applicable
 - Never push or pull unless explicitly asked
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,7 +185,8 @@ type Roborev struct {
 }
 
 type Tmux struct {
-	Command []string `toml:"command,omitempty"`
+	Command       []string `toml:"command,omitempty"`
+	AgentSessions *bool    `toml:"agent_sessions,omitempty"`
 }
 
 type Config struct {
@@ -265,6 +266,9 @@ port = 8091
 [activity]
 view_mode = "threaded"
 time_range = "7d"
+
+[tmux]
+agent_sessions = true
 `
 	if _, err := tmp.WriteString(defaultConfig); err != nil {
 		tmp.Close()
@@ -611,6 +615,15 @@ func (c *Config) TmuxCommand() []string {
 		return []string{"tmux"}
 	}
 	return append([]string(nil), c.Tmux.Command...)
+}
+
+// TmuxAgentSessionsEnabled reports whether runtime agent launches
+// should prefer tmux-backed sessions. Defaults to true so agent
+// activity is visible to tmux-based workspace fingerprinting.
+func (c *Config) TmuxAgentSessionsEnabled() bool {
+	return c == nil ||
+		c.Tmux.AgentSessions == nil ||
+		*c.Tmux.AgentSessions
 }
 
 // configFile is the subset of Config written to disk.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -932,6 +932,7 @@ func TestLoadTmuxCommandOmitted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(cfg.Tmux.Command)
 	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+	assert.True(cfg.TmuxAgentSessionsEnabled())
 }
 
 func TestLoadTmuxCommandEmptyArray(t *testing.T) {
@@ -943,6 +944,41 @@ command = []
 	cfg, err := Load(path)
 	require.NoError(t, err)
 	assert.Equal([]string{"tmux"}, cfg.TmuxCommand())
+}
+
+func TestLoadTmuxAgentSessionsDisabled(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[tmux]
+agent_sessions = false
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(cfg.TmuxAgentSessionsEnabled())
+}
+
+func TestSavePreservesTmuxAgentSessionsDisabled(t *testing.T) {
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	disabled := false
+
+	cfg := &Config{
+		SyncInterval:   "5m",
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Host:           "127.0.0.1",
+		Port:           8091,
+		DataDir:        dir,
+		Activity:       Activity{ViewMode: "threaded", TimeRange: "7d"},
+		Tmux: Tmux{
+			AgentSessions: &disabled,
+		},
+	}
+	require.NoError(t, cfg.Save(path))
+
+	reloaded, err := Load(path)
+	require.NoError(t, err)
+	assert.False(reloaded.TmuxAgentSessionsEnabled())
 }
 
 func TestTmuxCommandDefensiveCopy(t *testing.T) {

--- a/internal/db/migrations/000013_workspace_tmux_sessions.down.sql
+++ b/internal/db/migrations/000013_workspace_tmux_sessions.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS middleman_workspace_tmux_sessions_workspace_id_idx;
+DROP TABLE IF EXISTS middleman_workspace_tmux_sessions;

--- a/internal/db/migrations/000013_workspace_tmux_sessions.up.sql
+++ b/internal/db/migrations/000013_workspace_tmux_sessions.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS middleman_workspace_tmux_sessions (
+    workspace_id TEXT NOT NULL REFERENCES middleman_workspaces(id) ON DELETE CASCADE,
+    session_name TEXT NOT NULL,
+    target_key   TEXT NOT NULL,
+    created_at   DATETIME NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (workspace_id, session_name),
+    UNIQUE (session_name)
+);
+
+CREATE INDEX IF NOT EXISTS middleman_workspace_tmux_sessions_workspace_id_idx
+    ON middleman_workspace_tmux_sessions(workspace_id);

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2525,6 +2525,123 @@ func (d *DB) ListWorkspaceSetupEvents(
 	return out, rows.Err()
 }
 
+// UpsertWorkspaceTmuxSession records a tmux session owned by a
+// runtime launch inside a workspace. Re-launching the same target
+// keeps the original row fresh without duplicating it.
+func (d *DB) UpsertWorkspaceTmuxSession(
+	ctx context.Context,
+	session *WorkspaceTmuxSession,
+) error {
+	_, err := d.rw.ExecContext(ctx, `
+		INSERT INTO middleman_workspace_tmux_sessions
+		    (workspace_id, session_name, target_key)
+		VALUES (?, ?, ?)
+		ON CONFLICT(workspace_id, session_name) DO UPDATE SET
+		    target_key = excluded.target_key`,
+		session.WorkspaceID, session.SessionName, session.TargetKey,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert workspace tmux session: %w", err)
+	}
+	return nil
+}
+
+// ListWorkspaceTmuxSessions returns stored runtime tmux sessions for
+// a workspace ordered by target key and creation time.
+func (d *DB) ListWorkspaceTmuxSessions(
+	ctx context.Context,
+	workspaceID string,
+) ([]WorkspaceTmuxSession, error) {
+	rows, err := d.ro.QueryContext(ctx, `
+		SELECT workspace_id, session_name, target_key, created_at
+		FROM middleman_workspace_tmux_sessions
+		WHERE workspace_id = ?
+		ORDER BY target_key, created_at, session_name`, workspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace tmux sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []WorkspaceTmuxSession
+	for rows.Next() {
+		var session WorkspaceTmuxSession
+		if err := rows.Scan(
+			&session.WorkspaceID, &session.SessionName,
+			&session.TargetKey, &session.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan workspace tmux session: %w", err)
+		}
+		session.CreatedAt = session.CreatedAt.UTC()
+		out = append(out, session)
+	}
+	return out, rows.Err()
+}
+
+// ListAllWorkspaceTmuxSessions returns every stored runtime tmux
+// session. It is used by startup cleanup to distinguish live owned
+// sessions from stale managed sessions left behind by crashes.
+func (d *DB) ListAllWorkspaceTmuxSessions(
+	ctx context.Context,
+) ([]WorkspaceTmuxSession, error) {
+	rows, err := d.ro.QueryContext(ctx, `
+		SELECT workspace_id, session_name, target_key, created_at
+		FROM middleman_workspace_tmux_sessions
+		ORDER BY workspace_id, target_key, created_at, session_name`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list all workspace tmux sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []WorkspaceTmuxSession
+	for rows.Next() {
+		var session WorkspaceTmuxSession
+		if err := rows.Scan(
+			&session.WorkspaceID, &session.SessionName,
+			&session.TargetKey, &session.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan workspace tmux session: %w", err)
+		}
+		session.CreatedAt = session.CreatedAt.UTC()
+		out = append(out, session)
+	}
+	return out, rows.Err()
+}
+
+// DeleteWorkspaceTmuxSession removes one stored runtime tmux session.
+func (d *DB) DeleteWorkspaceTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+) error {
+	_, err := d.rw.ExecContext(ctx, `
+		DELETE FROM middleman_workspace_tmux_sessions
+		WHERE workspace_id = ? AND session_name = ?`,
+		workspaceID, sessionName,
+	)
+	if err != nil {
+		return fmt.Errorf("delete workspace tmux session: %w", err)
+	}
+	return nil
+}
+
+// DeleteWorkspaceTmuxSessions removes every stored runtime tmux
+// session for a workspace.
+func (d *DB) DeleteWorkspaceTmuxSessions(
+	ctx context.Context,
+	workspaceID string,
+) error {
+	_, err := d.rw.ExecContext(ctx, `
+		DELETE FROM middleman_workspace_tmux_sessions
+		WHERE workspace_id = ?`, workspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete workspace tmux sessions: %w", err)
+	}
+	return nil
+}
+
 // DeleteWorkspace removes a workspace by ID.
 func (d *DB) DeleteWorkspace(
 	ctx context.Context, id string,

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1889,6 +1889,46 @@ func TestWorkspaceCRUD(t *testing.T) {
 	assert.Equal("ensure clone: clone failed", events[0].Message)
 	assert.False(events[0].CreatedAt.IsZero())
 
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		ctx,
+		&WorkspaceTmuxSession{
+			WorkspaceID: "ws-abc-123",
+			SessionName: "middleman-ws-abc-123-codex",
+			TargetKey:   "codex",
+		},
+	))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		ctx,
+		&WorkspaceTmuxSession{
+			WorkspaceID: "ws-abc-123",
+			SessionName: "middleman-ws-abc-123-claude",
+			TargetKey:   "claude",
+		},
+	))
+	tmuxSessions, err := d.ListWorkspaceTmuxSessions(ctx, "ws-abc-123")
+	require.NoError(err)
+	require.Len(tmuxSessions, 2)
+	assert.Equal("middleman-ws-abc-123-claude", tmuxSessions[0].SessionName)
+	assert.Equal("claude", tmuxSessions[0].TargetKey)
+	assert.False(tmuxSessions[0].CreatedAt.IsZero())
+
+	allTmuxSessions, err := d.ListAllWorkspaceTmuxSessions(ctx)
+	require.NoError(err)
+	require.Len(allTmuxSessions, 2)
+
+	require.NoError(d.DeleteWorkspaceTmuxSession(
+		ctx, "ws-abc-123", "middleman-ws-abc-123-claude",
+	))
+	tmuxSessions, err = d.ListWorkspaceTmuxSessions(ctx, "ws-abc-123")
+	require.NoError(err)
+	require.Len(tmuxSessions, 1)
+	assert.Equal("middleman-ws-abc-123-codex", tmuxSessions[0].SessionName)
+
+	require.NoError(d.DeleteWorkspaceTmuxSessions(ctx, "ws-abc-123"))
+	tmuxSessions, err = d.ListWorkspaceTmuxSessions(ctx, "ws-abc-123")
+	require.NoError(err)
+	assert.Empty(tmuxSessions)
+
 	// Clear error message
 	require.NoError(d.UpdateWorkspaceStatus(
 		ctx, "ws-abc-123", "ready", nil,

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -301,6 +301,13 @@ type WorkspaceSetupEvent struct {
 	CreatedAt   time.Time
 }
 
+type WorkspaceTmuxSession struct {
+	WorkspaceID string
+	SessionName string
+	TargetKey   string
+	CreatedAt   time.Time
+}
+
 // ListActivityOpts holds filters and pagination for the activity feed.
 type ListActivityOpts struct {
 	Repo   string     // "owner/name" filter

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7675,6 +7675,103 @@ func TestWorkspaceRuntimeLaunchSingletonAndStopE2E(t *testing.T) {
 	assert.Empty(*afterStopResp.JSON200.Sessions)
 }
 
+func TestWorkspaceRuntimeLaunchAgentCreatesProbeableTmuxSessionE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+target=""
+mode=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$a"; fi
+  if [ "$a" = "display-message" ]; then mode="display-message"; fi
+  if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
+  prev="$a"
+done
+if [ "$mode" = "display-message" ]; then
+  case "$target" in
+    *-helper) printf '⠴ t3code-b5014b03\n' ;;
+    *) printf 'idle\n' ;;
+  esac
+  exit 0
+fi
+if [ "$mode" = "capture-pane" ]; then
+  printf 'stable\n'
+  exit 0
+fi
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: []string{"helper-agent", "--flag"},
+		}},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	client, _, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	resp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+
+	var newSession []string
+	require.Eventually(func() bool {
+		for _, argv := range readTmuxRecord(t, record) {
+			if len(argv) > 0 &&
+				argv[0] == "new-session" &&
+				strings.Contains(strings.Join(argv, "\n"), "helper-agent") {
+				newSession = argv
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 20*time.Millisecond)
+
+	session, ok := argAfter(newSession, "-s")
+	require.True(ok, "new-session should name a tmux session")
+	assert.Equal("middleman-"+ws.Id+"-helper", session)
+	assert.Contains(newSession, "-A")
+	assert.Contains(newSession, "-c")
+	assert.Contains(strings.Join(newSession, "\n"), "helper-agent")
+	assert.Contains(strings.Join(newSession, "\n"), "--flag")
+
+	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode())
+	require.NotNil(listResp.JSON200)
+	require.NotNil(listResp.JSON200.Workspaces)
+
+	var listed *generated.WorkspaceResponse
+	for i := range *listResp.JSON200.Workspaces {
+		if (*listResp.JSON200.Workspaces)[i].Id == ws.Id {
+			listed = &(*listResp.JSON200.Workspaces)[i]
+			break
+		}
+	}
+	require.NotNil(listed)
+	assert.True(listed.TmuxWorking)
+	assert.Equal(tmuxActivitySourceTitle, listed.TmuxActivitySource)
+	require.NotNil(listed.TmuxPaneTitle)
+	assert.Equal("⠴ t3code-b5014b03", *listed.TmuxPaneTitle)
+	assert.Contains(readTmuxRecord(t, record), []string{
+		"display-message", "-p", "-t", session, "#{pane_title}",
+	})
+}
+
 func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
@@ -7866,11 +7963,12 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
 	require := require.New(t)
+	disableTmuxAgentSessions := false
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "helper",
 		Label:   "Helper",
 		Command: serverRuntimeHelperCommand("echo"),
-	}}}
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
@@ -7921,11 +8019,12 @@ func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
 	require := require.New(t)
+	disableTmuxAgentSessions := false
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "helper",
 		Label:   "Helper",
 		Command: serverRuntimeHelperCommand("size"),
-	}}}
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7681,6 +7681,8 @@ func TestWorkspaceRuntimeLaunchAgentCreatesProbeableTmuxSessionE2E(t *testing.T)
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	tmuxPath := filepath.Join(dir, "fake-tmux")
+	agentPath := filepath.Join(dir, "helper-agent")
+	require.NoError(os.WriteFile(agentPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
 	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
 printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
 target=""
@@ -7710,11 +7712,11 @@ exit 0
 		Agents: []config.Agent{{
 			Key:     "helper",
 			Label:   "Helper",
-			Command: []string{"helper-agent", "--flag"},
+			Command: []string{agentPath, "--flag"},
 		}},
 		Tmux: config.Tmux{Command: []string{tmuxPath}},
 	}
-	client, _, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 
@@ -7733,7 +7735,7 @@ exit 0
 		for _, argv := range readTmuxRecord(t, record) {
 			if len(argv) > 0 &&
 				argv[0] == "new-session" &&
-				strings.Contains(strings.Join(argv, "\n"), "helper-agent") {
+				strings.Contains(strings.Join(argv, "\n"), agentPath) {
 				newSession = argv
 				return true
 			}
@@ -7746,7 +7748,7 @@ exit 0
 	assert.Equal("middleman-"+ws.Id+"-helper", session)
 	assert.Contains(newSession, "-A")
 	assert.Contains(newSession, "-c")
-	assert.Contains(strings.Join(newSession, "\n"), "helper-agent")
+	assert.Contains(strings.Join(newSession, "\n"), agentPath)
 	assert.Contains(strings.Join(newSession, "\n"), "--flag")
 
 	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
@@ -7770,6 +7772,83 @@ exit 0
 	assert.Contains(readTmuxRecord(t, record), []string{
 		"display-message", "-p", "-t", session, "#{pane_title}",
 	})
+	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal(session, stored[0].SessionName)
+	assert.Equal("helper", stored[0].TargetKey)
+}
+
+func TestWorkspaceResponseUsesStoredRuntimeTmuxSessionsAfterRestartE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+target=""
+mode=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$a"; fi
+  if [ "$a" = "display-message" ]; then mode="display-message"; fi
+  if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
+  prev="$a"
+done
+if [ "$mode" = "display-message" ]; then
+  case "$target" in
+    *-claude) printf '⠴ claude-activity\n' ;;
+    *) printf 'idle\n' ;;
+  esac
+  exit 0
+fi
+if [ "$mode" = "capture-pane" ]; then
+  printf 'stable\n'
+  exit 0
+fi
+exit 0
+`), 0o755))
+	cfg := &config.Config{Tmux: config.Tmux{Command: []string{tmuxPath}}}
+	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	require.NotEmpty(ws.TmuxSession)
+	require.NoError(database.UpsertWorkspaceTmuxSession(
+		ctx,
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: ws.Id,
+			SessionName: ws.TmuxSession + "-codex",
+			TargetKey:   "codex",
+		},
+	))
+	require.NoError(database.UpsertWorkspaceTmuxSession(
+		ctx,
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: ws.Id,
+			SessionName: ws.TmuxSession + "-claude",
+			TargetKey:   "claude",
+		},
+	))
+
+	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode())
+	require.NotNil(listResp.JSON200)
+	require.NotNil(listResp.JSON200.Workspaces)
+
+	var listed *generated.WorkspaceResponse
+	for i := range *listResp.JSON200.Workspaces {
+		if (*listResp.JSON200.Workspaces)[i].Id == ws.Id {
+			listed = &(*listResp.JSON200.Workspaces)[i]
+			break
+		}
+	}
+	require.NotNil(listed)
+	assert.True(listed.TmuxWorking)
+	assert.Equal(tmuxActivitySourceTitle, listed.TmuxActivitySource)
+	require.NotNil(listed.TmuxPaneTitle)
+	assert.Equal("⠴ claude-activity", *listed.TmuxPaneTitle)
 }
 
 func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8077,6 +8077,90 @@ func runtimeTmuxSessionNameForTest(workspaceID string, targetKey string) string 
 	return "middleman-" + workspaceID + "-" + hex.EncodeToString(sum[:8])
 }
 
+func TestWorkspaceRuntimeTmuxSessionsHashUnsafeTargetKeysE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	agentPath := filepath.Join(dir, "helper-agent")
+	require.NoError(os.WriteFile(agentPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+case "$1" in
+  has-session)
+    exit 1
+    ;;
+  new-session|set-option|attach-session|kill-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+	cfg := &config.Config{
+		Agents: []config.Agent{
+			{Key: "foo/bar", Label: "Foo Slash", Command: []string{agentPath}},
+			{Key: "foo:bar", Label: "Foo Colon", Command: []string{agentPath}},
+		},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	var launched []generated.SessionInfo
+	for _, targetKey := range []string{"foo/bar", "foo:bar"} {
+		resp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+			ctx, ws.Id,
+			generated.LaunchWorkspaceRuntimeSessionInputBody{
+				TargetKey: targetKey,
+			},
+		)
+		require.NoError(err)
+		require.Equal(http.StatusOK, resp.StatusCode())
+		require.NotNil(resp.JSON200)
+		launched = append(launched, *resp.JSON200)
+	}
+
+	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 2)
+	sessionsByTarget := map[string]string{}
+	for _, session := range stored {
+		sessionsByTarget[session.TargetKey] = session.SessionName
+	}
+	slashSession := runtimeTmuxSessionNameForTest(ws.Id, "foo/bar")
+	colonSession := runtimeTmuxSessionNameForTest(ws.Id, "foo:bar")
+	assert.Equal(slashSession, sessionsByTarget["foo/bar"])
+	assert.Equal(colonSession, sessionsByTarget["foo:bar"])
+	assert.NotEqual(slashSession, colonSession)
+	for _, sessionName := range []string{slashSession, colonSession} {
+		assert.NotContains(sessionName, "foo")
+		assert.NotContains(sessionName, "/")
+		assert.NotContains(sessionName, ":")
+	}
+
+	for _, session := range launched {
+		stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+			ctx, ws.Id, session.Key,
+		)
+		require.NoError(err)
+		require.Equal(http.StatusNoContent, stopResp.StatusCode())
+	}
+	stored, err = database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	assert.Empty(stored)
+	assert.Contains(readTmuxRecord(t, record), []string{
+		"kill-session", "-t", slashSession,
+	})
+	assert.Contains(readTmuxRecord(t, record), []string{
+		"kill-session", "-t", colonSession,
+	})
+}
+
 func TestWorkspaceRuntimeStopClearsStoredShellKeyTmuxSessionAfterRuntimeForgetE2E(
 	t *testing.T,
 ) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7858,6 +7858,93 @@ exit 0
 	})
 }
 
+func TestWorkspaceResponseProbesStoredRuntimeTmuxSessionWithoutBaseE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+target=""
+mode=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$a"; fi
+  if [ "$a" = "display-message" ]; then mode="display-message"; fi
+  if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
+  prev="$a"
+done
+case "$1" in
+  list-sessions)
+    exit 0
+    ;;
+esac
+if [ "$mode" = "display-message" ]; then
+  case "$target" in
+    *-helper) printf '⠴ t3code-b5014b03\n' ;;
+    *) printf 'idle\n' ;;
+  esac
+  exit 0
+fi
+if [ "$mode" = "capture-pane" ]; then
+  printf 'stable\n'
+  exit 0
+fi
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+	seedPR(t, database, "acme", "widget", 1)
+
+	worktreeDir := filepath.Join(dir, "worktrees")
+	ws := &workspace.Workspace{
+		ID:              "0000000000000001",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      1,
+		GitHeadRef:      "feature",
+		WorkspaceBranch: "feature",
+		WorktreePath:    filepath.Join(worktreeDir, "acme-widget-1"),
+		Status:          "ready",
+	}
+	require.NoError(database.InsertWorkspace(t.Context(), ws))
+	require.NoError(database.UpsertWorkspaceTmuxSession(
+		t.Context(),
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: ws.ID,
+			SessionName: "middleman-0000000000000001-helper",
+			TargetKey:   "helper",
+		},
+	))
+
+	cfg := &config.Config{Tmux: config.Tmux{Command: []string{tmuxPath}}}
+	srv := New(database, nil, nil, "/", cfg, ServerOptions{
+		WorktreeDir: worktreeDir,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+	resp, err := client.HTTP.GetWorkspacesByIdWithResponse(t.Context(), ws.ID)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	assert.True(resp.JSON200.TmuxWorking)
+	assert.Equal(tmuxActivitySourceTitle, resp.JSON200.TmuxActivitySource)
+	require.NotNil(resp.JSON200.TmuxPaneTitle)
+	assert.Equal("⠴ t3code-b5014b03", *resp.JSON200.TmuxPaneTitle)
+	assert.Contains(readTmuxRecord(t, record), []string{
+		"display-message", "-p", "-t",
+		"middleman-0000000000000001-helper", "#{pane_title}",
+	})
+}
+
 func TestWorkspaceRuntimeLaunchTmuxOwnerMarkerFailureCleansSessionE2E(
 	t *testing.T,
 ) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7705,6 +7705,9 @@ if [ "$mode" = "capture-pane" ]; then
   printf 'stable\n'
   exit 0
 fi
+if [ "$1" = "has-session" ]; then
+  exit 1
+fi
 exit 0
 `), 0o755))
 	t.Setenv("TMUX_RECORD", record)
@@ -7716,7 +7719,7 @@ exit 0
 		}},
 		Tmux: config.Tmux{Command: []string{tmuxPath}},
 	}
-	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	client, database, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 
@@ -7746,10 +7749,12 @@ exit 0
 	session, ok := argAfter(newSession, "-s")
 	require.True(ok, "new-session should name a tmux session")
 	assert.Equal("middleman-"+ws.Id+"-helper", session)
-	assert.Contains(newSession, "-A")
+	assert.Contains(newSession, "-d")
 	assert.Contains(newSession, "-c")
 	assert.Contains(strings.Join(newSession, "\n"), agentPath)
 	assert.Contains(strings.Join(newSession, "\n"), "--flag")
+	assert.Contains(newSession, "@middleman_owner")
+	assert.Contains(newSession, srv.workspaces.TmuxOwnerMarker())
 
 	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
 	require.NoError(err)
@@ -7777,6 +7782,79 @@ exit 0
 	require.Len(stored, 1)
 	assert.Equal(session, stored[0].SessionName)
 	assert.Equal("helper", stored[0].TargetKey)
+}
+
+func TestServerStartupReapsUnrecordedRuntimeTmuxSessionE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+target=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$a"; fi
+  prev="$a"
+done
+case "$1" in
+  list-sessions)
+    printf 'middleman-0000000000000001\nmiddleman-0000000000000001-helper\n'
+    exit 0
+    ;;
+  show-options)
+    printf '%s\n' "$MIDDLEMAN_TMUX_OWNER"
+    exit 0
+    ;;
+  kill-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+	seedPR(t, database, "acme", "widget", 1)
+
+	worktreeDir := filepath.Join(dir, "worktrees")
+	ownerMarker := workspace.NewManager(database, worktreeDir).TmuxOwnerMarker()
+	t.Setenv("MIDDLEMAN_TMUX_OWNER", ownerMarker)
+	ws := &workspace.Workspace{
+		ID:              "0000000000000001",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      1,
+		GitHeadRef:      "feature",
+		WorkspaceBranch: "feature",
+		WorktreePath:    filepath.Join(worktreeDir, "acme-widget-1"),
+		TmuxSession:     "middleman-0000000000000001",
+		Status:          "ready",
+	}
+	require.NoError(database.InsertWorkspace(t.Context(), ws))
+
+	cfg := &config.Config{Tmux: config.Tmux{Command: []string{tmuxPath}}}
+	srv := New(database, nil, nil, "/", cfg, ServerOptions{
+		WorktreeDir: worktreeDir,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+	resp, err := client.HTTP.GetWorkspacesByIdWithResponse(t.Context(), ws.ID)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+
+	argvs := readTmuxRecord(t, record)
+	assert.Contains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001-helper",
+	})
+	assert.NotContains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001",
+	})
 }
 
 func TestWorkspaceRuntimeStopTmuxCleanupFailureKeepsSessionE2E(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7619,11 +7619,12 @@ func TestWorkspaceRuntimeLaunchSingletonAndStopE2E(t *testing.T) {
 
 	require := require.New(t)
 	assert := Assert.New(t)
+	disableTmuxAgentSessions := false
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "helper",
 		Label:   "Helper",
 		Command: serverRuntimeHelperCommand("sleep"),
-	}}}
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
 	client, _, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
@@ -8381,11 +8382,12 @@ func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 
 	require := require.New(t)
 	assert := Assert.New(t)
+	disableTmuxAgentSessions := false
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "helper",
 		Label:   "Helper",
 		Command: serverRuntimeHelperCommand("sleep"),
-	}}}
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
@@ -8430,11 +8432,12 @@ func TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E(t *testing.T) {
 
 	require := require.New(t)
 	assert := Assert.New(t)
+	disableTmuxAgentSessions := false
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "helper",
 		Label:   "Helper",
 		Command: serverRuntimeHelperCommand("sleep"),
-	}}}
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8298,7 +8298,10 @@ exit 0
 	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
 	require.NoError(err)
 	require.Len(stored, 1)
-	assert.Equal(runtimeTmuxSessionNameForTest(ws.Id, "helper"), stored[0].SessionName)
+	assert.Equal(
+		runtimeTmuxSessionNameForTest(ws.Id, "helper"),
+		stored[0].SessionName,
+	)
 }
 
 func TestWorkspaceResponseUsesStoredRuntimeTmuxSessionsAfterRestartE2E(
@@ -8671,6 +8674,88 @@ func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
 		}
 	}
 	require.Contains(got.String(), "size:41:177")
+}
+
+func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
+	t *testing.T,
+) {
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not available")
+	}
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "size-agent")
+	require.NoError(os.WriteFile(agentPath, []byte(`#!/bin/sh
+IFS= read -r line
+set -- $(stty size 2>/dev/null || printf '0 0')
+printf 'size:%s:%s:%s\n' "$1" "$2" "$line"
+`), 0o755))
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: []string{agentPath},
+		}},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	client, database, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal(
+		runtimeTmuxSessionNameForTest(ws.Id, "helper"),
+		stored[0].SessionName,
+	)
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/api/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key +
+		"/terminal?cols=177&rows=41"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageBinary, []byte("size\n"),
+	))
+	readCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	var got strings.Builder
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+		if typ != websocket.MessageBinary {
+			continue
+		}
+		got.WriteString(string(data))
+		// tmux keeps one row for its status line by default, so the
+		// pane sees one fewer row than the attached terminal while
+		// preserving the requested column count.
+		if strings.Contains(got.String(), "size:40:177:size") {
+			return
+		}
+	}
+	require.Contains(got.String(), "size:40:177:size")
 }
 
 func createReadyWorkspace(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/wesm/middleman/internal/gitenv"
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/stacks"
+	"github.com/wesm/middleman/internal/workspace"
 	"github.com/wesm/middleman/internal/workspace/localruntime"
 )
 
@@ -7284,9 +7285,7 @@ func setupWorkspaceServerFixture(
 		Clones:      clones,
 		WorktreeDir: worktreeDir,
 	})
-	t.Cleanup(func() {
-		cleanupWorkspaceServerFixtureArtifacts(t, srv, database)
-	})
+	t.Cleanup(func() { cleanupWorkspaceServerFixtureArtifacts(t, srv, database) })
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
 	seedPR(t, database, "acme", "widget", 1)
@@ -7307,18 +7306,38 @@ func cleanupWorkspaceServerFixtureArtifacts(
 	database *db.DB,
 ) {
 	t.Helper()
-	if srv.workspaces == nil {
-		return
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	require.NoError(
+		t,
+		cleanupWorkspaceServerFixtureArtifactsWithContext(ctx, srv, database),
+	)
+}
+
+func cleanupWorkspaceServerFixtureArtifactsWithContext(
+	ctx context.Context,
+	srv *Server,
+	database *db.DB,
+) error {
+	if srv.workspaces == nil {
+		return nil
+	}
+
 	workspaces, err := database.ListWorkspaces(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		return fmt.Errorf("list workspaces: %w", err)
+	}
+	var errs []error
 	for _, ws := range workspaces {
 		_, err := srv.workspaces.Delete(ctx, ws.ID, true, nil)
-		require.NoError(t, err)
+		if err != nil {
+			errs = append(
+				errs,
+				fmt.Errorf("delete workspace %s: %w", ws.ID, err),
+			)
+		}
 	}
+	return errors.Join(errs...)
 }
 
 func waitForWorkspaceReady(
@@ -7390,6 +7409,78 @@ func TestWorkspaceServerFixtureCleansUpTmuxSessions(t *testing.T) {
 		}
 	}
 	require.True(killed, "fixture cleanup did not kill workspace tmux session")
+}
+
+func TestCleanupWorkspaceServerFixtureArtifactsKeepsDeletingAfterError(
+	t *testing.T,
+) {
+	require := require.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`if [ "$1" = "kill-session" ] && [ "$3" = "middleman-fails" ]; then` + "\n" +
+		`  echo "permission denied" >&2` + "\n" +
+		`  exit 1` + "\n" +
+		`fi` + "\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	manager := workspace.NewManager(database, filepath.Join(dir, "worktrees"))
+	manager.SetTmuxCommand([]string{script})
+	srv := &Server{workspaces: manager}
+	ctx := context.Background()
+	require.NoError(database.InsertWorkspace(ctx, &workspace.Workspace{
+		ID:              "ws-succeeds",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      1,
+		GitHeadRef:      "feature/succeeds",
+		WorkspaceBranch: "middleman/pr-1",
+		WorktreePath:    filepath.Join(dir, "succeeds"),
+		TmuxSession:     "middleman-succeeds",
+		Status:          "ready",
+	}))
+	time.Sleep(time.Millisecond)
+	require.NoError(database.InsertWorkspace(ctx, &workspace.Workspace{
+		ID:              "ws-fails",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      2,
+		GitHeadRef:      "feature/fails",
+		WorkspaceBranch: "middleman/pr-2",
+		WorktreePath:    filepath.Join(dir, "fails"),
+		TmuxSession:     "middleman-fails",
+		Status:          "ready",
+	}))
+
+	err = cleanupWorkspaceServerFixtureArtifactsWithContext(ctx, srv, database)
+	require.Error(err)
+	require.Contains(err.Error(), "ws-fails")
+	require.Contains(err.Error(), "permission denied")
+
+	killedSessions := map[string]bool{}
+	for _, argv := range readTmuxRecord(t, record) {
+		if len(argv) >= 3 &&
+			argv[0] == "kill-session" {
+			killedSessions[argv[2]] = true
+		}
+	}
+	require.True(
+		killedSessions["middleman-succeeds"],
+		"cleanup stopped before later workspace tmux session",
+	)
 }
 
 func TestWorkspaceRuntimeTargetsE2E(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -7854,6 +7855,114 @@ exit 0
 	})
 	assert.NotContains(argvs, []string{
 		"kill-session", "-t", "middleman-0000000000000001",
+	})
+}
+
+func TestWorkspaceRuntimeLaunchTmuxOwnerMarkerFailureCleansSessionE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	agentPath := filepath.Join(dir, "helper-agent")
+	require.NoError(os.WriteFile(agentPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+target=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$a"; fi
+  prev="$a"
+done
+case "$1" in
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    exit 0
+    ;;
+  set-option)
+    case "$target" in
+      *-helper)
+        echo "owner marker denied" >&2
+        exit 42
+        ;;
+    esac
+    exit 0
+    ;;
+  kill-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: []string{agentPath},
+		}},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	client, database, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	sessionName := "middleman-" + ws.Id + "-helper"
+
+	require.Eventually(func() bool {
+		return tmuxRecordContains(readTmuxRecord(t, record), []string{
+			"kill-session", "-t", sessionName,
+		})
+	}, 2*time.Second, 20*time.Millisecond)
+	assert.Contains(readTmuxRecord(t, record), []string{
+		"set-option", "-q", "-t", sessionName,
+		"@middleman_owner", srv.workspaces.TmuxOwnerMarker(),
+	})
+
+	var runtimeResp *generated.GetWorkspaceRuntimeResponse
+	require.Eventually(func() bool {
+		runtimeResp, err = client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.Id)
+		if err != nil ||
+			runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil ||
+			runtimeResp.JSON200.Sessions == nil ||
+			len(*runtimeResp.JSON200.Sessions) != 1 {
+			return false
+		}
+		return (*runtimeResp.JSON200.Sessions)[0].Status == "exited"
+	}, 2*time.Second, 20*time.Millisecond)
+
+	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal(sessionName, stored[0].SessionName)
+
+	stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, launchResp.JSON200.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, stopResp.StatusCode())
+	stored, err = database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	assert.Empty(stored)
+}
+
+func tmuxRecordContains(argvs [][]string, want []string) bool {
+	return slices.ContainsFunc(argvs, func(argv []string) bool {
+		return slices.Equal(argv, want)
 	})
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7881,6 +7881,12 @@ case "$1" in
     exit 1
     ;;
   new-session)
+    for a in "$@"; do
+      if [ "$a" = "@middleman_owner" ]; then
+        echo "owner marker denied" >&2
+        exit 42
+      fi
+    done
     exit 0
     ;;
   set-option)
@@ -7927,10 +7933,18 @@ exit 0
 			"kill-session", "-t", sessionName,
 		})
 	}, 2*time.Second, 20*time.Millisecond)
-	assert.Contains(readTmuxRecord(t, record), []string{
-		"set-option", "-q", "-t", sessionName,
-		"@middleman_owner", srv.workspaces.TmuxOwnerMarker(),
-	})
+	var runtimeNewSession []string
+	for _, argv := range readTmuxRecord(t, record) {
+		if len(argv) > 0 &&
+			argv[0] == "new-session" &&
+			slices.Contains(argv, sessionName) {
+			runtimeNewSession = argv
+			break
+		}
+	}
+	require.NotNil(runtimeNewSession)
+	assert.Contains(runtimeNewSession, "@middleman_owner")
+	assert.Contains(runtimeNewSession, srv.workspaces.TmuxOwnerMarker())
 
 	var runtimeResp *generated.GetWorkspaceRuntimeResponse
 	require.Eventually(func() bool {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7779,6 +7779,77 @@ exit 0
 	assert.Equal("helper", stored[0].TargetKey)
 }
 
+func TestWorkspaceRuntimeStopTmuxCleanupFailureKeepsSessionE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	agentPath := filepath.Join(dir, "helper-agent")
+	require.NoError(os.WriteFile(agentPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+target=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$a"; fi
+  prev="$a"
+done
+if [ "$1" = "kill-session" ]; then
+  case "$target" in
+    *-helper)
+      echo "permission denied" >&2
+      exit 42
+      ;;
+  esac
+fi
+exit 0
+`), 0o755))
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: []string{agentPath},
+		}},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	t.Cleanup(func() {
+		_ = database.DeleteWorkspaceTmuxSessions(context.Background(), ws.Id)
+	})
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+
+	stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, launchResp.JSON200.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusInternalServerError, stopResp.StatusCode())
+
+	getResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, getResp.StatusCode())
+	require.NotNil(getResp.JSON200)
+	require.NotNil(getResp.JSON200.Sessions)
+	require.Len(*getResp.JSON200.Sessions, 1)
+	assert.Equal(launchResp.JSON200.Key, (*getResp.JSON200.Sessions)[0].Key)
+
+	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal("middleman-"+ws.Id+"-helper", stored[0].SessionName)
+}
+
 func TestWorkspaceResponseUsesStoredRuntimeTmuxSessionsAfterRestartE2E(
 	t *testing.T,
 ) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -7697,7 +7699,7 @@ for a in "$@"; do
 done
 if [ "$mode" = "display-message" ]; then
   case "$target" in
-    *-helper) printf '⠴ t3code-b5014b03\n' ;;
+    middleman-????????????????-*) printf '⠴ t3code-b5014b03\n' ;;
     *) printf 'idle\n' ;;
   esac
   exit 0
@@ -7749,7 +7751,7 @@ exit 0
 
 	session, ok := argAfter(newSession, "-s")
 	require.True(ok, "new-session should name a tmux session")
-	assert.Equal("middleman-"+ws.Id+"-helper", session)
+	assert.Equal(runtimeTmuxSessionNameForTest(ws.Id, "helper"), session)
 	assert.Contains(newSession, "-d")
 	assert.Contains(newSession, "-c")
 	assert.Contains(strings.Join(newSession, "\n"), agentPath)
@@ -7801,7 +7803,7 @@ for a in "$@"; do
 done
 case "$1" in
   list-sessions)
-    printf 'middleman-0000000000000001\nmiddleman-0000000000000001-helper\n'
+    printf 'middleman-0000000000000001\nmiddleman-0000000000000001-0123456789abcdef\n'
     exit 0
     ;;
   show-options)
@@ -7851,7 +7853,7 @@ exit 0
 
 	argvs := readTmuxRecord(t, record)
 	assert.Contains(argvs, []string{
-		"kill-session", "-t", "middleman-0000000000000001-helper",
+		"kill-session", "-t", "middleman-0000000000000001-0123456789abcdef",
 	})
 	assert.NotContains(argvs, []string{
 		"kill-session", "-t", "middleman-0000000000000001",
@@ -7884,7 +7886,7 @@ case "$1" in
 esac
 if [ "$mode" = "display-message" ]; then
   case "$target" in
-    *-helper) printf '⠴ t3code-b5014b03\n' ;;
+    middleman-????????????????-*) printf '⠴ t3code-b5014b03\n' ;;
     *) printf 'idle\n' ;;
   esac
   exit 0
@@ -7920,10 +7922,13 @@ exit 0
 		t.Context(),
 		&db.WorkspaceTmuxSession{
 			WorkspaceID: ws.ID,
-			SessionName: "middleman-0000000000000001-helper",
-			TargetKey:   "helper",
+			SessionName: runtimeTmuxSessionNameForTest(
+				"0000000000000001", "helper",
+			),
+			TargetKey: "helper",
 		},
 	))
+	sessionName := runtimeTmuxSessionNameForTest("0000000000000001", "helper")
 
 	cfg := &config.Config{Tmux: config.Tmux{Command: []string{tmuxPath}}}
 	srv := New(database, nil, nil, "/", cfg, ServerOptions{
@@ -7941,7 +7946,7 @@ exit 0
 	assert.Equal("⠴ t3code-b5014b03", *resp.JSON200.TmuxPaneTitle)
 	assert.Contains(readTmuxRecord(t, record), []string{
 		"display-message", "-p", "-t",
-		"middleman-0000000000000001-helper", "#{pane_title}",
+		sessionName, "#{pane_title}",
 	})
 }
 
@@ -7978,7 +7983,7 @@ case "$1" in
     ;;
   set-option)
     case "$target" in
-      *-helper)
+      middleman-????????????????-*)
         echo "owner marker denied" >&2
         exit 42
         ;;
@@ -8013,7 +8018,7 @@ exit 0
 	require.NoError(err)
 	require.Equal(http.StatusOK, launchResp.StatusCode())
 	require.NotNil(launchResp.JSON200)
-	sessionName := "middleman-" + ws.Id + "-helper"
+	sessionName := runtimeTmuxSessionNameForTest(ws.Id, "helper")
 
 	require.Eventually(func() bool {
 		return tmuxRecordContains(readTmuxRecord(t, record), []string{
@@ -8067,6 +8072,11 @@ func tmuxRecordContains(argvs [][]string, want []string) bool {
 	})
 }
 
+func runtimeTmuxSessionNameForTest(workspaceID string, targetKey string) string {
+	sum := sha256.Sum256([]byte(targetKey))
+	return "middleman-" + workspaceID + "-" + hex.EncodeToString(sum[:8])
+}
+
 func TestWorkspaceRuntimeStopClearsStoredShellKeyTmuxSessionAfterRuntimeForgetE2E(
 	t *testing.T,
 ) {
@@ -8111,7 +8121,7 @@ exit 0
 	require.NoError(err)
 	require.Equal(http.StatusOK, launchResp.StatusCode())
 	require.NotNil(launchResp.JSON200)
-	sessionName := "middleman-" + ws.Id + "-shell"
+	sessionName := runtimeTmuxSessionNameForTest(ws.Id, "shell")
 
 	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
 	require.NoError(err)
@@ -8154,7 +8164,7 @@ for a in "$@"; do
 done
 if [ "$1" = "kill-session" ]; then
   case "$target" in
-    *-helper)
+    middleman-????????????????-*)
       echo "permission denied" >&2
       exit 42
       ;;
@@ -8204,7 +8214,7 @@ exit 0
 	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
 	require.NoError(err)
 	require.Len(stored, 1)
-	assert.Equal("middleman-"+ws.Id+"-helper", stored[0].SessionName)
+	assert.Equal(runtimeTmuxSessionNameForTest(ws.Id, "helper"), stored[0].SessionName)
 }
 
 func TestWorkspaceResponseUsesStoredRuntimeTmuxSessionsAfterRestartE2E(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8067,7 +8067,7 @@ func tmuxRecordContains(argvs [][]string, want []string) bool {
 	})
 }
 
-func TestWorkspaceRuntimeStopClearsStoredTmuxSessionAfterRuntimeForgetE2E(
+func TestWorkspaceRuntimeStopClearsStoredShellKeyTmuxSessionAfterRuntimeForgetE2E(
 	t *testing.T,
 ) {
 	require := require.New(t)
@@ -8092,8 +8092,8 @@ exit 0
 	t.Setenv("TMUX_RECORD", record)
 	cfg := &config.Config{
 		Agents: []config.Agent{{
-			Key:     "helper",
-			Label:   "Helper",
+			Key:     "shell",
+			Label:   "Shell Agent",
 			Command: []string{agentPath},
 		}},
 		Tmux: config.Tmux{Command: []string{tmuxPath}},
@@ -8105,13 +8105,13 @@ exit 0
 	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
 		ctx, ws.Id,
 		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
+			TargetKey: "shell",
 		},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, launchResp.StatusCode())
 	require.NotNil(launchResp.JSON200)
-	sessionName := "middleman-" + ws.Id + "-helper"
+	sessionName := "middleman-" + ws.Id + "-shell"
 
 	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
 	require.NoError(err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7285,6 +7285,10 @@ func setupWorkspaceServerFixture(
 		Clones:      clones,
 		WorktreeDir: worktreeDir,
 	})
+	// Cleanup callbacks run LIFO. Drain the server first so async
+	// workspace setup cannot create a tmux session after fixture
+	// artifact cleanup has listed workspaces. The DB cleanup was
+	// registered earlier, so it remains open for artifact cleanup.
 	t.Cleanup(func() { cleanupWorkspaceServerFixtureArtifacts(t, srv, database) })
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
@@ -7329,7 +7333,18 @@ func cleanupWorkspaceServerFixtureArtifactsWithContext(
 	}
 	var errs []error
 	for _, ws := range workspaces {
-		_, err := srv.workspaces.Delete(ctx, ws.ID, true, nil)
+		_, err := func() ([]string, error) {
+			beforeDestructive := func(stopCtx context.Context) {
+				if srv.runtime != nil {
+					srv.runtime.StopWorkspace(stopCtx, ws.ID)
+				}
+			}
+			if srv.runtime != nil {
+				srv.runtime.BeginStopping(ws.ID)
+				defer srv.runtime.EndStopping(ws.ID)
+			}
+			return srv.workspaces.Delete(ctx, ws.ID, true, beforeDestructive)
+		}()
 		if err != nil {
 			errs = append(
 				errs,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7980,6 +7980,75 @@ func tmuxRecordContains(argvs [][]string, want []string) bool {
 	})
 }
 
+func TestWorkspaceRuntimeStopClearsStoredTmuxSessionAfterRuntimeForgetE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	agentPath := filepath.Join(dir, "helper-agent")
+	require.NoError(os.WriteFile(agentPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+case "$1" in
+  has-session)
+    exit 1
+    ;;
+  new-session|set-option|attach-session|kill-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: []string{agentPath},
+		}},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	client, database, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	sessionName := "middleman-" + ws.Id + "-helper"
+
+	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal(sessionName, stored[0].SessionName)
+
+	require.NoError(srv.runtime.Stop(ctx, ws.Id, launchResp.JSON200.Key))
+	stored, err = database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+
+	stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, launchResp.JSON200.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, stopResp.StatusCode())
+	stored, err = database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	assert.Empty(stored)
+	assert.Contains(readTmuxRecord(t, record), []string{
+		"kill-session", "-t", sessionName,
+	})
+}
+
 func TestWorkspaceRuntimeStopTmuxCleanupFailureKeepsSessionE2E(
 	t *testing.T,
 ) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7284,6 +7284,9 @@ func setupWorkspaceServerFixture(
 		Clones:      clones,
 		WorktreeDir: worktreeDir,
 	})
+	t.Cleanup(func() {
+		cleanupWorkspaceServerFixtureArtifacts(t, srv, database)
+	})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
 	seedPR(t, database, "acme", "widget", 1)
@@ -7295,6 +7298,26 @@ func setupWorkspaceServerFixture(
 		database: database,
 		bare:     bare,
 		remote:   remote,
+	}
+}
+
+func cleanupWorkspaceServerFixtureArtifacts(
+	t *testing.T,
+	srv *Server,
+	database *db.DB,
+) {
+	t.Helper()
+	if srv.workspaces == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	workspaces, err := database.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	for _, ws := range workspaces {
+		_, err := srv.workspaces.Delete(ctx, ws.ID, true, nil)
+		require.NoError(t, err)
 	}
 }
 
@@ -7324,6 +7347,49 @@ func waitForWorkspaceReady(
 
 	require.NotNil(t, ready, "workspace never became ready: %s", wsID)
 	return ready
+}
+
+func TestWorkspaceServerFixtureCleansUpTmuxSessions(t *testing.T) {
+	require := require.New(t)
+	if testing.Short() {
+		t.Skip("workspace e2e tests skipped in short mode")
+	}
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then` + "\n" +
+		`    echo "can't find session: sim" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+
+	t.Run("fixture", func(t *testing.T) {
+		t.Setenv("TMUX_RECORD", record)
+		cfg := &config.Config{
+			Tmux: config.Tmux{Command: []string{script}},
+		}
+		client, _, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+
+		createReadyWorkspace(t, context.Background(), client)
+	})
+
+	var killed bool
+	for _, argv := range readTmuxRecord(t, record) {
+		if len(argv) >= 3 &&
+			argv[0] == "kill-session" &&
+			argv[1] == "-t" &&
+			strings.HasPrefix(argv[2], "middleman-") {
+			killed = true
+			break
+		}
+	}
+	require.True(killed, "fixture cleanup did not kill workspace tmux session")
 }
 
 func TestWorkspaceRuntimeTargetsE2E(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2559,60 +2559,110 @@ func (s *Server) toWorkspaceResponse(
 	}
 
 	applyWorktreeDivergence(ctx, &resp, summary.WorktreePath)
-
-	if s.tmuxActivity != nil {
-		if result, ok := s.tmuxActivity.Cached(summary.TmuxSession); ok {
-			applyTmuxActivity(&resp, result)
-			return resp
-		}
+	if activity, ok := s.probeWorkspaceTmuxActivity(
+		ctx, summary.ID, s.workspaceTmuxActivitySessions(summary),
+	); ok {
+		applyTmuxActivity(&resp, activity)
 	}
+	return resp
+}
 
+func (s *Server) workspaceTmuxActivitySessions(
+	summary *db.WorkspaceSummary,
+) []string {
+	sessions := make([]string, 0, 1)
+	seen := map[string]bool{}
+	if summary.TmuxSession != "" {
+		sessions = append(sessions, summary.TmuxSession)
+		seen[summary.TmuxSession] = true
+	}
+	if s.runtime == nil {
+		return sessions
+	}
+	for _, session := range s.runtime.TmuxSessions(summary.ID) {
+		if session == "" || seen[session] {
+			continue
+		}
+		sessions = append(sessions, session)
+		seen[session] = true
+	}
+	return sessions
+}
+
+func (s *Server) probeWorkspaceTmuxActivity(
+	ctx context.Context,
+	workspaceID string,
+	sessions []string,
+) (tmuxActivityResult, bool) {
+	if len(sessions) == 0 {
+		return tmuxActivityResult{}, false
+	}
 	tracker := s.tmuxActivity
 	if tracker == nil {
 		tracker = newTmuxActivityTracker(nil)
 	}
 	probeCtx, cancelProbe := context.WithTimeout(ctx, tmuxActivityProbeTimeout)
 	defer cancelProbe()
-	probe := tracker.StartProbe(probeCtx, summary.TmuxSession)
+
+	results := make([]tmuxActivityResult, 0, len(sessions))
+	for _, session := range sessions {
+		if s.tmuxActivity != nil {
+			if result, ok := tracker.Cached(session); ok {
+				results = append(results, result)
+				continue
+			}
+		}
+		result, ok := s.probeOneTmuxSession(
+			probeCtx, tracker, workspaceID, session,
+		)
+		if ok {
+			results = append(results, result)
+		}
+	}
+	return mergeTmuxActivityResults(results)
+}
+
+func (s *Server) probeOneTmuxSession(
+	ctx context.Context,
+	tracker *tmuxActivityTracker,
+	workspaceID string,
+	session string,
+) (tmuxActivityResult, bool) {
+	probe := tracker.StartProbe(ctx, session)
 	if !probe.Started {
 		if probe.HasFallback {
-			applyTmuxActivity(&resp, probe.Fallback)
-			return resp
+			return probe.Fallback, true
 		}
 		if probe.Wait != nil {
 			select {
 			case <-probe.Wait:
-				if result, ok := tracker.Cached(summary.TmuxSession); ok {
-					applyTmuxActivity(&resp, result)
-				}
-			case <-probeCtx.Done():
+				return tracker.Cached(session)
+			case <-ctx.Done():
 			}
 		}
-		return resp
+		return tmuxActivityResult{}, false
 	}
 
-	snapshot, err := s.workspaces.TmuxPaneSnapshot(probeCtx, summary.TmuxSession)
+	snapshot, err := s.workspaces.TmuxPaneSnapshot(ctx, session)
 	if err != nil {
 		probe.Probe.Cancel()
 		slog.Debug(
 			"read tmux pane snapshot",
-			"workspace_id", summary.ID,
-			"tmux_session", summary.TmuxSession,
+			"workspace_id", workspaceID,
+			"tmux_session", session,
 			"err", err,
 		)
 		if probe.HasFallback {
-			applyTmuxActivity(&resp, probe.Fallback)
+			return probe.Fallback, true
 		}
-		return resp
+		return tmuxActivityResult{}, false
 	}
 
-	activity := probe.Probe.Finish(tmuxActivityObservation{
+	return probe.Probe.Finish(tmuxActivityObservation{
 		PaneTitle: snapshot.Title,
 		Output:    snapshot.Output,
 		HasOutput: true,
-	})
-	applyTmuxActivity(&resp, activity)
-	return resp
+	}), true
 }
 
 func applyTmuxActivity(resp *workspaceResponse, activity tmuxActivityResult) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2553,8 +2553,7 @@ func (s *Server) toWorkspaceResponse(
 ) workspaceResponse {
 	resp := toWorkspaceResponse(summary)
 	if s.workspaces == nil ||
-		summary.Status != "ready" ||
-		summary.TmuxSession == "" {
+		summary.Status != "ready" {
 		return resp
 	}
 
@@ -2573,7 +2572,7 @@ func (s *Server) workspaceTmuxActivitySessions(
 ) []string {
 	sessions := make([]string, 0, 1)
 	seen := map[string]bool{}
-	if s.workspaces != nil && summary.TmuxSession != "" {
+	if s.workspaces != nil {
 		stored, err := s.workspaces.TmuxSessionsForWorkspace(
 			ctx, summary.ID, summary.TmuxSession,
 		)
@@ -2878,7 +2877,7 @@ func runtimeTargetKeyFromSessionKey(
 	key string,
 ) (string, bool) {
 	targetKey, ok := strings.CutPrefix(key, workspaceID+":")
-	return targetKey, ok && targetKey != "" && targetKey != "shell"
+	return targetKey, ok && targetKey != ""
 }
 
 func (s *Server) ensureWorkspaceRuntimeShell(

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2826,7 +2826,12 @@ func (s *Server) stopWorkspaceRuntimeSession(
 	if err := s.runtime.Stop(
 		ctx, summary.ID, input.SessionKey,
 	); err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		if errors.Is(err, localruntime.ErrSessionNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError(
+			"stop runtime session: " + err.Error(),
+		)
 	}
 	if tmuxSession != "" {
 		if err := s.workspaces.ForgetRuntimeTmuxSession(

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2827,6 +2827,22 @@ func (s *Server) stopWorkspaceRuntimeSession(
 		ctx, summary.ID, input.SessionKey,
 	); err != nil {
 		if errors.Is(err, localruntime.ErrSessionNotFound) {
+			if targetKey, ok := runtimeTargetKeyFromSessionKey(
+				summary.ID, input.SessionKey,
+			); ok {
+				stopped, stopErr := s.workspaces.StopStoredRuntimeTmuxSession(
+					ctx, summary.ID, targetKey,
+				)
+				if stopErr != nil {
+					return nil, huma.Error500InternalServerError(
+						"stop stored runtime tmux session: " +
+							stopErr.Error(),
+					)
+				}
+				if stopped {
+					return nil, nil
+				}
+			}
 			return nil, huma.Error404NotFound(err.Error())
 		}
 		return nil, huma.Error500InternalServerError(
@@ -2855,6 +2871,14 @@ func runtimeSessionTmuxSession(
 		}
 	}
 	return ""
+}
+
+func runtimeTargetKeyFromSessionKey(
+	workspaceID string,
+	key string,
+) (string, bool) {
+	targetKey, ok := strings.CutPrefix(key, workspaceID+":")
+	return targetKey, ok && targetKey != "" && targetKey != "shell"
 }
 
 func (s *Server) ensureWorkspaceRuntimeShell(

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2560,7 +2560,7 @@ func (s *Server) toWorkspaceResponse(
 
 	applyWorktreeDivergence(ctx, &resp, summary.WorktreePath)
 	if activity, ok := s.probeWorkspaceTmuxActivity(
-		ctx, summary.ID, s.workspaceTmuxActivitySessions(summary),
+		ctx, summary.ID, s.workspaceTmuxActivitySessions(ctx, summary),
 	); ok {
 		applyTmuxActivity(&resp, activity)
 	}
@@ -2568,11 +2568,32 @@ func (s *Server) toWorkspaceResponse(
 }
 
 func (s *Server) workspaceTmuxActivitySessions(
+	ctx context.Context,
 	summary *db.WorkspaceSummary,
 ) []string {
 	sessions := make([]string, 0, 1)
 	seen := map[string]bool{}
-	if summary.TmuxSession != "" {
+	if s.workspaces != nil && summary.TmuxSession != "" {
+		stored, err := s.workspaces.TmuxSessionsForWorkspace(
+			ctx, summary.ID, summary.TmuxSession,
+		)
+		if err != nil {
+			slog.Debug(
+				"list workspace tmux sessions",
+				"workspace_id", summary.ID,
+				"tmux_session", summary.TmuxSession,
+				"err", err,
+			)
+		}
+		for _, session := range stored {
+			if session == "" || seen[session] {
+				continue
+			}
+			sessions = append(sessions, session)
+			seen[session] = true
+		}
+	}
+	if summary.TmuxSession != "" && !seen[summary.TmuxSession] {
 		sessions = append(sessions, summary.TmuxSession)
 		seen[summary.TmuxSession] = true
 	}
@@ -2778,6 +2799,16 @@ func (s *Server) launchWorkspaceRuntimeSession(
 	if err != nil {
 		return nil, workspaceRuntimeLaunchError(err)
 	}
+	if session.TmuxSession != "" {
+		if err := s.workspaces.RecordRuntimeTmuxSession(
+			ctx, summary.ID, session.TmuxSession, session.TargetKey,
+		); err != nil {
+			_ = s.runtime.Stop(ctx, summary.ID, session.Key)
+			return nil, huma.Error500InternalServerError(
+				"record runtime tmux session: " + err.Error(),
+			)
+		}
+	}
 	return &workspaceRuntimeSessionOutput{Body: session}, nil
 }
 
@@ -2789,12 +2820,36 @@ func (s *Server) stopWorkspaceRuntimeSession(
 	if err != nil {
 		return nil, err
 	}
+	tmuxSession := runtimeSessionTmuxSession(
+		s.runtime.ListSessions(summary.ID), input.SessionKey,
+	)
 	if err := s.runtime.Stop(
 		ctx, summary.ID, input.SessionKey,
 	); err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
+	if tmuxSession != "" {
+		if err := s.workspaces.ForgetRuntimeTmuxSession(
+			ctx, summary.ID, tmuxSession,
+		); err != nil {
+			return nil, huma.Error500InternalServerError(
+				"forget runtime tmux session: " + err.Error(),
+			)
+		}
+	}
 	return nil, nil
+}
+
+func runtimeSessionTmuxSession(
+	sessions []localruntime.SessionInfo,
+	key string,
+) string {
+	for _, session := range sessions {
+		if session.Key == key {
+			return session.TmuxSession
+		}
+	}
+	return ""
 }
 
 func (s *Server) ensureWorkspaceRuntimeShell(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -380,7 +380,9 @@ func newServer(
 			Targets: localruntime.ResolveLaunchTargets(
 				agents, tmuxCmd, nil,
 			),
-			StripEnvVars: cfg.TokenEnvNames(),
+			TmuxCommand:             tmuxCmd,
+			WrapAgentSessionsInTmux: cfg.TmuxAgentSessionsEnabled(),
+			StripEnvVars:            cfg.TokenEnvNames(),
 		})
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -381,6 +381,7 @@ func newServer(
 				agents, tmuxCmd, nil,
 			),
 			TmuxCommand:             tmuxCmd,
+			TmuxOwnerMarker:         s.workspaces.TmuxOwnerMarker(),
 			WrapAgentSessionsInTmux: cfg.TmuxAgentSessionsEnabled(),
 			StripEnvVars:            cfg.TokenEnvNames(),
 		})

--- a/internal/server/tmux_activity.go
+++ b/internal/server/tmux_activity.go
@@ -280,6 +280,73 @@ func tmuxActivityResultFromSample(
 	return result
 }
 
+func mergeTmuxActivityResults(
+	results []tmuxActivityResult,
+) (tmuxActivityResult, bool) {
+	var merged tmuxActivityResult
+	for _, result := range results {
+		merged = mergeTmuxActivityResult(merged, result)
+	}
+	if merged.PaneTitle == "" &&
+		merged.Source == "" &&
+		merged.LastOutputAt == nil &&
+		!merged.Working {
+		return tmuxActivityResult{}, false
+	}
+	if merged.Source == "" {
+		merged.Source = tmuxActivitySourceNone
+	}
+	return merged, true
+}
+
+func mergeTmuxActivityResult(
+	current tmuxActivityResult,
+	next tmuxActivityResult,
+) tmuxActivityResult {
+	if current.Source == "" {
+		return next
+	}
+	if next.Source == "" {
+		return current
+	}
+	lastOutputAt := current.LastOutputAt
+	if lastOutputAt == nil ||
+		(next.LastOutputAt != nil && next.LastOutputAt.After(*lastOutputAt)) {
+		lastOutputAt = next.LastOutputAt
+	}
+
+	switch {
+	case !current.Working && next.Working:
+		next.LastOutputAt = lastOutputAt
+		return next
+	case current.Working && !next.Working:
+		current.LastOutputAt = lastOutputAt
+		return current
+	case activitySourceRank(next.Source) > activitySourceRank(current.Source):
+		next.LastOutputAt = lastOutputAt
+		return next
+	case activitySourceRank(next.Source) == activitySourceRank(current.Source) &&
+		next.PaneTitle != "" &&
+		current.PaneTitle == "":
+		current.PaneTitle = next.PaneTitle
+	}
+	current.LastOutputAt = lastOutputAt
+	return current
+}
+
+func activitySourceRank(source string) int {
+	switch source {
+	case tmuxActivitySourceTitle:
+		return 3
+	case tmuxActivitySourceOutput:
+		return 2
+	case tmuxActivitySourceNone:
+		return 1
+	default:
+		return 0
+	}
+}
+
 func normalizeTmuxOutput(output string) string {
 	output = strings.ReplaceAll(output, "\r\n", "\n")
 	output = strings.ReplaceAll(output, "\r", "\n")

--- a/internal/server/tmux_activity_test.go
+++ b/internal/server/tmux_activity_test.go
@@ -157,3 +157,47 @@ func TestNormalizeTmuxOutputForFingerprinting(t *testing.T) {
 		tmuxOutputFingerprint("one  \r\ntwo  \n"),
 	)
 }
+
+func TestMergeTmuxActivityPrefersWorkingSession(t *testing.T) {
+	assert := Assert.New(t)
+	lastOutput := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	merged, ok := mergeTmuxActivityResults([]tmuxActivityResult{
+		{
+			PaneTitle: "idle",
+			Source:    tmuxActivitySourceNone,
+		},
+		{
+			PaneTitle:    "codex",
+			Working:      true,
+			Source:       tmuxActivitySourceOutput,
+			LastOutputAt: &lastOutput,
+		},
+	})
+
+	assert.True(ok)
+	assert.True(merged.Working)
+	assert.Equal(tmuxActivitySourceOutput, merged.Source)
+	assert.Equal("codex", merged.PaneTitle)
+	assert.Equal(&lastOutput, merged.LastOutputAt)
+}
+
+func TestMergeTmuxActivityPrefersTitleOverOutput(t *testing.T) {
+	assert := Assert.New(t)
+	merged, ok := mergeTmuxActivityResults([]tmuxActivityResult{
+		{
+			PaneTitle: "agent output",
+			Working:   true,
+			Source:    tmuxActivitySourceOutput,
+		},
+		{
+			PaneTitle: "⠴ t3code-b5014b03",
+			Working:   true,
+			Source:    tmuxActivitySourceTitle,
+		},
+	})
+
+	assert.True(ok)
+	assert.True(merged.Working)
+	assert.Equal(tmuxActivitySourceTitle, merged.Source)
+	assert.Equal("⠴ t3code-b5014b03", merged.PaneTitle)
+}

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -1,9 +1,11 @@
 package localruntime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,6 +45,7 @@ type SessionInfo struct {
 	CreatedAt   time.Time        `json:"created_at"`
 	ExitedAt    *time.Time       `json:"exited_at,omitempty"`
 	ExitCode    *int             `json:"exit_code,omitempty"`
+	TmuxSession string           `json:"-"`
 }
 
 type Options struct {
@@ -223,7 +226,7 @@ func (m *Manager) Launch(
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		m.stopSession(ctx, started)
+		_ = m.stopSession(ctx, started)
 		waitSessionDone(started)
 		return SessionInfo{}, errManagerShutdown
 	}
@@ -290,10 +293,10 @@ func (m *Manager) Stop(
 		return fmt.Errorf("session %q not found", sessionKey)
 	}
 
-	m.stopSession(ctx, s)
+	cleanupErr := m.stopSession(ctx, s)
 	select {
 	case <-s.done:
-		return nil
+		return cleanupErr
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -350,7 +353,14 @@ func (m *Manager) StopWorkspace(
 	m.mu.Unlock()
 
 	for _, s := range stopping {
-		m.stopSession(ctx, s)
+		if err := m.stopSession(ctx, s); err != nil {
+			slog.Warn(
+				"stop workspace runtime session",
+				"workspace_id", workspaceID,
+				"session_key", s.snapshot().Key,
+				"err", err,
+			)
+		}
 	}
 	for _, s := range stopping {
 		select {
@@ -361,14 +371,20 @@ func (m *Manager) StopWorkspace(
 	}
 }
 
-func (m *Manager) stopSession(ctx context.Context, s *session) {
+func (m *Manager) stopSession(ctx context.Context, s *session) error {
 	if s == nil {
-		return
+		return nil
 	}
+	var cleanupErr error
 	if s.tmuxSession != "" {
-		_ = m.killTmuxSession(ctx, s.tmuxSession)
+		if err := m.killTmuxSession(ctx, s.tmuxSession); err != nil {
+			cleanupErr = fmt.Errorf(
+				"kill tmux session %q: %w", s.tmuxSession, err,
+			)
+		}
 	}
 	s.stop()
+	return cleanupErr
 }
 
 func (m *Manager) killTmuxSession(
@@ -386,7 +402,30 @@ func (m *Manager) killTmuxSession(
 		return nil
 	}
 	args := append(command[1:], "kill-session", "-t", session)
-	return exec.CommandContext(ctx, command[0], args...).Run()
+	cmd := exec.CommandContext(ctx, command[0], args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil || isTmuxSessionAbsent(stderr.Bytes(), err) {
+		return nil
+	}
+	msg := strings.TrimSpace(stderr.String())
+	if msg == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, msg)
+}
+
+func isTmuxSessionAbsent(stderr []byte, err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		return false
+	}
+	msg := string(stderr)
+	return strings.Contains(msg, "can't find session") ||
+		strings.Contains(msg, "no server running") ||
+		(strings.Contains(msg, "error connecting to") &&
+			strings.Contains(msg, "No such file or directory"))
 }
 
 // BeginStopping holds the stopping marker for workspaceID without
@@ -538,7 +577,7 @@ func (m *Manager) EnsureShell(
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		m.stopSession(ctx, started)
+		_ = m.stopSession(ctx, started)
 		waitSessionDone(started)
 		return SessionInfo{}, errManagerShutdown
 	}
@@ -610,10 +649,16 @@ func (m *Manager) Shutdown() {
 	m.shells = make(map[string]*session)
 	m.mu.Unlock()
 
+	waiting := make([]*session, 0, len(sessions))
 	for _, s := range sessions {
-		m.stopSession(ctx, s)
+		if s.tmuxSession != "" {
+			s.detach()
+			continue
+		}
+		s.stop()
+		waiting = append(waiting, s)
 	}
-	for _, s := range sessions {
+	for _, s := range waiting {
 		select {
 		case <-s.done:
 		case <-ctx.Done():
@@ -694,6 +739,13 @@ func (m *Manager) launchCommand(
 	if len(tmuxCommand) == 0 {
 		tmuxCommand = []string{"tmux"}
 	}
+	resolvedAgentCommand := append([]string(nil), command...)
+	resolvedPath, err := resolveExecutable(resolvedAgentCommand[0])
+	if err != nil {
+		return launchCommand{}, err
+	}
+	resolvedAgentCommand[0] = resolvedPath
+
 	tmuxSession := tmuxSessionName(workspaceID, target.Key)
 
 	wrapped := append(
@@ -706,7 +758,14 @@ func (m *Manager) launchCommand(
 	if cwd != "" {
 		wrapped = append(wrapped, "-c", cwd)
 	}
-	wrapped = append(wrapped, "exec "+shellCommand(command))
+	agentEnv := append(
+		sessionEnvironment(os.Environ(), m.stripEnvVars),
+		"TERM=xterm-256color",
+	)
+	wrapped = append(
+		wrapped,
+		"exec "+shellEnvCommand(agentEnv, resolvedAgentCommand),
+	)
 	return launchCommand{Command: wrapped, TmuxSession: tmuxSession}, nil
 }
 
@@ -739,6 +798,17 @@ func shellCommand(command []string) string {
 		parts = append(parts, shellQuote(arg))
 	}
 	return strings.Join(parts, " ")
+}
+
+func shellEnvCommand(env []string, command []string) string {
+	args := make([]string, 0, len(env)+len(command))
+	for _, kv := range env {
+		if strings.Contains(kv, "=") {
+			args = append(args, kv)
+		}
+	}
+	args = append(args, command...)
+	return "env -i " + shellCommand(args)
 }
 
 func shellQuote(s string) string {
@@ -848,6 +918,7 @@ func (s *session) snapshot() SessionInfo {
 	defer s.mu.Unlock()
 
 	info := s.info
+	info.TmuxSession = s.tmuxSession
 	if s.info.ExitedAt != nil {
 		exitedAt := *s.info.ExitedAt
 		info.ExitedAt = &exitedAt
@@ -962,6 +1033,14 @@ func (s *session) stop() {
 				_ = s.cmd.Process.Kill()
 			}
 		}
+		if s.ptmx != nil {
+			_ = s.ptmx.Close()
+		}
+	})
+}
+
+func (s *session) detach() {
+	s.stopOnce.Do(func() {
 		if s.ptmx != nil {
 			_ = s.ptmx.Close()
 		}

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -817,13 +817,32 @@ func (m *Manager) launchTmuxOwnedCommand(
 		"set-option", "-q", "-t", tmuxSession,
 		"@middleman_owner", m.tmuxOwnerMarker,
 	))
+	killSession := shellCommand(append(
+		append([]string(nil), tmuxCommand...),
+		"kill-session", "-t", tmuxSession,
+	))
 	attachSession := shellCommand(append(
 		append([]string(nil), tmuxCommand...),
 		"attach-session", "-t", tmuxSession,
 	))
 	script := fmt.Sprintf(
-		"if ! %s >/dev/null 2>&1; then\n  %s\nfi\n%s\nexec %s",
-		hasSession, newSession, setOwner, attachSession,
+		"created=0\n"+
+			"if ! %s >/dev/null 2>&1; then\n"+
+			"  created=1\n"+
+			"  if ! %s; then\n"+
+			"    %s >/dev/null 2>&1 || true\n"+
+			"    exit 1\n"+
+			"  fi\n"+
+			"fi\n"+
+			"if ! %s; then\n"+
+			"  if [ \"$created\" = \"1\" ]; then\n"+
+			"    %s >/dev/null 2>&1 || true\n"+
+			"  fi\n"+
+			"  exit 1\n"+
+			"fi\n"+
+			"exec %s",
+		hasSession, newSession, killSession, setOwner, killSession,
+		attachSession,
 	)
 	return []string{"/bin/sh", "-lc", script}
 }

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -53,6 +53,10 @@ type Options struct {
 	Targets      []LaunchTarget
 	ShellCommand []string
 	TmuxCommand  []string
+	// TmuxOwnerMarker tags tmux-backed agent sessions so workspace startup
+	// cleanup can identify middleman-owned runtime sessions that were created
+	// before their durable DB row was written.
+	TmuxOwnerMarker string
 	// WrapAgentSessionsInTmux starts agent targets under tmux when
 	// the tmux launch target is available. When tmux is unavailable
 	// or this is false, agents run directly in the runtime PTY.
@@ -70,6 +74,7 @@ type Manager struct {
 	shells           map[string]*session
 	shellCommand     []string
 	tmuxCommand      []string
+	tmuxOwnerMarker  string
 	wrapAgentsInTmux bool
 	stripEnvVars     []string
 	startLocks       map[string]*sync.Mutex
@@ -125,6 +130,7 @@ func NewManager(options Options) *Manager {
 		shells:           make(map[string]*session),
 		shellCommand:     append([]string(nil), options.ShellCommand...),
 		tmuxCommand:      append([]string(nil), options.TmuxCommand...),
+		tmuxOwnerMarker:  options.TmuxOwnerMarker,
 		wrapAgentsInTmux: options.WrapAgentSessionsInTmux,
 		stripEnvVars:     dedupeStrings(options.StripEnvVars),
 		startLocks:       make(map[string]*sync.Mutex),
@@ -753,6 +759,20 @@ func (m *Manager) launchCommand(
 
 	tmuxSession := tmuxSessionName(workspaceID, target.Key)
 
+	agentEnv := append(
+		sessionEnvironment(tmuxAgentEnvironment(os.Environ()), m.stripEnvVars),
+		"TERM=xterm-256color",
+	)
+	agentCommand := "exec " + shellEnvCommand(agentEnv, resolvedAgentCommand)
+	if m.tmuxOwnerMarker != "" {
+		return launchCommand{
+			Command: m.launchTmuxOwnedCommand(
+				tmuxCommand, tmuxSession, cwd, agentCommand,
+			),
+			TmuxSession: tmuxSession,
+		}, nil
+	}
+
 	wrapped := append(
 		tmuxCommand,
 		"new-session",
@@ -763,15 +783,49 @@ func (m *Manager) launchCommand(
 	if cwd != "" {
 		wrapped = append(wrapped, "-c", cwd)
 	}
-	agentEnv := append(
-		sessionEnvironment(os.Environ(), m.stripEnvVars),
-		"TERM=xterm-256color",
-	)
-	wrapped = append(
-		wrapped,
-		"exec "+shellEnvCommand(agentEnv, resolvedAgentCommand),
-	)
+	wrapped = append(wrapped, agentCommand)
 	return launchCommand{Command: wrapped, TmuxSession: tmuxSession}, nil
+}
+
+func (m *Manager) launchTmuxOwnedCommand(
+	tmuxCommand []string,
+	tmuxSession string,
+	cwd string,
+	agentCommand string,
+) []string {
+	hasSession := shellCommand(append(
+		append([]string(nil), tmuxCommand...),
+		"has-session", "-t", tmuxSession,
+	))
+	newSessionArgs := append(
+		append([]string(nil), tmuxCommand...),
+		"new-session", "-d", "-s", tmuxSession,
+	)
+	if cwd != "" {
+		newSessionArgs = append(newSessionArgs, "-c", cwd)
+	}
+	newSessionArgs = append(
+		newSessionArgs,
+		agentCommand,
+		";",
+		"set-option", "-q", "-t", tmuxSession,
+		"@middleman_owner", m.tmuxOwnerMarker,
+	)
+	newSession := shellCommand(newSessionArgs)
+	setOwner := shellCommand(append(
+		append([]string(nil), tmuxCommand...),
+		"set-option", "-q", "-t", tmuxSession,
+		"@middleman_owner", m.tmuxOwnerMarker,
+	))
+	attachSession := shellCommand(append(
+		append([]string(nil), tmuxCommand...),
+		"attach-session", "-t", tmuxSession,
+	))
+	script := fmt.Sprintf(
+		"if ! %s >/dev/null 2>&1; then\n  %s\nfi\n%s\nexec %s",
+		hasSession, newSession, setOwner, attachSession,
+	)
+	return []string{"/bin/sh", "-lc", script}
 }
 
 func tmuxSessionName(workspaceID string, targetKey string) string {
@@ -814,6 +868,32 @@ func shellEnvCommand(env []string, command []string) string {
 	}
 	args = append(args, command...)
 	return "env -i " + shellCommand(args)
+}
+
+func tmuxAgentEnvironment(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := kv[:eq]
+		if isTmuxAgentEnvironmentKey(key) {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+func isTmuxAgentEnvironmentKey(key string) bool {
+	switch key {
+	case "HOME", "PATH", "SHELL", "USER", "LOGNAME", "LANG",
+		"LC_ALL", "LC_CTYPE", "TMPDIR", "SSH_AUTH_SOCK",
+		"XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME":
+		return true
+	default:
+		return strings.HasPrefix(key, "LC_")
+	}
 }
 
 func shellQuote(s string) string {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -48,25 +48,32 @@ type SessionInfo struct {
 type Options struct {
 	Targets      []LaunchTarget
 	ShellCommand []string
+	TmuxCommand  []string
+	// WrapAgentSessionsInTmux starts agent targets under tmux when
+	// the tmux launch target is available. When tmux is unavailable
+	// or this is false, agents run directly in the runtime PTY.
+	WrapAgentSessionsInTmux bool
 	// StripEnvVars names additional env vars to strip beyond the
 	// built-in credential prefixes (e.g. a configured token env).
 	StripEnvVars []string
 }
 
 type Manager struct {
-	mu           sync.Mutex
-	targets      map[string]LaunchTarget
-	targetsList  []LaunchTarget
-	sessions     map[string]*session
-	shells       map[string]*session
-	shellCommand []string
-	stripEnvVars []string
-	startLocks   map[string]*sync.Mutex
-	stoppingWS   map[string]int
-	inflightWS   map[string]int
-	inflightCh   map[string]chan struct{}
-	startWG      sync.WaitGroup
-	closed       bool
+	mu               sync.Mutex
+	targets          map[string]LaunchTarget
+	targetsList      []LaunchTarget
+	sessions         map[string]*session
+	shells           map[string]*session
+	shellCommand     []string
+	tmuxCommand      []string
+	wrapAgentsInTmux bool
+	stripEnvVars     []string
+	startLocks       map[string]*sync.Mutex
+	stoppingWS       map[string]int
+	inflightWS       map[string]int
+	inflightCh       map[string]chan struct{}
+	startWG          sync.WaitGroup
+	closed           bool
 }
 
 // maxSessionOutputReplay caps how many bytes of recent PTY output
@@ -81,6 +88,7 @@ type session struct {
 	info         SessionInfo
 	cmd          *exec.Cmd
 	ptmx         *os.File
+	tmuxSession  string
 	done         chan struct{}
 	subscribers  map[chan []byte]struct{}
 	outputBuffer []byte
@@ -107,16 +115,18 @@ func NewManager(options Options) *Manager {
 		targetsList = append(targetsList, cloneTarget(cloned))
 	}
 	return &Manager{
-		targets:      targets,
-		targetsList:  targetsList,
-		sessions:     make(map[string]*session),
-		shells:       make(map[string]*session),
-		shellCommand: append([]string(nil), options.ShellCommand...),
-		stripEnvVars: dedupeStrings(options.StripEnvVars),
-		startLocks:   make(map[string]*sync.Mutex),
-		stoppingWS:   make(map[string]int),
-		inflightWS:   make(map[string]int),
-		inflightCh:   make(map[string]chan struct{}),
+		targets:          targets,
+		targetsList:      targetsList,
+		sessions:         make(map[string]*session),
+		shells:           make(map[string]*session),
+		shellCommand:     append([]string(nil), options.ShellCommand...),
+		tmuxCommand:      append([]string(nil), options.TmuxCommand...),
+		wrapAgentsInTmux: options.WrapAgentSessionsInTmux,
+		stripEnvVars:     dedupeStrings(options.StripEnvVars),
+		startLocks:       make(map[string]*sync.Mutex),
+		stoppingWS:       make(map[string]int),
+		inflightWS:       make(map[string]int),
+		inflightCh:       make(map[string]chan struct{}),
 	}
 }
 
@@ -190,6 +200,11 @@ func (m *Manager) Launch(
 	}
 	defer m.releaseInflight(workspaceID)
 
+	launch, err := m.launchCommand(target, workspaceID, cwd)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+
 	started, err := startSession(SessionInfo{
 		Key:         key,
 		WorkspaceID: workspaceID,
@@ -198,16 +213,17 @@ func (m *Manager) Launch(
 		Kind:        target.Kind,
 		Status:      SessionStatusStarting,
 		CreatedAt:   time.Now().UTC(),
-	}, target.Command, cwd, m.stripEnvVars)
+	}, launch.Command, cwd, m.stripEnvVars)
 	if err != nil {
 		return SessionInfo{}, err
 	}
+	started.tmuxSession = launch.TmuxSession
 	go started.watch()
 
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		started.stop()
+		m.stopSession(ctx, started)
 		waitSessionDone(started)
 		return SessionInfo{}, errManagerShutdown
 	}
@@ -245,6 +261,25 @@ func (m *Manager) ListSessions(workspaceID string) []SessionInfo {
 	return sessions
 }
 
+// TmuxSessions returns runtime-owned tmux sessions associated with
+// a workspace. These sessions are additional activity sources for
+// the workspace sidebar; the persisted workspace tmux session remains
+// owned by internal/workspace.Manager.
+func (m *Manager) TmuxSessions(workspaceID string) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sessions := make([]string, 0)
+	for _, s := range m.sessions {
+		info := s.snapshot()
+		if info.WorkspaceID == workspaceID && s.tmuxSession != "" {
+			sessions = append(sessions, s.tmuxSession)
+		}
+	}
+	sort.Strings(sessions)
+	return sessions
+}
+
 func (m *Manager) Stop(
 	ctx context.Context,
 	workspaceID string,
@@ -255,7 +290,7 @@ func (m *Manager) Stop(
 		return fmt.Errorf("session %q not found", sessionKey)
 	}
 
-	s.stop()
+	m.stopSession(ctx, s)
 	select {
 	case <-s.done:
 		return nil
@@ -315,7 +350,7 @@ func (m *Manager) StopWorkspace(
 	m.mu.Unlock()
 
 	for _, s := range stopping {
-		s.stop()
+		m.stopSession(ctx, s)
 	}
 	for _, s := range stopping {
 		select {
@@ -324,6 +359,34 @@ func (m *Manager) StopWorkspace(
 			return
 		}
 	}
+}
+
+func (m *Manager) stopSession(ctx context.Context, s *session) {
+	if s == nil {
+		return
+	}
+	if s.tmuxSession != "" {
+		_ = m.killTmuxSession(ctx, s.tmuxSession)
+	}
+	s.stop()
+}
+
+func (m *Manager) killTmuxSession(
+	ctx context.Context,
+	session string,
+) error {
+	if session == "" {
+		return nil
+	}
+	command := append([]string(nil), m.tmuxCommand...)
+	if len(command) == 0 {
+		command = []string{"tmux"}
+	}
+	if len(command) == 0 || command[0] == "" {
+		return nil
+	}
+	args := append(command[1:], "kill-session", "-t", session)
+	return exec.CommandContext(ctx, command[0], args...).Run()
 }
 
 // BeginStopping holds the stopping marker for workspaceID without
@@ -475,7 +538,7 @@ func (m *Manager) EnsureShell(
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
-		started.stop()
+		m.stopSession(ctx, started)
 		waitSessionDone(started)
 		return SessionInfo{}, errManagerShutdown
 	}
@@ -548,7 +611,7 @@ func (m *Manager) Shutdown() {
 	m.mu.Unlock()
 
 	for _, s := range sessions {
-		s.stop()
+		m.stopSession(ctx, s)
 	}
 	for _, s := range sessions {
 		select {
@@ -603,6 +666,86 @@ func (m *Manager) target(key string) (LaunchTarget, error) {
 		return LaunchTarget{}, fmt.Errorf("target not found: %s", key)
 	}
 	return cloneTarget(target), nil
+}
+
+type launchCommand struct {
+	Command     []string
+	TmuxSession string
+}
+
+func (m *Manager) launchCommand(
+	target LaunchTarget,
+	workspaceID string,
+	cwd string,
+) (launchCommand, error) {
+	command := append([]string(nil), target.Command...)
+	if target.Kind != LaunchTargetAgent || !m.wrapAgentsInTmux {
+		return launchCommand{Command: command}, nil
+	}
+
+	tmux, err := m.target(string(LaunchTargetTmux))
+	if err != nil || !tmux.Available {
+		return launchCommand{Command: command}, nil
+	}
+	tmuxCommand := append([]string(nil), m.tmuxCommand...)
+	if len(tmuxCommand) == 0 {
+		tmuxCommand = append([]string(nil), tmux.Command...)
+	}
+	if len(tmuxCommand) == 0 {
+		tmuxCommand = []string{"tmux"}
+	}
+	tmuxSession := tmuxSessionName(workspaceID, target.Key)
+
+	wrapped := append(
+		tmuxCommand,
+		"new-session",
+		"-A",
+		"-s",
+		tmuxSession,
+	)
+	if cwd != "" {
+		wrapped = append(wrapped, "-c", cwd)
+	}
+	wrapped = append(wrapped, "exec "+shellCommand(command))
+	return launchCommand{Command: wrapped, TmuxSession: tmuxSession}, nil
+}
+
+func tmuxSessionName(workspaceID string, targetKey string) string {
+	name := "middleman-" + workspaceID + "-" + targetKey
+	var b strings.Builder
+	b.Grow(len(name))
+	lastDash := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_' || r == '-':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func shellCommand(command []string) string {
+	parts := make([]string, 0, len(command)+1)
+	for _, arg := range command {
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func (m *Manager) runningSession(

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -30,6 +30,7 @@ const (
 
 var (
 	errManagerShutdown   = errors.New("runtime manager is shut down")
+	ErrSessionNotFound   = errors.New("runtime session not found")
 	errWorkspaceStopping = errors.New(
 		"workspace is being stopped",
 	)
@@ -288,15 +289,19 @@ func (m *Manager) Stop(
 	workspaceID string,
 	sessionKey string,
 ) error {
-	s, ok := m.remove(workspaceID, sessionKey)
+	s, ok := m.session(workspaceID, sessionKey)
 	if !ok {
-		return fmt.Errorf("session %q not found", sessionKey)
+		return fmt.Errorf("%w: %q", ErrSessionNotFound, sessionKey)
 	}
 
 	cleanupErr := m.stopSession(ctx, s)
+	if cleanupErr != nil {
+		return cleanupErr
+	}
+	m.removeIfSame(workspaceID, sessionKey, s)
 	select {
 	case <-s.done:
-		return cleanupErr
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -838,7 +843,7 @@ func (m *Manager) runningSession(
 	return nil
 }
 
-func (m *Manager) remove(
+func (m *Manager) session(
 	workspaceID string,
 	key string,
 ) (*session, bool) {
@@ -847,15 +852,34 @@ func (m *Manager) remove(
 
 	if s, ok := m.sessions[key]; ok &&
 		s.snapshot().WorkspaceID == workspaceID {
-		delete(m.sessions, key)
 		return s, true
 	}
 	if s, ok := m.shells[key]; ok &&
 		s.snapshot().WorkspaceID == workspaceID {
-		delete(m.shells, key)
 		return s, true
 	}
 	return nil, false
+}
+
+func (m *Manager) removeIfSame(
+	workspaceID string,
+	key string,
+	s *session,
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if current, ok := m.sessions[key]; ok &&
+		current == s &&
+		current.snapshot().WorkspaceID == workspaceID {
+		delete(m.sessions, key)
+		return
+	}
+	if current, ok := m.shells[key]; ok &&
+		current == s &&
+		current.snapshot().WorkspaceID == workspaceID {
+		delete(m.shells, key)
+	}
 }
 
 func startSession(

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -3,6 +3,8 @@ package localruntime
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -848,11 +850,16 @@ func (m *Manager) launchTmuxOwnedCommand(
 }
 
 func tmuxSessionName(workspaceID string, targetKey string) string {
-	name := "middleman-" + workspaceID + "-" + targetKey
+	sum := sha256.Sum256([]byte(targetKey))
+	return "middleman-" + tmuxSessionSafeComponent(workspaceID) + "-" +
+		hex.EncodeToString(sum[:8])
+}
+
+func tmuxSessionSafeComponent(value string) string {
 	var b strings.Builder
-	b.Grow(len(name))
+	b.Grow(len(value))
 	lastDash := false
-	for _, r := range name {
+	for _, r := range value {
 		switch {
 		case r >= 'a' && r <= 'z',
 			r >= 'A' && r <= 'Z',

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -291,8 +291,9 @@ func TestManagerLaunchCommandDoesNotWrapWhenConfigDisabled(t *testing.T) {
 }
 
 func TestManagerStopReportsTmuxCleanupFailure(t *testing.T) {
+	require := require.New(t)
 	tmuxPath := filepath.Join(t.TempDir(), "tmux-fails")
-	require.NoError(t, os.WriteFile(
+	require.NoError(os.WriteFile(
 		tmuxPath,
 		[]byte("#!/bin/sh\nexit 42\n"),
 		0o755,
@@ -314,8 +315,9 @@ func TestManagerStopReportsTmuxCleanupFailure(t *testing.T) {
 
 	err := mgr.Stop(context.Background(), "ws-1", "ws-1:codex")
 
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "kill tmux session")
+	require.Error(err)
+	require.Contains(err.Error(), "kill tmux session")
+	require.Len(mgr.ListSessions("ws-1"), 1)
 }
 
 func TestManagerStopIgnoresAbsentTmuxSession(t *testing.T) {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -114,6 +114,130 @@ func TestManagerLaunchMissingTarget(t *testing.T) {
 	require.Contains(t, err.Error(), "target not found")
 }
 
+func TestManagerTmuxSessionsReturnsWrappedAgentSessions(t *testing.T) {
+	assert := Assert.New(t)
+	mgr := NewManager(Options{})
+	mgr.sessions["ws-1:codex"] = &session{
+		info: SessionInfo{
+			Key:         "ws-1:codex",
+			WorkspaceID: "ws-1",
+			TargetKey:   "codex",
+			Kind:        LaunchTargetAgent,
+		},
+		tmuxSession: "middleman-ws-1-codex",
+	}
+	mgr.sessions["ws-1:direct"] = &session{
+		info: SessionInfo{
+			Key:         "ws-1:direct",
+			WorkspaceID: "ws-1",
+			TargetKey:   "direct",
+			Kind:        LaunchTargetAgent,
+		},
+	}
+	mgr.sessions["ws-2:codex"] = &session{
+		info: SessionInfo{
+			Key:         "ws-2:codex",
+			WorkspaceID: "ws-2",
+			TargetKey:   "codex",
+			Kind:        LaunchTargetAgent,
+		},
+		tmuxSession: "middleman-ws-2-codex",
+	}
+
+	assert.Equal(
+		[]string{"middleman-ws-1-codex"},
+		mgr.TmuxSessions("ws-1"),
+	)
+}
+
+func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
+	assert := Assert.New(t)
+	agent := helperTarget("codex", "sleep")
+	agent.Label = "Codex"
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			agent,
+			{
+				Key: "tmux", Label: "tmux", Kind: LaunchTargetTmux,
+				Source: "system", Command: []string{"/usr/bin/tmux"},
+				Available: true,
+			},
+		},
+		TmuxCommand:             []string{"/usr/bin/tmux"},
+		WrapAgentSessionsInTmux: true,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	launch, err := mgr.launchCommand(
+		agent, "ws:alpha", "/tmp/work tree",
+	)
+	require.NoError(t, err)
+
+	assert.Equal("/usr/bin/tmux", launch.Command[0])
+	assert.Equal(
+		[]string{
+			"new-session",
+			"-A",
+			"-s",
+			"middleman-ws-alpha-codex",
+			"-c",
+			"/tmp/work tree",
+		},
+		launch.Command[1:7],
+	)
+	assert.Contains(launch.Command[7], "exec ")
+	assert.Contains(launch.Command[7], shellQuote(agent.Command[0]))
+	assert.Equal("middleman-ws-alpha-codex", launch.TmuxSession)
+}
+
+func TestManagerLaunchCommandFallsBackWhenTmuxUnavailable(t *testing.T) {
+	assert := Assert.New(t)
+	agent := helperTarget("codex", "sleep")
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			agent,
+			{
+				Key: "tmux", Label: "tmux", Kind: LaunchTargetTmux,
+				Source: "system", Command: []string{"tmux"},
+				Available: false, DisabledReason: "tmux not found",
+			},
+		},
+		TmuxCommand:             []string{"tmux"},
+		WrapAgentSessionsInTmux: true,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	launch, err := mgr.launchCommand(agent, "ws-1", t.TempDir())
+	require.NoError(t, err)
+
+	assert.Equal(agent.Command, launch.Command)
+	assert.Empty(launch.TmuxSession)
+}
+
+func TestManagerLaunchCommandDoesNotWrapWhenConfigDisabled(t *testing.T) {
+	assert := Assert.New(t)
+	agent := helperTarget("codex", "sleep")
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			agent,
+			{
+				Key: "tmux", Label: "tmux", Kind: LaunchTargetTmux,
+				Source: "system", Command: []string{"/usr/bin/tmux"},
+				Available: true,
+			},
+		},
+		TmuxCommand:             []string{"/usr/bin/tmux"},
+		WrapAgentSessionsInTmux: false,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	launch, err := mgr.launchCommand(agent, "ws-1", t.TempDir())
+	require.NoError(t, err)
+
+	assert.Equal(agent.Command, launch.Command)
+	assert.Empty(launch.TmuxSession)
+}
+
 func TestManagerStopRemovesSession(t *testing.T) {
 	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
 

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -190,6 +190,42 @@ func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
 	assert.Equal("middleman-ws-alpha-codex", launch.TmuxSession)
 }
 
+func TestManagerLaunchCommandMarksWrappedAgentTmuxSession(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	agent := helperTarget("codex", "sleep")
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			agent,
+			{
+				Key: "tmux", Label: "tmux", Kind: LaunchTargetTmux,
+				Source: "system", Command: []string{"/usr/bin/tmux"},
+				Available: true,
+			},
+		},
+		TmuxCommand:             []string{"/usr/bin/tmux"},
+		TmuxOwnerMarker:         "middleman:test-owner",
+		WrapAgentSessionsInTmux: true,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	launch, err := mgr.launchCommand(agent, "ws-1", "/tmp/work tree")
+	require.NoError(err)
+
+	require.Len(launch.Command, 3)
+	assert.Equal([]string{"/bin/sh", "-lc"}, launch.Command[:2])
+	script := launch.Command[2]
+	assert.Contains(script, "has-session")
+	assert.Contains(script, "new-session")
+	assert.Contains(script, "set-option")
+	assert.Contains(script, "@middleman_owner")
+	assert.Contains(script, "middleman:test-owner")
+	assert.Contains(script, "attach-session")
+	assert.Contains(script, "middleman-ws-1-codex")
+	assert.Contains(script, shellQuote(agent.Command[0]))
+	assert.Equal("middleman-ws-1-codex", launch.TmuxSession)
+}
+
 func TestManagerLaunchCommandRejectsRelativeAgentCommandWhenWrapped(t *testing.T) {
 	agent := helperTarget("codex", "sleep")
 	agent.Command = []string{"./codex"}
@@ -215,6 +251,8 @@ func TestManagerLaunchCommandRejectsRelativeAgentCommandWhenWrapped(t *testing.T
 
 func TestManagerLaunchCommandUsesSanitizedEnvForWrappedAgent(t *testing.T) {
 	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "secret-token")
+	t.Setenv("CONTEXT7_API_KEY", "context7-secret")
+	t.Setenv("MIDDLEMAN_SAFE_FOR_TEST", "not-carried")
 	assert := Assert.New(t)
 	agent := helperTarget("codex", "sleep")
 	agent.Command = []string{"sh", "-c", "echo ok"}
@@ -238,7 +276,10 @@ func TestManagerLaunchCommandUsesSanitizedEnvForWrappedAgent(t *testing.T) {
 	tmuxCommand := strings.Join(launch.Command, "\n")
 	assert.Contains(tmuxCommand, "env -i")
 	assert.Contains(tmuxCommand, "TERM=xterm-256color")
+	assert.Contains(tmuxCommand, "HOME=")
 	assert.NotContains(tmuxCommand, "secret-token")
+	assert.NotContains(tmuxCommand, "context7-secret")
+	assert.NotContains(tmuxCommand, "not-carried")
 	assert.NotContains(tmuxCommand, "'sh'")
 }
 

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -218,12 +218,68 @@ func TestManagerLaunchCommandMarksWrappedAgentTmuxSession(t *testing.T) {
 	assert.Contains(script, "has-session")
 	assert.Contains(script, "new-session")
 	assert.Contains(script, "set-option")
+	assert.Contains(script, "kill-session")
+	assert.Contains(script, "exit 1")
 	assert.Contains(script, "@middleman_owner")
 	assert.Contains(script, "middleman:test-owner")
 	assert.Contains(script, "attach-session")
 	assert.Contains(script, "middleman-ws-1-codex")
 	assert.Contains(script, shellQuote(agent.Command[0]))
 	assert.Equal("middleman-ws-1-codex", launch.TmuxSession)
+}
+
+func TestManagerLaunchCommandCleansUpWhenOwnerMarkingFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "tmux-fails-set-option")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$@" >> "$TMUX_RECORD"
+case "$1" in
+  has-session)
+    exit 1
+    ;;
+  new-session)
+    exit 42
+    ;;
+  kill-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	agent := helperTarget("codex", "sleep")
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			agent,
+			{
+				Key: "tmux", Label: "tmux", Kind: LaunchTargetTmux,
+				Source: "system", Command: []string{tmuxPath},
+				Available: true,
+			},
+		},
+		TmuxCommand:             []string{tmuxPath},
+		TmuxOwnerMarker:         "middleman:test-owner",
+		WrapAgentSessionsInTmux: true,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	launch, err := mgr.launchCommand(agent, "ws-1", t.TempDir())
+	require.NoError(err)
+	cmd := exec.Command(launch.Command[0], launch.Command[1:]...)
+	cmd.Env = append(os.Environ(), "TMUX_RECORD="+record)
+
+	err = cmd.Run()
+	require.Error(err)
+	data, err := os.ReadFile(record)
+	require.NoError(err)
+	recorded := string(data)
+	assert.Contains(recorded, "new-session")
+	assert.Contains(recorded, "@middleman_owner")
+	assert.Contains(recorded, "kill-session")
 }
 
 func TestManagerLaunchCommandRejectsRelativeAgentCommandWhenWrapped(t *testing.T) {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -241,10 +241,12 @@ case "$1" in
     exit 1
     ;;
   new-session)
+    for a in "$@"; do
+      if [ "$a" = "@middleman_owner" ]; then
+        exit 42
+      fi
+    done
     exit 0
-    ;;
-  set-option)
-    exit 42
     ;;
   kill-session)
     exit 0

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -172,6 +172,7 @@ func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
 		agent, "ws:alpha", "/tmp/work tree",
 	)
 	require.NoError(t, err)
+	sessionName := tmuxSessionName("ws:alpha", "codex")
 
 	assert.Equal("/usr/bin/tmux", launch.Command[0])
 	assert.Equal(
@@ -179,7 +180,7 @@ func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
 			"new-session",
 			"-A",
 			"-s",
-			"middleman-ws-alpha-codex",
+			sessionName,
 			"-c",
 			"/tmp/work tree",
 		},
@@ -187,7 +188,7 @@ func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
 	)
 	assert.Contains(launch.Command[7], "exec ")
 	assert.Contains(launch.Command[7], shellQuote(agent.Command[0]))
-	assert.Equal("middleman-ws-alpha-codex", launch.TmuxSession)
+	assert.Equal(sessionName, launch.TmuxSession)
 }
 
 func TestManagerLaunchCommandMarksWrappedAgentTmuxSession(t *testing.T) {
@@ -211,6 +212,7 @@ func TestManagerLaunchCommandMarksWrappedAgentTmuxSession(t *testing.T) {
 
 	launch, err := mgr.launchCommand(agent, "ws-1", "/tmp/work tree")
 	require.NoError(err)
+	sessionName := tmuxSessionName("ws-1", "codex")
 
 	require.Len(launch.Command, 3)
 	assert.Equal([]string{"/bin/sh", "-lc"}, launch.Command[:2])
@@ -223,9 +225,22 @@ func TestManagerLaunchCommandMarksWrappedAgentTmuxSession(t *testing.T) {
 	assert.Contains(script, "@middleman_owner")
 	assert.Contains(script, "middleman:test-owner")
 	assert.Contains(script, "attach-session")
-	assert.Contains(script, "middleman-ws-1-codex")
+	assert.Contains(script, sessionName)
 	assert.Contains(script, shellQuote(agent.Command[0]))
-	assert.Equal("middleman-ws-1-codex", launch.TmuxSession)
+	assert.Equal(sessionName, launch.TmuxSession)
+}
+
+func TestTmuxSessionNameUsesOpaqueTargetHash(t *testing.T) {
+	assert := Assert.New(t)
+
+	fooSlash := tmuxSessionName("ws:alpha", "foo/bar")
+	fooColon := tmuxSessionName("ws:alpha", "foo:bar")
+
+	assert.NotEqual(fooSlash, fooColon)
+	assert.NotContains(fooSlash, "foo")
+	assert.NotContains(fooSlash, "/")
+	assert.NotContains(fooColon, ":")
+	assert.Contains(fooSlash, "middleman-ws-alpha-")
 }
 
 func TestManagerLaunchCommandCleansUpWhenOwnerMarkingFails(t *testing.T) {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -190,6 +190,58 @@ func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
 	assert.Equal("middleman-ws-alpha-codex", launch.TmuxSession)
 }
 
+func TestManagerLaunchCommandRejectsRelativeAgentCommandWhenWrapped(t *testing.T) {
+	agent := helperTarget("codex", "sleep")
+	agent.Command = []string{"./codex"}
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			agent,
+			{
+				Key: "tmux", Label: "tmux", Kind: LaunchTargetTmux,
+				Source: "system", Command: []string{"/usr/bin/tmux"},
+				Available: true,
+			},
+		},
+		TmuxCommand:             []string{"/usr/bin/tmux"},
+		WrapAgentSessionsInTmux: true,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	_, err := mgr.launchCommand(agent, "ws-1", t.TempDir())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absolute path")
+}
+
+func TestManagerLaunchCommandUsesSanitizedEnvForWrappedAgent(t *testing.T) {
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "secret-token")
+	assert := Assert.New(t)
+	agent := helperTarget("codex", "sleep")
+	agent.Command = []string{"sh", "-c", "echo ok"}
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			agent,
+			{
+				Key: "tmux", Label: "tmux", Kind: LaunchTargetTmux,
+				Source: "system", Command: []string{"/usr/bin/tmux"},
+				Available: true,
+			},
+		},
+		TmuxCommand:             []string{"/usr/bin/tmux"},
+		WrapAgentSessionsInTmux: true,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	launch, err := mgr.launchCommand(agent, "ws-1", t.TempDir())
+	require.NoError(t, err)
+
+	tmuxCommand := strings.Join(launch.Command, "\n")
+	assert.Contains(tmuxCommand, "env -i")
+	assert.Contains(tmuxCommand, "TERM=xterm-256color")
+	assert.NotContains(tmuxCommand, "secret-token")
+	assert.NotContains(tmuxCommand, "'sh'")
+}
+
 func TestManagerLaunchCommandFallsBackWhenTmuxUnavailable(t *testing.T) {
 	assert := Assert.New(t)
 	agent := helperTarget("codex", "sleep")
@@ -236,6 +288,128 @@ func TestManagerLaunchCommandDoesNotWrapWhenConfigDisabled(t *testing.T) {
 
 	assert.Equal(agent.Command, launch.Command)
 	assert.Empty(launch.TmuxSession)
+}
+
+func TestManagerStopReportsTmuxCleanupFailure(t *testing.T) {
+	tmuxPath := filepath.Join(t.TempDir(), "tmux-fails")
+	require.NoError(t, os.WriteFile(
+		tmuxPath,
+		[]byte("#!/bin/sh\nexit 42\n"),
+		0o755,
+	))
+	done := make(chan struct{})
+	close(done)
+	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
+	mgr.sessions["ws-1:codex"] = &session{
+		info: SessionInfo{
+			Key:         "ws-1:codex",
+			WorkspaceID: "ws-1",
+			TargetKey:   "codex",
+			Kind:        LaunchTargetAgent,
+		},
+		cmd:         &exec.Cmd{},
+		tmuxSession: "middleman-ws-1-codex",
+		done:        done,
+	}
+
+	err := mgr.Stop(context.Background(), "ws-1", "ws-1:codex")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "kill tmux session")
+}
+
+func TestManagerStopIgnoresAbsentTmuxSession(t *testing.T) {
+	tmuxPath := filepath.Join(t.TempDir(), "tmux-absent")
+	require.NoError(t, os.WriteFile(
+		tmuxPath,
+		[]byte("#!/bin/sh\necho \"can't find session: nope\" >&2\nexit 1\n"),
+		0o755,
+	))
+	done := make(chan struct{})
+	close(done)
+	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
+	mgr.sessions["ws-1:codex"] = &session{
+		info: SessionInfo{
+			Key:         "ws-1:codex",
+			WorkspaceID: "ws-1",
+			TargetKey:   "codex",
+			Kind:        LaunchTargetAgent,
+		},
+		cmd:         &exec.Cmd{},
+		tmuxSession: "middleman-ws-1-codex",
+		done:        done,
+	}
+
+	err := mgr.Stop(context.Background(), "ws-1", "ws-1:codex")
+
+	require.NoError(t, err)
+}
+
+func TestManagerShutdownLeavesTmuxSessionsRunning(t *testing.T) {
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	tmuxPath := filepath.Join(dir, "tmux-records")
+	require.NoError(t, os.WriteFile(
+		tmuxPath,
+		[]byte("#!/bin/sh\nprintf '%s\\0' \"$@\" >> \"$TMUX_RECORD\"\n"),
+		0o755,
+	))
+	t.Setenv("TMUX_RECORD", record)
+	done := make(chan struct{})
+	close(done)
+	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
+	mgr.sessions["ws-1:codex"] = &session{
+		info: SessionInfo{
+			Key:         "ws-1:codex",
+			WorkspaceID: "ws-1",
+			TargetKey:   "codex",
+			Kind:        LaunchTargetAgent,
+		},
+		cmd:         &exec.Cmd{},
+		tmuxSession: "middleman-ws-1-codex",
+		done:        done,
+	}
+
+	mgr.Shutdown()
+
+	_, err := os.Stat(record)
+	assert.True(os.IsNotExist(err), "shutdown should not invoke tmux cleanup")
+	assert.Empty(mgr.ListSessions("ws-1"))
+}
+
+func TestManagerShutdownTerminatesPTYManagedSessions(t *testing.T) {
+	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	ctx := context.Background()
+	mgr := NewManager(Options{Targets: []LaunchTarget{
+		helperTarget("helper", "sleep"),
+	}})
+
+	info, err := mgr.Launch(ctx, "ws-1", t.TempDir(), "helper")
+	require.NoError(err)
+
+	var pid int
+	require.Eventually(func() bool {
+		mgr.mu.Lock()
+		defer mgr.mu.Unlock()
+		s := mgr.sessions[info.Key]
+		if s == nil || s.cmd == nil || s.cmd.Process == nil {
+			return false
+		}
+		pid = s.cmd.Process.Pid
+		return pid > 0
+	}, 2*time.Second, 20*time.Millisecond)
+	require.NoError(syscall.Kill(pid, 0), "helper should be alive")
+
+	mgr.Shutdown()
+
+	assert.Eventually(func() bool {
+		return errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+	}, 5*time.Second, 25*time.Millisecond)
+	assert.Empty(mgr.ListSessions("ws-1"))
 }
 
 func TestManagerStopRemovesSession(t *testing.T) {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -241,6 +241,9 @@ case "$1" in
     exit 1
     ;;
   new-session)
+    exit 0
+    ;;
+  set-option)
     exit 42
     ;;
   kill-session)

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -886,15 +886,32 @@ func (m *Manager) cleanupWorkspaceArtifactsForDelete(
 func (m *Manager) cleanupTmuxSession(
 	ctx context.Context, ws *Workspace,
 ) error {
-	if err := m.killTmuxSession(ctx, ws.TmuxSession); err != nil &&
-		!isTmuxSessionAbsent([]byte(err.Error()), err) {
-		hasSession, checkErr := m.workspaceHasCreatedTmuxSession(ctx, ws)
-		if checkErr != nil {
-			return checkErr
+	sessions := []string{ws.TmuxSession}
+	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, ws.ID)
+	if err != nil {
+		return err
+	}
+	for _, storedSession := range stored {
+		sessions = append(sessions, storedSession.SessionName)
+	}
+
+	for _, session := range sessions {
+		if session == "" {
+			continue
 		}
-		if hasSession {
-			return fmt.Errorf("kill tmux session: %w", err)
+		if err := m.killTmuxSession(ctx, session); err != nil &&
+			!isTmuxSessionAbsent([]byte(err.Error()), err) {
+			hasSession, checkErr := m.workspaceHasCreatedTmuxSession(ctx, ws)
+			if checkErr != nil {
+				return checkErr
+			}
+			if hasSession {
+				return fmt.Errorf("kill tmux session %q: %w", session, err)
+			}
 		}
+	}
+	if err := m.db.DeleteWorkspaceTmuxSessions(ctx, ws.ID); err != nil {
+		return err
 	}
 	return nil
 }
@@ -952,7 +969,19 @@ func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 	}
 	live := make(map[string]bool, len(workspaces))
 	for _, ws := range workspaces {
+		if ws.TmuxSession == "" {
+			continue
+		}
 		live[ws.TmuxSession] = true
+	}
+	storedSessions, err := m.db.ListAllWorkspaceTmuxSessions(ctx)
+	if err != nil {
+		return err
+	}
+	for _, stored := range storedSessions {
+		if stored.SessionName != "" {
+			live[stored.SessionName] = true
+		}
 	}
 
 	sessions, err := m.listTmuxSessions(ctx)
@@ -960,7 +989,7 @@ func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 		return err
 	}
 	for _, session := range sessions {
-		if !isWorkspaceTmuxSessionName(session) {
+		if !isMiddlemanWorkspaceTmuxSessionName(session) {
 			continue
 		}
 		if live[session] {
@@ -990,6 +1019,24 @@ func isWorkspaceTmuxSessionName(session string) bool {
 		return false
 	}
 	for _, ch := range session[len(prefix):] {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func isMiddlemanWorkspaceTmuxSessionName(session string) bool {
+	if isWorkspaceTmuxSessionName(session) {
+		return true
+	}
+	const prefix = "middleman-"
+	if len(session) <= len(prefix)+16 ||
+		!strings.HasPrefix(session, prefix) ||
+		session[len(prefix)+16] != '-' {
+		return false
+	}
+	for _, ch := range session[len(prefix) : len(prefix)+16] {
 		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
 			return false
 		}
@@ -1091,6 +1138,68 @@ func (m *Manager) listTmuxSessions(
 		}
 	}
 	return sessions, nil
+}
+
+// RecordRuntimeTmuxSession records a tmux-backed runtime launch so
+// activity probing and cleanup survive an application restart.
+func (m *Manager) RecordRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+	targetKey string,
+) error {
+	if sessionName == "" {
+		return nil
+	}
+	return m.db.UpsertWorkspaceTmuxSession(ctx, &db.WorkspaceTmuxSession{
+		WorkspaceID: workspaceID,
+		SessionName: sessionName,
+		TargetKey:   targetKey,
+	})
+}
+
+// ForgetRuntimeTmuxSession removes a stored tmux-backed runtime
+// launch after an explicit stop succeeds.
+func (m *Manager) ForgetRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+) error {
+	if sessionName == "" {
+		return nil
+	}
+	return m.db.DeleteWorkspaceTmuxSession(ctx, workspaceID, sessionName)
+}
+
+// TmuxSessionsForWorkspace returns the persisted workspace tmux
+// session plus stored per-agent sessions. Runtime tmux sessions are
+// stored rather than discovered by naming convention so restart
+// recovery follows explicit ownership state.
+func (m *Manager) TmuxSessionsForWorkspace(
+	ctx context.Context,
+	workspaceID string,
+	baseSession string,
+) ([]string, error) {
+	if baseSession == "" {
+		return nil, nil
+	}
+	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, 1)
+	seen[baseSession] = true
+	out = append(out, baseSession)
+	for _, storedSession := range stored {
+		session := storedSession.SessionName
+		if session == "" || seen[session] {
+			continue
+		}
+		seen[session] = true
+		out = append(out, session)
+	}
+	return out, nil
 }
 
 // TmuxPaneTitle returns the active pane title for a session. Agents

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1036,12 +1036,7 @@ func isWorkspaceTmuxSessionName(session string) bool {
 		!strings.HasPrefix(session, prefix) {
 		return false
 	}
-	for _, ch := range session[len(prefix):] {
-		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
-			return false
-		}
-	}
-	return true
+	return isLowerHex(session[len(prefix):])
 }
 
 func isMiddlemanWorkspaceTmuxSessionName(session string) bool {
@@ -1049,12 +1044,24 @@ func isMiddlemanWorkspaceTmuxSessionName(session string) bool {
 		return true
 	}
 	const prefix = "middleman-"
-	if len(session) <= len(prefix)+16 ||
+	// Runtime session names intentionally only match the current opaque
+	// middleman-<workspace-id>-<target-key-hash> shape. Old readable
+	// target suffixes are not supported; stored DB rows are authoritative
+	// for restart activity and cleanup.
+	if len(session) != len(prefix)+16+1+16 ||
 		!strings.HasPrefix(session, prefix) ||
 		session[len(prefix)+16] != '-' {
 		return false
 	}
-	for _, ch := range session[len(prefix) : len(prefix)+16] {
+	return isLowerHex(session[len(prefix):len(prefix)+16]) &&
+		isLowerHex(session[len(prefix)+17:])
+}
+
+func isLowerHex(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, ch := range value {
 		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
 			return false
 		}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1195,6 +1195,43 @@ func (m *Manager) ForgetRuntimeTmuxSession(
 	return m.db.DeleteWorkspaceTmuxSession(ctx, workspaceID, sessionName)
 }
 
+// StopStoredRuntimeTmuxSession cleans up a persisted runtime tmux session even
+// when the in-memory runtime manager no longer knows about it.
+func (m *Manager) StopStoredRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	targetKey string,
+) (bool, error) {
+	if targetKey == "" {
+		return false, nil
+	}
+	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, workspaceID)
+	if err != nil {
+		return false, err
+	}
+	for _, storedSession := range stored {
+		if storedSession.TargetKey != targetKey ||
+			storedSession.SessionName == "" {
+			continue
+		}
+		if err := m.killTmuxSession(
+			ctx, storedSession.SessionName,
+		); err != nil && !isTmuxSessionAbsent([]byte(err.Error()), err) {
+			return true, fmt.Errorf(
+				"kill tmux session %q: %w",
+				storedSession.SessionName, err,
+			)
+		}
+		if err := m.db.DeleteWorkspaceTmuxSession(
+			ctx, workspaceID, storedSession.SessionName,
+		); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
 // TmuxSessionsForWorkspace returns the persisted workspace tmux
 // session plus stored per-agent sessions. Runtime tmux sessions are
 // stored rather than discovered by naming convention so restart
@@ -1204,17 +1241,16 @@ func (m *Manager) TmuxSessionsForWorkspace(
 	workspaceID string,
 	baseSession string,
 ) ([]string, error) {
-	if baseSession == "" {
-		return nil, nil
-	}
 	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
 	seen := map[string]bool{}
-	out := make([]string, 0, 1)
-	seen[baseSession] = true
-	out = append(out, baseSession)
+	out := make([]string, 0, len(stored)+1)
+	if baseSession != "" {
+		seen[baseSession] = true
+		out = append(out, baseSession)
+	}
 	for _, storedSession := range stored {
 		session := storedSession.SessionName
 		if session == "" || seen[session] {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -886,29 +886,47 @@ func (m *Manager) cleanupWorkspaceArtifactsForDelete(
 func (m *Manager) cleanupTmuxSession(
 	ctx context.Context, ws *Workspace,
 ) error {
-	sessions := []string{ws.TmuxSession}
+	type cleanupTarget struct {
+		session string
+		main    bool
+	}
+	sessions := []cleanupTarget{{session: ws.TmuxSession, main: true}}
 	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, ws.ID)
 	if err != nil {
 		return err
 	}
 	for _, storedSession := range stored {
-		sessions = append(sessions, storedSession.SessionName)
+		sessions = append(sessions, cleanupTarget{
+			session: storedSession.SessionName,
+		})
 	}
 
-	for _, session := range sessions {
-		if session == "" {
+	var cleanupErrs []error
+	for _, target := range sessions {
+		if target.session == "" {
 			continue
 		}
-		if err := m.killTmuxSession(ctx, session); err != nil &&
-			!isTmuxSessionAbsent([]byte(err.Error()), err) {
+		err := m.killTmuxSession(ctx, target.session)
+		if err == nil || isTmuxSessionAbsent([]byte(err.Error()), err) {
+			continue
+		}
+		if target.main {
 			hasSession, checkErr := m.workspaceHasCreatedTmuxSession(ctx, ws)
 			if checkErr != nil {
-				return checkErr
+				cleanupErrs = append(cleanupErrs, checkErr)
+				continue
 			}
-			if hasSession {
-				return fmt.Errorf("kill tmux session %q: %w", session, err)
+			if !hasSession {
+				continue
 			}
 		}
+		cleanupErrs = append(
+			cleanupErrs,
+			fmt.Errorf("kill tmux session %q: %w", target.session, err),
+		)
+	}
+	if err := errors.Join(cleanupErrs...); err != nil {
+		return err
 	}
 	if err := m.db.DeleteWorkspaceTmuxSessions(ctx, ws.ID); err != nil {
 		return err
@@ -1051,6 +1069,12 @@ func (m *Manager) tmuxOwnerMarker() string {
 	}
 	sum := sha256.Sum256([]byte(abs))
 	return "middleman:" + hex.EncodeToString(sum[:8])
+}
+
+// TmuxOwnerMarker returns the marker used to tag tmux sessions owned by this
+// workspace manager.
+func (m *Manager) TmuxOwnerMarker() string {
+	return m.tmuxOwnerMarker()
 }
 
 func (m *Manager) tmuxSessionOwnedByThisManager(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1039,6 +1039,86 @@ func TestManagerCleanupTmuxSessionKillsRuntimeSessionsForWorkspace(
 	assert.Empty(stored)
 }
 
+func TestManagerCleanupTmuxSessionPreservesStoredRowsAfterRuntimeKillFailure(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`target=""` + "\n" +
+		`prev=""` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$prev" = "-t" ]; then target="$a"; fi` + "\n" +
+		`  prev="$a"` + "\n" +
+		`done` + "\n" +
+		`if [ "$1" = "kill-session" ]; then` + "\n" +
+		`  case "$target" in` + "\n" +
+		`    middleman-0000000000000001)` + "\n" +
+		`      echo "can't find session: $target" >&2` + "\n" +
+		`      exit 1` + "\n" +
+		`      ;;` + "\n" +
+		`    middleman-0000000000000001-codex)` + "\n" +
+		`      echo "permission denied" >&2` + "\n" +
+		`      exit 42` + "\n" +
+		`      ;;` + "\n" +
+		`  esac` + "\n" +
+		`fi` + "\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+	ws := &Workspace{
+		ID:           "0000000000000001",
+		TmuxSession:  "middleman-0000000000000001",
+		Status:       "error",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/live",
+		WorktreePath: filepath.Join(t.TempDir(), "live"),
+	}
+	require.NoError(d.InsertWorkspace(context.Background(), ws))
+	for _, targetKey := range []string{"codex", "claude"} {
+		require.NoError(d.UpsertWorkspaceTmuxSession(
+			context.Background(),
+			&db.WorkspaceTmuxSession{
+				WorkspaceID: ws.ID,
+				SessionName: "middleman-0000000000000001-" + targetKey,
+				TargetKey:   targetKey,
+			},
+		))
+	}
+
+	err := mgr.cleanupTmuxSession(context.Background(), ws)
+	require.Error(err)
+	assert.Contains(err.Error(), "middleman-0000000000000001-codex")
+
+	argvs := readRecorderArgv(t, record)
+	assert.Contains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001",
+	})
+	assert.Contains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001-codex",
+	})
+	assert.Contains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001-claude",
+	})
+
+	stored, err := d.ListWorkspaceTmuxSessions(context.Background(), ws.ID)
+	require.NoError(err)
+	require.Len(stored, 2)
+}
+
 func TestManagerRequestRetryFailsWhenTmuxCleanupFails(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -776,11 +776,11 @@ func TestManagerReapOrphanTmuxSessionsKillsUnknownManagedSessions(t *testing.T) 
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'middleman-0000000000000001\nmiddleman-ffffffffffffffff\nmiddleman-aaaaaaaaaaaaaaaa\nmiddleman-notes\nother-session\n'` + "\n" +
+		`    printf 'middleman-0000000000000001\nmiddleman-ffffffffffffffff\nmiddleman-aaaaaaaaaaaaaaaa-0123456789abcdef\nmiddleman-aaaaaaaaaaaaaaaa-claude\nmiddleman-notes\nother-session\n'` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
 		`  if [ "$a" = "show-options" ]; then` + "\n" +
-		`    if [ "$5" = "middleman-aaaaaaaaaaaaaaaa" ]; then` + "\n" +
+		`    if [ "$5" = "middleman-aaaaaaaaaaaaaaaa-0123456789abcdef" ] || [ "$5" = "middleman-aaaaaaaaaaaaaaaa-claude" ]; then` + "\n" +
 		`      printf '%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
 		`      exit 0` + "\n" +
 		`    fi` + "\n" +
@@ -828,14 +828,26 @@ func TestManagerReapOrphanTmuxSessionsKillsUnknownManagedSessions(t *testing.T) 
 	assert.Equal(
 		[]string{
 			"wrap", "show-options", "-qv", "-t",
-			"middleman-aaaaaaaaaaaaaaaa", "@middleman_owner",
+			"middleman-aaaaaaaaaaaaaaaa-0123456789abcdef",
+			"@middleman_owner",
 		},
 		argvs[2],
 	)
 	assert.Equal(
-		[]string{"wrap", "kill-session", "-t", "middleman-aaaaaaaaaaaaaaaa"},
+		[]string{
+			"wrap", "kill-session", "-t",
+			"middleman-aaaaaaaaaaaaaaaa-0123456789abcdef",
+		},
 		argvs[3],
 	)
+	assert.NotContains(argvs, []string{
+		"wrap", "show-options", "-qv", "-t",
+		"middleman-aaaaaaaaaaaaaaaa-claude", "@middleman_owner",
+	})
+	assert.NotContains(argvs, []string{
+		"wrap", "kill-session", "-t",
+		"middleman-aaaaaaaaaaaaaaaa-claude",
+	})
 }
 
 func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
@@ -851,7 +863,7 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'middleman-0000000000000001\nmiddleman-0000000000000001-codex\nmiddleman-aaaaaaaaaaaaaaaa-claude\n'` + "\n" +
+		`    printf 'middleman-0000000000000001\nmiddleman-0000000000000001-57de4cf40144bdf7\nmiddleman-aaaaaaaaaaaaaaaa-c857d09db23e6822\n'` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
 		`  if [ "$a" = "show-options" ]; then` + "\n" +
@@ -884,7 +896,7 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		context.Background(),
 		&db.WorkspaceTmuxSession{
 			WorkspaceID: "0000000000000001",
-			SessionName: "middleman-0000000000000001-codex",
+			SessionName: "middleman-0000000000000001-57de4cf40144bdf7",
 			TargetKey:   "codex",
 		},
 	))
@@ -893,10 +905,12 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 
 	argvs := readRecorderArgv(t, record)
 	assert.Contains(argvs, []string{
-		"wrap", "kill-session", "-t", "middleman-aaaaaaaaaaaaaaaa-claude",
+		"wrap", "kill-session", "-t",
+		"middleman-aaaaaaaaaaaaaaaa-c857d09db23e6822",
 	})
 	assert.NotContains(argvs, []string{
-		"wrap", "kill-session", "-t", "middleman-0000000000000001-codex",
+		"wrap", "kill-session", "-t",
+		"middleman-0000000000000001-57de4cf40144bdf7",
 	})
 }
 
@@ -924,7 +938,7 @@ func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
 		context.Background(),
 		&db.WorkspaceTmuxSession{
 			WorkspaceID: "0000000000000001",
-			SessionName: "middleman-0000000000000001-codex",
+			SessionName: "middleman-0000000000000001-57de4cf40144bdf7",
 			TargetKey:   "codex",
 		},
 	))
@@ -932,7 +946,7 @@ func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
 		context.Background(),
 		&db.WorkspaceTmuxSession{
 			WorkspaceID: "0000000000000001",
-			SessionName: "middleman-0000000000000001-claude",
+			SessionName: "middleman-0000000000000001-c857d09db23e6822",
 			TargetKey:   "claude",
 		},
 	))
@@ -952,7 +966,7 @@ func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
 		context.Background(),
 		&db.WorkspaceTmuxSession{
 			WorkspaceID: "0000000000000002",
-			SessionName: "middleman-0000000000000002-codex",
+			SessionName: "middleman-0000000000000002-57de4cf40144bdf7",
 			TargetKey:   "codex",
 		},
 	))
@@ -966,8 +980,8 @@ func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
 
 	assert.Equal([]string{
 		"middleman-0000000000000001",
-		"middleman-0000000000000001-claude",
-		"middleman-0000000000000001-codex",
+		"middleman-0000000000000001-c857d09db23e6822",
+		"middleman-0000000000000001-57de4cf40144bdf7",
 	}, sessions)
 
 	sessions, err = mgr.TmuxSessionsForWorkspace(
@@ -977,8 +991,8 @@ func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
 	)
 	require.NoError(err)
 	assert.Equal([]string{
-		"middleman-0000000000000001-claude",
-		"middleman-0000000000000001-codex",
+		"middleman-0000000000000001-c857d09db23e6822",
+		"middleman-0000000000000001-57de4cf40144bdf7",
 	}, sessions)
 }
 
@@ -1017,7 +1031,7 @@ func TestManagerCleanupTmuxSessionKillsRuntimeSessionsForWorkspace(
 		context.Background(),
 		&db.WorkspaceTmuxSession{
 			WorkspaceID: ws.ID,
-			SessionName: "middleman-0000000000000001-codex",
+			SessionName: "middleman-0000000000000001-57de4cf40144bdf7",
 			TargetKey:   "codex",
 		},
 	))
@@ -1025,7 +1039,7 @@ func TestManagerCleanupTmuxSessionKillsRuntimeSessionsForWorkspace(
 		context.Background(),
 		&db.WorkspaceTmuxSession{
 			WorkspaceID: ws.ID,
-			SessionName: "middleman-0000000000000001-claude",
+			SessionName: "middleman-0000000000000001-c857d09db23e6822",
 			TargetKey:   "claude",
 		},
 	))
@@ -1037,13 +1051,16 @@ func TestManagerCleanupTmuxSessionKillsRuntimeSessionsForWorkspace(
 		"kill-session", "-t", "middleman-0000000000000001",
 	})
 	assert.Contains(argvs, []string{
-		"kill-session", "-t", "middleman-0000000000000001-claude",
+		"kill-session", "-t",
+		"middleman-0000000000000001-c857d09db23e6822",
 	})
 	assert.Contains(argvs, []string{
-		"kill-session", "-t", "middleman-0000000000000001-codex",
+		"kill-session", "-t",
+		"middleman-0000000000000001-57de4cf40144bdf7",
 	})
 	assert.NotContains(argvs, []string{
-		"kill-session", "-t", "middleman-0000000000000002-codex",
+		"kill-session", "-t",
+		"middleman-0000000000000002-57de4cf40144bdf7",
 	})
 	stored, err := d.ListWorkspaceTmuxSessions(context.Background(), ws.ID)
 	require.NoError(err)
@@ -1073,7 +1090,7 @@ func TestManagerCleanupTmuxSessionPreservesStoredRowsAfterRuntimeKillFailure(
 		`      echo "can't find session: $target" >&2` + "\n" +
 		`      exit 1` + "\n" +
 		`      ;;` + "\n" +
-		`    middleman-0000000000000001-codex)` + "\n" +
+		`    middleman-0000000000000001-57de4cf40144bdf7)` + "\n" +
 		`      echo "permission denied" >&2` + "\n" +
 		`      exit 42` + "\n" +
 		`      ;;` + "\n" +
@@ -1104,25 +1121,30 @@ func TestManagerCleanupTmuxSessionPreservesStoredRowsAfterRuntimeKillFailure(
 			context.Background(),
 			&db.WorkspaceTmuxSession{
 				WorkspaceID: ws.ID,
-				SessionName: "middleman-0000000000000001-" + targetKey,
-				TargetKey:   targetKey,
+				SessionName: map[string]string{
+					"codex":  "middleman-0000000000000001-57de4cf40144bdf7",
+					"claude": "middleman-0000000000000001-c857d09db23e6822",
+				}[targetKey],
+				TargetKey: targetKey,
 			},
 		))
 	}
 
 	err := mgr.cleanupTmuxSession(context.Background(), ws)
 	require.Error(err)
-	assert.Contains(err.Error(), "middleman-0000000000000001-codex")
+	assert.Contains(err.Error(), "middleman-0000000000000001-57de4cf40144bdf7")
 
 	argvs := readRecorderArgv(t, record)
 	assert.Contains(argvs, []string{
 		"kill-session", "-t", "middleman-0000000000000001",
 	})
 	assert.Contains(argvs, []string{
-		"kill-session", "-t", "middleman-0000000000000001-codex",
+		"kill-session", "-t",
+		"middleman-0000000000000001-57de4cf40144bdf7",
 	})
 	assert.Contains(argvs, []string{
-		"kill-session", "-t", "middleman-0000000000000001-claude",
+		"kill-session", "-t",
+		"middleman-0000000000000001-c857d09db23e6822",
 	})
 
 	stored, err := d.ListWorkspaceTmuxSessions(context.Background(), ws.ID)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -838,6 +838,207 @@ func TestManagerReapOrphanTmuxSessionsKillsUnknownManagedSessions(t *testing.T) 
 	)
 }
 
+func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    printf 'middleman-0000000000000001\nmiddleman-0000000000000001-codex\nmiddleman-aaaaaaaaaaaaaaaa-claude\n'` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		`  if [ "$a" = "show-options" ]; then` + "\n" +
+		`    printf '%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+	t.Setenv("MIDDLEMAN_TMUX_OWNER", mgr.tmuxOwnerMarker())
+
+	require.NoError(d.InsertWorkspace(context.Background(), &Workspace{
+		ID:           "0000000000000001",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/live",
+		WorktreePath: filepath.Join(t.TempDir(), "live"),
+		TmuxSession:  "middleman-0000000000000001",
+		Status:       "ready",
+	}))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		context.Background(),
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: "0000000000000001",
+			SessionName: "middleman-0000000000000001-codex",
+			TargetKey:   "codex",
+		},
+	))
+
+	require.NoError(mgr.ReapOrphanTmuxSessions(context.Background()))
+
+	argvs := readRecorderArgv(t, record)
+	assert.Contains(argvs, []string{
+		"wrap", "kill-session", "-t", "middleman-aaaaaaaaaaaaaaaa-claude",
+	})
+	assert.NotContains(argvs, []string{
+		"wrap", "kill-session", "-t", "middleman-0000000000000001-codex",
+	})
+}
+
+func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	require.NoError(d.InsertWorkspace(context.Background(), &Workspace{
+		ID:           "0000000000000001",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/live",
+		WorktreePath: filepath.Join(t.TempDir(), "live"),
+		TmuxSession:  "middleman-0000000000000001",
+		Status:       "ready",
+	}))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		context.Background(),
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: "0000000000000001",
+			SessionName: "middleman-0000000000000001-codex",
+			TargetKey:   "codex",
+		},
+	))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		context.Background(),
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: "0000000000000001",
+			SessionName: "middleman-0000000000000001-claude",
+			TargetKey:   "claude",
+		},
+	))
+	require.NoError(d.InsertWorkspace(context.Background(), &Workspace{
+		ID:           "0000000000000002",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "gadget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   2,
+		GitHeadRef:   "feature/other",
+		WorktreePath: filepath.Join(t.TempDir(), "other"),
+		TmuxSession:  "middleman-0000000000000002",
+		Status:       "ready",
+	}))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		context.Background(),
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: "0000000000000002",
+			SessionName: "middleman-0000000000000002-codex",
+			TargetKey:   "codex",
+		},
+	))
+
+	sessions, err := mgr.TmuxSessionsForWorkspace(
+		context.Background(),
+		"0000000000000001",
+		"middleman-0000000000000001",
+	)
+	require.NoError(err)
+
+	assert.Equal([]string{
+		"middleman-0000000000000001",
+		"middleman-0000000000000001-claude",
+		"middleman-0000000000000001-codex",
+	}, sessions)
+}
+
+func TestManagerCleanupTmuxSessionKillsRuntimeSessionsForWorkspace(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+	ws := &Workspace{
+		ID:           "0000000000000001",
+		TmuxSession:  "middleman-0000000000000001",
+		Status:       "ready",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/live",
+		WorktreePath: filepath.Join(t.TempDir(), "live"),
+	}
+	require.NoError(d.InsertWorkspace(context.Background(), ws))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		context.Background(),
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: ws.ID,
+			SessionName: "middleman-0000000000000001-codex",
+			TargetKey:   "codex",
+		},
+	))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		context.Background(),
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: ws.ID,
+			SessionName: "middleman-0000000000000001-claude",
+			TargetKey:   "claude",
+		},
+	))
+
+	require.NoError(mgr.cleanupTmuxSession(context.Background(), ws))
+
+	argvs := readRecorderArgv(t, record)
+	assert.Contains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001",
+	})
+	assert.Contains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001-claude",
+	})
+	assert.Contains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000001-codex",
+	})
+	assert.NotContains(argvs, []string{
+		"kill-session", "-t", "middleman-0000000000000002-codex",
+	})
+	stored, err := d.ListWorkspaceTmuxSessions(context.Background(), ws.ID)
+	require.NoError(err)
+	assert.Empty(stored)
+}
+
 func TestManagerRequestRetryFailsWhenTmuxCleanupFails(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -969,6 +969,17 @@ func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
 		"middleman-0000000000000001-claude",
 		"middleman-0000000000000001-codex",
 	}, sessions)
+
+	sessions, err = mgr.TmuxSessionsForWorkspace(
+		context.Background(),
+		"0000000000000001",
+		"",
+	)
+	require.NoError(err)
+	assert.Equal([]string{
+		"middleman-0000000000000001-claude",
+		"middleman-0000000000000001-codex",
+	}, sessions)
 }
 
 func TestManagerCleanupTmuxSessionKillsRuntimeSessionsForWorkspace(


### PR DESCRIPTION
- restore the sidebar working signal for agents launched from workspace runtime
- run agent sessions under tmux by default with config opt-out and fallback when tmux is unavailable
- clarify commit-message instructions so subjects describe intent, not mechanics