### PR TITLE
refactor: isolate detail refresh planning

### DIFF
--- a/docs/sync-engine.md
+++ b/docs/sync-engine.md
@@ -1,0 +1,17 @@
+# Sync Engine
+
+The sync engine runs broad repository indexing first, then spends the per-host
+detail budget on open items that need deeper refreshes.
+
+## Detail Refresh Planner
+
+`internal/github/detail_refresh_planner.go` owns the detail-drain planning
+phase. It accepts typed snapshots of tracked repositories and watched merge
+requests, applies the default GitHub host, filters stale database rows from
+repos that are no longer tracked, and returns `QueueItem` values for the shared
+priority queue.
+
+This keeps `Syncer` orchestration focused on lifecycle, locking, budget
+admission, and fetch execution. It also keeps host/key/defaulting rules in one
+place so planner tests can exercise queue input construction without building a
+GitHub `Client` mock or running the full sync loop.

--- a/internal/github/detail_refresh_planner.go
+++ b/internal/github/detail_refresh_planner.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wesm/middleman/internal/db"
+)
+
+const defaultGitHubHost = "github.com"
+
+type detailRefreshPlanner struct {
+	db *db.DB
+}
+
+type detailRefreshPlanInput struct {
+	TrackedRepos []RepoRef
+	WatchedMRs   []WatchedMR
+}
+
+type detailRefreshPlan struct {
+	Items              []QueueItem
+	PullRequestListErr error
+	IssueListErr       error
+}
+
+func newDetailRefreshPlanner(database *db.DB) detailRefreshPlanner {
+	return detailRefreshPlanner{db: database}
+}
+
+func (p detailRefreshPlanner) Build(
+	ctx context.Context,
+	input detailRefreshPlanInput,
+) detailRefreshPlan {
+	trackedRepos := detailTrackedRepoSet(input.TrackedRepos)
+	watchedMRs := detailWatchedMRSet(input.WatchedMRs)
+
+	plan := detailRefreshPlan{}
+	prs, err := p.db.ListMergeRequests(
+		ctx, db.ListMergeRequestsOpts{State: "open"},
+	)
+	if err != nil {
+		plan.PullRequestListErr = err
+		return plan
+	}
+	for _, pr := range prs {
+		repo, rErr := p.db.GetRepoByID(ctx, pr.RepoID)
+		if rErr != nil || repo == nil {
+			continue
+		}
+		if !trackedRepos[detailRepoKey(repo.PlatformHost, repo.Owner, repo.Name)] {
+			continue
+		}
+		plan.Items = append(plan.Items, QueueItem{
+			Type:            QueueItemPR,
+			RepoOwner:       repo.Owner,
+			RepoName:        repo.Name,
+			Number:          pr.Number,
+			PlatformHost:    detailDefaultHost(repo.PlatformHost),
+			UpdatedAt:       pr.UpdatedAt,
+			DetailFetchedAt: pr.DetailFetchedAt,
+			CIHadPending:    pr.CIHadPending,
+			Starred:         pr.Starred,
+			Watched:         watchedMRs[detailWatchedMRKey(repo.Owner, repo.Name, pr.Number)],
+			IsOpen:          true,
+		})
+	}
+
+	issues, err := p.db.ListIssues(
+		ctx, db.ListIssuesOpts{State: "open"},
+	)
+	if err != nil {
+		plan.IssueListErr = err
+		return plan
+	}
+	for _, issue := range issues {
+		repo, rErr := p.db.GetRepoByID(ctx, issue.RepoID)
+		if rErr != nil || repo == nil {
+			continue
+		}
+		if !trackedRepos[detailRepoKey(repo.PlatformHost, repo.Owner, repo.Name)] {
+			continue
+		}
+		plan.Items = append(plan.Items, QueueItem{
+			Type:            QueueItemIssue,
+			RepoOwner:       repo.Owner,
+			RepoName:        repo.Name,
+			Number:          issue.Number,
+			PlatformHost:    detailDefaultHost(repo.PlatformHost),
+			UpdatedAt:       issue.UpdatedAt,
+			DetailFetchedAt: issue.DetailFetchedAt,
+			Starred:         issue.Starred,
+			IsOpen:          true,
+		})
+	}
+
+	return plan
+}
+
+func detailTrackedRepoSet(repos []RepoRef) map[string]bool {
+	tracked := make(map[string]bool, len(repos))
+	for _, repo := range repos {
+		tracked[detailRepoKey(repo.PlatformHost, repo.Owner, repo.Name)] = true
+	}
+	return tracked
+}
+
+func detailWatchedMRSet(mrs []WatchedMR) map[string]bool {
+	watched := make(map[string]bool, len(mrs))
+	for _, mr := range mrs {
+		watched[detailWatchedMRKey(mr.Owner, mr.Name, mr.Number)] = true
+	}
+	return watched
+}
+
+func detailRepoKey(host, owner, name string) string {
+	return detailDefaultHost(host) + "\x00" + owner + "/" + name
+}
+
+func detailWatchedMRKey(owner, name string, number int) string {
+	return fmt.Sprintf("%s/%s#%d", owner, name, number)
+}
+
+func detailDefaultHost(host string) string {
+	if host == "" {
+		return defaultGitHubHost
+	}
+	return host
+}

