### PR TITLE
Fix frontend CI after generated client migration

### DIFF
--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -25,7 +25,7 @@ export function createRuntimeClient(
   fetch?: FetchFn,
   clientBaseURL = baseUrl,
 ) {
-  const inner = fetch ?? globalThis.fetch.bind(globalThis);
+  const inner = fetch ?? ((input: Request) => globalThis.fetch(input));
   return createAPIClient(clientBaseURL, {
     fetch: csrfFetch(inner),
     querySerializer,

--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -25,7 +25,10 @@ export function createRuntimeClient(
   fetch?: FetchFn,
   clientBaseURL = baseUrl,
 ) {
-  const inner = fetch ?? ((input: Request) => globalThis.fetch(input));
+  const inner =
+    fetch ??
+    ((...args: Parameters<typeof globalThis.fetch>) =>
+      globalThis.fetch(...args));
   return createAPIClient(clientBaseURL, {
     fetch: csrfFetch(inner),
     querySerializer,

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -105,6 +105,20 @@ const runningSession = {
   created_at: "2026-04-29T00:00:00Z",
 };
 
+const workspaceResponse = {
+  id: "ws-1",
+  platform_host: "github.com",
+  repo_owner: "acme",
+  repo_name: "widget",
+  item_type: "pull_request",
+  item_number: 7,
+  git_head_ref: "feature/session-exit",
+  worktree_path: "/tmp/worktree",
+  tmux_session: "middleman-ws-1",
+  status: "ready",
+  created_at: "2026-04-29T00:00:00Z",
+};
+
 function runtimeWithSession(createdAt: string) {
   return {
     launch_targets: [],
@@ -172,22 +186,22 @@ describe("WorkspaceTerminalView", () => {
     mocks.ensureWorkspaceShell.mockReset();
     mocks.terminalWrite.mockReset();
 
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        id: "ws-1",
-        platform_host: "github.com",
-        repo_owner: "acme",
-        repo_name: "widget",
-        item_type: "pull_request",
-        item_number: 7,
-        git_head_ref: "feature/session-exit",
-        worktree_path: "/tmp/worktree",
-        tmux_session: "middleman-ws-1",
-        status: "ready",
-        created_at: "2026-04-29T00:00:00Z",
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const { pathname } = new URL(url);
+        if (pathname.endsWith("/api/v1/workspaces/ws-1")) {
+          return Promise.resolve(Response.json(workspaceResponse));
+        }
+        if (pathname.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({
+            workspaces: [workspaceResponse],
+          }));
+        }
+        return Promise.resolve(Response.json({}));
       }),
-    }));
+    );
     vi.stubGlobal("EventSource", class {
       addEventListener(): void {}
       close(): void {}

--- a/packages/ui/src/api/csrf.test.ts
+++ b/packages/ui/src/api/csrf.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { csrfFetch } from "./csrf.js";
+
+describe("csrfFetch", () => {
+  it("forwards fetch init options when called with a URL", async () => {
+    let request: Request | null = null;
+    const inner = vi.fn(async (input: RequestInfo | URL) => {
+      request = input instanceof Request ? input : new Request(input);
+      return Response.json({});
+    });
+
+    const fetch = csrfFetch(inner);
+    await fetch("https://middleman.test/api/v1/settings", {
+      method: "POST",
+      body: JSON.stringify({ theme: "dark" }),
+      headers: { "X-Test": "present" },
+    });
+
+    expect(request?.url).toBe("https://middleman.test/api/v1/settings");
+    expect(request?.method).toBe("POST");
+    expect(request?.headers.get("X-Test")).toBe("present");
+    await expect(request?.text()).resolves.toBe('{"theme":"dark"}');
+  });
+});

--- a/packages/ui/src/api/csrf.ts
+++ b/packages/ui/src/api/csrf.ts
@@ -1,17 +1,16 @@
-export type FetchFn = (
-  input: Request,
-) => Promise<Response>;
+export type FetchFn = typeof globalThis.fetch;
 
 export function csrfFetch(inner: FetchFn): FetchFn {
-  return (input: Request) => {
-    const method = input.method.toUpperCase();
+  return (input, init) => {
+    const request = new Request(input, init);
+    const method = request.method.toUpperCase();
     if (method !== "GET" && method !== "HEAD") {
-      if (!input.headers.has("Content-Type")) {
-        const headers = new Headers(input.headers);
+      if (!request.headers.has("Content-Type")) {
+        const headers = new Headers(request.headers);
         headers.set("Content-Type", "application/json");
-        return inner(new Request(input, { headers }));
+        return inner(new Request(request, { headers }));
       }
     }
-    return inner(input);
+    return inner(request);
   };
 }


### PR DESCRIPTION
- Defer runtime client fetch lookup so Vitest and browser callers use the current fetch implementation.
- Return fresh routed Response objects from the workspace terminal test fixture so it matches the generated client contract.