### PR TITLE
Centralize routed item builders

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -20,6 +20,7 @@ Use this document as the intent-level guide for frontend UI work in `middleman`.
 
 - Tokens: `frontend/src/app.css`
 - Shared primitives: `packages/ui/src/components/shared/`
+- Routed item references and URL builders: `packages/ui/src/routes.ts`
 - Svelte guidance: `skills/svelte-core-bestpractices/` (`svelte-core-bestpractices`) and `skills/svelte-code-writer/` (`svelte-code-writer`)
 - Interaction contracts: `context/ui-interaction-contracts.md`
 - This guidance: `context/ui-design-system.md`
@@ -134,7 +135,7 @@ Default color intent:
 
 When editing Svelte components, use the Svelte skills `skills/svelte-core-bestpractices/` (`svelte-core-bestpractices`) and `skills/svelte-code-writer/` (`svelte-code-writer`) alongside this document.
 
-For TypeScript/Svelte state and routing contracts, avoid anonymous object type literals when the shape represents a domain concept that is reused or exposed across modules. Name shared item identity shapes, route payloads, embed callbacks, and API view models near the module that owns the concept, then import those types at call sites. In particular, PR/issue route and drawer state should use the shared item reference types from `frontend/src/lib/stores/router.svelte.ts` instead of repeating `{ owner; name; number }` style shapes.
+For TypeScript/Svelte state and routing contracts, avoid anonymous object type literals when the shape represents a domain concept that is reused or exposed across modules. Name shared item identity shapes, route payloads, embed callbacks, and API view models near the module that owns the concept, then import those types at call sites. PR/issue/file/focus route identity and URL construction belongs in the shared route item module at `packages/ui/src/routes.ts`; the frontend router remains the browser-location adapter over those builders. New routed item callers should use those named refs and builders instead of repeating `{ owner; name; number; platformHost }` shapes or hand-building `/pulls`, `/issues`, or `/focus` URLs.
 
 Before adding UI styling:
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,6 +11,11 @@
   } from "@middleman/ui";
   import type { StoreInstances } from "@middleman/ui";
   import type { ActivityItem } from "@middleman/ui/api/types";
+  import {
+    buildPullRequestFilesRoute,
+    buildPullRequestRoute,
+    type RoutedItemRef,
+  } from "@middleman/ui/routes";
   import { client } from "./lib/api/runtime.js";
 
   import AppHeader from "./lib/components/layout/AppHeader.svelte";
@@ -53,7 +58,6 @@
     isDiffView,
     getDetailTab,
     getSelectedPRFromRoute,
-    type RoutableItemRef,
   } from "./lib/stores/router.svelte.ts";
   import {
     buildActivitySelectionSearch,
@@ -200,7 +204,7 @@
     }
   });
 
