### PR TITLE
Add inline editing for issue and PR comments

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -414,6 +414,38 @@ components:
         - whitespace_only_count
         - files
       type: object
+    EditCommentInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/EditCommentInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        body:
+          type: string
+      required:
+        - body
+      type: object
+    EditIssueCommentInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/EditIssueCommentInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        body:
+          type: string
+        platform_host:
+          type: string
+      required:
+        - body
+      type: object
     EditPRContentInputBody:
       additionalProperties: false
       properties:
@@ -1607,6 +1639,8 @@ components:
           type:
             - string
             - "null"
+        fork:
+          type: boolean
         name:
           type: string
         owner:
@@ -1622,6 +1656,7 @@ components:
         - name
         - description
         - private
+        - fork
         - pushed_at
         - already_configured
       type: object
@@ -1721,6 +1756,8 @@ components:
         commits_since_release:
           format: int64
           type: integer
+        default_platform_host:
+          type: string
         draft_pr_count:
           format: int64
           type: integer
@@ -1762,6 +1799,7 @@ components:
           type: string
       required:
         - platform_host
+        - default_platform_host
         - owner
         - name
         - cached_pr_count
@@ -2764,6 +2802,51 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+  /repos/{owner}/{name}/issues/{number}/comments/{comment_id}:
+    patch:
+      operationId: edit-issue-comment
+      parameters:
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: comment_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EditIssueCommentInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IssueEvent"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
   /repos/{owner}/{name}/issues/{number}/github-state:
     post:
       operationId: set-issue-github-state
@@ -3128,6 +3211,51 @@ paths:
               schema:
                 $ref: "#/components/schemas/MREvent"
           description: Created
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+  /repos/{owner}/{name}/pulls/{number}/comments/{comment_id}:
+    patch:
+      operationId: edit-pr-comment
+      parameters:
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: comment_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EditCommentInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MREvent"
+          description: OK
         default:
           content:
             application/problem+json:

--- a/frontend/tests/e2e/comment-editing.spec.ts
+++ b/frontend/tests/e2e/comment-editing.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+type TimelineEvent = {
+  ID: number;
+  MergeRequestID?: number;
+  IssueID?: number;
+  PlatformID: number;
+  EventType: string;
+  Author: string;
+  Summary: string;
+  Body: string;
+  MetadataJSON: string;
+  CreatedAt: string;
+  DedupeKey: string;
+};
+
+async function fulfillJson(route: Route, body: unknown, status = 200): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+function prDetail(commentBody: string, event: TimelineEvent) {
+  return {
+    merge_request: {
+      ID: 1,
+      RepoID: 1,
+      GitHubID: 101,
+      Number: 42,
+      URL: "https://github.com/acme/widgets/pull/42",
+      Title: "Add browser regression coverage",
+      Author: "marius",
+      State: "open",
+      IsDraft: false,
+      Body: "Adds Playwright smoke tests for workspace panel.",
+      HeadBranch: "feature/playwright",
+      BaseBranch: "main",
+      Additions: 120,
+      Deletions: 12,
+      CommentCount: 1,
+      ReviewDecision: "APPROVED",
+      CIStatus: "success",
+      CIChecksJSON: "[]",
+      CreatedAt: "2026-03-29T14:00:00Z",
+      UpdatedAt: "2026-03-30T14:00:00Z",
+      LastActivityAt: "2026-03-30T14:00:00Z",
+      MergedAt: null,
+      ClosedAt: null,
+      KanbanStatus: "reviewing",
+      Starred: false,
+      repo_owner: "acme",
+      repo_name: "widgets",
+      platform_host: "github.com",
+      worktree_links: [],
+    },
+    events: [{ ...event, Body: commentBody }],
+    repo_owner: "acme",
+    repo_name: "widgets",
+    detail_loaded: true,
+    detail_fetched_at: "2026-03-30T14:00:00Z",
+    worktree_links: [],
+  };
+}
+
+function issueDetail(commentBody: string, event: TimelineEvent) {
+  return {
+    issue: {
+      ID: 2,
+      RepoID: 1,
+      GitHubID: 202,
+      Number: 7,
+      URL: "https://github.com/acme/widgets/issues/7",
+      Title: "Theme toggle does not stick",
+      Author: "marius",
+      State: "open",
+      Body: "",
+      CommentCount: 1,
+      LabelsJSON: "[]",
+      CreatedAt: "2026-03-28T14:00:00Z",
+      UpdatedAt: "2026-03-30T14:00:00Z",
+      LastActivityAt: "2026-03-30T14:00:00Z",
+      ClosedAt: null,
+      Starred: false,
+      platform_host: "github.com",
+      repo_owner: "acme",
+      repo_name: "widgets",
+    },
+    events: [{ ...event, Body: commentBody }],
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    detail_loaded: true,
+    detail_fetched_at: "2026-03-30T14:00:00Z",
+  };
+}
+
+async function editVisibleTimelineComment(page: Page, body: string): Promise<void> {
+  await page.getByText(/^Original /).hover();
+  await page.getByRole("button", { name: "Edit comment" }).first().click();
+  const editor = page.locator(".edit-panel .comment-editor-input");
+  await expect(editor).toBeVisible();
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await page.keyboard.type(body);
+  await page.getByRole("button", { name: "Save" }).click();
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("edits a pull request timeline comment", async ({ page }) => {
+  let commentBody = "Original PR comment";
+  let patchedBody = "";
+  const event: TimelineEvent = {
+    ID: 11,
+    MergeRequestID: 1,
+    PlatformID: 9101,
+    EventType: "issue_comment",
+    Author: "marius",
+    Summary: "",
+    Body: commentBody,
+    MetadataJSON: "",
+    CreatedAt: "2026-03-30T14:00:00Z",
+    DedupeKey: "comment-9101",
+  };
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42(?:[/?]|$)/,
+    async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      await fulfillJson(route, prDetail(commentBody, event));
+    },
+  );
+  await page.route("**/api/v1/repos/acme/widgets/pulls/42/comments/9101", async (route) => {
+    const reqBody = JSON.parse(route.request().postData() ?? "{}") as { body?: string };
+    patchedBody = reqBody.body ?? "";
+    commentBody = patchedBody;
+    await fulfillJson(route, { ...event, Body: patchedBody });
+  });
+
+  await page.goto("/pulls/acme/widgets/42");
+  await expect(page.getByText("Original PR comment")).toBeVisible();
+
+  await editVisibleTimelineComment(page, "Edited PR comment");
+
+  await expect.poll(() => patchedBody).toBe("Edited PR comment");
+  await expect(page.getByText("Edited PR comment")).toBeVisible();
+});
+
+test("edits an issue timeline comment", async ({ page }) => {
+  let commentBody = "Original issue comment";
+  let patchedBody = "";
+  const event: TimelineEvent = {
+    ID: 22,
+    IssueID: 2,
+    PlatformID: 9202,
+    EventType: "issue_comment",
+    Author: "marius",
+    Summary: "",
+    Body: commentBody,
+    MetadataJSON: "",
+    CreatedAt: "2026-03-30T14:00:00Z",
+    DedupeKey: "issue-comment-9202",
+  };
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/issues\/7(?:[/?]|$)/,
+    async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      await fulfillJson(route, issueDetail(commentBody, event));
+    },
+  );
+  await page.route("**/api/v1/repos/acme/widgets/issues/7/comments/9202", async (route) => {
+    const reqBody = JSON.parse(route.request().postData() ?? "{}") as { body?: string };
+    patchedBody = reqBody.body ?? "";
+    commentBody = patchedBody;
+    await fulfillJson(route, { ...event, Body: patchedBody });
+  });
+
+  await page.goto("/focus/issue/acme/widgets/7?platform_host=github.com");
+  await expect(page.getByText("Original issue comment")).toBeVisible();
+
+  await editVisibleTimelineComment(page, "Edited issue comment");
+
+  await expect.poll(() => patchedBody).toBe("Edited issue comment");
+  await expect(page.getByText("Edited issue comment")).toBeVisible();
+});

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -192,6 +192,21 @@ type DiffResponse struct {
 	WhitespaceOnlyCount int64       `json:"whitespace_only_count"`
 }
 
