### PR TITLE
Fix merge button state for conflicted pull requests

### DIFF
--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -454,6 +454,30 @@ test.describe("detail action buttons", () => {
     }
   });
 
+  test("conflicted pull request disables the merge action", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    try {
+      isolatedServer = await startIsolatedE2EServer();
+      const baseURL = isolatedServer.info.base_url;
+
+      await page.goto(`${baseURL}/pulls/acme/widgets/2`);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+      await expect(page.locator(".detail-title")).toContainText(
+        "Fix race condition in event loop",
+      );
+      await expect(page.getByText("This branch has conflicts")).toBeVisible();
+
+      const merge = page.locator(".btn--merge").first();
+      await expect(merge).toBeDisabled();
+      await merge.click({ force: true });
+      await expect(
+        page.locator(".modal-title", { hasText: "Merge Pull Request" }),
+      ).toHaveCount(0);
+    } finally {
+      await isolatedServer?.stop();
+    }
+  });
+
   test("narrow actions menu closes when clicking outside", async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 720 });
     await page.goto("/pulls/acme/widgets/1");

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -31,6 +31,7 @@ const prA = {
   repo_name: "widgets",
   platform_host: "github.com",
   worktree_links: [],
+  MergeableState: "",
 };
 
 const prB = {
@@ -246,6 +247,47 @@ async function setupHeldIssue(
 }
 
 test.describe("PR detail merge modal route reset", () => {
+  test("merge button is disabled when the PR has merge conflicts", async ({ page }) => {
+    await mockApi(page);
+    await mockSettings(page);
+
+    const conflictedPR = {
+      ...prA,
+      MergeableState: "dirty",
+    };
+
+    await page.route(
+      `**/api/v1/repos/${conflictedPR.repo_owner}/${conflictedPR.repo_name}/pulls/${conflictedPR.Number}`,
+      async (route) => {
+        if (route.request().method() === "GET") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(detailEnvelopePR(conflictedPR)),
+          });
+          return;
+        }
+        await route.fallback();
+      },
+    );
+
+    await page.goto(
+      `/pulls/${conflictedPR.repo_owner}/${conflictedPR.repo_name}/${conflictedPR.Number}`,
+    );
+
+    await expect(page.locator(".detail-title")).toContainText(
+      conflictedPR.Title,
+    );
+    await expect(page.getByText("This branch has conflicts")).toBeVisible();
+
+    const mergeButton = page.locator(".btn--merge").first();
+    await expect(mergeButton).toBeDisabled();
+    await mergeButton.click({ force: true });
+    await expect(
+      page.locator(".modal-title", { hasText: "Merge Pull Request" }),
+    ).toHaveCount(0);
+  });
+
   test("merge modal closes when the route changes and does not reopen for the new PR", async ({ page }) => {
     await mockApi(page);
     await mockSettings(page);

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -334,6 +334,12 @@
     return "Merge";
   }
 
+  function hasMergeConflicts(
+    pr: { State: string; MergeableState: string },
+  ): boolean {
+    return pr.State === "open" && pr.MergeableState === "dirty";
+  }
+
   const worktreeLinks = $derived(
     detailStore.getDetail()?.worktree_links ?? [],
   );
@@ -701,11 +707,15 @@
           {/if}
           {#if repoSettings}
             {@const mergeSettings = repoSettings}
+            {@const mergeDisabledByConflicts = hasMergeConflicts(pr)}
             <ActionButton
               class="btn--merge"
-              disabled={stalePR}
+              disabled={stalePR || mergeDisabledByConflicts}
+              title={mergeDisabledByConflicts
+                ? "Resolve merge conflicts before merging"
+                : ""}
               onclick={() => {
-                if (stalePR) return;
+                if (stalePR || mergeDisabledByConflicts) return;
                 showMergeModal = true;
                 closeActionMenu();
               }}
@@ -886,7 +896,7 @@
         </div>
       {/if}
 
-      {#if showMergeModal && repoSettings && !stalePR}
+      {#if showMergeModal && repoSettings && !stalePR && !hasMergeConflicts(pr)}
         {@const d = detailStore.getDetail()!}
         {@const p = d.merge_request}
         <MergeModal


### PR DESCRIPTION
## Summary
- Disable the PR detail merge button when GitHub reports the PR as `dirty`
- Block the merge modal from opening for conflicted PRs
- Add e2e coverage for the conflicted merge state in the PR detail view

## Testing
- `bun run typecheck`
- `bun run test:e2e:mock -- detail-stale-actions.spec.ts -g "merge button is disabled"`