### PR TITLE
Remember Repos tab filters

### DIFF
--- a/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
@@ -27,8 +27,13 @@
     type RepoSort,
     type RepoSummaryCard as RepoSummaryCardData,
   } from "./repoSummary.js";
+  import {
+    loadRepoSummaryFilters,
+    saveRepoSummaryFilters,
+  } from "./repoSummaryFilters.js";
 
   const stores = getStores();
+  const initialFilters = loadRepoSummaryFilters();
 
   let summaries = $state<RepoSummaryCardData[]>([]);
   let loading = $state(true);
@@ -42,9 +47,9 @@
   let issueSubmittingByRepo = $state<Record<string, boolean>>(
     {},
   );
-  let searchQuery = $state("");
-  let activeFilter = $state<RepoFilter>("all");
-  let sortMode = $state<RepoSort>("name");
+  let searchQuery = $state(initialFilters.searchQuery);
+  let activeFilter = $state<RepoFilter>(initialFilters.activeFilter);
+  let sortMode = $state<RepoSort>(initialFilters.sortMode);
 
   const totals = $derived.by(() =>
     summaries.reduce(
@@ -171,14 +176,25 @@
 
   function setFilter(filter: RepoFilter): void {
     activeFilter = filter;
+    persistFilters();
   }
 
   function updateSearch(event: Event): void {
     searchQuery = (event.currentTarget as HTMLInputElement).value;
+    persistFilters();
   }
 
   function setSort(sort: RepoSort): void {
     sortMode = sort;
+    persistFilters();
+  }
+
+  function persistFilters(): void {
+    saveRepoSummaryFilters({
+      searchQuery,
+      activeFilter,
+      sortMode,
+    });
   }
 
   function filterAndNavigate(

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -68,6 +68,7 @@ describe("RepoSummaryPage", () => {
     mockPost.mockReset();
     mockNavigate.mockReset();
     mockSetGlobalRepo.mockReset();
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -342,6 +343,92 @@ describe("RepoSummaryPage", () => {
       { target: { value: "fresh" } },
     );
     expect(screen.getByText("No repositories match")).toBeTruthy();
+  });
+
+  it("remembers repository filters when the page remounts", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        {
+          owner: "acme",
+          name: "fresh",
+          platform_host: "github.com",
+          cached_pr_count: 2,
+          open_pr_count: 1,
+          draft_pr_count: 0,
+          cached_issue_count: 1,
+          open_issue_count: 0,
+          most_recent_activity_at: "2026-04-17T15:04:05Z",
+          last_sync_completed_at: "2026-04-17T15:00:00Z",
+          last_sync_started_at: "2026-04-17T14:59:00Z",
+          last_sync_error: "",
+          active_authors: [],
+          recent_issues: [],
+          latest_release: {
+            tag_name: "v1.0.0",
+            name: "",
+            url: "",
+            target_commitish: "main",
+            prerelease: false,
+            published_at: "2026-04-16T12:00:00Z",
+          },
+          commits_since_release: 2,
+          commit_timeline: [],
+        },
+        {
+          owner: "acme",
+          name: "stale",
+          platform_host: "github.com",
+          cached_pr_count: 4,
+          open_pr_count: 0,
+          draft_pr_count: 0,
+          cached_issue_count: 3,
+          open_issue_count: 1,
+          most_recent_activity_at: "2026-04-17T15:04:05Z",
+          last_sync_completed_at: "2026-04-17T15:00:00Z",
+          last_sync_started_at: "2026-04-17T14:59:00Z",
+          last_sync_error: "",
+          active_authors: [],
+          recent_issues: [],
+          latest_release: {
+            tag_name: "v0.9.0",
+            name: "",
+            url: "",
+            target_commitish: "main",
+            prerelease: false,
+            published_at: "2026-03-01T12:00:00Z",
+          },
+          commits_since_release: 72,
+          commit_timeline: [],
+        },
+      ],
+      error: undefined,
+    });
+
+    render(RepoSummaryPage);
+
+    await screen.findByRole("button", { name: /acme\s*\/\s*fresh/ });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Stale" }),
+    );
+    await fireEvent.input(
+      screen.getByPlaceholderText("Filter repositories"),
+      { target: { value: "stale" } },
+    );
+
+    cleanup();
+    render(RepoSummaryPage);
+
+    await screen.findByRole("button", { name: /acme\s*\/\s*stale/ });
+    expect(
+      screen.queryByRole("button", { name: /acme\s*\/\s*fresh/ }),
+    ).toBeNull();
+    expect(
+      (screen.getByPlaceholderText("Filter repositories") as HTMLInputElement)
+        .value,
+    ).toBe("stale");
+    expect(
+      screen.getByRole("button", { name: "Stale" }).className,
+    ).toContain("repo-page__filter--active");
   });
 
   it("creates an issue from a repo card and navigates to it", async () => {

--- a/frontend/src/lib/components/repositories/repoSummaryFilters.ts
+++ b/frontend/src/lib/components/repositories/repoSummaryFilters.ts
@@ -1,0 +1,82 @@
+import type { RepoFilter, RepoSort } from "./repoSummary.js";
+
+const storageKey = "middleman:repoSummaryFilters";
+
+const validFilters = new Set<RepoFilter>([
+  "all",
+  "prs",
+  "issues",
+  "stale",
+]);
+const validSorts = new Set<RepoSort>([
+  "name",
+  "open-prs",
+  "open-issues",
+  "activity",
+  "stale",
+]);
+
+export interface RepoSummaryFilters {
+  searchQuery: string;
+  activeFilter: RepoFilter;
+  sortMode: RepoSort;
+}
+
+export const defaultRepoSummaryFilters: RepoSummaryFilters = {
+  searchQuery: "",
+  activeFilter: "all",
+  sortMode: "name",
+};
+
+function getStorage(): Storage | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeFilters(value: unknown): RepoSummaryFilters {
+  if (typeof value !== "object" || value === null) {
+    return { ...defaultRepoSummaryFilters };
+  }
+  const candidate = value as Partial<RepoSummaryFilters>;
+  return {
+    searchQuery:
+      typeof candidate.searchQuery === "string"
+        ? candidate.searchQuery
+        : defaultRepoSummaryFilters.searchQuery,
+    activeFilter:
+      candidate.activeFilter && validFilters.has(candidate.activeFilter)
+        ? candidate.activeFilter
+        : defaultRepoSummaryFilters.activeFilter,
+    sortMode:
+      candidate.sortMode && validSorts.has(candidate.sortMode)
+        ? candidate.sortMode
+        : defaultRepoSummaryFilters.sortMode,
+  };
+}
+
+export function loadRepoSummaryFilters(): RepoSummaryFilters {
+  const storage = getStorage();
+  if (!storage) return { ...defaultRepoSummaryFilters };
+
+  try {
+    return normalizeFilters(JSON.parse(storage.getItem(storageKey) ?? "null"));
+  } catch {
+    return { ...defaultRepoSummaryFilters };
+  }
+}
+
+export function saveRepoSummaryFilters(
+  filters: RepoSummaryFilters,
+): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(storageKey, JSON.stringify(normalizeFilters(filters)));
+  } catch {
+    // Storage blocked - filters still work for the current page instance.
+  }
+}

