### PR TITLE
Filter changed files by category

### DIFF
--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -472,4 +472,92 @@ describe("createDiffStore loadDiff", () => {
     expect(result).not.toBeNull();
     expect(result!.files).toEqual([]);
   });
+
+  it("filters loaded diff and file list by selected file category", async () => {
+    const result: DiffResult = {
+      stale: false,
+      whitespace_only_count: 0,
+      files: [
+        {
+          path: "docs/review-plan.md",
+          old_path: "docs/review-plan.md",
+          status: "modified",
+          is_binary: false,
+          is_whitespace_only: false,
+          additions: 1,
+          deletions: 1,
+          hunks: [],
+        },
+        {
+          path: "src/App.svelte",
+          old_path: "src/App.svelte",
+          status: "modified",
+          is_binary: false,
+          is_whitespace_only: false,
+          additions: 1,
+          deletions: 1,
+          hunks: [],
+        },
+        {
+          path: "src/App.test.ts",
+          old_path: "src/App.test.ts",
+          status: "modified",
+          is_binary: false,
+          is_whitespace_only: false,
+          additions: 1,
+          deletions: 1,
+          hunks: [],
+        },
+        {
+          path: "bun.lock",
+          old_path: "bun.lock",
+          status: "modified",
+          is_binary: false,
+          is_whitespace_only: false,
+          additions: 1,
+          deletions: 1,
+          hunks: [],
+        },
+      ],
+    };
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+
+        if (url.includes("/files")) {
+          return Response.json({ stale: false, files: result.files });
+        }
+        if (url.includes("/diff")) {
+          return Response.json(result);
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ getBasePath: () => "/" });
+    await store.loadDiff("owner", "repo", 1);
+
+    expect(store.getFileCategoryFilter()).toBe("all");
+    expect(store.getVisibleDiffFiles().map((file) => file.path)).toEqual([
+      "docs/review-plan.md",
+      "src/App.svelte",
+      "src/App.test.ts",
+      "bun.lock",
+    ]);
+
+    store.setFileCategoryFilter("tests");
+
+    expect(store.getVisibleDiffFiles().map((file) => file.path)).toEqual([
+      "src/App.test.ts",
+    ]);
+    expect(store.getVisibleFileList()?.files.map((file) => file.path)).toEqual([
+      "src/App.test.ts",
+    ]);
+  });
 });

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -550,6 +550,13 @@ describe("createDiffStore loadDiff", () => {
       "src/App.test.ts",
       "bun.lock",
     ]);
+    expect(store.getFileCategoryCounts()).toEqual({
+      plansDocs: 1,
+      code: 1,
+      tests: 1,
+      other: 1,
+      all: 4,
+    });
 
     store.setFileCategoryFilter("tests");
 

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 import type { DiffFile, DiffLine, DiffResult, FilesResult } from "@middleman/ui/api/types";
 import { acquireExclusiveLock } from "./support/exclusiveLock";
+import { startIsolatedE2EServer } from "./support/e2eServer";
 
 // --- Fixtures ---
 
