### PR TITLE
Fix: hide the implicit repository host

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ All fields are optional. Repos can be added in the config file or through the Se
 |-------|---------|-------------|
 | `sync_interval` | `"5m"` | How often to pull from GitHub |
 | `github_token_env` | `"MIDDLEMAN_GITHUB_TOKEN"` | Env var holding your token |
+| `default_platform_host` | `"github.com"` | Host treated as implicit in repository UI labels |
 | `host` | `"127.0.0.1"` | Listen address |
 | `port` | `8091` | Listen port |
 | `base_path` | `"/"` | URL prefix for reverse proxy deployments |
@@ -139,7 +140,7 @@ platform_host = "github.corp.example.com"
 token_env = "GHE_TOKEN"
 ```
 
-Each distinct host can use a separate token env var. Repos without `platform_host` default to `github.com`.
+Each distinct host can use a separate token env var. Repos without `platform_host` default to `github.com`. Set `default_platform_host` when you want another host to be hidden as the implied repository host in the UI.
 
 ## Embedding
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -2,6 +2,8 @@ sync_interval = "5m"
 # Environment variable containing your GitHub personal access token
 # Required scopes: repo (private repos) or public_repo (public only)
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+# Host treated as implicit in repository UI labels
+default_platform_host = "github.com"
 host = "127.0.0.1"
 port = 8091
 

--- a/frontend/src/lib/components/repositories/RepoIssueModal.svelte
+++ b/frontend/src/lib/components/repositories/RepoIssueModal.svelte
@@ -8,6 +8,7 @@
   import {
     repoKey,
     repoStateKey,
+    shouldShowPlatformHost,
     type RepoSummaryCard,
   } from "./repoSummary.js";
 
@@ -40,6 +41,7 @@
   const titleId = $derived(
     `repo-issue-modal-title-${stateKey}`,
   );
+  const showPlatformHost = $derived(shouldShowPlatformHost(summary));
 
   let titleInput = $state<HTMLInputElement | null>(null);
 
@@ -81,9 +83,11 @@
       <header class="issue-modal__header">
         <div class="issue-modal__title-group">
           <h2 id={titleId}>New issue in {key}</h2>
-          <Chip size="sm" class="chip--muted" uppercase={false}>
-            {summary.platform_host}
-          </Chip>
+          {#if showPlatformHost}
+            <Chip size="sm" class="chip--muted" uppercase={false}>
+              {summary.platform_host}
+            </Chip>
+          {/if}
         </div>
         <ActionButton size="sm" type="button" onclick={oncancel}>
           Cancel

--- a/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
@@ -9,6 +9,7 @@
     localDateTimeLabel,
     repoKey,
     repoStateKey,
+    shouldShowPlatformHost,
     type RepoMetric,
     type RepoSummaryCard,
   } from "./repoSummary.js";
@@ -43,6 +44,7 @@
   const repoURL = $derived(
     `https://${summary.platform_host || "github.com"}/${summary.owner}/${summary.name}`,
   );