-  type DrawerItem = RoutableItemRef & {
+  type DrawerItem = RoutedItemRef & {
     detailTab: ActivityDetailTab;
   };
 
@@ -276,8 +280,8 @@
     const tab = getDetailTab();
     const path =
       tab === "files"
-        ? `/pulls/${sel.owner}/${sel.name}/${sel.number}/files`
-        : `/pulls/${sel.owner}/${sel.name}/${sel.number}`;
+        ? buildPullRequestFilesRoute(sel)
+        : buildPullRequestRoute(sel);
     if (getSelectedPRFromRoute()) {
       replaceUrl(path);
     } else {
@@ -344,13 +348,9 @@
         e.preventDefault();
         const tab = getDetailTab();
         if (tab === "conversation") {
-          navigate(
-            `/pulls/${sel.owner}/${sel.name}/${sel.number}/files`,
-          );
+          navigate(buildPullRequestFilesRoute(sel));
         } else {
-          navigate(
-            `/pulls/${sel.owner}/${sel.name}/${sel.number}`,
-          );
+          navigate(buildPullRequestRoute(sel));
         }
         return;
       }

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { FilterDropdown, getStores } from "@middleman/ui";
   import type { RepoSummary } from "@middleman/ui/api/types";
+  import { buildIssueRoute } from "@middleman/ui/routes";
 
   import {
     RefreshIcon,
@@ -280,11 +281,13 @@
     issueBodyByRepo[key] = "";
     composerSummary = null;
     setGlobalRepo(repoStateKey(summary));
-    const platformQuery = summary.platform_host
-      ? `?platform_host=${encodeURIComponent(summary.platform_host)}`
-      : "";
     navigate(
-      `/issues/${summary.owner}/${summary.name}/${data.Number}${platformQuery}`,
+      buildIssueRoute({
+        owner: summary.owner,
+        name: summary.name,
+        number: data.Number,
+        platformHost: summary.platform_host,
+      }),
     );
   }
 
@@ -443,7 +446,12 @@
           onopenissue={(number) =>
             filterAndNavigate(
               summary,
-              `/issues/${summary.owner}/${summary.name}/${number}?platform_host=${encodeURIComponent(summary.platform_host)}`,
+              buildIssueRoute({
+                owner: summary.owner,
+                name: summary.name,
+                number,
+                platformHost: summary.platform_host,
+              }),
             )}
         />
       {/each}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import {
-    navigate,
-    buildItemRoute,
-  } from "../../stores/router.svelte.ts";
+  import { navigate } from "../../stores/router.svelte.ts";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import GitBranchIcon from "@lucide/svelte/icons/git-branch";
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -1,19 +1,15 @@
-export type RepoRef = {
-  owner: string;
-  name: string;
-};
+import {
+  buildRoutedItemRoute,
+  type IssueRouteRef,
+  type NumberedRouteItemRef,
+  type RepositoryRouteRef,
+  type RoutedItemRef,
+} from "@middleman/ui/routes";
 
-export type NumberedItemRef = RepoRef & {
-  number: number;
-};
-
-export type HostedItemRef = NumberedItemRef & {
-  platformHost?: string | undefined;
-};
-
-export type RoutableItemRef = HostedItemRef & {
-  itemType: "pr" | "issue";
-};
+export type RepoRef = RepositoryRouteRef;
+export type NumberedItemRef = NumberedRouteItemRef;
+export type HostedItemRef = IssueRouteRef;
+export type RoutableItemRef = RoutedItemRef;
 
 export type Route =
   | { page: "activity" }
@@ -208,15 +204,16 @@ export function buildItemRoute(
   number: number,
   platformHost?: string,
 ): string {
-  const issueQuery = type === "issue" && platformHost
-    ? `?platform_host=${encodeURIComponent(platformHost)}`
-    : "";
-  if (isFocusMode()) {
-    return `/focus/${type}/${owner}/${name}/${number}${issueQuery}`;
-  }
-  return type === "pr"
-    ? `/pulls/${owner}/${name}/${number}`
-    : `/issues/${owner}/${name}/${number}${issueQuery}`;
+  return buildRoutedItemRoute(
+    {
+      itemType: type,
+      owner,
+      name,
+      number,
+      ...(platformHost && { platformHost }),
+    },
+    { focus: isFocusMode() },
+  );
 }
 
 export function navigate(path: string, state?: Record<string, unknown>): void {

--- a/frontend/src/lib/utils/activitySelection.ts
+++ b/frontend/src/lib/utils/activitySelection.ts
@@ -1,14 +1,16 @@
+import {
+  buildIssueRoute,
+  buildPullRequestFilesRoute,
+  buildPullRequestRoute,
+  type RoutedItemRef,
+} from "@middleman/ui/routes";
+
 export type ActivitySelectionItemType = "pr" | "issue";
 export type ActivityDetailTab = "conversation" | "files";
 
-export interface ActivitySelection {
-  itemType: ActivitySelectionItemType;
-  owner: string;
-  name: string;
-  number: number;
-  platformHost?: string | undefined;
+export type ActivitySelection = RoutedItemRef & {
   detailTab: ActivityDetailTab;
-}
+};
 
 type Destination = "pulls" | "issues";
 
@@ -74,13 +76,11 @@ export function activitySelectionToRoute(
   if (!selection) return null;
   if (destination === "pulls") {
     if (selection.itemType !== "pr") return null;
-    const suffix = selection.detailTab === "files" ? "/files" : "";
-    return `/pulls/${selection.owner}/${selection.name}/${selection.number}${suffix}`;
+    return selection.detailTab === "files"
+      ? buildPullRequestFilesRoute(selection)
+      : buildPullRequestRoute(selection);
   }
 
   if (selection.itemType !== "issue") return null;
-  const qs = selection.platformHost
-    ? `?platform_host=${encodeURIComponent(selection.platformHost)}`
-    : "";
-  return `/issues/${selection.owner}/${selection.name}/${selection.number}${qs}`;
+  return buildIssueRoute(selection);
 }

--- a/frontend/tests/e2e-full/routed-items.spec.ts
+++ b/frontend/tests/e2e-full/routed-items.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, type Page, type Response } from "@playwright/test";
+
+const prTitle = "Add widget caching layer";
+const issueTitle = "Widget rendering broken on Safari";
+
+function detailResponse(
+  page: Page,
+  path: string,
+): Promise<Response> {
+  return page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return url.pathname === path && response.request().method() === "GET";
+  });
+}
+
+function issueDetailResponse(
+  page: Page,
+  path: string,
+  platformHost: string,
+): Promise<Response> {
+  return page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return url.pathname === path
+      && url.searchParams.get("platform_host") === platformHost
+      && response.request().method() === "GET";
+  });
+}
+
+test.describe("routed item builders through the UI", () => {
+  test("selecting a PR row routes to its API-backed detail", async ({ page }) => {
+    await page.goto("/pulls");
+    await page.locator(".pull-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const detailLoaded = detailResponse(
+      page,
+      "/api/v1/repos/acme/widgets/pulls/1",
+    );
+    await page.locator(".pull-item").filter({ hasText: prTitle }).first().click();
+
+    await expect(page).toHaveURL(/\/pulls\/acme\/widgets\/1$/);
+    await expect(page.locator(".pull-detail .detail-title")).toContainText(prTitle);
+    await expect((await detailLoaded).ok()).toBe(true);
+  });
+
+  test("selecting an issue row carries platform_host into route and detail API", async ({ page }) => {
+    await page.goto("/issues");
+    await page.locator(".issue-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const detailLoaded = issueDetailResponse(
+      page,
+      "/api/v1/repos/acme/widgets/issues/10",
+      "github.com",
+    );
+    await page.locator(".issue-item").filter({ hasText: issueTitle }).first().click();
+
+    await expect(page).toHaveURL(
+      /\/issues\/acme\/widgets\/10\?platform_host=github\.com$/,
+    );
+    await expect(page.locator(".issue-detail .detail-title")).toContainText(issueTitle);
+    await expect((await detailLoaded).ok()).toBe(true);
+  });
+
+  test("focus PR list routes selected rows to focus detail", async ({ page }) => {
+    await page.goto("/focus/mrs?repo=acme%2Fwidgets");
+    await page.locator(".focus-list .pull-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const detailLoaded = detailResponse(
+      page,
+      "/api/v1/repos/acme/widgets/pulls/1",
+    );
+    await page.locator(".focus-list .pull-item").filter({ hasText: prTitle }).first().click();
+
+    await expect(page).toHaveURL(/\/focus\/pr\/acme\/widgets\/1$/);
+    await expect(page.locator(".focus-layout .pull-detail .detail-title"))
+      .toContainText(prTitle);
+    await expect(page.locator(".app-header")).not.toBeAttached();
+    await expect((await detailLoaded).ok()).toBe(true);
+  });
+
+  test("focus issue list routes selected rows with platform_host", async ({ page }) => {
+    await page.goto("/focus/issues?repo=acme%2Fwidgets");
+    await page.locator(".focus-list .issue-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const detailLoaded = issueDetailResponse(
+      page,
+      "/api/v1/repos/acme/widgets/issues/10",
+      "github.com",
+    );
+    await page.locator(".focus-list .issue-item").filter({ hasText: issueTitle }).first().click();
+
+    await expect(page).toHaveURL(
+      /\/focus\/issue\/acme\/widgets\/10\?platform_host=github\.com$/,
+    );
+    await expect(page.locator(".focus-layout .issue-detail .detail-title"))
+      .toContainText(issueTitle);
+    await expect(page.locator(".app-header")).not.toBeAttached();
+    await expect((await detailLoaded).ok()).toBe(true);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,7 @@ const uiGeneratedClient = path.resolve(process.cwd(), "../packages/ui/src/api/ge
 const uiGeneratedSchema = path.resolve(process.cwd(), "../packages/ui/src/api/generated/schema.ts");
 const uiApiTypes = path.resolve(process.cwd(), "../packages/ui/src/api/types.ts");
 const uiApiCsrf = path.resolve(process.cwd(), "../packages/ui/src/api/csrf.ts");
+const uiRoutes = path.resolve(process.cwd(), "../packages/ui/src/routes.ts");
 const uiStoreDetail = path.resolve(process.cwd(), "../packages/ui/src/stores/detail.svelte.ts");
 const uiStoreEvents = path.resolve(process.cwd(), "../packages/ui/src/stores/events.svelte.ts");
 const uiStorePulls = path.resolve(process.cwd(), "../packages/ui/src/stores/pulls.svelte.ts");
@@ -165,6 +166,10 @@ const config = {
       {
         find: /^@middleman\/ui\/api\/csrf$/,
         replacement: uiApiCsrf,
+      },
+      {
+        find: /^@middleman\/ui\/routes$/,
+        replacement: uiRoutes,
       },
       {
         find: /^@middleman\/ui\/stores\/detail$/,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "./utils/clipboard": { "default": "./src/utils/clipboard.ts" },
     "./utils/highlight": { "default": "./src/utils/highlight.ts" },
     "./utils/repo-color": { "default": "./src/utils/repo-color.ts" },
+    "./routes": { "default": "./src/routes.ts" },
     "./stores/pulls": { "svelte": "./src/stores/pulls.svelte.ts", "default": "./src/stores/pulls.svelte.ts" },
     "./stores/issues": { "svelte": "./src/stores/issues.svelte.ts", "default": "./src/stores/issues.svelte.ts" },
     "./stores/detail": { "svelte": "./src/stores/detail.svelte.ts", "default": "./src/stores/detail.svelte.ts" },

--- a/packages/ui/src/components/detail/StackSidebar.svelte
+++ b/packages/ui/src/components/detail/StackSidebar.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
   import { getClient, getNavigate, getStores } from "../../context.js";
+  import {
+    buildPullRequestRoute,
+    type PullRequestRouteRef,
+  } from "../../routes.js";
 
   const client = getClient();
   const navigate = getNavigate();
   const { sync } = getStores();
 
-  interface Props {
-    owner: string;
-    name: string;
-    number: number;
-  }
+  type Props = PullRequestRouteRef;
 
   const { owner, name, number }: Props = $props();
 
@@ -122,7 +122,7 @@
     <div class="stack-header">STACK &middot; {data.stack_name}</div>
 
     <div class="stack-chain">
-      {#each data.members as member, i}
+      {#each data.members as member, i (member.number)}
         {@const isCurrent = member.number === number}
         {@const outline = isOutline(member)}
         {@const ci = ciLabel(member)}
@@ -149,7 +149,10 @@
             {#if isCurrent}
               <div class="current-label">You are here</div>
             {/if}
-            <button class="member-link" onclick={() => navigate(`/pulls/${owner}/${name}/${member.number}`)}>
+            <button
+              class="member-link"
+              onclick={() => navigate(buildPullRequestRoute({ owner, name, number: member.number }))}
+            >
               #{member.number} {member.title}
             </button>
             {#if ci || review}

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -3,6 +3,11 @@
   import IssueItem from "./IssueItem.svelte";
   import Chip from "../shared/Chip.svelte";
   import LeftSidebarToggle from "../shared/LeftSidebarToggle.svelte";
+  import type { Issue } from "../../api/types.js";
+  import {
+    buildIssueRoute,
+    type IssueRouteRef,
+  } from "../../routes.js";
 
   const { issues, sync, grouping, collapsedRepos, settings } = getStores();
   const navigate = getNavigate();
@@ -39,30 +44,27 @@
     }, 300);
   }
 
-  function handleSelect(
-    owner: string,
-    name: string,
-    number: number,
-    platformHost: string,
-  ): void {
-    issues.selectIssue(owner, name, number, platformHost);
-    navigate(
-      `/issues/${owner}/${name}/${number}?platform_host=${encodeURIComponent(platformHost)}`,
-    );
+  function routeRefForIssue(issue: Issue): IssueRouteRef {
+    return {
+      owner: issue.repo_owner ?? "",
+      name: issue.repo_name ?? "",
+      number: issue.Number,
+      platformHost: issue.platform_host,
+    };
   }
 
-  function isSelected(
-    owner: string,
-    name: string,
-    number: number,
-    platformHost: string,
-  ): boolean {
+  function handleSelect(ref: IssueRouteRef): void {
+    issues.selectIssue(ref.owner, ref.name, ref.number, ref.platformHost);
+    navigate(buildIssueRoute(ref));
+  }
+
+  function isSelected(ref: IssueRouteRef): boolean {
     const sel = issues.getSelectedIssue();
     return sel !== null
-      && sel.owner === owner
-      && sel.name === name
-      && sel.number === number
-      && sel.platformHost === platformHost;
+      && sel.owner === ref.owner
+      && sel.name === ref.name
+      && sel.number === ref.number
+      && sel.platformHost === ref.platformHost;
   }
 </script>
 
@@ -177,11 +179,12 @@
             </button>
             {#if !collapsed}
               {#each repoIssues as issue (issue.ID)}
+                {@const issueRef = routeRefForIssue(issue)}
                 <IssueItem
                   {issue}
                   showRepo={false}
-                  selected={isSelected(issue.repo_owner ?? "", issue.repo_name ?? "", issue.Number, issue.platform_host)}
-                  onclick={() => handleSelect(issue.repo_owner ?? "", issue.repo_name ?? "", issue.Number, issue.platform_host)}
+                  selected={isSelected(issueRef)}
+                  onclick={() => handleSelect(issueRef)}
                 />
               {/each}
             {/if}
@@ -189,11 +192,12 @@
         {/each}
       {:else}
         {#each issues.getIssues() as issue (issue.ID)}
+          {@const issueRef = routeRefForIssue(issue)}
           <IssueItem
             {issue}
             showRepo={true}
-            selected={isSelected(issue.repo_owner ?? "", issue.repo_name ?? "", issue.Number, issue.platform_host)}
-            onclick={() => handleSelect(issue.repo_owner ?? "", issue.repo_name ?? "", issue.Number, issue.platform_host)}
+            selected={isSelected(issueRef)}
+            onclick={() => handleSelect(issueRef)}
           />
         {/each}
       {/if}

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -5,6 +5,12 @@
   import PullItem from "./PullItem.svelte";
   import Chip from "../shared/Chip.svelte";
   import LeftSidebarToggle from "../shared/LeftSidebarToggle.svelte";
+  import type { PullRequest } from "../../api/types.js";
+  import {
+    buildPullRequestFilesRoute,
+    buildPullRequestRoute,
+    type PullRequestRouteRef,
+  } from "../../routes.js";
 
   const { pulls, sync, grouping, collapsedRepos, settings } = getStores();
   const navigate = getNavigate();
@@ -68,18 +74,29 @@
     }, 300);
   }
 
-  function handleSelect(owner: string, name: string, number: number): void {
-    pulls.selectPR(owner, name, number);
+  function routeRefForPull(pr: PullRequest): PullRequestRouteRef {
+    return {
+      owner: pr.repo_owner ?? "",
+      name: pr.repo_name ?? "",
+      number: pr.Number,
+    };
+  }
+
+  function handleSelect(ref: PullRequestRouteRef): void {
+    pulls.selectPR(ref.owner, ref.name, ref.number);
     if (_getDetailTab() === "files") {
-      navigate(`/pulls/${owner}/${name}/${number}/files`);
+      navigate(buildPullRequestFilesRoute(ref));
     } else {
-      navigate(`/pulls/${owner}/${name}/${number}`);
+      navigate(buildPullRequestRoute(ref));
     }
   }
 
-  function isSelected(owner: string, name: string, number: number): boolean {
+  function isSelected(ref: PullRequestRouteRef): boolean {
     const sel = pulls.getSelectedPR();
-    return sel !== null && sel.owner === owner && sel.name === name && sel.number === number;
+    return sel !== null
+      && sel.owner === ref.owner
+      && sel.name === ref.name
+      && sel.number === ref.number;
   }
 
   const selectedVisiblePR = $derived.by(() => {
@@ -225,9 +242,7 @@
       {#if groupingMode === "byRepo"}
         {#each [...pulls.pullsByRepo().entries()] as [repo, prs] (repo)}
           {@const userCollapsed = collapsedRepos.isCollapsed("pulls", repo)}
-          {@const hasSelectedPR = isDiffFocus && prs.some(
-            (p) => isSelected(p.repo_owner ?? "", p.repo_name ?? "", p.Number),
-          )}
+          {@const hasSelectedPR = isDiffFocus && prs.some((p) => isSelected(routeRefForPull(p)))}
           {@const collapsed = userCollapsed && !hasSelectedPR}
           <div class="repo-group">
             <button
@@ -249,13 +264,14 @@
             </button>
             {#if !collapsed}
               {#each prs as pr (pr.ID)}
-                {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+                {@const prRef = routeRefForPull(pr)}
+                {@const prSelected = isSelected(prRef)}
                 <PullItem
                   {pr}
                   showRepo={false}
                   selected={prSelected}
                   {importAction}
-                  onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+                  onclick={() => handleSelect(prRef)}
                 />
                 {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
                   <div class="diff-files-wrap">
@@ -271,13 +287,14 @@
           <div class="repo-group">
             <h3 class="repo-header">{wg.label}</h3>
             {#each wg.items as pr (pr.ID)}
-              {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+              {@const prRef = routeRefForPull(pr)}
+              {@const prSelected = isSelected(prRef)}
               <PullItem
                 {pr}
                 showRepo={true}
                 selected={prSelected}
                 {importAction}
-                onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+                onclick={() => handleSelect(prRef)}
               />
               {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
                 <div class="diff-files-wrap">
@@ -289,13 +306,14 @@
         {/each}
       {:else}
         {#each pulls.getPulls() as pr (pr.ID)}
-          {@const prSelected = isSelected(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+          {@const prRef = routeRefForPull(pr)}
+          {@const prSelected = isSelected(prRef)}
           <PullItem
             {pr}
             showRepo={true}
             selected={prSelected}
             {importAction}
-            onclick={() => handleSelect(pr.repo_owner ?? "", pr.repo_name ?? "", pr.Number)}
+            onclick={() => handleSelect(prRef)}
           />
           {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
             <div class="diff-files-wrap">

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -40,6 +40,23 @@ export {
   getHostState,
   getRoborevClient,
 } from "./context.js";
+export {
+  buildFocusIssueRoute,
+  buildFocusListRoute,
+  buildFocusPullRequestRoute,
+  buildIssueRoute,
+  buildPullRequestFilesRoute,
+  buildPullRequestRoute,
+  buildRoutedItemRoute,
+} from "./routes.js";
+export type {
+  FocusListRouteRef,
+  IssueRouteRef,
+  NumberedRouteItemRef,
+  PullRequestRouteRef,
+  RepositoryRouteRef,
+  RoutedItemRef,
+} from "./routes.js";
 
 // Store factories
 export { createPullsStore } from "./stores/pulls.svelte.js";

--- a/packages/ui/src/routes.test.ts
+++ b/packages/ui/src/routes.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFocusIssueRoute,
+  buildFocusListRoute,
+  buildFocusPullRequestRoute,
+  buildIssueRoute,
+  buildPullRequestFilesRoute,
+  buildPullRequestRoute,
+  buildRoutedItemRoute,
+} from "./routes.js";
+
+describe("route item builders", () => {
+  it("builds pull request conversation and files routes from a named ref", () => {
+    const ref = { owner: "acme", name: "widgets", number: 42 };
+
+    expect(buildPullRequestRoute(ref)).toBe("/pulls/acme/widgets/42");
+    expect(buildPullRequestFilesRoute(ref)).toBe("/pulls/acme/widgets/42/files");
+  });
+
+  it("builds issue routes with encoded platform hosts", () => {
+    expect(
+      buildIssueRoute({
+        owner: "acme",
+        name: "widgets",
+        number: 7,
+        platformHost: "ghe.example.com/team one",
+      }),
+    ).toBe("/issues/acme/widgets/7?platform_host=ghe.example.com%2Fteam%20one");
+  });
+
+  it("omits empty issue platform host query strings", () => {
+    expect(
+      buildIssueRoute({
+        owner: "acme",
+        name: "widgets",
+        number: 7,
+      }),
+    ).toBe("/issues/acme/widgets/7");
+  });
+
+  it("builds focus item and list routes", () => {
+    expect(
+      buildFocusPullRequestRoute({
+        owner: "acme",
+        name: "widgets",
+        number: 42,
+      }),
+    ).toBe("/focus/pr/acme/widgets/42");
+    expect(
+      buildFocusIssueRoute({
+        owner: "acme",
+        name: "widgets",
+        number: 7,
+        platformHost: "ghe.example.com",
+      }),
+    ).toBe("/focus/issue/acme/widgets/7?platform_host=ghe.example.com");
+    expect(buildFocusListRoute({ itemType: "mrs", repo: "acme/widgets" })).toBe(
+      "/focus/mrs?repo=acme%2Fwidgets",
+    );
+    expect(buildFocusListRoute({ itemType: "issues" })).toBe("/focus/issues");
+  });
+
+  it("builds routed item routes for normal and focus surfaces", () => {
+    const pr = {
+      itemType: "pr",
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+    } as const;
+    const issue = {
+      itemType: "issue",
+      owner: "acme",
+      name: "widgets",
+      number: 7,
+      platformHost: "ghe.example.com",
+    } as const;
+
+    expect(buildRoutedItemRoute(pr)).toBe("/pulls/acme/widgets/42");
+    expect(buildRoutedItemRoute(pr, { focus: true })).toBe("/focus/pr/acme/widgets/42");
+    expect(buildRoutedItemRoute(issue)).toBe(
+      "/issues/acme/widgets/7?platform_host=ghe.example.com",
+    );
+    expect(buildRoutedItemRoute(issue, { focus: true })).toBe(
+      "/focus/issue/acme/widgets/7?platform_host=ghe.example.com",
+    );
+  });
+});

--- a/packages/ui/src/routes.ts
+++ b/packages/ui/src/routes.ts
@@ -1,0 +1,64 @@
+export type RepositoryRouteRef = {
+  owner: string;
+  name: string;
+};
+
+export type NumberedRouteItemRef = RepositoryRouteRef & {
+  number: number;
+};
+
+export type PullRequestRouteRef = NumberedRouteItemRef & {
+  platformHost?: string | undefined;
+};
+
+export type IssueRouteRef = NumberedRouteItemRef & {
+  platformHost?: string | undefined;
+};
+
+export type RoutedItemRef =
+  | (PullRequestRouteRef & { itemType: "pr" })
+  | (IssueRouteRef & { itemType: "issue" });
+
+export type FocusListRouteRef = {
+  itemType: "mrs" | "issues";
+  repo?: string | undefined;
+};
+
+export function buildPullRequestRoute(ref: PullRequestRouteRef): string {
+  return `/pulls/${ref.owner}/${ref.name}/${ref.number}`;
+}
+
+export function buildPullRequestFilesRoute(ref: PullRequestRouteRef): string {
+  return `${buildPullRequestRoute(ref)}/files`;
+}
+
+export function buildIssueRoute(ref: IssueRouteRef): string {
+  return `/issues/${ref.owner}/${ref.name}/${ref.number}${platformHostQuery(ref.platformHost)}`;
+}
+
+export function buildFocusPullRequestRoute(ref: PullRequestRouteRef): string {
+  return `/focus/pr/${ref.owner}/${ref.name}/${ref.number}`;
+}
+
+export function buildFocusIssueRoute(ref: IssueRouteRef): string {
+  return `/focus/issue/${ref.owner}/${ref.name}/${ref.number}${platformHostQuery(ref.platformHost)}`;
+}
+
+export function buildFocusListRoute(ref: FocusListRouteRef): string {
+  const route = `/focus/${ref.itemType}`;
+  return ref.repo ? `${route}?repo=${encodeURIComponent(ref.repo)}` : route;
+}
+
+export function buildRoutedItemRoute(
+  ref: RoutedItemRef,
+  options: { focus?: boolean } = {},
+): string {
+  if (ref.itemType === "pr") {
+    return options.focus ? buildFocusPullRequestRoute(ref) : buildPullRequestRoute(ref);
+  }
+  return options.focus ? buildFocusIssueRoute(ref) : buildIssueRoute(ref);
+}
+
+function platformHostQuery(platformHost: string | undefined): string {
+  return platformHost ? `?platform_host=${encodeURIComponent(platformHost)}` : "";
+}

--- a/packages/ui/src/views/FocusListView.svelte
+++ b/packages/ui/src/views/FocusListView.svelte
@@ -3,6 +3,13 @@
   import { groupByWorkflow } from "../stores/workflow.svelte.js";
   import PullItem from "../components/sidebar/PullItem.svelte";
   import IssueItem from "../components/sidebar/IssueItem.svelte";
+  import type { Issue, PullRequest } from "../api/types.js";
+  import {
+    buildFocusIssueRoute,
+    buildFocusPullRequestRoute,
+    type IssueRouteRef,
+    type PullRequestRouteRef,
+  } from "../routes.js";
 
   const { pulls, issues, sync, settings, grouping } = getStores();
   const navigate = getNavigate();
@@ -91,23 +98,29 @@
     }, 300);
   }
 
-  function handlePRSelect(
-    owner: string,
-    name: string,
-    number: number,
-  ): void {
-    navigate(`/focus/pr/${owner}/${name}/${number}`);
+  function routeRefForPull(pr: PullRequest): PullRequestRouteRef {
+    return {
+      owner: pr.repo_owner ?? "",
+      name: pr.repo_name ?? "",
+      number: pr.Number,
+    };
   }
 
-  function handleIssueSelect(
-    owner: string,
-    name: string,
-    number: number,
-    platformHost: string,
-  ): void {
-    navigate(
-      `/focus/issue/${owner}/${name}/${number}?platform_host=${encodeURIComponent(platformHost)}`,
-    );
+  function routeRefForIssue(issue: Issue): IssueRouteRef {
+    return {
+      owner: issue.repo_owner ?? "",
+      name: issue.repo_name ?? "",
+      number: issue.Number,
+      platformHost: issue.platform_host,
+    };
+  }
+
+  function handlePRSelect(ref: PullRequestRouteRef): void {
+    navigate(buildFocusPullRequestRoute(ref));
+  }
+
+  function handleIssueSelect(ref: IssueRouteRef): void {
+    navigate(buildFocusIssueRoute(ref));
   }
 
   // Filter state accessors for PRs.
@@ -256,34 +269,26 @@
           <div class="workflow-group">
             <h3 class="group-header">{wg.label}</h3>
             {#each wg.items as pr (pr.ID)}
+              {@const prRef = routeRefForPull(pr)}
               <PullItem
                 {pr}
                 showRepo={!repo}
                 selected={false}
                 {importAction}
-                onclick={() =>
-                  handlePRSelect(
-                    pr.repo_owner ?? "",
-                    pr.repo_name ?? "",
-                    pr.Number,
-                  )}
+                onclick={() => handlePRSelect(prRef)}
               />
             {/each}
           </div>
         {/each}
       {:else}
         {#each prItems as pr (pr.ID)}
+          {@const prRef = routeRefForPull(pr)}
           <PullItem
             {pr}
             showRepo={!repo}
             selected={false}
             {importAction}
-            onclick={() =>
-              handlePRSelect(
-                pr.repo_owner ?? "",
-                pr.repo_name ?? "",
-                pr.Number,
-              )}
+            onclick={() => handlePRSelect(prRef)}
           />
         {/each}
       {/if}
@@ -305,17 +310,12 @@
         <p class="state-message">No issues found.</p>
       {:else}
         {#each issueItems as issue (issue.ID)}
+          {@const issueRef = routeRefForIssue(issue)}
           <IssueItem
             {issue}
             showRepo={!repo}
             selected={false}
-            onclick={() =>
-              handleIssueSelect(
-                issue.repo_owner ?? "",
-                issue.repo_name ?? "",
-                issue.Number,
-                issue.platform_host,
-              )}
+            onclick={() => handleIssueSelect(issueRef)}
           />
         {/each}
       {/if}

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -6,16 +6,12 @@
   import IssueDetail
     from "../components/detail/IssueDetail.svelte";
   import type { IssueDetailSyncMode } from "../stores/issues.svelte.js";
+  import type { IssueRouteRef } from "../routes.js";
 
   const { isSidebarToggleEnabled, toggleSidebar } = getSidebar();
 
   interface Props {
-    selectedIssue?: {
-      owner: string;
-      name: string;
-      number: number;
-      platformHost?: string | undefined;
-    } | null;
+    selectedIssue?: IssueRouteRef | null;
     isSidebarCollapsed?: boolean;
     hideSidebar?: boolean;
     sidebarWidth?: number;

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -12,16 +12,17 @@
   import StackSidebar
     from "../components/detail/StackSidebar.svelte";
   import type { DetailSyncMode } from "../stores/detail.svelte.js";
+  import {
+    buildPullRequestFilesRoute,
+    buildPullRequestRoute,
+    type PullRequestRouteRef,
+  } from "../routes.js";
 
   const { isSidebarToggleEnabled, toggleSidebar } = getSidebar();
   const navigate = getNavigate();
 
   interface Props {
-    selectedPR?: {
-      owner: string;
-      name: string;
-      number: number;
-    } | null;
+    selectedPR?: PullRequestRouteRef | null;
     detailTab?: "conversation" | "files";
     isSidebarCollapsed?: boolean;
     hideSidebar?: boolean;
@@ -52,8 +53,8 @@
     if (selectedPR === null) return;
     navigate(
       tab === "files"
-        ? `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}/files`
-        : `/pulls/${selectedPR.owner}/${selectedPR.name}/${selectedPR.number}`,
+        ? buildPullRequestFilesRoute(selectedPR)
+        : buildPullRequestRoute(selectedPR),
     );
   }
 </script>


### PR DESCRIPTION
## Summary
- add shared route builders for pull requests, issues, focus lists, and routed item refs
- replace scattered string-built item links across frontend and packages/ui callers
- document the shared route helper convention in the UI context notes

## How this makes the code better
- gives navigation callers one vocabulary for item route construction instead of repeating URL string templates
- preserves platform_host query handling through typed helpers, reducing host-qualified issue link drift
- makes route changes easier because list, detail, sidebar, and activity selection callers depend on the same route module