### PR TITLE
refactor: centralize tracked item projection

### DIFF
--- a/context/api-projection.md
+++ b/context/api-projection.md
@@ -1,0 +1,20 @@
+# API Projection
+
+PR and issue route handlers should keep data loading separate from API response
+assembly. The tracked item projection module in
+`internal/server/tracked_item_projection.go` owns the shared response shape for
+PR and issue list, detail, sync, and create responses.
+
+Keep these concerns in the projection module instead of repeating them in route
+handlers:
+
+- repository decoration (`platform_host`, `repo_owner`, `repo_name`)
+- `detail_loaded` and `detail_fetched_at`
+- UTC RFC3339 formatting for API timestamps, following ADR 0001
+- non-nil empty event and worktree link slices
+- workspace references for tracked item detail responses
+- worktree link response mapping for PR list and detail responses
+
+Handlers may still fetch rows, events, worktree links, workflow state, and
+workspace records. Once those inputs are loaded, call a projection helper so
+list/detail/sync/create responses stay uniform.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -535,6 +535,10 @@ func withSeedPRHeadSHA(headSHA string) seedPROpt {
 	return func(pr *db.MergeRequest) { pr.PlatformHeadSHA = headSHA }
 }
 
+func withSeedPRDetailFetchedAt(detailFetchedAt time.Time) seedPROpt {
+	return func(pr *db.MergeRequest) { pr.DetailFetchedAt = &detailFetchedAt }
+}
+
 // seedPR inserts a repo and a PR into the DB, returning the PR's internal ID.
 func seedPR(t *testing.T, database *db.DB, owner, name string, number int, opts ...seedPROpt) int64 {
 	t.Helper()
@@ -855,6 +859,93 @@ func TestAPIGetPull(t *testing.T) {
 	require.Equal("acme", resp.JSON200.RepoOwner)
 	require.Equal("widget", resp.JSON200.RepoName)
 	require.Equal("abc123def456", resp.JSON200.PlatformHeadSha)
+}
+
+func TestAPIPullListAndDetailProjectSharedResponseShape(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database := setupTestServer(t)
+	srv.workspaces = workspace.NewManager(database, filepath.Join(t.TempDir(), "worktrees"))
+
+	detailFetchedAt := testEDTTime(14, 25)
+	prID := seedPR(
+		t, database, "acme", "widget", 12,
+		withSeedPRDetailFetchedAt(detailFetchedAt),
+	)
+	require.NoError(database.SetWorktreeLinks(t.Context(), []db.WorktreeLink{{
+		MergeRequestID: prID,
+		WorktreeKey:    "wt-acme-widget-12",
+		WorktreePath:   "/tmp/acme-widget-12",
+		WorktreeBranch: "feature/projection",
+		LinkedAt:       time.Now().UTC().Truncate(time.Second),
+	}}))
+	require.NoError(database.InsertWorkspace(t.Context(), &db.Workspace{
+		ID:              "ws-pr-12",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      12,
+		GitHeadRef:      "feature/projection",
+		WorkspaceBranch: "feature/projection",
+		WorktreePath:    "/tmp/acme-widget-12",
+		TmuxSession:     "middleman-ws-pr-12",
+		Status:          "ready",
+	}))
+	client := setupTestClient(t, srv)
+
+	listResp, err := client.HTTP.ListPullsWithResponse(t.Context(), nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode())
+	require.NotNil(listResp.JSON200)
+	require.Len(*listResp.JSON200, 1)
+	listed := (*listResp.JSON200)[0]
+	assert.Equal("github.com", listed.PlatformHost)
+	assert.Equal("acme", listed.RepoOwner)
+	assert.Equal("widget", listed.RepoName)
+	assert.True(listed.DetailLoaded)
+	require.NotNil(listed.DetailFetchedAt)
+	assertRFC3339UTC(t, *listed.DetailFetchedAt, detailFetchedAt)
+	require.NotNil(listed.WorktreeLinks)
+	require.Len(*listed.WorktreeLinks, 1)
+	assert.Equal("wt-acme-widget-12", (*listed.WorktreeLinks)[0].WorktreeKey)
+	assert.Equal("/tmp/acme-widget-12", *(*listed.WorktreeLinks)[0].WorktreePath)
+	assert.Equal("feature/projection", *(*listed.WorktreeLinks)[0].WorktreeBranch)
+
+	detailResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		t.Context(), "acme", "widget", 12,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode())
+	require.NotNil(detailResp.JSON200)
+	assert.Equal("github.com", detailResp.JSON200.PlatformHost)
+	assert.Equal("acme", detailResp.JSON200.RepoOwner)
+	assert.Equal("widget", detailResp.JSON200.RepoName)
+	assert.EqualValues(12, detailResp.JSON200.MergeRequest.Number)
+	assert.True(detailResp.JSON200.DetailLoaded)
+	require.NotNil(detailResp.JSON200.DetailFetchedAt)
+	assertRFC3339UTC(t, *detailResp.JSON200.DetailFetchedAt, detailFetchedAt)
+	require.NotNil(detailResp.JSON200.Events)
+	assert.Empty(*detailResp.JSON200.Events)
+	require.NotNil(detailResp.JSON200.WorktreeLinks)
+	require.Len(*detailResp.JSON200.WorktreeLinks, 1)
+	assert.Equal("wt-acme-widget-12", (*detailResp.JSON200.WorktreeLinks)[0].WorktreeKey)
+	require.NotNil(detailResp.JSON200.Workspace)
+	assert.Equal("ws-pr-12", detailResp.JSON200.Workspace.Id)
+	assert.Equal("ready", detailResp.JSON200.Workspace.Status)
+
+	seedPR(t, database, "acme", "widget", 13)
+	emptyLinksResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		t.Context(), "acme", "widget", 13,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, emptyLinksResp.StatusCode())
+	require.NotNil(emptyLinksResp.JSON200)
+	require.NotNil(emptyLinksResp.JSON200.Events)
+	assert.Empty(*emptyLinksResp.JSON200.Events)
+	require.NotNil(emptyLinksResp.JSON200.WorktreeLinks)
+	assert.Empty(*emptyLinksResp.JSON200.WorktreeLinks)
 }
 
 func TestAPIGetPullAcceptsMixedCaseRepoPath(t *testing.T) {
@@ -4344,6 +4435,82 @@ func TestAPIGetIssueIncludesLabels(t *testing.T) {
 		Color:       "d73a4a",
 		IsDefault:   true,
 	}}, *resp.JSON200.Issue.Labels)
