### PR TITLE
Distill activity feed controls into a single progressive-disclosure view filter

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -29,6 +29,7 @@ Avoid GitHub notification clutter, overloaded activity streams, and surfaces whe
 - Maintain the user's scan line: prioritize compact hierarchy, stable columns, and fast recognition over decorative presentation.
 - Make state speak quietly: use semantic color, typography, and placement to clarify status without turning the UI into an alert wall.
 - Keep expert flow intact: keyboard navigation, predictable shortcuts, and preserved context matter more than onboarding spectacle.
+- Treat overlays as shared infrastructure: dropdowns, popovers, menus, and tooltips must float above split panes, sidebars, resize handles, drawers, and other overflow-constrained containers instead of being clipped by their local layout.
 - Local-first should feel trustworthy: sync, error, and data freshness states must be visible without being noisy.
 - GitHub fluency is assumed, but GitHub clutter is not copied.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,39 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Middleman is for maintainers who manage pull requests, issues, reviews, CI signals, and local workspaces across a small fixed set of repositories. They are usually already fluent in GitHub and want a calmer, faster command surface than GitHub notifications.
+
+Their context is task-oriented: scanning what changed, finding what needs attention, reviewing or merging work, and returning to focused development without losing state.
+
+## Product Purpose
+
+Middleman is a local-first GitHub PR and issue monitoring dashboard. It syncs GitHub data into SQLite, serves a fast Svelte interface, and keeps maintainers out of notification clutter while preserving the actions they need: triage, review, comment, merge, track activity, and manage repository settings.
+
+Success looks like an expert user understanding the state of their repos at a glance, moving through items with keyboard navigation, and taking action without bouncing through multiple GitHub pages.
+
+## Brand Personality
+
+Expert, dense, calm, and sharp. The interface should feel deliberate and efficient: compact enough for high-signal scanning, calm enough for repeated daily use, and crisp enough that status, ownership, and next action are immediately legible.
+
+## Anti-references
+
+Avoid GitHub notification clutter, overloaded activity streams, and surfaces where everything competes for attention. Avoid excessive animation, decorative motion, generic SaaS gloss, inflated controls, and ornamental dashboard styling that slows down expert triage.
+
+## Design Principles
+
+- Maintain the user's scan line: prioritize compact hierarchy, stable columns, and fast recognition over decorative presentation.
+- Make state speak quietly: use semantic color, typography, and placement to clarify status without turning the UI into an alert wall.
+- Keep expert flow intact: keyboard navigation, predictable shortcuts, and preserved context matter more than onboarding spectacle.
+- Local-first should feel trustworthy: sync, error, and data freshness states must be visible without being noisy.
+- GitHub fluency is assumed, but GitHub clutter is not copied.
+
+## Accessibility & Inclusion
+
+Keyboard navigation is a core product affordance, not a bonus. The interface should preserve visible focus states, make primary flows reachable without a pointer, avoid motion that is not tied to state, and keep reduced-motion users comfortable.
+
+Aim for WCAG AA contrast for text and controls, with status communication that does not rely on color alone.

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -70,6 +70,18 @@ Intent:
 
 Do not add new native `<select>` controls for visible app UI unless there is a platform-specific accessibility need that cannot be met by `SelectDropdown`.
 
+### Overlays
+
+Use shared overlay primitives for dropdowns, popovers, menus, tooltips, and similar floating controls.
+
+Intent:
+
+- overlays should float above panes, sidebars, drawers, resize handles, and scroll containers
+- overflow-constrained parents must not clip menus or hide available choices
+- repeated positioning, collision, z-index, and outside-click behavior belongs in the shared primitive, not local screen CSS
+
+Before placing an overlay inside a split view, compact sidebar, drawer, or scrollable region, verify that it can extend past its trigger container without being cut off.
+
 ### GitHubLabels
 
 Use `GitHubLabels` for actual GitHub labels.

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -952,6 +952,41 @@ test.describe("activity split view and detail drawers", () => {
     expect(resizedRailBox!.width).toBeGreaterThan(railBox!.width + 40);
   });
 