+// EditCommentInputBody defines model for EditCommentInputBody.
+type EditCommentInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+	Body   string  `json:"body"`
+}
+
+// EditIssueCommentInputBody defines model for EditIssueCommentInputBody.
+type EditIssueCommentInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string `json:"$schema,omitempty"`
+	Body         string  `json:"body"`
+	PlatformHost *string `json:"platform_host,omitempty"`
+}
+
 // EditPRContentInputBody defines model for EditPRContentInputBody.
 type EditPRContentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -966,6 +981,9 @@ type CreateIssueJSONRequestBody = CreateIssueInputBody
 // PostIssueCommentJSONRequestBody defines body for PostIssueComment for application/json ContentType.
 type PostIssueCommentJSONRequestBody = PostIssueCommentInputBody
 
+// EditIssueCommentJSONRequestBody defines body for EditIssueComment for application/json ContentType.
+type EditIssueCommentJSONRequestBody = EditIssueCommentInputBody
+
 // SetIssueGithubStateJSONRequestBody defines body for SetIssueGithubState for application/json ContentType.
 type SetIssueGithubStateJSONRequestBody = GithubStateInputBody
 
@@ -980,6 +998,9 @@ type PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody = ApprovePRInputB
 
 // PostPrCommentJSONRequestBody defines body for PostPrComment for application/json ContentType.
 type PostPrCommentJSONRequestBody = PostCommentInputBody
+
+// EditPrCommentJSONRequestBody defines body for EditPrComment for application/json ContentType.
+type EditPrCommentJSONRequestBody = EditCommentInputBody
 
 // SetPrGithubStateJSONRequestBody defines body for SetPrGithubState for application/json ContentType.
 type SetPrGithubStateJSONRequestBody = GithubStateInputBody