+}
+
+func TestAPIIssueListAndDetailProjectSharedResponseShape(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database := setupTestServer(t)
+	srv.workspaces = workspace.NewManager(database, filepath.Join(t.TempDir(), "worktrees"))
+
+	ctx := t.Context()
+	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	detailFetchedAt := testEDTTime(16, 5)
+	issueID, err := database.UpsertIssue(ctx, &db.Issue{
+		RepoID:          repoID,
+		PlatformID:      21000,
+		Number:          21,
+		URL:             "https://github.com/acme/widget/issues/21",
+		Title:           "Projection issue",
+		Author:          "testuser",
+		State:           "open",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NotZero(issueID)
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID:              "ws-issue-21",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypeIssue,
+		ItemNumber:      21,
+		GitHeadRef:      "middleman/issue-21",
+		WorkspaceBranch: "middleman/issue-21",
+		WorktreePath:    "/tmp/acme-widget-issue-21",
+		TmuxSession:     "middleman-ws-issue-21",
+		Status:          "ready",
+	}))
+	client := setupTestClient(t, srv)
+
+	listResp, err := client.HTTP.ListIssuesWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode())
+	require.NotNil(listResp.JSON200)
+	require.Len(*listResp.JSON200, 1)
+	listed := (*listResp.JSON200)[0]
+	assert.Equal("github.com", listed.PlatformHost)
+	assert.Equal("acme", listed.RepoOwner)
+	assert.Equal("widget", listed.RepoName)
+	assert.True(listed.DetailLoaded)
+	require.NotNil(listed.DetailFetchedAt)
+	assertRFC3339UTC(t, *listed.DetailFetchedAt, detailFetchedAt)
+
+	detailResp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		ctx, "acme", "widget", 21, nil,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode())
+	require.NotNil(detailResp.JSON200)
+	assert.Equal("github.com", detailResp.JSON200.PlatformHost)
+	assert.Equal("acme", detailResp.JSON200.RepoOwner)
+	assert.Equal("widget", detailResp.JSON200.RepoName)
+	assert.EqualValues(21, detailResp.JSON200.Issue.Number)
+	assert.True(detailResp.JSON200.DetailLoaded)
+	require.NotNil(detailResp.JSON200.DetailFetchedAt)
+	assertRFC3339UTC(t, *detailResp.JSON200.DetailFetchedAt, detailFetchedAt)
+	require.NotNil(detailResp.JSON200.Events)
+	assert.Empty(*detailResp.JSON200.Events)
+	require.NotNil(detailResp.JSON200.Workspace)
+	assert.Equal("ws-issue-21", detailResp.JSON200.Workspace.Id)
+	assert.Equal("ready", detailResp.JSON200.Workspace.Status)
 }
 
 func TestAPIGetIssueAcceptsMixedCaseRepoPath(t *testing.T) {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -299,38 +299,3 @@ func toRepoSummaryResponse(
 	}
 	return resp
 }
