### PR TITLE
Centralize workspace runtime lifecycle

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -55,6 +55,9 @@ The delete ordering is intentional: dirty preflight must run before runtime
 sessions are stopped, but the runtime stopping marker must span the whole
 delete call so a concurrent launch cannot start in a worktree after sessions
 were stopped and before the workspace row is removed.
+If a legacy or test server has a runtime manager but no `RuntimeLifecycle`,
+the fallback delete path must preserve the same marker and stop-before-
+destructive ordering.
 
 ## Non-Goals
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -32,6 +32,30 @@ browser and not an embedder protocol for arbitrary host state.
 These fields exist so PR-backed workspaces show PR/Reviews sidebars, while
 issue-backed workspaces show the issue sidebar and disable the PR/reviews path.
 
+## Runtime Lifecycle Seam
+
+Workspace runtime lifecycle coordination belongs below the HTTP server in
+`internal/workspace.RuntimeLifecycle`.
+
+- `internal/workspace/localruntime.Manager` is the process adapter. It starts,
+  stops, lists, restores, and attaches local runtime processes and tmux-backed
+  runtime sessions.
+- `internal/workspace.Manager` is the persistence/worktree adapter. It records
+  durable runtime tmux ownership rows and owns workspace deletion of persisted
+  rows, worktrees, branches, and base workspace tmux sessions.
+- `RuntimeLifecycle` composes those adapters for cross-adapter ordering:
+  launch + record + rollback, explicit stop + stored tmux fallback, natural
+  exit cleanup, and delete-time stopping marker + stop-before-destructive
+  cleanup.
+- Server handlers should call lifecycle methods for launching runtime sessions,
+  stopping runtime sessions, and deleting workspaces. They should not directly
+  interleave process cleanup with runtime tmux persistence.
+
+The delete ordering is intentional: dirty preflight must run before runtime
+sessions are stopped, but the runtime stopping marker must span the whole
+delete call so a concurrent launch cannot start in a worktree after sessions
+were stopped and before the workspace row is removed.
+
 ## Non-Goals
 
 - Represent arbitrary worktrees discovered on a host machine.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10027,6 +10027,27 @@ func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 	assert.Nil(srv.runtime.ShellSession(ws.Id))
 }
 
+func TestWorkspaceDeleteFallsBackWhenRuntimeLifecycleNilE2E(t *testing.T) {
+	require := require.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	srv.runtimeLifecycle = nil
+
+	force := true
+	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id,
+		&generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, delResp.StatusCode())
+
+	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusNotFound, getResp.StatusCode())
+}
+
 // TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E covers the case where the
 // workspace is dirty and delete is rejected with 409. Runtime sessions must
 // survive — killing them on a delete that didn't actually happen would leave

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10012,8 +10012,7 @@ func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, shellResp.StatusCode())
 
-	require.Len(srv.runtime.ListSessions(ws.Id), 1)
-	require.NotNil(srv.runtime.ShellSession(ws.Id))
+	requireWorkspaceRuntimeSessionsReady(t, srv, ws.Id)
 
 	force := true
 	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
@@ -10059,8 +10058,7 @@ func TestWorkspaceDeleteFallsBackWhenRuntimeLifecycleNilE2E(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, shellResp.StatusCode())
 
-	require.Len(srv.runtime.ListSessions(ws.Id), 1)
-	require.NotNil(srv.runtime.ShellSession(ws.Id))
+	requireWorkspaceRuntimeSessionsReady(t, srv, ws.Id)
 
 	srv.runtimeLifecycle = nil
 
@@ -10112,8 +10110,7 @@ func TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E(t *testing.T) {
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, shellResp.StatusCode())
-	require.Len(srv.runtime.ListSessions(ws.Id), 1)
-	require.NotNil(srv.runtime.ShellSession(ws.Id))
+	requireWorkspaceRuntimeSessionsReady(t, srv, ws.Id)
 
 	// Make the worktree dirty so a non-forced delete will be rejected.
 	require.NoError(os.WriteFile(
@@ -10130,6 +10127,18 @@ func TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E(t *testing.T) {
 	// The 409 must not have killed the runtime sessions.
 	assert.Len(srv.runtime.ListSessions(ws.Id), 1)
 	assert.NotNil(srv.runtime.ShellSession(ws.Id))
+}
+
+func requireWorkspaceRuntimeSessionsReady(
+	t *testing.T,
+	srv *Server,
+	workspaceID string,
+) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(srv.runtime.ListSessions(workspaceID)) == 1 &&
+			srv.runtime.ShellSession(workspaceID) != nil
+	}, time.Second, 10*time.Millisecond)
 }
 
 // TestWorkspaceListReportsCommitsAheadBehindE2E verifies that the
@@ -10916,8 +10925,18 @@ func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
 	require.Equal("ready", before.Status)
 	require.Nil(before.ErrorMessage)
 	require.NotEmpty(before.WorktreePath)
