### PR TITLE
Fix workspace navigation to restore the last selected tab

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -77,6 +77,8 @@
   const SIDEBAR_WIDTH_KEY = "middleman-workspace-sidebar-width";
   const WORKSPACE_LIST_WIDTH_KEY =
     "middleman-workspace-list-sidebar-width";
+  const ACTIVE_WORKSPACE_TAB_KEY_PREFIX =
+    "middleman-workspace-active-tab:";
 
   type SidebarTab = "pr" | "issue" | "reviews";
 
@@ -321,6 +323,26 @@
     return mountedSessionKeys.includes(sessionKey);
   }
 
+  function rememberActiveTab(key: string): void {
+    if (!workspaceId) return;
+    localStorage.setItem(
+      `${ACTIVE_WORKSPACE_TAB_KEY_PREFIX}${workspaceId}`,
+      key,
+    );
+  }
+
+  function selectWorkspaceTab(key: string): void {
+    activeTabKey = key;
+    rememberActiveTab(key);
+  }
+
+  function restoreWorkspaceTab(id: string): string {
+    const remembered = localStorage.getItem(
+      `${ACTIVE_WORKSPACE_TAB_KEY_PREFIX}${id}`,
+    );
+    return remembered ?? "home";
+  }
+
   function defaultSidebarTab(
     ws: Workspace,
   ): SidebarTab {
@@ -388,7 +410,7 @@
         activeTabKey.startsWith("session:") &&
         !activeSession
       ) {
-        activeTabKey = "home";
+        selectWorkspaceTab("home");
       }
       mountedSessionKeys = mountedSessionKeys.filter(
         (key) =>
@@ -409,7 +431,7 @@
     if (target?.kind === "tmux") {
       tmuxTabOpen = true;
       tmuxTerminalMounted = true;
-      activeTabKey = "tmux";
+      selectWorkspaceTab("tmux");
       return;
     }
 
@@ -426,7 +448,7 @@
       await fetchRuntime();
       if (id !== workspaceId) return;
       mountSessionTerminal(session.key);
-      activeTabKey = `session:${session.key}`;
+      selectWorkspaceTab(`session:${session.key}`);
     } catch (err) {
       if (id !== workspaceId) return;
       runtimeError =
@@ -438,7 +460,7 @@
 
   function openSession(sessionKey: string): void {
     mountSessionTerminal(sessionKey);
-    activeTabKey = `session:${sessionKey}`;
+    selectWorkspaceTab(`session:${sessionKey}`);
   }
 
   async function closeSession(session: RuntimeSession): Promise<void> {
@@ -457,7 +479,7 @@
       if (id !== workspaceId) return;
       unmountSessionTerminal(session.key);
       if (activeTabKey === `session:${session.key}`) {
-        activeTabKey = "home";
+        selectWorkspaceTab("home");
       }
     } catch (err) {
       if (id !== workspaceId) return;
@@ -604,6 +626,7 @@
   // it in place.
   $effect(() => {
     const id = workspaceId;
+    const restoredTab = restoreWorkspaceTab(id);
 
     // Tab state from the previous workspace can't be valid for a
     // different workspace's runtime, so reset these even though
@@ -612,8 +635,8 @@
     // on mount, so leaving the drawer open across a workspace
     // change would route keystrokes to the previous workspace's
     // shell while the user looks at the new workspace.
-    activeTabKey = "home";
-    tmuxTabOpen = false;
+    activeTabKey = restoredTab;
+    tmuxTabOpen = restoredTab === "tmux";
     shellOpen = false;
     launchingKey = null;
     shellLoading = false;
@@ -623,8 +646,10 @@
     loadError = null;
     actionError = null;
     runtimeError = null;
-    tmuxTerminalMounted = false;
-    mountedSessionKeys = [];
+    tmuxTerminalMounted = restoredTab === "tmux";
+    mountedSessionKeys = restoredTab.startsWith("session:")
+      ? [restoredTab.slice("session:".length)]
+      : [];
 
     if (!id) {
       // /workspaces route: drop workspace data so the empty-state
@@ -828,18 +853,18 @@
                   sessions={runtimeSessions}
                   tmuxOpen={tmuxTabOpen}
                   onSelectHome={() => {
-                    activeTabKey = "home";
+                    selectWorkspaceTab("home");
                   }}
                   onSelectTmux={() => {
                     tmuxTerminalMounted = true;
-                    activeTabKey = "tmux";
+                    selectWorkspaceTab("tmux");
                   }}
                   onSelectSession={openSession}
                   onCloseTmux={() => {
                     tmuxTabOpen = false;
                     tmuxTerminalMounted = false;
                     if (activeTabKey === "tmux") {
-                      activeTabKey = "home";
+                      selectWorkspaceTab("home");
                     }
                   }}
                   onCloseSession={(key) => {

--- a/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
@@ -36,6 +36,24 @@ async function waitForWorkspaceReady(
   throw new Error(`workspace ${workspaceId} did not become ready`);
 }
 
+async function createIssueWorkspace(
+  api: APIRequestContext,
+  issueNumber: number,
+): Promise<WorkspaceStatusResponse> {
+  const createResponse = await api.post(
+    `/api/v1/repos/acme/widgets/issues/${issueNumber}/workspace`,
+    {
+      data: {
+        platform_host: "github.com",
+      },
+    },
+  );
+  expect(createResponse.status()).toBe(202);
+  const createdWorkspace = await createResponse.json() as WorkspaceStatusResponse;
+  await waitForWorkspaceReady(api, createdWorkspace.id);
+  return createdWorkspace;
+}
+
 test.describe("workspace tab persistence", () => {
   test("opening tmux tab keeps Home pane mounted across tab switches", async ({ page }) => {
     test.skip(
@@ -112,6 +130,55 @@ test.describe("workspace tab persistence", () => {
       await expect(panes).toHaveCount(2);
       const reactivated = stage.locator(":scope > .stage-pane.active");
       await expect(reactivated).toHaveAttribute("data-test-tmux-id", "preserved");
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("returns to the most recently selected tab for each workspace", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const firstWorkspace = await createIssueWorkspace(api, 10);
+      const secondWorkspace = await createIssueWorkspace(api, 11);
+
+      await page.goto(
+        `${isolatedServer.info.base_url}/terminal/${firstWorkspace.id}`,
+      );
+
+      const homeTab = page.locator('.workspace-tabs [role="tab"]', {
+        hasText: "Home",
+      });
+      const tmuxTab = page.locator('.workspace-tabs [role="tab"]', {
+        hasText: "tmux",
+      });
+
+      await expect(homeTab).toHaveAttribute("aria-selected", "true");
+
+      await page.locator(".launch-trigger").click();
+      await page.locator(".launch-option", { hasText: "tmux" }).click();
+      await expect(tmuxTab).toHaveAttribute("aria-selected", "true");
+
+      await page.goto(
+        `${isolatedServer.info.base_url}/terminal/${secondWorkspace.id}`,
+      );
+      await expect(homeTab).toHaveAttribute("aria-selected", "true");
+
+      await page.goto(
+        `${isolatedServer.info.base_url}/terminal/${firstWorkspace.id}`,
+      );
+      await expect(tmuxTab).toHaveAttribute("aria-selected", "true");
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();


### PR DESCRIPTION
## Summary
- Remember the active workspace tab per workspace and restore it when navigating back to that workspace
- Keep Home as the fallback when no prior tab is stored
- Add an e2e regression that switches between two workspaces and verifies the original workspace reopens on its previously selected tab

## Testing
- `make frontend-check` passed
- `bun x playwright test --config=playwright-e2e.config.ts tests/e2e-full/workspace-tab-persistence.spec.ts` passed across Chromium, Firefox, and WebKit