### PR TITLE
Fix automatic cleanup for exited runtime sessions

### DIFF
--- a/docs/superpowers/plans/2026-04-29-runtime-session-auto-close.md
+++ b/docs/superpowers/plans/2026-04-29-runtime-session-auto-close.md
@@ -1,0 +1,118 @@
+# Runtime Session Auto-Close Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically close launched workspace agent and shell surfaces when their backing process exits, while cleaning persisted tmux runtime rows.
+
+**Architecture:** The runtime manager owns process lifecycle cleanup and removes naturally exited sessions from active maps. The server receives tmux-backed exit callbacks and forgets stored tmux rows. The Svelte workspace view reacts immediately to terminal exit events by unmounting closed panes and returning to Home.
+
+**Tech Stack:** Go, Huma, SQLite, tmux, Svelte 5, Bun, Playwright/component tests.
+
+---
+
+### Task 1: Runtime Manager Cleanup
+
+**Files:**
+- Modify: `internal/workspace/localruntime/types.go`
+- Modify: `internal/workspace/localruntime/manager.go`
+- Test: `internal/workspace/localruntime/manager_test.go`
+
+- [ ] **Step 1: Write failing manager tests**
+
+Add tests that launch the helper `exit` target and assert `ListSessions("ws-1")` becomes empty after natural exit. Add a shell equivalent that asserts `ShellSession("ws-1")` becomes nil after natural shell exit.
+
+- [ ] **Step 2: Run manager tests to verify failure**
+
+Run: `go test ./internal/workspace/localruntime -run 'TestManagerRemovesNaturallyExited(Session|Shell)' -shuffle=on`
+
+Expected: tests fail because exited sessions remain in manager maps.
+
+- [ ] **Step 3: Implement manager cleanup**
+
+Add an `OnSessionExit func(SessionInfo)` option. Store it in `Manager`. Start watcher goroutines through manager methods that call `session.watch()`, remove the exact session pointer from `sessions` or `shells`, then invoke `OnSessionExit` for natural exits. Do not invoke it from shutdown detach.
+
+- [ ] **Step 4: Run manager tests to verify pass**
+
+Run: `go test ./internal/workspace/localruntime -run 'TestManagerRemovesNaturallyExited(Session|Shell)' -shuffle=on`
+
+Expected: tests pass.
+
+### Task 2: Server Tmux Row Cleanup
+
+**Files:**
+- Modify: `internal/server/server.go`
+- Test: `internal/server/api_test.go`
+
+- [ ] **Step 1: Write failing API tests**
+
+Add one E2E test for non-tmux natural agent exit returning no runtime sessions. Add one tmux-backed E2E test that launches a short-lived helper target, waits for runtime sessions to empty, and asserts `ListWorkspaceTmuxSessions` returns no rows.
+
+- [ ] **Step 2: Run focused API tests to verify failure**
+
+Run: `go test ./internal/server -run 'TestWorkspaceRuntimeNatural.*Exit' -shuffle=on`
+
+Expected: tests fail because runtime sessions or stored tmux rows remain.
+
+- [ ] **Step 3: Wire server callback**
+
+Pass `OnSessionExit` into `localruntime.NewManager`. If `info.TmuxSession` is non-empty and `s.workspaces` is configured, call `ForgetRuntimeTmuxSession` under a bounded background context and log any error.
+
+- [ ] **Step 4: Run focused API tests to verify pass**
+
+Run: `go test ./internal/server -run 'TestWorkspaceRuntimeNatural.*Exit' -shuffle=on`
+
+Expected: tests pass.
+
+### Task 3: Workspace UI Auto-Close
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte`
+- Modify: `frontend/src/lib/components/terminal/ShellDrawer.svelte`
+- Test: `frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts` or nearest existing component test file
+
+- [ ] **Step 1: Write failing frontend tests**
+
+Add component tests proving agent session exit removes the tab and selects Home, and shell exit calls the parent close/refresh behavior.
+
+- [ ] **Step 2: Run frontend tests to verify failure**
+
+Run: `bun test frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts`
+
+Expected: tests fail because agent exit only refetches runtime and shell exit does not close the drawer.
+
+- [ ] **Step 3: Implement Svelte exit handlers**
+
+Add `handleSessionExit(sessionKey, id)` in `WorkspaceTerminalView.svelte`. It should ignore stale workspace ids, unmount the session terminal, select Home if active, remember Home for that workspace, and refresh runtime. Add `handleShellExit(id)` that closes `shellOpen`, clears loading, and refreshes runtime.
+
+- [ ] **Step 4: Validate Svelte code**
+
+Run: `npx @sveltejs/mcp@0.1.22 svelte-autofixer frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte --svelte-version 5`
+
+Expected: no required fixes.
+
+### Task 4: Final Verification
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run focused backend tests**
+
+Run: `go test ./internal/workspace/localruntime ./internal/server -run 'TestManagerRemovesNaturallyExited|TestWorkspaceRuntimeNatural.*Exit' -shuffle=on`
+
+Expected: pass.
+
+- [ ] **Step 2: Run focused frontend tests**
+
+Run: `bun test frontend/src/lib/components/terminal/TerminalPane.test.ts frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts`
+
+Expected: pass.
+
+- [ ] **Step 3: Run broader applicable tests**
+
+Run: `make test-short`
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+Commit with a conventional message explaining that exited runtime sessions now close automatically and clean up tmux state.

--- a/docs/superpowers/specs/2026-04-29-runtime-session-auto-close-design.md
+++ b/docs/superpowers/specs/2026-04-29-runtime-session-auto-close-design.md
@@ -1,0 +1,88 @@
+# Runtime Session Auto-Close Design
+
+## Problem
+
+Launched workspace agent sessions, such as Claude or Codex, can exit naturally when the user sends EOF or otherwise quits the process. Today the terminal websocket reports the exit and the runtime manager marks the process as exited, but the workspace UI can continue showing the tab and the backend can continue advertising the session. For tmux-backed agent sessions, the persisted runtime tmux row can also remain until a later cleanup path runs.
+
+This makes the session look reusable even though it is no longer a live process. A user can leave the workspace, return later, click the same agent, and land back in a terminated session instead of getting a clear fresh launch flow.
+
+## Goals
+
+- Treat natural process exit as the end of a launched runtime session.
+- Remove exited agent and subprocess tabs automatically from the workspace UI.
+- Keep backend runtime state aligned with what the UI shows.
+- Forget persisted tmux-backed runtime rows when the backing tmux session has exited or disappeared.
+- Preserve the existing workspace `tmux` tab behavior, which represents the base workspace terminal and intentionally reconnects.
+- Preserve explicit close behavior, including confirmation for running sessions.
+
+## Non-Goals
+
+- Do not change workspace deletion or base workspace tmux cleanup behavior.
+- Do not introduce a session history view or transcript retention.
+- Do not restart agent sessions automatically after a normal exit.
+- Do not change the configured launch target model.
+
+## Recommended Approach
+
+Use a combined backend and frontend cleanup flow.
+
+The runtime manager should remove launched sessions from its active session maps when their process exits naturally. If the session was tmux-backed, the server should also forget the persisted runtime tmux row once the tmux session is gone. This makes `/workspaces/{id}/runtime` return only live or starting runtime sessions.
+
+The frontend should still react immediately to the terminal websocket exit message. For agent session panes, `onExit` should unmount the pane, remove the tab from local UI state, select Home if the closed tab was active, and refresh runtime state in the background. This avoids leaving the user staring at a dead terminal while waiting for the next poll or runtime fetch.
+
+The base workspace `tmux` tab should keep its current reconnect behavior because it is not a launched agent session. The shell drawer should follow the same user-facing principle as agent sessions: when the shell process exits, close or collapse the live terminal surface and refresh runtime state so reopening Shell starts a fresh shell.
+
+## Backend Design
+
+Add an exit cleanup path to `internal/workspace/localruntime.Manager`.
+
+- The `session.watch` path already observes process exit, records status, exit time, and exit code, closes the PTY, and closes `done`.
+- Extend session startup so the manager can register an exit callback for launched sessions and shell sessions.
+- On natural exit, remove the session from `m.sessions` or `m.shells` only if the map still points at the same session pointer. This keeps explicit stop and concurrent replacement safe.
+- If the session had a `tmuxSession`, invoke a manager-level callback supplied by the server after removal. The callback should be non-blocking relative to the session lock and should tolerate absent tmux sessions.
+- Preserve shutdown behavior: runtime shutdown should still detach tmux-backed sessions so restart recovery can restore them, rather than treating server shutdown as natural user exit.
+
+Add a server cleanup callback.
+
+- When constructing `localruntime.Manager`, provide a callback that calls `workspace.Manager.ForgetRuntimeTmuxSession(ctx, workspaceID, tmuxSession)` once the tmux session is absent or after the runtime attach exits because the agent process ended.
+- Use a bounded context for cleanup and log warnings without surfacing them to the websocket path.
+- Explicit `DELETE /workspaces/{id}/runtime/sessions/{session_key}` should keep its existing stop-then-forget behavior.
+
+`GET /workspaces/{id}/runtime` should return no entry for a naturally exited session after cleanup. This is the authoritative state the frontend reconciles against.
+
+## Frontend Design
+
+Update `WorkspaceTerminalView.svelte`.
+
+- Replace the current agent pane `onExit={() => void fetchRuntime()}` with an exit handler that:
+  - removes the session key from `mountedSessionKeys`;
+  - selects Home if the active tab is that session;
+  - clears the remembered active tab for that workspace to Home;
+  - calls `fetchRuntime()` in the background.
+- Keep `reconnectOnExit={false}` for launched agent sessions.
+- Keep the base `tmux` tab using `reconnectOnExit={true}`.
+- For the shell drawer, close the drawer on exit and refresh runtime state so reopening Shell calls `ensureWorkspaceShell` and starts a fresh process.
+
+The UI should not show a special "exited" tab in the normal flow because the user action was to quit the process. The next natural action should be launching the target again from Home or the launch menu.
+
+## Testing
+
+Add backend E2E coverage with real SQLite and the existing runtime helper process.
+
+- Natural non-tmux agent exit: launch a helper target that exits, wait for runtime cleanup, then assert `GET /workspaces/{id}/runtime` returns no sessions.
+- Natural tmux-backed agent exit: launch a tmux-backed helper target that exits, attach through the websocket if needed to drive the process, wait for exit, then assert the runtime list is empty and `middleman_workspace_tmux_sessions` has no row for that workspace.
+- Ensure explicit stop behavior still removes sessions and stored tmux rows.
+
+Add frontend tests around `WorkspaceTerminalView.svelte` or the smallest suitable component boundary.
+
+- When a mounted session terminal emits `onExit`, the tab is removed and Home becomes active.
+- The base `tmux` tab remains mounted/reconnect-capable and is not auto-closed by the agent exit path.
+- Shell drawer exit closes the drawer and refreshes runtime state.
+
+Run focused Go tests with `-shuffle=on`, frontend tests with Bun, and regenerate API artifacts only if public API schemas change. This design should not require an API schema change.
+
+## Risks
+
+- Removing sessions immediately means users lose the short in-terminal `[Process exited]` marker. That is intentional for launched agents; the tab itself disappearing is clearer than retaining a dead pane.
+- Tmux cleanup must not run during middleman server shutdown, or restart recovery would break. The cleanup path must distinguish natural process exit from manager shutdown/detach.
+- The frontend should guard workspace-id transitions so an exit event from the old workspace cannot close a tab in the new workspace.

--- a/frontend/src/lib/components/terminal/ShellDrawer.svelte
+++ b/frontend/src/lib/components/terminal/ShellDrawer.svelte
@@ -10,7 +10,7 @@
     loading?: boolean;
     shellSession?: RuntimeSession | null;
     onToggle?: () => void;
-    onExit?: () => void;
+    onExit?: (workspaceId: string) => void;
   }
 
   const {
@@ -38,11 +38,13 @@
       {#if loading}
         <div class="drawer-state">Starting shell...</div>
       {:else if shellSession}
-        <TerminalPane
-          websocketPath={workspaceShellWebSocketPath(workspaceId)}
-          reconnectOnExit={false}
-          onExit={() => onExit?.()}
-        />
+        {#key shellSession.key}
+          <TerminalPane
+            websocketPath={workspaceShellWebSocketPath(shellSession.workspace_id)}
+            reconnectOnExit={false}
+            onExit={() => onExit?.(shellSession.workspace_id)}
+          />
+        {/key}
       {:else}
         <div class="drawer-state">Shell unavailable</div>
       {/if}

--- a/frontend/src/lib/components/terminal/ShellDrawer.svelte
+++ b/frontend/src/lib/components/terminal/ShellDrawer.svelte
@@ -10,7 +10,11 @@
     loading?: boolean;
     shellSession?: RuntimeSession | null;
     onToggle?: () => void;
-    onExit?: (workspaceId: string) => void;
+    onExit?: (
+      workspaceId: string,
+      shellKey: string,
+      createdAt: string,
+    ) => void;
   }
 
   const {
@@ -42,7 +46,12 @@
           <TerminalPane
             websocketPath={workspaceShellWebSocketPath(shellSession.workspace_id)}
             reconnectOnExit={false}
-            onExit={() => onExit?.(shellSession.workspace_id)}
+            onExit={() =>
+              onExit?.(
+                shellSession.workspace_id,
+                shellSession.key,
+                shellSession.created_at,
+              )}
           />
         {/key}
       {:else}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -40,6 +40,12 @@
     mr_is_draft?: boolean | null;
   }
 
+  interface ClosedShellSession {
+    workspaceId: string;
+    key: string;
+    createdAt: string;
+  }
+
   const {
     workspaceId,
   }: { workspaceId: string } = $props();
@@ -69,6 +75,7 @@
   let tmuxTerminalMounted = $state(false);
   let mountedSessionKeys = $state<string[]>([]);
   let closedSessionKeys = $state<string[]>([]);
+  let closedShellSession = $state<ClosedShellSession | null>(null);
   let launchingKey = $state<string | null>(null);
   let shellOpen = $state(false);
   let shellLoading = $state(false);
@@ -162,9 +169,16 @@
   const shellSession = $derived(
     runtimeLive ? (runtime?.shell_session ?? null) : null,
   );
+  const shellSessionLocallyClosed = $derived(
+    shellSession !== null &&
+      closedShellSession?.workspaceId === shellSession.workspace_id &&
+      closedShellSession?.key === shellSession.key &&
+      closedShellSession?.createdAt === shellSession.created_at,
+  );
   const shellSessionActive = $derived(
-    shellSession?.status === "running" ||
-      shellSession?.status === "starting",
+    !shellSessionLocallyClosed &&
+      (shellSession?.status === "running" ||
+        shellSession?.status === "starting"),
   );
   const activeSession = $derived.by(() => {
     if (!activeTabKey.startsWith("session:")) return null;
@@ -334,6 +348,27 @@
     );
   }
 
+  function markShellClosed(
+    id: string,
+    shellKey: string,
+    createdAt: string,
+  ): void {
+    closedShellSession = { workspaceId: id, key: shellKey, createdAt };
+  }
+
+  function clearClosedShellIfReplaced(
+    id: string,
+    shell: RuntimeSession | null | undefined,
+  ): void {
+    if (
+      closedShellSession?.workspaceId === id &&
+      (closedShellSession.key !== shell?.key ||
+        closedShellSession.createdAt !== shell?.created_at)
+    ) {
+      closedShellSession = null;
+    }
+  }
+
   function isSessionTerminalMounted(
     sessionKey: string,
   ): boolean {
@@ -426,6 +461,7 @@
       closedSessionKeys = closedSessionKeys.filter((key) =>
         data.sessions.some((session) => session.key === key),
       );
+      clearClosedShellIfReplaced(id, data.shell_session);
       if (
         activeTabKey.startsWith("session:") &&
         !activeSession
@@ -519,8 +555,13 @@
     void fetchRuntime();
   }
 
-  function handleShellExit(id: string): void {
+  function handleShellExit(
+    id: string,
+    shellKey: string,
+    createdAt: string,
+  ): void {
     if (id !== workspaceId) return;
+    markShellClosed(id, shellKey, createdAt);
     shellOpen = false;
     shellLoading = false;
     void fetchRuntime();
@@ -996,7 +1037,8 @@
                 loading={shellLoading}
                 shellSession={shellSessionActive ? shellSession : null}
                 onToggle={() => void toggleShell()}
-                onExit={(id) => handleShellExit(id)}
+                onExit={(id, shellKey, createdAt) =>
+                  handleShellExit(id, shellKey, createdAt)}
               />
             </div>
           </div>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -56,6 +56,7 @@
 
   let workspace = $state<Workspace | null>(null);
   let runtime = $state.raw<WorkspaceRuntimeState | null>(null);
+  let runtimeFetchSeq = 0;
   // The workspace ID that `runtime` was fetched for. Stored
   // alongside the payload so we never render or operate on
   // sessions/targets that belong to a previous workspace
@@ -452,9 +453,11 @@
   async function fetchRuntime(): Promise<void> {
     if (!workspaceId) return;
     const id = workspaceId;
+    const seq = runtimeFetchSeq + 1;
+    runtimeFetchSeq = seq;
     try {
       const data = await getWorkspaceRuntime(id);
-      if (id !== workspaceId) return;
+      if (id !== workspaceId || seq !== runtimeFetchSeq) return;
       runtime = data;
       runtimeForId = id;
       runtimeError = null;
@@ -473,7 +476,7 @@
           data.sessions.some((session) => session.key === key),
       );
     } catch (err) {
-      if (id !== workspaceId) return;
+      if (id !== workspaceId || seq !== runtimeFetchSeq) return;
       runtimeError =
         err instanceof Error
           ? err.message

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -979,7 +979,10 @@
                           reconnectOnExit={false}
                           active={activeTabKey === `session:${session.key}`}
                           onExit={() =>
-                            handleSessionExit(session.key, workspaceId)}
+                            handleSessionExit(
+                              session.key,
+                              session.workspace_id,
+                            )}
                           initialStatus={session.status}
                         />
                       {/if}
@@ -993,7 +996,7 @@
                 loading={shellLoading}
                 shellSession={shellSessionActive ? shellSession : null}
                 onToggle={() => void toggleShell()}
-                onExit={() => handleShellExit(workspaceId)}
+                onExit={(id) => handleShellExit(id)}
               />
             </div>
           </div>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -46,6 +46,12 @@
     createdAt: string;
   }
 
+  interface ClosedRuntimeSession {
+    workspaceId: string;
+    key: string;
+    createdAt: string;
+  }
+
   const {
     workspaceId,
   }: { workspaceId: string } = $props();
@@ -75,7 +81,7 @@
   let tmuxTabOpen = $state(false);
   let tmuxTerminalMounted = $state(false);
   let mountedSessionKeys = $state<string[]>([]);
-  let closedSessionKeys = $state<string[]>([]);
+  let closedSessions = $state<ClosedRuntimeSession[]>([]);
   let closedShellSession = $state<ClosedShellSession | null>(null);
   let launchingKey = $state<string | null>(null);
   let shellOpen = $state(false);
@@ -160,7 +166,10 @@
   const runtimeSessions = $derived(
     runtimeLive
       ? (runtime?.sessions ?? []).filter(
-          (session) => !closedSessionKeys.includes(session.key),
+          (session) =>
+            !closedSessions.some((closed) =>
+              sessionGenerationMatches(closed, session),
+            ),
         )
       : [],
   );
@@ -337,15 +346,37 @@
     );
   }
 
-  function markSessionClosed(sessionKey: string): void {
-    if (!closedSessionKeys.includes(sessionKey)) {
-      closedSessionKeys = [...closedSessionKeys, sessionKey];
+  function sessionGenerationMatches(
+    closed: ClosedRuntimeSession,
+    session: RuntimeSession,
+  ): boolean {
+    return (
+      closed.workspaceId === session.workspace_id &&
+      closed.key === session.key &&
+      closed.createdAt === session.created_at
+    );
+  }
+
+  function markSessionClosed(session: RuntimeSession): void {
+    if (
+      !closedSessions.some((closed) =>
+        sessionGenerationMatches(closed, session),
+      )
+    ) {
+      closedSessions = [
+        ...closedSessions,
+        {
+          workspaceId: session.workspace_id,
+          key: session.key,
+          createdAt: session.created_at,
+        },
+      ];
     }
   }
 
-  function clearClosedSession(sessionKey: string): void {
-    closedSessionKeys = closedSessionKeys.filter(
-      (key) => key !== sessionKey,
+  function clearClosedSession(session: RuntimeSession): void {
+    closedSessions = closedSessions.filter(
+      (closed) => !sessionGenerationMatches(closed, session),
     );
   }
 
@@ -461,9 +492,6 @@
       runtime = data;
       runtimeForId = id;
       runtimeError = null;
-      closedSessionKeys = closedSessionKeys.filter((key) =>
-        data.sessions.some((session) => session.key === key),
-      );
       clearClosedShellIfReplaced(id, data.shell_session);
       if (
         activeTabKey.startsWith("session:") &&
@@ -506,7 +534,7 @@
       if (id !== workspaceId) return;
       await fetchRuntime();
       if (id !== workspaceId) return;
-      clearClosedSession(session.key);
+      clearClosedSession(session);
       mountSessionTerminal(session.key);
       selectWorkspaceTab(`session:${session.key}`);
     } catch (err) {
@@ -548,11 +576,11 @@
     }
   }
 
-  function handleSessionExit(sessionKey: string, id: string): void {
-    if (id !== workspaceId) return;
-    markSessionClosed(sessionKey);
-    unmountSessionTerminal(sessionKey);
-    if (activeTabKey === `session:${sessionKey}`) {
+  function handleSessionExit(session: RuntimeSession): void {
+    if (session.workspace_id !== workspaceId) return;
+    markSessionClosed(session);
+    unmountSessionTerminal(session.key);
+    if (activeTabKey === `session:${session.key}`) {
       selectWorkspaceTab("home");
     }
     void fetchRuntime();
@@ -722,7 +750,7 @@
     shellOpen = false;
     launchingKey = null;
     shellLoading = false;
-    closedSessionKeys = [];
+    closedSessions = [];
 
     // Errors/transient flags from the prior workspace should not
     // bleed across — clear them but don't touch workspace/runtime.
@@ -1022,11 +1050,7 @@
                           )}
                           reconnectOnExit={false}
                           active={activeTabKey === `session:${session.key}`}
-                          onExit={() =>
-                            handleSessionExit(
-                              session.key,
-                              session.workspace_id,
-                            )}
+                          onExit={() => handleSessionExit(session)}
                           initialStatus={session.status}
                         />
                       {/if}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -68,6 +68,7 @@
   let tmuxTabOpen = $state(false);
   let tmuxTerminalMounted = $state(false);
   let mountedSessionKeys = $state<string[]>([]);
+  let closedSessionKeys = $state<string[]>([]);
   let launchingKey = $state<string | null>(null);
   let shellOpen = $state(false);
   let shellLoading = $state(false);
@@ -149,7 +150,11 @@
       workspace?.id === workspaceId,
   );
   const runtimeSessions = $derived(
-    runtimeLive ? (runtime?.sessions ?? []) : [],
+    runtimeLive
+      ? (runtime?.sessions ?? []).filter(
+          (session) => !closedSessionKeys.includes(session.key),
+        )
+      : [],
   );
   const launchTargets = $derived(
     runtimeLive ? (runtime?.launch_targets ?? []) : [],
@@ -317,6 +322,18 @@
     );
   }
 
+  function markSessionClosed(sessionKey: string): void {
+    if (!closedSessionKeys.includes(sessionKey)) {
+      closedSessionKeys = [...closedSessionKeys, sessionKey];
+    }
+  }
+
+  function clearClosedSession(sessionKey: string): void {
+    closedSessionKeys = closedSessionKeys.filter(
+      (key) => key !== sessionKey,
+    );
+  }
+
   function isSessionTerminalMounted(
     sessionKey: string,
   ): boolean {
@@ -406,6 +423,9 @@
       runtime = data;
       runtimeForId = id;
       runtimeError = null;
+      closedSessionKeys = closedSessionKeys.filter((key) =>
+        data.sessions.some((session) => session.key === key),
+      );
       if (
         activeTabKey.startsWith("session:") &&
         !activeSession
@@ -447,6 +467,7 @@
       if (id !== workspaceId) return;
       await fetchRuntime();
       if (id !== workspaceId) return;
+      clearClosedSession(session.key);
       mountSessionTerminal(session.key);
       selectWorkspaceTab(`session:${session.key}`);
     } catch (err) {
@@ -486,6 +507,23 @@
       runtimeError =
         err instanceof Error ? err.message : "Stop failed";
     }
+  }
+
+  function handleSessionExit(sessionKey: string, id: string): void {
+    if (id !== workspaceId) return;
+    markSessionClosed(sessionKey);
+    unmountSessionTerminal(sessionKey);
+    if (activeTabKey === `session:${sessionKey}`) {
+      selectWorkspaceTab("home");
+    }
+    void fetchRuntime();
+  }
+
+  function handleShellExit(id: string): void {
+    if (id !== workspaceId) return;
+    shellOpen = false;
+    shellLoading = false;
+    void fetchRuntime();
   }
 
   async function toggleShell(): Promise<void> {
@@ -640,6 +678,7 @@
     shellOpen = false;
     launchingKey = null;
     shellLoading = false;
+    closedSessionKeys = [];
 
     // Errors/transient flags from the prior workspace should not
     // bleed across — clear them but don't touch workspace/runtime.
@@ -939,7 +978,8 @@
                           )}
                           reconnectOnExit={false}
                           active={activeTabKey === `session:${session.key}`}
-                          onExit={() => void fetchRuntime()}
+                          onExit={() =>
+                            handleSessionExit(session.key, workspaceId)}
                           initialStatus={session.status}
                         />
                       {/if}
@@ -953,7 +993,7 @@
                 loading={shellLoading}
                 shellSession={shellSessionActive ? shellSession : null}
                 onToggle={() => void toggleShell()}
-                onExit={() => void fetchRuntime()}
+                onExit={() => handleShellExit(workspaceId)}
               />
             </div>
           </div>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -238,4 +238,40 @@ describe("WorkspaceTerminalView", () => {
       })).toBeTruthy(),
     );
   });
+
+  it("does not reopen the just-exited shell from stale runtime data", async () => {
+    localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithShellSession());
+    mocks.ensureWorkspaceShell.mockResolvedValue(undefined);
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    const shellButton = await screen.findByRole("button", {
+      name: "Open shell drawer",
+    });
+    await fireEvent.click(shellButton);
+    await waitFor(() => expect(sockets).toHaveLength(1));
+
+    sockets[0]!.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({ type: "exited", code: 0 }),
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", {
+        name: "Open shell drawer",
+      })).toBeTruthy(),
+    );
+
+    await fireEvent.click(shellButton);
+
+    await waitFor(() =>
+      expect(mocks.ensureWorkspaceShell).toHaveBeenCalledTimes(2),
+    );
+    expect(sockets).toHaveLength(1);
+  });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -128,6 +128,22 @@ function runtimeWithShellSession() {
   };
 }
 
+function runtimeWithoutShellSession() {
+  return {
+    launch_targets: [],
+    sessions: [],
+    shell_session: null,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
 describe("WorkspaceTerminalView", () => {
   beforeEach(() => {
     delete window.__BASE_PATH__;
@@ -272,6 +288,54 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() =>
       expect(mocks.ensureWorkspaceShell).toHaveBeenCalledTimes(2),
     );
+    expect(sockets).toHaveLength(1);
+  });
+
+  it("ignores older runtime responses after shell cleanup refreshes", async () => {
+    localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
+    const staleRefresh = deferred<ReturnType<typeof runtimeWithShellSession>>();
+    const freshRefresh = deferred<
+      ReturnType<typeof runtimeWithoutShellSession>
+    >();
+    mocks.getWorkspaceRuntime
+      .mockResolvedValueOnce(runtimeWithShellSession())
+      .mockResolvedValueOnce(runtimeWithShellSession())
+      .mockReturnValueOnce(staleRefresh.promise)
+      .mockReturnValueOnce(freshRefresh.promise);
+    mocks.ensureWorkspaceShell.mockResolvedValue(undefined);
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    const shellButton = await screen.findByRole("button", {
+      name: "Open shell drawer",
+    });
+    await fireEvent.click(shellButton);
+    await waitFor(() => expect(sockets).toHaveLength(1));
+
+    sockets[0]!.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({ type: "exited", code: 0 }),
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", {
+        name: "Open shell drawer",
+      })).toBeTruthy(),
+    );
+
+    await fireEvent.click(shellButton);
+    freshRefresh.resolve(runtimeWithoutShellSession());
+    await waitFor(() =>
+      expect(screen.getByText("Shell unavailable")).toBeTruthy(),
+    );
+
+    staleRefresh.resolve(runtimeWithShellSession());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(sockets).toHaveLength(1);
   });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1,0 +1,241 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureWorkspaceShell: vi.fn(),
+  getWorkspaceRuntime: vi.fn(),
+  launchWorkspaceSession: vi.fn(),
+  mockClearTextureAtlas: vi.fn(),
+  mockDispose: vi.fn(),
+  mockFit: vi.fn(),
+  mockLoadAddon: vi.fn(),
+  mockOnBinary: vi.fn(),
+  mockOnData: vi.fn(),
+  mockOpen: vi.fn(),
+  mockRefresh: vi.fn(),
+  stopWorkspaceSession: vi.fn(),
+  terminalWrite: vi.fn(),
+}));
+
+let sockets: MockWebSocket[] = [];
+
+class MockWebSocket {
+  static OPEN = 1;
+  readyState = 1;
+  binaryType = "arraybuffer";
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    sockets.push(this);
+  }
+
+  send(): void {}
+  close(): void {}
+}
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation((options) => ({
+    cols: 80,
+    rows: 24,
+    open: mocks.mockOpen,
+    loadAddon: mocks.mockLoadAddon,
+    onData: mocks.mockOnData,
+    onBinary: mocks.mockOnBinary,
+    dispose: mocks.mockDispose,
+    write: mocks.terminalWrite,
+    refresh: mocks.mockRefresh,
+    clearTextureAtlas: mocks.mockClearTextureAtlas,
+    options: { ...options },
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: mocks.mockFit,
+  })),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("@middleman/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@middleman/ui")>();
+  return {
+    ...actual,
+    getStores: () => ({
+      settings: {
+        getTerminalFontFamily: () => "",
+      },
+    }),
+  };
+});
+
+vi.mock("../../api/workspace-runtime.js", () => ({
+  ensureWorkspaceShell: mocks.ensureWorkspaceShell,
+  getWorkspaceRuntime: mocks.getWorkspaceRuntime,
+  launchWorkspaceSession: mocks.launchWorkspaceSession,
+  stopWorkspaceSession: mocks.stopWorkspaceSession,
+  workspaceSessionWebSocketPath: (workspaceId: string, sessionKey: string) =>
+    `/ws/v1/workspaces/${workspaceId}/runtime/sessions/${sessionKey}/terminal`,
+  workspaceShellWebSocketPath: (workspaceId: string) =>
+    `/ws/v1/workspaces/${workspaceId}/runtime/shell/terminal`,
+  workspaceTmuxWebSocketPath: (workspaceId: string) =>
+    `/ws/v1/workspaces/${workspaceId}/terminal`,
+}));
+
+import WorkspaceTerminalView from "./WorkspaceTerminalView.svelte";
+
+const runningSession = {
+  key: "ws-1:helper",
+  workspace_id: "ws-1",
+  target_key: "helper",
+  label: "Helper",
+  kind: "agent",
+  status: "running",
+  created_at: "2026-04-29T00:00:00Z",
+};
+
+function runtimeWithStaleSession() {
+  return {
+    launch_targets: [],
+    sessions: [runningSession],
+  };
+}
+
+function runtimeWithShellSession() {
+  return {
+    launch_targets: [],
+    sessions: [],
+    shell_session: {
+      key: "ws-1:shell",
+      workspace_id: "ws-1",
+      target_key: "plain_shell",
+      label: "Shell",
+      kind: "plain_shell",
+      status: "running",
+      created_at: "2026-04-29T00:00:00Z",
+    },
+  };
+}
+
+describe("WorkspaceTerminalView", () => {
+  beforeEach(() => {
+    delete window.__BASE_PATH__;
+    localStorage.clear();
+    localStorage.setItem(
+      "middleman-workspace-active-tab:ws-1",
+      "session:ws-1:helper",
+    );
+    sockets = [];
+    mocks.getWorkspaceRuntime.mockReset();
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithStaleSession());
+    mocks.launchWorkspaceSession.mockReset();
+    mocks.stopWorkspaceSession.mockReset();
+    mocks.ensureWorkspaceShell.mockReset();
+    mocks.terminalWrite.mockReset();
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "ws-1",
+        platform_host: "github.com",
+        repo_owner: "acme",
+        repo_name: "widget",
+        item_type: "pull_request",
+        item_number: 7,
+        git_head_ref: "feature/session-exit",
+        worktree_path: "/tmp/worktree",
+        tmux_session: "middleman-ws-1",
+        status: "ready",
+        created_at: "2026-04-29T00:00:00Z",
+      }),
+    }));
+    vi.stubGlobal("EventSource", class {
+      addEventListener(): void {}
+      close(): void {}
+    });
+    vi.stubGlobal("ResizeObserver", class {
+      observe(): void {}
+      disconnect(): void {}
+    });
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    );
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("closes an agent tab immediately when its terminal exits", async () => {
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("tab", { name: /Helper/ });
+    await waitFor(() => expect(sockets).toHaveLength(1));
+
+    sockets[0]!.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({ type: "exited", code: 0 }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByRole("tab", { name: /Helper/ })).toBeNull(),
+    );
+    expect(screen.getByRole("tab", { name: /Home/ }).getAttribute(
+      "aria-selected",
+    )).toBe("true");
+    expect(localStorage.getItem("middleman-workspace-active-tab:ws-1"))
+      .toBe("home");
+  });
+
+  it("closes the shell drawer when its terminal exits", async () => {
+    localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithShellSession());
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    const shellButton = await screen.findByRole("button", {
+      name: "Open shell drawer",
+    });
+    await fireEvent.click(shellButton);
+    await waitFor(() => expect(sockets).toHaveLength(1));
+
+    sockets[0]!.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({ type: "exited", code: 0 }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", {
+        name: "Open shell drawer",
+      })).toBeTruthy(),
+    );
+  });
+});

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -105,6 +105,18 @@ const runningSession = {
   created_at: "2026-04-29T00:00:00Z",
 };
 
+function runtimeWithSession(createdAt: string) {
+  return {
+    launch_targets: [],
+    sessions: [
+      {
+        ...runningSession,
+        created_at: createdAt,
+      },
+    ],
+  };
+}
+
 function runtimeWithStaleSession() {
   return {
     launch_targets: [],
@@ -224,6 +236,35 @@ describe("WorkspaceTerminalView", () => {
     )).toBe("true");
     expect(localStorage.getItem("middleman-workspace-active-tab:ws-1"))
       .toBe("home");
+  });
+
+  it("shows a relaunched agent with the same key and a new generation", async () => {
+    const relaunchedAt = "2026-04-29T00:01:00Z";
+    mocks.getWorkspaceRuntime
+      .mockResolvedValueOnce(runtimeWithStaleSession())
+      .mockResolvedValueOnce(runtimeWithSession(relaunchedAt));
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("tab", { name: /Helper/ });
+    await waitFor(() => expect(sockets).toHaveLength(1));
+
+    sockets[0]!.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({ type: "exited", code: 0 }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.getWorkspaceRuntime).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: /Helper/ })).toBeTruthy(),
+    );
   });
 
   it("closes the shell drawer when its terminal exits", async () => {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2561,13 +2561,19 @@ func (d *DB) UpsertWorkspaceTmuxSession(
 	ctx context.Context,
 	session *WorkspaceTmuxSession,
 ) error {
+	createdAt := canonicalUTCTime(session.CreatedAt)
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
 	_, err := d.rw.ExecContext(ctx, `
 		INSERT INTO middleman_workspace_tmux_sessions
