### PR TITLE
Fix markdown table rendering in PR descriptions

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -225,6 +225,9 @@ a:hover {
 }
 
 /* Markdown body rendering */
+.markdown-body {
+  overflow-x: auto;
+}
 .markdown-body p {
   margin-bottom: 0.5em;
 }
@@ -272,6 +275,40 @@ a:hover {
   max-width: 100%;
   height: auto;
   border-radius: var(--radius-sm);
+}
+.markdown-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 10px 0 12px;
+  font-size: 0.92em;
+  line-height: 1.45;
+}
+.markdown-body th,
+.markdown-body td {
+  padding: 6px 9px;
+  border: 1px solid var(--border-muted);
+  text-align: left;
+  vertical-align: top;
+  word-break: normal;
+  overflow-wrap: normal;
+}
+.markdown-body th {
+  background: var(--bg-surface-hover);
+  color: var(--text-secondary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.markdown-body th:not(:last-child),
+.markdown-body td:not(:last-child) {
+  width: 1%;
+  white-space: nowrap;
+}
+.markdown-body th:last-child,
+.markdown-body td:last-child {
+  overflow-wrap: anywhere;
+}
+.markdown-body tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--bg-surface-hover) 42%, transparent);
 }
 
 /* Item reference links (#123, owner/repo#456) */

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -65,6 +65,78 @@ test("edit body: cancel preserves original", async ({ page }) => {
   );
 });
 
+test("markdown tables keep compact columns readable", async ({ page }) => {
+  await page.route("**/api/v1/repos/acme/widgets/pulls/42", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        merge_request: {
+          ID: 1,
+          RepoID: 1,
+          GitHubID: 101,
+          Number: 42,
+          URL: "https://github.com/acme/widgets/pull/42",
+          Title: "Add browser regression coverage",
+          Author: "marius",
+          State: "open",
+          IsDraft: false,
+          Body: [
+            "| Task | Commit | Description |",
+            "| --- | --- | --- |",
+            "| 1 | b2af4711 | Add the generated client shape without flattening the response. |",
+          ].join("\n"),
+          HeadBranch: "feature/playwright",
+          BaseBranch: "main",
+          Additions: 120,
+          Deletions: 12,
+          CommentCount: 3,
+          ReviewDecision: "APPROVED",
+          CIStatus: "success",
+          CIChecksJSON: "[]",
+          CreatedAt: "2026-03-29T14:00:00Z",
+          UpdatedAt: "2026-03-30T14:00:00Z",
+          LastActivityAt: "2026-03-30T14:00:00Z",
+          MergedAt: null,
+          ClosedAt: null,
+          KanbanStatus: "reviewing",
+          Starred: false,
+          repo_owner: "acme",
+          repo_name: "widgets",
+          platform_host: "github.com",
+          worktree_links: [],
+        },
+        repo_owner: "acme",
+        repo_name: "widgets",
+        detail_loaded: true,
+        detail_fetched_at: "2026-03-30T14:00:00Z",
+        worktree_links: [],
+      }),
+    });
+  });
+
+  await page.goto("/pulls/acme/widgets/42");
+
+  const taskHeader = page
+    .locator(".markdown-body th")
+    .filter({ hasText: "Task" });
+  const commitCell = page
+    .locator(".markdown-body td")
+    .filter({ hasText: "b2af4711" });
+  await expect(taskHeader).toBeVisible();
+  await expect(commitCell).toBeVisible();
+  await expect(taskHeader).toHaveCSS("white-space", "nowrap");
+  await expect(commitCell).toHaveCSS("white-space", "nowrap");
+  await expect(page.locator(".markdown-body table")).toHaveCSS(
+    "border-collapse",
+    "collapse",
+  );
+});
+
 test("add description to empty-body PR shows add-description-btn", async ({ page }) => {
   // Override the GET route to return a PR with empty body.
   await page.route("**/api/v1/repos/acme/widgets/pulls/42", async (route) => {


### PR DESCRIPTION
## Summary
- Add shared markdown table defaults for rendered PR and issue descriptions.
- Keep compact columns like task numbers and commit hashes readable while long description cells wrap normally.
- Add a browser regression for markdown table layout in PR descriptions.