### PR TITLE
Add configurable default repository host for repo cards

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -41,6 +41,10 @@ func main() {
 		"roborev", defaultRoborevEndpoint,
 		"roborev daemon endpoint",
 	)
+	defaultPlatformHost := flag.String(
+		"default-platform-host", "github.com",
+		"default platform host for seeded config",
+	)
 	serverInfoFile := flag.String(
 		"server-info-file", "",
 		"path to write discovered server port info as JSON",
@@ -54,7 +58,9 @@ func main() {
 	)
 	defer stop()
 
-	if err := run(ctx, *port, *roborev, *serverInfoFile); err != nil {
+	if err := run(
+		ctx, *port, *roborev, *serverInfoFile, *defaultPlatformHost,
+	); err != nil {
 		slog.Error("fatal", "err", err)
 		os.Exit(1)
 	}
@@ -72,7 +78,15 @@ type globRefreshContextKey struct{}
 // run starts the e2e server and blocks until ctx is canceled or the
 // HTTP server errors out. Tests call it directly with a cancellable
 // context; main() wires it to SIGINT/SIGTERM.
-func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) error {
+func run(
+	ctx context.Context,
+	port int,
+	roborevEndpoint, serverInfoFile, defaultPlatformHost string,
+) error {
+	defaultPlatformHost = strings.TrimSpace(defaultPlatformHost)
+	if defaultPlatformHost == "" {
+		defaultPlatformHost = "github.com"
+	}
 	tmpDir, err := os.MkdirTemp("", "middleman-e2e-*")
 	if err != nil {
 		return fmt.Errorf("create temp dir: %w", err)
@@ -110,18 +124,34 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 		return fmt.Errorf("setup diff repo: %w", err)
 	}
 
+	repos := []config.Repo{
+		{Owner: "acme", Name: "widgets"},
+		{Owner: "acme", Name: "tools"},
+		{Owner: "acme", Name: "archived"},
+		{Owner: "roborev-dev", Name: "*"},
+	}
+	if !strings.EqualFold(defaultPlatformHost, "github.com") {
+		repos = []config.Repo{
+			{
+				Owner:        "enterprise",
+				Name:         "service",
+				PlatformHost: defaultPlatformHost,
+			},
+			{
+				Owner:        "acme",
+				Name:         "widgets",
+				PlatformHost: "github.com",
+			},
+		}
+	}
 	cfg := &config.Config{
-		SyncInterval:   "5m",
-		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
-		Host:           "127.0.0.1",
-		Port:           8091,
-		BasePath:       "/",
-		Repos: []config.Repo{
-			{Owner: "acme", Name: "widgets"},
-			{Owner: "acme", Name: "tools"},
-			{Owner: "acme", Name: "archived"},
-			{Owner: "roborev-dev", Name: "*"},
-		},
+		SyncInterval:        "5m",
+		GitHubTokenEnv:      "MIDDLEMAN_GITHUB_TOKEN",
+		DefaultPlatformHost: defaultPlatformHost,
+		Host:                "127.0.0.1",
+		Port:                8091,
+		BasePath:            "/",
+		Repos:               repos,
 		Activity: config.Activity{
 			ViewMode:  "flat",
 			TimeRange: "7d",
@@ -214,9 +244,13 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 	}
 	patchFixturePRSHAs(fc, "acme", "widgets", 1, diffRepo.HeadSHA, diffRepo.BaseSHA)
 
+	fixtureClients := map[string]ghclient.Client{
+		"github.com":        fc,
+		defaultPlatformHost: fc,
+	}
 	startupResolved := ghclient.ResolveConfiguredRepos(
 		ctx,
-		map[string]ghclient.Client{"github.com": fc},
+		fixtureClients,
 		cfg.Repos,
 	)
 	for _, repo := range startupResolved.Expanded {
@@ -224,6 +258,13 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 			ctx, repo.PlatformHost, repo.Owner, repo.Name,
 		); err != nil {
 			return fmt.Errorf("seed startup repo %s/%s: %w", repo.Owner, repo.Name, err)
+		}
+	}
+	if !strings.EqualFold(defaultPlatformHost, "github.com") {
+		if _, err := database.UpsertRepo(
+			ctx, defaultPlatformHost, "enterprise", "service",
+		); err != nil {
+			return fmt.Errorf("seed default-host repo: %w", err)
 		}
 	}
 
@@ -246,15 +287,24 @@ func run(ctx context.Context, port int, roborevEndpoint, serverInfoFile string) 
 	budget.Spend(75)
 
 	syncer := ghclient.NewSyncer(
-		map[string]ghclient.Client{"github.com": fc},
+		fixtureClients,
 		database, diffRepo.Manager, startupResolved.Expanded, time.Hour,
-		map[string]*ghclient.RateTracker{"github.com": rt},
-		map[string]*ghclient.SyncBudget{"github.com": budget},
+		map[string]*ghclient.RateTracker{
+			"github.com":        rt,
+			defaultPlatformHost: rt,
+		},
+		map[string]*ghclient.SyncBudget{
+			"github.com":        budget,
+			defaultPlatformHost: budget,
+		},
 	)
 
 	// Wire GraphQL fetcher so GQL rate data appears in the endpoint.
 	gqlFetcher := ghclient.NewGraphQLFetcher("fake-token", "github.com", gqlRT, budget)
-	syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{"github.com": gqlFetcher})
+	syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com":        gqlFetcher,
+		defaultPlatformHost: gqlFetcher,
+	})
 
 	assets, err := web.Assets()
 	if err != nil {

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -133,7 +133,7 @@ func TestRunDefaultRoborevFailsClosedThroughProxy(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile)
+		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com")
 	}()
 
 	baseURL := waitForServerInfoBaseURL(t, serverInfoFile, done)