-
-// toWorktreeLinkResponses converts DB links to API responses.
-// Returns an empty non-nil slice when input is nil.
-func toWorktreeLinkResponses(
-	links []db.WorktreeLink,
-) []worktreeLinkResponse {
-	out := make([]worktreeLinkResponse, len(links))
-	for i, l := range links {
-		out[i] = worktreeLinkResponse{
-			WorktreeKey:    l.WorktreeKey,
-			WorktreePath:   l.WorktreePath,
-			WorktreeBranch: l.WorktreeBranch,
-		}
-	}
-	return out
-}
-
-// indexWorktreeLinksByMR groups worktree link responses by
-// merge request ID.
-func indexWorktreeLinksByMR(
-	links []db.WorktreeLink,
-) map[int64][]worktreeLinkResponse {
-	m := make(map[int64][]worktreeLinkResponse)
-	for _, l := range links {
-		m[l.MergeRequestID] = append(
-			m[l.MergeRequestID],
-			worktreeLinkResponse{
-				WorktreeKey:    l.WorktreeKey,
-				WorktreePath:   l.WorktreePath,
-				WorktreeBranch: l.WorktreeBranch,
-			},
-		)
-	}
-	return m
-}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -659,22 +659,7 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 		if !ok {
 			continue
 		}
-		wl := linksByMR[mr.ID]
-		if wl == nil {
-			wl = []worktreeLinkResponse{}
-		}
-		resp := mergeRequestResponse{
-			MergeRequest:  mr,
-			RepoOwner:     rp.Owner,
-			RepoName:      rp.Name,
-			PlatformHost:  rp.PlatformHost,
-			WorktreeLinks: wl,
-			DetailLoaded:  mr.DetailFetchedAt != nil,
-		}
-		if mr.DetailFetchedAt != nil {
-			resp.DetailFetchedAt = formatUTCRFC3339(*mr.DetailFetchedAt)
-		}
-		out = append(out, resp)
+		out = append(out, projectMergeRequestListResponse(mr, rp, linksByMR[mr.ID]))
 	}
 
 	return &listPullsOutput{Body: out}, nil
@@ -706,9 +691,6 @@ func (s *Server) buildPullDetailResponse(
 	if err != nil {
 		return mergeRequestDetailResponse{}, huma.Error500InternalServerError("list mr events failed")
 	}
-	if events == nil {
-		events = []db.MREvent{}
-	}
 
 	dbLinks, err := s.db.GetWorktreeLinksForMR(ctx, mr.ID)
 	if err != nil {
@@ -723,38 +705,15 @@ func (s *Server) buildPullDetailResponse(
 			"load repo failed",
 		)
 	}
-	resp := mergeRequestDetailResponse{
+	return projectMergeRequestDetailResponse(mergeRequestDetailProjection{
 		MergeRequest:     mr,
 		Events:           events,
-		RepoOwner:        repo.Owner,
-		RepoName:         repo.Name,
-		PlatformHost:     repo.PlatformHost,
-		PlatformHeadSHA:  mr.PlatformHeadSHA,
-		PlatformBaseSHA:  mr.PlatformBaseSHA,
-		DiffHeadSHA:      mr.DiffHeadSHA,
-		MergeBaseSHA:     mr.MergeBaseSHA,
-		WorktreeLinks:    toWorktreeLinkResponses(dbLinks),
+		Repo:             *repo,
+		WorktreeLinks:    dbLinks,
 		WorkflowApproval: s.workflowApprovalState(ctx, repo.Owner, repo.Name, mr, wfMode),
 		Warnings:         s.diffWarnings(mr),
-		DetailLoaded:     mr.DetailFetchedAt != nil,
-	}
-	if mr.DetailFetchedAt != nil {
-		resp.DetailFetchedAt = formatUTCRFC3339(*mr.DetailFetchedAt)
-	}
-
-	if s.workspaces != nil {
-		wsRef, wsErr := s.workspaces.GetByMR(
-			ctx, repo.PlatformHost, repo.Owner, repo.Name, mr.Number,
-		)
-		if wsErr == nil && wsRef != nil {
-			resp.Workspace = &workspaceRef{
-				ID:     wsRef.ID,
-				Status: wsRef.Status,
-			}
-		}
-	}
-
-	return resp, nil
+		Workspace:        s.workspaceForMergeRequest(ctx, *repo, mr.Number),
+	}), nil
 }
 
 // diffWarnings returns warnings inferred from the persisted PR row. The