-		    (workspace_id, session_name, target_key)
-		VALUES (?, ?, ?)
+		    (workspace_id, session_name, target_key, created_at)
+		VALUES (?, ?, ?, ?)
 		ON CONFLICT(workspace_id, session_name) DO UPDATE SET
-		    target_key = excluded.target_key`,
+		    target_key = excluded.target_key,
+		    created_at = excluded.created_at`,
 		session.WorkspaceID, session.SessionName, session.TargetKey,
+		createdAt,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert workspace tmux session: %w", err)
@@ -2653,6 +2659,29 @@ func (d *DB) DeleteWorkspaceTmuxSession(
 		return fmt.Errorf("delete workspace tmux session: %w", err)
 	}
 	return nil
+}
+
+// DeleteWorkspaceTmuxSessionCreatedAt removes one stored runtime tmux session
+// only if it still belongs to the same runtime session generation.
+func (d *DB) DeleteWorkspaceTmuxSessionCreatedAt(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+	createdAt time.Time,
+) (bool, error) {
+	result, err := d.rw.ExecContext(ctx, `
+		DELETE FROM middleman_workspace_tmux_sessions
+		WHERE workspace_id = ? AND session_name = ? AND created_at = ?`,
+		workspaceID, sessionName, canonicalUTCTime(createdAt),
+	)
+	if err != nil {
+		return false, fmt.Errorf("delete workspace tmux session: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("delete workspace tmux session rows: %w", err)
+	}
+	return rows > 0, nil
 }
 
 // DeleteWorkspaceTmuxSessions removes every stored runtime tmux

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 	"testing"
 	"time"
@@ -1948,6 +1949,38 @@ func TestWorkspaceCRUD(t *testing.T) {
 	noSuch, err := d.GetWorkspace(ctx, "nonexistent")
 	require.NoError(err)
 	assert.Nil(noSuch)
+}
+
+func TestFreshWorkspaceTmuxSessionSchemaIncludesCreatedAt(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	d := openTestDB(t)
+	rows, err := d.ReadDB().QueryContext(
+		context.Background(),
+		`PRAGMA table_info(middleman_workspace_tmux_sessions)`,
+	)
+	require.NoError(err)
+	defer rows.Close()
+
+	columns := make(map[string]string)
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			columnType string
+			notNull    int
+			defaultVal sql.NullString
+			pk         int
+		)
+		require.NoError(rows.Scan(
+			&cid, &name, &columnType, &notNull, &defaultVal, &pk,
+		))
+		columns[name] = columnType
+	}
+	require.NoError(rows.Err())
+
+	assert.Equal("DATETIME", columns["created_at"])
 }
 
 func TestWorkspaceIdentifierCasefoldTriggers(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9324,7 +9324,7 @@ exit 0
 	})
 }
 
