### PR TITLE
Keep workspaces durable without tmux

### DIFF
--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -21,6 +22,7 @@ import (
 	"github.com/wesm/middleman/internal/gitclone"
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/server"
 	"github.com/wesm/middleman/internal/stacks"
 	"github.com/wesm/middleman/internal/web"
@@ -182,6 +184,8 @@ func runCLI(args []string, stdout io.Writer) error {
 			return err
 		case "config":
 			return runConfigCLI(args[1:], stdout)
+		case "pty-owner":
+			return runPtyOwnerCLI(args[1:])
 		}
 	}
 
@@ -195,6 +199,39 @@ func runCLI(args []string, stdout io.Writer) error {
 		return err
 	}
 	return run(*configPath)
+}
+
+func runPtyOwnerCLI(args []string) error {
+	fs := flag.NewFlagSet("middleman pty-owner", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	root := fs.String("root", "", "pty owner state root")
+	session := fs.String("session", "", "session name")
+	cwd := fs.String("cwd", "", "working directory")
+	commandJSON := fs.String("command-json", "", "JSON command argv")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *session == "" {
+		return fmt.Errorf("pty-owner session is required")
+	}
+	if *root == "" {
+		return fmt.Errorf("pty-owner root is required")
+	}
+	if *cwd == "" {
+		return fmt.Errorf("pty-owner cwd is required")
+	}
+	var command []string
+	if *commandJSON != "" {
+		if err := json.Unmarshal([]byte(*commandJSON), &command); err != nil {
+			return fmt.Errorf("parse pty-owner command-json: %w", err)
+		}
+	}
+	return ptyowner.RunOwner(context.Background(), ptyowner.Options{
+		Root:    *root,
+		Session: *session,
+		Cwd:     *cwd,
+		Command: command,
+	})
 }
 
 func runConfigCLI(args []string, stdout io.Writer) error {

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -428,3 +428,28 @@ func TestRunCLIConfigReadPortCreatesDefaultConfig(t *testing.T) {
 	require.NoError(err)
 	assert.Contains(string(content), "port = 8091")
 }
+
+func TestRunCLIPtyOwnerRejectsMissingRequiredFlags(t *testing.T) {
+	var stdout bytes.Buffer
+
+	err := runCLI([]string{"pty-owner"}, &stdout)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session")
+}
+
+func TestRunCLIPtyOwnerParsesBeforeServerStartup(t *testing.T) {
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+	var stdout bytes.Buffer
+
+	err := runCLI([]string{
+		"pty-owner",
+		"-root", t.TempDir(),
+		"-session", "bad/session",
+		"-cwd", t.TempDir(),
+		"-command-json", `["sh","-c","exit 0"]`,
+	}, &stdout)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsafe pty owner session")
+}

--- a/docs/superpowers/plans/2026-04-27-durable-pty-owner.md
+++ b/docs/superpowers/plans/2026-04-27-durable-pty-owner.md
@@ -1,0 +1,611 @@
+# Durable PTY Owner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let middleman create and reopen durable workspaces on hosts where tmux is unavailable by launching a lightweight middleman-owned PTY process.
+
+**Architecture:** Keep tmux as the preferred terminal backend. Add a `ptyowner` backend that middleman launches as a detached helper process from the same executable; the helper owns the shell PTY, exposes a local attach/control socket, and survives middleman server restarts until the workspace is deleted. Workspace setup, cleanup, and terminal WebSocket handling move behind a small backend interface so tmux and pty-owner share the same lifecycle.
+
+**Tech Stack:** Go, SQLite, existing Huma API, existing browser terminal WebSocket protocol, `github.com/creack/pty/v2` on Unix-like hosts, a Windows PTY implementation behind build tags during the Windows task.
+
+---
+
+## Current Context
+
+- `internal/workspace.Manager.Setup` currently treats `tmux new-session` as required before a workspace can become `ready`.
+- `internal/terminal.Handler` always calls `EnsureTmux` and then runs `tmux attach-session` under a local PTY for each browser WebSocket.
+- `internal/workspace/localruntime.Manager` can run direct PTYs, but those sessions are in-process and intentionally stop on middleman shutdown unless they were wrapped in tmux.
+- Workspace responses and sidebar activity are tmux-named today: `tmux_session`, `tmux_working`, `tmux_activity_source`, and related fields.
+- `middleman` already has a simple subcommand shape in `cmd/middleman/main.go`, so the owner can be a hidden subcommand without adding another installed binary.
+
+## Approach
+
+### Option 1: Make direct `localruntime` shell sessions durable
+
+This would persist runtime sessions and restart them after middleman restarts.
+
+Pros:
+- Reuses a lot of existing PTY session code.
+
+Cons:
+- Restarting is not durable; it loses process state.
+- It does not solve the main workspace terminal route, which currently expects the base tmux session.
+
+Rejected.
+
+### Option 2: Add a pty-owner helper process and backend abstraction
+
+Middleman starts a detached helper process per base workspace terminal when tmux is unavailable. The helper owns the PTY and serves a local socket protocol for attach, input, resize, recent output replay, status, and stop.
+
+Pros:
+- Matches tmux's key durability property: middleman can restart while the workspace shell keeps running.
+- Keeps tmux behavior unchanged where tmux exists.
+- Gives Windows a backend path that does not depend on tmux.
+
+Cons:
+- Adds an internal local protocol and helper process lifecycle to test.
+- Requires a Windows-specific PTY driver.
+
+Chosen.
+
+### Option 3: Embed a full terminal multiplexer library
+
+This would build panes/sessions/windows inside middleman.
+
+Pros:
+- Could eventually replace tmux-specific assumptions.
+
+Cons:
+- Much larger than needed for a single durable shell per workspace.
+- Higher risk to the existing terminal behavior.
+
+Rejected.
+
+## File Structure
+
+- Create `internal/ptyowner/protocol.go`: socket request/response and frame types shared by server and helper.
+- Create `internal/ptyowner/client.go`: helper discovery, ping, start, attach, resize, stop, and status client.
+- Create `internal/ptyowner/owner.go`: owner process runtime loop, PTY lifecycle, subscriber fanout, output replay, and shutdown.
+- Create `internal/ptyowner/paths.go`: session directory/socket path helpers rooted under middleman's data/worktree state.
+- Create `internal/ptyowner/driver_unix.go`: PTY start/resize implementation using `github.com/creack/pty/v2`.
+- Create `internal/ptyowner/driver_windows.go`: Windows PTY start/resize implementation, introduced with a proven ConPTY-backed dependency or a small `x/sys/windows` wrapper.
+- Create `internal/workspace/terminal_backend.go`: `TerminalBackend` interface and tmux/pty-owner backend selection.
+- Modify `internal/workspace/manager.go`: replace direct tmux setup/cleanup/ensure calls with backend calls while preserving tmux methods for the tmux backend.
+- Modify `internal/terminal/handler.go`: attach to the selected backend instead of always attaching tmux.
+- Modify `internal/server/server.go`: construct terminal backends, pass pty-owner paths/options, and skip tmux orphan cleanup when tmux is unavailable.
+- Modify `internal/server/huma_routes.go` and `internal/server/api_types.go`: preserve current response fields but compute activity from the selected backend when possible.
+- Modify `cmd/middleman/main.go`: add hidden `pty-owner` subcommand.
+- Add tests in `internal/ptyowner/*_test.go`, `internal/workspace/manager_test.go`, `internal/terminal/handler_test.go`, and `internal/server/api_test.go`.
+
+## Task 1: Add the PTY Owner Protocol
+
+**Files:**
+- Create: `internal/ptyowner/protocol.go`
+- Create: `internal/ptyowner/paths.go`
+- Test: `internal/ptyowner/protocol_test.go`
+
+- [ ] **Step 1: Write protocol and path tests**
+
+Add tests that assert:
+- session names reject path separators and empty values
+- socket/state paths are stable under a provided root
+- JSON control frames round-trip for `attach`, `resize`, `stop`, `status`, and `input`
+- binary output frames preserve arbitrary bytes
+
+Run: `go test ./internal/ptyowner -run 'TestProtocol|TestSessionPaths' -shuffle=on`
+
+Expected: FAIL because `internal/ptyowner` does not exist.
+
+- [ ] **Step 2: Implement protocol structs**
+
+Define:
+
+```go
+type Request struct {
+	Type string `json:"type"`
+	Cols int    `json:"cols,omitempty"`
+	Rows int    `json:"rows,omitempty"`
+	Data []byte `json:"data,omitempty"`
+}
+
+type Response struct {
+	Type     string `json:"type"`
+	OK       bool   `json:"ok,omitempty"`
+	Error    string `json:"error,omitempty"`
+	ExitCode *int   `json:"exit_code,omitempty"`
+}
+```
+
+Use newline-delimited JSON for control messages and length-prefixed binary frames for PTY output so the owner can multiplex replay, live output, and exit notification over one local connection.
+
+- [ ] **Step 3: Implement path helpers**
+
+Use a root like `<data-dir>/pty-owner/<session>/` with:
+- `control.sock` on Unix
+- `control.pipe` metadata naming `\\.\pipe\middleman-<session>` on Windows
+- `owner.json` containing session, cwd, pid, created_at, and backend version
+
+Reject session names that are empty or contain `/`, `\`, NUL, or `..`.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/ptyowner -run 'TestProtocol|TestSessionPaths' -shuffle=on`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ptyowner
+git commit -m "feat: define durable pty owner protocol"
+```
+
+Commit body:
+
+```text
+The pty owner needs a small local protocol before workspace setup can
+delegate terminal ownership away from tmux. This adds the shared frame
+types and stable per-session paths used by the owner and middleman.
+```
+
+## Task 2: Implement the Owner Runtime on Unix
+
+**Files:**
+- Create: `internal/ptyowner/owner.go`
+- Create: `internal/ptyowner/driver_unix.go`
+- Test: `internal/ptyowner/owner_test.go`
+
+- [ ] **Step 1: Write owner lifecycle tests**
+
+Cover:
+- owner starts a shell command in a PTY and emits output to an attached client
+- a detached client can reconnect and receive recent output replay
+- resize control calls the driver resize path
+- stop terminates the child process and removes the socket/state files
+- owner exits when the child exits and reports the exit code
+
+Run: `go test ./internal/ptyowner -run TestOwner -shuffle=on`
+
+Expected: FAIL because owner runtime is missing.
+
+- [ ] **Step 2: Implement the owner**
+
+Implement `RunOwner(ctx, Options) error` with:
+- command resolution using the same executable safety rules as `localruntime.resolveExecutable`
+- sanitized environment using the existing `localruntime` environment helper or a small exported wrapper
+- PTY output fanout to attached clients
+- a bounded replay buffer matching `localruntime.maxSessionOutputReplay` size
+- graceful stop with context timeout and process kill fallback
+
+- [ ] **Step 3: Add Unix PTY driver**
+
+Under `//go:build !windows`, wrap:
+- `pty.StartWithSize`
+- `pty.Setsize`
+- process wait/close
+
+Keep the owner package API platform-neutral so the Windows driver can land separately.
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/ptyowner -run TestOwner -shuffle=on`
+
+Expected: PASS on Unix-like hosts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ptyowner internal/workspace/localruntime
+git commit -m "feat: run durable pty owner sessions"
+```
+
+Commit body:
+
+```text
+The fallback backend needs a process outside the middleman server to
+own the workspace terminal. This adds the owner runtime, PTY driver,
+output replay, resize, and stop behavior for Unix-like hosts.
+```
+
+## Task 3: Add the Hidden `middleman pty-owner` Subcommand
+
+**Files:**
+- Modify: `cmd/middleman/main.go`
+- Test: `cmd/middleman/main_test.go`
+
+- [ ] **Step 1: Write CLI tests**
+
+Cover:
+- `runCLI([]string{"pty-owner"})` requires a session, cwd, and root
+- `version` and `config read` behavior remain unchanged
+- invalid owner args return an error without starting the normal server
+
+Run: `go test ./cmd/middleman -run 'TestRunCLIPtyOwner|TestRunCLIVersion|TestRunCLIConfig' -shuffle=on`
+
+Expected: FAIL for the new pty-owner tests.
+
+- [ ] **Step 2: Implement subcommand parsing**
+
+Add a hidden `pty-owner` branch before normal server startup:
+
+```go
+case "pty-owner":
+    return runPtyOwnerCLI(args[1:], stdout)
+```
+
+Flags:
+- `-session`
+- `-cwd`
+- `-root`
+- `-shell` optional repeated/JSON command flag, defaulting to the same login shell behavior as tmux setup
+
+Do not require GitHub token or config loading for this subcommand.
+
+- [ ] **Step 3: Verify**
+
+Run: `go test ./cmd/middleman -run 'TestRunCLIPtyOwner|TestRunCLIVersion|TestRunCLIConfig' -shuffle=on`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/middleman internal/ptyowner
+git commit -m "feat: expose pty owner helper command"
+```
+
+Commit body:
+
+```text
+Middleman launches the durable PTY owner from its own executable so
+installations do not need a second binary. The helper command bypasses
+normal server startup and owns only one workspace terminal session.
+```
+
+## Task 4: Introduce Workspace Terminal Backends
+
+**Files:**
+- Create: `internal/workspace/terminal_backend.go`
+- Modify: `internal/workspace/manager.go`
+- Test: `internal/workspace/manager_test.go`
+
+- [ ] **Step 1: Write backend selection tests**
+
+Cover:
+- tmux available selects tmux backend
+- tmux unavailable selects pty-owner backend
+- configured tmux command that exists still selects tmux
+- setup failure in the selected backend marks the workspace `error`
+- retry cleanup calls the selected backend cleanup
+
+Run: `go test ./internal/workspace -run 'TestManager.*TerminalBackend|TestManager.*Retry' -shuffle=on`
+
+Expected: FAIL because no backend abstraction exists.
+
+- [ ] **Step 2: Add the interface**
+
+Define:
+
+```go
+type TerminalBackend interface {
+    Kind() string
+    Start(ctx context.Context, session string, cwd string) error
+    Ensure(ctx context.Context, session string, cwd string) error
+    Stop(ctx context.Context, session string) error
+    Snapshot(ctx context.Context, session string) (TmuxPaneSnapshot, error)
+    IsAbsent(error) bool
+}
+```
+
+Name can stay tmux-flavored in public response structs for compatibility, but internal code should refer to terminal sessions.
+
+- [ ] **Step 3: Move tmux calls behind `tmuxBackend`**
+
+Keep existing tmux methods in `manager.go` or move them into `terminal_backend.go` with no behavior change:
+- `newTmuxSession`
+- `EnsureTmux`
+- `killTmuxSession`
+- `TmuxPaneSnapshot`
+- `ReapOrphanTmuxSessions`
+
+- [ ] **Step 4: Add `ptyOwnerBackend`**
+
+Use `ptyowner.Client` to:
+- start the helper if no live owner responds
+- ensure existing owner on attach
+- stop owner on delete/retry
+- return output/title snapshot from owner status when available
+
+- [ ] **Step 5: Wire setup and cleanup**
+
+Change `Setup` from hardcoded `m.newTmuxSession` to `m.terminal.Start`.
+Change cleanup from `cleanupTmuxSession` to `cleanupTerminalSession`, preserving stored runtime tmux cleanup for existing tmux-backed agent sessions.
+
+- [ ] **Step 6: Verify**
+
+Run: `go test ./internal/workspace -run 'TestManager.*TerminalBackend|TestManagerEnsureTmux|TestManagerReapOrphanTmuxSessions' -shuffle=on`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/workspace internal/ptyowner
+git commit -m "feat: choose durable workspace terminal backends"
+```
+
+Commit body:
+
+```text
+Workspace setup should no longer fail solely because tmux is missing.
+This introduces a terminal backend boundary and falls back to the
+pty-owner helper when tmux cannot be resolved.
+```
+
+## Task 5: Attach Browser Terminals Through the Selected Backend
+
+**Files:**
+- Modify: `internal/terminal/handler.go`
+- Modify: `internal/terminal/bridge.go`
+- Test: `internal/terminal/handler_test.go`
+
+- [ ] **Step 1: Write terminal handler tests**
+
+Cover:
+- tmux backend still shells out to `tmux attach-session`
+- pty-owner backend attaches to the owner socket
+- binary input reaches the owner
+- resize control reaches the owner
+- reconnect receives replayed output
+- only one active base terminal attachment is still enforced per workspace
+
+Run: `go test ./internal/terminal -run TestHandler -shuffle=on`
+
+Expected: FAIL for pty-owner attach behavior.
+
+- [ ] **Step 2: Add an attachment interface**
+
+Define an internal terminal attachment interface mirroring `localruntime.Attachment`:
+
+```go
+type Attachment interface {
+    Output() <-chan []byte
+    Done() <-chan struct{}
+    Write([]byte) error
+    Resize(cols, rows int) error
+    Close()
+    ExitCode() int
+}
+```
+
+Use it for the pty-owner path. Keep the tmux path as a local PTY running `tmux attach-session` if that backend is selected.
+
+- [ ] **Step 3: Update handler flow**
+
+After workspace readiness checks and slot claim:
+- call backend `Ensure`
+- if backend is tmux, preserve existing `tmux attach-session` flow
+- if backend is pty-owner, bridge WebSocket to the owner attachment
+
+- [ ] **Step 4: Verify**
+
+Run: `go test ./internal/terminal -run TestHandler -shuffle=on`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/terminal internal/workspace internal/ptyowner
+git commit -m "feat: attach workspace terminals without tmux"
+```
+
+Commit body:
+
+```text
+The browser terminal now attaches through the workspace terminal backend.
+Tmux attach behavior remains unchanged, while pty-owner workspaces bridge
+directly to the durable owner process.
+```
+
+## Task 6: Wire Server Startup and API Behavior
+
+**Files:**
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/huma_routes.go`
+- Modify: `internal/server/api_types.go`
+- Test: `internal/server/api_test.go`
+
+- [ ] **Step 1: Write full-stack API tests**
+
+Add e2e tests with real SQLite that simulate tmux absence:
+- creating a workspace reaches `ready` instead of `error`
+- `GET /workspaces/{id}` returns the existing response shape
+- WebSocket `/workspaces/{id}/terminal` can read/write through the pty-owner backend
+- server shutdown and recreation can reattach to the still-running owner
+- delete stops the owner and removes state files
+
+Run: `go test ./internal/server -run 'TestWorkspace.*PtyOwner|TestWorkspaceTerminal.*PtyOwner' -shuffle=on`
+
+Expected: FAIL because server construction does not yet pass owner options.
+
+- [ ] **Step 2: Add server options**
+
+Extend `server.ServerOptions` with an internal pty-owner root or derive it from `WorktreeDir`/config data dir:
+
+```go
+PtyOwnerDir string
+```
+
+In production, use `<cfg.DataDir>/pty-owner`.
+
+- [ ] **Step 3: Select backend during `newServer`**
+
+Resolve tmux availability once with the existing `ResolveLaunchTargets`/`lookPath` behavior. If the tmux target is unavailable, configure workspace manager and terminal handler with the pty-owner backend.
+
+Do not call `ReapOrphanTmuxSessions` when tmux is unavailable.
+
+- [ ] **Step 4: Preserve response compatibility**
+
+Keep JSON fields as-is for now:
+- `tmux_session` remains the stable session identifier
+- `tmux_working` can report true when either tmux or pty-owner shows activity
+- `tmux_activity_source` may gain a value such as `pty_owner` only if frontend tests are updated; otherwise map pty-owner recent output to `output`
+
+- [ ] **Step 5: Verify**
+
+Run: `go test ./internal/server -run 'TestWorkspace.*PtyOwner|TestWorkspaceTerminal.*PtyOwner|TestWorkspaceRuntimeTargets' -shuffle=on`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server internal/workspace internal/terminal internal/ptyowner
+git commit -m "feat: keep workspaces ready when tmux is unavailable"
+```
+
+Commit body:
+
+```text
+Workspace creation now falls back to a middleman-owned PTY process when
+tmux is missing. The API keeps the existing workspace response contract
+while allowing terminal reattachment after middleman restarts.
+```
+
+## Task 7: Add Windows Driver Support
+
+**Files:**
+- Create: `internal/ptyowner/driver_windows.go`
+- Modify: `go.mod`
+- Modify: `go.sum`
+- Test: `internal/ptyowner/owner_windows_test.go`
+
+- [ ] **Step 1: Choose and document the Windows PTY dependency**
+
+Use the smallest maintained ConPTY-backed Go package that supports:
+- start process attached to pseudoconsole
+- read/write
+- resize
+- wait/close
+
+If a new dependency is needed, add a short comment in `driver_windows.go` explaining why `github.com/creack/pty/v2` is not used for Windows.
+
+- [ ] **Step 2: Implement Windows driver behind build tags**
+
+Expose the same internal driver methods used by `owner.go`.
+
+- [ ] **Step 3: Add compile coverage**
+
+Run:
+
+```bash
+GOOS=windows GOARCH=amd64 go test ./internal/ptyowner -run TestSessionPaths -shuffle=on
+GOOS=windows GOARCH=amd64 go test ./cmd/middleman -run TestRunCLIPtyOwner -shuffle=on
+```
+
+Expected: PASS or a documented skip for tests that require a live ConPTY host.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/ptyowner go.mod go.sum
+git commit -m "feat: support pty owner on windows"
+```
+
+Commit body:
+
+```text
+Windows hosts do not have tmux, so the fallback backend needs a native
+PTY driver. This adds the ConPTY implementation behind build tags while
+keeping the owner protocol shared across platforms.
+```
+
+## Task 8: Update Runtime Target Semantics
+
+**Files:**
+- Modify: `internal/workspace/localruntime/targets.go`
+- Modify: `internal/workspace/localruntime/manager.go`
+- Test: `internal/workspace/localruntime/targets_test.go`
+- Test: `internal/workspace/localruntime/manager_test.go`
+
+- [ ] **Step 1: Write tests for no-tmux hosts**
+
+Cover:
+- tmux target is unavailable when tmux cannot be found
+- agent launches do not attempt tmux wrapping when tmux is unavailable
+- plain shell still works
+- pty-owner fallback does not make `tmux` appear available as a launch target
+
+Run: `go test ./internal/workspace/localruntime -run 'TestResolveLaunchTargets|TestLaunchCommand' -shuffle=on`
+
+Expected: existing tests pass, new no-tmux fallback tests may fail until behavior is explicit.
+
+- [ ] **Step 2: Keep agent wrapping strictly tmux-based**
+
+Do not wrap agent runtime sessions in pty-owner in this feature. The user request is durable base workspaces when no tmux exists; extending per-agent runtime durability can follow later.
+
+- [ ] **Step 3: Verify**
+
+Run: `go test ./internal/workspace/localruntime -run 'TestResolveLaunchTargets|TestLaunchCommand' -shuffle=on`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/workspace/localruntime
+git commit -m "fix: keep runtime launch targets honest without tmux"
+```
+
+Commit body:
+
+```text
+The pty-owner backend makes base workspaces durable, but it is not a
+tmux replacement for agent launch targets. Runtime target reporting now
+keeps that boundary explicit on hosts without tmux.
+```
+
+## Task 9: Final Verification
+
+**Files:**
+- All changed files
+
+- [ ] **Step 1: Regenerate API artifacts if response types changed**
+
+Run: `make api-generate`
+
+Expected: no diff unless OpenAPI response types changed intentionally.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+go test ./internal/ptyowner ./internal/workspace ./internal/terminal ./internal/server ./internal/workspace/localruntime -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full Go tests**
+
+Run: `make test`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run frontend tests only if JSON response semantics changed**
+
+Run: `bun test` from `frontend/` only if frontend code or generated API types change.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit any verification-only fixes**
+
+Use a conventional commit whose subject names the user-visible reason for the fix.
+
+## Self-Review
+
+- Spec coverage: The plan covers durable no-tmux workspaces, owner process launch, reconnect after middleman restart, cleanup, Windows support, and compatibility with existing tmux behavior.
+- Placeholder scan: No TODO/TBD placeholders are present.
+- Type consistency: `ptyowner` owns the local protocol; `workspace.TerminalBackend` owns lifecycle selection; `terminal.Handler` owns browser attach bridging.
+- Scope check: Per-agent runtime durability through pty-owner is intentionally excluded. Existing tmux-backed agent durability remains unchanged.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.gitea.io/sdk/gitea v0.25.0
 	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3 v3.0.0
 	github.com/BurntSushi/toml v1.6.0
+	github.com/aymanbagabas/go-pty v0.2.2
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty/v2 v2.0.1
@@ -50,6 +51,7 @@ require (
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -172,6 +174,7 @@ require (
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect
+	github.com/u-root/u-root v0.11.0 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
+github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bitfield/gotestdox v0.2.2 h1:x6RcPAbBbErKLnapz1QeAlf3ospg8efBsedU93CDsnE=
@@ -519,6 +521,10 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90 h1:zTk5683I9K62wtZ6eUa6vu6IWwVHXPnoKK5n2unAwv0=
+github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90/go.mod h1:lYt+LVfZBBwDZ3+PHk4k/c/TnKOkjJXiJO73E32Mmpc=
+github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=
+github.com/u-root/u-root v0.11.0/go.mod h1:DBkDtiZyONk9hzVEdB/PWI9B4TxDkElWlVTHseglrZY=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -49,7 +50,7 @@ func TestOpenAndSchema(t *testing.T) {
 		require.NoErrorf(t, err, "table %s should exist", tbl)
 	}
 
-	for _, column := range []string{"workspace_branch", "associated_pr_number"} {
+	for _, column := range []string{"workspace_branch", "associated_pr_number", "terminal_backend"} {
 		var found string
 		err := d.ReadDB().QueryRow(
 			`SELECT name
@@ -769,6 +770,52 @@ func TestOpenRepairsBrokenWorkspaceMigrationVersion11(t *testing.T) {
 	)
 }
 
+func TestOpenRepairsCurrentSchemaMissingWorkspaceTerminalBackend(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken-terminal-backend.db")
+
+	d, err := Open(path)
+	require.NoError(err)
+	require.NoError(d.Close())
+
+	raw, err := sql.Open("sqlite", path)
+	require.NoError(err)
+	_, err = raw.Exec(`ALTER TABLE middleman_workspaces DROP COLUMN terminal_backend`)
+	require.NoError(err)
+	require.NoError(raw.Close())
+
+	reopened, err := Open(path)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(reopened.Close()) })
+
+	var terminalBackendColumn string
+	err = reopened.ReadDB().QueryRow(
+		`SELECT name
+		 FROM pragma_table_info('middleman_workspaces')
+		 WHERE name = ?`,
+		"terminal_backend",
+	).Scan(&terminalBackendColumn)
+	require.NoError(err)
+	require.Equal("terminal_backend", terminalBackendColumn)
+
+	err = reopened.InsertWorkspace(ctx, &Workspace{
+		ID:              "ws-terminal-backend",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature/backend",
+		WorktreePath:    "/tmp/ws-terminal-backend",
+		TmuxSession:     "middleman-ws-terminal-backend",
+		Status:          "creating",
+		WorkspaceBranch: "feature/backend",
+	})
+	require.NoError(err)
+}
+
 func TestOpenMigratesWorkspaceUniquenessAndPreservesSetupEvents(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
@@ -986,7 +1033,7 @@ func legacySchemaSQLForTest(t *testing.T, version int) string {
 	for i := 1; i <= version; i++ {
 		contents, err := fs.ReadFile(
 			migrationFiles,
-			filepath.Join("migrations", legacyMigrationFilenameForTest(i)),
+			path.Join("migrations", legacyMigrationFilenameForTest(i)),
 		)
 		require.NoError(t, err)
 		parts = append(parts, string(contents))

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -133,6 +133,11 @@ func runMigrations(rw *sql.DB) (int, error) {
 			fmt.Errorf("database ended at migration version %d, expected %d", version, latest),
 		)
 	}
+	if err := reconcileWorkspaceTerminalBackendColumn(rw); err != nil {
+		return migratedb.NilVersion, wrapMigrationError(
+			fmt.Errorf("repair workspace terminal backend column: %w", err),
+		)
+	}
 
 	return startVersion, nil
 }
@@ -227,6 +232,26 @@ func hasColumn(
 	}
 
 	return false, rows.Err()
+}
+
+func reconcileWorkspaceTerminalBackendColumn(rw *sql.DB) error {
+	if !hasTable(rw, "middleman_workspaces") {
+		return nil
+	}
+	hasTerminalBackend, err := hasColumn(
+		rw, "middleman_workspaces", "terminal_backend",
+	)
+	if err != nil {
+		return err
+	}
+	if hasTerminalBackend {
+		return nil
+	}
+	_, err = rw.Exec(`
+		ALTER TABLE middleman_workspaces
+		    ADD COLUMN terminal_backend TEXT NOT NULL DEFAULT ''
+	`)
+	return err
 }
 
 func reconcileWorkspaceSetupMigrationVersion10(

--- a/internal/db/migrations/000020_workspace_terminal_backend.down.sql
+++ b/internal/db/migrations/000020_workspace_terminal_backend.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE middleman_workspaces
+    DROP COLUMN terminal_backend;

--- a/internal/db/migrations/000020_workspace_terminal_backend.up.sql
+++ b/internal/db/migrations/000020_workspace_terminal_backend.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE middleman_workspaces
+    ADD COLUMN terminal_backend TEXT NOT NULL DEFAULT '';

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -3291,20 +3291,23 @@ func (d *DB) InsertWorkspace(
 	if err != nil {
 		return err
 	}
+	if ws.TerminalBackend == "" {
+		ws.TerminalBackend = "tmux"
+	}
 	_, err = d.rw.ExecContext(ctx, `
 		INSERT INTO middleman_workspaces
 		    (id, platform, platform_host, repo_owner, repo_name,
 		     repo_owner_key, repo_name_key, repo_path_key,
 		     item_type, item_number, associated_pr_number,
 		     git_head_ref, mr_head_repo, workspace_branch,
-		     worktree_path, tmux_session, status,
+		     worktree_path, tmux_session, terminal_backend, status,
 		     error_message)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		ws.ID, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 		repoOwnerKey, repoNameKey, repoPathKey,
 		ws.ItemType, ws.ItemNumber, ws.AssociatedPRNumber,
 		ws.GitHeadRef, ws.MRHeadRepo, ws.WorkspaceBranch,
-		ws.WorktreePath, ws.TmuxSession, ws.Status,
+		ws.WorktreePath, ws.TmuxSession, ws.TerminalBackend, ws.Status,
 		ws.ErrorMessage,
 	)
 	if err != nil {
@@ -3322,14 +3325,14 @@ func (d *DB) GetWorkspace(
 		SELECT id, platform, platform_host, repo_owner, repo_name,
 		       item_type, item_number, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, status,
+		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at
 		FROM middleman_workspaces WHERE id = ?`, id,
 	).Scan(
 		&ws.ID, &ws.Platform, &ws.PlatformHost, &ws.RepoOwner, &ws.RepoName,
 		&ws.ItemType, &ws.ItemNumber, &ws.AssociatedPRNumber,
 		&ws.GitHeadRef, &ws.MRHeadRepo, &ws.WorkspaceBranch,
-		&ws.WorktreePath, &ws.TmuxSession, &ws.Status,
+		&ws.WorktreePath, &ws.TmuxSession, &ws.TerminalBackend, &ws.Status,
 		&ws.ErrorMessage, &ws.CreatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -3355,7 +3358,7 @@ func (d *DB) GetWorkspaceByMR(
 		SELECT id, platform, platform_host, repo_owner, repo_name,
 		       item_type, item_number, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, status,
+		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at
 		FROM middleman_workspaces
 		WHERE platform_host = ? AND repo_owner_key = ?
@@ -3365,7 +3368,7 @@ func (d *DB) GetWorkspaceByMR(
 		&ws.ID, &ws.Platform, &ws.PlatformHost, &ws.RepoOwner, &ws.RepoName,
 		&ws.ItemType, &ws.ItemNumber, &ws.AssociatedPRNumber,
 		&ws.GitHeadRef, &ws.MRHeadRepo, &ws.WorkspaceBranch,
-		&ws.WorktreePath, &ws.TmuxSession, &ws.Status,
+		&ws.WorktreePath, &ws.TmuxSession, &ws.TerminalBackend, &ws.Status,
 		&ws.ErrorMessage, &ws.CreatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -3391,7 +3394,7 @@ func (d *DB) GetWorkspaceByIssue(
 		SELECT id, platform, platform_host, repo_owner, repo_name,
 		       item_type, item_number, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, status,
+		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at
 		FROM middleman_workspaces
 		WHERE platform_host = ? AND repo_owner_key = ?
@@ -3401,7 +3404,7 @@ func (d *DB) GetWorkspaceByIssue(
 		&ws.ID, &ws.Platform, &ws.PlatformHost, &ws.RepoOwner, &ws.RepoName,
 		&ws.ItemType, &ws.ItemNumber, &ws.AssociatedPRNumber,
 		&ws.GitHeadRef, &ws.MRHeadRepo, &ws.WorkspaceBranch,
-		&ws.WorktreePath, &ws.TmuxSession, &ws.Status,
+		&ws.WorktreePath, &ws.TmuxSession, &ws.TerminalBackend, &ws.Status,
 		&ws.ErrorMessage, &ws.CreatedAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -3423,7 +3426,7 @@ func (d *DB) ListWorkspaces(
 		SELECT id, platform, platform_host, repo_owner, repo_name,
 		       item_type, item_number, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, status,
+		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at
 		FROM middleman_workspaces
 		ORDER BY created_at DESC`,
@@ -3443,7 +3446,7 @@ func (d *DB) ListWorkspaces(
 			&ws.GitHeadRef, &ws.MRHeadRepo,
 			&ws.WorkspaceBranch,
 			&ws.WorktreePath, &ws.TmuxSession,
-			&ws.Status, &ws.ErrorMessage, &ws.CreatedAt,
+			&ws.TerminalBackend, &ws.Status, &ws.ErrorMessage, &ws.CreatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan workspace: %w", err)
 		}
@@ -3760,7 +3763,7 @@ const workspaceSummaryColumns = `
 	w.id, w.platform, w.platform_host, w.repo_owner, w.repo_name,
 	w.item_type, w.item_number, w.associated_pr_number,
 	w.git_head_ref, w.mr_head_repo, w.workspace_branch,
-	w.worktree_path, w.tmux_session, w.status,
+	w.worktree_path, w.tmux_session, w.terminal_backend, w.status,
 	w.error_message, w.created_at,
 	CASE
 	    WHEN w.item_type = 'issue' THEN i.title
@@ -3799,7 +3802,7 @@ func scanWorkspaceSummary(
 		&s.ID, &s.Platform, &s.PlatformHost, &s.RepoOwner, &s.RepoName,
 		&s.ItemType, &s.ItemNumber, &s.AssociatedPRNumber,
 		&s.GitHeadRef, &s.MRHeadRepo, &s.WorkspaceBranch,
-		&s.WorktreePath, &s.TmuxSession, &s.Status,
+		&s.WorktreePath, &s.TmuxSession, &s.TerminalBackend, &s.Status,
 		&s.ErrorMessage, &s.CreatedAt,
 		&s.MRTitle, &s.MRState, &s.MRIsDraft, &s.MRCIStatus,
 		&s.MRReviewDecision, &s.MRAdditions, &s.MRDeletions,

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -382,6 +382,7 @@ type Workspace struct {
 	WorkspaceBranch string
 	WorktreePath    string
 	TmuxSession     string
+	TerminalBackend string
 	Status          string // "creating", "ready", "error"
 	ErrorMessage    *string
 	CreatedAt       time.Time

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -1,0 +1,481 @@
+package ptyowner
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Client struct {
+	Root      string
+	ExePath   string
+	ExeArgs   []string
+	Command   []string
+	InProcess bool
+}
+
+const (
+	clientRPCTimeout       = 5 * time.Second
+	startLockStaleAfter    = 30 * time.Second
+	startLockRetryInterval = 25 * time.Millisecond
+)
+
+type Attachment struct {
+	Output <-chan []byte
+	Done   <-chan struct{}
+
+	conn     net.Conn
+	enc      *json.Encoder
+	writeMu  sync.Mutex
+	token    string
+	exitCode func() int
+	close    func()
+}
+
+func NewClient(root string, command []string) *Client {
+	return &Client{
+		Root:    root,
+		Command: append([]string(nil), command...),
+	}
+}
+
+func (c *Client) Ensure(ctx context.Context, session, cwd string) error {
+	if err := c.Ping(ctx, session); err == nil {
+		return nil
+	} else if !isAbsentOwner(err) {
+		return err
+	}
+	paths, err := NewSessionPaths(c.Root, session)
+	if err != nil {
+		return err
+	}
+	unlock, err := acquireStartLock(ctx, paths)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := c.Ping(ctx, session); err == nil {
+		return nil
+	} else if !isAbsentOwner(err) {
+		return err
+	}
+	_ = os.RemoveAll(paths.Dir)
+
+	exe := c.ExePath
+	if exe == "" {
+		exe, err = os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolve middleman executable: %w", err)
+		}
+	}
+	command := append([]string(nil), c.Command...)
+	if len(command) == 0 {
+		command = defaultShellCommand()
+	}
+	commandJSON, err := json.Marshal(command)
+	if err != nil {
+		return err
+	}
+	if c.InProcess {
+		go func() {
+			_ = RunOwner(context.Background(), Options{
+				Root:    c.Root,
+				Session: session,
+				Cwd:     cwd,
+				Command: command,
+			})
+		}()
+		return c.waitReady(ctx, session)
+	}
+	args := append([]string(nil), c.ExeArgs...)
+	args = append(args,
+		"pty-owner",
+		"-root", c.Root,
+		"-session", session,
+		"-cwd", cwd,
+		"-command-json", string(commandJSON),
+	)
+	cmd := exec.Command(exe, args...)
+	cmd.Env = ownerHelperEnvironment(os.Environ())
+	detachCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start pty owner: %w", err)
+	}
+	go func() {
+		_ = cmd.Wait()
+	}()
+
+	return c.waitReady(ctx, session)
+}
+
+func acquireStartLock(
+	ctx context.Context,
+	paths SessionPaths,
+) (func(), error) {
+	if err := os.MkdirAll(paths.Root, 0o700); err != nil {
+		return nil, err
+	}
+	lockPath := startLockPath(paths)
+	for {
+		file, err := os.OpenFile(
+			lockPath,
+			os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+			0o600,
+		)
+		if err == nil {
+			_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
+			_ = file.Close()
+			return func() { _ = os.Remove(lockPath) }, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		if staleStartLock(lockPath) {
+			_ = os.Remove(lockPath)
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(startLockRetryInterval):
+		}
+	}
+}
+
+func startLockPath(paths SessionPaths) string {
+	return filepath.Join(paths.Root, "."+paths.Session+".ensure.lock")
+}
+
+func staleStartLock(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) > startLockStaleAfter
+}
+
+func (c *Client) waitReady(ctx context.Context, session string) error {
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := c.Ping(ctx, session); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("pty owner did not become ready: %w", lastErr)
+}
+
+func (c *Client) HasState(session string) bool {
+	paths, err := NewSessionPaths(c.Root, session)
+	if err != nil {
+		return false
+	}
+	_, err = readState(paths)
+	return err == nil
+}
+
+func (c *Client) Ping(ctx context.Context, session string) error {
+	conn, state, err := c.connect(ctx, session)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	clearDeadline := applyRPCDeadline(ctx, conn)
+	defer clearDeadline()
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	if err := enc.Encode(Request{Type: RequestStatus, Token: state.Token}); err != nil {
+		return err
+	}
+	var resp Response
+	if err := dec.Decode(&resp); err != nil {
+		return err
+	}
+	if !resp.OK {
+		return errors.New(resp.Error)
+	}
+	return nil
+}
+
+func (c *Client) Snapshot(ctx context.Context, session string) ([]byte, error) {
+	conn, state, err := c.connect(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	clearDeadline := applyRPCDeadline(ctx, conn)
+	defer clearDeadline()
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	if err := enc.Encode(Request{Type: RequestStatus, Token: state.Token}); err != nil {
+		return nil, err
+	}
+	var resp Response
+	if err := dec.Decode(&resp); err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, errors.New(resp.Error)
+	}
+	return append([]byte(nil), resp.Output...), nil
+}
+
+func (c *Client) Attach(
+	ctx context.Context,
+	session string,
+	cols int,
+	rows int,
+) (*Attachment, error) {
+	conn, state, err := c.connect(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	clearDeadline := applyRPCDeadline(ctx, conn)
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	if err := enc.Encode(Request{
+		Type: RequestAttach, Token: state.Token, Cols: cols, Rows: rows,
+	}); err != nil {
+		clearDeadline()
+		conn.Close()
+		return nil, err
+	}
+	var initial Response
+	if err := dec.Decode(&initial); err != nil {
+		clearDeadline()
+		conn.Close()
+		return nil, err
+	}
+	if !initial.OK {
+		clearDeadline()
+		conn.Close()
+		return nil, errors.New(initial.Error)
+	}
+	clearDeadline()
+
+	output := make(chan []byte, 64)
+	done := make(chan struct{})
+	var exitMu sync.Mutex
+	exitCode := -1
+	go func() {
+		defer close(done)
+		defer close(output)
+		for {
+			var resp Response
+			if err := dec.Decode(&resp); err != nil {
+				return
+			}
+			switch resp.Type {
+			case ResponseOutput:
+				chunk := append([]byte(nil), resp.Output...)
+				select {
+				case output <- chunk:
+				case <-ctx.Done():
+					return
+				}
+			case ResponseExit:
+				if resp.ExitCode != nil {
+					exitMu.Lock()
+					exitCode = *resp.ExitCode
+					exitMu.Unlock()
+				}
+				return
+			}
+		}
+	}()
+
+	return &Attachment{
+		Output: output,
+		Done:   done,
+		conn:   conn,
+		enc:    enc,
+		token:  state.Token,
+		exitCode: func() int {
+			exitMu.Lock()
+			defer exitMu.Unlock()
+			return exitCode
+		},
+		close: func() { _ = conn.Close() },
+	}, nil
+}
+
+func (c *Client) Stop(ctx context.Context, session string) error {
+	paths, pathErr := NewSessionPaths(c.Root, session)
+	if pathErr != nil {
+		return pathErr
+	}
+	conn, state, err := c.connect(ctx, session)
+	if err != nil {
+		if isAbsentOwner(err) {
+			_ = os.RemoveAll(paths.Dir)
+			return nil
+		}
+		return err
+	}
+	defer conn.Close()
+	clearDeadline := applyRPCDeadline(ctx, conn)
+	defer clearDeadline()
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	if err := enc.Encode(Request{Type: RequestStop, Token: state.Token}); err != nil {
+		return err
+	}
+	var resp Response
+	if err := dec.Decode(&resp); err != nil {
+		return err
+	}
+	if !resp.OK {
+		return errors.New(resp.Error)
+	}
+	return c.waitStopped(ctx, session, paths.Dir)
+}
+
+func isAbsentOwner(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || isStaleOwnerConnection(err)
+}
+
+func isStaleOwnerConnection(err error) bool {
+	var netErr *net.OpError
+	if !errors.As(err, &netErr) {
+		return false
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		netErr.Timeout() {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "actively refused")
+}
+
+func ownerHelperEnvironment(env []string) []string {
+	return sessionEnvironment(env, nil)
+}
+
+func applyRPCDeadline(ctx context.Context, conn net.Conn) func() {
+	deadline := time.Now().Add(clientRPCTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	_ = conn.SetDeadline(deadline)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+	return func() {
+		close(done)
+		_ = conn.SetDeadline(time.Time{})
+	}
+}
+
+func (c *Client) waitStopped(ctx context.Context, session, dir string) error {
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		if err := c.Ping(ctx, session); err != nil && isStaleOwnerConnection(err) {
+			_ = os.RemoveAll(dir)
+			return nil
+		} else if err != nil {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("pty owner did not stop: %w", lastErr)
+	}
+	return fmt.Errorf("pty owner did not stop")
+}
+
+func (c *Client) connect(
+	ctx context.Context,
+	session string,
+) (net.Conn, ownerState, error) {
+	paths, err := NewSessionPaths(c.Root, session)
+	if err != nil {
+		return nil, ownerState{}, err
+	}
+	state, err := readState(paths)
+	if err != nil {
+		return nil, ownerState{}, err
+	}
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", state.Addr)
+	if err != nil {
+		return nil, ownerState{}, err
+	}
+	return conn, state, nil
+}
+
+func (a *Attachment) Write(data []byte) error {
+	if a == nil || a.enc == nil {
+		return fmt.Errorf("pty owner attachment is closed")
+	}
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+	return a.enc.Encode(Request{
+		Type: RequestInput, Token: a.token, Data: data,
+	})
+}
+
+func (a *Attachment) Resize(cols, rows int) error {
+	if a == nil || a.enc == nil {
+		return fmt.Errorf("pty owner attachment is closed")
+	}
+	a.writeMu.Lock()
+	defer a.writeMu.Unlock()
+	return a.enc.Encode(Request{
+		Type: RequestResize, Token: a.token, Cols: cols, Rows: rows,
+	})
+}
+
+func (a *Attachment) ExitCode() int {
+	if a == nil || a.exitCode == nil {
+		return -1
+	}
+	return a.exitCode()
+}
+
+func (a *Attachment) Close() {
+	if a != nil && a.close != nil {
+		a.close()
+	}
+}
+
+func newToken() (string, error) {
+	var data [16]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(data[:]), nil
+}

--- a/internal/ptyowner/detach_unix.go
+++ b/internal/ptyowner/detach_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package ptyowner
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func detachCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/ptyowner/detach_windows.go
+++ b/internal/ptyowner/detach_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package ptyowner
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const (
+	windowsDetachedProcess       = 0x00000008
+	windowsCreateNewProcessGroup = 0x00000200
+)
+
+func detachCommand(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windowsCreateNewProcessGroup |
+		windowsDetachedProcess
+}

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -1,0 +1,497 @@
+package ptyowner
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	gopty "github.com/aymanbagabas/go-pty"
+)
+
+const maxOutputReplay = 64 * 1024
+
+const (
+	maxOwnerConnections      = 32
+	ownerFirstRequestTimeout = 5 * time.Second
+	maxOwnerFirstRequestSize = 8 * 1024
+	maxOwnerRequestSize      = 96 * 1024
+	maxOwnerInputSize        = 64 * 1024
+)
+
+type Options struct {
+	Root    string
+	Session string
+	Cwd     string
+	Command []string
+}
+
+type owner struct {
+	paths SessionPaths
+	state ownerState
+	pty   gopty.Pty
+	cmd   *gopty.Cmd
+
+	mu           sync.Mutex
+	outputBuffer []byte
+	subscribers  map[chan []byte]struct{}
+	exitCode     int
+	exited       bool
+	done         chan struct{}
+	drainDone    chan struct{}
+	stopOnce     sync.Once
+	closePtyOnce sync.Once
+	connSem      chan struct{}
+}
+
+func RunOwner(ctx context.Context, opts Options) error {
+	paths, err := NewSessionPaths(opts.Root, opts.Session)
+	if err != nil {
+		return err
+	}
+	command := append([]string(nil), opts.Command...)
+	if len(command) == 0 {
+		command = defaultShellCommand()
+	}
+	resolved, err := resolveExecutable(command[0])
+	if err != nil {
+		return err
+	}
+	command[0] = resolved
+
+	p, err := gopty.New()
+	if err != nil {
+		return fmt.Errorf("open pty: %w", err)
+	}
+
+	cmd := p.Command(command[0], command[1:]...)
+	cmd.Dir = opts.Cwd
+	cmd.Env = sessionEnvironment(os.Environ(), nil)
+	configureOwnerCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start pty command: %w", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		killOwnerProcess(cmd.Process)
+		_ = p.Close()
+		return err
+	}
+	defer listener.Close()
+
+	token, err := newToken()
+	if err != nil {
+		killOwnerProcess(cmd.Process)
+		_ = p.Close()
+		return err
+	}
+	o := &owner{
+		paths:       paths,
+		pty:         p,
+		cmd:         cmd,
+		subscribers: make(map[chan []byte]struct{}),
+		exitCode:    -1,
+		done:        make(chan struct{}),
+		drainDone:   make(chan struct{}),
+		connSem:     make(chan struct{}, maxOwnerConnections),
+		state: ownerState{
+			Session:   opts.Session,
+			Addr:      listener.Addr().String(),
+			Token:     token,
+			Cwd:       opts.Cwd,
+			PID:       os.Getpid(),
+			CreatedAt: time.Now().UTC(),
+		},
+	}
+	defer o.closePty()
+	if err := writeState(paths, o.state); err != nil {
+		killOwnerProcess(cmd.Process)
+		return err
+	}
+	defer os.RemoveAll(paths.Dir)
+
+	go func() {
+		defer close(o.drainDone)
+		o.drainOutput()
+	}()
+	go o.wait()
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				acceptErr <- err
+				return
+			}
+			select {
+			case o.connSem <- struct{}{}:
+				go func() {
+					defer func() { <-o.connSem }()
+					o.handleConn(conn)
+				}()
+			default:
+				_ = conn.Close()
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		o.stop()
+		<-o.done
+		return ctx.Err()
+	case <-o.done:
+		return nil
+	case err := <-acceptErr:
+		if errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		o.stop()
+		<-o.done
+		return err
+	}
+}
+
+func (o *owner) handleConn(conn net.Conn) {
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(ownerFirstRequestTimeout))
+
+	reader := bufio.NewReader(conn)
+	enc := json.NewEncoder(conn)
+	var first initialRequest
+	if err := decodeOwnerRequest(
+		reader, maxOwnerFirstRequestSize, &first,
+	); err != nil {
+		return
+	}
+	if first.Token != o.state.Token {
+		_ = enc.Encode(Response{
+			Type: ResponseError, Error: "invalid pty owner token",
+		})
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+
+	switch first.Type {
+	case RequestStatus:
+		_ = enc.Encode(Response{
+			Type: ResponseOK, OK: true, Output: o.snapshotOutput(),
+		})
+	case RequestStop:
+		_ = enc.Encode(Response{Type: ResponseOK, OK: true})
+		go o.stop()
+	case RequestAttach:
+		o.handleAttach(reader, enc, first.Request())
+	default:
+		_ = enc.Encode(Response{
+			Type: ResponseError, Error: "unknown pty owner request",
+		})
+	}
+}
+
+func (o *owner) handleAttach(
+	reader *bufio.Reader,
+	enc *json.Encoder,
+	first Request,
+) {
+	if first.Cols > 0 && first.Rows > 0 {
+		_ = o.pty.Resize(first.Cols, first.Rows)
+	}
+	if err := enc.Encode(Response{Type: ResponseOK, OK: true}); err != nil {
+		return
+	}
+	output, unsubscribe := o.subscribe()
+	defer unsubscribe()
+
+	writeDone := make(chan struct{})
+	var writeMu sync.Mutex
+	go func() {
+		defer close(writeDone)
+		for chunk := range output {
+			writeMu.Lock()
+			err := enc.Encode(Response{
+				Type: ResponseOutput, OK: true, Output: chunk,
+			})
+			writeMu.Unlock()
+			if err != nil {
+				return
+			}
+		}
+		code := o.currentExitCode()
+		writeMu.Lock()
+		_ = enc.Encode(Response{
+			Type: ResponseExit, OK: true, ExitCode: &code,
+		})
+		writeMu.Unlock()
+	}()
+
+	for {
+		var req Request
+		if err := decodeOwnerRequest(
+			reader, maxOwnerRequestSize, &req,
+		); err != nil {
+			return
+		}
+		if req.Token != o.state.Token {
+			return
+		}
+		switch req.Type {
+		case RequestInput:
+			if len(req.Data) > maxOwnerInputSize {
+				return
+			}
+			_, _ = o.pty.Write(req.Data)
+		case RequestResize:
+			if req.Cols > 0 && req.Rows > 0 {
+				_ = o.pty.Resize(req.Cols, req.Rows)
+			}
+		case RequestStop:
+			o.stop()
+		}
+
+		select {
+		case <-writeDone:
+			return
+		default:
+		}
+	}
+}
+
+type initialRequest struct {
+	Type  string `json:"type"`
+	Token string `json:"token,omitempty"`
+	Cols  int    `json:"cols,omitempty"`
+	Rows  int    `json:"rows,omitempty"`
+}
+
+func (r initialRequest) Request() Request {
+	return Request{
+		Type:  r.Type,
+		Token: r.Token,
+		Cols:  r.Cols,
+		Rows:  r.Rows,
+	}
+}
+
+func decodeOwnerRequest(
+	reader *bufio.Reader,
+	maxBytes int,
+	dst any,
+) error {
+	var data []byte
+	for {
+		chunk, err := reader.ReadSlice('\n')
+		data = append(data, chunk...)
+		if len(data) > maxBytes {
+			return fmt.Errorf("pty owner request exceeds %d bytes", maxBytes)
+		}
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, bufio.ErrBufferFull) {
+			return err
+		}
+	}
+	return json.Unmarshal(data, dst)
+}
+
+func (o *owner) drainOutput() {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := o.pty.Read(buf)
+		if n > 0 {
+			o.broadcast(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (o *owner) wait() {
+	code := waitExitCode(o.cmd.Wait())
+	select {
+	case <-o.drainDone:
+	case <-time.After(500 * time.Millisecond):
+	}
+	o.mu.Lock()
+	o.exitCode = code
+	o.exited = true
+	for ch := range o.subscribers {
+		delete(o.subscribers, ch)
+		close(ch)
+	}
+	o.mu.Unlock()
+	close(o.done)
+}
+
+func (o *owner) stop() {
+	o.stopOnce.Do(func() {
+		if o.cmd != nil && o.cmd.Process != nil {
+			killOwnerProcess(o.cmd.Process)
+		}
+		o.closePty()
+	})
+}
+
+func (o *owner) closePty() {
+	o.closePtyOnce.Do(func() {
+		_ = o.pty.Close()
+	})
+}
+
+func (o *owner) broadcast(data []byte) {
+	chunk := append([]byte(nil), data...)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.outputBuffer = append(o.outputBuffer, chunk...)
+	if extra := len(o.outputBuffer) - maxOutputReplay; extra > 0 {
+		o.outputBuffer = append([]byte(nil), o.outputBuffer[extra:]...)
+	}
+	for ch := range o.subscribers {
+		select {
+		case ch <- chunk:
+		default:
+			delete(o.subscribers, ch)
+			close(ch)
+		}
+	}
+}
+
+func (o *owner) subscribe() (<-chan []byte, func()) {
+	ch := make(chan []byte, 64)
+	o.mu.Lock()
+	if len(o.outputBuffer) > 0 {
+		ch <- append([]byte(nil), o.outputBuffer...)
+	}
+	if o.exited {
+		close(ch)
+		o.mu.Unlock()
+		return ch, func() {}
+	}
+	o.subscribers[ch] = struct{}{}
+	o.mu.Unlock()
+	return ch, func() {
+		o.mu.Lock()
+		if _, ok := o.subscribers[ch]; ok {
+			delete(o.subscribers, ch)
+			close(ch)
+		}
+		o.mu.Unlock()
+	}
+}
+
+func (o *owner) snapshotOutput() []byte {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]byte(nil), o.outputBuffer...)
+}
+
+func (o *owner) currentExitCode() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.exitCode
+}
+
+func resolveExecutable(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("session command is empty")
+	}
+	if filepath.IsAbs(name) {
+		return name, nil
+	}
+	if !strings.ContainsRune(name, filepath.Separator) {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			return "", fmt.Errorf(
+				"resolve session command %q via PATH: %w",
+				name, err,
+			)
+		}
+		if !filepath.IsAbs(path) {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				return "", fmt.Errorf(
+					"resolve session command %q via PATH: %w",
+					name, err,
+				)
+			}
+			path = abs
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf(
+		"session command %q must be an absolute path or a "+
+			"PATH-resolvable name; relative paths resolve inside "+
+			"the workspace worktree, which is untrusted",
+		name,
+	)
+}
+
+func defaultShellCommand() []string {
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return []string{shell}
+	}
+	if os.PathSeparator == '\\' {
+		return []string{"cmd.exe"}
+	}
+	return []string{"/bin/sh"}
+}
+
+var sessionVarPrefixes = []string{
+	"MIDDLEMAN_GITHUB_TOKEN",
+	"GITHUB_TOKEN",
+	"GH_TOKEN",
+	"GH_PAT",
+	"GITHUB_PAT",
+	"GITHUB_ENTERPRISE_TOKEN",
+	"GH_ENTERPRISE_TOKEN",
+}
+
+func sessionEnvironment(env []string, extraStrip []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			out = append(out, kv)
+			continue
+		}
+		key := kv[:eq]
+		if shouldStripSessionVar(key, extraStrip) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func shouldStripSessionVar(key string, extraStrip []string) bool {
+	for _, prefix := range sessionVarPrefixes {
+		if key == prefix || strings.HasPrefix(key, prefix+"_") {
+			return true
+		}
+	}
+	return slices.Contains(extraStrip, key)
+}
+
+func waitExitCode(waitErr error) int {
+	if waitErr == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -1,0 +1,349 @@
+package ptyowner
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnerAttachInputAndReplay(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("in-process PTY owner test requires a host PTY")
+	}
+
+	root := t.TempDir()
+	ctx := t.Context()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunOwner(ctx, Options{
+			Root:    root,
+			Session: "middleman-test",
+			Cwd:     t.TempDir(),
+			Command: []string{"sh", "-c", "printf ready; while IFS= read -r line; do echo got:$line; done"},
+		})
+	}()
+
+	client := Client{Root: root}
+	require.Eventually(func() bool {
+		return client.Ping(context.Background(), "middleman-test") == nil
+	}, 2*time.Second, 20*time.Millisecond)
+
+	first, err := client.Attach(context.Background(), "middleman-test", 120, 30)
+	require.NoError(err)
+	defer first.Close()
+
+	require.Contains(readUntil(t, first.Output, "ready"), "ready")
+	require.NoError(first.Write([]byte("hello\n")))
+	require.Contains(readUntil(t, first.Output, "got:hello"), "got:hello")
+	first.Close()
+
+	second, err := client.Attach(context.Background(), "middleman-test", 100, 20)
+	require.NoError(err)
+	defer second.Close()
+
+	assert.Contains(readUntil(t, second.Output, "got:hello"), "got:hello")
+	require.NoError(second.Resize(90, 25))
+	require.NoError(client.Stop(context.Background(), "middleman-test"))
+
+	select {
+	case err := <-done:
+		require.NoError(err)
+	case <-time.After(2 * time.Second):
+		require.Fail("owner did not stop")
+	}
+}
+
+func TestOwnerStopWhileRunOwnerReturns(t *testing.T) {
+	require := require.New(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("in-process PTY owner test requires a host PTY")
+	}
+
+	root := t.TempDir()
+	paths, err := NewSessionPaths(root, "middleman-stop-race")
+	require.NoError(err)
+	done := make(chan error, 1)
+	go func() {
+		done <- RunOwner(t.Context(), Options{
+			Root:    root,
+			Session: "middleman-stop-race",
+			Cwd:     t.TempDir(),
+			Command: []string{"sh", "-c", "while :; do sleep 0.05; done"},
+		})
+	}()
+
+	client := Client{Root: root}
+	require.Eventually(func() bool {
+		return client.Ping(context.Background(), "middleman-stop-race") == nil
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.NoError(client.Stop(context.Background(), "middleman-stop-race"))
+	_, err = os.Stat(paths.Dir)
+	require.True(os.IsNotExist(err))
+	select {
+	case err := <-done:
+		require.NoError(err)
+	case <-time.After(2 * time.Second):
+		require.Fail("owner did not stop")
+	}
+}
+
+func TestOwnerRejectsOversizedUnauthenticatedRequest(t *testing.T) {
+	require := require.New(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("in-process PTY owner test requires a host PTY")
+	}
+
+	root := t.TempDir()
+	session := "middleman-oversized-request"
+	done := make(chan error, 1)
+	go func() {
+		done <- RunOwner(t.Context(), Options{
+			Root:    root,
+			Session: session,
+			Cwd:     t.TempDir(),
+			Command: []string{"sh", "-c", "while :; do sleep 0.05; done"},
+		})
+	}()
+
+	client := Client{Root: root}
+	require.Eventually(func() bool {
+		return client.Ping(context.Background(), session) == nil
+	}, 2*time.Second, 20*time.Millisecond)
+
+	paths, err := NewSessionPaths(root, session)
+	require.NoError(err)
+	state, err := readState(paths)
+	require.NoError(err)
+	conn, err := net.Dial("tcp", state.Addr)
+	require.NoError(err)
+	_, err = conn.Write([]byte(
+		`{"type":"status","token":"wrong","data":"` +
+			strings.Repeat("A", maxOwnerFirstRequestSize) +
+			`"}` + "\n",
+	))
+	require.NoError(err)
+	require.NoError(conn.SetReadDeadline(time.Now().Add(time.Second)))
+	buf := make([]byte, 1)
+	_, err = conn.Read(buf)
+	require.Error(err)
+	require.NoError(conn.Close())
+
+	require.NoError(client.Ping(context.Background(), session))
+	require.NoError(client.Stop(context.Background(), session))
+	select {
+	case err := <-done:
+		require.NoError(err)
+	case <-time.After(2 * time.Second):
+		require.Fail("owner did not stop")
+	}
+}
+
+func TestOwnerHelperEnvironmentStripsCredentials(t *testing.T) {
+	out := ownerHelperEnvironment([]string{
+		"PATH=/usr/bin",
+		"MIDDLEMAN_GITHUB_TOKEN=secret-1",
+		"GITHUB_TOKEN=secret-2",
+		"GH_TOKEN_WORK=secret-3",
+		"KEEP=value",
+	})
+
+	require.ElementsMatch(t, []string{
+		"PATH=/usr/bin",
+		"KEEP=value",
+	}, out)
+}
+
+func TestClientStopTreatsStaleOwnerStateAsAbsent(t *testing.T) {
+	require := require.New(t)
+
+	root := t.TempDir()
+	paths, err := NewSessionPaths(root, "middleman-stale")
+	require.NoError(err)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	addr := listener.Addr().String()
+	require.NoError(listener.Close())
+	require.NoError(writeState(paths, ownerState{
+		Session: "middleman-stale",
+		Addr:    addr,
+		Token:   "token",
+		Cwd:     t.TempDir(),
+	}))
+
+	err = (&Client{Root: root}).Stop(context.Background(), "middleman-stale")
+
+	require.NoError(err)
+	_, err = os.Stat(paths.Dir)
+	require.True(os.IsNotExist(err))
+}
+
+func TestClientEnsurePreservesStateOnContextCancellation(t *testing.T) {
+	require := require.New(t)
+
+	root := t.TempDir()
+	paths, err := NewSessionPaths(root, "middleman-canceled-ensure")
+	require.NoError(err)
+	require.NoError(writeState(paths, ownerState{
+		Session: "middleman-canceled-ensure",
+		Addr:    "127.0.0.1:1",
+		Token:   "token",
+		Cwd:     t.TempDir(),
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = (&Client{Root: root}).Ensure(ctx, "middleman-canceled-ensure", t.TempDir())
+
+	require.Error(err)
+	_, err = os.Stat(paths.Dir)
+	require.NoError(err)
+}
+
+func TestClientEnsureSerializesConcurrentStarts(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("in-process PTY owner test requires a host PTY")
+	}
+
+	root := t.TempDir()
+	dir := t.TempDir()
+	record := filepath.Join(dir, "starts")
+	stop := filepath.Join(dir, "stop")
+	client := &Client{
+		Root:      root,
+		InProcess: true,
+		Command: []string{
+			"sh", "-c",
+			"printf start >> \"$MIDDLEMAN_START_RECORD\"; " +
+				"while [ ! -f \"$MIDDLEMAN_STOP_FILE\" ]; do sleep 0.05; done",
+		},
+	}
+	t.Setenv("MIDDLEMAN_START_RECORD", record)
+	t.Setenv("MIDDLEMAN_STOP_FILE", stop)
+	t.Cleanup(func() {
+		_ = os.WriteFile(stop, []byte("stop"), 0o644)
+		_ = client.Stop(context.Background(), "middleman-concurrent-ensure")
+	})
+
+	const callers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for range callers {
+		wg.Go(func() {
+			<-start
+			errs <- client.Ensure(
+				context.Background(),
+				"middleman-concurrent-ensure",
+				dir,
+			)
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(err)
+	}
+
+	data, err := os.ReadFile(record)
+	require.NoError(err)
+	assert.Equal("start", string(data))
+}
+
+func TestClientStopPreservesStateOnContextCancellation(t *testing.T) {
+	require := require.New(t)
+
+	root := t.TempDir()
+	paths, err := NewSessionPaths(root, "middleman-canceled-stop")
+	require.NoError(err)
+	require.NoError(writeState(paths, ownerState{
+		Session: "middleman-canceled-stop",
+		Addr:    "127.0.0.1:1",
+		Token:   "token",
+		Cwd:     t.TempDir(),
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = (&Client{Root: root}).Stop(ctx, "middleman-canceled-stop")
+
+	require.Error(err)
+	_, err = os.Stat(paths.Dir)
+	require.NoError(err)
+}
+
+func TestClientPingHonorsContextAfterConnect(t *testing.T) {
+	require := require.New(t)
+
+	root := t.TempDir()
+	paths, err := NewSessionPaths(root, "middleman-silent-owner")
+	require.NoError(err)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	defer listener.Close()
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+	require.NoError(writeState(paths, ownerState{
+		Session: "middleman-silent-owner",
+		Addr:    listener.Addr().String(),
+		Token:   "token",
+		Cwd:     t.TempDir(),
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err = (&Client{Root: root}).Ping(ctx, "middleman-silent-owner")
+
+	require.Error(err)
+	select {
+	case conn := <-accepted:
+		_ = conn.Close()
+	default:
+	}
+}
+
+func readUntil(t *testing.T, output <-chan []byte, needle string) string {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	var builder strings.Builder
+	for {
+		select {
+		case chunk, ok := <-output:
+			if !ok {
+				return builder.String()
+			}
+			builder.Write(chunk)
+			if strings.Contains(builder.String(), needle) {
+				return builder.String()
+			}
+		case <-deadline:
+			require.New(t).Failf(
+				"timed out waiting for output",
+				"wanted %q in %q", needle, builder.String(),
+			)
+		}
+	}
+}

--- a/internal/ptyowner/paths.go
+++ b/internal/ptyowner/paths.go
@@ -1,0 +1,90 @@
+package ptyowner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type SessionPaths struct {
+	Root      string
+	Session   string
+	Dir       string
+	StatePath string
+}
+
+type ownerState struct {
+	Session   string    `json:"session"`
+	Addr      string    `json:"addr"`
+	Token     string    `json:"token"`
+	Cwd       string    `json:"cwd"`
+	PID       int       `json:"pid"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func NewSessionPaths(root, session string) (SessionPaths, error) {
+	if err := validateSessionName(session); err != nil {
+		return SessionPaths{}, err
+	}
+	dir := filepath.Join(root, session)
+	return SessionPaths{
+		Root:      root,
+		Session:   session,
+		Dir:       dir,
+		StatePath: filepath.Join(dir, "owner.json"),
+	}, nil
+}
+
+func validateSessionName(session string) error {
+	if session == "" {
+		return fmt.Errorf("pty owner session name is empty")
+	}
+	if strings.Contains(session, "..") ||
+		strings.ContainsAny(session, `/\`) ||
+		strings.ContainsRune(session, 0) {
+		return fmt.Errorf("unsafe pty owner session name %q", session)
+	}
+	return nil
+}
+
+func readState(paths SessionPaths) (ownerState, error) {
+	data, err := os.ReadFile(paths.StatePath)
+	if err != nil {
+		return ownerState{}, err
+	}
+	var state ownerState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return ownerState{}, err
+	}
+	if state.Addr == "" || state.Token == "" {
+		return ownerState{}, fmt.Errorf("pty owner state is incomplete")
+	}
+	return state, nil
+}
+
+func writeState(paths SessionPaths, state ownerState) error {
+	if err := os.MkdirAll(paths.Dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(paths.Dir, ".owner-*.json")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, paths.StatePath)
+}

--- a/internal/ptyowner/process_unix.go
+++ b/internal/ptyowner/process_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package ptyowner
+
+import (
+	"os"
+	"syscall"
+
+	gopty "github.com/aymanbagabas/go-pty"
+)
+
+func configureOwnerCommand(cmd *gopty.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+func killOwnerProcess(process *os.Process) {
+	if err := syscall.Kill(-process.Pid, syscall.SIGKILL); err != nil {
+		_ = process.Kill()
+	}
+}

--- a/internal/ptyowner/process_windows.go
+++ b/internal/ptyowner/process_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package ptyowner
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+
+	gopty "github.com/aymanbagabas/go-pty"
+)
+
+func configureOwnerCommand(*gopty.Cmd) {}
+
+func killOwnerProcess(process *os.Process) {
+	err := exec.Command(
+		"taskkill", "/T", "/F", "/PID", strconv.Itoa(process.Pid),
+	).Run()
+	if err != nil {
+		_ = process.Kill()
+	}
+}

--- a/internal/ptyowner/protocol.go
+++ b/internal/ptyowner/protocol.go
@@ -1,0 +1,30 @@
+package ptyowner
+
+const (
+	RequestAttach = "attach"
+	RequestInput  = "input"
+	RequestResize = "resize"
+	RequestStatus = "status"
+	RequestStop   = "stop"
+
+	ResponseOK     = "ok"
+	ResponseOutput = "output"
+	ResponseExit   = "exit"
+	ResponseError  = "error"
+)
+
+type Request struct {
+	Type  string `json:"type"`
+	Token string `json:"token,omitempty"`
+	Cols  int    `json:"cols,omitempty"`
+	Rows  int    `json:"rows,omitempty"`
+	Data  []byte `json:"data,omitempty"`
+}
+
+type Response struct {
+	Type     string `json:"type"`
+	OK       bool   `json:"ok,omitempty"`
+	Error    string `json:"error,omitempty"`
+	ExitCode *int   `json:"exit_code,omitempty"`
+	Output   []byte `json:"output,omitempty"`
+}

--- a/internal/ptyowner/protocol_test.go
+++ b/internal/ptyowner/protocol_test.go
@@ -1,0 +1,69 @@
+package ptyowner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionPathsRejectUnsafeNames(t *testing.T) {
+	tests := []string{"", "../ws", "a/b", `a\b`, "a\x00b"}
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewSessionPaths(t.TempDir(), name)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSessionPathsAreStable(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	root := t.TempDir()
+
+	paths, err := NewSessionPaths(root, "middleman-abc123")
+
+	require.NoError(err)
+	assert.Equal(root, paths.Root)
+	assert.Contains(paths.Dir, "middleman-abc123")
+	assert.Contains(paths.StatePath, "owner.json")
+}
+
+func TestProtocolRequestRoundTrip(t *testing.T) {
+	assert := Assert.New(t)
+	want := Request{
+		Type:  RequestAttach,
+		Token: "secret",
+		Cols:  132,
+		Rows:  43,
+		Data:  []byte{0, 1, 2, 'x'},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(want))
+
+	var got Request
+	require.NoError(t, json.NewDecoder(&buf).Decode(&got))
+	assert.Equal(want, got)
+}
+
+func TestProtocolResponseRoundTrip(t *testing.T) {
+	assert := Assert.New(t)
+	code := 7
+	want := Response{
+		Type:     ResponseExit,
+		OK:       true,
+		ExitCode: &code,
+		Output:   []byte("recent output"),
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(want))
+
+	var got Response
+	require.NoError(t, json.NewDecoder(&buf).Decode(&got))
+	assert.Equal(want, got)
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -44,6 +45,7 @@ import (
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
+	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/stacks"
 	"github.com/wesm/middleman/internal/testutil"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
@@ -11573,25 +11575,49 @@ func setupTestServerWithWorkspacesServer(
 }
 
 type workspaceServerFixture struct {
-	server   *Server
-	client   *apiclient.Client
-	database *db.DB
-	bare     string
-	remote   string
+	server    *Server
+	client    *apiclient.Client
+	database  *db.DB
+	clones    *gitclone.Manager
+	worktrees string
+	bare      string
+	remote    string
 }
 
 func setupWorkspaceServerFixture(
 	t *testing.T,
 	cfg *config.Config,
 ) workspaceServerFixture {
+	return setupWorkspaceServerFixtureWithOptions(t, cfg, ServerOptions{})
+}
+
+func setupWorkspaceServerFixtureWithOptions(
+	t *testing.T,
+	cfg *config.Config,
+	options ServerOptions,
+) workspaceServerFixture {
 	t.Helper()
-	return setupWorkspaceServerFixtureWithHost(t, cfg, "github.com")
+	return setupWorkspaceServerFixtureWithHostAndOptions(
+		t, cfg, "github.com", options,
+	)
 }
 
 func setupWorkspaceServerFixtureWithHost(
 	t *testing.T,
 	cfg *config.Config,
 	platformHost string,
+) workspaceServerFixture {
+	t.Helper()
+	return setupWorkspaceServerFixtureWithHostAndOptions(
+		t, cfg, platformHost, ServerOptions{},
+	)
+}
+
+func setupWorkspaceServerFixtureWithHostAndOptions(
+	t *testing.T,
+	cfg *config.Config,
+	platformHost string,
+	options ServerOptions,
 ) workspaceServerFixture {
 	t.Helper()
 
@@ -11653,10 +11679,9 @@ func setupWorkspaceServerFixtureWithHost(
 	if cfg != nil && cfg.BasePath != "" {
 		basePath = cfg.BasePath
 	}
-	srv := New(database, syncer, nil, basePath, cfg, ServerOptions{
-		Clones:      clones,
-		WorktreeDir: worktreeDir,
-	})
+	options.Clones = clones
+	options.WorktreeDir = worktreeDir
+	srv := New(database, syncer, nil, basePath, cfg, options)
 	// Cleanup callbacks run LIFO. Drain the server first so async
 	// workspace setup cannot create a tmux session after fixture
 	// artifact cleanup has listed workspaces. The DB cleanup was
@@ -11672,11 +11697,13 @@ func setupWorkspaceServerFixtureWithHost(
 	}
 	client := setupTestClientWithBaseURL(t, srv, clientBaseURL)
 	return workspaceServerFixture{
-		server:   srv,
-		client:   client,
-		database: database,
-		bare:     bare,
-		remote:   remote,
+		server:    srv,
+		client:    client,
+		database:  database,
+		clones:    clones,
+		worktrees: worktreeDir,
+		bare:      bare,
+		remote:    remote,
 	}
 }
 
@@ -11963,6 +11990,256 @@ func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
 	assert.True(codex.Available)
 	require.NotNil(codex.Command)
 	assert.Equal([]string{agentPath, "--full-auto"}, *codex.Command)
+}
+
+func TestWorkspaceCreatesPtyOwnerSessionWhenTmuxUnavailableE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	fixture, dir, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	require.Equal("ready", ws.Status)
+	assert.NotEmpty(ws.TmuxSession)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(workspace.TerminalBackendPtyOwner, stored.TerminalBackend)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	workspaceTerminalWriteRead(
+		t, ctx, ts.URL, ws.Id, "printf 'owner-one\n'\n", "owner-one",
+	)
+
+	snapshot, err := fixture.server.workspaces.TerminalPaneSnapshot(
+		ctx, stored, ws.TmuxSession,
+	)
+	require.NoError(err)
+	assert.Contains(snapshot.Output, "owner-one")
+
+	_, err = fixture.database.WriteDB().ExecContext(
+		ctx,
+		`UPDATE middleman_workspaces SET terminal_backend = '' WHERE id = ?`,
+		ws.Id,
+	)
+	require.NoError(err)
+	legacyStored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(legacyStored)
+	assert.Empty(legacyStored.TerminalBackend)
+
+	ts.Close()
+	gracefulShutdown(t, fixture.server)
+
+	availableTmux := filepath.Join(dir, "available-tmux")
+	require.NoError(os.WriteFile(
+		availableTmux,
+		[]byte("#!/bin/sh\nexit 0\n"),
+		0o755,
+	))
+	restartedCfg := &config.Config{Tmux: config.Tmux{
+		Command: []string{availableTmux},
+	}}
+	restarted := New(
+		fixture.database, fixture.server.syncer, nil, "/", restartedCfg,
+		ServerOptions{
+			Clones:      fixture.clones,
+			WorktreeDir: fixture.worktrees,
+			PtyOwnerDir: ptyOwnerDir,
+		},
+	)
+	t.Cleanup(func() { gracefulShutdown(t, restarted) })
+	restartedClient := setupTestClient(t, restarted)
+	restartedTS := httptest.NewServer(restarted)
+	t.Cleanup(restartedTS.Close)
+
+	workspaceTerminalWriteRead(
+		t, ctx, restartedTS.URL, ws.Id, "printf 'owner-two\n'\n", "owner-two",
+	)
+
+	force := true
+	delResp, err := restartedClient.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, delResp.StatusCode())
+
+	deleted, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(deleted)
+	_, err = os.Stat(filepath.Join(ptyOwnerDir, ws.TmuxSession))
+	assert.True(os.IsNotExist(err))
+}
+
+func TestWorkspacePtyOwnerTerminalRejectsConcurrentAttachmentsE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+
+	first, _, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
+	require.NoError(err)
+	defer first.Close(websocket.StatusNormalClosure, "done")
+
+	second, resp, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
+	require.Error(err)
+	if second != nil {
+		second.Close(websocket.StatusNormalClosure, "done")
+	}
+	require.NotNil(resp)
+	assert.Equal(http.StatusConflict, resp.StatusCode)
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	require.NoError(first.Close(websocket.StatusNormalClosure, "done"))
+	third := workspaceTerminalDialEventually(t, ctx, ts.URL, ws.Id)
+	defer third.Close(websocket.StatusNormalClosure, "done")
+	workspaceTerminalConnWriteRead(
+		t, ctx, third, "printf 'owner-after-close\n'\n", "owner-after-close",
+	)
+}
+
+func TestWorkspacePtyOwnerTerminalFlushesFinalOutputOnExitE2E(t *testing.T) {
+	require := require.New(t)
+
+	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+
+	conn, _, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageBinary,
+		[]byte("printf 'final-owner-output\n'; exit\n"),
+	))
+	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var got strings.Builder
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+		if typ == websocket.MessageBinary {
+			got.WriteString(string(data))
+		}
+		if strings.Contains(got.String(), "final-owner-output") {
+			return
+		}
+	}
+	require.Contains(got.String(), "final-owner-output")
+}
+
+func setupPtyOwnerWorkspaceFixture(
+	t *testing.T,
+) (workspaceServerFixture, string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	ptyOwnerDir := filepath.Join(dir, "pty-owner")
+	cfg := &config.Config{Tmux: config.Tmux{
+		Command: []string{filepath.Join(dir, "missing-tmux")},
+	}}
+	t.Setenv("MIDDLEMAN_SERVER_PTY_OWNER_HELPER", "1")
+	return setupWorkspaceServerFixtureWithOptions(
+		t, cfg, ptyOwnerServerOptions(ptyOwnerDir),
+	), dir, ptyOwnerDir
+}
+
+func ptyOwnerServerOptions(ptyOwnerDir string) ServerOptions {
+	return ServerOptions{
+		PtyOwnerDir:     ptyOwnerDir,
+		PtyOwnerExePath: os.Args[0],
+		PtyOwnerExeArgs: []string{
+			"-test.run=TestServerPtyOwnerHelperProcess",
+			"--",
+		},
+	}
+}
+
+func cleanupPtyOwnerWorkspace(
+	t *testing.T,
+	ptyOwnerDir string,
+	session string,
+) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = (&ptyowner.Client{Root: ptyOwnerDir}).Stop(
+			context.Background(), session,
+		)
+	})
+}
+
+func TestWorkspaceRuntimeLaunchUnavailableTargetE2E(t *testing.T) {
+	disabled := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "disabled",
+		Label:   "Disabled",
+		Enabled: &disabled,
+	}}}
+	client, _, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	resp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "disabled",
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
+	require.Contains(t, string(resp.Body), "not available")
+}
+
+func TestWorkspaceRuntimeLaunchPlainShellUsesShellSessionE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	client, _, _, _, _ := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	resp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "plain_shell",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	shell := resp.JSON200
+	assert.Equal("plain_shell", shell.TargetKey)
+	assert.Equal(string(localruntime.LaunchTargetPlainShell), shell.Kind)
+	assert.Equal(string(localruntime.SessionStatusRunning), shell.Status)
+
+	getResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, getResp.StatusCode())
+	require.NotNil(getResp.JSON200)
+	require.NotNil(getResp.JSON200.ShellSession)
+	require.NotNil(getResp.JSON200.Sessions)
+	assert.Equal(shell.Key, getResp.JSON200.ShellSession.Key)
+	assert.Empty(*getResp.JSON200.Sessions)
 }
 
 func TestWorkspaceRuntimeLaunchSingletonAndStopE2E(t *testing.T) {
@@ -13052,6 +13329,20 @@ func TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E(t *testing.T) {
 	// The 409 must not have killed the runtime sessions.
 	assert.Len(srv.runtime.ListSessions(ws.Id), 1)
 	assert.NotNil(srv.runtime.ShellSession(ws.Id))
+
+	stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, launchResp.JSON200.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, stopResp.StatusCode())
+
+	launchAfterRejectResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "helper"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchAfterRejectResp.StatusCode())
+	assert.Len(srv.runtime.ListSessions(ws.Id), 1)
 }
 
 // TestWorkspaceListReportsCommitsAheadBehindE2E verifies that the
@@ -14010,6 +14301,93 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketBasePathE2E(t *testing.T) {
 	require.Contains(got.String(), "echo:ping")
 }
 
+func workspaceTerminalWriteRead(
+	t *testing.T,
+	ctx context.Context,
+	serverURL string,
+	workspaceID string,
+	input string,
+	needle string,
+) {
+	t.Helper()
+
+	conn, resp, err := workspaceTerminalDial(ctx, serverURL, workspaceID)
+	if err != nil && resp != nil && resp.Body != nil {
+		body, readErr := io.ReadAll(resp.Body)
+		require.NoError(t, readErr)
+		require.NoError(t, err, string(body))
+	}
+	require.NoError(t, err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(t, ctx, conn, input, needle)
+}
+
+func workspaceTerminalConnWriteRead(
+	t *testing.T,
+	ctx context.Context,
+	conn *websocket.Conn,
+	input string,
+	needle string,
+) {
+	t.Helper()
+
+	require.NoError(t, conn.Write(
+		ctx, websocket.MessageBinary, []byte(input),
+	))
+	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var got strings.Builder
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+		if typ != websocket.MessageBinary {
+			continue
+		}
+		got.WriteString(string(data))
+		if strings.Contains(got.String(), needle) {
+			return
+		}
+	}
+	require.Contains(t, got.String(), needle)
+}
+
+func workspaceTerminalDialEventually(
+	t *testing.T,
+	ctx context.Context,
+	serverURL string,
+	workspaceID string,
+) *websocket.Conn {
+	t.Helper()
+
+	var conn *websocket.Conn
+	require.Eventually(t, func() bool {
+		var resp *http.Response
+		var err error
+		conn, resp, err = workspaceTerminalDial(ctx, serverURL, workspaceID)
+		if err != nil && conn != nil {
+			conn.Close(websocket.StatusNormalClosure, "done")
+		}
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+		return err == nil
+	}, 2*time.Second, 20*time.Millisecond)
+	return conn
+}
+
+func workspaceTerminalDial(
+	ctx context.Context,
+	serverURL string,
+	workspaceID string,
+) (*websocket.Conn, *http.Response, error) {
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") +
+		"/api/v1/workspaces/" + workspaceID + "/terminal"
+	return websocket.Dial(ctx, wsURL, nil)
+}
+
 func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
@@ -14311,20 +14689,20 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 	mode := args[len(args)-1]
 	switch mode {
 	case "sleep":
-		select {}
+		blockServerRuntimeHelper()
 	case "echo":
 		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 		if err == nil {
 			fmt.Print("echo:" + line)
 		}
-		select {}
+		blockServerRuntimeHelper()
 	case "altscreen":
 		fmt.Print("\x1b[?1049h\x1b[Hcodex screen")
 		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 		if err == nil {
 			fmt.Print("\x1b[Hlive:" + line)
 		}
-		select {}
+		blockServerRuntimeHelper()
 	case "size":
 		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 		if err == nil {
@@ -14357,6 +14735,50 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 	default:
 		os.Exit(2)
 	}
+}
+
+func blockServerRuntimeHelper() {
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+func TestServerPtyOwnerHelperProcess(t *testing.T) {
+	if os.Getenv("MIDDLEMAN_SERVER_PTY_OWNER_HELPER") != "1" {
+		return
+	}
+	args := os.Args
+	sep := slices.Index(args, "--")
+	if sep >= 0 {
+		args = args[sep+1:]
+	}
+	if len(args) > 0 && args[0] == "pty-owner" {
+		args = args[1:]
+	}
+	fs := flag.NewFlagSet("test pty-owner", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	root := fs.String("root", "", "pty owner state root")
+	session := fs.String("session", "", "session name")
+	cwd := fs.String("cwd", "", "working directory")
+	commandJSON := fs.String("command-json", "", "JSON command argv")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	var command []string
+	if *commandJSON != "" {
+		if err := json.Unmarshal([]byte(*commandJSON), &command); err != nil {
+			os.Exit(2)
+		}
+	}
+	if err := ptyowner.RunOwner(context.Background(), ptyowner.Options{
+		Root:    *root,
+		Session: *session,
+		Cwd:     *cwd,
+		Command: command,
+	}); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
 func gitOutput(t *testing.T, dir string, args ...string) string {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3644,7 +3644,7 @@ func (s *Server) toWorkspaceResponse(
 
 	applyWorktreeDivergence(ctx, &resp, summary.WorktreePath)
 	if activity, ok := s.probeWorkspaceTmuxActivity(
-		ctx, summary.ID, s.workspaceTmuxActivitySessions(ctx, summary),
+		ctx, summary, s.workspaceTmuxActivitySessions(ctx, summary),
 	); ok {
 		applyTmuxActivity(&resp, activity)
 	}
@@ -3696,7 +3696,7 @@ func (s *Server) workspaceTmuxActivitySessions(
 
 func (s *Server) probeWorkspaceTmuxActivity(
 	ctx context.Context,
-	workspaceID string,
+	summary *db.WorkspaceSummary,
 	sessions []string,
 ) (tmuxActivityResult, bool) {
 	if len(sessions) == 0 {
@@ -3718,7 +3718,7 @@ func (s *Server) probeWorkspaceTmuxActivity(
 			}
 		}
 		result, ok := s.probeOneTmuxSession(
-			probeCtx, tracker, workspaceID, session,
+			probeCtx, tracker, summary, session,
 		)
 		if ok {
 			results = append(results, result)
@@ -3730,7 +3730,7 @@ func (s *Server) probeWorkspaceTmuxActivity(
 func (s *Server) probeOneTmuxSession(
 	ctx context.Context,
 	tracker *tmuxActivityTracker,
-	workspaceID string,
+	summary *db.WorkspaceSummary,
 	session string,
 ) (tmuxActivityResult, bool) {
 	probe := tracker.StartProbe(ctx, session)
@@ -3748,12 +3748,14 @@ func (s *Server) probeOneTmuxSession(
 		return tmuxActivityResult{}, false
 	}
 
-	snapshot, err := s.workspaces.TmuxPaneSnapshot(ctx, session)
+	snapshot, err := s.workspaces.TerminalPaneSnapshot(
+		ctx, &summary.Workspace, session,
+	)
 	if err != nil {
 		probe.Probe.Cancel()
 		slog.Debug(
 			"read tmux pane snapshot",
-			"workspace_id", workspaceID,
+			"workspace_id", summary.ID,
 			"tmux_session", session,
 			"err", err,
 		)
@@ -4050,27 +4052,16 @@ func (s *Server) deleteWorkspace(
 		)
 	}
 
-	// Order of operations:
-	//   1. dirty preflight inside Delete — returns 409 without
-	//      touching anything
-	//   2. (clean) StopWorkspace via the beforeDestructive hook so
-	//      agent/shell processes can't keep writing to the worktree
-	//      between the preflight and the destructive cleanup
-	//   3. destructive cleanup + record removal
-	// Stopping sessions before the preflight would kill processes for
-	// a workspace that survives a 409 dirty rejection; stopping them
-	// only after the destructive cleanup leaves a window where running
-	// processes could write new uncommitted changes that bypass the
-	// dirty check the user requested.
-	//
-	// BeginStopping/EndStopping holds the runtime's stopping marker
-	// across the whole Delete call — including step 3 — so a Launch
-	// arriving between StopWorkspace returning and DB removal cannot
-	// spawn a process in the soon-to-be-deleted worktree.
 	if s.runtime != nil {
+		// Block new launches before the dirty preflight; existing
+		// sessions are stopped only after the preflight passes.
 		s.runtime.BeginStopping(input.ID)
-		defer s.runtime.EndStopping(input.ID)
 	}
+	defer func() {
+		if s.runtime != nil {
+			s.runtime.EndStopping(input.ID)
+		}
+	}()
 	dirty, err := s.workspaces.Delete(
 		ctx, input.ID, input.Force,
 		func(stopCtx context.Context) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitclone"
 	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/workspace"
 	"github.com/wesm/middleman/internal/workspace/localruntime"
 )
@@ -57,9 +60,13 @@ type versionOutputBody struct {
 type versionOutput = bodyOutput[versionOutputBody]
 
 type ServerOptions struct {
-	EmbedConfig *EmbedConfig
-	Clones      *gitclone.Manager // optional clone manager for diff view
-	WorktreeDir string            // base dir for workspace worktrees
+	EmbedConfig       *EmbedConfig
+	Clones            *gitclone.Manager // optional clone manager for diff view
+	WorktreeDir       string            // base dir for workspace worktrees
+	PtyOwnerDir       string
+	PtyOwnerExePath   string
+	PtyOwnerExeArgs   []string
+	PtyOwnerInProcess bool
 }
 
 type shutdownDeadline struct {
@@ -412,23 +419,43 @@ func newServer(
 	// terminal handler all share the same value and the nil-safety
 	// of the call is explicit at this level.
 	tmuxCmd := cfg.TmuxCommand()
+	tmuxAvailable := tmuxCommandAvailable(tmuxCmd)
 	if options.WorktreeDir != "" {
 		s.workspaces = workspace.NewManager(database, options.WorktreeDir)
 		s.workspacePRMonitor = workspace.NewPRMonitor(database)
 		s.workspaces.SetTmuxCommand(tmuxCmd)
+		ptyOwnerDir := options.PtyOwnerDir
+		if ptyOwnerDir == "" {
+			ptyOwnerDir = filepath.Join(
+				filepath.Dir(options.WorktreeDir), "pty-owner",
+			)
+		}
+		ptyOwnerClient := &ptyowner.Client{
+			Root:      ptyOwnerDir,
+			ExePath:   options.PtyOwnerExePath,
+			ExeArgs:   append([]string(nil), options.PtyOwnerExeArgs...),
+			InProcess: options.PtyOwnerInProcess,
+		}
+		if !tmuxAvailable {
+			s.workspaces.SetPtyOwnerClient(ptyOwnerClient)
+		} else {
+			s.workspaces.SetPtyOwnerFallbackClient(ptyOwnerClient)
+		}
 		if clones != nil {
 			s.workspaces.SetClones(clones)
 		}
-		cleanupCtx, cleanupCancel := context.WithTimeout(
-			context.Background(), startupTmuxCleanupTimeout,
-		)
-		if err := s.workspaces.ReapOrphanTmuxSessions(cleanupCtx); err != nil {
-			slog.Warn("reap orphan tmux sessions", "err", err)
+		if tmuxAvailable {
+			cleanupCtx, cleanupCancel := context.WithTimeout(
+				context.Background(), startupTmuxCleanupTimeout,
+			)
+			if err := s.workspaces.ReapOrphanTmuxSessions(cleanupCtx); err != nil {
+				slog.Warn("reap orphan tmux sessions", "err", err)
+			}
+			if err := s.workspaces.PruneMissingTmuxSessions(cleanupCtx); err != nil {
+				slog.Warn("prune missing tmux sessions", "err", err)
+			}
+			cleanupCancel()
 		}
-		if err := s.workspaces.PruneMissingTmuxSessions(cleanupCtx); err != nil {
-			slog.Warn("prune missing tmux sessions", "err", err)
-		}
-		cleanupCancel()
 		var agents []config.Agent
 		if cfg != nil {
 			agents = cfg.Agents
@@ -597,6 +624,14 @@ func (s *Server) handleRuntimeSessionExit(info localruntime.SessionInfo) {
 			)
 		}
 	})
+}
+
+func tmuxCommandAvailable(command []string) bool {
+	if len(command) == 0 || command[0] == "" {
+		return false
+	}
+	_, err := exec.LookPath(command[0])
+	return err == nil
 }
 
 func (s *Server) bootstrapScript() string {

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/creack/pty/v2"
 
 	"github.com/wesm/middleman/internal/procutil"
+	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/workspace"
 )
 
@@ -108,6 +109,29 @@ func (h *Handler) ServeHTTP(
 
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
+
+	if h.Workspaces.UsesPtyOwnerForWorkspace(ws) {
+		if err := h.Workspaces.EnsureTerminal(ctx, ws); err != nil {
+			slog.Error("ensure pty owner", "err", err)
+			conn.Close(websocket.StatusInternalError, "failed to start pty owner")
+			return
+		}
+		attachment, err := h.Workspaces.AttachPtyOwnerTerminal(
+			ctx, ws.TmuxSession, cols, rows,
+		)
+		if err != nil {
+			slog.Error("attach pty owner", "err", err)
+			conn.Close(websocket.StatusInternalError, "failed to attach pty owner")
+			return
+		}
+		exited := bridgePtyOwnerAttachment(ctx, conn, attachment)
+		if exited {
+			conn.Close(websocket.StatusNormalClosure, "session ended")
+		} else {
+			conn.Close(websocket.StatusNormalClosure, "detached")
+		}
+		return
+	}
 
 	if tmuxErr := h.Workspaces.EnsureTmux(
 		ctx, ws.TmuxSession, ws.WorktreePath,
@@ -265,6 +289,102 @@ func (h *Handler) ServeHTTP(
 	)
 }
 
+func bridgePtyOwnerAttachment(
+	ctx context.Context,
+	conn *websocket.Conn,
+	attachment *ptyowner.Attachment,
+) bool {
+	defer attachment.Close()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	inputDone := make(chan struct{})
+	go func() {
+		defer close(inputDone)
+		for {
+			typ, data, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			switch typ {
+			case websocket.MessageBinary:
+				if err := attachment.Write(data); err != nil {
+					return
+				}
+			case websocket.MessageText:
+				var msg controlMsg
+				if err := json.Unmarshal(data, &msg); err != nil {
+					slog.Warn("bad pty owner terminal control message", "err", err)
+					continue
+				}
+				if msg.Type == "resize" {
+					_ = attachment.Resize(msg.Cols, msg.Rows)
+				}
+			}
+		}
+	}()
+
+	outputDone := make(chan struct{})
+	go func() {
+		defer close(outputDone)
+		for {
+			select {
+			case data, ok := <-attachment.Output:
+				if !ok {
+					return
+				}
+				if err := conn.Write(
+					ctx, websocket.MessageBinary, data,
+				); err != nil {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-attachment.Done:
+		select {
+		case <-outputDone:
+		case <-time.After(2 * time.Second):
+			cancel()
+			return false
+		}
+		cancel()
+		writeTerminalExit(conn, attachment.ExitCode())
+		return true
+	case <-inputDone:
+		cancel()
+		return false
+	case <-outputDone:
+		select {
+		case <-attachment.Done:
+			cancel()
+			writeTerminalExit(conn, attachment.ExitCode())
+			return true
+		case <-time.After(100 * time.Millisecond):
+			cancel()
+			return false
+		}
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func writeTerminalExit(conn *websocket.Conn, exitCode int) {
+	exitMsg, _ := json.Marshal(map[string]any{
+		"type": "exited",
+		"code": exitCode,
+	})
+	writeCtx, writeCancel := context.WithTimeout(
+		context.Background(), 2*time.Second)
+	_ = conn.Write(writeCtx, websocket.MessageText, exitMsg)
+	writeCancel()
+}
+
 func (h *Handler) claimTerminalSlot(
 	id string,
 ) (func(), error) {
@@ -272,6 +392,9 @@ func (h *Handler) claimTerminalSlot(
 	defer h.mu.Unlock()
 	if h.active == nil {
 		h.active = make(map[string]int)
+	}
+	if h.active[id] > 0 {
+		return nil, fmt.Errorf("workspace terminal already active")
 	}
 	h.active[id]++
 	active := h.active[id]

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -1,16 +1,20 @@
 package terminal
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 	"github.com/wesm/middleman/internal/workspace"
 )
@@ -105,7 +109,7 @@ func TestHandlerWorkspaceNotReady(t *testing.T) {
 	assert.Contains(rec.Body.String(), "not ready")
 }
 
-func TestHandlerAllowsConcurrentWorkspaceTerminals(t *testing.T) {
+func TestHandlerRejectsConcurrentWorkspaceTerminals(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -115,16 +119,86 @@ func TestHandlerAllowsConcurrentWorkspaceTerminals(t *testing.T) {
 	assert.NotNil(release)
 
 	release2, err := h.claimTerminalSlot("ws-1")
-	require.NoError(err)
-	assert.NotNil(release2)
+	require.Error(err)
+	assert.Nil(release2)
 
-	release2()
 	release()
 
 	release3, err := h.claimTerminalSlot("ws-1")
 	require.NoError(err)
 	assert.NotNil(release3)
 	release3()
+}
+
+func TestHandlerAttachesPtyOwnerTerminal(t *testing.T) {
+	require := require.New(t)
+
+	d := openTestDB(t)
+	mgr := workspace.NewManager(d, t.TempDir())
+	ownerRoot := t.TempDir()
+	mgr.SetPtyOwnerClient(&ptyowner.Client{Root: ownerRoot})
+	ws := &workspace.Workspace{
+		ID:              "ws-owner",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature/thing",
+		WorkspaceBranch: "feature/thing",
+		WorktreePath:    t.TempDir(),
+		TmuxSession:     "middleman-owner-test",
+		TerminalBackend: workspace.TerminalBackendPtyOwner,
+		Status:          "ready",
+	}
+	require.NoError(d.InsertWorkspace(t.Context(), ws))
+
+	ctx := t.Context()
+	ownerDone := make(chan error, 1)
+	go func() {
+		ownerDone <- ptyowner.RunOwner(ctx, ptyowner.Options{
+			Root:    ownerRoot,
+			Session: ws.TmuxSession,
+			Cwd:     ws.WorktreePath,
+			Command: []string{"sh", "-c", "printf ready; while IFS= read -r line; do echo got:$line; done"},
+		})
+	}()
+	require.Eventually(func() bool {
+		return (&ptyowner.Client{Root: ownerRoot}).Ping(
+			context.Background(), ws.TmuxSession,
+		) == nil
+	}, 2*time.Second, 20*time.Millisecond)
+	t.Cleanup(func() {
+		_ = (&ptyowner.Client{Root: ownerRoot}).Stop(
+			context.Background(), ws.TmuxSession,
+		)
+		select {
+		case <-ownerDone:
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/workspaces/{id}/terminal", &Handler{
+		Workspaces: mgr,
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	conn, _, err := websocket.Dial(
+		t.Context(),
+		"ws"+strings.TrimPrefix(server.URL, "http")+
+			"/api/v1/workspaces/"+ws.ID+"/terminal",
+		nil,
+	)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	require.Contains(readWebSocketUntil(t, conn, "ready"), "ready")
+	require.NoError(conn.Write(
+		t.Context(), websocket.MessageBinary, []byte("hello\n"),
+	))
+	require.Contains(readWebSocketUntil(t, conn, "got:hello"), "got:hello")
 }
 
 func TestProcessExitCode(t *testing.T) {
@@ -141,4 +215,33 @@ func TestParseSizeFallsBack(t *testing.T) {
 	assert := Assert.New(t)
 	assert.Equal(120, cols)
 	assert.Equal(30, rows)
+}
+
+func readWebSocketUntil(
+	t *testing.T,
+	conn *websocket.Conn,
+	needle string,
+) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var builder strings.Builder
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			require.New(t).Failf(
+				"read websocket",
+				"waiting for %q: %v; got %q",
+				needle, err, builder.String(),
+			)
+		}
+		if typ != websocket.MessageBinary {
+			continue
+		}
+		builder.Write(data)
+		if strings.Contains(builder.String(), needle) {
+			return builder.String()
+		}
+	}
 }

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -101,6 +101,13 @@ func worktreeDiffFilesFromRef(
 	if files == nil {
 		files = []gitclone.DiffFile{}
 	}
+	if hideWhitespace {
+		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, "")
+		if err != nil {
+			return nil, false, fmt.Errorf("whitespace files: %w", err)
+		}
+		files = filterWorktreeWhitespaceOnlyFiles(files, wsFiles)
+	}
 
 	numstatArgs := addWorktreeWhitespaceFlag([]string{
 		"diff", "--numstat", "-z", "-M", "-C", "--find-copies-harder",
@@ -323,6 +330,23 @@ func dropWhitespaceOnlyModifications(
 		out = append(out, files[i])
 	}
 	return out
+}
+
+func filterWorktreeWhitespaceOnlyFiles(
+	files []gitclone.DiffFile,
+	wsFiles map[string]bool,
+) []gitclone.DiffFile {
+	if len(files) == 0 || len(wsFiles) == 0 {
+		return files
+	}
+	filtered := files[:0]
+	for _, file := range files {
+		if wsFiles[file.Path] {
+			continue
+		}
+		filtered = append(filtered, file)
+	}
+	return filtered
 }
 
 func addWorktreeWhitespaceFlag(
@@ -603,21 +627,17 @@ func worktreeWhitespaceOnlyFiles(
 	if err != nil {
 		return nil, err
 	}
-	noWhitespaceArgs := appendWorktreePathspec([]string{
-		"diff", "--raw", "-z", "--no-renames", "-w", baseRef,
-	}, path)
-	outNoWhitespace, err := worktreeGitOutput(
-		ctx, dir, noWhitespaceArgs...,
-	)
-	if err != nil {
-		return nil, err
-	}
 
 	allFiles := worktreeRawPaths(outAll)
-	noWhitespaceFiles := worktreeRawPaths(outNoWhitespace)
 	result := make(map[string]bool)
 	for file := range allFiles {
-		if !noWhitespaceFiles[file] {
+		outNoWhitespace, err := worktreeGitOutput(ctx, dir,
+			"diff", "--numstat", "-z", "--no-renames", "-w", baseRef, "--", file,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(outNoWhitespace) == 0 {
 			result[file] = true
 		}
 	}

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -14,7 +14,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/creack/pty/v2"
@@ -1766,17 +1765,7 @@ func (s *session) closeSubscribers() {
 func (s *session) stop() {
 	s.stopOnce.Do(func() {
 		if s.cmd.Process != nil {
-			// pty.StartWithSize sets Setsid, so the launched
-			// process is a session/pgid leader. Send SIGKILL to
-			// -pid to reach every descendant in the group;
-			// otherwise an agent's detached children would
-			// outlive the session. Fall back to single-process
-			// kill if the group call fails.
-			if err := syscall.Kill(
-				-s.cmd.Process.Pid, syscall.SIGKILL,
-			); err != nil {
-				_ = s.cmd.Process.Kill()
-			}
+			killSessionProcess(s.cmd.Process)
 		}
 		if s.ptmx != nil {
 			_ = s.ptmx.Close()

--- a/internal/workspace/localruntime/process_unix.go
+++ b/internal/workspace/localruntime/process_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package localruntime
+
+import (
+	"os"
+	"syscall"
+)
+
+func killSessionProcess(process *os.Process) {
+	// pty.StartWithSize sets Setsid, so the launched process is a
+	// session/pgid leader. Send SIGKILL to -pid to reach every
+	// descendant in the group; otherwise an agent's detached children
+	// would outlive the session. Fall back to single-process kill if
+	// the group call fails.
+	if err := syscall.Kill(-process.Pid, syscall.SIGKILL); err != nil {
+		_ = process.Kill()
+	}
+}

--- a/internal/workspace/localruntime/process_windows.go
+++ b/internal/workspace/localruntime/process_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package localruntime
+
+import "os"
+
+func killSessionProcess(process *os.Process) {
+	_ = process.Kill()
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -31,13 +31,15 @@ import (
 // intentionally not a generic host worktree browser or arbitrary Git
 // automation layer.
 type Manager struct {
-	db            *db.DB
-	worktreeDir   string
-	clones        *gitclone.Manager
-	tmuxCmd       []string
-	retryMu       sync.Mutex
-	retryQueued   map[string]bool
-	runtimeTmuxMu sync.Mutex
+	db             *db.DB
+	worktreeDir    string
+	clones         *gitclone.Manager
+	tmuxCmd        []string
+	ptyOwner       PtyOwnerClient
+	preferPtyOwner bool
+	retryMu        sync.Mutex
+	retryQueued    map[string]bool
+	runtimeTmuxMu  sync.Mutex
 }
 
 // CreateIssueOptions controls how issue-backed workspaces choose their branch.
@@ -186,8 +188,9 @@ func (m *Manager) Create(
 			m.worktreeDir, platformHost, owner, name,
 			fmt.Sprintf("pr-%d", mrNumber),
 		),
-		TmuxSession: "middleman-" + id,
-		Status:      "creating",
+		TmuxSession:     "middleman-" + id,
+		TerminalBackend: m.PreferredTerminalBackend(),
+		Status:          "creating",
 	}
 
 	if err := m.db.InsertWorkspace(ctx, ws); err != nil {
@@ -300,8 +303,9 @@ func (m *Manager) CreateIssue(
 			m.worktreeDir, platformHost, owner, name,
 			fmt.Sprintf("issue-%d", issueNumber),
 		),
-		TmuxSession: "middleman-" + id,
-		Status:      "creating",
+		TmuxSession:     "middleman-" + id,
+		TerminalBackend: m.PreferredTerminalBackend(),
+		Status:          "creating",
 	}
 
 	if err := m.db.InsertWorkspace(ctx, ws); err != nil {
@@ -400,7 +404,7 @@ func (m *Manager) Setup(
 		)
 	}
 
-	err = m.newTmuxSession(ctx, ws.TmuxSession, ws.WorktreePath)
+	err = m.newTerminalSession(ctx, ws)
 	if err != nil {
 		m.rollbackWorktree(ctx, cloneDir, ws, branch)
 		return m.failSetup(
@@ -411,7 +415,7 @@ func (m *Manager) Setup(
 	m.recordSetupEvent(
 		ctx,
 		ws.ID, workspaceSetupStageTmuxSession, "success",
-		"tmux session started",
+		"terminal session started",
 	)
 
 	if err := m.updateWorkspaceStatus(
@@ -915,11 +919,29 @@ func (m *Manager) cleanupWorkspaceArtifactsForDelete(
 func (m *Manager) cleanupTmuxSession(
 	ctx context.Context, ws *Workspace,
 ) error {
+	usesPtyOwner := m.UsesPtyOwnerForWorkspace(ws)
+	if usesPtyOwner {
+		if m.ptyOwner == nil {
+			return fmt.Errorf("pty owner backend unavailable")
+		}
+		if err := m.ptyOwner.Stop(ctx, ws.TmuxSession); err != nil {
+			return fmt.Errorf(
+				"stop pty owner session %q: %w", ws.TmuxSession, err,
+			)
+		}
+	}
+
 	type cleanupTarget struct {
 		session string
 		main    bool
 	}
-	sessions := []cleanupTarget{{session: ws.TmuxSession, main: true}}
+	var sessions []cleanupTarget
+	if !usesPtyOwner {
+		sessions = append(sessions, cleanupTarget{
+			session: ws.TmuxSession,
+			main:    true,
+		})
+	}
 	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, ws.ID)
 	if err != nil {
 		return err
@@ -1106,6 +1128,9 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
 		if ws.Status != "ready" ||
 			ws.TmuxSession == "" ||
 			live[ws.TmuxSession] {
+			continue
+		}
+		if m.usesPtyOwnerForWorkspace(&ws) {
 			continue
 		}
 		msg := fmt.Sprintf(
@@ -1405,6 +1430,26 @@ func (m *Manager) TmuxPaneTitle(
 	ctx context.Context, session string,
 ) (string, error) {
 	return m.tmuxPaneTitle(ctx, session)
+}
+
+// TerminalPaneSnapshot returns recent terminal output for the backend
+// that owns the workspace's primary terminal. Runtime sessions remain
+// tmux-backed and should use TmuxPaneSnapshot directly.
+func (m *Manager) TerminalPaneSnapshot(
+	ctx context.Context, ws *db.Workspace,
+	session string,
+) (TmuxPaneSnapshot, error) {
+	if ws != nil && session == ws.TmuxSession && m.UsesPtyOwnerForWorkspace(ws) {
+		if m.ptyOwner == nil {
+			return TmuxPaneSnapshot{}, fmt.Errorf("pty owner backend unavailable")
+		}
+		output, err := m.ptyOwner.Snapshot(ctx, session)
+		if err != nil {
+			return TmuxPaneSnapshot{}, err
+		}
+		return TmuxPaneSnapshot{Output: string(output)}, nil
+	}
+	return m.TmuxPaneSnapshot(ctx, session)
 }
 
 // TmuxPaneSnapshot returns the active pane title and recent pane

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitclone"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
 
@@ -795,6 +796,91 @@ func TestManagerEnsureTmuxHasSessionPrefix(t *testing.T) {
 	)
 }
 
+func TestManagerEnsureTerminalUsesPtyOwnerWhenConfigured(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	script, record := writeRecorderScript(t)
+	owner := &fakePtyOwnerClient{}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+	mgr.SetPtyOwnerClient(owner)
+
+	require.NoError(mgr.EnsureTerminal(t.Context(), &db.Workspace{
+		TmuxSession:     "sess-owner",
+		WorktreePath:    "/tmp/ws",
+		TerminalBackend: TerminalBackendPtyOwner,
+	}))
+
+	assert.Equal([]fakePtyOwnerCall{{
+		Op: "ensure", Session: "sess-owner", Cwd: "/tmp/ws",
+	}}, owner.Calls)
+	_, err := os.Stat(record)
+	assert.True(os.IsNotExist(err))
+}
+
+func TestManagerCleanupTerminalUsesPtyOwnerForBaseSession(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	script, record := writeRecorderScript(t)
+	owner := &fakePtyOwnerClient{}
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+	mgr.SetPtyOwnerClient(owner)
+
+	ws, err := mgr.Create(t.Context(), "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	_, err = mgr.Delete(t.Context(), ws.ID, true, nil)
+	require.NoError(err)
+
+	assert.Equal([]fakePtyOwnerCall{{
+		Op: "stop", Session: ws.TmuxSession,
+	}}, owner.Calls)
+	_, err = os.Stat(record)
+	assert.True(os.IsNotExist(err))
+}
+
+func TestManagerCleanupPtyOwnerWorkspaceStopsStoredRuntimeTmuxSessions(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	script, record := writeRecorderScript(t)
+	owner := &fakePtyOwnerClient{}
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+	mgr.SetPtyOwnerClient(owner)
+
+	ws, err := mgr.Create(t.Context(), "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	require.NoError(mgr.RecordRuntimeTmuxSession(
+		t.Context(), ws.ID, "middleman-runtime-session", "agent-1",
+		time.Date(2026, 4, 29, 1, 0, 0, 0, time.UTC),
+	))
+
+	_, err = mgr.Delete(t.Context(), ws.ID, true, nil)
+	require.NoError(err)
+
+	assert.Equal([]fakePtyOwnerCall{{
+		Op: "stop", Session: ws.TmuxSession,
+	}}, owner.Calls)
+	argvs := readRecorderArgv(t, record)
+	require.Len(argvs, 1)
+	assert.Equal(
+		[]string{"wrap", "kill-session", "-t", "middleman-runtime-session"},
+		argvs[0],
+	)
+	stored, err := d.ListWorkspaceTmuxSessions(t.Context(), ws.ID)
+	require.NoError(err)
+	assert.Empty(stored)
+}
+
 func TestManagerDeleteUsesTmuxPrefix(t *testing.T) {
 	assert := Assert.New(t)
 
@@ -1180,6 +1266,11 @@ func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script, "wrap"})
+	mgr.SetPtyOwnerFallbackClient(&fakePtyOwnerClient{
+		StateSessions: map[string]bool{
+			"middleman-0000000000000003": true,
+		},
+	})
 	ctx := context.Background()
 
 	require.NoError(d.InsertWorkspace(ctx, &Workspace{
@@ -1206,6 +1297,24 @@ func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
 		TmuxSession:  "middleman-0000000000000002",
 		Status:       "ready",
 	}))
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "0000000000000003",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "legacy-owner",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   3,
+		GitHeadRef:   "feature/owner",
+		WorktreePath: filepath.Join(t.TempDir(), "owner"),
+		TmuxSession:  "middleman-0000000000000003",
+		Status:       "ready",
+	}))
+	_, err := d.WriteDB().ExecContext(
+		ctx,
+		`UPDATE middleman_workspaces SET terminal_backend = '' WHERE id = ?`,
+		"0000000000000003",
+	)
+	require.NoError(err)
 	require.NoError(d.UpsertWorkspaceTmuxSession(
 		ctx,
 		&db.WorkspaceTmuxSession{
@@ -1245,6 +1354,11 @@ func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
 	require.NotNil(stale.ErrorMessage)
 	assert.Contains(*stale.ErrorMessage, "tmux session is no longer running")
 	assert.Contains(*stale.ErrorMessage, "middleman-0000000000000002")
+
+	legacyOwner, err := d.GetWorkspace(ctx, "0000000000000003")
+	require.NoError(err)
+	require.NotNil(legacyOwner)
+	assert.Equal("ready", legacyOwner.Status)
 }
 
 func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
@@ -2124,4 +2238,57 @@ func TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "tmux has-session")
 	require.Contains(err.Error(), "real failure")
+}
+
+type fakePtyOwnerCall struct {
+	Op      string
+	Session string
+	Cwd     string
+}
+
+type fakePtyOwnerClient struct {
+	Calls         []fakePtyOwnerCall
+	StateExists   bool
+	StateSessions map[string]bool
+}
+
+func (f *fakePtyOwnerClient) HasState(session string) bool {
+	return f.StateExists || f.StateSessions[session]
+}
+
+func (f *fakePtyOwnerClient) Ensure(
+	_ context.Context,
+	session string,
+	cwd string,
+) error {
+	f.Calls = append(f.Calls, fakePtyOwnerCall{
+		Op: "ensure", Session: session, Cwd: cwd,
+	})
+	return nil
+}
+
+func (f *fakePtyOwnerClient) Attach(
+	context.Context,
+	string,
+	int,
+	int,
+) (*ptyowner.Attachment, error) {
+	return nil, nil
+}
+
+func (f *fakePtyOwnerClient) Stop(
+	_ context.Context,
+	session string,
+) error {
+	f.Calls = append(f.Calls, fakePtyOwnerCall{
+		Op: "stop", Session: session,
+	})
+	return nil
+}
+
+func (f *fakePtyOwnerClient) Snapshot(
+	context.Context,
+	string,
+) ([]byte, error) {
+	return nil, nil
 }

--- a/internal/workspace/terminal_backend.go
+++ b/internal/workspace/terminal_backend.go
@@ -1,0 +1,115 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/ptyowner"
+)
+
+const (
+	TerminalBackendTmux     = "tmux"
+	TerminalBackendPtyOwner = "pty_owner"
+)
+
+type PtyOwnerClient interface {
+	HasState(session string) bool
+	Ensure(ctx context.Context, session string, cwd string) error
+	Attach(
+		ctx context.Context,
+		session string,
+		cols int,
+		rows int,
+	) (*ptyowner.Attachment, error)
+	Stop(ctx context.Context, session string) error
+	Snapshot(ctx context.Context, session string) ([]byte, error)
+}
+
+func (m *Manager) SetPtyOwnerClient(client PtyOwnerClient) {
+	m.ptyOwner = client
+	m.preferPtyOwner = client != nil
+}
+
+func (m *Manager) SetPtyOwnerFallbackClient(client PtyOwnerClient) {
+	m.ptyOwner = client
+}
+
+func (m *Manager) UsesPtyOwner() bool {
+	return m.preferPtyOwner
+}
+
+func (m *Manager) UsesPtyOwnerForWorkspace(ws *db.Workspace) bool {
+	return m.usesPtyOwnerForWorkspace(ws)
+}
+
+func (m *Manager) PreferredTerminalBackend() string {
+	if m.preferPtyOwner {
+		return TerminalBackendPtyOwner
+	}
+	return TerminalBackendTmux
+}
+
+func (m *Manager) EnsureTerminal(
+	ctx context.Context,
+	ws *db.Workspace,
+) error {
+	if m.usesPtyOwnerForWorkspace(ws) {
+		if m.ptyOwner == nil {
+			return fmt.Errorf("pty owner backend unavailable")
+		}
+		return m.ptyOwner.Ensure(ctx, ws.TmuxSession, ws.WorktreePath)
+	}
+	return m.EnsureTmux(ctx, ws.TmuxSession, ws.WorktreePath)
+}
+
+func (m *Manager) AttachPtyOwnerTerminal(
+	ctx context.Context,
+	session string,
+	cols int,
+	rows int,
+) (*ptyowner.Attachment, error) {
+	if m.ptyOwner == nil {
+		return nil, ErrWorkspaceInvalidState
+	}
+	return m.ptyOwner.Attach(ctx, session, cols, rows)
+}
+
+func (m *Manager) newTerminalSession(
+	ctx context.Context,
+	ws *db.Workspace,
+) error {
+	if m.usesPtyOwnerForWorkspace(ws) {
+		if m.ptyOwner == nil {
+			return fmt.Errorf("pty owner backend unavailable")
+		}
+		return m.ptyOwner.Ensure(ctx, ws.TmuxSession, ws.WorktreePath)
+	}
+	return m.newTmuxSession(ctx, ws.TmuxSession, ws.WorktreePath)
+}
+
+func (m *Manager) usesPtyOwnerForWorkspace(ws *db.Workspace) bool {
+	return m.workspaceTerminalBackend(ws) == TerminalBackendPtyOwner
+}
+
+func (m *Manager) workspaceTerminalBackend(ws *db.Workspace) string {
+	backend := workspaceTerminalBackend(ws, m.preferPtyOwner)
+	if backend != "" {
+		return backend
+	}
+	if m.ptyOwner != nil && ws != nil && ws.TmuxSession != "" &&
+		m.ptyOwner.HasState(ws.TmuxSession) {
+		return TerminalBackendPtyOwner
+	}
+	return TerminalBackendTmux
+}
+
+func workspaceTerminalBackend(ws *db.Workspace, preferPtyOwner bool) string {
+	if ws != nil && ws.TerminalBackend != "" {
+		return ws.TerminalBackend
+	}
+	if preferPtyOwner {
+		return TerminalBackendPtyOwner
+	}
+	return ""
+}

--- a/packages/ui/src/utils/highlight.ts
+++ b/packages/ui/src/utils/highlight.ts
@@ -76,4 +76,3 @@ export async function tokenizeLineDual(
     return [{ content: code }];
   }
 }
-


### PR DESCRIPTION
- Add a middleman-owned PTY owner fallback for workspace terminals when tmux is unavailable.
- Keep tmux as the preferred backend and bridge browser terminals through the selected backend.
- Add lifecycle, terminal, server, and Windows compile coverage for the fallback path.