### PR TITLE
Copy detail item links from numbers

### DIFF
--- a/frontend/tests/e2e-full/detail-number-copy.spec.ts
+++ b/frontend/tests/e2e-full/detail-number-copy.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("detail number link copy", () => {
+  test.skip(({ browserName }) => browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
+
+  test("copies the PR GitHub link from the detail number", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.goto("/pulls/acme/widgets/1");
+    await page.locator(".pull-detail")
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const numberButton = page.getByRole("button", { name: "Copy PR #1 link" });
+    await expect(numberButton).toHaveText("#1");
+    await numberButton.click();
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe("https://github.com/acme/widgets/pull/1");
+    await expect(numberButton).toHaveAttribute("title", "Copied!");
+  });
+
+  test("copies the issue GitHub link from the detail number", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.goto("/issues/acme/widgets/10");
+    await page.locator(".issue-detail")
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const numberButton = page.getByRole("button", { name: "Copy issue #10 link" });
+    await expect(numberButton).toHaveText("#10");
+    await numberButton.click();
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe("https://github.com/acme/widgets/issues/10");
+    await expect(numberButton).toHaveAttribute("title", "Copied!");
+  });
+});

--- a/packages/ui/src/components/detail/CopyItemNumber.svelte
+++ b/packages/ui/src/components/detail/CopyItemNumber.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { copyToClipboard } from "../../utils/clipboard.js";
+
+  interface Props {
+    kind: "pull" | "issue";
+    number: number;
+    url: string;
+  }
+
+  const { kind, number, url }: Props = $props();
+
+  let copied = $state(false);
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const itemLabel = $derived(kind === "pull" ? "PR" : "issue");
+
+  onDestroy(() => {
+    if (copyTimeout !== null) {
+      clearTimeout(copyTimeout);
+    }
+  });
+
+  function copyLink(): void {
+    if (!url) return;
+    void copyToClipboard(url).then((ok) => {
+      if (!ok) return;
+      copied = true;
+      if (copyTimeout !== null) {
+        clearTimeout(copyTimeout);
+      }
+      copyTimeout = setTimeout(() => {
+        copied = false;
+        copyTimeout = null;
+      }, 1500);
+    });
+  }
+</script>
+
+<button
+  type="button"
+  class="copy-number-btn"
+  class:copy-number-btn--copied={copied}
+  onclick={copyLink}
+  disabled={!url}
+  aria-label={`Copy ${itemLabel} #${number} link`}
+  title={copied ? "Copied!" : `Copy ${itemLabel} link`}
+>
+  #{number}
+</button>
+
+<style>
+  .copy-number-btn {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    line-height: inherit;
+    padding: 0;
+    transition: box-shadow 0.1s, color 0.1s;
+  }
+
+  .copy-number-btn:hover,
+  .copy-number-btn:focus-visible {
+    color: var(--text-primary);
+    box-shadow: inset 0 -1px 0 var(--text-muted);
+  }
+
+  .copy-number-btn:focus-visible {
+    outline: 1px solid var(--border-strong);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+
+  .copy-number-btn--copied {
+    color: var(--accent-green);
+  }
+
+  .copy-number-btn:disabled {
+    cursor: default;
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+</style>

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -13,6 +13,7 @@
   import ActionButton from "../shared/ActionButton.svelte";
   import Chip from "../shared/Chip.svelte";
   import GitHubLabels from "../shared/GitHubLabels.svelte";
+  import CopyItemNumber from "./CopyItemNumber.svelte";
 
   const { issues, activity } = getStores();
   const client = getClient();
@@ -404,7 +405,7 @@
       <div class="meta-row">
         <span class="meta-item">{detail.repo_owner}/{detail.repo_name}</span>
         <span class="meta-sep">·</span>
-        <span class="meta-item">#{issue.Number}</span>
+        <CopyItemNumber kind="issue" number={issue.Number} url={issue.URL} />
         <span class="meta-sep">·</span>
         <span class="meta-item">{issue.Author}</span>
         <span class="meta-sep">·</span>

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -29,6 +29,7 @@
   import DiffSidebar from "../diff/DiffSidebar.svelte";
   import CIStatus from "./CIStatus.svelte";
   import DiffSummaryChip from "./DiffSummaryChip.svelte";
+  import CopyItemNumber from "./CopyItemNumber.svelte";
   import { DiffSummaryFilesResult } from "./diff-summary.js";
   import { buildDiffSummaryKey } from "./diff-summary-key.js";
 
@@ -602,7 +603,7 @@
       <div class="meta-row">
         <span class="meta-item">{detail.repo_owner}/{detail.repo_name}</span>
         <span class="meta-sep">·</span>
-        <span class="meta-item">#{pr.Number}</span>
+        <CopyItemNumber kind="pull" number={pr.Number} url={pr.URL} />
         <span class="meta-sep">·</span>
         <span class="meta-item">{pr.Author}</span>
         <span class="meta-sep">·</span>


### PR DESCRIPTION
- Make PR and issue numbers in detail panes copy their GitHub URL.
- Keep numbers styled as regular metadata with a subtle hover/focus affordance.
- Add e2e coverage for copying PR and issue links from detail headers.

Closes #200