-func TestWorkspaceRuntimeStopTmuxCleanupFailureKeepsSessionE2E(
+func TestWorkspaceRuntimeStopTmuxCleanupFailureCleansExitedSessionE2E(
 	t *testing.T,
 ) {
 	require := require.New(t)
@@ -9385,13 +9385,18 @@ exit 0
 	require.NoError(err)
 	require.Equal(http.StatusInternalServerError, stopResp.StatusCode())
 
-	getResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.Id)
-	require.NoError(err)
-	require.Equal(http.StatusOK, getResp.StatusCode())
-	require.NotNil(getResp.JSON200)
-	require.NotNil(getResp.JSON200.Sessions)
-	require.Len(*getResp.JSON200.Sessions, 1)
-	assert.Equal(launchResp.JSON200.Key, (*getResp.JSON200.Sessions)[0].Key)
+	assert.Eventually(func() bool {
+		getResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if err != nil ||
+			getResp.StatusCode() != http.StatusOK ||
+			getResp.JSON200 == nil ||
+			getResp.JSON200.Sessions == nil {
+			return false
+		}
+		return len(*getResp.JSON200.Sessions) == 0
+	}, 2*time.Second, 20*time.Millisecond)
 
 	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
 	require.NoError(err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8559,6 +8559,111 @@ func TestWorkspaceRuntimeLaunchSingletonAndStopE2E(t *testing.T) {
 	assert.Empty(*afterStopResp.JSON200.Sessions)
 }
 
+func TestWorkspaceRuntimeNaturalAgentExitRemovesSessionE2E(t *testing.T) {
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: serverRuntimeHelperCommand("exit"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	client, _, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil ||
+			runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil ||
+			runtimeResp.JSON200.Sessions == nil {
+			return false
+		}
+		return len(*runtimeResp.JSON200.Sessions) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	assert.NotEmpty(launchResp.JSON200.Key)
+}
+
+func TestWorkspaceRuntimeNaturalTmuxAgentExitForgetsStoredSessionE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "tmux-record")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$@" >> "$TMUX_RECORD"
+case "$1" in
+  has-session)
+    echo "can't find session: $3" >&2
+    exit 1
+    ;;
+  new-session|set-option|attach-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: []string{"/bin/sh", "-lc", "exit 0"},
+		}},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil ||
+			runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil ||
+			runtimeResp.JSON200.Sessions == nil {
+			return false
+		}
+		return len(*runtimeResp.JSON200.Sessions) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.Eventually(func() bool {
+		stored, storedErr := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+		return storedErr == nil && len(stored) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	assert.NotEmpty(launchResp.JSON200.Key)
+}
+
 func TestWorkspaceRuntimeIncludesStoredTmuxSessionsAfterReloadE2E(t *testing.T) {
 	requirePTYAvailable(t)
 	require := require.New(t)
@@ -10044,6 +10149,8 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 			}
 		}
 		return
