### PR TITLE
Fix merge modal options for the selected repo

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,15 @@
 import { defineConfig, devices } from "@playwright/test";
+import {
+  e2eReuseExistingServer,
+  getAvailablePort,
+  parseE2EPort,
+} from "./src/lib/dev/e2ePort";
+
+const host = "127.0.0.1";
+const port = parseE2EPort(process.env.PLAYWRIGHT_PORT)
+  ?? await getAvailablePort(host);
+process.env.PLAYWRIGHT_PORT = String(port);
+const baseURL = `http://${host}:${port}`;
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -8,13 +19,13 @@ export default defineConfig({
     timeout: 5_000,
   },
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL,
     trace: "on-first-retry",
   },
   webServer: {
-    command: "bun run dev --host 127.0.0.1 --port 4173 --strictPort",
-    port: 4173,
-    reuseExistingServer: !process.env.CI,
+    command: `bun run dev --host ${host} --port ${port} --strictPort`,
+    url: baseURL,
+    reuseExistingServer: e2eReuseExistingServer(),
     timeout: 120_000,
   },
   projects: [

--- a/frontend/src/lib/dev/e2ePort.test.ts
+++ b/frontend/src/lib/dev/e2ePort.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import net from "node:net";
+import {
+  e2eReuseExistingServer,
+  getAvailablePort,
+  parseE2EPort,
+} from "./e2ePort";
+
+describe("mock e2e port helpers", () => {
+  it("parses explicit Playwright ports conservatively", () => {
+    expect(parseE2EPort("4173")).toBe(4173);
+    expect(parseE2EPort("0")).toBeNull();
+    expect(parseE2EPort("65536")).toBeNull();
+    expect(parseE2EPort("abc")).toBeNull();
+    expect(parseE2EPort(undefined)).toBeNull();
+  });
+
+  it("only reuses an existing server after explicit opt-in", () => {
+    expect(e2eReuseExistingServer({})).toBe(false);
+    expect(e2eReuseExistingServer({
+      PLAYWRIGHT_REUSE_EXISTING_SERVER: "0",
+    })).toBe(false);
+    expect(e2eReuseExistingServer({
+      PLAYWRIGHT_REUSE_EXISTING_SERVER: "true",
+    })).toBe(true);
+    expect(e2eReuseExistingServer({
+      PLAYWRIGHT_REUSE_EXISTING_SERVER: "yes",
+    })).toBe(true);
+  });
+
+  it("returns a port that can be bound", async () => {
+    const port = await getAvailablePort();
+
+    await new Promise<void>((resolve, reject) => {
+      const server = net.createServer();
+      server.on("error", reject);
+      server.listen(port, "127.0.0.1", () => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/lib/dev/e2ePort.ts
+++ b/frontend/src/lib/dev/e2ePort.ts
@@ -1,0 +1,47 @@
+import net from "node:net";
+
+export function parseE2EPort(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return null;
+  }
+  return parsed;
+}
+
+export function e2eReuseExistingServer(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  switch (env.PLAYWRIGHT_REUSE_EXISTING_SERVER?.trim().toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export async function getAvailablePort(host = "127.0.0.1"): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      if (address == null || typeof address === "string") {
+        server.close(() => reject(new Error("failed to allocate test port")));
+        return;
+      }
+      const { port } = address;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -44,6 +44,19 @@ const prB = {
   HeadBranch: "feature/b",
 };
 
+const prSquashOnly = {
+  ...prA,
+  ID: 23,
+  RepoID: 2,
+  GitHubID: 1103,
+  Number: 300,
+  URL: "https://github.com/acme/squash-only/pull/300",
+  Title: "Squash-only PR title",
+  Body: "Body C",
+  HeadBranch: "feature/c",
+  repo_name: "squash-only",
+};
+
 const issueX = {
   ID: 31,
   RepoID: 1,
@@ -293,6 +306,98 @@ test.describe("PR detail merge modal route reset", () => {
     await expect(
       page.locator(".modal-title", { hasText: "Merge Pull Request" }),
     ).toHaveCount(0);
+  });
+
+  test("merge actions wait for settings that match the selected repo", async ({ page }) => {
+    await mockApi(page);
+    await mockSettings(page);
+
+    for (const pr of [prA, prSquashOnly]) {
+      await page.route(
+        `**/api/v1/repos/${pr.repo_owner}/${pr.repo_name}/pulls/${pr.Number}`,
+        async (route) => {
+          if (route.request().method() === "GET") {
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify(detailEnvelopePR(pr)),
+            });
+            return;
+          }
+          await route.fallback();
+        },
+      );
+    }
+
+    let releaseSquashSettings!: () => void;
+    const squashSettingsReady = new Promise<void>((resolve) => {
+      releaseSquashSettings = resolve;
+    });
+
+    await page.route(
+      `**/api/v1/repos/${prSquashOnly.repo_owner}/${prSquashOnly.repo_name}`,
+      async (route) => {
+        if (route.request().method() === "GET") {
+          await squashSettingsReady;
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              ID: prSquashOnly.RepoID,
+              Owner: prSquashOnly.repo_owner,
+              Name: prSquashOnly.repo_name,
+              AllowSquashMerge: true,
+              AllowMergeCommit: false,
+              AllowRebaseMerge: false,
+              LastSyncStartedAt: "2026-04-01T12:00:00Z",
+              LastSyncCompletedAt: "2026-04-01T12:00:30Z",
+              LastSyncError: "",
+              CreatedAt: "2026-03-01T00:00:00Z",
+            }),
+          });
+          return;
+        }
+        await route.fallback();
+      },
+    );
+
+    await page.goto(
+      `/pulls/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`,
+    );
+    await expect(page.locator(".detail-title")).toContainText(prA.Title);
+    await expect(page.locator(".btn--merge")).toBeVisible();
+
+    await page.evaluate(([owner, name, number]) => {
+      window.history.pushState(
+        null,
+        "",
+        `/pulls/${owner}/${name}/${number}`,
+      );
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }, [prSquashOnly.repo_owner, prSquashOnly.repo_name, prSquashOnly.Number] as const);
+
+    await expect(page.locator(".detail-title")).toContainText(
+      prSquashOnly.Title,
+    );
+    await expect(page.locator(".btn--merge")).toHaveCount(0);
+
+    releaseSquashSettings();
+
+    const mergeButton = page.locator(".btn--merge").first();
+    await expect(mergeButton).toBeVisible();
+    await mergeButton.click();
+
+    await expect(
+      page.locator(".modal-title", { hasText: "Merge Pull Request" }),
+    ).toBeVisible();
+    await expect(page.locator(".method-option")).toHaveCount(0);
+    await expect(
+      page.locator(".modal-footer").getByRole("button", {
+        name: "Squash and merge",
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Create a merge commit")).toHaveCount(0);
+    await expect(page.getByText("Rebase and merge")).toHaveCount(0);
   });
 });
 

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -269,19 +269,27 @@
   };
 
   let repoSettings = $state<RepoSettings | null>(null);
+  let repoSettingsRequestID = 0;
   let showMergeModal = $state(false);
 
   $effect(() => {
+    const requestID = ++repoSettingsRequestID;
+    repoSettings = null;
     client.GET("/repos/{owner}/{name}", {
       params: { path: { owner, name } },
     }).then(({ data, error }) => {
+      if (requestID !== repoSettingsRequestID) return;
       if (error || !data) return;
       repoSettings = {
         allowSquash: data.AllowSquashMerge,
         allowMerge: data.AllowMergeCommit,
         allowRebase: data.AllowRebaseMerge,
       };
-    }).catch(() => {});
+    }).catch(() => {
+      if (requestID === repoSettingsRequestID) {
+        repoSettings = null;
+      }
+    });
   });
 
   const workflowApproval = $derived(


### PR DESCRIPTION
## Summary
- Clear and revalidate repo merge settings when switching PRs so the merge dialog cannot inherit stale options from the previous repo.
- Make mock Playwright e2e runs choose an available port per run instead of sharing fixed `4173`, which avoids cross-worktree collisions.
- Add regression coverage for the squash-only repo case and for the dynamic test-port helpers.

## Testing
- `bun run test -- src/lib/dev/e2ePort.test.ts`
- `bun run test:e2e:mock -- detail-stale-actions.spec.ts`
- `bun run typecheck`