@@ -853,6 +854,65 @@ test.describe("diff view (git-backed)", () => {
     // Should have 4 changed files from the test repo.
     await expect(page.locator(".diff-file")).toHaveCount(4);
     await expect(page.locator(".diff-file-row")).toHaveCount(4);
+  });
+
+  test("category filter counts and filtering come from the real diff API", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const response = await page.request.post(
+        `${server.info.base_url}/__e2e/pr-diff-summary/advance-head`,
+      );
+      expect(response.ok()).toBe(true);
+
+      await page.goto(`${server.info.base_url}/pulls/acme/widgets/1/files`);
+      await waitForDiffLoaded(page);
+      await waitForSidebarFilesLoaded(page);
+
+      const categoryFilter = page.getByRole("group", {
+        name: "Filter changed files",
+      });
+      await expect(categoryFilter.getByRole("button", { name: "Plans/docs (2)" }))
+        .toBeVisible();
+      await expect(categoryFilter.getByRole("button", { name: "Code (2)" }))
+        .toBeVisible();
+      await expect(categoryFilter.getByRole("button", { name: "Tests (1)" }))
+        .toBeVisible();
+      await expect(categoryFilter.getByRole("button", { name: "Other (1)" }))
+        .toBeVisible();
+      await expect(categoryFilter.getByRole("button", { name: "All (6)" }))
+        .toHaveAttribute("aria-pressed", "true");
+
+      await categoryFilter.getByRole("button", { name: "Tests (1)" }).click();
+
+      await expect(page.locator(".diff-file")).toHaveCount(1);
+      await expect(page.locator(".diff-file-row")).toHaveCount(1);
+      await expect(page.locator('[data-file-path="internal/cache_test.go"]'))
+        .toBeVisible();
+      await expect(page.locator(".diff-file-row", { hasText: "cache_test.go" }))
+        .toBeVisible();
+      await expect(page.locator('[data-file-path="internal/cache.go"]'))
+        .toHaveCount(0);
+      await expect(page.locator(".diff-file-row", { hasText: "cache.go" }))
+        .toHaveCount(0);
+
+      await categoryFilter.getByRole("button", { name: "Plans/docs (2)" })
+        .click();
+
+      await expect(page.locator(".diff-file")).toHaveCount(2);
+      await expect(page.locator(".diff-file-row")).toHaveCount(2);
+      await expect(page.locator('[data-file-path="docs/cache-plan.md"]'))
+        .toBeVisible();
+      await expect(page.locator('[data-file-path="README.md"]'))
+        .toBeVisible();
+      await expect(page.locator(".diff-file-row", { hasText: "cache-plan.md" }))
+        .toBeVisible();
+      await expect(page.locator(".diff-file-row", { hasText: "README.md" }))
+        .toBeVisible();
+      await expect(page.locator('[data-file-path="internal/cache_test.go"]'))
+        .toHaveCount(0);
+    } finally {
+      await server.stop();
+    }
   });
 
   test("modified file has multiple hunks with correct content", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -367,10 +367,18 @@ test.describe("diff view", () => {
     const categoryFilter = page.getByRole("group", {
       name: "Filter changed files",
     });
-    await expect(categoryFilter.getByRole("button", { name: "All" }))
+    await expect(categoryFilter.getByRole("button", { name: "Plans/docs (0)" }))
+      .toBeVisible();
+    await expect(categoryFilter.getByRole("button", { name: "Code (3)" }))
+      .toBeVisible();
+    await expect(categoryFilter.getByRole("button", { name: "Tests (0)" }))
+      .toBeVisible();
+    await expect(categoryFilter.getByRole("button", { name: "Other (1)" }))
+      .toBeVisible();
+    await expect(categoryFilter.getByRole("button", { name: "All (4)" }))
       .toHaveAttribute("aria-pressed", "true");
 
-    await categoryFilter.getByRole("button", { name: "Code" }).click();
+    await categoryFilter.getByRole("button", { name: "Code (3)" }).click();
 
     await expect(page.locator(".diff-file")).toHaveCount(3);
     await expect(page.locator(".diff-file-row")).toHaveCount(3);
@@ -379,9 +387,9 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-file-row", { hasText: "logo.png" }))
       .toHaveCount(0);
 
-    await expect(categoryFilter.getByRole("button", { name: "Code" }))
+    await expect(categoryFilter.getByRole("button", { name: "Code (3)" }))
       .toHaveAttribute("aria-pressed", "true");
-    await categoryFilter.getByRole("button", { name: "All" }).click();
+    await categoryFilter.getByRole("button", { name: "All (4)" }).click();
 
     await expect(page.locator(".diff-file")).toHaveCount(4);
     await expect(page.locator(".diff-file-row")).toHaveCount(4);

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -356,6 +356,36 @@ test.describe("diff view", () => {
     await expect(segments.nth(2)).not.toHaveClass(/segment--active/);
   });
 
+  test("changed file category filter narrows the sidebar and rendered diff", async ({ page }) => {
+    await mockDiffApi(page, smallDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const categorySelect = page.getByRole("combobox", {
+      name: "Filter changed files: All",
+    });
+    await expect(categorySelect).toContainText("All");
+
+    await categorySelect.click();
+    await page.getByRole("option", { name: "Code" }).click();
+
+    await expect(page.locator(".diff-file")).toHaveCount(3);
+    await expect(page.locator(".diff-file-row")).toHaveCount(3);
+    await expect(page.locator(".diff-file", { hasText: "assets/logo.png" }))
+      .toHaveCount(0);
+    await expect(page.locator(".diff-file-row", { hasText: "logo.png" }))
+      .toHaveCount(0);
+
+    await page.getByRole("combobox", {
+      name: "Filter changed files: Code",
+    }).click();
+    await page.getByRole("option", { name: "All" }).click();
+
+    await expect(page.locator(".diff-file")).toHaveCount(4);
+    await expect(page.locator(".diff-file-row")).toHaveCount(4);
+  });
+
   test("hide whitespace toggle triggers re-fetch", async ({ page }) => {
     let fetchCount = 0;
     await page.route("**/api/v1/repos/acme/widgets/pulls/1/files", async (route) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -362,13 +362,15 @@ test.describe("diff view", () => {
     await waitForDiffLoaded(page);
     await waitForSidebarFilesLoaded(page);
 
-    const categorySelect = page.getByRole("combobox", {
-      name: "Filter changed files: All",
-    });
-    await expect(categorySelect).toContainText("All");
+    await expect(page.locator(".files-view > .diff-toolbar")).toBeVisible();
 
-    await categorySelect.click();
-    await page.getByRole("option", { name: "Code" }).click();
+    const categoryFilter = page.getByRole("group", {
+      name: "Filter changed files",
+    });
+    await expect(categoryFilter.getByRole("button", { name: "All" }))
+      .toHaveAttribute("aria-pressed", "true");
+
+    await categoryFilter.getByRole("button", { name: "Code" }).click();
 
     await expect(page.locator(".diff-file")).toHaveCount(3);
     await expect(page.locator(".diff-file-row")).toHaveCount(3);
@@ -377,10 +379,9 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-file-row", { hasText: "logo.png" }))
       .toHaveCount(0);
 
-    await page.getByRole("combobox", {
-      name: "Filter changed files: Code",
-    }).click();
-    await page.getByRole("option", { name: "All" }).click();
+    await expect(categoryFilter.getByRole("button", { name: "Code" }))
+      .toHaveAttribute("aria-pressed", "true");
+    await categoryFilter.getByRole("button", { name: "All" }).click();
 
     await expect(page.locator(".diff-file")).toHaveCount(4);
     await expect(page.locator(".diff-file-row")).toHaveCount(4);

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -27,6 +27,7 @@
   import GitHubLabels from "../shared/GitHubLabels.svelte";
   import DiffView from "../diff/DiffView.svelte";
   import DiffSidebar from "../diff/DiffSidebar.svelte";
+  import DiffToolbar from "../diff/DiffToolbar.svelte";
   import CIStatus from "./CIStatus.svelte";
   import DiffSummaryChip from "./DiffSummaryChip.svelte";
   import CopyItemNumber from "./CopyItemNumber.svelte";
@@ -512,12 +513,15 @@
         </div>
       {/if}
       {#if !hideTabs && activeTab === "files"}
-        <div class="files-layout">
-          <aside class="files-sidebar">
-            <DiffSidebar />
-          </aside>
-          <div class="files-main">
-            <DiffView {owner} {name} {number} />
+        <div class="files-view">
+          <DiffToolbar />
+          <div class="files-layout">
+            <aside class="files-sidebar">
+              <DiffSidebar />
+            </aside>
+            <div class="files-main">
+              <DiffView {owner} {name} {number} />
+            </div>
           </div>
         </div>
       {:else}
@@ -1108,6 +1112,14 @@
   .files-layout {
     display: flex;
     flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .files-view {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
     min-height: 0;
     overflow: hidden;
   }

--- a/packages/ui/src/components/detail/diff-summary.ts
+++ b/packages/ui/src/components/detail/diff-summary.ts
@@ -1,6 +1,11 @@
 import type { DiffFile } from "../../api/types.js";
+import {
+  categorizeDiffFile,
+  type DiffFileCategory,
+} from "../../utils/diff-categories.js";
 
-export type DiffSummaryCategory = "plansDocs" | "code" | "tests" | "other";
+export { categorizeDiffFile };
+export type DiffSummaryCategory = DiffFileCategory;
 
 export interface DiffLineTotals {
   additions: number;
@@ -30,111 +35,6 @@ export class DiffSummaryFilesResult {
 }
 
 const ZERO_TOTALS: DiffLineTotals = { additions: 0, deletions: 0 };
-
-const codeExtensions = new Set([
-  ".bash",
-  ".c",
-  ".cc",
-  ".cpp",
-  ".cs",
-  ".css",
-  ".go",
-  ".gql",
-  ".graphql",
-  ".h",
-  ".hpp",
-  ".html",
-  ".java",
-  ".js",
-  ".jsx",
-  ".kt",
-  ".kts",
-  ".less",
-  ".php",
-  ".py",
-  ".rb",
-  ".rs",
-  ".sass",
-  ".scss",
-  ".sh",
-  ".sql",
-  ".svelte",
-  ".swift",
-  ".ts",
-  ".tsx",
-  ".vue",
-  ".zsh",
-]);
-
-const docsExtensions = new Set([
-  ".adoc",
-  ".md",
-  ".mdx",
-  ".rst",
-  ".txt",
-]);
-
-const docsDirectoryNames = new Set(["doc", "docs", "documentation"]);
-
-function pathParts(path: string): string[] {
-  return path.toLowerCase().split(/[\\/]+/).filter(Boolean);
-}
-
-function basename(path: string): string {
-  const parts = pathParts(path);
-  return parts[parts.length - 1] ?? "";
-}
-
-function extension(path: string): string {
-  const base = basename(path);
-  const dot = base.lastIndexOf(".");
-  return dot >= 0 ? base.slice(dot) : "";
-}
-
-function hasTestSignal(parts: string[], base: string): boolean {
-  return (
-    parts.some((part) =>
-      part === "test" ||
-      part === "tests" ||
-      part === "__tests__" ||
-      part === "e2e" ||
-      part === "spec"
-    ) ||
-    base.includes(".test.") ||
-    base.includes(".spec.") ||
-    base.endsWith("_test.go") ||
-    base.endsWith("_test.py") ||
-    base.startsWith("test_") ||
-    base.endsWith(".snap")
-  );
-}
-
-function hasDocsSignal(parts: string[], base: string, ext: string): boolean {
-  return (
-    parts.some((part) => docsDirectoryNames.has(part)) ||
-    docsExtensions.has(ext) ||
-    [
-      "changelog",
-      "code_of_conduct",
-      "contributing",
-      "license",
-      "notice",
-      "readme",
-      "security",
-    ].some((name) => base === name || base.startsWith(`${name}.`))
-  );
-}
-
-export function categorizeDiffFile(path: string): DiffSummaryCategory {
-  const parts = pathParts(path);
-  const base = basename(path);
-  const ext = extension(path);
-
-  if (hasTestSignal(parts, base)) return "tests";
-  if (hasDocsSignal(parts, base, ext)) return "plansDocs";
-  if (codeExtensions.has(ext)) return "code";
-  return "other";
-}
 
 function emptySummary(): DiffLineSummary {
   return {

--- a/packages/ui/src/components/diff/DiffSidebar.svelte
+++ b/packages/ui/src/components/diff/DiffSidebar.svelte
@@ -65,10 +65,10 @@
     fileFilterText = "";
   });
   const showFileFilter = $derived(
-    (diff.getFileList()?.files.length ?? 0) >= 10,
+    (diff.getVisibleFileList()?.files.length ?? 0) >= 10,
   );
   const filteredDiffFiles = $derived.by(() => {
-    const list = diff.getFileList();
+    const list = diff.getVisibleFileList();
     if (!list) return null;
     // Only apply filter when the filter UI is visible to avoid
     // silent hiding when the next PR has fewer files.

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -1,15 +1,34 @@
 <script lang="ts">
   import { getStores } from "../../context.js";
+  import {
+    diffFileCategoryOptions,
+    type DiffFileCategoryFilter,
+  } from "../../utils/diff-categories.js";
+  import SelectDropdown from "../shared/SelectDropdown.svelte";
 
   const { diff } = getStores();
   const tabOptions = [1, 2, 4, 8] as const;
+
+  function setFileCategoryFilter(value: string): void {
+    diff.setFileCategoryFilter(value as DiffFileCategoryFilter);
+  }
 </script>
 
 <div class="diff-toolbar">
+  <div class="toolbar-group toolbar-group--category">
+    <span class="toolbar-label">Files</span>
+    <SelectDropdown
+      class="diff-category-select"
+      value={diff.getFileCategoryFilter()}
+      options={diffFileCategoryOptions}
+      onchange={setFileCategoryFilter}
+      title="Filter changed files"
+    />
+  </div>
   <div class="toolbar-group">
     <span class="toolbar-label">Tab width</span>
     <div class="segmented-control">
-      {#each tabOptions as opt}
+      {#each tabOptions as opt (opt)}
         <button
           class="segment"
           class:segment--active={diff.getTabWidth() === opt}
@@ -50,6 +69,10 @@
     display: flex;
     align-items: center;
     gap: 8px;
+  }
+
+  :global(.diff-category-select) {
+    min-width: 118px;
   }
 
   .toolbar-label {

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -7,6 +7,7 @@
 
   const { diff } = getStores();
   const tabOptions = [1, 2, 4, 8] as const;
+  const categoryCounts = $derived(diff.getFileCategoryCounts());
 
   function setFileCategoryFilter(value: DiffFileCategoryFilter): void {
     diff.setFileCategoryFilter(value);
@@ -24,7 +25,7 @@
           aria-pressed={diff.getFileCategoryFilter() === option.value}
           onclick={() => setFileCategoryFilter(option.value)}
         >
-          {option.label}
+          <span>{option.label}</span> <span class="category-count">({categoryCounts[option.value]})</span>
         </button>
       {/each}
     </div>
@@ -160,6 +161,11 @@
     background: var(--bg-surface);
     color: var(--text-primary);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+  .category-count {
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
   }
 
   .toggle-switch {

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -4,53 +4,59 @@
     diffFileCategoryOptions,
     type DiffFileCategoryFilter,
   } from "../../utils/diff-categories.js";
-  import SelectDropdown from "../shared/SelectDropdown.svelte";
 
   const { diff } = getStores();
   const tabOptions = [1, 2, 4, 8] as const;
 
-  function setFileCategoryFilter(value: string): void {
-    diff.setFileCategoryFilter(value as DiffFileCategoryFilter);
+  function setFileCategoryFilter(value: DiffFileCategoryFilter): void {
+    diff.setFileCategoryFilter(value);
   }
 </script>
 
 <div class="diff-toolbar">
   <div class="toolbar-group toolbar-group--category">
     <span class="toolbar-label">Files</span>
-    <SelectDropdown
-      class="diff-category-select"
-      value={diff.getFileCategoryFilter()}
-      options={diffFileCategoryOptions}
-      onchange={setFileCategoryFilter}
-      title="Filter changed files"
-    />
-  </div>
-  <div class="toolbar-group">
-    <span class="toolbar-label">Tab width</span>
-    <div class="segmented-control">
-      {#each tabOptions as opt (opt)}
+    <div class="category-toggle" role="group" aria-label="Filter changed files">
+      {#each diffFileCategoryOptions as option (option.value)}
         <button
-          class="segment"
-          class:segment--active={diff.getTabWidth() === opt}
-          onclick={() => diff.setTabWidth(opt)}
+          class="category-btn"
+          class:category-btn--active={diff.getFileCategoryFilter() === option.value}
+          aria-pressed={diff.getFileCategoryFilter() === option.value}
+          onclick={() => setFileCategoryFilter(option.value)}
         >
-          {opt}
+          {option.label}
         </button>
       {/each}
     </div>
   </div>
-  <div class="toolbar-group">
-    <span class="toolbar-label">Hide whitespace</span>
-    <button
-      class="toggle-switch"
-      class:toggle-switch--on={diff.getHideWhitespace()}
-      role="switch"
-      aria-checked={diff.getHideWhitespace()}
-      title={diff.getHideWhitespace() ? "Show whitespace changes" : "Hide whitespace changes"}
-      onclick={() => diff.setHideWhitespace(!diff.getHideWhitespace())}
-    >
-      <span class="toggle-knob"></span>
-    </button>
+  <div class="toolbar-settings">
+    <div class="toolbar-group">
+      <span class="toolbar-label">Tab width</span>
+      <div class="segmented-control">
+        {#each tabOptions as opt (opt)}
+          <button
+            class="segment"
+            class:segment--active={diff.getTabWidth() === opt}
+            onclick={() => diff.setTabWidth(opt)}
+          >
+            {opt}
+          </button>
+        {/each}
+      </div>
+    </div>
+    <div class="toolbar-group">
+      <span class="toolbar-label">Hide whitespace</span>
+      <button
+        class="toggle-switch"
+        class:toggle-switch--on={diff.getHideWhitespace()}
+        role="switch"
+        aria-checked={diff.getHideWhitespace()}
+        title={diff.getHideWhitespace() ? "Show whitespace changes" : "Hide whitespace changes"}
+        onclick={() => diff.setHideWhitespace(!diff.getHideWhitespace())}
+      >
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
   </div>
 </div>
 
@@ -58,7 +64,7 @@
   .diff-toolbar {
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 16px;
     padding: 6px 16px;
     background: var(--diff-toolbar-bg);
     border-bottom: 1px solid var(--diff-border);
@@ -71,8 +77,16 @@
     gap: 8px;
   }
 
-  :global(.diff-category-select) {
-    min-width: 118px;
+  .toolbar-group--category {
+    min-width: 0;
+  }
+
+  .toolbar-settings {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin-left: auto;
+    flex-shrink: 0;
   }
 
   .toolbar-label {
@@ -116,6 +130,38 @@
     background: var(--accent-blue);
   }
 
+  .category-toggle {
+    display: flex;
+    gap: 2px;
+    min-width: 0;
+    padding: 2px;
+    background: var(--bg-inset);
+    border-radius: 6px;
+  }
+
+  .category-btn {
+    min-width: 56px;
+    padding: 2px 8px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .category-btn:hover {
+    color: var(--text-primary);
+  }
+
+  .category-btn--active {
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
   .toggle-switch {
     position: relative;
     width: 36px;
@@ -146,4 +192,15 @@
     transform: translateX(16px);
   }
 
+  @media (max-width: 760px) {
+    .diff-toolbar {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .toolbar-settings {
+      margin-left: 0;
+      flex-wrap: wrap;
+    }
+  }
 </style>

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -1,0 +1,56 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import { STORES_KEY } from "../../context.js";
+import { createDiffStore } from "../../stores/diff.svelte.js";
+import DiffToolbar from "./DiffToolbar.svelte";
+
+function renderToolbar() {
+  const diff = createDiffStore();
+  render(DiffToolbar, {
+    context: new Map([[STORES_KEY, { diff }]]),
+  });
+  return { diff };
+}
+
+describe("DiffToolbar", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("defaults the changed file category filter to all and lists all categories last", async () => {
+    const { diff } = renderToolbar();
+
+    expect(diff.getFileCategoryFilter()).toBe("all");
+
+    const trigger = screen.getByRole("combobox", {
+      name: "Filter changed files: All",
+    });
+    expect(trigger.textContent).toContain("All");
+
+    await fireEvent.click(trigger);
+
+    const labels = within(screen.getByRole("listbox"))
+      .getAllByRole("option")
+      .map((option) => option.textContent?.trim());
+    expect(labels).toEqual([
+      "Plans/docs",
+      "Code",
+      "Tests",
+      "Other",
+      "All",
+    ]);
+
+    await fireEvent.click(
+      within(screen.getByRole("listbox"))
+        .getByRole("option", { name: "Code" }),
+    );
+
+    expect(diff.getFileCategoryFilter()).toBe("code");
+  });
+});

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -33,24 +33,24 @@ describe("DiffToolbar", () => {
       name: "Filter changed files",
     }))
       .getAllByRole("button")
-      .map((button) => button.textContent?.trim());
+      .map((button) => button.textContent?.replace(/\s+/g, " ").trim());
     expect(labels).toEqual([
-      "Plans/docs",
-      "Code",
-      "Tests",
-      "Other",
-      "All",
+      "Plans/docs (0)",
+      "Code (0)",
+      "Tests (0)",
+      "Other (0)",
+      "All (0)",
     ]);
 
-    expect(screen.getByRole("button", { name: "All" })
+    expect(screen.getByRole("button", { name: "All (0)" })
       .getAttribute("aria-pressed")).toBe("true");
 
     await fireEvent.click(
-      screen.getByRole("button", { name: "Code" }),
+      screen.getByRole("button", { name: "Code (0)" }),
     );
 
     expect(diff.getFileCategoryFilter()).toBe("code");
-    expect(screen.getByRole("button", { name: "Code" })
+    expect(screen.getByRole("button", { name: "Code (0)" })
       .getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -23,21 +23,17 @@ describe("DiffToolbar", () => {
     cleanup();
   });
 
-  it("defaults the changed file category filter to all and lists all categories last", async () => {
+  it("defaults the changed file category filter to all and renders category buttons", async () => {
     const { diff } = renderToolbar();
 
     expect(diff.getFileCategoryFilter()).toBe("all");
+    expect(screen.queryByRole("combobox")).toBeNull();
 
-    const trigger = screen.getByRole("combobox", {
-      name: "Filter changed files: All",
-    });
-    expect(trigger.textContent).toContain("All");
-
-    await fireEvent.click(trigger);
-
-    const labels = within(screen.getByRole("listbox"))
-      .getAllByRole("option")
-      .map((option) => option.textContent?.trim());
+    const labels = within(screen.getByRole("group", {
+      name: "Filter changed files",
+    }))
+      .getAllByRole("button")
+      .map((button) => button.textContent?.trim());
     expect(labels).toEqual([
       "Plans/docs",
       "Code",
@@ -46,11 +42,15 @@ describe("DiffToolbar", () => {
       "All",
     ]);
 
+    expect(screen.getByRole("button", { name: "All" })
+      .getAttribute("aria-pressed")).toBe("true");
+
     await fireEvent.click(
-      within(screen.getByRole("listbox"))
-        .getByRole("option", { name: "Code" }),
+      screen.getByRole("button", { name: "Code" }),
     );
 
     expect(diff.getFileCategoryFilter()).toBe("code");
+    expect(screen.getByRole("button", { name: "Code" })
+      .getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -3,7 +3,6 @@
   import { getStores } from "../../context.js";
 
   const { diff: diffStore } = getStores();
-  import DiffToolbar from "./DiffToolbar.svelte";
   import DiffFileComponent from "./DiffFile.svelte";
 
   interface Props {
@@ -136,7 +135,6 @@
       </div>
     {:else if diff}
       <div class="diff-main">
-        <DiffToolbar />
         <div
           class="diff-area"
           bind:this={diffArea}

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -27,6 +27,7 @@
   });
 
   const diff = $derived(diffStore.getDiff());
+  const visibleFiles = $derived(diffStore.getVisibleDiffFiles());
   const loading = $derived(diffStore.isDiffLoading());
   const error = $derived(diffStore.getDiffError());
   const tabWidth = $derived(diffStore.getTabWidth());
@@ -62,7 +63,7 @@
     const threshold = rect.top + 60;
 
     let current: string | null = null;
-    for (const file of diff.files) {
+    for (const file of visibleFiles) {
       const el = diffArea.querySelector(`[data-file-path="${CSS.escape(file.path)}"]`);
       if (!el) continue;
       const elRect = el.getBoundingClientRect();
@@ -82,9 +83,9 @@
     if ((e.target as HTMLElement).isContentEditable) return;
 
     if (e.key === "j" || e.key === "k") {
-      if (!diff || diff.files.length === 0) return;
+      if (!diff || visibleFiles.length === 0) return;
       e.preventDefault();
-      const paths = diff.files.map((f) => f.path);
+      const paths = visibleFiles.map((f) => f.path);
       const currentIdx = diffStore.getActiveFile() ? paths.indexOf(diffStore.getActiveFile()!) : -1;
       let nextIdx: number;
       if (e.key === "j") {
@@ -142,7 +143,12 @@
           onscroll={onDiffScroll}
           style:tab-size={tabWidth}
         >
-          {#each diff.files as file (file.path)}
+          {#if visibleFiles.length === 0}
+            <div class="diff-state diff-state--empty">
+              <p class="diff-state-msg">No changed files match this category.</p>
+            </div>
+          {/if}
+          {#each visibleFiles as file (file.path)}
             <DiffFileComponent
               {file}
               {owner}
@@ -199,6 +205,10 @@
     justify-content: center;
     gap: 8px;
     flex: 1;
+  }
+
+  .diff-state--empty {
+    min-height: 180px;
   }
 
   .diff-spinner {

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -6,6 +6,12 @@ import type {
 import { createAPIClient } from "../api/generated/client.js";
 import type { components } from "../api/generated/schema.js";
 import type { MiddlemanClient } from "../types.js";
+import {
+  countDiffFilesByCategory,
+  filterDiffFilesByCategory,
+  type DiffFileCategoryCounts,
+  type DiffFileCategoryFilter,
+} from "../utils/diff-categories.js";
 
 export type DiffScope =
   | { kind: "head" }
@@ -136,6 +142,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let activeFile = $state<string | null>(null);
   let scrollTarget = $state<string | null>(null);
   let scrolling = $state(false);
+  let fileCategoryFilter = $state<DiffFileCategoryFilter>("all");
   let commits = $state<CommitInfo[] | null>(null);
   let commitsLoading = $state(false);
   let commitsError = $state<string | null>(null);
@@ -169,6 +176,21 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     if (fileList) return { stale: fileList.stale, files: fileList.files ?? [] };
     return null;
   }
+  function getVisibleFileList(): FilesResult | null {
+    const list = getFileList();
+    if (!list) return null;
+    return {
+      stale: list.stale,
+      files: filterDiffFilesByCategory(list.files, fileCategoryFilter),
+    };
+  }
+  function getVisibleDiffFiles(): DiffResult["files"] {
+    if (!diff) return [];
+    return filterDiffFilesByCategory(diff.files ?? [], fileCategoryFilter);
+  }
+  function getFileCategoryCounts(): DiffFileCategoryCounts {
+    return countDiffFilesByCategory(getFileList()?.files ?? []);
+  }
   function isFileListLoading(): boolean {
     // Show loading until we have *some* file data. When /files fails
     // but /diff is still in flight, keep showing loading state.
@@ -179,6 +201,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
   function getHideWhitespace(): boolean {
     return hideWhitespace;
+  }
+  function getFileCategoryFilter(): DiffFileCategoryFilter {
+    return fileCategoryFilter;
   }
   function getActiveFile(): string | null {
     return activeFile;
@@ -201,6 +226,12 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
   function setActiveFile(path: string | null): void {
     activeFile = path;
+  }
+
+  function setFileCategoryFilter(nextFilter: DiffFileCategoryFilter): void {
+    fileCategoryFilter = nextFilter;
+    const visibleFiles = getVisibleFileList()?.files ?? getVisibleDiffFiles();
+    setActiveIfNeeded(visibleFiles);
   }
 
   function clearScrolling(): void {
@@ -268,7 +299,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       }
       const result = normalizeDiffResult(data);
       diff = result;
-      setActiveIfNeeded(result.files);
+      setActiveIfNeeded(getVisibleDiffFiles());
     } catch (err) {
       if (ac.signal.aborted) return;
       if (abortController !== ac) return;
@@ -344,6 +375,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentNumber = number;
     if (prChanged) {
       scope = { kind: "head" };
+      fileCategoryFilter = "all";
       commits = null;
       commitsLoading = false;
       commitsError = null;
@@ -375,7 +407,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         if (!data) return;
         const result = normalizeFilesResult(data);
         fileList = result;
-        setActiveIfNeeded(result.files);
+        setActiveIfNeeded(getVisibleFileList()?.files);
       } catch {
         if (filesAc.signal.aborted) return;
         if (fileListAbortController !== filesAc) return;
@@ -408,7 +440,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         }
         const result = normalizeDiffResult(data);
         diff = result;
-        setActiveIfNeeded(result.files);
+        setActiveIfNeeded(getVisibleDiffFiles());
       } catch (_err) {
         if (diffAc.signal.aborted) return;
         if (abortController !== diffAc) return;
@@ -446,6 +478,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     activeFile = null;
     scrollTarget = null;
     scrolling = false;
+    fileCategoryFilter = "all";
     commits = null;
     commitsLoading = false;
     commitsError = null;
@@ -573,11 +606,16 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     isDiffLoading,
     getDiffError,
     getFileList,
+    getVisibleFileList,
+    getVisibleDiffFiles,
+    getFileCategoryCounts,
     isFileListLoading,
     getTabWidth,
     getHideWhitespace,
+    getFileCategoryFilter,
     getActiveFile,
     setActiveFile,
+    setFileCategoryFilter,
     isScrolling,
     clearScrolling,
     requestScrollToFile,

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -2,6 +2,7 @@ import type { DiffFile } from "../api/types.js";
 
 export type DiffFileCategory = "plansDocs" | "code" | "tests" | "other";
 export type DiffFileCategoryFilter = DiffFileCategory | "all";
+export type DiffFileCategoryCounts = Record<DiffFileCategoryFilter, number>;
 
 export const diffFileCategoryOptions: {
   value: DiffFileCategoryFilter;
@@ -125,4 +126,20 @@ export function filterDiffFilesByCategory(
 ): DiffFile[] {
   if (filter === "all") return files;
   return files.filter((file) => categorizeDiffFile(file.path) === filter);
+}
+
+export function countDiffFilesByCategory(files: DiffFile[]): DiffFileCategoryCounts {
+  const counts: DiffFileCategoryCounts = {
+    plansDocs: 0,
+    code: 0,
+    tests: 0,
+    other: 0,
+    all: files.length,
+  };
+
+  for (const file of files) {
+    counts[categorizeDiffFile(file.path)] += 1;
+  }
+
+  return counts;
 }

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -1,0 +1,128 @@
+import type { DiffFile } from "../api/types.js";
+
+export type DiffFileCategory = "plansDocs" | "code" | "tests" | "other";
+export type DiffFileCategoryFilter = DiffFileCategory | "all";
+
+export const diffFileCategoryOptions: {
+  value: DiffFileCategoryFilter;
+  label: string;
+}[] = [
+  { value: "plansDocs", label: "Plans/docs" },
+  { value: "code", label: "Code" },
+  { value: "tests", label: "Tests" },
+  { value: "other", label: "Other" },
+  { value: "all", label: "All" },
+];
+
+const codeExtensions = new Set([
+  ".bash",
+  ".c",
+  ".cc",
+  ".cpp",
+  ".cs",
+  ".css",
+  ".go",
+  ".gql",
+  ".graphql",
+  ".h",
+  ".hpp",
+  ".html",
+  ".java",
+  ".js",
+  ".jsx",
+  ".kt",
+  ".kts",
+  ".less",
+  ".php",
+  ".py",
+  ".rb",
+  ".rs",
+  ".sass",
+  ".scss",
+  ".sh",
+  ".sql",
+  ".svelte",
+  ".swift",
+  ".ts",
+  ".tsx",
+  ".vue",
+  ".zsh",
+]);
+
+const docsExtensions = new Set([
+  ".adoc",
+  ".md",
+  ".mdx",
+  ".rst",
+  ".txt",
+]);
+
+const docsDirectoryNames = new Set(["doc", "docs", "documentation"]);
+
+function pathParts(path: string): string[] {
+  return path.toLowerCase().split(/[\\/]+/).filter(Boolean);
+}
+
+function basename(path: string): string {
+  const parts = pathParts(path);
+  return parts[parts.length - 1] ?? "";
+}
+
+function extension(path: string): string {
+  const base = basename(path);
+  const dot = base.lastIndexOf(".");
+  return dot >= 0 ? base.slice(dot) : "";
+}
+
+function hasTestSignal(parts: string[], base: string): boolean {
+  return (
+    parts.some((part) =>
+      part === "test" ||
+      part === "tests" ||
+      part === "__tests__" ||
+      part === "e2e" ||
+      part === "spec"
+    ) ||
+    base.includes(".test.") ||
+    base.includes(".spec.") ||
+    base.endsWith("_test.go") ||
+    base.endsWith("_test.py") ||
+    base.startsWith("test_") ||
+    base.endsWith(".snap")
+  );
+}
+
+function hasDocsSignal(parts: string[], base: string, ext: string): boolean {
+  return (
+    parts.some((part) => docsDirectoryNames.has(part)) ||
+    docsExtensions.has(ext) ||
+    [
+      "changelog",
+      "code_of_conduct",
+      "contributing",
+      "license",
+      "notice",
+      "readme",
+      "security",
+    ].some((name) => base === name || base.startsWith(`${name}.`))
+  );
+}
+
+export function categorizeDiffFile(path: string): DiffFileCategory {
+  const parts = pathParts(path);
+  const base = basename(path);
+  const ext = extension(path);
+
+  if (hasTestSignal(parts, base)) return "tests";
+  if (hasDocsSignal(parts, base, ext)) return "plansDocs";
+  if (codeExtensions.has(ext)) return "code";
+  return "other";
+}
+
+export function filterDiffFilesByCategory(
+  files: DiffFile[],
+  filter: DiffFileCategoryFilter,
+): DiffFile[] {
+  if (filter === "all") return files;
+  return files.filter((file) => categorizeDiffFile(file.path) === filter);
+}

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -7,6 +7,7 @@
   import PullDetail
     from "../components/detail/PullDetail.svelte";
   import DiffSidebar from "../components/diff/DiffSidebar.svelte";
+  import DiffToolbar from "../components/diff/DiffToolbar.svelte";
   import DiffView from "../components/diff/DiffView.svelte";
   import StackSidebar
     from "../components/detail/StackSidebar.svelte";
@@ -92,16 +93,19 @@
     </div>
     {#if detailTab === "files"}
       {#key `${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`}
-        <div class="files-layout">
-          <aside class="files-sidebar">
-            <DiffSidebar />
-          </aside>
-          <div class="files-main">
-            <DiffView
-              owner={selectedPR.owner}
-              name={selectedPR.name}
-              number={selectedPR.number}
-            />
+        <div class="files-view">
+          <DiffToolbar />
+          <div class="files-layout">
+            <aside class="files-sidebar">
+              <DiffSidebar />
+            </aside>
+            <div class="files-main">
+              <DiffView
+                owner={selectedPR.owner}
+                name={selectedPR.name}
+                number={selectedPR.number}
+              />
+            </div>
           </div>
         </div>
       {/key}
@@ -146,6 +150,14 @@
   .files-layout {
     display: flex;
     flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .files-view {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
     min-height: 0;
     overflow: hidden;
   }


### PR DESCRIPTION
## Summary
- Add a file category filter above the diff and file tree.
- Show per-category counts on the filter buttons.
- Keep tab width and whitespace settings aligned on the same toolbar.

![filtered-diff-category-counts.png](https://github.com/user-attachments/assets/a4f72baf-0af7-4745-8f95-fb3bf34af1f5)