+	case "exit":
+		os.Exit(3)
 	default:
 		os.Exit(2)
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8789,6 +8789,10 @@ fi
 if [ "$1" = "has-session" ]; then
   exit 1
 fi
+if [ "$1" = "attach-session" ]; then
+  cat >/dev/null
+  exit 0
+fi
 if [ -n "$new_session" ]; then
   printf '%s\n' "$new_session" >> "$session_file"
 fi
@@ -8965,6 +8969,10 @@ case "$1" in
     printf '%s\n' 'middleman-0000000000000001-e81d3b0e9d82feaa'
     exit 0
     ;;
+  attach-session)
+    cat >/dev/null
+    exit 0
+    ;;
 esac
 if [ "$mode" = "display-message" ]; then
   case "$target" in
@@ -9120,32 +9128,27 @@ exit 0
 	assert.Contains(runtimeNewSession, "@middleman_owner")
 	assert.Contains(runtimeNewSession, srv.workspaces.TmuxOwnerMarker())
 
-	var runtimeResp *generated.GetWorkspaceRuntimeResponse
 	require.Eventually(func() bool {
-		runtimeResp, err = client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.Id)
+		runtimeResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.Id)
 		if err != nil ||
 			runtimeResp.StatusCode() != http.StatusOK ||
 			runtimeResp.JSON200 == nil ||
