### PR TITLE
Fix PR and issue detail scrollbars at the pane edge

### DIFF
--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -62,7 +62,7 @@ describe("RepoImportModal", () => {
 
   it("hides private repositories and forks from preview selection", async () => {
     preview.mockResolvedValue({ owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" } });
+    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" }, agents: [] });
     render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -155,13 +155,16 @@ test.describe("issue list view", () => {
     expect(detailBox).not.toBeNull();
     expect(headerBox).not.toBeNull();
     if (areaBox !== null && detailBox !== null && headerBox !== null) {
-      const areaCenter = areaBox.x + areaBox.width / 2;
+      const scrollportWidth = await issueDetail.evaluate(
+        (el) => el.clientWidth,
+      );
+      const scrollportCenter = detailBox.x + scrollportWidth / 2;
       const headerCenter = headerBox.x + headerBox.width / 2;
       // Allow small slack for sub-pixel layout differences.
       expect(
         Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width)),
       ).toBeLessThan(2);
-      expect(Math.abs(headerCenter - areaCenter)).toBeLessThan(2);
+      expect(Math.abs(headerCenter - scrollportCenter)).toBeLessThan(2);
       expect(headerBox.width).toBeLessThanOrEqual(800);
     }
   });

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -8,7 +8,9 @@ import { expect, test, type Page } from "@playwright/test";
 //   acme/tools#5: open, dave, "Support config file loading"
 
 async function waitForIssueList(page: Page): Promise<void> {
-  await page.locator(".issue-item").first()
+  await page
+    .locator(".issue-item")
+    .first()
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
@@ -23,8 +25,12 @@ test.describe("issue list view", () => {
     await expect(countBadge).toHaveText(/^4 issues$/);
   });
 
-  test("sidebar issue pills use the shared chip component", async ({ page }) => {
-    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(/^4 issues$/);
+  test("sidebar issue pills use the shared chip component", async ({
+    page,
+  }) => {
+    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(
+      /^4 issues$/,
+    );
 
     await page.locator(".group-btn", { hasText: "All" }).click();
     const firstItem = page.locator(".issue-item").first();
@@ -44,8 +50,10 @@ test.describe("issue list view", () => {
     await input.fill("Safari");
 
     // Wait for the filtered result to appear (replaces fixed sleep).
-    await expect(page.locator(".filter-bar .list-count-chip"))
-      .toHaveText(/^1 issues?$/, { timeout: 5_000 });
+    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(
+      /^1 issues?$/,
+      { timeout: 5_000 },
+    );
 
     const items = page.locator(".issue-item");
     const count = await items.count();
@@ -57,8 +65,11 @@ test.describe("issue list view", () => {
     }
   });
 
-  test("issue detail state chip preserves shared chip layout", async ({ page }) => {
-    await page.locator(".issue-item")
+  test("issue detail state chip preserves shared chip layout", async ({
+    page,
+  }) => {
+    await page
+      .locator(".issue-item")
       .filter({ hasText: "Safari" })
       .first()
       .click();
@@ -81,10 +92,13 @@ test.describe("issue list view", () => {
     expect(stateChipStyles.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
   });
 
-  test("issue detail scrolls internally and centers horizontally", async ({ page }) => {
+  test("issue detail keeps the scrollbar on the pane edge", async ({
+    page,
+  }) => {
     // Open the Safari issue specifically. Matches widgets#10 on the
     // seeded fixture (max-width 800px centered layout).
-    await page.locator(".issue-item")
+    await page
+      .locator(".issue-item")
       .filter({ hasText: "Safari" })
       .first()
       .click();
@@ -129,20 +143,26 @@ test.describe("issue list view", () => {
     const finalScroll = await issueDetail.evaluate((el) => el.scrollTop);
     expect(finalScroll).toBeGreaterThan(0);
 
-    // Centering check: .issue-detail has max-width 800px and
-    // margin-inline: auto. Compare its horizontal center against the
-    // center of its parent .main-area container (the PR list view
-    // has a sidebar, so the viewport center is not relevant).
+    // The scroll container should span the detail pane so the native
+    // scrollbar is flush with the pane edge, not the centered content
+    // column. The header remains in the capped content column.
     const detailArea = page.locator(".main-area");
+    const contentHeader = page.locator(".issue-detail .detail-header");
     const areaBox = await detailArea.boundingBox();
     const detailBox = await issueDetail.boundingBox();
+    const headerBox = await contentHeader.boundingBox();
     expect(areaBox).not.toBeNull();
     expect(detailBox).not.toBeNull();
-    if (areaBox !== null && detailBox !== null) {
+    expect(headerBox).not.toBeNull();
+    if (areaBox !== null && detailBox !== null && headerBox !== null) {
       const areaCenter = areaBox.x + areaBox.width / 2;
-      const detailCenter = detailBox.x + detailBox.width / 2;
+      const headerCenter = headerBox.x + headerBox.width / 2;
       // Allow small slack for sub-pixel layout differences.
-      expect(Math.abs(detailCenter - areaCenter)).toBeLessThan(2);
+      expect(
+        Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width)),
+      ).toBeLessThan(2);
+      expect(Math.abs(headerCenter - areaCenter)).toBeLessThan(2);
+      expect(headerBox.width).toBeLessThanOrEqual(800);
     }
   });
 });

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -6,7 +6,9 @@ import { expect, test, type Page } from "@playwright/test";
 
 async function waitForPullList(page: Page): Promise<void> {
   // Wait for at least one PR item to appear (data loaded).
-  await page.locator(".pull-item").first()
+  await page
+    .locator(".pull-item")
+    .first()
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
@@ -21,15 +23,21 @@ test.describe("PR list view", () => {
     await expect(countBadge).toHaveText(/^8 PRs$/);
   });
 
-  test("sidebar status pills use the shared chip component", async ({ page }) => {
-    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(/^8 PRs$/);
+  test("sidebar status pills use the shared chip component", async ({
+    page,
+  }) => {
+    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(
+      /^8 PRs$/,
+    );
 
     // Seeded fixtures have no kanban_state rows; visiting a PR detail
     // creates the row server-side via EnsureKanbanState. Without this,
     // .status-chip never renders because PullItem hides it for empty
     // KanbanStatus.
     await page.locator(".pull-item").first().click();
-    await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 5_000 });
+    await page
+      .locator(".pull-detail")
+      .waitFor({ state: "visible", timeout: 5_000 });
     await page.goto("/pulls");
     await waitForPullList(page);
 
@@ -39,7 +47,9 @@ test.describe("PR list view", () => {
     await expect(firstItem.locator(".status-chip")).toBeVisible();
   });
 
-  test("closed state shows closed and merged PRs with correct count", async ({ page }) => {
+  test("closed state shows closed and merged PRs with correct count", async ({
+    page,
+  }) => {
     await page.locator(".state-btn", { hasText: "Closed" }).click();
 
     const countBadge = page.locator(".filter-bar .list-count-chip");
@@ -54,13 +64,74 @@ test.describe("PR list view", () => {
     // matching item is already visible in the unfiltered list, so
     // we must wait on a condition that only becomes true after
     // the debounced search request completes.
-    await expect(page.locator(".filter-bar .list-count-chip"))
-      .toHaveText(/^1 PRs?$/, { timeout: 5_000 });
+    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(
+      /^1 PRs?$/,
+      { timeout: 5_000 },
+    );
 
     // Verify the single remaining item is the expected one.
     const items = page.locator(".pull-item");
     await expect(items).toHaveCount(1);
-    await expect(items.first().locator(".title"))
-      .toContainText("caching layer");
+    await expect(items.first().locator(".title")).toContainText(
+      "caching layer",
+    );
+  });
+
+  test("PR detail keeps the scrollbar on the pane edge", async ({ page }) => {
+    await page
+      .locator(".pull-item")
+      .filter({ hasText: "caching layer" })
+      .first()
+      .click();
+
+    const pullDetail = page.locator(".pull-detail");
+    await expect(pullDetail).toBeVisible();
+
+    await pullDetail.evaluate((el) => {
+      const filler = document.createElement("div");
+      filler.style.height = "3000px";
+      filler.style.flexShrink = "0";
+      filler.style.background = "transparent";
+      filler.setAttribute("data-test-filler", "pull-scroll");
+      el.appendChild(filler);
+    });
+
+    const overflowY = await pullDetail.evaluate(
+      (el) => getComputedStyle(el).overflowY,
+    );
+    expect(["auto", "scroll"]).toContain(overflowY);
+
+    const before = await pullDetail.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      scrollTop: el.scrollTop,
+    }));
+    expect(before.scrollHeight).toBeGreaterThan(before.clientHeight);
+    expect(before.scrollTop).toBe(0);
+
+    await pullDetail.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    const finalScroll = await pullDetail.evaluate((el) => el.scrollTop);
+    expect(finalScroll).toBeGreaterThan(0);
+
+    const detailArea = page.locator(".main-area");
+    const contentHeader = page.locator(".pull-detail .detail-header");
+    const areaBox = await detailArea.boundingBox();
+    const detailBox = await pullDetail.boundingBox();
+    const headerBox = await contentHeader.boundingBox();
+    expect(areaBox).not.toBeNull();
+    expect(detailBox).not.toBeNull();
+    expect(headerBox).not.toBeNull();
+    if (areaBox !== null && detailBox !== null && headerBox !== null) {
+      const areaCenter = areaBox.x + areaBox.width / 2;
+      const headerCenter = headerBox.x + headerBox.width / 2;
+      expect(
+        Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width)),
+      ).toBeLessThan(2);
+      expect(Math.abs(headerCenter - areaCenter)).toBeLessThan(2);
+      expect(headerBox.width).toBeLessThanOrEqual(800);
+    }
   });
 });

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -125,12 +125,15 @@ test.describe("PR list view", () => {
     expect(detailBox).not.toBeNull();
     expect(headerBox).not.toBeNull();
     if (areaBox !== null && detailBox !== null && headerBox !== null) {
-      const areaCenter = areaBox.x + areaBox.width / 2;
+      const scrollportWidth = await pullDetail.evaluate(
+        (el) => el.clientWidth,
+      );
+      const scrollportCenter = detailBox.x + scrollportWidth / 2;
       const headerCenter = headerBox.x + headerBox.width / 2;
       expect(
         Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width)),
       ).toBeLessThan(2);
-      expect(Math.abs(headerCenter - areaCenter)).toBeLessThan(2);
+      expect(Math.abs(headerCenter - scrollportCenter)).toBeLessThan(2);
       expect(headerBox.width).toBeLessThanOrEqual(800);
     }
   });

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -360,6 +360,7 @@
     {@const issue = detail.issue}
     {@const labels = issue.labels ?? []}
     <div class="issue-detail">
+      <div class="issue-detail-content">
       {#if staleIssue && issues.getIssueDetailError() !== null}
         <div class="detail-load-error" data-testid="detail-load-error">
           Couldn't load this issue: {issues.getIssueDetailError()}
@@ -555,6 +556,7 @@
           <div class="loading-placeholder">Detail not yet loaded</div>
         {/if}
       </div>
+      </div>
     </div>
 
     {#if branchConflict}
@@ -710,14 +712,22 @@
 
   .issue-detail {
     padding: 20px 24px;
-    max-width: 800px;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    width: 100%;
+  }
+
+  .issue-detail-content {
     display: flex;
     flex-direction: column;
     gap: 16px;
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
     width: 100%;
+    max-width: 800px;
     margin-inline: auto;
   }
 

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -526,6 +526,7 @@
         </div>
       {:else}
         <div class="pull-detail">
+          <div class="pull-detail-content">
       {#if detailStore.isStaleRefreshing()}
         <div class="refresh-banner">
           <span class="sync-dot"></span>
@@ -1069,6 +1070,7 @@
           <div class="loading-placeholder">Detail not yet loaded</div>
         {/if}
       </div>
+          </div>
         </div>
       {/if}
     </div>
@@ -1164,18 +1166,24 @@
   }
 
   .pull-detail {
-    container: pull-detail / inline-size;
     padding: 20px 24px;
-    max-width: 800px;
     display: flex;
     flex-direction: column;
-    gap: 16px;
     flex: 1;
     min-height: 0;
     min-width: 0;
     overflow-y: auto;
     overflow-x: hidden;
     width: 100%;
+  }
+
+  .pull-detail-content {
+    container: pull-detail / inline-size;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 800px;
     margin-inline: auto;
   }
 


### PR DESCRIPTION
## Summary
- Move the scroll container for PR and issue detail views to the full pane width so the native scrollbar sits on the right edge of the panel.
- Keep the readable content column centered and capped at 800px inside that scroll container.
- Add e2e coverage for both PR and issue detail geometry, and update one settings test fixture to satisfy the current `Settings` shape.

## Testing
- `bun run test:e2e --project=chromium tests/e2e-full/issue-list.spec.ts tests/e2e-full/pull-list.spec.ts`
- `make frontend-check`
- `bunx vitest run src/lib/components/settings/RepoImportModal.test.ts`