### PR TITLE
Add PR timeline filters for focused review triage

### DIFF
--- a/docs/superpowers/plans/2026-04-29-pr-timeline-filter.md
+++ b/docs/superpowers/plans/2026-04-29-pr-timeline-filter.md
@@ -1,0 +1,1530 @@
+# PR Timeline Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a localStorage-backed PR detail activity filter and expand stored PR timeline events to include cross references, title changes, and base branch changes.
+
+**Architecture:** Extend the GitHub GraphQL timeline fetcher from force-push-only to a typed PR timeline event fetcher, normalize those events into the existing `middleman_mr_events` table, and render/filter them locally in the PR detail UI. No DB migration or settings API change is needed because new events fit the existing event row shape and PR filter state is browser-local.
+
+**Tech Stack:** Go, go-github/v84, GitHub GraphQL API, SQLite, Svelte 5, TypeScript, Vitest, Testing Library, shared `FilterDropdown`.
+
+---
+
+## File Structure
+
+- Modify `internal/github/client.go`: add `PullRequestTimelineEvent`, GraphQL query fields, and `ListPullRequestTimelineEvents`; keep `ListForcePushEvents` as a compatibility wrapper.
+- Modify `internal/github/client_test.go`: replace force-push-only GraphQL tests with tests covering force push, cross reference, title rename, base ref change, pagination, GraphQL errors, and null repository/pull request errors.
+- Modify `internal/github/normalize.go`: add `NormalizeTimelineEvent` and metadata structs for new system event types.
+- Modify `internal/github/normalize_test.go`: cover normalization for `cross_referenced`, `renamed_title`, `base_ref_changed`, and existing `force_push`.
+- Modify `internal/github/sync.go`: fetch typed timeline events in `refreshTimeline`, log optional failures, and upsert normalized system events alongside comments/reviews/commits.
+- Modify `internal/github/sync_test.go`: update mock client and add sync coverage for new timeline events plus optional timeline fetch failure.
+- Create `packages/ui/src/components/detail/prTimelineFilter.ts`: event classification, localStorage persistence, filter defaults, and filtering helpers.
+- Create `packages/ui/src/components/detail/prTimelineFilter.test.ts`: unit tests for default state, persistence, classification, bot filtering, and event filtering.
+- Create `packages/ui/src/components/detail/PRTimelineFilter.svelte`: reusable PR detail filter control that wraps shared `FilterDropdown`.
+- Create `packages/ui/src/components/detail/PRTimelineFilter.test.ts`: component tests proving the shared dropdown control toggles PR timeline filters.
+- Modify `packages/ui/src/components/detail/EventTimeline.svelte`: compact rendering for commit/system events and filtered-empty messaging.
+- Modify `packages/ui/src/components/detail/EventTimeline.test.ts`: cover compact commits and new system event rendering.
+- Modify `packages/ui/src/components/detail/PullDetail.svelte`: wire filter state above the Activity feed and pass filtered events to `EventTimeline`.
+
+---
+
+## Task 1: Backend Timeline Event Types And Client Tests
+
+**Files:**
+- Modify: `internal/github/client.go`
+- Modify: `internal/github/client_test.go`
+
+- [ ] **Step 1: Write failing client interface and parsing tests**
+
+Add tests in `internal/github/client_test.go` that call `ListPullRequestTimelineEvents` and expect all approved event types to parse from one paginated GraphQL response.
+
+```go
+func TestClientInterfaceIncludesListPullRequestTimelineEvents(t *testing.T) {
+	_, ok := reflect.TypeFor[Client]().MethodByName("ListPullRequestTimelineEvents")
+	require.True(t, ok)
+}
+
+func TestListPullRequestTimelineEvents(t *testing.T) {
+	require := require.New(t)
+	var calls int
+	var methods []string
+	var contentTypes []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		methods = append(methods, r.Method)
+		contentTypes = append(contentTypes, r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"HeadRefForcePushedEvent","id":"HFP_1","actor":{"login":"alice"},"beforeCommit":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"afterCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"createdAt":"2024-06-01T12:00:00Z","ref":{"name":"feature"}},{"__typename":"RenamedTitleEvent","id":"RTE_1","actor":{"login":"bob"},"createdAt":"2024-06-01T12:05:00Z","previousTitle":"Old title","currentTitle":"New title"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"BaseRefChangedEvent","id":"BRC_1","actor":{"login":"carol"},"createdAt":"2024-06-01T12:10:00Z","previousRefName":"main","currentRefName":"release"},{"__typename":"CrossReferencedEvent","id":"CRE_1","actor":{"login":"dave"},"createdAt":"2024-06-01T12:15:00Z","isCrossRepository":true,"willCloseTarget":false,"source":{"__typename":"Issue","number":77,"title":"Related bug","url":"https://github.com/other/repo/issues/77","repository":{"owner":{"login":"other"},"name":"repo"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &liveClient{
+		httpClient:      srv.Client(),
+		graphQLEndpoint: srv.URL + "/graphql",
+	}
+
+	events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
+	require.NoError(err)
+	require.Len(events, 4)
+	require.Equal("force_push", events[0].EventType)
+	require.Equal("HFP_1", events[0].NodeID)
+	require.Equal("alice", events[0].Actor)
+	require.Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", events[0].BeforeSHA)
+	require.Equal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", events[0].AfterSHA)
+	require.Equal("feature", events[0].Ref)
+	require.Equal("renamed_title", events[1].EventType)
+	require.Equal("Old title", events[1].PreviousTitle)
+	require.Equal("New title", events[1].CurrentTitle)
+	require.Equal("base_ref_changed", events[2].EventType)
+	require.Equal("main", events[2].PreviousRefName)
+	require.Equal("release", events[2].CurrentRefName)
+	require.Equal("cross_referenced", events[3].EventType)
+	require.Equal("Issue", events[3].SourceType)
+	require.Equal("other", events[3].SourceOwner)
+	require.Equal("repo", events[3].SourceRepo)
+	require.Equal(77, events[3].SourceNumber)
+	require.Equal("Related bug", events[3].SourceTitle)
+	require.True(events[3].IsCrossRepository)
+	require.False(events[3].WillCloseTarget)
+	require.Equal(2, calls)
+	require.Equal([]string{http.MethodPost, http.MethodPost}, methods)
+	require.Equal([]string{"application/json", "application/json"}, contentTypes)
+}
+```
+
+Update the existing error tests to call `ListPullRequestTimelineEvents` and expect the same error behavior:
+
+```go
+func TestListPullRequestTimelineEventsReturnsGraphQLErrors(t *testing.T) {
+	require := require.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errors":[{"message":"permission denied"}],"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+	}))
+	defer srv.Close()
+
+	c := &liveClient{
+		httpClient:      srv.Client(),
+		graphQLEndpoint: srv.URL,
+	}
+
+	events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
+	require.Nil(events)
+	require.ErrorContains(err, "permission denied")
+}
+```
+
+- [ ] **Step 2: Run the failing client tests**
+
+Run:
+
+```bash
+go test ./internal/github -run 'TestClientInterfaceIncludesListPullRequestTimelineEvents|TestListPullRequestTimelineEvents' -shuffle=on
+```
+
+Expected: FAIL because `Client` does not yet expose `ListPullRequestTimelineEvents`.
+
+- [ ] **Step 3: Implement typed timeline event fetch**
+
+In `internal/github/client.go`, add the typed event model near `ForcePushEvent`:
+
+```go
+type PullRequestTimelineEvent struct {
+	NodeID            string
+	EventType         string
+	Actor             string
+	CreatedAt         time.Time
+	BeforeSHA         string
+	AfterSHA          string
+	Ref               string
+	PreviousTitle     string
+	CurrentTitle      string
+	PreviousRefName   string
+	CurrentRefName    string
+	SourceType        string
+	SourceOwner       string
+	SourceRepo        string
+	SourceNumber      int
+	SourceTitle       string
+	SourceURL         string
+	IsCrossRepository bool
+	WillCloseTarget   bool
+}
+```
+
+Add this method to `Client`:
+
+```go
+ListPullRequestTimelineEvents(ctx context.Context, owner, repo string, number int) ([]PullRequestTimelineEvent, error)
+```
+
+Replace `forcePushTimelineQuery` with a broader query:
+
+```go
+const pullRequestTimelineEventsQuery = `
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      timelineItems(
+        itemTypes: [
+          HEAD_REF_FORCE_PUSHED_EVENT,
+          CROSS_REFERENCED_EVENT,
+          RENAMED_TITLE_EVENT,
+          BASE_REF_CHANGED_EVENT
+        ],
+        first: 100,
+        after: $cursor
+      ) {
+        nodes {
+          __typename
+          ... on Node { id }
+          ... on HeadRefForcePushedEvent {
+            actor { login }
+            beforeCommit { oid }
+            afterCommit { oid }
+            createdAt
+            ref { name }
+          }
+          ... on RenamedTitleEvent {
+            actor { login }
+            createdAt
+            previousTitle
+            currentTitle
+          }
+          ... on BaseRefChangedEvent {
+            actor { login }
+            createdAt
+            previousRefName
+            currentRefName
+          }
+          ... on CrossReferencedEvent {
+            actor { login }
+            createdAt
+            isCrossRepository
+            willCloseTarget
+            source {
+              __typename
+              ... on Issue {
+                number
+                title
+                url
+                repository { owner { login } name }
+              }
+              ... on PullRequest {
+                number
+                title
+                url
+                repository { owner { login } name }
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}`
+```
+
+Implement `ListPullRequestTimelineEvents` by adapting the current `ListForcePushEvents` loop, decoding `__typename`, and mapping type names:
+
+```go
+func timelineEventType(graphQLType string) string {
+	switch graphQLType {
+	case "HeadRefForcePushedEvent":
+		return "force_push"
+	case "CrossReferencedEvent":
+		return "cross_referenced"
+	case "RenamedTitleEvent":
+		return "renamed_title"
+	case "BaseRefChangedEvent":
+		return "base_ref_changed"
+	default:
+		return ""
+	}
+}
+```
+
+Keep `ListForcePushEvents` as a compatibility wrapper:
+
+```go
+func (c *liveClient) ListForcePushEvents(
+	ctx context.Context, owner, repo string, number int,
+) ([]ForcePushEvent, error) {
+	timelineEvents, err := c.ListPullRequestTimelineEvents(ctx, owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
+	var events []ForcePushEvent
+	for _, event := range timelineEvents {
+		if event.EventType != "force_push" {
+			continue
+		}
+		events = append(events, ForcePushEvent{
+			Actor:     event.Actor,
+			BeforeSHA: event.BeforeSHA,
+			AfterSHA:  event.AfterSHA,
+			Ref:       event.Ref,
+			CreatedAt: event.CreatedAt,
+		})
+	}
+	return events, nil
+}
+```
+
+- [ ] **Step 4: Run the client tests again**
+
+Run:
+
+```bash
+go test ./internal/github -run 'TestClientInterfaceIncludesListPullRequestTimelineEvents|TestListPullRequestTimelineEvents|TestListForcePushEvents' -shuffle=on
+```
+
+Expected: PASS.
+
+---
+
+## Task 2: Backend Timeline Event Normalization
+
+**Files:**
+- Modify: `internal/github/normalize.go`
+- Modify: `internal/github/normalize_test.go`
+
+- [ ] **Step 1: Write failing normalization tests**
+
+Add tests in `internal/github/normalize_test.go`:
+
+```go
+func TestNormalizeTimelineEventCrossReferenced(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 15, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:            "CRE_1",
+		EventType:         "cross_referenced",
+		Actor:             "alice",
+		CreatedAt:         createdAt,
+		SourceType:        "Issue",
+		SourceOwner:       "other",
+		SourceRepo:        "repo",
+		SourceNumber:      77,
+		SourceTitle:       "Related bug",
+		SourceURL:         "https://github.com/other/repo/issues/77",
+		IsCrossRepository: true,
+		WillCloseTarget:   false,
+	})
+
+	require.NotNil(event)
+	assert.Equal(int64(17), event.MergeRequestID)
+	assert.Equal("cross_referenced", event.EventType)
+	assert.Equal("alice", event.Author)
+	assert.Equal("Referenced from other/repo#77", event.Summary)
+	assert.Equal(createdAt, event.CreatedAt)
+	assert.Equal("timeline-CRE_1", event.DedupeKey)
+	assert.Contains(event.MetadataJSON, `"source_title":"Related bug"`)
+	assert.Contains(event.MetadataJSON, `"is_cross_repository":true`)
+}
+
+func TestNormalizeTimelineEventRenamedTitle(t *testing.T) {
+	assert := assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 5, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:        "RTE_1",
+		EventType:     "renamed_title",
+		Actor:         "bob",
+		CreatedAt:     createdAt,
+		PreviousTitle: "Old title",
+		CurrentTitle:  "New title",
+	})
+
+	assert.Equal("renamed_title", event.EventType)
+	assert.Equal("bob", event.Author)
+	assert.Equal(`"Old title" -> "New title"`, event.Summary)
+	assert.Contains(event.MetadataJSON, `"previous_title":"Old title"`)
+	assert.Contains(event.MetadataJSON, `"current_title":"New title"`)
+}
+
+func TestNormalizeTimelineEventBaseRefChanged(t *testing.T) {
+	assert := assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 10, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:          "BRC_1",
+		EventType:       "base_ref_changed",
+		Actor:           "carol",
+		CreatedAt:       createdAt,
+		PreviousRefName: "main",
+		CurrentRefName:  "release",
+	})
+
+	assert.Equal("base_ref_changed", event.EventType)
+	assert.Equal("carol", event.Author)
+	assert.Equal("main -> release", event.Summary)
+	assert.Contains(event.MetadataJSON, `"previous_ref_name":"main"`)
+	assert.Contains(event.MetadataJSON, `"current_ref_name":"release"`)
+}
+```
+
+- [ ] **Step 2: Run the failing normalization tests**
+
+Run:
+
+```bash
+go test ./internal/github -run 'TestNormalizeTimelineEvent' -shuffle=on
+```
+
+Expected: FAIL because `NormalizeTimelineEvent` does not exist.
+
+- [ ] **Step 3: Implement timeline normalization**
+
+In `internal/github/normalize.go`, add metadata structs and a normalizer:
+
+```go
+type crossReferenceMetadata struct {
+	SourceType        string `json:"source_type"`
+	SourceOwner       string `json:"source_owner"`
+	SourceRepo        string `json:"source_repo"`
+	SourceNumber      int    `json:"source_number"`
+	SourceTitle       string `json:"source_title"`
+	SourceURL         string `json:"source_url"`
+	IsCrossRepository bool   `json:"is_cross_repository"`
+	WillCloseTarget   bool   `json:"will_close_target"`
+}
+
+type renamedTitleMetadata struct {
+	PreviousTitle string `json:"previous_title"`
+	CurrentTitle  string `json:"current_title"`
+}
+
+type baseRefChangedMetadata struct {
+	PreviousRefName string `json:"previous_ref_name"`
+	CurrentRefName  string `json:"current_ref_name"`
+}
+
+func NormalizeTimelineEvent(mrID int64, event PullRequestTimelineEvent) *db.MREvent {
+	switch event.EventType {
+	case "force_push":
+		fp := NormalizeForcePushEvent(mrID, ForcePushEvent{
+			Actor:     event.Actor,
+			BeforeSHA: event.BeforeSHA,
+			AfterSHA:  event.AfterSHA,
+			Ref:       event.Ref,
+			CreatedAt: event.CreatedAt,
+		})
+		if event.NodeID != "" {
+			fp.DedupeKey = "timeline-" + event.NodeID
+		}
+		return &fp
+	case "cross_referenced":
+		metadata, _ := json.Marshal(crossReferenceMetadata{
+			SourceType:        event.SourceType,
+			SourceOwner:       event.SourceOwner,
+			SourceRepo:        event.SourceRepo,
+			SourceNumber:      event.SourceNumber,
+			SourceTitle:       event.SourceTitle,
+			SourceURL:         event.SourceURL,
+			IsCrossRepository: event.IsCrossRepository,
+			WillCloseTarget:   event.WillCloseTarget,
+		})
+		return &db.MREvent{
+			MergeRequestID: mrID,
+			EventType:      "cross_referenced",
+			Author:         event.Actor,
+			Summary:        fmt.Sprintf("Referenced from %s/%s#%d", event.SourceOwner, event.SourceRepo, event.SourceNumber),
+			MetadataJSON:   string(metadata),
+			CreatedAt:      event.CreatedAt,
+			DedupeKey:      timelineDedupeKey(event),
+		}
+	case "renamed_title":
+		metadata, _ := json.Marshal(renamedTitleMetadata{
+			PreviousTitle: event.PreviousTitle,
+			CurrentTitle:  event.CurrentTitle,
+		})
+		return &db.MREvent{
+			MergeRequestID: mrID,
+			EventType:      "renamed_title",
+			Author:         event.Actor,
+			Summary:        fmt.Sprintf("%q -> %q", event.PreviousTitle, event.CurrentTitle),
+			MetadataJSON:   string(metadata),
+			CreatedAt:      event.CreatedAt,
+			DedupeKey:      timelineDedupeKey(event),
+		}
+	case "base_ref_changed":
+		metadata, _ := json.Marshal(baseRefChangedMetadata{
+			PreviousRefName: event.PreviousRefName,
+			CurrentRefName:  event.CurrentRefName,
+		})
+		return &db.MREvent{
+			MergeRequestID: mrID,
+			EventType:      "base_ref_changed",
+			Author:         event.Actor,
+			Summary:        event.PreviousRefName + " -> " + event.CurrentRefName,
+			MetadataJSON:   string(metadata),
+			CreatedAt:      event.CreatedAt,
+			DedupeKey:      timelineDedupeKey(event),
+		}
+	default:
+		return nil
+	}
+}
+
+func timelineDedupeKey(event PullRequestTimelineEvent) string {
+	if event.NodeID != "" {
+		return "timeline-" + event.NodeID
+	}
+	raw := strings.Join([]string{
+		event.EventType,
+		event.CreatedAt.UTC().Format(time.RFC3339Nano),
+		event.Actor,
+		event.PreviousTitle,
+		event.CurrentTitle,
+		event.PreviousRefName,
+		event.CurrentRefName,
+		fmt.Sprintf("%s/%s#%d", event.SourceOwner, event.SourceRepo, event.SourceNumber),
+	}, "|")
+	return "timeline-" + shortHash(raw)
+}
+```
+
+Add `shortHash` in `normalize.go` with `crypto/sha1`, `encoding/hex`, and the first 12 hex characters:
+
+```go
+func shortHash(value string) string {
+	sum := sha1.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])[:12]
+}
+```
+
+- [ ] **Step 4: Run normalization tests**
+
+Run:
+
+```bash
+go test ./internal/github -run 'TestNormalizeTimelineEvent|TestNormalizeForcePushEvent' -shuffle=on
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Sync New Timeline Events
+
+**Files:**
+- Modify: `internal/github/sync.go`
+- Modify: `internal/github/sync_test.go`
+
+- [ ] **Step 1: Update mock client and write failing sync tests**
+
+In `internal/github/sync_test.go`, add fields and method to `mockClient`:
+
+```go
+	timelineEvents    []PullRequestTimelineEvent
+	timelineEventsErr error
+```
+
+```go
+func (m *mockClient) ListPullRequestTimelineEvents(_ context.Context, _, _ string, _ int) ([]PullRequestTimelineEvent, error) {
+	m.trackCall()
+	if m.timelineEventsErr != nil {
+		return nil, m.timelineEventsErr
+	}
+	return m.timelineEvents, nil
+}
+```
+
+Add this test near `TestSyncStoresForcePushEvent`:
+
+```go
+func TestSyncStoresPullRequestTimelineEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	mc := &mockClient{
+		openPRs: []*gh.PullRequest{buildOpenPR(1, now)},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		timelineEvents: []PullRequestTimelineEvent{
+			{
+				NodeID:            "CRE_1",
+				EventType:         "cross_referenced",
+				Actor:             "alice",
+				CreatedAt:         now.Add(-3 * time.Minute),
+				SourceType:        "Issue",
+				SourceOwner:       "other",
+				SourceRepo:        "repo",
+				SourceNumber:      77,
+				SourceTitle:       "Related bug",
+				SourceURL:         "https://github.com/other/repo/issues/77",
+				IsCrossRepository: true,
+			},
+			{
+				NodeID:          "BRC_1",
+				EventType:       "base_ref_changed",
+				Actor:           "bob",
+				CreatedAt:       now.Add(-2 * time.Minute),
+				PreviousRefName: "main",
+				CurrentRefName:  "release",
+			},
+			{
+				NodeID:        "RTE_1",
+				EventType:     "renamed_title",
+				Actor:         "carol",
+				CreatedAt:     now.Add(-1 * time.Minute),
+				PreviousTitle: "Old",
+				CurrentTitle:  "New",
+			},
+		},
+	}
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
+	syncer.RunOnce(ctx)
+
+	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(pr)
+
+	events, err := d.ListMREvents(ctx, pr.ID)
+	require.NoError(err)
+
+	byType := map[string]db.MREvent{}
+	for _, event := range events {
+		byType[event.EventType] = event
+	}
+	assert.Contains(byType, "cross_referenced")
+	assert.Contains(byType, "base_ref_changed")
+	assert.Contains(byType, "renamed_title")
+	assert.Contains(byType["cross_referenced"].MetadataJSON, `"source_title":"Related bug"`)
+	assert.Equal("main -> release", byType["base_ref_changed"].Summary)
+	assert.Equal(`"Old" -> "New"`, byType["renamed_title"].Summary)
+}
+```
+
+Add optional-failure coverage:
+
+```go
+func TestSyncIgnoresPullRequestTimelineFetchFailures(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	commentID := int64(123)
+	body := "human comment"
+	user := &gh.User{Login: new("alice")}
+
+	mc := &mockClient{
+		openPRs: []*gh.PullRequest{buildOpenPR(1, now)},
+		comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			User:      user,
+			Body:      &body,
+			CreatedAt: makeTimestamp(now.Add(-time.Minute)),
+		}},
+		reviews:           []*gh.PullRequestReview{},
+		commits:           []*gh.RepositoryCommit{},
+		timelineEventsErr: errors.New("graphql unavailable"),
+	}
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
+	syncer.RunOnce(ctx)
+
+	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(pr)
+	events, err := d.ListMREvents(ctx, pr.ID)
+	require.NoError(err)
+	require.NotEmpty(events)
+	require.Equal("issue_comment", events[0].EventType)
+}
+```
+
+- [ ] **Step 2: Run the failing sync tests**
+
+Run:
+
+```bash
+go test ./internal/github -run 'TestSyncStoresPullRequestTimelineEvents|TestSyncIgnoresPullRequestTimelineFetchFailures' -shuffle=on
+```
+
+Expected: FAIL because sync does not call `ListPullRequestTimelineEvents`.
+
+- [ ] **Step 3: Implement sync wiring**
+
+In `refreshTimeline`, replace the force-push-only fetch block with:
+
+```go
+timelineEvents, err := client.ListPullRequestTimelineEvents(ctx, repo.Owner, repo.Name, number)
+if err != nil {
+	slog.Warn("timeline event fetch failed during timeline refresh",
+		"repo", repo.Owner+"/"+repo.Name,
+		"number", number,
+		"err", err,
+	)
+	timelineEvents = nil
+}
+```
+
+Replace the force-push append loop with:
+
+```go
+for _, timelineEvent := range timelineEvents {
+	event := NormalizeTimelineEvent(mrID, timelineEvent)
+	if event == nil {
+		continue
+	}
+	events = append(events, *event)
+}
+```
+
+Keep `computeLastActivity` unchanged for now. The existing behavior derives last activity from PR updated time, comments, reviews, and commits; system timeline events should display in detail but do not need to alter list ordering in this slice.
+
+- [ ] **Step 4: Run sync tests**
+
+Run:
+
+```bash
+go test ./internal/github -run 'TestSyncStoresPullRequestTimelineEvents|TestSyncIgnoresPullRequestTimelineFetchFailures|TestSyncStoresForcePushEvent' -shuffle=on
+```
+
+Expected: PASS.
+
+---
+
+## Task 4: PR Timeline Filter Helper
+
+**Files:**
+- Create: `packages/ui/src/components/detail/prTimelineFilter.ts`
+- Create: `packages/ui/src/components/detail/prTimelineFilter.test.ts`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Create `packages/ui/src/components/detail/prTimelineFilter.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PREvent } from "../../api/types.js";
+import {
+  DEFAULT_PR_TIMELINE_FILTER,
+  filterPREvents,
+  loadPRTimelineFilter,
+  savePRTimelineFilter,
+  timelineEventBucket,
+} from "./prTimelineFilter.js";
+
+function event(overrides: Partial<PREvent>): PREvent {
+  return {
+    ID: 1,
+    MergeRequestID: 1,
+    PlatformID: null,
+    EventType: "issue_comment",
+    Author: "alice",
+    Summary: "",
+    Body: "body",
+    MetadataJSON: "",
+    CreatedAt: "2024-06-01T12:00:00Z",
+    DedupeKey: "event-1",
+    ...overrides,
+  } as PREvent;
+}
+
+describe("prTimelineFilter", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to showing every bucket and bot activity", () => {
+    expect(loadPRTimelineFilter()).toEqual(DEFAULT_PR_TIMELINE_FILTER);
+  });
+
+  it("persists valid filter state to localStorage", () => {
+    savePRTimelineFilter({
+      showMessages: false,
+      showCommitDetails: true,
+      showEvents: true,
+      showForcePushes: false,
+      hideBots: true,
+    });
+
+    expect(loadPRTimelineFilter()).toEqual({
+      showMessages: false,
+      showCommitDetails: true,
+      showEvents: true,
+      showForcePushes: false,
+      hideBots: true,
+    });
+  });
+
+  it("classifies event buckets", () => {
+    expect(timelineEventBucket(event({ EventType: "issue_comment" }))).toBe("messages");
+    expect(timelineEventBucket(event({ EventType: "review" }))).toBe("messages");
+    expect(timelineEventBucket(event({ EventType: "commit" }))).toBe("commitDetails");
+    expect(timelineEventBucket(event({ EventType: "force_push" }))).toBe("forcePushes");
+    expect(timelineEventBucket(event({ EventType: "cross_referenced" }))).toBe("events");
+    expect(timelineEventBucket(event({ EventType: "renamed_title" }))).toBe("events");
+    expect(timelineEventBucket(event({ EventType: "base_ref_changed" }))).toBe("events");
+  });
+
+  it("filters by disabled buckets and bots", () => {
+    const events = [
+      event({ ID: 1, EventType: "issue_comment", Author: "alice" }),
+      event({ ID: 2, EventType: "review", Author: "renovate[bot]" }),
+      event({ ID: 3, EventType: "commit", Author: "alice" }),
+      event({ ID: 4, EventType: "force_push", Author: "alice" }),
+      event({ ID: 5, EventType: "base_ref_changed", Author: "alice" }),
+    ];
+
+    expect(filterPREvents(events, {
+      showMessages: true,
+      showCommitDetails: false,
+      showEvents: true,
+      showForcePushes: false,
+      hideBots: true,
+    }).map((item) => item.ID)).toEqual([1, 5]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing helper tests**
+
+Run:
+
+```bash
+cd frontend && bunx vitest run ../packages/ui/src/components/detail/prTimelineFilter.test.ts
+```
+
+Expected: FAIL because `prTimelineFilter.ts` does not exist.
+
+- [ ] **Step 3: Implement helper**
+
+Create `packages/ui/src/components/detail/prTimelineFilter.ts`:
+
+```ts
+import type { PREvent } from "../../api/types.js";
+
+export interface PRTimelineFilterState {
+  showMessages: boolean;
+  showCommitDetails: boolean;
+  showEvents: boolean;
+  showForcePushes: boolean;
+  hideBots: boolean;
+}
+
+export type PRTimelineEventBucket =
+  | "messages"
+  | "commitDetails"
+  | "events"
+  | "forcePushes";
+
+export const PR_TIMELINE_FILTER_STORAGE_KEY = "middleman-pr-timeline-filter";
+
+export const DEFAULT_PR_TIMELINE_FILTER: PRTimelineFilterState = {
+  showMessages: true,
+  showCommitDetails: true,
+  showEvents: true,
+  showForcePushes: true,
+  hideBots: false,
+};
+
+const BOT_SUFFIXES = ["[bot]", "-bot", "bot"];
+
+export function isBotAuthor(author: string): boolean {
+  const lower = author.toLowerCase();
+  return BOT_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
+export function timelineEventBucket(event: PREvent): PRTimelineEventBucket {
+  switch (event.EventType) {
+    case "issue_comment":
+    case "review":
+    case "review_comment":
+      return "messages";
+    case "commit":
+      return "commitDetails";
+    case "force_push":
+      return "forcePushes";
+    default:
+      return "events";
+  }
+}
+
+function normalizeFilter(value: Partial<PRTimelineFilterState> | null): PRTimelineFilterState {
+  return {
+    showMessages: value?.showMessages ?? DEFAULT_PR_TIMELINE_FILTER.showMessages,
+    showCommitDetails: value?.showCommitDetails ?? DEFAULT_PR_TIMELINE_FILTER.showCommitDetails,
+    showEvents: value?.showEvents ?? DEFAULT_PR_TIMELINE_FILTER.showEvents,
+    showForcePushes: value?.showForcePushes ?? DEFAULT_PR_TIMELINE_FILTER.showForcePushes,
+    hideBots: value?.hideBots ?? DEFAULT_PR_TIMELINE_FILTER.hideBots,
+  };
+}
+
+export function loadPRTimelineFilter(): PRTimelineFilterState {
+  try {
+    const raw = localStorage.getItem(PR_TIMELINE_FILTER_STORAGE_KEY);
+    if (!raw) return DEFAULT_PR_TIMELINE_FILTER;
+    const parsed = JSON.parse(raw) as Partial<PRTimelineFilterState>;
+    return normalizeFilter(parsed);
+  } catch {
+    return DEFAULT_PR_TIMELINE_FILTER;
+  }
+}
+
+export function savePRTimelineFilter(filter: PRTimelineFilterState): void {
+  try {
+    localStorage.setItem(PR_TIMELINE_FILTER_STORAGE_KEY, JSON.stringify(filter));
+  } catch {
+    // localStorage can be unavailable in private browsing or embedded contexts.
+  }
+}
+
+export function filterPREvents(events: PREvent[], filter: PRTimelineFilterState): PREvent[] {
+  return events.filter((event) => {
+    if (filter.hideBots && isBotAuthor(event.Author)) return false;
+    switch (timelineEventBucket(event)) {
+      case "messages":
+        return filter.showMessages;
+      case "commitDetails":
+        return filter.showCommitDetails;
+      case "events":
+        return filter.showEvents;
+      case "forcePushes":
+        return filter.showForcePushes;
+    }
+  });
+}
+
+export function activePRTimelineFilterCount(filter: PRTimelineFilterState): number {
+  return [
+    !filter.showMessages,
+    !filter.showCommitDetails,
+    !filter.showEvents,
+    !filter.showForcePushes,
+    filter.hideBots,
+  ].filter(Boolean).length;
+}
+```
+
+- [ ] **Step 4: Run helper tests**
+
+Run:
+
+```bash
+cd frontend && bunx vitest run ../packages/ui/src/components/detail/prTimelineFilter.test.ts
+```
+
+Expected: PASS.
+
+---
+
+## Task 5: PR Timeline Filter Component
+
+**Files:**
+- Create: `packages/ui/src/components/detail/PRTimelineFilter.svelte`
+- Create: `packages/ui/src/components/detail/PRTimelineFilter.test.ts`
+
+- [ ] **Step 1: Write failing component tests**
+
+Create `packages/ui/src/components/detail/PRTimelineFilter.test.ts`:
+
+```ts
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PRTimelineFilter from "./PRTimelineFilter.svelte";
+import { DEFAULT_PR_TIMELINE_FILTER } from "./prTimelineFilter.js";
+
+describe("PRTimelineFilter", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the shared filter dropdown trigger and emits changes", async () => {
+    const onChange = vi.fn();
+    render(PRTimelineFilter, {
+      props: {
+        filter: DEFAULT_PR_TIMELINE_FILTER,
+        onChange,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /filters/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /messages/i }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_PR_TIMELINE_FILTER,
+      showMessages: false,
+    });
+    expect(document.querySelector(".filter-dropdown")).toBeTruthy();
+  });
+
+  it("shows active filter count and reset", async () => {
+    const onChange = vi.fn();
+    render(PRTimelineFilter, {
+      props: {
+        filter: {
+          ...DEFAULT_PR_TIMELINE_FILTER,
+          showCommitDetails: false,
+          hideBots: true,
+        },
+        onChange,
+      },
+    });
+
+    expect(screen.getByText("2")).toBeTruthy();
+    await fireEvent.click(screen.getByRole("button", { name: /filters/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /show all/i }));
+
+    expect(onChange).toHaveBeenCalledWith(DEFAULT_PR_TIMELINE_FILTER);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing component tests**
+
+Run:
+
+```bash
+cd frontend && bunx vitest run ../packages/ui/src/components/detail/PRTimelineFilter.test.ts
+```
+
+Expected: FAIL because `PRTimelineFilter.svelte` does not exist.
+
+- [ ] **Step 3: Implement component using shared `FilterDropdown`**
+
+Create `packages/ui/src/components/detail/PRTimelineFilter.svelte`:
+
+```svelte
+<script lang="ts">
+  import FilterDropdown from "../shared/FilterDropdown.svelte";
+  import {
+    DEFAULT_PR_TIMELINE_FILTER,
+    activePRTimelineFilterCount,
+    type PRTimelineFilterState,
+  } from "./prTimelineFilter.js";
+
+  interface Props {
+    filter: PRTimelineFilterState;
+    onChange: (filter: PRTimelineFilterState) => void;
+  }
+
+  let { filter, onChange }: Props = $props();
+
+  const activeCount = $derived(activePRTimelineFilterCount(filter));
+
+  function update(patch: Partial<PRTimelineFilterState>): void {
+    onChange({ ...filter, ...patch });
+  }
+
+  const sections = $derived.by(() => [
+    {
+      title: "Content",
+      items: [
+        {
+          id: "messages",
+          label: "Messages",
+          active: filter.showMessages,
+          color: "var(--accent-blue)",
+          onSelect: () => update({ showMessages: !filter.showMessages }),
+        },
+        {
+          id: "commit-details",
+          label: "Commit details",
+          active: filter.showCommitDetails,
+          color: "var(--accent-green)",
+          onSelect: () => update({ showCommitDetails: !filter.showCommitDetails }),
+        },
+        {
+          id: "events",
+          label: "Events",
+          active: filter.showEvents,
+          color: "var(--accent-amber)",
+          onSelect: () => update({ showEvents: !filter.showEvents }),
+        },
+        {
+          id: "force-pushes",
+          label: "Force pushes",
+          active: filter.showForcePushes,
+          color: "var(--accent-red)",
+          onSelect: () => update({ showForcePushes: !filter.showForcePushes }),
+        },
+      ],
+    },
+    {
+      title: "Visibility",
+      items: [
+        {
+          id: "hide-bots",
+          label: "Hide bot activity",
+          active: filter.hideBots,
+          color: "var(--accent-purple)",
+          onSelect: () => update({ hideBots: !filter.hideBots }),
+        },
+      ],
+    },
+  ]);
+</script>
+
+<FilterDropdown
+  label="Filters"
+  active={activeCount > 0}
+  badgeCount={activeCount}
+  title="Filter PR activity"
+  {sections}
+  minWidth="220px"
+  {...activeCount > 0
+    ? {
+        resetLabel: "Show all",
+        onReset: () => onChange(DEFAULT_PR_TIMELINE_FILTER),
+      }
+    : {}}
+/>
+```
+
+- [ ] **Step 4: Run component tests and Svelte autofixer**
+
+Run:
+
+```bash
+cd frontend && bunx vitest run ../packages/ui/src/components/detail/PRTimelineFilter.test.ts
+npx @sveltejs/mcp@0.1.22 svelte-autofixer packages/ui/src/components/detail/PRTimelineFilter.svelte --svelte-version 5
+```
+
+Expected: PASS from Vitest and no required Svelte autofixer changes.
+
+---
+
+## Task 6: Compact Event Timeline Rendering
+
+**Files:**
+- Modify: `packages/ui/src/components/detail/EventTimeline.svelte`
+- Modify: `packages/ui/src/components/detail/EventTimeline.test.ts`
+
+- [ ] **Step 1: Write failing rendering tests**
+
+Extend `packages/ui/src/components/detail/EventTimeline.test.ts`:
+
+```ts
+it("renders commit events as compact one-line commit detail rows", () => {
+  render(EventTimeline, {
+    props: {
+      events: [makeEvent({
+        EventType: "commit",
+        Summary: "abcdef1234567890",
+        Body: "feat: add timeline filters\n\nLong body",
+      })],
+    },
+  });
+
+  expect(screen.getByText("abcdef1")).toBeTruthy();
+  expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
+  expect(document.querySelector(".event--compact")).toBeTruthy();
+  expect(document.querySelector(".commit-title")).toBeTruthy();
+});
+
+it("renders system events as compact rows", () => {
+  render(EventTimeline, {
+    props: {
+      events: [
+        makeEvent({
+          ID: 2,
+          EventType: "renamed_title",
+          Summary: "\"Old\" -> \"New\"",
+          MetadataJSON: JSON.stringify({
+            previous_title: "Old",
+            current_title: "New",
+          }),
+        }),
+        makeEvent({
+          ID: 3,
+          EventType: "base_ref_changed",
+          Summary: "main -> release",
+          MetadataJSON: JSON.stringify({
+            previous_ref_name: "main",
+            current_ref_name: "release",
+          }),
+        }),
+        makeEvent({
+          ID: 4,
+          EventType: "cross_referenced",
+          Summary: "Referenced from other/repo#77",
+          MetadataJSON: JSON.stringify({
+            source_owner: "other",
+            source_repo: "repo",
+            source_number: 77,
+            source_title: "Related bug",
+            source_url: "https://github.com/other/repo/issues/77",
+          }),
+        }),
+      ],
+    },
+  });
+
+  expect(screen.getByText("Title changed")).toBeTruthy();
+  expect(screen.getByText("Base changed")).toBeTruthy();
+  expect(screen.getByText("Referenced")).toBeTruthy();
+  expect(screen.getByText("Related bug")).toBeTruthy();
+  expect(document.querySelectorAll(".event--compact").length).toBe(3);
+});
+
+it("shows filtered empty copy when filters hide all events", () => {
+  render(EventTimeline, {
+    props: {
+      events: [],
+      filtered: true,
+    },
+  });
+
+  expect(screen.getByText("No activity matches the current filters")).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run failing rendering tests**
+
+Run:
+
+```bash
+cd frontend && bunx vitest run ../packages/ui/src/components/detail/EventTimeline.test.ts
+```
+
+Expected: FAIL because compact rendering and `filtered` prop do not exist.
+
+- [ ] **Step 3: Implement compact render paths**
+
+In `EventTimeline.svelte`, add `filtered?: boolean` to props:
+
+```ts
+interface Props {
+  events: Array<PREvent | IssueEvent>;
+  repoOwner?: string;
+  repoName?: string;
+  filtered?: boolean;
+}
+
+const {
+  events,
+  repoOwner,
+  repoName,
+  filtered = false,
+}: Props = $props();
+```
+
+Add helpers:
+
+```ts
+function isCompactEvent(eventType: string): boolean {
+  return eventType === "commit"
+    || eventType === "force_push"
+    || eventType === "cross_referenced"
+    || eventType === "renamed_title"
+    || eventType === "base_ref_changed";
+}
+
+function shortCommit(summary: string): string {
+  return summary.length > 7 ? summary.slice(0, 7) : summary;
+}
+
+function commitTitle(body: string): string {
+  return body.split(/\r?\n/, 1)[0] ?? "";
+}
+
+function systemEventLabel(eventType: string): string {
+  switch (eventType) {
+    case "cross_referenced": return "Referenced";
+    case "renamed_title": return "Title changed";
+    case "base_ref_changed": return "Base changed";
+    case "force_push": return "Force-pushed";
+    default: return typeLabels[eventType] ?? eventType;
+  }
+}
+
+function parseMetadata(event: PREvent | IssueEvent): Record<string, unknown> {
+  if (!event.MetadataJSON) return {};
+  try {
+    const parsed = JSON.parse(event.MetadataJSON) as Record<string, unknown>;
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+```
+
+Render compact events inside the existing `{#each}`:
+
+```svelte
+{#if isCompactEvent(event.EventType)}
+  {@const metadata = parseMetadata(event)}
+  <div class="event-card event-card--compact">
+    <div class="event-header event-header--compact">
+      <span
+        class="event-type"
+        style="color: {typeColors[event.EventType] ?? 'var(--text-muted)'}"
+      >
+        {systemEventLabel(event.EventType)}
+      </span>
+      {#if event.Author}
+        <span class="event-author">{event.Author}</span>
+      {/if}
+      <span class="event-time">{timeAgo(event.CreatedAt)}</span>
+      {#if event.EventType === "commit"}
+        <span class="commit-sha">{shortCommit(event.Summary)}</span>
+        <span class="commit-title">{commitTitle(event.Body)}</span>
+      {:else if event.EventType === "cross_referenced"}
+        <a
+          class="system-event-link"
+          href={String(metadata.source_url ?? "")}
+          target="_blank"
+          rel="noopener noreferrer"
+        >{String(metadata.source_title ?? event.Summary)}</a>
+      {:else}
+        <span class="system-event-summary">{event.Summary}</span>
+      {/if}
+    </div>
+  </div>
+{:else}
+  <!-- existing full card body -->
+{/if}
+```
+
+Add compact CSS:
+
+```css
+.event-card--compact {
+  padding: 7px 10px;
+}
+
+.event-header--compact {
+  min-width: 0;
+  flex-wrap: nowrap;
+}
+
+.commit-sha {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.commit-title,
+.system-event-summary,
+.system-event-link {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.commit-title {
+  flex: 1;
+  color: var(--text-primary);
+}
+```
+
+Set the empty copy:
+
+```svelte
+{#if events.length === 0}
+  <p class="empty">{filtered ? "No activity matches the current filters" : "No activity yet"}</p>
+```
+
+- [ ] **Step 4: Run rendering tests and Svelte autofixer**
+
+Run:
+
+```bash
+cd frontend && bunx vitest run ../packages/ui/src/components/detail/EventTimeline.test.ts
+npx @sveltejs/mcp@0.1.22 svelte-autofixer packages/ui/src/components/detail/EventTimeline.svelte --svelte-version 5
+```
+
+Expected: PASS from Vitest and no required Svelte autofixer changes.
+
+---
+
+## Task 7: Wire Filter Into Pull Detail
+
+**Files:**
+- Modify: `packages/ui/src/components/detail/PullDetail.svelte`
+
+- [ ] **Step 1: Add filter state and derived filtered events**
+
+In `PullDetail.svelte`, import the filter component and helpers:
+
+```ts
+import PRTimelineFilter from "./PRTimelineFilter.svelte";
+import {
+  filterPREvents,
+  loadPRTimelineFilter,
+  savePRTimelineFilter,
+  activePRTimelineFilterCount,
+  type PRTimelineFilterState,
+} from "./prTimelineFilter.js";
+```
+
+Add state near the other local `$state` fields:
+
+```ts
+let timelineFilter = $state<PRTimelineFilterState>(loadPRTimelineFilter());
+
+const filteredTimelineEvents = $derived.by(() => {
+  const events = detailStore.getDetail()?.events ?? [];
+  return filterPREvents(events, timelineFilter);
+});
+
+const hasActiveTimelineFilters = $derived(
+  activePRTimelineFilterCount(timelineFilter) > 0,
+);
+
+function updateTimelineFilter(next: PRTimelineFilterState): void {
+  timelineFilter = next;
+  savePRTimelineFilter(next);
+}
+```
+
+- [ ] **Step 2: Render the filter above `EventTimeline`**
+
+Replace the Activity section header and timeline call:
+
+```svelte
+<div class="section">
+  <div class="section-title-row">
+    <h3 class="section-title">Activity</h3>
+    {#if detailStore.getDetailLoaded()}
+      <PRTimelineFilter
+        filter={timelineFilter}
+        onChange={updateTimelineFilter}
+      />
+    {/if}
+  </div>
+  {#if detailStore.getDetailLoaded()}
+    <EventTimeline
+      events={filteredTimelineEvents}
+      repoOwner={owner}
+      repoName={name}
+      filtered={hasActiveTimelineFilters}
+    />
+  {:else if detailStore.isDetailSyncing()}
+    <div class="loading-placeholder">
+      <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">
+        <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
+      </svg>
+      Loading discussion...
+    </div>
+  {:else}
+    <div class="loading-placeholder">Detail not yet loaded</div>
+  {/if}
+</div>
+```
+
+Add scoped CSS for the title/filter row:
+
+```css
+.section-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+```
+
+- [ ] **Step 3: Run Svelte autofixer**
+
+Run:
+
+```bash
+npx @sveltejs/mcp@0.1.22 svelte-autofixer packages/ui/src/components/detail/PullDetail.svelte --svelte-version 5
+```
+
+Expected: no required Svelte autofixer changes.
+
+---
+
+## Task 8: Verification And API Artifacts
+
+**Files:**
+- Modify generated files only if Huma/OpenAPI output changes unexpectedly.
+
+- [ ] **Step 1: Run focused Go tests**
+
+Run:
+
+```bash
+go test ./internal/github -run 'TestListPullRequestTimelineEvents|TestNormalizeTimelineEvent|TestSyncStoresPullRequestTimelineEvents|TestSyncIgnoresPullRequestTimelineFetchFailures|TestSyncStoresForcePushEvent' -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused frontend tests**
+
+Run:
+
+```bash
+cd frontend && bunx vitest run \
+  ../packages/ui/src/components/detail/prTimelineFilter.test.ts \
+  ../packages/ui/src/components/detail/PRTimelineFilter.test.ts \
+  ../packages/ui/src/components/detail/EventTimeline.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run frontend checks**
+
+Run:
+
+```bash
+make frontend-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full relevant Go tests**
+
+Run:
+
+```bash
+go test ./internal/github ./internal/server ./internal/db -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Build frontend**
+
+Run:
+
+```bash
+make frontend
+```
+
+Expected: PASS and `internal/web/dist/` refreshed.
+
+- [ ] **Step 6: Inspect git diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only planned backend/frontend files and generated frontend dist files if `make frontend` refreshed embedded assets.
+
+- [ ] **Step 7: Commit implementation**
+
+Run:
+
+```bash
+git add internal/github packages/ui/src/components/detail internal/web/dist
+git commit -m "feat: filter PR timeline activity" -m "Add local PR detail feed filters and sync additional GitHub timeline events so maintainers can focus on human messages while retaining commit and system-event context."
+```
+
+Expected: commit succeeds through hooks. Do not push.

--- a/docs/superpowers/specs/2026-04-29-pr-timeline-filter-design.md
+++ b/docs/superpowers/specs/2026-04-29-pr-timeline-filter-design.md
@@ -1,0 +1,147 @@
+# PR Timeline Filter Design
+
+## Goal
+
+Add a PR detail activity filter that remembers browser-local preferences and lets maintainers focus the feed on human-authored content while still being able to inspect commits, force pushes, and PR system events when needed.
+
+## Scope
+
+This feature covers the pull request detail Activity section only. The Activity page defaults remain server-backed settings, and the PR detail filter uses `localStorage` so each browser remembers its own PR feed preferences.
+
+The feature also expands the stored PR timeline events to include the first set of GitHub system events that maintainers need for triage:
+
+- Cross references from issues or pull requests.
+- PR title changes.
+- Base branch changes.
+
+The existing stored event types remain supported:
+
+- `issue_comment`
+- `review`
+- `commit`
+- `force_push`
+
+Review comments are UI-aware today but are not currently fetched by the sync path. This design does not add review comment fetching unless it can be done within the same GitHub timeline query without adding a separate REST path.
+
+## User Experience
+
+The PR detail Activity section gets a compact filter control above the feed, using the existing shared `FilterDropdown` component. Fresh browsers default to showing everything.
+
+The dropdown has these sections:
+
+- Content
+  - Messages: comments and reviews.
+  - Commit details: compact commit rows.
+  - Events: cross references, title changes, and base branch changes.
+  - Force pushes: force-push rows.
+- Visibility
+  - Hide bot activity.
+
+The filter state persists in `localStorage` and applies to every PR detail feed in that browser. It does not write URL parameters and does not change server config.
+
+When no events remain after filtering, the timeline shows a short empty state that makes it clear filters are hiding activity.
+
+## Rendering
+
+Messages keep the current card treatment and markdown rendering.
+
+Commit events render as compact one-line commit detail rows. Each row shows:
+
+- Event date/time using the existing time formatting style.
+- Short commit hash derived from the event summary SHA.
+- Commit title, taken from the first line of the commit message body.
+
+The commit title stays on one line and truncates with browser CSS overflow handling.
+
+System events render as compact rows rather than full message cards:
+
+- Cross reference: shows the source issue or pull request if available.
+- Title change: shows previous title and current title.
+- Base branch change: shows previous branch and current branch.
+- Force push: continues to show the short before/after SHA summary.
+
+Bot filtering uses the same author heuristic as the Activity page: lowercased author names ending in `[bot]`, `-bot`, or `bot` are considered bot-authored.
+
+## Data Model
+
+No database migration is required. `middleman_mr_events` already stores:
+
+- `event_type`
+- `author`
+- `summary`
+- `body`
+- `metadata_json`
+- `created_at`
+- `dedupe_key`
+
+New system events use new `event_type` values:
+
+- `cross_referenced`
+- `renamed_title`
+- `base_ref_changed`
+
+Each new event stores a human-readable `summary` for simple rendering and structured details in `metadata_json` for precise UI output.
+
+Stable dedupe keys should be based on the GitHub GraphQL node ID when available. If a node ID is unavailable, the key should combine event type, timestamp, actor, and event-specific values such as branch names or titles.
+
+## GitHub Sync
+
+The existing GraphQL timeline path currently fetches `HEAD_REF_FORCE_PUSHED_EVENT`. It should be extended to fetch:
+
+- `CROSS_REFERENCED_EVENT`
+- `RENAMED_TITLE_EVENT`
+- `BASE_REF_CHANGED_EVENT`
+- `HEAD_REF_FORCE_PUSHED_EVENT`
+
+The GraphQL query should request only the fields needed for normalization:
+
+- Shared fields: `id`, `actor { login }`, `createdAt`
+- `CrossReferencedEvent`: `source`, `isCrossRepository`, `willCloseTarget`
+- `RenamedTitleEvent`: previous title and current title
+- `BaseRefChangedEvent`: previous ref name and current ref name
+- `HeadRefForcePushedEvent`: before commit, after commit, and ref
+
+Timeline fetch failures for these system events should follow the current force-push behavior: log a warning, keep the rest of the detail sync usable, and avoid failing the whole PR detail refresh solely because the optional timeline event query failed.
+
+## Components And Boundaries
+
+Backend:
+
+- `internal/github/client.go`: extend the GraphQL timeline event fetch shape.
+- `internal/github/normalize.go`: add normalizers for the new system events.
+- `internal/github/sync.go`: upsert the new events during PR timeline refresh.
+- `internal/db/queries.go`: keep generic event storage unchanged unless query helpers need small adjustments.
+
+Frontend:
+
+- `packages/ui/src/components/detail/PullDetail.svelte`: add the filter row above Activity and pass filtered events into the timeline.
+- `packages/ui/src/components/detail/EventTimeline.svelte`: render commit/system event rows compactly and keep message rows as cards.
+- `packages/ui/src/components/shared/FilterDropdown.svelte`: reuse as-is unless a small generic accessibility or layout improvement is needed.
+- A small helper module may be added under `packages/ui/src/components/detail/` for PR timeline filter state and event classification so component code stays readable.
+
+## Testing
+
+Backend tests should cover:
+
+- GraphQL timeline parsing for cross reference, title change, base change, and force push events.
+- Normalization into stable event types, summaries, metadata, authors, timestamps, and dedupe keys.
+- PR detail sync upserts new timeline events without dropping existing comments, reviews, commits, or force pushes.
+- Optional timeline fetch failures do not fail the entire PR detail refresh.
+
+Frontend tests should cover:
+
+- Default localStorage state shows everything.
+- Toggling Messages, Commit details, Events, Force pushes, and Hide bot activity filters the displayed rows.
+- Preferences persist across component remounts.
+- Commit rows show date/time, short SHA, and one-line truncated title.
+- The PR filter uses the shared `FilterDropdown` component rather than a new dropdown implementation.
+
+Verification should run the Svelte autofixer for edited `.svelte` files, relevant frontend tests, relevant Go tests with `-shuffle=on`, and the standard build/test target needed for the touched layers.
+
+## Non-Goals
+
+- Do not add server-backed PR detail filter settings.
+- Do not add URL query parameters for PR detail feed filters.
+- Do not redesign the Activity page filters.
+- Do not migrate existing databases.
+- Do not add every GitHub timeline event type in this slice.

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -62,7 +62,7 @@ describe("RepoImportModal", () => {
 
   it("hides private repositories and forks from preview selection", async () => {
     preview.mockResolvedValue({ owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" } });
+    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" }, agents: [] });
     render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });

--- a/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
+++ b/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const storageKey = "middleman-pr-timeline-filter";
+
+async function openPRTimeline(page: Page): Promise<void> {
+  await page.goto("/pulls/acme/widgets/1");
+  await page.locator(".pull-detail")
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await expect(page.getByText("feat: add cache store")).toBeVisible();
+  await expect(page.getByText("Widget rendering broken on Safari"))
+    .toBeVisible();
+}
+
+async function openTimelineFilters(page: Page): Promise<void> {
+  await page.locator('button[title="Filter PR activity"]').click();
+  await expect(page.locator(".filter-dropdown")).toBeVisible();
+}
+
+test.describe("PR timeline filters", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate((key) => {
+      localStorage.removeItem(key);
+    }, storageKey);
+  });
+
+  test("renders seeded commit and system timeline events", async ({ page }) => {
+    await openPRTimeline(page);
+
+    await expect(page.getByText("Force-pushed")).toBeVisible();
+    await expect(page.getByText("abc4444 -> def5555")).toBeVisible();
+    await expect(page.getByText("Referenced")).toBeVisible();
+    await expect(page.getByText("Widget rendering broken on Safari"))
+      .toBeVisible();
+    await expect(page.getByText("Title changed")).toBeVisible();
+    await expect(page.getByText(
+      '"Add widget cache" -> "Add widget caching layer"',
+    )).toBeVisible();
+    await expect(page.getByText("Base changed")).toBeVisible();
+    await expect(page.getByText("develop -> main")).toBeVisible();
+  });
+
+  test("hides and restores commit and system event buckets", async ({ page }) => {
+    await openPRTimeline(page);
+    await openTimelineFilters(page);
+
+    await page.getByRole("button", { name: "Commit details" }).click();
+    await expect(page.getByText("feat: add cache store")).not.toBeVisible();
+    await page.getByRole("button", { name: "Commit details" }).click();
+    await expect(page.getByText("feat: add cache store")).toBeVisible();
+
+    await page.getByRole("button", { name: "Events" }).click();
+    await expect(page.getByText("Widget rendering broken on Safari"))
+      .not.toBeVisible();
+    await expect(page.getByText(
+      '"Add widget cache" -> "Add widget caching layer"',
+    )).not.toBeVisible();
+    await expect(page.getByText("develop -> main")).not.toBeVisible();
+    await page.getByRole("button", { name: "Events" }).click();
+    await expect(page.getByText("Widget rendering broken on Safari"))
+      .toBeVisible();
+
+    await page.getByRole("button", { name: "Force pushes" }).click();
+    await expect(page.getByText("abc4444 -> def5555")).not.toBeVisible();
+    await page.getByRole("button", { name: "Force pushes" }).click();
+    await expect(page.getByText("abc4444 -> def5555")).toBeVisible();
+  });
+
+  test("persists timeline filter preferences in localStorage", async ({ page }) => {
+    await openPRTimeline(page);
+    await openTimelineFilters(page);
+
+    await page.getByRole("button", { name: "Events" }).click();
+    await expect(page.getByText("Widget rendering broken on Safari"))
+      .not.toBeVisible();
+    await expect(page.locator('button[title="Filter PR activity"]'))
+      .toContainText("1");
+
+    await expect.poll(async () =>
+      await page.evaluate((key) => localStorage.getItem(key), storageKey),
+    ).toContain('"showEvents":false');
+
+    await page.reload();
+    await page.locator(".pull-detail")
+      .waitFor({ state: "visible", timeout: 10_000 });
+    await expect(page.getByText("Widget rendering broken on Safari"))
+      .not.toBeVisible();
+    await expect(page.locator('button[title="Filter PR activity"]'))
+      .toContainText("1");
+  });
+
+  test(
+    "shows a filtered-empty state when every event bucket is hidden",
+    async ({ page }) => {
+      await openPRTimeline(page);
+      await openTimelineFilters(page);
+
+      await page.getByRole("button", { name: "Messages" }).click();
+      await page.getByRole("button", { name: "Commit details" }).click();
+      await page.getByRole("button", { name: "Events" }).click();
+      await page.getByRole("button", { name: "Force pushes" }).click();
+
+      await expect(page.getByText("No activity matches the current filters"))
+        .toBeVisible();
+    },
+  );
+});

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -182,7 +182,7 @@ test("repository import can hide forks and private repositories before adding", 
 
   await dialog.getByRole("button", { name: "Add selected repositories" }).click();
 
-  expect(bulkRepos).toEqual([{ owner: "import-lab", name: "public-source" }]);
+  await expect.poll(() => bulkRepos).toEqual([{ owner: "import-lab", name: "public-source" }]);
 });
 
 test("repository import traps keyboard focus inside the dialog", async ({ page }) => {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -23,6 +23,28 @@ type ForcePushEvent struct {
 	CreatedAt time.Time
 }
 
+type PullRequestTimelineEvent struct {
+	NodeID            string
+	EventType         string
+	Actor             string
+	CreatedAt         time.Time
+	BeforeSHA         string
+	AfterSHA          string
+	Ref               string
+	PreviousTitle     string
+	CurrentTitle      string
+	PreviousRefName   string
+	CurrentRefName    string
+	SourceType        string
+	SourceOwner       string
+	SourceRepo        string
+	SourceNumber      int
+	SourceTitle       string
+	SourceURL         string
+	IsCrossRepository bool
+	WillCloseTarget   bool
+}
+
 // EditPullRequestOpts holds optional fields for editing a pull request.
 // Nil pointer fields are omitted from the GitHub API call.
 type EditPullRequestOpts struct {
@@ -45,6 +67,7 @@ type Client interface {
 	ListIssueCommentsIfChanged(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error)
 	ListReviews(ctx context.Context, owner, repo string, number int) ([]*gh.PullRequestReview, error)
 	ListCommits(ctx context.Context, owner, repo string, number int) ([]*gh.RepositoryCommit, error)
+	ListPullRequestTimelineEvents(ctx context.Context, owner, repo string, number int) ([]PullRequestTimelineEvent, error)
 	ListForcePushEvents(ctx context.Context, owner, repo string, number int) ([]ForcePushEvent, error)
 	GetCombinedStatus(ctx context.Context, owner, repo, ref string) (*gh.CombinedStatus, error)
 	ListCheckRunsForRef(ctx context.Context, owner, repo, ref string) ([]*gh.CheckRun, error)
@@ -177,18 +200,61 @@ func (c *liveClient) CreateIssue(
 	return issue, nil
 }
 
-const forcePushTimelineQuery = `
+const pullRequestTimelineEventsQuery = `
 query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
-      timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT], first: 100, after: $cursor) {
+      timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT], first: 100, after: $cursor) {
         nodes {
+          __typename
+          ... on Node {
+            id
+          }
           ... on HeadRefForcePushedEvent {
             actor { login }
             beforeCommit { oid }
             afterCommit { oid }
             createdAt
             ref { name }
+          }
+          ... on CrossReferencedEvent {
+            actor { login }
+            createdAt
+            isCrossRepository
+            willCloseTarget
+            source {
+              __typename
+              ... on Issue {
+                number
+                title
+                url
+                repository {
+                  owner { login }
+                  name
+                }
+              }
+              ... on PullRequest {
+                number
+                title
+                url
+                repository {
+                  owner { login }
+                  name
+                }
+              }
+            }
+          }
+          ... on RenamedTitleEvent {
+            actor { login }
+            createdAt
+            previousTitle
+            currentTitle
+          }
+          ... on BaseRefChangedEvent {
+            actor { login }
+            createdAt
+            previousRefName
+            currentRefName
           }
         }
         pageInfo {
@@ -578,23 +644,19 @@ func (c *liveClient) ListCommits(
 	return all, nil
 }
 
-func (c *liveClient) ListForcePushEvents(
+func (c *liveClient) ListPullRequestTimelineEvents(
 	ctx context.Context, owner, repo string, number int,
-) ([]ForcePushEvent, error) {
-	type graphQLRequest struct {
-		Query     string         `json:"query"`
-		Variables map[string]any `json:"variables"`
-	}
+) ([]PullRequestTimelineEvent, error) {
 	type graphQLResponse struct {
-		Errors []struct {
-			Message string `json:"message"`
-		} `json:"errors"`
-		Data struct {
+		Errors []graphQLError `json:"errors"`
+		Data   struct {
 			Repository *struct {
 				PullRequest *struct {
 					TimelineItems struct {
 						Nodes []struct {
-							Actor *struct {
+							TypeName string `json:"__typename"`
+							ID       string `json:"id"`
+							Actor    *struct {
 								Login string `json:"login"`
 							} `json:"actor"`
 							BeforeCommit *struct {
@@ -603,10 +665,26 @@ func (c *liveClient) ListForcePushEvents(
 							AfterCommit *struct {
 								OID string `json:"oid"`
 							} `json:"afterCommit"`
-							CreatedAt time.Time `json:"createdAt"`
-							Ref       *struct {
-								Name string `json:"name"`
-							} `json:"ref"`
+							CreatedAt       time.Time              `json:"createdAt"`
+							Ref             *struct{ Name string } `json:"ref"`
+							PreviousTitle   string                 `json:"previousTitle"`
+							CurrentTitle    string                 `json:"currentTitle"`
+							PreviousRefName string                 `json:"previousRefName"`
+							CurrentRefName  string                 `json:"currentRefName"`
+							Source          *struct {
+								TypeName   string `json:"__typename"`
+								Number     int    `json:"number"`
+								Title      string `json:"title"`
+								URL        string `json:"url"`
+								Repository *struct {
+									Owner *struct {
+										Login string `json:"login"`
+									} `json:"owner"`
+									Name string `json:"name"`
+								} `json:"repository"`
+							} `json:"source"`
+							IsCrossRepository bool `json:"isCrossRepository"`
+							WillCloseTarget   bool `json:"willCloseTarget"`
 						} `json:"nodes"`
 						PageInfo struct {
 							HasNextPage bool    `json:"hasNextPage"`
@@ -618,11 +696,11 @@ func (c *liveClient) ListForcePushEvents(
 		} `json:"data"`
 	}
 
-	var events []ForcePushEvent
+	var events []PullRequestTimelineEvent
 	var cursor *string
 	for {
 		payload, err := json.Marshal(graphQLRequest{
-			Query: forcePushTimelineQuery,
+			Query: pullRequestTimelineEventsQuery,
 			Variables: map[string]any{
 				"owner":  owner,
 				"repo":   repo,
@@ -631,7 +709,7 @@ func (c *liveClient) ListForcePushEvents(
 			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("marshal force-push query: %w", err)
+			return nil, fmt.Errorf("marshal pull request timeline query: %w", err)
 		}
 
 		req, err := http.NewRequestWithContext(
@@ -641,7 +719,7 @@ func (c *liveClient) ListForcePushEvents(
 			bytes.NewReader(payload),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("create force-push request: %w", err)
+			return nil, fmt.Errorf("create pull request timeline request: %w", err)
 		}
 		req.Header.Set("Accept", "application/vnd.github+json")
 		req.Header.Set("Content-Type", "application/json")
@@ -649,7 +727,7 @@ func (c *liveClient) ListForcePushEvents(
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"list force-push events for %s/%s#%d: %w",
+				"list pull request timeline events for %s/%s#%d: %w",
 				owner, repo, number, err,
 			)
 		}
@@ -657,7 +735,7 @@ func (c *liveClient) ListForcePushEvents(
 		if resp.StatusCode != http.StatusOK {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf(
-				"list force-push events for %s/%s#%d: graphql status %s",
+				"list pull request timeline events for %s/%s#%d: graphql status %s",
 				owner, repo, number, resp.Status,
 			)
 		}
@@ -666,43 +744,55 @@ func (c *liveClient) ListForcePushEvents(
 		if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf(
-				"decode force-push events for %s/%s#%d: %w",
+				"decode pull request timeline events for %s/%s#%d: %w",
 				owner, repo, number, err,
 			)
 		}
 		_ = resp.Body.Close()
 
 		if len(decoded.Errors) > 0 {
-			messages := make([]string, 0, len(decoded.Errors))
-			for _, graphQLError := range decoded.Errors {
-				if graphQLError.Message != "" {
-					messages = append(messages, graphQLError.Message)
-				}
-			}
-			if len(messages) == 0 {
-				messages = append(messages, "unknown GraphQL error")
-			}
 			return nil, fmt.Errorf(
-				"list force-push events for %s/%s#%d: graphql errors: %s",
-				owner, repo, number, strings.Join(messages, "; "),
+				"list pull request timeline events for %s/%s#%d: graphql errors: %s",
+				owner, repo, number, joinGraphQLErrorMessages(decoded.Errors),
 			)
 		}
 
 		if decoded.Data.Repository == nil {
 			return nil, fmt.Errorf(
-				"list force-push events for %s/%s#%d: missing repository in graphql response",
+				"list pull request timeline events for %s/%s#%d: missing repository in graphql response",
 				owner, repo, number,
 			)
 		}
 		if decoded.Data.Repository.PullRequest == nil {
 			return nil, fmt.Errorf(
-				"list force-push events for %s/%s#%d: missing pull request in graphql response",
+				"list pull request timeline events for %s/%s#%d: missing pull request in graphql response",
 				owner, repo, number,
 			)
 		}
 
 		for _, node := range decoded.Data.Repository.PullRequest.TimelineItems.Nodes {
-			event := ForcePushEvent{CreatedAt: node.CreatedAt}
+			event := PullRequestTimelineEvent{
+				NodeID:            node.ID,
+				CreatedAt:         node.CreatedAt,
+				PreviousTitle:     node.PreviousTitle,
+				CurrentTitle:      node.CurrentTitle,
+				PreviousRefName:   node.PreviousRefName,
+				CurrentRefName:    node.CurrentRefName,
+				IsCrossRepository: node.IsCrossRepository,
+				WillCloseTarget:   node.WillCloseTarget,
+			}
+			switch node.TypeName {
+			case "HeadRefForcePushedEvent":
+				event.EventType = "force_push"
+			case "CrossReferencedEvent":
+				event.EventType = "cross_referenced"
+			case "RenamedTitleEvent":
+				event.EventType = "renamed_title"
+			case "BaseRefChangedEvent":
+				event.EventType = "base_ref_changed"
+			default:
+				continue
+			}
 			if node.Actor != nil {
 				event.Actor = node.Actor.Login
 			}
@@ -715,6 +805,18 @@ func (c *liveClient) ListForcePushEvents(
 			if node.Ref != nil {
 				event.Ref = node.Ref.Name
 			}
+			if node.Source != nil {
+				event.SourceType = node.Source.TypeName
+				event.SourceNumber = node.Source.Number
+				event.SourceTitle = node.Source.Title
+				event.SourceURL = node.Source.URL
+				if node.Source.Repository != nil {
+					event.SourceRepo = node.Source.Repository.Name
+					if node.Source.Repository.Owner != nil {
+						event.SourceOwner = node.Source.Repository.Owner.Login
+					}
+				}
+			}
 			events = append(events, event)
 		}
 
@@ -725,6 +827,30 @@ func (c *liveClient) ListForcePushEvents(
 		cursor = pageInfo.EndCursor
 	}
 
+	return events, nil
+}
+
+func (c *liveClient) ListForcePushEvents(
+	ctx context.Context, owner, repo string, number int,
+) ([]ForcePushEvent, error) {
+	timelineEvents, err := c.ListPullRequestTimelineEvents(ctx, owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]ForcePushEvent, 0, len(timelineEvents))
+	for _, timelineEvent := range timelineEvents {
+		if timelineEvent.EventType != "force_push" {
+			continue
+		}
+		events = append(events, ForcePushEvent{
+			Actor:     timelineEvent.Actor,
+			BeforeSHA: timelineEvent.BeforeSHA,
+			AfterSHA:  timelineEvent.AfterSHA,
+			Ref:       timelineEvent.Ref,
+			CreatedAt: timelineEvent.CreatedAt,
+		})
+	}
 	return events, nil
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -19,24 +19,13 @@ import (
 var _ Client = (*liveClient)(nil)
 
 func (m *mockClient) ListPullRequestTimelineEvents(
-	ctx context.Context, owner, repo string, number int,
+	_ context.Context, _, _ string, _ int,
 ) ([]PullRequestTimelineEvent, error) {
-	forcePushEvents, err := m.ListForcePushEvents(ctx, owner, repo, number)
-	if err != nil {
-		return nil, err
+	m.trackCall()
+	if m.timelineEventsErr != nil {
+		return nil, m.timelineEventsErr
 	}
-	events := make([]PullRequestTimelineEvent, 0, len(forcePushEvents))
-	for _, forcePushEvent := range forcePushEvents {
-		events = append(events, PullRequestTimelineEvent{
-			EventType: "force_push",
-			Actor:     forcePushEvent.Actor,
-			CreatedAt: forcePushEvent.CreatedAt,
-			BeforeSHA: forcePushEvent.BeforeSHA,
-			AfterSHA:  forcePushEvent.AfterSHA,
-			Ref:       forcePushEvent.Ref,
-		})
-	}
-	return events, nil
+	return m.timelineEvents, nil
 }
 
 func TestNewClientReturnsNonNil(t *testing.T) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,27 @@ import (
 
 // Compile-time assertion that liveClient satisfies Client.
 var _ Client = (*liveClient)(nil)
+
+func (m *mockClient) ListPullRequestTimelineEvents(
+	ctx context.Context, owner, repo string, number int,
+) ([]PullRequestTimelineEvent, error) {
+	forcePushEvents, err := m.ListForcePushEvents(ctx, owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
+	events := make([]PullRequestTimelineEvent, 0, len(forcePushEvents))
+	for _, forcePushEvent := range forcePushEvents {
+		events = append(events, PullRequestTimelineEvent{
+			EventType: "force_push",
+			Actor:     forcePushEvent.Actor,
+			CreatedAt: forcePushEvent.CreatedAt,
+			BeforeSHA: forcePushEvent.BeforeSHA,
+			AfterSHA:  forcePushEvent.AfterSHA,
+			Ref:       forcePushEvent.Ref,
+		})
+	}
+	return events, nil
+}
 
 func TestNewClientReturnsNonNil(t *testing.T) {
 	c, err := NewClient("fake-token", "", nil, nil)
@@ -49,6 +71,11 @@ func TestGraphQLEndpointForHost(t *testing.T) {
 
 func TestClientInterfaceIncludesListForcePushEvents(t *testing.T) {
 	_, ok := reflect.TypeFor[Client]().MethodByName("ListForcePushEvents")
+	require.True(t, ok)
+}
+
+func TestClientInterfaceIncludesListPullRequestTimelineEvents(t *testing.T) {
+	_, ok := reflect.TypeFor[Client]().MethodByName("ListPullRequestTimelineEvents")
 	require.True(t, ok)
 }
 
@@ -197,10 +224,10 @@ func TestListForcePushEvents(t *testing.T) {
 		contentTypes = append(contentTypes, r.Header.Get("Content-Type"))
 		w.Header().Set("Content-Type", "application/json")
 		if calls == 1 {
-			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"actor":{"login":"alice"},"beforeCommit":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"afterCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"createdAt":"2024-06-01T12:00:00Z","ref":{"name":"feature"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`))
+			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"HeadRefForcePushedEvent","id":"HFP_1","actor":{"login":"alice"},"beforeCommit":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"afterCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"createdAt":"2024-06-01T12:00:00Z","ref":{"name":"feature"}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"actor":{"login":"alice"},"beforeCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"afterCommit":{"oid":"cccccccccccccccccccccccccccccccccccccccc"},"createdAt":"2024-06-01T12:05:00Z","ref":{"name":"feature"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"HeadRefForcePushedEvent","id":"HFP_2","actor":{"login":"alice"},"beforeCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"afterCommit":{"oid":"cccccccccccccccccccccccccccccccccccccccc"},"createdAt":"2024-06-01T12:05:00Z","ref":{"name":"feature"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -222,7 +249,60 @@ func TestListForcePushEvents(t *testing.T) {
 	require.Equal([]string{"application/json", "application/json"}, contentTypes)
 }
 
-func TestListForcePushEventsReturnsGraphQLErrors(t *testing.T) {
+func TestListPullRequestTimelineEvents(t *testing.T) {
+	require := require.New(t)
+	var calls int
+	var methods []string
+	var contentTypes []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		methods = append(methods, r.Method)
+		contentTypes = append(contentTypes, r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"HeadRefForcePushedEvent","id":"HFP_1","actor":{"login":"alice"},"beforeCommit":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"afterCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"createdAt":"2024-06-01T12:00:00Z","ref":{"name":"feature"}},{"__typename":"RenamedTitleEvent","id":"RTE_1","actor":{"login":"bob"},"createdAt":"2024-06-01T12:05:00Z","previousTitle":"Old title","currentTitle":"New title"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"BaseRefChangedEvent","id":"BRC_1","actor":{"login":"carol"},"createdAt":"2024-06-01T12:10:00Z","previousRefName":"main","currentRefName":"release"},{"__typename":"CrossReferencedEvent","id":"CRE_1","actor":{"login":"dave"},"createdAt":"2024-06-01T12:15:00Z","isCrossRepository":true,"willCloseTarget":false,"source":{"__typename":"Issue","number":77,"title":"Related bug","url":"https://github.com/other/repo/issues/77","repository":{"owner":{"login":"other"},"name":"repo"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &liveClient{
+		httpClient:      srv.Client(),
+		graphQLEndpoint: srv.URL + "/graphql",
+	}
+
+	events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
+	require.NoError(err)
+	require.Len(events, 4)
+	require.Equal("force_push", events[0].EventType)
+	require.Equal("HFP_1", events[0].NodeID)
+	require.Equal("alice", events[0].Actor)
+	require.Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", events[0].BeforeSHA)
+	require.Equal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", events[0].AfterSHA)
+	require.Equal("feature", events[0].Ref)
+	require.Equal("renamed_title", events[1].EventType)
+	require.Equal("Old title", events[1].PreviousTitle)
+	require.Equal("New title", events[1].CurrentTitle)
+	require.Equal("base_ref_changed", events[2].EventType)
+	require.Equal("main", events[2].PreviousRefName)
+	require.Equal("release", events[2].CurrentRefName)
+	require.Equal("cross_referenced", events[3].EventType)
+	require.Equal("Issue", events[3].SourceType)
+	require.Equal("other", events[3].SourceOwner)
+	require.Equal("repo", events[3].SourceRepo)
+	require.Equal(77, events[3].SourceNumber)
+	require.Equal("Related bug", events[3].SourceTitle)
+	require.True(events[3].IsCrossRepository)
+	require.False(events[3].WillCloseTarget)
+	require.Equal(2, calls)
+	require.Equal([]string{http.MethodPost, http.MethodPost}, methods)
+	require.Equal([]string{"application/json", "application/json"}, contentTypes)
+}
+
+func TestListPullRequestTimelineEventsReturnsGraphQLErrors(t *testing.T) {
 	require := require.New(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -235,12 +315,12 @@ func TestListForcePushEventsReturnsGraphQLErrors(t *testing.T) {
 		graphQLEndpoint: srv.URL,
 	}
 
-	events, err := c.ListForcePushEvents(t.Context(), "owner", "repo", 42)
+	events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
 	require.Nil(events)
 	require.ErrorContains(err, "permission denied")
 }
 
-func TestListForcePushEventsRejectsNullGraphQLNodes(t *testing.T) {
+func TestListPullRequestTimelineEventsRejectsNullGraphQLNodes(t *testing.T) {
 	tests := []struct {
 		name string
 		body string
@@ -272,7 +352,7 @@ func TestListForcePushEventsRejectsNullGraphQLNodes(t *testing.T) {
 				graphQLEndpoint: srv.URL,
 			}
 
-			events, err := c.ListForcePushEvents(t.Context(), "owner", "repo", 42)
+			events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
 			require.Nil(events)
 			require.ErrorContains(err, tt.want)
 		})

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -84,6 +84,10 @@ type gqlPR struct {
 			}
 		}
 	} `graphql:"lastCommit: commits(last: 1)"`
+	TimelineItems struct {
+		Nodes    []gqlPullRequestTimelineItem
+		PageInfo pageInfo
+	} `graphql:"timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT], first: 100)"`
 }
 
 type gqlComment struct {
@@ -114,6 +118,77 @@ type gqlCommit struct {
 		Date time.Time
 		User *struct{ Login string }
 	}
+}
+
+type gqlPullRequestTimelineItem struct {
+	Typename                string                     `graphql:"__typename"`
+	Node                    gqlNodeFragment            `graphql:"... on Node"`
+	HeadRefForcePushedEvent gqlHeadRefForcePushedEvent `graphql:"... on HeadRefForcePushedEvent"`
+	CrossReferencedEvent    gqlCrossReferencedEvent    `graphql:"... on CrossReferencedEvent"`
+	RenamedTitleEvent       gqlRenamedTitleEvent       `graphql:"... on RenamedTitleEvent"`
+	BaseRefChangedEvent     gqlBaseRefChangedEvent     `graphql:"... on BaseRefChangedEvent"`
+}
+
+type gqlNodeFragment struct {
+	ID string
+}
+
+type gqlActorRef struct {
+	Login string
+}
+
+type gqlHeadRefForcePushedEvent struct {
+	Actor        *gqlActorRef
+	BeforeCommit *struct {
+		OID string `graphql:"oid"`
+	}
+	AfterCommit *struct {
+		OID string `graphql:"oid"`
+	}
+	CreatedAt time.Time
+	Ref       *struct {
+		Name string
+	}
+}
+
+type gqlCrossReferencedEvent struct {
+	Actor             *gqlActorRef
+	CreatedAt         time.Time
+	IsCrossRepository bool
+	WillCloseTarget   bool
+	Source            gqlReferencedSubject
+}
+
+type gqlReferencedSubject struct {
+	Typename    string                 `graphql:"__typename"`
+	Issue       gqlReferencedIssueOrPR `graphql:"... on Issue"`
+	PullRequest gqlReferencedIssueOrPR `graphql:"... on PullRequest"`
+}
+
+type gqlReferencedIssueOrPR struct {
+	Number     int
+	Title      string
+	URL        string `graphql:"url"`
+	Repository struct {
+		Owner struct {
+			Login string
+		}
+		Name string
+	}
+}
+
+type gqlRenamedTitleEvent struct {
+	Actor         *gqlActorRef
+	CreatedAt     time.Time
+	PreviousTitle string
+	CurrentTitle  string
+}
+
+type gqlBaseRefChangedEvent struct {
+	Actor           *gqlActorRef
+	CreatedAt       time.Time
+	PreviousRefName string
+	CurrentRefName  string
 }
 
 type gqlIssueQuery struct {
@@ -421,11 +496,13 @@ type BulkPR struct {
 	Comments         []*gh.IssueComment
 	Reviews          []*gh.PullRequestReview
 	Commits          []*gh.RepositoryCommit
+	TimelineEvents   []PullRequestTimelineEvent
 	CheckRuns        []*gh.CheckRun
 	Statuses         []*gh.RepoStatus
 	CommentsComplete bool
 	ReviewsComplete  bool
 	CommitsComplete  bool
+	TimelineComplete bool
 	CIComplete       bool
 }
 
@@ -674,6 +751,7 @@ func convertGQLPR(gql *gqlPR) BulkPR {
 		CommentsComplete: !gql.Comments.PageInfo.HasNextPage,
 		ReviewsComplete:  !gql.Reviews.PageInfo.HasNextPage,
 		CommitsComplete:  !gql.AllCommits.PageInfo.HasNextPage,
+		TimelineComplete: !gql.TimelineItems.PageInfo.HasNextPage,
 	}
 
 	for i := range gql.Comments.Nodes {
@@ -684,6 +762,12 @@ func convertGQLPR(gql *gqlPR) BulkPR {
 	}
 	for i := range gql.AllCommits.Nodes {
 		bulk.Commits = append(bulk.Commits, adaptCommit(&gql.AllCommits.Nodes[i]))
+	}
+	for i := range gql.TimelineItems.Nodes {
+		event, ok := adaptPullRequestTimelineEvent(&gql.TimelineItems.Nodes[i])
+		if ok {
+			bulk.TimelineEvents = append(bulk.TimelineEvents, event)
+		}
 	}
 
 	bulk.CIComplete = true
@@ -698,4 +782,74 @@ func convertGQLPR(gql *gqlPR) BulkPR {
 	}
 
 	return bulk
+}
+
+func adaptPullRequestTimelineEvent(gql *gqlPullRequestTimelineItem) (PullRequestTimelineEvent, bool) {
+	if gql == nil {
+		return PullRequestTimelineEvent{}, false
+	}
+	event := PullRequestTimelineEvent{NodeID: gql.Node.ID}
+	switch gql.Typename {
+	case "HeadRefForcePushedEvent":
+		src := gql.HeadRefForcePushedEvent
+		event.EventType = "force_push"
+		event.CreatedAt = src.CreatedAt
+		if src.Actor != nil {
+			event.Actor = src.Actor.Login
+		}
+		if src.BeforeCommit != nil {
+			event.BeforeSHA = src.BeforeCommit.OID
+		}
+		if src.AfterCommit != nil {
+			event.AfterSHA = src.AfterCommit.OID
+		}
+		if src.Ref != nil {
+			event.Ref = src.Ref.Name
+		}
+	case "CrossReferencedEvent":
+		src := gql.CrossReferencedEvent
+		event.EventType = "cross_referenced"
+		event.CreatedAt = src.CreatedAt
+		event.IsCrossRepository = src.IsCrossRepository
+		event.WillCloseTarget = src.WillCloseTarget
+		if src.Actor != nil {
+			event.Actor = src.Actor.Login
+		}
+		event.SourceType = src.Source.Typename
+		switch src.Source.Typename {
+		case "Issue":
+			copyReferencedSubject(&event, src.Source.Issue)
+		case "PullRequest":
+			copyReferencedSubject(&event, src.Source.PullRequest)
+		}
+	case "RenamedTitleEvent":
+		src := gql.RenamedTitleEvent
+		event.EventType = "renamed_title"
+		event.CreatedAt = src.CreatedAt
+		event.PreviousTitle = src.PreviousTitle
+		event.CurrentTitle = src.CurrentTitle
+		if src.Actor != nil {
+			event.Actor = src.Actor.Login
+		}
+	case "BaseRefChangedEvent":
+		src := gql.BaseRefChangedEvent
+		event.EventType = "base_ref_changed"
+		event.CreatedAt = src.CreatedAt
+		event.PreviousRefName = src.PreviousRefName
+		event.CurrentRefName = src.CurrentRefName
+		if src.Actor != nil {
+			event.Actor = src.Actor.Login
+		}
+	default:
+		return PullRequestTimelineEvent{}, false
+	}
+	return event, true
+}
+
+func copyReferencedSubject(event *PullRequestTimelineEvent, source gqlReferencedIssueOrPR) {
+	event.SourceNumber = source.Number
+	event.SourceTitle = source.Title
+	event.SourceURL = source.URL
+	event.SourceOwner = source.Repository.Owner.Login
+	event.SourceRepo = source.Repository.Name
 }

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -1,13 +1,16 @@
 package github
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	gh "github.com/google/go-github/v84/github"
+	"github.com/shurcooL/githubv4"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -249,6 +252,7 @@ func TestConvertGQLPRCompleteness(t *testing.T) {
 	assert.True(bulk.CommentsComplete)
 	assert.True(bulk.ReviewsComplete)
 	assert.True(bulk.CommitsComplete)
+	assert.True(bulk.TimelineComplete)
 	assert.True(bulk.CIComplete)
 
 	// Comments incomplete
@@ -256,6 +260,86 @@ func TestConvertGQLPRCompleteness(t *testing.T) {
 	bulk = convertGQLPR(&gql)
 	assert.False(bulk.CommentsComplete)
 	assert.True(bulk.ReviewsComplete)
+
+	gql.Comments.PageInfo.HasNextPage = false
+	gql.TimelineItems.PageInfo.HasNextPage = true
+	bulk = convertGQLPR(&gql)
+	assert.False(bulk.TimelineComplete)
+}
+
+func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	now := time.Date(2024, 6, 3, 15, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	var sawTimelineItems bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		sawTimelineItems = bytes.Contains(body, []byte("timelineItems"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequests":{"nodes":[{
+			"databaseId":1001,
+			"number":1,
+			"title":"Timeline PR",
+			"state":"OPEN",
+			"isDraft":false,
+			"body":"",
+			"url":"https://github.com/owner/repo/pull/1",
+			"author":{"login":"alice"},
+			"createdAt":"` + now + `",
+			"updatedAt":"` + now + `",
+			"mergedAt":null,
+			"closedAt":null,
+			"additions":1,
+			"deletions":0,
+			"mergeable":"MERGEABLE",
+			"reviewDecision":"",
+			"headRefName":"feature",
+			"baseRefName":"main",
+			"headRefOid":"abc123",
+			"baseRefOid":"def456",
+			"headRepository":{"url":"https://github.com/owner/repo"},
+			"labels":{"nodes":[]},
+			"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+			"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+			"allCommits":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+			"lastCommit":{"nodes":[]},
+			"timelineItems":{"nodes":[{
+				"__typename":"BaseRefChangedEvent",
+				"id":"BRC_1",
+				"actor":{"login":"bob"},
+				"createdAt":"` + now + `",
+				"previousRefName":"main",
+				"currentRefName":"release"
+			}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+	}))
+	defer srv.Close()
+
+	fetcher := NewGraphQLFetcherWithClient(
+		githubv4.NewEnterpriseClient(srv.URL, srv.Client()), nil,
+	)
+
+	result, err := fetcher.FetchRepoPRs(t.Context(), "owner", "repo")
+	require.NoError(err)
+	require.NotNil(result)
+	require.Len(result.PullRequests, 1)
+	require.True(sawTimelineItems)
+	require.Len(result.PullRequests[0].TimelineEvents, 1)
+
+	event := result.PullRequests[0].TimelineEvents[0]
+	assert.Equal("base_ref_changed", event.EventType)
+	assert.Equal("BRC_1", event.NodeID)
+	assert.Equal("bob", event.Actor)
+	assert.Equal("main", event.PreviousRefName)
+	assert.Equal("release", event.CurrentRefName)
+	assert.True(result.PullRequests[0].TimelineComplete)
 }
 
 func TestNormalizeBulkCI(t *testing.T) {

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -155,6 +157,27 @@ type forcePushMetadata struct {
 	Ref       string `json:"ref"`
 }
 
+type crossReferenceMetadata struct {
+	SourceType        string `json:"source_type"`
+	SourceOwner       string `json:"source_owner"`
+	SourceRepo        string `json:"source_repo"`
+	SourceNumber      int    `json:"source_number"`
+	SourceTitle       string `json:"source_title"`
+	SourceURL         string `json:"source_url"`
+	IsCrossRepository bool   `json:"is_cross_repository"`
+	WillCloseTarget   bool   `json:"will_close_target"`
+}
+
+type renamedTitleMetadata struct {
+	PreviousTitle string `json:"previous_title"`
+	CurrentTitle  string `json:"current_title"`
+}
+
+type baseRefChangedMetadata struct {
+	PreviousRefName string `json:"previous_ref_name"`
+	CurrentRefName  string `json:"current_ref_name"`
+}
+
 func NormalizeForcePushEvent(mrID int64, fp ForcePushEvent) db.MREvent {
 	metadata, _ := json.Marshal(forcePushMetadata{
 		BeforeSHA: fp.BeforeSHA,
@@ -171,6 +194,98 @@ func NormalizeForcePushEvent(mrID int64, fp ForcePushEvent) db.MREvent {
 		CreatedAt:      fp.CreatedAt,
 		DedupeKey:      fmt.Sprintf("force-push-%s-%s", fp.BeforeSHA, fp.AfterSHA),
 	}
+}
+
+func NormalizeTimelineEvent(mrID int64, event PullRequestTimelineEvent) *db.MREvent {
+	switch event.EventType {
+	case "force_push":
+		normalized := NormalizeForcePushEvent(mrID, ForcePushEvent{
+			Actor:     event.Actor,
+			BeforeSHA: event.BeforeSHA,
+			AfterSHA:  event.AfterSHA,
+			Ref:       event.Ref,
+			CreatedAt: event.CreatedAt,
+		})
+		normalized.DedupeKey = timelineDedupeKey(event)
+		return &normalized
+	case "cross_referenced":
+		metadata, _ := json.Marshal(crossReferenceMetadata{
+			SourceType:        event.SourceType,
+			SourceOwner:       event.SourceOwner,
+			SourceRepo:        event.SourceRepo,
+			SourceNumber:      event.SourceNumber,
+			SourceTitle:       event.SourceTitle,
+			SourceURL:         event.SourceURL,
+			IsCrossRepository: event.IsCrossRepository,
+			WillCloseTarget:   event.WillCloseTarget,
+		})
+		return &db.MREvent{
+			MergeRequestID: mrID,
+			EventType:      "cross_referenced",
+			Author:         event.Actor,
+			Summary:        fmt.Sprintf("Referenced from %s/%s#%d", event.SourceOwner, event.SourceRepo, event.SourceNumber),
+			MetadataJSON:   string(metadata),
+			CreatedAt:      event.CreatedAt,
+			DedupeKey:      timelineDedupeKey(event),
+		}
+	case "renamed_title":
+		metadata, _ := json.Marshal(renamedTitleMetadata{
+			PreviousTitle: event.PreviousTitle,
+			CurrentTitle:  event.CurrentTitle,
+		})
+		return &db.MREvent{
+			MergeRequestID: mrID,
+			EventType:      "renamed_title",
+			Author:         event.Actor,
+			Summary:        fmt.Sprintf("%q -> %q", event.PreviousTitle, event.CurrentTitle),
+			MetadataJSON:   string(metadata),
+			CreatedAt:      event.CreatedAt,
+			DedupeKey:      timelineDedupeKey(event),
+		}
+	case "base_ref_changed":
+		metadata, _ := json.Marshal(baseRefChangedMetadata{
+			PreviousRefName: event.PreviousRefName,
+			CurrentRefName:  event.CurrentRefName,
+		})
+		return &db.MREvent{
+			MergeRequestID: mrID,
+			EventType:      "base_ref_changed",
+			Author:         event.Actor,
+			Summary:        event.PreviousRefName + " -> " + event.CurrentRefName,
+			MetadataJSON:   string(metadata),
+			CreatedAt:      event.CreatedAt,
+			DedupeKey:      timelineDedupeKey(event),
+		}
+	default:
+		return nil
+	}
+}
+
+func timelineDedupeKey(event PullRequestTimelineEvent) string {
+	if event.NodeID != "" {
+		return "timeline-" + event.NodeID
+	}
+	raw := strings.Join([]string{
+		event.EventType,
+		event.CreatedAt.UTC().Format(time.RFC3339Nano),
+		event.Actor,
+		event.BeforeSHA,
+		event.AfterSHA,
+		event.Ref,
+		event.PreviousTitle,
+		event.CurrentTitle,
+		event.PreviousRefName,
+		event.CurrentRefName,
+		event.SourceType,
+		event.SourceOwner,
+		event.SourceRepo,
+		fmt.Sprint(event.SourceNumber),
+		event.SourceTitle,
+		event.SourceURL,
+		fmt.Sprint(event.IsCrossRepository),
+		fmt.Sprint(event.WillCloseTarget),
+	}, "\x00")
+	return "timeline-" + shortHash(raw)
 }
 
 // DeriveOverallCIStatus computes an aggregate CI status from check runs
@@ -444,6 +559,11 @@ func shortSHA(sha string) string {
 		return sha[:7]
 	}
 	return sha
+}
+
+func shortHash(value string) string {
+	sum := sha1.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])[:12]
 }
 
 func appName(r *gh.CheckRun) string {

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -206,7 +206,6 @@ func NormalizeTimelineEvent(mrID int64, event PullRequestTimelineEvent) *db.MREv
 			Ref:       event.Ref,
 			CreatedAt: event.CreatedAt,
 		})
-		normalized.DedupeKey = timelineDedupeKey(event)
 		return &normalized
 	case "cross_referenced":
 		metadata, _ := json.Marshal(crossReferenceMetadata{
@@ -280,7 +279,6 @@ func timelineDedupeKey(event PullRequestTimelineEvent) string {
 		event.SourceOwner,
 		event.SourceRepo,
 		fmt.Sprint(event.SourceNumber),
-		event.SourceTitle,
 		event.SourceURL,
 		fmt.Sprint(event.IsCrossRepository),
 		fmt.Sprint(event.WillCloseTarget),

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -206,6 +206,9 @@ func NormalizeTimelineEvent(mrID int64, event PullRequestTimelineEvent) *db.MREv
 			Ref:       event.Ref,
 			CreatedAt: event.CreatedAt,
 		})
+		if event.NodeID != "" {
+			normalized.DedupeKey = timelineDedupeKey(event)
+		}
 		return &normalized
 	case "cross_referenced":
 		metadata, _ := json.Marshal(crossReferenceMetadata{

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -286,6 +286,7 @@ func TestNormalizeTimelineEventCrossReferenced(t *testing.T) {
 }
 
 func TestNormalizeTimelineEventRenamedTitle(t *testing.T) {
+	require := require.New(t)
 	assert := Assert.New(t)
 	createdAt := time.Date(2024, 6, 1, 12, 5, 0, 0, time.UTC)
 
@@ -298,6 +299,7 @@ func TestNormalizeTimelineEventRenamedTitle(t *testing.T) {
 		CurrentTitle:  "New title",
 	})
 
+	require.NotNil(event)
 	assert.Equal("renamed_title", event.EventType)
 	assert.Equal("bob", event.Author)
 	assert.Equal(`"Old title" -> "New title"`, event.Summary)
@@ -306,6 +308,7 @@ func TestNormalizeTimelineEventRenamedTitle(t *testing.T) {
 }
 
 func TestNormalizeTimelineEventBaseRefChanged(t *testing.T) {
+	require := require.New(t)
 	assert := Assert.New(t)
 	createdAt := time.Date(2024, 6, 1, 12, 10, 0, 0, time.UTC)
 
@@ -318,6 +321,7 @@ func TestNormalizeTimelineEventBaseRefChanged(t *testing.T) {
 		CurrentRefName:  "release",
 	})
 
+	require.NotNil(event)
 	assert.Equal("base_ref_changed", event.EventType)
 	assert.Equal("carol", event.Author)
 	assert.Equal("main -> release", event.Summary)
@@ -346,10 +350,48 @@ func TestNormalizeTimelineEventForcePush(t *testing.T) {
 	assert.Equal("dana", event.Author)
 	assert.Equal("aaaaaaa -> bbbbbbb", event.Summary)
 	assert.Equal(createdAt, event.CreatedAt)
-	assert.Equal("timeline-HRFPE_1", event.DedupeKey)
+	assert.Equal("force-push-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", event.DedupeKey)
 	assert.Contains(event.MetadataJSON, `"before_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`)
 	assert.Contains(event.MetadataJSON, `"after_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"`)
 	assert.Contains(event.MetadataJSON, `"ref":"feature"`)
+}
+
+func TestNormalizeTimelineEventFallbackDedupeIgnoresCrossReferenceTitle(t *testing.T) {
+	require := require.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 25, 0, 0, time.UTC)
+
+	first := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		EventType:         "cross_referenced",
+		Actor:             "alice",
+		CreatedAt:         createdAt,
+		SourceType:        "Issue",
+		SourceOwner:       "other",
+		SourceRepo:        "repo",
+		SourceNumber:      77,
+		SourceTitle:       "Original title",
+		SourceURL:         "https://github.com/other/repo/issues/77",
+		IsCrossRepository: true,
+		WillCloseTarget:   false,
+	})
+	second := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		EventType:         "cross_referenced",
+		Actor:             "alice",
+		CreatedAt:         createdAt,
+		SourceType:        "Issue",
+		SourceOwner:       "other",
+		SourceRepo:        "repo",
+		SourceNumber:      77,
+		SourceTitle:       "Renamed title",
+		SourceURL:         "https://github.com/other/repo/issues/77",
+		IsCrossRepository: true,
+		WillCloseTarget:   false,
+	})
+
+	require.NotNil(first)
+	require.NotNil(second)
+	require.Equal(first.DedupeKey, second.DedupeKey)
+	require.Contains(first.MetadataJSON, `"source_title":"Original title"`)
+	require.Contains(second.MetadataJSON, `"source_title":"Renamed title"`)
 }
 
 func TestNormalizeCommitEvent_CreatedAtIsUTC(t *testing.T) {

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -254,6 +254,104 @@ func TestNormalizeForcePushEvent(t *testing.T) {
 	require.Contains(event.MetadataJSON, `"ref":"feature"`)
 }
 
+func TestNormalizeTimelineEventCrossReferenced(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 15, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:            "CRE_1",
+		EventType:         "cross_referenced",
+		Actor:             "alice",
+		CreatedAt:         createdAt,
+		SourceType:        "Issue",
+		SourceOwner:       "other",
+		SourceRepo:        "repo",
+		SourceNumber:      77,
+		SourceTitle:       "Related bug",
+		SourceURL:         "https://github.com/other/repo/issues/77",
+		IsCrossRepository: true,
+		WillCloseTarget:   false,
+	})
+
+	require.NotNil(event)
+	assert.Equal(int64(17), event.MergeRequestID)
+	assert.Equal("cross_referenced", event.EventType)
+	assert.Equal("alice", event.Author)
+	assert.Equal("Referenced from other/repo#77", event.Summary)
+	assert.Equal(createdAt, event.CreatedAt)
+	assert.Equal("timeline-CRE_1", event.DedupeKey)
+	assert.Contains(event.MetadataJSON, `"source_title":"Related bug"`)
+	assert.Contains(event.MetadataJSON, `"is_cross_repository":true`)
+}
+
+func TestNormalizeTimelineEventRenamedTitle(t *testing.T) {
+	assert := Assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 5, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:        "RTE_1",
+		EventType:     "renamed_title",
+		Actor:         "bob",
+		CreatedAt:     createdAt,
+		PreviousTitle: "Old title",
+		CurrentTitle:  "New title",
+	})
+
+	assert.Equal("renamed_title", event.EventType)
+	assert.Equal("bob", event.Author)
+	assert.Equal(`"Old title" -> "New title"`, event.Summary)
+	assert.Contains(event.MetadataJSON, `"previous_title":"Old title"`)
+	assert.Contains(event.MetadataJSON, `"current_title":"New title"`)
+}
+
+func TestNormalizeTimelineEventBaseRefChanged(t *testing.T) {
+	assert := Assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 10, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:          "BRC_1",
+		EventType:       "base_ref_changed",
+		Actor:           "carol",
+		CreatedAt:       createdAt,
+		PreviousRefName: "main",
+		CurrentRefName:  "release",
+	})
+
+	assert.Equal("base_ref_changed", event.EventType)
+	assert.Equal("carol", event.Author)
+	assert.Equal("main -> release", event.Summary)
+	assert.Contains(event.MetadataJSON, `"previous_ref_name":"main"`)
+	assert.Contains(event.MetadataJSON, `"current_ref_name":"release"`)
+}
+
+func TestNormalizeTimelineEventForcePush(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 20, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:    "HRFPE_1",
+		EventType: "force_push",
+		Actor:     "dana",
+		BeforeSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		AfterSHA:  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		Ref:       "feature",
+		CreatedAt: createdAt,
+	})
+
+	require.NotNil(event)
+	assert.Equal(int64(17), event.MergeRequestID)
+	assert.Equal("force_push", event.EventType)
+	assert.Equal("dana", event.Author)
+	assert.Equal("aaaaaaa -> bbbbbbb", event.Summary)
+	assert.Equal(createdAt, event.CreatedAt)
+	assert.Equal("timeline-HRFPE_1", event.DedupeKey)
+	assert.Contains(event.MetadataJSON, `"before_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`)
+	assert.Contains(event.MetadataJSON, `"after_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"`)
+	assert.Contains(event.MetadataJSON, `"ref":"feature"`)
+}
+
 func TestNormalizeCommitEvent_CreatedAtIsUTC(t *testing.T) {
 	assert := Assert.New(t)
 	//nolint:forbidigo // Test fixture intentionally uses a non-UTC zone to verify normalization.

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -350,7 +350,7 @@ func TestNormalizeTimelineEventForcePush(t *testing.T) {
 	assert.Equal("dana", event.Author)
 	assert.Equal("aaaaaaa -> bbbbbbb", event.Summary)
 	assert.Equal(createdAt, event.CreatedAt)
-	assert.Equal("force-push-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", event.DedupeKey)
+	assert.Equal("timeline-HRFPE_1", event.DedupeKey)
 	assert.Contains(event.MetadataJSON, `"before_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`)
 	assert.Contains(event.MetadataJSON, `"after_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"`)
 	assert.Contains(event.MetadataJSON, `"ref":"feature"`)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2185,7 +2185,7 @@ func (s *Syncer) syncOpenMRFromBulk(
 		}
 	}
 
-	// Timeline events — comments, reviews, commits.
+	// Timeline events — comments, reviews, commits, and system events.
 	// Events use ON CONFLICT DO NOTHING, so partial data is safe.
 	var events []db.MREvent
 	for _, c := range bulk.Comments {
@@ -2196,6 +2196,11 @@ func (s *Syncer) syncOpenMRFromBulk(
 	}
 	for _, c := range bulk.Commits {
 		events = append(events, NormalizeCommitEvent(mrID, c))
+	}
+	for _, timelineEvent := range bulk.TimelineEvents {
+		if event := NormalizeTimelineEvent(mrID, timelineEvent); event != nil {
+			events = append(events, *event)
+		}
 	}
 	if bulk.CommentsComplete {
 		if err := s.replacePRCommentEvents(ctx, mrID, bulk.Comments); err != nil {
@@ -2268,12 +2273,18 @@ func (s *Syncer) syncOpenMRFromBulk(
 	allComplete := bulk.CommentsComplete &&
 		bulk.ReviewsComplete &&
 		bulk.CommitsComplete &&
+		bulk.TimelineComplete &&
 		bulk.CIComplete
 	if allComplete {
 		reviewDecision := DeriveReviewDecision(bulk.Reviews)
 		lastActivity := computeLastActivity(
 			bulk.PR, bulk.Comments, bulk.Reviews, bulk.Commits,
 		)
+		for _, timelineEvent := range bulk.TimelineEvents {
+			if timelineEvent.CreatedAt.After(lastActivity) {
+				lastActivity = timelineEvent.CreatedAt
+			}
+		}
 		if err := s.db.UpdateMRDerivedFields(
 			ctx, repoID, number, db.MRDerivedFields{
 				ReviewDecision: reviewDecision,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2280,11 +2280,6 @@ func (s *Syncer) syncOpenMRFromBulk(
 		lastActivity := computeLastActivity(
 			bulk.PR, bulk.Comments, bulk.Reviews, bulk.Commits,
 		)
-		for _, timelineEvent := range bulk.TimelineEvents {
-			if timelineEvent.CreatedAt.After(lastActivity) {
-				lastActivity = timelineEvent.CreatedAt
-			}
-		}
 		if err := s.db.UpdateMRDerivedFields(
 			ctx, repoID, number, db.MRDerivedFields{
 				ReviewDecision: reviewDecision,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2615,14 +2615,14 @@ func (s *Syncer) refreshTimeline(
 		return fmt.Errorf("list commits for MR #%d: %w", number, err)
 	}
 
-	forcePushEvents, err := client.ListForcePushEvents(ctx, repo.Owner, repo.Name, number)
+	timelineEvents, err := client.ListPullRequestTimelineEvents(ctx, repo.Owner, repo.Name, number)
 	if err != nil {
-		slog.Warn("force-push fetch failed during timeline refresh",
+		slog.Warn("timeline event fetch failed during timeline refresh",
 			"repo", repo.Owner+"/"+repo.Name,
 			"number", number,
 			"err", err,
 		)
-		forcePushEvents = nil
+		timelineEvents = nil
 	}
 
 	var events []db.MREvent
@@ -2635,8 +2635,12 @@ func (s *Syncer) refreshTimeline(
 	for _, c := range commits {
 		events = append(events, NormalizeCommitEvent(mrID, c))
 	}
-	for _, fp := range forcePushEvents {
-		events = append(events, NormalizeForcePushEvent(mrID, fp))
+	for _, timelineEvent := range timelineEvents {
+		event := NormalizeTimelineEvent(mrID, timelineEvent)
+		if event == nil {
+			continue
+		}
+		events = append(events, *event)
 	}
 
 	if err := s.replacePRCommentEvents(ctx, mrID, comments); err != nil {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4873,6 +4873,7 @@ func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *test
 		CommentsComplete: true,
 		ReviewsComplete:  true,
 		CommitsComplete:  true,
+		TimelineComplete: true,
 		CIComplete:       true,
 	}, false)
 	require.NoError(err)
@@ -4893,6 +4894,7 @@ func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *test
 		CommentsComplete: true,
 		ReviewsComplete:  true,
 		CommitsComplete:  true,
+		TimelineComplete: true,
 		CIComplete:       true,
 	}, false)
 	require.NoError(err)
@@ -4978,6 +4980,55 @@ func TestSyncOpenMRFromBulkUpdatesCommentFieldsWhenOnlyCommentsAreComplete(t *te
 	events, err = d.ListMREvents(ctx, mr.ID)
 	require.NoError(err)
 	assert.Empty(events)
+}
+
+func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 3, 14, 0, 0, 0, time.UTC)
+	timelineAt := now.Add(3 * time.Minute)
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}},
+		d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+
+	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
+		PR: buildOpenPR(1, now),
+		TimelineEvents: []PullRequestTimelineEvent{{
+			NodeID:          "BRC_1",
+			EventType:       "base_ref_changed",
+			Actor:           "alice",
+			PreviousRefName: "main",
+			CurrentRefName:  "release",
+			CreatedAt:       timelineAt,
+		}},
+		CommentsComplete: true,
+		ReviewsComplete:  true,
+		CommitsComplete:  true,
+		TimelineComplete: true,
+		CIComplete:       true,
+	}, false)
+	require.NoError(err)
+
+	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NotNil(mr.DetailFetchedAt)
+	assert.Equal(timelineAt.UTC(), mr.LastActivityAt.UTC())
+
+	events, err := d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("base_ref_changed", events[0].EventType)
+	assert.Equal("main -> release", events[0].Summary)
 }
 
 // buildOpenPRWithSHA mirrors buildOpenPR but lets the caller set the

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5022,7 +5022,7 @@ func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(mr)
 	require.NotNil(mr.DetailFetchedAt)
-	assert.Equal(timelineAt.UTC(), mr.LastActivityAt.UTC())
+	assert.Equal(now.UTC(), mr.LastActivityAt.UTC())
 
 	events, err := d.ListMREvents(ctx, mr.ID)
 	require.NoError(err)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -64,6 +64,8 @@ type mockClient struct {
 	comments                        []*gh.IssueComment
 	reviews                         []*gh.PullRequestReview
 	commits                         []*gh.RepositoryCommit
+	timelineEvents                  []PullRequestTimelineEvent
+	timelineEventsErr               error
 	forcePushEvents                 []ForcePushEvent
 	forcePushEventsErr              error
 	ciStatus                        *gh.CombinedStatus
@@ -585,7 +587,8 @@ func TestSyncStoresForcePushEvent(t *testing.T) {
 				Author:  &gh.CommitAuthor{Name: new("dev"), Date: makeTimestamp(now.Add(-1 * time.Hour))},
 			},
 		}},
-		forcePushEvents: []ForcePushEvent{{
+		timelineEvents: []PullRequestTimelineEvent{{
+			EventType: "force_push",
 			Actor:     "alice",
 			BeforeSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			AfterSHA:  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -619,6 +622,107 @@ func TestSyncStoresForcePushEvent(t *testing.T) {
 	assert.Equal("alice", forcePush.Author)
 	assert.Equal("aaaaaaa -> bbbbbbb", forcePush.Summary)
 	assert.Contains(forcePush.MetadataJSON, `"ref":"feature"`)
+}
+
+func TestSyncStoresPullRequestTimelineEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	mc := &mockClient{
+		openPRs:  []*gh.PullRequest{buildOpenPR(1, now)},
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		timelineEvents: []PullRequestTimelineEvent{
+			{
+				NodeID:            "CRE_1",
+				EventType:         "cross_referenced",
+				Actor:             "alice",
+				CreatedAt:         now.Add(-3 * time.Minute),
+				SourceType:        "Issue",
+				SourceOwner:       "other",
+				SourceRepo:        "repo",
+				SourceNumber:      77,
+				SourceTitle:       "Related bug",
+				SourceURL:         "https://github.com/other/repo/issues/77",
+				IsCrossRepository: true,
+			},
+			{
+				NodeID:          "BRC_1",
+				EventType:       "base_ref_changed",
+				Actor:           "bob",
+				CreatedAt:       now.Add(-2 * time.Minute),
+				PreviousRefName: "main",
+				CurrentRefName:  "release",
+			},
+			{
+				NodeID:        "RTE_1",
+				EventType:     "renamed_title",
+				Actor:         "carol",
+				CreatedAt:     now.Add(-1 * time.Minute),
+				PreviousTitle: "Old",
+				CurrentTitle:  "New",
+			},
+		},
+	}
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
+	syncer.RunOnce(ctx)
+
+	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(pr)
+
+	events, err := d.ListMREvents(ctx, pr.ID)
+	require.NoError(err)
+
+	byType := map[string]db.MREvent{}
+	for _, event := range events {
+		byType[event.EventType] = event
+	}
+	assert.Contains(byType, "cross_referenced")
+	assert.Contains(byType, "base_ref_changed")
+	assert.Contains(byType, "renamed_title")
+	assert.Contains(byType["cross_referenced"].MetadataJSON, `"source_title":"Related bug"`)
+	assert.Equal("main -> release", byType["base_ref_changed"].Summary)
+	assert.Equal(`"Old" -> "New"`, byType["renamed_title"].Summary)
+}
+
+func TestSyncIgnoresPullRequestTimelineFetchFailures(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	commentID := int64(123)
+	body := "human comment"
+	user := &gh.User{Login: new("alice")}
+
+	mc := &mockClient{
+		openPRs: []*gh.PullRequest{buildOpenPR(1, now)},
+		comments: []*gh.IssueComment{{
+			ID:        &commentID,
+			User:      user,
+			Body:      &body,
+			CreatedAt: makeTimestamp(now.Add(-time.Minute)),
+		}},
+		reviews:           []*gh.PullRequestReview{},
+		commits:           []*gh.RepositoryCommit{},
+		timelineEventsErr: errors.New("graphql unavailable"),
+	}
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
+	syncer.RunOnce(ctx)
+
+	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(pr)
+	events, err := d.ListMREvents(ctx, pr.ID)
+	require.NoError(err)
+	require.NotEmpty(events)
+	require.Equal("issue_comment", events[0].EventType)
 }
 
 func TestSyncStoresPRLabels(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -209,6 +209,12 @@ func (m *mockGH) ListForcePushEvents(
 	return nil, nil
 }
 
+func (m *mockGH) ListPullRequestTimelineEvents(
+	_ context.Context, _, _ string, _ int,
+) ([]ghclient.PullRequestTimelineEvent, error) {
+	return nil, nil
+}
+
 func (m *mockGH) GetCombinedStatus(
 	ctx context.Context, owner, repo, ref string,
 ) (*gh.CombinedStatus, error) {

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -296,6 +296,13 @@ func (c *FixtureClient) ListForcePushEvents(
 	return nil, nil
 }
 
+// ListPullRequestTimelineEvents returns nil (read-only stub).
+func (c *FixtureClient) ListPullRequestTimelineEvents(
+	_ context.Context, _, _ string, _ int,
+) ([]ghclient.PullRequestTimelineEvent, error) {
+	return nil, nil
+}
+
 // GetCombinedStatus returns a seeded combined status by repo/ref.
 func (c *FixtureClient) GetCombinedStatus(
 	_ context.Context, owner, repo, ref string,

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -505,6 +505,42 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			CreatedAt:      commitBase.Add(6 * time.Hour),
 			DedupeKey:      "w1-commit-4",
 		},
+		{
+			MergeRequestID: w1ID,
+			EventType:      "force_push",
+			Author:         "alice",
+			Summary:        "abc4444 -> def5555",
+			MetadataJSON:   `{"before_sha":"abc4444444444444444444444444444444444444","after_sha":"def5555555555555555555555555555555555555","ref":"feature/caching"}`,
+			CreatedAt:      commitBase.Add(8 * time.Hour),
+			DedupeKey:      "w1-force-push-1",
+		},
+		{
+			MergeRequestID: w1ID,
+			EventType:      "cross_referenced",
+			Author:         "carol",
+			Summary:        "Referenced from acme/widgets#10",
+			MetadataJSON:   `{"source_type":"Issue","source_owner":"acme","source_repo":"widgets","source_number":10,"source_title":"Widget rendering broken on Safari","source_url":"https://github.com/acme/widgets/issues/10","is_cross_repository":false,"will_close_target":false}`,
+			CreatedAt:      commitBase.Add(9 * time.Hour),
+			DedupeKey:      "w1-cross-reference-1",
+		},
+		{
+			MergeRequestID: w1ID,
+			EventType:      "renamed_title",
+			Author:         "alice",
+			Summary:        `"Add widget cache" -> "Add widget caching layer"`,
+			MetadataJSON:   `{"previous_title":"Add widget cache","current_title":"Add widget caching layer"}`,
+			CreatedAt:      commitBase.Add(10 * time.Hour),
+			DedupeKey:      "w1-renamed-title-1",
+		},
+		{
+			MergeRequestID: w1ID,
+			EventType:      "base_ref_changed",
+			Author:         "alice",
+			Summary:        "develop -> main",
+			MetadataJSON:   `{"previous_ref_name":"develop","current_ref_name":"main"}`,
+			CreatedAt:      commitBase.Add(11 * time.Hour),
+			DedupeKey:      "w1-base-ref-changed-1",
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("upsert widgets PR#1 events: %w", err)

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { IssueEvent, PREvent } from "../../api/types.js";
   import { renderMarkdown } from "../../utils/markdown.js";
-  import { timeAgo } from "../../utils/time.js";
+  import { localDateTimeLabel, timeAgo } from "../../utils/time.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
 
   interface Props {
@@ -117,7 +117,7 @@
               {#if event.Author}
                 <span class="event-author">{event.Author}</span>
               {/if}
-              <span class="event-time">{timeAgo(event.CreatedAt)}</span>
+              <span class="event-time">{localDateTimeLabel(event.CreatedAt)}</span>
               {#if event.EventType === "commit"}
                 <span class="commit-sha">{shortCommit(event.Summary)}</span>
                 <span class="commit-title">{commitTitle(event.Body)}</span>

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -69,10 +69,17 @@
   function parseMetadata(event: PREvent | IssueEvent): Record<string, unknown> {
     if (!event.MetadataJSON) return {};
     try {
-      return JSON.parse(event.MetadataJSON) as Record<string, unknown>;
+      const parsed = JSON.parse(event.MetadataJSON) as unknown;
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+      return parsed as Record<string, unknown>;
     } catch {
       return {};
     }
+  }
+
+  function metadataString(metadata: Record<string, unknown>, key: string): string | null {
+    const value = metadata[key];
+    return typeof value === "string" && value.length > 0 ? value : null;
   }
 
   let copiedId = $state<string | null>(null);
@@ -122,14 +129,20 @@
                 <span class="commit-sha">{shortCommit(event.Summary)}</span>
                 <span class="commit-title">{commitTitle(event.Body)}</span>
               {:else if event.EventType === "cross_referenced"}
-                <a
-                  class="system-event-link"
-                  href={String(metadata.source_url ?? "")}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {String(metadata.source_title ?? event.Summary)}
-                </a>
+                {@const sourceUrl = metadataString(metadata, "source_url")}
+                {@const sourceTitle = metadataString(metadata, "source_title") ?? event.Summary}
+                {#if sourceUrl}
+                  <a
+                    class="system-event-link"
+                    href={sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {sourceTitle}
+                  </a>
+                {:else}
+                  <span class="system-event-summary">{sourceTitle}</span>
+                {/if}
               {:else}
                 <span class="system-event-summary">{event.Summary}</span>
               {/if}

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -8,9 +8,10 @@
     events: Array<PREvent | IssueEvent>;
     repoOwner?: string;
     repoName?: string;
+    filtered?: boolean;
   }
 
-  const { events, repoOwner, repoName }: Props = $props();
+  const { events, repoOwner, repoName, filtered = false }: Props = $props();
 
   const typeLabels: Record<string, string> = {
     issue_comment: "Comment",
@@ -32,6 +33,48 @@
     return eventType === "issue_comment" || eventType === "review" || eventType === "review_comment";
   }
 
+  function isCompactEvent(eventType: string): boolean {
+    return (
+      eventType === "commit" ||
+      eventType === "force_push" ||
+      eventType === "cross_referenced" ||
+      eventType === "renamed_title" ||
+      eventType === "base_ref_changed"
+    );
+  }
+
+  function shortCommit(summary: string): string {
+    return summary.length > 7 ? summary.slice(0, 7) : summary;
+  }
+
+  function commitTitle(body: string): string {
+    return body.split(/\r?\n/, 1)[0] ?? "";
+  }
+
+  function systemEventLabel(eventType: string): string {
+    switch (eventType) {
+      case "cross_referenced":
+        return "Referenced";
+      case "renamed_title":
+        return "Title changed";
+      case "base_ref_changed":
+        return "Base changed";
+      case "force_push":
+        return "Force-pushed";
+      default:
+        return typeLabels[eventType] ?? eventType;
+    }
+  }
+
+  function parseMetadata(event: PREvent | IssueEvent): Record<string, unknown> {
+    if (!event.MetadataJSON) return {};
+    try {
+      return JSON.parse(event.MetadataJSON) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+
   let copiedId = $state<string | null>(null);
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -49,11 +92,11 @@
 </script>
 
 {#if events.length === 0}
-  <p class="empty">No activity yet</p>
+  <p class="empty">{filtered ? "No activity matches the current filters" : "No activity yet"}</p>
 {:else}
   <ol class="timeline">
     {#each events as event (event.ID)}
-      <li class="event">
+      <li class={isCompactEvent(event.EventType) ? "event event--compact" : "event"}>
         <div class="event-rail">
           <span
             class="dot"
@@ -61,51 +104,84 @@
           ></span>
           <span class="rail-line"></span>
         </div>
-        <div class="event-card">
-          <div class="event-header">
-            <span
-              class="event-type"
-              style="color: {typeColors[event.EventType] ?? 'var(--text-muted)'}"
-            >
-              {typeLabels[event.EventType] ?? event.EventType}
-            </span>
-            {#if event.Author}
-              <span class="event-author">{event.Author}</span>
-            {/if}
-            <span class="event-time">{timeAgo(event.CreatedAt)}</span>
-          </div>
-          {#if event.Summary && (event.EventType === "commit" || event.EventType === "force_push")}
-            <p class="event-summary">{event.Summary}</p>
-          {/if}
-          {#if event.Body}
-            <div class="event-body-wrap">
-              <button
-                class="copy-icon-btn"
-                class:copied={copiedId === String(event.ID)}
-                onclick={() => copyText(String(event.ID), event.Body)}
-                title={copiedId === String(event.ID) ? "Copied!" : "Copy to clipboard"}
+        {#if isCompactEvent(event.EventType)}
+          {@const metadata = parseMetadata(event)}
+          <div class="event-card event-card--compact">
+            <div class="event-header event-header--compact">
+              <span
+                class="event-type"
+                style="color: {typeColors[event.EventType] ?? 'var(--text-muted)'}"
               >
-                {#if copiedId === String(event.ID)}
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/>
-                  </svg>
-                {:else}
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
-                    <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
-                  </svg>
-                {/if}
-              </button>
-              <div class="event-body {shouldRenderMarkdown(event.EventType) ? 'markdown-body' : ''}">
-                {#if shouldRenderMarkdown(event.EventType)}
-                  {@html renderMarkdown(event.Body, repoOwner && repoName ? { owner: repoOwner, name: repoName } : undefined)}
-                {:else}
-                  {event.Body}
-                {/if}
-              </div>
+                {systemEventLabel(event.EventType)}
+              </span>
+              {#if event.Author}
+                <span class="event-author">{event.Author}</span>
+              {/if}
+              <span class="event-time">{timeAgo(event.CreatedAt)}</span>
+              {#if event.EventType === "commit"}
+                <span class="commit-sha">{shortCommit(event.Summary)}</span>
+                <span class="commit-title">{commitTitle(event.Body)}</span>
+              {:else if event.EventType === "cross_referenced"}
+                <a
+                  class="system-event-link"
+                  href={String(metadata.source_url ?? "")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {String(metadata.source_title ?? event.Summary)}
+                </a>
+              {:else}
+                <span class="system-event-summary">{event.Summary}</span>
+              {/if}
             </div>
-          {/if}
-        </div>
+          </div>
+        {:else}
+          <div class="event-card">
+            <div class="event-header">
+              <span
+                class="event-type"
+                style="color: {typeColors[event.EventType] ?? 'var(--text-muted)'}"
+              >
+                {typeLabels[event.EventType] ?? event.EventType}
+              </span>
+              {#if event.Author}
+                <span class="event-author">{event.Author}</span>
+              {/if}
+              <span class="event-time">{timeAgo(event.CreatedAt)}</span>
+            </div>
+            {#if event.Summary && (event.EventType === "commit" || event.EventType === "force_push")}
+              <p class="event-summary">{event.Summary}</p>
+            {/if}
+            {#if event.Body}
+              <div class="event-body-wrap">
+                <button
+                  class="copy-icon-btn"
+                  class:copied={copiedId === String(event.ID)}
+                  onclick={() => copyText(String(event.ID), event.Body)}
+                  title={copiedId === String(event.ID) ? "Copied!" : "Copy to clipboard"}
+                >
+                  {#if copiedId === String(event.ID)}
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/>
+                    </svg>
+                  {:else}
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
+                      <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
+                    </svg>
+                  {/if}
+                </button>
+                <div class="event-body {shouldRenderMarkdown(event.EventType) ? 'markdown-body' : ''}">
+                  {#if shouldRenderMarkdown(event.EventType)}
+                    {@html renderMarkdown(event.Body, repoOwner && repoName ? { owner: repoOwner, name: repoName } : undefined)}
+                  {:else}
+                    {event.Body}
+                  {/if}
+                </div>
+              </div>
+            {/if}
+          </div>
+        {/if}
       </li>
     {/each}
   </ol>
@@ -171,11 +247,24 @@
     margin: 4px 0 4px 8px;
   }
 
+  .event-card--compact {
+    padding: 7px 10px;
+  }
+
   .event-header {
     display: flex;
     align-items: center;
     gap: 6px;
     flex-wrap: wrap;
+  }
+
+  .event-header--compact {
+    min-width: 0;
+    flex-wrap: nowrap;
+  }
+
+  .event-header--compact .event-time {
+    margin-left: 0;
   }
 
   .event-type {
@@ -205,6 +294,45 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .commit-sha {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .commit-title,
+  .system-event-summary,
+  .system-event-link {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .commit-title {
+    flex: 1;
+    color: var(--text-primary);
+  }
+
+  .system-event-summary,
+  .system-event-link {
+    flex: 1;
+    font-size: 12px;
+  }
+
+  .system-event-summary {
+    color: var(--text-secondary);
+  }
+
+  .system-event-link {
+    color: var(--accent-blue);
+    text-decoration: none;
+  }
+
+  .system-event-link:hover {
+    text-decoration: underline;
   }
 
   /* Body wrap for copy button positioning */

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { IssueEvent, PREvent } from "../../api/types.js";
   import { renderMarkdown } from "../../utils/markdown.js";
-  import { localDateTimeLabel, timeAgo } from "../../utils/time.js";
+  import { timeAgo } from "../../utils/time.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
 
   interface Props {
@@ -137,13 +137,14 @@
               {#if event.Author}
                 <span class="event-author">{event.Author}</span>
               {/if}
-              <span class="event-time">{localDateTimeLabel(event.CreatedAt)}</span>
               {#if event.EventType === "commit"}
                 <span class="commit-sha">{shortCommit(event.Summary)}</span>
                 <span class="commit-title">{commitTitle(event.Body)}</span>
+                <span class="event-time">{timeAgo(event.CreatedAt)}</span>
               {:else if event.EventType === "cross_referenced"}
                 {@const sourceUrl = metadataString(metadata, "source_url")}
                 {@const sourceTitle = metadataString(metadata, "source_title") ?? event.Summary}
+                <span class="event-time">{timeAgo(event.CreatedAt)}</span>
                 {#if sourceUrl}
                   <a
                     class="system-event-link"
@@ -157,11 +158,12 @@
                   <span class="system-event-summary">{sourceTitle}</span>
                 {/if}
               {:else}
+                <span class="event-time">{timeAgo(event.CreatedAt)}</span>
                 <span class="system-event-summary">{event.Summary}</span>
               {/if}
             </div>
             {#if event.EventType === "commit" && showCommitDetails && commitDetails}
-              <div class="commit-body-details">{commitDetails}</div>
+              <div class="event-body commit-body-details">{commitDetails}</div>
             {/if}
           </div>
         {:else}
@@ -347,13 +349,7 @@
 
   .commit-body-details {
     margin-top: 7px;
-    padding-top: 7px;
-    border-top: 1px solid var(--border-muted);
-    color: var(--text-secondary);
-    font-size: 12px;
-    line-height: 1.5;
-    white-space: pre-wrap;
-    word-break: break-word;
+    padding-right: 10px;
   }
 
   .system-event-summary,

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -9,9 +9,16 @@
     repoOwner?: string;
     repoName?: string;
     filtered?: boolean;
+    showCommitDetails?: boolean;
   }
 
-  const { events, repoOwner, repoName, filtered = false }: Props = $props();
+  const {
+    events,
+    repoOwner,
+    repoName,
+    filtered = false,
+    showCommitDetails = true,
+  }: Props = $props();
 
   const typeLabels: Record<string, string> = {
     issue_comment: "Comment",
@@ -49,6 +56,11 @@
 
   function commitTitle(body: string): string {
     return body.split(/\r?\n/, 1)[0] ?? "";
+  }
+
+  function commitBodyDetails(body: string): string {
+    const lines = body.split(/\r?\n/);
+    return lines.slice(1).join("\n").trim();
   }
 
   function systemEventLabel(eventType: string): string {
@@ -113,6 +125,7 @@
         </div>
         {#if isCompactEvent(event.EventType)}
           {@const metadata = parseMetadata(event)}
+          {@const commitDetails = event.EventType === "commit" ? commitBodyDetails(event.Body) : ""}
           <div class="event-card event-card--compact">
             <div class="event-header event-header--compact">
               <span
@@ -147,6 +160,9 @@
                 <span class="system-event-summary">{event.Summary}</span>
               {/if}
             </div>
+            {#if event.EventType === "commit" && showCommitDetails && commitDetails}
+              <div class="commit-body-details">{commitDetails}</div>
+            {/if}
           </div>
         {:else}
           <div class="event-card">
@@ -327,6 +343,17 @@
   .commit-title {
     flex: 1;
     color: var(--text-primary);
+  }
+
+  .commit-body-details {
+    margin-top: 7px;
+    padding-top: 7px;
+    border-top: 1px solid var(--border-muted);
+    color: var(--text-secondary);
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 
   .system-event-summary,

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { slide } from "svelte/transition";
   import type { IssueEvent, PREvent } from "../../api/types.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { timeAgo } from "../../utils/time.js";
@@ -163,7 +164,12 @@
               {/if}
             </div>
             {#if event.EventType === "commit" && showCommitDetails && commitDetails}
-              <div class="event-body commit-body-details">{commitDetails}</div>
+              <div
+                class="event-body commit-body-details"
+                transition:slide={{ duration: 100 }}
+              >
+                {commitDetails}
+              </div>
             {/if}
           </div>
         {:else}

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -107,4 +107,79 @@ describe("EventTimeline", () => {
     expect(bodyStyle.getPropertyValue("border")).toBe("");
     expect(bodyStyle.getPropertyValue("border-radius")).toBe("");
   });
+
+  it("renders commit events as compact one-line commit detail rows", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            EventType: "commit",
+            Summary: "abcdef1234567890",
+            Body: "feat: add timeline filters\n\nLong body",
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getByText("abcdef1")).toBeTruthy();
+    expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
+    expect(document.querySelector(".event--compact")).toBeTruthy();
+    expect(document.querySelector(".commit-title")).toBeTruthy();
+  });
+
+  it("renders system events as compact rows", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 2,
+            EventType: "renamed_title",
+            Summary: `"Old" -> "New"`,
+            MetadataJSON: JSON.stringify({
+              previous_title: "Old",
+              current_title: "New",
+            }),
+          }),
+          makeEvent({
+            ID: 3,
+            EventType: "base_ref_changed",
+            Summary: "main -> release",
+            MetadataJSON: JSON.stringify({
+              previous_ref_name: "main",
+              current_ref_name: "release",
+            }),
+          }),
+          makeEvent({
+            ID: 4,
+            EventType: "cross_referenced",
+            Summary: "Referenced from other/repo#77",
+            MetadataJSON: JSON.stringify({
+              source_owner: "other",
+              source_repo: "repo",
+              source_number: 77,
+              source_title: "Related bug",
+              source_url: "https://github.com/other/repo/issues/77",
+            }),
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getByText("Title changed")).toBeTruthy();
+    expect(screen.getByText("Base changed")).toBeTruthy();
+    expect(screen.getByText("Referenced")).toBeTruthy();
+    expect(screen.getByText("Related bug")).toBeTruthy();
+    expect(document.querySelectorAll(".event--compact").length).toBe(3);
+  });
+
+  it("shows filtered empty copy when filters hide all events", () => {
+    render(EventTimeline, {
+      props: {
+        events: [],
+        filtered: true,
+      },
+    });
+
+    expect(screen.getByText("No activity matches the current filters")).toBeTruthy();
+  });
 });

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/svelte";
 import { compile } from "svelte/compiler";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import componentSource from "./EventTimeline.svelte?raw";
 import EventTimeline from "./EventTimeline.svelte";
 import type { PREvent } from "../../api/types.js";
@@ -53,6 +53,7 @@ function findCompiledStyleRule(
 describe("EventTimeline", () => {
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it("renders force-push label, actor, and SHA transition", () => {
@@ -109,6 +110,8 @@ describe("EventTimeline", () => {
   });
 
   it("renders commit events as compact one-line commit detail rows", () => {
+    vi.spyOn(Date.prototype, "toLocaleString").mockReturnValue("Jun 1, 2024, 8:00 AM");
+
     render(EventTimeline, {
       props: {
         events: [
@@ -123,6 +126,7 @@ describe("EventTimeline", () => {
 
     expect(screen.getByText("abcdef1")).toBeTruthy();
     expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
+    expect(screen.getByText("Jun 1, 2024, 8:00 AM")).toBeTruthy();
     expect(document.querySelector(".event--compact")).toBeTruthy();
     expect(document.querySelector(".commit-title")).toBeTruthy();
   });

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -54,6 +54,7 @@ describe("EventTimeline", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("renders force-push label, actor, and SHA transition", () => {
@@ -110,7 +111,8 @@ describe("EventTimeline", () => {
   });
 
   it("renders commit events as compact one-line commit detail rows", () => {
-    vi.spyOn(Date.prototype, "toLocaleString").mockReturnValue("Jun 1, 2024, 8:00 AM");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T16:00:00Z"));
 
     render(EventTimeline, {
       props: {
@@ -127,12 +129,24 @@ describe("EventTimeline", () => {
     expect(screen.getByText("abcdef1")).toBeTruthy();
     expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
     expect(screen.getByText("Long body")).toBeTruthy();
-    expect(screen.getByText("Jun 1, 2024, 8:00 AM")).toBeTruthy();
+    expect(screen.getByText("4h ago")).toBeTruthy();
     expect(document.querySelector(".event--compact")).toBeTruthy();
     expect(document.querySelector(".commit-title")).toBeTruthy();
+    expect(
+      document.querySelector(".commit-body-details")?.classList.contains("event-body"),
+    ).toBe(true);
+    expect(
+      document
+        .querySelector(".event-header--compact")
+        ?.lastElementChild
+        ?.classList.contains("event-time"),
+    ).toBe(true);
   });
 
   it("can hide commit body details while keeping the title row", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T16:00:00Z"));
+
     render(EventTimeline, {
       props: {
         events: [
@@ -148,7 +162,14 @@ describe("EventTimeline", () => {
 
     expect(screen.getByText("abcdef1")).toBeTruthy();
     expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
+    expect(screen.getByText("4h ago")).toBeTruthy();
     expect(screen.queryByText("Long body")).toBeNull();
+    expect(
+      document
+        .querySelector(".event-header--compact")
+        ?.lastElementChild
+        ?.classList.contains("event-time"),
+    ).toBe(true);
   });
 
   it("renders system events as compact rows", () => {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -126,9 +126,29 @@ describe("EventTimeline", () => {
 
     expect(screen.getByText("abcdef1")).toBeTruthy();
     expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
+    expect(screen.getByText("Long body")).toBeTruthy();
     expect(screen.getByText("Jun 1, 2024, 8:00 AM")).toBeTruthy();
     expect(document.querySelector(".event--compact")).toBeTruthy();
     expect(document.querySelector(".commit-title")).toBeTruthy();
+  });
+
+  it("can hide commit body details while keeping the title row", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            EventType: "commit",
+            Summary: "abcdef1234567890",
+            Body: "feat: add timeline filters\n\nLong body",
+          }),
+        ],
+        showCommitDetails: false,
+      },
+    });
+
+    expect(screen.getByText("abcdef1")).toBeTruthy();
+    expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
+    expect(screen.queryByText("Long body")).toBeNull();
   });
 
   it("renders system events as compact rows", () => {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -176,6 +176,33 @@ describe("EventTimeline", () => {
     expect(document.querySelectorAll(".event--compact").length).toBe(3);
   });
 
+  it("falls back to non-link cross-reference text when metadata is invalid", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 5,
+            EventType: "cross_referenced",
+            Summary: "Referenced from other/repo#77",
+            MetadataJSON: "null",
+          }),
+          makeEvent({
+            ID: 6,
+            EventType: "cross_referenced",
+            Summary: "Referenced from other/repo#78",
+            MetadataJSON: JSON.stringify({
+              source_title: "Related follow-up",
+            }),
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getByText("Referenced from other/repo#77")).toBeTruthy();
+    expect(screen.getByText("Related follow-up")).toBeTruthy();
+    expect(document.querySelectorAll(".system-event-link").length).toBe(0);
+  });
+
   it("shows filtered empty copy when filters hide all events", () => {
     render(EventTimeline, {
       props: {

--- a/packages/ui/src/components/detail/PRTimelineFilter.svelte
+++ b/packages/ui/src/components/detail/PRTimelineFilter.svelte
@@ -77,6 +77,7 @@
   title="Filter PR activity"
   {sections}
   minWidth="220px"
+  align="end"
   {...activeCount > 0
     ? {
         resetLabel: "Show all",

--- a/packages/ui/src/components/detail/PRTimelineFilter.svelte
+++ b/packages/ui/src/components/detail/PRTimelineFilter.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import FilterDropdown from "../shared/FilterDropdown.svelte";
+  import {
+    activePRTimelineFilterCount,
+    DEFAULT_PR_TIMELINE_FILTER,
+    type PRTimelineFilterState,
+  } from "./prTimelineFilter.js";
+
+  interface Props {
+    filter: PRTimelineFilterState;
+    onChange: (filter: PRTimelineFilterState) => void;
+  }
+
+  let { filter, onChange }: Props = $props();
+
+  const activeCount = $derived(activePRTimelineFilterCount(filter));
+
+  function update(patch: Partial<PRTimelineFilterState>): void {
+    onChange({ ...filter, ...patch });
+  }
+
+  const sections = $derived.by(() => [
+    {
+      title: "Content",
+      items: [
+        {
+          id: "messages",
+          label: "Messages",
+          active: filter.showMessages,
+          color: "var(--accent-blue)",
+          onSelect: () => update({ showMessages: !filter.showMessages }),
+        },
+        {
+          id: "commit-details",
+          label: "Commit details",
+          active: filter.showCommitDetails,
+          color: "var(--accent-green)",
+          onSelect: () =>
+            update({ showCommitDetails: !filter.showCommitDetails }),
+        },
+        {
+          id: "events",
+          label: "Events",
+          active: filter.showEvents,
+          color: "var(--accent-amber)",
+          onSelect: () => update({ showEvents: !filter.showEvents }),
+        },
+        {
+          id: "force-pushes",
+          label: "Force pushes",
+          active: filter.showForcePushes,
+          color: "var(--accent-red)",
+          onSelect: () =>
+            update({ showForcePushes: !filter.showForcePushes }),
+        },
+      ],
+    },
+    {
+      title: "Visibility",
+      items: [
+        {
+          id: "hide-bots",
+          label: "Hide bot activity",
+          active: filter.hideBots,
+          color: "var(--accent-purple)",
+          onSelect: () => update({ hideBots: !filter.hideBots }),
+        },
+      ],
+    },
+  ]);
+</script>
+
+<FilterDropdown
+  label="Filters"
+  active={activeCount > 0}
+  badgeCount={activeCount}
+  title="Filter PR activity"
+  {sections}
+  minWidth="220px"
+  {...activeCount > 0
+    ? {
+        resetLabel: "Show all",
+        onReset: () => onChange(DEFAULT_PR_TIMELINE_FILTER),
+      }
+    : {}}
+/>

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -10,6 +10,7 @@
   import { timeAgo } from "../../utils/time.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import EventTimeline from "./EventTimeline.svelte";
+  import PRTimelineFilter from "./PRTimelineFilter.svelte";
   import CommentBox from "./CommentBox.svelte";
   import ApproveButton from "./ApproveButton.svelte";
   import ApproveWorkflowsButton from "./ApproveWorkflowsButton.svelte";
@@ -32,6 +33,13 @@
   import CopyItemNumber from "./CopyItemNumber.svelte";
   import { DiffSummaryFilesResult } from "./diff-summary.js";
   import { buildDiffSummaryKey } from "./diff-summary-key.js";
+  import {
+    activePRTimelineFilterCount,
+    filterPREvents,
+    loadPRTimelineFilter,
+    savePRTimelineFilter,
+    type PRTimelineFilterState,
+  } from "./prTimelineFilter.js";
 
   const { detail: detailStore, pulls, activity } = getStores();
   const client = getClient();
@@ -61,6 +69,20 @@
 
   let activeTab = $state<"conversation" | "files">("conversation");
   let ciExpanded = $state(false);
+  let timelineFilter = $state<PRTimelineFilterState>(
+    loadPRTimelineFilter(),
+  );
+  const filteredTimelineEvents = $derived.by(() =>
+    filterPREvents(detailStore.getDetail()?.events ?? [], timelineFilter),
+  );
+  const hasActiveTimelineFilters = $derived(
+    activePRTimelineFilterCount(timelineFilter) > 0,
+  );
+
+  function updateTimelineFilter(next: PRTimelineFilterState): void {
+    timelineFilter = next;
+    savePRTimelineFilter(next);
+  }
 
   // Mutating actions (close/reopen, kanban state, star, save title/body,
   // workspace creation, etc.) read the (owner, name, number) PROPS, but
@@ -1051,9 +1073,20 @@
 
       <!-- Activity -->
       <div class="section">
-        <h3 class="section-title">Activity</h3>
+        <div class="section-title-row">
+          <h3 class="section-title">Activity</h3>
+          <PRTimelineFilter
+            filter={timelineFilter}
+            onChange={updateTimelineFilter}
+          />
+        </div>
         {#if detailStore.getDetailLoaded()}
-          <EventTimeline events={detail.events ?? []} repoOwner={owner} repoName={name} />
+          <EventTimeline
+            events={filteredTimelineEvents}
+            repoOwner={owner}
+            repoName={name}
+            filtered={hasActiveTimelineFilters}
+          />
         {:else if detailStore.isDetailSyncing()}
           <div class="loading-placeholder">
             <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -1590,6 +1623,13 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+  }
+
+  .section-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
   }
 
   .section-title {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -1086,6 +1086,7 @@
             repoOwner={owner}
             repoName={name}
             filtered={hasActiveTimelineFilters}
+            showCommitDetails={timelineFilter.showCommitDetails}
           />
         {:else if detailStore.isDetailSyncing()}
           <div class="loading-placeholder">

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -146,6 +146,23 @@ describe("prTimelineFilter", () => {
     );
   });
 
+  it("keeps commit title rows when commit details are disabled", () => {
+    const events = [
+      event({ ID: 1, EventType: "commit", Author: "alice" }),
+      event({ ID: 2, EventType: "issue_comment", Author: "alice" }),
+    ];
+
+    expect(
+      filterPREvents(events, {
+        showMessages: true,
+        showCommitDetails: false,
+        showEvents: true,
+        showForcePushes: true,
+        hideBots: false,
+      }).map((item) => item.ID),
+    ).toEqual([1, 2]);
+  });
+
   it("filters by disabled buckets and bots", () => {
     const events = [
       event({ ID: 1, EventType: "issue_comment", Author: "alice" }),
@@ -163,7 +180,7 @@ describe("prTimelineFilter", () => {
         showForcePushes: false,
         hideBots: true,
       }).map((item) => item.ID),
-    ).toEqual([1, 5]);
+    ).toEqual([1, 3, 5]);
   });
 
   it("counts active timeline filters", () => {

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -1,5 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PREvent } from "../../api/types.js";
+import PRTimelineFilter from "./PRTimelineFilter.svelte";
 import {
   activePRTimelineFilterCount,
   DEFAULT_PR_TIMELINE_FILTER,
@@ -175,5 +177,72 @@ describe("prTimelineFilter", () => {
         hideBots: true,
       }),
     ).toBe(3);
+  });
+});
+
+describe("PRTimelineFilter", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the shared filter dropdown trigger and emits changes", async () => {
+    const onChange = vi.fn();
+    render(PRTimelineFilter, {
+      props: {
+        filter: DEFAULT_PR_TIMELINE_FILTER,
+        onChange,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /filters/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /messages/i }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_PR_TIMELINE_FILTER,
+      showMessages: false,
+    });
+    expect(document.querySelector(".filter-dropdown")).toBeTruthy();
+  });
+
+  it("shows active filter count and reset", async () => {
+    const onChange = vi.fn();
+    render(PRTimelineFilter, {
+      props: {
+        filter: {
+          ...DEFAULT_PR_TIMELINE_FILTER,
+          showCommitDetails: false,
+          hideBots: true,
+        },
+        onChange,
+      },
+    });
+
+    expect(screen.getByText("2")).toBeTruthy();
+    await fireEvent.click(screen.getByRole("button", { name: /filters/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /show all/i }));
+
+    expect(onChange).toHaveBeenCalledWith(DEFAULT_PR_TIMELINE_FILTER);
+  });
+
+  it("offers timeline filter labels", async () => {
+    const onChange = vi.fn();
+    render(PRTimelineFilter, {
+      props: {
+        filter: DEFAULT_PR_TIMELINE_FILTER,
+        onChange,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    expect(screen.getByRole("button", { name: /messages/i })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /commit details/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /events/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /force pushes/i })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /hide bot activity/i }),
+    ).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PREvent } from "../../api/types.js";
 import {
   activePRTimelineFilterCount,
@@ -50,6 +50,74 @@ describe("prTimelineFilter", () => {
       showForcePushes: false,
       hideBots: true,
     });
+  });
+
+  it("returns defaults for corrupt persisted JSON", () => {
+    localStorage.setItem("middleman-pr-timeline-filter", "{");
+
+    expect(loadPRTimelineFilter()).toEqual(DEFAULT_PR_TIMELINE_FILTER);
+  });
+
+  it("uses defaults for invalid persisted fields while preserving booleans", () => {
+    localStorage.setItem(
+      "middleman-pr-timeline-filter",
+      JSON.stringify({
+        showMessages: "false",
+        showCommitDetails: false,
+        showEvents: 0,
+        showForcePushes: true,
+        hideBots: "true",
+      }),
+    );
+
+    expect(loadPRTimelineFilter()).toEqual({
+      showMessages: true,
+      showCommitDetails: false,
+      showEvents: true,
+      showForcePushes: true,
+      hideBots: false,
+    });
+  });
+
+  it("returns defaults when persisted JSON is not an object", () => {
+    localStorage.setItem("middleman-pr-timeline-filter", JSON.stringify([]));
+    expect(loadPRTimelineFilter()).toEqual(DEFAULT_PR_TIMELINE_FILTER);
+
+    localStorage.setItem(
+      "middleman-pr-timeline-filter",
+      JSON.stringify("filter"),
+    );
+    expect(loadPRTimelineFilter()).toEqual(DEFAULT_PR_TIMELINE_FILTER);
+  });
+
+  it("returns defaults when localStorage reads throw", () => {
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+
+    try {
+      expect(loadPRTimelineFilter()).toEqual(DEFAULT_PR_TIMELINE_FILTER);
+    } finally {
+      getItem.mockRestore();
+    }
+  });
+
+  it("does not throw when localStorage writes throw", () => {
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("storage full");
+      });
+
+    try {
+      expect(() =>
+        savePRTimelineFilter(DEFAULT_PR_TIMELINE_FILTER),
+      ).not.toThrow();
+    } finally {
+      setItem.mockRestore();
+    }
   });
 
   it("classifies event buckets", () => {

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PREvent } from "../../api/types.js";
+import {
+  activePRTimelineFilterCount,
+  DEFAULT_PR_TIMELINE_FILTER,
+  filterPREvents,
+  loadPRTimelineFilter,
+  savePRTimelineFilter,
+  timelineEventBucket,
+} from "./prTimelineFilter.js";
+
+function event(overrides: Partial<PREvent>): PREvent {
+  return {
+    ID: 1,
+    MergeRequestID: 1,
+    PlatformID: null,
+    EventType: "issue_comment",
+    Author: "alice",
+    Summary: "",
+    Body: "body",
+    MetadataJSON: "",
+    CreatedAt: "2024-06-01T12:00:00Z",
+    DedupeKey: "event-1",
+    ...overrides,
+  } as PREvent;
+}
+
+describe("prTimelineFilter", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to showing every bucket and bot activity", () => {
+    expect(loadPRTimelineFilter()).toEqual(DEFAULT_PR_TIMELINE_FILTER);
+  });
+
+  it("persists valid filter state to localStorage", () => {
+    savePRTimelineFilter({
+      showMessages: false,
+      showCommitDetails: true,
+      showEvents: true,
+      showForcePushes: false,
+      hideBots: true,
+    });
+
+    expect(loadPRTimelineFilter()).toEqual({
+      showMessages: false,
+      showCommitDetails: true,
+      showEvents: true,
+      showForcePushes: false,
+      hideBots: true,
+    });
+  });
+
+  it("classifies event buckets", () => {
+    expect(timelineEventBucket(event({ EventType: "issue_comment" }))).toBe(
+      "messages",
+    );
+    expect(timelineEventBucket(event({ EventType: "review" }))).toBe(
+      "messages",
+    );
+    expect(timelineEventBucket(event({ EventType: "commit" }))).toBe(
+      "commitDetails",
+    );
+    expect(timelineEventBucket(event({ EventType: "force_push" }))).toBe(
+      "forcePushes",
+    );
+    expect(timelineEventBucket(event({ EventType: "cross_referenced" }))).toBe(
+      "events",
+    );
+    expect(timelineEventBucket(event({ EventType: "renamed_title" }))).toBe(
+      "events",
+    );
+    expect(timelineEventBucket(event({ EventType: "base_ref_changed" }))).toBe(
+      "events",
+    );
+  });
+
+  it("filters by disabled buckets and bots", () => {
+    const events = [
+      event({ ID: 1, EventType: "issue_comment", Author: "alice" }),
+      event({ ID: 2, EventType: "review", Author: "renovate[bot]" }),
+      event({ ID: 3, EventType: "commit", Author: "alice" }),
+      event({ ID: 4, EventType: "force_push", Author: "alice" }),
+      event({ ID: 5, EventType: "base_ref_changed", Author: "alice" }),
+    ];
+
+    expect(
+      filterPREvents(events, {
+        showMessages: true,
+        showCommitDetails: false,
+        showEvents: true,
+        showForcePushes: false,
+        hideBots: true,
+      }).map((item) => item.ID),
+    ).toEqual([1, 5]);
+  });
+
+  it("counts active timeline filters", () => {
+    expect(activePRTimelineFilterCount(DEFAULT_PR_TIMELINE_FILTER)).toBe(0);
+    expect(
+      activePRTimelineFilterCount({
+        showMessages: false,
+        showCommitDetails: true,
+        showEvents: false,
+        showForcePushes: true,
+        hideBots: true,
+      }),
+    ).toBe(3);
+  });
+});

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -160,7 +160,7 @@ describe("prTimelineFilter", () => {
         showForcePushes: true,
         hideBots: false,
       }).map((item) => item.ID),
-    ).toEqual([1, 2]);
+    ).toEqual([2]);
   });
 
   it("filters by disabled buckets and bots", () => {
@@ -180,7 +180,7 @@ describe("prTimelineFilter", () => {
         showForcePushes: false,
         hideBots: true,
       }).map((item) => item.ID),
-    ).toEqual([1, 3, 5]);
+    ).toEqual([1, 5]);
   });
 
   it("counts active timeline filters", () => {

--- a/packages/ui/src/components/detail/prTimelineFilter.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.ts
@@ -1,0 +1,115 @@
+import type { PREvent } from "../../api/types.js";
+
+export interface PRTimelineFilterState {
+  showMessages: boolean;
+  showCommitDetails: boolean;
+  showEvents: boolean;
+  showForcePushes: boolean;
+  hideBots: boolean;
+}
+
+export type PRTimelineEventBucket =
+  | "messages"
+  | "commitDetails"
+  | "events"
+  | "forcePushes";
+
+export const PR_TIMELINE_FILTER_STORAGE_KEY = "middleman-pr-timeline-filter";
+
+export const DEFAULT_PR_TIMELINE_FILTER: PRTimelineFilterState = {
+  showMessages: true,
+  showCommitDetails: true,
+  showEvents: true,
+  showForcePushes: true,
+  hideBots: false,
+};
+
+const BOT_SUFFIXES = ["[bot]", "-bot", "bot"];
+
+export function isBotAuthor(author: string): boolean {
+  const lower = author.toLowerCase();
+  return BOT_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
+export function timelineEventBucket(event: PREvent): PRTimelineEventBucket {
+  switch (event.EventType) {
+    case "issue_comment":
+    case "review":
+    case "review_comment":
+      return "messages";
+    case "commit":
+      return "commitDetails";
+    case "force_push":
+      return "forcePushes";
+    default:
+      return "events";
+  }
+}
+
+function normalizeFilter(
+  value: Partial<PRTimelineFilterState> | null,
+): PRTimelineFilterState {
+  return {
+    showMessages:
+      value?.showMessages ?? DEFAULT_PR_TIMELINE_FILTER.showMessages,
+    showCommitDetails:
+      value?.showCommitDetails ?? DEFAULT_PR_TIMELINE_FILTER.showCommitDetails,
+    showEvents: value?.showEvents ?? DEFAULT_PR_TIMELINE_FILTER.showEvents,
+    showForcePushes:
+      value?.showForcePushes ?? DEFAULT_PR_TIMELINE_FILTER.showForcePushes,
+    hideBots: value?.hideBots ?? DEFAULT_PR_TIMELINE_FILTER.hideBots,
+  };
+}
+
+export function loadPRTimelineFilter(): PRTimelineFilterState {
+  try {
+    const raw = localStorage.getItem(PR_TIMELINE_FILTER_STORAGE_KEY);
+    if (!raw) return DEFAULT_PR_TIMELINE_FILTER;
+    const parsed = JSON.parse(raw) as Partial<PRTimelineFilterState>;
+    return normalizeFilter(parsed);
+  } catch {
+    return DEFAULT_PR_TIMELINE_FILTER;
+  }
+}
+
+export function savePRTimelineFilter(filter: PRTimelineFilterState): void {
+  try {
+    localStorage.setItem(
+      PR_TIMELINE_FILTER_STORAGE_KEY,
+      JSON.stringify(filter),
+    );
+  } catch {
+    // localStorage can be unavailable in private browsing or embedded contexts.
+  }
+}
+
+export function filterPREvents(
+  events: PREvent[],
+  filter: PRTimelineFilterState,
+): PREvent[] {
+  return events.filter((event) => {
+    if (filter.hideBots && isBotAuthor(event.Author)) return false;
+    switch (timelineEventBucket(event)) {
+      case "messages":
+        return filter.showMessages;
+      case "commitDetails":
+        return filter.showCommitDetails;
+      case "events":
+        return filter.showEvents;
+      case "forcePushes":
+        return filter.showForcePushes;
+    }
+  });
+}
+
+export function activePRTimelineFilterCount(
+  filter: PRTimelineFilterState,
+): number {
+  return [
+    !filter.showMessages,
+    !filter.showCommitDetails,
+    !filter.showEvents,
+    !filter.showForcePushes,
+    filter.hideBots,
+  ].filter(Boolean).length;
+}

--- a/packages/ui/src/components/detail/prTimelineFilter.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.ts
@@ -111,7 +111,7 @@ export function filterPREvents(
       case "messages":
         return filter.showMessages;
       case "commitDetails":
-        return filter.showCommitDetails;
+        return true;
       case "events":
         return filter.showEvents;
       case "forcePushes":

--- a/packages/ui/src/components/detail/prTimelineFilter.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.ts
@@ -46,18 +46,37 @@ export function timelineEventBucket(event: PREvent): PRTimelineEventBucket {
   }
 }
 
-function normalizeFilter(
-  value: Partial<PRTimelineFilterState> | null,
-): PRTimelineFilterState {
+function booleanOrDefault(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeFilter(value: unknown): PRTimelineFilterState {
+  const persisted =
+    value !== null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
   return {
-    showMessages:
-      value?.showMessages ?? DEFAULT_PR_TIMELINE_FILTER.showMessages,
-    showCommitDetails:
-      value?.showCommitDetails ?? DEFAULT_PR_TIMELINE_FILTER.showCommitDetails,
-    showEvents: value?.showEvents ?? DEFAULT_PR_TIMELINE_FILTER.showEvents,
-    showForcePushes:
-      value?.showForcePushes ?? DEFAULT_PR_TIMELINE_FILTER.showForcePushes,
-    hideBots: value?.hideBots ?? DEFAULT_PR_TIMELINE_FILTER.hideBots,
+    showMessages: booleanOrDefault(
+      persisted.showMessages,
+      DEFAULT_PR_TIMELINE_FILTER.showMessages,
+    ),
+    showCommitDetails: booleanOrDefault(
+      persisted.showCommitDetails,
+      DEFAULT_PR_TIMELINE_FILTER.showCommitDetails,
+    ),
+    showEvents: booleanOrDefault(
+      persisted.showEvents,
+      DEFAULT_PR_TIMELINE_FILTER.showEvents,
+    ),
+    showForcePushes: booleanOrDefault(
+      persisted.showForcePushes,
+      DEFAULT_PR_TIMELINE_FILTER.showForcePushes,
+    ),
+    hideBots: booleanOrDefault(
+      persisted.hideBots,
+      DEFAULT_PR_TIMELINE_FILTER.hideBots,
+    ),
   };
 }
 
@@ -65,8 +84,7 @@ export function loadPRTimelineFilter(): PRTimelineFilterState {
   try {
     const raw = localStorage.getItem(PR_TIMELINE_FILTER_STORAGE_KEY);
     if (!raw) return DEFAULT_PR_TIMELINE_FILTER;
-    const parsed = JSON.parse(raw) as Partial<PRTimelineFilterState>;
-    return normalizeFilter(parsed);
+    return normalizeFilter(JSON.parse(raw) as unknown);
   } catch {
     return DEFAULT_PR_TIMELINE_FILTER;
   }

--- a/packages/ui/src/components/detail/prTimelineFilter.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.ts
@@ -111,7 +111,7 @@ export function filterPREvents(
       case "messages":
         return filter.showMessages;
       case "commitDetails":
-        return true;
+        return filter.showCommitDetails;
       case "events":
         return filter.showEvents;
       case "forcePushes":

--- a/packages/ui/src/components/shared/FilterDropdown.svelte
+++ b/packages/ui/src/components/shared/FilterDropdown.svelte
@@ -29,6 +29,7 @@
     resetLabel?: string;
     onReset?: () => void;
     minWidth?: string;
+    align?: "start" | "end";
     icon?: "filter" | "sort";
   }
 
@@ -44,6 +45,7 @@
     resetLabel,
     onReset,
     minWidth = "200px",
+    align = "start",
     icon = "filter",
   }: Props = $props();
 
@@ -136,6 +138,7 @@
   {#if isOpen}
     <div
       class="filter-dropdown"
+      class:filter-dropdown--align-end={align === "end"}
       bind:this={dropdownRef}
       style:min-width={minWidth}
     >
@@ -249,6 +252,11 @@
     box-shadow: var(--shadow-md);
     z-index: 50;
     padding: 4px 0;
+  }
+
+  .filter-dropdown--align-end {
+    left: auto;
+    right: 0;
   }
 
   .filter-section-title {

--- a/packages/ui/src/components/shared/FilterDropdown.test.ts
+++ b/packages/ui/src/components/shared/FilterDropdown.test.ts
@@ -137,6 +137,39 @@ describe("FilterDropdown", () => {
     expect(document.querySelector(".filter-dropdown")).toBeNull();
   });
 
+  it("supports end-aligned dropdown placement", async () => {
+    render(FilterDropdown, {
+      props: {
+        label: "Filters",
+        align: "end",
+        sections: [
+          {
+            items: [
+              {
+                id: "messages",
+                label: "Messages",
+                active: true,
+                onSelect: vi.fn(),
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: /filters/i,
+      }),
+    );
+
+    expect(
+      document
+        .querySelector(".filter-dropdown")
+        ?.classList.contains("filter-dropdown--align-end"),
+    ).toBe(true);
+  });
+
   it("closes and blocks selection when disabled flips true while open", async () => {
     const onSelect = vi.fn();
     const onReset = vi.fn();

--- a/packages/ui/src/utils/time.test.ts
+++ b/packages/ui/src/utils/time.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  localDateTimeLabel,
   localDateLabel,
   parseAPITimestamp,
   timeAgo,
@@ -28,6 +29,18 @@ describe("time helpers", () => {
     localDateLabel("2026-04-11T12:00:00Z");
 
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses local date-time formatting only in the presentation helper", () => {
+    const spy = vi
+      .spyOn(Date.prototype, "toLocaleString")
+      .mockReturnValue("Apr 11, 2026, 8:00 AM");
+
+    expect(localDateTimeLabel("2026-04-11T12:00:00Z")).toBe("Apr 11, 2026, 8:00 AM");
+    expect(spy).toHaveBeenCalledWith(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
   });
 
   it("computes relative time from canonical instants", () => {

--- a/packages/ui/src/utils/time.ts
+++ b/packages/ui/src/utils/time.ts
@@ -46,3 +46,13 @@ export function timeAgo(dateStr: string): string {
 export function localDateLabel(dateStr: string): string {
   return parseAPITimestamp(dateStr).toLocaleDateString();
 }
+
+/**
+ * Converts an API timestamp to a local date and time label for display.
+ */
+export function localDateTimeLabel(dateStr: string): string {
+  return parseAPITimestamp(dateStr).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}


### PR DESCRIPTION
## Summary
- Capture GitHub PR timeline system events during bulk and detail sync, including force-pushes, cross-references, title renames, and base-branch changes
- Render commits and system events as compact timeline rows with clearer timestamps, links, and optional commit body expansion
- Add persisted PR timeline filters for comments, reviews, commits, system events, bot activity, and commit details

## Demo

https://github.com/user-attachments/assets/de077dac-8eda-45ae-b75e-e49dcdb677f7