### PR TITLE
Add tag fallback for repos without GitHub releases

### DIFF
--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -62,7 +62,7 @@ describe("RepoImportModal", () => {
 
   it("hides private repositories and forks from preview selection", async () => {
     preview.mockResolvedValue({ owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" } });
+    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" }, agents: [] });
     render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -38,6 +38,7 @@ type Client interface {
 	GetUser(ctx context.Context, login string) (*gh.User, error)
 	ListRepositoriesByOwner(ctx context.Context, owner string) ([]*gh.Repository, error)
 	ListReleases(ctx context.Context, owner, repo string, perPage int) ([]*gh.RepositoryRelease, error)
+	ListTags(ctx context.Context, owner, repo string, perPage int) ([]*gh.RepositoryTag, error)
 	ListOpenIssues(ctx context.Context, owner, repo string) ([]*gh.Issue, error)
 	GetIssue(ctx context.Context, owner, repo string, number int) (*gh.Issue, error)
 	CreateIssue(ctx context.Context, owner, repo, title, body string) (*gh.Issue, error)
@@ -159,6 +160,22 @@ func (c *liveClient) ListReleases(
 		return nil, err
 	}
 	return releases, nil
+}
+
+func (c *liveClient) ListTags(
+	ctx context.Context, owner, repo string, perPage int,
+) ([]*gh.RepositoryTag, error) {
+	if perPage < 1 {
+		perPage = 1
+	}
+	tags, resp, err := c.gh.Repositories.ListTags(ctx, owner, repo, &gh.ListOptions{
+		PerPage: perPage,
+	})
+	c.trackRate(resp)
+	if err != nil {
+		return nil, err
+	}
+	return tags, nil
 }
 
 func (c *liveClient) CreateIssue(

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -90,6 +90,45 @@ func TestListReleasesTracksRate(t *testing.T) {
 	require.Equal(5000, rt.RateLimit())
 }
 
+func TestListTagsTracksRate(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	rt := NewRateTracker(database, "github.example.com", "rest")
+	resetAt := time.Now().Add(time.Hour).Unix()
+	var gotMethod string
+	var gotPerPage string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/acme/widgets/tags", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPerPage = r.URL.Query().Get("per_page")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4997")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt, 10))
+		_, _ = w.Write([]byte(`[{"name":"v1.0.0","commit":{"sha":"abcdef1234567890abcdef1234567890abcdef12"}}]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ghClient, err := gh.NewClient(srv.Client()).WithEnterpriseURLs(
+		srv.URL+"/api/v3/", srv.URL+"/api/uploads/",
+	)
+	require.NoError(err)
+	c := &liveClient{gh: ghClient, rateTracker: rt}
+
+	tags, err := c.ListTags(t.Context(), "acme", "widgets", 2)
+	require.NoError(err)
+	require.Len(tags, 1)
+	require.Equal(http.MethodGet, gotMethod)
+	require.Equal("2", gotPerPage)
+	require.Equal("v1.0.0", tags[0].GetName())
+	require.Equal("abcdef1234567890abcdef1234567890abcdef12", tags[0].GetCommit().GetSHA())
+	require.Equal(1, rt.RequestsThisHour())
+	require.Equal(4997, rt.Remaining())
+	require.Equal(5000, rt.RateLimit())
+}
+
 func TestListRepositoriesByOwnerUsesAuthenticatedEndpointForViewer(t *testing.T) {
 	require := require.New(t)
 	var paths []string

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1265,54 +1266,95 @@ func (s *Syncer) syncRepoOverview(
 		overview.LatestRelease = &overview.Releases[0]
 	}
 
-	if len(selectedReleases) > 0 && s.clones != nil && cloneFetchOK {
-		host := repo.PlatformHost
-		if host == "" {
-			host = "github.com"
-		}
-		latestRelease := selectedReleases[0]
-		count, _, countErr := s.clones.CommitTimelineSinceTag(
-			ctx, host, repo.Owner, repo.Name,
-			latestRelease.GetTagName(), 1,
-		)
-		if countErr != nil {
-			slog.Warn("count commits since latest release failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"tag", latestRelease.GetTagName(), "err", countErr,
-			)
-		} else {
-			overview.CommitsSinceRelease = &count
-		}
-
-		timelineRelease := selectedReleases[len(selectedReleases)-1]
-		_, points, err := s.clones.CommitTimelineSinceTag(
-			ctx, host, repo.Owner, repo.Name,
-			timelineRelease.GetTagName(), repoOverviewTimelineLimit,
-		)
+	var timelineTags []string
+	selectedTags := []*gh.RepositoryTag(nil)
+	if len(selectedReleases) == 0 {
+		tags, err := client.ListTags(ctx, repo.Owner, repo.Name, 3)
 		if err != nil {
-			slog.Warn("build repo commit timeline failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"tag", timelineRelease.GetTagName(), "err", err,
+			slog.Warn("list repo tags failed",
+				"repo", repo.Owner+"/"+repo.Name, "err", err,
 			)
-		} else {
-			overview.CommitTimeline = make([]db.RepoCommitTimelinePoint, 0, len(points))
-			for _, point := range points {
-				overview.CommitTimeline = append(overview.CommitTimeline, db.RepoCommitTimelinePoint{
-					SHA:         point.SHA,
-					Message:     point.Message,
-					CommittedAt: point.CommittedAt.UTC(),
-				})
-			}
-			now := time.Now().UTC()
-			overview.TimelineUpdatedAt = &now
+			return
+		}
+		selectedTags = displayTags(tags, 3)
+		for _, tag := range selectedTags {
+			overview.Releases = append(overview.Releases, repoReleaseFromTag(
+				repo.PlatformHost,
+				repo.Owner,
+				repo.Name,
+				tag,
+			))
+		}
+		if len(overview.Releases) > 0 {
+			overview.LatestRelease = &overview.Releases[0]
+		}
+		for _, tag := range selectedTags {
+			timelineTags = append(timelineTags, tag.GetName())
+		}
+	} else {
+		for _, release := range selectedReleases {
+			timelineTags = append(timelineTags, release.GetTagName())
 		}
 	}
+
+	s.addRepoOverviewTimeline(ctx, repo, cloneFetchOK, timelineTags, &overview)
 
 	if err := s.db.UpsertRepoOverview(ctx, repoID, overview); err != nil {
 		slog.Warn("store repo overview failed",
 			"repo", repo.Owner+"/"+repo.Name, "err", err,
 		)
 	}
+}
+
+func (s *Syncer) addRepoOverviewTimeline(
+	ctx context.Context,
+	repo RepoRef,
+	cloneFetchOK bool,
+	tags []string,
+	overview *db.RepoOverview,
+) {
+	if len(tags) == 0 || s.clones == nil || !cloneFetchOK {
+		return
+	}
+	host := repo.PlatformHost
+	if host == "" {
+		host = "github.com"
+	}
+	latestTag := tags[0]
+	count, _, countErr := s.clones.CommitTimelineSinceTag(
+		ctx, host, repo.Owner, repo.Name, latestTag, 1,
+	)
+	if countErr != nil {
+		slog.Warn("count commits since latest version failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"tag", latestTag, "err", countErr,
+		)
+	} else {
+		overview.CommitsSinceRelease = &count
+	}
+
+	timelineTag := tags[len(tags)-1]
+	_, points, err := s.clones.CommitTimelineSinceTag(
+		ctx, host, repo.Owner, repo.Name,
+		timelineTag, repoOverviewTimelineLimit,
+	)
+	if err != nil {
+		slog.Warn("build repo commit timeline failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"tag", timelineTag, "err", err,
+		)
+		return
+	}
+	overview.CommitTimeline = make([]db.RepoCommitTimelinePoint, 0, len(points))
+	for _, point := range points {
+		overview.CommitTimeline = append(overview.CommitTimeline, db.RepoCommitTimelinePoint{
+			SHA:         point.SHA,
+			Message:     point.Message,
+			CommittedAt: point.CommittedAt.UTC(),
+		})
+	}
+	now := time.Now().UTC()
+	overview.TimelineUpdatedAt = &now
 }
 
 func displayReleases(
@@ -1335,6 +1377,26 @@ func displayReleases(
 	return out
 }
 
+func displayTags(
+	tags []*gh.RepositoryTag,
+	limit int,
+) []*gh.RepositoryTag {
+	if limit < 1 {
+		limit = 1
+	}
+	out := make([]*gh.RepositoryTag, 0, limit)
+	for _, tag := range tags {
+		if tag == nil || tag.GetName() == "" {
+			continue
+		}
+		out = append(out, tag)
+		if len(out) == limit {
+			return out
+		}
+	}
+	return out
+}
+
 func repoReleaseFromGitHub(release *gh.RepositoryRelease) db.RepoRelease {
 	out := db.RepoRelease{
 		TagName:         release.GetTagName(),
@@ -1349,6 +1411,20 @@ func repoReleaseFromGitHub(release *gh.RepositoryRelease) db.RepoRelease {
 		out.PublishedAt = &publishedAt
 	}
 	return out
+}
+
+func repoReleaseFromTag(platformHost, owner, repo string, tag *gh.RepositoryTag) db.RepoRelease {
+	host := platformHost
+	if host == "" {
+		host = "github.com"
+	}
+	tagName := tag.GetName()
+	return db.RepoRelease{
+		TagName:         tagName,
+		Name:            tagName,
+		URL:             "https://" + host + "/" + owner + "/" + repo + "/tree/" + url.PathEscape(tagName),
+		TargetCommitish: tag.GetCommit().GetSHA(),
+	}
 }
 
 // indexSyncRepo performs the cheap index scan: list endpoints only,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1274,22 +1274,22 @@ func (s *Syncer) syncRepoOverview(
 			slog.Warn("list repo tags failed",
 				"repo", repo.Owner+"/"+repo.Name, "err", err,
 			)
-			return
-		}
-		selectedTags = displayTags(tags, 3)
-		for _, tag := range selectedTags {
-			overview.Releases = append(overview.Releases, repoReleaseFromTag(
-				repo.PlatformHost,
-				repo.Owner,
-				repo.Name,
-				tag,
-			))
-		}
-		if len(overview.Releases) > 0 {
-			overview.LatestRelease = &overview.Releases[0]
-		}
-		for _, tag := range selectedTags {
-			timelineTags = append(timelineTags, tag.GetName())
+		} else {
+			selectedTags = displayTags(tags, 3)
+			for _, tag := range selectedTags {
+				overview.Releases = append(overview.Releases, repoReleaseFromTag(
+					repo.PlatformHost,
+					repo.Owner,
+					repo.Name,
+					tag,
+				))
+			}
+			if len(overview.Releases) > 0 {
+				overview.LatestRelease = &overview.Releases[0]
+			}
+			for _, tag := range selectedTags {
+				timelineTags = append(timelineTags, tag.GetName())
+			}
 		}
 	} else {
 		for _, release := range selectedReleases {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -634,6 +634,71 @@ func TestSyncRepoOverviewUsesTagsWhenRepoHasNoReleases(t *testing.T) {
 	assert.False(overview.LatestRelease.Prerelease)
 }
 
+func TestSyncRepoOverviewClearsReleasesWhenTagFallbackFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	publishedAt := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	commitsSince := 9
+	err = d.UpsertRepoOverview(ctx, repoID, db.RepoOverview{
+		LatestRelease: &db.RepoRelease{
+			TagName:     "v1.0.0",
+			Name:        "Version 1.0.0",
+			URL:         "https://github.com/owner/repo/releases/tag/v1.0.0",
+			PublishedAt: &publishedAt,
+		},
+		Releases: []db.RepoRelease{{
+			TagName:     "v1.0.0",
+			Name:        "Version 1.0.0",
+			URL:         "https://github.com/owner/repo/releases/tag/v1.0.0",
+			PublishedAt: &publishedAt,
+		}},
+		CommitsSinceRelease: &commitsSince,
+		CommitTimeline: []db.RepoCommitTimelinePoint{{
+			SHA:         "abc123",
+			Message:     "Old release timeline",
+			CommittedAt: time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC),
+		}},
+	})
+	require.NoError(err)
+
+	client := &mockClient{
+		listReleases: []*gh.RepositoryRelease{},
+		listTagsErr:  errors.New("tags unavailable"),
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		d,
+		nil,
+		nil,
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	syncer.syncRepoOverview(
+		ctx,
+		client,
+		RepoRef{PlatformHost: "github.com", Owner: "owner", Name: "repo"},
+		repoID,
+		false,
+	)
+
+	summaries, err := d.ListRepoSummaries(ctx)
+	require.NoError(err)
+	require.Len(summaries, 1)
+	overview := summaries[0].Overview
+
+	assert.Nil(overview.LatestRelease)
+	assert.Empty(overview.Releases)
+	assert.Nil(overview.CommitsSinceRelease)
+	assert.Empty(overview.CommitTimeline)
+}
+
 func TestSyncStoresForcePushEvent(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -58,6 +58,9 @@ type mockClient struct {
 	listReleases                    []*gh.RepositoryRelease
 	listReleasesErr                 error
 	listReleasesFn                  func(context.Context, string, string, int) ([]*gh.RepositoryRelease, error)
+	listTags                        []*gh.RepositoryTag
+	listTagsErr                     error
+	listTagsFn                      func(context.Context, string, string, int) ([]*gh.RepositoryTag, error)
 	listOpenPRsFn                   func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listPullRequestsPageFn          func(context.Context, string, string, string, int) ([]*gh.PullRequest, bool, error)
 	listIssuesPageFn                func(context.Context, string, string, string, int) ([]*gh.Issue, bool, error)
@@ -162,6 +165,19 @@ func (m *mockClient) ListReleases(
 		return nil, m.listReleasesErr
 	}
 	return m.listReleases, nil
+}
+
+func (m *mockClient) ListTags(
+	ctx context.Context, owner, repo string, perPage int,
+) ([]*gh.RepositoryTag, error) {
+	m.trackCall()
+	if m.listTagsFn != nil {
+		return m.listTagsFn(ctx, owner, repo, perPage)
+	}
+	if m.listTagsErr != nil {
+		return nil, m.listTagsErr
+	}
+	return m.listTags, nil
 }
 
 func (m *mockClient) GetPullRequest(
@@ -564,6 +580,58 @@ func TestSyncRepoOverviewPreservesTimelineWhenCloneUnavailable(t *testing.T) {
 	assert.Equal("abc123", overview.CommitTimeline[0].SHA)
 	assert.Equal("Keep cached timeline", overview.CommitTimeline[0].Message)
 	assert.Equal(oldTimelineUpdatedAt, *overview.TimelineUpdatedAt)
+}
+
+func TestSyncRepoOverviewUsesTagsWhenRepoHasNoReleases(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	tagName := "v1.2.3"
+	sha := "abcdef1234567890abcdef1234567890abcdef12"
+	client := &mockClient{
+		listReleases: []*gh.RepositoryRelease{},
+		listTags: []*gh.RepositoryTag{{
+			Name: &tagName,
+			Commit: &gh.Commit{
+				SHA: &sha,
+			},
+		}},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		d,
+		nil,
+		nil,
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	syncer.syncRepoOverview(
+		ctx,
+		client,
+		RepoRef{PlatformHost: "github.com", Owner: "owner", Name: "repo"},
+		repoID,
+		false,
+	)
+
+	summaries, err := d.ListRepoSummaries(ctx)
+	require.NoError(err)
+	require.Len(summaries, 1)
+	overview := summaries[0].Overview
+	require.NotNil(overview.LatestRelease)
+	require.Len(overview.Releases, 1)
+
+	assert.Equal("v1.2.3", overview.LatestRelease.TagName)
+	assert.Equal("v1.2.3", overview.LatestRelease.Name)
+	assert.Equal("https://github.com/owner/repo/tree/v1.2.3", overview.LatestRelease.URL)
+	assert.Equal(sha, overview.LatestRelease.TargetCommitish)
+	assert.Nil(overview.LatestRelease.PublishedAt)
+	assert.False(overview.LatestRelease.Prerelease)
 }
 
 func TestSyncStoresForcePushEvent(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2444,6 +2444,97 @@ func TestAPIListRepoSummariesUsesTagsWhenNoReleases(t *testing.T) {
 	assert.Empty(*tagged.CommitTimeline)
 }
 
+func TestAPIListRepoSummariesClearsStaleOverviewWhenTagFallbackFails(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+
+	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "tagless")
+	require.NoError(err)
+
+	publishedAt := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	timelineUpdatedAt := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	commitsSince := 9
+	err = database.UpsertRepoOverview(ctx, repoID, db.RepoOverview{
+		LatestRelease: &db.RepoRelease{
+			TagName:     "v1.0.0",
+			Name:        "Version 1.0.0",
+			URL:         "https://github.com/acme/tagless/releases/tag/v1.0.0",
+			PublishedAt: &publishedAt,
+		},
+		Releases: []db.RepoRelease{{
+			TagName:     "v1.0.0",
+			Name:        "Version 1.0.0",
+			URL:         "https://github.com/acme/tagless/releases/tag/v1.0.0",
+			PublishedAt: &publishedAt,
+		}},
+		CommitsSinceRelease: &commitsSince,
+		CommitTimeline: []db.RepoCommitTimelinePoint{{
+			SHA:         "abc123",
+			Message:     "Old release timeline",
+			CommittedAt: time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC),
+		}},
+		TimelineUpdatedAt: &timelineUpdatedAt,
+	})
+	require.NoError(err)
+
+	mock := &mockGH{
+		listReleasesFn: func(
+			_ context.Context, owner, repo string, perPage int,
+		) ([]*gh.RepositoryRelease, error) {
+			assert.Equal("acme", owner)
+			assert.Equal("tagless", repo)
+			assert.Equal(10, perPage)
+			return []*gh.RepositoryRelease{}, nil
+		},
+		listTagsFn: func(
+			_ context.Context, owner, repo string, perPage int,
+		) ([]*gh.RepositoryTag, error) {
+			assert.Equal("acme", owner)
+			assert.Equal("tagless", repo)
+			assert.Equal(3, perPage)
+			return nil, errors.New("tags unavailable")
+		},
+	}
+	repos := []ghclient.RepoRef{{
+		Owner: "acme", Name: "tagless", PlatformHost: "github.com",
+	}}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, repos, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	syncer.RunOnce(ctx)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.ListRepoSummariesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+
+	tagless := (*resp.JSON200)[0]
+	require.NotNil(tagless.Releases)
+	require.NotNil(tagless.CommitTimeline)
+
+	assert.Equal("acme", tagless.Owner)
+	assert.Equal("tagless", tagless.Name)
+	assert.Nil(tagless.LatestRelease)
+	assert.Empty(*tagless.Releases)
+	assert.Nil(tagless.CommitsSinceRelease)
+	assert.Empty(*tagless.CommitTimeline)
+	assert.Nil(tagless.TimelineUpdatedAt)
+}
+
 func TestAPICreateIssue(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -80,6 +80,7 @@ type mockGH struct {
 	approveWorkflowRunFn      func(context.Context, string, string, int64) error
 	listReposByOwnerFn        func(context.Context, string) ([]*gh.Repository, error)
 	listReleasesFn            func(context.Context, string, string, int) ([]*gh.RepositoryRelease, error)
+	listTagsFn                func(context.Context, string, string, int) ([]*gh.RepositoryTag, error)
 	listOpenPullRequestsFn    func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listCheckRunsForRefFn     func(context.Context, string, string, string) ([]*gh.CheckRun, error)
 	getCombinedStatusFn       func(context.Context, string, string, string) (*gh.CombinedStatus, error)
@@ -157,6 +158,15 @@ func (m *mockGH) ListReleases(
 ) ([]*gh.RepositoryRelease, error) {
 	if m.listReleasesFn != nil {
 		return m.listReleasesFn(ctx, owner, repo, perPage)
+	}
+	return nil, nil
+}
+
+func (m *mockGH) ListTags(
+	ctx context.Context, owner, repo string, perPage int,
+) ([]*gh.RepositoryTag, error) {
+	if m.listTagsFn != nil {
+		return m.listTagsFn(ctx, owner, repo, perPage)
 	}
 	return nil, nil
 }
@@ -2360,6 +2370,78 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	assert.Equal("post latest 2", (*widgets.CommitTimeline)[0].Message)
 	assert.Equal("post latest 1", (*widgets.CommitTimeline)[1].Message)
 	assert.Len((*widgets.CommitTimeline)[0].Sha, 40)
+}
+
+func TestAPIListRepoSummariesUsesTagsWhenNoReleases(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+
+	tagName := "v0.5.0"
+	sha := "1234567890abcdef1234567890abcdef12345678"
+	mock := &mockGH{
+		listReleasesFn: func(
+			_ context.Context, owner, repo string, perPage int,
+		) ([]*gh.RepositoryRelease, error) {
+			assert.Equal("acme", owner)
+			assert.Equal("tagged", repo)
+			assert.Equal(10, perPage)
+			return nil, nil
+		},
+		listTagsFn: func(
+			_ context.Context, owner, repo string, perPage int,
+		) ([]*gh.RepositoryTag, error) {
+			assert.Equal("acme", owner)
+			assert.Equal("tagged", repo)
+			assert.Equal(3, perPage)
+			return []*gh.RepositoryTag{{
+				Name: &tagName,
+				Commit: &gh.Commit{
+					SHA: &sha,
+				},
+			}}, nil
+		},
+	}
+	repos := []ghclient.RepoRef{{
+		Owner: "acme", Name: "tagged", PlatformHost: "github.com",
+	}}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, repos, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	syncer.RunOnce(ctx)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.ListRepoSummariesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+
+	tagged := (*resp.JSON200)[0]
+	require.NotNil(tagged.LatestRelease)
+	require.NotNil(tagged.Releases)
+
+	assert.Equal("v0.5.0", tagged.LatestRelease.TagName)
+	assert.Equal("v0.5.0", tagged.LatestRelease.Name)
+	assert.Equal("https://github.com/acme/tagged/tree/v0.5.0", tagged.LatestRelease.Url)
+	assert.Equal(sha, tagged.LatestRelease.TargetCommitish)
+	assert.Nil(tagged.LatestRelease.PublishedAt)
+	assert.False(tagged.LatestRelease.Prerelease)
+	assert.Len(*tagged.Releases, 1)
+	assert.Equal("v0.5.0", (*tagged.Releases)[0].TagName)
+	assert.Nil(tagged.CommitsSinceRelease)
+	assert.Empty(*tagged.CommitTimeline)
 }
 
 func TestAPICreateIssue(t *testing.T) {

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -32,6 +32,7 @@ type FixtureClient struct {
 	Comments                  map[string][]*gh.IssueComment
 	ReposByOwner              map[string][]*gh.Repository
 	Releases                  map[string][]*gh.RepositoryRelease
+	Tags                      map[string][]*gh.RepositoryTag
 	CombinedStatuses          map[string]*gh.CombinedStatus
 	CheckRuns                 map[string][]*gh.CheckRun
 	ListRepositoriesByOwnerFn func(context.Context, string) ([]*gh.Repository, error)
@@ -49,6 +50,7 @@ func NewFixtureClient() ghclient.Client {
 		Comments:         make(map[string][]*gh.IssueComment),
 		ReposByOwner:     make(map[string][]*gh.Repository),
 		Releases:         make(map[string][]*gh.RepositoryRelease),
+		Tags:             make(map[string][]*gh.RepositoryTag),
 		CombinedStatuses: make(map[string]*gh.CombinedStatus),
 		CheckRuns:        make(map[string][]*gh.CheckRun),
 		nextID:           10_000,
@@ -113,6 +115,21 @@ func (c *FixtureClient) ListReleases(
 	}
 	out := make([]*gh.RepositoryRelease, len(releases))
 	copy(out, releases)
+	return out, nil
+}
+
+func (c *FixtureClient) ListTags(
+	_ context.Context, owner, repo string, perPage int,
+) ([]*gh.RepositoryTag, error) {
+	tags := c.Tags[repoKey(owner, repo)]
+	if len(tags) == 0 {
+		return nil, nil
+	}
+	if perPage > 0 && perPage < len(tags) {
+		tags = tags[:perPage]
+	}
+	out := make([]*gh.RepositoryTag, len(tags))
+	copy(out, tags)
 	return out, nil
 }
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -669,6 +669,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 				OpenIssues: openIssues,
 				Issues:     allIssues,
 				Comments:   make(map[string][]*gh.IssueComment),
+				Tags:       make(map[string][]*gh.RepositoryTag),
 				CombinedStatuses: map[string]*gh.CombinedStatus{
 					refKey("acme", "widgets", widgetsPR1HeadSHA): {
 						State: new("success"),


### PR DESCRIPTION
## Summary
- Add GitHub tag listing to the sync client and repository overview pipeline
- Use tags as release/version proxies when a repo has no displayable releases
- Keep overview data and timeline behavior consistent for the repo page, with regression coverage for both the happy path and tag-fallback failure path

## Testing
- `make test` passed
- Repository-summary API coverage verifies the new tag-backed overview data