### PR TITLE
ci: publish tagged middleman releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum *.tar.gz *.zip > SHA256SUMS
+          sha256sum ./*.tar.gz ./*.zip > SHA256SUMS
           cat SHA256SUMS
 
       - name: Get tag message
@@ -189,10 +189,12 @@ jobs:
 
           if [ -n "$TAG_MSG" ]; then
             DELIM="TAGMSG_$(date +%s%N)"
-            echo "body<<$DELIM" >> "$GITHUB_OUTPUT"
-            echo "$TAG_MSG" >> "$GITHUB_OUTPUT"
-            echo "$DELIM" >> "$GITHUB_OUTPUT"
-            echo "has_body=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "body<<$DELIM"
+              echo "$TAG_MSG"
+              echo "$DELIM"
+              echo "has_body=true"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "has_body=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,209 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            runner: ubuntu-latest
+          - goarch: arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Build frontend
+        run: cd frontend && bun install --frozen-lockfile && bun run build
+
+      - name: Embed frontend
+        run: |
+          rm -rf internal/web/dist
+          cp -r frontend/dist internal/web/dist
+
+      - name: Build
+        env:
+          GOOS: linux
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          COMMIT="${GITHUB_SHA::8}"
+          BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+          mkdir -p dist
+          LDFLAGS="-s -w -X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}"
+          go build -buildvcs=false -ldflags="$LDFLAGS" -trimpath \
+            -o dist/middleman ./cmd/middleman
+
+          ./dist/middleman --version
+
+          cd dist
+          ARCHIVE="middleman_${VERSION}_linux_${{ matrix.goarch }}.tar.gz"
+          tar czf "$ARCHIVE" middleman
+          rm middleman
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: middleman-linux-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            goos: darwin
+            goarch: amd64
+          - os: macos-15
+            goos: darwin
+            goarch: arm64
+          - os: windows-latest
+            goos: windows
+            goarch: amd64
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Build frontend
+        run: cd frontend && bun install --frozen-lockfile && bun run build
+
+      - name: Embed frontend
+        shell: bash
+        run: |
+          rm -rf internal/web/dist
+          cp -r frontend/dist internal/web/dist
+
+      - name: Build
+        shell: bash
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.goos == 'darwin' && '11.0' || '' }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          COMMIT="${GITHUB_SHA::8}"
+          BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          EXT=""
+          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+
+          mkdir -p dist
+          LDFLAGS="-s -w -X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}"
+          go build -buildvcs=false -ldflags="$LDFLAGS" -trimpath \
+            -o dist/middleman${EXT} ./cmd/middleman
+
+          if [ "$GOOS" != "darwin" ] || [ "$GOARCH" = "$(go env GOHOSTARCH)" ]; then
+            ./dist/middleman${EXT} --version
+          fi
+
+          cd dist
+          if [ "$GOOS" = "windows" ]; then
+            ARCHIVE="middleman_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.zip"
+            7z a "$ARCHIVE" middleman${EXT}
+          else
+            ARCHIVE="middleman_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz"
+            tar czf "$ARCHIVE" middleman${EXT}
+          fi
+          rm middleman${EXT}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: middleman-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+
+  release:
+    needs: [build-linux, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum *.tar.gz *.zip > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Get tag message
+        id: tag_message
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+
+          TAG_TYPE=$(git cat-file -t "$TAG_NAME" 2>/dev/null || true)
+          if [ "$TAG_TYPE" != "tag" ]; then
+            echo "Warning: $TAG_NAME is a lightweight tag, using auto-generated notes"
+            echo "has_body=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TAG_MSG=$(git tag -l --format='%(contents:body)' "$TAG_NAME")
+
+          if [ -n "$TAG_MSG" ]; then
+            DELIM="TAGMSG_$(date +%s%N)"
+            echo "body<<$DELIM" >> "$GITHUB_OUTPUT"
+            echo "$TAG_MSG" >> "$GITHUB_OUTPUT"
+            echo "$DELIM" >> "$GITHUB_OUTPUT"
+            echo "has_body=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_body=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
+        with:
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
+            artifacts/SHA256SUMS
+          body: ${{ steps.tag_message.outputs.has_body == 'true' && steps.tag_message.outputs.body || '' }}
+          generate_release_notes: ${{ steps.tag_message.outputs.has_body != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -54,7 +53,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
-          COMMIT="${GITHUB_SHA::8}"
+          COMMIT="${GITHUB_SHA:0:8}"
           BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
           mkdir -p dist
@@ -122,7 +121,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
-          COMMIT="${GITHUB_SHA::8}"
+          COMMIT="${GITHUB_SHA:0:8}"
           BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           EXT=""
           if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           go build -buildvcs=false -ldflags="$LDFLAGS" -trimpath \
             -o dist/middleman ./cmd/middleman
 
-          ./dist/middleman --version
+          ./dist/middleman version
 
           cd dist
           ARCHIVE="middleman_${VERSION}_linux_${{ matrix.goarch }}.tar.gz"
@@ -132,7 +132,7 @@ jobs:
             -o dist/middleman${EXT} ./cmd/middleman
 
           if [ "$GOOS" != "darwin" ] || [ "$GOARCH" = "$(go env GOHOSTARCH)" ]; then
-            ./dist/middleman${EXT} --version
+            ./dist/middleman${EXT} version
           fi
 
           cd dist


### PR DESCRIPTION
## Summary
- Add a tag-triggered release workflow for middleman
- Build embedded-frontend CLI binaries for Linux, macOS, and Windows
- Upload release archives with SHA256 checksums and create GitHub releases

## Test Plan
- GitHub pre-commit hooks validated the workflow YAML during commit