--- a/frontend/tests/e2e-full/repo-summaries.spec.ts
+++ b/frontend/tests/e2e-full/repo-summaries.spec.ts
@@ -1,6 +1,34 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("repository summaries", () => {
+  test("remembers filters after tab changes", async ({ page }) => {
+    await page.goto("/repos");
+
+    await page.getByPlaceholder("Filter repositories").fill("widgets");
+
+    await expect(
+      page.getByRole("button", { name: /acme\s*\/\s*widgets/ }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /acme\s*\/\s*tools/ }).first(),
+    ).toHaveCount(0);
+
+    await page.getByRole("button", { name: "PRs", exact: true }).click();
+    await expect(page).toHaveURL(/\/pulls$/);
+
+    await page.getByRole("button", { name: "Repos", exact: true }).click();
+    await expect(page).toHaveURL(/\/repos$/);
+    await expect(
+      page.getByPlaceholder("Filter repositories"),
+    ).toHaveValue("widgets");
+    await expect(
+      page.getByRole("button", { name: /acme\s*\/\s*widgets/ }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /acme\s*\/\s*tools/ }).first(),
+    ).toHaveCount(0);
+  });
+
   test("shows repo stats and can create an issue", async ({ page }) => {
     await page.goto("/repos");
 

--- a/frontend/tests/e2e-full/repo-summaries.spec.ts
+++ b/frontend/tests/e2e-full/repo-summaries.spec.ts
@@ -4,13 +4,25 @@ test.describe("repository summaries", () => {
   test("remembers filters after tab changes", async ({ page }) => {
     await page.goto("/repos");
 
-    await page.getByPlaceholder("Filter repositories").fill("widgets");
+    await page.getByPlaceholder("Filter repositories").fill("acme");
+    await page.getByRole("button", { name: "Has issues" }).click();
+    await page.locator(".repo-page__sort-dropdown")
+      .getByRole("button", { name: "Name" })
+      .click();
+    await page.locator(".filter-dropdown")
+      .getByRole("button", { name: "Open issues" })
+      .click();
 
+    const repoCards = page.locator(".repo-card");
+    await expect(repoCards).toHaveCount(2);
     await expect(
-      page.getByRole("button", { name: /acme\s*\/\s*widgets/ }).first(),
+      repoCards.nth(0).getByRole("button", { name: /acme\s*\/\s*widgets/ }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: /acme\s*\/\s*tools/ }).first(),
+      repoCards.nth(1).getByRole("button", { name: /acme\s*\/\s*tools/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /acme\s*\/\s*archived/ }),
     ).toHaveCount(0);
 
     await page.getByRole("button", { name: "PRs", exact: true }).click();
@@ -20,12 +32,24 @@ test.describe("repository summaries", () => {
     await expect(page).toHaveURL(/\/repos$/);
     await expect(
       page.getByPlaceholder("Filter repositories"),
-    ).toHaveValue("widgets");
+    ).toHaveValue("acme");
     await expect(
-      page.getByRole("button", { name: /acme\s*\/\s*widgets/ }).first(),
+      page.getByRole("button", { name: "Has issues" }),
+    ).toHaveClass(/repo-page__filter--active/);
+    await expect(
+      page.locator(".repo-page__sort-dropdown")
+        .getByRole("button", { name: "Open issues" }),
+    ).toBeVisible();
+
+    await expect(repoCards).toHaveCount(2);
+    await expect(
+      repoCards.nth(0).getByRole("button", { name: /acme\s*\/\s*widgets/ }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: /acme\s*\/\s*tools/ }).first(),
+      repoCards.nth(1).getByRole("button", { name: /acme\s*\/\s*tools/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /acme\s*\/\s*archived/ }),
     ).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- Remember the Repos tab search query, filter segment, and sort mode across tab changes.
- Restore the same filtered repository list when the Repos page remounts.
- Add component and full-stack regression coverage for the tab-change flow.

## Why
Maintainers use the Repos tab as a triage surface. Switching to PRs, Issues, or another tab remounts the Repos page, which reset the in-progress filter context and forced users to rebuild the same view each time they returned. Persisting these controls keeps the maintainer's current repo slice intact while moving through the dashboard.

Fixes #197
