### PR TITLE
Fix tmux-backed workspace terminal reconnects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,14 +116,17 @@ air-install:
 dev: ensure-embed-dir check-air
 	@mkdir -p "$(DEV_LOG_DIR)"
 	@echo "backend debug log: $${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}"
+	@echo "backend console log level: $${MIDDLEMAN_LOG_STDERR_LEVEL:-info}"
 	@echo "tail with: tail -F $${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}"
 	@if [ -n "$(MIDDLEMAN_CONFIG)" ]; then \
 		MIDDLEMAN_LOG_LEVEL="$${MIDDLEMAN_LOG_LEVEL:-debug}" \
 		MIDDLEMAN_LOG_FILE="$${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}" \
+		MIDDLEMAN_LOG_STDERR_LEVEL="$${MIDDLEMAN_LOG_STDERR_LEVEL:-info}" \
 		"$(AIR_BIN)" -c .air.toml -- -config "$(MIDDLEMAN_CONFIG)" $(ARGS); \
 	else \
 		MIDDLEMAN_LOG_LEVEL="$${MIDDLEMAN_LOG_LEVEL:-debug}" \
 		MIDDLEMAN_LOG_FILE="$${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}" \
+		MIDDLEMAN_LOG_STDERR_LEVEL="$${MIDDLEMAN_LOG_STDERR_LEVEL:-info}" \
 		"$(AIR_BIN)" -c .air.toml -- $(ARGS); \
 	fi
 
@@ -212,7 +215,7 @@ help:
 	@echo "  install        - Build and install to ~/.local/bin or GOPATH"
 	@echo "  air-install    - Install air live reload tool"
 	@echo ""
-	@echo "  dev            - Run Go server with air live reload and debug logs in tmp/logs/backend-dev.log"
+	@echo "  dev            - Run Go server with air live reload, debug file logs, and info-level console logs"
 	@echo "  frontend       - Build frontend SPA"
 	@echo "  frontend-dev   - Install deps and run Vite dev server, logging to tmp/logs/frontend-dev.log (honors MIDDLEMAN_CONFIG)"
 	@echo "  frontend-dev-bun - Install deps with Bun and run Vite dev server (honors MIDDLEMAN_CONFIG)"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
 	elif [ -n "$$(go env GOBIN)" ] && [ -x "$$(go env GOBIN)/air$(EXE_SUFFIX)" ]; then printf "%s" "$$(go env GOBIN)/air$(EXE_SUFFIX)"; \
 	elif [ -x "$(GOPATH_FIRST)/bin/air$(EXE_SUFFIX)" ]; then printf "%s" "$(GOPATH_FIRST)/bin/air$(EXE_SUFFIX)"; \
 	fi)
+DEV_LOG_DIR ?= tmp/logs
+DEV_BACKEND_LOG ?= $(DEV_LOG_DIR)/backend-dev.log
 
 .PHONY: ensure-embed-dir check-air air-install build build-release install \
         frontend frontend-dev frontend-dev-bun frontend-check api-generate roborev-api-generate \
@@ -112,9 +114,16 @@ air-install:
 
 # Run Go server in dev mode with live reload and API artifact refresh (use alongside `make frontend-dev`)
 dev: ensure-embed-dir check-air
+	@mkdir -p "$(DEV_LOG_DIR)"
+	@echo "backend debug log: $${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}"
+	@echo "tail with: tail -F $${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}"
 	@if [ -n "$(MIDDLEMAN_CONFIG)" ]; then \
+		MIDDLEMAN_LOG_LEVEL="$${MIDDLEMAN_LOG_LEVEL:-debug}" \
+		MIDDLEMAN_LOG_FILE="$${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}" \
 		"$(AIR_BIN)" -c .air.toml -- -config "$(MIDDLEMAN_CONFIG)" $(ARGS); \
 	else \
+		MIDDLEMAN_LOG_LEVEL="$${MIDDLEMAN_LOG_LEVEL:-debug}" \
+		MIDDLEMAN_LOG_FILE="$${MIDDLEMAN_LOG_FILE:-$(DEV_BACKEND_LOG)}" \
 		"$(AIR_BIN)" -c .air.toml -- $(ARGS); \
 	fi
 
@@ -203,7 +212,7 @@ help:
 	@echo "  install        - Build and install to ~/.local/bin or GOPATH"
 	@echo "  air-install    - Install air live reload tool"
 	@echo ""
-	@echo "  dev            - Run Go server with air live reload and API artifact refresh (honors MIDDLEMAN_CONFIG)"
+	@echo "  dev            - Run Go server with air live reload and debug logs in tmp/logs/backend-dev.log"
 	@echo "  frontend       - Build frontend SPA"
 	@echo "  frontend-dev   - Install deps and run Vite dev server, logging to tmp/logs/frontend-dev.log (honors MIDDLEMAN_CONFIG)"
 	@echo "  frontend-dev-bun - Install deps with Bun and run Vite dev server (honors MIDDLEMAN_CONFIG)"

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -32,9 +32,79 @@ var (
 )
 
 func main() {
+	closeLog, err := configureLogging(os.Stderr)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "configure logging: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := closeLog(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "close log file: %v\n", err)
+		}
+	}()
+
 	if err := runCLI(os.Args[1:], os.Stdout); err != nil {
 		slog.Error("fatal", "err", err)
 		os.Exit(1)
+	}
+}
+
+func configureLogging(stderr io.Writer) (func() error, error) {
+	level, err := parseLogLevel(os.Getenv("MIDDLEMAN_LOG_LEVEL"))
+	if err != nil {
+		return nil, err
+	}
+
+	var writer = stderr
+	var file *os.File
+	logFile := strings.TrimSpace(os.Getenv("MIDDLEMAN_LOG_FILE"))
+	if logFile != "" {
+		if err := os.MkdirAll(filepath.Dir(logFile), 0o700); err != nil {
+			return nil, fmt.Errorf("create log directory: %w", err)
+		}
+		file, err = os.OpenFile(
+			logFile,
+			os.O_CREATE|os.O_WRONLY|os.O_APPEND,
+			0o600,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("open log file: %w", err)
+		}
+		writer = io.MultiWriter(stderr, file)
+	}
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		writer,
+		&slog.HandlerOptions{Level: level},
+	)))
+	slog.Debug(
+		"logging configured",
+		"level", level.String(),
+		"file", logFile,
+	)
+
+	return func() error {
+		if file == nil {
+			return nil
+		}
+		return file.Close()
+	}, nil
+}
+
+func parseLogLevel(raw string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf(
+			"unsupported MIDDLEMAN_LOG_LEVEL %q", raw,
+		)
 	}
 }
 
@@ -118,6 +188,14 @@ func run(configPath string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	slog.Debug(
+		"config loaded",
+		"config_path", configPath,
+		"data_dir", cfg.DataDir,
+		"db_path", cfg.DBPath(),
+		"listen_addr", cfg.ListenAddr(),
+		"repo_count", len(cfg.Repos),
+	)
 
 	globalToken := cfg.GitHubToken()
 	if globalToken == "" {
@@ -200,6 +278,7 @@ func run(configPath string) error {
 	repos := resolveStartupRepos(
 		context.Background(), cfg, clients, database,
 	)
+	slog.Debug("startup repos resolved", "count", len(repos))
 
 	cloneMgr := gitclone.New(
 		filepath.Join(cfg.DataDir, "clones"), cloneTokens,
@@ -231,6 +310,11 @@ func run(configPath string) error {
 		cfg, configPath, server.ServerOptions{
 			WorktreeDir: filepath.Join(cfg.DataDir, "worktrees"),
 		},
+	)
+	slog.Debug(
+		"server initialized",
+		"base_path", cfg.BasePath,
+		"worktree_dir", filepath.Join(cfg.DataDir, "worktrees"),
 	)
 
 	// Wire status callback and prime the SSE event hub so clients

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -25,6 +25,47 @@ import (
 	"github.com/wesm/middleman/internal/web"
 )
 
+type splitLogHandler struct {
+	handlers []slog.Handler
+}
+
+func (h splitLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h splitLogHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, handler := range h.handlers {
+		if !handler.Enabled(ctx, r.Level) {
+			continue
+		}
+		if err := handler.Handle(ctx, r.Clone()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h splitLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	handlers := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		handlers = append(handlers, handler.WithAttrs(attrs))
+	}
+	return splitLogHandler{handlers: handlers}
+}
+
+func (h splitLogHandler) WithGroup(name string) slog.Handler {
+	handlers := make([]slog.Handler, 0, len(h.handlers))
+	for _, handler := range h.handlers {
+		handlers = append(handlers, handler.WithGroup(name))
+	}
+	return splitLogHandler{handlers: handlers}
+}
+
 var (
 	version   = "dev"
 	commit    = "unknown"
@@ -55,9 +96,25 @@ func configureLogging(stderr io.Writer) (func() error, error) {
 		return nil, err
 	}
 
-	var writer = stderr
 	var file *os.File
 	logFile := strings.TrimSpace(os.Getenv("MIDDLEMAN_LOG_FILE"))
+	stderrLevel := level
+	if logFile != "" {
+		stderrLevel = slog.LevelInfo
+	}
+	if raw := os.Getenv("MIDDLEMAN_LOG_STDERR_LEVEL"); strings.TrimSpace(raw) != "" {
+		stderrLevel, err = parseLogLevel(raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	handlers := []slog.Handler{
+		slog.NewTextHandler(
+			stderr,
+			&slog.HandlerOptions{Level: stderrLevel},
+		),
+	}
 	if logFile != "" {
 		if err := os.MkdirAll(filepath.Dir(logFile), 0o700); err != nil {
 			return nil, fmt.Errorf("create log directory: %w", err)
@@ -70,16 +127,20 @@ func configureLogging(stderr io.Writer) (func() error, error) {
 		if err != nil {
 			return nil, fmt.Errorf("open log file: %w", err)
 		}
-		writer = io.MultiWriter(stderr, file)
+		handlers = append(
+			handlers,
+			slog.NewTextHandler(
+				file,
+				&slog.HandlerOptions{Level: level},
+			),
+		)
 	}
 
-	slog.SetDefault(slog.New(slog.NewTextHandler(
-		writer,
-		&slog.HandlerOptions{Level: level},
-	)))
+	slog.SetDefault(slog.New(splitLogHandler{handlers: handlers}))
 	slog.Debug(
 		"logging configured",
 		"level", level.String(),
+		"stderr_level", stderrLevel.String(),
 		"file", logFile,
 	)
 

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -229,4 +230,32 @@ func TestRunCLIConfigReadPortCreatesDefaultConfig(t *testing.T) {
 	content, err := os.ReadFile(cfgPath)
 	require.NoError(err)
 	assert.Contains(string(content), "port = 8091")
+}
+
+func TestConfigureLoggingWritesDebugLogsToFile(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	orig := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	logPath := filepath.Join(t.TempDir(), "middleman.log")
+	t.Setenv("MIDDLEMAN_LOG_LEVEL", "debug")
+	t.Setenv("MIDDLEMAN_LOG_FILE", logPath)
+
+	var stderr bytes.Buffer
+	closeLog, err := configureLogging(&stderr)
+	require.NoError(err)
+
+	slog.Debug("debug marker", "workspace_id", "ws-1")
+	slog.Info("info marker")
+	require.NoError(closeLog())
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(err)
+	logs := string(content)
+	assert.Contains(logs, "debug marker")
+	assert.Contains(logs, "workspace_id=ws-1")
+	assert.Contains(logs, "info marker")
+	assert.Contains(stderr.String(), "debug marker")
 }

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -230,32 +229,4 @@ func TestRunCLIConfigReadPortCreatesDefaultConfig(t *testing.T) {
 	content, err := os.ReadFile(cfgPath)
 	require.NoError(err)
 	assert.Contains(string(content), "port = 8091")
-}
-
-func TestConfigureLoggingWritesDebugLogsToFile(t *testing.T) {
-	require := require.New(t)
-	assert := Assert.New(t)
-
-	orig := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(orig) })
-
-	logPath := filepath.Join(t.TempDir(), "middleman.log")
-	t.Setenv("MIDDLEMAN_LOG_LEVEL", "debug")
-	t.Setenv("MIDDLEMAN_LOG_FILE", logPath)
-
-	var stderr bytes.Buffer
-	closeLog, err := configureLogging(&stderr)
-	require.NoError(err)
-
-	slog.Debug("debug marker", "workspace_id", "ws-1")
-	slog.Info("info marker")
-	require.NoError(closeLog())
-
-	content, err := os.ReadFile(logPath)
-	require.NoError(err)
-	logs := string(content)
-	assert.Contains(logs, "debug marker")
-	assert.Contains(logs, "workspace_id=ws-1")
-	assert.Contains(logs, "info marker")
-	assert.Contains(stderr.String(), "debug marker")
 }

--- a/frontend/src/lib/api/workspace-runtime.test.ts
+++ b/frontend/src/lib/api/workspace-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   ensureWorkspaceShell,
@@ -11,6 +11,10 @@ import {
 } from "./workspace-runtime.js";
 
 describe("workspace-runtime api", () => {
+  afterEach(() => {
+    delete window.__BASE_PATH__;
+  });
+
   it("loads runtime state and normalizes nullable arrays", async () => {
     const fetchMock = vi.fn(async () =>
       new Response(
@@ -116,6 +120,37 @@ describe("workspace-runtime api", () => {
     );
     expect(workspaceTmuxWebSocketPath("ws-1")).toBe(
       "/ws/v1/workspaces/ws-1/terminal",
+    );
+  });
+
+  it("includes the configured base path in runtime and websocket paths", async () => {
+    window.__BASE_PATH__ = "/middleman/";
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          launch_targets: [],
+          sessions: [],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await getWorkspaceRuntime("ws-1", fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/middleman/api/v1/workspaces/ws-1/runtime",
+    );
+    expect(workspaceSessionWebSocketPath("ws-1", "ws-1:helper")).toBe(
+      "/middleman/ws/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper/terminal",
+    );
+    expect(workspaceShellWebSocketPath("ws-1")).toBe(
+      "/middleman/ws/v1/workspaces/ws-1/runtime/shell/terminal",
+    );
+    expect(workspaceTmuxWebSocketPath("ws-1")).toBe(
+      "/middleman/ws/v1/workspaces/ws-1/terminal",
     );
   });
 });

--- a/frontend/src/lib/api/workspace-runtime.test.ts
+++ b/frontend/src/lib/api/workspace-runtime.test.ts
@@ -109,13 +109,13 @@ describe("workspace-runtime api", () => {
     expect(
       workspaceSessionWebSocketPath("ws-1", "ws-1:helper"),
     ).toBe(
-      "/api/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper/terminal",
+      "/ws/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper/terminal",
     );
     expect(workspaceShellWebSocketPath("ws-1")).toBe(
-      "/api/v1/workspaces/ws-1/runtime/shell/terminal",
+      "/ws/v1/workspaces/ws-1/runtime/shell/terminal",
     );
     expect(workspaceTmuxWebSocketPath("ws-1")).toBe(
-      "/api/v1/workspaces/ws-1/terminal",
+      "/ws/v1/workspaces/ws-1/terminal",
     );
   });
 });

--- a/frontend/src/lib/api/workspace-runtime.ts
+++ b/frontend/src/lib/api/workspace-runtime.ts
@@ -14,13 +14,22 @@ export type WorkspaceRuntimeState = Omit<
 
 export type RuntimeFetch = typeof fetch;
 
-const basePath =
-  typeof window !== "undefined" ? window.__BASE_PATH__ ?? "/" : "/";
-const baseUrl = `${basePath.replace(/\/$/, "")}/api/v1`;
-const wsBaseUrl = "/ws/v1";
+function basePath(): string {
+  const path =
+    typeof window !== "undefined" ? window.__BASE_PATH__ ?? "/" : "/";
+  return path.replace(/\/$/, "");
+}
+
+function apiBaseUrl(): string {
+  return `${basePath()}/api/v1`;
+}
+
+function wsBaseUrl(): string {
+  return `${basePath()}/ws/v1`;
+}
 
 function workspaceRuntimeURL(workspaceId: string): string {
-  return `${baseUrl}/workspaces/${encodeURIComponent(workspaceId)}/runtime`;
+  return `${apiBaseUrl()}/workspaces/${encodeURIComponent(workspaceId)}/runtime`;
 }
 
 async function readJSON<T>(
@@ -114,7 +123,7 @@ export function workspaceSessionWebSocketPath(
   sessionKey: string,
 ): string {
   return (
-    `${wsBaseUrl}/workspaces/${encodeURIComponent(workspaceId)}` +
+    `${wsBaseUrl()}/workspaces/${encodeURIComponent(workspaceId)}` +
     `/runtime/sessions/${encodeURIComponent(sessionKey)}` +
     "/terminal"
   );
@@ -124,7 +133,7 @@ export function workspaceShellWebSocketPath(
   workspaceId: string,
 ): string {
   return (
-    `${wsBaseUrl}/workspaces/${encodeURIComponent(workspaceId)}` +
+    `${wsBaseUrl()}/workspaces/${encodeURIComponent(workspaceId)}` +
     "/runtime/shell/terminal"
   );
 }
@@ -133,7 +142,7 @@ export function workspaceTmuxWebSocketPath(
   workspaceId: string,
 ): string {
   return (
-    `${wsBaseUrl}/workspaces/${encodeURIComponent(workspaceId)}` +
+    `${wsBaseUrl()}/workspaces/${encodeURIComponent(workspaceId)}` +
     "/terminal"
   );
 }

--- a/frontend/src/lib/api/workspace-runtime.ts
+++ b/frontend/src/lib/api/workspace-runtime.ts
@@ -17,6 +17,7 @@ export type RuntimeFetch = typeof fetch;
 const basePath =
   typeof window !== "undefined" ? window.__BASE_PATH__ ?? "/" : "/";
 const baseUrl = `${basePath.replace(/\/$/, "")}/api/v1`;
+const wsBaseUrl = "/ws/v1";
 
 function workspaceRuntimeURL(workspaceId: string): string {
   return `${baseUrl}/workspaces/${encodeURIComponent(workspaceId)}/runtime`;
@@ -113,7 +114,7 @@ export function workspaceSessionWebSocketPath(
   sessionKey: string,
 ): string {
   return (
-    `/api/v1/workspaces/${encodeURIComponent(workspaceId)}` +
+    `${wsBaseUrl}/workspaces/${encodeURIComponent(workspaceId)}` +
     `/runtime/sessions/${encodeURIComponent(sessionKey)}` +
     "/terminal"
   );
@@ -123,7 +124,7 @@ export function workspaceShellWebSocketPath(
   workspaceId: string,
 ): string {
   return (
-    `/api/v1/workspaces/${encodeURIComponent(workspaceId)}` +
+    `${wsBaseUrl}/workspaces/${encodeURIComponent(workspaceId)}` +
     "/runtime/shell/terminal"
   );
 }
@@ -132,7 +133,7 @@ export function workspaceTmuxWebSocketPath(
   workspaceId: string,
 ): string {
   return (
-    `/api/v1/workspaces/${encodeURIComponent(workspaceId)}` +
+    `${wsBaseUrl}/workspaces/${encodeURIComponent(workspaceId)}` +
     "/terminal"
   );
 }

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -62,7 +62,7 @@
   function defaultWebsocketPath(): string {
     if (!workspaceId) return "";
     return (
-      `/api/v1/workspaces/${encodeURIComponent(workspaceId)}` +
+      `/ws/v1/workspaces/${encodeURIComponent(workspaceId)}` +
       "/terminal"
     );
   }
@@ -87,6 +87,8 @@
     if (/^wss?:\/\//.test(withSize)) {
       return withSize;
     }
+    const devUrl = buildDevApiWsUrl(withSize);
+    if (devUrl) return devUrl;
     const proto = location.protocol === "https:" ? "wss" : "ws";
     const normalizedPath = withSize.startsWith("/")
       ? withSize
@@ -95,6 +97,25 @@
       `${proto}://${location.host}${basePath}` +
       normalizedPath
     );
+  }
+
+  function buildDevApiWsUrl(path: string): string | null {
+    if (!import.meta.env.DEV) return null;
+    const apiUrl = window.__MIDDLEMAN_DEV_API_URL__?.trim();
+    if (!apiUrl || !path.startsWith("/api/")) return null;
+
+    try {
+      const base = new URL(apiUrl);
+      const requested = new URL(path, "http://middleman.local");
+      const basePath = base.pathname.replace(/\/$/, "");
+      base.protocol = base.protocol === "https:" ? "wss:" : "ws:";
+      base.pathname = `${basePath}${requested.pathname}`;
+      base.search = requested.search;
+      base.hash = "";
+      return base.toString();
+    } catch {
+      return null;
+    }
   }
 
   function sendResize(cols: number, rows: number): void {

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -10,6 +10,7 @@
     workspaceId?: string;
     websocketPath?: string;
     reconnectOnExit?: boolean;
+    active?: boolean;
     onExit?: (code: number) => void;
     // When the session is already exited at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
@@ -21,6 +22,7 @@
     workspaceId,
     websocketPath,
     reconnectOnExit = true,
+    active = true,
     onExit,
     initialStatus,
   }: TerminalPaneProps = $props();
@@ -37,6 +39,7 @@
   let restartTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectDelay = 1000;
   let resizeObserver: ResizeObserver | null = null;
+  let refreshFrame: number | null = null;
   let disposed = false;
   let exited = false;
   const encoder = new TextEncoder();
@@ -124,6 +127,36 @@
     }
   }
 
+  function sendRefresh(cols: number, rows: number): void {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "refresh", cols, rows }));
+    }
+  }
+
+  function refreshVisibleTerminal(): void {
+    if (!terminal) return;
+
+    fitAddon?.fit();
+    try {
+      terminal.clearTextureAtlas();
+    } catch {
+      // Some renderer fallbacks do not maintain a texture atlas.
+    }
+    terminal.refresh(0, Math.max(0, terminal.rows - 1));
+    sendResize(terminal.cols, terminal.rows);
+    sendRefresh(terminal.cols, terminal.rows);
+  }
+
+  function scheduleTerminalRefresh(): void {
+    if (refreshFrame !== null) {
+      cancelAnimationFrame(refreshFrame);
+    }
+    refreshFrame = requestAnimationFrame(() => {
+      refreshFrame = null;
+      refreshVisibleTerminal();
+    });
+  }
+
   function connect(): void {
     if (disposed || !terminal) return;
 
@@ -137,6 +170,7 @@
 
     socket.onopen = () => {
       reconnectDelay = 1000;
+      if (active) scheduleTerminalRefresh();
     };
 
     socket.onmessage = (ev: MessageEvent) => {
@@ -225,6 +259,10 @@
       clearTimeout(restartTimer);
       restartTimer = null;
     }
+    if (refreshFrame !== null) {
+      cancelAnimationFrame(refreshFrame);
+      refreshFrame = null;
+    }
     if (ws) {
       ws.onclose = null;
       ws.onerror = null;
@@ -245,6 +283,11 @@
     // cell widths and glyph metrics line up after the family changes.
     webglAddon?.clearTextureAtlas();
     fitAddon?.fit();
+  });
+
+  $effect(() => {
+    if (!terminal || !active) return;
+    scheduleTerminalRefresh();
   });
 
   onMount(() => {

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -33,7 +33,6 @@
   let containerEl: HTMLDivElement;
   let terminal: Terminal | null = $state(null);
   let fitAddon: FitAddon | null = null;
-  let webglAddon: WebglAddon | null = null;
   let ws: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let restartTimer: ReturnType<typeof setTimeout> | null = null;
@@ -122,14 +121,20 @@
   }
 
   function sendResize(cols: number, rows: number): void {
-    if (ws?.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "resize", cols, rows }));
-    }
+    sendControl("resize", cols, rows);
   }
 
   function sendRefresh(cols: number, rows: number): void {
+    sendControl("refresh", cols, rows);
+  }
+
+  function sendControl(
+    type: "resize" | "refresh",
+    cols: number,
+    rows: number,
+  ): void {
     if (ws?.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "refresh", cols, rows }));
+      ws.send(JSON.stringify({ type, cols, rows }));
     }
   }
 