--- a/internal/github/detail_refresh_planner_test.go
+++ b/internal/github/detail_refresh_planner_test.go
@@ -1,0 +1,127 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/db"
+)
+
+func TestDetailRefreshPlannerBuildsItemsForTrackedRepos(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+	untrackedRepoID, err := d.UpsertRepo(ctx, "github.com", "owner", "untracked")
+	require.NoError(err)
+
+	now := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	detailFetchedAt := now.Add(-time.Hour)
+
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      101,
+		Number:          7,
+		URL:             "https://github.com/owner/repo/pull/7",
+		Title:           "Tracked PR",
+		Author:          "alice",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123",
+		PlatformBaseSHA: "def456",
+		CreatedAt:       now.Add(-2 * time.Hour),
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+		CIHadPending:    true,
+	})
+	require.NoError(err)
+	_, err = d.UpsertIssue(ctx, &db.Issue{
+		RepoID:          repoID,
+		PlatformID:      201,
+		Number:          8,
+		URL:             "https://github.com/owner/repo/issues/8",
+		Title:           "Tracked issue",
+		Author:          "bob",
+		State:           "open",
+		CreatedAt:       now.Add(-3 * time.Hour),
+		UpdatedAt:       now.Add(-30 * time.Minute),
+		LastActivityAt:  now.Add(-30 * time.Minute),
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          untrackedRepoID,
+		PlatformID:      301,
+		Number:          9,
+		URL:             "https://github.com/owner/untracked/pull/9",
+		Title:           "Untracked PR",
+		Author:          "carol",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123",
+		PlatformBaseSHA: "def456",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	planner := newDetailRefreshPlanner(d)
+	plan := planner.Build(ctx, detailRefreshPlanInput{
+		TrackedRepos: []RepoRef{{
+			Owner: "owner",
+			Name:  "repo",
+			// Empty host must match the DB's canonical github.com host.
+		}},
+		WatchedMRs: []WatchedMR{{
+			Owner:  "owner",
+			Name:   "repo",
+			Number: 7,
+		}},
+	})
+
+	require.NoError(plan.PullRequestListErr)
+	require.NoError(plan.IssueListErr)
+	require.Len(plan.Items, 2)
+
+	pr := plan.Items[0]
+	assert.Equal(QueueItemPR, pr.Type)
+	assert.Equal("github.com", pr.PlatformHost)
+	assert.Equal("owner", pr.RepoOwner)
+	assert.Equal("repo", pr.RepoName)
+	assert.Equal(7, pr.Number)
+	assert.True(pr.CIHadPending)
+	assert.True(pr.Watched)
+	assert.True(pr.IsOpen)
+
+	issue := plan.Items[1]
+	assert.Equal(QueueItemIssue, issue.Type)
+	assert.Equal("github.com", issue.PlatformHost)
+	assert.Equal("owner", issue.RepoOwner)
+	assert.Equal("repo", issue.RepoName)
+	assert.Equal(8, issue.Number)
+	assert.Equal(&detailFetchedAt, issue.DetailFetchedAt)
+	assert.False(issue.Watched)
+	assert.True(issue.IsOpen)
+}
+
+func TestDetailRefreshPlannerRepoKeysDefaultHostAndSeparateHosts(t *testing.T) {
+	assert := Assert.New(t)
+
+	tracked := detailTrackedRepoSet([]RepoRef{
+		{Owner: "owner", Name: "repo"},
+		{PlatformHost: "ghe.corp.example", Owner: "owner", Name: "repo"},
+	})
+
+	assert.True(tracked[detailRepoKey("github.com", "owner", "repo")])
+	assert.True(tracked[detailRepoKey("", "owner", "repo")])
+	assert.True(tracked[detailRepoKey("ghe.corp.example", "owner", "repo")])
+	assert.False(tracked[detailRepoKey("gitlab.example", "owner", "repo")])
+}

--- a/internal/github/detail_refresh_planner_test.go
+++ b/internal/github/detail_refresh_planner_test.go
@@ -112,16 +112,74 @@ func TestDetailRefreshPlannerBuildsItemsForTrackedRepos(t *testing.T) {
 	assert.True(issue.IsOpen)
 }
 
-func TestDetailRefreshPlannerRepoKeysDefaultHostAndSeparateHosts(t *testing.T) {
+func TestDetailRefreshPlannerSeparatesReposByHost(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
 
-	tracked := detailTrackedRepoSet([]RepoRef{
-		{Owner: "owner", Name: "repo"},
-		{PlatformHost: "ghe.corp.example", Owner: "owner", Name: "repo"},
+	githubRepoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	require.NoError(err)
+	gheRepoID, err := d.UpsertRepo(ctx, "ghe.corp.example", "owner", "repo")
+	require.NoError(err)
+
+	now := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	for _, row := range []struct {
+		repoID int64
+		number int
+		url    string
+	}{
+		{
+			repoID: githubRepoID,
+			number: 7,
+			url:    "https://github.com/owner/repo/pull/7",
+		},
+		{
+			repoID: gheRepoID,
+			number: 8,
+			url:    "https://ghe.corp.example/owner/repo/pull/8",
+		},
+	} {
+		_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID:          row.repoID,
+			PlatformID:      int64(100 + row.number),
+			Number:          row.number,
+			URL:             row.url,
+			Title:           "Tracked PR",
+			Author:          "alice",
+			State:           "open",
+			HeadBranch:      "feature",
+			BaseBranch:      "main",
+			PlatformHeadSHA: "abc123",
+			PlatformBaseSHA: "def456",
+			CreatedAt:       now.Add(-2 * time.Hour),
+			UpdatedAt:       now,
+			LastActivityAt:  now,
+		})
+		require.NoError(err)
+	}
+
+	planner := newDetailRefreshPlanner(d)
+	githubPlan := planner.Build(ctx, detailRefreshPlanInput{
+		TrackedRepos: []RepoRef{{Owner: "owner", Name: "repo"}},
+	})
+	ghePlan := planner.Build(ctx, detailRefreshPlanInput{
+		TrackedRepos: []RepoRef{{
+			PlatformHost: "ghe.corp.example",
+			Owner:        "owner",
+			Name:         "repo",
+		}},
 	})
 
-	assert.True(tracked[detailRepoKey("github.com", "owner", "repo")])
-	assert.True(tracked[detailRepoKey("", "owner", "repo")])
-	assert.True(tracked[detailRepoKey("ghe.corp.example", "owner", "repo")])
-	assert.False(tracked[detailRepoKey("gitlab.example", "owner", "repo")])
+	require.NoError(githubPlan.PullRequestListErr)
+	require.NoError(githubPlan.IssueListErr)
+	require.Len(githubPlan.Items, 1)
+	assert.Equal("github.com", githubPlan.Items[0].PlatformHost)
+	assert.Equal(7, githubPlan.Items[0].Number)
+
+	require.NoError(ghePlan.PullRequestListErr)
+	require.NoError(ghePlan.IssueListErr)
+	require.Len(ghePlan.Items, 1)
+	assert.Equal("ghe.corp.example", ghePlan.Items[0].PlatformHost)
+	assert.Equal(8, ghePlan.Items[0].Number)
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1827,8 +1828,8 @@ func (s *Syncer) drainPendingCommentSyncs(
 	eligibleHosts map[string]bool,
 ) {
 	s.commentRefreshMu.Lock()
-	prs := append([]queuedPRCommentSync(nil), s.pendingPRCommentSyncs...)
-	issues := append([]queuedIssueCommentSync(nil), s.pendingIssueCommentSyncs...)
+	prs := slices.Clone(s.pendingPRCommentSyncs)
+	issues := slices.Clone(s.pendingIssueCommentSyncs)
 	s.pendingPRCommentSyncs = nil
 	s.pendingIssueCommentSyncs = nil
 	s.commentRefreshMu.Unlock()

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3423,102 +3423,34 @@ func (s *Syncer) drainDetailQueue(
 func (s *Syncer) buildDetailQueueItems(
 	ctx context.Context,
 ) []QueueItem {
-	// Build set of tracked repos to filter out stale DB rows
-	// from removed repos.
 	s.reposMu.Lock()
-	trackedRepos := make(map[string]bool, len(s.repos))
-	for _, r := range s.repos {
-		host := r.PlatformHost
-		if host == "" {
-			host = "github.com"
-		}
-		trackedRepos[host+"\x00"+r.Owner+"/"+r.Name] = true
-	}
+	trackedRepos := make([]RepoRef, len(s.repos))
+	copy(trackedRepos, s.repos)
 	s.reposMu.Unlock()
 
-	// Gather watched MR numbers for matching.
 	s.watchMu.Lock()
-	watched := make(map[string]bool, len(s.watchedMRs))
-	for _, w := range s.watchedMRs {
-		key := fmt.Sprintf(
-			"%s/%s#%d", w.Owner, w.Name, w.Number,
-		)
-		watched[key] = true
-	}
+	watchedMRs := make([]WatchedMR, len(s.watchedMRs))
+	copy(watchedMRs, s.watchedMRs)
 	s.watchMu.Unlock()
 
-	var items []QueueItem
-
-	// Open PRs.
-	prs, err := s.db.ListMergeRequests(
-		ctx, db.ListMergeRequestsOpts{State: "open"},
-	)
-	if err != nil {
+	plan := newDetailRefreshPlanner(s.db).Build(ctx, detailRefreshPlanInput{
+		TrackedRepos: trackedRepos,
+		WatchedMRs:   watchedMRs,
+	})
+	if plan.PullRequestListErr != nil {
 		slog.Warn("detail drain: list open PRs failed",
-			"err", err,
+			"err", plan.PullRequestListErr,
 		)
 		return nil
 	}
-	for _, pr := range prs {
-		repo, rErr := s.db.GetRepoByID(ctx, pr.RepoID)
-		if rErr != nil || repo == nil {
-			continue
-		}
-		repoKey := repo.PlatformHost + "\x00" + repo.Owner + "/" + repo.Name
-		if !trackedRepos[repoKey] {
-			continue
-		}
-		watchKey := fmt.Sprintf(
-			"%s/%s#%d", repo.Owner, repo.Name, pr.Number,
-		)
-		items = append(items, QueueItem{
-			Type:            QueueItemPR,
-			RepoOwner:       repo.Owner,
-			RepoName:        repo.Name,
-			Number:          pr.Number,
-			PlatformHost:    repo.PlatformHost,
-			UpdatedAt:       pr.UpdatedAt,
-			DetailFetchedAt: pr.DetailFetchedAt,
-			CIHadPending:    pr.CIHadPending,
-			Starred:         pr.Starred,
-			Watched:         watched[watchKey],
-			IsOpen:          true,
-		})
-	}
-
-	// Open issues.
-	issues, err := s.db.ListIssues(
-		ctx, db.ListIssuesOpts{State: "open"},
-	)
-	if err != nil {
+	if plan.IssueListErr != nil {
 		slog.Warn("detail drain: list open issues failed",
-			"err", err,
+			"err", plan.IssueListErr,
 		)
-		return items
-	}
-	for _, issue := range issues {
-		repo, rErr := s.db.GetRepoByID(ctx, issue.RepoID)
-		if rErr != nil || repo == nil {
-			continue
-		}
-		repoKey := repo.PlatformHost + "\x00" + repo.Owner + "/" + repo.Name
-		if !trackedRepos[repoKey] {
-			continue
-		}
-		items = append(items, QueueItem{
-			Type:            QueueItemIssue,
-			RepoOwner:       repo.Owner,
-			RepoName:        repo.Name,
-			Number:          issue.Number,
-			PlatformHost:    repo.PlatformHost,
-			UpdatedAt:       issue.UpdatedAt,
-			DetailFetchedAt: issue.DetailFetchedAt,
-			Starred:         issue.Starred,
-			IsOpen:          true,
-		})
+		return plan.Items
 	}
 
-	return items
+	return plan.Items
 }
 
 // --- Backfill Discovery ---


### PR DESCRIPTION
- Move detail-drain queue construction into a focused planner module.
- Keep host defaulting, tracked-repo filtering, watched-item keys, and queue item assembly in one place.
- This makes `Syncer` simpler: it snapshots mutable state and orchestrates the phase instead of rebuilding planner rules inline.
- The new module improves calling uniformity because callers pass typed snapshots and receive `QueueItem` values, while tests can verify planning without GitHub client mocks or a full sync loop.

Validation:
- `go test ./internal/github -run TestDetailRefreshPlannerBuildsItemsForTrackedRepos -shuffle=on`
- `go test ./internal/github -run 'TestDetailRefreshPlanner' -shuffle=on`
- `go test ./internal/github -shuffle=on`
- `git diff --check`
- `go test ./internal/server -run TestWorkspaceListTmuxActivityStressDoesNotLeakProcesses -shuffle=on` passes in isolation

Note: `go test ./... -shuffle=on` and `go test ./internal/server -shuffle=on` currently fail in unrelated workspace/tmux runtime tests under host process/runtime churn; the sync-module package verification passes.