--- a/frontend/src/lib/components/repositories/repoSummary.test.ts
+++ b/frontend/src/lib/components/repositories/repoSummary.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { repoKey, shouldShowPlatformHost } from "./repoSummary.js";
+
+describe("repo summary labels", () => {
+  it("hides github.com when it is the default platform host", () => {
+    const summary = {
+      platform_host: "github.com",
+      default_platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+    };
+
+    expect(shouldShowPlatformHost(summary)).toBe(false);
+    expect(repoKey(summary)).toBe("acme/widgets");
+  });
+
+  it("hides a configured non-github default platform host", () => {
+    const summary = {
+      platform_host: "ghe.example.com",
+      default_platform_host: "ghe.example.com",
+      owner: "acme",
+      name: "widgets",
+    };
+
+    expect(shouldShowPlatformHost(summary)).toBe(false);
+    expect(repoKey(summary)).toBe("acme/widgets");
+  });
+
+  it("includes a non-default platform host in repository labels", () => {
+    const summary = {
+      platform_host: "ghe.example.com",
+      default_platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+    };
+
+    expect(shouldShowPlatformHost(summary)).toBe(true);
+    expect(repoKey(summary)).toBe("ghe.example.com/acme/widgets");
+  });
+});

--- a/frontend/src/lib/components/repositories/repoSummary.ts
+++ b/frontend/src/lib/components/repositories/repoSummary.ts
@@ -29,9 +29,20 @@ export type RepoSort = "name" | "open-prs" | "open-issues" | "activity" | "stale
 export const staleReleaseCommitThreshold = 50;
 
 export function repoKey(summary: {
+  platform_host?: string;
+  default_platform_host?: string | undefined;
   owner: string;
   name: string;
 }): string {
+  if (
+    summary.platform_host
+    && shouldShowPlatformHost({
+      platform_host: summary.platform_host,
+      default_platform_host: summary.default_platform_host,
+    })
+  ) {
+    return `${summary.platform_host}/${summary.owner}/${summary.name}`;
+  }
   return `${summary.owner}/${summary.name}`;
 }
 