@@ -137,13 +142,8 @@
     if (!terminal) return;
 
     fitAddon?.fit();
-    try {
-      terminal.clearTextureAtlas();
-    } catch {
-      // Some renderer fallbacks do not maintain a texture atlas.
-    }
+    terminal.clearTextureAtlas();
     terminal.refresh(0, Math.max(0, terminal.rows - 1));
-    sendResize(terminal.cols, terminal.rows);
     sendRefresh(terminal.cols, terminal.rows);
   }
 
@@ -281,7 +281,7 @@
     terminal.options.fontFamily = terminalFontFamily;
     // The WebGL renderer caches glyphs per font; force a rebuild so
     // cell widths and glyph metrics line up after the family changes.
-    webglAddon?.clearTextureAtlas();
+    terminal.clearTextureAtlas();
     fitAddon?.fit();
   });
 
@@ -319,10 +319,8 @@
         const wgl = new WebglAddon();
         wgl.onContextLoss(() => {
           wgl.dispose();
-          if (webglAddon === wgl) webglAddon = null;
         });
         term.loadAddon(wgl);
-        webglAddon = wgl;
       } catch {
         // WebGL unavailable; canvas renderer used as fallback.
       }

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -92,13 +92,19 @@
     const devUrl = buildDevApiWsUrl(withSize);
     if (devUrl) return devUrl;
     const proto = location.protocol === "https:" ? "wss" : "ws";