+  test("activity split view lets the View dropdown float past the rail splitter", async ({ page }) => {
+    await page.goto("/");
+    await waitForActivityTable(page);
+
+    await openActivityPRSplit(page);
+
+    const rail = page.locator(".activity-pane");
+    const viewButton = rail.locator(".filter-btn", { hasText: "View" });
+    await expect(viewButton).toBeVisible();
+    await viewButton.click();
+
+    const dropdown = page.locator(".activity-feed .filter-dropdown");
+    await expect(dropdown).toBeVisible();
+
+    const railBox = await rail.boundingBox();
+    const dropdownBox = await dropdown.boundingBox();
+    expect(railBox).not.toBeNull();
+    expect(dropdownBox).not.toBeNull();
+    const railRight = railBox!.x + railBox!.width;
+    const dropdownRight = dropdownBox!.x + dropdownBox!.width;
+    expect(dropdownRight).toBeGreaterThan(railRight + 8);
+
+    const itemBeyondRail = await page.evaluate(
+      ({ x, y }) => {
+        const element = document.elementFromPoint(x, y);
+        return element?.closest(".filter-dropdown") !== null;
+      },
+      {
+        x: railRight + 8,
+        y: dropdownBox!.y + 24,
+      },
+    );
+    expect(itemBeyondRail).toBe(true);
+  });
+
   test("activity split view can collapse and expand the activity rail", async ({ page }) => {
     await page.goto("/");
     await waitForActivityTable(page);

--- a/frontend/tests/e2e-full/activity-filters.spec.ts
+++ b/frontend/tests/e2e-full/activity-filters.spec.ts
@@ -15,6 +15,15 @@ async function waitForTable(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function selectActivityFilterItem(
+  page: Page,
+  label: string,
+): Promise<void> {
+  await page.locator(".filter-btn").click();
+  await page.locator(".filter-dropdown").waitFor({ state: "visible" });
+  await page.locator(".filter-item", { hasText: label }).click();
+}
+
 // Verify every badge in the activity table matches the expected text.
 // Uses auto-retrying assertions so it waits for the DOM to settle.
 async function expectAllBadges(
@@ -70,9 +79,7 @@ test.describe("activity feed filters", () => {
     ).toBeVisible();
 
     // Open filter dropdown and disable Comments.
-    await page.locator(".filter-btn").click();
-    await page.locator(".filter-dropdown").waitFor({ state: "visible" });
-    await page.locator(".filter-item", { hasText: "Comments" }).click();
+    await selectActivityFilterItem(page, "Comments");
 
     await expect(
       page.locator(".evt-label.evt-comment"),
@@ -87,10 +94,7 @@ test.describe("activity feed filters", () => {
     ).toBeVisible();
 
     // Open filter dropdown and enable "Hide closed/merged".
-    await page.locator(".filter-btn").click();
-    await page.locator(".filter-dropdown").waitFor({ state: "visible" });
-    await page.locator(".filter-item", { hasText: "Hide closed/merged" })
-      .click();
+    await selectActivityFilterItem(page, "Hide closed/merged");
 
     await expect(
       page.locator(".state-badge.state-closed"),
@@ -108,9 +112,7 @@ test.describe("activity feed filters", () => {
     await expect(botCells.first()).toBeVisible();
 
     // Open filter dropdown and enable "Hide bots".
-    await page.locator(".filter-btn").click();
-    await page.locator(".filter-dropdown").waitFor({ state: "visible" });
-    await page.locator(".filter-item", { hasText: "Hide bots" }).click();
+    await selectActivityFilterItem(page, "Hide bots");
 
     await expect(botCells).toHaveCount(0, { timeout: 5_000 });
   });
@@ -124,7 +126,7 @@ test.describe("activity feed filters", () => {
     // Use a web-first assertion that retries until the row count
     // drops below the 7d count, proving the filtered response
     // has rendered.
-    await page.locator(".seg-btn", { hasText: "24h" }).click();
+    await selectActivityFilterItem(page, "24h");
     await expect(page.locator(".activity-row"))
       .not.toHaveCount(count7d, { timeout: 10_000 });
     const count24h = await page.locator(".activity-row").count();
@@ -159,10 +161,7 @@ test.describe("activity feed filters", () => {
       await expectAllBadges(page, "PR");
 
       // Enable hide closed/merged (client-side filter).
-      await page.locator(".filter-btn").click();
-      await page.locator(".filter-dropdown").waitFor({ state: "visible" });
-      await page.locator(".filter-item", { hasText: "Hide closed/merged" })
-        .click();
+      await selectActivityFilterItem(page, "Hide closed/merged");
       await page.locator(".controls-bar")
         .click({ position: { x: 5, y: 5 } });
 
@@ -203,7 +202,7 @@ test.describe("activity UTC timestamp presentation", () => {
   });
 
   test("activity API timestamps stay UTC and render as local dates", async ({ page }) => {
-    await page.locator(".seg-btn", { hasText: "30d" }).click();
+    await selectActivityFilterItem(page, "30d");
     await expect(page.locator(".activity-row").first()).toBeVisible();
 
     const payload = await page.evaluate(async () => {

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -14,6 +14,24 @@ async function waitForIssueList(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function openActivityViewDropdown(page: Page) {
+  const dropdown = page.locator(".activity-feed .filter-dropdown");
+  if (await dropdown.isVisible()) {
+    return dropdown;
+  }
+  await page.locator(".activity-feed .filter-btn", { hasText: "View" }).click();
+  await expect(dropdown).toBeVisible();
+  return dropdown;
+}
+
+async function selectActivityViewItem(
+  page: Page,
+  label: string | RegExp,
+): Promise<void> {
+  const dropdown = await openActivityViewDropdown(page);
+  await dropdown.locator(".filter-item", { hasText: label }).click();
+}
+
 test.describe("grouping toggle", () => {
   test.beforeEach(async ({ page }) => {
     // Clear persisted grouping once before first app bootstrap so tests start
@@ -93,7 +111,7 @@ test.describe("grouping toggle", () => {
     await page.goto("/");
 
     // Switch to threaded mode.
-    await page.locator(".seg-btn", { hasText: "Threaded" }).click();
+    await selectActivityViewItem(page, "Threaded");
 
     // Wait for threaded view to render.
     await page.locator(".threaded-view .item-row").first()
@@ -112,13 +130,10 @@ test.describe("grouping toggle", () => {
     await page.goto("/");
 
     // Switch to threaded + ungrouped.
-    await page.locator(".seg-btn", { hasText: "Threaded" }).click();
+    await selectActivityViewItem(page, "Threaded");
     await page.locator(".threaded-view .item-row").first()
       .waitFor({ state: "visible", timeout: 10_000 });
-    // Click "All" in the grouping toggle (the segmented-control containing "By Repo").
-    const groupControl = page.locator(".segmented-control")
-      .filter({ has: page.locator(".seg-btn", { hasText: "By Repo" }) });
-    await groupControl.locator(".seg-btn", { hasText: "All" }).click();
+    await selectActivityViewItem(page, "All");
 
     // Wait for repo tags to appear (ungrouped).
     await page.locator(".repo-tag").first()
@@ -134,19 +149,19 @@ test.describe("grouping toggle", () => {
   test("activity toggle hidden in flat mode, visible in threaded", async ({ page }) => {
     await page.goto("/");
 
-    // In flat mode (default), the By Repo / All toggle should not exist.
-    // The flat/threaded control is visible; check there's no "By Repo" button.
-    await page.locator(".seg-btn", { hasText: "Flat" })
-      .waitFor({ state: "visible", timeout: 10_000 });
-    await expect(page.locator(".seg-btn", { hasText: "By Repo" }))
+    // In flat mode (default), the view dropdown should not offer grouping.
+    let dropdown = await openActivityViewDropdown(page);
+    await expect(dropdown.locator(".filter-item", { hasText: /By repo/i }))
       .toHaveCount(0);
+    await page.keyboard.press("Escape");
 
     // Switch to threaded mode.
-    await page.locator(".seg-btn", { hasText: "Threaded" }).click();
+    await selectActivityViewItem(page, "Threaded");
     await page.locator(".threaded-view").waitFor({ state: "visible", timeout: 10_000 });
 
-    // Now By Repo / All toggle should be visible.
-    await expect(page.locator(".seg-btn", { hasText: "By Repo" }))
+    // Now grouping controls should be available from the view dropdown.
+    dropdown = page.locator(".activity-feed .filter-dropdown");
+    await expect(dropdown.locator(".filter-item", { hasText: /By repo/i }))
       .toBeVisible();
   });
 
@@ -164,12 +179,8 @@ test.describe("grouping toggle", () => {
       .toHaveText("No activity found", { timeout: 10_000 });
 
     // Now switch to threaded + ungrouped. ActivityThreaded receives [].
-    await page.locator(".seg-btn", { hasText: "Threaded" }).click();
-    // The "By Repo/All" toggle appears in threaded mode. Switch to ungrouped
-    // by finding "All" within the same segmented-control as "By Repo".
-    const groupControl = page.locator(".segmented-control")
-      .filter({ has: page.locator(".seg-btn", { hasText: "By Repo" }) });
-    await groupControl.locator(".seg-btn", { hasText: "All" }).click();
+    await selectActivityViewItem(page, "Threaded");
+    await selectActivityViewItem(page, "All");
 
     // The threaded view's own empty state should render.
     await expect(page.locator(".threaded-view .empty-state"))

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -160,7 +160,7 @@ test.describe("grouping toggle", () => {
     await page.locator(".threaded-view").waitFor({ state: "visible", timeout: 10_000 });
 
     // Now grouping controls should be available from the view dropdown.
-    dropdown = page.locator(".activity-feed .filter-dropdown");
+    dropdown = await openActivityViewDropdown(page);
     await expect(dropdown.locator(".filter-item", { hasText: /By repo/i }))
       .toBeVisible();
   });

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -242,7 +242,12 @@
     },
   ]);
 
-  const compactFilterSections = $derived.by(() => [
+  const currentViewDetail = $derived.by(() => {
+    const mode = activity.getViewMode() === "flat" ? "Flat" : "Threaded";
+    return `${mode} · ${activity.getTimeRange()}`;
+  });
+
+  const filterSections = $derived.by(() => [
     {
       title: "View",
       items: [
@@ -349,38 +354,19 @@
         <button class="seg-btn" class:active={activity.getItemFilter() === "prs"} onclick={() => handleItemFilterChange("prs")}>PRs</button>
         <button class="seg-btn" class:active={activity.getItemFilter() === "issues"} onclick={() => handleItemFilterChange("issues")}>Issues</button>
       </div>
-
-      {#if !compact}
-        <div class="segmented-control">
-          <button class="seg-btn" class:active={activity.getViewMode() === "flat"} onclick={() => handleViewModeChange("flat")}>Flat</button>
-          <button class="seg-btn" class:active={activity.getViewMode() === "threaded"} onclick={() => handleViewModeChange("threaded")}>Threaded</button>
-        </div>
-
-        {#if activity.getViewMode() === "threaded"}
-          <div class="segmented-control">
-            <button class="seg-btn" class:active={grouping.getGroupByRepo()} onclick={() => grouping.setGroupByRepo(true)}>By Repo</button>
-            <button class="seg-btn" class:active={!grouping.getGroupByRepo()} onclick={() => grouping.setGroupByRepo(false)}>All</button>
-          </div>
-        {/if}
-
-        <div class="segmented-control">
-          {#each TIME_RANGES as r (r.value)}
-            <button class="seg-btn" class:active={activity.getTimeRange() === r.value} onclick={() => handleTimeRangeChange(r.value)}>{r.label}</button>
-          {/each}
-        </div>
-      {/if}
     </div>
 
     <FilterDropdown
-      label="Filters"
+      label="View"
+      detail={currentViewDetail}
       active={hiddenFilterCount > 0}
       badgeCount={hiddenFilterCount}
-      title="Filter activity types"
-      sections={compact ? compactFilterSections : activityFilterSections}
-      minWidth={compact ? "220px" : "200px"}
+      title="View and filter activity"
+      sections={filterSections}
+      minWidth="220px"
       {...hiddenFilterCount > 0
         ? {
-            resetLabel: "Show all",
+            resetLabel: "Show hidden activity",
             onReset: resetFilters,
           }
         : {}}

--- a/packages/ui/src/components/shared/FilterDropdown.svelte
+++ b/packages/ui/src/components/shared/FilterDropdown.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import FunnelIcon from "@lucide/svelte/icons/funnel";
   import ArrowUpDownIcon from "@lucide/svelte/icons/arrow-up-down";
+  import { tick } from "svelte";
 
   interface FilterDropdownItem {
     id: string;
@@ -52,6 +53,7 @@
   let isOpen = $state(false);
   let buttonRef = $state<HTMLButtonElement>();
   let dropdownRef = $state<HTMLDivElement>();
+  let dropdownStyle = $state("");
 
   const isActive = $derived(active || badgeCount > 0);
   const hasReset = $derived(
@@ -64,6 +66,10 @@
 
   $effect(() => {
     if (!isOpen) return;
+
+    function updatePosition(): void {
+      positionDropdown();
+    }
 
     function handleMousedown(event: MouseEvent): void {
       const target = event.target as Node;
@@ -80,6 +86,8 @@
 
     document.addEventListener("mousedown", handleMousedown);
     document.addEventListener("keydown", handleKeydown);
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
     return () => {
       document.removeEventListener(
         "mousedown",
@@ -89,12 +97,53 @@
         "keydown",
         handleKeydown,
       );
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
     };
   });
 
-  function toggleOpen(): void {
+  function positionDropdown(): void {
+    if (!buttonRef || !dropdownRef) return;
+
+    const trigger = buttonRef.getBoundingClientRect();
+    const dropdownWidth = dropdownRef.offsetWidth;
+    const gap = 4;
+    const viewportPadding = 8;
+    let left = align === "end"
+      ? trigger.right - dropdownWidth
+      : trigger.left;
+    left = Math.min(
+      Math.max(viewportPadding, left),
+      Math.max(viewportPadding, window.innerWidth - dropdownWidth - viewportPadding),
+    );
+
+    const dropdownHeight = dropdownRef.offsetHeight;
+    const below = trigger.bottom + gap;
+    const above = trigger.top - dropdownHeight - gap;
+    const top = below + dropdownHeight > window.innerHeight - viewportPadding
+      ? Math.max(viewportPadding, above)
+      : below;
+
+    dropdownStyle = [
+      `left: ${left}px`,
+      `top: ${top}px`,
+      `min-width: ${minWidth}`,
+    ].join("; ");
+  }
+
+  async function openDropdown(): Promise<void> {
+    isOpen = true;
+    await tick();
+    positionDropdown();
+  }
+
+  async function toggleOpen(): Promise<void> {
     if (disabled) return;
-    isOpen = !isOpen;
+    if (isOpen) {
+      isOpen = false;
+      return;
+    }
+    await openDropdown();
   }
 
   function handleSelect(item: FilterDropdownItem): void {
@@ -140,7 +189,7 @@
       class="filter-dropdown"
       class:filter-dropdown--align-end={align === "end"}
       bind:this={dropdownRef}
-      style:min-width={minWidth}
+      style={dropdownStyle}
     >
       {#each sections as section, index (section.title ?? `section-${index}`)}
         {#if index > 0}
@@ -242,21 +291,17 @@
   }
 
   .filter-dropdown {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    margin-top: 4px;
+    position: fixed;
     background: var(--bg-surface);
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
     box-shadow: var(--shadow-md);
-    z-index: 50;
+    z-index: 1000;
     padding: 4px 0;
   }
 
   .filter-dropdown--align-end {
-    left: auto;
-    right: 0;
+    transform-origin: top right;
   }
 
   .filter-section-title {

--- a/packages/ui/src/components/shared/FilterDropdown.svelte
+++ b/packages/ui/src/components/shared/FilterDropdown.svelte
@@ -127,7 +127,6 @@
     dropdownStyle = [
       `left: ${left}px`,
       `top: ${top}px`,
-      `min-width: ${minWidth}`,
     ].join("; ");
   }
 
@@ -190,6 +189,7 @@
       class:filter-dropdown--align-end={align === "end"}
       bind:this={dropdownRef}
       style={dropdownStyle}
+      style:min-width={minWidth}
     >
       {#each sections as section, index (section.title ?? `section-${index}`)}
         {#if index > 0}


### PR DESCRIPTION
## Summary
- Simplified the activity feed toolbar so the default scan path is just item scope, search, and one `View` dropdown.
- Moved view mode, grouping, time range, and activity visibility into progressive disclosure instead of showing them all at once.
- Makes filter selection possible when an item is selected and the activity feed becomes a sidebar.
- Updated the activity filter e2e coverage to select the moved controls through the dropdown.

## Testing
- Playwright e2e: `frontend/tests/e2e-full/activity-filters.spec.ts` passed in Chromium.
- Svelte validation passed with `svelte-check` and the Svelte autofixer reported no issues for the edited component.
