### PR TITLE
Idea: try restty for terminal rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,13 +9,11 @@
       "dependencies": {
         "@lucide/svelte": "1.3.0",
         "@middleman/ui": "workspace:*",
-        "@xterm/addon-fit": "^0.11.0",
-        "@xterm/addon-webgl": "^0.19.0",
-        "@xterm/xterm": "^6.0.0",
         "dompurify": "3.3.3",
         "js-toml": "^1.0.3",
         "marked": "17.0.5",
         "openapi-fetch": "^0.17.0",
+        "restty": "^0.1.35",
         "shiki": "^4.0.2",
       },
       "devDependencies": {
@@ -429,12 +427,6 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
-    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
-
-    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
-
-    "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
-
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -815,6 +807,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "restty": ["restty@0.1.35", "", { "dependencies": { "text-shaper": "0.1.22" } }, "sha512-IUr4NsdYCTErKBxuAd0eu/KdiGZhADBxA0ddSPEEIxAz8np3RT1bLiL9iIH+wglmUeSmHRmJzkPN7hGJJ+E/Yw=="],
+
     "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
@@ -862,6 +856,8 @@
     "svelte-tiptap": ["svelte-tiptap@3.0.1", "", { "peerDependencies": { "@floating-ui/dom": "^1.0.0", "@tiptap/core": "^3.0.0", "@tiptap/extension-bubble-menu": "^3.0.0", "@tiptap/extension-floating-menu": "^3.0.0", "@tiptap/pm": "^3.0.0", "svelte": "^5.0.0" } }, "sha512-Vi3kVGOd01f7mslOxGbJB7z2QavdvH+6WffhB+Y5fleTiZaW0YWqIboyO2u/uh4BQeosiINmmuRJ+Qwb7mYP+A=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "text-shaper": ["text-shaper@0.1.22", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-OYxqPcNEox3tlXilxZVPNub8EU/A6Lxy9vlCAe362fiGI9f3pMav497wL7cecX0CPq1yVtiBn/lii/ZZUUk9bQ=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1607,6 +1607,8 @@ components:
           type:
             - string
             - "null"
+        fork:
+          type: boolean
         name:
           type: string
         owner:
@@ -1622,6 +1624,7 @@ components:
         - name
         - description
         - private
+        - fork
         - pushed_at
         - already_configured
       type: object
@@ -1721,6 +1724,8 @@ components:
         commits_since_release:
           format: int64
           type: integer
+        default_platform_host:
+          type: string
         draft_pr_count:
           format: int64
           type: integer
@@ -1762,6 +1767,7 @@ components:
           type: string
       required:
         - platform_host
+        - default_platform_host
         - owner
         - name
         - cached_pr_count

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,16 +18,14 @@
     "demo-workspace": "playwright test --config tests/demo/playwright-demo.config.ts"
   },
   "dependencies": {
+    "@lucide/svelte": "1.3.0",
     "@middleman/ui": "workspace:*",
-    "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-webgl": "^0.19.0",
-    "@xterm/xterm": "^6.0.0",
     "dompurify": "3.3.3",
     "js-toml": "^1.0.3",
     "marked": "17.0.5",
     "openapi-fetch": "^0.17.0",
-    "shiki": "^4.0.2",
-    "@lucide/svelte": "1.3.0"
+    "restty": "^0.1.35",
+    "shiki": "^4.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -62,7 +62,7 @@ describe("RepoImportModal", () => {
 
   it("hides private repositories and forks from preview selection", async () => {
     preview.mockResolvedValue({ owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" } });
+    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "" }, agents: [] });
     render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { getStores } from "@middleman/ui";
-  import { Terminal } from "@xterm/xterm";
-  import { FitAddon } from "@xterm/addon-fit";
-  import { WebglAddon } from "@xterm/addon-webgl";
-  import "@xterm/xterm/css/xterm.css";
+  import { Terminal } from "restty/xterm";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
 
   interface TerminalPaneProps {
@@ -33,7 +30,6 @@
 
   let containerEl: HTMLDivElement;
   let terminal: Terminal | null = $state(null);
-  let fitAddon: FitAddon | null = null;
   let ws: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let restartTimer: ReturnType<typeof setTimeout> | null = null;
@@ -43,8 +39,11 @@
   let disposed = false;
   let exited = false;
   const encoder = new TextEncoder();
+  const outputDecoder = new TextDecoder();
 
   const MAX_RECONNECT_DELAY = 30000;
+  const FALLBACK_CELL_WIDTH = 8;
+  const FALLBACK_CELL_HEIGHT = 18;
 
   function defaultTerminalFontFamily(): string {
     const rootFontFamily = getComputedStyle(
@@ -142,12 +141,64 @@
     }
   }
 
+  function normalizeTerminalInput(data: string): string {
+    return data.replaceAll("\b", "\x7f");
+  }
+
+  function sendTerminalInput(data: string): void {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(encoder.encode(normalizeTerminalInput(data)));
+    }
+  }
+
+  function measureCellSize(): { width: number; height: number } {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return {
+        width: FALLBACK_CELL_WIDTH,
+        height: FALLBACK_CELL_HEIGHT,
+      };
+    }
+
+    ctx.font = `14px ${terminalFontFamily}`;
+    const metrics = ctx.measureText("W");
+    const measuredHeight =
+      metrics.actualBoundingBoxAscent +
+      metrics.actualBoundingBoxDescent;
+    return {
+      width: metrics.width || FALLBACK_CELL_WIDTH,
+      height: measuredHeight
+        ? Math.ceil(measuredHeight * 1.35)
+        : FALLBACK_CELL_HEIGHT,
+    };
+  }
+
+  function fitTerminal(notify = true): void {
+    if (!terminal || !containerEl) return;
+    if (containerEl.clientWidth <= 0 || containerEl.clientHeight <= 0) {
+      return;
+    }
+
+    const { width, height } = measureCellSize();
+    const cols = Math.max(
+      2,
+      Math.floor(containerEl.clientWidth / width),
+    );
+    const rows = Math.max(
+      1,
+      Math.floor(containerEl.clientHeight / height),
+    );
+
+    if (cols === terminal.cols && rows === terminal.rows) return;
+    terminal.resize(cols, rows);
+    if (notify) sendResize(cols, rows);
+  }
+
   function refreshVisibleTerminal(): void {
     if (!terminal) return;
 
-    fitAddon?.fit();
-    terminal.clearTextureAtlas();
-    terminal.refresh(0, Math.max(0, terminal.rows - 1));
+    fitTerminal(false);
     sendRefresh(terminal.cols, terminal.rows);
   }
 
@@ -180,7 +231,12 @@
     socket.onmessage = (ev: MessageEvent) => {
       if (!terminal) return;
       if (ev.data instanceof ArrayBuffer) {
-        terminal.write(new Uint8Array(ev.data));
+        terminal.write(
+          outputDecoder.decode(
+            new Uint8Array(ev.data),
+            { stream: true },
+          ),
+        );
       } else if (typeof ev.data === "string") {
         try {
           const msg = JSON.parse(ev.data) as {
@@ -282,11 +338,8 @@
 
   $effect(() => {
     if (!terminal) return;
-    terminal.options.fontFamily = terminalFontFamily;
-    // The WebGL renderer caches glyphs per font; force a rebuild so
-    // cell widths and glyph metrics line up after the family changes.
-    terminal.clearTextureAtlas();
-    fitAddon?.fit();
+    terminal.setOption("fontFamily", terminalFontFamily);
+    fitTerminal();
   });
 
   $effect(() => {
@@ -309,48 +362,21 @@
         },
         cursorBlink: true,
         fontFamily: terminalFontFamily,
-        fontSize: 14,
+        appOptions: {
+          fontSize: 14,
+        },
       });
       terminal = term;
 
       term.open(containerEl);
-
-      const fit = new FitAddon();
-      fitAddon = fit;
-      term.loadAddon(fit);
-
-      try {
-        const wgl = new WebglAddon();
-        wgl.onContextLoss(() => {
-          wgl.dispose();
-        });
-        term.loadAddon(wgl);
-      } catch {
-        // WebGL unavailable; canvas renderer used as fallback.
-      }
-
-      fit.fit();
+      fitTerminal(false);
 
       term.onData((data: string) => {
-        if (ws?.readyState === WebSocket.OPEN) {
-          ws.send(encoder.encode(data));
-        }
-      });
-
-      term.onBinary((data: string) => {
-        if (ws?.readyState === WebSocket.OPEN) {
-          const buf = new Uint8Array(data.length);
-          for (let i = 0; i < data.length; i++) {
-            buf[i] = data.charCodeAt(i) & 0xff;
-          }
-          ws.send(buf.buffer);
-        }
+        sendTerminalInput(data);
       });
 
       resizeObserver = new ResizeObserver(() => {
-        if (!fitAddon || !terminal) return;
-        fitAddon.fit();
-        sendResize(terminal.cols, terminal.rows);
+        fitTerminal();
       });
       resizeObserver.observe(containerEl);
 
@@ -362,11 +388,8 @@
       connect();
     }
 
-    // Custom fonts (JetBrains Mono, etc.) may still be loading when
-    // the pane mounts. Initializing xterm before fonts settle locks
-    // in fallback-font cell metrics, so the WebGL atlas and the
-    // measured cols/rows drift away from what gets painted — which
-    // looks like cursor/prompt overlap in the running shell.
+    // Waiting for fonts keeps the measured cell dimensions aligned
+    // with the terminal canvas before we open the WebSocket.
     if (document.fonts && typeof document.fonts.ready?.then === "function") {
       void document.fonts.ready.then(start);
     } else {
@@ -381,7 +404,10 @@
 
 <style>
   .terminal-container {
+    position: relative;
     width: 100%;
     height: 100%;
+    overflow: hidden;
+    background: #0d1117;
   }
 </style>

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -1,18 +1,17 @@
-import { cleanup, render } from "@testing-library/svelte";
+import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockFit = vi.fn();
-const mockOpen = vi.fn();
-const mockLoadAddon = vi.fn();
-const mockOnData = vi.fn();
-const mockOnBinary = vi.fn();
-const mockDispose = vi.fn();
-const mockRefresh = vi.fn();
-const mockClearTextureAtlas = vi.fn();
-const terminalCtor = vi.fn();
-const terminalWrite = vi.fn();
+const mocks = vi.hoisted(() => ({
+  configuredFontFamily: "",
+  mockDispose: vi.fn(),
+  mockOnData: vi.fn(),
+  mockOpen: vi.fn(),
+  mockResize: vi.fn(),
+  mockSetOption: vi.fn(),
+  terminalCtor: vi.fn(),
+  terminalWrite: vi.fn(),
+}));
 
-let configuredFontFamily = "";
 let sockets: MockWebSocket[] = [];
 
 class MockWebSocket {
@@ -44,57 +43,42 @@ function socketAt(index: number): MockWebSocket {
 vi.mock("@middleman/ui", () => ({
   getStores: () => ({
     settings: {
-      getTerminalFontFamily: () => configuredFontFamily,
+      getTerminalFontFamily: () => mocks.configuredFontFamily,
     },
   }),
 }));
 
-vi.mock("@xterm/xterm", () => ({
+vi.mock("restty/xterm", () => ({
   Terminal: vi.fn().mockImplementation((options) => {
-    terminalCtor(options);
+    mocks.terminalCtor(options);
     return {
       cols: 80,
       rows: 24,
-      open: mockOpen,
-      loadAddon: mockLoadAddon,
-      onData: mockOnData,
-      onBinary: mockOnBinary,
-      dispose: mockDispose,
-      write: terminalWrite,
-      refresh: mockRefresh,
-      clearTextureAtlas: mockClearTextureAtlas,
+      open: mocks.mockOpen,
+      onData: mocks.mockOnData,
+      dispose: mocks.mockDispose,
+      write: mocks.terminalWrite,
+      resize: mocks.mockResize,
+      setOption: mocks.mockSetOption,
       options: { ...options },
     };
   }),
-}));
-
-vi.mock("@xterm/addon-fit", () => ({
-  FitAddon: vi.fn().mockImplementation(() => ({
-    fit: mockFit,
-  })),
-}));
-
-vi.mock("@xterm/addon-webgl", () => ({
-  WebglAddon: vi.fn().mockImplementation(() => ({})),
 }));
 
 import TerminalPane from "./TerminalPane.svelte";
 
 describe("TerminalPane", () => {
   beforeEach(() => {
-    configuredFontFamily = "";
+    mocks.configuredFontFamily = "";
     delete window.__BASE_PATH__;
     window.__MIDDLEMAN_DEV_API_URL__ = "http://127.0.0.1:8091";
-    terminalCtor.mockReset();
-    mockFit.mockReset();
-    mockOpen.mockReset();
-    mockLoadAddon.mockReset();
-    mockOnData.mockReset();
-    mockOnBinary.mockReset();
-    mockDispose.mockReset();
-    mockRefresh.mockReset();
-    mockClearTextureAtlas.mockReset();
-    terminalWrite.mockReset();
+    mocks.terminalCtor.mockReset();
+    mocks.mockOpen.mockReset();
+    mocks.mockOnData.mockReset();
+    mocks.mockDispose.mockReset();
+    mocks.mockResize.mockReset();
+    mocks.mockSetOption.mockReset();
+    mocks.terminalWrite.mockReset();
     sockets = [];
 
     vi.stubGlobal("ResizeObserver", class {
@@ -116,41 +100,44 @@ describe("TerminalPane", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
-  it("uses the configured settings font family for xterm", () => {
-    configuredFontFamily = "\"Fira Code\", monospace";
+  it("uses the configured settings font family for restty", async () => {
+    mocks.configuredFontFamily = "\"Fira Code\", monospace";
 
     render(TerminalPane, {
       props: { workspaceId: "ws-123" },
     });
 
-    expect(terminalCtor).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fontFamily: "\"Fira Code\", monospace",
-      }),
+    await waitFor(() =>
+      expect(mocks.terminalCtor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fontFamily: "\"Fira Code\", monospace",
+        }),
+      ),
     );
   });
 
-  it("uses the /ws terminal route for the default workspace socket", () => {
+  it("uses the /ws terminal route for the default workspace socket", async () => {
     render(TerminalPane, {
       props: { workspaceId: "ws-123" },
     });
 
-    expect(sockets).toHaveLength(1);
+    await waitFor(() => expect(sockets).toHaveLength(1));
     const url = new URL(socketAt(0).url);
     expect(url.origin).toBe("ws://localhost:3000");
     expect(url.pathname).toBe("/ws/v1/workspaces/ws-123/terminal");
   });
 
-  it("applies the base path to the default workspace socket", () => {
+  it("applies the base path to the default workspace socket", async () => {
     window.__BASE_PATH__ = "/middleman/";
 
     render(TerminalPane, {
       props: { workspaceId: "ws-123" },
     });
 
-    expect(sockets).toHaveLength(1);
+    await waitFor(() => expect(sockets).toHaveLength(1));
     const url = new URL(socketAt(0).url);
     expect(url.origin).toBe("ws://localhost:3000");
     expect(url.pathname).toBe(
@@ -158,7 +145,7 @@ describe("TerminalPane", () => {
     );
   });
 
-  it("connects to an explicit websocket path", () => {
+  it("connects to an explicit websocket path", async () => {
     render(TerminalPane, {
       props: {
         websocketPath:
@@ -166,7 +153,7 @@ describe("TerminalPane", () => {
       },
     });
 
-    expect(sockets).toHaveLength(1);
+    await waitFor(() => expect(sockets).toHaveLength(1));
     const url = new URL(socketAt(0).url);
     expect(url.origin).toBe("ws://127.0.0.1:8091");
     expect(url.pathname).toBe(
@@ -176,7 +163,7 @@ describe("TerminalPane", () => {
     expect(url.searchParams.get("rows")).toBe("24");
   });
 
-  it("keeps /ws paths on the current dev origin for Vite proxying", () => {
+  it("keeps /ws paths on the current dev origin for Vite proxying", async () => {
     render(TerminalPane, {
       props: {
         websocketPath:
@@ -184,7 +171,7 @@ describe("TerminalPane", () => {
       },
     });
 
-    expect(sockets).toHaveLength(1);
+    await waitFor(() => expect(sockets).toHaveLength(1));
     const url = new URL(socketAt(0).url);
     expect(url.origin).toBe("ws://localhost:3000");
     expect(url.pathname).toBe(
@@ -192,7 +179,29 @@ describe("TerminalPane", () => {
     );
   });
 
-  it("does not duplicate the base path for explicit websocket paths", () => {
+  it("sends terminal input as binary and maps backspace to DEL", async () => {
+    render(TerminalPane, {
+      props: { workspaceId: "ws-123" },
+    });
+
+    await waitFor(() => expect(sockets).toHaveLength(1));
+    const onData = mocks.mockOnData.mock.calls[0]?.[0] as
+      | ((data: string) => void)
+      | undefined;
+    expect(onData).toBeDefined();
+
+    onData?.("ab\b");
+
+    const sent = socketAt(0).sent.at(-1);
+    expect(ArrayBuffer.isView(sent)).toBe(true);
+    expect(Array.from(sent as Uint8Array)).toEqual([
+      97,
+      98,
+      0x7f,
+    ]);
+  });
+
+  it("does not duplicate the base path for explicit websocket paths", async () => {
     window.__BASE_PATH__ = "/middleman/";
 
     render(TerminalPane, {
@@ -202,7 +211,7 @@ describe("TerminalPane", () => {
       },
     });
 
-    expect(sockets).toHaveLength(1);
+    await waitFor(() => expect(sockets).toHaveLength(1));
     const url = new URL(socketAt(0).url);
     expect(url.origin).toBe("ws://localhost:3000");
     expect(url.pathname).toBe(
@@ -219,7 +228,8 @@ describe("TerminalPane", () => {
       },
     });
 
-    expect(mockRefresh).not.toHaveBeenCalled();
+    await waitFor(() => expect(sockets).toHaveLength(1));
+    expect(mocks.mockResize).not.toHaveBeenCalled();
     expect(socketAt(0).sent).toEqual([]);
 
     await rerender({
@@ -228,15 +238,13 @@ describe("TerminalPane", () => {
       active: true,
     });
 
-    expect(mockFit).toHaveBeenCalled();
-    expect(mockClearTextureAtlas).toHaveBeenCalled();
-    expect(mockRefresh).toHaveBeenCalledWith(0, 23);
+    expect(mocks.mockResize).not.toHaveBeenCalled();
     expect(socketAt(0).sent).toContain(
       JSON.stringify({ type: "refresh", cols: 80, rows: 24 }),
     );
   });
 
-  it("does not open a websocket when initialStatus is exited", () => {
+  it("does not open a websocket when initialStatus is exited", async () => {
     render(TerminalPane, {
       props: {
         websocketPath:
@@ -246,14 +254,15 @@ describe("TerminalPane", () => {
       },
     });
 
-    expect(sockets).toHaveLength(0);
-    expect(terminalWrite).toHaveBeenCalledWith(
-      expect.stringContaining("[Process exited]"),
+    await waitFor(() =>
+      expect(mocks.terminalWrite).toHaveBeenCalledWith(
+        expect.stringContaining("[Process exited]"),
+      ),
     );
+    expect(sockets).toHaveLength(0);
   });
 
-  it("does not restart sessions when reconnectOnExit is false", () => {
-    vi.useFakeTimers();
+  it("does not restart sessions when reconnectOnExit is false", async () => {
     const onExit = vi.fn();
 
     render(TerminalPane, {
@@ -265,7 +274,8 @@ describe("TerminalPane", () => {
       },
     });
 
-    expect(sockets).toHaveLength(1);
+    await waitFor(() => expect(sockets).toHaveLength(1));
+    vi.useFakeTimers();
     const socket = socketAt(0);
     socket.onmessage?.(
       new MessageEvent("message", {
@@ -276,11 +286,9 @@ describe("TerminalPane", () => {
     vi.advanceTimersByTime(30000);
 
     expect(sockets).toHaveLength(1);
-    expect(terminalWrite).toHaveBeenCalledWith(
+    expect(mocks.terminalWrite).toHaveBeenCalledWith(
       expect.stringContaining("[Process exited]"),
     );
     expect(onExit).toHaveBeenCalledWith(0);
-
-    vi.useRealTimers();
   });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1332,7 +1332,7 @@
     overflow: hidden;
   }
 
-  /* Tabs stay mounted across switches so xterm scrollback and the
+  /* Tabs stay mounted across switches so terminal scrollback and the
    * WebSocket survive — non-active panes are layered below and
    * hidden via visibility so layout/sizing is preserved. */
   .stage-pane {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -11,14 +11,11 @@ const mocks = vi.hoisted(() => ({
   ensureWorkspaceShell: vi.fn(),
   getWorkspaceRuntime: vi.fn(),
   launchWorkspaceSession: vi.fn(),
-  mockClearTextureAtlas: vi.fn(),
   mockDispose: vi.fn(),
-  mockFit: vi.fn(),
-  mockLoadAddon: vi.fn(),
-  mockOnBinary: vi.fn(),
   mockOnData: vi.fn(),
   mockOpen: vi.fn(),
-  mockRefresh: vi.fn(),
+  mockResize: vi.fn(),
+  mockSetOption: vi.fn(),
   stopWorkspaceSession: vi.fn(),
   terminalWrite: vi.fn(),
 }));
@@ -42,30 +39,18 @@ class MockWebSocket {
   close(): void {}
 }
 
-vi.mock("@xterm/xterm", () => ({
+vi.mock("restty/xterm", () => ({
   Terminal: vi.fn().mockImplementation((options) => ({
     cols: 80,
     rows: 24,
     open: mocks.mockOpen,
-    loadAddon: mocks.mockLoadAddon,
     onData: mocks.mockOnData,
-    onBinary: mocks.mockOnBinary,
     dispose: mocks.mockDispose,
     write: mocks.terminalWrite,
-    refresh: mocks.mockRefresh,
-    clearTextureAtlas: mocks.mockClearTextureAtlas,
+    resize: mocks.mockResize,
+    setOption: mocks.mockSetOption,
     options: { ...options },
   })),
-}));
-
-vi.mock("@xterm/addon-fit", () => ({
-  FitAddon: vi.fn().mockImplementation(() => ({
-    fit: mocks.mockFit,
-  })),
-}));
-
-vi.mock("@xterm/addon-webgl", () => ({
-  WebglAddon: vi.fn().mockImplementation(() => ({})),
 }));
 
 vi.mock("@middleman/ui", async (importOriginal) => {
@@ -185,6 +170,7 @@ describe("WorkspaceTerminalView", () => {
     mocks.stopWorkspaceSession.mockReset();
     mocks.ensureWorkspaceShell.mockReset();
     mocks.terminalWrite.mockReset();
+    mocks.mockSetOption.mockReset();
 
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- Replace xterm.js with restty's xterm compatibility layer as an exploratory renderer.
- Keep the existing terminal WebSocket protocol with a small input normalization shim.
- Potential idea only: local testing did not show much rendering performance change, though restty may improve edge case terminal handling.

This should not be treated as ready to merge without more keyboard and browser permission validation.