### PR TITLE
Add configurable workspace agents

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -123,6 +123,26 @@ components:
         - owner
         - name
       type: object
+    Agent:
+      additionalProperties: false
+      properties:
+        command:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        enabled:
+          type: boolean
+        key:
+          type: string
+        label:
+          type: string
+      required:
+        - key
+        - label
+        - command
+      type: object
     ApprovePRInputBody:
       additionalProperties: false
       properties:
@@ -1865,6 +1885,12 @@ components:
           type: string
         activity:
           $ref: "#/components/schemas/Activity"
+        agents:
+          items:
+            $ref: "#/components/schemas/Agent"
+          type:
+            - array
+            - "null"
         repos:
           items:
             $ref: "#/components/schemas/ConfiguredRepoStatus"
@@ -1877,6 +1903,7 @@ components:
         - repos
         - activity
         - terminal
+        - agents
       type: object
     StackContextResponse:
       additionalProperties: false
@@ -2051,6 +2078,10 @@ components:
           type: string
         activity:
           $ref: "#/components/schemas/Activity"
+        agents:
+          items:
+            $ref: "#/components/schemas/Agent"
+          type: array
         terminal:
           $ref: "#/components/schemas/Terminal"
       type: object

--- a/frontend/src/lib/api/settings.test.ts
+++ b/frontend/src/lib/api/settings.test.ts
@@ -69,19 +69,24 @@ describe("settings api", () => {
       ],
     });
 
-    expect(fetch).toHaveBeenCalledWith("/api/v1/settings", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        agents: [
-          {
-            key: "codex",
-            label: "Codex",
-            command: ["codex", "--full-auto"],
-            enabled: true,
-          },
-        ],
-      }),
+    const request = vi.mocked(fetch).mock.calls[0]?.[0];
+    expect(request).toBeInstanceOf(Request);
+    expect(new URL((request as Request).url).pathname).toBe(
+      "/api/v1/settings",
+    );
+    expect((request as Request).method).toBe("PUT");
+    expect((request as Request).headers.get("Content-Type")).toBe(
+      "application/json",
+    );
+    await expect((request as Request).clone().json()).resolves.toEqual({
+      agents: [
+        {
+          key: "codex",
+          label: "Codex",
+          command: ["codex", "--full-auto"],
+          enabled: true,
+        },
+      ],
     });
   });
 

