### PR TITLE
Include private owned repos in repository import

### DIFF
--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -26,6 +26,7 @@ export interface RepoPreviewRow {
   name: string;
   description: string | null;
   private: boolean;
+  fork: boolean;
   pushed_at: string | null;
   already_configured: boolean;
 }

--- a/frontend/src/lib/components/settings/RepoImportModal.svelte
+++ b/frontend/src/lib/components/settings/RepoImportModal.svelte
@@ -28,6 +28,8 @@
   let selected = $state<Set<string>>(new Set());
   let filterText = $state("");
   let statusFilter = $state<StatusFilter>("all");
+  let hideForks = $state(false);
+  let hidePrivate = $state(false);
   let sort = $state<SortState>({ field: "pushed_at", direction: "desc" });
   let anchorKey = $state<string | null>(null);
   let loading = $state(false);
@@ -37,9 +39,11 @@
   let inputEl = $state<HTMLInputElement | null>(null);
 
   const sortedRows = $derived(sortRows(rows, sort));
-  const visibleRows = $derived(filterRows(sortedRows, filterText, statusFilter, selected));
-  const selectedCount = $derived(rows.filter((row) => selected.has(rowKey(row)) && !row.already_configured).length);
-  const submitRows = $derived(selectedRowsForSubmit(sortedRows, selected));
+  const visibilityFilters = $derived({ hideForks, hidePrivate });
+  const visibleRows = $derived(filterRows(sortedRows, filterText, statusFilter, selected, visibilityFilters));
+  const selectableVisibleCount = $derived(visibleRows.filter((row) => !row.already_configured).length);
+  const selectedCount = $derived(visibleRows.filter((row) => selected.has(rowKey(row)) && !row.already_configured).length);
+  const submitRows = $derived(selectedRowsForSubmit(sortedRows, selected, visibilityFilters));
 
   $effect(() => {
     if (open) {
@@ -54,6 +58,8 @@
     selected = new Set();
     filterText = "";
     statusFilter = "all";
+    hideForks = false;
+    hidePrivate = false;
     sort = { field: "pushed_at", direction: "desc" };
     anchorKey = null;
   }
@@ -209,9 +215,13 @@
           {selected}
           {filterText}
           {statusFilter}
+          {hideForks}
+          {hidePrivate}
           {sort}
           onFilterText={(value) => { filterText = value; }}
           onStatusFilter={(value) => { statusFilter = value; }}
+          onHideForks={(value) => { hideForks = value; }}
+          onHidePrivate={(value) => { hidePrivate = value; }}
           onSort={toggleSort}
           onToggle={toggleRow}
           onSelectVisible={() => { selected = setAllVisible(selected, visibleRows, true); }}
@@ -222,7 +232,7 @@
       {/if}
 
       <footer class="modal-footer">
-        <span>Selected {selectedCount} of {rows.length}</span>
+        <span>Selected {selectedCount} of {selectableVisibleCount}</span>
         <div class="footer-actions">
           <button class="secondary-btn" type="button" onclick={closeIfAllowed} disabled={submitting}>Cancel</button>
           <button class="submit-btn" type="button" onclick={() => void handleSubmit()} disabled={submitting || selectedCount === 0}>

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -12,10 +12,10 @@ const preview = vi.mocked(previewRepos);
 const bulk = vi.mocked(bulkAddRepos);
 
 const rows = [
-  { owner: "acme", name: "worker", description: "Background jobs", private: false, pushed_at: "2026-04-20T00:00:00Z", already_configured: false },
-  { owner: "acme", name: "api", description: "HTTP API", private: true, pushed_at: "2026-04-22T00:00:00Z", already_configured: false },
-  { owner: "acme", name: "widget", description: "Configured", private: false, pushed_at: "2026-04-21T00:00:00Z", already_configured: true },
-  { owner: "acme", name: "empty", description: null, private: false, pushed_at: null, already_configured: false },
+  { owner: "acme", name: "worker", description: "Background jobs", private: false, fork: false, pushed_at: "2026-04-20T00:00:00Z", already_configured: false },
+  { owner: "acme", name: "api", description: "HTTP API", private: true, fork: false, pushed_at: "2026-04-22T00:00:00Z", already_configured: false },
+  { owner: "acme", name: "widget", description: "Configured", private: false, fork: true, pushed_at: "2026-04-21T00:00:00Z", already_configured: true },
+  { owner: "acme", name: "empty", description: null, private: false, fork: false, pushed_at: null, already_configured: false },
 ];
 
 describe("RepoImportModal", () => {
@@ -33,7 +33,7 @@ describe("RepoImportModal", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
 
     await screen.findByText("acme/api");
-    expect(screen.getByText("Selected 3 of 4")).toBeTruthy();
+    expect(screen.getByText("Selected 3 of 3")).toBeTruthy();
     expect((screen.getByRole("checkbox", { name: "Select acme/widget" }) as HTMLInputElement).disabled).toBe(true);
     expect(screen.getByText("Never pushed")).toBeTruthy();
   });
@@ -58,6 +58,29 @@ describe("RepoImportModal", () => {
       { owner: "acme", name: "empty" },
     ]));
     expect(onImported).toHaveBeenCalled();
+  });
+
+  it("hides private repositories and forks from preview selection", async () => {
+    preview.mockResolvedValue({ owner: "acme", pattern: "*", repos: rows });
+    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" } });
+    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    await screen.findByText("acme/api");
+
+    await fireEvent.click(screen.getByLabelText("Hide private"));
+    await fireEvent.click(screen.getByLabelText("Hide forks"));
+    expect(screen.queryByText("acme/api")).toBeNull();
+    expect(screen.queryByText("acme/widget")).toBeNull();
+    expect(screen.getByText("Selected 2 of 2")).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Add selected repositories" }));
+
+    await waitFor(() => expect(bulk).toHaveBeenCalledWith([
+      { owner: "acme", name: "worker" },
+      { owner: "acme", name: "empty" },
+    ]));
   });
 
   it("does not start duplicate previews while loading", async () => {

--- a/frontend/src/lib/components/settings/RepoPreviewTable.svelte
+++ b/frontend/src/lib/components/settings/RepoPreviewTable.svelte
@@ -7,9 +7,13 @@
     selected: Set<string>;
     filterText: string;
     statusFilter: StatusFilter;
+    hideForks: boolean;
+    hidePrivate: boolean;
     sort: SortState;
     onFilterText: (value: string) => void;
     onStatusFilter: (value: StatusFilter) => void;
+    onHideForks: (value: boolean) => void;
+    onHidePrivate: (value: boolean) => void;
     onSort: (field: SortState["field"]) => void;
     onToggle: (row: RepoImportRow, checked: boolean, shiftKey: boolean) => void;
     onSelectVisible: () => void;
@@ -21,9 +25,13 @@
     selected,
     filterText,
     statusFilter,
+    hideForks,
+    hidePrivate,
     sort,
     onFilterText,
     onStatusFilter,
+    onHideForks,
+    onHidePrivate,
     onSort,
     onToggle,
     onSelectVisible,
@@ -65,6 +73,22 @@
     <option value="unselected">Unselected</option>
     <option value="already-added">Already added</option>
   </select>
+  <label class="toggle-filter">
+    <input
+      type="checkbox"
+      checked={hideForks}
+      onchange={(event) => onHideForks(event.currentTarget.checked)}
+    />
+    <span>Hide forks</span>
+  </label>
+  <label class="toggle-filter">
+    <input
+      type="checkbox"
+      checked={hidePrivate}
+      onchange={(event) => onHidePrivate(event.currentTarget.checked)}
+    />
+    <span>Hide private</span>
+  </label>
   <button type="button" class="shortcut-btn" onclick={onSelectVisible}>All</button>
   <button type="button" class="shortcut-btn" onclick={onDeselectVisible}>None</button>
 </div>
@@ -97,7 +121,10 @@
           <td class="repo-name">{row.owner}/{row.name}</td>
           <td class="description">{row.description ?? ""}</td>
           <td>{formatPushedAt(row.pushed_at)}</td>
-          <td><span class="chip chip-muted">{row.private ? "Private" : "Public"}</span></td>
+          <td>
+            <span class="chip chip-muted">{row.private ? "Private" : "Public"}</span>
+            {#if row.fork}<span class="chip chip-muted">Fork</span>{/if}
+          </td>
           <td>{#if row.already_configured}<span class="chip chip-amber">Already added</span>{/if}</td>
         </tr>
       {:else}
@@ -111,6 +138,8 @@
   .repo-preview-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
   .filter-input { flex: 1; min-width: 220px; font-size: 13px; padding: 6px 10px; background: var(--bg-inset); border: 1px solid var(--border-muted); border-radius: var(--radius-sm); }
   select { font-size: 13px; padding: 6px 8px; background: var(--bg-inset); color: var(--text-primary); border: 1px solid var(--border-muted); border-radius: var(--radius-sm); }
+  .toggle-filter { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--text-secondary); white-space: nowrap; }
+  .toggle-filter input { margin: 0; }
   .shortcut-btn, .sort-btn { font-size: 12px; color: var(--accent-blue); }
   .table-wrap { overflow: auto; border: 1px solid var(--border-muted); border-radius: var(--radius-md); }
   .repo-preview-table { width: 100%; border-collapse: collapse; font-size: 12px; }
@@ -122,7 +151,7 @@
   .description { color: var(--text-secondary); min-width: 180px; }
   .disabled-row { opacity: 0.72; }
   .empty-cell { text-align: center; color: var(--text-muted); padding: 24px; }
-  .chip { box-sizing: border-box; display: inline-flex; align-items: center; justify-content: center; min-height: 18px; padding: 0 6px; border-radius: 9px; font-size: 10px; font-weight: 600; line-height: 1; letter-spacing: 0.03em; text-transform: uppercase; white-space: nowrap; }
+  .chip { box-sizing: border-box; display: inline-flex; align-items: center; justify-content: center; min-height: 18px; margin-right: 4px; padding: 0 6px; border-radius: 9px; font-size: 10px; font-weight: 600; line-height: 1; letter-spacing: 0.03em; text-transform: uppercase; white-space: nowrap; }
   .chip-muted { background: var(--bg-inset); color: var(--text-muted); }
   .chip-amber { background: color-mix(in srgb, var(--accent-amber) 15%, transparent); color: var(--accent-amber); }
 </style>

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -117,6 +117,7 @@ describe("RepoSettings", () => {
         name: "api",
         description: "HTTP API",
         private: false,
+        fork: false,
         pushed_at: null,
         already_configured: false,
       }],

--- a/frontend/src/lib/components/settings/repoImportSelection.test.ts
+++ b/frontend/src/lib/components/settings/repoImportSelection.test.ts
@@ -11,10 +11,10 @@ import {
 } from "./repoImportSelection.js";
 
 const rows: RepoImportRow[] = [
-  { owner: "acme", name: "worker", description: "Background jobs", private: false, pushed_at: "2026-04-20T00:00:00Z", already_configured: false },
-  { owner: "acme", name: "api", description: "HTTP API", private: true, pushed_at: "2026-04-22T00:00:00Z", already_configured: false },
-  { owner: "acme", name: "empty", description: null, private: false, pushed_at: null, already_configured: false },
-  { owner: "acme", name: "widget", description: "Configured", private: false, pushed_at: "2026-04-21T00:00:00Z", already_configured: true },
+  { owner: "acme", name: "worker", description: "Background jobs", private: false, fork: false, pushed_at: "2026-04-20T00:00:00Z", already_configured: false },
+  { owner: "acme", name: "api", description: "HTTP API", private: true, fork: false, pushed_at: "2026-04-22T00:00:00Z", already_configured: false },
+  { owner: "acme", name: "empty", description: null, private: false, fork: false, pushed_at: null, already_configured: false },
+  { owner: "acme", name: "widget", description: "Configured", private: false, fork: true, pushed_at: "2026-04-21T00:00:00Z", already_configured: true },
 ];
 
 describe("repo import selection helpers", () => {
@@ -35,6 +35,12 @@ describe("repo import selection helpers", () => {
     const selected = new Set([rowKey(rows[0]!)]);
     expect(filterRows(rows, "", "selected", selected).map((row) => row.name)).toEqual(["worker"]);
     expect(filterRows(rows, "", "unselected", selected).map((row) => row.name)).toEqual(["api", "empty"]);
+  });
+
+  it("filters private repositories and forks independently", () => {
+    expect(filterRows(rows, "", "all", new Set(), { hidePrivate: true }).map((row) => row.name)).toEqual(["worker", "empty", "widget"]);
+    expect(filterRows(rows, "", "all", new Set(), { hideForks: true }).map((row) => row.name)).toEqual(["worker", "api", "empty"]);
+    expect(filterRows(rows, "", "all", new Set(), { hidePrivate: true, hideForks: true }).map((row) => row.name)).toEqual(["worker", "empty"]);
   });
 
   it("sorts deterministically with null pushed_at last", () => {
@@ -78,5 +84,6 @@ describe("repo import selection helpers", () => {
     const sorted = sortRows(rows, { field: "name", direction: "asc" });
     const selected = new Set(["acme/worker", "acme/api"]);
     expect(selectedRowsForSubmit(sorted, selected).map((row) => row.name)).toEqual(["api", "worker"]);
+    expect(selectedRowsForSubmit(sorted, selected, { hidePrivate: true }).map((row) => row.name)).toEqual(["worker"]);
   });
 });

--- a/frontend/src/lib/components/settings/repoImportSelection.ts
+++ b/frontend/src/lib/components/settings/repoImportSelection.ts
@@ -7,6 +7,7 @@ export interface RepoImportRow {
   name: string;
   description: string | null;
   private: boolean;
+  fork: boolean;
   pushed_at: string | null;
   already_configured: boolean;
 }
@@ -14,6 +15,11 @@ export interface RepoImportRow {
 export interface SortState {
   field: SortField;
   direction: SortDirection;
+}
+
+export interface RepoVisibilityFilters {
+  hideForks?: boolean;
+  hidePrivate?: boolean;
 }
 
 export function rowKey(row: Pick<RepoImportRow, "owner" | "name">): string {
@@ -41,9 +47,12 @@ export function filterRows(
   query: string,
   status: StatusFilter,
   selected = new Set<string>(),
+  visibilityFilters: RepoVisibilityFilters = {},
 ): RepoImportRow[] {
   const needle = query.trim().toLowerCase();
   return rows.filter((row) => {
+    if (visibilityFilters.hidePrivate && row.private) return false;
+    if (visibilityFilters.hideForks && row.fork) return false;
     const key = rowKey(row);
     const matchesText = needle === "" ||
       key.includes(needle) ||
@@ -123,6 +132,11 @@ export function applyRangeSelection(input: {
 export function selectedRowsForSubmit(
   sortedRows: RepoImportRow[],
   selected: Set<string>,
+  visibilityFilters: RepoVisibilityFilters = {},
 ): RepoImportRow[] {
-  return sortedRows.filter((row) => selected.has(rowKey(row)) && !row.already_configured);
+  return sortedRows.filter((row) => {
+    if (visibilityFilters.hidePrivate && row.private) return false;
+    if (visibilityFilters.hideForks && row.fork) return false;
+    return selected.has(rowKey(row)) && !row.already_configured;
+  });
 }

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -107,6 +107,84 @@ test("settings imports a selected subset from a repository glob", async ({ page 
   }).toBe("api");
 });
 
+test("repository import can hide forks and private repositories before adding", async ({ page }) => {
+  let bulkRepos: Array<{ owner: string; name: string }> | undefined;
+  await page.route("**/api/v1/repos/preview", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        owner: "import-lab",
+        pattern: "*",
+        repos: [
+          {
+            owner: "import-lab",
+            name: "public-source",
+            description: "Source repository",
+            private: false,
+            fork: false,
+            pushed_at: "2026-04-22T10:00:00Z",
+            already_configured: false,
+          },
+          {
+            owner: "import-lab",
+            name: "private-source",
+            description: "Private repository",
+            private: true,
+            fork: false,
+            pushed_at: "2026-04-23T10:00:00Z",
+            already_configured: false,
+          },
+          {
+            owner: "import-lab",
+            name: "public-fork",
+            description: "Forked repository",
+            private: false,
+            fork: true,
+            pushed_at: "2026-04-24T10:00:00Z",
+            already_configured: false,
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("**/api/v1/repos/bulk", async (route) => {
+    const body = route.request().postDataJSON() as { repos: Array<{ owner: string; name: string }> };
+    bulkRepos = body.repos;
+    await route.fulfill({
+      contentType: "application/json",
+      status: 201,
+      body: JSON.stringify({
+        repos: [{ owner: "import-lab", name: "public-source", is_glob: false, matched_repo_count: 1 }],
+        activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false },
+        terminal: { font_family: "" },
+      }),
+    });
+  });
+
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+
+  await page.getByRole("button", { name: "Add repositories…" }).click();
+  const dialog = page.getByRole("dialog", { name: "Add repositories" });
+  await dialog.getByLabel("Repository pattern").fill("import-lab/*");
+  await dialog.getByRole("button", { name: "Preview" }).click();
+
+  await expect(dialog.getByText("import-lab/public-source")).toBeVisible();
+  await expect(dialog.getByText("import-lab/private-source")).toBeVisible();
+  await expect(dialog.getByText("import-lab/public-fork")).toBeVisible();
+
+  await dialog.getByLabel("Hide private").check();
+  await dialog.getByLabel("Hide forks").check();
+  await expect(dialog.getByText("import-lab/public-source")).toBeVisible();
+  await expect(dialog.getByText("import-lab/private-source")).toHaveCount(0);
+  await expect(dialog.getByText("import-lab/public-fork")).toHaveCount(0);
+  await expect(dialog.getByText("Selected 1 of 1")).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Add selected repositories" }).click();
+
+  expect(bulkRepos).toEqual([{ owner: "import-lab", name: "public-source" }]);
+});
+
 test("repository import traps keyboard focus inside the dialog", async ({ page }) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
   await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
@@ -157,6 +235,7 @@ test("repository import ignores older preview responses", async ({ page }) => {
             name: "middleman",
             description: "Main dashboard",
             private: false,
+            fork: false,
             pushed_at: "2026-04-22T10:00:00Z",
             already_configured: false,
           }],
@@ -174,6 +253,7 @@ test("repository import ignores older preview responses", async ({ page }) => {
           name: "review-bot",
           description: "Review automation",
           private: false,
+          fork: false,
           pushed_at: "2026-04-24T09:15:00Z",
           already_configured: false,
         }],

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -611,6 +611,7 @@ type RepoPreviewResponse struct {
 type RepoPreviewRow struct {
 	AlreadyConfigured bool    `json:"already_configured"`
 	Description       *string `json:"description"`
+	Fork              bool    `json:"fork"`
 	Name              string  `json:"name"`
 	Owner             string  `json:"owner"`
 	Private           bool    `json:"private"`

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	gh "github.com/google/go-github/v84/github"
@@ -128,6 +129,8 @@ type liveClient struct {
 	rateTracker     *RateTracker
 	graphQLEndpoint string
 	etag            *etagTransport
+	viewerMu        sync.Mutex
+	viewerLogin     string
 }
 
 // InvalidateListETagsForRepo evicts cached ETag entries for the repo's
@@ -389,6 +392,33 @@ func (c *liveClient) ListOpenIssues(
 func (c *liveClient) ListRepositoriesByOwner(
 	ctx context.Context, owner string,
 ) ([]*gh.Repository, error) {
+	viewerLogin, viewerErr := c.authenticatedLogin(ctx)
+	if viewerErr == nil && strings.EqualFold(owner, viewerLogin) {
+		repos, err := collectPages(
+			ctx,
+			func(opts *gh.ListOptions) ([]*gh.Repository, *gh.Response, error) {
+				page, resp, err := c.gh.Repositories.ListByAuthenticatedUser(
+					ctx, &gh.RepositoryListByAuthenticatedUserOptions{
+						Affiliation: "owner",
+						ListOptions: *opts,
+					},
+				)
+				if err != nil {
+					return nil, resp, err
+				}
+				return page, resp, nil
+			},
+			c.trackRate,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"listing repositories for authenticated owner %s: %w",
+				owner, err,
+			)
+		}
+		return repos, nil
+	}
+
 	orgRepos, err := collectPages(
 		ctx,
 		func(opts *gh.ListOptions) ([]*gh.Repository, *gh.Response, error) {
@@ -432,6 +462,25 @@ func (c *liveClient) ListRepositoriesByOwner(
 		)
 	}
 	return userRepos, nil
+}
+
+func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
+	c.viewerMu.Lock()
+	defer c.viewerMu.Unlock()
+	if c.viewerLogin != "" {
+		return c.viewerLogin, nil
+	}
+	user, resp, err := c.gh.Users.Get(ctx, "")
+	c.trackRate(resp)
+	if err != nil {
+		return "", fmt.Errorf("getting authenticated user: %w", err)
+	}
+	login := user.GetLogin()
+	if login == "" {
+		return "", fmt.Errorf("authenticated user login is empty")
+	}
+	c.viewerLogin = login
+	return login, nil
 }
 
 func (c *liveClient) GetIssue(

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,10 +1,12 @@
 package github
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,6 +88,101 @@ func TestListReleasesTracksRate(t *testing.T) {
 	require.Equal(1, rt.RequestsThisHour())
 	require.Equal(4998, rt.Remaining())
 	require.Equal(5000, rt.RateLimit())
+}
+
+func TestListRepositoriesByOwnerUsesAuthenticatedEndpointForViewer(t *testing.T) {
+	require := require.New(t)
+	var paths []string
+	var authenticatedAffiliation string
+	var authenticatedType string
+	var publicUserEndpointUsed bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/user", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"login":"mariusvniekerk"}`))
+	})
+	mux.HandleFunc("/api/v3/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.String())
+		authenticatedAffiliation = r.URL.Query().Get("affiliation")
+		authenticatedType = r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"name":     "dotfiles2026",
+			"private":  true,
+			"fork":     false,
+			"owner":    map[string]string{"login": "mariusvniekerk"},
+			"archived": false,
+		}})
+	})
+	mux.HandleFunc("/api/v3/users/mariusvniekerk/repos", func(w http.ResponseWriter, r *http.Request) {
+		publicUserEndpointUsed = true
+		http.Error(w, "unexpected endpoint", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ghClient, err := gh.NewClient(srv.Client()).WithEnterpriseURLs(
+		srv.URL+"/api/v3/", srv.URL+"/api/uploads/",
+	)
+	require.NoError(err)
+	c := &liveClient{gh: ghClient}
+
+	repos, err := c.ListRepositoriesByOwner(t.Context(), "mariusvniekerk")
+	require.NoError(err)
+	require.Len(repos, 1)
+	require.Equal("dotfiles2026", repos[0].GetName())
+	require.True(repos[0].GetPrivate())
+	require.Equal("owner", authenticatedAffiliation)
+	require.Empty(authenticatedType)
+	require.False(publicUserEndpointUsed)
+	require.Equal([]string{
+		"/api/v3/user",
+		"/api/v3/user/repos?affiliation=owner&per_page=100",
+	}, paths)
+}
+
+func TestListRepositoriesByOwnerUsesPublicUserEndpointForOtherUsers(t *testing.T) {
+	require := require.New(t)
+	var paths []string
+	var userRepoType string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/user", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"login":"mariusvniekerk"}`))
+	})
+	mux.HandleFunc("/api/v3/orgs/acme/repos", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.String())
+		http.Error(w, "not an org", http.StatusNotFound)
+	})
+	mux.HandleFunc("/api/v3/users/acme/repos", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.String())
+		userRepoType = r.URL.Query().Get("type")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"name":  "public-repo",
+			"owner": map[string]string{"login": "acme"},
+		}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ghClient, err := gh.NewClient(srv.Client()).WithEnterpriseURLs(
+		srv.URL+"/api/v3/", srv.URL+"/api/uploads/",
+	)
+	require.NoError(err)
+	c := &liveClient{gh: ghClient}
+
+	repos, err := c.ListRepositoriesByOwner(t.Context(), "acme")
+	require.NoError(err)
+	require.Len(repos, 1)
+	require.Equal("public-repo", repos[0].GetName())
+	require.Equal("owner", userRepoType)
+	require.True(strings.HasPrefix(paths[1], "/api/v3/orgs/acme/repos?"))
+	require.True(strings.HasPrefix(paths[2], "/api/v3/users/acme/repos?"))
 }
 
 func TestListForcePushEvents(t *testing.T) {

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	gh "github.com/google/go-github/v84/github"
 	"github.com/wesm/middleman/internal/config"
 	ghclient "github.com/wesm/middleman/internal/github"
 )
@@ -37,6 +38,7 @@ type repoPreviewRow struct {
 	Name              string  `json:"name"`
 	Description       *string `json:"description"`
 	Private           bool    `json:"private"`
+	Fork              bool    `json:"fork"`
 	PushedAt          *string `json:"pushed_at"`
 	AlreadyConfigured bool    `json:"already_configured"`
 }
@@ -111,6 +113,39 @@ func exactConfiguredRepoSet(repos []config.Repo) map[string]struct{} {
 	return set
 }
 
+func repoImportPatternHasGlob(pattern string) bool {
+	return strings.ContainsAny(pattern, "*?[]")
+}
+
+func buildRepoPreviewRow(
+	repo *gh.Repository,
+	fallbackOwner string,
+	exactConfigured map[string]struct{},
+) repoPreviewRow {
+	name := repo.GetName()
+	canonicalOwner := repo.GetOwner().GetLogin()
+	if canonicalOwner == "" {
+		canonicalOwner = fallbackOwner
+	}
+	canonicalOwner = strings.ToLower(canonicalOwner)
+	canonicalName := strings.ToLower(name)
+	var pushedAt *string
+	if repo.PushedAt != nil {
+		formatted := repo.PushedAt.Time.UTC().Format(time.RFC3339)
+		pushedAt = &formatted
+	}
+	_, already := exactConfigured[canonicalOwner+"/"+canonicalName]
+	return repoPreviewRow{
+		Owner:             canonicalOwner,
+		Name:              canonicalName,
+		Description:       repo.Description,
+		Private:           repo.GetPrivate(),
+		Fork:              repo.GetFork(),
+		PushedAt:          pushedAt,
+		AlreadyConfigured: already,
+	}
+}
+
 func buildRepoPreviewRows(
 	ctx context.Context,
 	client ghclient.Client,
@@ -137,26 +172,13 @@ func buildRepoPreviewRows(
 		if !matched {
 			continue
 		}
-		canonicalOwner := repo.GetOwner().GetLogin()
-		if canonicalOwner == "" {
-			canonicalOwner = owner
+		rows = append(rows, buildRepoPreviewRow(repo, owner, exactConfigured))
+	}
+	if len(rows) == 0 && !repoImportPatternHasGlob(pattern) {
+		repo, err := client.GetRepository(ctx, owner, pattern)
+		if err == nil && !repo.GetArchived() {
+			rows = append(rows, buildRepoPreviewRow(repo, owner, exactConfigured))
 		}
-		canonicalOwner = strings.ToLower(canonicalOwner)
-		canonicalName := strings.ToLower(name)
-		var pushedAt *string
-		if repo.PushedAt != nil {
-			formatted := repo.PushedAt.Time.UTC().Format(time.RFC3339)
-			pushedAt = &formatted
-		}
-		_, already := exactConfigured[canonicalOwner+"/"+canonicalName]
-		rows = append(rows, repoPreviewRow{
-			Owner:             canonicalOwner,
-			Name:              canonicalName,
-			Description:       repo.Description,
-			Private:           repo.GetPrivate(),
-			PushedAt:          pushedAt,
-			AlreadyConfigured: already,
-		})
 	}
 	return rows, nil
 }

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -909,6 +909,8 @@ func TestHandlePreviewReposFiltersAndMarksAlreadyConfigured(t *testing.T) {
 	pushedOlder := gh.Timestamp{Time: time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC)}
 	privateRepo := true
 	publicRepo := false
+	regularRepo := false
+	forkRepo := true
 	mock := &mockGH{
 		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
 			return []*gh.Repository{
@@ -917,6 +919,7 @@ func TestHandlePreviewReposFiltersAndMarksAlreadyConfigured(t *testing.T) {
 					Owner:       &gh.User{Login: new(owner)},
 					Description: new("already configured widget"),
 					Private:     &privateRepo,
+					Fork:        &regularRepo,
 					Archived:    new(false),
 					PushedAt:    &pushedOlder,
 				},
@@ -925,6 +928,7 @@ func TestHandlePreviewReposFiltersAndMarksAlreadyConfigured(t *testing.T) {
 					Owner:       &gh.User{Login: new(owner)},
 					Description: new("api service"),
 					Private:     &publicRepo,
+					Fork:        &forkRepo,
 					Archived:    new(false),
 					PushedAt:    &pushedNewer,
 				},
@@ -977,9 +981,70 @@ name = "widget-*"
 	assert.Equal(pushedOlder.Time.UTC().Format(time.RFC3339), *resp.Repos[0].PushedAt)
 	assert.Equal("widget-api", resp.Repos[1].Name)
 	assert.False(resp.Repos[1].Private)
+	assert.True(resp.Repos[1].Fork)
 	assert.False(resp.Repos[1].AlreadyConfigured)
 	assert.NotContains(rr.Body.String(), "widget-archive")
 	assert.NotContains(rr.Body.String(), "other")
+}
+
+func TestHandlePreviewReposFallsBackToExactLookupWhenListOmitsRepo(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	privateRepo := true
+	forkRepo := false
+	pushedAt := gh.Timestamp{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	name := "dotfiles2026"
+	ownerLogin := "mariusvniekerk"
+	description := "personal dotfiles"
+	var listCalls atomic.Int32
+	var getCalls atomic.Int32
+	mock := &mockGH{
+		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
+			listCalls.Add(1)
+			assert.Equal("mariusvniekerk", owner)
+			return []*gh.Repository{}, nil
+		},
+		getRepositoryFn: func(_ context.Context, owner, repo string) (*gh.Repository, error) {
+			getCalls.Add(1)
+			assert.Equal("mariusvniekerk", owner)
+			assert.Equal("dotfiles2026", repo)
+			return &gh.Repository{
+				Name:        &name,
+				Owner:       &gh.User{Login: &ownerLogin},
+				Description: &description,
+				Private:     &privateRepo,
+				Fork:        &forkRepo,
+				Archived:    new(false),
+				PushedAt:    &pushedAt,
+			}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+`, mock)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+		"owner":   "mariusvniekerk",
+		"pattern": "dotfiles2026",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp repoPreviewResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp.Repos, 1)
+	assert.Equal(int32(1), listCalls.Load())
+	assert.Equal(int32(1), getCalls.Load())
+	assert.Equal("mariusvniekerk", resp.Repos[0].Owner)
+	assert.Equal("dotfiles2026", resp.Repos[0].Name)
+	assert.Equal("personal dotfiles", *resp.Repos[0].Description)
+	assert.True(resp.Repos[0].Private)
+	assert.False(resp.Repos[0].Fork)
+	assert.False(resp.Repos[0].AlreadyConfigured)
+	require.NotNil(resp.Repos[0].PushedAt)
+	assert.Equal(pushedAt.Time.UTC().Format(time.RFC3339), *resp.Repos[0].PushedAt)
 }
 
 func TestHandlePreviewReposRejectsInvalidPattern(t *testing.T) {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1539,6 +1539,7 @@ export interface components {
         RepoPreviewRow: {
             already_configured: boolean;
             description: string | null;
+            fork: boolean;
             name: string;
             owner: string;
             private: boolean;


### PR DESCRIPTION
## Summary
- Include private repositories owned by the authenticated user in Add repositories previews.
- Keep exact private repo lookup as a fallback for direct searches.
- Add Hide forks and Hide private controls to the import preview.