### PR TITLE
Fix issue detail actions to match PR buttons and add frontend bootstrap target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DEV_LOG_DIR ?= tmp/logs
 DEV_BACKEND_LOG ?= $(DEV_LOG_DIR)/backend-dev.log
 
 .PHONY: ensure-embed-dir check-air air-install build build-release install \
-        frontend frontend-dev frontend-dev-bun frontend-check api-generate roborev-api-generate \
+        frontend-deps frontend frontend-dev frontend-dev-bun frontend-check api-generate roborev-api-generate \
         dev test test-short test-e2e test-e2e-roborev vet lint nilaway testify-helper-check \
         frontend-api-client-check huma-route-check script-tests guardrail-check tidy svelte-skills svelte-skills-sync clean install-hooks help
 
@@ -57,9 +57,13 @@ install: build-release
 		cp $(BINARY) "$$INSTALL_DIR/$(BINARY)"; \
 	fi
 
+# Install Bun workspace dependencies for frontend and packages/ui
+frontend-deps:
+	bun install
+
 # Build frontend SPA and copy into embed directory
-frontend:
-	cd frontend && bun install && bun run build
+frontend: frontend-deps
+	cd frontend && bun run build
 	rm -rf internal/web/dist
 	cp -r frontend/dist internal/web/dist
 	printf 'ok\n' > internal/web/dist/stub.html
@@ -69,11 +73,11 @@ frontend-dev:
 	./scripts/frontend-dev.sh $(ARGS)
 
 # Run Vite dev server with Bun (use alongside `make dev`)
-frontend-dev-bun:
-	cd frontend && bun install && bun run dev
+frontend-dev-bun: frontend-deps
+	cd frontend && bun run dev
 
 # Run TypeScript/Svelte lint and type checks
-frontend-check:
+frontend-check: frontend-deps
 	cd packages/ui && bun run typecheck && bun run lint
 	cd frontend && bun run typecheck && bun run lint
 
@@ -233,6 +237,7 @@ help:
 	@echo "  air-install    - Install air live reload tool"
 	@echo ""
 	@echo "  dev            - Run Go server with air live reload, debug file logs, and info-level console logs"
+	@echo "  frontend-deps  - Install Bun workspace dependencies for frontend and packages/ui"
 	@echo "  frontend       - Build frontend SPA"
 	@echo "  frontend-dev   - Install deps and run Vite dev server, logging to tmp/logs/frontend-dev.log (honors MIDDLEMAN_CONFIG)"
 	@echo "  frontend-dev-bun - Install deps with Bun and run Vite dev server (honors MIDDLEMAN_CONFIG)"

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -62,7 +62,7 @@ describe("RepoImportModal", () => {
 
   it("hides private repositories and forks from preview selection", async () => {
     preview.mockResolvedValue({ owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" } });
+    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" }, agents: [] });
     render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -14,6 +14,10 @@
   import Chip from "../shared/Chip.svelte";
   import GitHubLabels from "../shared/GitHubLabels.svelte";
   import CopyItemNumber from "./CopyItemNumber.svelte";
+  import MonitorUpIcon from "@lucide/svelte/icons/monitor-up";
+  import PackagePlusIcon from "@lucide/svelte/icons/package-plus";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
+  import XIcon from "@lucide/svelte/icons/x";
 
   const { issues, activity } = getStores();
   const client = getClient();
@@ -465,20 +469,27 @@
           <ActionButton
             class="btn--workspace"
             onclick={() => navigate(`/terminal/${workspace.id}`)}
-            tone="success"
-            surface="solid"
+            tone="info"
+            surface="soft"
             size="sm"
+            label="Open Workspace"
+            shortLabel="Workspace"
           >
-            Open Workspace
+            <MonitorUpIcon size="14" strokeWidth="2.2" aria-hidden="true" />
           </ActionButton>
         {:else}
-          <button
+          <ActionButton
             class="btn--workspace"
             disabled={workspaceCreating || staleIssue}
             onclick={() => void createWorkspace()}
+            tone="info"
+            surface="soft"
+            size="sm"
+            label={workspaceCreating ? "Creating..." : "Create Workspace"}
+            shortLabel={workspaceCreating ? "Creating..." : "Create Workspace"}
           >
-            {workspaceCreating ? "Creating..." : "Create Workspace"}
-          </button>
+            <PackagePlusIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+          </ActionButton>
         {/if}
         {#if issue.State === "open"}
           <ActionButton
@@ -488,8 +499,10 @@
             tone="danger"
             surface="outline"
             size="sm"
+            label={stateSubmitting ? "Closing..." : "Close issue"}
+            shortLabel={stateSubmitting ? "Closing..." : "Close"}
           >
-            {stateSubmitting ? "Closing..." : "Close issue"}
+            <XIcon size="14" strokeWidth="2.2" aria-hidden="true" />
           </ActionButton>
         {:else}
           <ActionButton
@@ -499,8 +512,10 @@
             tone="success"
             surface="solid"
             size="sm"
+            label={stateSubmitting ? "Reopening..." : "Reopen issue"}
+            shortLabel={stateSubmitting ? "Reopening..." : "Reopen"}
           >
-            {stateSubmitting ? "Reopening..." : "Reopen issue"}
+            <RefreshCwIcon size="14" strokeWidth="2.2" aria-hidden="true" />
           </ActionButton>
         {/if}
         {#if workspaceError}
@@ -897,27 +912,6 @@
     align-items: center;
     gap: 8px;
     padding: 8px 0;
-  }
-
-  .btn--workspace {
-    padding: 4px 12px;
-    border-radius: 6px;
-    font-size: 12px;
-    font-weight: 500;
-    border: 1px solid var(--accent-blue, #0969da);
-    background: var(--accent-blue, #0969da);
-    color: #fff;
-    cursor: pointer;
-    transition: filter 0.1s;
-  }
-
-  .btn--workspace:hover {
-    filter: brightness(1.1);
-  }
-
-  .btn--workspace:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
   }
 
   .action-error {


### PR DESCRIPTION
## Summary
- Reused the shared `ActionButton` component in issue detail for workspace and close/reopen actions so the issue UI matches PR behavior.
- Added lucide icons and responsive labels for issue workspace and state buttons, and removed the bespoke workspace button styling.
- Added a root `frontend-deps` Make target that runs `bun install`, then made frontend build/check/dev-Bun targets depend on it for fresh worktrees.
- Fixed a stale frontend test fixture by adding the missing `agents` field.

## Testing
- `make frontend-deps`
- `make frontend-check`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd frontend typecheck`
- Hook-enforced commit checks passed