@@ -1136,6 +1157,11 @@ type ClientInterface interface {
 
 	PostIssueComment(ctx context.Context, owner string, name string, number int64, body PostIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EditIssueCommentWithBody request with any body
+	EditIssueCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EditIssueComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// SetIssueGithubStateWithBody request with any body
 	SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1175,6 +1201,11 @@ type ClientInterface interface {
 	PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	PostPrComment(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EditPrCommentWithBody request with any body
+	EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberCommits request
 	GetReposByOwnerByNamePullsByNumberCommits(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1535,6 +1566,30 @@ func (c *Client) PostIssueComment(ctx context.Context, owner string, name string
 	return c.Client.Do(req)
 }
 
+func (c *Client) EditIssueCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditIssueCommentRequestWithBody(c.Server, owner, name, number, commentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditIssueComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditIssueCommentRequest(c.Server, owner, name, number, commentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSetIssueGithubStateRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
@@ -1705,6 +1760,30 @@ func (c *Client) PostPrCommentWithBody(ctx context.Context, owner string, name s
 
 func (c *Client) PostPrComment(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostPrCommentRequest(c.Server, owner, name, number, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrCommentRequestWithBody(c.Server, owner, name, number, commentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrCommentRequest(c.Server, owner, name, number, commentId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3164,6 +3243,74 @@ func NewPostIssueCommentRequestWithBody(server string, owner string, name string
 	return req, nil
 }
 
+// NewEditIssueCommentRequest calls the generic EditIssueComment builder with application/json body
+func NewEditIssueCommentRequest(server string, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEditIssueCommentRequestWithBody(server, owner, name, number, commentId, "application/json", bodyReader)
+}
+
+// NewEditIssueCommentRequestWithBody generates requests for EditIssueComment with any type of body
+func NewEditIssueCommentRequestWithBody(server string, owner string, name string, number int64, commentId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "comment_id", commentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repos/%s/%s/issues/%s/comments/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewSetIssueGithubStateRequest calls the generic SetIssueGithubState builder with application/json body
 func NewSetIssueGithubStateRequest(server string, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -3744,6 +3891,74 @@ func NewPostPrCommentRequestWithBody(server string, owner string, name string, n
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewEditPrCommentRequest calls the generic EditPrComment builder with application/json body
+func NewEditPrCommentRequest(server string, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEditPrCommentRequestWithBody(server, owner, name, number, commentId, "application/json", bodyReader)
+}
+
+// NewEditPrCommentRequestWithBody generates requests for EditPrComment with any type of body
+func NewEditPrCommentRequestWithBody(server string, owner string, name string, number int64, commentId int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "comment_id", commentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repos/%s/%s/pulls/%s/comments/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -5180,6 +5395,11 @@ type ClientWithResponsesInterface interface {
 
 	PostIssueCommentWithResponse(ctx context.Context, owner string, name string, number int64, body PostIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostIssueCommentResponse, error)
 
+	// EditIssueCommentWithBodyWithResponse request with any body
+	EditIssueCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueCommentResponse, error)
+
+	EditIssueCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueCommentResponse, error)
+
 	// SetIssueGithubStateWithBodyWithResponse request with any body
 	SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
 
@@ -5219,6 +5439,11 @@ type ClientWithResponsesInterface interface {
 	PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
 
 	PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
+
+	// EditPrCommentWithBodyWithResponse request with any body
+	EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
+
+	EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberCommitsWithResponse request
 	GetReposByOwnerByNamePullsByNumberCommitsWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberCommitsResponse, error)
@@ -5671,6 +5896,29 @@ func (r PostIssueCommentResponse) StatusCode() int {
 	return 0
 }
 
+type EditIssueCommentResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *IssueEvent
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r EditIssueCommentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditIssueCommentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type SetIssueGithubStateResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -5894,6 +6142,29 @@ func (r PostPrCommentResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostPrCommentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EditPrCommentResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *MREvent
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r EditPrCommentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditPrCommentResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6758,6 +7029,23 @@ func (c *ClientWithResponses) PostIssueCommentWithResponse(ctx context.Context, 
 	return ParsePostIssueCommentResponse(rsp)
 }
 
+// EditIssueCommentWithBodyWithResponse request with arbitrary body returning *EditIssueCommentResponse
+func (c *ClientWithResponses) EditIssueCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueCommentResponse, error) {
+	rsp, err := c.EditIssueCommentWithBody(ctx, owner, name, number, commentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditIssueCommentResponse(rsp)
+}
+
+func (c *ClientWithResponses) EditIssueCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueCommentResponse, error) {
+	rsp, err := c.EditIssueComment(ctx, owner, name, number, commentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditIssueCommentResponse(rsp)
+}
+
 // SetIssueGithubStateWithBodyWithResponse request with arbitrary body returning *SetIssueGithubStateResponse
 func (c *ClientWithResponses) SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
 	rsp, err := c.SetIssueGithubStateWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
@@ -6886,6 +7174,23 @@ func (c *ClientWithResponses) PostPrCommentWithResponse(ctx context.Context, own
 		return nil, err
 	}
 	return ParsePostPrCommentResponse(rsp)
+}
+
+// EditPrCommentWithBodyWithResponse request with arbitrary body returning *EditPrCommentResponse
+func (c *ClientWithResponses) EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
+	rsp, err := c.EditPrCommentWithBody(ctx, owner, name, number, commentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditPrCommentResponse(rsp)
+}
+
+func (c *ClientWithResponses) EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
+	rsp, err := c.EditPrComment(ctx, owner, name, number, commentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditPrCommentResponse(rsp)
 }
 
 // GetReposByOwnerByNamePullsByNumberCommitsWithResponse request returning *GetReposByOwnerByNamePullsByNumberCommitsResponse
@@ -7710,6 +8015,39 @@ func ParsePostIssueCommentResponse(rsp *http.Response) (*PostIssueCommentRespons
 	return response, nil
 }
 
+// ParseEditIssueCommentResponse parses an HTTP response from a EditIssueCommentWithResponse call
+func ParseEditIssueCommentResponse(rsp *http.Response) (*EditIssueCommentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditIssueCommentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IssueEvent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseSetIssueGithubStateResponse parses an HTTP response from a SetIssueGithubStateWithResponse call
 func ParseSetIssueGithubStateResponse(rsp *http.Response) (*SetIssueGithubStateResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -8020,6 +8358,39 @@ func ParsePostPrCommentResponse(rsp *http.Response) (*PostPrCommentResponse, err
 			return nil, err
 		}
 		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEditPrCommentResponse parses an HTTP response from a EditPrCommentWithResponse call
+func ParseEditPrCommentResponse(rsp *http.Response) (*EditPrCommentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditPrCommentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest MREvent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ErrorModel

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -920,6 +920,29 @@ func (d *DB) UpsertMREvents(ctx context.Context, events []MREvent) error {
 	})
 }
 
+func (d *DB) MRCommentEventExists(
+	ctx context.Context,
+	mrID int64,
+	platformID int64,
+) (bool, error) {
+	var exists bool
+	err := d.ro.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM middleman_mr_events
+			WHERE merge_request_id = ?
+			  AND platform_id = ?
+			  AND event_type = 'issue_comment'
+		 )`,
+		mrID,
+		platformID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check mr comment event exists: %w", err)
+	}
+	return exists, nil
+}
+
 // DeleteMissingMRCommentEvents removes issue_comment rows for a PR whose
 // dedupe keys are absent from the latest GitHub comment list.
 func (d *DB) DeleteMissingMRCommentEvents(
@@ -1791,6 +1814,29 @@ func (d *DB) UpsertIssueEvents(ctx context.Context, events []IssueEvent) error {
 		}
 		return nil
 	})
+}
+
+func (d *DB) IssueCommentEventExists(
+	ctx context.Context,
+	issueID int64,
+	platformID int64,
+) (bool, error) {
+	var exists bool
+	err := d.ro.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM middleman_issue_events
+			WHERE issue_id = ?
+			  AND platform_id = ?
+			  AND event_type = 'issue_comment'
+		)`,
+		issueID,
+		platformID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check issue comment event exists: %w", err)
+	}
+	return exists, nil
 }
 
 // DeleteMissingIssueCommentEvents removes issue_comment rows for an issue whose

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -75,6 +75,7 @@ type Client interface {
 	ListWorkflowRunsForHeadSHA(ctx context.Context, owner, repo, headSHA string) ([]*gh.WorkflowRun, error)
 	ApproveWorkflowRun(ctx context.Context, owner, repo string, runID int64) error
 	CreateIssueComment(ctx context.Context, owner, repo string, number int, body string) (*gh.IssueComment, error)
+	EditIssueComment(ctx context.Context, owner, repo string, commentID int64, body string) (*gh.IssueComment, error)
 	GetRepository(ctx context.Context, owner, repo string) (*gh.Repository, error)
 	CreateReview(ctx context.Context, owner, repo string, number int, event string, body string) (*gh.PullRequestReview, error)
 	MarkPullRequestReadyForReview(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error)
@@ -969,6 +970,21 @@ func (c *liveClient) CreateIssueComment(
 	c.trackRate(resp)
 	if err != nil {
 		return nil, fmt.Errorf("creating comment on %s/%s#%d: %w", owner, repo, number, err)
+	}
+	return comment, nil
+}
+
+func (c *liveClient) EditIssueComment(
+	ctx context.Context, owner, repo string, commentID int64, body string,
+) (*gh.IssueComment, error) {
+	comment, resp, err := c.gh.Issues.EditComment(
+		ctx, owner, repo, commentID, &gh.IssueComment{Body: new(body)},
+	)
+	c.trackRate(resp)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"editing comment %d on %s/%s: %w", commentID, owner, repo, err,
+		)
 	}
 	return comment, nil
 }

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -279,6 +279,13 @@ func (m *mockClient) CreateIssueComment(
 	return nil, nil
 }
 
+func (m *mockClient) EditIssueComment(
+	_ context.Context, _, _ string, _ int64, _ string,
+) (*gh.IssueComment, error) {
+	m.trackCall()
+	return nil, nil
+}
+
 func (m *mockClient) GetRepository(
 	ctx context.Context, owner, repo string,
 ) (*gh.Repository, error) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -75,6 +75,7 @@ type mockGH struct {
 	markReadyForReviewFn      func(context.Context, string, string, int) (*gh.PullRequest, error)
 	editPullRequestFn         func(context.Context, string, string, int, ghclient.EditPullRequestOpts) (*gh.PullRequest, error)
 	editIssueFn               func(context.Context, string, string, int, string) (*gh.Issue, error)
+	editIssueCommentFn        func(context.Context, string, string, int64, string) (*gh.IssueComment, error)
 	mergePullRequestFn        func(context.Context, string, string, int, string, string, string) (*gh.PullRequestMergeResult, error)
 	listWorkflowRunsForHeadFn func(context.Context, string, string, string) ([]*gh.WorkflowRun, error)
 	approveWorkflowRunFn      func(context.Context, string, string, int64) error
@@ -268,6 +269,23 @@ func (m *mockGH) CreateIssueComment(
 	return &gh.IssueComment{
 		ID:   &id,
 		Body: &body,
+	}, nil
+}
+
+func (m *mockGH) EditIssueComment(
+	ctx context.Context, owner, repo string, commentID int64, body string,
+) (*gh.IssueComment, error) {
+	if m.editIssueCommentFn != nil {
+		return m.editIssueCommentFn(ctx, owner, repo, commentID, body)
+	}
+	login := "fixture-bot"
+	now := gh.Timestamp{Time: time.Now().UTC()}
+	return &gh.IssueComment{
+		ID:        &commentID,
+		Body:      &body,
+		User:      &gh.User{Login: &login},
+		CreatedAt: &now,
+		UpdatedAt: &now,
 	}, nil
 }
 
@@ -2741,6 +2759,94 @@ func TestAPIPostPrCommentAllowsMixedCaseTrackedRepo(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusCreated, resp.StatusCode())
 	require.NotNil(resp.JSON201)
+}
+
+func TestAPIEditPrCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	commentID := int64(9876)
+	createdAt := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	mock := &mockGH{
+		editIssueCommentFn: func(_ context.Context, owner, repo string, gotCommentID int64, body string) (*gh.IssueComment, error) {
+			assert.Equal("acme", owner)
+			assert.Equal("widget", repo)
+			assert.Equal(commentID, gotCommentID)
+			assert.Equal("edited body", body)
+			login := "maintainer"
+			return &gh.IssueComment{
+				ID:        &gotCommentID,
+				Body:      &body,
+				User:      &gh.User{Login: &login},
+				CreatedAt: &gh.Timestamp{Time: createdAt},
+				UpdatedAt: &gh.Timestamp{Time: createdAt.Add(time.Minute)},
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	mrID := seedPR(t, database, "acme", "widget", 7)
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/repos/acme/widget/pulls/7/comments/9876",
+		strings.NewReader(`{"body":"edited body"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(http.StatusOK, rec.Code)
+	events, err := database.ListMREvents(t.Context(), mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("edited body", events[0].Body)
+	assert.Equal("maintainer", events[0].Author)
+	require.NotNil(events[0].PlatformID)
+	assert.Equal(commentID, *events[0].PlatformID)
+}
+
+func TestAPIEditIssueCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	commentID := int64(1234)
+	createdAt := time.Date(2026, 4, 29, 13, 0, 0, 0, time.UTC)
+	mock := &mockGH{
+		editIssueCommentFn: func(_ context.Context, owner, repo string, gotCommentID int64, body string) (*gh.IssueComment, error) {
+			assert.Equal("acme", owner)
+			assert.Equal("widget", repo)
+			assert.Equal(commentID, gotCommentID)
+			assert.Equal("edited issue body", body)
+			login := "maintainer"
+			return &gh.IssueComment{
+				ID:        &gotCommentID,
+				Body:      &body,
+				User:      &gh.User{Login: &login},
+				CreatedAt: &gh.Timestamp{Time: createdAt},
+				UpdatedAt: &gh.Timestamp{Time: createdAt.Add(time.Minute)},
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	issueID := seedIssue(t, database, "acme", "widget", 5, "open")
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/repos/acme/widget/issues/5/comments/1234",
+		strings.NewReader(`{"body":"edited issue body"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(http.StatusOK, rec.Code)
+	events, err := database.ListIssueEvents(t.Context(), issueID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("edited issue body", events[0].Body)
+	assert.Equal("maintainer", events[0].Author)
+	require.NotNil(events[0].PlatformID)
+	assert.Equal(commentID, *events[0].PlatformID)
 }
 
 func TestAPICommentAutocomplete(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2784,6 +2784,15 @@ func TestAPIEditPrCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 	}
 	srv, database := setupTestServerWithMock(t, mock)
 	mrID := seedPR(t, database, "acme", "widget", 7)
+	require.NoError(database.UpsertMREvents(t.Context(), []db.MREvent{{
+		MergeRequestID: mrID,
+		PlatformID:     &commentID,
+		EventType:      "issue_comment",
+		Author:         "maintainer",
+		Body:           "original body",
+		CreatedAt:      createdAt,
+		DedupeKey:      "comment-9876",
+	}}))
 
 	req := httptest.NewRequest(
 		http.MethodPatch,
@@ -2803,6 +2812,44 @@ func TestAPIEditPrCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 	assert.Equal("maintainer", events[0].Author)
 	require.NotNil(events[0].PlatformID)
 	assert.Equal(commentID, *events[0].PlatformID)
+}
+
+func TestAPIEditPrCommentRejectsCommentFromDifferentPR(t *testing.T) {
+	require := require.New(t)
+	commentID := int64(5555)
+	var editCalls atomic.Int32
+	mock := &mockGH{
+		editIssueCommentFn: func(_ context.Context, _, _ string, _ int64, _ string) (*gh.IssueComment, error) {
+			editCalls.Add(1)
+			return nil, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	routeMRID := seedPR(t, database, "acme", "widget", 7)
+	otherMRID := seedPR(t, database, "acme", "widget", 8)
+	require.NotEqual(routeMRID, otherMRID)
+	require.NoError(database.UpsertMREvents(t.Context(), []db.MREvent{{
+		MergeRequestID: otherMRID,
+		PlatformID:     &commentID,
+		EventType:      "issue_comment",
+		Author:         "maintainer",
+		Body:           "other PR body",
+		CreatedAt:      time.Now().UTC(),
+		DedupeKey:      "comment-5555",
+	}}))
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/repos/acme/widget/pulls/7/comments/5555",
+		strings.NewReader(`{"body":"wrong target"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(http.StatusNotFound, rec.Code)
+	require.Equal(int32(0), editCalls.Load())
 }
 
 func TestAPIEditIssueCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
@@ -2828,6 +2875,15 @@ func TestAPIEditIssueCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 	}
 	srv, database := setupTestServerWithMock(t, mock)
 	issueID := seedIssue(t, database, "acme", "widget", 5, "open")
+	require.NoError(database.UpsertIssueEvents(t.Context(), []db.IssueEvent{{
+		IssueID:    issueID,
+		PlatformID: &commentID,
+		EventType:  "issue_comment",
+		Author:     "maintainer",
+		Body:       "original issue body",
+		CreatedAt:  createdAt,
+		DedupeKey:  "issue-comment-1234",
+	}}))
 
 	req := httptest.NewRequest(
 		http.MethodPatch,
@@ -2847,6 +2903,44 @@ func TestAPIEditIssueCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 	assert.Equal("maintainer", events[0].Author)
 	require.NotNil(events[0].PlatformID)
 	assert.Equal(commentID, *events[0].PlatformID)
+}
+
+func TestAPIEditIssueCommentRejectsCommentFromDifferentIssue(t *testing.T) {
+	require := require.New(t)
+	commentID := int64(6666)
+	var editCalls atomic.Int32
+	mock := &mockGH{
+		editIssueCommentFn: func(_ context.Context, _, _ string, _ int64, _ string) (*gh.IssueComment, error) {
+			editCalls.Add(1)
+			return nil, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	routeIssueID := seedIssue(t, database, "acme", "widget", 5, "open")
+	otherIssueID := seedIssue(t, database, "acme", "widget", 6, "open")
+	require.NotEqual(routeIssueID, otherIssueID)
+	require.NoError(database.UpsertIssueEvents(t.Context(), []db.IssueEvent{{
+		IssueID:    otherIssueID,
+		PlatformID: &commentID,
+		EventType:  "issue_comment",
+		Author:     "maintainer",
+		Body:       "other issue body",
+		CreatedAt:  time.Now().UTC(),
+		DedupeKey:  "issue-comment-6666",
+	}}))
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/repos/acme/widget/issues/5/comments/6666",
+		strings.NewReader(`{"body":"wrong target"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	require.Equal(http.StatusNotFound, rec.Code)
+	require.Equal(int32(0), editCalls.Load())
 }
 
 func TestAPICommentAutocomplete(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1033,17 +1033,25 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
+	ref := repoNumberPathRef{owner: input.Owner, name: input.Name, number: input.Number}
+	mrID, err := s.lookupMRID(ctx, ref)
+	if err != nil {
+		return nil, huma.Error404NotFound(err.Error())
+	}
+
+	exists, err := s.db.MRCommentEventExists(ctx, mrID, input.CommentID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("validate comment target failed")
+	}
+	if !exists {
+		return nil, huma.Error404NotFound("comment not found for pull request")
+	}
+
 	comment, err := client.EditIssueComment(
 		ctx, input.Owner, input.Name, input.CommentID, input.Body.Body,
 	)
 	if err != nil {
 		return nil, huma.Error502BadGateway("edit comment on GitHub failed")
-	}
-
-	ref := repoNumberPathRef{owner: input.Owner, name: input.Name, number: input.Number}
-	mrID, err := s.lookupMRID(ctx, ref)
-	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
 	}
 
 	event := ghclient.NormalizeCommentEvent(mrID, comment)
@@ -1325,13 +1333,6 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
-	comment, err := client.EditIssueComment(
-		ctx, input.Owner, input.Name, input.CommentID, input.Body.Body,
-	)
-	if err != nil {
-		return nil, huma.Error502BadGateway("edit comment on GitHub failed")
-	}
-
 	ref := repoNumberPathRef{
 		owner:        input.Owner,
 		name:         input.Name,
@@ -1341,6 +1342,21 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 	issueID, err := s.lookupIssueID(ctx, ref)
 	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
+	}
+
+	exists, err := s.db.IssueCommentEventExists(ctx, issueID, input.CommentID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("validate comment target failed")
+	}
+	if !exists {
+		return nil, huma.Error404NotFound("comment not found for issue")
+	}
+
+	comment, err := client.EditIssueComment(
+		ctx, input.Owner, input.Name, input.CommentID, input.Body.Body,
+	)
+	if err != nil {
+		return nil, huma.Error502BadGateway("edit comment on GitHub failed")
 	}
 
 	event := ghclient.NormalizeIssueCommentEvent(issueID, comment)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -75,6 +75,20 @@ type postCommentOutput struct {
 	Body   db.MREvent
 }
 
+type editCommentInput struct {
+	Owner     string `path:"owner"`
+	Name      string `path:"name"`
+	Number    int    `path:"number"`
+	CommentID int64  `path:"comment_id"`
+	Body      struct {
+		Body string `json:"body"`
+	}
+}
+
+type editCommentOutput struct {
+	Body db.MREvent
+}
+
 type listIssuesInput struct {
 	Repo    string `query:"repo"`
 	State   string `query:"state"`
@@ -112,6 +126,21 @@ type postIssueCommentInput struct {
 type postIssueCommentOutput struct {
 	Status int `status:"201"`
 	Body   db.IssueEvent
+}
+
+type editIssueCommentInput struct {
+	Owner     string `path:"owner"`
+	Name      string `path:"name"`
+	Number    int    `path:"number"`
+	CommentID int64  `path:"comment_id"`
+	Body      struct {
+		Body         string `json:"body"`
+		PlatformHost string `json:"platform_host,omitempty"`
+	}
+}
+
+type editIssueCommentOutput struct {
+	Body db.IssueEvent
 }
 
 type createIssueInput struct {
@@ -394,6 +423,12 @@ func (s *Server) registerAPI(api huma.API) {
 		Path:          "/repos/{owner}/{name}/pulls/{number}/comments",
 		DefaultStatus: http.StatusCreated,
 	}, s.postComment)
+	huma.Register(api, huma.Operation{
+		OperationID:   "edit-pr-comment",
+		Method:        http.MethodPatch,
+		Path:          "/repos/{owner}/{name}/pulls/{number}/comments/{comment_id}",
+		DefaultStatus: http.StatusOK,
+	}, s.editComment)
 
 	huma.Get(api, "/issues", s.listIssues)
 	huma.Register(api, huma.Operation{
@@ -409,6 +444,12 @@ func (s *Server) registerAPI(api huma.API) {
 		Path:          "/repos/{owner}/{name}/issues/{number}/comments",
 		DefaultStatus: http.StatusCreated,
 	}, s.postIssueComment)
+	huma.Register(api, huma.Operation{
+		OperationID:   "edit-issue-comment",
+		Method:        http.MethodPatch,
+		Path:          "/repos/{owner}/{name}/issues/{number}/comments/{comment_id}",
+		DefaultStatus: http.StatusOK,
+	}, s.editIssueComment)
 
 	huma.Post(api, "/repos/{owner}/{name}/items/{number}/resolve", s.resolveItem)
 
@@ -982,6 +1023,37 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 	return &postCommentOutput{Status: http.StatusCreated, Body: event}, nil
 }
 
+func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*editCommentOutput, error) {
+	if strings.TrimSpace(input.Body.Body) == "" {
+		return nil, huma.Error400BadRequest("comment body must not be empty")
+	}
+
+	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	if err != nil {
+		return nil, huma.Error404NotFound(err.Error())
+	}
+
+	comment, err := client.EditIssueComment(
+		ctx, input.Owner, input.Name, input.CommentID, input.Body.Body,
+	)
+	if err != nil {
+		return nil, huma.Error502BadGateway("edit comment on GitHub failed")
+	}
+
+	ref := repoNumberPathRef{owner: input.Owner, name: input.Name, number: input.Number}
+	mrID, err := s.lookupMRID(ctx, ref)
+	if err != nil {
+		return nil, huma.Error404NotFound(err.Error())
+	}
+
+	event := ghclient.NormalizeCommentEvent(mrID, comment)
+	if err := s.db.UpsertMREvents(ctx, []db.MREvent{event}); err != nil {
+		return nil, huma.Error500InternalServerError("persist edited comment failed")
+	}
+
+	return &editCommentOutput{Body: event}, nil
+}
+
 func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listIssuesOutput, error) {
 	if input.State != "" {
 		valid := map[string]bool{
@@ -1231,6 +1303,52 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 	}
 
 	return &postIssueCommentOutput{Status: http.StatusCreated, Body: event}, nil
+}
+
+func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentInput) (*editIssueCommentOutput, error) {
+	if strings.TrimSpace(input.Body.Body) == "" {
+		return nil, huma.Error400BadRequest("comment body must not be empty")
+	}
+
+	repo, err := s.lookupRepo(
+		ctx, input.Owner, input.Name, input.Body.PlatformHost,
+	)
+	if err != nil {
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("repo lookup failed")
+	}
+
+	client, err := s.syncer.ClientForHost(repo.PlatformHost)
+	if err != nil {
+		return nil, huma.Error404NotFound(err.Error())
+	}
+
+	comment, err := client.EditIssueComment(
+		ctx, input.Owner, input.Name, input.CommentID, input.Body.Body,
+	)
+	if err != nil {
+		return nil, huma.Error502BadGateway("edit comment on GitHub failed")
+	}
+
+	ref := repoNumberPathRef{
+		owner:        input.Owner,
+		name:         input.Name,
+		number:       input.Number,
+		platformHost: repo.PlatformHost,
+	}
+	issueID, err := s.lookupIssueID(ctx, ref)
+	if err != nil {
+		return nil, huma.Error404NotFound(err.Error())
+	}
+
+	event := ghclient.NormalizeIssueCommentEvent(issueID, comment)
+	if err := s.db.UpsertIssueEvents(ctx, []db.IssueEvent{event}); err != nil {
+		return nil, huma.Error500InternalServerError("persist edited comment failed")
+	}
+
+	return &editIssueCommentOutput{Body: event}, nil
 }
 
 func (s *Server) setStarred(ctx context.Context, input *starredInput) (*statusOnlyOutput, error) {

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 )
 
 var errFixtureReadOnly = errors.New("fixture client: mutation not supported")
+var errFixtureNotFound = errors.New("fixture client: not found")
 
 type fixtureReadyForReviewStaleStateError struct {
 	message string
@@ -374,6 +376,29 @@ func (c *FixtureClient) CreateIssueComment(
 	key := issueKey(owner, repo, number)
 	c.Comments[key] = append(c.Comments[key], comment)
 	return comment, nil
+}
+
+func (c *FixtureClient) EditIssueComment(
+	_ context.Context, owner, repo string, commentID int64, body string,
+) (*gh.IssueComment, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	prefix := repoKey(owner, repo) + "#"
+	for key, comments := range c.Comments {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		for _, comment := range comments {
+			if comment.GetID() == commentID {
+				comment.Body = &body
+				updatedAt := time.Now().UTC()
+				comment.UpdatedAt = &gh.Timestamp{Time: updatedAt}
+				return comment, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("%w: comment %d", errFixtureNotFound, commentID)
 }
 
 // CreateReview returns an error (mutations not supported).

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -236,6 +236,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/repos/{owner}/{name}/issues/{number}/comments/{comment_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["edit-issue-comment"];
+        trace?: never;
+    };
     "/repos/{owner}/{name}/issues/{number}/github-state": {
         parameters: {
             query?: never;
@@ -383,6 +399,22 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/repos/{owner}/{name}/pulls/{number}/comments/{comment_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["edit-pr-comment"];
         trace?: never;
     };
     "/repos/{owner}/{name}/pulls/{number}/commits": {
@@ -1004,6 +1036,25 @@ export interface components {
             stale: boolean;
             /** Format: int64 */
             whitespace_only_count: number;
+        };
+        EditCommentInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/EditCommentInputBody.json
+             */
+            readonly $schema?: string;
+            body: string;
+        };
+        EditIssueCommentInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/EditIssueCommentInputBody.json
+             */
+            readonly $schema?: string;
+            body: string;
+            platform_host?: string;
         };
         EditPRContentInputBody: {
             /**
@@ -2367,6 +2418,44 @@ export interface operations {
             };
         };
     };
+    "edit-issue-comment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                name: string;
+                number: number;
+                comment_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EditIssueCommentInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IssueEvent"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "set-issue-github-state": {
         parameters: {
             query?: never;
@@ -2701,6 +2790,44 @@ export interface operations {
         responses: {
             /** @description Created */
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MREvent"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "edit-pr-comment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                owner: string;
+                name: string;
+                number: number;
+                comment_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EditCommentInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
+  import CheckIcon from "@lucide/svelte/icons/check";
+  import CopyIcon from "@lucide/svelte/icons/copy";
+  import PencilIcon from "@lucide/svelte/icons/pencil";
+  import XIcon from "@lucide/svelte/icons/x";
   import { slide } from "svelte/transition";
   import type { IssueEvent, PREvent } from "../../api/types.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { timeAgo } from "../../utils/time.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
+  import CommentEditor from "./CommentEditor.svelte";
 
   interface Props {
     events: Array<PREvent | IssueEvent>;
@@ -11,6 +16,7 @@
     repoName?: string;
     filtered?: boolean;
     showCommitDetails?: boolean;
+    onEditComment?: (event: PREvent | IssueEvent, body: string) => Promise<boolean>;
   }
 
   const {
@@ -19,6 +25,7 @@
     repoName,
     filtered = false,
     showCommitDetails = true,
+    onEditComment,
   }: Props = $props();
 
   const typeLabels: Record<string, string> = {
@@ -97,6 +104,58 @@
 
   let copiedId = $state<string | null>(null);
   let copyTimeout: ReturnType<typeof setTimeout> | null = null;
+  let editingId = $state<number | null>(null);
+  let editDraft = $state("");
+  let savingEditId = $state<number | null>(null);
+  let editError = $state<string | null>(null);
+
+  function canEditComment(event: PREvent | IssueEvent): boolean {
+    return (
+      event.EventType === "issue_comment" &&
+      event.PlatformID != null &&
+      repoOwner !== undefined &&
+      repoName !== undefined &&
+      onEditComment !== undefined
+    );
+  }
+
+  function startEdit(event: PREvent | IssueEvent): void {
+    editingId = event.ID;
+    editDraft = event.Body;
+    editError = null;
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+    editDraft = "";
+    editError = null;
+  }
+
+  async function saveEdit(event: PREvent | IssueEvent): Promise<void> {
+    const nextBody = editDraft.trim();
+    if (nextBody === "") {
+      editError = "Comment body must not be empty";
+      return;
+    }
+    if (nextBody === event.Body.trim()) {
+      cancelEdit();
+      return;
+    }
+    if (onEditComment === undefined) return;
+
+    savingEditId = event.ID;
+    editError = null;
+    try {
+      const ok = await onEditComment(event, nextBody);
+      if (ok) {
+        cancelEdit();
+      } else {
+        editError = "Could not edit comment";
+      }
+    } finally {
+      savingEditId = null;
+    }
+  }
 
   function copyText(id: string, text: string): void {
     void copyToClipboard(text).then((ok) => {
@@ -191,30 +250,127 @@
             {/if}
             {#if event.Body}
               <div class="event-body-wrap">
-                <button
-                  class="copy-icon-btn"
-                  class:copied={copiedId === String(event.ID)}
-                  onclick={() => copyText(String(event.ID), event.Body)}
-                  title={copiedId === String(event.ID) ? "Copied!" : "Copy to clipboard"}
-                >
-                  {#if copiedId === String(event.ID)}
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/>
-                    </svg>
-                  {:else}
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
-                      <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
-                    </svg>
+                <div class="event-actions">
+                  {#if canEditComment(event)}
+                    <button
+                      class="event-action-btn"
+                      onclick={() => startEdit(event)}
+                      title="Edit comment"
+                      aria-label="Edit comment"
+                      disabled={savingEditId !== null}
+                    >
+                      <PencilIcon size={14} />
+                    </button>
                   {/if}
-                </button>
-                <div class="event-body {shouldRenderMarkdown(event.EventType) ? 'markdown-body' : ''}">
-                  {#if shouldRenderMarkdown(event.EventType)}
-                    {@html renderMarkdown(event.Body, repoOwner && repoName ? { owner: repoOwner, name: repoName } : undefined)}
-                  {:else}
-                    {event.Body}
-                  {/if}
+                  <button
+                    class="event-action-btn"
+                    class:copied={copiedId === String(event.ID)}
+                    onclick={() => copyText(String(event.ID), event.Body)}
+                    title={copiedId === String(event.ID) ? "Copied!" : "Copy to clipboard"}
+                    aria-label={copiedId === String(event.ID) ? "Copied" : "Copy comment"}
+                  >
+                    {#if copiedId === String(event.ID)}
+                      <CheckIcon size={14} />
+                    {:else}
+                      <CopyIcon size={14} />
+                    {/if}
+                  </button>
                 </div>
+                {#if editingId === event.ID && repoOwner && repoName}
+                  <div class="edit-panel">
+                    <CommentEditor
+                      owner={repoOwner}
+                      name={repoName}
+                      value={editDraft}
+                      disabled={savingEditId === event.ID}
+                      oninput={(nextBody) => {
+                        editDraft = nextBody;
+                      }}
+                      onsubmit={() => {
+                        void saveEdit(event);
+                      }}
+                    />
+                    {#if editError}
+                      <p class="edit-error">{editError}</p>
+                    {/if}
+                    <div class="edit-actions">
+                      <button
+                        class="edit-action edit-action--primary"
+                        onclick={() => void saveEdit(event)}
+                        disabled={savingEditId === event.ID}
+                      >
+                        <CheckIcon size={14} />
+                        {savingEditId === event.ID ? "Saving..." : "Save"}
+                      </button>
+                      <button
+                        class="edit-action"
+                        onclick={cancelEdit}
+                        disabled={savingEditId === event.ID}
+                      >
+                        <XIcon size={14} />
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                {:else}
+                  <div class="event-body {shouldRenderMarkdown(event.EventType) ? 'markdown-body' : ''}">
+                    {#if shouldRenderMarkdown(event.EventType)}
+                      {@html renderMarkdown(event.Body, repoOwner && repoName ? { owner: repoOwner, name: repoName } : undefined)}
+                    {:else}
+                      {event.Body}
+                    {/if}
+                  </div>
+                {/if}
+              </div>
+            {:else if canEditComment(event)}
+              <div class="event-body-wrap">
+                {#if editingId === event.ID && repoOwner && repoName}
+                  <div class="edit-panel">
+                    <CommentEditor
+                      owner={repoOwner}
+                      name={repoName}
+                      value={editDraft}
+                      disabled={savingEditId === event.ID}
+                      oninput={(nextBody) => {
+                        editDraft = nextBody;
+                      }}
+                      onsubmit={() => {
+                        void saveEdit(event);
+                      }}
+                    />
+                    {#if editError}
+                      <p class="edit-error">{editError}</p>
+                    {/if}
+                    <div class="edit-actions">
+                      <button
+                        class="edit-action edit-action--primary"
+                        onclick={() => void saveEdit(event)}
+                        disabled={savingEditId === event.ID}
+                      >
+                        <CheckIcon size={14} />
+                        {savingEditId === event.ID ? "Saving..." : "Save"}
+                      </button>
+                      <button
+                        class="edit-action"
+                        onclick={cancelEdit}
+                        disabled={savingEditId === event.ID}
+                      >
+                        <XIcon size={14} />
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                {:else}
+                  <button
+                    class="event-action-btn empty-edit-btn"
+                    onclick={() => startEdit(event)}
+                    title="Edit comment"
+                    aria-label="Edit comment"
+                    disabled={savingEditId !== null}
+                  >
+                    <PencilIcon size={14} />
+                  </button>
+                {/if}
               </div>
             {/if}
           </div>
@@ -383,10 +539,16 @@
     margin-top: 8px;
   }
 
-  .copy-icon-btn {
+  .event-actions {
     position: absolute;
     top: 6px;
     right: 6px;
+    display: flex;
+    gap: 2px;
+    z-index: 1;
+  }
+
+  .event-action-btn {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -396,31 +558,35 @@
     color: var(--text-muted);
     opacity: 0;
     transition: opacity 0.15s, background 0.15s, color 0.15s;
-    z-index: 1;
   }
 
-  .event-body-wrap:hover .copy-icon-btn,
-  .copy-icon-btn:focus-visible {
+  .event-body-wrap:hover .event-action-btn,
+  .event-action-btn:focus-visible {
     opacity: 1;
   }
 
-  .copy-icon-btn:hover {
+  .event-action-btn:hover:not(:disabled) {
     background: var(--bg-surface-hover);
     color: var(--text-secondary);
   }
 
-  .copy-icon-btn:active {
+  .event-action-btn:active:not(:disabled) {
     transform: scale(0.92);
   }
 
-  .copy-icon-btn.copied {
+  .event-action-btn.copied {
     opacity: 1;
     color: var(--accent-green);
     background: color-mix(in srgb, var(--accent-green) 12%, transparent);
   }
 
+  .event-action-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
   @media (hover: none) {
-    .copy-icon-btn {
+    .event-action-btn {
       opacity: 1;
     }
   }
@@ -436,5 +602,63 @@
 
   .event-body.markdown-body {
     white-space: normal;
+  }
+
+  .edit-panel {
+    padding: 8px 0 2px;
+  }
+
+  .edit-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+
+  .edit-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-height: 28px;
+    padding: 5px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: var(--bg-inset);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .edit-action--primary {
+    border-color: var(--accent-blue);
+    background: var(--accent-blue);
+    color: white;
+  }
+
+  .edit-action:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .edit-action:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .edit-action--primary:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent-blue) 86%, black);
+    color: white;
+  }
+
+  .edit-error {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--accent-red);
+  }
+
+  .empty-edit-btn {
+    position: static;
+    opacity: 1;
+    margin-top: 8px;
   }
 </style>

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { compile } from "svelte/compiler";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import componentSource from "./EventTimeline.svelte?raw";
@@ -253,5 +253,27 @@ describe("EventTimeline", () => {
     });
 
     expect(screen.getByText("No activity matches the current filters")).toBeTruthy();
+  });
+
+  it("shows inline edit controls for editable issue comments", async () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            Body: "Original comment",
+            EventType: "issue_comment",
+            PlatformID: 44,
+          }),
+        ],
+        repoOwner: "acme",
+        repoName: "widget",
+        onEditComment: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Edit comment" }));
+
+    expect(screen.getByRole("button", { name: /save/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -62,6 +62,14 @@
     return actualHost !== expectedHost;
   });
 
+  async function editTimelineComment(
+    event: { PlatformID: number | null },
+    body: string,
+  ): Promise<boolean> {
+    if (event.PlatformID === null) return false;
+    return issues.editIssueComment(owner, name, number, event.PlatformID, body);
+  }
+
   $effect(() => {
     const requestOwner = owner;
     const requestName = name;
@@ -543,7 +551,12 @@
       <div class="section">
         <h3 class="section-title">Activity</h3>
         {#if issues.getIssueDetailLoaded()}
-          <EventTimeline events={detail.events ?? []} repoOwner={owner} repoName={name} />
+          <EventTimeline
+            events={detail.events ?? []}
+            repoOwner={owner}
+            repoName={name}
+            onEditComment={editTimelineComment}
+          />
         {:else if issues.isIssueDetailSyncing()}
           <div class="loading-placeholder">
             <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -80,6 +80,14 @@
     activePRTimelineFilterCount(timelineFilter) > 0,
   );
 
+  async function editTimelineComment(
+    event: { PlatformID: number | null },
+    body: string,
+  ): Promise<boolean> {
+    if (event.PlatformID === null) return false;
+    return detailStore.editComment(owner, name, number, event.PlatformID, body);
+  }
+
   function updateTimelineFilter(next: PRTimelineFilterState): void {
     timelineFilter = next;
     savePRTimelineFilter(next);
@@ -1091,6 +1099,7 @@
             repoName={name}
             filtered={hasActiveTimelineFilters}
             showCommitDetails={timelineFilter.showCommitDetails}
+            onEditComment={editTimelineComment}
           />
         {:else if detailStore.isDetailSyncing()}
           <div class="loading-placeholder">

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -697,6 +697,44 @@ export function createDetailStore(
     }
   }
 
+  async function editComment(
+    owner: string,
+    name: string,
+    number: number,
+    commentID: number,
+    body: string,
+  ): Promise<boolean> {
+    storeError = null;
+    try {
+      const { error: requestError } = await apiClient.PATCH(
+        "/repos/{owner}/{name}/pulls/{number}/comments/{comment_id}",
+        {
+          params: {
+            path: {
+              owner,
+              name,
+              number,
+              comment_id: commentID,
+            },
+          },
+          body: { body },
+        },
+      );
+      if (requestError) {
+        throw new Error(
+          requestError.detail ??
+            requestError.title ??
+            "failed to edit comment",
+        );
+      }
+    } catch (err) {
+      storeError = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+    await refreshDetail(owner, name, number);
+    return true;
+  }
+
   return {
     getDetail,
     isDetailLoading,
@@ -713,6 +751,7 @@ export function createDetailStore(
     stopDetailPolling,
     toggleDetailPRStar,
     submitComment,
+    editComment,
   };
 }
 

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -537,6 +537,49 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     }
   }
 
+  async function editIssueComment(
+    owner: string,
+    name: string,
+    number: number,
+    commentID: number,
+    body: string,
+  ): Promise<boolean> {
+    const platformHost = currentIssuePlatformHost(owner, name, number);
+
+    detailError = null;
+    try {
+      const { error: requestError } = await apiClient.PATCH(
+        "/repos/{owner}/{name}/issues/{number}/comments/{comment_id}",
+        {
+          params: {
+            path: {
+              owner,
+              name,
+              number,
+              comment_id: commentID,
+            },
+          },
+          body: {
+            body,
+            ...(platformHost && {
+              platform_host: platformHost,
+            }),
+          },
+        },
+      );
+      if (requestError) {
+        throw new Error(
+          apiErrorMessage(requestError, "failed to edit comment"),
+        );
+      }
+    } catch (err) {
+      detailError = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+    await refreshIssueDetail(owner, name, number, platformHost);
+    return true;
+  }
+
   async function toggleIssueStar(
     owner: string,
     name: string,
@@ -708,6 +751,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     stopIssueDetailPolling,
     clearIssueDetail,
     submitIssueComment,
+    editIssueComment,
     toggleIssueStar,
     selectNextIssue,
     selectPrevIssue,


### PR DESCRIPTION
## Summary
- Add PATCH endpoints for editing issue and PR comments through GitHub, then persist the updated comment back into the local timeline
- Expose inline edit controls on comment events in the issue and PR activity views
- Regenerate the OpenAPI and generated API clients to match the new routes

## Testing
- Added backend API tests covering PR and issue comment edits
- Added UI coverage for inline edit controls in the event timeline
- Ran Go tests for the new edit paths, UI typecheck, and Svelte/Vitest validation