-			runtimeResp.JSON200.Sessions == nil ||
-			len(*runtimeResp.JSON200.Sessions) != 1 {
+			runtimeResp.JSON200.Sessions == nil {
 			return false
 		}
-		return (*runtimeResp.JSON200.Sessions)[0].Status == "exited"
+		return len(*runtimeResp.JSON200.Sessions) == 0
 	}, 2*time.Second, 20*time.Millisecond)
 
-	stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
-	require.NoError(err)
-	require.Len(stored, 1)
-	assert.Equal(sessionName, stored[0].SessionName)
+	require.Eventually(func() bool {
+		stored, err := database.ListWorkspaceTmuxSessions(ctx, ws.Id)
+		return err == nil && len(stored) == 0
+	}, 2*time.Second, 20*time.Millisecond)
 
 	stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
 		ctx, ws.Id, launchResp.JSON200.Key,
 	)
 	require.NoError(err)
-	require.Equal(http.StatusNoContent, stopResp.StatusCode())
-	stored, err = database.ListWorkspaceTmuxSessions(ctx, ws.Id)
-	require.NoError(err)
-	assert.Empty(stored)
+	require.Equal(http.StatusNotFound, stopResp.StatusCode())
 }
 
 func tmuxRecordContains(argvs [][]string, want []string) bool {
@@ -9175,7 +9178,11 @@ case "$1" in
   has-session)
     exit 1
     ;;