@@ -1103,17 +1062,7 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 		if !ok {
 			continue
 		}
-		resp := issueResponse{
-			Issue:        issue,
-			PlatformHost: rp.PlatformHost,
-			RepoOwner:    rp.Owner,
-			RepoName:     rp.Name,
-			DetailLoaded: issue.DetailFetchedAt != nil,
-		}
-		if issue.DetailFetchedAt != nil {
-			resp.DetailFetchedAt = formatUTCRFC3339(*issue.DetailFetchedAt)
-		}
-		out = append(out, resp)
+		out = append(out, projectIssueListResponse(issue, rp))
 	}
 
 	return &listIssuesOutput{Body: out}, nil
@@ -1203,16 +1152,7 @@ func (s *Server) createIssue(
 	}
 	savedIssue.ID = issueID
 
-	out := issueResponse{
-		Issue:        *savedIssue,
-		PlatformHost: repo.PlatformHost,
-		RepoOwner:    repo.Owner,
-		RepoName:     repo.Name,
-		DetailLoaded: savedIssue.DetailFetchedAt != nil,
-	}
-	if savedIssue.DetailFetchedAt != nil {
-		out.DetailFetchedAt = formatUTCRFC3339(*savedIssue.DetailFetchedAt)
-	}
+	out := projectIssueListResponse(*savedIssue, *repo)
 
 	return &createIssueOutput{
 		Status: http.StatusCreated,
@@ -1234,35 +1174,9 @@ func (s *Server) getIssue(ctx context.Context, input *issueRepoNumberInput) (*ge
 		return nil, huma.Error500InternalServerError("get issue failed")
 	}
 
-	events, err := s.db.ListIssueEvents(ctx, issue.ID)
+	issueResp, err := s.buildIssueDetailResponse(ctx, repo, issue)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("list issue events failed")
-	}
-	if events == nil {
-		events = []db.IssueEvent{}
-	}
-
-	issueResp := issueDetailResponse{
-		Issue:        issue,
-		Events:       events,
-		PlatformHost: repo.PlatformHost,
-		RepoOwner:    repo.Owner,
-		RepoName:     repo.Name,
-		DetailLoaded: issue.DetailFetchedAt != nil,
-	}
-	if issue.DetailFetchedAt != nil {
-		issueResp.DetailFetchedAt = formatUTCRFC3339(*issue.DetailFetchedAt)
-	}
-	if s.workspaces != nil {
-		wsRef, wsErr := s.workspaces.GetByIssue(
-			ctx, repo.PlatformHost, repo.Owner, repo.Name, issue.Number,
-		)
-		if wsErr == nil && wsRef != nil {
-			issueResp.Workspace = &workspaceRef{
-				ID:     wsRef.ID,
-				Status: wsRef.Status,
-			}
-		}
 	}
 	return &getIssueOutput{Body: issueResp}, nil
 }
@@ -2024,35 +1938,9 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 		return nil, huma.Error500InternalServerError("get issue: " + err.Error())
 	}
 