-    const normalizedPath = withSize.startsWith("/")
-      ? withSize
-      : `/${withSize}`;
-    return (
-      `${proto}://${location.host}${basePath}` +
-      normalizedPath
-    );
+    return `${proto}://${location.host}${withBasePath(withSize)}`;
+  }
+
+  function withBasePath(path: string): string {
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    if (!basePath) return normalizedPath;
+    if (
+      normalizedPath === basePath ||
+      normalizedPath.startsWith(`${basePath}/`)
+    ) {
+      return normalizedPath;
+    }
+    return `${basePath}${normalizedPath}`;
   }
 
   function buildDevApiWsUrl(path: string): string | null {

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -83,6 +83,7 @@ import TerminalPane from "./TerminalPane.svelte";
 describe("TerminalPane", () => {
   beforeEach(() => {
     configuredFontFamily = "";
+    delete window.__BASE_PATH__;
     window.__MIDDLEMAN_DEV_API_URL__ = "http://127.0.0.1:8091";
     terminalCtor.mockReset();
     mockFit.mockReset();
@@ -142,6 +143,21 @@ describe("TerminalPane", () => {
     expect(url.pathname).toBe("/ws/v1/workspaces/ws-123/terminal");
   });
 
+  it("applies the base path to the default workspace socket", () => {
+    window.__BASE_PATH__ = "/middleman/";
+
+    render(TerminalPane, {
+      props: { workspaceId: "ws-123" },
+    });
+
+    expect(sockets).toHaveLength(1);
+    const url = new URL(socketAt(0).url);
+    expect(url.origin).toBe("ws://localhost:3000");
+    expect(url.pathname).toBe(
+      "/middleman/ws/v1/workspaces/ws-123/terminal",
+    );
+  });
+
   it("connects to an explicit websocket path", () => {
     render(TerminalPane, {
       props: {
@@ -173,6 +189,24 @@ describe("TerminalPane", () => {
     expect(url.origin).toBe("ws://localhost:3000");
     expect(url.pathname).toBe(
       "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
+    );
+  });
+
+  it("does not duplicate the base path for explicit websocket paths", () => {
+    window.__BASE_PATH__ = "/middleman/";
+
+    render(TerminalPane, {
+      props: {
+        websocketPath:
+          "/middleman/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
+      },
+    });
+
+    expect(sockets).toHaveLength(1);
+    const url = new URL(socketAt(0).url);
+    expect(url.origin).toBe("ws://localhost:3000");
+    expect(url.pathname).toBe(
+      "/middleman/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
     );
   });
 

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -7,6 +7,8 @@ const mockLoadAddon = vi.fn();
 const mockOnData = vi.fn();
 const mockOnBinary = vi.fn();
 const mockDispose = vi.fn();
+const mockRefresh = vi.fn();
+const mockClearTextureAtlas = vi.fn();
 const terminalCtor = vi.fn();
 const terminalWrite = vi.fn();
 
@@ -21,12 +23,15 @@ class MockWebSocket {
   onmessage: ((event: MessageEvent) => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
+  sent: unknown[] = [];
 
   constructor(public url: string) {
     sockets.push(this);
   }
 
-  send(): void {}
+  send(data: unknown): void {
+    this.sent.push(data);
+  }
   close(): void {}
 }
 
@@ -56,6 +61,8 @@ vi.mock("@xterm/xterm", () => ({
       onBinary: mockOnBinary,
       dispose: mockDispose,
       write: terminalWrite,
+      refresh: mockRefresh,
+      clearTextureAtlas: mockClearTextureAtlas,
       options: { ...options },
     };
   }),
@@ -84,6 +91,8 @@ describe("TerminalPane", () => {
     mockOnData.mockReset();
     mockOnBinary.mockReset();
     mockDispose.mockReset();
+    mockRefresh.mockReset();
+    mockClearTextureAtlas.mockReset();
     terminalWrite.mockReset();
     sockets = [];
 
@@ -93,6 +102,14 @@ describe("TerminalPane", () => {
     });
 
     vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    );
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
   });
 
   afterEach(() => {
@@ -156,6 +173,32 @@ describe("TerminalPane", () => {
     expect(url.origin).toBe("ws://localhost:3000");
     expect(url.pathname).toBe(
       "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
+    );
+  });
+
+  it("refreshes the terminal when a hidden pane becomes active", async () => {
+    const { rerender } = render(TerminalPane, {
+      props: {
+        websocketPath:
+          "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
+        active: false,
+      },
+    });
+
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(socketAt(0).sent).toEqual([]);
+
+    await rerender({
+      websocketPath:
+        "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
+      active: true,
+    });
+
+    expect(mockFit).toHaveBeenCalled();
+    expect(mockClearTextureAtlas).toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalledWith(0, 23);
+    expect(socketAt(0).sent).toContain(
+      JSON.stringify({ type: "refresh", cols: 80, rows: 24 }),
     );
   });
 

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -76,6 +76,7 @@ import TerminalPane from "./TerminalPane.svelte";
 describe("TerminalPane", () => {
   beforeEach(() => {
     configuredFontFamily = "";
+    window.__MIDDLEMAN_DEV_API_URL__ = "http://127.0.0.1:8091";
     terminalCtor.mockReset();
     mockFit.mockReset();
     mockOpen.mockReset();
@@ -113,6 +114,17 @@ describe("TerminalPane", () => {
     );
   });
 
+  it("uses the /ws terminal route for the default workspace socket", () => {
+    render(TerminalPane, {
+      props: { workspaceId: "ws-123" },
+    });
+
+    expect(sockets).toHaveLength(1);
+    const url = new URL(socketAt(0).url);
+    expect(url.origin).toBe("ws://localhost:3000");
+    expect(url.pathname).toBe("/ws/v1/workspaces/ws-123/terminal");
+  });
+
   it("connects to an explicit websocket path", () => {
     render(TerminalPane, {
       props: {
@@ -123,11 +135,28 @@ describe("TerminalPane", () => {
 
     expect(sockets).toHaveLength(1);
     const url = new URL(socketAt(0).url);
+    expect(url.origin).toBe("ws://127.0.0.1:8091");
     expect(url.pathname).toBe(
       "/api/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
     );
     expect(url.searchParams.get("cols")).toBe("80");
     expect(url.searchParams.get("rows")).toBe("24");
+  });
+
+  it("keeps /ws paths on the current dev origin for Vite proxying", () => {
+    render(TerminalPane, {
+      props: {
+        websocketPath:
+          "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
+      },
+    });
+
+    expect(sockets).toHaveLength(1);
+    const url = new URL(socketAt(0).url);
+    expect(url.origin).toBe("ws://localhost:3000");
+    expect(url.pathname).toBe(
+      "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ahelper/terminal",
+    );
   });
 
   it("does not open a websocket when initialStatus is exited", () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -66,6 +66,8 @@
   let eventSource = $state<EventSource | null>(null);
   let activeTabKey = $state("home");
   let tmuxTabOpen = $state(false);
+  let tmuxTerminalMounted = $state(false);
+  let mountedSessionKeys = $state<string[]>([]);
   let launchingKey = $state<string | null>(null);
   let shellOpen = $state(false);
   let shellLoading = $state(false);
@@ -301,6 +303,24 @@
     return ws.mr_title ?? ws.git_head_ref;
   }
 
+  function mountSessionTerminal(sessionKey: string): void {
+    if (!mountedSessionKeys.includes(sessionKey)) {
+      mountedSessionKeys = [...mountedSessionKeys, sessionKey];
+    }
+  }
+
+  function unmountSessionTerminal(sessionKey: string): void {
+    mountedSessionKeys = mountedSessionKeys.filter(
+      (key) => key !== sessionKey,
+    );
+  }
+
+  function isSessionTerminalMounted(
+    sessionKey: string,
+  ): boolean {
+    return mountedSessionKeys.includes(sessionKey);
+  }
+
   function defaultSidebarTab(
     ws: Workspace,
   ): SidebarTab {
@@ -370,6 +390,10 @@
       ) {
         activeTabKey = "home";
       }
+      mountedSessionKeys = mountedSessionKeys.filter(
+        (key) =>
+          data.sessions.some((session) => session.key === key),
+      );
     } catch (err) {
       if (id !== workspaceId) return;
       runtimeError =
@@ -384,6 +408,7 @@
     const target = launchTargets.find((t) => t.key === targetKey);
     if (target?.kind === "tmux") {
       tmuxTabOpen = true;
+      tmuxTerminalMounted = true;
       activeTabKey = "tmux";
       return;
     }
@@ -400,6 +425,7 @@
       if (id !== workspaceId) return;
       await fetchRuntime();
       if (id !== workspaceId) return;
+      mountSessionTerminal(session.key);
       activeTabKey = `session:${session.key}`;
     } catch (err) {
       if (id !== workspaceId) return;
@@ -411,6 +437,7 @@
   }
 
   function openSession(sessionKey: string): void {
+    mountSessionTerminal(sessionKey);
     activeTabKey = `session:${sessionKey}`;
   }
 
@@ -428,6 +455,7 @@
       if (id !== workspaceId) return;
       await fetchRuntime();
       if (id !== workspaceId) return;
+      unmountSessionTerminal(session.key);
       if (activeTabKey === `session:${session.key}`) {
         activeTabKey = "home";
       }
@@ -595,6 +623,8 @@
     loadError = null;
     actionError = null;
     runtimeError = null;
+    tmuxTerminalMounted = false;
+    mountedSessionKeys = [];
 
     if (!id) {
       // /workspaces route: drop workspace data so the empty-state
@@ -801,11 +831,13 @@
                     activeTabKey = "home";
                   }}
                   onSelectTmux={() => {
+                    tmuxTerminalMounted = true;
                     activeTabKey = "tmux";
                   }}
                   onSelectSession={openSession}
                   onCloseTmux={() => {
                     tmuxTabOpen = false;
+                    tmuxTerminalMounted = false;
                     if (activeTabKey === "tmux") {
                       activeTabKey = "home";
                     }
@@ -858,10 +890,14 @@
                       class="stage-pane"
                       class:active={activeTabKey === "tmux"}
                     >
-                      <TerminalPane
-                        websocketPath={workspaceTmuxWebSocketPath(workspaceId)}
-                        reconnectOnExit={true}
-                      />
+                      {#if tmuxTerminalMounted}
+                        <TerminalPane
+                          websocketPath={workspaceTmuxWebSocketPath(
+                            workspaceId,
+                          )}
+                          reconnectOnExit={true}
+                        />
+                      {/if}
                     </div>
                   {/if}
                   {#each runtimeSessions as session (session.key)}
@@ -869,15 +905,17 @@
                       class="stage-pane"
                       class:active={activeTabKey === `session:${session.key}`}
                     >
-                      <TerminalPane
-                        websocketPath={workspaceSessionWebSocketPath(
-                          workspaceId,
-                          session.key,
-                        )}
-                        reconnectOnExit={false}
-                        onExit={() => void fetchRuntime()}
-                        initialStatus={session.status}
-                      />
+                      {#if isSessionTerminalMounted(session.key)}
+                        <TerminalPane
+                          websocketPath={workspaceSessionWebSocketPath(
+                            workspaceId,
+                            session.key,
+                          )}
+                          reconnectOnExit={false}
+                          onExit={() => void fetchRuntime()}
+                          initialStatus={session.status}
+                        />
+                      {/if}
                     </div>
                   {/each}
                 {/if}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -896,6 +896,7 @@
                             workspaceId,
                           )}
                           reconnectOnExit={true}
+                          active={activeTabKey === "tmux"}
                         />
                       {/if}
                     </div>
@@ -912,6 +913,7 @@
                             session.key,
                           )}
                           reconnectOnExit={false}
+                          active={activeTabKey === `session:${session.key}`}
                           onExit={() => void fetchRuntime()}
                           initialStatus={session.status}
                         />

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import config, {
   resolveViteServerPort,
+  webSocketDebugEnabled,
 } from "../../../vite.config";
 
 describe("vite config", () => {
@@ -64,6 +65,16 @@ describe("vite config", () => {
       changeOrigin: true,
       ws: true,
     });
+    expect(proxy["/ws"]).not.toHaveProperty("configure");
+  });
+
+  it("requires explicit opt-in for websocket proxy diagnostics", () => {
+    expect(webSocketDebugEnabled({})).toBe(false);
+    expect(webSocketDebugEnabled({ MIDDLEMAN_WS_DEBUG: "0" })).toBe(false);
+    expect(webSocketDebugEnabled({ MIDDLEMAN_WS_DEBUG: "false" })).toBe(false);
+    expect(webSocketDebugEnabled({ MIDDLEMAN_WS_DEBUG: "1" })).toBe(true);
+    expect(webSocketDebugEnabled({ MIDDLEMAN_WS_DEBUG: "true" })).toBe(true);
+    expect(webSocketDebugEnabled({ MIDDLEMAN_WS_DEBUG: "yes" })).toBe(true);
   });
 
   it("uses the Vite CLI port for dev server HMR settings", () => {

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import config from "../../../vite.config";
+import config, {
+  resolveViteServerPort,
+} from "../../../vite.config";
 
 describe("vite config", () => {
   it("aliases @middleman/ui to the workspace source tree", () => {
@@ -24,5 +26,49 @@ describe("vite config", () => {
   it("pins the dev server host to IPv4 loopback", () => {
     expect(config.server?.host).toBe("127.0.0.1");
     expect(config.server?.port).toBe(5174);
+    expect(config.server?.strictPort).toBe(true);
+    expect(config.server?.hmr).toEqual({
+      protocol: "ws",
+      host: "127.0.0.1",
+      clientPort: 5174,
+      path: "/__vite_hmr",
+    });
+  });
+
+  it("keeps API proxy connections open for SSE streams", () => {
+    const proxy = config.server?.proxy;
+    expect(proxy).toBeDefined();
+    expect(typeof proxy).toBe("object");
+    if (!proxy || typeof proxy !== "object" || Array.isArray(proxy)) {
+      throw new Error("expected object proxy config");
+    }
+
+    const apiProxy = proxy["/api"];
+    expect(apiProxy).toMatchObject({
+      changeOrigin: true,
+      timeout: 0,
+      proxyTimeout: 0,
+    });
+    expect(apiProxy).not.toMatchObject({ ws: true });
+  });
+
+  it("proxies terminal websocket upgrades under /ws only", () => {
+    const proxy = config.server?.proxy;
+    expect(proxy).toBeDefined();
+    expect(typeof proxy).toBe("object");
+    if (!proxy || typeof proxy !== "object" || Array.isArray(proxy)) {
+      throw new Error("expected object proxy config");
+    }
+
+    expect(proxy["/ws"]).toMatchObject({
+      changeOrigin: true,
+      ws: true,
+    });
+  });
+
+  it("uses the Vite CLI port for dev server HMR settings", () => {
+    expect(resolveViteServerPort(["vite", "--port", "4173"])).toBe(4173);
+    expect(resolveViteServerPort(["vite", "--port=4180"])).toBe(4180);
+    expect(resolveViteServerPort(["vite"])).toBe(5174);
   });
 });

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -188,6 +188,7 @@ interface MiddlemanNavigateEvent {
 
 interface Window {
   __BASE_PATH__?: string;
+  __MIDDLEMAN_DEV_API_URL__?: string;
   __middleman_config?: MiddlemanConfig;
   __middleman_notify_config_changed?: () => void;
   __middleman_update_workspace?: (data: WorkspaceData) => void;

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -672,6 +672,99 @@ test.describe("workspace launch home", () => {
   );
 
   test(
+    "does not attach restored runtime sessions until selected",
+    async ({ page }) => {
+      await setupTerminalMocks(page, {
+        runtime: {
+          ...workspaceRuntime,
+          sessions: [
+            {
+              key: "ws-123:codex",
+              workspace_id: "ws-123",
+              target_key: "codex",
+              label: "Codex",
+              kind: "agent",
+              status: "running",
+              created_at: "2026-04-10T12:00:00Z",
+            },
+          ],
+          shell_session: null,
+        },
+      });
+
+      await page.addInitScript(() => {
+        const OriginalWebSocket = window.WebSocket;
+        const urls: string[] = [];
+        Object.defineProperty(
+          window,
+          "__middlemanWebSocketUrls",
+          {
+            value: urls,
+          },
+        );
+        window.WebSocket = class extends OriginalWebSocket {
+          constructor(
+            url: string | URL,
+            protocols?: string | string[],
+          ) {
+            urls.push(String(url));
+            if (protocols === undefined) {
+              super(url);
+            } else {
+              super(url, protocols);
+            }
+          }
+        };
+      });
+
+      await page.goto("/terminal/ws-123");
+
+      const tabs = page.locator(".workspace-tabs");
+      await expect(
+        tabs.getByRole("tab", { name: "Codex" }),
+      ).toBeVisible();
+      const initialTerminalSockets = await page.evaluate(() =>
+        (
+          (
+            window as unknown as {
+              __middlemanWebSocketUrls: string[];
+            }
+          ).__middlemanWebSocketUrls ?? []
+        ).filter((url) =>
+          url.includes("/ws/v1/workspaces/ws-123/"),
+        ),
+      );
+      expect(initialTerminalSockets).toEqual([]);
+
+      await tabs.getByRole("tab", { name: "Codex" }).click();
+
+      await expect(
+        page.locator(".terminal-container"),
+      ).toBeVisible();
+      await expect
+        .poll(async () => {
+          const urls = await page.evaluate(() =>
+            (
+              (
+                window as unknown as {
+                  __middlemanWebSocketUrls: string[];
+                }
+              ).__middlemanWebSocketUrls ?? []
+            ).filter((url) =>
+              url.includes("/ws/v1/workspaces/ws-123/"),
+            ),
+          );
+          return urls.some((url) =>
+            url.includes(
+              "/runtime/sessions/ws-123%3Acodex/terminal",
+            ),
+          );
+        })
+        .toBe(true);
+    },
+  );
+
+  test(
     "launches an agent into a compact running tab",
     async ({ page }) => {
       await page.goto("/terminal/ws-123");

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,12 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { svelteTesting } from "@testing-library/svelte/vite";
-import { searchForWorkspaceRoot, type Plugin, type UserConfig } from "vite";
+import {
+  searchForWorkspaceRoot,
+  type Plugin,
+  type ProxyOptions,
+  type UserConfig,
+} from "vite";
 import type { InlineConfig } from "vitest/node";
 import { resolveDevApiUrl } from "./src/lib/dev/apiProxyTarget";
 import { healthcheckPlugin } from "./src/lib/dev/healthcheckPlugin";
@@ -72,6 +77,33 @@ function parsePort(value: string | undefined): number | null {
     return null;
   }
   return parsed;
+}
+
+function logWebSocketProxyRequests(): NonNullable<
+  ProxyOptions["configure"]
+> {
+  return (proxy) => {
+    proxy.on("proxyReqWs", (_proxyReq, req, socket) => {
+      const url = req.url ?? "<unknown>";
+      console.info(`[vite:ws-proxy] open ${url}`);
+      socket.on("error", (err) => {
+        console.error(
+          `[vite:ws-proxy] socket error ${url}: ${err.message}`,
+        );
+      });
+    });
+    proxy.on("error", (err, req) => {
+      const url = req?.url ?? "<unknown>";
+      console.error(`[vite:ws-proxy] error ${url}: ${err.message}`);
+    });
+    proxy.on("close", (_proxyRes, _proxySocket, proxyHead) => {
+      const headLength =
+        proxyHead instanceof Buffer ? proxyHead.length : 0;
+      console.info(
+        `[vite:ws-proxy] close proxyHeadBytes=${headLength}`,
+      );
+    });
+  };
 }
 
 const config = {
@@ -171,6 +203,7 @@ const config = {
         target: apiUrl,
         changeOrigin: true,
         ws: true,
+        configure: logWebSocketProxyRequests(),
       },
     },
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -106,6 +106,32 @@ function logWebSocketProxyRequests(): NonNullable<
   };
 }
 
+export function webSocketDebugEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  switch (env.MIDDLEMAN_WS_DEBUG?.trim().toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function terminalWebSocketProxy(url: string): ProxyOptions {
+  const proxy: ProxyOptions = {
+    target: url,
+    changeOrigin: true,
+    ws: true,
+  };
+  if (webSocketDebugEnabled()) {
+    proxy.configure = logWebSocketProxyRequests();
+  }
+  return proxy;
+}
+
 const config = {
   base: "/",
   plugins: [
@@ -199,12 +225,7 @@ const config = {
         timeout: 0,
         proxyTimeout: 0,
       },
-      "/ws": {
-        target: apiUrl,
-        changeOrigin: true,
-        ws: true,
-        configure: logWebSocketProxyRequests(),
-      },
+      "/ws": terminalWebSocketProxy(apiUrl),
     },
   },
   test: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { svelteTesting } from "@testing-library/svelte/vite";
-import { searchForWorkspaceRoot, type UserConfig } from "vite";
+import { searchForWorkspaceRoot, type Plugin, type UserConfig } from "vite";
 import type { InlineConfig } from "vitest/node";
 import { resolveDevApiUrl } from "./src/lib/dev/apiProxyTarget";
 import { healthcheckPlugin } from "./src/lib/dev/healthcheckPlugin";
@@ -11,6 +11,7 @@ const require = createRequire(import.meta.url);
 const testingLibrarySvelteEntry = require.resolve("@testing-library/svelte");
 
 const apiUrl = resolveDevApiUrl();
+const devServerPort = resolveViteServerPort();
 const workspaceRoot = searchForWorkspaceRoot(process.cwd());
 const uiPkg = path.resolve(process.cwd(), "../packages/ui");
 const uiIndex = path.resolve(process.cwd(), "../packages/ui/src/index.ts");
@@ -28,9 +29,59 @@ const uiStoreDiff = path.resolve(process.cwd(), "../packages/ui/src/stores/diff.
 const uiStoreGrouping = path.resolve(process.cwd(), "../packages/ui/src/stores/grouping.svelte.ts");
 const uiStoreSettings = path.resolve(process.cwd(), "../packages/ui/src/stores/settings.svelte.ts");
 
+function devApiUrlPlugin(url: string): Plugin {
+  return {
+    name: "middleman-dev-api-url",
+    apply: "serve",
+    transformIndexHtml() {
+      return [
+        {
+          tag: "script",
+          children:
+            `window.__MIDDLEMAN_DEV_API_URL__ = ${JSON.stringify(url)};`,
+          injectTo: "head-prepend",
+        },
+      ];
+    },
+  };
+}
+
+export function resolveViteServerPort(
+  argv: readonly string[] = process.argv,
+): number {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg) continue;
+    if (arg === "--port" && i+1 < argv.length) {
+      const next = argv[i+1];
+      const parsed = parsePort(next);
+      if (parsed !== null) return parsed;
+    }
+    if (arg.startsWith("--port=")) {
+      const parsed = parsePort(arg.slice("--port=".length));
+      if (parsed !== null) return parsed;
+    }
+  }
+  return 5174;
+}
+
+function parsePort(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return null;
+  }
+  return parsed;
+}
+
 const config = {
   base: "/",
-  plugins: [healthcheckPlugin(), svelte(), svelteTesting()],
+  plugins: [
+    healthcheckPlugin(),
+    devApiUrlPlugin(apiUrl),
+    svelte(),
+    svelteTesting(),
+  ],
   resolve: {
     alias: [
       {
@@ -100,10 +151,23 @@ const config = {
   },
   server: {
     host: "127.0.0.1",
-    port: 5174,
+    port: devServerPort,
+    strictPort: true,
+    hmr: {
+      protocol: "ws",
+      host: "127.0.0.1",
+      clientPort: devServerPort,
+      path: "/__vite_hmr",
+    },
     fs: { allow: [workspaceRoot, uiPkg] },
     proxy: {
       "/api": {
+        target: apiUrl,
+        changeOrigin: true,
+        timeout: 0,
+        proxyTimeout: 0,
+      },
+      "/ws": {
         target: apiUrl,
         changeOrigin: true,
         ws: true,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8594,7 +8594,7 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/api/v1/workspaces/" + ws.Id +
+		"/ws/v1/workspaces/" + ws.Id +
 		"/runtime/sessions/" + session.Key + "/terminal"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	require.NoError(err)
@@ -8620,6 +8620,91 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 		}
 	}
 	require.Contains(got.String(), "echo:ping")
+}
+
+func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: serverRuntimeHelperCommand("altscreen"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+	time.Sleep(100 * time.Millisecond)
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	type terminalRead struct {
+		typ  websocket.MessageType
+		data []byte
+		err  error
+	}
+	reads := make(chan terminalRead, 1)
+	readOnce := func() {
+		go func() {
+			typ, data, readErr := conn.Read(context.Background())
+			reads <- terminalRead{typ: typ, data: data, err: readErr}
+		}()
+	}
+	readOnce()
+	select {
+	case read := <-reads:
+		require.NoError(read.err)
+		require.Empty(
+			string(read.data),
+			"late attach must not replay stale alternate-screen output",
+		)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageBinary, []byte("paint\n"),
+	))
+	var got strings.Builder
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case read := <-reads:
+			require.NoError(read.err)
+			if read.typ == websocket.MessageBinary {
+				got.WriteString(string(read.data))
+			}
+			if strings.Contains(got.String(), "live:paint") {
+				break
+			}
+			readOnce()
+			continue
+		case <-deadline:
+			require.Contains(got.String(), "live:paint")
+		}
+		break
+	}
+	assert.NotContains(got.String(), "codex screen")
+	require.Contains(got.String(), "live:paint")
 }
 
 func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
@@ -8650,7 +8735,7 @@ func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/api/v1/workspaces/" + ws.Id +
+		"/ws/v1/workspaces/" + ws.Id +
 		"/runtime/sessions/" + session.Key +
 		"/terminal?cols=177&rows=41"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
@@ -8729,7 +8814,7 @@ printf 'size:%s:%s:%s\n' "$1" "$2" "$line"
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/api/v1/workspaces/" + ws.Id +
+		"/ws/v1/workspaces/" + ws.Id +
 		"/runtime/sessions/" + session.Key +
 		"/terminal?cols=177&rows=41"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
@@ -8820,6 +8905,13 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 		if err == nil {
 			fmt.Print("echo:" + line)
+		}
+		select {}
+	case "altscreen":
+		fmt.Print("\x1b[?1049h\x1b[Hcodex screen")
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err == nil {
+			fmt.Print("\x1b[Hlive:" + line)
 		}
 		select {}
 	case "size":

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7679,6 +7679,89 @@ func TestWorkspaceRuntimeLaunchSingletonAndStopE2E(t *testing.T) {
 	assert.Empty(*afterStopResp.JSON200.Sessions)
 }
 
+func TestWorkspaceRuntimeIncludesStoredTmuxSessionsAfterReloadE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+case "$1" in
+  list-sessions)
+    printf '%s\n' "$RESTORED_TMUX_SESSION"
+    exit 0
+    ;;
+  attach-session)
+    sleep 30
+    exit 0
+    ;;
+  kill-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+	seedPR(t, database, "acme", "widget", 1)
+	worktreeDir := filepath.Join(dir, "worktrees")
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: serverRuntimeHelperCommand("sleep"),
+	}}, Tmux: config.Tmux{Command: []string{tmuxPath}}}
+	ctx := context.Background()
+	ws := &workspace.Workspace{
+		ID:              "0000000000000001",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      1,
+		GitHeadRef:      "feature",
+		WorkspaceBranch: "feature",
+		WorktreePath:    filepath.Join(worktreeDir, "acme-widget-1"),
+		TmuxSession:     "middleman-0000000000000001",
+		Status:          "ready",
+	}
+	require.NoError(database.InsertWorkspace(ctx, ws))
+	tmuxSession := runtimeTmuxSessionNameForTest(ws.ID, "helper")
+	t.Setenv("RESTORED_TMUX_SESSION", tmuxSession)
+	require.NoError(database.UpsertWorkspaceTmuxSession(
+		ctx,
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: ws.ID,
+			SessionName: tmuxSession,
+			TargetKey:   "helper",
+		},
+	))
+	srv := New(database, nil, nil, "/", cfg, ServerOptions{
+		WorktreeDir: worktreeDir,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	require.Len(srv.runtime.ListSessions(ws.ID), 1)
+
+	resp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.ID)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Sessions)
+	require.Len(*resp.JSON200.Sessions, 1)
+
+	session := (*resp.JSON200.Sessions)[0]
+	assert.Equal(ws.ID+":helper", session.Key)
+	assert.Equal(ws.ID, session.WorkspaceId)
+	assert.Equal("helper", session.TargetKey)
+	assert.Equal("Helper", session.Label)
+	assert.Equal(string(localruntime.LaunchTargetAgent), session.Kind)
+	assert.Equal(string(localruntime.SessionStatusRunning), session.Status)
+	assert.False(session.CreatedAt.IsZero())
+	assert.Equal(time.UTC, session.CreatedAt.Location())
+}
+
 func TestWorkspaceRuntimeLaunchAgentCreatesProbeableTmuxSessionE2E(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7687,6 +7687,7 @@ func TestWorkspaceRuntimeIncludesStoredTmuxSessionsAfterReloadE2E(t *testing.T) 
 	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
 case "$1" in
   list-sessions)
+    printf '%s\n' middleman-0000000000000001
     printf '%s\n' "$RESTORED_TMUX_SESSION"
     exit 0
     ;;
@@ -7965,6 +7966,7 @@ for a in "$@"; do
 done
 case "$1" in
   list-sessions)
+    printf '%s\n' 'middleman-0000000000000001-e81d3b0e9d82feaa'
     exit 0
     ;;
 esac
@@ -8618,6 +8620,61 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 	)
 	assert.Equal(int64(2), *found.CommitsAhead)
 	assert.Equal(int64(0), *found.CommitsBehind)
+}
+
+func TestWorkspaceListPrunesMissingTmuxSessionsE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	if testing.Short() {
+		t.Skip("workspace e2e tests skipped in short mode")
+	}
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    printf 'middleman-0000000000000001\n'` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	cfg := &config.Config{
+		Tmux: config.Tmux{Command: []string{script}},
+	}
+	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID:           "0000000000000002",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/stale",
+		WorktreePath: filepath.Join(dir, "stale"),
+		TmuxSession:  "middleman-0000000000000002",
+		Status:       "ready",
+	}))
+
+	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode())
+	require.NotNil(listResp.JSON200)
+	require.NotNil(listResp.JSON200.Workspaces)
+	require.Len(*listResp.JSON200.Workspaces, 1)
+	got := (*listResp.JSON200.Workspaces)[0]
+	assert.Equal("0000000000000002", got.Id)
+	assert.Equal("error", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Contains(*got.ErrorMessage, "tmux session is no longer running")
+
+	stored, err := database.GetWorkspace(ctx, "0000000000000002")
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("error", stored.Status)
 }
 
 func TestWorkspaceRuntimeEnsureShellE2E(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8656,7 +8656,7 @@ func TestWorkspaceListPrunesMissingTmuxSessionsE2E(t *testing.T) {
 	body := "#!/bin/sh\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'middleman-0000000000000001\n'` + "\n" +
+		`    printf 'middleman-0000000000000001\nmiddleman-0000000000000002-e81d3b0e9d82feaa\n'` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
 		"done\n" +
@@ -8680,6 +8680,17 @@ func TestWorkspaceListPrunesMissingTmuxSessionsE2E(t *testing.T) {
 		TmuxSession:  "middleman-0000000000000002",
 		Status:       "ready",
 	}))
+	runtimeSession := runtimeTmuxSessionNameForTest(
+		"0000000000000002", "helper",
+	)
+	require.NoError(database.UpsertWorkspaceTmuxSession(
+		ctx,
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: "0000000000000002",
+			SessionName: runtimeSession,
+			TargetKey:   "helper",
+		},
+	))
 
 	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
 	require.NoError(err)
@@ -8697,6 +8708,12 @@ func TestWorkspaceListPrunesMissingTmuxSessionsE2E(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal("error", stored.Status)
+	runtimeRows, err := database.ListWorkspaceTmuxSessions(
+		ctx, "0000000000000002",
+	)
+	require.NoError(err)
+	require.Len(runtimeRows, 1)
+	assert.Equal(runtimeSession, runtimeRows[0].SessionName)
 }
 
 func TestWorkspaceRuntimeEnsureShellE2E(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -360,6 +360,15 @@ func setupTestServerWithRepos(
 
 func setupTestClient(t *testing.T, srv *Server) *apiclient.Client {
 	t.Helper()
+	return setupTestClientWithBaseURL(t, srv, "http://middleman.test")
+}
+
+func setupTestClientWithBaseURL(
+	t *testing.T,
+	srv *Server,
+	baseURL string,
+) *apiclient.Client {
+	t.Helper()
 
 	httpClient := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -387,7 +396,7 @@ func setupTestClient(t *testing.T, srv *Server) *apiclient.Client {
 		}),
 	}
 
-	client, err := apiclient.NewWithHTTPClient("http://middleman.test", httpClient)
+	client, err := apiclient.NewWithHTTPClient(baseURL, httpClient)
 	require.NoError(t, err)
 
 	return client
@@ -7284,7 +7293,11 @@ func setupWorkspaceServerFixture(
 		database, nil, repos, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := New(database, syncer, nil, "/", cfg, ServerOptions{
+	basePath := "/"
+	if cfg != nil && cfg.BasePath != "" {
+		basePath = cfg.BasePath
+	}
+	srv := New(database, syncer, nil, basePath, cfg, ServerOptions{
 		Clones:      clones,
 		WorktreeDir: worktreeDir,
 	})
@@ -7297,7 +7310,11 @@ func setupWorkspaceServerFixture(
 
 	seedPR(t, database, "acme", "widget", 1)
 
-	client := setupTestClient(t, srv)
+	clientBaseURL := "http://middleman.test"
+	if basePath != "/" {
+		clientBaseURL += strings.TrimSuffix(basePath, "/")
+	}
+	client := setupTestClientWithBaseURL(t, srv, clientBaseURL)
 	return workspaceServerFixture{
 		server:   srv,
 		client:   client,
@@ -8774,6 +8791,66 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 	t.Cleanup(ts.Close)
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
 		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageBinary, []byte("ping\n"),
+	))
+	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var got strings.Builder
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+		if typ != websocket.MessageBinary {
+			continue
+		}
+		got.WriteString(string(data))
+		if strings.Contains(got.String(), "echo:ping") {
+			return
+		}
+	}
+	require.Contains(got.String(), "echo:ping")
+}
+
+func TestWorkspaceRuntimeSessionTerminalWebSocketBasePathE2E(t *testing.T) {
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{
+		BasePath: "/middleman/",
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: serverRuntimeHelperCommand("echo"),
+		}},
+		Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions},
+	}
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/middleman/ws/v1/workspaces/" + ws.Id +
 		"/runtime/sessions/" + session.Key + "/terminal"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	require.NoError(err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7773,13 +7773,20 @@ func TestWorkspaceRuntimeLaunchAgentCreatesProbeableTmuxSessionE2E(t *testing.T)
 	require.NoError(os.WriteFile(agentPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
 	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
 printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+session_file="${TMUX_RECORD}.sessions"
 target=""
 mode=""
+new_session=""
 prev=""
 for a in "$@"; do
   if [ "$prev" = "-t" ]; then target="$a"; fi
+  if [ "$prev" = "-s" ]; then new_session="$a"; fi
   if [ "$a" = "display-message" ]; then mode="display-message"; fi
   if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
+  if [ "$a" = "list-sessions" ]; then
+    [ -f "$session_file" ] && cat "$session_file"
+    exit 0
+  fi
   prev="$a"
 done
 if [ "$mode" = "display-message" ]; then
@@ -7795,6 +7802,9 @@ if [ "$mode" = "capture-pane" ]; then
 fi
 if [ "$1" = "has-session" ]; then
   exit 1
+fi
+if [ -n "$new_session" ]; then
+  printf '%s\n' "$new_session" >> "$session_file"
 fi
 exit 0
 `), 0o755))
@@ -8405,6 +8415,10 @@ for a in "$@"; do
   if [ "$prev" = "-t" ]; then target="$a"; fi
   if [ "$a" = "display-message" ]; then mode="display-message"; fi
   if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
+  if [ "$a" = "list-sessions" ]; then
+    printf '%s\n' "$TMUX_LIVE_SESSIONS"
+    exit 0
+  fi
   prev="$a"
 done
 if [ "$mode" = "display-message" ]; then
@@ -8425,6 +8439,14 @@ exit 0
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 	require.NotEmpty(ws.TmuxSession)
+	t.Setenv(
+		"TMUX_LIVE_SESSIONS",
+		strings.Join([]string{
+			ws.TmuxSession,
+			ws.TmuxSession + "-codex",
+			ws.TmuxSession + "-claude",
+		}, "\n"),
+	)
 	require.NoError(database.UpsertWorkspaceTmuxSession(
 		ctx,
 		&db.WorkspaceTmuxSession{

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2429,6 +2429,10 @@ func (s *Server) listWorkspaces(
 		return out, nil
 	}
 
+	if err := s.workspaces.PruneMissingTmuxSessions(ctx); err != nil {
+		slog.Debug("prune missing tmux sessions", "err", err)
+	}
+
 	summaries, err := s.workspaces.ListSummaries(ctx)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -385,6 +385,9 @@ func newServer(
 			WrapAgentSessionsInTmux: cfg.TmuxAgentSessionsEnabled(),
 			StripEnvVars:            cfg.TokenEnvNames(),
 		})
+		if err := s.restoreRuntimeTmuxSessions(context.Background()); err != nil {
+			slog.Warn("restore runtime tmux sessions", "err", err)
+		}
 	}
 
 	if s.workspaces != nil {
@@ -517,6 +520,31 @@ func newServer(
 	}
 
 	return s
+}
+
+func (s *Server) restoreRuntimeTmuxSessions(ctx context.Context) error {
+	if s.db == nil || s.runtime == nil {
+		return nil
+	}
+	stored, err := s.db.ListAllWorkspaceTmuxSessions(ctx)
+	if err != nil {
+		return err
+	}
+	if len(stored) == 0 {
+		return nil
+	}
+
+	sessions := make([]localruntime.RestoredTmuxSession, 0, len(stored))
+	for _, session := range stored {
+		sessions = append(sessions, localruntime.RestoredTmuxSession{
+			WorkspaceID: session.WorkspaceID,
+			SessionName: session.SessionName,
+			TargetKey:   session.TargetKey,
+			CreatedAt:   session.CreatedAt,
+		})
+	}
+	slog.Debug("restoring runtime tmux sessions", "count", len(sessions))
+	return s.runtime.RestoreTmuxSessions(ctx, sessions)
 }
 
 func (s *Server) bootstrapScript() string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -396,13 +396,25 @@ func newServer(
 			"GET /api/v1/workspaces/{id}/terminal",
 			termHandler,
 		)
+		mux.Handle(
+			"GET /ws/v1/workspaces/{id}/terminal",
+			termHandler,
+		)
 		if s.runtime != nil {
 			mux.HandleFunc(
 				"GET /api/v1/workspaces/{id}/runtime/sessions/{session_key}/terminal",
 				s.handleWorkspaceRuntimeSessionTerminal,
 			)
 			mux.HandleFunc(
+				"GET /ws/v1/workspaces/{id}/runtime/sessions/{session_key}/terminal",
+				s.handleWorkspaceRuntimeSessionTerminal,
+			)
+			mux.HandleFunc(
 				"GET /api/v1/workspaces/{id}/runtime/shell/terminal",
+				s.handleWorkspaceRuntimeShellTerminal,
+			)
+			mux.HandleFunc(
+				"GET /ws/v1/workspaces/{id}/runtime/shell/terminal",
 				s.handleWorkspaceRuntimeShellTerminal,
 			)
 		}
@@ -547,6 +559,23 @@ func scriptSafe(s string) string {
 
 // ServeHTTP implements http.Handler so Server can be used directly.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	slog.Debug(
+		"http request started",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"query", r.URL.RawQuery,
+		"remote_addr", r.RemoteAddr,
+		"user_agent", r.UserAgent(),
+	)
+	defer func() {
+		slog.Debug(
+			"http request completed",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"duration", time.Since(start).String(),
+		)
+	}()
 	if r.Method != http.MethodGet && s.isMutatingAPIRequest(r) {
 		if !checkCSRF(w, r) {
 			return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -371,6 +371,9 @@ func newServer(
 		if err := s.workspaces.ReapOrphanTmuxSessions(cleanupCtx); err != nil {
 			slog.Warn("reap orphan tmux sessions", "err", err)
 		}
+		if err := s.workspaces.PruneMissingTmuxSessions(cleanupCtx); err != nil {
+			slog.Warn("prune missing tmux sessions", "err", err)
+		}
 		cleanupCancel()
 		var agents []config.Agent
 		if cfg != nil {

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -1567,7 +1567,7 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 	// httptest baseURL (the generated client cannot upgrade to
 	// WebSocket, so we dial directly with coder/websocket).
 	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) +
-		"/api/v1/workspaces/" + wsID + "/terminal"
+		"/ws/v1/workspaces/" + wsID + "/terminal"
 	dialCtx, dialCancel := context.WithTimeout(
 		ctx, 3*time.Second,
 	)
@@ -1969,7 +1969,7 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 	)
 
 	wsURL := strings.Replace(baseURL, "http://", "ws://", 1) +
-		"/api/v1/workspaces/" + wsID + "/terminal"
+		"/ws/v1/workspaces/" + wsID + "/terminal"
 	dialCtx, dialCancel := context.WithTimeout(
 		ctx, 3*time.Second,
 	)

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -60,7 +60,15 @@ func writeTmuxRecorder(t *testing.T) (script, record string) {
 	script = filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`session_file="${TMUX_RECORD}.sessions"` + "\n" +
+		`new_session=""` + "\n" +
+		`prev=""` + "\n" +
 		`for a in "$@"; do` + "\n" +
+		`  if [ "$prev" = "-s" ]; then new_session="$a"; fi` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    [ -f "$session_file" ] && cat "$session_file"` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
 		`    echo "can't find session: sim" >&2` + "\n" +
 		`    exit 1` + "\n" +
@@ -73,7 +81,9 @@ func writeTmuxRecorder(t *testing.T) (script, record string) {
 		`    printf '%s\n' "$TMUX_PANE_OUTPUT"` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
+		`  prev="$a"` + "\n" +
 		"done\n" +
+		`if [ -n "$new_session" ]; then printf '%s\n' "$new_session" >> "$session_file"; fi` + "\n" +
 		"exit 0\n"
 	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
 	t.Setenv("TMUX_RECORD", record)
@@ -423,6 +433,10 @@ func TestWorkspaceResponseTracksTmuxOutputActivity(t *testing.T) {
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
 		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    printf '%s\n' "$TMUX_LIVE_SESSIONS"` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
 		`    echo "can't find session: sim" >&2` + "\n" +
 		`    exit 1` + "\n" +
@@ -508,6 +522,10 @@ func TestListWorkspacesFetchesTmuxActivityConcurrently(t *testing.T) {
 	script := filepath.Join(dir, "fake-tmux")
 	body := "#!/bin/sh\n" +
 		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    printf '%s\n' "$TMUX_LIVE_SESSIONS"` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
 		`    echo "can't find session: sim" >&2` + "\n" +
 		`    exit 1` + "\n" +
@@ -572,6 +590,13 @@ func TestListWorkspacesFetchesTmuxActivityConcurrently(t *testing.T) {
 	require.Equal(http.StatusAccepted, createResp2.StatusCode())
 	require.NotNil(createResp2.JSON202)
 	waitForWorkspaceReady(t, ctx, client, createResp2.JSON202.Id)
+	t.Setenv(
+		"TMUX_LIVE_SESSIONS",
+		strings.Join([]string{
+			"middleman-" + createResp1.JSON202.Id,
+			"middleman-" + createResp2.JSON202.Id,
+		}, "\n"),
+	)
 	srv.tmuxActivity = newTmuxActivityTracker(func() time.Time {
 		return time.Date(2026, 4, 23, 12, 0, 5, 0, time.UTC)
 	})
@@ -667,6 +692,12 @@ func TestConcurrentWorkspaceListsCoalesceTmuxActivityProbe(t *testing.T) {
 	body := "#!/bin/sh\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    printf '%s\n' "$TMUX_LIVE_SESSIONS"` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		`done` + "\n" +
+		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
 		`    echo "can't find session: sim" >&2` + "\n" +
 		`    exit 1` + "\n" +
@@ -685,6 +716,7 @@ func TestConcurrentWorkspaceListsCoalesceTmuxActivityProbe(t *testing.T) {
 		"exit 0\n"
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 	t.Setenv("TMUX_RECORD", record)
+	t.Setenv("TMUX_LIVE_SESSIONS", "middleman-ws-coalesce")
 
 	client, _, database, srv := setupWrapperServerWithScriptAndDBAndServer(
 		t, script,
@@ -758,6 +790,12 @@ func TestWorkspaceListTmuxActivityRefreshesEveryReadyWorkspace(t *testing.T) {
 	body := "#!/bin/sh\n" +
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    printf '%s\n' "$TMUX_LIVE_SESSIONS"` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		`done` + "\n" +
+		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "has-session" ]; then` + "\n" +
 		`    echo "can't find session: sim" >&2` + "\n" +
 		`    exit 1` + "\n" +
@@ -799,6 +837,11 @@ func TestWorkspaceListTmuxActivityRefreshesEveryReadyWorkspace(t *testing.T) {
 			Status:      "ready",
 		}))
 	}
+	liveSessions := make([]string, 0, len(wantSessions))
+	for session := range wantSessions {
+		liveSessions = append(liveSessions, session)
+	}
+	t.Setenv("TMUX_LIVE_SESSIONS", strings.Join(liveSessions, "\n"))
 	srv.tmuxActivity = newTmuxActivityTracker(func() time.Time {
 		return time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
 	})

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -24,6 +24,13 @@ func (s *Server) handleWorkspaceRuntimeSessionTerminal(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
+	slog.Debug(
+		"runtime terminal websocket request",
+		"workspace_id", r.PathValue("id"),
+		"session_key", r.PathValue("session_key"),
+		"path", r.URL.Path,
+		"query", r.URL.RawQuery,
+	)
 	summary, ok := s.readyRuntimeWorkspaceForHTTP(
 		w, r, r.PathValue("id"),
 	)
@@ -35,6 +42,12 @@ func (s *Server) handleWorkspaceRuntimeSessionTerminal(
 		summary.ID, r.PathValue("session_key"),
 	)
 	if err != nil {
+		slog.Debug(
+			"runtime terminal attach failed",
+			"workspace_id", summary.ID,
+			"session_key", r.PathValue("session_key"),
+			"err", err,
+		)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -45,6 +58,12 @@ func (s *Server) handleWorkspaceRuntimeShellTerminal(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
+	slog.Debug(
+		"runtime shell websocket request",
+		"workspace_id", r.PathValue("id"),
+		"path", r.URL.Path,
+		"query", r.URL.RawQuery,
+	)
 	summary, ok := s.readyRuntimeWorkspaceForHTTP(
 		w, r, r.PathValue("id"),
 	)
@@ -54,6 +73,11 @@ func (s *Server) handleWorkspaceRuntimeShellTerminal(
 
 	attachment, err := s.runtime.AttachShell(summary.ID)
 	if err != nil {
+		slog.Debug(
+			"runtime shell attach failed",
+			"workspace_id", summary.ID,
+			"err", err,
+		)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -73,7 +97,21 @@ func (s *Server) serveRuntimeTerminal(
 		attachment.Close()
 		return
 	}
+	info := attachment.Info()
+	slog.Debug(
+		"runtime terminal websocket accepted",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"target_key", info.TargetKey,
+	)
 	if cols, rows, ok := parseRuntimeTerminalSize(r); ok {
+		slog.Debug(
+			"runtime terminal initial resize",
+			"workspace_id", info.WorkspaceID,
+			"session_key", info.Key,
+			"cols", cols,
+			"rows", rows,
+		)
 		if err := attachment.Resize(cols, rows); err != nil {
 			slog.Warn("runtime terminal initial resize", "err", err)
 		}
@@ -81,8 +119,18 @@ func (s *Server) serveRuntimeTerminal(
 
 	exited := bridgeRuntimeAttachment(r.Context(), conn, attachment)
 	if exited {
+		slog.Debug(
+			"runtime terminal websocket closing after session exit",
+			"workspace_id", info.WorkspaceID,
+			"session_key", info.Key,
+		)
 		conn.Close(websocket.StatusNormalClosure, "session ended")
 	} else {
+		slog.Debug(
+			"runtime terminal websocket closing after detach",
+			"workspace_id", info.WorkspaceID,
+			"session_key", info.Key,
+		)
 		conn.Close(websocket.StatusNormalClosure, "detached")
 	}
 }
@@ -110,6 +158,11 @@ func (s *Server) readyRuntimeWorkspaceForHTTP(
 		return nil, false
 	}
 	if summary.Status != "ready" {
+		slog.Debug(
+			"runtime websocket rejected: workspace not ready",
+			"workspace_id", id,
+			"status", summary.Status,
+		)
 		http.Error(
 			w,
 			"workspace not ready (status: "+summary.Status+")",
@@ -156,11 +209,16 @@ func bridgeRuntimeAttachment(
 		for {
 			typ, data, err := conn.Read(ctx)
 			if err != nil {
+				slog.Debug("runtime terminal websocket read ended", "err", err)
 				return
 			}
 			switch typ {
 			case websocket.MessageBinary:
 				if err := attachment.Write(data); err != nil {
+					slog.Debug(
+						"runtime terminal pty write ended",
+						"err", err,
+					)
 					return
 				}
 			case websocket.MessageText:
@@ -181,6 +239,10 @@ func bridgeRuntimeAttachment(
 				if err := conn.Write(
 					ctx, websocket.MessageBinary, data,
 				); err != nil {
+					slog.Debug(
+						"runtime terminal websocket write ended",
+						"err", err,
+					)
 					return
 				}
 			case <-ctx.Done():
@@ -224,6 +286,14 @@ func handleRuntimeTerminalControl(
 	if msg.Type != "resize" {
 		return
 	}
+	info := attachment.Info()
+	slog.Debug(
+		"runtime terminal resize requested",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"cols", msg.Cols,
+		"rows", msg.Rows,
+	)
 	if err := attachment.Resize(msg.Cols, msg.Rows); err != nil {
 		slog.Warn("runtime terminal resize", "err", err)
 	}

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -284,11 +284,9 @@ func handleRuntimeTerminalControl(
 		slog.Warn("bad runtime terminal control message", "err", err)
 		return
 	}
-	if msg.Type != "resize" && msg.Type != "refresh" {
-		return
-	}
 	info := attachment.Info()
-	if msg.Type == "refresh" {
+	switch msg.Type {
+	case "refresh":
 		slog.Debug(
 			"runtime terminal refresh requested",
 			"workspace_id", info.WorkspaceID,
@@ -307,16 +305,17 @@ func handleRuntimeTerminalControl(
 			slog.Warn("runtime terminal refresh", "err", err)
 		}
 		return
-	}
-	slog.Debug(
-		"runtime terminal resize requested",
-		"workspace_id", info.WorkspaceID,
-		"session_key", info.Key,
-		"cols", msg.Cols,
-		"rows", msg.Rows,
-	)
-	if err := attachment.Resize(msg.Cols, msg.Rows); err != nil {
-		slog.Warn("runtime terminal resize", "err", err)
+	case "resize":
+		slog.Debug(
+			"runtime terminal resize requested",
+			"workspace_id", info.WorkspaceID,
+			"session_key", info.Key,
+			"cols", msg.Cols,
+			"rows", msg.Rows,
+		)
+		if err := attachment.Resize(msg.Cols, msg.Rows); err != nil {
+			slog.Warn("runtime terminal resize", "err", err)
+		}
 	}
 }
 

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -222,7 +222,7 @@ func bridgeRuntimeAttachment(
 					return
 				}
 			case websocket.MessageText:
-				handleRuntimeTerminalControl(attachment, data)
+				handleRuntimeTerminalControl(ctx, attachment, data)
 			}
 		}
 	}()
@@ -275,6 +275,7 @@ func bridgeRuntimeAttachment(
 }
 
 func handleRuntimeTerminalControl(
+	ctx context.Context,
 	attachment *localruntime.Attachment,
 	data []byte,
 ) {
@@ -283,10 +284,30 @@ func handleRuntimeTerminalControl(
 		slog.Warn("bad runtime terminal control message", "err", err)
 		return
 	}
-	if msg.Type != "resize" {
+	if msg.Type != "resize" && msg.Type != "refresh" {
 		return
 	}
 	info := attachment.Info()
+	if msg.Type == "refresh" {
+		slog.Debug(
+			"runtime terminal refresh requested",
+			"workspace_id", info.WorkspaceID,
+			"session_key", info.Key,
+			"cols", msg.Cols,
+			"rows", msg.Rows,
+		)
+		if msg.Cols > 0 && msg.Rows > 0 {
+			if err := attachment.Resize(msg.Cols, msg.Rows); err != nil {
+				slog.Warn("runtime terminal refresh resize", "err", err)
+			}
+		}
+		refreshCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		if err := attachment.Refresh(refreshCtx); err != nil {
+			slog.Warn("runtime terminal refresh", "err", err)
+		}
+		return
+	}
 	slog.Debug(
 		"runtime terminal resize requested",
 		"workspace_id", info.WorkspaceID,

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -24,7 +24,7 @@ func (s *Server) handleWorkspaceRuntimeSessionTerminal(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	slog.Debug(
+	logWebsocketDebug(
 		"runtime terminal websocket request",
 		"workspace_id", r.PathValue("id"),
 		"session_key", r.PathValue("session_key"),
@@ -42,7 +42,7 @@ func (s *Server) handleWorkspaceRuntimeSessionTerminal(
 		summary.ID, r.PathValue("session_key"),
 	)
 	if err != nil {
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime terminal attach failed",
 			"workspace_id", summary.ID,
 			"session_key", r.PathValue("session_key"),
@@ -58,7 +58,7 @@ func (s *Server) handleWorkspaceRuntimeShellTerminal(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	slog.Debug(
+	logWebsocketDebug(
 		"runtime shell websocket request",
 		"workspace_id", r.PathValue("id"),
 		"path", r.URL.Path,
@@ -73,7 +73,7 @@ func (s *Server) handleWorkspaceRuntimeShellTerminal(
 
 	attachment, err := s.runtime.AttachShell(summary.ID)
 	if err != nil {
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime shell attach failed",
 			"workspace_id", summary.ID,
 			"err", err,
@@ -98,14 +98,14 @@ func (s *Server) serveRuntimeTerminal(
 		return
 	}
 	info := attachment.Info()
-	slog.Debug(
+	logWebsocketDebug(
 		"runtime terminal websocket accepted",
 		"workspace_id", info.WorkspaceID,
 		"session_key", info.Key,
 		"target_key", info.TargetKey,
 	)
 	if cols, rows, ok := parseRuntimeTerminalSize(r); ok {
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime terminal initial resize",
 			"workspace_id", info.WorkspaceID,
 			"session_key", info.Key,
@@ -119,14 +119,14 @@ func (s *Server) serveRuntimeTerminal(
 
 	exited := bridgeRuntimeAttachment(r.Context(), conn, attachment)
 	if exited {
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime terminal websocket closing after session exit",
 			"workspace_id", info.WorkspaceID,
 			"session_key", info.Key,
 		)
 		conn.Close(websocket.StatusNormalClosure, "session ended")
 	} else {
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime terminal websocket closing after detach",
 			"workspace_id", info.WorkspaceID,
 			"session_key", info.Key,
@@ -158,7 +158,7 @@ func (s *Server) readyRuntimeWorkspaceForHTTP(
 		return nil, false
 	}
 	if summary.Status != "ready" {
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime websocket rejected: workspace not ready",
 			"workspace_id", id,
 			"status", summary.Status,
@@ -209,13 +209,13 @@ func bridgeRuntimeAttachment(
 		for {
 			typ, data, err := conn.Read(ctx)
 			if err != nil {
-				slog.Debug("runtime terminal websocket read ended", "err", err)
+				logWebsocketDebug("runtime terminal websocket read ended", "err", err)
 				return
 			}
 			switch typ {
 			case websocket.MessageBinary:
 				if err := attachment.Write(data); err != nil {
-					slog.Debug(
+					logWebsocketDebug(
 						"runtime terminal pty write ended",
 						"err", err,
 					)
@@ -239,7 +239,7 @@ func bridgeRuntimeAttachment(
 				if err := conn.Write(
 					ctx, websocket.MessageBinary, data,
 				); err != nil {
-					slog.Debug(
+					logWebsocketDebug(
 						"runtime terminal websocket write ended",
 						"err", err,
 					)
@@ -287,7 +287,7 @@ func handleRuntimeTerminalControl(
 	info := attachment.Info()
 	switch msg.Type {
 	case "refresh":
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime terminal refresh requested",
 			"workspace_id", info.WorkspaceID,
 			"session_key", info.Key,
@@ -306,7 +306,7 @@ func handleRuntimeTerminalControl(
 		}
 		return
 	case "resize":
-		slog.Debug(
+		logWebsocketDebug(
 			"runtime terminal resize requested",
 			"workspace_id", info.WorkspaceID,
 			"session_key", info.Key,

--- a/internal/server/ws_debug.go
+++ b/internal/server/ws_debug.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func logWebsocketDebug(msg string, args ...any) {
+	if !websocketDebugEnabled() {
+		return
+	}
+	slog.Debug(msg, args...)
+}
+
+func websocketDebugEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MIDDLEMAN_WS_DEBUG"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/terminal/bridge.go
+++ b/internal/terminal/bridge.go
@@ -41,10 +41,12 @@ func ptyToWS(
 			if wErr := conn.Write(
 				ctx, websocket.MessageBinary, buf[:n],
 			); wErr != nil {
+				slog.Debug("terminal websocket write ended", "err", wErr)
 				return
 			}
 		}
 		if err != nil {
+			slog.Debug("terminal pty read ended", "err", err)
 			return
 		}
 	}
@@ -58,12 +60,14 @@ func wsToPTY(
 	for {
 		typ, data, err := conn.Read(ctx)
 		if err != nil {
+			slog.Debug("terminal websocket read ended", "err", err)
 			return
 		}
 
 		switch typ {
 		case websocket.MessageBinary:
 			if _, wErr := ptmx.Write(data); wErr != nil {
+				slog.Debug("terminal pty write ended", "err", wErr)
 				return
 			}
 		case websocket.MessageText:
@@ -84,6 +88,11 @@ func handleControl(ptmx *os.File, msg *controlMsg) {
 	if msg.Cols <= 0 || msg.Rows <= 0 {
 		return
 	}
+	slog.Debug(
+		"terminal resize requested",
+		"cols", msg.Cols,
+		"rows", msg.Rows,
+	)
 	if err := pty.Setsize(ptmx, &pty.Winsize{
 		Rows: uint16(msg.Rows),
 		Cols: uint16(msg.Cols),

--- a/internal/terminal/bridge.go
+++ b/internal/terminal/bridge.go
@@ -41,12 +41,12 @@ func ptyToWS(
 			if wErr := conn.Write(
 				ctx, websocket.MessageBinary, buf[:n],
 			); wErr != nil {
-				slog.Debug("terminal websocket write ended", "err", wErr)
+				logWebsocketDebug("terminal websocket write ended", "err", wErr)
 				return
 			}
 		}
 		if err != nil {
-			slog.Debug("terminal pty read ended", "err", err)
+			logWebsocketDebug("terminal pty read ended", "err", err)
 			return
 		}
 	}
@@ -60,14 +60,14 @@ func wsToPTY(
 	for {
 		typ, data, err := conn.Read(ctx)
 		if err != nil {
-			slog.Debug("terminal websocket read ended", "err", err)
+			logWebsocketDebug("terminal websocket read ended", "err", err)
 			return
 		}
 
 		switch typ {
 		case websocket.MessageBinary:
 			if _, wErr := ptmx.Write(data); wErr != nil {
-				slog.Debug("terminal pty write ended", "err", wErr)
+				logWebsocketDebug("terminal pty write ended", "err", wErr)
 				return
 			}
 		case websocket.MessageText:
@@ -88,7 +88,7 @@ func handleControl(ptmx *os.File, msg *controlMsg) {
 	if msg.Cols <= 0 || msg.Rows <= 0 {
 		return
 	}
-	slog.Debug(
+	logWebsocketDebug(
 		"terminal resize requested",
 		"cols", msg.Cols,
 		"rows", msg.Rows,

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -36,7 +36,7 @@ func (h *Handler) ServeHTTP(
 		http.Error(w, "missing workspace id", http.StatusBadRequest)
 		return
 	}
-	slog.Debug(
+	logWebsocketDebug(
 		"workspace terminal websocket request",
 		"workspace_id", id,
 		"path", r.URL.Path,
@@ -55,7 +55,7 @@ func (h *Handler) ServeHTTP(
 		return
 	}
 	if ws == nil {
-		slog.Debug(
+		logWebsocketDebug(
 			"workspace terminal rejected: workspace not found",
 			"workspace_id", id,
 		)
@@ -63,7 +63,7 @@ func (h *Handler) ServeHTTP(
 		return
 	}
 	if ws.Status != "ready" {
-		slog.Debug(
+		logWebsocketDebug(
 			"workspace terminal rejected: workspace not ready",
 			"workspace_id", id,
 			"status", ws.Status,
@@ -77,7 +77,7 @@ func (h *Handler) ServeHTTP(
 	}
 
 	cols, rows := parseSize(r)
-	slog.Debug(
+	logWebsocketDebug(
 		"workspace terminal attaching",
 		"workspace_id", id,
 		"tmux_session", ws.TmuxSession,
@@ -87,7 +87,7 @@ func (h *Handler) ServeHTTP(
 
 	releaseTerminal, err := h.claimTerminalSlot(id)
 	if err != nil {
-		slog.Debug(
+		logWebsocketDebug(
 			"workspace terminal rejected: slot unavailable",
 			"workspace_id", id,
 			"err", err,
@@ -104,7 +104,7 @@ func (h *Handler) ServeHTTP(
 		slog.Error("websocket accept", "err", err)
 		return
 	}
-	slog.Debug("workspace terminal websocket accepted", "workspace_id", id)
+	logWebsocketDebug("workspace terminal websocket accepted", "workspace_id", id)
 
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
@@ -123,7 +123,7 @@ func (h *Handler) ServeHTTP(
 		)
 		return
 	}
-	slog.Debug(
+	logWebsocketDebug(
 		"workspace terminal tmux ready",
 		"workspace_id", id,
 		"tmux_session", ws.TmuxSession,
@@ -138,7 +138,7 @@ func (h *Handler) ServeHTTP(
 	argv = append(argv, "attach-session", "-t", ws.TmuxSession)
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
-	slog.Debug(
+	logWebsocketDebug(
 		"workspace terminal starting tmux attach",
 		"workspace_id", id,
 		"program", argv[0],
@@ -177,7 +177,7 @@ func (h *Handler) ServeHTTP(
 		return
 	}
 	defer ptmx.Close()
-	slog.Debug(
+	logWebsocketDebug(
 		"workspace terminal pty started",
 		"workspace_id", id,
 		"pid", cmd.Process.Pid,
@@ -224,14 +224,14 @@ func (h *Handler) ServeHTTP(
 	select {
 	case exitCode = <-cmdDone:
 		// tmux exited normally.
-		slog.Debug(
+		logWebsocketDebug(
 			"workspace terminal tmux attach exited",
 			"workspace_id", id,
 			"exit_code", exitCode,
 		)
 	case <-bridgeDone:
 		// Browser disconnected. Cancel context to kill tmux attach.
-		slog.Debug(
+		logWebsocketDebug(
 			"workspace terminal bridge disconnected",
 			"workspace_id", id,
 		)
@@ -258,7 +258,7 @@ func (h *Handler) ServeHTTP(
 	cancel()
 	wg.Wait()
 	conn.Close(websocket.StatusNormalClosure, "session ended")
-	slog.Debug(
+	logWebsocketDebug(
 		"workspace terminal websocket closed",
 		"workspace_id", id,
 		"exit_code", exitCode,
@@ -275,7 +275,7 @@ func (h *Handler) claimTerminalSlot(
 	}
 	h.active[id]++
 	active := h.active[id]
-	slog.Debug(
+	logWebsocketDebug(
 		"workspace terminal slot claimed",
 		"workspace_id", id,
 		"active", active,
@@ -291,7 +291,7 @@ func (h *Handler) claimTerminalSlot(
 				delete(h.active, id)
 				active = 0
 			}
-			slog.Debug(
+			logWebsocketDebug(
 				"workspace terminal slot released",
 				"workspace_id", id,
 				"active", active,

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -25,7 +25,7 @@ type Handler struct {
 	TmuxCommand []string
 
 	mu     sync.Mutex
-	active map[string]bool
+	active map[string]int
 }
 
 func (h *Handler) ServeHTTP(
@@ -36,6 +36,14 @@ func (h *Handler) ServeHTTP(
 		http.Error(w, "missing workspace id", http.StatusBadRequest)
 		return
 	}
+	slog.Debug(
+		"workspace terminal websocket request",
+		"workspace_id", id,
+		"path", r.URL.Path,
+		"query", r.URL.RawQuery,
+		"remote_addr", r.RemoteAddr,
+		"user_agent", r.UserAgent(),
+	)
 
 	ws, err := h.Workspaces.Get(r.Context(), id)
 	if err != nil {
@@ -47,10 +55,19 @@ func (h *Handler) ServeHTTP(
 		return
 	}
 	if ws == nil {
+		slog.Debug(
+			"workspace terminal rejected: workspace not found",
+			"workspace_id", id,
+		)
 		http.Error(w, "workspace not found", http.StatusNotFound)
 		return
 	}
 	if ws.Status != "ready" {
+		slog.Debug(
+			"workspace terminal rejected: workspace not ready",
+			"workspace_id", id,
+			"status", ws.Status,
+		)
 		http.Error(
 			w,
 			fmt.Sprintf("workspace not ready (status: %s)", ws.Status),
@@ -60,9 +77,21 @@ func (h *Handler) ServeHTTP(
 	}
 
 	cols, rows := parseSize(r)
+	slog.Debug(
+		"workspace terminal attaching",
+		"workspace_id", id,
+		"tmux_session", ws.TmuxSession,
+		"cols", cols,
+		"rows", rows,
+	)
 
 	releaseTerminal, err := h.claimTerminalSlot(id)
 	if err != nil {
+		slog.Debug(
+			"workspace terminal rejected: slot unavailable",
+			"workspace_id", id,
+			"err", err,
+		)
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}
@@ -75,6 +104,7 @@ func (h *Handler) ServeHTTP(
 		slog.Error("websocket accept", "err", err)
 		return
 	}
+	slog.Debug("workspace terminal websocket accepted", "workspace_id", id)
 
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
@@ -93,6 +123,11 @@ func (h *Handler) ServeHTTP(
 		)
 		return
 	}
+	slog.Debug(
+		"workspace terminal tmux ready",
+		"workspace_id", id,
+		"tmux_session", ws.TmuxSession,
+	)
 
 	prefix := h.TmuxCommand
 	if len(prefix) == 0 {
@@ -103,6 +138,13 @@ func (h *Handler) ServeHTTP(
 	argv = append(argv, "attach-session", "-t", ws.TmuxSession)
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	slog.Debug(
+		"workspace terminal starting tmux attach",
+		"workspace_id", id,
+		"program", argv[0],
+		"argc", len(argv),
+		"tmux_session", ws.TmuxSession,
+	)
 
 	releaseProc, err := procutil.TryAcquire(
 		ctx, "terminal attach subprocess capacity",
@@ -135,6 +177,11 @@ func (h *Handler) ServeHTTP(
 		return
 	}
 	defer ptmx.Close()
+	slog.Debug(
+		"workspace terminal pty started",
+		"workspace_id", id,
+		"pid", cmd.Process.Pid,
+	)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -177,8 +224,17 @@ func (h *Handler) ServeHTTP(
 	select {
 	case exitCode = <-cmdDone:
 		// tmux exited normally.
+		slog.Debug(
+			"workspace terminal tmux attach exited",
+			"workspace_id", id,
+			"exit_code", exitCode,
+		)
 	case <-bridgeDone:
 		// Browser disconnected. Cancel context to kill tmux attach.
+		slog.Debug(
+			"workspace terminal bridge disconnected",
+			"workspace_id", id,
+		)
 		cancel()
 		_ = ptmx.Close()
 		// Wait briefly for cmd to finish.
@@ -202,6 +258,11 @@ func (h *Handler) ServeHTTP(
 	cancel()
 	wg.Wait()
 	conn.Close(websocket.StatusNormalClosure, "session ended")
+	slog.Debug(
+		"workspace terminal websocket closed",
+		"workspace_id", id,
+		"exit_code", exitCode,
+	)
 }
 
 func (h *Handler) claimTerminalSlot(
@@ -210,18 +271,31 @@ func (h *Handler) claimTerminalSlot(
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.active == nil {
-		h.active = make(map[string]bool)
+		h.active = make(map[string]int)
 	}
-	if h.active[id] {
-		return nil, fmt.Errorf("workspace terminal already attached")
-	}
-	h.active[id] = true
+	h.active[id]++
+	active := h.active[id]
+	slog.Debug(
+		"workspace terminal slot claimed",
+		"workspace_id", id,
+		"active", active,
+	)
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			h.mu.Lock()
 			defer h.mu.Unlock()
-			delete(h.active, id)
+			h.active[id]--
+			active := h.active[id]
+			if active <= 0 {
+				delete(h.active, id)
+				active = 0
+			}
+			slog.Debug(
+				"workspace terminal slot released",
+				"workspace_id", id,
+				"active", active,
+			)
 		})
 	}, nil
 }

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -108,7 +108,7 @@ func TestHandlerWorkspaceNotReady(t *testing.T) {
 	assert.Contains(rec.Body.String(), "not ready")
 }
 
-func TestHandlerClaimWorkspaceTerminal(t *testing.T) {
+func TestHandlerAllowsConcurrentWorkspaceTerminals(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -118,9 +118,10 @@ func TestHandlerClaimWorkspaceTerminal(t *testing.T) {
 	assert.NotNil(release)
 
 	release2, err := h.claimTerminalSlot("ws-1")
-	require.Error(err)
-	assert.Nil(release2)
+	require.NoError(err)
+	assert.NotNil(release2)
 
+	release2()
 	release()
 
 	release3, err := h.claimTerminalSlot("ws-1")

--- a/internal/terminal/ws_debug.go
+++ b/internal/terminal/ws_debug.go
@@ -1,0 +1,23 @@
+package terminal
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func logWebsocketDebug(msg string, args ...any) {
+	if !websocketDebugEnabled() {
+		return
+	}
+	slog.Debug(msg, args...)
+}
+
+func websocketDebugEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MIDDLEMAN_WS_DEBUG"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -423,6 +423,8 @@ func (m *Manager) restoreTmuxSession(
 		return err
 	}
 	started.tmuxSession = tmuxSession
+	// startSession already starts drainOutput; restored tmux attach
+	// sessions only need the process watcher here.
 	go started.watch()
 
 	m.mu.Lock()

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -417,6 +417,7 @@ func (m *Manager) restoreTmuxSession(
 		Kind:        target.Kind,
 		Status:      SessionStatusStarting,
 		CreatedAt:   createdAt,
+		TmuxSession: tmuxSession,
 	}, command, "", m.stripEnvVars)
 	if err != nil {
 		return err

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -94,17 +94,38 @@ type Manager struct {
 // startup output entirely.
 const maxSessionOutputReplay = 64 * 1024
 
+var (
+	alternateScreenEnterSequences = [][]byte{
+		[]byte("\x1b[?47h"),
+		[]byte("\x1b[?1047h"),
+		[]byte("\x1b[?1049h"),
+	}
+	alternateScreenExitSequences = [][]byte{
+		[]byte("\x1b[?47l"),
+		[]byte("\x1b[?1047l"),
+		[]byte("\x1b[?1049l"),
+	}
+	maxAlternateScreenSequenceLen = maxByteSliceLen(
+		append(
+			slices.Clone(alternateScreenEnterSequences),
+			alternateScreenExitSequences...,
+		),
+	)
+)
+
 type session struct {
-	mu           sync.Mutex
-	info         SessionInfo
-	cmd          *exec.Cmd
-	ptmx         *os.File
-	tmuxSession  string
-	done         chan struct{}
-	subscribers  map[chan []byte]struct{}
-	outputBuffer []byte
-	outputClosed bool
-	stopOnce     sync.Once
+	mu                    sync.Mutex
+	info                  SessionInfo
+	cmd                   *exec.Cmd
+	ptmx                  *os.File
+	tmuxSession           string
+	done                  chan struct{}
+	subscribers           map[chan []byte]struct{}
+	outputBuffer          []byte
+	outputClosed          bool
+	alternateScreenActive bool
+	alternateScreenTail   []byte
+	stopOnce              sync.Once
 }
 
 type Attachment struct {
@@ -161,12 +182,28 @@ func dedupeStrings(in []string) []string {
 	return out
 }
 
+func maxByteSliceLen(slices [][]byte) int {
+	maxLen := 0
+	for _, slice := range slices {
+		if len(slice) > maxLen {
+			maxLen = len(slice)
+		}
+	}
+	return maxLen
+}
+
 func (m *Manager) Launch(
 	ctx context.Context,
 	workspaceID string,
 	cwd string,
 	targetKey string,
 ) (SessionInfo, error) {
+	slog.Debug(
+		"runtime launch requested",
+		"workspace_id", workspaceID,
+		"target_key", targetKey,
+		"cwd", cwd,
+	)
 	if err := ctx.Err(); err != nil {
 		return SessionInfo{}, err
 	}
@@ -199,6 +236,12 @@ func (m *Manager) Launch(
 		return SessionInfo{}, err
 	}
 	if existing := m.runningSession(m.sessions, key); existing != nil {
+		slog.Debug(
+			"runtime launch reused existing session",
+			"workspace_id", workspaceID,
+			"session_key", key,
+			"target_key", targetKey,
+		)
 		return existing.snapshot(), nil
 	}
 
@@ -214,8 +257,23 @@ func (m *Manager) Launch(
 
 	launch, err := m.launchCommand(target, workspaceID, cwd)
 	if err != nil {
+		slog.Debug(
+			"runtime launch command failed",
+			"workspace_id", workspaceID,
+			"session_key", key,
+			"target_key", targetKey,
+			"err", err,
+		)
 		return SessionInfo{}, err
 	}
+	slog.Debug(
+		"runtime launch starting session",
+		"workspace_id", workspaceID,
+		"session_key", key,
+		"target_key", targetKey,
+		"kind", target.Kind,
+		"tmux_session", launch.TmuxSession,
+	)
 
 	started, err := startSession(SessionInfo{
 		Key:         key,
@@ -227,6 +285,13 @@ func (m *Manager) Launch(
 		CreatedAt:   time.Now().UTC(),
 	}, launch.Command, cwd, m.stripEnvVars)
 	if err != nil {
+		slog.Debug(
+			"runtime launch start failed",
+			"workspace_id", workspaceID,
+			"session_key", key,
+			"target_key", targetKey,
+			"err", err,
+		)
 		return SessionInfo{}, err
 	}
 	started.tmuxSession = launch.TmuxSession
@@ -237,10 +302,21 @@ func (m *Manager) Launch(
 		m.mu.Unlock()
 		_ = m.stopSession(ctx, started)
 		waitSessionDone(started)
+		slog.Debug(
+			"runtime launch discarded session after shutdown",
+			"workspace_id", workspaceID,
+			"session_key", key,
+		)
 		return SessionInfo{}, errManagerShutdown
 	}
 	m.sessions[key] = started
 	m.mu.Unlock()
+	slog.Debug(
+		"runtime launch session stored",
+		"workspace_id", workspaceID,
+		"session_key", key,
+		"target_key", targetKey,
+	)
 
 	return started.snapshot(), nil
 }
@@ -522,20 +598,60 @@ func (m *Manager) AttachSession(
 	workspaceID string,
 	key string,
 ) (*Attachment, error) {
+	slog.Debug(
+		"runtime terminal attach requested",
+		"workspace_id", workspaceID,
+		"session_key", key,
+	)
 	m.mu.Lock()
 	s := m.sessions[key]
 	m.mu.Unlock()
-	return attachToSession(s, workspaceID, key)
+	attachment, err := attachToSession(s, workspaceID, key)
+	if err != nil {
+		slog.Debug(
+			"runtime terminal attach rejected",
+			"workspace_id", workspaceID,
+			"session_key", key,
+			"err", err,
+		)
+		return nil, err
+	}
+	slog.Debug(
+		"runtime terminal attach accepted",
+		"workspace_id", workspaceID,
+		"session_key", key,
+	)
+	return attachment, nil
 }
 
 func (m *Manager) AttachShell(
 	workspaceID string,
 ) (*Attachment, error) {
 	key := sessionKey(workspaceID, "shell")
+	slog.Debug(
+		"runtime shell attach requested",
+		"workspace_id", workspaceID,
+		"session_key", key,
+	)
 	m.mu.Lock()
 	s := m.shells[key]
 	m.mu.Unlock()
-	return attachToSession(s, workspaceID, key)
+	attachment, err := attachToSession(s, workspaceID, key)
+	if err != nil {
+		slog.Debug(
+			"runtime shell attach rejected",
+			"workspace_id", workspaceID,
+			"session_key", key,
+			"err", err,
+		)
+		return nil, err
+	}
+	slog.Debug(
+		"runtime shell attach accepted",
+		"workspace_id", workspaceID,
+		"session_key", key,
+	)
+	return attachment, nil
 }
 
 func (m *Manager) EnsureShell(
@@ -543,6 +659,11 @@ func (m *Manager) EnsureShell(
 	workspaceID string,
 	cwd string,
 ) (SessionInfo, error) {
+	slog.Debug(
+		"runtime shell ensure requested",
+		"workspace_id", workspaceID,
+		"cwd", cwd,
+	)
 	if err := ctx.Err(); err != nil {
 		return SessionInfo{}, err
 	}
@@ -556,6 +677,11 @@ func (m *Manager) EnsureShell(
 		return SessionInfo{}, err
 	}
 	if existing := m.runningSession(m.shells, key); existing != nil {
+		slog.Debug(
+			"runtime shell ensure reused existing session",
+			"workspace_id", workspaceID,
+			"session_key", key,
+		)
 		return existing.snapshot(), nil
 	}
 
@@ -583,6 +709,12 @@ func (m *Manager) EnsureShell(
 		CreatedAt:   time.Now().UTC(),
 	}, command, cwd, m.stripEnvVars)
 	if err != nil {
+		slog.Debug(
+			"runtime shell start failed",
+			"workspace_id", workspaceID,
+			"session_key", key,
+			"err", err,
+		)
 		return SessionInfo{}, err
 	}
 	go started.watch()
@@ -592,10 +724,20 @@ func (m *Manager) EnsureShell(
 		m.mu.Unlock()
 		_ = m.stopSession(ctx, started)
 		waitSessionDone(started)
+		slog.Debug(
+			"runtime shell discarded session after shutdown",
+			"workspace_id", workspaceID,
+			"session_key", key,
+		)
 		return SessionInfo{}, errManagerShutdown
 	}
 	m.shells[key] = started
 	m.mu.Unlock()
+	slog.Debug(
+		"runtime shell session stored",
+		"workspace_id", workspaceID,
+		"session_key", key,
+	)
 
 	return started.snapshot(), nil
 }
@@ -1010,6 +1152,15 @@ func startSession(
 	if err != nil {
 		return nil, err
 	}
+	slog.Debug(
+		"runtime session resolving command",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"target_key", info.TargetKey,
+		"program", resolvedPath,
+		"argc", len(command),
+		"cwd", cwd,
+	)
 
 	cmd := exec.Command(resolvedPath, command[1:]...)
 	if cwd != "" {
@@ -1030,6 +1181,13 @@ func startSession(
 	if err != nil {
 		return nil, fmt.Errorf("start pty: %w", err)
 	}
+	slog.Debug(
+		"runtime session pty started",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"target_key", info.TargetKey,
+		"pid", cmd.Process.Pid,
+	)
 
 	info.Status = SessionStatusRunning
 	s := &session{
@@ -1068,10 +1226,18 @@ func (s *session) watch() {
 	s.info.Status = SessionStatusExited
 	s.info.ExitedAt = &now
 	s.info.ExitCode = &exitCode
+	info := s.info
 	s.mu.Unlock()
 
 	_ = s.ptmx.Close()
 	close(s.done)
+	slog.Debug(
+		"runtime session exited",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"target_key", info.TargetKey,
+		"exit_code", exitCode,
+	)
 }
 
 func (s *session) drainOutput() {
@@ -1094,10 +1260,7 @@ func (s *session) broadcast(data []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.outputBuffer = append(s.outputBuffer, chunk...)
-	if extra := len(s.outputBuffer) - maxSessionOutputReplay; extra > 0 {
-		s.outputBuffer = append([]byte(nil), s.outputBuffer[extra:]...)
-	}
+	s.appendReplayOutputLocked(chunk)
 
 	for ch := range s.subscribers {
 		select {
@@ -1109,13 +1272,107 @@ func (s *session) broadcast(data []byte) {
 	}
 }
 
+type alternateScreenEvent struct {
+	start  int
+	end    int
+	active bool
+}
+
+func (s *session) appendReplayOutputLocked(chunk []byte) {
+	// Alternate-screen TUIs are stateful. Replaying a suffix of their
+	// screen history into a fresh terminal can corrupt the attach, so
+	// keep only normal-screen output for future subscribers.
+	scan := append(slices.Clone(s.alternateScreenTail), chunk...)
+	events := alternateScreenEvents(scan)
+	tailLen := len(s.alternateScreenTail)
+	active := s.alternateScreenActive
+	normalStart := 0
+
+	for _, event := range events {
+		if event.end <= tailLen {
+			continue
+		}
+		chunkStart := max(event.start-tailLen, 0)
+		chunkEnd := min(event.end-tailLen, len(chunk))
+		if !active && chunkStart > normalStart {
+			s.appendOutputBufferLocked(chunk[normalStart:chunkStart])
+		}
+		if event.active {
+			s.outputBuffer = nil
+		}
+		active = event.active
+		normalStart = chunkEnd
+	}
+
+	if !active && normalStart < len(chunk) {
+		s.appendOutputBufferLocked(chunk[normalStart:])
+	}
+	s.alternateScreenActive = active
+	s.alternateScreenTail = trailingBytes(scan, maxAlternateScreenSequenceLen-1)
+}
+
+func (s *session) appendOutputBufferLocked(chunk []byte) {
+	s.outputBuffer = append(s.outputBuffer, chunk...)
+	if extra := len(s.outputBuffer) - maxSessionOutputReplay; extra > 0 {
+		s.outputBuffer = append([]byte(nil), s.outputBuffer[extra:]...)
+	}
+}
+
+func alternateScreenEvents(data []byte) []alternateScreenEvent {
+	events := make([]alternateScreenEvent, 0, 2)
+	for i := range data {
+		if seq, ok := matchingSequence(data[i:], alternateScreenEnterSequences); ok {
+			events = append(events, alternateScreenEvent{
+				start:  i,
+				end:    i + len(seq),
+				active: true,
+			})
+			continue
+		}
+		if seq, ok := matchingSequence(data[i:], alternateScreenExitSequences); ok {
+			events = append(events, alternateScreenEvent{
+				start:  i,
+				end:    i + len(seq),
+				active: false,
+			})
+		}
+	}
+	return events
+}
+
+func matchingSequence(data []byte, sequences [][]byte) ([]byte, bool) {
+	for _, seq := range sequences {
+		if bytes.HasPrefix(data, seq) {
+			return seq, true
+		}
+	}
+	return nil, false
+}
+
+func trailingBytes(data []byte, maxLen int) []byte {
+	if maxLen <= 0 || len(data) == 0 {
+		return nil
+	}
+	if len(data) > maxLen {
+		data = data[len(data)-maxLen:]
+	}
+	return slices.Clone(data)
+}
+
 func (s *session) subscribe() (<-chan []byte, func()) {
 	ch := make(chan []byte, 64)
 
 	s.mu.Lock()
-	if len(s.outputBuffer) > 0 {
+	info := s.info
+	if len(s.outputBuffer) > 0 && !s.alternateScreenActive {
 		replay := append([]byte(nil), s.outputBuffer...)
 		ch <- replay
+		slog.Debug(
+			"runtime terminal replay queued",
+			"workspace_id", info.WorkspaceID,
+			"session_key", info.Key,
+			"bytes", len(replay),
+		)
 	}
 	if s.outputClosed {
 		close(ch)
@@ -1123,15 +1380,30 @@ func (s *session) subscribe() (<-chan []byte, func()) {
 		return ch, func() {}
 	}
 	s.subscribers[ch] = struct{}{}
+	subscriberCount := len(s.subscribers)
 	s.mu.Unlock()
+	slog.Debug(
+		"runtime terminal subscriber added",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"subscribers", subscriberCount,
+	)
 
 	return ch, func() {
 		s.mu.Lock()
+		info := s.info
 		if _, ok := s.subscribers[ch]; ok {
 			delete(s.subscribers, ch)
 			close(ch)
 		}
+		subscriberCount := len(s.subscribers)
 		s.mu.Unlock()
+		slog.Debug(
+			"runtime terminal subscriber removed",
+			"workspace_id", info.WorkspaceID,
+			"session_key", info.Key,
+			"subscribers", subscriberCount,
+		)
 	}
 }
 

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -51,6 +51,13 @@ type SessionInfo struct {
 	TmuxSession string           `json:"-"`
 }
 
+type RestoredTmuxSession struct {
+	WorkspaceID string
+	SessionName string
+	TargetKey   string
+	CreatedAt   time.Time
+}
+
 type Options struct {
 	Targets      []LaunchTarget
 	ShellCommand []string
@@ -319,6 +326,120 @@ func (m *Manager) Launch(
 	)
 
 	return started.snapshot(), nil
+}
+
+func (m *Manager) RestoreTmuxSessions(
+	ctx context.Context,
+	sessions []RestoredTmuxSession,
+) error {
+	for _, restored := range sessions {
+		if err := m.restoreTmuxSession(ctx, restored); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Manager) restoreTmuxSession(
+	ctx context.Context,
+	restored RestoredTmuxSession,
+) error {
+	workspaceID := strings.TrimSpace(restored.WorkspaceID)
+	targetKey := strings.TrimSpace(restored.TargetKey)
+	tmuxSession := strings.TrimSpace(restored.SessionName)
+	if workspaceID == "" || targetKey == "" || tmuxSession == "" {
+		return nil
+	}
+
+	key := sessionKey(workspaceID, targetKey)
+	startMu := m.startLock(key)
+	startMu.Lock()
+	defer startMu.Unlock()
+
+	if err := m.ensureOpen(); err != nil {
+		return err
+	}
+	if existing := m.runningSession(m.sessions, key); existing != nil {
+		slog.Debug(
+			"runtime tmux restore reused existing session",
+			"workspace_id", workspaceID,
+			"session_key", key,
+			"target_key", targetKey,
+			"tmux_session", tmuxSession,
+		)
+		return nil
+	}
+
+	target, err := m.target(targetKey)
+	if err != nil {
+		target = LaunchTarget{
+			Key:    targetKey,
+			Label:  targetKey,
+			Kind:   LaunchTargetAgent,
+			Source: "stored",
+		}
+	}
+	if target.Label == "" {
+		target.Label = targetKey
+	}
+	if target.Kind == "" {
+		target.Kind = LaunchTargetAgent
+	}
+
+	createdAt := restored.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	command := append([]string(nil), m.tmuxCommand...)
+	if len(command) == 0 {
+		command = []string{"tmux"}
+	}
+	command = append(command, "attach-session", "-t", tmuxSession)
+
+	if err := m.beginStart(); err != nil {
+		return err
+	}
+	defer m.finishStart()
+
+	slog.Debug(
+		"runtime tmux restore starting attach",
+		"workspace_id", workspaceID,
+		"session_key", key,
+		"target_key", targetKey,
+		"tmux_session", tmuxSession,
+	)
+	started, err := startSession(SessionInfo{
+		Key:         key,
+		WorkspaceID: workspaceID,
+		TargetKey:   targetKey,
+		Label:       target.Label,
+		Kind:        target.Kind,
+		Status:      SessionStatusStarting,
+		CreatedAt:   createdAt,
+	}, command, "", m.stripEnvVars)
+	if err != nil {
+		return err
+	}
+	started.tmuxSession = tmuxSession
+	go started.watch()
+
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		_ = m.stopSession(ctx, started)
+		waitSessionDone(started)
+		return errManagerShutdown
+	}
+	m.sessions[key] = started
+	m.mu.Unlock()
+	slog.Debug(
+		"runtime tmux restore session stored",
+		"workspace_id", workspaceID,
+		"session_key", key,
+		"target_key", targetKey,
+		"tmux_session", tmuxSession,
+	)
+	return nil
 }
 
 func (m *Manager) LaunchTargets() []LaunchTarget {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -139,10 +139,11 @@ type Attachment struct {
 	Output <-chan []byte
 	Done   <-chan struct{}
 
-	info   func() SessionInfo
-	write  func([]byte) error
-	resize func(cols, rows int) error
-	close  func()
+	info    func() SessionInfo
+	write   func([]byte) error
+	resize  func(cols, rows int) error
+	refresh func(context.Context) error
+	close   func()
 }
 
 func NewManager(options Options) *Manager {
@@ -626,6 +627,77 @@ func (m *Manager) killTmuxSession(
 	return fmt.Errorf("%w: %s", err, msg)
 }
 
+func (m *Manager) refreshSession(
+	ctx context.Context,
+	s *session,
+) error {
+	if s == nil {
+		return nil
+	}
+	info := s.snapshot()
+	if info.TmuxSession == "" {
+		return nil
+	}
+	return m.refreshTmuxSessionClients(ctx, info.TmuxSession)
+}
+
+func (m *Manager) refreshTmuxSessionClients(
+	ctx context.Context,
+	session string,
+) error {
+	if session == "" {
+		return nil
+	}
+	command := append([]string(nil), m.tmuxCommand...)
+	if len(command) == 0 {
+		command = []string{"tmux"}
+	}
+	if len(command) == 0 || command[0] == "" {
+		return nil
+	}
+
+	listArgs := append(
+		command[1:],
+		"list-clients", "-t", session, "-F", "#{client_tty}",
+	)
+	listCmd := exec.CommandContext(ctx, command[0], listArgs...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	listCmd.Stdout = &stdout
+	listCmd.Stderr = &stderr
+	if err := listCmd.Run(); err != nil {
+		if isTmuxSessionAbsent(stderr.Bytes(), err) {
+			return nil
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return err
+		}
+		return fmt.Errorf("%w: %s", err, msg)
+	}
+
+	var errs []error
+	for client := range strings.FieldsSeq(stdout.String()) {
+		refreshArgs := append(
+			command[1:],
+			"refresh-client", "-t", client,
+		)
+		refreshCmd := exec.CommandContext(
+			ctx, command[0], refreshArgs...,
+		)
+		var refreshStderr bytes.Buffer
+		refreshCmd.Stderr = &refreshStderr
+		if err := refreshCmd.Run(); err != nil {
+			msg := strings.TrimSpace(refreshStderr.String())
+			if msg != "" {
+				err = fmt.Errorf("%w: %s", err, msg)
+			}
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func isTmuxSessionAbsent(stderr []byte, err error) bool {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
@@ -727,7 +799,9 @@ func (m *Manager) AttachSession(
 	m.mu.Lock()
 	s := m.sessions[key]
 	m.mu.Unlock()
-	attachment, err := attachToSession(s, workspaceID, key)
+	attachment, err := attachToSession(
+		s, workspaceID, key, m.refreshSession,
+	)
 	if err != nil {
 		slog.Debug(
 			"runtime terminal attach rejected",
@@ -757,7 +831,9 @@ func (m *Manager) AttachShell(
 	m.mu.Lock()
 	s := m.shells[key]
 	m.mu.Unlock()
-	attachment, err := attachToSession(s, workspaceID, key)
+	attachment, err := attachToSession(
+		s, workspaceID, key, m.refreshSession,
+	)
 	if err != nil {
 		slog.Debug(
 			"runtime shell attach rejected",
@@ -875,6 +951,13 @@ func (a *Attachment) Resize(cols, rows int) error {
 		return errors.New("attachment is closed")
 	}
 	return a.resize(cols, rows)
+}
+
+func (a *Attachment) Refresh(ctx context.Context) error {
+	if a == nil || a.refresh == nil {
+		return errors.New("attachment is closed")
+	}
+	return a.refresh(ctx)
 }
 
 func (a *Attachment) Info() SessionInfo {
@@ -1691,6 +1774,7 @@ func attachToSession(
 	s *session,
 	workspaceID string,
 	key string,
+	refresh func(context.Context, *session) error,
 ) (*Attachment, error) {
 	if s == nil {
 		return nil, fmt.Errorf("session %q not found", key)
@@ -1721,6 +1805,12 @@ func attachToSession(
 				Rows: uint16(rows),
 				Cols: uint16(cols),
 			})
+		},
+		refresh: func(ctx context.Context) error {
+			if refresh == nil {
+				return nil
+			}
+			return refresh(ctx, s)
 		},
 		close: unsubscribe,
 	}, nil

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -150,6 +150,52 @@ func TestManagerTmuxSessionsReturnsWrappedAgentSessions(t *testing.T) {
 	)
 }
 
+func TestAttachmentRefreshRefreshesTmuxClients(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "tmux.log")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %s
+if [ "$1" = "list-clients" ]; then
+  printf '/dev/ttys001\n/dev/ttys002\n'
+fi
+`, shellQuote(logPath))
+	require.NoError(os.WriteFile(tmuxPath, []byte(script), 0o755))
+
+	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
+	s := &session{
+		info: SessionInfo{
+			Key:         "ws-1:codex",
+			WorkspaceID: "ws-1",
+			TargetKey:   "codex",
+			Status:      SessionStatusRunning,
+		},
+		tmuxSession: "middleman-ws-1-codex",
+		done:        make(chan struct{}),
+		subscribers: make(map[chan []byte]struct{}),
+	}
+	attachment, err := attachToSession(
+		s, "ws-1", "ws-1:codex", mgr.refreshSession,
+	)
+	require.NoError(err)
+	defer attachment.Close()
+
+	require.NoError(attachment.Refresh(context.Background()))
+
+	logData, err := os.ReadFile(logPath)
+	require.NoError(err)
+	log := string(logData)
+	assert.Contains(
+		log,
+		"list-clients -t middleman-ws-1-codex -F #{client_tty}",
+	)
+	assert.Contains(log, "refresh-client -t /dev/ttys001")
+	assert.Contains(log, "refresh-client -t /dev/ttys002")
+}
+
 func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
 	assert := Assert.New(t)
 	agent := helperTarget("codex", "sleep")

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -881,6 +881,104 @@ func TestSessionSubscribeReplaysBufferedOutput(t *testing.T) {
 	}
 }
 
+func TestSessionSubscribeSkipsReplayWhileAlternateScreenActive(t *testing.T) {
+	s := &session{
+		subscribers: make(map[chan []byte]struct{}),
+	}
+	s.broadcast([]byte("startup-banner\r\n$ "))
+	s.broadcast([]byte("\x1b[?1049h\x1b[Hcodex screen"))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	assert := Assert.New(t)
+	select {
+	case data := <-ch:
+		assert.Failf(
+			"subscriber received alternate screen replay",
+			"unexpected replay: %q",
+			string(data),
+		)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	s.broadcast([]byte("\x1b[Hupdated screen"))
+	select {
+	case data := <-ch:
+		assert.Equal("\x1b[Hupdated screen", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive live output")
+	}
+}
+
+func TestSessionSubscribeReplaysNormalOutputAfterAlternateScreenExit(t *testing.T) {
+	s := &session{
+		subscribers: make(map[chan []byte]struct{}),
+	}
+	s.broadcast([]byte("startup-banner\r\n$ "))
+	s.broadcast([]byte("\x1b[?1049h\x1b[Hcodex screen"))
+	s.broadcast([]byte("\x1b[?1049l\r\n$ "))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	assert := Assert.New(t)
+	select {
+	case data := <-ch:
+		assert.Equal("\r\n$ ", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive normal replay after exit")
+	}
+}
+
+func TestSessionAlternateScreenTrackingHandlesSplitEscapeSequences(t *testing.T) {
+	s := &session{
+		subscribers: make(map[chan []byte]struct{}),
+	}
+	s.broadcast([]byte("startup-banner\r\n$ \x1b[?104"))
+	s.broadcast([]byte("9h\x1b[Hcodex screen"))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	assert := Assert.New(t)
+	select {
+	case data := <-ch:
+		assert.Failf(
+			"subscriber received split alternate screen replay",
+			"unexpected replay: %q",
+			string(data),
+		)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	s.broadcast([]byte("\x1b[?104"))
+	s.broadcast([]byte("9l\r\n$ "))
+	var live strings.Builder
+	select {
+	case data := <-ch:
+		live.Write(data)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive live split exit prefix")
+	}
+	select {
+	case data := <-ch:
+		live.Write(data)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive live split exit suffix")
+	}
+	assert.Equal("\x1b[?1049l\r\n$ ", live.String())
+
+	ch2, cancel2 := s.subscribe()
+	t.Cleanup(cancel2)
+	select {
+	case data := <-ch2:
+		assert.Equal("\r\n$ ", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive replay after split exit")
+	}
+}
+
 func TestSessionSubscribeAfterCloseStillReplays(t *testing.T) {
 	s := &session{
 		subscribers: make(map[chan []byte]struct{}),

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -150,52 +150,6 @@ func TestManagerTmuxSessionsReturnsWrappedAgentSessions(t *testing.T) {
 	)
 }
 
-func TestAttachmentRefreshRefreshesTmuxClients(t *testing.T) {
-	require := require.New(t)
-	assert := Assert.New(t)
-
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "tmux.log")
-	tmuxPath := filepath.Join(dir, "tmux")
-	script := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> %s
-if [ "$1" = "list-clients" ]; then
-  printf '/dev/ttys001\n/dev/ttys002\n'
-fi
-`, shellQuote(logPath))
-	require.NoError(os.WriteFile(tmuxPath, []byte(script), 0o755))
-
-	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
-	s := &session{
-		info: SessionInfo{
-			Key:         "ws-1:codex",
-			WorkspaceID: "ws-1",
-			TargetKey:   "codex",
-			Status:      SessionStatusRunning,
-		},
-		tmuxSession: "middleman-ws-1-codex",
-		done:        make(chan struct{}),
-		subscribers: make(map[chan []byte]struct{}),
-	}
-	attachment, err := attachToSession(
-		s, "ws-1", "ws-1:codex", mgr.refreshSession,
-	)
-	require.NoError(err)
-	defer attachment.Close()
-
-	require.NoError(attachment.Refresh(context.Background()))
-
-	logData, err := os.ReadFile(logPath)
-	require.NoError(err)
-	log := string(logData)
-	assert.Contains(
-		log,
-		"list-clients -t middleman-ws-1-codex -F #{client_tty}",
-	)
-	assert.Contains(log, "refresh-client -t /dev/ttys001")
-	assert.Contains(log, "refresh-client -t /dev/ttys002")
-}
-
 func TestManagerLaunchCommandWrapsAgentsInTmuxWhenEnabled(t *testing.T) {
 	assert := Assert.New(t)
 	agent := helperTarget("codex", "sleep")

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1049,13 +1049,11 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	liveRuntimeWorkspaces := make(map[string]bool, len(storedSessions))
 	for _, stored := range storedSessions {
 		if stored.SessionName == "" {
 			continue
 		}
 		if live[stored.SessionName] {
-			liveRuntimeWorkspaces[stored.WorkspaceID] = true
 			continue
 		}
 		slog.Debug(
@@ -1078,8 +1076,7 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
 	for _, ws := range workspaces {
 		if ws.Status != "ready" ||
 			ws.TmuxSession == "" ||
-			live[ws.TmuxSession] ||
-			liveRuntimeWorkspaces[ws.ID] {
+			live[ws.TmuxSession] {
 			continue
 		}
 		msg := fmt.Sprintf(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1030,6 +1030,76 @@ func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 	return nil
 }
 
+// PruneMissingTmuxSessions reconciles persisted tmux ownership state against
+// the host tmux server. Runtime-session rows whose tmux session was killed
+// outside middleman are removed. Ready workspaces whose primary tmux session is
+// missing are marked errored so list responses stop probing dead session names
+// and the UI can offer retry/delete.
+func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
+	sessions, err := m.listTmuxSessions(ctx)
+	if err != nil {
+		return err
+	}
+	live := make(map[string]bool, len(sessions))
+	for _, session := range sessions {
+		live[session] = true
+	}
+
+	storedSessions, err := m.db.ListAllWorkspaceTmuxSessions(ctx)
+	if err != nil {
+		return err
+	}
+	liveRuntimeWorkspaces := make(map[string]bool, len(storedSessions))
+	for _, stored := range storedSessions {
+		if stored.SessionName == "" {
+			continue
+		}
+		if live[stored.SessionName] {
+			liveRuntimeWorkspaces[stored.WorkspaceID] = true
+			continue
+		}
+		slog.Debug(
+			"prune missing runtime tmux session",
+			"workspace_id", stored.WorkspaceID,
+			"target_key", stored.TargetKey,
+			"tmux_session", stored.SessionName,
+		)
+		if err := m.db.DeleteWorkspaceTmuxSession(
+			ctx, stored.WorkspaceID, stored.SessionName,
+		); err != nil {
+			return err
+		}
+	}
+
+	workspaces, err := m.db.ListWorkspaces(ctx)
+	if err != nil {
+		return fmt.Errorf("list workspaces: %w", err)
+	}
+	for _, ws := range workspaces {
+		if ws.Status != "ready" ||
+			ws.TmuxSession == "" ||
+			live[ws.TmuxSession] ||
+			liveRuntimeWorkspaces[ws.ID] {
+			continue
+		}
+		msg := fmt.Sprintf(
+			"tmux session is no longer running: %s",
+			ws.TmuxSession,
+		)
+		slog.Debug(
+			"mark workspace missing tmux session",
+			"workspace_id", ws.ID,
+			"tmux_session", ws.TmuxSession,
+		)
+		if err := m.db.UpdateWorkspaceStatus(
+			ctx, ws.ID, "error", &msg,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func isWorkspaceTmuxSessionName(session string) bool {
 	const prefix = "middleman-"
 	if len(session) != len(prefix)+16 ||

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -914,6 +914,97 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 	})
 }
 
+func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    printf 'middleman-0000000000000001\nmiddleman-0000000000000001-57de4cf40144bdf7\n'` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+	ctx := context.Background()
+
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "0000000000000001",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/live",
+		WorktreePath: filepath.Join(t.TempDir(), "live"),
+		TmuxSession:  "middleman-0000000000000001",
+		Status:       "ready",
+	}))
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "0000000000000002",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "gadget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   2,
+		GitHeadRef:   "feature/stale",
+		WorktreePath: filepath.Join(t.TempDir(), "stale"),
+		TmuxSession:  "middleman-0000000000000002",
+		Status:       "ready",
+	}))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		ctx,
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: "0000000000000001",
+			SessionName: "middleman-0000000000000001-57de4cf40144bdf7",
+			TargetKey:   "codex",
+		},
+	))
+	require.NoError(d.UpsertWorkspaceTmuxSession(
+		ctx,
+		&db.WorkspaceTmuxSession{
+			WorkspaceID: "0000000000000001",
+			SessionName: "middleman-0000000000000001-c857d09db23e6822",
+			TargetKey:   "claude",
+		},
+	))
+
+	require.NoError(mgr.PruneMissingTmuxSessions(ctx))
+
+	stored, err := d.ListWorkspaceTmuxSessions(ctx, "0000000000000001")
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal(
+		"middleman-0000000000000001-57de4cf40144bdf7",
+		stored[0].SessionName,
+	)
+
+	live, err := d.GetWorkspace(ctx, "0000000000000001")
+	require.NoError(err)
+	require.NotNil(live)
+	assert.Equal("ready", live.Status)
+
+	stale, err := d.GetWorkspace(ctx, "0000000000000002")
+	require.NoError(err)
+	require.NotNil(stale)
+	assert.Equal("error", stale.Status)
+	require.NotNil(stale.ErrorMessage)
+	assert.Contains(*stale.ErrorMessage, "tmux session is no longer running")
+	assert.Contains(*stale.ErrorMessage, "middleman-0000000000000002")
+}
+
 func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Why:
- Workspace terminal sessions could disappear from the tab bar after a restart even though their tmux sessions were still alive.
- Firefox/dev-proxy and non-root base-path setups could route terminal WebSockets differently from REST, causing connects to fail or hit the wrong endpoint.
- Alternate-screen TUIs such as Codex could repaint badly after tab switches unless the browser terminal and tmux side were refreshed together.

Summary:
- Route runtime terminal sockets through /ws with dev proxy diagnostics and base-path-aware URLs.
- Restore persisted tmux-backed runtime sessions on server startup and prune records for externally killed sessions.
- Repaint active terminal tabs and request tmux refreshes so alternate-screen TUIs recover when tabs reactivate.