-	beforeEvents, err := database.ListWorkspaceSetupEvents(ctx, wsID)
-	require.NoError(err)
+	var beforeEvents []db.WorkspaceSetupEvent
+	require.Eventually(func() bool {
+		events, err := database.ListWorkspaceSetupEvents(ctx, wsID)
+		if err != nil {
+			return false
+		}
+		beforeEvents = events
+		return countWorkspaceSetupEvents(events, "setup", "started") > 0 &&
+			countWorkspaceSetupEvents(events, "setup", "ready") > 0
+	}, time.Second, 10*time.Millisecond)
+	beforeSetupStarts := countWorkspaceSetupEvents(beforeEvents, "setup", "started")
+	beforeSetupReady := countWorkspaceSetupEvents(beforeEvents, "setup", "ready")
 
 	retryResp, err := client.HTTP.RetryWorkspaceWithResponse(ctx, wsID)
 	require.NoError(err)
@@ -10933,7 +10952,27 @@ func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
 
 	afterEvents, err := database.ListWorkspaceSetupEvents(ctx, wsID)
 	require.NoError(err)
-	assert.Len(afterEvents, len(beforeEvents))
+	assert.Equal(
+		beforeSetupStarts,
+		countWorkspaceSetupEvents(afterEvents, "setup", "started"),
+	)
+	assert.Equal(
+		beforeSetupReady,
+		countWorkspaceSetupEvents(afterEvents, "setup", "ready"),
+	)
+}
+
+func countWorkspaceSetupEvents(
+	events []db.WorkspaceSetupEvent,
+	stage, outcome string,
+) int {
+	count := 0
+	for _, event := range events {
+		if event.Stage == stage && event.Outcome == outcome {
+			count++
+		}
+	}
+	return count
 }
 
 func TestWorkspaceCreateNotFound(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10028,11 +10028,40 @@ func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 }
 
 func TestWorkspaceDeleteFallsBackWhenRuntimeLifecycleNilE2E(t *testing.T) {
-	require := require.New(t)
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: serverRuntimeHelperCommand("sleep"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+
+	shellResp, err := client.HTTP.EnsureWorkspaceRuntimeShellWithResponse(
+		ctx, ws.Id,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, shellResp.StatusCode())
+
+	require.Len(srv.runtime.ListSessions(ws.Id), 1)
+	require.NotNil(srv.runtime.ShellSession(ws.Id))
+
 	srv.runtimeLifecycle = nil
 
 	force := true
@@ -10046,6 +10075,9 @@ func TestWorkspaceDeleteFallsBackWhenRuntimeLifecycleNilE2E(t *testing.T) {
 	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(ctx, ws.Id)
 	require.NoError(err)
 	require.Equal(http.StatusNotFound, getResp.StatusCode())
+
+	assert.Empty(srv.runtime.ListSessions(ws.Id))
+	assert.Nil(srv.runtime.ShellSession(ws.Id))
 }
 
 // TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E covers the case where the

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3317,7 +3317,17 @@ func (s *Server) deleteWorkspace(
 			ctx, input.ID, input.Force,
 		)
 	} else {
-		dirty, err = s.workspaces.Delete(ctx, input.ID, input.Force, nil)
+		var beforeDestructive func(context.Context)
+		if s.runtime != nil {
+			s.runtime.BeginStopping(input.ID)
+			defer s.runtime.EndStopping(input.ID)
+			beforeDestructive = func(stopCtx context.Context) {
+				s.runtime.StopWorkspace(stopCtx, input.ID)
+			}
+		}
+		dirty, err = s.workspaces.Delete(
+			ctx, input.ID, input.Force, beforeDestructive,
+		)
 	}
 	if err != nil {
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3174,46 +3174,21 @@ func (s *Server) launchWorkspaceRuntimeSession(
 		return nil, huma.Error400BadRequest("target_key is required")
 	}
 
-	if targetKey == string(localruntime.LaunchTargetPlainShell) {
-		session, err := s.runtime.EnsureShell(
-			ctx, summary.ID, summary.WorktreePath,
-		)
-		if err != nil {
+	session, err := s.runtimeLifecycle.LaunchSession(
+		ctx,
+		workspace.RuntimeWorkspace{
+			ID:           summary.ID,
+			WorktreePath: summary.WorktreePath,
+		},
+		targetKey,
+	)
+	if err != nil {
+		if targetKey == string(localruntime.LaunchTargetPlainShell) {
 			return nil, huma.Error500InternalServerError(
 				"ensure shell: " + err.Error(),
 			)
 		}
-		return &workspaceRuntimeSessionOutput{Body: session}, nil
-	}
-
-	session, err := s.runtime.Launch(
-		ctx, summary.ID, summary.WorktreePath, targetKey,
-	)
-	if err != nil {
 		return nil, workspaceRuntimeLaunchError(err)
-	}
-	if session.TmuxSession != "" {
-		if err := s.workspaces.RecordRuntimeTmuxSession(
-			ctx, summary.ID, session.TmuxSession, session.TargetKey,
-			session.CreatedAt,
-		); err != nil {
-			_ = s.runtime.Stop(ctx, summary.ID, session.Key)
-			return nil, huma.Error500InternalServerError(
-				"record runtime tmux session: " + err.Error(),
-			)
-		}
-		if runtimeSessionTmuxSession(
-			s.runtime.ListSessions(summary.ID), session.Key,
-		) == "" {
-			if _, err := s.workspaces.ForgetMissingRuntimeTmuxSession(
-				ctx, summary.ID, session.TmuxSession,
-				session.CreatedAt,
-			); err != nil {
-				return nil, huma.Error500InternalServerError(
-					"forget missing runtime tmux session: " + err.Error(),
-				)
-			}
-		}
 	}
 	return &workspaceRuntimeSessionOutput{Body: session}, nil
 }
@@ -3226,65 +3201,15 @@ func (s *Server) stopWorkspaceRuntimeSession(
 	if err != nil {
 		return nil, err
 	}
-	tmuxSession := runtimeSessionTmuxSession(
-		s.runtime.ListSessions(summary.ID), input.SessionKey,
-	)
-	if err := s.runtime.Stop(
+	if err := s.runtimeLifecycle.StopSession(
 		ctx, summary.ID, input.SessionKey,
 	); err != nil {
 		if errors.Is(err, localruntime.ErrSessionNotFound) {
-			if targetKey, ok := runtimeTargetKeyFromSessionKey(
-				summary.ID, input.SessionKey,
-			); ok {
-				stopped, stopErr := s.workspaces.StopStoredRuntimeTmuxSession(
-					ctx, summary.ID, targetKey,
-				)
-				if stopErr != nil {
-					return nil, huma.Error500InternalServerError(
-						"stop stored runtime tmux session: " +
-							stopErr.Error(),
-					)
-				}
-				if stopped {
-					return nil, nil
-				}
-			}
 			return nil, huma.Error404NotFound(err.Error())
 		}
-		return nil, huma.Error500InternalServerError(
-			"stop runtime session: " + err.Error(),
-		)
-	}
-	if tmuxSession != "" {
-		if err := s.workspaces.ForgetRuntimeTmuxSession(
-			ctx, summary.ID, tmuxSession,
-		); err != nil {
-			return nil, huma.Error500InternalServerError(
-				"forget runtime tmux session: " + err.Error(),
-			)
-		}
+		return nil, huma.Error500InternalServerError(err.Error())
 	}
 	return nil, nil
-}
-
-func runtimeSessionTmuxSession(
-	sessions []localruntime.SessionInfo,
-	key string,
-) string {
-	for _, session := range sessions {
-		if session.Key == key {
-			return session.TmuxSession
-		}
-	}
-	return ""
-}
-
-func runtimeTargetKeyFromSessionKey(
-	workspaceID string,
-	key string,
-) (string, bool) {
-	targetKey, ok := strings.CutPrefix(key, workspaceID+":")
-	return targetKey, ok && targetKey != ""
 }
 
 func (s *Server) ensureWorkspaceRuntimeShell(
@@ -3296,8 +3221,13 @@ func (s *Server) ensureWorkspaceRuntimeShell(
 		return nil, err
 	}
 
-	session, err := s.runtime.EnsureShell(
-		ctx, summary.ID, summary.WorktreePath,
+	session, err := s.runtimeLifecycle.LaunchSession(
+		ctx,
+		workspace.RuntimeWorkspace{
+			ID:           summary.ID,
+			WorktreePath: summary.WorktreePath,
+		},
+		string(localruntime.LaunchTargetPlainShell),
 	)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(
@@ -3311,7 +3241,7 @@ func (s *Server) getReadyRuntimeWorkspace(
 	ctx context.Context,
 	id string,
 ) (*db.WorkspaceSummary, error) {
-	if s.workspaces == nil || s.runtime == nil {
+	if s.workspaces == nil || s.runtime == nil || s.runtimeLifecycle == nil {
 		return nil, huma.Error503ServiceUnavailable(
 			"workspace runtime not configured",
 		)
@@ -3339,6 +3269,10 @@ func workspaceRuntimeLaunchError(err error) error {
 	if strings.Contains(msg, "target not found") {
 		return huma.Error404NotFound(msg)
 	}
+	if strings.HasPrefix(msg, "record runtime tmux session:") ||
+		strings.HasPrefix(msg, "forget missing runtime tmux session:") {
+		return huma.Error500InternalServerError(msg)
+	}
 	if strings.Contains(msg, "not available") ||
 		strings.Contains(msg, "no command") {
 		return huma.Error400BadRequest(msg)
@@ -3358,6 +3292,11 @@ func (s *Server) deleteWorkspace(
 			"workspace manager not configured",
 		)
 	}
+	if s.runtimeLifecycle == nil {
+		return nil, huma.Error503ServiceUnavailable(
+			"workspace runtime not configured",
+		)
+	}
 
 	// Order of operations:
 	//   1. dirty preflight inside Delete — returns 409 without
@@ -3372,21 +3311,12 @@ func (s *Server) deleteWorkspace(
 	// processes could write new uncommitted changes that bypass the
 	// dirty check the user requested.
 	//
-	// BeginStopping/EndStopping holds the runtime's stopping marker
-	// across the whole Delete call — including step 3 — so a Launch
-	// arriving between StopWorkspace returning and DB removal cannot
-	// spawn a process in the soon-to-be-deleted worktree.
-	if s.runtime != nil {
-		s.runtime.BeginStopping(input.ID)
-		defer s.runtime.EndStopping(input.ID)
-	}
-	dirty, err := s.workspaces.Delete(
+	// RuntimeLifecycle holds the runtime's stopping marker across
+	// the whole Delete call — including step 3 — so a Launch arriving
+	// between StopWorkspace returning and DB removal cannot spawn a
+	// process in the soon-to-be-deleted worktree.
+	dirty, err := s.runtimeLifecycle.DeleteWorkspace(
 		ctx, input.ID, input.Force,
-		func(stopCtx context.Context) {
-			if s.runtime != nil {
-				s.runtime.StopWorkspace(stopCtx, input.ID)
-			}
-		},
 	)
 	if err != nil {
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3292,11 +3292,6 @@ func (s *Server) deleteWorkspace(
 			"workspace manager not configured",
 		)
 	}
-	if s.runtimeLifecycle == nil {
-		return nil, huma.Error503ServiceUnavailable(
-			"workspace runtime not configured",
-		)
-	}
 
 	// Order of operations:
 	//   1. dirty preflight inside Delete — returns 409 without
@@ -3315,9 +3310,15 @@ func (s *Server) deleteWorkspace(
 	// the whole Delete call — including step 3 — so a Launch arriving
 	// between StopWorkspace returning and DB removal cannot spawn a
 	// process in the soon-to-be-deleted worktree.
-	dirty, err := s.runtimeLifecycle.DeleteWorkspace(
-		ctx, input.ID, input.Force,
-	)
+	var dirty []string
+	var err error
+	if s.runtimeLifecycle != nil {
+		dirty, err = s.runtimeLifecycle.DeleteWorkspace(
+			ctx, input.ID, input.Force,
+		)
+	} else {
+		dirty, err = s.workspaces.Delete(ctx, input.ID, input.Force, nil)
+	}
 	if err != nil {
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {
 			return nil, huma.Error404NotFound(err.Error())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,6 +123,7 @@ type Server struct {
 	syncer             *ghclient.Syncer
 	clones             *gitclone.Manager
 	workspaces         *workspace.Manager
+	runtimeLifecycle   *workspace.RuntimeLifecycle
 	workspacePRMonitor *workspace.PRMonitor
 	tmuxActivity       *tmuxActivityTracker
 	runtime            *localruntime.Manager
@@ -443,6 +444,9 @@ func newServer(
 			StripEnvVars:            cfg.TokenEnvNames(),
 			OnSessionExit:           s.handleRuntimeSessionExit,
 		})
+		s.runtimeLifecycle = workspace.NewRuntimeLifecycle(
+			s.runtime, s.workspaces,
+		)
 		if err := s.restoreRuntimeTmuxSessions(context.Background()); err != nil {
 			slog.Warn("restore runtime tmux sessions", "err", err)
 		}
@@ -575,7 +579,7 @@ func (s *Server) restoreRuntimeTmuxSessions(ctx context.Context) error {
 }
 
 func (s *Server) handleRuntimeSessionExit(info localruntime.SessionInfo) {
-	if info.TmuxSession == "" || s.workspaces == nil {
+	if info.TmuxSession == "" || s.runtimeLifecycle == nil {
 		return
 	}
 	s.runBackground(func(ctx context.Context) {
@@ -583,9 +587,8 @@ func (s *Server) handleRuntimeSessionExit(info localruntime.SessionInfo) {
 			ctx, runtimeSessionCleanupTimeout,
 		)
 		defer cancel()
-		if _, err := s.workspaces.ForgetMissingRuntimeTmuxSession(
-			cleanupCtx, info.WorkspaceID, info.TmuxSession,
-			info.CreatedAt,
+		if _, err := s.runtimeLifecycle.ForgetMissingSession(
+			cleanupCtx, info,
 		); err != nil {
 			slog.Warn(
 				"forget missing runtime tmux session",

--- a/internal/workspace/runtime_lifecycle.go
+++ b/internal/workspace/runtime_lifecycle.go
@@ -1,0 +1,220 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wesm/middleman/internal/workspace/localruntime"
+)
+
+// RuntimeWorkspace is the workspace state the runtime lifecycle needs to
+// launch a process without knowing about server response shapes.
+type RuntimeWorkspace struct {
+	ID           string
+	WorktreePath string
+}
+
+type runtimeProcessAdapter interface {
+	EnsureShell(
+		ctx context.Context,
+		workspaceID string,
+		cwd string,
+	) (localruntime.SessionInfo, error)
+	Launch(
+		ctx context.Context,
+		workspaceID string,
+		cwd string,
+		targetKey string,
+	) (localruntime.SessionInfo, error)
+	ListSessions(workspaceID string) []localruntime.SessionInfo
+	Stop(ctx context.Context, workspaceID string, sessionKey string) error
+	StopWorkspace(ctx context.Context, workspaceID string)
+	BeginStopping(workspaceID string)
+	EndStopping(workspaceID string)
+}
+
+type runtimePersistenceAdapter interface {
+	RecordRuntimeTmuxSession(
+		ctx context.Context,
+		workspaceID string,
+		sessionName string,
+		targetKey string,
+		createdAt time.Time,
+	) error
+	ForgetRuntimeTmuxSession(
+		ctx context.Context,
+		workspaceID string,
+		sessionName string,
+	) error
+	ForgetMissingRuntimeTmuxSession(
+		ctx context.Context,
+		workspaceID string,
+		sessionName string,
+		createdAt time.Time,
+	) (bool, error)
+	StopStoredRuntimeTmuxSession(
+		ctx context.Context,
+		workspaceID string,
+		targetKey string,
+	) (bool, error)
+	Delete(
+		ctx context.Context,
+		id string,
+		force bool,
+		beforeDestructive func(context.Context),
+	) ([]string, error)
+}
+
+// RuntimeLifecycle coordinates runtime process state with durable workspace
+// ownership state. localruntime.Manager remains the process adapter, while
+// Manager remains the persistence/worktree adapter.
+type RuntimeLifecycle struct {
+	process     runtimeProcessAdapter
+	persistence runtimePersistenceAdapter
+}
+
+func NewRuntimeLifecycle(
+	process runtimeProcessAdapter,
+	persistence runtimePersistenceAdapter,
+) *RuntimeLifecycle {
+	return &RuntimeLifecycle{
+		process:     process,
+		persistence: persistence,
+	}
+}
+
+// LaunchSession starts or reuses a runtime session and records any tmux-backed
+// ownership row before returning it to callers.
+func (l *RuntimeLifecycle) LaunchSession(
+	ctx context.Context,
+	ws RuntimeWorkspace,
+	targetKey string,
+) (localruntime.SessionInfo, error) {
+	if targetKey == string(localruntime.LaunchTargetPlainShell) {
+		return l.process.EnsureShell(ctx, ws.ID, ws.WorktreePath)
+	}
+
+	session, err := l.process.Launch(ctx, ws.ID, ws.WorktreePath, targetKey)
+	if err != nil {
+		return localruntime.SessionInfo{}, err
+	}
+	if session.TmuxSession == "" {
+		return session, nil
+	}
+
+	if err := l.persistence.RecordRuntimeTmuxSession(
+		ctx, ws.ID, session.TmuxSession, session.TargetKey,
+		session.CreatedAt,
+	); err != nil {
+		_ = l.process.Stop(ctx, ws.ID, session.Key)
+		return localruntime.SessionInfo{}, fmt.Errorf(
+			"record runtime tmux session: %w", err,
+		)
+	}
+	if runtimeSessionTmuxSession(
+		l.process.ListSessions(ws.ID), session.Key,
+	) == "" {
+		if _, err := l.persistence.ForgetMissingRuntimeTmuxSession(
+			ctx, ws.ID, session.TmuxSession, session.CreatedAt,
+		); err != nil {
+			return localruntime.SessionInfo{}, fmt.Errorf(
+				"forget missing runtime tmux session: %w", err,
+			)
+		}
+	}
+	return session, nil
+}
+
+func (l *RuntimeLifecycle) StopSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionKey string,
+) error {
+	tmuxSession := runtimeSessionTmuxSession(
+		l.process.ListSessions(workspaceID), sessionKey,
+	)
+	if err := l.process.Stop(ctx, workspaceID, sessionKey); err != nil {
+		if errors.Is(err, localruntime.ErrSessionNotFound) {
+			if targetKey, ok := runtimeTargetKeyFromSessionKey(
+				workspaceID, sessionKey,
+			); ok {
+				stopped, stopErr := l.persistence.
+					StopStoredRuntimeTmuxSession(
+						ctx, workspaceID, targetKey,
+					)
+				if stopErr != nil {
+					return fmt.Errorf(
+						"stop stored runtime tmux session: %w",
+						stopErr,
+					)
+				}
+				if stopped {
+					return nil
+				}
+			}
+			return err
+		}
+		return fmt.Errorf("stop runtime session: %w", err)
+	}
+	if tmuxSession != "" {
+		if err := l.persistence.ForgetRuntimeTmuxSession(
+			ctx, workspaceID, tmuxSession,
+		); err != nil {
+			return fmt.Errorf("forget runtime tmux session: %w", err)
+		}
+	}
+	return nil
+}
+
+// DeleteWorkspace keeps the runtime stopping marker active across the whole
+// workspace delete flow, while only stopping sessions after the workspace
+// adapter's dirty preflight has allowed destructive cleanup to proceed.
+func (l *RuntimeLifecycle) DeleteWorkspace(
+	ctx context.Context,
+	id string,
+	force bool,
+) ([]string, error) {
+	l.process.BeginStopping(id)
+	defer l.process.EndStopping(id)
+	return l.persistence.Delete(
+		ctx, id, force,
+		func(stopCtx context.Context) {
+			l.process.StopWorkspace(stopCtx, id)
+		},
+	)
+}
+
+func (l *RuntimeLifecycle) ForgetMissingSession(
+	ctx context.Context,
+	info localruntime.SessionInfo,
+) (bool, error) {
+	if info.TmuxSession == "" {
+		return false, nil
+	}
+	return l.persistence.ForgetMissingRuntimeTmuxSession(
+		ctx, info.WorkspaceID, info.TmuxSession, info.CreatedAt,
+	)
+}
+
+func runtimeSessionTmuxSession(
+	sessions []localruntime.SessionInfo,
+	key string,
+) string {
+	for _, session := range sessions {
+		if session.Key == key {
+			return session.TmuxSession
+		}
+	}
+	return ""
+}
+
+func runtimeTargetKeyFromSessionKey(
+	workspaceID string,
+	key string,
+) (string, bool) {
+	targetKey, ok := strings.CutPrefix(key, workspaceID+":")
+	return targetKey, ok && targetKey != ""
+}

--- a/internal/workspace/runtime_lifecycle_test.go
+++ b/internal/workspace/runtime_lifecycle_test.go
@@ -1,0 +1,411 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wesm/middleman/internal/workspace/localruntime"
+)
+
+func TestRuntimeLifecycleLaunchStopsSessionWhenTmuxRecordFails(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	createdAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	process := &fakeRuntimeProcess{
+		launchInfo: localruntime.SessionInfo{
+			Key:         "ws-1:helper",
+			WorkspaceID: "ws-1",
+			TargetKey:   "helper",
+			TmuxSession: "middleman-ws-1-helper",
+			CreatedAt:   createdAt,
+		},
+	}
+	persistence := &fakeRuntimePersistence{
+		recordErr: errors.New("write failed"),
+	}
+	lifecycle := NewRuntimeLifecycle(process, persistence)
+
+	_, err := lifecycle.LaunchSession(
+		ctx,
+		RuntimeWorkspace{ID: "ws-1", WorktreePath: "/tmp/ws-1"},
+		"helper",
+	)
+
+	require.Error(err)
+	assert.Contains(err.Error(), "record runtime tmux session")
+	assert.Equal([]runtimeStopCall{{
+		workspaceID: "ws-1",
+		sessionKey:  "ws-1:helper",
+	}}, process.stopCalls)
+	assert.Equal([]runtimeRecordCall{{
+		workspaceID: "ws-1",
+		sessionName: "middleman-ws-1-helper",
+		targetKey:   "helper",
+		createdAt:   createdAt,
+	}}, persistence.recordCalls)
+}
+
+func TestRuntimeLifecycleLaunchForgetsTmuxRecordWhenSessionAlreadyExited(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	createdAt := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	process := &fakeRuntimeProcess{
+		launchInfo: localruntime.SessionInfo{
+			Key:         "ws-1:helper",
+			WorkspaceID: "ws-1",
+			TargetKey:   "helper",
+			TmuxSession: "middleman-ws-1-helper",
+			CreatedAt:   createdAt,
+		},
+		listSessions: []localruntime.SessionInfo{{
+			Key:         "ws-1:other",
+			WorkspaceID: "ws-1",
+			TargetKey:   "other",
+			TmuxSession: "middleman-ws-1-other",
+		}},
+	}
+	persistence := &fakeRuntimePersistence{}
+	lifecycle := NewRuntimeLifecycle(process, persistence)
+
+	session, err := lifecycle.LaunchSession(
+		ctx,
+		RuntimeWorkspace{ID: "ws-1", WorktreePath: "/tmp/ws-1"},
+		"helper",
+	)
+
+	require.NoError(err)
+	assert.Equal("ws-1:helper", session.Key)
+	assert.Equal([]runtimeForgetMissingCall{{
+		workspaceID: "ws-1",
+		sessionName: "middleman-ws-1-helper",
+		createdAt:   createdAt,
+	}}, persistence.forgetMissingCalls)
+}
+
+func TestRuntimeLifecycleStopSessionForgetsRecordedTmuxSession(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	process := &fakeRuntimeProcess{
+		listSessions: []localruntime.SessionInfo{{
+			Key:         "ws-1:helper",
+			WorkspaceID: "ws-1",
+			TargetKey:   "helper",
+			TmuxSession: "middleman-ws-1-helper",
+		}},
+	}
+	persistence := &fakeRuntimePersistence{}
+	lifecycle := NewRuntimeLifecycle(process, persistence)
+
+	err := lifecycle.StopSession(ctx, "ws-1", "ws-1:helper")
+
+	require.NoError(err)
+	assert.Equal([]runtimeStopCall{{
+		workspaceID: "ws-1",
+		sessionKey:  "ws-1:helper",
+	}}, process.stopCalls)
+	assert.Equal([]runtimeForgetCall{{
+		workspaceID: "ws-1",
+		sessionName: "middleman-ws-1-helper",
+	}}, persistence.forgetCalls)
+}
+
+func TestRuntimeLifecycleStopSessionFallsBackToStoredTmuxSession(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	process := &fakeRuntimeProcess{
+		stopErr: localruntime.ErrSessionNotFound,
+	}
+	persistence := &fakeRuntimePersistence{stopStored: true}
+	lifecycle := NewRuntimeLifecycle(process, persistence)
+
+	err := lifecycle.StopSession(ctx, "ws-1", "ws-1:helper")
+
+	require.NoError(err)
+	assert.Equal([]runtimeStopStoredCall{{
+		workspaceID: "ws-1",
+		targetKey:   "helper",
+	}}, persistence.stopStoredCalls)
+	assert.Empty(persistence.forgetCalls)
+}
+
+func TestRuntimeLifecycleDeleteWorkspaceHoldsStoppingMarkerUntilDeleteReturns(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	process := &fakeRuntimeProcess{}
+	var events []string
+	persistence := &fakeRuntimePersistence{
+		deleteFunc: func(
+			deleteCtx context.Context,
+			id string,
+			force bool,
+			beforeDestructive func(context.Context),
+		) ([]string, error) {
+			events = append(events, "delete:start")
+			assert.True(process.isStopping(id))
+			beforeDestructive(deleteCtx)
+			assert.True(process.isStopping(id))
+			events = append(events, "delete:return")
+			return nil, nil
+		},
+	}
+	process.recordEvent = func(event string) {
+		events = append(events, event)
+	}
+	lifecycle := NewRuntimeLifecycle(process, persistence)
+
+	dirty, err := lifecycle.DeleteWorkspace(ctx, "ws-1", true)
+
+	require.NoError(err)
+	assert.Empty(dirty)
+	assert.Equal([]string{
+		"begin:ws-1",
+		"delete:start",
+		"stop-workspace:ws-1",
+		"delete:return",
+		"end:ws-1",
+	}, events)
+	assert.False(process.isStopping("ws-1"))
+}
+
+func TestRuntimeLifecycleDeleteWorkspaceDoesNotStopRuntimeOnDirtyRejection(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	process := &fakeRuntimeProcess{}
+	var events []string
+	persistence := &fakeRuntimePersistence{
+		deleteFunc: func(
+			deleteCtx context.Context,
+			id string,
+			force bool,
+			beforeDestructive func(context.Context),
+		) ([]string, error) {
+			events = append(events, "delete:start")
+			assert.True(process.isStopping(id))
+			return []string{"dirty.txt"}, nil
+		},
+	}
+	process.recordEvent = func(event string) {
+		events = append(events, event)
+	}
+	lifecycle := NewRuntimeLifecycle(process, persistence)
+
+	dirty, err := lifecycle.DeleteWorkspace(ctx, "ws-1", false)
+
+	require.NoError(err)
+	assert.Equal([]string{"dirty.txt"}, dirty)
+	assert.Equal([]string{
+		"begin:ws-1",
+		"delete:start",
+		"end:ws-1",
+	}, events)
+	assert.Empty(process.stopWorkspaceCalls)
+}
+
+type fakeRuntimeProcess struct {
+	launchInfo         localruntime.SessionInfo
+	launchErr          error
+	ensureShellInfo    localruntime.SessionInfo
+	ensureShellErr     error
+	listSessions       []localruntime.SessionInfo
+	stopErr            error
+	stopCalls          []runtimeStopCall
+	stopWorkspaceCalls []string
+	stopping           map[string]int
+	recordEvent        func(string)
+}
+
+func (f *fakeRuntimeProcess) EnsureShell(
+	ctx context.Context,
+	workspaceID string,
+	cwd string,
+) (localruntime.SessionInfo, error) {
+	return f.ensureShellInfo, f.ensureShellErr
+}
+
+func (f *fakeRuntimeProcess) Launch(
+	ctx context.Context,
+	workspaceID string,
+	cwd string,
+	targetKey string,
+) (localruntime.SessionInfo, error) {
+	return f.launchInfo, f.launchErr
+}
+
+func (f *fakeRuntimeProcess) ListSessions(
+	workspaceID string,
+) []localruntime.SessionInfo {
+	return append([]localruntime.SessionInfo(nil), f.listSessions...)
+}
+
+func (f *fakeRuntimeProcess) Stop(
+	ctx context.Context,
+	workspaceID string,
+	sessionKey string,
+) error {
+	f.stopCalls = append(f.stopCalls, runtimeStopCall{
+		workspaceID: workspaceID,
+		sessionKey:  sessionKey,
+	})
+	return f.stopErr
+}
+
+func (f *fakeRuntimeProcess) StopWorkspace(
+	ctx context.Context,
+	workspaceID string,
+) {
+	f.stopWorkspaceCalls = append(f.stopWorkspaceCalls, workspaceID)
+	if f.recordEvent != nil {
+		f.recordEvent("stop-workspace:" + workspaceID)
+	}
+}
+
+func (f *fakeRuntimeProcess) BeginStopping(workspaceID string) {
+	if f.stopping == nil {
+		f.stopping = map[string]int{}
+	}
+	f.stopping[workspaceID]++
+	if f.recordEvent != nil {
+		f.recordEvent("begin:" + workspaceID)
+	}
+}
+
+func (f *fakeRuntimeProcess) EndStopping(workspaceID string) {
+	f.stopping[workspaceID]--
+	if f.stopping[workspaceID] <= 0 {
+		delete(f.stopping, workspaceID)
+	}
+	if f.recordEvent != nil {
+		f.recordEvent("end:" + workspaceID)
+	}
+}
+
+func (f *fakeRuntimeProcess) isStopping(workspaceID string) bool {
+	return f.stopping[workspaceID] > 0
+}
+
+type fakeRuntimePersistence struct {
+	recordErr          error
+	forgetErr          error
+	forgetMissingErr   error
+	stopStored         bool
+	stopStoredErr      error
+	deleteFunc         func(context.Context, string, bool, func(context.Context)) ([]string, error)
+	recordCalls        []runtimeRecordCall
+	forgetCalls        []runtimeForgetCall
+	forgetMissingCalls []runtimeForgetMissingCall
+	stopStoredCalls    []runtimeStopStoredCall
+}
+
+func (f *fakeRuntimePersistence) RecordRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+	targetKey string,
+	createdAt time.Time,
+) error {
+	f.recordCalls = append(f.recordCalls, runtimeRecordCall{
+		workspaceID: workspaceID,
+		sessionName: sessionName,
+		targetKey:   targetKey,
+		createdAt:   createdAt,
+	})
+	return f.recordErr
+}
+
+func (f *fakeRuntimePersistence) ForgetRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+) error {
+	f.forgetCalls = append(f.forgetCalls, runtimeForgetCall{
+		workspaceID: workspaceID,
+		sessionName: sessionName,
+	})
+	return f.forgetErr
+}
+
+func (f *fakeRuntimePersistence) ForgetMissingRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	sessionName string,
+	createdAt time.Time,
+) (bool, error) {
+	f.forgetMissingCalls = append(
+		f.forgetMissingCalls,
+		runtimeForgetMissingCall{
+			workspaceID: workspaceID,
+			sessionName: sessionName,
+			createdAt:   createdAt,
+		},
+	)
+	return true, f.forgetMissingErr
+}
+
+func (f *fakeRuntimePersistence) StopStoredRuntimeTmuxSession(
+	ctx context.Context,
+	workspaceID string,
+	targetKey string,
+) (bool, error) {
+	f.stopStoredCalls = append(f.stopStoredCalls, runtimeStopStoredCall{
+		workspaceID: workspaceID,
+		targetKey:   targetKey,
+	})
+	return f.stopStored, f.stopStoredErr
+}
+
+func (f *fakeRuntimePersistence) Delete(
+	ctx context.Context,
+	id string,
+	force bool,
+	beforeDestructive func(context.Context),
+) ([]string, error) {
+	if f.deleteFunc == nil {
+		return nil, nil
+	}
+	return f.deleteFunc(ctx, id, force, beforeDestructive)
+}
+
+type runtimeStopCall struct {
+	workspaceID string
+	sessionKey  string
+}
+
+type runtimeRecordCall struct {
+	workspaceID string
+	sessionName string
+	targetKey   string
+	createdAt   time.Time
+}
+
+type runtimeForgetCall struct {
+	workspaceID string
+	sessionName string
+}
+
+type runtimeForgetMissingCall struct {
+	workspaceID string
+	sessionName string
+	createdAt   time.Time
+}
+
+type runtimeStopStoredCall struct {
+	workspaceID string
+	targetKey   string
+}


### PR DESCRIPTION
## Summary
- add a runtime lifecycle coordinator for workspace launch, stop, cleanup, and delete flows
- move process-plus-persistence choreography out of HTTP handlers
- document the workspace runtime ownership boundary

## How this makes the code better
- gives handlers one uniform API for runtime transitions instead of repeated tmux/session cleanup branches
- keeps durable tmux ownership cleanup in the same place as process stop behavior
- makes future workspace runtime changes smaller because lifecycle rules live in one module