-	events, err := s.db.ListIssueEvents(ctx, issue.ID)
+	syncIssueResp, err := s.buildIssueDetailResponse(ctx, repo, issue)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("list issue events: " + err.Error())
-	}
-	if events == nil {
-		events = []db.IssueEvent{}
-	}
-
-	syncIssueResp := issueDetailResponse{
-		Issue:        issue,
-		Events:       events,
-		PlatformHost: repo.PlatformHost,
-		RepoOwner:    repo.Owner,
-		RepoName:     repo.Name,
-		DetailLoaded: issue.DetailFetchedAt != nil,
-	}
-	if issue.DetailFetchedAt != nil {
-		syncIssueResp.DetailFetchedAt = formatUTCRFC3339(*issue.DetailFetchedAt)
-	}
-	if s.workspaces != nil {
-		wsRef, wsErr := s.workspaces.GetByIssue(
-			ctx, repo.PlatformHost, repo.Owner, repo.Name, issue.Number,
-		)
-		if wsErr == nil && wsRef != nil {
-			syncIssueResp.Workspace = &workspaceRef{
-				ID:     wsRef.ID,
-				Status: wsRef.Status,
-			}
-		}
 	}
 	return &syncIssueOutput{Body: syncIssueResp}, nil
 }

--- a/internal/server/tracked_item_projection.go
+++ b/internal/server/tracked_item_projection.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/workspace"
+)
+
+type mergeRequestDetailProjection struct {
+	MergeRequest     *db.MergeRequest
+	Events           []db.MREvent
+	Repo             db.Repo
+	WorktreeLinks    []db.WorktreeLink
+	WorkflowApproval workflowApprovalResponse
+	Warnings         []string
+	Workspace        *workspace.Workspace
+}
+
+type issueDetailProjection struct {
+	Issue     *db.Issue
+	Events    []db.IssueEvent
+	Repo      db.Repo
+	Workspace *workspace.Workspace
+}
+
+func projectMergeRequestListResponse(
+	mr db.MergeRequest,
+	repo db.Repo,
+	links []worktreeLinkResponse,
+) mergeRequestResponse {
+	if links == nil {
+		links = []worktreeLinkResponse{}
+	}
+	detailLoaded, detailFetchedAt := projectDetailFetchedAt(mr.DetailFetchedAt)
+	resp := mergeRequestResponse{
+		MergeRequest:    mr,
+		RepoOwner:       repo.Owner,
+		RepoName:        repo.Name,
+		PlatformHost:    repo.PlatformHost,
+		WorktreeLinks:   links,
+		DetailLoaded:    detailLoaded,
+		DetailFetchedAt: detailFetchedAt,
+	}
+	return resp
+}
+
+func projectMergeRequestDetailResponse(
+	input mergeRequestDetailProjection,
+) mergeRequestDetailResponse {
+	events := input.Events
+	if events == nil {
+		events = []db.MREvent{}
+	}
+	resp := mergeRequestDetailResponse{
+		MergeRequest:     input.MergeRequest,
+		Events:           events,
+		RepoOwner:        input.Repo.Owner,
+		RepoName:         input.Repo.Name,
+		PlatformHost:     input.Repo.PlatformHost,
+		WorktreeLinks:    toWorktreeLinkResponses(input.WorktreeLinks),
+		WorkflowApproval: input.WorkflowApproval,
+		Warnings:         input.Warnings,
+		Workspace:        projectWorkspaceRef(input.Workspace),
+	}
+	if input.MergeRequest != nil {
+		detailLoaded, detailFetchedAt := projectDetailFetchedAt(
+			input.MergeRequest.DetailFetchedAt,
+		)
+		resp.PlatformHeadSHA = input.MergeRequest.PlatformHeadSHA
+		resp.PlatformBaseSHA = input.MergeRequest.PlatformBaseSHA
+		resp.DiffHeadSHA = input.MergeRequest.DiffHeadSHA
+		resp.MergeBaseSHA = input.MergeRequest.MergeBaseSHA
+		resp.DetailLoaded = detailLoaded
+		resp.DetailFetchedAt = detailFetchedAt
+	}
+	return resp
+}
+
+func projectIssueListResponse(issue db.Issue, repo db.Repo) issueResponse {
+	detailLoaded, detailFetchedAt := projectDetailFetchedAt(issue.DetailFetchedAt)
+	resp := issueResponse{
+		Issue:           issue,
+		PlatformHost:    repo.PlatformHost,
+		RepoOwner:       repo.Owner,
+		RepoName:        repo.Name,
+		DetailLoaded:    detailLoaded,
+		DetailFetchedAt: detailFetchedAt,
+	}
+	return resp
+}
+
+func projectIssueDetailResponse(input issueDetailProjection) issueDetailResponse {
+	events := input.Events
+	if events == nil {
+		events = []db.IssueEvent{}
+	}
+	resp := issueDetailResponse{
+		Issue:        input.Issue,
+		Events:       events,
+		PlatformHost: input.Repo.PlatformHost,
+		RepoOwner:    input.Repo.Owner,
+		RepoName:     input.Repo.Name,
+		Workspace:    projectWorkspaceRef(input.Workspace),
+	}
+	if input.Issue != nil {
+		detailLoaded, detailFetchedAt := projectDetailFetchedAt(input.Issue.DetailFetchedAt)
+		resp.DetailLoaded = detailLoaded
+		resp.DetailFetchedAt = detailFetchedAt
+	}
+	return resp
+}
+
+func projectDetailFetchedAt(t *time.Time) (bool, string) {
+	if t == nil {
+		return false, ""
+	}
+	return true, formatUTCRFC3339(*t)
+}
+
+func projectWorkspaceRef(ws *workspace.Workspace) *workspaceRef {
+	if ws == nil {
+		return nil
+	}
+	return &workspaceRef{
+		ID:     ws.ID,
+		Status: ws.Status,
+	}
+}
+
+func (s *Server) workspaceForMergeRequest(
+	ctx context.Context,
+	repo db.Repo,
+	number int,
+) *workspace.Workspace {
+	if s.workspaces == nil {
+		return nil
+	}
+	ws, err := s.workspaces.GetByMR(
+		ctx, repo.PlatformHost, repo.Owner, repo.Name, number,
+	)
+	if err != nil {
+		return nil
+	}
+	return ws
+}
+
+func (s *Server) workspaceForIssue(
+	ctx context.Context,
+	repo db.Repo,
+	number int,
+) *workspace.Workspace {
+	if s.workspaces == nil {
+		return nil
+	}
+	ws, err := s.workspaces.GetByIssue(
+		ctx, repo.PlatformHost, repo.Owner, repo.Name, number,
+	)
+	if err != nil {
+		return nil
+	}
+	return ws
+}
+
+func (s *Server) buildIssueDetailResponse(
+	ctx context.Context,
+	repo *db.Repo,
+	issue *db.Issue,
+) (issueDetailResponse, error) {
+	events, err := s.db.ListIssueEvents(ctx, issue.ID)
+	if err != nil {
+		return issueDetailResponse{}, err
+	}
+	return projectIssueDetailResponse(issueDetailProjection{
+		Issue:     issue,
+		Events:    events,
+		Repo:      *repo,
+		Workspace: s.workspaceForIssue(ctx, *repo, issue.Number),
+	}), nil
+}
+
+// toWorktreeLinkResponses converts DB links to API responses.
+// Returns an empty non-nil slice when input is nil.
+func toWorktreeLinkResponses(
+	links []db.WorktreeLink,
+) []worktreeLinkResponse {
+	out := make([]worktreeLinkResponse, len(links))
+	for i, l := range links {
+		out[i] = worktreeLinkResponse{
+			WorktreeKey:    l.WorktreeKey,
+			WorktreePath:   l.WorktreePath,
+			WorktreeBranch: l.WorktreeBranch,
+		}
+	}
+	return out
+}
+
+// indexWorktreeLinksByMR groups worktree link responses by merge request ID.
+func indexWorktreeLinksByMR(
+	links []db.WorktreeLink,
+) map[int64][]worktreeLinkResponse {
+	m := make(map[int64][]worktreeLinkResponse)
+	for _, l := range links {
+		m[l.MergeRequestID] = append(
+			m[l.MergeRequestID],
+			worktreeLinkResponse{
+				WorktreeKey:    l.WorktreeKey,
+				WorktreePath:   l.WorktreePath,
+				WorktreeBranch: l.WorktreeBranch,
+			},
+		)
+	}
+	return m
+}