-  new-session|set-option|attach-session|kill-session)
+  attach-session)
+    cat >/dev/null
+    exit 0
+    ;;
+  new-session|set-option|kill-session)
     exit 0
     ;;
 esac
@@ -9259,7 +9266,11 @@ case "$1" in
   has-session)
     exit 1
     ;;
-  new-session|set-option|attach-session|kill-session)
+  attach-session)
+    cat >/dev/null
+    exit 0
+    ;;
+  new-session|set-option|kill-session)
     exit 0
     ;;
 esac
@@ -9328,6 +9339,10 @@ for a in "$@"; do
   if [ "$prev" = "-t" ]; then target="$a"; fi
   prev="$a"
 done
+if [ "$1" = "attach-session" ]; then
+  cat >/dev/null
+  exit 0
+fi
 if [ "$1" = "kill-session" ]; then
   case "$target" in
     middleman-????????????????-*)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9060,6 +9060,7 @@ for a in "$@"; do
 done
 case "$1" in
   has-session)
+    echo "can't find session: $3" >&2
     exit 1
     ;;
   new-session)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3039,6 +3039,17 @@ func (s *Server) launchWorkspaceRuntimeSession(
 				"record runtime tmux session: " + err.Error(),
 			)
 		}
+		if runtimeSessionTmuxSession(
+			s.runtime.ListSessions(summary.ID), session.Key,
+		) == "" {
+			if err := s.workspaces.ForgetRuntimeTmuxSession(
+				ctx, summary.ID, session.TmuxSession,
+			); err != nil {
+				return nil, huma.Error500InternalServerError(
+					"forget exited runtime tmux session: " + err.Error(),
+				)
+			}
+		}
 	}
 	return &workspaceRuntimeSessionOutput{Body: session}, nil
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3033,6 +3033,7 @@ func (s *Server) launchWorkspaceRuntimeSession(
 	if session.TmuxSession != "" {
 		if err := s.workspaces.RecordRuntimeTmuxSession(
 			ctx, summary.ID, session.TmuxSession, session.TargetKey,
+			session.CreatedAt,
 		); err != nil {
 			_ = s.runtime.Stop(ctx, summary.ID, session.Key)
 			return nil, huma.Error500InternalServerError(
@@ -3044,6 +3045,7 @@ func (s *Server) launchWorkspaceRuntimeSession(
 		) == "" {
 			if _, err := s.workspaces.ForgetMissingRuntimeTmuxSession(
 				ctx, summary.ID, session.TmuxSession,
+				session.CreatedAt,
 			); err != nil {
 				return nil, huma.Error500InternalServerError(
 					"forget missing runtime tmux session: " + err.Error(),

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3042,11 +3042,11 @@ func (s *Server) launchWorkspaceRuntimeSession(
 		if runtimeSessionTmuxSession(
 			s.runtime.ListSessions(summary.ID), session.Key,
 		) == "" {
-			if err := s.workspaces.ForgetRuntimeTmuxSession(
+			if _, err := s.workspaces.ForgetMissingRuntimeTmuxSession(
 				ctx, summary.ID, session.TmuxSession,
 			); err != nil {
 				return nil, huma.Error500InternalServerError(
-					"forget exited runtime tmux session: " + err.Error(),
+					"forget missing runtime tmux session: " + err.Error(),
 				)
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -571,6 +571,7 @@ func (s *Server) handleRuntimeSessionExit(info localruntime.SessionInfo) {
 		defer cancel()
 		if _, err := s.workspaces.ForgetMissingRuntimeTmuxSession(
 			cleanupCtx, info.WorkspaceID, info.TmuxSession,
+			info.CreatedAt,
 		); err != nil {
 			slog.Warn(
 				"forget missing runtime tmux session",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -569,11 +569,11 @@ func (s *Server) handleRuntimeSessionExit(info localruntime.SessionInfo) {
 			ctx, runtimeSessionCleanupTimeout,
 		)
 		defer cancel()
-		if err := s.workspaces.ForgetRuntimeTmuxSession(
+		if _, err := s.workspaces.ForgetMissingRuntimeTmuxSession(
 			cleanupCtx, info.WorkspaceID, info.TmuxSession,
 		); err != nil {
 			slog.Warn(
-				"forget exited runtime tmux session",
+				"forget missing runtime tmux session",
 				"workspace_id", info.WorkspaceID,
 				"session_key", info.Key,
 				"tmux_session", info.TmuxSession,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -61,7 +61,10 @@ type shutdownDeadline struct {
 	set      bool
 }
 
-var startupTmuxCleanupTimeout = 2 * time.Second
+var (
+	startupTmuxCleanupTimeout    = 2 * time.Second
+	runtimeSessionCleanupTimeout = 2 * time.Second
+)
 
 func (d *shutdownDeadline) tighten(deadline time.Time) {
 	d.mu.Lock()
@@ -390,6 +393,7 @@ func newServer(
 			TmuxOwnerMarker:         s.workspaces.TmuxOwnerMarker(),
 			WrapAgentSessionsInTmux: cfg.TmuxAgentSessionsEnabled(),
 			StripEnvVars:            cfg.TokenEnvNames(),
+			OnSessionExit:           s.handleRuntimeSessionExit,
 		})
 		if err := s.restoreRuntimeTmuxSessions(context.Background()); err != nil {
 			slog.Warn("restore runtime tmux sessions", "err", err)
@@ -554,6 +558,29 @@ func (s *Server) restoreRuntimeTmuxSessions(ctx context.Context) error {
 	}
 	slog.Debug("restoring runtime tmux sessions", "count", len(sessions))
 	return s.runtime.RestoreTmuxSessions(ctx, sessions)
+}
+
+func (s *Server) handleRuntimeSessionExit(info localruntime.SessionInfo) {
+	if info.TmuxSession == "" || s.workspaces == nil {
+		return
+	}
+	s.runBackground(func(ctx context.Context) {
+		cleanupCtx, cancel := context.WithTimeout(
+			ctx, runtimeSessionCleanupTimeout,
+		)
+		defer cancel()
+		if err := s.workspaces.ForgetRuntimeTmuxSession(
+			cleanupCtx, info.WorkspaceID, info.TmuxSession,
+		); err != nil {
+			slog.Warn(
+				"forget exited runtime tmux session",
+				"workspace_id", info.WorkspaceID,
+				"session_key", info.Key,
+				"tmux_session", info.TmuxSession,
+				"err", err,
+			)
+		}
+	})
 }
 
 func (s *Server) bootstrapScript() string {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -597,17 +597,17 @@ func (m *Manager) stopSession(ctx context.Context, s *session) error {
 	if s == nil {
 		return nil
 	}
-	s.markStopRequested()
-	var cleanupErr error
 	if s.tmuxSession != "" {
 		if err := m.killTmuxSession(ctx, s.tmuxSession); err != nil {
-			cleanupErr = fmt.Errorf(
+			s.stop()
+			return fmt.Errorf(
 				"kill tmux session %q: %w", s.tmuxSession, err,
 			)
 		}
 	}
+	s.markStopRequested()
 	s.stop()
-	return cleanupErr
+	return nil
 }
 
 func (m *Manager) killTmuxSession(

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -137,6 +137,7 @@ type session struct {
 	alternateScreenActive bool
 	alternateScreenTail   []byte
 	stopOnce              sync.Once
+	stopRequested         bool
 }
 
 type Attachment struct {
@@ -308,11 +309,11 @@ func (m *Manager) Launch(
 		return SessionInfo{}, err
 	}
 	started.tmuxSession = launch.TmuxSession
-	go m.watchSession(started, false)
 
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
+		go m.watchSession(started, false)
 		_ = m.stopSession(ctx, started)
 		waitSessionDone(started)
 		slog.Debug(
@@ -324,6 +325,7 @@ func (m *Manager) Launch(
 	}
 	m.sessions[key] = started
 	m.mu.Unlock()
+	go m.watchSession(started, false)
 	slog.Debug(
 		"runtime launch session stored",
 		"workspace_id", workspaceID,
@@ -428,19 +430,20 @@ func (m *Manager) restoreTmuxSession(
 		return err
 	}
 	started.tmuxSession = tmuxSession
-	// startSession already starts drainOutput; restored tmux attach
-	// sessions only need the process watcher here.
-	go m.watchSession(started, false)
 
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
+		go m.watchSession(started, false)
 		_ = m.stopSession(ctx, started)
 		waitSessionDone(started)
 		return errManagerShutdown
 	}
 	m.sessions[key] = started
 	m.mu.Unlock()
+	// startSession already starts drainOutput; restored tmux attach
+	// sessions only need the process watcher here.
+	go m.watchSession(started, false)
 	slog.Debug(
 		"runtime tmux restore session stored",
 		"workspace_id", workspaceID,
@@ -594,6 +597,7 @@ func (m *Manager) stopSession(ctx context.Context, s *session) error {
 	if s == nil {
 		return nil
 	}
+	s.markStopRequested()
 	var cleanupErr error
 	if s.tmuxSession != "" {
 		if err := m.killTmuxSession(ctx, s.tmuxSession); err != nil {
@@ -922,11 +926,11 @@ func (m *Manager) EnsureShell(
 		)
 		return SessionInfo{}, err
 	}
-	go m.watchSession(started, true)
 
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
+		go m.watchSession(started, true)
 		_ = m.stopSession(ctx, started)
 		waitSessionDone(started)
 		slog.Debug(
@@ -938,6 +942,7 @@ func (m *Manager) EnsureShell(
 	}
 	m.shells[key] = started
 	m.mu.Unlock()
+	go m.watchSession(started, true)
 	slog.Debug(
 		"runtime shell session stored",
 		"workspace_id", workspaceID,
@@ -1347,6 +1352,9 @@ func (m *Manager) watchSession(
 	shell bool,
 ) {
 	info := s.watch()
+	if s.wasStopRequested() {
+		return
+	}
 	if m.removeExitedSession(info, s, shell) && m.onSessionExit != nil {
 		m.onSessionExit(info)
 	}
@@ -1683,6 +1691,18 @@ func (s *session) stop() {
 			_ = s.ptmx.Close()
 		}
 	})
+}
+
+func (s *session) markStopRequested() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stopRequested = true
+}
+
+func (s *session) wasStopRequested() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopRequested
 }
 
 func (s *session) detach() {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -73,6 +73,9 @@ type Options struct {
 	// StripEnvVars names additional env vars to strip beyond the
 	// built-in credential prefixes (e.g. a configured token env).
 	StripEnvVars []string
+	// OnSessionExit is called after a launched runtime session or shell exits
+	// naturally and is removed from the manager's active session maps.
+	OnSessionExit func(SessionInfo)
 }
 
 type Manager struct {
@@ -86,6 +89,7 @@ type Manager struct {
 	tmuxOwnerMarker  string
 	wrapAgentsInTmux bool
 	stripEnvVars     []string
+	onSessionExit    func(SessionInfo)
 	startLocks       map[string]*sync.Mutex
 	stoppingWS       map[string]int
 	inflightWS       map[string]int
@@ -164,6 +168,7 @@ func NewManager(options Options) *Manager {
 		tmuxOwnerMarker:  options.TmuxOwnerMarker,
 		wrapAgentsInTmux: options.WrapAgentSessionsInTmux,
 		stripEnvVars:     dedupeStrings(options.StripEnvVars),
+		onSessionExit:    options.OnSessionExit,
 		startLocks:       make(map[string]*sync.Mutex),
 		stoppingWS:       make(map[string]int),
 		inflightWS:       make(map[string]int),
@@ -303,7 +308,7 @@ func (m *Manager) Launch(
 		return SessionInfo{}, err
 	}
 	started.tmuxSession = launch.TmuxSession
-	go started.watch()
+	go m.watchSession(started, false)
 
 	m.mu.Lock()
 	if m.closed {
@@ -425,7 +430,7 @@ func (m *Manager) restoreTmuxSession(
 	started.tmuxSession = tmuxSession
 	// startSession already starts drainOutput; restored tmux attach
 	// sessions only need the process watcher here.
-	go started.watch()
+	go m.watchSession(started, false)
 
 	m.mu.Lock()
 	if m.closed {
@@ -917,7 +922,7 @@ func (m *Manager) EnsureShell(
 		)
 		return SessionInfo{}, err
 	}
-	go started.watch()
+	go m.watchSession(started, true)
 
 	m.mu.Lock()
 	if m.closed {
@@ -1337,6 +1342,36 @@ func (m *Manager) removeIfSame(
 	}
 }
 
+func (m *Manager) watchSession(
+	s *session,
+	shell bool,
+) {
+	info := s.watch()
+	if m.removeExitedSession(info, s, shell) && m.onSessionExit != nil {
+		m.onSessionExit(info)
+	}
+}
+
+func (m *Manager) removeExitedSession(
+	info SessionInfo,
+	s *session,
+	shell bool,
+) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sessions := m.sessions
+	if shell {
+		sessions = m.shells
+	}
+	current, ok := sessions[info.Key]
+	if !ok || current != s {
+		return false
+	}
+	delete(sessions, info.Key)
+	return true
+}
+
 func startSession(
 	info SessionInfo,
 	command []string,
@@ -1425,7 +1460,7 @@ func (s *session) snapshot() SessionInfo {
 	return info
 }
 
-func (s *session) watch() {
+func (s *session) watch() SessionInfo {
 	exitCode := waitExitCode(s.cmd.Wait())
 	now := time.Now().UTC()
 
@@ -1434,6 +1469,7 @@ func (s *session) watch() {
 	s.info.ExitedAt = &now
 	s.info.ExitCode = &exitCode
 	info := s.info
+	info.TmuxSession = s.tmuxSession
 	s.mu.Unlock()
 
 	_ = s.ptmx.Close()
@@ -1445,6 +1481,7 @@ func (s *session) watch() {
 		"target_key", info.TargetKey,
 		"exit_code", exitCode,
 	)
+	return info
 }
 
 func (s *session) drainOutput() {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -450,6 +450,43 @@ func TestManagerStopReportsTmuxCleanupFailure(t *testing.T) {
 	require.Len(mgr.ListSessions("ws-1"), 1)
 }
 
+func TestManagerStopFailedTmuxCleanupDoesNotSuppressExitCleanup(t *testing.T) {
+	requirePTYAvailable(t)
+	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	tmuxPath := filepath.Join(t.TempDir(), "tmux-fails")
+	require.NoError(os.WriteFile(
+		tmuxPath,
+		[]byte("#!/bin/sh\nexit 42\n"),
+		0o755,
+	))
+	ctx := context.Background()
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			helperTarget("helper", "sleep"),
+		},
+		TmuxCommand: []string{tmuxPath},
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	info, err := mgr.Launch(ctx, "ws-1", t.TempDir(), "helper")
+	require.NoError(err)
+
+	mgr.mu.Lock()
+	mgr.sessions[info.Key].tmuxSession = "middleman-ws-1-helper"
+	mgr.mu.Unlock()
+
+	err = mgr.Stop(ctx, "ws-1", info.Key)
+
+	require.Error(err)
+	require.Contains(err.Error(), "kill tmux session")
+	assert.Eventually(func() bool {
+		return len(mgr.ListSessions("ws-1")) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
 func TestManagerStopIgnoresAbsentTmuxSession(t *testing.T) {
 	tmuxPath := filepath.Join(t.TempDir(), "tmux-absent")
 	require.NoError(t, os.WriteFile(

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -733,13 +733,16 @@ func TestManagerStopKillsDescendantProcesses(t *testing.T) {
 		"descendant child should die with the session leader")
 }
 
-func TestManagerReportsExitedProcess(t *testing.T) {
+func TestManagerRemovesNaturallyExitedSession(t *testing.T) {
 	requirePTYAvailable(t)
 	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
 
 	ctx := context.Background()
+	exited := make(chan SessionInfo, 1)
 	mgr := NewManager(Options{Targets: []LaunchTarget{
 		helperTarget("helper", "exit"),
+	}, OnSessionExit: func(info SessionInfo) {
+		exited <- info
 	}})
 	t.Cleanup(mgr.Shutdown)
 
@@ -748,19 +751,57 @@ func TestManagerReportsExitedProcess(t *testing.T) {
 
 	var got SessionInfo
 	require.Eventually(t, func() bool {
-		sessions := mgr.ListSessions("ws-1")
-		if len(sessions) != 1 {
+		select {
+		case got = <-exited:
+			return true
+		default:
 			return false
 		}
-		got = sessions[0]
-		return got.Status == SessionStatusExited
 	}, 2*time.Second, 20*time.Millisecond)
 
 	assert := Assert.New(t)
 	assert.Equal(session.Key, got.Key)
+	assert.Equal(SessionStatusExited, got.Status)
 	assert.NotNil(got.ExitedAt)
 	assert.NotNil(got.ExitCode)
 	assert.Equal(3, *got.ExitCode)
+	assert.Empty(mgr.ListSessions("ws-1"))
+}
+
+func TestManagerRemovesNaturallyExitedShell(t *testing.T) {
+	requirePTYAvailable(t)
+	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
+
+	ctx := context.Background()
+	exited := make(chan SessionInfo, 1)
+	mgr := NewManager(Options{
+		ShellCommand: helperCommand("exit"),
+		OnSessionExit: func(info SessionInfo) {
+			exited <- info
+		},
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	shell, err := mgr.EnsureShell(ctx, "ws-1", t.TempDir())
+	require.NoError(t, err)
+
+	var got SessionInfo
+	require.Eventually(t, func() bool {
+		select {
+		case got = <-exited:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond)
+
+	assert := Assert.New(t)
+	assert.Equal(shell.Key, got.Key)
+	assert.Equal(SessionStatusExited, got.Status)
+	assert.NotNil(got.ExitedAt)
+	assert.NotNil(got.ExitCode)
+	assert.Equal(3, *got.ExitCode)
+	assert.Nil(mgr.ShellSession("ws-1"))
 }
 
 func TestManagerShellSingletonPerWorkspace(t *testing.T) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -30,12 +30,13 @@ import (
 // intentionally not a generic host worktree browser or arbitrary Git
 // automation layer.
 type Manager struct {
-	db          *db.DB
-	worktreeDir string
-	clones      *gitclone.Manager
-	tmuxCmd     []string
-	retryMu     sync.Mutex
-	retryQueued map[string]bool
+	db            *db.DB
+	worktreeDir   string
+	clones        *gitclone.Manager
+	tmuxCmd       []string
+	retryMu       sync.Mutex
+	retryQueued   map[string]bool
+	runtimeTmuxMu sync.Mutex
 }
 
 // CreateIssueOptions controls how issue-backed workspaces choose their branch.
@@ -1245,14 +1246,18 @@ func (m *Manager) RecordRuntimeTmuxSession(
 	workspaceID string,
 	sessionName string,
 	targetKey string,
+	createdAt time.Time,
 ) error {
 	if sessionName == "" {
 		return nil
 	}
+	m.runtimeTmuxMu.Lock()
+	defer m.runtimeTmuxMu.Unlock()
 	return m.db.UpsertWorkspaceTmuxSession(ctx, &db.WorkspaceTmuxSession{
 		WorkspaceID: workspaceID,
 		SessionName: sessionName,
 		TargetKey:   targetKey,
+		CreatedAt:   createdAt,
 	})
 }
 
@@ -1266,6 +1271,8 @@ func (m *Manager) ForgetRuntimeTmuxSession(
 	if sessionName == "" {
 		return nil
 	}
+	m.runtimeTmuxMu.Lock()
+	defer m.runtimeTmuxMu.Unlock()
 	return m.db.DeleteWorkspaceTmuxSession(ctx, workspaceID, sessionName)
 }
 
@@ -1275,10 +1282,13 @@ func (m *Manager) ForgetMissingRuntimeTmuxSession(
 	ctx context.Context,
 	workspaceID string,
 	sessionName string,
+	createdAt time.Time,
 ) (bool, error) {
 	if sessionName == "" {
 		return false, nil
 	}
+	m.runtimeTmuxMu.Lock()
+	defer m.runtimeTmuxMu.Unlock()
 	exists, err := m.tmuxSessionExists(ctx, sessionName)
 	if err != nil {
 		return false, err
@@ -1286,12 +1296,9 @@ func (m *Manager) ForgetMissingRuntimeTmuxSession(
 	if exists {
 		return false, nil
 	}
-	if err := m.db.DeleteWorkspaceTmuxSession(
-		ctx, workspaceID, sessionName,
-	); err != nil {
-		return false, err
-	}
-	return true, nil
+	return m.db.DeleteWorkspaceTmuxSessionCreatedAt(
+		ctx, workspaceID, sessionName, createdAt,
+	)
 }
 
 // StopStoredRuntimeTmuxSession cleans up a persisted runtime tmux session even
@@ -1304,6 +1311,8 @@ func (m *Manager) StopStoredRuntimeTmuxSession(
 	if targetKey == "" {
 		return false, nil
 	}
+	m.runtimeTmuxMu.Lock()
+	defer m.runtimeTmuxMu.Unlock()
 	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, workspaceID)
 	if err != nil {
 		return false, err

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1269,6 +1269,31 @@ func (m *Manager) ForgetRuntimeTmuxSession(
 	return m.db.DeleteWorkspaceTmuxSession(ctx, workspaceID, sessionName)
 }
 
+// ForgetMissingRuntimeTmuxSession removes a stored runtime tmux session only
+// after tmux reports that the session no longer exists.
+func (m *Manager) ForgetMissingRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+) (bool, error) {
+	if sessionName == "" {
+		return false, nil
+	}
+	exists, err := m.tmuxSessionExists(ctx, sessionName)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return false, nil
+	}
+	if err := m.db.DeleteWorkspaceTmuxSession(
+		ctx, workspaceID, sessionName,
+	); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // StopStoredRuntimeTmuxSession cleans up a persisted runtime tmux session even
 // when the in-memory runtime manager no longer knows about it.
 func (m *Manager) StopStoredRuntimeTmuxSession(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1243,6 +1243,59 @@ func TestManagerCleanupTmuxSessionPreservesStoredRowsAfterRuntimeKillFailure(
 	require.Len(stored, 2)
 }
 
+func TestManagerForgetMissingRuntimeTmuxSessionPreservesRecreatedRow(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`if [ "$1" = "has-session" ]; then` + "\n" +
+		`  echo "can't find session: $3" >&2` + "\n" +
+		`  exit 1` + "\n" +
+		`fi` + "\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script})
+	require.NoError(d.InsertWorkspace(context.Background(), &Workspace{
+		ID:           "ws-1",
+		TmuxSession:  "middleman-ws-1",
+		Status:       "ready",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/live",
+		WorktreePath: filepath.Join(t.TempDir(), "live"),
+	}))
+	oldCreatedAt := time.Date(2026, 4, 29, 1, 0, 0, 0, time.UTC)
+	newCreatedAt := time.Date(2026, 4, 29, 1, 1, 0, 0, time.UTC)
+	sessionName := "middleman-ws-1-helper"
+	require.NoError(mgr.RecordRuntimeTmuxSession(
+		context.Background(), "ws-1", sessionName, "helper", oldCreatedAt,
+	))
+	require.NoError(mgr.RecordRuntimeTmuxSession(
+		context.Background(), "ws-1", sessionName, "helper", newCreatedAt,
+	))
+
+	deleted, err := mgr.ForgetMissingRuntimeTmuxSession(
+		context.Background(), "ws-1", sessionName, oldCreatedAt,
+	)
+	require.NoError(err)
+	assert.False(deleted)
+
+	stored, err := d.ListWorkspaceTmuxSessions(context.Background(), "ws-1")
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal(newCreatedAt, stored[0].CreatedAt)
+}
+
 func TestManagerRequestRetryFailsWhenTmuxCleanupFails(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
## Summary
- Remove naturally exited runtime sessions from the local runtime manager so they no longer linger in workspace state
- Forget persisted tmux runtime rows after a tmux-backed session exits
- Close agent and shell terminal surfaces immediately in the Svelte workspace UI when their backing process ends
- Add backend and frontend coverage for natural exit cleanup flows

## Testing
- Added focused Go E2E coverage for natural agent exit and tmux-backed exit cleanup
- Added Svelte component tests for agent tab removal and shell drawer closure on exit
- Not run (not requested)