--- a/frontend/src/lib/api/settings.test.ts
+++ b/frontend/src/lib/api/settings.test.ts
@@ -1,4 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  bulkAddRepos,
+  previewRepos,
+  removeRepo,
+  updateSettings,
+} from "./settings.js";
 
 describe("settings api", () => {
   beforeEach(() => {
@@ -12,8 +18,6 @@ describe("settings api", () => {
   });
 
   it("encodes repo names for delete requests", async () => {
-    const { removeRepo } = await import("./settings.js");
-
     await removeRepo("acme", "widgets-?");
 
     const request = vi.mocked(fetch).mock.calls[0]?.[0];
@@ -25,8 +29,6 @@ describe("settings api", () => {
   });
 
   it("posts preview requests", async () => {
-    const { previewRepos } = await import("./settings.js");
-
     await previewRepos("acme", "widget-*");
 
     const request = vi.mocked(fetch).mock.calls[0]?.[0];
@@ -42,8 +44,6 @@ describe("settings api", () => {
   });
 
   it("posts bulk add requests", async () => {
-    const { bulkAddRepos } = await import("./settings.js");
-
     await bulkAddRepos([{ owner: "acme", name: "api" }]);
 
     const request = vi.mocked(fetch).mock.calls[0]?.[0];
@@ -57,6 +57,34 @@ describe("settings api", () => {
     });
   });
 
+  it("posts agent settings updates", async () => {
+    await updateSettings({
+      agents: [
+        {
+          key: "codex",
+          label: "Codex",
+          command: ["codex", "--full-auto"],
+          enabled: true,
+        },
+      ],
+    });
+
+    expect(fetch).toHaveBeenCalledWith("/api/v1/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agents: [
+          {
+            key: "codex",
+            label: "Codex",
+            command: ["codex", "--full-auto"],
+            enabled: true,
+          },
+        ],
+      }),
+    });
+  });
+
   it("uses json error envelope when present", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       Response.json(
@@ -67,7 +95,6 @@ describe("settings api", () => {
         },
       ),
     );
-    const { previewRepos } = await import("./settings.js");
 
     await expect(previewRepos("acme", "[")).rejects.toThrow("invalid glob pattern");
   });

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -6,6 +6,8 @@ import { apiErrorMessage, client } from "./runtime.js";
 type SettingsResponse = components["schemas"]["SettingsResponse"];
 type RepoPreviewGeneratedResponse =
   components["schemas"]["RepoPreviewResponse"];
+type UpdateSettingsRequest =
+  components["schemas"]["UpdateSettingsRequest"];
 
 function requestErrorMessage(
   error: { detail?: string; title?: string } | undefined,
@@ -50,6 +52,29 @@ function normalizePreviewResponse(
   } as RepoPreviewResponse;
 }
 
+function normalizeUpdateRequest(
+  settings: {
+    activity?: Settings["activity"];
+    terminal?: Settings["terminal"];
+    agents?: Settings["agents"];
+  },
+): UpdateSettingsRequest {
+  const request: UpdateSettingsRequest = {};
+  if (settings.activity) {
+    request.activity = settings.activity;
+  }
+  if (settings.terminal) {
+    request.terminal = settings.terminal;
+  }
+  if (settings.agents) {
+    request.agents = settings.agents.map((agent) => ({
+      ...agent,
+      command: agent.command ?? null,
+    }));
+  }
+  return request;
+}
+
 export async function getSettings(): Promise<Settings> {
   const { data, error, response } = await client.GET("/settings");
   if (!data) {
@@ -71,7 +96,7 @@ export async function updateSettings(
   },
 ): Promise<Settings> {
   const { data, error, response } = await client.PUT("/settings", {
-    body: settings,
+    body: normalizeUpdateRequest(settings),
   });
   if (!data) {
     throw new Error(

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -67,6 +67,7 @@ export async function updateSettings(
   settings: {
     activity?: Settings["activity"];
     terminal?: Settings["terminal"];
+    agents?: Settings["agents"];
   },
 ): Promise<Settings> {
   const { data, error, response } = await client.PUT("/settings", {

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -204,19 +204,23 @@
     let current = "";
     let quote: "\"" | "'" | null = null;
     let escaping = false;
+    let tokenStarted = false;
 
     for (const char of input.trim()) {
       if (escaping) {
         current += char;
         escaping = false;
+        tokenStarted = true;
         continue;
       }
       if (char === "\\" && quote !== "'") {
         escaping = true;
+        tokenStarted = true;
         continue;
       }
       if ((char === "\"" || char === "'") && quote === null) {
         quote = char;
+        tokenStarted = true;
         continue;
       }
       if (char === quote) {
@@ -224,16 +228,18 @@
         continue;
       }
       if (/\s/.test(char) && quote === null) {
-        if (current !== "") {
+        if (tokenStarted) {
           args.push(current);
           current = "";
+          tokenStarted = false;
         }
         continue;
       }
       current += char;
+      tokenStarted = true;
     }
     if (escaping) current += "\\";
-    if (current !== "") args.push(current);
+    if (tokenStarted) args.push(current);
     return args;
   }
 </script>

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -401,10 +401,11 @@
     <button
       class="save-btn"
       type="button"
+      aria-label="Save workspace agents"
       disabled={!canSave}
       onclick={() => void save()}
     >
-      {saving ? "Saving..." : "Save agents"}
+      {saving ? "Saving..." : "Save"}
     </button>
   </div>
 </div>
@@ -419,7 +420,10 @@
   .agent-list {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    overflow: hidden;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
   }
 
   .agent-row {
@@ -427,9 +431,12 @@
     flex-direction: column;
     gap: 10px;
     padding: 8px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-surface);
+    border-top: 1px solid var(--border-muted);
+    background: transparent;
+  }
+
+  .agent-row:first-child {
+    border-top: 0;
   }
 
   .agent-row-header,
@@ -519,7 +526,6 @@
 
   .settings-actions {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     gap: 12px;
   }
@@ -547,6 +553,7 @@
   }
 
   .save-btn {
+    margin-left: auto;
     color: white;
     background: var(--accent-blue);
   }
@@ -573,10 +580,6 @@
     .agent-fields--custom {
       grid-template-columns: 1fr;
       align-items: stretch;
-    }
-
-    .settings-actions {
-      justify-content: flex-start;
     }
   }
 </style>

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
   import type { AgentSettings as AgentSettingsType } from "@middleman/ui/api/types";
+  import { slide } from "svelte/transition";
   import { updateSettings } from "../../api/settings.js";
   import { isEmbedded } from "../../stores/embed-config.svelte.js";
 
@@ -323,17 +323,18 @@
               disabled={saving}
               onclick={() => toggleExpanded(draft)}
             >
-              {#if draft.expanded}
-                <ChevronDownIcon size="13" strokeWidth="2" aria-hidden="true" />
-              {:else}
+              <span class={["chevron-icon", draft.expanded && "chevron-icon--expanded"]}>
                 <ChevronRightIcon size="13" strokeWidth="2" aria-hidden="true" />
-              {/if}
+              </span>
             </button>
           </div>
         </div>
 
         {#if draft.expanded}
-          <div class={["agent-fields", !draft.builtin && "agent-fields--custom"]}>
+          <div
+            class={["agent-fields", !draft.builtin && "agent-fields--custom"]}
+            transition:slide={{ duration: 120 }}
+          >
             {#if !draft.builtin}
               <label class="field">
                 <span>Key</span>
@@ -512,6 +513,15 @@
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
     background: var(--bg-surface);
+  }
+
+  .chevron-icon {
+    display: inline-flex;
+    transition: transform 120ms ease-out;
+  }
+
+  .chevron-icon--expanded {
+    transform: rotate(90deg);
   }
 
   .icon-btn:hover:not(:disabled) {

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -44,8 +44,11 @@
   // svelte-ignore state_referenced_locally
   let drafts = $state<AgentDraft[]>(initialDrafts(agents));
 
-  const serializedAgents = $derived(serializeDrafts(drafts));
   const savedAgents = $derived(normalizeAgents(agents));
+  const preservedDefaultBuiltinKeys = $derived(defaultBuiltinKeys(savedAgents));
+  const serializedAgents = $derived(
+    serializeDrafts(drafts, preservedDefaultBuiltinKeys),
+  );
   const hasInvalidDraft = $derived(drafts.some((draft) => !isDraftValid(draft)));
   const isDirty = $derived(
     JSON.stringify(serializedAgents) !== JSON.stringify(savedAgents),
@@ -102,7 +105,29 @@
       .sort((left, right) => left.key.localeCompare(right.key));
   }
 
-  function serializeDrafts(rows: AgentDraft[]): AgentSettingsType[] {
+  function defaultBuiltinKeys(configured: AgentSettingsType[]): Set<string> {
+    return new Set(
+      configured
+        .filter((agent) => isDefaultBuiltinAgent(agent))
+        .map((agent) => agent.key),
+    );
+  }
+
+  function isDefaultBuiltinAgent(agent: AgentSettingsType): boolean {
+    const builtin = builtins.find((candidate) => candidate.key === agent.key);
+    if (!builtin) return false;
+    if (!agent.enabled || agent.label !== builtin.label) return false;
+    const command = agent.command ?? [];
+    return (
+      command.length === 0 ||
+      (command.length === 1 && command[0] === builtin.binary)
+    );
+  }
+
+  function serializeDrafts(
+    rows: AgentDraft[],
+    preservedDefaultKeys = new Set<string>(),
+  ): AgentSettingsType[] {
     const agentsToSave: AgentSettingsType[] = [];
     for (const draft of rows) {
       const key = draft.key.trim().toLowerCase();
@@ -120,7 +145,7 @@
           label === builtin.label &&
           binary === builtin.binary &&
           args.length === 0;
-        if (isDefault) continue;
+        if (isDefault && !preservedDefaultKeys.has(key)) continue;
       }
 
       agentsToSave.push({
@@ -378,8 +403,8 @@
 
   .agent-row--custom {
     grid-template-columns:
-      minmax(112px, 0.8fr) minmax(88px, 0.7fr) minmax(112px, 0.9fr)
-      minmax(120px, 1fr) minmax(150px, 1.2fr) 28px;
+      minmax(88px, 0.8fr) minmax(72px, 0.7fr) minmax(96px, 0.9fr)
+      minmax(96px, 1fr) minmax(128px, 1.2fr) 28px;
   }
 
   .enable-field,

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -291,6 +291,30 @@
           </label>
 
           <div class="row-actions">
+            {#if draft.builtin && draft.expanded}
+              <button
+                class="icon-btn"
+                type="button"
+                title="Reset"
+                aria-label={`Reset ${agentName(draft)}`}
+                disabled={saving}
+                onclick={() => resetBuiltin(draft)}
+              >
+                <RotateCcwIcon size="13" strokeWidth="2" aria-hidden="true" />
+              </button>
+            {:else if !draft.builtin && draft.expanded}
+              <button
+                class="icon-btn icon-btn--danger"
+                type="button"
+                title="Remove"
+                aria-label={`Remove ${agentName(draft)}`}
+                disabled={saving}
+                onclick={() => removeCustomAgent(draft.id)}
+              >
+                <TrashIcon size="13" strokeWidth="2" aria-hidden="true" />
+              </button>
+            {/if}
+
             <button
               class="icon-btn"
               type="button"
@@ -305,30 +329,6 @@
                 <ChevronRightIcon size="13" strokeWidth="2" aria-hidden="true" />
               {/if}
             </button>
-
-            {#if draft.builtin}
-              <button
-                class="icon-btn"
-                type="button"
-                title="Reset"
-                aria-label={`Reset ${agentName(draft)}`}
-                disabled={saving}
-                onclick={() => resetBuiltin(draft)}
-              >
-                <RotateCcwIcon size="13" strokeWidth="2" aria-hidden="true" />
-              </button>
-            {:else}
-              <button
-                class="icon-btn icon-btn--danger"
-                type="button"
-                title="Remove"
-                aria-label={`Remove ${agentName(draft)}`}
-                disabled={saving}
-                onclick={() => removeCustomAgent(draft.id)}
-              >
-                <TrashIcon size="13" strokeWidth="2" aria-hidden="true" />
-              </button>
-            {/if}
           </div>
         </div>
 

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -392,11 +392,12 @@
   }
 
   .agent-row {
+    position: relative;
     display: grid;
-    grid-template-columns: minmax(112px, 0.9fr) minmax(120px, 1fr) minmax(150px, 1.2fr) 28px;
+    grid-template-columns: minmax(112px, 0.9fr) minmax(120px, 1fr) minmax(150px, 1.2fr);
     gap: 8px;
     align-items: end;
-    padding: 8px;
+    padding: 8px 40px 8px 8px;
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
     background: var(--bg-surface);
@@ -405,7 +406,7 @@
   .agent-row--custom {
     grid-template-columns:
       minmax(88px, 0.8fr) minmax(72px, 0.7fr) minmax(96px, 0.9fr)
-      minmax(96px, 1fr) minmax(128px, 1.2fr) 28px;
+      minmax(96px, 1fr) minmax(128px, 1.2fr);
   }
 
   .enable-field,
@@ -440,10 +441,12 @@
   }
 
   .row-actions {
+    position: absolute;
+    top: 8px;
+    right: 8px;
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    min-height: 28px;
   }
 
   .icon-btn {
@@ -526,7 +529,6 @@
       align-items: stretch;
     }
 
-    .row-actions,
     .settings-actions {
       justify-content: flex-start;
     }

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -81,7 +81,8 @@
     const command = agent?.command ?? [];
     const key = builtin?.key ?? agent?.key ?? "";
     const label = agent?.label ?? builtin?.label ?? key;
-    const binary = command[0] ?? builtin?.binary ?? "";
+    const binary =
+      command[0] ?? (agent?.enabled === false ? "" : builtin?.binary ?? "");
     return {
       id: builtin ? `builtin:${builtin.key}` : `custom:${key}:${customID++}`,
       builtin: builtin !== null,

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
+  import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
@@ -25,6 +27,7 @@
     binary: string;
     args: string;
     enabled: boolean;
+    expanded: boolean;
   }
 
   const builtins: BuiltinAgent[] = [
@@ -91,6 +94,7 @@
       binary,
       args: stringifyArgs(command.slice(1)),
       enabled: agent?.enabled ?? true,
+      expanded: builtin === null && agent === undefined,
     };
   }
 
@@ -170,6 +174,10 @@
     return draft.label.trim() || draft.key.trim() || "Custom agent";
   }
 
+  function toggleExpanded(draft: AgentDraft): void {
+    draft.expanded = !draft.expanded;
+  }
+
   function addCustomAgent(): void {
     drafts = [
       ...drafts,
@@ -181,6 +189,7 @@
         binary: "",
         args: "",
         enabled: true,
+        expanded: true,
       },
     ];
   }
@@ -196,6 +205,7 @@
     draft.binary = builtin.binary;
     draft.args = "";
     draft.enabled = true;
+    draft.expanded = true;
   }
 
   async function save(): Promise<void> {
@@ -274,81 +284,102 @@
   <div class="agent-list">
     {#each drafts as draft (draft.id)}
       <div class={["agent-row", !draft.builtin && "agent-row--custom"]}>
-        <label class="enable-field">
-          <input type="checkbox" bind:checked={draft.enabled} disabled={saving} />
-          <span>{agentName(draft)}</span>
-        </label>
-
-        {#if !draft.builtin}
-          <label class="field">
-            <span>Key</span>
-            <input
-              type="text"
-              bind:value={draft.key}
-              aria-label="Custom agent key"
-              disabled={saving}
-              placeholder="review"
-            />
+        <div class="agent-row-header">
+          <label class="enable-field">
+            <input type="checkbox" bind:checked={draft.enabled} disabled={saving} />
+            <span>{agentName(draft)}</span>
           </label>
-          <label class="field">
-            <span>Label</span>
-            <input
-              type="text"
-              bind:value={draft.label}
-              aria-label="Custom agent label"
-              disabled={saving}
-              placeholder="Review Agent"
-            />
-          </label>
-        {/if}
 
-        <label class="field">
-          <span>Binary</span>
-          <input
-            type="text"
-            bind:value={draft.binary}
-            aria-label={`${agentName(draft)} binary`}
-            disabled={saving || !draft.enabled}
-            placeholder={draft.key || "agent"}
-          />
-        </label>
-
-        <label class="field field--args">
-          <span>Arguments</span>
-          <input
-            type="text"
-            bind:value={draft.args}
-            aria-label={`${agentName(draft)} arguments`}
-            disabled={saving || !draft.enabled}
-            placeholder="--flag value"
-          />
-        </label>
-
-        <div class="row-actions">
-          {#if draft.builtin}
+          <div class="row-actions">
             <button
               class="icon-btn"
               type="button"
-              title="Reset"
-              aria-label={`Reset ${agentName(draft)}`}
+              title={draft.expanded ? "Collapse" : "Edit"}
+              aria-label={`${draft.expanded ? "Collapse" : "Edit"} ${agentName(draft)}`}
               disabled={saving}
-              onclick={() => resetBuiltin(draft)}
+              onclick={() => toggleExpanded(draft)}
             >
-              <RotateCcwIcon size="13" strokeWidth="2" aria-hidden="true" />
+              {#if draft.expanded}
+                <ChevronDownIcon size="13" strokeWidth="2" aria-hidden="true" />
+              {:else}
+                <ChevronRightIcon size="13" strokeWidth="2" aria-hidden="true" />
+              {/if}
             </button>
-          {:else}
-            <button
-              class="icon-btn icon-btn--danger"
-              type="button"
-              title="Remove"
-              aria-label={`Remove ${agentName(draft)}`}
-              disabled={saving}
-              onclick={() => removeCustomAgent(draft.id)}
-            >
-              <TrashIcon size="13" strokeWidth="2" aria-hidden="true" />
-            </button>
-          {/if}
+
+            {#if draft.builtin}
+              <button
+                class="icon-btn"
+                type="button"
+                title="Reset"
+                aria-label={`Reset ${agentName(draft)}`}
+                disabled={saving}
+                onclick={() => resetBuiltin(draft)}
+              >
+                <RotateCcwIcon size="13" strokeWidth="2" aria-hidden="true" />
+              </button>
+            {:else}
+              <button
+                class="icon-btn icon-btn--danger"
+                type="button"
+                title="Remove"
+                aria-label={`Remove ${agentName(draft)}`}
+                disabled={saving}
+                onclick={() => removeCustomAgent(draft.id)}
+              >
+                <TrashIcon size="13" strokeWidth="2" aria-hidden="true" />
+              </button>
+            {/if}
+          </div>
         </div>
+
+        {#if draft.expanded}
+          <div class={["agent-fields", !draft.builtin && "agent-fields--custom"]}>
+            {#if !draft.builtin}
+              <label class="field">
+                <span>Key</span>
+                <input
+                  type="text"
+                  bind:value={draft.key}
+                  aria-label="Custom agent key"
+                  disabled={saving}
+                  placeholder="review"
+                />
+              </label>
+              <label class="field">
+                <span>Label</span>
+                <input
+                  type="text"
+                  bind:value={draft.label}
+                  aria-label="Custom agent label"
+                  disabled={saving}
+                  placeholder="Review Agent"
+                />
+              </label>
+            {/if}
+
+            <label class="field">
+              <span>Binary</span>
+              <input
+                type="text"
+                bind:value={draft.binary}
+                aria-label={`${agentName(draft)} binary`}
+                disabled={saving || !draft.enabled}
+                placeholder={draft.key || "agent"}
+              />
+            </label>
+
+            <label class="field field--args">
+              <span>Arguments</span>
+              <input
+                type="text"
+                bind:value={draft.args}
+                aria-label={`${agentName(draft)} arguments`}
+                disabled={saving || !draft.enabled}
+                placeholder="--flag value"
+              />
+            </label>
+          </div>
+        {/if}
       </div>
     {/each}
   </div>
@@ -392,18 +423,35 @@
   }
 
   .agent-row {
-    position: relative;
-    display: grid;
-    grid-template-columns: minmax(112px, 0.9fr) minmax(120px, 1fr) minmax(150px, 1.2fr);
-    gap: 8px;
-    align-items: end;
-    padding: 8px 40px 8px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 8px;
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
     background: var(--bg-surface);
   }
 
-  .agent-row--custom {
+  .agent-row-header,
+  .row-actions {
+    display: flex;
+    align-items: center;
+  }
+
+  .agent-row-header {
+    justify-content: space-between;
+    gap: 12px;
+    min-height: 24px;
+  }
+
+  .agent-fields {
+    display: grid;
+    grid-template-columns: minmax(120px, 1fr) minmax(150px, 1.2fr);
+    gap: 8px;
+    align-items: end;
+  }
+
+  .agent-fields--custom {
     grid-template-columns:
       minmax(88px, 0.8fr) minmax(72px, 0.7fr) minmax(96px, 0.9fr)
       minmax(96px, 1fr) minmax(128px, 1.2fr);
@@ -421,6 +469,7 @@
     align-self: center;
     flex-direction: row;
     align-items: center;
+    flex: 1 1 auto;
     color: var(--text-primary);
     font-size: 12px;
     font-weight: 600;
@@ -441,12 +490,9 @@
   }
 
   .row-actions {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    display: flex;
+    flex: 0 0 auto;
     justify-content: flex-end;
-    align-items: center;
+    gap: 6px;
   }
 
   .icon-btn {
@@ -523,8 +569,8 @@
   }
 
   @media (max-width: 860px) {
-    .agent-row,
-    .agent-row--custom {
+    .agent-fields,
+    .agent-fields--custom {
       grid-template-columns: 1fr;
       align-items: stretch;
     }

--- a/frontend/src/lib/components/settings/AgentSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentSettings.svelte
@@ -1,0 +1,502 @@
+<script lang="ts">
+  import PlusIcon from "@lucide/svelte/icons/plus";
+  import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
+  import TrashIcon from "@lucide/svelte/icons/trash-2";
+  import type { AgentSettings as AgentSettingsType } from "@middleman/ui/api/types";
+  import { updateSettings } from "../../api/settings.js";
+  import { isEmbedded } from "../../stores/embed-config.svelte.js";
+
+  interface Props {
+    agents: AgentSettingsType[];
+    onUpdate: (agents: AgentSettingsType[]) => void;
+  }
+
+  interface BuiltinAgent {
+    key: string;
+    label: string;
+    binary: string;
+  }
+
+  interface AgentDraft {
+    id: string;
+    builtin: boolean;
+    key: string;
+    label: string;
+    binary: string;
+    args: string;
+    enabled: boolean;
+  }
+
+  const builtins: BuiltinAgent[] = [
+    { key: "codex", label: "Codex", binary: "codex" },
+    { key: "claude", label: "Claude", binary: "claude" },
+    { key: "gemini", label: "Gemini", binary: "gemini" },
+    { key: "opencode", label: "opencode", binary: "opencode" },
+    { key: "aider", label: "aider", binary: "aider" },
+  ];
+
+  let { agents, onUpdate }: Props = $props();
+
+  const embedded = isEmbedded();
+  let customID = 0;
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+  // svelte-ignore state_referenced_locally
+  let drafts = $state<AgentDraft[]>(initialDrafts(agents));
+
+  const serializedAgents = $derived(serializeDrafts(drafts));
+  const savedAgents = $derived(normalizeAgents(agents));
+  const hasInvalidDraft = $derived(drafts.some((draft) => !isDraftValid(draft)));
+  const isDirty = $derived(
+    JSON.stringify(serializedAgents) !== JSON.stringify(savedAgents),
+  );
+  const canSave = $derived(
+    !embedded && !saving && isDirty && !hasInvalidDraft,
+  );
+
+  function initialDrafts(configured: AgentSettingsType[]): AgentDraft[] {
+    const byKey: Record<string, AgentSettingsType | undefined> = {};
+    for (const agent of normalizeAgents(configured)) {
+      byKey[agent.key] = agent;
+    }
+    const rows = builtins.map((builtin) => {
+      const configuredAgent = byKey[builtin.key];
+      delete byKey[builtin.key];
+      return draftFromAgent(builtin, configuredAgent);
+    });
+    for (const agent of Object.values(byKey)) {
+      if (!agent) continue;
+      rows.push(draftFromAgent(null, agent));
+    }
+    return rows;
+  }
+
+  function draftFromAgent(
+    builtin: BuiltinAgent | null,
+    agent: AgentSettingsType | undefined,
+  ): AgentDraft {
+    const command = agent?.command ?? [];
+    const key = builtin?.key ?? agent?.key ?? "";
+    const label = agent?.label ?? builtin?.label ?? key;
+    const binary = command[0] ?? builtin?.binary ?? "";
+    return {
+      id: builtin ? `builtin:${builtin.key}` : `custom:${key}:${customID++}`,
+      builtin: builtin !== null,
+      key,
+      label,
+      binary,
+      args: stringifyArgs(command.slice(1)),
+      enabled: agent?.enabled ?? true,
+    };
+  }
+
+  function normalizeAgents(configured: AgentSettingsType[]): AgentSettingsType[] {
+    return configured
+      .map((agent) => ({
+        key: agent.key.trim().toLowerCase(),
+        label: agent.label.trim(),
+        command: [...(agent.command ?? [])],
+        enabled: agent.enabled ?? true,
+      }))
+      .filter((agent) => agent.key !== "")
+      .sort((left, right) => left.key.localeCompare(right.key));
+  }
+
+  function serializeDrafts(rows: AgentDraft[]): AgentSettingsType[] {
+    const agentsToSave: AgentSettingsType[] = [];
+    for (const draft of rows) {
+      const key = draft.key.trim().toLowerCase();
+      if (key === "") continue;
+      const builtin = builtins.find((candidate) => candidate.key === key);
+      const enabled = draft.enabled;
+      const binary = draft.binary.trim();
+      const args = parseArgs(draft.args);
+      const label = (draft.label.trim() || builtin?.label || key);
+      const command = binary === "" ? [] : [binary, ...args];
+
+      if (draft.builtin && builtin) {
+        const isDefault =
+          enabled &&
+          label === builtin.label &&
+          binary === builtin.binary &&
+          args.length === 0;
+        if (isDefault) continue;
+      }
+
+      agentsToSave.push({
+        key,
+        label,
+        command,
+        enabled,
+      });
+    }
+    return normalizeAgents(agentsToSave);
+  }
+
+  function isDraftValid(draft: AgentDraft): boolean {
+    const key = draft.key.trim();
+    if (!draft.builtin && key === "") return false;
+    if (draft.enabled && draft.binary.trim() === "") return false;
+    return true;
+  }
+
+  function agentName(draft: AgentDraft): string {
+    return draft.label.trim() || draft.key.trim() || "Custom agent";
+  }
+
+  function addCustomAgent(): void {
+    drafts = [
+      ...drafts,
+      {
+        id: `custom:new:${customID++}`,
+        builtin: false,
+        key: "",
+        label: "",
+        binary: "",
+        args: "",
+        enabled: true,
+      },
+    ];
+  }
+
+  function removeCustomAgent(id: string): void {
+    drafts = drafts.filter((draft) => draft.id !== id);
+  }
+
+  function resetBuiltin(draft: AgentDraft): void {
+    const builtin = builtins.find((candidate) => candidate.key === draft.key);
+    if (!builtin) return;
+    draft.label = builtin.label;
+    draft.binary = builtin.binary;
+    draft.args = "";
+    draft.enabled = true;
+  }
+
+  async function save(): Promise<void> {
+    if (!canSave) return;
+    saving = true;
+    error = null;
+    try {
+      const settings = await updateSettings({ agents: serializedAgents });
+      const nextAgents = settings.agents ?? [];
+      agents = nextAgents;
+      drafts = initialDrafts(nextAgents);
+      onUpdate(nextAgents);
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      saving = false;
+    }
+  }
+
+  function stringifyArgs(args: string[]): string {
+    return args.map(quoteArg).join(" ");
+  }
+
+  function quoteArg(arg: string): string {
+    if (arg === "") return "\"\"";
+    if (!/\s|["'\\]/.test(arg)) return arg;
+    return `"${arg.replace(/(["\\])/g, "\\$1")}"`;
+  }
+
+  function parseArgs(input: string): string[] {
+    const args: string[] = [];
+    let current = "";
+    let quote: "\"" | "'" | null = null;
+    let escaping = false;
+
+    for (const char of input.trim()) {
+      if (escaping) {
+        current += char;
+        escaping = false;
+        continue;
+      }
+      if (char === "\\" && quote !== "'") {
+        escaping = true;
+        continue;
+      }
+      if ((char === "\"" || char === "'") && quote === null) {
+        quote = char;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+        continue;
+      }
+      if (/\s/.test(char) && quote === null) {
+        if (current !== "") {
+          args.push(current);
+          current = "";
+        }
+        continue;
+      }
+      current += char;
+    }
+    if (escaping) current += "\\";
+    if (current !== "") args.push(current);
+    return args;
+  }
+</script>
+
+<div class="agent-settings">
+  <div class="agent-list">
+    {#each drafts as draft (draft.id)}
+      <div class={["agent-row", !draft.builtin && "agent-row--custom"]}>
+        <label class="enable-field">
+          <input type="checkbox" bind:checked={draft.enabled} disabled={saving} />
+          <span>{agentName(draft)}</span>
+        </label>
+
+        {#if !draft.builtin}
+          <label class="field">
+            <span>Key</span>
+            <input
+              type="text"
+              bind:value={draft.key}
+              aria-label="Custom agent key"
+              disabled={saving}
+              placeholder="review"
+            />
+          </label>
+          <label class="field">
+            <span>Label</span>
+            <input
+              type="text"
+              bind:value={draft.label}
+              aria-label="Custom agent label"
+              disabled={saving}
+              placeholder="Review Agent"
+            />
+          </label>
+        {/if}
+
+        <label class="field">
+          <span>Binary</span>
+          <input
+            type="text"
+            bind:value={draft.binary}
+            aria-label={`${agentName(draft)} binary`}
+            disabled={saving || !draft.enabled}
+            placeholder={draft.key || "agent"}
+          />
+        </label>
+
+        <label class="field field--args">
+          <span>Arguments</span>
+          <input
+            type="text"
+            bind:value={draft.args}
+            aria-label={`${agentName(draft)} arguments`}
+            disabled={saving || !draft.enabled}
+            placeholder="--flag value"
+          />
+        </label>
+
+        <div class="row-actions">
+          {#if draft.builtin}
+            <button
+              class="icon-btn"
+              type="button"
+              title="Reset"
+              aria-label={`Reset ${agentName(draft)}`}
+              disabled={saving}
+              onclick={() => resetBuiltin(draft)}
+            >
+              <RotateCcwIcon size="13" strokeWidth="2" aria-hidden="true" />
+            </button>
+          {:else}
+            <button
+              class="icon-btn icon-btn--danger"
+              type="button"
+              title="Remove"
+              aria-label={`Remove ${agentName(draft)}`}
+              disabled={saving}
+              onclick={() => removeCustomAgent(draft.id)}
+            >
+              <TrashIcon size="13" strokeWidth="2" aria-hidden="true" />
+            </button>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  {#if error}
+    <p class="error-msg">{error}</p>
+  {/if}
+
+  <div class="settings-actions">
+    <button
+      class="add-btn"
+      type="button"
+      disabled={saving}
+      onclick={addCustomAgent}
+    >
+      <PlusIcon size="13" strokeWidth="2" aria-hidden="true" />
+      <span>Add custom agent</span>
+    </button>
+    <button
+      class="save-btn"
+      type="button"
+      disabled={!canSave}
+      onclick={() => void save()}
+    >
+      {saving ? "Saving..." : "Save agents"}
+    </button>
+  </div>
+</div>
+
+<style>
+  .agent-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .agent-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .agent-row {
+    display: grid;
+    grid-template-columns: minmax(112px, 0.9fr) minmax(120px, 1fr) minmax(150px, 1.2fr) 28px;
+    gap: 8px;
+    align-items: end;
+    padding: 8px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+  }
+
+  .agent-row--custom {
+    grid-template-columns:
+      minmax(112px, 0.8fr) minmax(88px, 0.7fr) minmax(112px, 0.9fr)
+      minmax(120px, 1fr) minmax(150px, 1.2fr) 28px;
+  }
+
+  .enable-field,
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+  }
+
+  .enable-field {
+    align-self: center;
+    flex-direction: row;
+    align-items: center;
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .field span {
+    color: var(--text-muted);
+    font-size: 10.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .field input {
+    width: 100%;
+    min-width: 0;
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+
+  .row-actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    min-height: 28px;
+  }
+
+  .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    color: var(--text-muted);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+  }
+
+  .icon-btn:hover:not(:disabled) {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+  }
+
+  .icon-btn--danger:hover:not(:disabled) {
+    color: var(--accent-red);
+    border-color: color-mix(in srgb, var(--accent-red) 45%, var(--border-muted));
+  }
+
+  .settings-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .add-btn,
+  .save-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 28px;
+    padding: 5px 10px;
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  .add-btn {
+    color: var(--text-secondary);
+    border: 1px solid var(--border-muted);
+  }
+
+  .add-btn:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .save-btn {
+    color: white;
+    background: var(--accent-blue);
+  }
+
+  .save-btn:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .save-btn:disabled,
+  .add-btn:disabled,
+  .icon-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .error-msg {
+    margin: 0;
+    color: var(--accent-red);
+    font-size: 12px;
+  }
+
+  @media (max-width: 860px) {
+    .agent-row,
+    .agent-row--custom {
+      grid-template-columns: 1fr;
+      align-items: stretch;
+    }
+
+    .row-actions,
+    .settings-actions {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/settings/AgentSettings.test.ts
+++ b/frontend/src/lib/components/settings/AgentSettings.test.ts
@@ -25,6 +25,14 @@ vi.mock("../../stores/embed-config.svelte.js", () => ({
   isEmbedded: () => false,
 }));
 
+Object.defineProperty(Element.prototype, "animate", {
+  configurable: true,
+  value: () => ({
+    cancel: vi.fn(),
+    finished: Promise.resolve(),
+  }),
+});
+
 import AgentSettings from "./AgentSettings.svelte";
 
 async function expandAgent(name: string): Promise<void> {

--- a/frontend/src/lib/components/settings/AgentSettings.test.ts
+++ b/frontend/src/lib/components/settings/AgentSettings.test.ts
@@ -27,6 +27,10 @@ vi.mock("../../stores/embed-config.svelte.js", () => ({
 
 import AgentSettings from "./AgentSettings.svelte";
 
+async function expandAgent(name: string): Promise<void> {
+  await fireEvent.click(screen.getByRole("button", { name: `Edit ${name}` }));
+}
+
 describe("AgentSettings", () => {
   afterEach(() => {
     cleanup();
@@ -51,6 +55,7 @@ describe("AgentSettings", () => {
       },
     });
 
+    await expandAgent("Codex");
     await fireEvent.input(screen.getByLabelText("Codex binary"), {
       target: { value: "/opt/codex" },
     });
@@ -95,6 +100,7 @@ describe("AgentSettings", () => {
       },
     });
 
+    await expandAgent("Codex");
     await fireEvent.input(screen.getByLabelText("Codex arguments"), {
       target: { value: "\"\"" },
     });
@@ -127,6 +133,8 @@ describe("AgentSettings", () => {
       },
     });
 
+    expect(screen.getByLabelText("Codex")).toBeTruthy();
+    expect(screen.queryByLabelText("Codex binary")).toBeNull();
     expect(
       (screen.getByRole("button", { name: "Save agents" }) as HTMLButtonElement)
         .disabled,
@@ -164,6 +172,7 @@ describe("AgentSettings", () => {
       },
     });
 
+    await expandAgent("Claude");
     await fireEvent.input(screen.getByLabelText("Claude arguments"), {
       target: { value: "--permission-mode acceptEdits" },
     });
@@ -220,6 +229,7 @@ describe("AgentSettings", () => {
       },
     });
 
+    await expandAgent("Claude");
     await fireEvent.input(screen.getByLabelText("Claude arguments"), {
       target: { value: "--permission-mode acceptEdits" },
     });

--- a/frontend/src/lib/components/settings/AgentSettings.test.ts
+++ b/frontend/src/lib/components/settings/AgentSettings.test.ts
@@ -1,0 +1,130 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const { mockUpdateSettings } = vi.hoisted(() => ({
+  mockUpdateSettings: vi.fn(),
+}));
+
+vi.mock("../../api/settings.js", () => ({
+  updateSettings: mockUpdateSettings,
+}));
+
+vi.mock("../../stores/embed-config.svelte.js", () => ({
+  isEmbedded: () => false,
+}));
+
+import AgentSettings from "./AgentSettings.svelte";
+
+describe("AgentSettings", () => {
+  afterEach(() => {
+    cleanup();
+    mockUpdateSettings.mockReset();
+  });
+
+  it("persists built-in agent binary and argument overrides", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      agents: [{
+        key: "codex",
+        label: "Codex",
+        command: ["/opt/codex", "--full-auto"],
+        enabled: true,
+      }],
+    });
+    const onUpdate = vi.fn();
+
+    render(AgentSettings, {
+      props: {
+        agents: [],
+        onUpdate,
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Codex binary"), {
+      target: { value: "/opt/codex" },
+    });
+    await fireEvent.input(screen.getByLabelText("Codex arguments"), {
+      target: { value: "--full-auto" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        agents: [{
+          key: "codex",
+          label: "Codex",
+          command: ["/opt/codex", "--full-auto"],
+          enabled: true,
+        }],
+      });
+    });
+    expect(onUpdate).toHaveBeenCalledWith([{
+      key: "codex",
+      label: "Codex",
+      command: ["/opt/codex", "--full-auto"],
+      enabled: true,
+    }]);
+  });
+
+  it("adds custom agents to the saved settings", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      agents: [{
+        key: "review",
+        label: "Review Agent",
+        command: ["review-agent", "--strict"],
+        enabled: true,
+      }],
+    });
+    const onUpdate = vi.fn();
+
+    render(AgentSettings, {
+      props: {
+        agents: [],
+        onUpdate,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Add custom agent" }));
+    await fireEvent.input(screen.getByLabelText("Custom agent key"), {
+      target: { value: "review" },
+    });
+    await fireEvent.input(screen.getByLabelText("Custom agent label"), {
+      target: { value: "Review Agent" },
+    });
+    await fireEvent.input(screen.getByLabelText("Review Agent binary"), {
+      target: { value: "review-agent" },
+    });
+    await fireEvent.input(screen.getByLabelText("Review Agent arguments"), {
+      target: { value: "--strict" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        agents: [{
+          key: "review",
+          label: "Review Agent",
+          command: ["review-agent", "--strict"],
+          enabled: true,
+        }],
+      });
+    });
+    expect(onUpdate).toHaveBeenCalledWith([{
+      key: "review",
+      label: "Review Agent",
+      command: ["review-agent", "--strict"],
+      enabled: true,
+    }]);
+  });
+});

--- a/frontend/src/lib/components/settings/AgentSettings.test.ts
+++ b/frontend/src/lib/components/settings/AgentSettings.test.ts
@@ -112,6 +112,83 @@ describe("AgentSettings", () => {
     });
   });
 
+  it("does not mark explicit default built-in agents dirty", () => {
+    const onUpdate = vi.fn();
+
+    render(AgentSettings, {
+      props: {
+        agents: [{
+          key: "codex",
+          label: "Codex",
+          command: ["codex"],
+          enabled: true,
+        }],
+        onUpdate,
+      },
+    });
+
+    expect(
+      (screen.getByRole("button", { name: "Save agents" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("preserves explicit default built-in agents when saving other changes", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      agents: [
+        {
+          key: "codex",
+          label: "Codex",
+          command: ["codex"],
+          enabled: true,
+        },
+        {
+          key: "claude",
+          label: "Claude",
+          command: ["claude", "--permission-mode", "acceptEdits"],
+          enabled: true,
+        },
+      ],
+    });
+    const onUpdate = vi.fn();
+
+    render(AgentSettings, {
+      props: {
+        agents: [{
+          key: "codex",
+          label: "Codex",
+          command: ["codex"],
+          enabled: true,
+        }],
+        onUpdate,
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Claude arguments"), {
+      target: { value: "--permission-mode acceptEdits" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        agents: [
+          {
+            key: "claude",
+            label: "Claude",
+            command: ["claude", "--permission-mode", "acceptEdits"],
+            enabled: true,
+          },
+          {
+            key: "codex",
+            label: "Codex",
+            command: ["codex"],
+            enabled: true,
+          },
+        ],
+      });
+    });
+  });
+
   it("adds custom agents to the saved settings", async () => {
     mockUpdateSettings.mockResolvedValue({
       agents: [{

--- a/frontend/src/lib/components/settings/AgentSettings.test.ts
+++ b/frontend/src/lib/components/settings/AgentSettings.test.ts
@@ -62,7 +62,7 @@ describe("AgentSettings", () => {
     await fireEvent.input(screen.getByLabelText("Codex arguments"), {
       target: { value: "--full-auto" },
     });
-    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save workspace agents" }));
 
     await waitFor(() => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({
@@ -104,7 +104,7 @@ describe("AgentSettings", () => {
     await fireEvent.input(screen.getByLabelText("Codex arguments"), {
       target: { value: "\"\"" },
     });
-    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save workspace agents" }));
 
     await waitFor(() => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({
@@ -136,7 +136,7 @@ describe("AgentSettings", () => {
     expect(screen.getByLabelText("Codex")).toBeTruthy();
     expect(screen.queryByLabelText("Codex binary")).toBeNull();
     expect(
-      (screen.getByRole("button", { name: "Save agents" }) as HTMLButtonElement)
+      (screen.getByRole("button", { name: "Save workspace agents" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
   });
@@ -176,7 +176,7 @@ describe("AgentSettings", () => {
     await fireEvent.input(screen.getByLabelText("Claude arguments"), {
       target: { value: "--permission-mode acceptEdits" },
     });
-    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save workspace agents" }));
 
     await waitFor(() => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({
@@ -233,7 +233,7 @@ describe("AgentSettings", () => {
     await fireEvent.input(screen.getByLabelText("Claude arguments"), {
       target: { value: "--permission-mode acceptEdits" },
     });
-    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save workspace agents" }));
 
     await waitFor(() => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({
@@ -286,7 +286,7 @@ describe("AgentSettings", () => {
     await fireEvent.input(screen.getByLabelText("Review Agent arguments"), {
       target: { value: "--strict" },
     });
-    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save workspace agents" }));
 
     await waitFor(() => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({

--- a/frontend/src/lib/components/settings/AgentSettings.test.ts
+++ b/frontend/src/lib/components/settings/AgentSettings.test.ts
@@ -77,6 +77,41 @@ describe("AgentSettings", () => {
     }]);
   });
 
+  it("preserves quoted empty arguments when saving", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      agents: [{
+        key: "codex",
+        label: "Codex",
+        command: ["codex", ""],
+        enabled: true,
+      }],
+    });
+    const onUpdate = vi.fn();
+
+    render(AgentSettings, {
+      props: {
+        agents: [],
+        onUpdate,
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Codex arguments"), {
+      target: { value: "\"\"" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        agents: [{
+          key: "codex",
+          label: "Codex",
+          command: ["codex", ""],
+          enabled: true,
+        }],
+      });
+    });
+  });
+
   it("adds custom agents to the saved settings", async () => {
     mockUpdateSettings.mockResolvedValue({
       agents: [{

--- a/frontend/src/lib/components/settings/AgentSettings.test.ts
+++ b/frontend/src/lib/components/settings/AgentSettings.test.ts
@@ -189,6 +189,62 @@ describe("AgentSettings", () => {
     });
   });
 
+  it("preserves disabled built-in agents with empty commands when saving other changes", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      agents: [
+        {
+          key: "codex",
+          label: "Codex",
+          command: [],
+          enabled: false,
+        },
+        {
+          key: "claude",
+          label: "Claude",
+          command: ["claude", "--permission-mode", "acceptEdits"],
+          enabled: true,
+        },
+      ],
+    });
+    const onUpdate = vi.fn();
+
+    render(AgentSettings, {
+      props: {
+        agents: [{
+          key: "codex",
+          label: "Codex",
+          command: [],
+          enabled: false,
+        }],
+        onUpdate,
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Claude arguments"), {
+      target: { value: "--permission-mode acceptEdits" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save agents" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        agents: [
+          {
+            key: "claude",
+            label: "Claude",
+            command: ["claude", "--permission-mode", "acceptEdits"],
+            enabled: true,
+          },
+          {
+            key: "codex",
+            label: "Codex",
+            command: [],
+            enabled: false,
+          },
+        ],
+      });
+    });
+  });
+
   it("adds custom agents to the saved settings", async () => {
     mockUpdateSettings.mockResolvedValue({
       agents: [{

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -41,7 +41,7 @@ describe("RepoImportModal", () => {
   it("filters, deselects visible rows, and submits remaining selected rows", async () => {
     const onImported = vi.fn();
     preview.mockResolvedValue({ owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" } });
+    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" }, agents: [] });
     render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported } });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -130,6 +130,7 @@ describe("RepoSettings", () => {
         hide_bots: false,
       },
       terminal: { font_family: "" },
+      agents: [],
     });
     render(RepoSettings, {
       props: {

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -7,6 +7,7 @@
   import RepoSettings from "./RepoSettings.svelte";
   import ActivitySettings from "./ActivitySettings.svelte";
   import TerminalSettings from "./TerminalSettings.svelte";
+  import AgentSettings from "./AgentSettings.svelte";
 
   const { settings: settingsStore } = getStores();
 
@@ -57,6 +58,15 @@
           settingsStore.setTerminalFontFamily(
             terminal.font_family,
           );
+        }}
+      />
+    </SettingsSection>
+
+    <SettingsSection title="Workspace agents">
+      <AgentSettings
+        agents={settings.agents}
+        onUpdate={(agents) => {
+          settings = { ...settings!, agents };
         }}
       />
     </SettingsSection>

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -43,6 +43,7 @@ function makeSettings(): Settings {
     terminal: {
       font_family: "\"Fira Code\", monospace",
     },
+    agents: [],
   };
 }
 

--- a/frontend/tests/e2e-full/settings-agents.spec.ts
+++ b/frontend/tests/e2e-full/settings-agents.spec.ts
@@ -126,3 +126,76 @@ test("settings preserves explicit default built-in agents during other saves", a
     claude: ["claude", "--permission-mode", "acceptEdits"],
   });
 });
+
+test("settings preserves disabled built-in agents with empty commands", async ({
+  page,
+}) => {
+  if (!api) {
+    throw new Error("settings agents API context not initialized");
+  }
+  const apiContext = api;
+  const seedResponse = await apiContext.put("/api/v1/settings", {
+    data: {
+      agents: [{
+        key: "codex",
+        label: "Codex",
+        command: [],
+        enabled: false,
+      }],
+    },
+  });
+  const seedBody = await seedResponse.text();
+  expect(
+    seedResponse.status(),
+    `PUT /api/v1/settings seed failed: ${seedBody}`,
+  ).toBe(200);
+
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
+
+  const saveButton = page.getByRole("button", { name: "Save agents" });
+  await expect(page.getByLabel("Codex binary")).toHaveValue("");
+  await expect(saveButton).toBeDisabled();
+
+  await page.getByLabel("Claude arguments").fill("--permission-mode acceptEdits");
+  await expect(saveButton).toBeEnabled();
+  const saveResponsePromise = page.waitForResponse((response) =>
+    response.url().endsWith("/api/v1/settings") &&
+    response.request().method() === "PUT"
+  );
+  await saveButton.click();
+  const saveResponse = await saveResponsePromise;
+  const saveBody = await saveResponse.text();
+  expect(
+    saveResponse.status(),
+    `PUT /api/v1/settings failed: ${saveBody}`,
+  ).toBe(200);
+
+  await expect.poll(async () => {
+    const response = await apiContext.get("/api/v1/settings");
+    const settings = await response.json() as {
+      agents: Array<{
+        key: string;
+        command: string[] | null;
+        enabled: boolean;
+      }>;
+    };
+    const codex = settings.agents.find((agent) => agent.key === "codex");
+    return {
+      codex: codex && {
+        key: codex.key,
+        command: codex.command ?? [],
+        enabled: codex.enabled,
+      },
+      claude: settings.agents.find((agent) => agent.key === "claude")?.command,
+    };
+  }).toEqual({
+    codex: {
+      key: "codex",
+      command: [],
+      enabled: false,
+    },
+    claude: ["claude", "--permission-mode", "acceptEdits"],
+  });
+});

--- a/frontend/tests/e2e-full/settings-agents.spec.ts
+++ b/frontend/tests/e2e-full/settings-agents.spec.ts
@@ -40,7 +40,7 @@ test("settings preserves quoted empty workspace agent arguments", async ({
 
   await expandAgent(page, "Codex");
   const argsInput = page.getByLabel("Codex arguments");
-  const saveButton = page.getByRole("button", { name: "Save agents" });
+  const saveButton = page.getByRole("button", { name: "Save workspace agents" });
 
   await argsInput.fill("\"\"");
   await expect(saveButton).toBeEnabled();
@@ -101,7 +101,7 @@ test("settings preserves explicit default built-in agents during other saves", a
   await page.locator(".settings-page")
     .waitFor({ state: "visible", timeout: 10_000 });
 
-  const saveButton = page.getByRole("button", { name: "Save agents" });
+  const saveButton = page.getByRole("button", { name: "Save workspace agents" });
   await expect(page.getByRole("checkbox", { name: "Codex" })).toBeVisible();
   await expect(page.getByLabel("Codex arguments")).toHaveCount(0);
   await expandAgent(page, "Codex");
@@ -165,7 +165,7 @@ test("settings preserves disabled built-in agents with empty commands", async ({
   await page.locator(".settings-page")
     .waitFor({ state: "visible", timeout: 10_000 });
 
-  const saveButton = page.getByRole("button", { name: "Save agents" });
+  const saveButton = page.getByRole("button", { name: "Save workspace agents" });
   await expandAgent(page, "Codex");
   await expect(page.getByLabel("Codex binary")).toHaveValue("");
   await expect(saveButton).toBeDisabled();

--- a/frontend/tests/e2e-full/settings-agents.spec.ts
+++ b/frontend/tests/e2e-full/settings-agents.spec.ts
@@ -12,6 +12,8 @@ import {
 let isolatedServer: IsolatedE2EServer | undefined;
 let api: APIRequestContext | undefined;
 
+test.describe.configure({ mode: "serial" });
+
 test.beforeAll(async () => {
   isolatedServer = await startIsolatedE2EServer();
   api = await playwrightRequest.newContext({
@@ -63,4 +65,64 @@ test("settings preserves quoted empty workspace agent arguments", async ({
   await page.locator(".settings-page")
     .waitFor({ state: "visible", timeout: 10_000 });
   await expect(page.getByLabel("Codex arguments")).toHaveValue("\"\"");
+});
+
+test("settings preserves explicit default built-in agents during other saves", async ({
+  page,
+}) => {
+  if (!api) {
+    throw new Error("settings agents API context not initialized");
+  }
+  const apiContext = api;
+  const seedResponse = await apiContext.put("/api/v1/settings", {
+    data: {
+      agents: [{
+        key: "codex",
+        label: "Codex",
+        command: ["codex"],
+        enabled: true,
+      }],
+    },
+  });
+  const seedBody = await seedResponse.text();
+  expect(
+    seedResponse.status(),
+    `PUT /api/v1/settings seed failed: ${seedBody}`,
+  ).toBe(200);
+
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
+
+  const saveButton = page.getByRole("button", { name: "Save agents" });
+  await expect(page.getByLabel("Codex arguments")).toHaveValue("");
+  await expect(saveButton).toBeDisabled();
+
+  await page.getByLabel("Claude arguments").fill("--permission-mode acceptEdits");
+  await expect(saveButton).toBeEnabled();
+  const saveResponsePromise = page.waitForResponse((response) =>
+    response.url().endsWith("/api/v1/settings") &&
+    response.request().method() === "PUT"
+  );
+  await saveButton.click();
+  const saveResponse = await saveResponsePromise;
+  const saveBody = await saveResponse.text();
+  expect(
+    saveResponse.status(),
+    `PUT /api/v1/settings failed: ${saveBody}`,
+  ).toBe(200);
+
+  await expect.poll(async () => {
+    const response = await apiContext.get("/api/v1/settings");
+    const settings = await response.json() as {
+      agents: Array<{ key: string; command: string[] }>;
+    };
+    return {
+      codex: settings.agents.find((agent) => agent.key === "codex")?.command,
+      claude: settings.agents.find((agent) => agent.key === "claude")?.command,
+    };
+  }).toEqual({
+    codex: ["codex"],
+    claude: ["claude", "--permission-mode", "acceptEdits"],
+  });
 });

--- a/frontend/tests/e2e-full/settings-agents.spec.ts
+++ b/frontend/tests/e2e-full/settings-agents.spec.ts
@@ -1,0 +1,66 @@
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+} from "@playwright/test";
+import {
+  startIsolatedE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
+
+let isolatedServer: IsolatedE2EServer | undefined;
+let api: APIRequestContext | undefined;
+
+test.beforeAll(async () => {
+  isolatedServer = await startIsolatedE2EServer();
+  api = await playwrightRequest.newContext({
+    baseURL: isolatedServer.info.base_url,
+  });
+});
+
+test.afterAll(async () => {
+  await api?.dispose();
+  await isolatedServer?.stop();
+});
+
+test("settings preserves quoted empty workspace agent arguments", async ({
+  page,
+}) => {
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
+
+  const argsInput = page.getByLabel("Codex arguments");
+  const saveButton = page.getByRole("button", { name: "Save agents" });
+
+  await argsInput.fill("\"\"");
+  await expect(saveButton).toBeEnabled();
+  const saveResponsePromise = page.waitForResponse((response) =>
+    response.url().endsWith("/api/v1/settings") &&
+    response.request().method() === "PUT"
+  );
+  await saveButton.click();
+  const saveResponse = await saveResponsePromise;
+  const saveBody = await saveResponse.text();
+  expect(
+    saveResponse.status(),
+    `PUT /api/v1/settings failed: ${saveBody}`,
+  ).toBe(200);
+
+  await expect.poll(async () => {
+    if (!api) {
+      throw new Error("settings agents API context not initialized");
+    }
+    const response = await api.get("/api/v1/settings");
+    const settings = await response.json() as {
+      agents: Array<{ key: string; command: string[] }>;
+    };
+    return settings.agents.find((agent) => agent.key === "codex")?.command;
+  }).toEqual(["codex", ""]);
+
+  await page.reload();
+  await page.locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await expect(page.getByLabel("Codex arguments")).toHaveValue("\"\"");
+});

--- a/frontend/tests/e2e-full/settings-agents.spec.ts
+++ b/frontend/tests/e2e-full/settings-agents.spec.ts
@@ -1,5 +1,6 @@
 import {
   expect,
+  type Page,
   request as playwrightRequest,
   test,
   type APIRequestContext,
@@ -26,6 +27,10 @@ test.afterAll(async () => {
   await isolatedServer?.stop();
 });
 
+async function expandAgent(page: Page, name: string): Promise<void> {
+  await page.getByRole("button", { name: `Edit ${name}` }).click();
+}
+
 test("settings preserves quoted empty workspace agent arguments", async ({
   page,
 }) => {
@@ -33,6 +38,7 @@ test("settings preserves quoted empty workspace agent arguments", async ({
   await page.locator(".settings-page")
     .waitFor({ state: "visible", timeout: 10_000 });
 
+  await expandAgent(page, "Codex");
   const argsInput = page.getByLabel("Codex arguments");
   const saveButton = page.getByRole("button", { name: "Save agents" });
 
@@ -64,6 +70,7 @@ test("settings preserves quoted empty workspace agent arguments", async ({
   await page.reload();
   await page.locator(".settings-page")
     .waitFor({ state: "visible", timeout: 10_000 });
+  await expandAgent(page, "Codex");
   await expect(page.getByLabel("Codex arguments")).toHaveValue("\"\"");
 });
 
@@ -95,9 +102,13 @@ test("settings preserves explicit default built-in agents during other saves", a
     .waitFor({ state: "visible", timeout: 10_000 });
 
   const saveButton = page.getByRole("button", { name: "Save agents" });
+  await expect(page.getByRole("checkbox", { name: "Codex" })).toBeVisible();
+  await expect(page.getByLabel("Codex arguments")).toHaveCount(0);
+  await expandAgent(page, "Codex");
   await expect(page.getByLabel("Codex arguments")).toHaveValue("");
   await expect(saveButton).toBeDisabled();
 
+  await expandAgent(page, "Claude");
   await page.getByLabel("Claude arguments").fill("--permission-mode acceptEdits");
   await expect(saveButton).toBeEnabled();
   const saveResponsePromise = page.waitForResponse((response) =>
@@ -155,9 +166,11 @@ test("settings preserves disabled built-in agents with empty commands", async ({
     .waitFor({ state: "visible", timeout: 10_000 });
 
   const saveButton = page.getByRole("button", { name: "Save agents" });
+  await expandAgent(page, "Codex");
   await expect(page.getByLabel("Codex binary")).toHaveValue("");
   await expect(saveButton).toBeDisabled();
 
+  await expandAgent(page, "Claude");
   await page.getByLabel("Claude arguments").fill("--permission-mode acceptEdits");
   await expect(saveButton).toBeEnabled();
   const saveResponsePromise = page.waitForResponse((response) =>

--- a/frontend/tests/e2e-full/settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/settings-terminal-font.spec.ts
@@ -32,7 +32,7 @@ test("settings saves and reloads the workspace terminal font family", async ({
     .waitFor({ state: "visible", timeout: 10_000 });
 
   const input = page.getByLabel("Monospace font family");
-  const saveButton = page.getByRole("button", { name: "Save" });
+  const saveButton = page.getByRole("button", { name: "Save", exact: true });
   await expect(input).toHaveValue("");
 
   await input.click();

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -67,6 +67,14 @@ type AddRepoInputBody struct {
 	Owner  string  `json:"owner"`
 }
 
+// Agent defines model for Agent.
+type Agent struct {
+	Command *[]string `json:"command"`
+	Enabled *bool     `json:"enabled,omitempty"`
+	Key     string    `json:"key"`
+	Label   string    `json:"label"`
+}
+
 // ApprovePRInputBody defines model for ApprovePRInputBody.
 type ApprovePRInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -720,6 +728,7 @@ type SettingsResponse struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema   *string                 `json:"$schema,omitempty"`
 	Activity Activity                `json:"activity"`
+	Agents   *[]Agent                `json:"agents"`
 	Repos    *[]ConfiguredRepoStatus `json:"repos"`
 	Terminal Terminal                `json:"terminal"`
 }
@@ -791,6 +800,7 @@ type UpdateSettingsRequest struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema   *string   `json:"$schema,omitempty"`
 	Activity *Activity `json:"activity,omitempty"`
+	Agents   *[]Agent  `json:"agents,omitempty"`
 	Terminal *Terminal `json:"terminal,omitempty"`
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8451,6 +8451,72 @@ func TestWorkspaceRuntimeTargetsUseConfiguredTmuxCommandE2E(t *testing.T) {
 	assert.True(tmux.Available)
 }
 
+func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		SyncInterval:   "5m",
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Host:           "127.0.0.1",
+		Port:           8091,
+		BasePath:       "/",
+		DataDir:        dir,
+		Activity: config.Activity{
+			ViewMode:  "threaded",
+			TimeRange: "7d",
+		},
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	require.NoError(cfg.Save(cfgPath))
+
+	agentPath := filepath.Join(dir, "codex-custom")
+	require.NoError(os.WriteFile(
+		agentPath,
+		[]byte("#!/bin/sh\nexit 0\n"),
+		0o755,
+	))
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	srv.cfgPath = cfgPath
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	agents := []config.Agent{{
+		Key:     "codex",
+		Label:   "Custom Codex",
+		Command: []string{agentPath, "--full-auto"},
+	}}
+	updateResp := doJSON(
+		t, srv, http.MethodPut, "/api/v1/settings",
+		updateSettingsRequest{Agents: &agents},
+	)
+	require.Equal(http.StatusOK, updateResp.Code, updateResp.Body.String())
+
+	reloaded, err := config.Load(cfgPath)
+	require.NoError(err)
+	require.Len(reloaded.Agents, 1)
+	assert.Equal([]string{agentPath, "--full-auto"}, reloaded.Agents[0].Command)
+
+	runtimeResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, runtimeResp.StatusCode())
+	require.NotNil(runtimeResp.JSON200)
+	require.NotNil(runtimeResp.JSON200.LaunchTargets)
+
+	var codex generated.LaunchTarget
+	for _, target := range *runtimeResp.JSON200.LaunchTargets {
+		if target.Key == "codex" {
+			codex = target
+			break
+		}
+	}
+	assert.Equal("Custom Codex", codex.Label)
+	assert.True(codex.Available)
+	require.NotNil(codex.Command)
+	assert.Equal([]string{agentPath, "--full-auto"}, *codex.Command)
+}
+
 func TestWorkspaceRuntimeLaunchUnavailableTargetE2E(t *testing.T) {
 	disabled := false
 	cfg := &config.Config{Agents: []config.Agent{{

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -10,17 +10,20 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/wesm/middleman/internal/config"
 	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/workspace/localruntime"
 )
 
 type settingsResponse struct {
 	Repos    []ghclient.ConfiguredRepoStatus `json:"repos"`
 	Activity config.Activity                 `json:"activity"`
 	Terminal config.Terminal                 `json:"terminal"`
+	Agents   []config.Agent                  `json:"agents"`
 }
 
 type updateSettingsRequest struct {
 	Activity *config.Activity `json:"activity,omitempty"`
 	Terminal *config.Terminal `json:"terminal,omitempty"`
+	Agents   *[]config.Agent  `json:"agents,omitempty"`
 }
 
 func (s *Server) configuredClients(
@@ -48,6 +51,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	repos := append([]config.Repo(nil), s.cfg.Repos...)
 	activity := s.cfg.Activity
 	terminal := s.cfg.Terminal
+	agents := cloneConfigAgents(s.cfg.Agents)
 	s.cfgMu.Unlock()
 
 	tracked := s.syncer.TrackedRepos()
@@ -66,6 +70,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		Repos:    configured,
 		Activity: activity,
 		Terminal: terminal,
+		Agents:   agents,
 	}
 }
 
@@ -257,6 +262,7 @@ func (s *Server) updateSettings(
 	s.cfgMu.Lock()
 	prevActivity := s.cfg.Activity
 	prevTerminal := s.cfg.Terminal
+	prevAgents := cloneConfigAgents(s.cfg.Agents)
 	if input.Body.Activity != nil {
 		candidate := *input.Body.Activity
 		if candidate.ViewMode == "" {
@@ -270,22 +276,50 @@ func (s *Server) updateSettings(
 	if input.Body.Terminal != nil {
 		s.cfg.Terminal = *input.Body.Terminal
 	}
+	if input.Body.Agents != nil {
+		s.cfg.Agents = cloneConfigAgents(*input.Body.Agents)
+	}
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Activity = prevActivity
 		s.cfg.Terminal = prevTerminal
+		s.cfg.Agents = prevAgents
 		s.cfgMu.Unlock()
 		return nil, huma.Error400BadRequest(err.Error())
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Activity = prevActivity
 		s.cfg.Terminal = prevTerminal
+		s.cfg.Agents = prevAgents
 		s.cfgMu.Unlock()
 		return nil, huma.Error500InternalServerError(
 			"save config: " + err.Error())
 	}
+	s.refreshRuntimeTargetsLocked()
 	s.cfgMu.Unlock()
 
 	return &settingsOutput{Body: s.buildLocalSettingsResponse()}, nil
+}
+
+func cloneConfigAgents(agents []config.Agent) []config.Agent {
+	if agents == nil {
+		return []config.Agent{}
+	}
+	cloned := make([]config.Agent, len(agents))
+	for i, agent := range agents {
+		cloned[i] = agent
+		cloned[i].Command = append([]string(nil), agent.Command...)
+	}
+	return cloned
+}
+
+func (s *Server) refreshRuntimeTargetsLocked() {
+	if s.runtime == nil || s.cfg == nil {
+		return
+	}
+	tmuxCmd := s.cfg.TmuxCommand()
+	s.runtime.UpdateTargets(localruntime.ResolveLaunchTargets(
+		s.cfg.Agents, tmuxCmd, nil,
+	))
 }
 
 func (s *Server) addConfiguredRepo(

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wesm/middleman/internal/config"
 	"github.com/wesm/middleman/internal/db"
 	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/workspace/localruntime"
 )
 
 func setupTestServerWithConfig(
@@ -92,19 +93,37 @@ func doJSON(
 }
 
 func TestHandleGetSettings(t *testing.T) {
+	require := require.New(t)
 	assert := Assert.New(t)
-	srv, _, _ := setupTestServerWithConfig(t)
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[agents]]
+key = "codex"
+label = "Codex"
+command = ["codex", "--full-auto"]
+`, &mockGH{})
 
 	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
-	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
-	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
-	require.Len(t, resp.Repos, 1)
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp.Repos, 1)
 	assert.Equal("acme", resp.Repos[0].Owner)
 	assert.Equal(1, resp.Repos[0].MatchedRepoCount)
 	assert.Equal("threaded", resp.Activity.ViewMode)
 	assert.Empty(resp.Terminal.FontFamily)
+	require.Len(resp.Agents, 1)
+	assert.Equal("codex", resp.Agents[0].Key)
+	assert.Equal([]string{"codex", "--full-auto"}, resp.Agents[0].Command)
 }
 
 func TestHandleUpdateSettings(t *testing.T) {
@@ -174,6 +193,104 @@ hide_bots = true
 	assert.True(cfg2.Activity.HideClosed)
 	assert.True(cfg2.Activity.HideBots)
 	assert.Equal("\"Iosevka Term\", monospace", cfg2.Terminal.FontFamily)
+}
+
+func TestHandleUpdateSettingsPersistsAgents(t *testing.T) {
+	assert := Assert.New(t)
+	srv, _, cfgPath := setupTestServerWithConfig(t)
+	disabled := false
+	agents := []config.Agent{{
+		Key:     "codex",
+		Label:   "Codex with flags",
+		Command: []string{"/opt/codex", "--full-auto", "--search"},
+	}, {
+		Key:     "notes",
+		Label:   "Notes",
+		Command: []string{"/usr/local/bin/notes-agent", "--draft"},
+	}, {
+		Key:     "claude",
+		Label:   "Claude",
+		Enabled: &disabled,
+	}}
+
+	body := updateSettingsRequest{Agents: &agents}
+	rr := doJSON(
+		t, srv, http.MethodPut, "/api/v1/settings", body,
+	)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	cfg2, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	require.Len(t, cfg2.Agents, 3)
+	assert.Equal("codex", cfg2.Agents[0].Key)
+	assert.Equal(
+		[]string{"/opt/codex", "--full-auto", "--search"},
+		cfg2.Agents[0].Command,
+	)
+	assert.Equal("notes", cfg2.Agents[1].Key)
+	assert.False(cfg2.Agents[2].EnabledOrDefault())
+}
+
+func TestHandleUpdateSettingsRefreshesRuntimeTargets(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := filepath.Join(dir, "codex-custom")
+	require.NoError(t, os.WriteFile(
+		agentPath,
+		[]byte("#!/bin/sh\nexit 0\n"),
+		0o755,
+	))
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, &mockGH{})
+	srv.runtime = localruntime.NewManager(localruntime.Options{
+		Targets: []localruntime.LaunchTarget{{
+			Key: "codex", Label: "Codex", Kind: localruntime.LaunchTargetAgent,
+			Source: "builtin", Command: []string{"codex"},
+			Available: false, DisabledReason: "codex not found on PATH",
+		}},
+	})
+	t.Cleanup(srv.runtime.Shutdown)
+
+	agents := []config.Agent{{
+		Key:     "codex",
+		Label:   "Custom Codex",
+		Command: []string{agentPath, "--full-auto"},
+	}}
+	rr := doJSON(
+		t, srv, http.MethodPut, "/api/v1/settings",
+		updateSettingsRequest{Agents: &agents},
+	)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	target := findRuntimeTargetForSettingsTest(
+		t, srv.runtime.LaunchTargets(), "codex",
+	)
+	assert := Assert.New(t)
+	assert.Equal("Custom Codex", target.Label)
+	assert.Equal([]string{agentPath, "--full-auto"}, target.Command)
+	assert.True(target.Available)
+}
+
+func findRuntimeTargetForSettingsTest(
+	t *testing.T,
+	targets []localruntime.LaunchTarget,
+	key string,
+) localruntime.LaunchTarget {
+	t.Helper()
+	for _, target := range targets {
+		if target.Key == key {
+			return target
+		}
+	}
+	require.Failf(t, "target not found", "key %q", key)
+	return localruntime.LaunchTarget{}
 }
 
 func TestHandleUpdateSettingsInvalid(t *testing.T) {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -465,6 +465,21 @@ func (m *Manager) LaunchTargets() []LaunchTarget {
 	return targets
 }
 
+func (m *Manager) UpdateTargets(targets []LaunchTarget) {
+	next := make(map[string]LaunchTarget, len(targets))
+	nextList := make([]LaunchTarget, 0, len(targets))
+	for _, target := range targets {
+		cloned := cloneTarget(target)
+		next[target.Key] = cloned
+		nextList = append(nextList, cloneTarget(cloned))
+	}
+
+	m.mu.Lock()
+	m.targets = next
+	m.targetsList = nextList
+	m.mu.Unlock()
+}
+
 func (m *Manager) ListSessions(workspaceID string) []SessionInfo {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -127,6 +127,33 @@ func TestManagerLaunchMissingTarget(t *testing.T) {
 	require.Contains(t, err.Error(), "target not found")
 }
 
+func TestManagerUpdateTargetsAffectsFutureLaunches(t *testing.T) {
+	requirePTYAvailable(t)
+	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
+	assert := Assert.New(t)
+
+	ctx := context.Background()
+	mgr := NewManager(Options{Targets: []LaunchTarget{
+		helperTarget("helper", "exit"),
+	}})
+	t.Cleanup(mgr.Shutdown)
+
+	mgr.UpdateTargets([]LaunchTarget{{
+		Key: "custom", Label: "Custom", Kind: LaunchTargetAgent,
+		Source: "config", Command: helperCommand("exit"),
+		Available: true,
+	}})
+
+	_, err := mgr.Launch(ctx, "ws-1", t.TempDir(), "helper")
+	require.Error(t, err)
+	assert.Contains(err.Error(), "target not found")
+
+	session, err := mgr.Launch(ctx, "ws-1", t.TempDir(), "custom")
+	require.NoError(t, err)
+	assert.Equal("custom", session.TargetKey)
+	assert.Equal("Custom", session.Label)
+}
+
 func TestManagerTmuxSessionsReturnsWrappedAgentSessions(t *testing.T) {
 	assert := Assert.New(t)
 	mgr := NewManager(Options{})

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -871,6 +871,12 @@ export interface components {
             name: string;
             owner: string;
         };
+        Agent: {
+            command: string[] | null;
+            enabled?: boolean;
+            key: string;
+            label: string;
+        };
         ApprovePRInputBody: {
             /**
              * Format: uri
@@ -1659,6 +1665,7 @@ export interface components {
              */
             readonly $schema?: string;
             activity: components["schemas"]["Activity"];
+            agents: components["schemas"]["Agent"][] | null;
             repos: components["schemas"]["ConfiguredRepoStatus"][] | null;
             terminal: components["schemas"]["Terminal"];
         };
@@ -1741,6 +1748,7 @@ export interface components {
              */
             readonly $schema?: string;
             activity?: components["schemas"]["Activity"];
+            agents?: components["schemas"]["Agent"][];
             terminal?: components["schemas"]["Terminal"];
         };
         VersionOutputBody: {

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -66,6 +66,13 @@ export interface TerminalSettings {
   font_family: string;
 }
 
+export interface AgentSettings {
+  key: string;
+  label: string;
+  command?: string[];
+  enabled?: boolean;
+}
+
 export interface ConfigRepo {
   owner: string;
   name: string;
@@ -77,6 +84,7 @@ export interface Settings {
   repos: ConfigRepo[];
   activity: ActivitySettings;
   terminal: TerminalSettings;
+  agents: AgentSettings[];
 }
 
 export interface DiffResult {


### PR DESCRIPTION
## Summary
- Add workspace agent settings to the app config and settings API, including binary overrides, extra arguments, enable/disable state, and custom agents
- Refresh local runtime launch targets when settings change so the workspace view uses the updated agent list immediately
- Update the settings UI to edit agents with a compact accordion layout and preserve tricky argument cases like quoted empty strings

## Testing
- Added and updated unit coverage for settings parsing, serialization, and runtime target refresh behavior
- Added end-to-end Playwright coverage for workspace agent settings persistence, including explicit defaults and disabled agents with empty commands
- Ran frontend type checks, Svelte validation, and local browser-based UI verification