### PR TITLE
Refactor frontend route item shapes into named types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ make vet        # go vet
 - Tests should be fast and isolated
 - No emojis in code or output
 - For database schema changes, follow `context/db-migrations.md`; `internal/db/migrations/` is the source of truth for schema evolution.
-- For UI work, follow `context/ui-design-system.md`; prefer extending shared UI primitives over adding one-off local badge/chip/button styling.
+- For frontend UI and TypeScript/Svelte conventions, follow `context/ui-design-system.md`; prefer extending shared UI primitives over adding one-off local badge/chip/button styling, and name reused domain object shapes instead of repeating anonymous inline types.
 - Datetimes are UTC across storage and API boundaries. Store timestamps in UTC, emit API timestamps as UTC RFC3339, and only convert to local time in the Svelte UI presentation layer.
 
 ## Git Workflow

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -99,6 +99,8 @@ Default color intent:
 
 When editing Svelte components, use the Svelte skills `skills/svelte-core-bestpractices/` (`svelte-core-bestpractices`) and `skills/svelte-code-writer/` (`svelte-code-writer`) alongside this document.
 
+For TypeScript/Svelte state and routing contracts, avoid anonymous object type literals when the shape represents a domain concept that is reused or exposed across modules. Name shared item identity shapes, route payloads, embed callbacks, and API view models near the module that owns the concept, then import those types at call sites. In particular, PR/issue route and drawer state should use the shared item reference types from `frontend/src/lib/stores/router.svelte.ts` instead of repeating `{ owner; name; number }` style shapes.
+
 Before adding UI styling:
 
 1. Check whether an existing shared primitive already expresses the pattern.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -199,14 +199,7 @@
     }
   });
 
-  let drawerItem = $state<{
-    itemType: "pr" | "issue";
-    platformHost?: string | undefined;
-    owner: string;
-    name: string;
-    number: number;
-    detailTab: "conversation" | "files";
-  } | null>(null);
+  let drawerItem = $state<ActivitySelection | null>(null);
 
   function sameActivitySelection(
     left: ActivitySelection | null,

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -53,11 +53,12 @@
     isDiffView,
     getDetailTab,
     getSelectedPRFromRoute,
+    type RoutableItemRef,
   } from "./lib/stores/router.svelte.ts";
   import {
     buildActivitySelectionSearch,
     parseActivitySelection,
-    type ActivitySelection,
+    type ActivityDetailTab,
   } from "./lib/utils/activitySelection.js";
   import {
     getGlobalRepo,
@@ -199,11 +200,15 @@
     }
   });
 