+  const showPlatformHost = $derived(shouldShowPlatformHost(summary));
   const syncTime = $derived(
     summary.last_sync_completed_at
       || summary.last_sync_started_at,
@@ -193,8 +195,8 @@
           href={repoURL}
           target="_blank"
           rel="noopener noreferrer"
-          title="Open on GitHub"
-          aria-label={`Open ${summary.owner}/${summary.name} on GitHub`}
+          title={`Open on ${summary.platform_host || "github.com"}`}
+          aria-label={`Open ${summary.owner}/${summary.name} on ${summary.platform_host || "github.com"}`}
         >
           <ExternalLinkIcon
             size="14"
@@ -203,9 +205,11 @@
           />
         </a>
       </div>
-      <Chip size="sm" class="chip--muted" uppercase={false}>
-        {summary.platform_host}
-      </Chip>
+      {#if showPlatformHost}
+        <Chip size="sm" class="chip--muted" uppercase={false}>
+          {summary.platform_host}
+        </Chip>
+      {/if}
     </div>
 
     <div class="repo-card__actions">

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -154,7 +154,7 @@ describe("RepoSummaryPage", () => {
       }),
     ).toBeTruthy();
     const repoLink = screen.getByRole("link", {
-      name: "Open acme/widgets on GitHub",
+      name: "Open acme/widgets on github.com",
     });
     expect(repoLink.getAttribute("href")).toBe(
       "https://github.com/acme/widgets",
@@ -185,6 +185,46 @@ describe("RepoSummaryPage", () => {
     expect(
       screen.queryByText("Ship repo overview timeline"),
     ).toBeNull();
+  });
+
+  it("hides the configured default platform host on repo cards", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        {
+          owner: "acme",
+          name: "widgets",
+          platform_host: "github.com",
+          default_platform_host: "github.com",
+          cached_pr_count: 0,
+          open_pr_count: 0,
+          draft_pr_count: 0,
+          cached_issue_count: 0,
+          open_issue_count: 0,
+          active_authors: [],
+          recent_issues: [],
+        },
+        {
+          owner: "enterprise",
+          name: "service",
+          platform_host: "ghe.example.com",
+          default_platform_host: "github.com",
+          cached_pr_count: 0,
+          open_pr_count: 0,
+          draft_pr_count: 0,
+          cached_issue_count: 0,
+          open_issue_count: 0,
+          active_authors: [],
+          recent_issues: [],
+        },
+      ],
+      error: undefined,
+    });
+
+    render(RepoSummaryPage);
+
+    await screen.findByRole("button", { name: /acme\s*\/\s*widgets/ });
+    expect(screen.queryByText("github.com")).toBeNull();
+    expect(screen.getByText("ghe.example.com")).toBeTruthy();
   });
 
   it("keeps cached output visible when a sync issue exists", async () => {

--- a/frontend/src/lib/components/repositories/repoSummary.ts
+++ b/frontend/src/lib/components/repositories/repoSummary.ts
@@ -43,6 +43,16 @@ export function repoStateKey(summary: {
   return `${summary.platform_host}/${summary.owner}/${summary.name}`;
 }
 
+export function shouldShowPlatformHost(summary: {
+  platform_host: string;
+  default_platform_host?: string;
+}): boolean {
+  const host = (summary.platform_host || "github.com").toLowerCase();
+  const defaultHost = (summary.default_platform_host || "github.com")
+    .toLowerCase();
+  return host !== defaultHost;
+}
+
 export function localDateTimeLabel(dateStr: string): string {
   return new Date(dateStr).toLocaleString();
 }
@@ -73,6 +83,7 @@ export function normalizeSummaries(
 ): RepoSummaryCard[] {
   return (data ?? []).map((summary) => ({
     ...summary,
+    default_platform_host: summary.default_platform_host || "github.com",
     active_authors: summary.active_authors ?? [],
     recent_issues: summary.recent_issues ?? [],
     commit_timeline: summary.commit_timeline ?? [],

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -657,6 +657,7 @@ type RepoSummaryResponse struct {
 	CachedPrCount        int64                             `json:"cached_pr_count"`
 	CommitTimeline       *[]RepoSummaryCommitPointResponse `json:"commit_timeline"`
 	CommitsSinceRelease  *int64                            `json:"commits_since_release,omitempty"`
+	DefaultPlatformHost  string                            `json:"default_platform_host"`
 	DraftPrCount         int64                             `json:"draft_pr_count"`
 	LastSyncCompletedAt  *string                           `json:"last_sync_completed_at,omitempty"`
 	LastSyncError        *string                           `json:"last_sync_error,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ const (
 	defaultTimeRange         = "7d"
 	defaultBasePath          = "/"
 	defaultSyncBudgetPerHour = 500
+	defaultPlatformHost      = "github.com"
 )
 
 type Repo struct {
@@ -190,19 +191,20 @@ type Tmux struct {
 }
 
 type Config struct {
-	SyncInterval      string   `toml:"sync_interval"`
-	GitHubTokenEnv    string   `toml:"github_token_env"`
-	Host              string   `toml:"host"`
-	Port              int      `toml:"port"`
-	BasePath          string   `toml:"base_path"`
-	DataDir           string   `toml:"data_dir"`
-	SyncBudgetPerHour int      `toml:"sync_budget_per_hour"`
-	Repos             []Repo   `toml:"repos"`
-	Activity          Activity `toml:"activity"`
-	Terminal          Terminal `toml:"terminal"`
-	Agents            []Agent  `toml:"agents"`
-	Roborev           Roborev  `toml:"roborev"`
-	Tmux              Tmux     `toml:"tmux"`
+	SyncInterval        string   `toml:"sync_interval"`
+	GitHubTokenEnv      string   `toml:"github_token_env"`
+	DefaultPlatformHost string   `toml:"default_platform_host"`
+	Host                string   `toml:"host"`
+	Port                int      `toml:"port"`
+	BasePath            string   `toml:"base_path"`
+	DataDir             string   `toml:"data_dir"`
+	SyncBudgetPerHour   int      `toml:"sync_budget_per_hour"`
+	Repos               []Repo   `toml:"repos"`
+	Activity            Activity `toml:"activity"`
+	Terminal            Terminal `toml:"terminal"`
+	Agents              []Agent  `toml:"agents"`
+	Roborev             Roborev  `toml:"roborev"`
+	Tmux                Tmux     `toml:"tmux"`
 }
 
 func DefaultConfigPath() string {
@@ -255,6 +257,7 @@ func EnsureDefault(path string) error {
 
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+default_platform_host = "github.com"
 host = "127.0.0.1"
 port = 8091
 
@@ -324,10 +327,11 @@ func writeExclusive(src, dst string) error {
 
 func Load(path string) (*Config, error) {
 	cfg := &Config{
-		SyncInterval:   defaultSyncInterval,
-		GitHubTokenEnv: defaultGitHubTokenEnv,
-		Host:           defaultHost,
-		Port:           defaultPort,
+		SyncInterval:        defaultSyncInterval,
+		GitHubTokenEnv:      defaultGitHubTokenEnv,
+		DefaultPlatformHost: defaultPlatformHost,
+		Host:                defaultHost,
+		Port:                defaultPort,
 	}
 
 	data, err := os.ReadFile(path)
@@ -375,6 +379,13 @@ func Load(path string) (*Config, error) {
 }
 
 func (c *Config) Validate() error {
+	c.DefaultPlatformHost = strings.ToLower(
+		strings.TrimSpace(c.DefaultPlatformHost),
+	)
+	if c.DefaultPlatformHost == "" {
+		c.DefaultPlatformHost = defaultPlatformHost
+	}
+
 	for i := range c.Repos {
 		if c.Repos[i].ownerHasGlob() {
 			return fmt.Errorf(
@@ -628,34 +639,39 @@ func (c *Config) TmuxAgentSessionsEnabled() bool {
 
 // configFile is the subset of Config written to disk.
 type configFile struct {
-	SyncInterval      string   `toml:"sync_interval"`
-	GitHubTokenEnv    string   `toml:"github_token_env"`
-	Host              string   `toml:"host"`
-	Port              int      `toml:"port"`
-	SyncBudgetPerHour int      `toml:"sync_budget_per_hour,omitempty"`
-	BasePath          string   `toml:"base_path,omitempty"`
-	DataDir           string   `toml:"data_dir,omitempty"`
-	Repos             []Repo   `toml:"repos"`
-	Activity          Activity `toml:"activity"`
-	Terminal          Terminal `toml:"terminal,omitempty"`
-	Agents            []Agent  `toml:"agents,omitempty"`
-	Roborev           Roborev  `toml:"roborev,omitempty"`
-	Tmux              Tmux     `toml:"tmux,omitempty"`
+	SyncInterval        string   `toml:"sync_interval"`
+	GitHubTokenEnv      string   `toml:"github_token_env"`
+	DefaultPlatformHost string   `toml:"default_platform_host,omitempty"`
+	Host                string   `toml:"host"`
+	Port                int      `toml:"port"`
+	SyncBudgetPerHour   int      `toml:"sync_budget_per_hour,omitempty"`
+	BasePath            string   `toml:"base_path,omitempty"`
+	DataDir             string   `toml:"data_dir,omitempty"`
+	Repos               []Repo   `toml:"repos"`
+	Activity            Activity `toml:"activity"`
+	Terminal            Terminal `toml:"terminal,omitempty"`
+	Agents              []Agent  `toml:"agents,omitempty"`
+	Roborev             Roborev  `toml:"roborev,omitempty"`
+	Tmux                Tmux     `toml:"tmux,omitempty"`
 }
 
 // Save writes the current config to the given path.
 func (c *Config) Save(path string) error {
 	f := configFile{
-		SyncInterval:   c.SyncInterval,
-		GitHubTokenEnv: c.GitHubTokenEnv,
-		Host:           c.Host,
-		Port:           c.Port,
-		Repos:          c.Repos,
-		Activity:       c.Activity,
-		Terminal:       c.Terminal,
-		Agents:         c.Agents,
-		Roborev:        c.Roborev,
-		Tmux:           c.Tmux,
+		SyncInterval:        c.SyncInterval,
+		GitHubTokenEnv:      c.GitHubTokenEnv,
+		DefaultPlatformHost: c.DefaultPlatformHost,
+		Host:                c.Host,
+		Port:                c.Port,
+		Repos:               c.Repos,
+		Activity:            c.Activity,
+		Terminal:            c.Terminal,
+		Agents:              c.Agents,
+		Roborev:             c.Roborev,
+		Tmux:                c.Tmux,
+	}
+	if c.DefaultPlatformHost == defaultPlatformHost {
+		f.DefaultPlatformHost = ""
 	}
 	if c.SyncBudgetPerHour != defaultSyncBudgetPerHour {
 		f.SyncBudgetPerHour = c.SyncBudgetPerHour

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,6 +105,21 @@ name = "repo"
 	assert.Equal("5m", cfg.SyncInterval)
 	assert.Equal("127.0.0.1", cfg.Host)
 	assert.Equal(8091, cfg.Port)
+	assert.Equal("github.com", cfg.DefaultPlatformHost)
+}
+
+func TestLoadNormalizesDefaultPlatformHost(t *testing.T) {
+	assert := Assert.New(t)
+	cfg, cfg2 := roundTripConfigString(t, `
+default_platform_host = "GHE.Example.COM"
+
+[[repos]]
+owner = "test"
+name = "repo"
+`)
+
+	assert.Equal("ghe.example.com", cfg.DefaultPlatformHost)
+	assert.Equal("ghe.example.com", cfg2.DefaultPlatformHost)
 }
 
 func TestLoadNoRepos(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2215,6 +2215,39 @@ func TestAPIListRepoSummaries(t *testing.T) {
 	assert.NotEmpty((*widgets.RecentIssues)[0].Title)
 }
 
+func TestAPIListRepoSummariesIncludesDefaultPlatformHost(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+default_platform_host = "ghe.example.com"
+
+[[repos]]
+owner = "acme"
+name = "widgets"
+platform_host = "ghe.example.com"
+`, &mockGH{})
+
+	_, err := database.UpsertRepo(
+		t.Context(), "ghe.example.com", "acme", "widgets",
+	)
+	require.NoError(err)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:        "acme",
+		Name:         "widgets",
+		PlatformHost: "ghe.example.com",
+	}})
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repos/summary", nil)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var summaries []repoSummaryResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&summaries))
+	require.Len(summaries, 1)
+	assert.Equal("ghe.example.com", summaries[0].PlatformHost)
+	assert.Equal("ghe.example.com", summaries[0].DefaultPlatformHost)
+}
+
 func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -107,6 +107,7 @@ type repoSummaryCommitPointResponse struct {
 
 type repoSummaryResponse struct {
 	PlatformHost         string                           `json:"platform_host"`
+	DefaultPlatformHost  string                           `json:"default_platform_host"`
 	Owner                string                           `json:"owner"`
 	Name                 string                           `json:"name"`
 	LastSyncStartedAt    string                           `json:"last_sync_started_at,omitempty"`

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -211,19 +211,23 @@ func formatUTCRFC3339(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }
 
-func toRepoSummaryResponse(summary db.RepoSummary) repoSummaryResponse {
+func toRepoSummaryResponse(
+	summary db.RepoSummary,
+	defaultPlatformHost string,
+) repoSummaryResponse {
 	resp := repoSummaryResponse{
-		PlatformHost:     summary.Repo.PlatformHost,
-		Owner:            summary.Repo.Owner,
-		Name:             summary.Repo.Name,
-		LastSyncError:    summary.Repo.LastSyncError,
-		CachedPRCount:    summary.CachedPRCount,
-		OpenPRCount:      summary.OpenPRCount,
-		DraftPRCount:     summary.DraftPRCount,
-		CachedIssueCount: summary.CachedIssueCount,
-		OpenIssueCount:   summary.OpenIssueCount,
-		ActiveAuthors:    make([]repoSummaryAuthorResponse, 0, len(summary.ActiveAuthors)),
-		RecentIssues:     make([]repoSummaryIssueResponse, 0, len(summary.RecentIssues)),
+		PlatformHost:        summary.Repo.PlatformHost,
+		DefaultPlatformHost: defaultPlatformHost,
+		Owner:               summary.Repo.Owner,
+		Name:                summary.Repo.Name,
+		LastSyncError:       summary.Repo.LastSyncError,
+		CachedPRCount:       summary.CachedPRCount,
+		OpenPRCount:         summary.OpenPRCount,
+		DraftPRCount:        summary.DraftPRCount,
+		CachedIssueCount:    summary.CachedIssueCount,
+		OpenIssueCount:      summary.OpenIssueCount,
+		ActiveAuthors:       make([]repoSummaryAuthorResponse, 0, len(summary.ActiveAuthors)),
+		RecentIssues:        make([]repoSummaryIssueResponse, 0, len(summary.RecentIssues)),
 	}
 	if summary.Repo.LastSyncStartedAt != nil {
 		resp.LastSyncStartedAt = formatUTCRFC3339(*summary.Repo.LastSyncStartedAt)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1735,9 +1735,12 @@ func (s *Server) listRepoSummaries(
 		summaries = s.filterConfiguredRepoSummaries(summaries)
 	}
 
+	defaultPlatformHost := s.defaultPlatformHost()
 	out := make([]repoSummaryResponse, 0, len(summaries))
 	for _, summary := range summaries {
-		out = append(out, toRepoSummaryResponse(summary))
+		out = append(out, toRepoSummaryResponse(
+			summary, defaultPlatformHost,
+		))
 	}
 
 	return &listRepoSummariesOutput{Body: out}, nil

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -228,6 +228,19 @@ func samePlatformHost(left, right string) bool {
 	return strings.EqualFold(left, right)
 }
 
+func (s *Server) defaultPlatformHost() string {
+	if s.cfg == nil {
+		return "github.com"
+	}
+	s.cfgMu.Lock()
+	host := s.cfg.DefaultPlatformHost
+	s.cfgMu.Unlock()
+	if strings.TrimSpace(host) == "" {
+		return "github.com"
+	}
+	return strings.ToLower(strings.TrimSpace(host))
+}
+
 func classifyResolveError(err error) (int, string) {
 	switch {
 	case errors.Is(err, ghclient.ErrConfiguredRepoArchived):

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1580,6 +1580,7 @@ export interface components {
             commit_timeline: components["schemas"]["RepoSummaryCommitPointResponse"][] | null;
             /** Format: int64 */
             commits_since_release?: number;
+            default_platform_host: string;
             /** Format: int64 */
             draft_pr_count: number;
             last_sync_completed_at?: string;


### PR DESCRIPTION
## Summary
- Add `default_platform_host` to config so the implied repo host is configurable, defaulting to `github.com`
- Hide the platform host chip on repo cards and issue modals when it matches the configured default
- Extend the repo summary API and regenerated clients so the frontend can make that distinction consistently
- Document the new setting in the README and config example

## Testing
- Added Go regression coverage for config parsing and repo summary API output
- Added frontend coverage for hiding the default host while still showing non-default hosts
- Ran targeted Go tests, the repo summary Vitest file, `svelte-check`, and Svelte autofixer on the touched components