### PR TITLE
Centralize repository identity resolution

### DIFF
--- a/context/repository-identity.md
+++ b/context/repository-identity.md
@@ -14,20 +14,24 @@ enough for that operation.
 ## Server Boundary
 
 HTTP handlers should resolve repositories through the repository identity
-module in `internal/repoidentity`. `internal/server/repo_identity.go` is only
-the adapter from route-local structs to that module. Handlers should not
-repeat:
+module in `internal/repoidentity`, but only after the server boundary has a
+concrete `platform_host`. `internal/server/repo_identity.go` is only the
+adapter from route-local structs to that module. The module must not perform
+hostless owner/name guessing, because host is a mandatory part of repository
+identity.
 
-- whether `owner/name` is enough;
+Handlers should centralize:
+
+- whether omitted `platform_host` can be derived from an unambiguous tracked repo;
 - when omitted `platform_host` must be rejected as ambiguous;
 - how not-found and ambiguity errors are represented;
 - how a repo row becomes the stable `repo_id` used for item lookups.
 
 The server uses strict identity resolution for routes that operate on one
-repository: if the caller omits `platform_host`, `owner/name` must resolve to
-exactly one known repo. `repoidentity.ErrAmbiguous` is a client input problem
-and should map to HTTP 400 with a message asking for `platform_host`; it should
-not be collapsed into a generic 500.
+repository: if the caller omits `platform_host`, the handler must derive it
+from exactly one configured repo before calling `repoidentity`. Ambiguous input
+is a client problem and should map to HTTP 400 with a message asking for
+`platform_host`; it should not be collapsed into a generic 500.
 
 ## Item Resolution
 

--- a/context/repository-identity.md
+++ b/context/repository-identity.md
@@ -21,11 +21,11 @@ module in `internal/server/repo_identity.go`. Handlers should not repeat:
 - how not-found and ambiguity errors are represented;
 - how a repo row becomes the stable `repo_id` used for item lookups.
 
-Use `repoLookupOwnerNameAllowed` for legacy routes where the path only carries
-`owner/name` and the existing behavior is to select the deterministic
-owner/name match from the database. Use
-`repoLookupRequireUnambiguousOwnerName` for mutations where the target repo
-must be unambiguous unless the caller provides `platform_host`.
+The server uses strict identity resolution for routes that operate on one
+repository: if the caller omits `platform_host`, `owner/name` must resolve to
+exactly one known repo. `errRepoAmbiguous` is a client input problem and should
+map to HTTP 400 with a message asking for `platform_host`; it should not be
+collapsed into a generic 500.
 
 ## Item Resolution
 
@@ -37,3 +37,10 @@ crossing when stale database rows exist.
 `ResolveLocalItem` intentionally treats a missing local repo row as "not found
 locally" instead of a hard error so `/items/{number}/resolve` can fall through
 to the sync path for tracked repositories.
+
+Before that sync fallback runs, the handler must check configured repositories
+as well as local database rows. If multiple tracked repos share the same
+`owner/name`, a no-host `/items/{number}/resolve` request is ambiguous even
+when SQLite has not seen either repo yet. In that case the server must return
+HTTP 400 instead of calling the no-host sync path, because the syncer would
+otherwise pick a host using first-match `hostFor` behavior.

--- a/context/repository-identity.md
+++ b/context/repository-identity.md
@@ -14,7 +14,9 @@ enough for that operation.
 ## Server Boundary
 
 HTTP handlers should resolve repositories through the repository identity
-module in `internal/server/repo_identity.go`. Handlers should not repeat:
+module in `internal/repoidentity`. `internal/server/repo_identity.go` is only
+the adapter from route-local structs to that module. Handlers should not
+repeat:
 
 - whether `owner/name` is enough;
 - when omitted `platform_host` must be rejected as ambiguous;
@@ -23,9 +25,9 @@ module in `internal/server/repo_identity.go`. Handlers should not repeat:
 
 The server uses strict identity resolution for routes that operate on one
 repository: if the caller omits `platform_host`, `owner/name` must resolve to
-exactly one known repo. `errRepoAmbiguous` is a client input problem and should
-map to HTTP 400 with a message asking for `platform_host`; it should not be
-collapsed into a generic 500.
+exactly one known repo. `repoidentity.ErrAmbiguous` is a client input problem
+and should map to HTTP 400 with a message asking for `platform_host`; it should
+not be collapsed into a generic 500.
 
 ## Item Resolution
 

--- a/context/repository-identity.md
+++ b/context/repository-identity.md
@@ -1,0 +1,39 @@
+# Repository Identity
+
+Repository identity in the backend is the tuple:
+
+```text
+platform_host + owner + name
+```
+
+`owner` and `name` are case-folded before storage and lookup. An empty
+`platform_host` at the storage boundary means `github.com`; route inputs that
+omit `platform_host` are different: they are asking whether `owner/name` is
+enough for that operation.
+
+## Server Boundary
+
+HTTP handlers should resolve repositories through the repository identity
+module in `internal/server/repo_identity.go`. Handlers should not repeat:
+
+- whether `owner/name` is enough;
+- when omitted `platform_host` must be rejected as ambiguous;
+- how not-found and ambiguity errors are represented;
+- how a repo row becomes the stable `repo_id` used for item lookups.
+
+Use `repoLookupOwnerNameAllowed` for legacy routes where the path only carries
+`owner/name` and the existing behavior is to select the deterministic
+owner/name match from the database. Use
+`repoLookupRequireUnambiguousOwnerName` for mutations where the target repo
+must be unambiguous unless the caller provides `platform_host`.
+
+## Item Resolution
+
+Resolve repo identity before resolving pull request or issue numbers. After a
+repo is resolved, item lookup must use `repo_id + number`, not another
+owner/name query. This keeps same-owner/name rows on different hosts from
+crossing when stale database rows exist.
+
+`ResolveLocalItem` intentionally treats a missing local repo row as "not found
+locally" instead of a hard error so `/items/{number}/resolve` can fall through
+to the sync path for tracked repositories.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3621,6 +3621,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -155,8 +155,11 @@ components:
           type: string
         body:
           type: string
+        platform_host:
+          type: string
       required:
         - body
+        - platform_host
       type: object
     BulkAddRepoRequest:
       additionalProperties: false
@@ -308,6 +311,7 @@ components:
       required:
         - title
         - body
+        - platform_host
       type: object
     CreateIssueWorkspaceInputBody:
       additionalProperties: false
@@ -426,8 +430,11 @@ components:
           type: string
         body:
           type: string
+        platform_host:
+          type: string
       required:
         - body
+        - platform_host
       type: object
     EditIssueCommentInputBody:
       additionalProperties: false
@@ -445,6 +452,7 @@ components:
           type: string
       required:
         - body
+        - platform_host
       type: object
     EditPRContentInputBody:
       additionalProperties: false
@@ -458,8 +466,12 @@ components:
           type: string
         body:
           type: string
+        platform_host:
+          type: string
         title:
           type: string
+      required:
+        - platform_host
       type: object
     ErrorDetail:
       additionalProperties: false
@@ -558,6 +570,7 @@ components:
           type: string
       required:
         - state
+        - platform_host
       type: object
     GithubStateOutputBody:
       additionalProperties: false
@@ -1033,10 +1046,13 @@ components:
           type: string
         method:
           type: string
+        platform_host:
+          type: string
       required:
         - commit_title
         - commit_message
         - method
+        - platform_host
       type: object
     MergeRequest:
       additionalProperties: false
@@ -1405,8 +1421,11 @@ components:
           type: string
         body:
           type: string
+        platform_host:
+          type: string
       required:
         - body
+        - platform_host
       type: object
     PostIssueCommentInputBody:
       additionalProperties: false
@@ -1424,6 +1443,22 @@ components:
           type: string
       required:
         - body
+        - platform_host
+      type: object
+    PrActionInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/PrActionInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        platform_host:
+          type: string
+      required:
+        - platform_host
       type: object
     RateLimitHostStatus:
       additionalProperties: false
@@ -1906,10 +1941,13 @@ components:
           format: uri
           readOnly: true
           type: string
+        platform_host:
+          type: string
         status:
           type: string
       required:
         - status
+        - platform_host
       type: object
     SettingsResponse:
       additionalProperties: false
@@ -2071,6 +2109,7 @@ components:
         - owner
         - name
         - number
+        - platform_host
       type: object
     SyncStatus:
       additionalProperties: false
@@ -2867,11 +2906,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -3100,11 +3134,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -3144,11 +3173,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -3189,11 +3213,12 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PrActionInputBody"
+        required: true
       responses:
         "200":
           content:
@@ -3228,11 +3253,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -3278,11 +3298,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -3465,11 +3480,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -3543,11 +3553,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:
@@ -3588,11 +3593,12 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PrActionInputBody"
+        required: true
       responses:
         "200":
           content:
@@ -3661,11 +3667,6 @@ paths:
           schema:
             format: int64
             type: integer
-        - explode: false
-          in: query
-          name: platform_host
-          schema:
-            type: string
       requestBody:
         content:
           application/json:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3057,6 +3057,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3646,6 +3651,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3680,6 +3690,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "202":
           description: Accepted

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3134,6 +3134,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2867,6 +2867,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3095,6 +3100,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3218,6 +3228,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3263,6 +3278,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3302,6 +3322,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3362,6 +3387,11 @@ paths:
           schema:
             description: End SHA for range diff (inclusive)
             type: string
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3396,6 +3426,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3430,6 +3465,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3169,6 +3169,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3488,6 +3493,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -3528,6 +3538,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3018,6 +3018,11 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: platform_host
+          schema:
+            type: string
       responses:
         "200":
           content:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -53,6 +53,7 @@
     isDiffView,
     getDetailTab,
     getSelectedPRFromRoute,
+    buildItemRoute,
     type RoutableItemRef,
   } from "./lib/stores/router.svelte.ts";
   import {
@@ -179,6 +180,7 @@
           route.selected.owner,
           route.selected.name,
           route.selected.number,
+          route.selected.platformHost,
         );
       } else {
         stores.pulls.clearSelection();
@@ -274,14 +276,21 @@
     const sel = stores.pulls.getSelectedPR();
     if (!sel) return;
     const tab = getDetailTab();
-    const path =
-      tab === "files"
-        ? `/pulls/${sel.owner}/${sel.name}/${sel.number}/files`
-        : `/pulls/${sel.owner}/${sel.name}/${sel.number}`;
+    const path = buildItemRoute(
+      "pr",
+      sel.owner,
+      sel.name,
+      sel.number,
+      sel.platformHost,
+    );
+    const [pathname, query = ""] = path.split("?");
+    const tabPath = tab === "files"
+      ? `${pathname}/files${query ? `?${query}` : ""}`
+      : path;
     if (getSelectedPRFromRoute()) {
-      replaceUrl(path);
+      replaceUrl(tabPath);
     } else {
-      navigate(path);
+      navigate(tabPath);
     }
   }
 
@@ -481,6 +490,7 @@
               owner: r.owner,
               name: r.name,
               number: r.number,
+              platformHost: r.platformHost,
             }}
             detailTab="conversation"
             isSidebarCollapsed={true}

--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -91,9 +91,8 @@ describe("ApproveButton tooltips", () => {
       {
         params: {
           path: { owner: "acme", name: "widget", number: 7 },
-          query: { platform_host: "ghe.example.com" },
         },
-        body: { body: "" },
+        body: { body: "", platform_host: "ghe.example.com" },
       },
     );
     expect(mockLoadDetail).toHaveBeenCalledWith(

--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -1,17 +1,30 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPost = vi.fn();
+const mockLoadDetail = vi.fn();
+const mockLoadPulls = vi.fn();
 
 vi.mock("../../packages/ui/src/context.js", () => ({
-  getClient: () => ({ POST: vi.fn() }),
+  getClient: () => ({ POST: mockPost }),
   getStores: () => ({
-    detail: { loadDetail: vi.fn() },
-    pulls: { loadPulls: vi.fn() },
+    detail: { loadDetail: mockLoadDetail },
+    pulls: { loadPulls: mockLoadPulls },
   }),
 }));
 
 import ApproveButton from "../../packages/ui/src/components/detail/ApproveButton.svelte";
 
 describe("ApproveButton tooltips", () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockLoadDetail.mockReset();
+    mockLoadPulls.mockReset();
+    mockPost.mockResolvedValue({});
+    mockLoadDetail.mockResolvedValue(undefined);
+    mockLoadPulls.mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     cleanup();
   });
@@ -57,6 +70,37 @@ describe("ApproveButton tooltips", () => {
       screen.getByRole("button", { name: /approve/i }).getAttribute("title"),
     ).toBe(
       "Open the approval form to submit a code review on this pull request",
+    );
+  });
+
+  it("passes platform_host when approving a host-qualified PR", async () => {
+    render(ApproveButton, {
+      props: {
+        owner: "acme",
+        name: "widget",
+        number: 7,
+        platformHost: "ghe.example.com",
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /^approve$/i }));
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/repos/{owner}/{name}/pulls/{number}/approve",
+      {
+        params: {
+          path: { owner: "acme", name: "widget", number: 7 },
+          query: { platform_host: "ghe.example.com" },
+        },
+        body: { body: "" },
+      },
+    );
+    expect(mockLoadDetail).toHaveBeenCalledWith(
+      "acme",
+      "widget",
+      7,
+      { platformHost: "ghe.example.com" },
     );
   });
 });

--- a/frontend/src/ApproveWorkflowsButton.test.ts
+++ b/frontend/src/ApproveWorkflowsButton.test.ts
@@ -59,10 +59,49 @@ describe("ApproveWorkflowsButton", () => {
 
     expect(mockPost).toHaveBeenCalledWith(
       "/repos/{owner}/{name}/pulls/{number}/approve-workflows",
-      { params: { path: { owner: "acme", name: "widget", number: 7 } } },
+      {
+        params: {
+          path: { owner: "acme", name: "widget", number: 7 },
+        },
+      },
     );
-    expect(mockRefreshDetailOnly).toHaveBeenCalledWith("acme", "widget", 7);
+    expect(mockRefreshDetailOnly).toHaveBeenCalledWith(
+      "acme",
+      "widget",
+      7,
+      undefined,
+    );
     expect(mockLoadPulls).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes platform_host when approving host-qualified workflows", async () => {
+    mockPost.mockResolvedValue({
+      data: { status: "approved_workflows", approved_count: 1 },
+    });
+
+    render(ApproveWorkflowsButton, {
+      props: {
+        owner: "acme",
+        name: "widget",
+        number: 7,
+        platformHost: "ghe.example.com",
+        count: 1,
+      },
+    });
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /^approve workflows$/i }),
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/repos/{owner}/{name}/pulls/{number}/approve-workflows",
+      {
+        params: {
+          path: { owner: "acme", name: "widget", number: 7 },
+          query: { platform_host: "ghe.example.com" },
+        },
+      },
+    );
   });
 
   it("shows an inline error when approval fails", async () => {

--- a/frontend/src/ApproveWorkflowsButton.test.ts
+++ b/frontend/src/ApproveWorkflowsButton.test.ts
@@ -63,6 +63,7 @@ describe("ApproveWorkflowsButton", () => {
         params: {
           path: { owner: "acme", name: "widget", number: 7 },
         },
+        body: { platform_host: "" },
       },
     );
     expect(mockRefreshDetailOnly).toHaveBeenCalledWith(
@@ -98,8 +99,8 @@ describe("ApproveWorkflowsButton", () => {
       {
         params: {
           path: { owner: "acme", name: "widget", number: 7 },
-          query: { platform_host: "ghe.example.com" },
         },
+        body: { platform_host: "ghe.example.com" },
       },
     );
   });

--- a/frontend/src/ReadyForReviewButton.test.ts
+++ b/frontend/src/ReadyForReviewButton.test.ts
@@ -76,8 +76,8 @@ describe("ReadyForReviewButton", () => {
       {
         params: {
           path: { owner: "wesm", name: "middleman", number: 141 },
-          query: { platform_host: "ghe.example.com" },
         },
+        body: { platform_host: "ghe.example.com" },
       },
     );
   });

--- a/frontend/src/ReadyForReviewButton.test.ts
+++ b/frontend/src/ReadyForReviewButton.test.ts
@@ -45,8 +45,41 @@ describe("ReadyForReviewButton", () => {
       screen.getByRole("button", { name: /ready for review/i }),
     );
 
-    expect(mockLoadDetail).toHaveBeenCalledWith("wesm", "middleman", 141);
+    expect(mockLoadDetail).toHaveBeenCalledWith(
+      "wesm",
+      "middleman",
+      141,
+      { platformHost: undefined },
+    );
     expect(mockLoadPulls).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes platform_host when marking a host-qualified PR ready", async () => {
+    mockPost.mockResolvedValue({ data: { status: "ready_for_review" } });
+
+    render(ReadyForReviewButton, {
+      props: {
+        owner: "wesm",
+        name: "middleman",
+        number: 141,
+        platformHost: "ghe.example.com",
+        size: "sm",
+      },
+    });
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /ready for review/i }),
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/repos/{owner}/{name}/pulls/{number}/ready-for-review",
+      {
+        params: {
+          path: { owner: "wesm", name: "middleman", number: 141 },
+          query: { platform_host: "ghe.example.com" },
+        },
+      },
+    );
   });
 
   it("refreshes stale draft state after a GitHub 404", async () => {
@@ -65,7 +98,12 @@ describe("ReadyForReviewButton", () => {
       screen.getByRole("button", { name: /ready for review/i }),
     );
 
-    expect(mockLoadDetail).toHaveBeenCalledWith("wesm", "middleman", 141);
+    expect(mockLoadDetail).toHaveBeenCalledWith(
+      "wesm",
+      "middleman",
+      141,
+      { platformHost: undefined },
+    );
     expect(mockLoadPulls).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/components/detail-comment-persistence.test.ts
+++ b/frontend/src/lib/components/detail-comment-persistence.test.ts
@@ -767,7 +767,7 @@ describe("comment draft persistence", () => {
     await fireEvent.keyDown(getCommentEditor(), { key: "Enter", metaKey: true });
 
     await waitFor(() => {
-      expect(submitSpy).toHaveBeenCalledWith("octo", "repo", 1, "@al");
+      expect(submitSpy).toHaveBeenCalledWith("octo", "repo", 1, undefined, "@al");
     });
   });
 
@@ -814,7 +814,13 @@ describe("comment draft persistence", () => {
     await fireEvent.keyDown(getCommentEditor(), { key: "Enter", metaKey: true });
 
     await waitFor(() => {
-      expect(submitSpy).toHaveBeenCalledWith("octo", "repo", 1, "hello @alice");
+      expect(submitSpy).toHaveBeenCalledWith(
+        "octo",
+        "repo",
+        1,
+        undefined,
+        "hello @alice",
+      );
     });
   });
 });

--- a/frontend/src/lib/stores/detail-comment.svelte.test.ts
+++ b/frontend/src/lib/stores/detail-comment.svelte.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createDetailStore } from "@middleman/ui/stores/detail";
 import type { MiddlemanClient } from "@middleman/ui";
+import type { KanbanStatus } from "@middleman/ui/api/types";
 
 interface MockDetail {
   repo_owner: string;
   repo_name: string;
-  merge_request: { Number: number };
+  platform_host: string;
+  merge_request: { Number: number; KanbanStatus: string };
   events: unknown[];
 }
 
@@ -17,7 +19,8 @@ function makeDetail(
   return {
     repo_owner: "octo",
     repo_name: "repo",
-    merge_request: { Number: number },
+    platform_host: "ghe.example.com",
+    merge_request: { Number: number, KanbanStatus: "new" },
     events,
   };
 }
@@ -212,5 +215,59 @@ describe("createDetailStore submitComment", () => {
     await Promise.resolve();
 
     expect(store.getDetail()?.events).toHaveLength(1);
+  });
+});
+
+describe("createDetailStore updateKanbanState", () => {
+  it("passes platform_host through kanban updates and refreshes", async () => {
+    const detailData = makeDetail([], 1);
+    const client = {
+      GET: vi.fn(async () => ({ data: detailData })),
+      POST: vi.fn(),
+      PUT: vi.fn(async () => ({})),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const pulls = {
+      loadPulls: vi.fn(async () => undefined),
+      optimisticKanbanUpdate: vi.fn(),
+      getPullKanbanStatus: vi.fn((): KanbanStatus => "new"),
+    };
+    const store = createDetailStore({ client, pulls });
+
+    await store.loadDetail("octo", "repo", 1, {
+      sync: false,
+      platformHost: "ghe.example.com",
+    });
+    await store.updateKanbanState(
+      "octo",
+      "repo",
+      1,
+      "ghe.example.com",
+      "reviewing",
+    );
+
+    expect(client.PUT).toHaveBeenCalledWith(
+      "/repos/{owner}/{name}/pulls/{number}/state",
+      {
+        params: {
+          path: { owner: "octo", name: "repo", number: 1 },
+          query: { platform_host: "ghe.example.com" },
+        },
+        body: { status: "reviewing" },
+      },
+    );
+    expect(pulls.getPullKanbanStatus).toHaveBeenCalledWith(
+      "octo",
+      "repo",
+      1,
+      "ghe.example.com",
+    );
+    expect(pulls.optimisticKanbanUpdate).toHaveBeenCalledWith(
+      "octo",
+      "repo",
+      1,
+      "ghe.example.com",
+      "reviewing",
+    );
   });
 });

--- a/frontend/src/lib/stores/detail-comment.svelte.test.ts
+++ b/frontend/src/lib/stores/detail-comment.svelte.test.ts
@@ -50,9 +50,8 @@ describe("createDetailStore submitComment", () => {
       {
         params: {
           path: { owner: "octo", name: "repo", number: 1 },
-          query: { platform_host: "ghe.example.com" },
         },
-        body: { body: "hello" },
+        body: { body: "hello", platform_host: "ghe.example.com" },
       },
     );
   });
@@ -282,9 +281,8 @@ describe("createDetailStore updateKanbanState", () => {
       {
         params: {
           path: { owner: "octo", name: "repo", number: 1 },
-          query: { platform_host: "ghe.example.com" },
         },
-        body: { status: "reviewing" },
+        body: { status: "reviewing", platform_host: "ghe.example.com" },
       },
     );
     expect(pulls.getPullKanbanStatus).toHaveBeenCalledWith(

--- a/frontend/src/lib/stores/detail-comment.svelte.test.ts
+++ b/frontend/src/lib/stores/detail-comment.svelte.test.ts
@@ -26,6 +26,37 @@ function makeDetail(
 }
 
 describe("createDetailStore submitComment", () => {
+  it("passes platform_host through comment creation", async () => {
+    const detailData = makeDetail();
+    const client = {
+      GET: vi.fn(async () => ({ data: detailData })),
+      POST: vi.fn(async (path: string) => {
+        if (path.includes("/sync")) return { data: detailData };
+        return { data: { ID: 42 } };
+      }),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("octo", "repo", 1, {
+      sync: false,
+      platformHost: "ghe.example.com",
+    });
+    await store.submitComment("octo", "repo", 1, "ghe.example.com", "hello");
+
+    expect(client.POST).toHaveBeenCalledWith(
+      "/repos/{owner}/{name}/pulls/{number}/comments",
+      {
+        params: {
+          path: { owner: "octo", name: "repo", number: 1 },
+          query: { platform_host: "ghe.example.com" },
+        },
+        body: { body: "hello" },
+      },
+    );
+  });
+
   it("never flips loading flag while refreshing after a comment", async () => {
     const detailData = makeDetail();
     const loadingDuringRefresh: boolean[] = [];
@@ -62,7 +93,7 @@ describe("createDetailStore submitComment", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    await holder.store.submitComment("octo", "repo", 1, "hello");
+    await holder.store.submitComment("octo", "repo", 1, undefined, "hello");
 
     expect(getCallCount).toBeGreaterThan(1);
     expect(loadingDuringRefresh.length).toBeGreaterThan(0);
@@ -101,7 +132,7 @@ describe("createDetailStore submitComment", () => {
     await store.loadDetail("octo", "repo", 1);
 
     // Fire submitComment without awaiting; refresh GET will block on refreshPromise.
-    const submitPromise = store.submitComment("octo", "repo", 1, "hi");
+    const submitPromise = store.submitComment("octo", "repo", 1, undefined, "hi");
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -150,7 +181,7 @@ describe("createDetailStore submitComment", () => {
     loadPulls.mockClear();
     postCalls.length = 0;
 
-    await store.submitComment("octo", "repo", 1, "hi");
+    await store.submitComment("octo", "repo", 1, undefined, "hi");
     // Drain the background syncDetail fired by submitComment.
     await Promise.resolve();
     await Promise.resolve();
@@ -204,7 +235,7 @@ describe("createDetailStore submitComment", () => {
     await store.loadDetail("octo", "repo", 1);
 
     // submitComment refreshes silently and should pick up the new event.
-    await store.submitComment("octo", "repo", 1, "hello");
+    await store.submitComment("octo", "repo", 1, undefined, "hello");
     expect(store.getDetail()?.events).toHaveLength(1);
 
     // The background sync now returns stale data (no comment).

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -540,7 +540,7 @@ describe("createDiffStore loadDiff", () => {
       },
     );
 
-    const store = createDiffStore({ getBasePath: () => "/" });
+    const store = createDiffStore({ client: testClient() });
     await store.loadDiff("owner", "repo", 1);
 
     expect(store.getFileCategoryFilter()).toBe("all");

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -20,7 +20,7 @@ export type Route =
   | { page: "design-system" }
   | { page: "repos" }
   | { page: "workspaces" }
-  | { page: "pulls"; view: "list" | "board"; selected?: NumberedItemRef; tab?: "files" }
+  | { page: "pulls"; view: "list" | "board"; selected?: HostedItemRef; tab?: "files" }
   | { page: "issues"; selected?: HostedItemRef }
   | { page: "settings" }
   | ({ page: "focus" } & RoutableItemRef)
@@ -80,12 +80,15 @@ function parseRoute(fullPath: string): Route {
       /^\/focus\/pr\/([^/]+)\/([^/]+)\/(\d+)$/,
     );
     if (prMatch) {
+      const sp = new URLSearchParams(search);
+      const platformHost = sp.get("platform_host") ?? undefined;
       return {
         page: "focus",
         itemType: "pr",
         owner: prMatch[1]!,
         name: prMatch[2]!,
         number: parseInt(prMatch[3]!, 10),
+        ...(platformHost && { platformHost }),
       };
     }
     const issueMatch = path.match(
@@ -110,6 +113,8 @@ function parseRoute(fullPath: string): Route {
   if (path.startsWith("/pulls")) {
     const rest = path.slice("/pulls".length);
     if (rest === "/board") return { page: "pulls", view: "board" };
+    const sp = new URLSearchParams(search);
+    const platformHost = sp.get("platform_host") ?? undefined;
     const filesMatch = rest.match(/^\/([^/]+)\/([^/]+)\/(\d+)\/files$/);
     if (filesMatch) {
       return {
@@ -119,6 +124,7 @@ function parseRoute(fullPath: string): Route {
           owner: filesMatch[1]!,
           name: filesMatch[2]!,
           number: parseInt(filesMatch[3]!, 10),
+          ...(platformHost && { platformHost }),
         },
         tab: "files",
       };
@@ -128,7 +134,12 @@ function parseRoute(fullPath: string): Route {
       return {
         page: "pulls",
         view: "list",
-        selected: { owner: match[1]!, name: match[2]!, number: parseInt(match[3]!, 10) },
+        selected: {
+          owner: match[1]!,
+          name: match[2]!,
+          number: parseInt(match[3]!, 10),
+          ...(platformHost && { platformHost }),
+        },
       };
     }
     return { page: "pulls", view: "list" };
@@ -208,15 +219,15 @@ export function buildItemRoute(
   number: number,
   platformHost?: string,
 ): string {
-  const issueQuery = type === "issue" && platformHost
+  const hostQuery = platformHost
     ? `?platform_host=${encodeURIComponent(platformHost)}`
     : "";
   if (isFocusMode()) {
-    return `/focus/${type}/${owner}/${name}/${number}${issueQuery}`;
+    return `/focus/${type}/${owner}/${name}/${number}${hostQuery}`;
   }
   return type === "pr"
-    ? `/pulls/${owner}/${name}/${number}`
-    : `/issues/${owner}/${name}/${number}${issueQuery}`;
+    ? `/pulls/${owner}/${name}/${number}${hostQuery}`
+    : `/issues/${owner}/${name}/${number}${hostQuery}`;
 }
 
 export function navigate(path: string, state?: Record<string, unknown>): void {
@@ -336,7 +347,7 @@ export function getDetailTab(): DetailTab {
   return "conversation";
 }
 
-export function getSelectedPRFromRoute(): NumberedItemRef | null {
+export function getSelectedPRFromRoute(): HostedItemRef | null {
   if (route.page !== "pulls") return null;
   if ("selected" in route && route.selected) {
     return route.selected;

--- a/frontend/src/lib/utils/activitySelection.test.ts
+++ b/frontend/src/lib/utils/activitySelection.test.ts
@@ -58,6 +58,17 @@ describe("activity selection URL state", () => {
     });
   });
 
+  it("parses PR platform host", () => {
+    expect(parseActivitySelection("?selected=pr:acme/widgets/1&platform_host=ghe.example.com")).toEqual({
+      itemType: "pr",
+      owner: "acme",
+      name: "widgets",
+      number: 1,
+      platformHost: "ghe.example.com",
+      detailTab: "conversation",
+    });
+  });
+
   it("preserves existing Activity filters when writing selection", () => {
     const next = buildActivitySelectionSearch("?range=30d&view=threaded", {
       itemType: "pr",
@@ -98,7 +109,7 @@ describe("activity selection URL state", () => {
     expect(next.has("selected_tab")).toBe(false);
   });
 
-  it("overwrites an issue selection with a PR and drops platform host", () => {
+  it("overwrites an issue selection with a PR and drops stale platform host", () => {
     const next = buildActivitySelectionSearch(
       "?selected=issue:acme/widgets/10&platform_host=ghe.example.com&search=bug",
       {
@@ -115,6 +126,20 @@ describe("activity selection URL state", () => {
     expect(next.has("platform_host")).toBe(false);
   });
 
+  it("writes PR platform host when present", () => {
+    const next = buildActivitySelectionSearch("?range=7d", {
+      itemType: "pr",
+      owner: "acme",
+      name: "widgets",
+      number: 1,
+      platformHost: "ghe.example.com",
+      detailTab: "conversation",
+    });
+
+    expect(next.get("selected")).toBe("pr:acme/widgets/1");
+    expect(next.get("platform_host")).toBe("ghe.example.com");
+  });
+
   it("builds destination routes for matching tabs", () => {
     const pr: ActivitySelection = {
       itemType: "pr",
@@ -128,6 +153,21 @@ describe("activity selection URL state", () => {
       "/pulls/acme/widgets/1/files",
     );
     expect(activitySelectionToRoute(pr, "issues")).toBeNull();
+  });
+
+  it("builds PR destination routes with platform host", () => {
+    const pr: ActivitySelection = {
+      itemType: "pr",
+      owner: "acme",
+      name: "widgets",
+      number: 1,
+      platformHost: "ghe.example.com",
+      detailTab: "files",
+    };
+
+    expect(activitySelectionToRoute(pr, "pulls")).toBe(
+      "/pulls/acme/widgets/1/files?platform_host=ghe.example.com",
+    );
   });
 
   it("builds issue destination routes with platform host", () => {

--- a/frontend/src/lib/utils/activitySelection.ts
+++ b/frontend/src/lib/utils/activitySelection.ts
@@ -30,8 +30,7 @@ export function parseActivitySelection(search: string): ActivitySelection | null
       ? "files"
       : "conversation";
 
-  const platformHost =
-    itemType === "issue" ? (sp.get("platform_host") ?? undefined) : undefined;
+  const platformHost = sp.get("platform_host") ?? undefined;
 
   return {
     itemType,
@@ -61,7 +60,7 @@ export function buildActivitySelectionSearch(
   if (selection.itemType === "pr" && selection.detailTab === "files") {
     sp.set("selected_tab", "files");
   }
-  if (selection.itemType === "issue" && selection.platformHost) {
+  if (selection.platformHost) {
     sp.set("platform_host", selection.platformHost);
   }
   return sp;
@@ -75,7 +74,10 @@ export function activitySelectionToRoute(
   if (destination === "pulls") {
     if (selection.itemType !== "pr") return null;
     const suffix = selection.detailTab === "files" ? "/files" : "";
-    return `/pulls/${selection.owner}/${selection.name}/${selection.number}${suffix}`;
+    const qs = selection.platformHost
+      ? `?platform_host=${encodeURIComponent(selection.platformHost)}`
+      : "";
+    return `/pulls/${selection.owner}/${selection.name}/${selection.number}${suffix}${qs}`;
   }
 
   if (selection.itemType !== "issue") return null;

--- a/frontend/src/lib/utils/itemRefHandler.test.ts
+++ b/frontend/src/lib/utils/itemRefHandler.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  post: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock("../api/runtime.js", () => ({
+  client: {
+    POST: mocks.post,
+  },
+}));
+
+vi.mock("../stores/router.svelte.js", () => ({
+  buildItemRoute: (
+    type: "pr" | "issue",
+    owner: string,
+    name: string,
+    number: number,
+    platformHost?: string,
+  ) => {
+    const hostQuery = platformHost ? `?platform_host=${platformHost}` : "";
+    return `/${type}/${owner}/${name}/${number}${hostQuery}`;
+  },
+  navigate: mocks.navigate,
+}));
+
+vi.mock("../stores/flash.svelte.js", () => ({
+  showFlash: vi.fn(),
+}));
+
+import { initItemRefHandler } from "./itemRefHandler.js";
+
+describe("itemRefHandler", () => {
+  let cleanupHandler: (() => void) | undefined;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    mocks.post.mockReset();
+    mocks.navigate.mockReset();
+  });
+
+  afterEach(() => {
+    cleanupHandler?.();
+    cleanupHandler = undefined;
+    document.body.innerHTML = "";
+  });
+
+  it("preserves platformHost when resolved item references are PRs", async () => {
+    mocks.post.mockResolvedValue({
+      data: {
+        item_type: "pr",
+        number: 42,
+        repo_tracked: true,
+      },
+    });
+    cleanupHandler = initItemRefHandler();
+    document.body.innerHTML = `
+      <a class="item-ref"
+        href="/pulls/acme/widget/42"
+        data-owner="acme"
+        data-name="widget"
+        data-number="42"
+        data-platform-host="ghe.example.com">#42</a>
+    `;
+
+    document.querySelector<HTMLAnchorElement>(".item-ref")?.click();
+    await Promise.resolve();
+
+    expect(mocks.post).toHaveBeenCalledWith(
+      "/repos/{owner}/{name}/items/{number}/resolve",
+      {
+        params: {
+          path: { owner: "acme", name: "widget", number: 42 },
+          query: { platform_host: "ghe.example.com" },
+        },
+      },
+    );
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/pr/acme/widget/42?platform_host=ghe.example.com",
+    );
+  });
+});

--- a/frontend/src/lib/utils/itemRefHandler.test.ts
+++ b/frontend/src/lib/utils/itemRefHandler.test.ts
@@ -11,19 +11,16 @@ vi.mock("../api/runtime.js", () => ({
   },
 }));
 
-vi.mock("../stores/router.svelte.js", () => ({
-  buildItemRoute: (
-    type: "pr" | "issue",
-    owner: string,
-    name: string,
-    number: number,
-    platformHost?: string,
-  ) => {
-    const hostQuery = platformHost ? `?platform_host=${platformHost}` : "";
-    return `/${type}/${owner}/${name}/${number}${hostQuery}`;
-  },
-  navigate: mocks.navigate,
-}));
+vi.mock("../stores/router.svelte.js", async () => {
+  const actual = await vi.importActual<typeof import("../stores/router.svelte.js")>(
+    "../stores/router.svelte.js",
+  );
+
+  return {
+    ...actual,
+    navigate: mocks.navigate,
+  };
+});
 
 vi.mock("../stores/flash.svelte.js", () => ({
   showFlash: vi.fn(),
@@ -80,7 +77,7 @@ describe("itemRefHandler", () => {
       },
     );
     expect(mocks.navigate).toHaveBeenCalledWith(
-      "/pr/acme/widget/42?platform_host=ghe.example.com",
+      "/pulls/acme/widget/42?platform_host=ghe.example.com",
     );
   });
 

--- a/frontend/src/lib/utils/itemRefHandler.test.ts
+++ b/frontend/src/lib/utils/itemRefHandler.test.ts
@@ -58,13 +58,16 @@ describe("itemRefHandler", () => {
     document.body.innerHTML = `
       <a class="item-ref"
         href="/pulls/acme/widget/42"
+        data-middleman-item-ref="true"
         data-owner="acme"
         data-name="widget"
         data-number="42"
         data-platform-host="ghe.example.com">#42</a>
     `;
 
-    document.querySelector<HTMLAnchorElement>(".item-ref")?.click();
+    document.querySelector<HTMLAnchorElement>(".item-ref")?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+    );
     await Promise.resolve();
 
     expect(mocks.post).toHaveBeenCalledWith(
@@ -79,5 +82,24 @@ describe("itemRefHandler", () => {
     expect(mocks.navigate).toHaveBeenCalledWith(
       "/pr/acme/widget/42?platform_host=ghe.example.com",
     );
+  });
+
+  it("ignores raw HTML that mimics item ref classes without the trusted marker", async () => {
+    cleanupHandler = initItemRefHandler();
+    document.body.innerHTML = `
+      <a class="item-ref"
+        href="#raw"
+        data-owner="acme"
+        data-name="widget"
+        data-number="42">#42</a>
+    `;
+
+    document.querySelector<HTMLAnchorElement>(".item-ref")?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+    );
+    await Promise.resolve();
+
+    expect(mocks.post).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/utils/itemRefHandler.ts
+++ b/frontend/src/lib/utils/itemRefHandler.ts
@@ -19,12 +19,18 @@ async function resolveAndNavigate(
   owner: string,
   name: string,
   number: number,
+  platformHost: string | undefined,
   thisRequestId: number,
 ): Promise<void> {
   try {
     const { data, error, response } = await client.POST(
       "/repos/{owner}/{name}/items/{number}/resolve",
-      { params: { path: { owner, name, number } } },
+      {
+        params: {
+          path: { owner, name, number },
+          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+        },
+      },
     );
 
     // A newer click superseded this one — discard the result.
@@ -51,6 +57,7 @@ async function resolveAndNavigate(
       owner,
       name,
       number,
+      data.item_type === "issue" ? platformHost : undefined,
     );
     navigate(path);
   } catch {
@@ -69,11 +76,18 @@ function handleClick(e: MouseEvent): void {
   const owner = anchor.dataset.owner;
   const name = anchor.dataset.name;
   const numberStr = anchor.dataset.number;
+  const platformHost = anchor.dataset.platformHost;
   if (!owner || !name || !numberStr) return;
 
   e.preventDefault();
   requestId++;
-  void resolveAndNavigate(owner, name, parseInt(numberStr, 10), requestId);
+  void resolveAndNavigate(
+    owner,
+    name,
+    parseInt(numberStr, 10),
+    platformHost,
+    requestId,
+  );
 }
 
 export function initItemRefHandler(): () => void {

--- a/frontend/src/lib/utils/itemRefHandler.ts
+++ b/frontend/src/lib/utils/itemRefHandler.ts
@@ -57,7 +57,7 @@ async function resolveAndNavigate(
       owner,
       name,
       number,
-      data.item_type === "issue" ? platformHost : undefined,
+      platformHost,
     );
     navigate(path);
   } catch {

--- a/frontend/src/lib/utils/itemRefHandler.ts
+++ b/frontend/src/lib/utils/itemRefHandler.ts
@@ -7,7 +7,11 @@ let requestId = 0;
 function findItemRef(target: EventTarget | null): HTMLAnchorElement | null {
   let el = target as HTMLElement | null;
   while (el) {
-    if (el instanceof HTMLAnchorElement && el.classList.contains("item-ref")) {
+    if (
+      el instanceof HTMLAnchorElement &&
+      el.classList.contains("item-ref") &&
+      el.dataset.middlemanItemRef === "true"
+    ) {
       return el;
     }
     el = el.parentElement;

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -1252,7 +1252,7 @@ test.describe("activity split view and detail drawers", () => {
     // still shows widgets#1 as open), but the kanban board reads only
     // from the mocked /pulls endpoint.
     await page.route(
-      "**/api/v1/repos/*/*/pulls/*/github-state",
+      "**/api/v1/repos/*/*/pulls/*/github-state*",
       async (route) => {
         pullsContainsWidgets1 = false;
         await route.fulfill({

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -556,11 +556,14 @@ test.describe("detail action buttons", () => {
         const url = new URL(response.url());
         return response.request().method() === "POST"
           && url.origin === new URL(baseURL).origin
-          && url.pathname === "/api/v1/repos/acme/widgets/pulls/6/ready-for-review"
-          && url.searchParams.get("platform_host") === "github.com";
+          && url.pathname === "/api/v1/repos/acme/widgets/pulls/6/ready-for-review";
       });
       await page.locator(".actions-menu-popover .btn--ready").click();
-      expect((await readyResponse).status()).toBe(200);
+      const response = await readyResponse;
+      expect(response.status()).toBe(200);
+      expect(response.request().postDataJSON()).toMatchObject({
+        platform_host: "github.com",
+      });
       await expect(page.locator(".actions-menu-popover")).toHaveCount(0);
     } finally {
       await isolatedServer?.stop();
@@ -630,14 +633,16 @@ test.describe("detail action buttons", () => {
         const url = new URL(response.url());
         return response.request().method() === "POST"
           && url.origin === new URL(server.info.base_url).origin
-          && url.pathname === "/api/v1/repos/acme/widgets/pulls/6/ready-for-review"
-          && url.searchParams.get("platform_host") === "github.com";
+          && url.pathname === "/api/v1/repos/acme/widgets/pulls/6/ready-for-review";
       });
 
       await page.locator(".btn--ready").click();
 
       const readyResponse = await readyResponsePromise;
       expect(readyResponse.status()).toBe(200);
+      expect(readyResponse.request().postDataJSON()).toMatchObject({
+        platform_host: "github.com",
+      });
       expect((await readyResponse.json()).status).toBe("ready_for_review");
 
       await expect(page.locator(".btn--ready")).toHaveCount(0);

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -553,8 +553,11 @@ test.describe("detail action buttons", () => {
       await expect(page.locator(".actions-menu-popover")).toBeVisible();
 
       const readyResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
         return response.request().method() === "POST"
-          && response.url() === `${baseURL}/api/v1/repos/acme/widgets/pulls/6/ready-for-review`;
+          && url.origin === new URL(baseURL).origin
+          && url.pathname === "/api/v1/repos/acme/widgets/pulls/6/ready-for-review"
+          && url.searchParams.get("platform_host") === "github.com";
       });
       await page.locator(".actions-menu-popover .btn--ready").click();
       expect((await readyResponse).status()).toBe(200);
@@ -624,9 +627,11 @@ test.describe("detail action buttons", () => {
       await expect(page.locator(".pull-detail")).toBeVisible();
 
       const readyResponsePromise = page.waitForResponse((response) => {
-        const url = response.url();
+        const url = new URL(response.url());
         return response.request().method() === "POST"
-          && url === `${server.info.base_url}/api/v1/repos/acme/widgets/pulls/6/ready-for-review`;
+          && url.origin === new URL(server.info.base_url).origin
+          && url.pathname === "/api/v1/repos/acme/widgets/pulls/6/ready-for-review"
+          && url.searchParams.get("platform_host") === "github.com";
       });
 
       await page.locator(".btn--ready").click();

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -502,7 +502,7 @@ test.describe("detail action buttons", () => {
 
   test("narrow actions menu shows state change failures after closing", async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 720 });
-    await page.route("**/api/v1/repos/acme/widgets/pulls/1/github-state", async (route) => {
+    await page.route("**/api/v1/repos/acme/widgets/pulls/1/github-state*", async (route) => {
       await route.fulfill({
         status: 500,
         contentType: "application/json",

--- a/frontend/tests/e2e-full/pr-detail-branches.spec.ts
+++ b/frontend/tests/e2e-full/pr-detail-branches.spec.ts
@@ -1,14 +1,16 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { startIsolatedE2EServer } from "./support/e2eServer";
 
-test.describe("PR detail branch info", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/pulls/acme/widgets/1");
-    await page.locator(".pull-detail")
-      .waitFor({ state: "visible", timeout: 10_000 });
-  });
+async function gotoPRDetail(page: Page) {
+  await page.goto("/pulls/acme/widgets/1");
+  await page.locator(".pull-detail")
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
 
+test.describe("PR detail branch info", () => {
   test("shows head and base branch buttons", async ({ page }) => {
+    await gotoPRDetail(page);
+
     const metaBranch = page.locator(".meta-branch");
     await expect(metaBranch).toBeVisible();
 
@@ -24,6 +26,8 @@ test.describe("PR detail branch info", () => {
   test("click branch shows copied feedback", async ({
     page, context, browserName,
   }) => {
+    await gotoPRDetail(page);
+
     if (browserName === "chromium") {
       await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     }
@@ -42,7 +46,7 @@ test.describe("PR detail branch info", () => {
   });
 
   test("summarizes changed lines by category in the popover", async ({ page }) => {
-    await page.route("**/api/v1/repos/acme/widgets/pulls/1/files", async (route) => {
+    await page.route("**/api/v1/repos/acme/widgets/pulls/1/files*", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -84,9 +88,7 @@ test.describe("PR detail branch info", () => {
       });
     });
 
-    await page.goto("/pulls/acme/widgets/1");
-    await page.locator(".pull-detail")
-      .waitFor({ state: "visible", timeout: 10_000 });
+    await gotoPRDetail(page);
 
     const trigger = page.locator(".diff-summary-trigger");
     await expect(trigger).toHaveText("+240/-30");

--- a/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
+++ b/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
@@ -66,6 +66,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   const seen: Record<string, string[]> = {
     detail: [],
     asyncSync: [],
+    state: [],
     ready: [],
     approve: [],
     workflows: [],
@@ -111,6 +112,15 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
       const url = new URL(route.request().url());
       seen.asyncSync.push(url.searchParams.get("platform_host") ?? "");
       await route.fulfill({ status: 202 });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/state(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.state.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({ status: 200 });
     },
   );
 
@@ -194,6 +204,10 @@ test("host-qualified PR detail actions preserve platform_host", async ({ page })
     .toBeVisible();
   await expect.poll(() => seen.detail).toContain(platformHost);
   await expect.poll(() => seen.asyncSync).toContain(platformHost);
+
+  await page.getByRole("combobox", { name: /change workflow status/i }).click();
+  await page.getByRole("option", { name: "Reviewing" }).click();
+  await expect.poll(() => seen.state).toContain(platformHost);
 
   await page.locator(".btn--ready").click();
   await expect.poll(() => seen.ready).toContain(platformHost);

--- a/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
+++ b/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
@@ -67,6 +67,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
     detail: [],
     asyncSync: [],
     ready: [],
+    approve: [],
     workflows: [],
     merge: [],
     resolve: [],
@@ -127,6 +128,19 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   );
 
   await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/approve(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.approve.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "approved" }),
+      });
+    },
+  );
+
+  await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/approve-workflows(?:[?]|$)/,
     async (route) => {
       const url = new URL(route.request().url());
@@ -161,7 +175,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          item_type: "issue",
+          item_type: "pr",
           number: 7,
           repo_tracked: true,
         }),
@@ -184,6 +198,10 @@ test("host-qualified PR detail actions preserve platform_host", async ({ page })
   await page.locator(".btn--ready").click();
   await expect.poll(() => seen.ready).toContain(platformHost);
 
+  await page.locator(".btn--approve").click();
+  await page.getByRole("button", { name: /^Approve$/ }).click();
+  await expect.poll(() => seen.approve).toContain(platformHost);
+
   await page.locator(".btn--workflow-approval").click();
   await expect.poll(() => seen.workflows).toContain(platformHost);
 
@@ -193,5 +211,5 @@ test("host-qualified PR detail actions preserve platform_host", async ({ page })
 
   await page.locator(".markdown-body .item-ref", { hasText: "#7" }).click();
   await expect.poll(() => seen.resolve).toContain(platformHost);
-  await expect(page).toHaveURL(/\/issues\/acme\/widgets\/7\?platform_host=ghe\.example\.com$/);
+  await expect(page).toHaveURL(/\/pulls\/acme\/widgets\/7\?platform_host=ghe\.example\.com$/);
 });

--- a/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
+++ b/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
@@ -1,0 +1,197 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+const platformHost = "ghe.example.com";
+
+const hostedPR = {
+  ID: 42,
+  RepoID: 2,
+  GitHubID: 4242,
+  Number: 42,
+  URL: "https://ghe.example.com/acme/widgets/pull/42",
+  Title: "Host qualified PR",
+  Author: "marius",
+  State: "open",
+  IsDraft: true,
+  Body: "Tracks #7 before merge.",
+  HeadBranch: "mirror/host-qualified",
+  BaseBranch: "main",
+  Additions: 12,
+  Deletions: 3,
+  CommentCount: 1,
+  ReviewDecision: "APPROVED",
+  CIStatus: "success",
+  CIChecksJSON: "[]",
+  CreatedAt: "2026-04-01T12:00:00Z",
+  UpdatedAt: "2026-04-01T12:00:00Z",
+  LastActivityAt: "2026-04-01T12:00:00Z",
+  MergedAt: null,
+  ClosedAt: null,
+  KanbanStatus: "awaiting_merge",
+  Starred: false,
+  repo_owner: "acme",
+  repo_name: "widgets",
+  platform_host: platformHost,
+  worktree_links: [],
+  MergeableState: "clean",
+};
+
+function hostedPRDetail() {
+  return {
+    merge_request: hostedPR,
+    events: [],
+    repo_owner: hostedPR.repo_owner,
+    repo_name: hostedPR.repo_name,
+    platform_host: platformHost,
+    platform_head_sha: "head-sha",
+    platform_base_sha: "base-sha",
+    diff_head_sha: "head-sha",
+    merge_base_sha: "base-sha",
+    worktree_links: [],
+    workflow_approval: {
+      checked: true,
+      required: true,
+      count: 2,
+    },
+    warnings: [],
+    detail_loaded: true,
+    detail_fetched_at: "2026-04-01T12:00:00Z",
+  };
+}
+
+async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
+  await mockApi(page);
+
+  const seen: Record<string, string[]> = {
+    detail: [],
+    asyncSync: [],
+    ready: [],
+    workflows: [],
+    merge: [],
+    resolve: [],
+  };
+
+  await page.route("**/api/v1/settings", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repos: [
+          {
+            owner: "acme",
+            name: "widgets",
+            is_glob: false,
+            matched_repo_count: 2,
+          },
+        ],
+        activity: { hidden_authors: [] },
+        terminal: { font_family: "" },
+      }),
+    });
+  });
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.detail.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(hostedPRDetail()),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/sync\/async(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.asyncSync.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({ status: 202 });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/ready-for-review(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.ready.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "ready_for_review" }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/approve-workflows(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.workflows.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "approved_workflows" }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/merge(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.merge.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ merged: true, sha: "merge-sha" }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/items\/7\/resolve(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.resolve.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          item_type: "issue",
+          number: 7,
+          repo_tracked: true,
+        }),
+      });
+    },
+  );
+
+  return seen;
+}
+
+test("host-qualified PR detail actions preserve platform_host", async ({ page }) => {
+  const seen = await setupHostedPR(page);
+
+  await page.goto("/pulls/acme/widgets/42?platform_host=ghe.example.com");
+  await expect(page.getByRole("heading", { name: "Host qualified PR" }))
+    .toBeVisible();
+  await expect.poll(() => seen.detail).toContain(platformHost);
+  await expect.poll(() => seen.asyncSync).toContain(platformHost);
+
+  await page.locator(".btn--ready").click();
+  await expect.poll(() => seen.ready).toContain(platformHost);
+
+  await page.locator(".btn--workflow-approval").click();
+  await expect.poll(() => seen.workflows).toContain(platformHost);
+
+  await page.locator(".btn--merge").click();
+  await page.getByRole("button", { name: "Squash and merge" }).click();
+  await expect.poll(() => seen.merge).toContain(platformHost);
+
+  await page.locator(".markdown-body .item-ref", { hasText: "#7" }).click();
+  await expect.poll(() => seen.resolve).toContain(platformHost);
+  await expect(page).toHaveURL(/\/issues\/acme\/widgets\/7\?platform_host=ghe\.example\.com$/);
+});

--- a/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
+++ b/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
@@ -67,6 +67,11 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
     detail: [],
     asyncSync: [],
     state: [],
+    githubState: [],
+    content: [],
+    comments: [],
+    files: [],
+    diff: [],
     ready: [],
     approve: [],
     workflows: [],
@@ -121,6 +126,101 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
       const url = new URL(route.request().url());
       seen.state.push(url.searchParams.get("platform_host") ?? "");
       await route.fulfill({ status: 200 });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/github-state(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.githubState.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ state: "closed" }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/comments(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.comments.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ ID: 99, Kind: "comment", Body: "queued" }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/files(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.files.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          stale: false,
+          files: [
+            {
+              path: "src/App.svelte",
+              old_path: "src/App.svelte",
+              status: "modified",
+              is_binary: false,
+              is_whitespace_only: false,
+              additions: 10,
+              deletions: 2,
+              hunks: [],
+            },
+          ],
+        }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/diff(?:[?]|$)/,
+    async (route) => {
+      const url = new URL(route.request().url());
+      seen.diff.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          stale: false,
+          whitespace_only_count: 0,
+          files: [
+            {
+              path: "src/App.svelte",
+              old_path: "src/App.svelte",
+              status: "modified",
+              is_binary: false,
+              is_whitespace_only: false,
+              additions: 10,
+              deletions: 2,
+              hunks: [],
+            },
+          ],
+        }),
+      });
+    },
+  );
+
+  await page.route(
+    /\/api\/v1\/repos\/acme\/widgets\/pulls\/42(?:[?]|$)/,
+    async (route) => {
+      if (route.request().method() !== "PATCH") return route.fallback();
+      const url = new URL(route.request().url());
+      seen.content.push(url.searchParams.get("platform_host") ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(hostedPRDetail()),
+      });
     },
   );
 
@@ -208,6 +308,24 @@ test("host-qualified PR detail actions preserve platform_host", async ({ page })
   await page.getByRole("combobox", { name: /change workflow status/i }).click();
   await page.getByRole("option", { name: "Reviewing" }).click();
   await expect.poll(() => seen.state).toContain(platformHost);
+
+  await page.locator(".btn--close").click();
+  await expect.poll(() => seen.githubState).toContain(platformHost);
+
+  await page.locator(".body-section .edit-body-btn").click();
+  await page.locator(".body-edit-textarea").fill("Updated body");
+  await page.locator(".body-edit .title-edit-save").click();
+  await expect.poll(() => seen.content).toContain(platformHost);
+
+  await page.locator(".comment-editor-input").fill("Queued comment");
+  await page.getByRole("button", { name: "Comment" }).click();
+  await expect.poll(() => seen.comments).toContain(platformHost);
+
+  await page.getByRole("button", { name: "Files changed" }).click();
+  await expect.poll(() => seen.files).toContain(platformHost);
+  await expect.poll(() => seen.diff).toContain(platformHost);
+
+  await page.getByRole("button", { name: "Conversation" }).click();
 
   await page.locator(".btn--ready").click();
   await expect.poll(() => seen.ready).toContain(platformHost);

--- a/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
+++ b/frontend/tests/e2e/host-qualified-pr-actions.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 
 import { mockApi } from "./support/mockApi";
 
@@ -58,6 +58,11 @@ function hostedPRDetail() {
     detail_loaded: true,
     detail_fetched_at: "2026-04-01T12:00:00Z",
   };
+}
+
+function requestBodyPlatformHost(route: Route): string {
+  const body = route.request().postDataJSON() as { platform_host?: string } | null;
+  return body?.platform_host ?? "";
 }
 
 async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
@@ -123,8 +128,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/state(?:[?]|$)/,
     async (route) => {
-      const url = new URL(route.request().url());
-      seen.state.push(url.searchParams.get("platform_host") ?? "");
+      seen.state.push(requestBodyPlatformHost(route));
       await route.fulfill({ status: 200 });
     },
   );
@@ -132,8 +136,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/github-state(?:[?]|$)/,
     async (route) => {
-      const url = new URL(route.request().url());
-      seen.githubState.push(url.searchParams.get("platform_host") ?? "");
+      seen.githubState.push(requestBodyPlatformHost(route));
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -145,8 +148,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/comments(?:[?]|$)/,
     async (route) => {
-      const url = new URL(route.request().url());
-      seen.comments.push(url.searchParams.get("platform_host") ?? "");
+      seen.comments.push(requestBodyPlatformHost(route));
       await route.fulfill({
         status: 201,
         contentType: "application/json",
@@ -214,8 +216,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42(?:[?]|$)/,
     async (route) => {
       if (route.request().method() !== "PATCH") return route.fallback();
-      const url = new URL(route.request().url());
-      seen.content.push(url.searchParams.get("platform_host") ?? "");
+      seen.content.push(requestBodyPlatformHost(route));
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -227,8 +228,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/ready-for-review(?:[?]|$)/,
     async (route) => {
-      const url = new URL(route.request().url());
-      seen.ready.push(url.searchParams.get("platform_host") ?? "");
+      seen.ready.push(requestBodyPlatformHost(route));
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -240,8 +240,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/approve(?:[?]|$)/,
     async (route) => {
-      const url = new URL(route.request().url());
-      seen.approve.push(url.searchParams.get("platform_host") ?? "");
+      seen.approve.push(requestBodyPlatformHost(route));
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -253,8 +252,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/approve-workflows(?:[?]|$)/,
     async (route) => {
-      const url = new URL(route.request().url());
-      seen.workflows.push(url.searchParams.get("platform_host") ?? "");
+      seen.workflows.push(requestBodyPlatformHost(route));
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -266,8 +264,7 @@ async function setupHostedPR(page: Page): Promise<Record<string, string[]>> {
   await page.route(
     /\/api\/v1\/repos\/acme\/widgets\/pulls\/42\/merge(?:[?]|$)/,
     async (route) => {
-      const url = new URL(route.request().url());
-      seen.merge.push(url.searchParams.get("platform_host") ?? "");
+      seen.merge.push(requestBodyPlatformHost(route));
       await route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -947,6 +947,11 @@ type PostReposByOwnerByNameItemsByNumberResolveParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
+// GetReposByOwnerByNamePullsByNumberParams defines parameters for GetReposByOwnerByNamePullsByNumber.
+type GetReposByOwnerByNamePullsByNumberParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
 // PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams defines parameters for PostReposByOwnerByNamePullsByNumberApproveWorkflows.
 type PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
@@ -973,6 +978,16 @@ type PostReposByOwnerByNamePullsByNumberMergeParams struct {
 
 // PostReposByOwnerByNamePullsByNumberReadyForReviewParams defines parameters for PostReposByOwnerByNamePullsByNumberReadyForReview.
 type PostReposByOwnerByNamePullsByNumberReadyForReviewParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// PostReposByOwnerByNamePullsByNumberSyncParams defines parameters for PostReposByOwnerByNamePullsByNumberSync.
+type PostReposByOwnerByNamePullsByNumberSyncParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// EnqueuePrSyncParams defines parameters for EnqueuePrSync.
+type EnqueuePrSyncParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
@@ -1202,7 +1217,7 @@ type ClientInterface interface {
 	PostReposByOwnerByNameItemsByNumberResolve(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameItemsByNumberResolveParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumber request
-	GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditPrContentWithBody request with any body
 	EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1261,10 +1276,10 @@ type ClientInterface interface {
 	SetKanbanState(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberSync request
-	PostReposByOwnerByNamePullsByNumberSync(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberSync(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EnqueuePrSync request
-	EnqueuePrSync(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EnqueuePrSync(ctx context.Context, owner string, name string, number int64, params *EnqueuePrSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RefreshRepo request
 	RefreshRepo(ctx context.Context, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1694,8 +1709,8 @@ func (c *Client) PostReposByOwnerByNameItemsByNumberResolve(ctx context.Context,
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetReposByOwnerByNamePullsByNumberRequest(c.Server, owner, name, number)
+func (c *Client) GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReposByOwnerByNamePullsByNumberRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1958,8 +1973,8 @@ func (c *Client) SetKanbanState(ctx context.Context, owner string, name string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberSync(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberSyncRequest(c.Server, owner, name, number)
+func (c *Client) PostReposByOwnerByNamePullsByNumberSync(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberSyncRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1970,8 +1985,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberSync(ctx context.Context, ow
 	return c.Client.Do(req)
 }
 
-func (c *Client) EnqueuePrSync(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEnqueuePrSyncRequest(c.Server, owner, name, number)
+func (c *Client) EnqueuePrSync(ctx context.Context, owner string, name string, number int64, params *EnqueuePrSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnqueuePrSyncRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3664,7 +3679,7 @@ func NewPostReposByOwnerByNameItemsByNumberResolveRequest(server string, owner s
 }
 
 // NewGetReposByOwnerByNamePullsByNumberRequest generates requests for GetReposByOwnerByNamePullsByNumber
-func NewGetReposByOwnerByNamePullsByNumberRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewGetReposByOwnerByNamePullsByNumberRequest(server string, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3701,6 +3716,28 @@ func NewGetReposByOwnerByNamePullsByNumberRequest(server string, owner string, n
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -4618,7 +4655,7 @@ func NewSetKanbanStateRequestWithBody(server string, owner string, name string, 
 }
 
 // NewPostReposByOwnerByNamePullsByNumberSyncRequest generates requests for PostReposByOwnerByNamePullsByNumberSync
-func NewPostReposByOwnerByNamePullsByNumberSyncRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberSyncRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4657,6 +4694,28 @@ func NewPostReposByOwnerByNamePullsByNumberSyncRequest(server string, owner stri
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
@@ -4666,7 +4725,7 @@ func NewPostReposByOwnerByNamePullsByNumberSyncRequest(server string, owner stri
 }
 
 // NewEnqueuePrSyncRequest generates requests for EnqueuePrSync
-func NewEnqueuePrSyncRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewEnqueuePrSyncRequest(server string, owner string, name string, number int64, params *EnqueuePrSyncParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4703,6 +4762,28 @@ func NewEnqueuePrSyncRequest(server string, owner string, name string, number in
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
@@ -5528,7 +5609,7 @@ type ClientWithResponsesInterface interface {
 	PostReposByOwnerByNameItemsByNumberResolveWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameItemsByNumberResolveParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNameItemsByNumberResolveResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberWithResponse request
-	GetReposByOwnerByNamePullsByNumberWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberResponse, error)
+	GetReposByOwnerByNamePullsByNumberWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberResponse, error)
 
 	// EditPrContentWithBodyWithResponse request with any body
 	EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
@@ -5587,10 +5668,10 @@ type ClientWithResponsesInterface interface {
 	SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberSyncWithResponse request
-	PostReposByOwnerByNamePullsByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberSyncResponse, error)
+	PostReposByOwnerByNamePullsByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberSyncResponse, error)
 
 	// EnqueuePrSyncWithResponse request
-	EnqueuePrSyncWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*EnqueuePrSyncResponse, error)
+	EnqueuePrSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *EnqueuePrSyncParams, reqEditors ...RequestEditorFn) (*EnqueuePrSyncResponse, error)
 
 	// RefreshRepoWithResponse request
 	RefreshRepoWithResponse(ctx context.Context, owner string, name string, reqEditors ...RequestEditorFn) (*RefreshRepoResponse, error)
@@ -7216,8 +7297,8 @@ func (c *ClientWithResponses) PostReposByOwnerByNameItemsByNumberResolveWithResp
 }
 
 // GetReposByOwnerByNamePullsByNumberWithResponse request returning *GetReposByOwnerByNamePullsByNumberResponse
-func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberResponse, error) {
-	rsp, err := c.GetReposByOwnerByNamePullsByNumber(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberResponse, error) {
+	rsp, err := c.GetReposByOwnerByNamePullsByNumber(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7407,8 +7488,8 @@ func (c *ClientWithResponses) SetKanbanStateWithResponse(ctx context.Context, ow
 }
 
 // PostReposByOwnerByNamePullsByNumberSyncWithResponse request returning *PostReposByOwnerByNamePullsByNumberSyncResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberSyncResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberSync(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberSyncResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberSync(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7416,8 +7497,8 @@ func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberSyncWithRespons
 }
 
 // EnqueuePrSyncWithResponse request returning *EnqueuePrSyncResponse
-func (c *ClientWithResponses) EnqueuePrSyncWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*EnqueuePrSyncResponse, error) {
-	rsp, err := c.EnqueuePrSync(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) EnqueuePrSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *EnqueuePrSyncParams, reqEditors ...RequestEditorFn) (*EnqueuePrSyncResponse, error) {
+	rsp, err := c.EnqueuePrSync(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -78,8 +78,9 @@ type Agent struct {
 // ApprovePRInputBody defines model for ApprovePRInputBody.
 type ApprovePRInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema *string `json:"$schema,omitempty"`
-	Body   string  `json:"body"`
+	Schema       *string `json:"$schema,omitempty"`
+	Body         string  `json:"body"`
+	PlatformHost string  `json:"platform_host"`
 }
 
 // BulkAddRepoRequest defines model for BulkAddRepoRequest.
@@ -148,7 +149,7 @@ type CreateIssueInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema       *string `json:"$schema,omitempty"`
 	Body         string  `json:"body"`
-	PlatformHost *string `json:"platform_host,omitempty"`
+	PlatformHost string  `json:"platform_host"`
 	Title        string  `json:"title"`
 }
 
@@ -195,8 +196,9 @@ type DiffResponse struct {
 // EditCommentInputBody defines model for EditCommentInputBody.
 type EditCommentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema *string `json:"$schema,omitempty"`
-	Body   string  `json:"body"`
+	Schema       *string `json:"$schema,omitempty"`
+	Body         string  `json:"body"`
+	PlatformHost string  `json:"platform_host"`
 }
 
 // EditIssueCommentInputBody defines model for EditIssueCommentInputBody.
@@ -204,15 +206,16 @@ type EditIssueCommentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema       *string `json:"$schema,omitempty"`
 	Body         string  `json:"body"`
-	PlatformHost *string `json:"platform_host,omitempty"`
+	PlatformHost string  `json:"platform_host"`
 }
 
 // EditPRContentInputBody defines model for EditPRContentInputBody.
 type EditPRContentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema *string `json:"$schema,omitempty"`
-	Body   *string `json:"body,omitempty"`
-	Title  *string `json:"title,omitempty"`
+	Schema       *string `json:"$schema,omitempty"`
+	Body         *string `json:"body,omitempty"`
+	PlatformHost string  `json:"platform_host"`
+	Title        *string `json:"title,omitempty"`
 }
 
 // ErrorDetail defines model for ErrorDetail.
@@ -263,7 +266,7 @@ type FilesResponse struct {
 type GithubStateInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema       *string `json:"$schema,omitempty"`
-	PlatformHost *string `json:"platform_host,omitempty"`
+	PlatformHost string  `json:"platform_host"`
 	State        string  `json:"state"`
 }
 
@@ -436,6 +439,7 @@ type MergePRInputBody struct {
 	CommitMessage string  `json:"commit_message"`
 	CommitTitle   string  `json:"commit_title"`
 	Method        string  `json:"method"`
+	PlatformHost  string  `json:"platform_host"`
 }
 
 // MergeRequest defines model for MergeRequest.
@@ -550,8 +554,9 @@ type MrImportMetadataResponse struct {
 // PostCommentInputBody defines model for PostCommentInputBody.
 type PostCommentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema *string `json:"$schema,omitempty"`
-	Body   string  `json:"body"`
+	Schema       *string `json:"$schema,omitempty"`
+	Body         string  `json:"body"`
+	PlatformHost string  `json:"platform_host"`
 }
 
 // PostIssueCommentInputBody defines model for PostIssueCommentInputBody.
@@ -559,7 +564,14 @@ type PostIssueCommentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema       *string `json:"$schema,omitempty"`
 	Body         string  `json:"body"`
-	PlatformHost *string `json:"platform_host,omitempty"`
+	PlatformHost string  `json:"platform_host"`
+}
+
+// PrActionInputBody defines model for PrActionInputBody.
+type PrActionInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string `json:"$schema,omitempty"`
+	PlatformHost string  `json:"platform_host"`
 }
 
 // RateLimitHostStatus defines model for RateLimitHostStatus.
@@ -736,8 +748,9 @@ type SessionInfo struct {
 // SetKanbanStateInputBody defines model for SetKanbanStateInputBody.
 type SetKanbanStateInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema *string `json:"$schema,omitempty"`
-	Status string  `json:"status"`
+	Schema       *string `json:"$schema,omitempty"`
+	PlatformHost string  `json:"platform_host"`
+	Status       string  `json:"status"`
 }
 
 // SettingsResponse defines model for SettingsResponse.
@@ -793,7 +806,7 @@ type StarredRequest struct {
 	Name         string  `json:"name"`
 	Number       int64   `json:"number"`
 	Owner        string  `json:"owner"`
-	PlatformHost *string `json:"platform_host,omitempty"`
+	PlatformHost string  `json:"platform_host"`
 }
 
 // SyncStatus defines model for SyncStatus.
@@ -932,11 +945,6 @@ type GetReposByOwnerByNameIssuesByNumberParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
-// SetIssueGithubStateParams defines parameters for SetIssueGithubState.
-type SetIssueGithubStateParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
 // PostReposByOwnerByNameIssuesByNumberSyncParams defines parameters for PostReposByOwnerByNameIssuesByNumberSync.
 type PostReposByOwnerByNameIssuesByNumberSyncParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
@@ -954,31 +962,6 @@ type PostReposByOwnerByNameItemsByNumberResolveParams struct {
 
 // GetReposByOwnerByNamePullsByNumberParams defines parameters for GetReposByOwnerByNamePullsByNumber.
 type GetReposByOwnerByNamePullsByNumberParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// EditPrContentParams defines parameters for EditPrContent.
-type EditPrContentParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// PostReposByOwnerByNamePullsByNumberApproveParams defines parameters for PostReposByOwnerByNamePullsByNumberApprove.
-type PostReposByOwnerByNamePullsByNumberApproveParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams defines parameters for PostReposByOwnerByNamePullsByNumberApproveWorkflows.
-type PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// PostPrCommentParams defines parameters for PostPrComment.
-type PostPrCommentParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// EditPrCommentParams defines parameters for EditPrComment.
-type EditPrCommentParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
@@ -1004,26 +987,6 @@ type GetReposByOwnerByNamePullsByNumberDiffParams struct {
 
 // GetReposByOwnerByNamePullsByNumberFilesParams defines parameters for GetReposByOwnerByNamePullsByNumberFiles.
 type GetReposByOwnerByNamePullsByNumberFilesParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// SetPrGithubStateParams defines parameters for SetPrGithubState.
-type SetPrGithubStateParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// PostReposByOwnerByNamePullsByNumberMergeParams defines parameters for PostReposByOwnerByNamePullsByNumberMerge.
-type PostReposByOwnerByNamePullsByNumberMergeParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// PostReposByOwnerByNamePullsByNumberReadyForReviewParams defines parameters for PostReposByOwnerByNamePullsByNumberReadyForReview.
-type PostReposByOwnerByNamePullsByNumberReadyForReviewParams struct {
-	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
-}
-
-// SetKanbanStateParams defines parameters for SetKanbanState.
-type SetKanbanStateParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
@@ -1077,6 +1040,9 @@ type EditPrContentJSONRequestBody = EditPRContentInputBody
 // PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody defines body for PostReposByOwnerByNamePullsByNumberApprove for application/json ContentType.
 type PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody = ApprovePRInputBody
 
+// PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody defines body for PostReposByOwnerByNamePullsByNumberApproveWorkflows for application/json ContentType.
+type PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody = PrActionInputBody
+
 // PostPrCommentJSONRequestBody defines body for PostPrComment for application/json ContentType.
 type PostPrCommentJSONRequestBody = PostCommentInputBody
 
@@ -1088,6 +1054,9 @@ type SetPrGithubStateJSONRequestBody = GithubStateInputBody
 
 // PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody defines body for PostReposByOwnerByNamePullsByNumberMerge for application/json ContentType.
 type PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody = MergePRInputBody
+
+// PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody defines body for PostReposByOwnerByNamePullsByNumberReadyForReview for application/json ContentType.
+type PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody = PrActionInputBody
 
 // SetKanbanStateJSONRequestBody defines body for SetKanbanState for application/json ContentType.
 type SetKanbanStateJSONRequestBody = SetKanbanStateInputBody
@@ -1244,9 +1213,9 @@ type ClientInterface interface {
 	EditIssueComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetIssueGithubStateWithBody request with any body
-	SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SetIssueGithubState(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetIssueGithubState(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNameIssuesByNumberSync request
 	PostReposByOwnerByNameIssuesByNumberSync(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameIssuesByNumberSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1266,27 +1235,29 @@ type ClientInterface interface {
 	GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditPrContentWithBody request with any body
-	EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	EditPrContent(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrContent(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWithBody request with any body
-	PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostReposByOwnerByNamePullsByNumberApproveWorkflows request
-	PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBody request with any body
+	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostPrCommentWithBody request with any body
-	PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostPrComment(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostPrComment(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditPrCommentWithBody request with any body
-	EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberCommits request
 	GetReposByOwnerByNamePullsByNumberCommits(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberCommitsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1298,28 +1269,30 @@ type ClientInterface interface {
 	GetReposByOwnerByNamePullsByNumberFiles(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetPrGithubStateWithBody request with any body
-	SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SetPrGithubState(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetPrGithubState(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberImportMetadata request
 	GetReposByOwnerByNamePullsByNumberImportMetadata(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberMergeWithBody request with any body
-	PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostReposByOwnerByNamePullsByNumberReadyForReview request
-	PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// PostReposByOwnerByNamePullsByNumberReadyForReviewWithBody request with any body
+	PostReposByOwnerByNamePullsByNumberReadyForReviewWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberStack request
 	GetReposByOwnerByNamePullsByNumberStack(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetKanbanStateWithBody request with any body
-	SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SetKanbanState(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetKanbanState(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberSync request
 	PostReposByOwnerByNamePullsByNumberSync(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1671,8 +1644,8 @@ func (c *Client) EditIssueComment(ctx context.Context, owner string, name string
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetIssueGithubStateRequestWithBody(c.Server, owner, name, number, params, contentType, body)
+func (c *Client) SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetIssueGithubStateRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1683,8 +1656,8 @@ func (c *Client) SetIssueGithubStateWithBody(ctx context.Context, owner string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetIssueGithubState(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetIssueGithubStateRequest(c.Server, owner, name, number, params, body)
+func (c *Client) SetIssueGithubState(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetIssueGithubStateRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1767,8 +1740,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner s
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrContentRequestWithBody(c.Server, owner, name, number, params, contentType, body)
+func (c *Client) EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrContentRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1779,8 +1752,8 @@ func (c *Client) EditPrContentWithBody(ctx context.Context, owner string, name s
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrContent(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrContentRequest(c.Server, owner, name, number, params, body)
+func (c *Client) EditPrContent(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrContentRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1791,8 +1764,8 @@ func (c *Client) EditPrContent(ctx context.Context, owner string, name string, n
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(c.Server, owner, name, number, params, contentType, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1803,8 +1776,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequest(c.Server, owner, name, number, params, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1815,8 +1788,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context,
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(c.Server, owner, name, number, params)
+func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1827,8 +1800,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPrCommentRequestWithBody(c.Server, owner, name, number, params, contentType, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1839,8 +1812,8 @@ func (c *Client) PostPrCommentWithBody(ctx context.Context, owner string, name s
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPrComment(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPrCommentRequest(c.Server, owner, name, number, params, body)
+func (c *Client) PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostPrCommentRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1851,8 +1824,8 @@ func (c *Client) PostPrComment(ctx context.Context, owner string, name string, n
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrCommentRequestWithBody(c.Server, owner, name, number, commentId, params, contentType, body)
+func (c *Client) PostPrComment(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostPrCommentRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1863,8 +1836,20 @@ func (c *Client) EditPrCommentWithBody(ctx context.Context, owner string, name s
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrCommentRequest(c.Server, owner, name, number, commentId, params, body)
+func (c *Client) EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrCommentRequestWithBody(c.Server, owner, name, number, commentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrCommentRequest(c.Server, owner, name, number, commentId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1911,8 +1896,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumberFiles(ctx context.Context, ow
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetPrGithubStateRequestWithBody(c.Server, owner, name, number, params, contentType, body)
+func (c *Client) SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetPrGithubStateRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1923,8 +1908,8 @@ func (c *Client) SetPrGithubStateWithBody(ctx context.Context, owner string, nam
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetPrGithubState(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetPrGithubStateRequest(c.Server, owner, name, number, params, body)
+func (c *Client) SetPrGithubState(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetPrGithubStateRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1947,8 +1932,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumberImportMetadata(ctx context.Co
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(c.Server, owner, name, number, params, contentType, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1959,8 +1944,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Co
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequest(c.Server, owner, name, number, params, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1971,8 +1956,20 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, o
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(c.Server, owner, name, number, params)
+func (c *Client) PostReposByOwnerByNamePullsByNumberReadyForReviewWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequestWithBody(c.Server, owner, name, number, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1995,8 +1992,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumberStack(ctx context.Context, ow
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetKanbanStateRequestWithBody(c.Server, owner, name, number, params, contentType, body)
+func (c *Client) SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetKanbanStateRequestWithBody(c.Server, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2007,8 +2004,8 @@ func (c *Client) SetKanbanStateWithBody(ctx context.Context, owner string, name 
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetKanbanState(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetKanbanStateRequest(c.Server, owner, name, number, params, body)
+func (c *Client) SetKanbanState(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetKanbanStateRequest(c.Server, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3393,18 +3390,18 @@ func NewEditIssueCommentRequestWithBody(server string, owner string, name string
 }
 
 // NewSetIssueGithubStateRequest calls the generic SetIssueGithubState builder with application/json body
-func NewSetIssueGithubStateRequest(server string, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody) (*http.Request, error) {
+func NewSetIssueGithubStateRequest(server string, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSetIssueGithubStateRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
+	return NewSetIssueGithubStateRequestWithBody(server, owner, name, number, "application/json", bodyReader)
 }
 
 // NewSetIssueGithubStateRequestWithBody generates requests for SetIssueGithubState with any type of body
-func NewSetIssueGithubStateRequestWithBody(server string, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewSetIssueGithubStateRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3441,28 +3438,6 @@ func NewSetIssueGithubStateRequestWithBody(server string, owner string, name str
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -3817,18 +3792,18 @@ func NewGetReposByOwnerByNamePullsByNumberRequest(server string, owner string, n
 }
 
 // NewEditPrContentRequest calls the generic EditPrContent builder with application/json body
-func NewEditPrContentRequest(server string, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody) (*http.Request, error) {
+func NewEditPrContentRequest(server string, owner string, name string, number int64, body EditPrContentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewEditPrContentRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
+	return NewEditPrContentRequestWithBody(server, owner, name, number, "application/json", bodyReader)
 }
 
 // NewEditPrContentRequestWithBody generates requests for EditPrContent with any type of body
-func NewEditPrContentRequestWithBody(server string, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewEditPrContentRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3867,28 +3842,6 @@ func NewEditPrContentRequestWithBody(server string, owner string, name string, n
 		return nil, err
 	}
 
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
 	req, err := http.NewRequest("PATCH", queryURL.String(), body)
 	if err != nil {
 		return nil, err
@@ -3900,18 +3853,18 @@ func NewEditPrContentRequestWithBody(server string, owner string, name string, n
 }
 
 // NewPostReposByOwnerByNamePullsByNumberApproveRequest calls the generic PostReposByOwnerByNamePullsByNumberApprove builder with application/json body
-func NewPostReposByOwnerByNamePullsByNumberApproveRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberApproveRequest(server string, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
+	return NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server, owner, name, number, "application/json", bodyReader)
 }
 
 // NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody generates requests for PostReposByOwnerByNamePullsByNumberApprove with any type of body
-func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3950,28 +3903,6 @@ func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string,
 		return nil, err
 	}
 
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
 	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
@@ -3982,8 +3913,19 @@ func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string,
 	return req, nil
 }
 
-// NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest generates requests for PostReposByOwnerByNamePullsByNumberApproveWorkflows
-func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams) (*http.Request, error) {
+// NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest calls the generic PostReposByOwnerByNamePullsByNumberApproveWorkflows builder with application/json body
+func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(server string, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+}
+
+// NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequestWithBody generates requests for PostReposByOwnerByNamePullsByNumberApproveWorkflows with any type of body
+func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4022,49 +3964,29 @@ func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(server string
 		return nil, err
 	}
 
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
 
 // NewPostPrCommentRequest calls the generic PostPrComment builder with application/json body
-func NewPostPrCommentRequest(server string, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody) (*http.Request, error) {
+func NewPostPrCommentRequest(server string, owner string, name string, number int64, body PostPrCommentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostPrCommentRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
+	return NewPostPrCommentRequestWithBody(server, owner, name, number, "application/json", bodyReader)
 }
 
 // NewPostPrCommentRequestWithBody generates requests for PostPrComment with any type of body
-func NewPostPrCommentRequestWithBody(server string, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewPostPrCommentRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4103,28 +4025,6 @@ func NewPostPrCommentRequestWithBody(server string, owner string, name string, n
 		return nil, err
 	}
 
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
 	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
@@ -4136,18 +4036,18 @@ func NewPostPrCommentRequestWithBody(server string, owner string, name string, n
 }
 
 // NewEditPrCommentRequest calls the generic EditPrComment builder with application/json body
-func NewEditPrCommentRequest(server string, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody) (*http.Request, error) {
+func NewEditPrCommentRequest(server string, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewEditPrCommentRequestWithBody(server, owner, name, number, commentId, params, "application/json", bodyReader)
+	return NewEditPrCommentRequestWithBody(server, owner, name, number, commentId, "application/json", bodyReader)
 }
 
 // NewEditPrCommentRequestWithBody generates requests for EditPrComment with any type of body
-func NewEditPrCommentRequestWithBody(server string, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewEditPrCommentRequestWithBody(server string, owner string, name string, number int64, commentId int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4191,28 +4091,6 @@ func NewEditPrCommentRequestWithBody(server string, owner string, name string, n
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("PATCH", queryURL.String(), body)
@@ -4500,18 +4378,18 @@ func NewGetReposByOwnerByNamePullsByNumberFilesRequest(server string, owner stri
 }
 
 // NewSetPrGithubStateRequest calls the generic SetPrGithubState builder with application/json body
-func NewSetPrGithubStateRequest(server string, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody) (*http.Request, error) {
+func NewSetPrGithubStateRequest(server string, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSetPrGithubStateRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
+	return NewSetPrGithubStateRequestWithBody(server, owner, name, number, "application/json", bodyReader)
 }
 
 // NewSetPrGithubStateRequestWithBody generates requests for SetPrGithubState with any type of body
-func NewSetPrGithubStateRequestWithBody(server string, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewSetPrGithubStateRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4548,28 +4426,6 @@ func NewSetPrGithubStateRequestWithBody(server string, owner string, name string
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -4631,18 +4487,18 @@ func NewGetReposByOwnerByNamePullsByNumberImportMetadataRequest(server string, o
 }
 
 // NewPostReposByOwnerByNamePullsByNumberMergeRequest calls the generic PostReposByOwnerByNamePullsByNumberMerge builder with application/json body
-func NewPostReposByOwnerByNamePullsByNumberMergeRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberMergeRequest(server string, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
+	return NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server, owner, name, number, "application/json", bodyReader)
 }
 
 // NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody generates requests for PostReposByOwnerByNamePullsByNumberMerge with any type of body
-func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4681,28 +4537,6 @@ func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, o
 		return nil, err
 	}
 
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
 	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
@@ -4713,8 +4547,19 @@ func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, o
 	return req, nil
 }
 
-// NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest generates requests for PostReposByOwnerByNamePullsByNumberReadyForReview
-func NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams) (*http.Request, error) {
+// NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest calls the generic PostReposByOwnerByNamePullsByNumberReadyForReview builder with application/json body
+func NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(server string, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+}
+
+// NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequestWithBody generates requests for PostReposByOwnerByNamePullsByNumberReadyForReview with any type of body
+func NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4753,32 +4598,12 @@ func NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(server string, 
 		return nil, err
 	}
 
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -4832,18 +4657,18 @@ func NewGetReposByOwnerByNamePullsByNumberStackRequest(server string, owner stri
 }
 
 // NewSetKanbanStateRequest calls the generic SetKanbanState builder with application/json body
-func NewSetKanbanStateRequest(server string, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody) (*http.Request, error) {
+func NewSetKanbanStateRequest(server string, owner string, name string, number int64, body SetKanbanStateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSetKanbanStateRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
+	return NewSetKanbanStateRequestWithBody(server, owner, name, number, "application/json", bodyReader)
 }
 
 // NewSetKanbanStateRequestWithBody generates requests for SetKanbanState with any type of body
-func NewSetKanbanStateRequestWithBody(server string, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewSetKanbanStateRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4880,28 +4705,6 @@ func NewSetKanbanStateRequestWithBody(server string, owner string, name string, 
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.PlatformHost != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("PUT", queryURL.String(), body)
@@ -5850,9 +5653,9 @@ type ClientWithResponsesInterface interface {
 	EditIssueCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueCommentResponse, error)
 
 	// SetIssueGithubStateWithBodyWithResponse request with any body
-	SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
+	SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
 
-	SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
+	SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
 
 	// PostReposByOwnerByNameIssuesByNumberSyncWithResponse request
 	PostReposByOwnerByNameIssuesByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameIssuesByNumberSyncParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNameIssuesByNumberSyncResponse, error)
@@ -5872,27 +5675,29 @@ type ClientWithResponsesInterface interface {
 	GetReposByOwnerByNamePullsByNumberWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberResponse, error)
 
 	// EditPrContentWithBodyWithResponse request with any body
-	EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
+	EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
 
-	EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
+	EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse request with any body
-	PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
+	PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
 
-	PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
+	PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
 
-	// PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse request
-	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error)
+	// PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBodyWithResponse request with any body
+	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error)
+
+	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error)
 
 	// PostPrCommentWithBodyWithResponse request with any body
-	PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
+	PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
 
-	PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
+	PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
 
 	// EditPrCommentWithBodyWithResponse request with any body
-	EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
+	EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
 
-	EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
+	EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberCommitsWithResponse request
 	GetReposByOwnerByNamePullsByNumberCommitsWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberCommitsParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberCommitsResponse, error)
@@ -5904,28 +5709,30 @@ type ClientWithResponsesInterface interface {
 	GetReposByOwnerByNamePullsByNumberFilesWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberFilesParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberFilesResponse, error)
 
 	// SetPrGithubStateWithBodyWithResponse request with any body
-	SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
+	SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
 
-	SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
+	SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberImportMetadataWithResponse request
 	GetReposByOwnerByNamePullsByNumberImportMetadataWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberImportMetadataResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse request with any body
-	PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
+	PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
 
-	PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
+	PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
 
-	// PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse request
-	PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error)
+	// PostReposByOwnerByNamePullsByNumberReadyForReviewWithBodyWithResponse request with any body
+	PostReposByOwnerByNamePullsByNumberReadyForReviewWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error)
+
+	PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberStackWithResponse request
 	GetReposByOwnerByNamePullsByNumberStackWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberStackResponse, error)
 
 	// SetKanbanStateWithBodyWithResponse request with any body
-	SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
+	SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
 
-	SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
+	SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberSyncWithResponse request
 	PostReposByOwnerByNamePullsByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberSyncResponse, error)
@@ -7496,16 +7303,16 @@ func (c *ClientWithResponses) EditIssueCommentWithResponse(ctx context.Context, 
 }
 
 // SetIssueGithubStateWithBodyWithResponse request with arbitrary body returning *SetIssueGithubStateResponse
-func (c *ClientWithResponses) SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
-	rsp, err := c.SetIssueGithubStateWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
+	rsp, err := c.SetIssueGithubStateWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSetIssueGithubStateResponse(rsp)
 }
 
-func (c *ClientWithResponses) SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
-	rsp, err := c.SetIssueGithubState(ctx, owner, name, number, params, body, reqEditors...)
+func (c *ClientWithResponses) SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
+	rsp, err := c.SetIssueGithubState(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7566,16 +7373,16 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberWithResponse(ctx
 }
 
 // EditPrContentWithBodyWithResponse request with arbitrary body returning *EditPrContentResponse
-func (c *ClientWithResponses) EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
-	rsp, err := c.EditPrContentWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
+	rsp, err := c.EditPrContentWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseEditPrContentResponse(rsp)
 }
 
-func (c *ClientWithResponses) EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
-	rsp, err := c.EditPrContent(ctx, owner, name, number, params, body, reqEditors...)
+func (c *ClientWithResponses) EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
+	rsp, err := c.EditPrContent(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7583,25 +7390,33 @@ func (c *ClientWithResponses) EditPrContentWithResponse(ctx context.Context, own
 }
 
 // PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse request with arbitrary body returning *PostReposByOwnerByNamePullsByNumberApproveResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostReposByOwnerByNamePullsByNumberApproveResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberApprove(ctx, owner, name, number, params, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberApprove(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostReposByOwnerByNamePullsByNumberApproveResponse(rsp)
 }
 
-// PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse request returning *PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx, owner, name, number, params, reqEditors...)
+// PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBodyWithResponse request with arbitrary body returning *PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7609,16 +7424,16 @@ func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWorkflow
 }
 
 // PostPrCommentWithBodyWithResponse request with arbitrary body returning *PostPrCommentResponse
-func (c *ClientWithResponses) PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
-	rsp, err := c.PostPrCommentWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
+	rsp, err := c.PostPrCommentWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostPrCommentResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
-	rsp, err := c.PostPrComment(ctx, owner, name, number, params, body, reqEditors...)
+func (c *ClientWithResponses) PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
+	rsp, err := c.PostPrComment(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7626,16 +7441,16 @@ func (c *ClientWithResponses) PostPrCommentWithResponse(ctx context.Context, own
 }
 
 // EditPrCommentWithBodyWithResponse request with arbitrary body returning *EditPrCommentResponse
-func (c *ClientWithResponses) EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
-	rsp, err := c.EditPrCommentWithBody(ctx, owner, name, number, commentId, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
+	rsp, err := c.EditPrCommentWithBody(ctx, owner, name, number, commentId, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseEditPrCommentResponse(rsp)
 }
 
-func (c *ClientWithResponses) EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
-	rsp, err := c.EditPrComment(ctx, owner, name, number, commentId, params, body, reqEditors...)
+func (c *ClientWithResponses) EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
+	rsp, err := c.EditPrComment(ctx, owner, name, number, commentId, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7670,16 +7485,16 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberFilesWithRespons
 }
 
 // SetPrGithubStateWithBodyWithResponse request with arbitrary body returning *SetPrGithubStateResponse
-func (c *ClientWithResponses) SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
-	rsp, err := c.SetPrGithubStateWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
+	rsp, err := c.SetPrGithubStateWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSetPrGithubStateResponse(rsp)
 }
 
-func (c *ClientWithResponses) SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
-	rsp, err := c.SetPrGithubState(ctx, owner, name, number, params, body, reqEditors...)
+func (c *ClientWithResponses) SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
+	rsp, err := c.SetPrGithubState(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7696,25 +7511,33 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberImportMetadataWi
 }
 
 // PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse request with arbitrary body returning *PostReposByOwnerByNamePullsByNumberMergeResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostReposByOwnerByNamePullsByNumberMergeResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberMerge(ctx, owner, name, number, params, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberMerge(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostReposByOwnerByNamePullsByNumberMergeResponse(rsp)
 }
 
-// PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse request returning *PostReposByOwnerByNamePullsByNumberReadyForReviewResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberReadyForReview(ctx, owner, name, number, params, reqEditors...)
+// PostReposByOwnerByNamePullsByNumberReadyForReviewWithBodyWithResponse request with arbitrary body returning *PostReposByOwnerByNamePullsByNumberReadyForReviewResponse
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberReadyForReviewWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberReadyForReviewWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostReposByOwnerByNamePullsByNumberReadyForReviewResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberReadyForReview(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7731,16 +7554,16 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberStackWithRespons
 }
 
 // SetKanbanStateWithBodyWithResponse request with arbitrary body returning *SetKanbanStateResponse
-func (c *ClientWithResponses) SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
-	rsp, err := c.SetKanbanStateWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
+	rsp, err := c.SetKanbanStateWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSetKanbanStateResponse(rsp)
 }
 
-func (c *ClientWithResponses) SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
-	rsp, err := c.SetKanbanState(ctx, owner, name, number, params, body, reqEditors...)
+func (c *ClientWithResponses) SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
+	rsp, err := c.SetKanbanState(ctx, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -947,6 +947,11 @@ type PostReposByOwnerByNameItemsByNumberResolveParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
+// PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams defines parameters for PostReposByOwnerByNamePullsByNumberApproveWorkflows.
+type PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
 // GetReposByOwnerByNamePullsByNumberDiffParams defines parameters for GetReposByOwnerByNamePullsByNumberDiff.
 type GetReposByOwnerByNamePullsByNumberDiffParams struct {
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
@@ -959,6 +964,16 @@ type GetReposByOwnerByNamePullsByNumberDiffParams struct {
 
 	// To End SHA for range diff (inclusive)
 	To *string `form:"to,omitempty" json:"to,omitempty"`
+}
+
+// PostReposByOwnerByNamePullsByNumberMergeParams defines parameters for PostReposByOwnerByNamePullsByNumberMerge.
+type PostReposByOwnerByNamePullsByNumberMergeParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// PostReposByOwnerByNamePullsByNumberReadyForReviewParams defines parameters for PostReposByOwnerByNamePullsByNumberReadyForReview.
+type PostReposByOwnerByNamePullsByNumberReadyForReviewParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
 // ListStacksParams defines parameters for ListStacks.
@@ -1200,7 +1215,7 @@ type ClientInterface interface {
 	PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWorkflows request
-	PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostPrCommentWithBody request with any body
 	PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1230,12 +1245,12 @@ type ClientInterface interface {
 	GetReposByOwnerByNamePullsByNumberImportMetadata(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberMergeWithBody request with any body
-	PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberReadyForReview request
-	PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberStack request
 	GetReposByOwnerByNamePullsByNumberStack(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1739,8 +1754,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context,
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(c.Server, owner, name, number)
+func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1871,8 +1886,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumberImportMetadata(ctx context.Co
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(c.Server, owner, name, number, contentType, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(c.Server, owner, name, number, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1883,8 +1898,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx context.Co
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequest(c.Server, owner, name, number, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberMergeRequest(c.Server, owner, name, number, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1895,8 +1910,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberMerge(ctx context.Context, o
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(c.Server, owner, name, number)
+func (c *Client) PostReposByOwnerByNamePullsByNumberReadyForReview(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3819,7 +3834,7 @@ func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string,
 }
 
 // NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest generates requests for PostReposByOwnerByNamePullsByNumberApproveWorkflows
-func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3856,6 +3871,28 @@ func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(server string
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
@@ -4319,18 +4356,18 @@ func NewGetReposByOwnerByNamePullsByNumberImportMetadataRequest(server string, o
 }
 
 // NewPostReposByOwnerByNamePullsByNumberMergeRequest calls the generic PostReposByOwnerByNamePullsByNumberMerge builder with application/json body
-func NewPostReposByOwnerByNamePullsByNumberMergeRequest(server string, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberMergeRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+	return NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
 }
 
 // NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody generates requests for PostReposByOwnerByNamePullsByNumberMerge with any type of body
-func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4369,6 +4406,28 @@ func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, o
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
@@ -4380,7 +4439,7 @@ func NewPostReposByOwnerByNamePullsByNumberMergeRequestWithBody(server string, o
 }
 
 // NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest generates requests for PostReposByOwnerByNamePullsByNumberReadyForReview
-func NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4417,6 +4476,28 @@ func NewPostReposByOwnerByNamePullsByNumberReadyForReviewRequest(server string, 
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
@@ -5460,7 +5541,7 @@ type ClientWithResponsesInterface interface {
 	PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse request
-	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error)
+	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error)
 
 	// PostPrCommentWithBodyWithResponse request with any body
 	PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
@@ -5490,12 +5571,12 @@ type ClientWithResponsesInterface interface {
 	GetReposByOwnerByNamePullsByNumberImportMetadataWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberImportMetadataResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse request with any body
-	PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
+	PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
 
-	PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
+	PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse request
-	PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error)
+	PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberStackWithResponse request
 	GetReposByOwnerByNamePullsByNumberStackWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberStackResponse, error)
@@ -7178,8 +7259,8 @@ func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithResp
 }
 
 // PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse request returning *PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7274,16 +7355,16 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberImportMetadataWi
 }
 
 // PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse request with arbitrary body returning *PostReposByOwnerByNamePullsByNumberMergeResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberMergeWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostReposByOwnerByNamePullsByNumberMergeResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberMerge(ctx, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberMergeParams, body PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberMergeResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberMerge(ctx, owner, name, number, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7291,8 +7372,8 @@ func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberMergeWithRespon
 }
 
 // PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse request returning *PostReposByOwnerByNamePullsByNumberReadyForReviewResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberReadyForReview(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberReadyForReviewParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberReadyForReviewResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberReadyForReview(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -952,6 +952,11 @@ type GetReposByOwnerByNamePullsByNumberParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
+// PostReposByOwnerByNamePullsByNumberApproveParams defines parameters for PostReposByOwnerByNamePullsByNumberApprove.
+type PostReposByOwnerByNamePullsByNumberApproveParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
 // PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams defines parameters for PostReposByOwnerByNamePullsByNumberApproveWorkflows.
 type PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
@@ -1225,9 +1230,9 @@ type ClientInterface interface {
 	EditPrContent(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWithBody request with any body
-	PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWorkflows request
 	PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1745,8 +1750,8 @@ func (c *Client) EditPrContent(ctx context.Context, owner string, name string, n
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(c.Server, owner, name, number, contentType, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(c.Server, owner, name, number, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1757,8 +1762,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequest(c.Server, owner, name, number, body)
+func (c *Client) PostReposByOwnerByNamePullsByNumberApprove(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNamePullsByNumberApproveRequest(c.Server, owner, name, number, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3810,18 +3815,18 @@ func NewEditPrContentRequestWithBody(server string, owner string, name string, n
 }
 
 // NewPostReposByOwnerByNamePullsByNumberApproveRequest calls the generic PostReposByOwnerByNamePullsByNumberApprove builder with application/json body
-func NewPostReposByOwnerByNamePullsByNumberApproveRequest(server string, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberApproveRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+	return NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
 }
 
 // NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody generates requests for PostReposByOwnerByNamePullsByNumberApprove with any type of body
-func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3858,6 +3863,28 @@ func NewPostReposByOwnerByNamePullsByNumberApproveRequestWithBody(server string,
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -5617,9 +5644,9 @@ type ClientWithResponsesInterface interface {
 	EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse request with any body
-	PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
+	PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
 
-	PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
+	PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse request
 	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error)
@@ -7323,16 +7350,16 @@ func (c *ClientWithResponses) EditPrContentWithResponse(ctx context.Context, own
 }
 
 // PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse request with arbitrary body returning *PostReposByOwnerByNamePullsByNumberApproveResponse
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostReposByOwnerByNamePullsByNumberApproveResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
-	rsp, err := c.PostReposByOwnerByNamePullsByNumberApprove(ctx, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, body PostReposByOwnerByNamePullsByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error) {
+	rsp, err := c.PostReposByOwnerByNamePullsByNumberApprove(ctx, owner, name, number, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -986,6 +986,11 @@ type PostReposByOwnerByNamePullsByNumberReadyForReviewParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
+// SetKanbanStateParams defines parameters for SetKanbanState.
+type SetKanbanStateParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
 // PostReposByOwnerByNamePullsByNumberSyncParams defines parameters for PostReposByOwnerByNamePullsByNumberSync.
 type PostReposByOwnerByNamePullsByNumberSyncParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
@@ -1276,9 +1281,9 @@ type ClientInterface interface {
 	GetReposByOwnerByNamePullsByNumberStack(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetKanbanStateWithBody request with any body
-	SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SetKanbanState(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetKanbanState(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberSync request
 	PostReposByOwnerByNamePullsByNumberSync(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1954,8 +1959,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumberStack(ctx context.Context, ow
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetKanbanStateRequestWithBody(c.Server, owner, name, number, contentType, body)
+func (c *Client) SetKanbanStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetKanbanStateRequestWithBody(c.Server, owner, name, number, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1966,8 +1971,8 @@ func (c *Client) SetKanbanStateWithBody(ctx context.Context, owner string, name 
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetKanbanState(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetKanbanStateRequest(c.Server, owner, name, number, body)
+func (c *Client) SetKanbanState(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetKanbanStateRequest(c.Server, owner, name, number, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4621,18 +4626,18 @@ func NewGetReposByOwnerByNamePullsByNumberStackRequest(server string, owner stri
 }
 
 // NewSetKanbanStateRequest calls the generic SetKanbanState builder with application/json body
-func NewSetKanbanStateRequest(server string, owner string, name string, number int64, body SetKanbanStateJSONRequestBody) (*http.Request, error) {
+func NewSetKanbanStateRequest(server string, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSetKanbanStateRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+	return NewSetKanbanStateRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
 }
 
 // NewSetKanbanStateRequestWithBody generates requests for SetKanbanState with any type of body
-func NewSetKanbanStateRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewSetKanbanStateRequestWithBody(server string, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4669,6 +4674,28 @@ func NewSetKanbanStateRequestWithBody(server string, owner string, name string, 
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("PUT", queryURL.String(), body)
@@ -5690,9 +5717,9 @@ type ClientWithResponsesInterface interface {
 	GetReposByOwnerByNamePullsByNumberStackWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberStackResponse, error)
 
 	// SetKanbanStateWithBodyWithResponse request with any body
-	SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
+	SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
 
-	SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
+	SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberSyncWithResponse request
 	PostReposByOwnerByNamePullsByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberSyncParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberSyncResponse, error)
@@ -7498,16 +7525,16 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberStackWithRespons
 }
 
 // SetKanbanStateWithBodyWithResponse request with arbitrary body returning *SetKanbanStateResponse
-func (c *ClientWithResponses) SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
-	rsp, err := c.SetKanbanStateWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SetKanbanStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
+	rsp, err := c.SetKanbanStateWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSetKanbanStateResponse(rsp)
 }
 
-func (c *ClientWithResponses) SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
-	rsp, err := c.SetKanbanState(ctx, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) SetKanbanStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetKanbanStateParams, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error) {
+	rsp, err := c.SetKanbanState(ctx, owner, name, number, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -942,6 +942,11 @@ type EnqueueIssueSyncParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
+// PostReposByOwnerByNameItemsByNumberResolveParams defines parameters for PostReposByOwnerByNameItemsByNumberResolve.
+type PostReposByOwnerByNameItemsByNumberResolveParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
 // GetReposByOwnerByNamePullsByNumberDiffParams defines parameters for GetReposByOwnerByNamePullsByNumberDiff.
 type GetReposByOwnerByNamePullsByNumberDiffParams struct {
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
@@ -1179,7 +1184,7 @@ type ClientInterface interface {
 	CreateIssueWorkspace(ctx context.Context, owner string, name string, number int64, body CreateIssueWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNameItemsByNumberResolve request
-	PostReposByOwnerByNameItemsByNumberResolve(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostReposByOwnerByNameItemsByNumberResolve(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameItemsByNumberResolveParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumber request
 	GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1662,8 +1667,8 @@ func (c *Client) CreateIssueWorkspace(ctx context.Context, owner string, name st
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostReposByOwnerByNameItemsByNumberResolve(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostReposByOwnerByNameItemsByNumberResolveRequest(c.Server, owner, name, number)
+func (c *Client) PostReposByOwnerByNameItemsByNumberResolve(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameItemsByNumberResolveParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostReposByOwnerByNameItemsByNumberResolveRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3574,7 +3579,7 @@ func NewCreateIssueWorkspaceRequestWithBody(server string, owner string, name st
 }
 
 // NewPostReposByOwnerByNameItemsByNumberResolveRequest generates requests for PostReposByOwnerByNameItemsByNumberResolve
-func NewPostReposByOwnerByNameItemsByNumberResolveRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewPostReposByOwnerByNameItemsByNumberResolveRequest(server string, owner string, name string, number int64, params *PostReposByOwnerByNameItemsByNumberResolveParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3611,6 +3616,28 @@ func NewPostReposByOwnerByNameItemsByNumberResolveRequest(server string, owner s
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
@@ -5417,7 +5444,7 @@ type ClientWithResponsesInterface interface {
 	CreateIssueWorkspaceWithResponse(ctx context.Context, owner string, name string, number int64, body CreateIssueWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIssueWorkspaceResponse, error)
 
 	// PostReposByOwnerByNameItemsByNumberResolveWithResponse request
-	PostReposByOwnerByNameItemsByNumberResolveWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNameItemsByNumberResolveResponse, error)
+	PostReposByOwnerByNameItemsByNumberResolveWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameItemsByNumberResolveParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNameItemsByNumberResolveResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberWithResponse request
 	GetReposByOwnerByNamePullsByNumberWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberResponse, error)
@@ -7099,8 +7126,8 @@ func (c *ClientWithResponses) CreateIssueWorkspaceWithResponse(ctx context.Conte
 }
 
 // PostReposByOwnerByNameItemsByNumberResolveWithResponse request returning *PostReposByOwnerByNameItemsByNumberResolveResponse
-func (c *ClientWithResponses) PostReposByOwnerByNameItemsByNumberResolveWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNameItemsByNumberResolveResponse, error) {
-	rsp, err := c.PostReposByOwnerByNameItemsByNumberResolve(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) PostReposByOwnerByNameItemsByNumberResolveWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameItemsByNumberResolveParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNameItemsByNumberResolveResponse, error) {
+	rsp, err := c.PostReposByOwnerByNameItemsByNumberResolve(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -932,6 +932,11 @@ type GetReposByOwnerByNameIssuesByNumberParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
+// SetIssueGithubStateParams defines parameters for SetIssueGithubState.
+type SetIssueGithubStateParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
 // PostReposByOwnerByNameIssuesByNumberSyncParams defines parameters for PostReposByOwnerByNameIssuesByNumberSync.
 type PostReposByOwnerByNameIssuesByNumberSyncParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
@@ -952,6 +957,11 @@ type GetReposByOwnerByNamePullsByNumberParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
+// EditPrContentParams defines parameters for EditPrContent.
+type EditPrContentParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
 // PostReposByOwnerByNamePullsByNumberApproveParams defines parameters for PostReposByOwnerByNamePullsByNumberApprove.
 type PostReposByOwnerByNamePullsByNumberApproveParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
@@ -959,6 +969,21 @@ type PostReposByOwnerByNamePullsByNumberApproveParams struct {
 
 // PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams defines parameters for PostReposByOwnerByNamePullsByNumberApproveWorkflows.
 type PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// PostPrCommentParams defines parameters for PostPrComment.
+type PostPrCommentParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// EditPrCommentParams defines parameters for EditPrComment.
+type EditPrCommentParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// GetReposByOwnerByNamePullsByNumberCommitsParams defines parameters for GetReposByOwnerByNamePullsByNumberCommits.
+type GetReposByOwnerByNamePullsByNumberCommitsParams struct {
 	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
@@ -973,7 +998,18 @@ type GetReposByOwnerByNamePullsByNumberDiffParams struct {
 	From *string `form:"from,omitempty" json:"from,omitempty"`
 
 	// To End SHA for range diff (inclusive)
-	To *string `form:"to,omitempty" json:"to,omitempty"`
+	To           *string `form:"to,omitempty" json:"to,omitempty"`
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// GetReposByOwnerByNamePullsByNumberFilesParams defines parameters for GetReposByOwnerByNamePullsByNumberFiles.
+type GetReposByOwnerByNamePullsByNumberFilesParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
+}
+
+// SetPrGithubStateParams defines parameters for SetPrGithubState.
+type SetPrGithubStateParams struct {
+	PlatformHost *string `form:"platform_host,omitempty" json:"platform_host,omitempty"`
 }
 
 // PostReposByOwnerByNamePullsByNumberMergeParams defines parameters for PostReposByOwnerByNamePullsByNumberMerge.
@@ -1208,9 +1244,9 @@ type ClientInterface interface {
 	EditIssueComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetIssueGithubStateWithBody request with any body
-	SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SetIssueGithubState(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetIssueGithubState(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNameIssuesByNumberSync request
 	PostReposByOwnerByNameIssuesByNumberSync(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameIssuesByNumberSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1230,9 +1266,9 @@ type ClientInterface interface {
 	GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditPrContentWithBody request with any body
-	EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	EditPrContent(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrContent(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWithBody request with any body
 	PostReposByOwnerByNamePullsByNumberApproveWithBody(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1243,28 +1279,28 @@ type ClientInterface interface {
 	PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostPrCommentWithBody request with any body
-	PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostPrComment(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostPrComment(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditPrCommentWithBody request with any body
-	EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberCommits request
-	GetReposByOwnerByNamePullsByNumberCommits(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetReposByOwnerByNamePullsByNumberCommits(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberCommitsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberDiff request
 	GetReposByOwnerByNamePullsByNumberDiff(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberFiles request
-	GetReposByOwnerByNamePullsByNumberFiles(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetReposByOwnerByNamePullsByNumberFiles(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetPrGithubStateWithBody request with any body
-	SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	SetPrGithubState(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetPrGithubState(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetReposByOwnerByNamePullsByNumberImportMetadata request
 	GetReposByOwnerByNamePullsByNumberImportMetadata(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1635,8 +1671,8 @@ func (c *Client) EditIssueComment(ctx context.Context, owner string, name string
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetIssueGithubStateRequestWithBody(c.Server, owner, name, number, contentType, body)
+func (c *Client) SetIssueGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetIssueGithubStateRequestWithBody(c.Server, owner, name, number, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1647,8 +1683,8 @@ func (c *Client) SetIssueGithubStateWithBody(ctx context.Context, owner string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetIssueGithubState(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetIssueGithubStateRequest(c.Server, owner, name, number, body)
+func (c *Client) SetIssueGithubState(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetIssueGithubStateRequest(c.Server, owner, name, number, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1731,8 +1767,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumber(ctx context.Context, owner s
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrContentRequestWithBody(c.Server, owner, name, number, contentType, body)
+func (c *Client) EditPrContentWithBody(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrContentRequestWithBody(c.Server, owner, name, number, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1743,8 +1779,8 @@ func (c *Client) EditPrContentWithBody(ctx context.Context, owner string, name s
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrContent(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrContentRequest(c.Server, owner, name, number, body)
+func (c *Client) EditPrContent(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrContentRequest(c.Server, owner, name, number, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1791,8 +1827,8 @@ func (c *Client) PostReposByOwnerByNamePullsByNumberApproveWorkflows(ctx context
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPrCommentRequestWithBody(c.Server, owner, name, number, contentType, body)
+func (c *Client) PostPrCommentWithBody(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostPrCommentRequestWithBody(c.Server, owner, name, number, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1803,8 +1839,8 @@ func (c *Client) PostPrCommentWithBody(ctx context.Context, owner string, name s
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPrComment(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPrCommentRequest(c.Server, owner, name, number, body)
+func (c *Client) PostPrComment(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostPrCommentRequest(c.Server, owner, name, number, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1815,8 +1851,8 @@ func (c *Client) PostPrComment(ctx context.Context, owner string, name string, n
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrCommentRequestWithBody(c.Server, owner, name, number, commentId, contentType, body)
+func (c *Client) EditPrCommentWithBody(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrCommentRequestWithBody(c.Server, owner, name, number, commentId, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1827,8 +1863,8 @@ func (c *Client) EditPrCommentWithBody(ctx context.Context, owner string, name s
 	return c.Client.Do(req)
 }
 
-func (c *Client) EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEditPrCommentRequest(c.Server, owner, name, number, commentId, body)
+func (c *Client) EditPrComment(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditPrCommentRequest(c.Server, owner, name, number, commentId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1839,8 +1875,8 @@ func (c *Client) EditPrComment(ctx context.Context, owner string, name string, n
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetReposByOwnerByNamePullsByNumberCommits(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetReposByOwnerByNamePullsByNumberCommitsRequest(c.Server, owner, name, number)
+func (c *Client) GetReposByOwnerByNamePullsByNumberCommits(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberCommitsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReposByOwnerByNamePullsByNumberCommitsRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1863,8 +1899,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumberDiff(ctx context.Context, own
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetReposByOwnerByNamePullsByNumberFiles(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetReposByOwnerByNamePullsByNumberFilesRequest(c.Server, owner, name, number)
+func (c *Client) GetReposByOwnerByNamePullsByNumberFiles(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReposByOwnerByNamePullsByNumberFilesRequest(c.Server, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1875,8 +1911,8 @@ func (c *Client) GetReposByOwnerByNamePullsByNumberFiles(ctx context.Context, ow
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetPrGithubStateRequestWithBody(c.Server, owner, name, number, contentType, body)
+func (c *Client) SetPrGithubStateWithBody(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetPrGithubStateRequestWithBody(c.Server, owner, name, number, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1887,8 +1923,8 @@ func (c *Client) SetPrGithubStateWithBody(ctx context.Context, owner string, nam
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetPrGithubState(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetPrGithubStateRequest(c.Server, owner, name, number, body)
+func (c *Client) SetPrGithubState(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetPrGithubStateRequest(c.Server, owner, name, number, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3357,18 +3393,18 @@ func NewEditIssueCommentRequestWithBody(server string, owner string, name string
 }
 
 // NewSetIssueGithubStateRequest calls the generic SetIssueGithubState builder with application/json body
-func NewSetIssueGithubStateRequest(server string, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody) (*http.Request, error) {
+func NewSetIssueGithubStateRequest(server string, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSetIssueGithubStateRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+	return NewSetIssueGithubStateRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
 }
 
 // NewSetIssueGithubStateRequestWithBody generates requests for SetIssueGithubState with any type of body
-func NewSetIssueGithubStateRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewSetIssueGithubStateRequestWithBody(server string, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3405,6 +3441,28 @@ func NewSetIssueGithubStateRequestWithBody(server string, owner string, name str
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -3759,18 +3817,18 @@ func NewGetReposByOwnerByNamePullsByNumberRequest(server string, owner string, n
 }
 
 // NewEditPrContentRequest calls the generic EditPrContent builder with application/json body
-func NewEditPrContentRequest(server string, owner string, name string, number int64, body EditPrContentJSONRequestBody) (*http.Request, error) {
+func NewEditPrContentRequest(server string, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewEditPrContentRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+	return NewEditPrContentRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
 }
 
 // NewEditPrContentRequestWithBody generates requests for EditPrContent with any type of body
-func NewEditPrContentRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewEditPrContentRequestWithBody(server string, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3807,6 +3865,28 @@ func NewEditPrContentRequestWithBody(server string, owner string, name string, n
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("PATCH", queryURL.String(), body)
@@ -3973,18 +4053,18 @@ func NewPostReposByOwnerByNamePullsByNumberApproveWorkflowsRequest(server string
 }
 
 // NewPostPrCommentRequest calls the generic PostPrComment builder with application/json body
-func NewPostPrCommentRequest(server string, owner string, name string, number int64, body PostPrCommentJSONRequestBody) (*http.Request, error) {
+func NewPostPrCommentRequest(server string, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostPrCommentRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+	return NewPostPrCommentRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
 }
 
 // NewPostPrCommentRequestWithBody generates requests for PostPrComment with any type of body
-func NewPostPrCommentRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewPostPrCommentRequestWithBody(server string, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4023,6 +4103,28 @@ func NewPostPrCommentRequestWithBody(server string, owner string, name string, n
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
@@ -4034,18 +4136,18 @@ func NewPostPrCommentRequestWithBody(server string, owner string, name string, n
 }
 
 // NewEditPrCommentRequest calls the generic EditPrComment builder with application/json body
-func NewEditPrCommentRequest(server string, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody) (*http.Request, error) {
+func NewEditPrCommentRequest(server string, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewEditPrCommentRequestWithBody(server, owner, name, number, commentId, "application/json", bodyReader)
+	return NewEditPrCommentRequestWithBody(server, owner, name, number, commentId, params, "application/json", bodyReader)
 }
 
 // NewEditPrCommentRequestWithBody generates requests for EditPrComment with any type of body
-func NewEditPrCommentRequestWithBody(server string, owner string, name string, number int64, commentId int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewEditPrCommentRequestWithBody(server string, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4091,6 +4193,28 @@ func NewEditPrCommentRequestWithBody(server string, owner string, name string, n
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("PATCH", queryURL.String(), body)
 	if err != nil {
 		return nil, err
@@ -4102,7 +4226,7 @@ func NewEditPrCommentRequestWithBody(server string, owner string, name string, n
 }
 
 // NewGetReposByOwnerByNamePullsByNumberCommitsRequest generates requests for GetReposByOwnerByNamePullsByNumberCommits
-func NewGetReposByOwnerByNamePullsByNumberCommitsRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewGetReposByOwnerByNamePullsByNumberCommitsRequest(server string, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberCommitsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4139,6 +4263,28 @@ func NewGetReposByOwnerByNamePullsByNumberCommitsRequest(server string, owner st
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -4256,6 +4402,22 @@ func NewGetReposByOwnerByNamePullsByNumberDiffRequest(server string, owner strin
 
 		}
 
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -4268,7 +4430,7 @@ func NewGetReposByOwnerByNamePullsByNumberDiffRequest(server string, owner strin
 }
 
 // NewGetReposByOwnerByNamePullsByNumberFilesRequest generates requests for GetReposByOwnerByNamePullsByNumberFiles
-func NewGetReposByOwnerByNamePullsByNumberFilesRequest(server string, owner string, name string, number int64) (*http.Request, error) {
+func NewGetReposByOwnerByNamePullsByNumberFilesRequest(server string, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberFilesParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4307,6 +4469,28 @@ func NewGetReposByOwnerByNamePullsByNumberFilesRequest(server string, owner stri
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
@@ -4316,18 +4500,18 @@ func NewGetReposByOwnerByNamePullsByNumberFilesRequest(server string, owner stri
 }
 
 // NewSetPrGithubStateRequest calls the generic SetPrGithubState builder with application/json body
-func NewSetPrGithubStateRequest(server string, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody) (*http.Request, error) {
+func NewSetPrGithubStateRequest(server string, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewSetPrGithubStateRequestWithBody(server, owner, name, number, "application/json", bodyReader)
+	return NewSetPrGithubStateRequestWithBody(server, owner, name, number, params, "application/json", bodyReader)
 }
 
 // NewSetPrGithubStateRequestWithBody generates requests for SetPrGithubState with any type of body
-func NewSetPrGithubStateRequestWithBody(server string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+func NewSetPrGithubStateRequestWithBody(server string, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4364,6 +4548,28 @@ func NewSetPrGithubStateRequestWithBody(server string, owner string, name string
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PlatformHost != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "platform_host", *params.PlatformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -5644,9 +5850,9 @@ type ClientWithResponsesInterface interface {
 	EditIssueCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditIssueCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueCommentResponse, error)
 
 	// SetIssueGithubStateWithBodyWithResponse request with any body
-	SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
+	SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
 
-	SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
+	SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error)
 
 	// PostReposByOwnerByNameIssuesByNumberSyncWithResponse request
 	PostReposByOwnerByNameIssuesByNumberSyncWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNameIssuesByNumberSyncParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNameIssuesByNumberSyncResponse, error)
@@ -5666,9 +5872,9 @@ type ClientWithResponsesInterface interface {
 	GetReposByOwnerByNamePullsByNumberWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberResponse, error)
 
 	// EditPrContentWithBodyWithResponse request with any body
-	EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
+	EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
 
-	EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
+	EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
 
 	// PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse request with any body
 	PostReposByOwnerByNamePullsByNumberApproveWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveResponse, error)
@@ -5679,28 +5885,28 @@ type ClientWithResponsesInterface interface {
 	PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(ctx context.Context, owner string, name string, number int64, params *PostReposByOwnerByNamePullsByNumberApproveWorkflowsParams, reqEditors ...RequestEditorFn) (*PostReposByOwnerByNamePullsByNumberApproveWorkflowsResponse, error)
 
 	// PostPrCommentWithBodyWithResponse request with any body
-	PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
+	PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
 
-	PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
+	PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
 
 	// EditPrCommentWithBodyWithResponse request with any body
-	EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
+	EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
 
-	EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
+	EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberCommitsWithResponse request
-	GetReposByOwnerByNamePullsByNumberCommitsWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberCommitsResponse, error)
+	GetReposByOwnerByNamePullsByNumberCommitsWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberCommitsParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberCommitsResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberDiffWithResponse request
 	GetReposByOwnerByNamePullsByNumberDiffWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberDiffParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberDiffResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberFilesWithResponse request
-	GetReposByOwnerByNamePullsByNumberFilesWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberFilesResponse, error)
+	GetReposByOwnerByNamePullsByNumberFilesWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberFilesParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberFilesResponse, error)
 
 	// SetPrGithubStateWithBodyWithResponse request with any body
-	SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
+	SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
 
-	SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
+	SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
 
 	// GetReposByOwnerByNamePullsByNumberImportMetadataWithResponse request
 	GetReposByOwnerByNamePullsByNumberImportMetadataWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberImportMetadataResponse, error)
@@ -7290,16 +7496,16 @@ func (c *ClientWithResponses) EditIssueCommentWithResponse(ctx context.Context, 
 }
 
 // SetIssueGithubStateWithBodyWithResponse request with arbitrary body returning *SetIssueGithubStateResponse
-func (c *ClientWithResponses) SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
-	rsp, err := c.SetIssueGithubStateWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SetIssueGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
+	rsp, err := c.SetIssueGithubStateWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSetIssueGithubStateResponse(rsp)
 }
 
-func (c *ClientWithResponses) SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
-	rsp, err := c.SetIssueGithubState(ctx, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) SetIssueGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetIssueGithubStateParams, body SetIssueGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueGithubStateResponse, error) {
+	rsp, err := c.SetIssueGithubState(ctx, owner, name, number, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7360,16 +7566,16 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberWithResponse(ctx
 }
 
 // EditPrContentWithBodyWithResponse request with arbitrary body returning *EditPrContentResponse
-func (c *ClientWithResponses) EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
-	rsp, err := c.EditPrContentWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+func (c *ClientWithResponses) EditPrContentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
+	rsp, err := c.EditPrContentWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseEditPrContentResponse(rsp)
 }
 
-func (c *ClientWithResponses) EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
-	rsp, err := c.EditPrContent(ctx, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) EditPrContentWithResponse(ctx context.Context, owner string, name string, number int64, params *EditPrContentParams, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error) {
+	rsp, err := c.EditPrContent(ctx, owner, name, number, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7403,16 +7609,16 @@ func (c *ClientWithResponses) PostReposByOwnerByNamePullsByNumberApproveWorkflow
 }
 
 // PostPrCommentWithBodyWithResponse request with arbitrary body returning *PostPrCommentResponse
-func (c *ClientWithResponses) PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
-	rsp, err := c.PostPrCommentWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PostPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
+	rsp, err := c.PostPrCommentWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePostPrCommentResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
-	rsp, err := c.PostPrComment(ctx, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) PostPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, params *PostPrCommentParams, body PostPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error) {
+	rsp, err := c.PostPrComment(ctx, owner, name, number, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7420,16 +7626,16 @@ func (c *ClientWithResponses) PostPrCommentWithResponse(ctx context.Context, own
 }
 
 // EditPrCommentWithBodyWithResponse request with arbitrary body returning *EditPrCommentResponse
-func (c *ClientWithResponses) EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
-	rsp, err := c.EditPrCommentWithBody(ctx, owner, name, number, commentId, contentType, body, reqEditors...)
+func (c *ClientWithResponses) EditPrCommentWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
+	rsp, err := c.EditPrCommentWithBody(ctx, owner, name, number, commentId, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseEditPrCommentResponse(rsp)
 }
 
-func (c *ClientWithResponses) EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
-	rsp, err := c.EditPrComment(ctx, owner, name, number, commentId, body, reqEditors...)
+func (c *ClientWithResponses) EditPrCommentWithResponse(ctx context.Context, owner string, name string, number int64, commentId int64, params *EditPrCommentParams, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error) {
+	rsp, err := c.EditPrComment(ctx, owner, name, number, commentId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7437,8 +7643,8 @@ func (c *ClientWithResponses) EditPrCommentWithResponse(ctx context.Context, own
 }
 
 // GetReposByOwnerByNamePullsByNumberCommitsWithResponse request returning *GetReposByOwnerByNamePullsByNumberCommitsResponse
-func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberCommitsWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberCommitsResponse, error) {
-	rsp, err := c.GetReposByOwnerByNamePullsByNumberCommits(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberCommitsWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberCommitsParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberCommitsResponse, error) {
+	rsp, err := c.GetReposByOwnerByNamePullsByNumberCommits(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7455,8 +7661,8 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberDiffWithResponse
 }
 
 // GetReposByOwnerByNamePullsByNumberFilesWithResponse request returning *GetReposByOwnerByNamePullsByNumberFilesResponse
-func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberFilesWithResponse(ctx context.Context, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberFilesResponse, error) {
-	rsp, err := c.GetReposByOwnerByNamePullsByNumberFiles(ctx, owner, name, number, reqEditors...)
+func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberFilesWithResponse(ctx context.Context, owner string, name string, number int64, params *GetReposByOwnerByNamePullsByNumberFilesParams, reqEditors ...RequestEditorFn) (*GetReposByOwnerByNamePullsByNumberFilesResponse, error) {
+	rsp, err := c.GetReposByOwnerByNamePullsByNumberFiles(ctx, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -7464,16 +7670,16 @@ func (c *ClientWithResponses) GetReposByOwnerByNamePullsByNumberFilesWithRespons
 }
 
 // SetPrGithubStateWithBodyWithResponse request with arbitrary body returning *SetPrGithubStateResponse
-func (c *ClientWithResponses) SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
-	rsp, err := c.SetPrGithubStateWithBody(ctx, owner, name, number, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SetPrGithubStateWithBodyWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
+	rsp, err := c.SetPrGithubStateWithBody(ctx, owner, name, number, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseSetPrGithubStateResponse(rsp)
 }
 
-func (c *ClientWithResponses) SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
-	rsp, err := c.SetPrGithubState(ctx, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) SetPrGithubStateWithResponse(ctx context.Context, owner string, name string, number int64, params *SetPrGithubStateParams, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error) {
+	rsp, err := c.SetPrGithubState(ctx, owner, name, number, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -450,6 +450,50 @@ func (d *DB) ListRepos(ctx context.Context) ([]Repo, error) {
 	return repos, rows.Err()
 }
 
+// ListReposByOwnerName returns every repo matching owner/name across hosts.
+func (d *DB) ListReposByOwnerName(ctx context.Context, owner, name string) ([]Repo, error) {
+	_, owner, name = canonicalRepoIdentifier("", owner, name)
+	rows, err := d.ro.QueryContext(ctx,
+		`SELECT id, platform, platform_host, owner, name,
+		        last_sync_started_at, last_sync_completed_at,
+		        last_sync_error, allow_squash_merge, allow_merge_commit,
+		        allow_rebase_merge,
+		        backfill_pr_page, backfill_pr_complete,
+		        backfill_pr_completed_at,
+		        backfill_issue_page, backfill_issue_complete,
+		        backfill_issue_completed_at,
+		        created_at
+		 FROM middleman_repos
+		 WHERE owner = ? AND name = ?
+		 ORDER BY platform_host ASC`, owner, name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list repos by owner/name: %w", err)
+	}
+	defer rows.Close()
+
+	var repos []Repo
+	for rows.Next() {
+		var r Repo
+		if err := rows.Scan(
+			&r.ID, &r.Platform, &r.PlatformHost, &r.Owner, &r.Name,
+			&r.LastSyncStartedAt, &r.LastSyncCompletedAt,
+			&r.LastSyncError,
+			&r.AllowSquashMerge, &r.AllowMergeCommit, &r.AllowRebaseMerge,
+			&r.BackfillPRPage, &r.BackfillPRComplete,
+			&r.BackfillPRCompletedAt,
+			&r.BackfillIssuePage, &r.BackfillIssueComplete,
+			&r.BackfillIssueCompletedAt,
+			&r.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan repo: %w", err)
+		}
+		normalizeRepoTimestamps(&r)
+		repos = append(repos, r)
+	}
+	return repos, rows.Err()
+}
+
 // UpdateRepoSyncStarted records the time a sync began.
 func (d *DB) UpdateRepoSyncStarted(ctx context.Context, id int64, t time.Time) error {
 	t = canonicalUTCTime(t)

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -24,6 +24,29 @@ func canonicalRepoIdentifier(host, owner, name string) (string, string, string) 
 	return strings.ToLower(host), strings.ToLower(owner), strings.ToLower(name)
 }
 
+type mergeRequestScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanMergeRequest(scanner mergeRequestScanner) (MergeRequest, error) {
+	var mr MergeRequest
+	err := scanner.Scan(
+		&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.Number, &mr.URL, &mr.Title,
+		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft,
+		&mr.Body, &mr.HeadBranch, &mr.BaseBranch,
+		&mr.PlatformHeadSHA, &mr.PlatformBaseSHA,
+		&mr.DiffHeadSHA, &mr.DiffBaseSHA, &mr.MergeBaseSHA,
+		&mr.HeadRepoCloneURL,
+		&mr.Additions, &mr.Deletions, &mr.CommentCount, &mr.ReviewDecision,
+		&mr.CIStatus, &mr.CIChecksJSON,
+		&mr.CreatedAt, &mr.UpdatedAt, &mr.LastActivityAt,
+		&mr.MergedAt, &mr.ClosedAt, &mr.MergeableState,
+		&mr.DetailFetchedAt, &mr.CIHadPending,
+		&mr.KanbanStatus, &mr.Starred,
+	)
+	return mr, err
+}
+
 func lookupLabelIDByNameTx(ctx context.Context, tx *sql.Tx, repoID int64, name string) (int64, bool, error) {
 	var id int64
 	err := tx.QueryRowContext(ctx,
@@ -706,8 +729,7 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 // GetMergeRequest returns a merge request by repo owner/name and MR number, or nil if not found.
 func (d *DB) GetMergeRequest(ctx context.Context, owner, name string, number int) (*MergeRequest, error) {
 	_, owner, name = canonicalRepoIdentifier("", owner, name)
-	var mr MergeRequest
-	err := d.ro.QueryRowContext(ctx, `
+	mr, err := scanMergeRequest(d.ro.QueryRowContext(ctx, `
 		SELECT p.id, p.repo_id, p.platform_id, p.number, p.url, p.title,
 		       p.author, p.author_display_name, p.state, p.is_draft,
 		       p.body, p.head_branch, p.base_branch,
@@ -728,20 +750,7 @@ func (d *DB) GetMergeRequest(ctx context.Context, owner, name string, number int
 		    ON s.item_type = 'pr' AND s.repo_id = p.repo_id AND s.number = p.number
 		WHERE r.owner = ? AND r.name = ? AND p.number = ?`,
 		owner, name, number,
-	).Scan(
-		&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.Number, &mr.URL, &mr.Title,
-		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft,
-		&mr.Body, &mr.HeadBranch, &mr.BaseBranch,
-		&mr.PlatformHeadSHA, &mr.PlatformBaseSHA,
-		&mr.DiffHeadSHA, &mr.DiffBaseSHA, &mr.MergeBaseSHA,
-		&mr.HeadRepoCloneURL,
-		&mr.Additions, &mr.Deletions, &mr.CommentCount, &mr.ReviewDecision,
-		&mr.CIStatus, &mr.CIChecksJSON,
-		&mr.CreatedAt, &mr.UpdatedAt, &mr.LastActivityAt,
-		&mr.MergedAt, &mr.ClosedAt, &mr.MergeableState,
-		&mr.DetailFetchedAt, &mr.CIHadPending,
-		&mr.KanbanStatus, &mr.Starred,
-	)
+	))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -758,8 +767,7 @@ func (d *DB) GetMergeRequest(ctx context.Context, owner, name string, number int
 
 // GetMergeRequestByRepoIDAndNumber returns a merge request by repo ID and number.
 func (d *DB) GetMergeRequestByRepoIDAndNumber(ctx context.Context, repoID int64, number int) (*MergeRequest, error) {
-	var mr MergeRequest
-	err := d.ro.QueryRowContext(ctx, `
+	mr, err := scanMergeRequest(d.ro.QueryRowContext(ctx, `
 		SELECT p.id, p.repo_id, p.platform_id, p.number, p.url, p.title,
 		       p.author, p.author_display_name, p.state, p.is_draft,
 		       p.body, p.head_branch, p.base_branch,
@@ -779,20 +787,7 @@ func (d *DB) GetMergeRequestByRepoIDAndNumber(ctx context.Context, repoID int64,
 		    ON s.item_type = 'pr' AND s.repo_id = p.repo_id AND s.number = p.number
 		WHERE p.repo_id = ? AND p.number = ?`,
 		repoID, number,
-	).Scan(
-		&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.Number, &mr.URL, &mr.Title,
-		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft,
-		&mr.Body, &mr.HeadBranch, &mr.BaseBranch,
-		&mr.PlatformHeadSHA, &mr.PlatformBaseSHA,
-		&mr.DiffHeadSHA, &mr.DiffBaseSHA, &mr.MergeBaseSHA,
-		&mr.HeadRepoCloneURL,
-		&mr.Additions, &mr.Deletions, &mr.CommentCount, &mr.ReviewDecision,
-		&mr.CIStatus, &mr.CIChecksJSON,
-		&mr.CreatedAt, &mr.UpdatedAt, &mr.LastActivityAt,
-		&mr.MergedAt, &mr.ClosedAt, &mr.MergeableState,
-		&mr.DetailFetchedAt, &mr.CIHadPending,
-		&mr.KanbanStatus, &mr.Starred,
-	)
+	))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -888,21 +883,8 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 	var mrs []MergeRequest
 	var mrIDs []int64
 	for rows.Next() {
-		var mr MergeRequest
-		if err := rows.Scan(
-			&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.Number, &mr.URL, &mr.Title,
-			&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft,
-			&mr.Body, &mr.HeadBranch, &mr.BaseBranch,
-			&mr.PlatformHeadSHA, &mr.PlatformBaseSHA,
-			&mr.DiffHeadSHA, &mr.DiffBaseSHA, &mr.MergeBaseSHA,
-			&mr.HeadRepoCloneURL,
-			&mr.Additions, &mr.Deletions, &mr.CommentCount, &mr.ReviewDecision,
-			&mr.CIStatus, &mr.CIChecksJSON,
-			&mr.CreatedAt, &mr.UpdatedAt, &mr.LastActivityAt,
-			&mr.MergedAt, &mr.ClosedAt, &mr.MergeableState,
-			&mr.DetailFetchedAt, &mr.CIHadPending,
-			&mr.KanbanStatus, &mr.Starred,
-		); err != nil {
+		mr, err := scanMergeRequest(rows)
+		if err != nil {
 			return nil, fmt.Errorf("scan merge request: %w", err)
 		}
 		mrs = append(mrs, mr)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -505,6 +505,28 @@ func TestGetRepoByOwnerName(t *testing.T) {
 	assert.Nil(missing)
 }
 
+func TestListReposByOwnerNameReturnsMatchingHosts(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	githubID, err := d.UpsertRepo(ctx, "github.com", "Acme", "Widget")
+	require.NoError(err)
+	gheID, err := d.UpsertRepo(ctx, "ghe.example.com", "acme", "widget")
+	require.NoError(err)
+	_, err = d.UpsertRepo(ctx, "github.com", "acme", "other")
+	require.NoError(err)
+
+	repos, err := d.ListReposByOwnerName(ctx, "ACME", "WIDGET")
+	require.NoError(err)
+	require.Len(repos, 2)
+	assert.Equal(gheID, repos[0].ID)
+	assert.Equal("ghe.example.com", repos[0].PlatformHost)
+	assert.Equal(githubID, repos[1].ID)
+	assert.Equal("github.com", repos[1].PlatformHost)
+}
+
 func TestUpdateRepoSync(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -534,6 +534,22 @@ func (s *Syncer) ClientForRepo(
 	)
 }
 
+// ClientForRepoOnHost returns the Client for a tracked repo on a specific
+// platform host, or an error if that host-qualified repo is not tracked.
+func (s *Syncer) ClientForRepoOnHost(
+	owner, name, host string,
+) (Client, error) {
+	if host == "" {
+		host = "github.com"
+	}
+	if !s.isTrackedRepoOnHost(owner, name, host) {
+		return nil, fmt.Errorf(
+			"repo %s/%s on %s is not tracked", owner, name, host,
+		)
+	}
+	return s.clientFor(RepoRef{Owner: owner, Name: name, PlatformHost: host})
+}
+
 // ClientForHost returns the Client for a specific host,
 // or an error if no client is configured for that host.
 func (s *Syncer) ClientForHost(
@@ -3819,6 +3835,15 @@ func (s *Syncer) IsTrackedRepoOnHost(owner, name, host string) bool {
 // Returns an error if the repo is not in the configured repo list.
 func (s *Syncer) SyncMR(ctx context.Context, owner, name string, number int) error {
 	return s.syncMRWithHost(ctx, owner, name, number, "")
+}
+
+// SyncMROnHost fetches fresh data for a single MR from a specific tracked host.
+func (s *Syncer) SyncMROnHost(
+	ctx context.Context,
+	host, owner, name string,
+	number int,
+) error {
+	return s.syncMRWithHost(ctx, owner, name, number, host)
 }
 
 // syncMRWithHost is the internal implementation of SyncMR.

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3757,6 +3757,25 @@ func (s *Syncer) IsTrackedRepo(owner, name string) bool {
 	return false
 }
 
+// IsTrackedRepoAmbiguous checks whether owner/name matches more than one
+// configured repo and therefore needs an explicit platform host.
+func (s *Syncer) IsTrackedRepoAmbiguous(owner, name string) bool {
+	s.reposMu.Lock()
+	repos := s.repos
+	s.reposMu.Unlock()
+	matches := 0
+	for _, r := range repos {
+		if strings.EqualFold(r.Owner, owner) &&
+			strings.EqualFold(r.Name, name) {
+			matches++
+			if matches > 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // TrackedRepos returns a snapshot of the tracked repositories.
 func (s *Syncer) TrackedRepos() []RepoRef {
 	s.reposMu.Lock()

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4079,13 +4079,32 @@ func (s *Syncer) syncIssueWithHost(
 func (s *Syncer) SyncItemByNumber(
 	ctx context.Context, owner, name string, number int,
 ) (string, error) {
-	if !s.IsTrackedRepo(owner, name) {
-		return "", fmt.Errorf("repo %s/%s is not tracked", owner, name)
+	return s.syncItemByNumberWithHost(ctx, owner, name, number, "")
+}
+
+// SyncItemByNumberOnHost resolves and syncs an item for a specific tracked host.
+func (s *Syncer) SyncItemByNumberOnHost(
+	ctx context.Context,
+	host, owner, name string,
+	number int,
+) (string, error) {
+	return s.syncItemByNumberWithHost(ctx, owner, name, number, host)
+}
+
+func (s *Syncer) syncItemByNumberWithHost(
+	ctx context.Context,
+	owner, name string,
+	number int,
+	hostHint string,
+) (string, error) {
+	host := hostHint
+	if host == "" {
+		host = s.hostFor(owner, name)
+	}
+	if !s.isTrackedRepoOnHost(owner, name, host) {
+		return "", fmt.Errorf("repo %s/%s on %s is not tracked", owner, name, host)
 	}
 
-	// GitHub's Issues API returns both issues and PRs. If the
-	// response has PullRequestLinks, it's a PR.
-	host := s.hostFor(owner, name)
 	repo := RepoRef{Owner: owner, Name: name, PlatformHost: host}
 	client, err := s.clientFor(repo)
 	if err != nil {
@@ -4104,7 +4123,7 @@ func (s *Syncer) SyncItemByNumber(
 	}
 
 	if ghIssue.PullRequestLinks != nil {
-		if err := s.SyncMR(ctx, owner, name, number); err != nil {
+		if err := s.syncMRWithHost(ctx, owner, name, number, host); err != nil {
 			// A DiffSyncError means the PR row, timeline, and CI status
 			// were upserted successfully and only the diff computation
 			// failed. The item type is known, so resolution can still
@@ -4123,7 +4142,7 @@ func (s *Syncer) SyncItemByNumber(
 		return "pr", nil
 	}
 
-	if err := s.SyncIssue(ctx, owner, name, number); err != nil {
+	if err := s.syncIssueWithHost(ctx, owner, name, number, host); err != nil {
 		return "", fmt.Errorf(
 			"sync issue %s/%s#%d: %w", owner, name, number, err,
 		)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3761,35 +3761,31 @@ func (s *Syncer) backfillRepo(
 
 // IsTrackedRepo checks whether the given repo is in the configured list.
 func (s *Syncer) IsTrackedRepo(owner, name string) bool {
-	s.reposMu.Lock()
-	repos := s.repos
-	s.reposMu.Unlock()
-	for _, r := range repos {
-		if strings.EqualFold(r.Owner, owner) &&
-			strings.EqualFold(r.Name, name) {
-			return true
-		}
-	}
-	return false
+	return len(s.matchingTrackedRepos(owner, name)) > 0
 }
 
 // IsTrackedRepoAmbiguous checks whether owner/name matches more than one
 // configured repo and therefore needs an explicit platform host.
 func (s *Syncer) IsTrackedRepoAmbiguous(owner, name string) bool {
+	return len(s.matchingTrackedRepos(owner, name)) > 1
+}
+
+func (s *Syncer) matchingTrackedRepos(owner, name string) []RepoRef {
 	s.reposMu.Lock()
-	repos := s.repos
-	s.reposMu.Unlock()
-	matches := 0
-	for _, r := range repos {
-		if strings.EqualFold(r.Owner, owner) &&
-			strings.EqualFold(r.Name, name) {
-			matches++
-			if matches > 1 {
-				return true
-			}
+	defer s.reposMu.Unlock()
+
+	var matches []RepoRef
+	for _, repo := range s.repos {
+		if sameRepoName(repo, owner, name) {
+			matches = append(matches, repo)
 		}
 	}
-	return false
+	return matches
+}
+
+func sameRepoName(repo RepoRef, owner, name string) bool {
+	return strings.EqualFold(repo.Owner, owner) &&
+		strings.EqualFold(repo.Name, name)
 }
 
 // TrackedRepos returns a snapshot of the tracked repositories.
@@ -3804,24 +3800,20 @@ func (s *Syncer) TrackedRepos() []RepoRef {
 // is in the configured list. Used by the watched-MR path where the
 // host is known and must match exactly.
 func (s *Syncer) isTrackedRepoOnHost(owner, name, host string) bool {
-	if host == "" {
-		host = "github.com"
-	}
-	s.reposMu.Lock()
-	repos := s.repos
-	s.reposMu.Unlock()
-	for _, r := range repos {
-		rHost := r.PlatformHost
-		if rHost == "" {
-			rHost = "github.com"
-		}
-		if strings.EqualFold(r.Owner, owner) &&
-			strings.EqualFold(r.Name, name) &&
-			strings.EqualFold(rHost, host) {
+	host = defaultPlatformHost(host)
+	for _, repo := range s.matchingTrackedRepos(owner, name) {
+		if strings.EqualFold(defaultPlatformHost(repo.PlatformHost), host) {
 			return true
 		}
 	}
 	return false
+}
+
+func defaultPlatformHost(host string) string {
+	if host == "" {
+		return "github.com"
+	}
+	return host
 }
 
 // IsTrackedRepoOnHost checks whether the given repo on a specific host

--- a/internal/repoidentity/repoidentity.go
+++ b/internal/repoidentity/repoidentity.go
@@ -1,0 +1,193 @@
+package repoidentity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/wesm/middleman/internal/db"
+)
+
+// Store is the persistence surface needed to resolve repository identity.
+type Store interface {
+	ListReposByOwnerName(ctx context.Context, owner, name string) ([]db.Repo, error)
+	GetRepoByHostOwnerName(
+		ctx context.Context,
+		platformHost, owner, name string,
+	) (*db.Repo, error)
+	GetMergeRequestByRepoIDAndNumber(
+		ctx context.Context,
+		repoID int64,
+		number int,
+	) (*db.MergeRequest, error)
+	GetIssueByRepoIDAndNumber(
+		ctx context.Context,
+		repoID int64,
+		number int,
+	) (*db.Issue, error)
+	ResolveItemNumber(
+		ctx context.Context,
+		repoID int64,
+		number int,
+	) (itemType string, found bool, err error)
+}
+
+type Ref struct {
+	Owner        string
+	Name         string
+	PlatformHost string
+}
+
+type NumberRef struct {
+	Owner        string
+	Name         string
+	Number       int
+	PlatformHost string
+}
+
+type ResolvedLocalItem struct {
+	Repo     *db.Repo
+	ItemType string
+	Found    bool
+}
+
+var (
+	ErrAmbiguous = errors.New("repo ambiguous")
+	ErrNotFound  = errors.New("repo not found")
+)
+
+type Module struct {
+	store Store
+}
+
+func New(store Store) Module {
+	return Module{store: store}
+}
+
+func (m Module) LookupRepo(ctx context.Context, ref Ref) (*db.Repo, error) {
+	ref = normalizeRef(ref)
+	if ref.PlatformHost != "" {
+		return m.lookupRepoOnHost(ctx, ref)
+	}
+	repos, err := m.store.ListReposByOwnerName(ctx, ref.Owner, ref.Name)
+	if err != nil {
+		return nil, fmt.Errorf("list matching repos: %w", err)
+	}
+	switch len(repos) {
+	case 0:
+		return nil, ErrNotFound
+	case 1:
+		return &repos[0], nil
+	default:
+		return nil, ErrAmbiguous
+	}
+}
+
+func (m Module) LookupRepoID(ctx context.Context, ref Ref) (int64, error) {
+	repo, err := m.LookupRepo(ctx, ref)
+	if err != nil {
+		return 0, err
+	}
+	return repo.ID, nil
+}
+
+func (m Module) LookupMRID(ctx context.Context, ref NumberRef) (int64, error) {
+	repo, err := m.LookupRepo(ctx, Ref{
+		Owner:        ref.Owner,
+		Name:         ref.Name,
+		PlatformHost: ref.PlatformHost,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	mr, err := m.store.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, ref.Number)
+	if err != nil {
+		return 0, err
+	}
+	if mr == nil {
+		return 0, fmt.Errorf("MR %s/%s#%d not found", ref.Owner, ref.Name, ref.Number)
+	}
+	return mr.ID, nil
+}
+
+func (m Module) LookupIssueID(ctx context.Context, ref NumberRef) (int64, error) {
+	_, issue, err := m.LookupIssue(ctx, ref)
+	if err != nil {
+		return 0, err
+	}
+	return issue.ID, nil
+}
+
+func (m Module) LookupIssue(
+	ctx context.Context,
+	ref NumberRef,
+) (*db.Repo, *db.Issue, error) {
+	repo, err := m.LookupRepo(ctx, Ref{
+		Owner:        ref.Owner,
+		Name:         ref.Name,
+		PlatformHost: ref.PlatformHost,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	issue, err := m.store.GetIssueByRepoIDAndNumber(ctx, repo.ID, ref.Number)
+	if err != nil {
+		return nil, nil, err
+	}
+	if issue == nil {
+		return repo, nil, fmt.Errorf(
+			"issue %s/%s#%d not found", ref.Owner, ref.Name, ref.Number,
+		)
+	}
+	return repo, issue, nil
+}
+
+func (m Module) ResolveLocalItem(
+	ctx context.Context,
+	ref NumberRef,
+) (ResolvedLocalItem, error) {
+	repo, err := m.LookupRepo(ctx, Ref{
+		Owner:        ref.Owner,
+		Name:         ref.Name,
+		PlatformHost: ref.PlatformHost,
+	})
+	if errors.Is(err, ErrNotFound) {
+		return ResolvedLocalItem{}, nil
+	}
+	if err != nil {
+		return ResolvedLocalItem{}, err
+	}
+
+	itemType, found, err := m.store.ResolveItemNumber(ctx, repo.ID, ref.Number)
+	if err != nil {
+		return ResolvedLocalItem{}, err
+	}
+	return ResolvedLocalItem{
+		Repo:     repo,
+		ItemType: itemType,
+		Found:    found,
+	}, nil
+}
+
+func (m Module) lookupRepoOnHost(ctx context.Context, ref Ref) (*db.Repo, error) {
+	repo, err := m.store.GetRepoByHostOwnerName(
+		ctx, ref.PlatformHost, ref.Owner, ref.Name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get repo: %w", err)
+	}
+	if repo == nil {
+		return nil, ErrNotFound
+	}
+	return repo, nil
+}
+
+func normalizeRef(ref Ref) Ref {
+	return Ref{
+		Owner:        strings.ToLower(strings.TrimSpace(ref.Owner)),
+		Name:         strings.ToLower(strings.TrimSpace(ref.Name)),
+		PlatformHost: strings.ToLower(strings.TrimSpace(ref.PlatformHost)),
+	}
+}

--- a/internal/repoidentity/repoidentity.go
+++ b/internal/repoidentity/repoidentity.go
@@ -11,7 +11,6 @@ import (
 
 // Store is the persistence surface needed to resolve repository identity.
 type Store interface {
-	ListReposByOwnerName(ctx context.Context, owner, name string) ([]db.Repo, error)
 	GetRepoByHostOwnerName(
 		ctx context.Context,
 		platformHost, owner, name string,
@@ -53,8 +52,9 @@ type ResolvedLocalItem struct {
 }
 
 var (
-	ErrAmbiguous = errors.New("repo ambiguous")
-	ErrNotFound  = errors.New("repo not found")
+	ErrAmbiguous           = errors.New("repo ambiguous")
+	ErrMissingPlatformHost = errors.New("platform host is required")
+	ErrNotFound            = errors.New("repo not found")
 )
 
 type Module struct {
@@ -67,21 +67,10 @@ func New(store Store) Module {
 
 func (m Module) LookupRepo(ctx context.Context, ref Ref) (*db.Repo, error) {
 	ref = normalizeRef(ref)
-	if ref.PlatformHost != "" {
-		return m.lookupRepoOnHost(ctx, ref)
+	if ref.PlatformHost == "" {
+		return nil, ErrMissingPlatformHost
 	}
-	repos, err := m.store.ListReposByOwnerName(ctx, ref.Owner, ref.Name)
-	if err != nil {
-		return nil, fmt.Errorf("list matching repos: %w", err)
-	}
-	switch len(repos) {
-	case 0:
-		return nil, ErrNotFound
-	case 1:
-		return &repos[0], nil
-	default:
-		return nil, ErrAmbiguous
-	}
+	return m.lookupRepoOnHost(ctx, ref)
 }
 
 func (m Module) LookupRepoID(ctx context.Context, ref Ref) (int64, error) {

--- a/internal/repoidentity/repoidentity_test.go
+++ b/internal/repoidentity/repoidentity_test.go
@@ -9,14 +9,13 @@ import (
 	"github.com/wesm/middleman/internal/db"
 )
 
-func TestLookupRepoRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testing.T) {
+func TestLookupRepoRequiresPlatformHost(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
 	store := &fakeStore{
 		repos: []db.Repo{
 			{ID: 1, PlatformHost: "github.com", Owner: "acme", Name: "widget"},
-			{ID: 2, PlatformHost: "ghe.example.com", Owner: "acme", Name: "widget"},
 		},
 	}
 	module := New(store)
@@ -25,17 +24,18 @@ func TestLookupRepoRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testing.T) {
 		Owner: " Acme ",
 		Name:  "Widget",
 	})
-	require.ErrorIs(err, ErrAmbiguous)
+	require.ErrorIs(err, ErrMissingPlatformHost)
 	assert.Nil(repo)
+	assert.Zero(store.listReposByOwnerNameCalls)
 
 	repo, err = module.LookupRepo(t.Context(), Ref{
 		Owner:        " Acme ",
 		Name:         "Widget",
-		PlatformHost: "GHE.EXAMPLE.COM",
+		PlatformHost: "GITHUB.COM",
 	})
 	require.NoError(err)
 	require.NotNil(repo)
-	assert.EqualValues(2, repo.ID)
+	assert.EqualValues(1, repo.ID)
 }
 
 func TestLookupIssueUsesRepoIDAfterHostSelection(t *testing.T) {
@@ -70,9 +70,10 @@ func TestResolveLocalItemTreatsMissingLocalRepoAsUnresolved(t *testing.T) {
 	require := require.New(t)
 
 	result, err := New(&fakeStore{}).ResolveLocalItem(t.Context(), NumberRef{
-		Owner:  "acme",
-		Name:   "widget",
-		Number: 99,
+		Owner:        "acme",
+		Name:         "widget",
+		Number:       99,
+		PlatformHost: "github.com",
 	})
 	require.NoError(err)
 	assert.False(result.Found)
@@ -80,16 +81,18 @@ func TestResolveLocalItemTreatsMissingLocalRepoAsUnresolved(t *testing.T) {
 }
 
 type fakeStore struct {
-	repos  []db.Repo
-	mrs    map[int64]map[int]*db.MergeRequest
-	issues map[int64]map[int]*db.Issue
-	items  map[int64]map[int]string
+	repos                     []db.Repo
+	mrs                       map[int64]map[int]*db.MergeRequest
+	issues                    map[int64]map[int]*db.Issue
+	items                     map[int64]map[int]string
+	listReposByOwnerNameCalls int
 }
 
 func (f *fakeStore) ListReposByOwnerName(
 	_ context.Context,
 	owner, name string,
 ) ([]db.Repo, error) {
+	f.listReposByOwnerNameCalls++
 	var repos []db.Repo
 	for _, repo := range f.repos {
 		if repo.Owner == owner && repo.Name == name {

--- a/internal/repoidentity/repoidentity_test.go
+++ b/internal/repoidentity/repoidentity_test.go
@@ -1,0 +1,149 @@
+package repoidentity
+
+import (
+	"context"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/db"
+)
+
+func TestLookupRepoRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	store := &fakeStore{
+		repos: []db.Repo{
+			{ID: 1, PlatformHost: "github.com", Owner: "acme", Name: "widget"},
+			{ID: 2, PlatformHost: "ghe.example.com", Owner: "acme", Name: "widget"},
+		},
+	}
+	module := New(store)
+
+	repo, err := module.LookupRepo(t.Context(), Ref{
+		Owner: " Acme ",
+		Name:  "Widget",
+	})
+	require.ErrorIs(err, ErrAmbiguous)
+	assert.Nil(repo)
+
+	repo, err = module.LookupRepo(t.Context(), Ref{
+		Owner:        " Acme ",
+		Name:         "Widget",
+		PlatformHost: "GHE.EXAMPLE.COM",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	assert.EqualValues(2, repo.ID)
+}
+
+func TestLookupIssueUsesRepoIDAfterHostSelection(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	store := &fakeStore{
+		repos: []db.Repo{
+			{ID: 1, PlatformHost: "github.com", Owner: "acme", Name: "widget"},
+			{ID: 2, PlatformHost: "ghe.example.com", Owner: "acme", Name: "widget"},
+		},
+		issues: map[int64]map[int]*db.Issue{
+			1: {5: {ID: 101, RepoID: 1, Number: 5}},
+			2: {5: {ID: 202, RepoID: 2, Number: 5}},
+		},
+	}
+	module := New(store)
+
+	_, issue, err := module.LookupIssue(t.Context(), NumberRef{
+		Owner:        "acme",
+		Name:         "widget",
+		Number:       5,
+		PlatformHost: "ghe.example.com",
+	})
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.EqualValues(202, issue.ID)
+}
+
+func TestResolveLocalItemTreatsMissingLocalRepoAsUnresolved(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	result, err := New(&fakeStore{}).ResolveLocalItem(t.Context(), NumberRef{
+		Owner:  "acme",
+		Name:   "widget",
+		Number: 99,
+	})
+	require.NoError(err)
+	assert.False(result.Found)
+	assert.Nil(result.Repo)
+}
+
+type fakeStore struct {
+	repos  []db.Repo
+	mrs    map[int64]map[int]*db.MergeRequest
+	issues map[int64]map[int]*db.Issue
+	items  map[int64]map[int]string
+}
+
+func (f *fakeStore) ListReposByOwnerName(
+	_ context.Context,
+	owner, name string,
+) ([]db.Repo, error) {
+	var repos []db.Repo
+	for _, repo := range f.repos {
+		if repo.Owner == owner && repo.Name == name {
+			repos = append(repos, repo)
+		}
+	}
+	return repos, nil
+}
+
+func (f *fakeStore) GetRepoByHostOwnerName(
+	_ context.Context,
+	platformHost, owner, name string,
+) (*db.Repo, error) {
+	for i := range f.repos {
+		repo := &f.repos[i]
+		if repo.PlatformHost == platformHost &&
+			repo.Owner == owner &&
+			repo.Name == name {
+			return repo, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeStore) GetMergeRequestByRepoIDAndNumber(
+	_ context.Context,
+	repoID int64,
+	number int,
+) (*db.MergeRequest, error) {
+	if f.mrs == nil {
+		return nil, nil
+	}
+	return f.mrs[repoID][number], nil
+}
+
+func (f *fakeStore) GetIssueByRepoIDAndNumber(
+	_ context.Context,
+	repoID int64,
+	number int,
+) (*db.Issue, error) {
+	if f.issues == nil {
+		return nil, nil
+	}
+	return f.issues[repoID][number], nil
+}
+
+func (f *fakeStore) ResolveItemNumber(
+	_ context.Context,
+	repoID int64,
+	number int,
+) (string, bool, error) {
+	if f.items == nil {
+		return "", false, nil
+	}
+	itemType := f.items[repoID][number]
+	return itemType, itemType != "", nil
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2138,6 +2138,7 @@ func TestAPISetKanbanState(t *testing.T) {
 		"acme",
 		"widget",
 		1,
+		nil,
 		generated.SetKanbanStateJSONRequestBody{Status: "reviewing"},
 	)
 	require.NoError(err)
@@ -2159,11 +2160,86 @@ func TestAPISetKanbanStateRejectsInvalidStatus(t *testing.T) {
 		"acme",
 		"widget",
 		1,
+		nil,
 		generated.SetKanbanStateJSONRequestBody{Status: "nonsense"},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
 	require.NotNil(t, resp.ApplicationproblemJSONDefault)
+}
+
+func TestAPISetKanbanStateRejectsAmbiguousRepo(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPut,
+		"/api/v1/repos/acme/widget/pulls/1/state",
+		map[string]string{"status": "reviewing"},
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+
+	githubRepo, err := database.GetRepoByHostOwnerName(t.Context(), "github.com", "acme", "widget")
+	require.NoError(err)
+	require.NotNil(githubRepo)
+	githubPR, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), githubRepo.ID, 1)
+	require.NoError(err)
+	require.NotNil(githubPR)
+	assert.Equal("new", githubPR.KanbanStatus)
+
+	ghesRepo, err := database.GetRepoByHostOwnerName(t.Context(), "ghe.example.com", "acme", "widget")
+	require.NoError(err)
+	require.NotNil(ghesRepo)
+	ghesPR, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), ghesRepo.ID, 1)
+	require.NoError(err)
+	require.NotNil(ghesPR)
+	assert.Equal("new", ghesPR.KanbanStatus)
+}
+
+func TestAPISetKanbanStateUsesPlatformHostQuery(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPut,
+		"/api/v1/repos/acme/widget/pulls/1/state?platform_host=ghe.example.com",
+		map[string]string{"status": "reviewing"},
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+
+	githubRepo, err := database.GetRepoByHostOwnerName(t.Context(), "github.com", "acme", "widget")
+	require.NoError(err)
+	require.NotNil(githubRepo)
+	githubPR, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), githubRepo.ID, 1)
+	require.NoError(err)
+	require.NotNil(githubPR)
+	assert.Equal("new", githubPR.KanbanStatus)
+
+	ghesRepo, err := database.GetRepoByHostOwnerName(t.Context(), "ghe.example.com", "acme", "widget")
+	require.NoError(err)
+	require.NotNil(ghesRepo)
+	ghesPR, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), ghesRepo.ID, 1)
+	require.NoError(err)
+	require.NotNil(ghesPR)
+	assert.Equal("reviewing", ghesPR.KanbanStatus)
 }
 
 func TestAPIListRepos(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -616,11 +616,11 @@ func TestAPIMergePR405ReturnsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.MergePRInputBody{
+		generated.PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
 			Method:        "squash",
+			PlatformHost:  "github.com",
 		},
 	)
 	require.NoError(err)
@@ -646,11 +646,11 @@ func TestAPIMergePR409ReturnsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.MergePRInputBody{
+		generated.PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
 			Method:        "squash",
+			PlatformHost:  "github.com",
 		},
 	)
 	require.NoError(err)
@@ -673,11 +673,11 @@ func TestAPIMergePRNetworkErrorReturns502(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.MergePRInputBody{
+		generated.PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
 			Method:        "squash",
+			PlatformHost:  "github.com",
 		},
 	)
 	require.NoError(err)
@@ -703,11 +703,11 @@ func TestAPIMergePR422ForwardsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.MergePRInputBody{
+		generated.PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
 			Method:        "squash",
+			PlatformHost:  "github.com",
 		},
 	)
 	require.NoError(err)
@@ -733,11 +733,11 @@ func TestAPIMergePR403ForwardsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.MergePRInputBody{
+		generated.PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
 			Method:        "squash",
+			PlatformHost:  "github.com",
 		},
 	)
 	require.NoError(err)
@@ -763,11 +763,11 @@ func TestAPIMergePR5xxReturns502WithGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.MergePRInputBody{
+		generated.PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
 			Method:        "squash",
+			PlatformHost:  "github.com",
 		},
 	)
 	require.NoError(err)
@@ -786,11 +786,11 @@ func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.MergePRInputBody{
+		generated.PostReposByOwnerByNamePullsByNumberMergeJSONRequestBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
 			Method:        "squash",
+			PlatformHost:  "github.com",
 		},
 	)
 	require.NoError(err)
@@ -1130,7 +1130,7 @@ func TestAPIApproveWorkflows(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1182,7 +1182,7 @@ func TestAPIApproveWorkflowsZeroMatchesStillSyncsPR(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1252,7 +1252,7 @@ func TestAPIApproveWorkflowsReturnsUnderlyingApprovalErrorAfterPartialFailure(t 
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -1389,7 +1389,7 @@ func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1515,7 +1515,7 @@ func TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1583,7 +1583,7 @@ func TestAPIApproveWorkflowsRejectsRunFromDifferentForkAtSameSHA(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberApproveWorkflowsJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -2142,8 +2142,10 @@ func TestAPISetKanbanState(t *testing.T) {
 		"acme",
 		"widget",
 		1,
-		nil,
-		generated.SetKanbanStateJSONRequestBody{Status: "reviewing"},
+		generated.SetKanbanStateJSONRequestBody{
+			Status:       "reviewing",
+			PlatformHost: "github.com",
+		},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -2164,8 +2166,10 @@ func TestAPISetKanbanStateRejectsInvalidStatus(t *testing.T) {
 		"acme",
 		"widget",
 		1,
-		nil,
-		generated.SetKanbanStateJSONRequestBody{Status: "nonsense"},
+		generated.SetKanbanStateJSONRequestBody{
+			Status:       "nonsense",
+			PlatformHost: "github.com",
+		},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -2187,7 +2191,10 @@ func TestAPISetKanbanStateRejectsAmbiguousRepo(t *testing.T) {
 		srv,
 		http.MethodPut,
 		"/api/v1/repos/acme/widget/pulls/1/state",
-		map[string]string{"status": "reviewing"},
+		map[string]string{
+			"status":        "reviewing",
+			"platform_host": "",
+		},
 	)
 
 	require.Equal(http.StatusBadRequest, rr.Code)
@@ -2209,7 +2216,7 @@ func TestAPISetKanbanStateRejectsAmbiguousRepo(t *testing.T) {
 	assert.Equal("new", ghesPR.KanbanStatus)
 }
 
-func TestAPISetKanbanStateUsesPlatformHostQuery(t *testing.T) {
+func TestAPISetKanbanStateUsesPlatformHostBody(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
@@ -2223,8 +2230,11 @@ func TestAPISetKanbanStateUsesPlatformHostQuery(t *testing.T) {
 		t,
 		srv,
 		http.MethodPut,
-		"/api/v1/repos/acme/widget/pulls/1/state?platform_host=ghe.example.com",
-		map[string]string{"status": "reviewing"},
+		"/api/v1/repos/acme/widget/pulls/1/state",
+		map[string]string{
+			"status":        "reviewing",
+			"platform_host": "ghe.example.com",
+		},
 	)
 
 	require.Equal(http.StatusOK, rr.Code)
@@ -2869,8 +2879,7 @@ func TestAPIPostPrCommentAllowsMixedCaseTrackedRepo(t *testing.T) {
 		"acme",
 		"widget",
 		7,
-		nil,
-		generated.PostPrCommentJSONRequestBody{Body: "looks good"},
+		generated.PostPrCommentJSONRequestBody{Body: "looks good", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusCreated, resp.StatusCode())
@@ -2913,7 +2922,7 @@ func TestAPIEditPrCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/7/comments/9876",
-		strings.NewReader(`{"body":"edited body"}`),
+		strings.NewReader(`{"body":"edited body","platform_host":"github.com"}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -2957,7 +2966,7 @@ func TestAPIEditPrCommentRejectsCommentFromDifferentPR(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/7/comments/5555",
-		strings.NewReader(`{"body":"wrong target"}`),
+		strings.NewReader(`{"body":"wrong target","platform_host":"github.com"}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -3004,7 +3013,7 @@ func TestAPIEditIssueCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPatch,
 		"/api/v1/repos/acme/widget/issues/5/comments/1234",
-		strings.NewReader(`{"body":"edited issue body"}`),
+		strings.NewReader(`{"body":"edited issue body","platform_host":"github.com"}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -3048,7 +3057,7 @@ func TestAPIEditIssueCommentRejectsCommentFromDifferentIssue(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPatch,
 		"/api/v1/repos/acme/widget/issues/5/comments/6666",
-		strings.NewReader(`{"body":"wrong target"}`),
+		strings.NewReader(`{"body":"wrong target","platform_host":"github.com"}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -3364,7 +3373,7 @@ func TestAPIReadyForReview(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -3529,8 +3538,7 @@ func TestAPIClosePR(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
+		generated.SetPrGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -3556,8 +3564,7 @@ func TestAPIReopenPR(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		ctx, "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "open"},
+		generated.SetPrGithubStateJSONRequestBody{State: "open", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -3582,8 +3589,7 @@ func TestAPIClosePRRejectsMerged(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		ctx, "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "open"},
+		generated.SetPrGithubStateJSONRequestBody{State: "open", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusConflict, resp.StatusCode())
@@ -3596,8 +3602,7 @@ func TestAPIClosePRInvalidState(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "nonsense"},
+		generated.SetPrGithubStateJSONRequestBody{State: "nonsense", PlatformHost: "github.com"},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -3614,8 +3619,7 @@ func TestAPICloseIssue(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
-		nil,
-		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
+		generated.SetIssueGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -3634,8 +3638,7 @@ func TestAPIReopenIssue(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
-		nil,
-		generated.SetIssueGithubStateJSONRequestBody{State: "open"},
+		generated.SetIssueGithubStateJSONRequestBody{State: "open", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -3706,8 +3709,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
+		generated.SetPrGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -4157,7 +4159,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -4242,8 +4244,7 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
-		nil,
-		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
+		generated.SetIssueGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -4881,7 +4882,7 @@ func TestAPISetIssueStateUsesPlatformHostBody(t *testing.T) {
 	assert.Equal("closed", ghesIssue.State)
 }
 
-func TestAPISetIssueStateUsesPlatformHostQuery(t *testing.T) {
+func TestAPISetIssueStateIgnoresPlatformHostQuery(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
 	ctx := context.Background()
@@ -4967,9 +4968,9 @@ func TestAPISetIssueStateUsesPlatformHostQuery(t *testing.T) {
 	rr := httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	require.Equal(http.StatusUnprocessableEntity, rr.Code, rr.Body.String())
 	assert.Zero(githubEditCalls)
-	assert.Equal(1, ghesEditCalls)
+	assert.Zero(ghesEditCalls)
 
 	githubRepo, err := database.GetRepoByHostOwnerName(
 		ctx, "github.com", "acme", "widget",
@@ -4993,7 +4994,7 @@ func TestAPISetIssueStateUsesPlatformHostQuery(t *testing.T) {
 	)
 	require.NoError(err)
 	require.NotNil(ghesIssue)
-	assert.Equal("closed", ghesIssue.State)
+	assert.Equal("open", ghesIssue.State)
 }
 
 // TestAPIIssueDataFromGraphQLSync verifies the API correctly serves
@@ -6715,8 +6716,7 @@ func TestAPISetIssueGitHubStateReturns404WhenNoClientConfigured(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		ctx, "acme", "widget", 5,
-		nil,
-		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
+		generated.SetIssueGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusNotFound, resp.StatusCode())
@@ -6742,8 +6742,7 @@ func TestAPIClosePR422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
+		generated.SetPrGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -6776,8 +6775,7 @@ func TestAPICloseIssue422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
-		nil,
-		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
+		generated.SetIssueGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -6819,8 +6817,7 @@ func TestAPIClosePR422AlreadyClosed(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
+		generated.SetPrGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6844,7 +6841,7 @@ func TestAPIReadyForReview502OnNilPR(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -6863,7 +6860,7 @@ func TestAPIReadyForReviewReturnsUnderlyingErrorDetail(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -6928,7 +6925,7 @@ func TestAPIReadyForReviewStaleStateRefreshesAndReturnsSuccess(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6982,7 +6979,7 @@ func TestAPIReadyForReview404RefreshesStaleDraftState(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
+		generated.PostReposByOwnerByNamePullsByNumberReadyForReviewJSONRequestBody{PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -7015,7 +7012,7 @@ func TestAPIReadyForReviewRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 		srv,
 		http.MethodPost,
 		"/api/v1/repos/acme/widget/pulls/1/ready-for-review",
-		nil,
+		map[string]string{"platform_host": ""},
 	)
 
 	require.Equal(http.StatusBadRequest, rr.Code)
@@ -7044,7 +7041,7 @@ func TestAPIApprovePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 		srv,
 		http.MethodPost,
 		"/api/v1/repos/acme/widget/pulls/1/approve",
-		map[string]string{"body": "ship it"},
+		map[string]string{"body": "ship it", "platform_host": ""},
 	)
 
 	require.Equal(http.StatusBadRequest, rr.Code)
@@ -7081,7 +7078,7 @@ func TestAPIApprovePRRejectsAmbiguousTrackedRepoBeforeMutation(t *testing.T) {
 		srv,
 		http.MethodPost,
 		"/api/v1/repos/acme/widget/pulls/1/approve",
-		map[string]string{"body": "ship it"},
+		map[string]string{"body": "ship it", "platform_host": ""},
 	)
 
 	require.Equal(http.StatusBadRequest, rr.Code)
@@ -7110,7 +7107,7 @@ func TestAPISetPRGitHubStateRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 		srv,
 		http.MethodPost,
 		"/api/v1/repos/acme/widget/pulls/1/github-state",
-		map[string]string{"state": "closed"},
+		map[string]string{"state": "closed", "platform_host": ""},
 	)
 
 	require.Equal(http.StatusBadRequest, rr.Code)
@@ -7139,7 +7136,7 @@ func TestAPIEditPRContentRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 		srv,
 		http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]string{"title": "New title"},
+		map[string]string{"title": "New title", "platform_host": ""},
 	)
 
 	require.Equal(http.StatusBadRequest, rr.Code)
@@ -7169,14 +7166,14 @@ func TestAPIPostPrCommentRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 		srv,
 		http.MethodPost,
 		"/api/v1/repos/acme/widget/pulls/1/comments",
-		map[string]string{"body": "hello"},
+		map[string]string{"body": "hello", "platform_host": ""},
 	)
 
 	require.Equal(http.StatusBadRequest, rr.Code)
 	assert.Zero(commentCalls)
 }
 
-func TestAPIApprovePRUsesPlatformHostQuery(t *testing.T) {
+func TestAPIApprovePRUsesPlatformHostBody(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -7233,8 +7230,11 @@ func TestAPIApprovePRUsesPlatformHostQuery(t *testing.T) {
 		t,
 		srv,
 		http.MethodPost,
-		"/api/v1/repos/acme/widget/pulls/7/approve?platform_host=ghe.example.com",
-		map[string]string{"body": "ship it"},
+		"/api/v1/repos/acme/widget/pulls/7/approve",
+		map[string]string{
+			"body":          "ship it",
+			"platform_host": "ghe.example.com",
+		},
 	)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
@@ -7268,6 +7268,7 @@ func TestAPIMergePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 			"commit_title":   "title",
 			"commit_message": "body",
 			"method":         "squash",
+			"platform_host":  "",
 		},
 	)
 
@@ -7275,7 +7276,7 @@ func TestAPIMergePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 	assert.Zero(mergeCalls)
 }
 
-func TestAPIMergePRUsesPlatformHostQuery(t *testing.T) {
+func TestAPIMergePRUsesPlatformHostBody(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -7331,11 +7332,12 @@ func TestAPIMergePRUsesPlatformHostQuery(t *testing.T) {
 		t,
 		srv,
 		http.MethodPost,
-		"/api/v1/repos/acme/widget/pulls/7/merge?platform_host=ghe.example.com",
+		"/api/v1/repos/acme/widget/pulls/7/merge",
 		map[string]string{
 			"commit_title":   "title",
 			"commit_message": "body",
 			"method":         "squash",
+			"platform_host":  "ghe.example.com",
 		},
 	)
 
@@ -7390,8 +7392,7 @@ func TestAPIClosePR422Merged(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
-		nil,
-		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
+		generated.SetPrGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusConflict, resp.StatusCode())
@@ -7643,8 +7644,7 @@ func TestAPICloseIssue422AlreadyClosed(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
-		nil,
-		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
+		generated.SetIssueGithubStateJSONRequestBody{State: "closed", PlatformHost: "github.com"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -12742,7 +12742,7 @@ func TestAPIEditPRTitleAndBody(t *testing.T) {
 
 	rr := doJSON(t, srv, http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]string{"title": "updated title", "body": "updated body"})
+		map[string]string{"title": "updated title", "body": "updated body", "platform_host": "github.com"})
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -12760,7 +12760,7 @@ func TestAPIEditPRTitleOnly(t *testing.T) {
 
 	rr := doJSON(t, srv, http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]string{"title": "new title"})
+		map[string]string{"title": "new title", "platform_host": "github.com"})
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -12778,7 +12778,7 @@ func TestAPIEditPRBodyOnly(t *testing.T) {
 
 	rr := doJSON(t, srv, http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]string{"body": "new body"})
+		map[string]string{"body": "new body", "platform_host": "github.com"})
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -12796,7 +12796,7 @@ func TestAPIEditPRClearBody(t *testing.T) {
 
 	rr := doJSON(t, srv, http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]string{"body": ""})
+		map[string]string{"body": "", "platform_host": "github.com"})
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -12814,7 +12814,7 @@ func TestAPIEditPRNoFields400(t *testing.T) {
 
 	rr := doJSON(t, srv, http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]any{})
+		map[string]any{"platform_host": "github.com"})
 	require.Equal(http.StatusBadRequest, rr.Code)
 }
 
@@ -12825,7 +12825,7 @@ func TestAPIEditPRBlankTitle400(t *testing.T) {
 
 	rr := doJSON(t, srv, http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]string{"title": "   "})
+		map[string]string{"title": "   ", "platform_host": "github.com"})
 	require.Equal(http.StatusBadRequest, rr.Code)
 }
 
@@ -12849,7 +12849,7 @@ func TestAPIEditPRPreservesDerivedFields(t *testing.T) {
 
 	rr := doJSON(t, srv, http.MethodPatch,
 		"/api/v1/repos/acme/widget/pulls/1",
-		map[string]string{"title": "changed title"})
+		map[string]string{"title": "changed title", "platform_host": "github.com"})
 	require.Equal(http.StatusOK, rr.Code)
 
 	after, err := database.GetMergeRequest(ctx, "acme", "widget", 1)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -72,6 +72,7 @@ type mockGH struct {
 	getIssueFn                func(context.Context, string, string, int) (*gh.Issue, error)
 	createIssueFn             func(context.Context, string, string, string, string) (*gh.Issue, error)
 	getUserFn                 func(context.Context, string) (*gh.User, error)
+	createReviewFn            func(context.Context, string, string, int, string, string) (*gh.PullRequestReview, error)
 	markReadyForReviewFn      func(context.Context, string, string, int) (*gh.PullRequest, error)
 	editPullRequestFn         func(context.Context, string, string, int, ghclient.EditPullRequestOpts) (*gh.PullRequest, error)
 	editIssueFn               func(context.Context, string, string, int, string) (*gh.Issue, error)
@@ -303,8 +304,11 @@ func (m *mockGH) GetRepository(
 }
 
 func (m *mockGH) CreateReview(
-	_ context.Context, _, _ string, _ int, _ string, _ string,
+	ctx context.Context, owner, repo string, number int, event, body string,
 ) (*gh.PullRequestReview, error) {
+	if m.createReviewFn != nil {
+		return m.createReviewFn(ctx, owner, repo, number, event, body)
+	}
 	id := int64(99)
 	state := "APPROVED"
 	return &gh.PullRequestReview{ID: &id, State: &state}, nil
@@ -6810,6 +6814,101 @@ func TestAPIReadyForReviewRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 	assert.Zero(readyCalls)
 }
 
+func TestAPIApprovePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var reviewCalls int
+	mock := &mockGH{
+		createReviewFn: func(_ context.Context, _, _ string, _ int, _, _ string) (*gh.PullRequestReview, error) {
+			reviewCalls++
+			return nil, nil
+		},
+	}
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/1/approve",
+		map[string]string{"body": "ship it"},
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(reviewCalls)
+}
+
+func TestAPIApprovePRUsesPlatformHostQuery(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+	seedPROnHost(t, database, "github.com", "acme", "widget", 7)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 7)
+
+	var githubReviewCalls int
+	var ghesReviewCalls int
+	githubClient := &mockGH{
+		createReviewFn: func(_ context.Context, _, _ string, _ int, _, _ string) (*gh.PullRequestReview, error) {
+			githubReviewCalls++
+			return nil, errors.New("github.com client should not approve")
+		},
+	}
+	ghesClient := &mockGH{
+		createReviewFn: func(_ context.Context, _, _ string, number int, _, body string) (*gh.PullRequestReview, error) {
+			ghesReviewCalls++
+			id := int64(7700 + number)
+			state := "APPROVED"
+			submittedAt := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequestReview{
+				ID:          &id,
+				State:       &state,
+				Body:        &body,
+				SubmittedAt: &submittedAt,
+				User:        &gh.User{Login: new("reviewer")},
+			}, nil
+		},
+	}
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{
+			"github.com":      githubClient,
+			"ghe.example.com": ghesClient,
+		},
+		database,
+		nil,
+		[]ghclient.RepoRef{
+			{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+			{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+		},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/7/approve?platform_host=ghe.example.com",
+		map[string]string{"body": "ship it"},
+	)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.Zero(githubReviewCalls)
+	assert.Equal(1, ghesReviewCalls)
+}
+
 func TestAPIMergePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -6962,6 +7061,50 @@ func TestAPIClosePR422Merged(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusConflict, resp.StatusCode())
+}
+
+func TestAPIGetPullAmbiguousOwnerNameRequiresPlatformHost(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 7)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 7)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		t.Context(), "acme", "widget", 7, nil,
+	)
+
+	require.NoError(err)
+	require.Equal(http.StatusBadRequest, resp.StatusCode())
+}
+
+func TestAPIGetPullUsesPlatformHostQuery(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 7)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 7)
+	client := setupTestClient(t, srv)
+	platformHost := "ghe.example.com"
+
+	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
+		t.Context(), "acme", "widget", 7,
+		&generated.GetReposByOwnerByNamePullsByNumberParams{
+			PlatformHost: &platformHost,
+		},
+	)
+
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	assert.Equal("ghe.example.com", resp.JSON200.PlatformHost)
+	assert.Equal("https://ghe.example.com/acme/widget/pull/7", resp.JSON200.MergeRequest.URL)
 }
 
 func TestResolveItem_PR(t *testing.T) {
@@ -12061,9 +12204,12 @@ func TestWorkspacePRDetailPlatformHost(t *testing.T) {
 	ctx := t.Context()
 
 	// PR on github.com
+	githubHost := "github.com"
 	r1, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", 10,
-		nil,
+		&generated.GetReposByOwnerByNamePullsByNumberParams{
+			PlatformHost: &githubHost,
+		},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, r1.StatusCode())
@@ -12071,9 +12217,12 @@ func TestWorkspacePRDetailPlatformHost(t *testing.T) {
 	assert.Equal("github.com", r1.JSON200.PlatformHost)
 
 	// PR on ghe.example.com (same owner/name, different number)
+	ghesHost := "ghe.example.com"
 	r2, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", 20,
-		nil,
+		&generated.GetReposByOwnerByNamePullsByNumberParams{
+			PlatformHost: &ghesHost,
+		},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, r2.StatusCode())

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -6740,7 +6740,7 @@ func TestResolveItem_PR(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
-		t.Context(), "acme", "widget", 42,
+		t.Context(), "acme", "widget", 42, nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6758,12 +6758,54 @@ func TestResolveItem_Issue(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
-		t.Context(), "acme", "widget", 7,
+		t.Context(), "acme", "widget", 7, nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 	require.NotNil(resp.JSON200)
 	require.Equal("issue", resp.JSON200.ItemType)
+	require.EqualValues(7, resp.JSON200.Number)
+	require.True(resp.JSON200.RepoTracked)
+}
+
+func TestResolveItem_AmbiguousOwnerNameRequiresPlatformHost(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedIssueOnHost(t, database, "github.com", "acme", "widget", 7, "open", "GitHub issue")
+	seedIssueOnHost(t, database, "ghe.example.com", "acme", "widget", 7, "open", "GHE issue")
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
+		t.Context(), "acme", "widget", 7, nil,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusBadRequest, resp.StatusCode())
+}
+
+func TestResolveItem_ExplicitPlatformHostResolvesRepoScopedItem(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedIssueOnHost(t, database, "github.com", "acme", "widget", 7, "open", "GitHub issue")
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 7)
+	client := setupTestClient(t, srv)
+	platformHost := "ghe.example.com"
+
+	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
+		t.Context(), "acme", "widget", 7,
+		&generated.PostReposByOwnerByNameItemsByNumberResolveParams{
+			PlatformHost: &platformHost,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Equal("pr", resp.JSON200.ItemType)
 	require.EqualValues(7, resp.JSON200.Number)
 	require.True(resp.JSON200.RepoTracked)
 }
@@ -6774,7 +6816,7 @@ func TestResolveItem_UntrackedRepo(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
-		t.Context(), "unknown", "repo", 1,
+		t.Context(), "unknown", "repo", 1, nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6799,7 +6841,7 @@ func TestResolveItem_NotFoundOnGitHub(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
-		t.Context(), "acme", "widget", 999,
+		t.Context(), "acme", "widget", 999, nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusNotFound, resp.StatusCode())
@@ -6820,7 +6862,7 @@ func TestResolveItem_GitHubServerError(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
-		t.Context(), "acme", "widget", 999,
+		t.Context(), "acme", "widget", 999, nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -6785,6 +6785,30 @@ func TestResolveItem_AmbiguousOwnerNameRequiresPlatformHost(t *testing.T) {
 	require.Equal(http.StatusBadRequest, resp.StatusCode())
 }
 
+func TestResolveItem_AmbiguousTrackedRepoRequiresPlatformHostBeforeSync(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var getIssueCalls int
+	mock := &mockGH{
+		getIssueFn: func(_ context.Context, _, _ string, _ int) (*gh.Issue, error) {
+			getIssueCalls++
+			return nil, nil
+		},
+	}
+	srv, _ := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostReposByOwnerByNameItemsByNumberResolveWithResponse(
+		t.Context(), "acme", "widget", 7, nil,
+	)
+	require.NoError(err)
+	assert.Equal(http.StatusBadRequest, resp.StatusCode())
+	assert.Zero(getIssueCalls)
+}
+
 func TestResolveItem_ExplicitPlatformHostResolvesRepoScopedItem(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
@@ -6866,6 +6890,23 @@ func TestResolveItem_GitHubServerError(t *testing.T) {
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
+}
+
+func TestGetIssue_AmbiguousOwnerNameRequiresPlatformHost(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedIssueOnHost(t, database, "github.com", "acme", "widget", 7, "open", "GitHub issue")
+	seedIssueOnHost(t, database, "ghe.example.com", "acme", "widget", 7, "open", "GHE issue")
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.GetReposByOwnerByNameIssuesByNumberWithResponse(
+		t.Context(), "acme", "widget", 7, nil,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusBadRequest, resp.StatusCode())
 }
 
 func TestAPICloseIssue422AlreadyClosed(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2769,6 +2769,44 @@ func TestAPICreateIssue(t *testing.T) {
 	assert.Equal("a2eeef", issue.Labels[0].Color)
 }
 
+func TestAPICreateIssueRejectsAmbiguousTrackedRepoBeforeMutation(t *testing.T) {
+	require := require.New(t)
+	githubCalled := false
+	mock := &mockGH{
+		createIssueFn: func(_ context.Context, _, _, _, _ string) (*gh.Issue, error) {
+			githubCalled = true
+			return nil, errors.New("should reject before GitHub mutation")
+		},
+	}
+	srv, database := setupTestServerWithRepos(
+		t,
+		mock,
+		[]ghclient.RepoRef{
+			{Owner: "acme", Name: "widgets", PlatformHost: "github.com"},
+			{Owner: "acme", Name: "widgets", PlatformHost: "ghe.example.com"},
+		},
+	)
+	client := setupTestClient(t, srv)
+	_, err := database.UpsertRepo(t.Context(), "github.com", "acme", "widgets")
+	require.NoError(err)
+
+	resp, err := client.HTTP.CreateIssueWithResponse(
+		t.Context(),
+		"acme",
+		"widgets",
+		generated.CreateIssueJSONRequestBody{Title: "Ambiguous", Body: "No host"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusBadRequest, resp.StatusCode())
+	require.False(githubCalled)
+	require.NotNil(resp.ApplicationproblemJSONDefault)
+	require.NotNil(resp.ApplicationproblemJSONDefault.Detail)
+	require.Contains(
+		*resp.ApplicationproblemJSONDefault.Detail,
+		"platform_host is required for ambiguous repo",
+	)
+}
+
 func TestAPICreateIssueUsesPlatformHost(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -3403,6 +3441,39 @@ func TestAPISetStarred(t *testing.T) {
 	starred, err := database.IsStarred(t.Context(), "pr", 1, 1)
 	require.NoError(err)
 	require.True(starred)
+}
+
+func TestAPISetStarredRejectsAmbiguousTrackedRepo(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(
+		t,
+		&mockGH{},
+		[]ghclient.RepoRef{
+			{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+			{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+		},
+	)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.SetStarredWithResponse(t.Context(), generated.SetStarredJSONRequestBody{
+		ItemType: "pr",
+		Owner:    "acme",
+		Name:     "widget",
+		Number:   1,
+	})
+	require.NoError(err)
+	require.Equal(http.StatusBadRequest, resp.StatusCode())
+	require.NotNil(resp.ApplicationproblemJSONDefault)
+	require.NotNil(resp.ApplicationproblemJSONDefault.Detail)
+	require.Contains(
+		*resp.ApplicationproblemJSONDefault.Detail,
+		"platform_host is required for ambiguous repo",
+	)
+
+	starred, err := database.IsStarred(t.Context(), "pr", 1, 1)
+	require.NoError(err)
+	require.False(starred)
 }
 
 func TestAPIUnsetStarred(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -608,6 +608,7 @@ func TestAPIMergePR405ReturnsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
@@ -637,6 +638,7 @@ func TestAPIMergePR409ReturnsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
@@ -663,6 +665,7 @@ func TestAPIMergePRNetworkErrorReturns502(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
@@ -692,6 +695,7 @@ func TestAPIMergePR422ForwardsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
@@ -721,6 +725,7 @@ func TestAPIMergePR403ForwardsGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
@@ -750,6 +755,7 @@ func TestAPIMergePR5xxReturns502WithGitHubMessage(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
@@ -772,6 +778,7 @@ func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberMergeWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
 			CommitMessage: "msg",
@@ -1109,6 +1116,7 @@ func TestAPIApproveWorkflows(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1160,6 +1168,7 @@ func TestAPIApproveWorkflowsZeroMatchesStillSyncsPR(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1229,6 +1238,7 @@ func TestAPIApproveWorkflowsReturnsUnderlyingApprovalErrorAfterPartialFailure(t 
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -1364,6 +1374,7 @@ func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1488,6 +1499,7 @@ func TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1555,6 +1567,7 @@ func TestAPIApproveWorkflowsRejectsRunFromDifferentForkAtSameSHA(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberApproveWorkflowsWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -3248,6 +3261,7 @@ func TestAPIReadyForReview(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -4026,6 +4040,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -4597,6 +4612,32 @@ func TestAPISyncIssueUsesPlatformHostQuery(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(ghesIssue)
 	assert.Equal("GHES synced issue", ghesIssue.Title)
+}
+
+func TestAPISyncIssueRejectsAmbiguousTrackedRepoBeforeSync(t *testing.T) {
+	assert := Assert.New(t)
+	var getIssueCalls int
+	mock := &mockGH{
+		getIssueFn: func(_ context.Context, _, _ string, _ int) (*gh.Issue, error) {
+			getIssueCalls++
+			return nil, nil
+		},
+	}
+	srv, _ := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/issues/7/sync",
+		nil,
+	)
+
+	assert.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(getIssueCalls)
 }
 
 func TestAPISetIssueStateUsesPlatformHostBody(t *testing.T) {
@@ -6553,6 +6594,7 @@ func TestAPIReadyForReview502OnNilPR(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -6571,6 +6613,7 @@ func TestAPIReadyForReviewReturnsUnderlyingErrorDetail(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -6635,6 +6678,7 @@ func TestAPIReadyForReviewStaleStateRefreshesAndReturnsSuccess(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6688,6 +6732,7 @@ func TestAPIReadyForReview404RefreshesStaleDraftState(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberReadyForReviewWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6696,6 +6741,151 @@ func TestAPIReadyForReview404RefreshesStaleDraftState(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(pr)
 	require.False(pr.IsDraft)
+}
+
+func TestAPIReadyForReviewRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var readyCalls int
+	mock := &mockGH{
+		markReadyForReviewFn: func(_ context.Context, _, _ string, _ int) (*gh.PullRequest, error) {
+			readyCalls++
+			return nil, nil
+		},
+	}
+	srv, _ := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/1/ready-for-review",
+		nil,
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(readyCalls)
+}
+
+func TestAPIMergePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var mergeCalls int
+	mock := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, _ int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			mergeCalls++
+			return nil, nil
+		},
+	}
+	srv, _ := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/1/merge",
+		map[string]string{
+			"commit_title":   "title",
+			"commit_message": "body",
+			"method":         "squash",
+		},
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(mergeCalls)
+}
+
+func TestAPIMergePRUsesPlatformHostQuery(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+	seedPROnHost(t, database, "github.com", "acme", "widget", 7)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 7)
+
+	var githubMergeCalls int
+	var ghesMergeCalls int
+	githubClient := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, _ int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			githubMergeCalls++
+			return nil, errors.New("github.com client should not merge")
+		},
+	}
+	ghesClient := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, number int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			ghesMergeCalls++
+			merged := true
+			sha := "merge-sha"
+			msg := fmt.Sprintf("merged #%d", number)
+			return &gh.PullRequestMergeResult{
+				Merged:  &merged,
+				SHA:     &sha,
+				Message: &msg,
+			}, nil
+		},
+	}
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{
+			"github.com":      githubClient,
+			"ghe.example.com": ghesClient,
+		},
+		database,
+		nil,
+		[]ghclient.RepoRef{
+			{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+			{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+		},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/7/merge?platform_host=ghe.example.com",
+		map[string]string{
+			"commit_title":   "title",
+			"commit_message": "body",
+			"method":         "squash",
+		},
+	)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.Zero(githubMergeCalls)
+	assert.Equal(1, ghesMergeCalls)
+
+	githubRepo, err := database.GetRepoByHostOwnerName(ctx, "github.com", "acme", "widget")
+	require.NoError(err)
+	require.NotNil(githubRepo)
+	githubPR, err := database.GetMergeRequestByRepoIDAndNumber(ctx, githubRepo.ID, 7)
+	require.NoError(err)
+	require.NotNil(githubPR)
+	assert.Equal("open", githubPR.State)
+
+	ghesRepo, err := database.GetRepoByHostOwnerName(ctx, "ghe.example.com", "acme", "widget")
+	require.NoError(err)
+	require.NotNil(ghesRepo)
+	ghesPR, err := database.GetMergeRequestByRepoIDAndNumber(ctx, ghesRepo.ID, 7)
+	require.NoError(err)
+	require.NotNil(ghesPR)
+	assert.Equal("merged", ghesPR.State)
+	assert.NotNil(ghesPR.ClosedAt)
+	assert.NotNil(ghesPR.MergedAt)
 }
 
 func TestAPIClosePR422Merged(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -71,6 +71,7 @@ type mockGH struct {
 	getPullRequestFn          func(context.Context, string, string, int) (*gh.PullRequest, error)
 	getIssueFn                func(context.Context, string, string, int) (*gh.Issue, error)
 	createIssueFn             func(context.Context, string, string, string, string) (*gh.Issue, error)
+	createIssueCommentFn      func(context.Context, string, string, int, string) (*gh.IssueComment, error)
 	getUserFn                 func(context.Context, string) (*gh.User, error)
 	createReviewFn            func(context.Context, string, string, int, string, string) (*gh.PullRequestReview, error)
 	markReadyForReviewFn      func(context.Context, string, string, int) (*gh.PullRequest, error)
@@ -264,8 +265,11 @@ func (m *mockGH) ApproveWorkflowRun(
 }
 
 func (m *mockGH) CreateIssueComment(
-	_ context.Context, _, _ string, _ int, body string,
+	ctx context.Context, owner, repo string, number int, body string,
 ) (*gh.IssueComment, error) {
+	if m.createIssueCommentFn != nil {
+		return m.createIssueCommentFn(ctx, owner, repo, number, body)
+	}
 	id := int64(42)
 	return &gh.IssueComment{
 		ID:   &id,
@@ -2865,6 +2869,7 @@ func TestAPIPostPrCommentAllowsMixedCaseTrackedRepo(t *testing.T) {
 		"acme",
 		"widget",
 		7,
+		nil,
 		generated.PostPrCommentJSONRequestBody{Body: "looks good"},
 	)
 	require.NoError(err)
@@ -3524,6 +3529,7 @@ func TestAPIClosePR(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -3550,6 +3556,7 @@ func TestAPIReopenPR(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		ctx, "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "open"},
 	)
 	require.NoError(err)
@@ -3575,6 +3582,7 @@ func TestAPIClosePRRejectsMerged(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		ctx, "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "open"},
 	)
 	require.NoError(err)
@@ -3588,6 +3596,7 @@ func TestAPIClosePRInvalidState(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "nonsense"},
 	)
 	require.NoError(t, err)
@@ -3605,6 +3614,7 @@ func TestAPICloseIssue(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
+		nil,
 		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -3624,6 +3634,7 @@ func TestAPIReopenIssue(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
+		nil,
 		generated.SetIssueGithubStateJSONRequestBody{State: "open"},
 	)
 	require.NoError(err)
@@ -3695,6 +3706,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -4230,6 +4242,7 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
+		nil,
 		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -6587,6 +6600,7 @@ func TestAPISetIssueGitHubStateReturns404WhenNoClientConfigured(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		ctx, "acme", "widget", 5,
+		nil,
 		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -6613,6 +6627,7 @@ func TestAPIClosePR422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -6646,6 +6661,7 @@ func TestAPICloseIssue422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
+		nil,
 		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -6688,6 +6704,7 @@ func TestAPIClosePR422AlreadyClosed(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -6919,6 +6936,94 @@ func TestAPIApprovePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 	assert.Zero(reviewCalls)
 }
 
+func TestAPISetPRGitHubStateRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var editCalls int
+	mock := &mockGH{
+		editPullRequestFn: func(_ context.Context, _, _ string, _ int, _ ghclient.EditPullRequestOpts) (*gh.PullRequest, error) {
+			editCalls++
+			return nil, nil
+		},
+	}
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/1/github-state",
+		map[string]string{"state": "closed"},
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(editCalls)
+}
+
+func TestAPIEditPRContentRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var editCalls int
+	mock := &mockGH{
+		editPullRequestFn: func(_ context.Context, _, _ string, _ int, _ ghclient.EditPullRequestOpts) (*gh.PullRequest, error) {
+			editCalls++
+			return nil, nil
+		},
+	}
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPatch,
+		"/api/v1/repos/acme/widget/pulls/1",
+		map[string]string{"title": "New title"},
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(editCalls)
+}
+
+func TestAPIPostPrCommentRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var commentCalls int
+	mock := &mockGH{
+		createIssueCommentFn: func(_ context.Context, _, _ string, _ int, body string) (*gh.IssueComment, error) {
+			commentCalls++
+			id := int64(42)
+			return &gh.IssueComment{ID: &id, Body: &body}, nil
+		},
+	}
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/1/comments",
+		map[string]string{"body": "hello"},
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(commentCalls)
+}
+
 func TestAPIApprovePRUsesPlatformHostQuery(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -7133,6 +7238,7 @@ func TestAPIClosePR422Merged(t *testing.T) {
 
 	resp, err := client.HTTP.SetPrGithubStateWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 		generated.SetPrGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(t, err)
@@ -7385,6 +7491,7 @@ func TestAPICloseIssue422AlreadyClosed(t *testing.T) {
 
 	resp, err := client.HTTP.SetIssueGithubStateWithResponse(
 		t.Context(), "acme", "widget", 5,
+		nil,
 		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
 	)
 	require.NoError(err)
@@ -7573,6 +7680,7 @@ func TestAPIGetFiles503WhenCloneManagerNil(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberFilesWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusServiceUnavailable, resp.StatusCode())
@@ -8335,6 +8443,7 @@ func TestAPIGetCommits(t *testing.T) {
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberCommitsWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -8350,6 +8459,7 @@ func TestAPIGetCommits_NotFound(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberCommitsWithResponse(
 		t.Context(), "acme", "widget", 999,
+		nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode())

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -853,6 +853,7 @@ func TestAPIGetPull(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -872,6 +873,7 @@ func TestAPIGetPullAcceptsMixedCaseRepoPath(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "Acme", "Widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -929,6 +931,7 @@ func TestAPIGetPullIncludesBranches(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -951,6 +954,7 @@ func TestAPIGetPullIncludesLabels(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -983,6 +987,7 @@ func TestAPIGetPullIsDBOnly(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1042,6 +1047,7 @@ func TestAPISyncPRIncludesWorkflowApproval(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1307,6 +1313,7 @@ func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1432,6 +1439,7 @@ func TestAPISyncPRIgnoresWorkflowRunsForOtherPRAtSameSHA(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1581,6 +1589,7 @@ func TestAPIGetPullNotFound(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 999,
+		nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode())
@@ -1619,6 +1628,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissing(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1676,6 +1686,7 @@ func TestAPIGetPullNoDiffWarningWhenSHAsPresent(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 2,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1730,6 +1741,7 @@ func TestAPIGetPullEmitsStaleDiffWarning(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 3,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1786,6 +1798,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnBaseDrift(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 4,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1843,6 +1856,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnMergedPR(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 5,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1893,6 +1907,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissingClosed(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 6,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -1947,6 +1962,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnClosedPR(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 7,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -2002,6 +2018,7 @@ func TestAPIGetPullNoDiffWarningOnMergedPRWithBaseDrift(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 8,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -2083,6 +2100,7 @@ func TestAPISyncPRSanitizesDiffFailureWarning(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 		t.Context(), "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	// Diff-sync failures are non-fatal: the handler must return 200
@@ -3584,6 +3602,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 	go func() {
 		resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 			t.Context(), "acme", "widget", 1,
+			nil,
 		)
 		if err != nil {
 			syncErr <- err
@@ -3695,6 +3714,7 @@ func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
 	go func() {
 		resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 			t.Context(), "acme", "widget", 1,
+			nil,
 		)
 		if err != nil {
 			syncErr <- err
@@ -3711,6 +3731,7 @@ func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
 
 	detailResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, detailResp.StatusCode())
@@ -3789,12 +3810,14 @@ func TestAPISyncPRClearsCIWhenHeadSHAChanges(t *testing.T) {
 
 	syncResp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, syncResp.StatusCode())
 
 	detailResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, detailResp.StatusCode())
@@ -3857,6 +3880,7 @@ func TestAPIEnqueuePRSyncReturnsBeforeGitHubFetchCompletes(t *testing.T) {
 	defer cancel()
 	resp, err := client.HTTP.EnqueuePrSyncWithResponse(
 		ctx, "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusAccepted, resp.StatusCode())
@@ -4028,6 +4052,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 	go func() {
 		resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 			t.Context(), "acme", "widget", 1,
+			nil,
 		)
 		if err != nil {
 			syncErr <- err
@@ -4623,10 +4648,12 @@ func TestAPISyncIssueRejectsAmbiguousTrackedRepoBeforeSync(t *testing.T) {
 			return nil, nil
 		},
 	}
-	srv, _ := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
 		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
 	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
 
 	rr := doJSON(
 		t,
@@ -5171,6 +5198,7 @@ func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
 
 	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, firstResp.StatusCode())
@@ -5192,6 +5220,7 @@ func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
 
 	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, secondResp.StatusCode())
@@ -5304,6 +5333,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, firstResp.StatusCode())
@@ -5320,6 +5350,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, secondResp.StatusCode())
@@ -5458,6 +5489,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenAnotherPRChanges(t *testing.T) {
 
 	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(targetNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, firstResp.StatusCode())
@@ -5473,6 +5505,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenAnotherPRChanges(t *testing.T) {
 
 	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(targetNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, secondResp.StatusCode())
@@ -5943,6 +5976,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 
 	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, firstResp.StatusCode())
@@ -5960,6 +5994,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 
 	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, secondResp.StatusCode())
@@ -6290,6 +6325,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 
 	firstResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, firstResp.StatusCode())
@@ -6307,6 +6343,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 
 	secondResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, secondResp.StatusCode())
@@ -6416,6 +6453,7 @@ func TestE2EGraphQLBulkSyncKeepsNewestCICheckBySuiteCreatedAt(t *testing.T) {
 
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6753,10 +6791,12 @@ func TestAPIReadyForReviewRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 			return nil, nil
 		},
 	}
-	srv, _ := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
 		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
 	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
 
 	rr := doJSON(
 		t,
@@ -6780,10 +6820,12 @@ func TestAPIMergePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 			return nil, nil
 		},
 	}
-	srv, _ := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
 		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
 	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
 
 	rr := doJSON(
 		t,
@@ -7676,6 +7718,7 @@ func TestAPIGetPullDetailLoaded(t *testing.T) {
 	// Before detail fetch: detail_loaded=false.
 	resp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -7707,6 +7750,7 @@ func TestAPIGetPullDetailLoaded(t *testing.T) {
 
 	resp2, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		t.Context(), "acme", "widget", 2,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp2.StatusCode())
@@ -8743,6 +8787,7 @@ func TestCICheckDedupLatestRunWinsE2E(t *testing.T) {
 
 	resp, err := client.HTTP.PostReposByOwnerByNamePullsByNumberSyncWithResponse(
 		context.Background(), "acme", "widget", int64(prNumber),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11219,6 +11264,7 @@ func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 	// MR detail should include the workspace reference.
 	mrResp, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", 1,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, mrResp.StatusCode())
@@ -12017,6 +12063,7 @@ func TestWorkspacePRDetailPlatformHost(t *testing.T) {
 	// PR on github.com
 	r1, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", 10,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, r1.StatusCode())
@@ -12026,6 +12073,7 @@ func TestWorkspacePRDetailPlatformHost(t *testing.T) {
 	// PR on ghe.example.com (same owner/name, different number)
 	r2, err := client.HTTP.GetReposByOwnerByNamePullsByNumberWithResponse(
 		ctx, "acme", "widget", 20,
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, r2.StatusCode())

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4881,6 +4881,121 @@ func TestAPISetIssueStateUsesPlatformHostBody(t *testing.T) {
 	assert.Equal("closed", ghesIssue.State)
 }
 
+func TestAPISetIssueStateUsesPlatformHostQuery(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+
+	database, err := db.Open(
+		filepath.Join(t.TempDir(), "test.db"),
+	)
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	seedIssueOnHost(
+		t, database,
+		"github.com", "acme", "widget", 7,
+		"open", "GitHub issue",
+	)
+	seedIssueOnHost(
+		t, database,
+		"ghe.example.com", "acme", "widget", 7,
+		"open", "GHES issue",
+	)
+
+	var githubEditCalls int
+	var ghesEditCalls int
+	githubClient := &mockGH{
+		editIssueFn: func(_ context.Context, _, _ string, _ int, _ string) (*gh.Issue, error) {
+			githubEditCalls++
+			return nil, errors.New("github.com client should not edit issue")
+		},
+	}
+	ghesClient := &mockGH{
+		editIssueFn: func(_ context.Context, _, _ string, number int, state string) (*gh.Issue, error) {
+			ghesEditCalls++
+			url := fmt.Sprintf("https://ghe.example.com/acme/widget/issues/%d", number)
+			createdAt := gh.Timestamp{Time: time.Now().UTC()}
+			updatedAt := gh.Timestamp{Time: time.Now().UTC()}
+			title := "GHES issue"
+			return &gh.Issue{
+				Number:    &number,
+				Title:     &title,
+				State:     &state,
+				HTMLURL:   &url,
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+				User:      &gh.User{Login: new("ghes-user")},
+			}, nil
+		},
+	}
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{
+			"github.com":      githubClient,
+			"ghe.example.com": ghesClient,
+		},
+		database,
+		nil,
+		[]ghclient.RepoRef{
+			{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+			{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+		},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := New(
+		database, syncer, nil, "/", nil, ServerOptions{},
+	)
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/issues/7/github-state?platform_host=ghe.example.com",
+		strings.NewReader(`{"state":"closed"}`),
+	).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.Zero(githubEditCalls)
+	assert.Equal(1, ghesEditCalls)
+
+	githubRepo, err := database.GetRepoByHostOwnerName(
+		ctx, "github.com", "acme", "widget",
+	)
+	require.NoError(err)
+	require.NotNil(githubRepo)
+	githubIssue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, githubRepo.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(githubIssue)
+	assert.Equal("open", githubIssue.State)
+
+	ghesRepo, err := database.GetRepoByHostOwnerName(
+		ctx, "ghe.example.com", "acme", "widget",
+	)
+	require.NoError(err)
+	require.NotNil(ghesRepo)
+	ghesIssue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, ghesRepo.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(ghesIssue)
+	assert.Equal("closed", ghesIssue.State)
+}
+
 // TestAPIIssueDataFromGraphQLSync verifies the API correctly serves
 // issue data that was persisted by the GraphQL sync path. The sync
 // path itself (GraphQL fetch → normalize → DB upsert) is tested in
@@ -6923,6 +7038,43 @@ func TestAPIApprovePRRejectsAmbiguousRepoBeforeMutation(t *testing.T) {
 	})
 	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
 	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 1)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/repos/acme/widget/pulls/1/approve",
+		map[string]string{"body": "ship it"},
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	assert.Zero(reviewCalls)
+}
+
+func TestAPIApprovePRRejectsAmbiguousTrackedRepoBeforeMutation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	var reviewCalls int
+	mock := &mockGH{
+		createReviewFn: func(_ context.Context, _, _ string, _ int, _, body string) (*gh.PullRequestReview, error) {
+			reviewCalls++
+			id := int64(42)
+			state := "APPROVED"
+			submittedAt := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequestReview{
+				ID:          &id,
+				State:       &state,
+				Body:        &body,
+				SubmittedAt: &submittedAt,
+				User:        &gh.User{Login: new("reviewer")},
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
 
 	rr := doJSON(
 		t,

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -67,11 +67,33 @@ func (s *Server) lookupRepo(
 	ctx context.Context,
 	owner, name, platformHost string,
 ) (*db.Repo, error) {
+	if err := s.requireTrackedRepoUnambiguous(owner, name, platformHost); err != nil {
+		return nil, err
+	}
 	return s.repoIdentity().LookupRepo(ctx, repoIdentityRef{
 		owner:        owner,
 		name:         name,
 		platformHost: platformHost,
 	})
+}
+
+func (s *Server) requireTrackedRepoUnambiguous(
+	owner, name, platformHost string,
+) error {
+	if strings.TrimSpace(platformHost) == "" &&
+		s.syncer.IsTrackedRepoAmbiguous(owner, name) {
+		return errRepoAmbiguous
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func (s *Server) filterConfiguredRepoSummaries(
@@ -89,11 +111,21 @@ func (s *Server) filterConfiguredRepoSummaries(
 
 // lookupMRID resolves the internal MR id from the common route tuple.
 func (s *Server) lookupMRID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
+	if err := s.requireTrackedRepoUnambiguous(
+		ref.owner, ref.name, ref.platformHost,
+	); err != nil {
+		return 0, err
+	}
 	return s.repoIdentity().LookupMRID(ctx, ref)
 }
 
 // lookupIssueID resolves the internal issue id from the common route tuple.
 func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
+	if err := s.requireTrackedRepoUnambiguous(
+		ref.owner, ref.name, ref.platformHost,
+	); err != nil {
+		return 0, err
+	}
 	return s.repoIdentity().LookupIssueID(ctx, ref)
 }
 
@@ -101,6 +133,11 @@ func (s *Server) lookupIssue(
 	ctx context.Context,
 	ref repoNumberPathRef,
 ) (*db.Repo, *db.Issue, error) {
+	if err := s.requireTrackedRepoUnambiguous(
+		ref.owner, ref.name, ref.platformHost,
+	); err != nil {
+		return nil, nil, err
+	}
 	return s.repoIdentity().LookupIssue(ctx, ref)
 }
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -71,7 +71,7 @@ func (s *Server) lookupRepo(
 		owner:        owner,
 		name:         name,
 		platformHost: platformHost,
-	}, repoLookupOwnerNameAllowed)
+	})
 }
 
 func (s *Server) filterConfiguredRepoSummaries(
@@ -93,7 +93,7 @@ func (s *Server) lookupRepoID(ctx context.Context, owner, name string) (int64, e
 	return s.repoIdentity().LookupRepoID(ctx, repoIdentityRef{
 		owner: owner,
 		name:  name,
-	}, repoLookupOwnerNameAllowed)
+	})
 }
 
 // lookupMRID resolves the internal MR id from the common route tuple.

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -87,15 +87,6 @@ func (s *Server) requireTrackedRepoUnambiguous(
 	return nil
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
-}
-
 func (s *Server) filterConfiguredRepoSummaries(
 	summaries []db.RepoSummary,
 ) []db.RepoSummary {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -67,14 +67,26 @@ func (s *Server) lookupRepo(
 	ctx context.Context,
 	owner, name, platformHost string,
 ) (*db.Repo, error) {
-	if err := s.requireTrackedRepoUnambiguous(owner, name, platformHost); err != nil {
+	resolvedHost, err := s.resolveRepoHost(owner, name, platformHost)
+	if err != nil {
 		return nil, err
 	}
 	return s.repoIdentity().LookupRepo(ctx, repoIdentityRef{
 		owner:        owner,
 		name:         name,
-		platformHost: platformHost,
+		platformHost: resolvedHost,
 	})
+}
+
+func (s *Server) resolveRepoHost(owner, name, platformHost string) (string, error) {
+	platformHost = strings.TrimSpace(platformHost)
+	if err := s.requireTrackedRepoUnambiguous(owner, name, platformHost); err != nil {
+		return "", err
+	}
+	if platformHost != "" {
+		return platformHost, nil
+	}
+	return s.syncer.HostForRepo(owner, name), nil
 }
 
 func (s *Server) requireTrackedRepoUnambiguous(
@@ -102,34 +114,40 @@ func (s *Server) filterConfiguredRepoSummaries(
 
 // lookupMRID resolves the internal MR id from the common route tuple.
 func (s *Server) lookupMRID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
-	if err := s.requireTrackedRepoUnambiguous(
-		ref.owner, ref.name, ref.platformHost,
-	); err != nil {
+	resolved, err := s.resolveNumberPathRef(ref)
+	if err != nil {
 		return 0, err
 	}
-	return s.repoIdentity().LookupMRID(ctx, ref)
+	return s.repoIdentity().LookupMRID(ctx, resolved)
 }
 
 // lookupIssueID resolves the internal issue id from the common route tuple.
 func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
-	if err := s.requireTrackedRepoUnambiguous(
-		ref.owner, ref.name, ref.platformHost,
-	); err != nil {
+	resolved, err := s.resolveNumberPathRef(ref)
+	if err != nil {
 		return 0, err
 	}
-	return s.repoIdentity().LookupIssueID(ctx, ref)
+	return s.repoIdentity().LookupIssueID(ctx, resolved)
 }
 
 func (s *Server) lookupIssue(
 	ctx context.Context,
 	ref repoNumberPathRef,
 ) (*db.Repo, *db.Issue, error) {
-	if err := s.requireTrackedRepoUnambiguous(
-		ref.owner, ref.name, ref.platformHost,
-	); err != nil {
+	resolved, err := s.resolveNumberPathRef(ref)
+	if err != nil {
 		return nil, nil, err
 	}
-	return s.repoIdentity().LookupIssue(ctx, ref)
+	return s.repoIdentity().LookupIssue(ctx, resolved)
+}
+
+func (s *Server) resolveNumberPathRef(ref repoNumberPathRef) (repoNumberPathRef, error) {
+	platformHost, err := s.resolveRepoHost(ref.owner, ref.name, ref.platformHost)
+	if err != nil {
+		return repoNumberPathRef{}, err
+	}
+	ref.platformHost = platformHost
+	return ref, nil
 }
 
 // parseRepoFilter splits the repo query parameter when it is in owner/name or

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -22,7 +22,7 @@ type starredRequest struct {
 	Owner        string `json:"owner"`
 	Name         string `json:"name"`
 	Number       int    `json:"number"`
-	PlatformHost string `json:"platform_host,omitempty"`
+	PlatformHost string `json:"platform_host"`
 }
 
 var errRepoNotFound = repoidentity.ErrNotFound

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -87,15 +87,6 @@ func (s *Server) filterConfiguredRepoSummaries(
 	return filtered
 }
 
-// lookupRepoID resolves a repository from owner/name inputs and returns a
-// stable not-found error for handlers that need repo identity only.
-func (s *Server) lookupRepoID(ctx context.Context, owner, name string) (int64, error) {
-	return s.repoIdentity().LookupRepoID(ctx, repoIdentityRef{
-		owner: owner,
-		name:  name,
-	})
-}
-
 // lookupMRID resolves the internal MR id from the common route tuple.
 func (s *Server) lookupMRID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
 	return s.repoIdentity().LookupMRID(ctx, ref)

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -67,24 +67,11 @@ func (s *Server) lookupRepo(
 	ctx context.Context,
 	owner, name, platformHost string,
 ) (*db.Repo, error) {
-	var (
-		repo *db.Repo
-		err  error
-	)
-	if platformHost != "" {
-		repo, err = s.db.GetRepoByHostOwnerName(
-			ctx, platformHost, owner, name,
-		)
-	} else {
-		repo, err = s.db.GetRepoByOwnerName(ctx, owner, name)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get repo: %w", err)
-	}
-	if repo == nil {
-		return nil, errRepoNotFound
-	}
-	return repo, nil
+	return s.repoIdentity().LookupRepo(ctx, repoIdentityRef{
+		owner:        owner,
+		name:         name,
+		platformHost: platformHost,
+	}, repoLookupOwnerNameAllowed)
 }
 
 func (s *Server) filterConfiguredRepoSummaries(
@@ -103,85 +90,27 @@ func (s *Server) filterConfiguredRepoSummaries(
 // lookupRepoID resolves a repository from owner/name inputs and returns a
 // stable not-found error for handlers that need repo identity only.
 func (s *Server) lookupRepoID(ctx context.Context, owner, name string) (int64, error) {
-	repo, err := s.lookupRepo(ctx, owner, name, "")
-	if err != nil {
-		return 0, err
-	}
-	return repo.ID, nil
-}
-
-func (s *Server) lookupRepoIDOnHost(
-	ctx context.Context,
-	owner, name, platformHost string,
-) (int64, error) {
-	repo, err := s.lookupRepo(ctx, owner, name, platformHost)
-	if err != nil {
-		return 0, err
-	}
-	return repo.ID, nil
+	return s.repoIdentity().LookupRepoID(ctx, repoIdentityRef{
+		owner: owner,
+		name:  name,
+	}, repoLookupOwnerNameAllowed)
 }
 
 // lookupMRID resolves the internal MR id from the common route tuple.
 func (s *Server) lookupMRID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
-	return s.db.GetMRIDByRepoAndNumber(ctx, ref.owner, ref.name, ref.number)
+	return s.repoIdentity().LookupMRID(ctx, ref)
 }
 
 // lookupIssueID resolves the internal issue id from the common route tuple.
 func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
-	if ref.platformHost == "" {
-		return s.db.GetIssueIDByRepoAndNumber(
-			ctx, ref.owner, ref.name, ref.number,
-		)
-	}
-	repoID, err := s.lookupRepoIDOnHost(
-		ctx, ref.owner, ref.name, ref.platformHost,
-	)
-	if err != nil {
-		return 0, err
-	}
-	issue, err := s.db.GetIssueByRepoIDAndNumber(
-		ctx, repoID, ref.number,
-	)
-	if err != nil {
-		return 0, err
-	}
-	if issue == nil {
-		return 0, fmt.Errorf(
-			"issue %s/%s#%d not found", ref.owner, ref.name, ref.number,
-		)
-	}
-	return issue.ID, nil
+	return s.repoIdentity().LookupIssueID(ctx, ref)
 }
 
 func (s *Server) lookupIssue(
 	ctx context.Context,
 	ref repoNumberPathRef,
 ) (*db.Repo, *db.Issue, error) {
-	repo, err := s.lookupRepo(
-		ctx, ref.owner, ref.name, ref.platformHost,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-	var issue *db.Issue
-	if ref.platformHost != "" {
-		issue, err = s.db.GetIssueByRepoIDAndNumber(
-			ctx, repo.ID, ref.number,
-		)
-	} else {
-		issue, err = s.db.GetIssue(
-			ctx, ref.owner, ref.name, ref.number,
-		)
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-	if issue == nil {
-		return repo, nil, fmt.Errorf(
-			"issue %s/%s#%d not found", ref.owner, ref.name, ref.number,
-		)
-	}
-	return repo, issue, nil
+	return s.repoIdentity().LookupIssue(ctx, ref)
 }
 
 // parseRepoFilter splits the repo query parameter when it is in owner/name or

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/repoidentity"
 )
 
 type repoNumberPathRef struct {
@@ -25,7 +25,7 @@ type starredRequest struct {
 	PlatformHost string `json:"platform_host,omitempty"`
 }
 
-var errRepoNotFound = errors.New("repo not found")
+var errRepoNotFound = repoidentity.ErrNotFound
 
 // buildRepoLookup materializes a repo-id keyed map used to annotate list
 // responses with owner/name information.

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -38,6 +38,13 @@ type repoNumberInput struct {
 	Number int    `path:"number"`
 }
 
+type prDetailInput struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+}
+
 type prActionInput struct {
 	Owner        string `path:"owner"`
 	Name         string `path:"name"`
@@ -629,8 +636,22 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 	return &listPullsOutput{Body: out}, nil
 }
 
-func (s *Server) getPull(ctx context.Context, input *repoNumberInput) (*getPullOutput, error) {
-	mr, err := s.db.GetMergeRequest(ctx, input.Owner, input.Name, input.Number)
+func (s *Server) getPull(ctx context.Context, input *prDetailInput) (*getPullOutput, error) {
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	var mr *db.MergeRequest
+	var err error
+	if platformHost == "" {
+		mr, err = s.db.GetMergeRequest(ctx, input.Owner, input.Name, input.Number)
+	} else {
+		repoObj, lookupErr := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+		if lookupErr != nil {
+			if errors.Is(lookupErr, errRepoNotFound) {
+				return nil, huma.Error404NotFound("pull request not found")
+			}
+			return nil, huma.Error500InternalServerError("get repo failed")
+		}
+		mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
+	}
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request failed")
 	}
@@ -1412,28 +1433,28 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 
 func (s *Server) approveWorkflows(ctx context.Context, input *prActionInput) (*actionStatusOutput, error) {
 	platformHost := strings.TrimSpace(input.PlatformHost)
-	client, err := s.clientForPRAction(input.Owner, input.Name, platformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
 			return nil, huma.Error400BadRequest(
 				"platform_host is required for ambiguous repo",
 			)
 		}
-		return nil, huma.Error404NotFound(err.Error())
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("get pull request failed")
+	}
+	if mr == nil {
+		return nil, huma.Error404NotFound("pull request not found")
 	}
 
-	_, err = s.lookupMRID(ctx, repoNumberPathRef{
-		owner:        input.Owner,
-		name:         input.Name,
-		number:       input.Number,
-		platformHost: platformHost,
-	})
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
@@ -1496,17 +1517,6 @@ func (s *Server) approveWorkflows(ctx context.Context, input *prActionInput) (*a
 	}}, nil
 }
 
-func (s *Server) clientForPRAction(owner, name, platformHost string) (ghclient.Client, error) {
-	platformHost = strings.TrimSpace(platformHost)
-	if platformHost != "" {
-		return s.syncer.ClientForRepoOnHost(owner, name, platformHost)
-	}
-	if s.syncer.IsTrackedRepoAmbiguous(owner, name) {
-		return nil, errRepoAmbiguous
-	}
-	return s.syncer.ClientForRepo(owner, name)
-}
-
 func (s *Server) syncMRAfterPRAction(
 	ctx context.Context,
 	owner, name string,
@@ -1522,13 +1532,21 @@ func (s *Server) syncMRAfterPRAction(
 
 func (s *Server) readyForReview(ctx context.Context, input *prActionInput) (*actionStatusOutput, error) {
 	platformHost := strings.TrimSpace(input.PlatformHost)
-	client, err := s.clientForPRAction(input.Owner, input.Name, platformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
 			return nil, huma.Error400BadRequest(
 				"platform_host is required for ambiguous repo",
 			)
 		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
+	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
@@ -1579,15 +1597,6 @@ func (s *Server) readyForReview(ctx context.Context, input *prActionInput) (*act
 		return nil, huma.Error502BadGateway("GitHub API returned no pull request")
 	}
 
-	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
-	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
-	}
 	if repoObj != nil {
 		normalized, normalizeErr := ghclient.NormalizePR(repoObj.ID, pr)
 		if normalizeErr != nil {
@@ -1610,13 +1619,21 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 	}
 
 	platformHost := strings.TrimSpace(input.PlatformHost)
-	client, err := s.clientForPRAction(input.Owner, input.Name, platformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
 			return nil, huma.Error400BadRequest(
 				"platform_host is required for ambiguous repo",
 			)
 		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
+	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
@@ -1668,15 +1685,6 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 		return nil, huma.Error502BadGateway("GitHub merge error: " + err.Error())
 	}
 
-	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
-	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
-	}
 	if repoObj != nil {
 		now := s.now().UTC()
 		if err := s.db.UpdateMRState(ctx, repoObj.ID, input.Number, "merged", &now, &now); err != nil {
@@ -1974,14 +1982,25 @@ func (s *Server) getRateLimits(
 	}, nil
 }
 
-func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROutput, error) {
+func (s *Server) syncPR(ctx context.Context, input *prDetailInput) (*syncPROutput, error) {
 	// SyncMR distinguishes a non-fatal diff failure from a hard sync failure
 	// via DiffSyncError. The PR row, timeline, and CI status are all current
 	// in either case, so degrade gracefully: keep the response, but report
 	// the diff problem as a warning so the UI can explain why the diff view
 	// is stale or empty.
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	if platformHost == "" && s.syncer.IsTrackedRepoAmbiguous(input.Owner, input.Name) {
+		return nil, huma.Error400BadRequest(
+			"platform_host is required for ambiguous repo",
+		)
+	}
 	var diffErr *ghclient.DiffSyncError
-	syncErr := s.syncer.SyncMR(ctx, input.Owner, input.Name, input.Number)
+	var syncErr error
+	if platformHost != "" {
+		syncErr = s.syncer.SyncMROnHost(ctx, platformHost, input.Owner, input.Name, input.Number)
+	} else {
+		syncErr = s.syncer.SyncMR(ctx, input.Owner, input.Name, input.Number)
+	}
 	if syncErr != nil && !errors.As(syncErr, &diffErr) {
 		if strings.Contains(syncErr.Error(), "is not tracked") {
 			return nil, huma.Error403Forbidden(syncErr.Error())
@@ -1989,7 +2008,19 @@ func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROut
 		return nil, huma.Error502BadGateway("sync PR: " + syncErr.Error())
 	}
 
-	mr, err := s.db.GetMergeRequest(ctx, input.Owner, input.Name, input.Number)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound("pull request not found after sync")
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request: " + err.Error())
 	}
@@ -2018,17 +2049,30 @@ func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROut
 	return &syncPROutput{Body: body}, nil
 }
 
-func (s *Server) enqueuePRSync(_ context.Context, input *repoNumberInput) (*acceptedOutput, error) {
-	key := "pr:github.com:" + input.Owner + "/" + input.Name + "#" + strconv.Itoa(input.Number)
+func (s *Server) enqueuePRSync(_ context.Context, input *prDetailInput) (*acceptedOutput, error) {
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	if platformHost == "" && s.syncer.IsTrackedRepoAmbiguous(input.Owner, input.Name) {
+		return nil, huma.Error400BadRequest(
+			"platform_host is required for ambiguous repo",
+		)
+	}
+	if platformHost == "" {
+		platformHost = s.syncer.HostForRepo(input.Owner, input.Name)
+	}
+	key := "pr:" + platformHost + ":" + input.Owner + "/" + input.Name + "#" + strconv.Itoa(input.Number)
 	s.enqueueDetailSync(
 		key,
 		[]any{
 			"type", "pr",
+			"platform_host", platformHost,
 			"owner", input.Owner,
 			"name", input.Name,
 			"number", input.Number,
 		},
 		func(ctx context.Context) error {
+			if platformHost != "" {
+				return s.syncer.SyncMROnHost(ctx, platformHost, input.Owner, input.Name, input.Number)
+			}
 			return s.syncer.SyncMR(ctx, input.Owner, input.Name, input.Number)
 		},
 	)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -64,10 +64,11 @@ type resolveItemInput struct {
 type getMRImportMetadataOutput = bodyOutput[mrImportMetadataResponse]
 
 type setKanbanStateInput struct {
-	Owner  string `path:"owner"`
-	Name   string `path:"name"`
-	Number int    `path:"number"`
-	Body   struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+	Body         struct {
 		Status string `json:"status"`
 	}
 }
@@ -863,9 +864,19 @@ func (s *Server) setKanbanState(ctx context.Context, input *setKanbanStateInput)
 		return nil, huma.Error400BadRequest("status must be one of: new, reviewing, waiting, awaiting_merge")
 	}
 
-	ref := repoNumberPathRef{owner: input.Owner, name: input.Name, number: input.Number}
+	ref := repoNumberPathRef{
+		owner:        input.Owner,
+		name:         input.Name,
+		number:       input.Number,
+		platformHost: strings.TrimSpace(input.PlatformHost),
+	}
 	mrID, err := s.lookupMRID(ctx, ref)
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		return nil, huma.Error404NotFound(err.Error())
 	}
 	if err := s.db.SetKanbanState(ctx, mrID, input.Body.Status); err != nil {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -38,6 +38,13 @@ type repoNumberInput struct {
 	Number int    `path:"number"`
 }
 
+type prActionInput struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+}
+
 type getPullOutput = bodyOutput[mergeRequestDetailResponse]
 
 type resolveItemInput struct {
@@ -179,10 +186,11 @@ type actionStatusBody struct {
 type actionStatusOutput = bodyOutput[actionStatusBody]
 
 type mergePRInput struct {
-	Owner  string `path:"owner"`
-	Name   string `path:"name"`
-	Number int    `path:"number"`
-	Body   struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+	Body         struct {
 		CommitTitle   string `json:"commit_title"`
 		CommitMessage string `json:"commit_message"`
 		Method        string `json:"method"`
@@ -1402,17 +1410,30 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	return &actionStatusOutput{Body: actionStatusBody{Status: "approved"}}, nil
 }
 
-func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (*actionStatusOutput, error) {
-	mr, err := s.db.GetMergeRequest(ctx, input.Owner, input.Name, input.Number)
+func (s *Server) approveWorkflows(ctx context.Context, input *prActionInput) (*actionStatusOutput, error) {
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	client, err := s.clientForPRAction(input.Owner, input.Name, platformHost)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get pull request failed")
-	}
-	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		return nil, huma.Error404NotFound(err.Error())
 	}
 
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	_, err = s.lookupMRID(ctx, repoNumberPathRef{
+		owner:        input.Owner,
+		name:         input.Name,
+		number:       input.Number,
+		platformHost: platformHost,
+	})
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
@@ -1444,7 +1465,13 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 	for _, run := range pending {
 		if err := client.ApproveWorkflowRun(ctx, input.Owner, input.Name, run.GetID()); err != nil {
 			if approvedCount > 0 {
-				if syncErr := s.syncer.SyncMR(context.WithoutCancel(ctx), input.Owner, input.Name, input.Number); syncErr != nil {
+				if syncErr := s.syncMRAfterPRAction(
+					context.WithoutCancel(ctx),
+					input.Owner,
+					input.Name,
+					input.Number,
+					platformHost,
+				); syncErr != nil {
 					slog.Warn("sync after workflow approval failure", "err", syncErr)
 				}
 			}
@@ -1453,7 +1480,13 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 		approvedCount++
 	}
 
-	if syncErr := s.syncer.SyncMR(context.WithoutCancel(ctx), input.Owner, input.Name, input.Number); syncErr != nil {
+	if syncErr := s.syncMRAfterPRAction(
+		context.WithoutCancel(ctx),
+		input.Owner,
+		input.Name,
+		input.Number,
+		platformHost,
+	); syncErr != nil {
 		slog.Warn("sync after workflow approval", "err", syncErr)
 	}
 
@@ -1463,9 +1496,39 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 	}}, nil
 }
 
-func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*actionStatusOutput, error) {
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+func (s *Server) clientForPRAction(owner, name, platformHost string) (ghclient.Client, error) {
+	platformHost = strings.TrimSpace(platformHost)
+	if platformHost != "" {
+		return s.syncer.ClientForRepoOnHost(owner, name, platformHost)
+	}
+	if s.syncer.IsTrackedRepoAmbiguous(owner, name) {
+		return nil, errRepoAmbiguous
+	}
+	return s.syncer.ClientForRepo(owner, name)
+}
+
+func (s *Server) syncMRAfterPRAction(
+	ctx context.Context,
+	owner, name string,
+	number int,
+	platformHost string,
+) error {
+	platformHost = strings.TrimSpace(platformHost)
+	if platformHost != "" {
+		return s.syncer.SyncMROnHost(ctx, platformHost, owner, name, number)
+	}
+	return s.syncer.SyncMR(ctx, owner, name, number)
+}
+
+func (s *Server) readyForReview(ctx context.Context, input *prActionInput) (*actionStatusOutput, error) {
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	client, err := s.clientForPRAction(input.Owner, input.Name, platformHost)
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
@@ -1483,7 +1546,13 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 			staleState = errors.As(err, &ghErr) && ghErr != nil && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound
 		}
 		if staleState {
-			if syncErr := s.syncer.SyncMR(context.WithoutCancel(ctx), input.Owner, input.Name, input.Number); syncErr != nil {
+			if syncErr := s.syncMRAfterPRAction(
+				context.WithoutCancel(ctx),
+				input.Owner,
+				input.Name,
+				input.Number,
+				platformHost,
+			); syncErr != nil {
 				slog.Warn(
 					"sync after ready for review stale state failed",
 					"owner", input.Owner,
@@ -1510,13 +1579,24 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 		return nil, huma.Error502BadGateway("GitHub API returned no pull request")
 	}
 
-	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, "")
-	if err == nil && repoObj != nil {
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+	if repoObj != nil {
 		normalized, normalizeErr := ghclient.NormalizePR(repoObj.ID, pr)
-		if normalizeErr == nil {
-			if mrID, upsertErr := s.db.UpsertMergeRequest(ctx, normalized); upsertErr == nil {
-				_ = s.db.EnsureKanbanState(ctx, mrID)
-			}
+		if normalizeErr != nil {
+			return nil, huma.Error502BadGateway("GitHub API error: " + normalizeErr.Error())
+		}
+		if mrID, upsertErr := s.db.UpsertMergeRequest(ctx, normalized); upsertErr == nil {
+			_ = s.db.EnsureKanbanState(ctx, mrID)
+		} else {
+			return nil, huma.Error500InternalServerError("update pull request: " + upsertErr.Error())
 		}
 	}
 
@@ -1529,8 +1609,14 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 		return nil, huma.Error400BadRequest("invalid merge method: must be merge, squash, or rebase")
 	}
 
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	client, err := s.clientForPRAction(input.Owner, input.Name, platformHost)
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
@@ -1555,8 +1641,12 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 			if ghErr.Response.StatusCode == http.StatusMethodNotAllowed ||
 				ghErr.Response.StatusCode == http.StatusConflict {
 				s.runBackground(func(bgCtx context.Context) {
-					if syncErr := s.syncer.SyncMR(
-						bgCtx, input.Owner, input.Name, input.Number,
+					if syncErr := s.syncMRAfterPRAction(
+						bgCtx,
+						input.Owner,
+						input.Name,
+						input.Number,
+						platformHost,
 					); syncErr != nil {
 						slog.Warn("background sync after merge failure", "err", syncErr)
 					}
@@ -1578,10 +1668,20 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 		return nil, huma.Error502BadGateway("GitHub merge error: " + err.Error())
 	}
 
-	repoObj, _ := s.lookupRepo(ctx, input.Owner, input.Name, "")
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
 	if repoObj != nil {
 		now := s.now().UTC()
-		_ = s.db.UpdateMRState(ctx, repoObj.ID, input.Number, "merged", &now, &now)
+		if err := s.db.UpdateMRState(ctx, repoObj.ID, input.Number, "merged", &now, &now); err != nil {
+			return nil, huma.Error500InternalServerError("update mr state: " + err.Error())
+		}
 	}
 
 	return &mergePROutput{
@@ -1937,9 +2037,15 @@ func (s *Server) enqueuePRSync(_ context.Context, input *repoNumberInput) (*acce
 
 func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*syncIssueOutput, error) {
 	var err error
-	if input.PlatformHost != "" {
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	if platformHost == "" && s.syncer.IsTrackedRepoAmbiguous(input.Owner, input.Name) {
+		return nil, huma.Error400BadRequest(
+			"platform_host is required for ambiguous repo",
+		)
+	}
+	if platformHost != "" {
 		err = s.syncer.SyncIssueOnHost(
-			ctx, input.PlatformHost, input.Owner, input.Name, input.Number,
+			ctx, platformHost, input.Owner, input.Name, input.Number,
 		)
 	} else {
 		err = s.syncer.SyncIssue(ctx, input.Owner, input.Name, input.Number)
@@ -1955,7 +2061,7 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 		owner:        input.Owner,
 		name:         input.Name,
 		number:       input.Number,
-		platformHost: input.PlatformHost,
+		platformHost: platformHost,
 	})
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1158,6 +1158,11 @@ func (s *Server) getIssue(ctx context.Context, input *issueRepoNumberInput) (*ge
 		platformHost: input.PlatformHost,
 	})
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		if errors.Is(err, errRepoNotFound) || strings.Contains(err.Error(), "not found") {
 			return nil, huma.Error404NotFound("issue not found")
 		}
@@ -1704,6 +1709,11 @@ func (s *Server) setIssueGitHubState(
 		platformHost: input.Body.PlatformHost,
 	})
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		if errors.Is(err, errRepoNotFound) || strings.Contains(err.Error(), "not found") {
 			return nil, huma.Error404NotFound("issue not found")
 		}
@@ -1948,6 +1958,11 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 		platformHost: input.PlatformHost,
 	})
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		if errors.Is(err, errRepoNotFound) || strings.Contains(err.Error(), "not found") {
 			return nil, huma.Error404NotFound("issue not found after sync")
 		}
@@ -2107,6 +2122,11 @@ func (s *Server) resolveItem(
 				RepoTracked: false,
 			},
 		}, nil
+	}
+	if platformHost == "" && s.syncer.IsTrackedRepoAmbiguous(owner, name) {
+		return nil, huma.Error400BadRequest(
+			"platform_host is required for ambiguous repo",
+		)
 	}
 
 	localItem, err := s.repoIdentity().ResolveLocalItem(ctx, repoNumberPathRef{

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -40,6 +40,13 @@ type repoNumberInput struct {
 
 type getPullOutput = bodyOutput[mergeRequestDetailResponse]
 
+type resolveItemInput struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+}
+
 type getMRImportMetadataOutput = bodyOutput[mrImportMetadataResponse]
 
 type setKanbanStateInput struct {
@@ -1066,7 +1073,7 @@ func (s *Server) createIssue(
 		owner:        input.Owner,
 		name:         input.Name,
 		platformHost: platformHost,
-	}, repoLookupRequireUnambiguousOwnerName)
+	})
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
 			return nil, huma.Error400BadRequest(
@@ -2084,11 +2091,16 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 }
 
 func (s *Server) resolveItem(
-	ctx context.Context, input *repoNumberInput,
+	ctx context.Context, input *resolveItemInput,
 ) (*resolveItemOutput, error) {
 	owner, name, number := input.Owner, input.Name, input.Number
+	platformHost := strings.TrimSpace(input.PlatformHost)
 
-	if !s.syncer.IsTrackedRepo(owner, name) {
+	tracked := s.syncer.IsTrackedRepo(owner, name)
+	if platformHost != "" {
+		tracked = s.syncer.IsTrackedRepoOnHost(owner, name, platformHost)
+	}
+	if !tracked {
 		return &resolveItemOutput{
 			Body: resolveItemResponse{
 				Number:      number,
@@ -2098,11 +2110,17 @@ func (s *Server) resolveItem(
 	}
 
 	localItem, err := s.repoIdentity().ResolveLocalItem(ctx, repoNumberPathRef{
-		owner:  owner,
-		name:   name,
-		number: number,
+		owner:        owner,
+		name:         name,
+		number:       number,
+		platformHost: platformHost,
 	})
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		return nil, huma.Error500InternalServerError(
 			"resolve item: " + err.Error(),
 		)
@@ -2117,9 +2135,16 @@ func (s *Server) resolveItem(
 		}, nil
 	}
 
-	itemType, err := s.syncer.SyncItemByNumber(
-		ctx, owner, name, number,
-	)
+	var itemType string
+	if platformHost != "" {
+		itemType, err = s.syncer.SyncItemByNumberOnHost(
+			ctx, platformHost, owner, name, number,
+		)
+	} else {
+		itemType, err = s.syncer.SyncItemByNumber(
+			ctx, owner, name, number,
+		)
+	}
 	// A DiffSyncError means the PR row was upserted but the diff
 	// computation failed. Resolution doesn't need diff data, so treat
 	// the result as success here. The resolve response has no warnings
@@ -2171,8 +2196,13 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 		owner:        body.Owner,
 		name:         body.Name,
 		platformHost: body.PlatformHost,
-	}, repoLookupOwnerNameAllowed)
+	})
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return 0, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		if errors.Is(err, errRepoNotFound) {
 			return 0, huma.Error404NotFound(err.Error())
 		}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1062,28 +1062,17 @@ func (s *Server) createIssue(
 	}
 
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
-
-	if platformHost == "" {
-		repos, err := s.db.ListRepos(ctx)
-		if err != nil {
-			return nil, huma.Error500InternalServerError("repo lookup failed")
-		}
-		matches := 0
-		for _, candidate := range repos {
-			if strings.EqualFold(candidate.Owner, input.Owner) &&
-				strings.EqualFold(candidate.Name, input.Name) {
-				matches++
-			}
-		}
-		if matches > 1 {
+	repo, err := s.repoIdentity().LookupRepo(ctx, repoIdentityRef{
+		owner:        input.Owner,
+		name:         input.Name,
+		platformHost: platformHost,
+	}, repoLookupRequireUnambiguousOwnerName)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
 			return nil, huma.Error400BadRequest(
 				"platform_host is required for ambiguous repo",
 			)
 		}
-	}
-
-	repo, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
-	if err != nil {
 		if errors.Is(err, errRepoNotFound) {
 			return nil, huma.Error404NotFound("repo not found")
 		}
@@ -1509,7 +1498,7 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 		return nil, huma.Error502BadGateway("GitHub API returned no pull request")
 	}
 
-	repoObj, err := s.db.GetRepoByOwnerName(ctx, input.Owner, input.Name)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, "")
 	if err == nil && repoObj != nil {
 		normalized, normalizeErr := ghclient.NormalizePR(repoObj.ID, pr)
 		if normalizeErr == nil {
@@ -1577,7 +1566,7 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 		return nil, huma.Error502BadGateway("GitHub merge error: " + err.Error())
 	}
 
-	repoObj, _ := s.db.GetRepoByOwnerName(ctx, input.Owner, input.Name)
+	repoObj, _ := s.lookupRepo(ctx, input.Owner, input.Name, "")
 	if repoObj != nil {
 		now := s.now().UTC()
 		_ = s.db.UpdateMRState(ctx, repoObj.ID, input.Number, "merged", &now, &now)
@@ -2108,30 +2097,24 @@ func (s *Server) resolveItem(
 		}, nil
 	}
 
-	repo, err := s.db.GetRepoByOwnerName(ctx, owner, name)
+	localItem, err := s.repoIdentity().ResolveLocalItem(ctx, repoNumberPathRef{
+		owner:  owner,
+		name:   name,
+		number: number,
+	})
 	if err != nil {
 		return nil, huma.Error500InternalServerError(
-			"get repo: " + err.Error(),
+			"resolve item: " + err.Error(),
 		)
 	}
-	if repo != nil {
-		itemType, found, err := s.db.ResolveItemNumber(
-			ctx, repo.ID, number,
-		)
-		if err != nil {
-			return nil, huma.Error500InternalServerError(
-				"resolve item: " + err.Error(),
-			)
-		}
-		if found {
-			return &resolveItemOutput{
-				Body: resolveItemResponse{
-					ItemType:    itemType,
-					Number:      number,
-					RepoTracked: true,
-				},
-			}, nil
-		}
+	if localItem.Found {
+		return &resolveItemOutput{
+			Body: resolveItemResponse{
+				ItemType:    localItem.ItemType,
+				Number:      number,
+				RepoTracked: true,
+			},
+		}, nil
 	}
 
 	itemType, err := s.syncer.SyncItemByNumber(
@@ -2184,17 +2167,11 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 		return 0, huma.Error400BadRequest("item_type must be 'pr' or 'issue'")
 	}
 
-	var (
-		repoID int64
-		err    error
-	)
-	if body.PlatformHost != "" {
-		repoID, err = s.lookupRepoIDOnHost(
-			ctx, body.Owner, body.Name, body.PlatformHost,
-		)
-	} else {
-		repoID, err = s.lookupRepoID(ctx, body.Owner, body.Name)
-	}
+	repoID, err := s.repoIdentity().LookupRepoID(ctx, repoIdentityRef{
+		owner:        body.Owner,
+		name:         body.Name,
+		platformHost: body.PlatformHost,
+	}, repoLookupOwnerNameAllowed)
 	if err != nil {
 		if errors.Is(err, errRepoNotFound) {
 			return 0, huma.Error404NotFound(err.Error())

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1134,11 +1134,7 @@ func (s *Server) createIssue(
 	}
 
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
-	repo, err := s.repoIdentity().LookupRepo(ctx, repoIdentityRef{
-		owner:        input.Owner,
-		name:         input.Name,
-		platformHost: platformHost,
-	})
+	repo, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
 			return nil, huma.Error400BadRequest(
@@ -2302,12 +2298,16 @@ func (s *Server) resolveItem(
 		)
 	}
 
-	localItem, err := s.repoIdentity().ResolveLocalItem(ctx, repoNumberPathRef{
+	localItemRef, err := s.resolveNumberPathRef(repoNumberPathRef{
 		owner:        owner,
 		name:         name,
 		number:       number,
 		platformHost: platformHost,
 	})
+	if err != nil {
+		return nil, repoIdentityError(err)
+	}
+	localItem, err := s.repoIdentity().ResolveLocalItem(ctx, localItemRef)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
 			return nil, huma.Error400BadRequest(
@@ -2328,16 +2328,9 @@ func (s *Server) resolveItem(
 		}, nil
 	}
 
-	var itemType string
-	if platformHost != "" {
-		itemType, err = s.syncer.SyncItemByNumberOnHost(
-			ctx, platformHost, owner, name, number,
-		)
-	} else {
-		itemType, err = s.syncer.SyncItemByNumber(
-			ctx, owner, name, number,
-		)
-	}
+	itemType, err := s.syncer.SyncItemByNumberOnHost(
+		ctx, localItemRef.platformHost, owner, name, number,
+	)
 	// A DiffSyncError means the PR row was upserted but the diff
 	// computation failed. Resolution doesn't need diff data, so treat
 	// the result as success here. The resolve response has no warnings
@@ -2385,11 +2378,7 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 		return 0, huma.Error400BadRequest("item_type must be 'pr' or 'issue'")
 	}
 
-	repoID, err := s.repoIdentity().LookupRepoID(ctx, repoIdentityRef{
-		owner:        body.Owner,
-		name:         body.Name,
-		platformHost: body.PlatformHost,
-	})
+	repo, err := s.lookupRepo(ctx, body.Owner, body.Name, body.PlatformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
 			return 0, huma.Error400BadRequest(
@@ -2402,7 +2391,7 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 		return 0, huma.Error500InternalServerError("repo lookup failed")
 	}
 
-	return repoID, nil
+	return repo.ID, nil
 }
 
 // --- Commits ---
@@ -2438,7 +2427,7 @@ func (s *Server) diffRefsForPR(
 }
 
 func repoIdentityError(err error) error {
-	if errors.Is(err, errRepoAmbiguous) {
+	if errors.Is(err, errRepoAmbiguous) || errors.Is(err, errRepoMissingPlatformHost) {
 		return huma.Error400BadRequest(
 			"platform_host is required for ambiguous repo",
 		)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -907,15 +907,7 @@ func (s *Server) editPRContent(
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 
 	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
@@ -1000,15 +992,7 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
@@ -1045,15 +1029,7 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
@@ -1484,15 +1460,7 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 
 	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
@@ -1521,15 +1489,7 @@ func (s *Server) approveWorkflows(ctx context.Context, input *prActionInput) (*a
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
 	if err != nil {
@@ -1620,15 +1580,7 @@ func (s *Server) readyForReview(ctx context.Context, input *prActionInput) (*act
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 
 	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
@@ -1707,15 +1659,7 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 
 	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
@@ -1799,15 +1743,7 @@ func (s *Server) setPRGitHubState(
 	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
-		if errors.Is(err, errRepoAmbiguous) {
-			return nil, huma.Error400BadRequest(
-				"platform_host is required for ambiguous repo",
-			)
-		}
-		if errors.Is(err, errRepoNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
-		}
-		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+		return nil, repoIdentityError(err)
 	}
 
 	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -47,10 +47,12 @@ type prDetailInput struct {
 }
 
 type prActionInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	PlatformHost string `query:"platform_host"`
+	Owner  string `path:"owner"`
+	Name   string `path:"name"`
+	Number int    `path:"number"`
+	Body   struct {
+		PlatformHost string `json:"platform_host"`
+	}
 }
 
 type getPullOutput = bodyOutput[mergeRequestDetailResponse]
@@ -65,37 +67,37 @@ type resolveItemInput struct {
 type getMRImportMetadataOutput = bodyOutput[mrImportMetadataResponse]
 
 type setKanbanStateInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	PlatformHost string `query:"platform_host"`
-	Body         struct {
-		Status string `json:"status"`
+	Owner  string `path:"owner"`
+	Name   string `path:"name"`
+	Number int    `path:"number"`
+	Body   struct {
+		Status       string `json:"status"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
 type statusOnlyOutput = okStatusOutput
 
 type postCommentInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	PlatformHost string `query:"platform_host"`
-	Body         struct {
-		Body string `json:"body"`
+	Owner  string `path:"owner"`
+	Name   string `path:"name"`
+	Number int    `path:"number"`
+	Body   struct {
+		Body         string `json:"body"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
 type postCommentOutput = createdOutput[db.MREvent]
 
 type editCommentInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	CommentID    int64  `path:"comment_id"`
-	PlatformHost string `query:"platform_host"`
-	Body         struct {
-		Body string `json:"body"`
+	Owner     string `path:"owner"`
+	Name      string `path:"name"`
+	Number    int    `path:"number"`
+	CommentID int64  `path:"comment_id"`
+	Body      struct {
+		Body         string `json:"body"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
@@ -127,7 +129,7 @@ type postIssueCommentInput struct {
 	Number int    `path:"number"`
 	Body   struct {
 		Body         string `json:"body"`
-		PlatformHost string `json:"platform_host,omitempty"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
@@ -140,7 +142,7 @@ type editIssueCommentInput struct {
 	CommentID int64  `path:"comment_id"`
 	Body      struct {
 		Body         string `json:"body"`
-		PlatformHost string `json:"platform_host,omitempty"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
@@ -152,7 +154,7 @@ type createIssueInput struct {
 	Body  struct {
 		Title        string `json:"title"`
 		Body         string `json:"body"`
-		PlatformHost string `json:"platform_host,omitempty"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
@@ -181,12 +183,12 @@ type commentAutocompleteInput struct {
 type commentAutocompleteOutput = bodyOutput[commentAutocompleteResponse]
 
 type approvePRInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	PlatformHost string `query:"platform_host"`
-	Body         struct {
-		Body string `json:"body"`
+	Owner  string `path:"owner"`
+	Name   string `path:"name"`
+	Number int    `path:"number"`
+	Body   struct {
+		Body         string `json:"body"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
@@ -198,14 +200,14 @@ type actionStatusBody struct {
 type actionStatusOutput = bodyOutput[actionStatusBody]
 
 type mergePRInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	PlatformHost string `query:"platform_host"`
-	Body         struct {
+	Owner  string `path:"owner"`
+	Name   string `path:"name"`
+	Number int    `path:"number"`
+	Body   struct {
 		CommitTitle   string `json:"commit_title"`
 		CommitMessage string `json:"commit_message"`
 		Method        string `json:"method"`
+		PlatformHost  string `json:"platform_host"`
 	}
 }
 
@@ -218,26 +220,25 @@ type mergePRBody struct {
 type mergePROutput = bodyOutput[mergePRBody]
 
 type editPRContentInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	PlatformHost string `query:"platform_host"`
-	Body         struct {
-		Title *string `json:"title,omitempty"`
-		Body  *string `json:"body,omitempty"`
+	Owner  string `path:"owner"`
+	Name   string `path:"name"`
+	Number int    `path:"number"`
+	Body   struct {
+		Title        *string `json:"title,omitempty"`
+		Body         *string `json:"body,omitempty"`
+		PlatformHost string  `json:"platform_host"`
 	}
 }
 
 type editPRContentOutput = bodyOutput[mergeRequestDetailResponse]
 
 type githubStateInput struct {
-	Owner        string `path:"owner"`
-	Name         string `path:"name"`
-	Number       int    `path:"number"`
-	PlatformHost string `query:"platform_host"`
-	Body         struct {
+	Owner  string `path:"owner"`
+	Name   string `path:"name"`
+	Number int    `path:"number"`
+	Body   struct {
 		State        string `json:"state"`
-		PlatformHost string `json:"platform_host,omitempty"`
+		PlatformHost string `json:"platform_host"`
 	}
 }
 
@@ -873,7 +874,7 @@ func (s *Server) setKanbanState(ctx context.Context, input *setKanbanStateInput)
 		owner:        input.Owner,
 		name:         input.Name,
 		number:       input.Number,
-		platformHost: strings.TrimSpace(input.PlatformHost),
+		platformHost: strings.TrimSpace(input.Body.PlatformHost),
 	}
 	mrID, err := s.lookupMRID(ctx, ref)
 	if err != nil {
@@ -903,7 +904,7 @@ func (s *Server) editPRContent(
 		return nil, huma.Error400BadRequest("title must not be blank")
 	}
 
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -996,7 +997,7 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 		return nil, huma.Error400BadRequest("comment body must not be empty")
 	}
 
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -1041,7 +1042,7 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 		return nil, huma.Error400BadRequest("comment body must not be empty")
 	}
 
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -1480,7 +1481,7 @@ func (s *Server) getCommentAutocomplete(
 }
 
 func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionStatusOutput, error) {
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -1517,7 +1518,7 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 }
 
 func (s *Server) approveWorkflows(ctx context.Context, input *prActionInput) (*actionStatusOutput, error) {
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -1616,7 +1617,7 @@ func (s *Server) syncMRAfterPRAction(
 }
 
 func (s *Server) readyForReview(ctx context.Context, input *prActionInput) (*actionStatusOutput, error) {
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -1703,7 +1704,7 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 		return nil, huma.Error400BadRequest("invalid merge method: must be merge, squash, or rebase")
 	}
 
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -1795,7 +1796,7 @@ func (s *Server) setPRGitHubState(
 		)
 	}
 
-	platformHost := strings.TrimSpace(input.PlatformHost)
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {
@@ -1895,10 +1896,7 @@ func (s *Server) setIssueGitHubState(
 		)
 	}
 
-	platformHost := strings.TrimSpace(input.PlatformHost)
-	if platformHost == "" {
-		platformHost = strings.TrimSpace(input.Body.PlatformHost)
-	}
+	platformHost := strings.TrimSpace(input.Body.PlatformHost)
 	repo, issue, err := s.lookupIssue(ctx, repoNumberPathRef{
 		owner:        input.Owner,
 		name:         input.Name,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1899,7 +1899,7 @@ func (s *Server) setIssueGitHubState(
 		owner:        input.Owner,
 		name:         input.Name,
 		number:       input.Number,
-		platformHost: input.Body.PlatformHost,
+		platformHost: firstNonEmpty(input.PlatformHost, input.Body.PlatformHost),
 	})
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -177,10 +177,11 @@ type commentAutocompleteInput struct {
 type commentAutocompleteOutput = bodyOutput[commentAutocompleteResponse]
 
 type approvePRInput struct {
-	Owner  string `path:"owner"`
-	Name   string `path:"name"`
-	Number int    `path:"number"`
-	Body   struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+	Body         struct {
 		Body string `json:"body"`
 	}
 }
@@ -638,20 +639,20 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 
 func (s *Server) getPull(ctx context.Context, input *prDetailInput) (*getPullOutput, error) {
 	platformHost := strings.TrimSpace(input.PlatformHost)
-	var mr *db.MergeRequest
-	var err error
-	if platformHost == "" {
-		mr, err = s.db.GetMergeRequest(ctx, input.Owner, input.Name, input.Number)
-	} else {
-		repoObj, lookupErr := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
-		if lookupErr != nil {
-			if errors.Is(lookupErr, errRepoNotFound) {
-				return nil, huma.Error404NotFound("pull request not found")
-			}
-			return nil, huma.Error500InternalServerError("get repo failed")
+	repoObj, lookupErr := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if lookupErr != nil {
+		if errors.Is(lookupErr, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
 		}
-		mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
+		if errors.Is(lookupErr, errRepoNotFound) {
+			return nil, huma.Error404NotFound("pull request not found")
+		}
+		return nil, huma.Error500InternalServerError("get repo failed")
 	}
+
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request failed")
 	}
@@ -1411,7 +1412,21 @@ func (s *Server) getCommentAutocomplete(
 }
 
 func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionStatusOutput, error) {
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
 	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
@@ -1421,10 +1436,12 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 		return nil, huma.Error502BadGateway("GitHub API error")
 	}
 
-	ref := repoNumberPathRef{owner: input.Owner, name: input.Name, number: input.Number}
-	mrID, lookupErr := s.lookupMRID(ctx, ref)
-	if lookupErr == nil {
-		event := ghclient.NormalizeReviewEvent(mrID, review)
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("get pull request failed")
+	}
+	if mr != nil {
+		event := ghclient.NormalizeReviewEvent(mr.ID, review)
 		_ = s.db.UpsertMREvents(ctx, []db.MREvent{event})
 	}
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -76,10 +77,11 @@ type setKanbanStateInput struct {
 type statusOnlyOutput = okStatusOutput
 
 type postCommentInput struct {
-	Owner  string `path:"owner"`
-	Name   string `path:"name"`
-	Number int    `path:"number"`
-	Body   struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+	Body         struct {
 		Body string `json:"body"`
 	}
 }
@@ -87,11 +89,12 @@ type postCommentInput struct {
 type postCommentOutput = createdOutput[db.MREvent]
 
 type editCommentInput struct {
-	Owner     string `path:"owner"`
-	Name      string `path:"name"`
-	Number    int    `path:"number"`
-	CommentID int64  `path:"comment_id"`
-	Body      struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	CommentID    int64  `path:"comment_id"`
+	PlatformHost string `query:"platform_host"`
+	Body         struct {
 		Body string `json:"body"`
 	}
 }
@@ -215,10 +218,11 @@ type mergePRBody struct {
 type mergePROutput = bodyOutput[mergePRBody]
 
 type editPRContentInput struct {
-	Owner  string `path:"owner"`
-	Name   string `path:"name"`
-	Number int    `path:"number"`
-	Body   struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+	Body         struct {
 		Title *string `json:"title,omitempty"`
 		Body  *string `json:"body,omitempty"`
 	}
@@ -227,10 +231,11 @@ type editPRContentInput struct {
 type editPRContentOutput = bodyOutput[mergeRequestDetailResponse]
 
 type githubStateInput struct {
-	Owner  string `path:"owner"`
-	Name   string `path:"name"`
-	Number int    `path:"number"`
-	Body   struct {
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
+	Body         struct {
 		State        string `json:"state"`
 		PlatformHost string `json:"platform_host,omitempty"`
 	}
@@ -898,14 +903,26 @@ func (s *Server) editPRContent(
 		return nil, huma.Error400BadRequest("title must not be blank")
 	}
 
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
 	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
-	mr, err := s.db.GetMergeRequest(
-		ctx, input.Owner, input.Name, input.Number,
-	)
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(
 			"get pull request failed",
@@ -957,9 +974,7 @@ func (s *Server) editPRContent(
 		)
 	}
 
-	mr, err = s.db.GetMergeRequest(
-		ctx, input.Owner, input.Name, input.Number,
-	)
+	mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
 	if err != nil || mr == nil {
 		return nil, huma.Error500InternalServerError(
 			"re-read pull request failed",
@@ -981,7 +996,29 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 		return nil, huma.Error400BadRequest("comment body must not be empty")
 	}
 
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("get pull request failed")
+	}
+	if mr == nil {
+		return nil, huma.Error404NotFound("pull request not found")
+	}
+
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
 	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
@@ -991,13 +1028,7 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 		return nil, huma.Error502BadGateway("create comment on GitHub failed")
 	}
 
-	ref := repoNumberPathRef{owner: input.Owner, name: input.Name, number: input.Number}
-	mrID, err := s.lookupMRID(ctx, ref)
-	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
-	}
-
-	event := ghclient.NormalizeCommentEvent(mrID, comment)
+	event := ghclient.NormalizeCommentEvent(mr.ID, comment)
 	if err := s.db.UpsertMREvents(ctx, []db.MREvent{event}); err != nil {
 		_ = err
 	}
@@ -1010,18 +1041,34 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 		return nil, huma.Error400BadRequest("comment body must not be empty")
 	}
 
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("get pull request failed")
+	}
+	if mr == nil {
+		return nil, huma.Error404NotFound("pull request not found")
+	}
+
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
 	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
-	ref := repoNumberPathRef{owner: input.Owner, name: input.Name, number: input.Number}
-	mrID, err := s.lookupMRID(ctx, ref)
-	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
-	}
-
-	exists, err := s.db.MRCommentEventExists(ctx, mrID, input.CommentID)
+	exists, err := s.db.MRCommentEventExists(ctx, mr.ID, input.CommentID)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("validate comment target failed")
 	}
@@ -1036,7 +1083,7 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 		return nil, huma.Error502BadGateway("edit comment on GitHub failed")
 	}
 
-	event := ghclient.NormalizeCommentEvent(mrID, comment)
+	event := ghclient.NormalizeCommentEvent(mr.ID, comment)
 	if err := s.db.UpsertMREvents(ctx, []db.MREvent{event}); err != nil {
 		return nil, huma.Error500InternalServerError("persist edited comment failed")
 	}
@@ -1252,6 +1299,11 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 		ctx, input.Owner, input.Name, input.Body.PlatformHost,
 	)
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		if errors.Is(err, errRepoNotFound) {
 			return nil, huma.Error404NotFound(err.Error())
 		}
@@ -1298,6 +1350,11 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 		ctx, input.Owner, input.Name, input.Body.PlatformHost,
 	)
 	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
 		if errors.Is(err, errRepoNotFound) {
 			return nil, huma.Error404NotFound(err.Error())
 		}
@@ -1738,14 +1795,26 @@ func (s *Server) setPRGitHubState(
 		)
 	}
 
-	client, err := s.syncer.ClientForRepo(input.Owner, input.Name)
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	repoObj, err := s.lookupRepo(ctx, input.Owner, input.Name, platformHost)
+	if err != nil {
+		if errors.Is(err, errRepoAmbiguous) {
+			return nil, huma.Error400BadRequest(
+				"platform_host is required for ambiguous repo",
+			)
+		}
+		if errors.Is(err, errRepoNotFound) {
+			return nil, huma.Error404NotFound(err.Error())
+		}
+		return nil, huma.Error500InternalServerError("get repo: " + err.Error())
+	}
+
+	client, err := s.syncer.ClientForRepoOnHost(repoObj.Owner, repoObj.Name, repoObj.PlatformHost)
 	if err != nil {
 		return nil, huma.Error404NotFound(err.Error())
 	}
 
-	mr, err := s.db.GetMergeRequest(
-		ctx, input.Owner, input.Name, input.Number,
-	)
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(
 			"get pull request: " + err.Error(),
@@ -1768,45 +1837,33 @@ func (s *Server) setPRGitHubState(
 		if errors.As(err, &ghErr) && ghErr != nil && ghErr.Response != nil &&
 			ghErr.Response.StatusCode == http.StatusUnprocessableEntity {
 			// Re-fetch to sync local state and determine the real cause.
-			repoID, repoErr := s.lookupRepoID(
-				ctx, input.Owner, input.Name,
+			ghPR, fetchErr := client.GetPullRequest(
+				ctx, input.Owner, input.Name, input.Number,
 			)
-			if repoErr == nil {
-				ghPR, fetchErr := client.GetPullRequest(
-					ctx, input.Owner, input.Name, input.Number,
-				)
-				if fetchErr == nil {
-					if ghPR == nil {
-						return nil, huma.Error502BadGateway("GitHub API returned no pull request")
-					}
-					normalized, normalizeErr := ghclient.NormalizePR(repoID, ghPR)
-					if normalizeErr != nil {
-						return nil, huma.Error502BadGateway("GitHub API error: " + normalizeErr.Error())
-					}
-					_, _ = s.db.UpsertMergeRequest(ctx, normalized)
-					if ghPR.GetMerged() {
-						return nil, huma.Error409Conflict(
-							"cannot change state of a merged pull request",
-						)
-					}
-					// Already in requested state (concurrent edit).
-					if ghPR.GetState() == input.Body.State {
-						out := &githubStateOutput{}
-						out.Body.State = input.Body.State
-						return out, nil
-					}
+			if fetchErr == nil {
+				if ghPR == nil {
+					return nil, huma.Error502BadGateway("GitHub API returned no pull request")
+				}
+				normalized, normalizeErr := ghclient.NormalizePR(repoObj.ID, ghPR)
+				if normalizeErr != nil {
+					return nil, huma.Error502BadGateway("GitHub API error: " + normalizeErr.Error())
+				}
+				_, _ = s.db.UpsertMergeRequest(ctx, normalized)
+				if ghPR.GetMerged() {
+					return nil, huma.Error409Conflict(
+						"cannot change state of a merged pull request",
+					)
+				}
+				// Already in requested state (concurrent edit).
+				if ghPR.GetState() == input.Body.State {
+					out := &githubStateOutput{}
+					out.Body.State = input.Body.State
+					return out, nil
 				}
 			}
 		}
 		return nil, huma.Error502BadGateway(
 			"GitHub API error: " + err.Error(),
-		)
-	}
-
-	repoID, err := s.lookupRepoID(ctx, input.Owner, input.Name)
-	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get repo: " + err.Error(),
 		)
 	}
 
@@ -1816,7 +1873,7 @@ func (s *Server) setPRGitHubState(
 		closedAt = &now
 	}
 	if err := s.db.UpdateMRState(
-		ctx, repoID, input.Number,
+		ctx, repoObj.ID, input.Number,
 		input.Body.State, nil, closedAt,
 	); err != nil {
 		return nil, huma.Error500InternalServerError(
@@ -2414,14 +2471,54 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 
 type getCommitsOutput = bodyOutput[commitsResponse]
 
-func (s *Server) getCommits(ctx context.Context, input *repoNumberInput) (*getCommitsOutput, error) {
+func (s *Server) diffRefsForPR(
+	ctx context.Context,
+	owner string,
+	name string,
+	number int,
+	platformHost string,
+) (*db.Repo, *db.DiffSHAs, error) {
+	repoObj, err := s.lookupRepo(ctx, owner, name, strings.TrimSpace(platformHost))
+	if err != nil {
+		return nil, nil, err
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoObj.ID, number)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to look up PR: %w", err)
+	}
+	if mr == nil {
+		return repoObj, nil, nil
+	}
+	return repoObj, &db.DiffSHAs{
+		PlatformHeadSHA: mr.PlatformHeadSHA,
+		PlatformBaseSHA: mr.PlatformBaseSHA,
+		DiffHeadSHA:     mr.DiffHeadSHA,
+		DiffBaseSHA:     mr.DiffBaseSHA,
+		MergeBaseSHA:    mr.MergeBaseSHA,
+		State:           mr.State,
+	}, nil
+}
+
+func repoIdentityError(err error) error {
+	if errors.Is(err, errRepoAmbiguous) {
+		return huma.Error400BadRequest(
+			"platform_host is required for ambiguous repo",
+		)
+	}
+	if errors.Is(err, errRepoNotFound) {
+		return huma.Error404NotFound(err.Error())
+	}
+	return huma.Error500InternalServerError("get repo: " + err.Error())
+}
+
+func (s *Server) getCommits(ctx context.Context, input *prDetailInput) (*getCommitsOutput, error) {
 	if s.clones == nil {
 		return nil, huma.Error503ServiceUnavailable("commits not available: clone manager not configured")
 	}
 
-	shas, err := s.db.GetDiffSHAs(ctx, input.Owner, input.Name, input.Number)
+	repoObj, shas, err := s.diffRefsForPR(ctx, input.Owner, input.Name, input.Number, input.PlatformHost)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to look up PR")
+		return nil, repoIdentityError(err)
 	}
 	if shas == nil {
 		return nil, huma.Error404NotFound("pull request not found")
@@ -2430,7 +2527,7 @@ func (s *Server) getCommits(ctx context.Context, input *repoNumberInput) (*getCo
 		return nil, huma.Error404NotFound("commits not available for this pull request")
 	}
 
-	host := s.syncer.HostForRepo(input.Owner, input.Name)
+	host := repoObj.PlatformHost
 	commits, err := s.clones.ListCommits(ctx, host, input.Owner, input.Name, shas.MergeBaseSHA, shas.DiffHeadSHA)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
@@ -2454,13 +2551,14 @@ func (s *Server) getCommits(ctx context.Context, input *repoNumberInput) (*getCo
 // --- Diff ---
 
 type getDiffInput struct {
-	Owner      string `path:"owner"`
-	Name       string `path:"name"`
-	Number     int    `path:"number"`
-	Whitespace string `query:"whitespace"`
-	Commit     string `query:"commit" doc:"Scope to a single commit SHA"`
-	From       string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
-	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	Whitespace   string `query:"whitespace"`
+	Commit       string `query:"commit" doc:"Scope to a single commit SHA"`
+	From         string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
+	To           string `query:"to"     doc:"End SHA for range diff (inclusive)"`
+	PlatformHost string `query:"platform_host"`
 }
 
 type getDiffOutput = bodyOutput[diffResponse]
@@ -2470,9 +2568,9 @@ func (s *Server) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOutp
 		return nil, huma.Error503ServiceUnavailable("diff view not available: clone manager not configured")
 	}
 
-	shas, err := s.db.GetDiffSHAs(ctx, input.Owner, input.Name, input.Number)
+	repoObj, shas, err := s.diffRefsForPR(ctx, input.Owner, input.Name, input.Number, input.PlatformHost)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to look up PR")
+		return nil, repoIdentityError(err)
 	}
 	if shas == nil {
 		return nil, huma.Error404NotFound("pull request not found")
@@ -2481,7 +2579,7 @@ func (s *Server) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOutp
 		return nil, huma.Error404NotFound("diff not available for this pull request")
 	}
 
-	host := s.syncer.HostForRepo(input.Owner, input.Name)
+	host := repoObj.PlatformHost
 	hideWhitespace := input.Whitespace == "hide"
 
 	// Determine diff range based on scope query params.
@@ -2548,9 +2646,10 @@ func (s *Server) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOutp
 // --- Files (lightweight) ---
 
 type getFilesInput struct {
-	Owner  string `path:"owner"`
-	Name   string `path:"name"`
-	Number int    `path:"number"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	PlatformHost string `query:"platform_host"`
 }
 
 type getFilesOutput = bodyOutput[filesResponse]
@@ -2560,9 +2659,9 @@ func (s *Server) getFiles(ctx context.Context, input *getFilesInput) (*getFilesO
 		return nil, huma.Error503ServiceUnavailable("files view not available: clone manager not configured")
 	}
 
-	shas, err := s.db.GetDiffSHAs(ctx, input.Owner, input.Name, input.Number)
+	repoObj, shas, err := s.diffRefsForPR(ctx, input.Owner, input.Name, input.Number, input.PlatformHost)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to look up PR")
+		return nil, repoIdentityError(err)
 	}
 	if shas == nil {
 		return nil, huma.Error404NotFound("pull request not found")
@@ -2571,7 +2670,7 @@ func (s *Server) getFiles(ctx context.Context, input *getFilesInput) (*getFilesO
 		return nil, huma.Error404NotFound("file list not available for this pull request")
 	}
 
-	host := s.syncer.HostForRepo(input.Owner, input.Name)
+	host := repoObj.PlatformHost
 	files, err := s.clones.DiffFiles(ctx, host, input.Owner, input.Name, shas.MergeBaseSHA, shas.DiffHeadSHA)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1895,11 +1895,15 @@ func (s *Server) setIssueGitHubState(
 		)
 	}
 
+	platformHost := strings.TrimSpace(input.PlatformHost)
+	if platformHost == "" {
+		platformHost = strings.TrimSpace(input.Body.PlatformHost)
+	}
 	repo, issue, err := s.lookupIssue(ctx, repoNumberPathRef{
 		owner:        input.Owner,
 		name:         input.Name,
 		number:       input.Number,
-		platformHost: firstNonEmpty(input.PlatformHost, input.Body.PlatformHost),
+		platformHost: platformHost,
 	})
 	if err != nil {
 		if errors.Is(err, errRepoAmbiguous) {

--- a/internal/server/repo_identity.go
+++ b/internal/server/repo_identity.go
@@ -2,11 +2,9 @@ package server
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/repoidentity"
 )
 
 type repoIdentityRef struct {
@@ -16,159 +14,83 @@ type repoIdentityRef struct {
 }
 
 type repositoryIdentityModule struct {
-	server *Server
+	module repoidentity.Module
 }
 
-type resolvedLocalItem struct {
-	Repo     *db.Repo
-	ItemType string
-	Found    bool
-}
+type resolvedLocalItem = repoidentity.ResolvedLocalItem
 
-var errRepoAmbiguous = errors.New("repo ambiguous")
+var errRepoAmbiguous = repoidentity.ErrAmbiguous
 
 func (s *Server) repoIdentity() repositoryIdentityModule {
-	return repositoryIdentityModule{server: s}
+	return repositoryIdentityModule{module: repoidentity.New(s.db)}
 }
 
 func (m repositoryIdentityModule) LookupRepo(
 	ctx context.Context,
 	ref repoIdentityRef,
 ) (*db.Repo, error) {
-	ref = normalizeRepoIdentityRef(ref)
-	if ref.platformHost != "" {
-		return m.lookupRepoOnHost(ctx, ref)
-	}
-	repos, err := m.server.db.ListReposByOwnerName(ctx, ref.owner, ref.name)
-	if err != nil {
-		return nil, fmt.Errorf("list matching repos: %w", err)
-	}
-	switch len(repos) {
-	case 0:
-		return nil, errRepoNotFound
-	case 1:
-		return &repos[0], nil
-	default:
-		return nil, errRepoAmbiguous
-	}
+	return m.module.LookupRepo(ctx, repoidentity.Ref{
+		Owner:        ref.owner,
+		Name:         ref.name,
+		PlatformHost: ref.platformHost,
+	})
 }
 
 func (m repositoryIdentityModule) LookupRepoID(
 	ctx context.Context,
 	ref repoIdentityRef,
 ) (int64, error) {
-	repo, err := m.LookupRepo(ctx, ref)
-	if err != nil {
-		return 0, err
-	}
-	return repo.ID, nil
+	return m.module.LookupRepoID(ctx, repoidentity.Ref{
+		Owner:        ref.owner,
+		Name:         ref.name,
+		PlatformHost: ref.platformHost,
+	})
 }
 
 func (m repositoryIdentityModule) LookupMRID(
 	ctx context.Context,
 	ref repoNumberPathRef,
 ) (int64, error) {
-	repo, err := m.LookupRepo(ctx, repoIdentityRef{
-		owner:        ref.owner,
-		name:         ref.name,
-		platformHost: ref.platformHost,
+	return m.module.LookupMRID(ctx, repoidentity.NumberRef{
+		Owner:        ref.owner,
+		Name:         ref.name,
+		Number:       ref.number,
+		PlatformHost: ref.platformHost,
 	})
-	if err != nil {
-		return 0, err
-	}
-
-	mr, err := m.server.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, ref.number)
-	if err != nil {
-		return 0, err
-	}
-	if mr == nil {
-		return 0, fmt.Errorf("MR %s/%s#%d not found", ref.owner, ref.name, ref.number)
-	}
-	return mr.ID, nil
 }
 
 func (m repositoryIdentityModule) LookupIssueID(
 	ctx context.Context,
 	ref repoNumberPathRef,
 ) (int64, error) {
-	_, issue, err := m.LookupIssue(ctx, ref)
-	if err != nil {
-		return 0, err
-	}
-	return issue.ID, nil
+	return m.module.LookupIssueID(ctx, repoidentity.NumberRef{
+		Owner:        ref.owner,
+		Name:         ref.name,
+		Number:       ref.number,
+		PlatformHost: ref.platformHost,
+	})
 }
 
 func (m repositoryIdentityModule) LookupIssue(
 	ctx context.Context,
 	ref repoNumberPathRef,
 ) (*db.Repo, *db.Issue, error) {
-	repo, err := m.LookupRepo(ctx, repoIdentityRef{
-		owner:        ref.owner,
-		name:         ref.name,
-		platformHost: ref.platformHost,
+	return m.module.LookupIssue(ctx, repoidentity.NumberRef{
+		Owner:        ref.owner,
+		Name:         ref.name,
+		Number:       ref.number,
+		PlatformHost: ref.platformHost,
 	})
-	if err != nil {
-		return nil, nil, err
-	}
-	issue, err := m.server.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, ref.number)
-	if err != nil {
-		return nil, nil, err
-	}
-	if issue == nil {
-		return repo, nil, fmt.Errorf(
-			"issue %s/%s#%d not found", ref.owner, ref.name, ref.number,
-		)
-	}
-	return repo, issue, nil
 }
 
 func (m repositoryIdentityModule) ResolveLocalItem(
 	ctx context.Context,
 	ref repoNumberPathRef,
 ) (resolvedLocalItem, error) {
-	repo, err := m.LookupRepo(ctx, repoIdentityRef{
-		owner:        ref.owner,
-		name:         ref.name,
-		platformHost: ref.platformHost,
+	return m.module.ResolveLocalItem(ctx, repoidentity.NumberRef{
+		Owner:        ref.owner,
+		Name:         ref.name,
+		Number:       ref.number,
+		PlatformHost: ref.platformHost,
 	})
-	if errors.Is(err, errRepoNotFound) {
-		return resolvedLocalItem{}, nil
-	}
-	if err != nil {
-		return resolvedLocalItem{}, err
-	}
-
-	itemType, found, err := m.server.db.ResolveItemNumber(ctx, repo.ID, ref.number)
-	if err != nil {
-		return resolvedLocalItem{}, err
-	}
-	return resolvedLocalItem{
-		Repo:     repo,
-		ItemType: itemType,
-		Found:    found,
-	}, nil
-}
-
-func (m repositoryIdentityModule) lookupRepoOnHost(
-	ctx context.Context,
-	ref repoIdentityRef,
-) (*db.Repo, error) {
-	repo, err := m.server.db.GetRepoByHostOwnerName(
-		ctx, ref.platformHost, ref.owner, ref.name,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("get repo: %w", err)
-	}
-	if repo == nil {
-		return nil, errRepoNotFound
-	}
-	return repo, nil
-}
-
-func normalizeRepoIdentityRef(ref repoIdentityRef) repoIdentityRef {
-	return repoIdentityRef{
-		owner:        strings.ToLower(strings.TrimSpace(ref.owner)),
-		name:         strings.ToLower(strings.TrimSpace(ref.name)),
-		platformHost: strings.ToLower(strings.TrimSpace(ref.platformHost)),
-	}
 }

--- a/internal/server/repo_identity.go
+++ b/internal/server/repo_identity.go
@@ -15,13 +15,6 @@ type repoIdentityRef struct {
 	platformHost string
 }
 
-type repoLookupMode int
-
-const (
-	repoLookupOwnerNameAllowed repoLookupMode = iota
-	repoLookupRequireUnambiguousOwnerName
-)
-
 type repositoryIdentityModule struct {
 	server *Server
 }
@@ -41,43 +34,30 @@ func (s *Server) repoIdentity() repositoryIdentityModule {
 func (m repositoryIdentityModule) LookupRepo(
 	ctx context.Context,
 	ref repoIdentityRef,
-	mode repoLookupMode,
 ) (*db.Repo, error) {
 	ref = normalizeRepoIdentityRef(ref)
 	if ref.platformHost != "" {
 		return m.lookupRepoOnHost(ctx, ref)
 	}
-	if mode == repoLookupRequireUnambiguousOwnerName {
-		repos, err := m.server.db.ListReposByOwnerName(ctx, ref.owner, ref.name)
-		if err != nil {
-			return nil, fmt.Errorf("list matching repos: %w", err)
-		}
-		switch len(repos) {
-		case 0:
-			return nil, errRepoNotFound
-		case 1:
-			return &repos[0], nil
-		default:
-			return nil, errRepoAmbiguous
-		}
-	}
-
-	repo, err := m.server.db.GetRepoByOwnerName(ctx, ref.owner, ref.name)
+	repos, err := m.server.db.ListReposByOwnerName(ctx, ref.owner, ref.name)
 	if err != nil {
-		return nil, fmt.Errorf("get repo: %w", err)
+		return nil, fmt.Errorf("list matching repos: %w", err)
 	}
-	if repo == nil {
+	switch len(repos) {
+	case 0:
 		return nil, errRepoNotFound
+	case 1:
+		return &repos[0], nil
+	default:
+		return nil, errRepoAmbiguous
 	}
-	return repo, nil
 }
 
 func (m repositoryIdentityModule) LookupRepoID(
 	ctx context.Context,
 	ref repoIdentityRef,
-	mode repoLookupMode,
 ) (int64, error) {
-	repo, err := m.LookupRepo(ctx, ref, mode)
+	repo, err := m.LookupRepo(ctx, ref)
 	if err != nil {
 		return 0, err
 	}
@@ -92,7 +72,7 @@ func (m repositoryIdentityModule) LookupMRID(
 		owner:        ref.owner,
 		name:         ref.name,
 		platformHost: ref.platformHost,
-	}, repoLookupOwnerNameAllowed)
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -126,7 +106,7 @@ func (m repositoryIdentityModule) LookupIssue(
 		owner:        ref.owner,
 		name:         ref.name,
 		platformHost: ref.platformHost,
-	}, repoLookupOwnerNameAllowed)
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -150,7 +130,7 @@ func (m repositoryIdentityModule) ResolveLocalItem(
 		owner:        ref.owner,
 		name:         ref.name,
 		platformHost: ref.platformHost,
-	}, repoLookupOwnerNameAllowed)
+	})
 	if errors.Is(err, errRepoNotFound) {
 		return resolvedLocalItem{}, nil
 	}

--- a/internal/server/repo_identity.go
+++ b/internal/server/repo_identity.go
@@ -19,7 +19,10 @@ type repositoryIdentityModule struct {
 
 type resolvedLocalItem = repoidentity.ResolvedLocalItem
 
-var errRepoAmbiguous = repoidentity.ErrAmbiguous
+var (
+	errRepoAmbiguous           = repoidentity.ErrAmbiguous
+	errRepoMissingPlatformHost = repoidentity.ErrMissingPlatformHost
+)
 
 func (s *Server) repoIdentity() repositoryIdentityModule {
 	return repositoryIdentityModule{module: repoidentity.New(s.db)}

--- a/internal/server/repo_identity.go
+++ b/internal/server/repo_identity.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/wesm/middleman/internal/db"
+)
+
+type repoIdentityRef struct {
+	owner        string
+	name         string
+	platformHost string
+}
+
+type repoLookupMode int
+
+const (
+	repoLookupOwnerNameAllowed repoLookupMode = iota
+	repoLookupRequireUnambiguousOwnerName
+)
+
+type repositoryIdentityModule struct {
+	server *Server
+}
+
+type resolvedLocalItem struct {
+	Repo     *db.Repo
+	ItemType string
+	Found    bool
+}
+
+var errRepoAmbiguous = errors.New("repo ambiguous")
+
+func (s *Server) repoIdentity() repositoryIdentityModule {
+	return repositoryIdentityModule{server: s}
+}
+
+func (m repositoryIdentityModule) LookupRepo(
+	ctx context.Context,
+	ref repoIdentityRef,
+	mode repoLookupMode,
+) (*db.Repo, error) {
+	ref = normalizeRepoIdentityRef(ref)
+	if ref.platformHost != "" {
+		return m.lookupRepoOnHost(ctx, ref)
+	}
+	if mode == repoLookupRequireUnambiguousOwnerName {
+		repos, err := m.server.db.ListReposByOwnerName(ctx, ref.owner, ref.name)
+		if err != nil {
+			return nil, fmt.Errorf("list matching repos: %w", err)
+		}
+		switch len(repos) {
+		case 0:
+			return nil, errRepoNotFound
+		case 1:
+			return &repos[0], nil
+		default:
+			return nil, errRepoAmbiguous
+		}
+	}
+
+	repo, err := m.server.db.GetRepoByOwnerName(ctx, ref.owner, ref.name)
+	if err != nil {
+		return nil, fmt.Errorf("get repo: %w", err)
+	}
+	if repo == nil {
+		return nil, errRepoNotFound
+	}
+	return repo, nil
+}
+
+func (m repositoryIdentityModule) LookupRepoID(
+	ctx context.Context,
+	ref repoIdentityRef,
+	mode repoLookupMode,
+) (int64, error) {
+	repo, err := m.LookupRepo(ctx, ref, mode)
+	if err != nil {
+		return 0, err
+	}
+	return repo.ID, nil
+}
+
+func (m repositoryIdentityModule) LookupMRID(
+	ctx context.Context,
+	ref repoNumberPathRef,
+) (int64, error) {
+	repo, err := m.LookupRepo(ctx, repoIdentityRef{
+		owner:        ref.owner,
+		name:         ref.name,
+		platformHost: ref.platformHost,
+	}, repoLookupOwnerNameAllowed)
+	if err != nil {
+		return 0, err
+	}
+
+	mr, err := m.server.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, ref.number)
+	if err != nil {
+		return 0, err
+	}
+	if mr == nil {
+		return 0, fmt.Errorf("MR %s/%s#%d not found", ref.owner, ref.name, ref.number)
+	}
+	return mr.ID, nil
+}
+
+func (m repositoryIdentityModule) LookupIssueID(
+	ctx context.Context,
+	ref repoNumberPathRef,
+) (int64, error) {
+	_, issue, err := m.LookupIssue(ctx, ref)
+	if err != nil {
+		return 0, err
+	}
+	return issue.ID, nil
+}
+
+func (m repositoryIdentityModule) LookupIssue(
+	ctx context.Context,
+	ref repoNumberPathRef,
+) (*db.Repo, *db.Issue, error) {
+	repo, err := m.LookupRepo(ctx, repoIdentityRef{
+		owner:        ref.owner,
+		name:         ref.name,
+		platformHost: ref.platformHost,
+	}, repoLookupOwnerNameAllowed)
+	if err != nil {
+		return nil, nil, err
+	}
+	issue, err := m.server.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, ref.number)
+	if err != nil {
+		return nil, nil, err
+	}
+	if issue == nil {
+		return repo, nil, fmt.Errorf(
+			"issue %s/%s#%d not found", ref.owner, ref.name, ref.number,
+		)
+	}
+	return repo, issue, nil
+}
+
+func (m repositoryIdentityModule) ResolveLocalItem(
+	ctx context.Context,
+	ref repoNumberPathRef,
+) (resolvedLocalItem, error) {
+	repo, err := m.LookupRepo(ctx, repoIdentityRef{
+		owner:        ref.owner,
+		name:         ref.name,
+		platformHost: ref.platformHost,
+	}, repoLookupOwnerNameAllowed)
+	if errors.Is(err, errRepoNotFound) {
+		return resolvedLocalItem{}, nil
+	}
+	if err != nil {
+		return resolvedLocalItem{}, err
+	}
+
+	itemType, found, err := m.server.db.ResolveItemNumber(ctx, repo.ID, ref.number)
+	if err != nil {
+		return resolvedLocalItem{}, err
+	}
+	return resolvedLocalItem{
+		Repo:     repo,
+		ItemType: itemType,
+		Found:    found,
+	}, nil
+}
+
+func (m repositoryIdentityModule) lookupRepoOnHost(
+	ctx context.Context,
+	ref repoIdentityRef,
+) (*db.Repo, error) {
+	repo, err := m.server.db.GetRepoByHostOwnerName(
+		ctx, ref.platformHost, ref.owner, ref.name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get repo: %w", err)
+	}
+	if repo == nil {
+		return nil, errRepoNotFound
+	}
+	return repo, nil
+}
+
+func normalizeRepoIdentityRef(ref repoIdentityRef) repoIdentityRef {
+	return repoIdentityRef{
+		owner:        strings.ToLower(strings.TrimSpace(ref.owner)),
+		name:         strings.ToLower(strings.TrimSpace(ref.name)),
+		platformHost: strings.ToLower(strings.TrimSpace(ref.platformHost)),
+	}
+}

--- a/internal/server/repo_identity_test.go
+++ b/internal/server/repo_identity_test.go
@@ -22,7 +22,7 @@ func TestRepositoryIdentityRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testi
 	repo, err := srv.repoIdentity().LookupRepo(ctx, repoIdentityRef{
 		owner: "acme",
 		name:  "widget",
-	}, repoLookupRequireUnambiguousOwnerName)
+	})
 	require.ErrorIs(err, errRepoAmbiguous)
 	assert.Nil(repo)
 
@@ -30,7 +30,7 @@ func TestRepositoryIdentityRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testi
 		owner:        "acme",
 		name:         "widget",
 		platformHost: "ghe.example.com",
-	}, repoLookupRequireUnambiguousOwnerName)
+	})
 	require.NoError(err)
 	require.NotNil(repo)
 	assert.Equal(gheID, repo.ID)
@@ -95,7 +95,7 @@ func TestRepositoryIdentityReturnsNotFoundForMissingRepo(t *testing.T) {
 	repo, err := srv.repoIdentity().LookupRepo(t.Context(), repoIdentityRef{
 		owner: "missing",
 		name:  "repo",
-	}, repoLookupOwnerNameAllowed)
+	})
 	require.ErrorIs(t, err, errRepoNotFound)
 	require.Nil(t, repo)
 }

--- a/internal/server/repo_identity_test.go
+++ b/internal/server/repo_identity_test.go
@@ -8,7 +8,7 @@ import (
 	ghclient "github.com/wesm/middleman/internal/github"
 )
 
-func TestRepositoryIdentityRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testing.T) {
+func TestRepositoryIdentityRequiresPlatformHost(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -23,7 +23,7 @@ func TestRepositoryIdentityRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testi
 		owner: "acme",
 		name:  "widget",
 	})
-	require.ErrorIs(err, errRepoAmbiguous)
+	require.ErrorIs(err, errRepoMissingPlatformHost)
 	assert.Nil(repo)
 
 	repo, err = srv.repoIdentity().LookupRepo(ctx, repoIdentityRef{
@@ -80,9 +80,10 @@ func TestRepositoryIdentityTreatsMissingLocalRepoAsUnresolvedItem(t *testing.T) 
 	srv, _ := setupTestServer(t)
 
 	result, err := srv.repoIdentity().ResolveLocalItem(t.Context(), repoNumberPathRef{
-		owner:  "acme",
-		name:   "widget",
-		number: 99,
+		owner:        "acme",
+		name:         "widget",
+		number:       99,
+		platformHost: "github.com",
 	})
 	require.NoError(err)
 	assert.False(result.Found)
@@ -93,8 +94,9 @@ func TestRepositoryIdentityReturnsNotFoundForMissingRepo(t *testing.T) {
 	srv, _ := setupTestServer(t)
 
 	repo, err := srv.repoIdentity().LookupRepo(t.Context(), repoIdentityRef{
-		owner: "missing",
-		name:  "repo",
+		owner:        "missing",
+		name:         "repo",
+		platformHost: "github.com",
 	})
 	require.ErrorIs(t, err, errRepoNotFound)
 	require.Nil(t, repo)

--- a/internal/server/repo_identity_test.go
+++ b/internal/server/repo_identity_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ghclient "github.com/wesm/middleman/internal/github"
+)
+
+func TestRepositoryIdentityRequiresPlatformHostWhenOwnerNameIsAmbiguous(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	_, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(err)
+	gheID, err := database.UpsertRepo(ctx, "ghe.example.com", "acme", "widget")
+	require.NoError(err)
+
+	repo, err := srv.repoIdentity().LookupRepo(ctx, repoIdentityRef{
+		owner: "acme",
+		name:  "widget",
+	}, repoLookupRequireUnambiguousOwnerName)
+	require.ErrorIs(err, errRepoAmbiguous)
+	assert.Nil(repo)
+
+	repo, err = srv.repoIdentity().LookupRepo(ctx, repoIdentityRef{
+		owner:        "acme",
+		name:         "widget",
+		platformHost: "ghe.example.com",
+	}, repoLookupRequireUnambiguousOwnerName)
+	require.NoError(err)
+	require.NotNil(repo)
+	assert.Equal(gheID, repo.ID)
+	assert.Equal("ghe.example.com", repo.PlatformHost)
+}
+
+func TestRepositoryIdentityResolvesItemsByRepoIDAfterHostSelection(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: "ghe.example.com"},
+	})
+	githubIssueID := seedIssueOnHost(
+		t, database, "github.com", "acme", "widget", 5, "open", "GitHub issue",
+	)
+	gheIssueID := seedIssueOnHost(
+		t, database, "ghe.example.com", "acme", "widget", 5, "open", "GHE issue",
+	)
+
+	_, issue, err := srv.repoIdentity().LookupIssue(t.Context(), repoNumberPathRef{
+		owner:        "acme",
+		name:         "widget",
+		number:       5,
+		platformHost: "ghe.example.com",
+	})
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.Equal(gheIssueID, issue.ID)
+
+	_, issue, err = srv.repoIdentity().LookupIssue(t.Context(), repoNumberPathRef{
+		owner:        "acme",
+		name:         "widget",
+		number:       5,
+		platformHost: "github.com",
+	})
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.Equal(githubIssueID, issue.ID)
+}
+
+func TestRepositoryIdentityTreatsMissingLocalRepoAsUnresolvedItem(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+
+	result, err := srv.repoIdentity().ResolveLocalItem(t.Context(), repoNumberPathRef{
+		owner:  "acme",
+		name:   "widget",
+		number: 99,
+	})
+	require.NoError(err)
+	assert.False(result.Found)
+	assert.Nil(result.Repo)
+}
+
+func TestRepositoryIdentityReturnsNotFoundForMissingRepo(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	repo, err := srv.repoIdentity().LookupRepo(t.Context(), repoIdentityRef{
+		owner: "missing",
+		name:  "repo",
+	}, repoLookupOwnerNameAllowed)
+	require.ErrorIs(t, err, errRepoNotFound)
+	require.Nil(t, repo)
+}

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2458,7 +2458,9 @@ export interface operations {
     };
     "set-issue-github-state": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -2670,7 +2672,9 @@ export interface operations {
     };
     "edit-pr-content": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -2781,7 +2785,9 @@ export interface operations {
     };
     "post-pr-comment": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -2818,7 +2824,9 @@ export interface operations {
     };
     "edit-pr-comment": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -2856,7 +2864,9 @@ export interface operations {
     };
     "get-repos-by-owner-by-name-pulls-by-number-commits": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -2897,6 +2907,7 @@ export interface operations {
                 from?: string;
                 /** @description End SHA for range diff (inclusive) */
                 to?: string;
+                platform_host?: string;
             };
             header?: never;
             path: {
@@ -2930,7 +2941,9 @@ export interface operations {
     };
     "get-repos-by-owner-by-name-pulls-by-number-files": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -2963,7 +2976,9 @@ export interface operations {
     };
     "set-pr-github-state": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2742,7 +2742,9 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-approve-workflows": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -3027,7 +3029,9 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-merge": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -3064,7 +3068,9 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-ready-for-review": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -917,6 +917,7 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
+            platform_host: string;
         };
         BulkAddRepoRequest: {
             name: string;
@@ -986,7 +987,7 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
-            platform_host?: string;
+            platform_host: string;
             title: string;
         };
         CreateIssueWorkspaceInputBody: {
@@ -1045,6 +1046,7 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
+            platform_host: string;
         };
         EditIssueCommentInputBody: {
             /**
@@ -1054,7 +1056,7 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
-            platform_host?: string;
+            platform_host: string;
         };
         EditPRContentInputBody: {
             /**
@@ -1064,6 +1066,7 @@ export interface components {
              */
             readonly $schema?: string;
             body?: string;
+            platform_host: string;
             title?: string;
         };
         ErrorDetail: {
@@ -1130,7 +1133,7 @@ export interface components {
              * @example /api/v1/schemas/GithubStateInputBody.json
              */
             readonly $schema?: string;
-            platform_host?: string;
+            platform_host: string;
             state: string;
         };
         GithubStateOutputBody: {
@@ -1344,6 +1347,7 @@ export interface components {
             commit_message: string;
             commit_title: string;
             method: string;
+            platform_host: string;
         };
         MergeRequest: {
             /** Format: int64 */
@@ -1488,6 +1492,7 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
+            platform_host: string;
         };
         PostIssueCommentInputBody: {
             /**
@@ -1497,7 +1502,16 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
-            platform_host?: string;
+            platform_host: string;
+        };
+        PrActionInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/PrActionInputBody.json
+             */
+            readonly $schema?: string;
+            platform_host: string;
         };
         RateLimitHostStatus: {
             /** Format: int64 */
@@ -1708,6 +1722,7 @@ export interface components {
              * @example /api/v1/schemas/SetKanbanStateInputBody.json
              */
             readonly $schema?: string;
+            platform_host: string;
             status: string;
         };
         SettingsResponse: {
@@ -1774,7 +1789,7 @@ export interface components {
             /** Format: int64 */
             number: number;
             owner: string;
-            platform_host?: string;
+            platform_host: string;
         };
         SyncStatus: {
             /**
@@ -2458,9 +2473,7 @@ export interface operations {
     };
     "set-issue-github-state": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -2672,9 +2685,7 @@ export interface operations {
     };
     "edit-pr-content": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -2711,9 +2722,7 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-approve": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -2750,9 +2759,7 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-approve-workflows": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -2761,7 +2768,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PrActionInputBody"];
+            };
+        };
         responses: {
             /** @description OK */
             200: {
@@ -2785,9 +2796,7 @@ export interface operations {
     };
     "post-pr-comment": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -2824,9 +2833,7 @@ export interface operations {
     };
     "edit-pr-comment": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -2976,9 +2983,7 @@ export interface operations {
     };
     "set-pr-github-state": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -3048,9 +3053,7 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-merge": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -3087,9 +3090,7 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-ready-for-review": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;
@@ -3098,7 +3099,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PrActionInputBody"];
+            };
+        };
         responses: {
             /** @description OK */
             200: {
@@ -3155,9 +3160,7 @@ export interface operations {
     };
     "set-kanban-state": {
         parameters: {
-            query?: {
-                platform_host?: string;
-            };
+            query?: never;
             header?: never;
             path: {
                 owner: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2600,7 +2600,9 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-items-by-number-resolve": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2635,7 +2635,9 @@ export interface operations {
     };
     "get-repos-by-owner-by-name-pulls-by-number": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -3171,7 +3173,9 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-sync": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;
@@ -3204,7 +3208,9 @@ export interface operations {
     };
     "enqueue-pr-sync": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -3140,7 +3140,9 @@ export interface operations {
     };
     "set-kanban-state": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2707,7 +2707,9 @@ export interface operations {
     };
     "post-repos-by-owner-by-name-pulls-by-number-approve": {
         parameters: {
-            query?: never;
+            query?: {
+                platform_host?: string;
+            };
             header?: never;
             path: {
                 owner: string;

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -330,9 +330,8 @@
       && selectedItem.owner === item.repo_owner
       && selectedItem.name === item.repo_name
       && selectedItem.number === item.item_number
-      && (item.item_type !== "issue"
-        || !selectedItem.platformHost
-        || selectedItem.platformHost === item.platform_host);
+      && (!selectedItem.platformHost
+        || selectedItem.platformHost === (item.platform_host || "github.com"));
   }
 
   function handleLinkClick(e: Event, url: string): void {

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -137,6 +137,39 @@ describe("ActivityFeed compact mode", () => {
     ).toHaveLength(2);
   });
 
+  it("highlights only the matching host for host-qualified PR selection", () => {
+    items.value = [
+      activityItem("github", {
+        item_title: "GitHub copy",
+        platform_host: "github.com",
+      }),
+      activityItem("ghes", {
+        item_title: "GHES copy",
+        item_url: "https://ghe.example.com/acme/widgets/pull/1",
+        platform_host: "ghe.example.com",
+      }),
+    ];
+
+    const { container } = render(ActivityFeed, {
+      props: {
+        compact: true,
+        selectedItem: {
+          itemType: "pr",
+          owner: "acme",
+          name: "widgets",
+          number: 1,
+          platformHost: "ghe.example.com",
+        },
+      },
+    });
+
+    const selectedRows = container.querySelectorAll(
+      ".activity-compact-row.selected",
+    );
+    expect(selectedRows).toHaveLength(1);
+    expect(selectedRows[0]?.textContent).toContain("GHES copy");
+  });
+
   it("uses shared semantic chips for compact item kind and state", () => {
     items.value = [
       activityItem("merged", {

--- a/packages/ui/src/components/DetailDrawer.svelte
+++ b/packages/ui/src/components/DetailDrawer.svelte
@@ -38,12 +38,13 @@
       </span>
     </div>
     <div class="drawer-body">
-      {#key `${owner}/${name}/${number}`}
+      {#key `${platformHost ?? ""}/${owner}/${name}/${number}`}
         {#if itemType === "pr"}
           <PullDetail
             {owner}
             {name}
             {number}
+            {platformHost}
             {...(onPullsRefresh ? { onPullsRefresh } : {})}
           />
         {:else}

--- a/packages/ui/src/components/activityRows.test.ts
+++ b/packages/ui/src/components/activityRows.test.ts
@@ -9,6 +9,7 @@ function item(
   id: string,
   activity_type: string,
   author: string,
+  platformHost = "github.com",
 ): ActivityItem {
   return {
     id,
@@ -16,10 +17,11 @@ function item(
     activity_type,
     repo_owner: "acme",
     repo_name: "widgets",
+    platform_host: platformHost,
     item_type: "pr",
     item_number: 7,
     item_title: "Rewrite branch",
-    item_url: "https://github.com/acme/widgets/pull/7",
+    item_url: `https://${platformHost}/acme/widgets/pull/7`,
     item_state: "open",
     author,
     created_at: new Date(Number(id) * 1000).toISOString(),
@@ -57,5 +59,18 @@ describe("collapseActivityCommitRuns", () => {
         && rows[1]!.activity_type,
     ).toBe("force_push");
     expect(isCollapsedActivityRow(rows[2]!)).toBe(true);
+  });
+
+  it("does not collapse commits from duplicate repos on different hosts", () => {
+    const rows = collapseActivityCommitRuns([
+      item("5", "commit", "alice", "github.com"),
+      item("4", "commit", "alice", "ghe.example.com"),
+      item("3", "commit", "alice", "ghe.example.com"),
+    ]);
+
+    expect(rows).toHaveLength(3);
+    expect(isCollapsedActivityRow(rows[0]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[1]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[2]!)).toBe(false);
   });
 });

--- a/packages/ui/src/components/activityRows.ts
+++ b/packages/ui/src/components/activityRows.ts
@@ -20,6 +20,10 @@ export function isCollapsedActivityRow(
   return "kind" in row && row.kind === "collapsed";
 }
 
+function activityHost(item: ActivityItem): string {
+  return item.platform_host || "github.com";
+}
+
 export function collapseActivityCommitRuns(
   items: ActivityItem[],
 ): ActivityRow[] {
@@ -43,6 +47,7 @@ export function collapseActivityCommitRuns(
         || next.repo_owner !== item.repo_owner
         || next.repo_name !== item.repo_name
         || next.item_number !== item.item_number
+        || activityHost(next) !== activityHost(item)
       ) {
         break;
       }

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -48,9 +48,8 @@
       const { error } = await client.POST("/repos/{owner}/{name}/pulls/{number}/approve", {
         params: {
           path: { owner, name, number },
-          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
         },
-        body: { body: body.trim() },
+        body: { body: body.trim(), platform_host: platformHost ?? "" },
       });
       if (error) {
         throw new Error(error.detail ?? error.title ?? "failed to approve pull request");

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -10,6 +10,7 @@
     owner: string;
     name: string;
     number: number;
+    platformHost?: string | undefined;
     size?: "sm" | "md";
     disabled?: boolean;
   }
@@ -18,6 +19,7 @@
     owner,
     name,
     number,
+    platformHost,
     size = "md",
     disabled = false,
   }: Props = $props();
@@ -44,7 +46,10 @@
     error = null;
     try {
       const { error } = await client.POST("/repos/{owner}/{name}/pulls/{number}/approve", {
-        params: { path: { owner, name, number } },
+        params: {
+          path: { owner, name, number },
+          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+        },
         body: { body: body.trim() },
       });
       if (error) {
@@ -52,7 +57,7 @@
       }
       body = "";
       expanded = false;
-      await detail.loadDetail(owner, name, number);
+      await detail.loadDetail(owner, name, number, { platformHost });
       await pulls.loadPulls();
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);

--- a/packages/ui/src/components/detail/ApproveWorkflowsButton.svelte
+++ b/packages/ui/src/components/detail/ApproveWorkflowsButton.svelte
@@ -50,8 +50,8 @@
         {
           params: {
             path: { owner, name, number },
-            ...(platformHost ? { query: { platform_host: platformHost } } : {}),
           },
+          body: { platform_host: platformHost ?? "" },
         },
       );
       if (requestError) {

--- a/packages/ui/src/components/detail/ApproveWorkflowsButton.svelte
+++ b/packages/ui/src/components/detail/ApproveWorkflowsButton.svelte
@@ -10,6 +10,7 @@
     owner: string;
     name: string;
     number: number;
+    platformHost?: string | undefined;
     count: number;
     size?: "sm" | "md";
     disabled?: boolean;
@@ -20,6 +21,7 @@
     owner,
     name,
     number,
+    platformHost,
     count,
     size = "md",
     disabled = false,
@@ -46,7 +48,10 @@
       const { error: requestError } = await client.POST(
         "/repos/{owner}/{name}/pulls/{number}/approve-workflows",
         {
-          params: { path: { owner, name, number } },
+          params: {
+            path: { owner, name, number },
+            ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+          },
         },
       );
       if (requestError) {
@@ -56,7 +61,7 @@
             "failed to approve workflows",
         );
       }
-      await detail.refreshDetailOnly(owner, name, number);
+      await detail.refreshDetailOnly(owner, name, number, platformHost);
       await pulls.loadPulls();
       oncompleted?.();
     } catch (err) {

--- a/packages/ui/src/components/detail/CommentBox.svelte
+++ b/packages/ui/src/components/detail/CommentBox.svelte
@@ -73,6 +73,7 @@
         submittedOwner,
         submittedName,
         submittedNumber,
+        submittedPlatformHost,
         submittedBody,
       );
       const storeError = detail.getDetailError();

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -14,6 +14,7 @@
     events: Array<PREvent | IssueEvent>;
     repoOwner?: string;
     repoName?: string;
+    platformHost?: string | undefined;
     filtered?: boolean;
     showCommitDetails?: boolean;
     onEditComment?: (event: PREvent | IssueEvent, body: string) => Promise<boolean>;
@@ -23,6 +24,7 @@
     events,
     repoOwner,
     repoName,
+    platformHost,
     filtered = false,
     showCommitDetails = true,
     onEditComment,
@@ -315,7 +317,12 @@
                 {:else}
                   <div class="event-body {shouldRenderMarkdown(event.EventType) ? 'markdown-body' : ''}">
                     {#if shouldRenderMarkdown(event.EventType)}
-                      {@html renderMarkdown(event.Body, repoOwner && repoName ? { owner: repoOwner, name: repoName } : undefined)}
+                      {@html renderMarkdown(
+                        event.Body,
+                        repoOwner && repoName
+                          ? { owner: repoOwner, name: repoName, platformHost }
+                          : undefined,
+                      )}
                     {:else}
                       {event.Body}
                     {/if}

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -467,7 +467,11 @@
                 </svg>
               {/if}
             </button>
-            <div class="inset-box markdown-body">{@html renderMarkdown(issue.Body, { owner, name })}</div>
+            <div class="inset-box markdown-body">{@html renderMarkdown(issue.Body, {
+              owner,
+              name,
+              platformHost: detail.platform_host,
+            })}</div>
           </div>
         </div>
       {/if}
@@ -571,6 +575,7 @@
             events={detail.events ?? []}
             repoOwner={owner}
             repoName={name}
+            platformHost={detail.platform_host}
             onEditComment={editTimelineComment}
           />
         {:else if issues.isIssueDetailSyncing()}

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -154,9 +154,7 @@
           params: { path: { owner, name, number } },
           body: {
             state: newState,
-            ...(detail && {
-              platform_host: detail.platform_host,
-            }),
+            platform_host: detail?.platform_host ?? platformHost ?? "",
           },
         },
       );

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -33,6 +33,7 @@
     commit_title: string;
     commit_message: string;
     method: Method;
+    platform_host: string;
   };
 
   function buildMethods(): MethodOption[] {
@@ -85,11 +86,11 @@
         commit_title: commitTitle,
         commit_message: commitMessage,
         method: selectedMethod,
+        platform_host: platformHost ?? "",
       };
       const { error } = await client.POST("/repos/{owner}/{name}/pulls/{number}/merge", {
         params: {
           path: { owner, name, number },
-          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
         },
         body: params,
       });

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -8,6 +8,7 @@
     owner: string;
     name: string;
     number: number;
+    platformHost?: string | undefined;
     prTitle: string;
     prBody: string;
     prAuthor: string;
@@ -20,7 +21,7 @@
   }
 
   const {
-    owner, name, number, prTitle, prBody,
+    owner, name, number, platformHost, prTitle, prBody,
     prAuthor, prAuthorDisplayName,
     allowSquash, allowMerge, allowRebase,
     onclose, onmerged,
@@ -86,7 +87,10 @@
         method: selectedMethod,
       };
       const { error } = await client.POST("/repos/{owner}/{name}/pulls/{number}/merge", {
-        params: { path: { owner, name, number } },
+        params: {
+          path: { owner, name, number },
+          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+        },
         body: params,
       });
       if (error) {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -52,6 +52,7 @@
     owner: string;
     name: string;
     number: number;
+    platformHost?: string | undefined;
     onPullsRefresh?: () => Promise<void>;
     hideTabs?: boolean;
     hideWorkspaceAction?: boolean;
@@ -62,6 +63,7 @@
     owner,
     name,
     number,
+    platformHost,
     onPullsRefresh,
     hideTabs = false,
     hideWorkspaceAction = false,
@@ -106,7 +108,8 @@
     return (
       d.repo_owner !== owner ||
       d.repo_name !== name ||
-      (d.merge_request?.Number ?? -1) !== number
+      (d.merge_request?.Number ?? -1) !== number ||
+      (platformHost !== undefined && d.platform_host !== platformHost)
     );
   });
 
@@ -114,15 +117,24 @@
     const requestOwner = owner;
     const requestName = name;
     const requestNumber = number;
+    const requestPlatformHost = platformHost;
     const requestAutoSync = autoSync;
     untrack(() => {
       void detailStore.loadDetail(
         requestOwner,
         requestName,
         requestNumber,
-        { sync: requestAutoSync },
+        {
+          sync: requestAutoSync,
+          platformHost: requestPlatformHost,
+        },
       );
-      detailStore.startDetailPolling(requestOwner, requestName, requestNumber);
+      detailStore.startDetailPolling(
+        requestOwner,
+        requestName,
+        requestNumber,
+        requestPlatformHost,
+      );
     });
     return () => detailStore.stopDetailPolling();
   });
@@ -287,11 +299,17 @@
     stateSubmitting = true;
     stateError = null;
     try {
+      const detail = detailStore.getDetail();
       const { error: requestError } = await client.POST(
         "/repos/{owner}/{name}/pulls/{number}/github-state",
         {
           params: { path: { owner, name, number } },
-          body: { state: newState },
+          body: {
+            state: newState,
+            ...(detail?.platform_host
+              ? { platform_host: detail.platform_host }
+              : {}),
+          },
         },
       );
       if (requestError) {
@@ -301,7 +319,9 @@
             ?? "failed to change PR state",
         );
       }
-      await detailStore.loadDetail(owner, name, number);
+      await detailStore.loadDetail(owner, name, number, {
+        platformHost: detail?.platform_host,
+      });
       await refreshPulls();
       await activity.loadActivity();
     } catch (err) {
@@ -763,13 +783,14 @@
       {#snippet primaryActionButtons()}
         {#if pr.State === "open"}
           {#if pr.IsDraft}
-            <ReadyForReviewButton
-              {owner}
-              {name}
-              {number}
-              size="sm"
-              disabled={stalePR}
-              oncompleted={closeActionMenu}
+          <ReadyForReviewButton
+            {owner}
+            {name}
+            {number}
+            platformHost={detail.platform_host}
+            size="sm"
+            disabled={stalePR}
+            oncompleted={closeActionMenu}
             />
           {/if}
           <ApproveButton
@@ -784,6 +805,7 @@
               {owner}
               {name}
               {number}
+              platformHost={detail.platform_host}
               count={workflowApproval.count ?? 0}
               size="sm"
               disabled={stalePR}
@@ -988,6 +1010,7 @@
           {owner}
           {name}
           {number}
+          platformHost={d.platform_host}
           prTitle={p.Title}
           prBody={p.Body}
           prAuthor={p.Author}
@@ -998,7 +1021,9 @@
           onclose={() => { showMergeModal = false; }}
           onmerged={() => {
             showMergeModal = false;
-            void detailStore.loadDetail(owner, name, number);
+            void detailStore.loadDetail(owner, name, number, {
+              platformHost: d.platform_host,
+            });
             void pulls.loadPulls();
             void activity.loadActivity();
           }}
@@ -1064,7 +1089,11 @@
                 </svg>
               {/if}
             </button>
-            <div class="inset-box markdown-body">{@html renderMarkdown(pr.Body, { owner, name })}</div>
+            <div class="inset-box markdown-body">{@html renderMarkdown(pr.Body, {
+              owner,
+              name,
+              platformHost: detail.platform_host,
+            })}</div>
           </div>
         {:else}
           <button class="add-description-btn" onclick={startEditBody}>
@@ -1098,6 +1127,7 @@
             events={filteredTimelineEvents}
             repoOwner={owner}
             repoName={name}
+            platformHost={detail.platform_host}
             filtered={hasActiveTimelineFilters}
             showCommitDetails={timelineFilter.showCommitDetails}
             onEditComment={editTimelineComment}

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -381,7 +381,14 @@
 
   function onKanbanChange(value: string): void {
     if (stalePR) return;
-    void detailStore.updateKanbanState(owner, name, number, value as KanbanStatus);
+    const currentPlatformHost = detailStore.getDetail()?.platform_host ?? platformHost;
+    void detailStore.updateKanbanState(
+      owner,
+      name,
+      number,
+      currentPlatformHost,
+      value as KanbanStatus,
+    );
   }
 
   function mergeActionLabel(settings: RepoSettings): string {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -797,6 +797,7 @@
             {owner}
             {name}
             {number}
+            platformHost={detail.platform_host}
             size="sm"
             disabled={stalePR}
           />

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -315,11 +315,11 @@
         {
           params: {
             path: { owner, name, number },
-            ...(detail?.platform_host
-              ? { query: { platform_host: detail.platform_host } }
-              : {}),
           },
-          body: { state: newState },
+          body: {
+            state: newState,
+            platform_host: detail?.platform_host ?? "",
+          },
         },
       );
       if (requestError) {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -81,13 +81,23 @@
   const hasActiveTimelineFilters = $derived(
     activePRTimelineFilterCount(timelineFilter) > 0,
   );
+  const currentPlatformHost = $derived(
+    detailStore.getDetail()?.platform_host ?? platformHost,
+  );
 
   async function editTimelineComment(
     event: { PlatformID: number | null },
     body: string,
   ): Promise<boolean> {
     if (event.PlatformID === null) return false;
-    return detailStore.editComment(owner, name, number, event.PlatformID, body);
+    return detailStore.editComment(
+      owner,
+      name,
+      number,
+      event.PlatformID,
+      currentPlatformHost,
+      body,
+    );
   }
 
   function updateTimelineFilter(next: PRTimelineFilterState): void {
@@ -228,7 +238,7 @@
     savingTitle = true;
     try {
       await detailStore.updatePRContent(
-        owner, name, number, { title: trimmed },
+        owner, name, number, currentPlatformHost, { title: trimmed },
       );
       editingTitle = false;
       titleDraft = "";
@@ -275,7 +285,7 @@
     savingBody = true;
     try {
       await detailStore.updatePRContent(
-        owner, name, number, { body: bodyDraft },
+        owner, name, number, currentPlatformHost, { body: bodyDraft },
       );
       editingBody = false;
       bodyDraft = "";
@@ -303,13 +313,13 @@
       const { error: requestError } = await client.POST(
         "/repos/{owner}/{name}/pulls/{number}/github-state",
         {
-          params: { path: { owner, name, number } },
-          body: {
-            state: newState,
+          params: {
+            path: { owner, name, number },
             ...(detail?.platform_host
-              ? { platform_host: detail.platform_host }
+              ? { query: { platform_host: detail.platform_host } }
               : {}),
           },
+          body: { state: newState },
         },
       );
       if (requestError) {
@@ -381,7 +391,6 @@
 
   function onKanbanChange(value: string): void {
     if (stalePR) return;
-    const currentPlatformHost = detailStore.getDetail()?.platform_host ?? platformHost;
     void detailStore.updateKanbanState(
       owner,
       name,
@@ -511,7 +520,12 @@
     const { data, error } = await client.GET(
       "/repos/{owner}/{name}/pulls/{number}/files",
       {
-        params: { path: { owner, name, number } },
+        params: {
+          path: { owner, name, number },
+          ...(currentPlatformHost
+            ? { query: { platform_host: currentPlatformHost } }
+            : {}),
+        },
       },
     );
     if (error) {
@@ -577,7 +591,7 @@
               <DiffSidebar />
             </aside>
             <div class="files-main">
-              <DiffView {owner} {name} {number} />
+              <DiffView {owner} {name} {number} platformHost={detail.platform_host} />
             </div>
           </div>
         </div>
@@ -628,7 +642,13 @@
                 disabled={stalePR}
                 onclick={() => {
                   if (stalePR) return;
-                  void detailStore.toggleDetailPRStar(owner, name, number, pr.Starred);
+                  void detailStore.toggleDetailPRStar(
+                    owner,
+                    name,
+                    number,
+                    detail.platform_host,
+                    pr.Starred,
+                  );
                 }}
                 title={pr.Starred ? "Unstar" : "Star"}
               >

--- a/packages/ui/src/components/detail/ReadyForReviewButton.svelte
+++ b/packages/ui/src/components/detail/ReadyForReviewButton.svelte
@@ -10,6 +10,7 @@
     owner: string;
     name: string;
     number: number;
+    platformHost?: string | undefined;
     size?: "sm" | "md";
     disabled?: boolean;
     oncompleted?: () => void;
@@ -19,6 +20,7 @@
     owner,
     name,
     number,
+    platformHost,
     size = "md",
     disabled = false,
     oncompleted,
@@ -37,19 +39,22 @@
     error = null;
     try {
       const { error } = await client.POST("/repos/{owner}/{name}/pulls/{number}/ready-for-review", {
-        params: { path: { owner, name, number } },
+        params: {
+          path: { owner, name, number },
+          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+        },
       });
       if (error) {
         throw new Error(error.detail ?? error.title ?? "failed to mark pull request ready for review");
       }
-      await detail.loadDetail(owner, name, number);
+      await detail.loadDetail(owner, name, number, { platformHost });
       await pulls.loadPulls();
       oncompleted?.();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (shouldRefreshStaleDraftState(message)) {
         try {
-          await detail.loadDetail(owner, name, number);
+          await detail.loadDetail(owner, name, number, { platformHost });
           await pulls.loadPulls();
         } catch {
           // Preserve the original mutation error if the stale-state refresh also fails.

--- a/packages/ui/src/components/detail/ReadyForReviewButton.svelte
+++ b/packages/ui/src/components/detail/ReadyForReviewButton.svelte
@@ -41,8 +41,8 @@
       const { error } = await client.POST("/repos/{owner}/{name}/pulls/{number}/ready-for-review", {
         params: {
           path: { owner, name, number },
-          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
         },
+        body: { platform_host: platformHost ?? "" },
       });
       if (error) {
         throw new Error(error.detail ?? error.title ?? "failed to mark pull request ready for review");

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -9,15 +9,16 @@
     owner: string;
     name: string;
     number: number;
+    platformHost?: string | undefined;
   }
 
-  const { owner, name, number }: Props = $props();
+  const { owner, name, number, platformHost }: Props = $props();
 
   let diffArea: HTMLDivElement | undefined = $state();
   let scrollRaf = 0;
 
   onMount(() => {
-    void diffStore.loadDiff(owner, name, number);
+    void diffStore.loadDiff(owner, name, number, platformHost);
 
     return () => {
       cancelAnimationFrame(scrollRaf);

--- a/packages/ui/src/components/kanban/KanbanBoard.svelte
+++ b/packages/ui/src/components/kanban/KanbanBoard.svelte
@@ -34,13 +34,19 @@
   ] as const;
 
   // --- Drawer state ---
-  let drawerPR = $state<{ owner: string; name: string; number: number } | null>(null);
+  let drawerPR = $state<{
+    owner: string;
+    name: string;
+    number: number;
+    platformHost?: string;
+  } | null>(null);
 
   function handleSelect(pr: PullRequest): void {
     drawerPR = {
       owner: pr.repo_owner ?? "",
       name: pr.repo_name ?? "",
       number: pr.Number,
+      platformHost: pr.platform_host,
     };
   }
 
@@ -54,11 +60,15 @@
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     status: KanbanStatus,
   ): Promise<void> {
     try {
       const { error } = await client.PUT("/repos/{owner}/{name}/pulls/{number}/state", {
-        params: { path: { owner, name, number } },
+        params: {
+          path: { owner, name, number },
+          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+        },
         body: { status },
       });
       if (error) {
@@ -97,6 +107,7 @@
       owner={drawerPR.owner}
       name={drawerPR.name}
       number={drawerPR.number}
+      platformHost={drawerPR.platformHost}
       onClose={closeDrawer}
       onPullsRefresh={() => pulls.loadPulls({ state: "open" })}
     />

--- a/packages/ui/src/components/kanban/KanbanBoard.svelte
+++ b/packages/ui/src/components/kanban/KanbanBoard.svelte
@@ -67,9 +67,8 @@
       const { error } = await client.PUT("/repos/{owner}/{name}/pulls/{number}/state", {
         params: {
           path: { owner, name, number },
-          ...(platformHost ? { query: { platform_host: platformHost } } : {}),
         },
-        body: { status },
+        body: { status, platform_host: platformHost ?? "" },
       });
       if (error) {
         throw new Error(error.detail ?? error.title ?? "failed to update kanban state");

--- a/packages/ui/src/components/kanban/KanbanCard.svelte
+++ b/packages/ui/src/components/kanban/KanbanCard.svelte
@@ -23,6 +23,7 @@
       owner: pr.repo_owner ?? "",
       name: pr.repo_name ?? "",
       number: pr.Number,
+      platformHost: pr.platform_host,
     }));
   }
 </script>

--- a/packages/ui/src/components/kanban/KanbanColumn.svelte
+++ b/packages/ui/src/components/kanban/KanbanColumn.svelte
@@ -8,7 +8,13 @@
     color: string;
     pulls: PullRequest[];
     onSelect: (pr: PullRequest) => void;
-    onDrop: (owner: string, name: string, number: number, status: KanbanStatus) => void;
+    onDrop: (
+      owner: string,
+      name: string,
+      number: number,
+      platformHost: string | undefined,
+      status: KanbanStatus,
+    ) => void;
   }
 
   const { id, title, color, pulls, onSelect, onDrop }: Props = $props();
@@ -34,8 +40,9 @@
         owner: string;
         name: string;
         number: number;
+        platformHost?: string;
       };
-      onDrop(data.owner, data.name, data.number, id as KanbanStatus);
+      onDrop(data.owner, data.name, data.number, data.platformHost, id as KanbanStatus);
     } catch {
       // Invalid drag data
     }

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -36,6 +36,7 @@
       pr.repo_owner ?? "",
       pr.repo_name ?? "",
       pr.Number,
+      pr.platform_host,
       pr.Starred,
     );
   }

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -67,18 +67,51 @@
     }, 300);
   }
 
-  function handleSelect(owner: string, name: string, number: number): void {
-    pulls.selectPR(owner, name, number);
-    if (_getDetailTab() === "files") {
-      navigate(`/pulls/${owner}/${name}/${number}/files`);
-    } else {
-      navigate(`/pulls/${owner}/${name}/${number}`);
-    }
+  function pullRoute(
+    owner: string,
+    name: string,
+    number: number,
+    platformHost?: string,
+  ): string {
+    const platformQuery = platformHost
+      ? `?platform_host=${encodeURIComponent(platformHost)}`
+      : "";
+    return _getDetailTab() === "files"
+      ? `/pulls/${owner}/${name}/${number}/files${platformQuery}`
+      : `/pulls/${owner}/${name}/${number}${platformQuery}`;
   }
 
-  function isSelected(owner: string, name: string, number: number): boolean {
+  function handleSelect(
+    owner: string,
+    name: string,
+    number: number,
+    platformHost?: string,
+  ): void {
+    pulls.selectPR(owner, name, number, platformHost);
+    navigate(pullRoute(owner, name, number, platformHost));
+  }
+
+  function sameSelectedPR(
+    owner: string,
+    name: string,
+    number: number,
+    platformHost?: string,
+  ): boolean {
     const sel = pulls.getSelectedPR();
-    return sel !== null && sel.owner === owner && sel.name === name && sel.number === number;
+    return sel !== null
+      && sel.owner === owner
+      && sel.name === name
+      && sel.number === number
+      && (sel.platformHost === undefined || sel.platformHost === platformHost);
+  }
+
+  function isSelected(
+    owner: string,
+    name: string,
+    number: number,
+    platformHost?: string,
+  ): boolean {
+    return sameSelectedPR(owner, name, number, platformHost);
   }
 
   const selectedVisiblePR = $derived.by(() => {
@@ -87,7 +120,11 @@
     const pr = pulls.getPulls().find(
       (p) => (p.repo_owner ?? "") === sel.owner
         && (p.repo_name ?? "") === sel.name
-        && p.Number === sel.number,
+        && p.Number === sel.number
+        && (
+          sel.platformHost === undefined
+          || p.platform_host === sel.platformHost
+        ),
     );
     if (!pr) return null;
     // In byRepo mode, a user-collapsed repo group hides the PR row — treat
@@ -228,7 +265,12 @@
         {#each [...pulls.pullsByRepo().entries()] as [repo, prs] (repo)}
           {@const userCollapsed = collapsedRepos.isCollapsed("pulls", repo)}
           {@const hasSelectedPR = isDiffFocus && prs.some(
-            (p) => isSelected(p.repo_owner ?? "", p.repo_name ?? "", p.Number),
+            (p) => isSelected(
+              p.repo_owner ?? "",
+              p.repo_name ?? "",
+              p.Number,
+              p.platform_host,
+            ),
           )}
           {@const collapsed = userCollapsed && !hasSelectedPR}
           <div class="repo-group">
@@ -251,13 +293,13 @@
             </button>
             {#if !collapsed}
               {#each prs as pr (pr.ID)}
-                {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+                {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number, pr.platform_host)}
                 <PullItem
                   {pr}
                   showRepo={false}
                   selected={prSelected}
                   {importAction}
-                  onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+                  onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number, pr.platform_host)}
                 />
                 {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
                   <div class="diff-files-wrap">
@@ -273,13 +315,13 @@
           <div class="repo-group">
             <h3 class="repo-header">{wg.label}</h3>
             {#each wg.items as pr (pr.ID)}
-              {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+              {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number, pr.platform_host)}
               <PullItem
                 {pr}
                 showRepo={true}
                 selected={prSelected}
                 {importAction}
-                onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+                onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number, pr.platform_host)}
               />
               {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
                 <div class="diff-files-wrap">
@@ -291,13 +333,13 @@
         {/each}
       {:else}
         {#each pulls.getPulls() as pr (pr.ID)}
-          {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+          {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number, pr.platform_host)}
           <PullItem
             {pr}
             showRepo={true}
             selected={prSelected}
             {importAction}
-            onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+            onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number, pr.platform_host)}
           />
           {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
             <div class="diff-files-wrap">

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -127,8 +127,9 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): string {
-    return `${owner}/${name}/${number}`;
+    return `${platformHost ?? ""}:${owner}/${name}/${number}`;
   }
 
   function isDetailShowing(
@@ -154,12 +155,18 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
     expectedGen: number = syncGeneration,
   ): Promise<void> {
     try {
       const { data } = await apiClient.GET(
         "/repos/{owner}/{name}/pulls/{number}",
-        { params: { path: { owner, name, number } } },
+        {
+          params: {
+            path: { owner, name, number },
+            ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+          },
+        },
       );
       // Re-check the generation after the awaited request: if the
       // selected PR changed mid-flight, dropping the assignment keeps
@@ -181,6 +188,7 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     gen: number,
   ): Promise<void> {
     syncing = true;
@@ -188,7 +196,12 @@ export function createDetailStore(
       const { data, error: requestError } =
         await apiClient.POST(
           "/repos/{owner}/{name}/pulls/{number}/sync",
-          { params: { path: { owner, name, number } } },
+          {
+            params: {
+              path: { owner, name, number },
+              ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+            },
+          },
         );
       if (gen !== syncGeneration) return;
       if (requestError) {
@@ -234,13 +247,14 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
-    options?: { sync?: DetailSyncMode },
+    options?: { sync?: DetailSyncMode; platformHost?: string | undefined },
   ): Promise<void> {
     const syncMode = options?.sync ?? true;
+    const platformHost = options?.platformHost;
     // Dedup by item identity only. A second caller with a different
     // sync mode joins the in-flight load and may promote the sync
     // intent if its requested mode is stronger.
-    const key = prKey(owner, name, number);
+    const key = prKey(owner, name, number, platformHost);
     if (
       loading &&
       activeLoad?.key === key &&
@@ -277,7 +291,12 @@ export function createDetailStore(
         const { data, error: requestError } =
           await apiClient.GET(
             "/repos/{owner}/{name}/pulls/{number}",
-            { params: { path: { owner, name, number } } },
+            {
+              params: {
+                path: { owner, name, number },
+                ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+              },
+            },
           );
         if (gen !== syncGeneration) return;
         if (requestError) {
@@ -307,12 +326,13 @@ export function createDetailStore(
       // request isn't lost when it joined an in-flight load.
       const finalSyncMode = currentLoad.syncMode;
       if (gen === syncGeneration && finalSyncMode === true) {
-        void syncDetail(owner, name, number, gen);
+        void syncDetail(owner, name, number, platformHost, gen);
       } else if (gen === syncGeneration && finalSyncMode === "background") {
         void enqueueBackgroundDetailSync(
           owner,
           name,
           number,
+          platformHost,
           gen,
           detail?.detail_fetched_at,
         );
@@ -326,6 +346,7 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     gen: number,
     previousFetchedAt?: string,
   ): Promise<void> {
@@ -333,13 +354,19 @@ export function createDetailStore(
     try {
       const { error: requestError } = await apiClient.POST(
         "/repos/{owner}/{name}/pulls/{number}/sync/async",
-        { params: { path: { owner, name, number } } },
+        {
+          params: {
+            path: { owner, name, number },
+            ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+          },
+        },
       );
       if (requestError) return;
       await refreshAfterBackgroundDetailSync(
         owner,
         name,
         number,
+        platformHost,
         gen,
         previousFetchedAt,
       );
@@ -353,13 +380,14 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     gen: number,
     previousFetchedAt?: string,
   ): Promise<void> {
     for (const ms of [300, 700, 1_500, 3_000, 5_000]) {
       await delay(ms);
       if (gen !== syncGeneration) return;
-      await refreshDetail(owner, name, number, gen);
+      await refreshDetail(owner, name, number, platformHost, gen);
       if (gen !== syncGeneration) return;
       const fetchedAt = detail?.detail_fetched_at;
       if (fetchedAt && fetchedAt !== previousFetchedAt) {
@@ -372,8 +400,9 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): Promise<void> {
-    await refreshDetail(owner, name, number);
+    await refreshDetail(owner, name, number, platformHost);
   }
 
   async function updateKanbanState(
@@ -562,15 +591,16 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): void {
     stopDetailPolling();
     detailPollHandle = setInterval(() => {
-      void refreshDetail(owner, name, number);
+      void refreshDetail(owner, name, number, platformHost);
     }, 60_000);
     if (syncDep) {
       unsubSyncComplete =
         syncDep.subscribeSyncComplete(() => {
-          void refreshDetail(owner, name, number);
+          void refreshDetail(owner, name, number, platformHost);
         });
     }
   }
@@ -688,12 +718,12 @@ export function createDetailStore(
     syncing = false;
     // Silent refresh: avoid flipping loading flag, which would
     // unmount the detail tree and reset scroll position.
-    await refreshDetail(owner, name, number);
+    await refreshDetail(owner, name, number, detail?.platform_host);
     // Pull authoritative state from GitHub so PR row metadata
     // (last_activity_at, comment_count) and the pulls list catch
     // up. Skip if the user navigated away mid-refresh.
     if (gen === syncGeneration) {
-      void syncDetail(owner, name, number, gen);
+      void syncDetail(owner, name, number, detail?.platform_host, gen);
     }
   }
 
@@ -731,7 +761,7 @@ export function createDetailStore(
       storeError = err instanceof Error ? err.message : String(err);
       return false;
     }
-    await refreshDetail(owner, name, number);
+    await refreshDetail(owner, name, number, detail?.platform_host);
     return true;
   }
 

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -458,14 +458,13 @@ export function createDetailStore(
       const { error: requestError } =
         await apiClient.PUT(
           "/repos/{owner}/{name}/pulls/{number}/state",
-            {
-              params: {
-                path: { owner, name, number },
-                ...(platformHost ? { query: { platform_host: platformHost } } : {}),
-              },
-              body: { status },
+          {
+            params: {
+              path: { owner, name, number },
             },
-          );
+            body: { status, platform_host: platformHost ?? "" },
+          },
+        );
       if (requestError) {
         throw new Error(
           requestError.detail ??
@@ -562,9 +561,8 @@ export function createDetailStore(
           {
             params: {
               path: { owner, name, number },
-              ...(platformHost ? { query: { platform_host: platformHost } } : {}),
             },
-            body: fields,
+            body: { ...fields, platform_host: platformHost ?? "" },
           },
         );
       if (requestError) {
@@ -657,7 +655,7 @@ export function createDetailStore(
               owner,
               name,
               number,
-              ...(platformHost ? { platform_host: platformHost } : {}),
+              platform_host: platformHost ?? "",
             },
           });
         if (requestError) {
@@ -675,7 +673,7 @@ export function createDetailStore(
               owner,
               name,
               number,
-              ...(platformHost ? { platform_host: platformHost } : {}),
+              platform_host: platformHost ?? "",
             },
           });
         if (requestError) {
@@ -718,9 +716,8 @@ export function createDetailStore(
           {
             params: {
               path: { owner, name, number },
-              ...(platformHost ? { query: { platform_host: platformHost } } : {}),
             },
-            body: { body },
+            body: { body, platform_host: platformHost ?? "" },
           },
         );
       if (requestError) {
@@ -770,9 +767,8 @@ export function createDetailStore(
               number,
               comment_id: commentID,
             },
-            ...(platformHost ? { query: { platform_host: platformHost } } : {}),
           },
-          body: { body },
+          body: { body, platform_host: platformHost ?? "" },
         },
       );
       if (requestError) {

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -15,12 +15,14 @@ export interface DetailStoreOptions {
       owner: string,
       name: string,
       number: number,
+      platformHost: string | undefined,
       status: KanbanStatus,
     ) => void;
     getPullKanbanStatus?: (
       owner: string,
       name: string,
       number: number,
+      platformHost?: string | undefined,
     ) => KanbanStatus | undefined;
   };
   sync?: {
@@ -136,12 +138,14 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): boolean {
     return (
       detail !== null &&
       detail.repo_owner === owner &&
       detail.repo_name === name &&
-      detail.merge_request.Number === number
+      detail.merge_request.Number === number &&
+      (platformHost === undefined || detail.platform_host === platformHost)
     );
   }
 
@@ -409,9 +413,10 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     status: KanbanStatus,
   ): Promise<void> {
-    const key = prKey(owner, name, number);
+    const key = prKey(owner, name, number, platformHost);
     const seq = (kanbanSeqByPR.get(key) ?? 0) + 1;
     kanbanSeqByPR.set(key, seq);
 
@@ -419,6 +424,7 @@ export function createDetailStore(
       owner,
       name,
       number,
+      platformHost,
     )
       ? (detail!.merge_request
           .KanbanStatus as KanbanStatus)
@@ -428,6 +434,7 @@ export function createDetailStore(
         owner,
         name,
         number,
+        platformHost,
       );
 
     if (prevDetailStatus !== undefined) {
@@ -443,6 +450,7 @@ export function createDetailStore(
       owner,
       name,
       number,
+      platformHost,
       status,
     );
 
@@ -450,11 +458,14 @@ export function createDetailStore(
       const { error: requestError } =
         await apiClient.PUT(
           "/repos/{owner}/{name}/pulls/{number}/state",
-          {
-            params: { path: { owner, name, number } },
-            body: { status },
-          },
-        );
+            {
+              params: {
+                path: { owner, name, number },
+                ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+              },
+              body: { status },
+            },
+          );
       if (requestError) {
         throw new Error(
           requestError.detail ??
@@ -470,7 +481,7 @@ export function createDetailStore(
             : String(err);
         if (
           prevDetailStatus !== undefined &&
-          isDetailShowing(owner, name, number)
+          isDetailShowing(owner, name, number, platformHost)
         ) {
           detail = {
             ...detail!,
@@ -485,14 +496,15 @@ export function createDetailStore(
             owner,
             name,
             number,
+            platformHost,
             prevPullsStatus,
           );
         }
         const reloads: Promise<void>[] = [];
         if (pullsDep) reloads.push(pullsDep.loadPulls());
-        if (isDetailShowing(owner, name, number)) {
+        if (isDetailShowing(owner, name, number, platformHost)) {
           reloads.push(
-            loadDetail(owner, name, number),
+            loadDetail(owner, name, number, { platformHost }),
           );
         }
         await Promise.all(reloads);
@@ -507,9 +519,9 @@ export function createDetailStore(
       const refreshes: Promise<void>[] = [
         refreshPullsIfActive(),
       ];
-      if (isDetailShowing(owner, name, number)) {
+      if (isDetailShowing(owner, name, number, platformHost)) {
         refreshes.push(
-          loadDetail(owner, name, number),
+          loadDetail(owner, name, number, { platformHost }),
         );
       }
       await Promise.all(refreshes);

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -532,9 +532,10 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     fields: { title?: string; body?: string },
   ): Promise<void> {
-    if (!detail || !isDetailShowing(owner, name, number))
+    if (!detail || !isDetailShowing(owner, name, number, platformHost))
       return;
 
     const prevTitle = detail.merge_request.Title;
@@ -559,7 +560,10 @@ export function createDetailStore(
         await apiClient.PATCH(
           "/repos/{owner}/{name}/pulls/{number}",
           {
-            params: { path: { owner, name, number } },
+            params: {
+              path: { owner, name, number },
+              ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+            },
             body: fields,
           },
         );
@@ -572,7 +576,7 @@ export function createDetailStore(
         );
       }
       // Apply server-canonical response.
-      if (data && isDetailShowing(owner, name, number)) {
+      if (data && isDetailShowing(owner, name, number, platformHost)) {
         detail = data as PullDetail;
       }
     } catch (err) {
@@ -580,7 +584,7 @@ export function createDetailStore(
         err instanceof Error ? err.message : String(err);
       // Revert optimistic update.
       if (
-        isDetailShowing(owner, name, number) &&
+        isDetailShowing(owner, name, number, platformHost) &&
         detail
       ) {
         detail = {
@@ -632,6 +636,7 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     currentlyStarred: boolean,
   ): Promise<void> {
     if (detail !== null) {
@@ -652,6 +657,7 @@ export function createDetailStore(
               owner,
               name,
               number,
+              ...(platformHost ? { platform_host: platformHost } : {}),
             },
           });
         if (requestError) {
@@ -669,6 +675,7 @@ export function createDetailStore(
               owner,
               name,
               number,
+              ...(platformHost ? { platform_host: platformHost } : {}),
             },
           });
         if (requestError) {
@@ -700,6 +707,7 @@ export function createDetailStore(
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     body: string,
   ): Promise<void> {
     storeError = null;
@@ -708,7 +716,10 @@ export function createDetailStore(
         await apiClient.POST(
           "/repos/{owner}/{name}/pulls/{number}/comments",
           {
-            params: { path: { owner, name, number } },
+            params: {
+              path: { owner, name, number },
+              ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+            },
             body: { body },
           },
         );
@@ -730,12 +741,12 @@ export function createDetailStore(
     syncing = false;
     // Silent refresh: avoid flipping loading flag, which would
     // unmount the detail tree and reset scroll position.
-    await refreshDetail(owner, name, number, detail?.platform_host);
+    await refreshDetail(owner, name, number, platformHost);
     // Pull authoritative state from GitHub so PR row metadata
     // (last_activity_at, comment_count) and the pulls list catch
     // up. Skip if the user navigated away mid-refresh.
     if (gen === syncGeneration) {
-      void syncDetail(owner, name, number, detail?.platform_host, gen);
+      void syncDetail(owner, name, number, platformHost, gen);
     }
   }
 
@@ -744,6 +755,7 @@ export function createDetailStore(
     name: string,
     number: number,
     commentID: number,
+    platformHost: string | undefined,
     body: string,
   ): Promise<boolean> {
     storeError = null;
@@ -758,6 +770,7 @@ export function createDetailStore(
               number,
               comment_id: commentID,
             },
+            ...(platformHost ? { query: { platform_host: platformHost } } : {}),
           },
           body: { body },
         },
@@ -773,7 +786,7 @@ export function createDetailStore(
       storeError = err instanceof Error ? err.message : String(err);
       return false;
     }
-    await refreshDetail(owner, name, number, detail?.platform_host);
+    await refreshDetail(owner, name, number, platformHost);
     return true;
   }
 

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -151,6 +151,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let currentOwner = $state("");
   let currentName = $state("");
   let currentNumber = $state(0);
+  let currentPlatformHost = $state<string | undefined>(undefined);
 
   function getCurrentPR(): { owner: string; name: string; number: number } | null {
     if (!currentOwner) return null;
@@ -340,6 +341,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     commit?: string;
     from?: string;
     to?: string;
+    platform_host?: string;
   } {
     return {
       ...(hideWhitespace && { whitespace: "hide" }),
@@ -348,6 +350,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         from: scope.fromSha,
         to: scope.toSha,
       }),
+      ...(currentPlatformHost && { platform_host: currentPlatformHost }),
     };
   }
 
@@ -365,14 +368,17 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): Promise<void> {
     const prChanged =
       owner !== currentOwner ||
       name !== currentName ||
-      number !== currentNumber;
+      number !== currentNumber ||
+      platformHost !== currentPlatformHost;
     currentOwner = owner;
     currentName = name;
     currentNumber = number;
+    currentPlatformHost = platformHost;
     if (prChanged) {
       scope = { kind: "head" };
       fileCategoryFilter = "all";
@@ -399,7 +405,10 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         const { data } = await apiClient.GET(
           "/repos/{owner}/{name}/pulls/{number}/files",
           {
-            params: { path: { owner, name, number } },
+            params: {
+              path: { owner, name, number },
+              ...(platformHost ? { query: { platform_host: platformHost } } : {}),
+            },
             signal: filesAc.signal,
           },
         );
@@ -486,6 +495,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentOwner = "";
     currentName = "";
     currentNumber = 0;
+    currentPlatformHost = undefined;
   }
 
   async function loadCommits(): Promise<void> {
@@ -497,24 +507,50 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     const owner = currentOwner;
     const name = currentName;
     const number = currentNumber;
+    const platformHost = currentPlatformHost;
     try {
       const { data, error, response } = await apiClient.GET(
-        "/repos/{owner}/{name}/pulls/{number}/commits",
+          "/repos/{owner}/{name}/pulls/{number}/commits",
         {
-          params: { path: { owner, name, number } },
+          params: {
+            path: { owner, name, number },
+            ...(currentPlatformHost
+              ? { query: { platform_host: currentPlatformHost } }
+              : {}),
+          },
         },
       );
-      if (currentOwner !== owner || currentName !== name || currentNumber !== number) return;
+      if (
+        currentOwner !== owner ||
+        currentName !== name ||
+        currentNumber !== number ||
+        currentPlatformHost !== platformHost
+      ) return;
       if (!data) {
         throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
-      if (currentOwner !== owner || currentName !== name || currentNumber !== number) return;
+      if (
+        currentOwner !== owner ||
+        currentName !== name ||
+        currentNumber !== number ||
+        currentPlatformHost !== platformHost
+      ) return;
       commits = data.commits ?? [];
     } catch (err) {
-      if (currentOwner !== owner || currentName !== name || currentNumber !== number) return;
+      if (
+        currentOwner !== owner ||
+        currentName !== name ||
+        currentNumber !== number ||
+        currentPlatformHost !== platformHost
+      ) return;
       commitsError = err instanceof Error ? err.message : String(err);
     } finally {
-      if (currentOwner === owner && currentName === name && currentNumber === number) {
+      if (
+        currentOwner === owner &&
+        currentName === name &&
+        currentNumber === number &&
+        currentPlatformHost === platformHost
+      ) {
         commitsLoading = false;
       }
     }
@@ -539,7 +575,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   function selectCommit(sha: string): void {
     scope = { kind: "commit", sha };
     if (currentOwner && currentName && currentNumber) {
-      void loadDiff(currentOwner, currentName, currentNumber);
+      void loadDiff(currentOwner, currentName, currentNumber, currentPlatformHost);
     }
   }
 
@@ -551,14 +587,14 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     const [older, newer] = fromIdx > toIdx ? [fromSha, toSha] : [toSha, fromSha];
     scope = { kind: "range", fromSha: older, toSha: newer };
     if (currentOwner && currentName && currentNumber) {
-      void loadDiff(currentOwner, currentName, currentNumber);
+      void loadDiff(currentOwner, currentName, currentNumber, currentPlatformHost);
     }
   }
 
   function resetToHead(): void {
     scope = { kind: "head" };
     if (currentOwner && currentName && currentNumber) {
-      void loadDiff(currentOwner, currentName, currentNumber);
+      void loadDiff(currentOwner, currentName, currentNumber, currentPlatformHost);
     }
   }
 

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -508,9 +508,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
           params: { path: { owner, name, number } },
           body: {
             body,
-            ...(platformHost && {
-              platform_host: platformHost,
-            }),
+            platform_host: platformHost ?? "",
           },
         },
       );
@@ -561,9 +559,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
           },
           body: {
             body,
-            ...(platformHost && {
-              platform_host: platformHost,
-            }),
+            platform_host: platformHost ?? "",
           },
         },
       );
@@ -596,9 +592,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
             owner,
             name,
             number,
-            ...(platformHost && {
-              platform_host: platformHost,
-            }),
+            platform_host: platformHost ?? "",
           },
         });
         if (requestError) {
@@ -613,9 +607,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
             owner,
             name,
             number,
-            ...(platformHost && {
-              platform_host: platformHost,
-            }),
+            platform_host: platformHost ?? "",
           },
         });
         if (requestError) {

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -46,7 +46,12 @@ export function createPullsStore(opts: PullsStoreOptions) {
   let filterState = $state<string>("open");
   let searchQuery = $state<string | undefined>(undefined);
   let selectedPR = $state<
-    { owner: string; name: string; number: number } | null
+    {
+      owner: string;
+      name: string;
+      number: number;
+      platformHost?: string | undefined;
+    } | null
   >(null);
 
   // --- reads ---
@@ -67,6 +72,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     owner: string;
     name: string;
     number: number;
+    platformHost?: string | undefined;
   } | null {
     return selectedPR;
   }
@@ -135,6 +141,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
           first.repo_owner ?? "",
           first.repo_name ?? "",
           first.Number,
+          first.platform_host,
         );
       }
       return;
@@ -151,6 +158,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
         next.repo_owner ?? "",
         next.repo_name ?? "",
         next.Number,
+        next.platform_host,
       );
     }
   }
@@ -166,6 +174,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
           last.repo_owner ?? "",
           last.repo_name ?? "",
           last.Number,
+          last.platform_host,
         );
       }
       return;
@@ -183,6 +192,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
           prev.repo_owner ?? "",
           prev.repo_name ?? "",
           prev.Number,
+          prev.platform_host,
         );
       }
     }
@@ -208,8 +218,14 @@ export function createPullsStore(opts: PullsStoreOptions) {
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): void {
-    selectedPR = { owner, name, number };
+    selectedPR = {
+      owner,
+      name,
+      number,
+      ...(platformHost ? { platformHost } : {}),
+    };
   }
 
   function clearSelection(): void {
@@ -295,6 +311,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): Promise<FetchPullResult> {
     try {
       const { data, error, response } = await apiClient.GET(
@@ -302,6 +319,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
         {
           params: {
             path: { owner, name, number },
+            ...(platformHost ? { query: { platform_host: platformHost } } : {}),
           },
         },
       );
@@ -319,7 +337,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
         status: "found",
         pull: {
           ...mr,
-          platform_host: "",
+          platform_host: data.platform_host,
           repo_owner: data.repo_owner,
           repo_name: data.repo_name,
           detail_loaded: data.detail_loaded,

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -237,12 +237,14 @@ export function createPullsStore(opts: PullsStoreOptions) {
     owner: string,
     name: string,
     number: number,
+    platformHost?: string,
   ): KanbanStatus | undefined {
     const pr = pulls.find(
       (p) =>
         p.repo_owner === owner &&
         p.repo_name === name &&
-        p.Number === number,
+        p.Number === number &&
+        (platformHost === undefined || p.platform_host === platformHost),
     );
     return pr?.KanbanStatus as KanbanStatus | undefined;
   }
@@ -252,12 +254,14 @@ export function createPullsStore(opts: PullsStoreOptions) {
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     status: KanbanStatus,
   ): void {
     pulls = pulls.map((pr) =>
       pr.repo_owner === owner &&
       pr.repo_name === name &&
-      pr.Number === number
+      pr.Number === number &&
+      (platformHost === undefined || pr.platform_host === platformHost)
         ? { ...pr, KanbanStatus: status }
         : pr,
     );

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -282,7 +282,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
             owner,
             name,
             number,
-            ...(platformHost ? { platform_host: platformHost } : {}),
+            platform_host: platformHost ?? "",
           },
         });
         if (error) {
@@ -297,7 +297,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
             owner,
             name,
             number,
-            ...(platformHost ? { platform_host: platformHost } : {}),
+            platform_host: platformHost ?? "",
           },
         });
         if (error) {

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -271,6 +271,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     owner: string,
     name: string,
     number: number,
+    platformHost: string | undefined,
     currentlyStarred: boolean,
   ): Promise<void> {
     try {
@@ -281,6 +282,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
             owner,
             name,
             number,
+            ...(platformHost ? { platform_host: platformHost } : {}),
           },
         });
         if (error) {
@@ -295,6 +297,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
             owner,
             name,
             number,
+            ...(platformHost ? { platform_host: platformHost } : {}),
           },
         });
         if (error) {

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "./markdown.js";
+
+describe("renderMarkdown", () => {
+  it("marks generated item refs as trusted navigation targets", () => {
+    const html = renderMarkdown("See #42", {
+      owner: "acme",
+      name: "widget",
+      platformHost: "ghe.example.com",
+    });
+
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const link = doc.querySelector("a.item-ref");
+    expect(link?.getAttribute("data-middleman-item-ref")).toBe("true");
+    expect(link?.getAttribute("data-owner")).toBe("acme");
+    expect(link?.getAttribute("data-name")).toBe("widget");
+    expect(link?.getAttribute("data-number")).toBe("42");
+    expect(link?.getAttribute("data-platform-host")).toBe("ghe.example.com");
+  });
+
+  it("does not trust raw HTML that forges item ref attributes", () => {
+    const html = renderMarkdown(`
+<a class="item-ref"
+  href="/pulls/acme/widget/42"
+  data-middleman-item-ref="true"
+  data-owner="acme"
+  data-name="widget"
+  data-number="42"
+  data-platform-host="ghe.example.com">#42</a>
+`);
+
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const link = doc.querySelector("a.item-ref");
+    expect(link?.getAttribute("data-middleman-item-ref")).toBeNull();
+    expect(link?.getAttribute("data-owner")).toBe("acme");
+    expect(link?.getAttribute("data-name")).toBe("widget");
+    expect(link?.getAttribute("data-number")).toBe("42");
+    expect(link?.getAttribute("data-platform-host")).toBe("ghe.example.com");
+  });
+});

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -5,6 +5,7 @@ import DOMPurify from "dompurify";
 interface RepoContext {
   owner: string;
   name: string;
+  platformHost?: string | undefined;
 }
 
 function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
@@ -24,7 +25,7 @@ function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
       }
       return adjusted >= 0 ? adjusted : undefined;
     },
-    tokenizer(this: { lexer: { state: { inLink: boolean } } }, src: string): { type: string; raw: string; owner: string; name: string; number: number; text: string } | undefined {
+    tokenizer(this: { lexer: { state: { inLink: boolean } } }, src: string): { type: string; raw: string; owner: string; name: string; number: number; text: string; platformHost?: string | undefined } | undefined {
       // Don't tokenize inside markdown link/image labels
       // to avoid producing invalid nested <a> elements.
       if (this.lexer.state.inLink) return undefined;
@@ -52,15 +53,19 @@ function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
           owner: repo.owner,
           name: repo.name,
           number: parseInt(bareMatch[1]!, 10),
+          ...(repo.platformHost ? { platformHost: repo.platformHost } : {}),
           text: bareMatch[0],
         };
       }
       return undefined;
     },
     renderer(token): string {
-      const t = token as unknown as { owner: string; name: string; number: number; text: string };
+      const t = token as unknown as { owner: string; name: string; number: number; text: string; platformHost?: string | undefined };
       const href = `https://github.com/${t.owner}/${t.name}/issues/${t.number}`;
-      return `<a class="item-ref" href="${href}" data-owner="${t.owner}" data-name="${t.name}" data-number="${t.number}">${t.text}</a>`;
+      const platformHostAttr = t.platformHost
+        ? ` data-platform-host="${t.platformHost}"`
+        : "";
+      return `<a class="item-ref" href="${href}" data-owner="${t.owner}" data-name="${t.name}" data-number="${t.number}"${platformHostAttr}>${t.text}</a>`;
     },
   };
 }
@@ -90,7 +95,15 @@ export function renderMarkdown(
 
   const html = DOMPurify.sanitize(
     getMarked(repo).parse(raw) as string,
-    { ADD_ATTR: ["target", "data-owner", "data-name", "data-number"] },
+    {
+      ADD_ATTR: [
+        "target",
+        "data-owner",
+        "data-name",
+        "data-number",
+        "data-platform-host",
+      ],
+    },
   );
   if (htmlCache.size > 500) htmlCache.clear();
   htmlCache.set(key, html);

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -8,6 +8,15 @@ interface RepoContext {
   platformHost?: string | undefined;
 }
 
+const itemRefTokenAttr = "data-middleman-item-ref-token";
+let activeItemRefToken = "";
+
+function trustedItemRefToken(): string {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
 function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
   return {
     name: "itemRef",
@@ -65,13 +74,32 @@ function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
       const platformHostAttr = t.platformHost
         ? ` data-platform-host="${t.platformHost}"`
         : "";
-      return `<a class="item-ref" href="${href}" data-middleman-item-ref="true" data-owner="${t.owner}" data-name="${t.name}" data-number="${t.number}"${platformHostAttr}>${t.text}</a>`;
+      const tokenAttr = activeItemRefToken
+        ? ` ${itemRefTokenAttr}="${activeItemRefToken}"`
+        : "";
+      return `<a class="item-ref" href="${href}"${tokenAttr} data-owner="${t.owner}" data-name="${t.name}" data-number="${t.number}"${platformHostAttr}>${t.text}</a>`;
     },
   };
 }
 
 const htmlCache = new Map<string, string>();
 const markedCache = new Map<string, Marked>();
+
+function trustGeneratedItemRefs(html: string, token: string): string {
+  if (typeof document === "undefined") {
+    return html;
+  }
+
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  for (const element of template.content.querySelectorAll(`[${itemRefTokenAttr}]`)) {
+    if (element.getAttribute(itemRefTokenAttr) === token) {
+      element.setAttribute("data-middleman-item-ref", "true");
+    }
+    element.removeAttribute(itemRefTokenAttr);
+  }
+  return template.innerHTML;
+}
 
 function getMarked(repo?: RepoContext): Marked {
   const key = repo ? `${repo.platformHost ?? ""}:${repo.owner}/${repo.name}` : "";
@@ -95,8 +123,17 @@ export function renderMarkdown(
   const cached = htmlCache.get(key);
   if (cached !== undefined) return cached;
 
-  const html = DOMPurify.sanitize(
-    getMarked(repo).parse(raw) as string,
+  const token = trustedItemRefToken();
+  activeItemRefToken = token;
+  let parsed: string;
+  try {
+    parsed = getMarked(repo).parse(raw) as string;
+  } finally {
+    activeItemRefToken = "";
+  }
+
+  const sanitized = DOMPurify.sanitize(
+    parsed,
     {
       ADD_ATTR: [
         "target",
@@ -104,10 +141,12 @@ export function renderMarkdown(
         "data-name",
         "data-number",
         "data-platform-host",
-        "data-middleman-item-ref",
+        itemRefTokenAttr,
       ],
+      FORBID_ATTR: ["data-middleman-item-ref"],
     },
   );
+  const html = trustGeneratedItemRefs(sanitized, token);
   if (htmlCache.size > 500) htmlCache.clear();
   htmlCache.set(key, html);
   return html;

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -65,7 +65,7 @@ function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
       const platformHostAttr = t.platformHost
         ? ` data-platform-host="${t.platformHost}"`
         : "";
-      return `<a class="item-ref" href="${href}" data-owner="${t.owner}" data-name="${t.name}" data-number="${t.number}"${platformHostAttr}>${t.text}</a>`;
+      return `<a class="item-ref" href="${href}" data-middleman-item-ref="true" data-owner="${t.owner}" data-name="${t.name}" data-number="${t.number}"${platformHostAttr}>${t.text}</a>`;
     },
   };
 }
@@ -74,7 +74,7 @@ const htmlCache = new Map<string, string>();
 const markedCache = new Map<string, Marked>();
 
 function getMarked(repo?: RepoContext): Marked {
-  const key = repo ? `${repo.owner}/${repo.name}` : "";
+  const key = repo ? `${repo.platformHost ?? ""}:${repo.owner}/${repo.name}` : "";
   let instance = markedCache.get(key);
   if (!instance) {
     instance = new Marked({ breaks: true, gfm: true });
@@ -89,7 +89,9 @@ export function renderMarkdown(
   repo?: RepoContext,
 ): string {
   if (!raw) return "";
-  const key = repo ? `${repo.owner}/${repo.name}\0${raw}` : raw;
+  const key = repo
+    ? `${repo.platformHost ?? ""}:${repo.owner}/${repo.name}\0${raw}`
+    : raw;
   const cached = htmlCache.get(key);
   if (cached !== undefined) return cached;
 
@@ -102,6 +104,7 @@ export function renderMarkdown(
         "data-name",
         "data-number",
         "data-platform-host",
+        "data-middleman-item-ref",
       ],
     },
   );

--- a/packages/ui/src/views/ActivityFeedView.svelte
+++ b/packages/ui/src/views/ActivityFeedView.svelte
@@ -252,6 +252,7 @@
             owner: activeDrawer.owner,
             name: activeDrawer.name,
             number: activeDrawer.number,
+            platformHost: activeDrawer.platformHost,
           }}
           detailTab={effectiveDetailTab}
           isSidebarCollapsed={true}

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -96,7 +96,7 @@
       </button>
     </div>
     {#if detailTab === "files"}
-      {#key `${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`}
+      {#key `${selectedPR.platformHost ?? ""}:${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`}
         <div class="files-view">
           <DiffToolbar />
           <div class="files-layout">
@@ -108,6 +108,7 @@
                 owner={selectedPR.owner}
                 name={selectedPR.name}
                 number={selectedPR.number}
+                platformHost={selectedPR.platformHost}
               />
             </div>
           </div>

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -21,6 +21,7 @@
       owner: string;
       name: string;
       number: number;
+      platformHost?: string | undefined;
     } | null;
     detailTab?: "conversation" | "files";
     isSidebarCollapsed?: boolean;
@@ -50,10 +51,13 @@
       return;
     }
     if (selectedPR === null) return;
+    const platformQuery = selectedPR.platformHost
+      ? `?platform_host=${encodeURIComponent(selectedPR.platformHost)}`
+      : "";
     navigate(
       tab === "files"
-        ? `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}/files`
-        : `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`,
+        ? `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}/files${platformQuery}`
+        : `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}${platformQuery}`,
     );
   }
 </script>
@@ -114,6 +118,7 @@
         owner={selectedPR.owner}
         name={selectedPR.name}
         number={selectedPR.number}
+        platformHost={selectedPR.platformHost}
         autoSync={autoSyncDetail}
         hideTabs={true}
       />


### PR DESCRIPTION
## Summary
- add a repository identity resolver for host-qualified owner/name lookups and item-number resolution
- route repo-bound API handlers through stable repo IDs before loading pull requests or issues
- document the repository identity boundary for future handler work

## How this makes the code better
- removes repeated owner/name/platform_host resolution from handlers and legacy helpers
- gives all repo-bound callers the same ambiguity, not-found, and host fallback behavior
- prevents future route code from accidentally mixing same owner/name repositories across hosts