### PR TITLE
Add GitHub link icon to repository summary cards

### DIFF
--- a/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ActionButton, Chip } from "@middleman/ui";
   import { timeAgo } from "@middleman/ui/utils/time";
+  import { ExternalLinkIcon } from "../../icons.js";
   import RepoMetricGrid from "./RepoMetricGrid.svelte";
   import {
     displayReleaseName,
@@ -39,6 +40,9 @@
 
   const key = $derived(repoKey(summary));
   const stateKey = $derived(repoStateKey(summary));
+  const repoURL = $derived(
+    `https://${summary.platform_host || "github.com"}/${summary.owner}/${summary.name}`,
+  );
   const syncTime = $derived(
     summary.last_sync_completed_at
       || summary.last_sync_started_at,
@@ -184,6 +188,20 @@
           <span class="repo-card__slash">/</span>
           <span>{summary.name}</span>
         </button>
+        <a
+          class="repo-card__gh-link"
+          href={repoURL}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Open on GitHub"
+          aria-label={`Open ${summary.owner}/${summary.name} on GitHub`}
+        >
+          <ExternalLinkIcon
+            size="14"
+            strokeWidth="2"
+            aria-hidden="true"
+          />
+        </a>
       </div>
       <Chip size="sm" class="chip--muted" uppercase={false}>
         {summary.platform_host}
@@ -382,6 +400,19 @@
 
   .repo-card__name:hover {
     color: var(--accent-blue);
+  }
+
+  .repo-card__gh-link {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    color: var(--text-muted);
+    transition: color 0.1s;
+  }
+
+  .repo-card__gh-link:hover {
+    color: var(--accent-blue);
+    text-decoration: none;
   }
 
   .repo-card__slash {

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -152,6 +152,13 @@ describe("RepoSummaryPage", () => {
         name: /acme\s*\/\s*widgets/,
       }),
     ).toBeTruthy();
+    const repoLink = screen.getByRole("link", {
+      name: "Open acme/widgets on GitHub",
+    });
+    expect(repoLink.getAttribute("href")).toBe(
+      "https://github.com/acme/widgets",
+    );
+    expect(repoLink.getAttribute("target")).toBe("_blank");
     expect(screen.getAllByText("Open PRs").length).toBeGreaterThan(1);
     expect(screen.getByText("v2.8.1")).toBeTruthy();
     expect(screen.getByText("8 commits")).toBeTruthy();

--- a/frontend/src/lib/icons.test.ts
+++ b/frontend/src/lib/icons.test.ts
@@ -6,6 +6,7 @@ import * as icons from "./icons.ts";
 const approvedIconNames = [
   "AlertIcon",
   "ChevronDownIcon",
+  "ExternalLinkIcon",
   "MergeConflictIcon",
   "MoonIcon",
   "RefreshIcon",

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -1,5 +1,6 @@
 export { default as AlertIcon } from "@lucide/svelte/icons/alert-triangle";
 export { default as ChevronDownIcon } from "@lucide/svelte/icons/chevron-down";
+export { default as ExternalLinkIcon } from "@lucide/svelte/icons/external-link";
 export { default as MergeConflictIcon } from "@lucide/svelte/icons/git-merge";
 export { default as MoonIcon } from "@lucide/svelte/icons/moon";
 export { default as RefreshIcon } from "@lucide/svelte/icons/refresh-ccw";

--- a/frontend/tests/e2e-full/repo-summaries.spec.ts
+++ b/frontend/tests/e2e-full/repo-summaries.spec.ts
@@ -17,6 +17,11 @@ test.describe("repository summaries", () => {
     await expect(page.getByText("Total repos")).toBeVisible();
     await expect(widgetsCard).toContainText("Open PRs");
     await expect(widgetsCard).toContainText("Recent open issues");
+    await expect(
+      widgetsCard.getByRole("link", {
+        name: "Open acme/widgets on GitHub",
+      }),
+    ).toHaveAttribute("href", "https://github.com/acme/widgets");
 
     await expect(
       widgetsCard.getByRole("button", { name: "View PRs" }),


### PR DESCRIPTION
## Summary
- Add an external-link icon to repository summary cards so each repo can open directly on GitHub
- Use the cached platform host when building the repo URL, which keeps GitHub Enterprise repos pointed at the correct host
- Cover the new affordance in both component and e2e regression tests

## Testing
- Component test updated to assert the repo link href and accessible name
- Playwright repo summaries flow updated to verify the link in the rendered page
- Local Svelte check and focused frontend/e2e tests passed