--- a/internal/server/tracked_item_projection_test.go
+++ b/internal/server/tracked_item_projection_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/workspace"
+)
+
+func TestProjectMergeRequestListResponseNormalizesDetailTimestampAndLinks(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	detailFetchedAt := testEDTTime(9, 30)
+	resp := projectMergeRequestListResponse(
+		db.MergeRequest{
+			ID:              11,
+			RepoID:          22,
+			Number:          3,
+			Title:           "Projection PR",
+			DetailFetchedAt: &detailFetchedAt,
+		},
+		db.Repo{
+			PlatformHost: "ghe.example.com",
+			Owner:        "acme",
+			Name:         "widget",
+		},
+		nil,
+	)
+
+	assert.Equal("ghe.example.com", resp.PlatformHost)
+	assert.Equal("acme", resp.RepoOwner)
+	assert.Equal("widget", resp.RepoName)
+	assert.True(resp.DetailLoaded)
+	require.NotEmpty(resp.DetailFetchedAt)
+	assertRFC3339UTC(t, resp.DetailFetchedAt, detailFetchedAt)
+	assert.NotNil(resp.WorktreeLinks)
+	assert.Empty(resp.WorktreeLinks)
+}
+
+func TestProjectIssueDetailResponseNormalizesEmptyEventsWorkspaceAndDetailTimestamp(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	detailFetchedAt := testEDTTime(15, 45)
+	resp := projectIssueDetailResponse(issueDetailProjection{
+		Issue: &db.Issue{
+			ID:              33,
+			RepoID:          44,
+			Number:          7,
+			Title:           "Projection issue",
+			DetailFetchedAt: &detailFetchedAt,
+		},
+		Events: nil,
+		Repo: db.Repo{
+			PlatformHost: "github.example.com",
+			Owner:        "acme",
+			Name:         "widget",
+		},
+		Workspace: &workspace.Workspace{
+			ID:     "ws-123",
+			Status: "ready",
+		},
+	})
+
+	assert.Equal("github.example.com", resp.PlatformHost)
+	assert.Equal("acme", resp.RepoOwner)
+	assert.Equal("widget", resp.RepoName)
+	assert.True(resp.DetailLoaded)
+	require.NotEmpty(resp.DetailFetchedAt)
+	assertRFC3339UTC(t, resp.DetailFetchedAt, detailFetchedAt)
+	assert.NotNil(resp.Events)
+	assert.Empty(resp.Events)
+	require.NotNil(resp.Workspace)
+	assert.Equal("ws-123", resp.Workspace.ID)
+	assert.Equal("ready", resp.Workspace.Status)
+}
+
+func TestProjectIssueListResponseNormalizesRepoAndDetailTimestamp(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	detailFetchedAt := testEDTTime(10, 5)
+	resp := projectIssueListResponse(
+		db.Issue{
+			ID:              34,
+			RepoID:          45,
+			Number:          8,
+			Title:           "Projection issue list",
+			DetailFetchedAt: &detailFetchedAt,
+		},
+		db.Repo{
+			PlatformHost: "ghe.example.com",
+			Owner:        "acme",
+			Name:         "widget",
+		},
+	)
+
+	assert.Equal("ghe.example.com", resp.PlatformHost)
+	assert.Equal("acme", resp.RepoOwner)
+	assert.Equal("widget", resp.RepoName)
+	assert.True(resp.DetailLoaded)
+	require.NotEmpty(resp.DetailFetchedAt)
+	assertRFC3339UTC(t, resp.DetailFetchedAt, detailFetchedAt)
+}
+
+func TestProjectMergeRequestDetailResponseKeepsEmptySlicesNonNil(t *testing.T) {
+	assert := Assert.New(t)
+
+	resp := projectMergeRequestDetailResponse(mergeRequestDetailProjection{
+		MergeRequest: &db.MergeRequest{
+			ID:     55,
+			RepoID: 66,
+			Number: 9,
+			Title:  "Projection detail",
+		},
+		Events:        nil,
+		WorktreeLinks: nil,
+		Repo: db.Repo{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+		},
+	})
+
+	assert.False(resp.DetailLoaded)
+	assert.Empty(resp.DetailFetchedAt)
+	assert.NotNil(resp.Events)
+	assert.Empty(resp.Events)
+	assert.NotNil(resp.WorktreeLinks)
+	assert.Empty(resp.WorktreeLinks)
+}


### PR DESCRIPTION
- Move PR and issue response assembly into a tracked item projection module.
- Keep repo decoration, UTC detail timestamps, detail-loaded flags, empty slices, worktree links, and workspace refs in one place.
- This makes handlers simpler because they fetch rows and pass them through one projection seam instead of rebuilding response rules inline.
- The new projection tests make API-shape invariants easier to verify without duplicating assertions across every route.

Validation:
- go test ./internal/server -run 'TestProject|TestAPIGetPull|TestAPIListPulls|TestAPIGetIssue|TestAPIListIssues|TestAPISyncPR|TestAPISyncIssue' -shuffle=on\n- git diff --check