-  let drawerItem = $state<ActivitySelection | null>(null);
+  type DrawerItem = RoutableItemRef & {
+    detailTab: ActivityDetailTab;
+  };
+
+  let drawerItem = $state<DrawerItem | null>(null);
 
   function sameActivitySelection(
-    left: ActivitySelection | null,
-    right: ActivitySelection | null,
+    left: DrawerItem | null,
+    right: DrawerItem | null,
   ): boolean {
     if (left === right) return true;
     if (left === null || right === null) return false;
@@ -216,7 +221,7 @@
   }
 
   function updateDrawerURL(
-    item: ActivitySelection | null,
+    item: DrawerItem | null,
   ): void {
     if (getPage() !== "activity") return;
     const sp = buildActivitySelectionSearch(

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -1,12 +1,29 @@
+export type RepoRef = {
+  owner: string;
+  name: string;
+};
+
+export type NumberedItemRef = RepoRef & {
+  number: number;
+};
+
+export type HostedItemRef = NumberedItemRef & {
+  platformHost?: string | undefined;
+};
+
+export type RoutableItemRef = HostedItemRef & {
+  itemType: "pr" | "issue";
+};
+
 export type Route =
   | { page: "activity" }
   | { page: "design-system" }
   | { page: "repos" }
   | { page: "workspaces" }
-  | { page: "pulls"; view: "list" | "board"; selected?: { owner: string; name: string; number: number }; tab?: "files" }
-  | { page: "issues"; selected?: { owner: string; name: string; number: number; platformHost?: string | undefined } }
+  | { page: "pulls"; view: "list" | "board"; selected?: NumberedItemRef; tab?: "files" }
+  | { page: "issues"; selected?: HostedItemRef }
   | { page: "settings" }
-  | { page: "focus"; itemType: "pr" | "issue"; owner: string; name: string; number: number; platformHost?: string | undefined }
+  | ({ page: "focus" } & RoutableItemRef)
   | { page: "focus"; itemType: "mrs"; repo?: string }
   | { page: "focus"; itemType: "issues"; repo?: string }
   | { page: "reviews"; jobId?: number }
@@ -319,7 +336,7 @@ export function getDetailTab(): DetailTab {
   return "conversation";
 }
 
-export function getSelectedPRFromRoute(): { owner: string; name: string; number: number } | null {
+export function getSelectedPRFromRoute(): NumberedItemRef | null {
   if (route.page !== "pulls") return null;
   if ("selected" in route && route.selected) {
     return route.selected;

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -1878,6 +1878,71 @@ func TestDeleteWorkspacePreservesRowWhenTmuxKillFails(t *testing.T) {
 	assert.Equal(wsID, getResp.JSON200.Id)
 }
 
+func TestDeleteWorkspaceTreatsTmuxServerExitAsGoneE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "has-session" ]; then` + "\n" +
+		`    echo "can't find session: sim" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		`  if [ "$a" = "kill-session" ]; then` + "\n" +
+		`    echo "server exited unexpectedly" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+
+	client, _, database := setupWrapperServerWithScriptAndDB(t, script)
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		t.Context(),
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	wsID := createResp.JSON202.Id
+
+	require.Eventually(
+		func() bool {
+			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+				t.Context(), wsID,
+			)
+			if getErr != nil || getResp.JSON200 == nil {
+				return false
+			}
+			return getResp.JSON200.Status == "ready"
+		},
+		5*time.Second, 50*time.Millisecond,
+	)
+
+	force := true
+	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
+		t.Context(), wsID, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, delResp.StatusCode())
+
+	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(t.Context(), wsID)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, getResp.StatusCode())
+
+	stored, err := database.GetWorkspace(t.Context(), wsID)
+	require.NoError(err)
+	assert.Nil(stored)
+}
+
 func TestDeleteErroredWorkspaceAllowsUnavailableTmux(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -907,7 +907,7 @@ func (m *Manager) cleanupTmuxSession(
 			continue
 		}
 		err := m.killTmuxSession(ctx, target.session)
-		if err == nil || isTmuxSessionAbsent([]byte(err.Error()), err) {
+		if err == nil || isTmuxKillSessionGone(err) {
 			continue
 		}
 		if target.main {
@@ -1021,7 +1021,7 @@ func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 			continue
 		}
 		if err := m.killTmuxSession(ctx, session); err != nil &&
-			!isTmuxSessionAbsent([]byte(err.Error()), err) {
+			!isTmuxKillSessionGone(err) {
 			return fmt.Errorf(
 				"kill orphan tmux session %q: %w", session, err,
 			)
@@ -1290,7 +1290,7 @@ func (m *Manager) StopStoredRuntimeTmuxSession(
 		}
 		if err := m.killTmuxSession(
 			ctx, storedSession.SessionName,
-		); err != nil && !isTmuxSessionAbsent([]byte(err.Error()), err) {
+		); err != nil && !isTmuxKillSessionGone(err) {
 			return true, fmt.Errorf(
 				"kill tmux session %q: %w",
 				storedSession.SessionName, err,
@@ -1419,7 +1419,7 @@ func (m *Manager) newTmuxSession(
 	}
 	if err := m.setTmuxOwnerMarker(ctx, session); err != nil {
 		if killErr := m.killTmuxSession(ctx, session); killErr != nil &&
-			!isTmuxSessionAbsent([]byte(killErr.Error()), killErr) {
+			!isTmuxKillSessionGone(killErr) {
 			return fmt.Errorf(
 				"set tmux owner marker: %w; cleanup new tmux session: %v",
 				err, killErr,
@@ -1495,6 +1495,15 @@ func isTmuxSessionAbsent(stderr []byte, err error) bool {
 		strings.Contains(msg, "no server running") ||
 		(strings.Contains(msg, "error connecting to") &&
 			strings.Contains(msg, "No such file or directory"))
+}
+
+func isTmuxKillSessionGone(err error) bool {
+	if err == nil {
+		return true
+	}
+	msg := err.Error()
+	return isTmuxSessionAbsent([]byte(msg), err) ||
+		strings.Contains(msg, "server exited unexpectedly")
 }
 
 // killTmuxSession kills a tmux session via the manager's prefix.

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -730,6 +730,53 @@ func TestManagerDeleteFailsWhenTmuxKillFails(t *testing.T) {
 	)
 }
 
+func TestManagerDeleteTreatsTmuxServerExitDuringKillAsGone(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "kill-session" ]; then` + "\n" +
+		`    echo "server exited unexpectedly" >&2` + "\n" +
+		`    exit 1` + "\n" +
+		`  fi` + "\n" +
+		"done\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+
+	ctx := context.Background()
+	ws, err := mgr.Create(ctx, "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	require.NoError(d.UpdateWorkspaceStatus(ctx, ws.ID, "ready", nil))
+
+	dirty, err := mgr.Delete(ctx, ws.ID, true, nil)
+	assert.Nil(dirty)
+	require.NoError(err)
+
+	got, getErr := mgr.Get(ctx, ws.ID)
+	require.NoError(getErr)
+	assert.Nil(got)
+
+	argvs := readRecorderArgv(t, record)
+	require.Len(argvs, 1)
+	assert.Equal(
+		[]string{"wrap", "kill-session", "-t", ws.TmuxSession},
+		argvs[0],
+	)
+}
+
 func TestManagerDeleteAllowsErroredWorkspaceWhenTmuxUnavailable(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
## Summary
- Added shared TypeScript types for repo, PR/issue, and routable item references in the Svelte router module.
- Replaced inline `{ owner, name, number }`-style route and drawer shapes with the shared types.
- Updated frontend guidance docs to call out naming reused domain object shapes instead of repeating anonymous inline types.

## Testing
- Not run (not requested)