@@ -45,7 +56,7 @@ export function repoStateKey(summary: {
 
 export function shouldShowPlatformHost(summary: {
   platform_host: string;
-  default_platform_host?: string;
+  default_platform_host?: string | undefined;
 }): boolean {
   const host = (summary.platform_host || "github.com").toLowerCase();
   const defaultHost = (summary.default_platform_host || "github.com")

--- a/frontend/tests/e2e-full/activity-filters.spec.ts
+++ b/frontend/tests/e2e-full/activity-filters.spec.ts
@@ -182,14 +182,15 @@ test.describe("activity feed filters", () => {
 });
 
 test.describe("activity UTC timestamp presentation", () => {
-  let isolatedServer: IsolatedE2EServer;
+  let isolatedServer: IsolatedE2EServer | undefined;
 
   test.beforeAll(async () => {
+    test.setTimeout(60_000);
     isolatedServer = await startIsolatedE2EServer();
   });
 
   test.afterAll(async () => {
-    await isolatedServer.stop();
+    await isolatedServer?.stop();
   });
 
   test.beforeEach(async ({ page }) => {
@@ -197,7 +198,7 @@ test.describe("activity UTC timestamp presentation", () => {
       const originalNow = Date.now.bind(Date);
       Date.now = () => originalNow() + offsetMs;
     }, 2 * 24 * 60 * 60 * 1000);
-    await page.goto(isolatedServer.info.base_url);
+    await page.goto(isolatedServer!.info.base_url);
     await waitForTable(page);
   });
 

--- a/frontend/tests/e2e-full/repo-summaries.spec.ts
+++ b/frontend/tests/e2e-full/repo-summaries.spec.ts
@@ -1,6 +1,35 @@
 import { expect, test } from "@playwright/test";
+import { startIsolatedE2EServerWithOptions } from "./support/e2eServer";
 
 test.describe("repository summaries", () => {
+  test("hides a configured non-github default host in repo labels", async ({ page }) => {
+    const server = await startIsolatedE2EServerWithOptions({
+      defaultPlatformHost: "ghe.example.com",
+    });
+    try {
+      await page.goto(`${server.info.base_url}/repos`);
+
+      const repoCards = page.locator(".repo-card");
+      const enterpriseCard = repoCards.filter({
+        has: page.getByRole("button", {
+          name: /enterprise\s*\/\s*service/,
+        }),
+      }).first();
+      await expect(enterpriseCard).toBeVisible();
+      await expect(enterpriseCard.getByText("ghe.example.com")).toHaveCount(0);
+
+      const githubCard = repoCards.filter({
+        has: page.getByRole("button", {
+          name: /acme\s*\/\s*widgets/,
+        }),
+      }).first();
+      await expect(githubCard).toBeVisible();
+      await expect(githubCard.getByText("github.com")).toBeVisible();
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("remembers filters after tab changes", async ({ page }) => {
     await page.goto("/repos");
 

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -20,6 +20,10 @@ export type IsolatedE2EServer = {
   stop: () => Promise<void>;
 };
 
+export type IsolatedE2EServerOptions = {
+  defaultPlatformHost?: string;
+};
+
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../../..");
 const serverInfoDir = mkdtempSync(path.join(os.tmpdir(), "middleman-e2e-"));
@@ -267,7 +271,10 @@ async function removeServerInfo(filePath: string): Promise<void> {
   await rm(filePath, { force: true });
 }
 
-async function spawnServer(infoFile: string): Promise<{
+async function spawnServer(
+  infoFile: string,
+  options: IsolatedE2EServerOptions = {},
+): Promise<{
   child: ChildProcess;
   info: E2EServerInfo;
 }> {
@@ -281,6 +288,9 @@ async function spawnServer(infoFile: string): Promise<{
     "-server-info-file",
     infoFile,
   ];
+  if (options.defaultPlatformHost) {
+    args.push("-default-platform-host", options.defaultPlatformHost);
+  }
   if (process.env.ROBOREV_ENDPOINT) {
     args.push("-roborev", process.env.ROBOREV_ENDPOINT);
   }
@@ -402,9 +412,15 @@ export async function stopE2EServer(): Promise<void> {
 }
 
 export async function startIsolatedE2EServer(): Promise<IsolatedE2EServer> {
+  return startIsolatedE2EServerWithOptions();
+}
+
+export async function startIsolatedE2EServerWithOptions(
+  options: IsolatedE2EServerOptions = {},
+): Promise<IsolatedE2EServer> {
   const isolatedInfoDir = mkdtempSync(path.join(os.tmpdir(), "middleman-e2e-"));
   const isolatedInfoFile = path.join(isolatedInfoDir, "server-info.json");
-  const started = await spawnServer(isolatedInfoFile);
+  const started = await spawnServer(isolatedInfoFile, options);
 
   return {
     info: started.info,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10281,7 +10281,7 @@ func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
 	require.NoError(conn.Write(
 		ctx, websocket.MessageBinary, []byte("size\n"),
 	))
-	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	readCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
 	var got strings.Builder
 	for {


### PR DESCRIPTION
## Summary
- Add `default_platform_host` to config, defaulting to `github.com`, so the repos UI can treat one host as implied.
- Hide the platform host chip on repository cards and issue modals when the repo uses the configured default host.
- Keep non-default hosts visible, and surface the new setting through the repo summary API and generated client types.
- Update config docs/example config and add regression coverage for config, API, and repo-page rendering.

## Testing
- Go tests for config and server repo-summary behavior.
- Frontend Vitest coverage for the repos page host-label behavior.
- Svelte check passed.
- Generated API artifacts were refreshed successfully.