### PR TITLE
Centralize compact status chips

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -28,13 +28,14 @@ Use this document as the intent-level guide for frontend UI work in `middleman`.
 
 ### Chip
 
-Use `Chip` for compact status and metadata UI.
+Use `Chip` and its semantic chip wrappers for compact status and metadata UI.
 
 Intent:
 
 - one shared geometry for small labeled UI
 - consistent vertical alignment, spacing, casing, and density
 - reusable across detail views, sidebars, and compact status surfaces
+- semantic tone, dot, kind, and state semantics at the call site
 
 Use it for:
 
@@ -43,7 +44,14 @@ Use it for:
 - repo and count badges
 - other compact metadata markers
 
-Do not create new local `.badge`, `.pill`, or `.chip` geometry when `Chip` fits.
+Use `Chip` directly when the caller already knows the semantic `tone`
+(`success`, `warning`, `danger`, `info`, `merged`, `workspace`, `muted`,
+or `neutral`) or needs the shared dotted status treatment. Use
+`ItemKindChip` for PR/issue kind and `ItemStateChip` for PR/issue state
+rather than repeating kind/state class maps in feature components.
+
+Do not create new local `.badge`, `.pill`, `.tag`, or `.chip` geometry when
+`Chip`, `ItemKindChip`, or `ItemStateChip` fits.
 
 In this repo, the standard term is **chip**, not pill.
 

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -14,6 +14,8 @@
     parseAPITimestamp,
   } from "../utils/time.js";
   import Chip from "./shared/Chip.svelte";
+  import ItemKindChip from "./shared/ItemKindChip.svelte";
+  import ItemStateChip from "./shared/ItemStateChip.svelte";
 
   const { activity, settings, sync, grouping } = getStores();
   const navigate = getNavigate();
@@ -162,40 +164,8 @@
     }
   }
 
-  function itemTypeLabel(item: ActivityItem): string {
-    return item.item_type === "pr" ? "PR" : "Issue";
-  }
-
-  function badgeClass(item: ActivityItem): string {
-    if (item.item_state === "merged") return "badge-merged";
-    if (item.item_state === "closed") return "badge-closed";
-    return item.item_type === "pr" ? "badge-pr" : "badge-issue";
-  }
-
-  function kindChipClass(item: ActivityItem): string {
-    const legacyClass = badgeClass(item);
-    const toneClass =
-      legacyClass === "badge-pr" ? "chip--blue"
-      : legacyClass === "badge-closed" ? "chip--red"
-      : "chip--purple";
-    return `badge ${legacyClass} ${toneClass}`;
-  }
-
-  function itemTypeChipClass(itemType: string): string {
-    return itemType === "pr"
-      ? "badge badge-pr chip--blue"
-      : "badge badge-issue chip--purple";
-  }
-
-  function stateChipClass(state: string): string {
-    const toneClass = state === "merged" ? "chip--purple" : "chip--red";
-    return `state-badge state-${state} ${toneClass}`;
-  }
-
-  function stateLabel(item: ActivityItem): string | null {
-    if (item.item_state === "merged") return "Merged";
-    if (item.item_state === "closed") return "Closed";
-    return null;
+  function hasStateChip(item: ActivityItem): boolean {
+    return item.item_state === "merged" || item.item_state === "closed";
   }
 
   const displayItems = $derived.by(() => {
@@ -446,10 +416,7 @@
                 type="button"
               >
                 <span class="compact-row-top">
-                  <Chip
-                    size="sm"
-                    class={itemTypeChipClass(row.representative.item_type)}
-                  >{row.representative.item_type === "pr" ? "PR" : "Issue"}</Chip>
+                  <ItemKindChip kind={row.representative.item_type} />
                   <span class="item-number">#{row.representative.item_number}</span>
                   <span class="compact-time">{relativeTime(row.latest)}</span>
                 </span>
@@ -472,10 +439,10 @@
                 type="button"
               >
                 <span class="compact-row-top">
-                  <Chip size="sm" class={kindChipClass(row)}>{itemTypeLabel(row)}</Chip>
+                  <ItemKindChip kind={row.item_type} />
                   <span class="item-number">#{row.item_number}</span>
-                  {#if stateLabel(row)}
-                    <Chip size="sm" class={stateChipClass(row.item_state)}>{stateLabel(row)}</Chip>
+                  {#if hasStateChip(row)}
+                    <ItemStateChip state={row.item_state} />
                   {/if}
                   <span class="compact-time">{relativeTime(row.created_at)}</span>
                 </span>
@@ -511,10 +478,7 @@
               {#if isCollapsedActivityRow(row)}
                 <tr class="activity-row collapsed-row" onclick={() => handleRowClick(row.representative)}>
                   <td class="col-kind">
-                    <Chip
-                      size="sm"
-                      class={itemTypeChipClass(row.representative.item_type)}
-                    >{row.representative.item_type === "pr" ? "PR" : "Issue"}</Chip>
+                    <ItemKindChip kind={row.representative.item_type} />
                   </td>
                   <td class="col-event">
                     <Chip
@@ -541,9 +505,9 @@
               {:else}
                 <tr class="activity-row" onclick={() => handleRowClick(row)}>
                   <td class="col-kind">
-                    <Chip size="sm" class={kindChipClass(row)}>{itemTypeLabel(row)}</Chip>
-                    {#if stateLabel(row)}
-                      <Chip size="sm" class={stateChipClass(row.item_state)}>{stateLabel(row)}</Chip>
+                    <ItemKindChip kind={row.item_type} />
+                    {#if hasStateChip(row)}
+                      <ItemStateChip state={row.item_state} />
                     {/if}
                   </td>
                   <td class="col-event">
@@ -807,6 +771,20 @@
   .collapsed-row {
     background: var(--bg-inset);
   }
+
+  .col-kind :global(.chip + .chip) {
+    margin-left: 3px;
+  }
+
+  .evt-label {
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .evt-label.evt-comment { color: var(--accent-amber); }
+  .evt-label.evt-review { color: var(--accent-green); }
+  .evt-label.evt-commit { color: var(--accent-teal); }
+  .evt-label.evt-force-push { color: var(--accent-red); }
 
   .col-repo {
     color: var(--text-muted);

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -776,15 +776,15 @@
     margin-left: 3px;
   }
 
-  .evt-label {
+  :global(.evt-label) {
     font-size: 12px;
     color: var(--text-secondary);
   }
 
-  .evt-label.evt-comment { color: var(--accent-amber); }
-  .evt-label.evt-review { color: var(--accent-green); }
-  .evt-label.evt-commit { color: var(--accent-teal); }
-  .evt-label.evt-force-push { color: var(--accent-red); }
+  :global(.evt-label.evt-comment) { color: var(--accent-amber); }
+  :global(.evt-label.evt-review) { color: var(--accent-green); }
+  :global(.evt-label.evt-commit) { color: var(--accent-teal); }
+  :global(.evt-label.evt-force-push) { color: var(--accent-red); }
 
   .col-repo {
     color: var(--text-muted);

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -136,4 +136,26 @@ describe("ActivityFeed compact mode", () => {
       container.querySelectorAll(".activity-compact-row.selected"),
     ).toHaveLength(2);
   });
+
+  it("uses shared semantic chips for compact item kind and state", () => {
+    items.value = [
+      activityItem("merged", {
+        item_state: "merged",
+      }),
+    ];
+
+    const { container } = render(ActivityFeed, {
+      props: {
+        compact: true,
+      },
+    });
+
+    const row = container.querySelector(".activity-compact-row");
+    expect(row?.querySelector(".chip--kind-pr")?.textContent?.trim())
+      .toBe("PR");
+    expect(row?.querySelector(".chip--state-merged")?.textContent)
+      .toContain("Merged");
+    expect(row?.querySelector(".badge")).toBeNull();
+    expect(row?.querySelector(".state-badge")).toBeNull();
+  });
 });

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -156,6 +156,6 @@ describe("ActivityFeed compact mode", () => {
     expect(row?.querySelector(".chip--state-merged")?.textContent)
       .toContain("Merged");
     expect(row?.querySelector(".badge")).not.toBeNull();
-    expect(row?.querySelector(".state-badge")).toBeNull();
+    expect(row?.querySelector(".state-badge")).not.toBeNull();
   });
 });

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -155,7 +155,7 @@ describe("ActivityFeed compact mode", () => {
       .toBe("PR");
     expect(row?.querySelector(".chip--state-merged")?.textContent)
       .toContain("Merged");
-    expect(row?.querySelector(".badge")).toBeNull();
+    expect(row?.querySelector(".badge")).not.toBeNull();
     expect(row?.querySelector(".state-badge")).toBeNull();
   });
 });

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -228,7 +228,9 @@
               uppercase={false}
               class="repo-chip repo-tag"
               style="color: {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)}; background: color-mix(in srgb, {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)} 15%, transparent);"
-            >{itemGroup.repoOwner}/{itemGroup.repoName}</Chip>
+            >
+              <span class="repo-chip__label">{itemGroup.repoOwner}/{itemGroup.repoName}</span>
+            </Chip>
           {/if}
           {#if itemGroup.itemState === "merged"}
             <ItemStateChip state="merged" />
@@ -395,9 +397,16 @@
 
   :global(.repo-chip) {
     flex-shrink: 1;
+    max-width: 40%;
+    min-width: 0;
+  }
+
+  :global(.repo-chip) .repo-chip__label {
+    display: block;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 40%;
+    white-space: nowrap;
   }
 
   .threaded-view--compact {

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -226,7 +226,7 @@
             <Chip
               size="xs"
               uppercase={false}
-              class="repo-chip"
+              class="repo-chip repo-tag"
               style="color: {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)}; background: color-mix(in srgb, {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)} 15%, transparent);"
             >{itemGroup.repoOwner}/{itemGroup.repoName}</Chip>
           {/if}

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -9,6 +9,9 @@
     localDateLabel,
     parseAPITimestamp,
   } from "../utils/time.js";
+  import Chip from "./shared/Chip.svelte";
+  import ItemKindChip from "./shared/ItemKindChip.svelte";
+  import ItemStateChip from "./shared/ItemStateChip.svelte";
 
   const { grouping } = getStores();
   import { repoColor } from "../utils/repo-color.js";
@@ -216,19 +219,21 @@
           class:selected={isSelectedItemGroup(itemGroup)}
           onclick={() => handleItemClick(itemGroup)}
         >
-          <span class="item-badge" class:badge-pr={itemGroup.itemType === "pr"} class:badge-issue={itemGroup.itemType === "issue"}>
-            {itemGroup.itemType === "pr" ? "PR" : "Issue"}
-          </span>
+          <ItemKindChip
+            kind={itemGroup.itemType === "pr" ? "pr" : "issue"}
+          />
           {#if !grouping.getGroupByRepo()}
-            <span
-              class="repo-tag"
+            <Chip
+              size="xs"
+              uppercase={false}
+              class="repo-chip"
               style="color: {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)}; background: color-mix(in srgb, {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)} 15%, transparent);"
-            >{itemGroup.repoOwner}/{itemGroup.repoName}</span>
+            >{itemGroup.repoOwner}/{itemGroup.repoName}</Chip>
           {/if}
           {#if itemGroup.itemState === "merged"}
-            <span class="state-tag state-merged">Merged</span>
+            <ItemStateChip state="merged" />
           {:else if itemGroup.itemState === "closed"}
-            <span class="state-tag state-closed">Closed</span>
+            <ItemStateChip state="closed" />
           {/if}
           <span class="item-ref">#{itemGroup.itemNumber}</span>
           <span class="item-title">{itemGroup.itemTitle}</span>
@@ -314,42 +319,6 @@
     box-shadow: inset 3px 0 0 var(--accent-blue);
   }
 
-  .item-badge {
-    font-size: 9px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    padding: 1px 4px;
-    border-radius: 3px;
-    flex-shrink: 0;
-  }
-
-  .badge-pr {
-    background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-    color: var(--accent-blue);
-  }
-  .badge-issue {
-    background: color-mix(in srgb, var(--accent-purple) 15%, transparent);
-    color: var(--accent-purple);
-  }
-
-  .state-tag {
-    font-size: 9px;
-    font-weight: 600;
-    text-transform: uppercase;
-    padding: 1px 4px;
-    border-radius: 3px;
-    flex-shrink: 0;
-  }
-  .state-merged {
-    background: color-mix(in srgb, var(--accent-purple) 20%, transparent);
-    color: var(--accent-purple);
-  }
-  .state-closed {
-    background: color-mix(in srgb, var(--accent-red) 15%, transparent);
-    color: var(--accent-red);
-  }
-
   .item-ref {
     font-size: 12px;
     color: var(--text-muted);
@@ -424,13 +393,8 @@
     font-size: 13px;
   }
 
-  .repo-tag {
-    font-size: 9px;
-    font-weight: 600;
-    padding: 1px 4px;
-    border-radius: 3px;
+  :global(.repo-chip) {
     flex-shrink: 1;
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 40%;

--- a/packages/ui/src/components/ActivityThreaded.test.ts
+++ b/packages/ui/src/components/ActivityThreaded.test.ts
@@ -1,0 +1,62 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ActivityItem } from "../api/types.js";
+import ActivityThreaded from "./ActivityThreaded.svelte";
+
+function activityItem(
+  id: string,
+  overrides: Partial<ActivityItem> = {},
+): ActivityItem {
+  return {
+    id,
+    cursor: id,
+    activity_type: "comment",
+    author: "alice",
+    body_preview: "",
+    created_at: "2026-04-27T12:00:00Z",
+    item_number: 1,
+    item_state: "open",
+    item_title: "Add widget caching layer",
+    item_type: "pr",
+    item_url: "https://github.com/acme/widgets/pull/1",
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widgets-with-a-long-name",
+    ...overrides,
+  };
+}
+
+const groupByRepo = vi.hoisted(() => ({
+  value: false,
+}));
+
+vi.mock("../context.js", () => ({
+  getStores: () => ({
+    grouping: {
+      getGroupByRepo: () => groupByRepo.value,
+    },
+  }),
+}));
+
+describe("ActivityThreaded", () => {
+  afterEach(() => {
+    cleanup();
+    groupByRepo.value = false;
+  });
+
+  it("keeps repo chip selector compatibility and applies ellipsis to an inner label", () => {
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [activityItem("comment")],
+        onSelectItem: undefined,
+      },
+    });
+
+    const chip = container.querySelector(".repo-chip.repo-tag");
+    const label = chip?.querySelector(".repo-chip__label");
+
+    expect(chip).not.toBeNull();
+    expect(label?.textContent).toBe("acme/widgets-with-a-long-name");
+  });
+});

--- a/packages/ui/src/components/roborev/StatusBadge.svelte
+++ b/packages/ui/src/components/roborev/StatusBadge.svelte
@@ -18,6 +18,8 @@
         return "success";
       case "failed":
         return "danger";
+      case "canceled":
+        return "canceled";
       default:
         return "muted";
     }

--- a/packages/ui/src/components/roborev/StatusBadge.svelte
+++ b/packages/ui/src/components/roborev/StatusBadge.svelte
@@ -29,7 +29,7 @@
   {tone}
   dot
   uppercase={false}
-  class={`review-status-chip review-status-chip--${status}`}
+  class={`status-badge review-status-chip review-status-chip--${status}`}
 >
   {status}
 </Chip>

--- a/packages/ui/src/components/roborev/StatusBadge.svelte
+++ b/packages/ui/src/components/roborev/StatusBadge.svelte
@@ -1,72 +1,35 @@
 <script lang="ts">
+  import Chip, {
+    type ChipTone,
+  } from "../shared/Chip.svelte";
+
   interface Props {
     status: string;
   }
   let { status }: Props = $props();
+
+  const tone: ChipTone = $derived.by(() => {
+    switch (status) {
+      case "queued":
+        return "warning";
+      case "running":
+        return "info";
+      case "done":
+        return "success";
+      case "failed":
+        return "danger";
+      default:
+        return "muted";
+    }
+  });
 </script>
 
-<span class="status-badge status-{status}">
-  <span class="dot"></span>
+<Chip
+  size="sm"
+  {tone}
+  dot
+  uppercase={false}
+  class={`review-status-chip review-status-chip--${status}`}
+>
   {status}
-</span>
-
-<style>
-  .status-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 2px 8px;
-    border-radius: 999px;
-    font-size: 11px;
-    font-weight: 500;
-    line-height: 1.4;
-    white-space: nowrap;
-  }
-
-  .dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-
-  .status-queued {
-    color: var(--review-queued);
-    background: color-mix(
-      in srgb, var(--review-queued) 12%, transparent
-    );
-  }
-  .status-queued .dot { background: var(--review-queued); }
-
-  .status-running {
-    color: var(--review-running);
-    background: color-mix(
-      in srgb, var(--review-running) 12%, transparent
-    );
-  }
-  .status-running .dot { background: var(--review-running); }
-
-  .status-done {
-    color: var(--review-done);
-    background: color-mix(
-      in srgb, var(--review-done) 12%, transparent
-    );
-  }
-  .status-done .dot { background: var(--review-done); }
-
-  .status-failed {
-    color: var(--review-failed);
-    background: color-mix(
-      in srgb, var(--review-failed) 12%, transparent
-    );
-  }
-  .status-failed .dot { background: var(--review-failed); }
-
-  .status-canceled {
-    color: var(--review-canceled);
-    background: color-mix(
-      in srgb, var(--review-canceled) 12%, transparent
-    );
-  }
-  .status-canceled .dot { background: var(--review-canceled); }
-</style>
+</Chip>

--- a/packages/ui/src/components/roborev/StatusBadge.svelte
+++ b/packages/ui/src/components/roborev/StatusBadge.svelte
@@ -29,7 +29,7 @@
   {tone}
   dot
   uppercase={false}
-  class={`status-badge review-status-chip review-status-chip--${status}`}
+  class={`status-badge status-${status} review-status-chip review-status-chip--${status}`}
 >
   {status}
 </Chip>

--- a/packages/ui/src/components/roborev/StatusBadge.test.ts
+++ b/packages/ui/src/components/roborev/StatusBadge.test.ts
@@ -21,4 +21,16 @@ describe("StatusBadge", () => {
     expect(chip?.classList.contains("status-badge")).toBe(true);
     expect(chip?.querySelector(".chip__dot")).not.toBeNull();
   });
+
+  it("keeps canceled reviews visually distinct from unknown statuses", () => {
+    render(StatusBadge, {
+      props: {
+        status: "canceled",
+      },
+    });
+
+    const chip = screen.getByText("canceled").closest(".chip");
+    expect(chip?.classList.contains("chip--tone-canceled")).toBe(true);
+    expect(chip?.classList.contains("status-canceled")).toBe(true);
+  });
 });

--- a/packages/ui/src/components/roborev/StatusBadge.test.ts
+++ b/packages/ui/src/components/roborev/StatusBadge.test.ts
@@ -1,0 +1,24 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+
+import StatusBadge from "./StatusBadge.svelte";
+
+describe("StatusBadge", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders review status through the shared dotted chip semantics", () => {
+    render(StatusBadge, {
+      props: {
+        status: "running",
+      },
+    });
+
+    const chip = screen.getByText("running").closest(".chip");
+    expect(chip).not.toBeNull();
+    expect(chip?.classList.contains("chip--tone-info")).toBe(true);
+    expect(chip?.querySelector(".chip__dot")).not.toBeNull();
+    expect(chip?.querySelector(".status-badge")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/roborev/StatusBadge.test.ts
+++ b/packages/ui/src/components/roborev/StatusBadge.test.ts
@@ -18,7 +18,7 @@ describe("StatusBadge", () => {
     const chip = screen.getByText("running").closest(".chip");
     expect(chip).not.toBeNull();
     expect(chip?.classList.contains("chip--tone-info")).toBe(true);
+    expect(chip?.classList.contains("status-badge")).toBe(true);
     expect(chip?.querySelector(".chip__dot")).not.toBeNull();
-    expect(chip?.querySelector(".status-badge")).toBeNull();
   });
 });

--- a/packages/ui/src/components/shared/Chip.svelte
+++ b/packages/ui/src/components/shared/Chip.svelte
@@ -8,6 +8,7 @@
     | "danger"
     | "info"
     | "merged"
+    | "canceled"
     | "workspace";
 </script>
 
@@ -195,6 +196,11 @@
   .chip--tone-muted {
     background: var(--bg-inset);
     color: var(--text-muted);
+  }
+
+  .chip--tone-canceled {
+    background: color-mix(in srgb, var(--review-canceled) 15%, transparent);
+    color: var(--review-canceled);
   }
 
   .chip--tone-neutral {

--- a/packages/ui/src/components/shared/Chip.svelte
+++ b/packages/ui/src/components/shared/Chip.svelte
@@ -64,14 +64,7 @@
     aria-expanded={expanded}
     {disabled}
     onclick={onclick}
-  >
-    {#if dot}
-      <span class="chip__dot" aria-hidden="true"></span>
-    {/if}
-    {#if children}
-      {@render children()}
-    {/if}
-  </button>
+  >{#if dot}<span class="chip__dot" aria-hidden="true"></span>{/if}{#if children}{@render children()}{/if}</button>
 {:else}
   <span
     class={[
@@ -85,14 +78,7 @@
     ]}
     {title}
     {style}
-  >
-    {#if dot}
-      <span class="chip__dot" aria-hidden="true"></span>
-    {/if}
-    {#if children}
-      {@render children()}
-    {/if}
-  </span>
+  >{#if dot}<span class="chip__dot" aria-hidden="true"></span>{/if}{#if children}{@render children()}{/if}</span>
 {/if}
 
 <style>

--- a/packages/ui/src/components/shared/Chip.svelte
+++ b/packages/ui/src/components/shared/Chip.svelte
@@ -1,23 +1,38 @@
+<script module lang="ts">
+  export type ChipSize = "xs" | "sm" | "md";
+  export type ChipTone =
+    | "muted"
+    | "neutral"
+    | "success"
+    | "warning"
+    | "danger"
+    | "info"
+    | "merged"
+    | "workspace";
+</script>
+
 <script lang="ts">
   import type { Snippet } from "svelte";
 
-  type Size = "sm" | "md";
-
   interface Props {
-    size?: Size;
+    size?: ChipSize;
+    tone?: ChipTone;
+    dot?: boolean;
     interactive?: boolean;
     uppercase?: boolean;
-    title?: string;
-    style?: string;
-    expanded?: boolean;
+    title?: string | undefined;
+    style?: string | undefined;
+    expanded?: boolean | undefined;
     disabled?: boolean;
     class?: string;
-    onclick?: (event: MouseEvent) => void;
-    children?: Snippet;
+    onclick?: ((event: MouseEvent) => void) | undefined;
+    children?: Snippet | undefined;
   }
 
   let {
     size = "md",
+    tone = undefined,
+    dot = false,
     interactive = false,
     uppercase = true,
     title = undefined,
@@ -37,6 +52,7 @@
     class={[
       "chip",
       `chip--${size}`,
+      tone ? `chip--tone-${tone}` : undefined,
       {
         "chip--interactive": interactive,
         "chip--plain-case": !uppercase,
@@ -49,6 +65,9 @@
     {disabled}
     onclick={onclick}
   >
+    {#if dot}
+      <span class="chip__dot" aria-hidden="true"></span>
+    {/if}
     {#if children}
       {@render children()}
     {/if}
@@ -58,6 +77,7 @@
     class={[
       "chip",
       `chip--${size}`,
+      tone ? `chip--tone-${tone}` : undefined,
       {
         "chip--plain-case": !uppercase,
       },
@@ -66,6 +86,9 @@
     {title}
     {style}
   >
+    {#if dot}
+      <span class="chip__dot" aria-hidden="true"></span>
+    {/if}
     {#if children}
       {@render children()}
     {/if}
@@ -85,6 +108,14 @@
     text-transform: uppercase;
     vertical-align: middle;
     white-space: nowrap;
+  }
+
+  .chip--xs {
+    min-height: 16px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-size: 9px;
+    line-height: 1.15;
   }
 
   .chip--sm {
@@ -123,18 +154,35 @@
     letter-spacing: normal;
   }
 
+  .chip__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+  }
+
+  .chip--xs .chip__dot {
+    width: 5px;
+    height: 5px;
+  }
+
   .chip--green,
-  .chip--open {
+  .chip--open,
+  .chip--tone-success {
     background: color-mix(in srgb, var(--accent-green) 15%, transparent);
     color: var(--accent-green);
   }
 
-  .chip--red {
+  .chip--red,
+  .chip--tone-danger {
     background: color-mix(in srgb, var(--accent-red) 15%, transparent);
     color: var(--accent-red);
   }
 
-  .chip--amber {
+  .chip--amber,
+  .chip--draft,
+  .chip--tone-warning {
     background: color-mix(in srgb, var(--accent-amber) 15%, transparent);
     color: var(--accent-amber);
   }
@@ -145,17 +193,31 @@
   }
 
   .chip--purple,
-  .chip--closed {
+  .chip--closed,
+  .chip--tone-merged {
     background: color-mix(in srgb, var(--accent-purple) 15%, transparent);
     color: var(--accent-purple);
   }
 
-  .chip--muted {
+  .chip--blue,
+  .chip--tone-info {
+    background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+    color: var(--accent-blue);
+  }
+
+  .chip--muted,
+  .chip--tone-muted {
     background: var(--bg-inset);
     color: var(--text-muted);
   }
 
-  .chip--teal {
+  .chip--tone-neutral {
+    background: var(--bg-inset);
+    color: var(--text-secondary);
+  }
+
+  .chip--teal,
+  .chip--tone-workspace {
     background: color-mix(
       in srgb,
       var(--accent-teal, var(--accent-green)) 15%,

--- a/packages/ui/src/components/shared/Chip.test.ts
+++ b/packages/ui/src/components/shared/Chip.test.ts
@@ -1,0 +1,29 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { createRawSnippet } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+
+import Chip from "./Chip.svelte";
+
+describe("Chip", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("expresses semantic tone and dot state without caller-owned classes", () => {
+    render(Chip, {
+      props: {
+        tone: "success",
+        dot: true,
+        uppercase: false,
+        children: createRawSnippet(() => ({
+          render: () => "<span>Running</span>",
+        })),
+      },
+    });
+
+    const chip = screen.getByText("Running").closest(".chip");
+    expect(chip).not.toBeNull();
+    expect(chip?.classList.contains("chip--tone-success")).toBe(true);
+    expect(chip?.querySelector(".chip__dot")).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/shared/ItemKindChip.svelte
+++ b/packages/ui/src/components/shared/ItemKindChip.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import Chip, {
+    type ChipSize,
+    type ChipTone,
+  } from "./Chip.svelte";
+
+  interface Props {
+    kind: string;
+    size?: ChipSize;
+    title?: string;
+    class?: string;
+  }
+
+  const {
+    kind,
+    size = "xs",
+    title = undefined,
+    class: className = "",
+  }: Props = $props();
+
+  const normalized = $derived(kind.toLowerCase());
+  const label = $derived(normalized === "pr" ? "PR" : "Issue");
+  const tone: ChipTone = $derived(
+    normalized === "pr" ? "info" : "merged",
+  );
+  const chipClass = $derived(
+    ["chip--kind", `chip--kind-${normalized}`, className]
+      .filter(Boolean)
+      .join(" "),
+  );
+</script>
+
+<Chip {size} {tone} {title} class={chipClass}>
+  {label}
+</Chip>

--- a/packages/ui/src/components/shared/ItemKindChip.svelte
+++ b/packages/ui/src/components/shared/ItemKindChip.svelte
@@ -24,7 +24,7 @@
     normalized === "pr" ? "info" : "merged",
   );
   const chipClass = $derived(
-    ["chip--kind", `chip--kind-${normalized}`, className]
+    ["badge", "chip--kind", `chip--kind-${normalized}`, className]
       .filter(Boolean)
       .join(" "),
   );

--- a/packages/ui/src/components/shared/ItemStateChip.svelte
+++ b/packages/ui/src/components/shared/ItemStateChip.svelte
@@ -37,7 +37,13 @@
     }
   });
   const chipClass = $derived(
-    ["chip--state", `chip--state-${normalized}`, className]
+    [
+      "state-badge",
+      `state-${normalized}`,
+      "chip--state",
+      `chip--state-${normalized}`,
+      className,
+    ]
       .filter(Boolean)
       .join(" "),
   );

--- a/packages/ui/src/components/shared/ItemStateChip.svelte
+++ b/packages/ui/src/components/shared/ItemStateChip.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import Chip, {
+    type ChipSize,
+    type ChipTone,
+  } from "./Chip.svelte";
+
+  interface Props {
+    state: string;
+    size?: ChipSize;
+    title?: string;
+    class?: string;
+  }
+
+  const {
+    state,
+    size = "xs",
+    title = undefined,
+    class: className = "",
+  }: Props = $props();
+
+  const normalized = $derived(state.toLowerCase());
+  const label = $derived(
+    normalized === "pr" ? "PR" : normalized[0]?.toUpperCase() + normalized.slice(1),
+  );
+  const tone: ChipTone = $derived.by(() => {
+    switch (normalized) {
+      case "open":
+        return "success";
+      case "draft":
+        return "warning";
+      case "merged":
+        return "merged";
+      case "closed":
+        return "danger";
+      default:
+        return "muted";
+    }
+  });
+  const chipClass = $derived(
+    ["chip--state", `chip--state-${normalized}`, className]
+      .filter(Boolean)
+      .join(" "),
+  );
+</script>
+
+<Chip {size} {tone} {title} class={chipClass}>
+  {label}
+</Chip>

--- a/packages/ui/src/components/workspace/WorktreeRow.svelte
+++ b/packages/ui/src/components/workspace/WorktreeRow.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type {
     WorkspaceActivity,
-    WorkspaceLinkedPR,
     WorkspaceWorktree,
   } from "../../api/types.js";
+  import Chip, {
+    type ChipTone,
+  } from "../shared/Chip.svelte";
 
   interface Props {
     worktree: WorkspaceWorktree;
@@ -46,6 +48,21 @@
     running: "var(--accent-blue)",
     needsAttention: "var(--accent-amber)",
   };
+
+  function linkedPRTone(state: string): ChipTone {
+    switch (state) {
+      case "open":
+        return "success";
+      case "merged":
+        return "merged";
+      case "closed":
+        return "danger";
+      case "draft":
+        return "muted";
+      default:
+        return "muted";
+    }
+  }
 
   function handleContextMenu(e: MouseEvent): void {
     e.preventDefault();
@@ -134,10 +151,10 @@
     <span class="name-row">
       <span class="name">{title}</span>
       {#if worktree.isPrimary}
-        <span class="kind-badge root-badge">ROOT</span>
+        <Chip size="xs" tone="info">ROOT</Chip>
       {/if}
       {#if worktree.sessionBackend === "localTmux"}
-        <span class="kind-badge tmux-badge">tmux</span>
+        <Chip size="xs" tone="warning">tmux</Chip>
       {/if}
       {#if worktree.isStale}
         <span class="stale-icon" title="Stale worktree">⚠</span>
@@ -159,10 +176,12 @@
     {#if worktree.linkedPR || worktree.diff || showBranch}
       <span class="meta-row">
         {#if worktree.linkedPR}
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <span
-            class="pr-badge pr-{worktree.linkedPR.state}"
+          <Chip
+            size="xs"
+            tone={linkedPRTone(worktree.linkedPR.state)}
+            interactive
+            uppercase={false}
+            class={`workspace-pr-chip chip--state-${worktree.linkedPR.state}`}
             title="PR #{worktree.linkedPR.number}"
             onclick={(e: MouseEvent) => e.stopPropagation()}
           >
@@ -202,7 +221,7 @@
                 />
               </svg>
             {/if}
-          </span>
+          </Chip>
         {/if}
 
         {#if worktree.diff}
@@ -328,6 +347,11 @@
     min-width: 0;
   }
 
+  .name-row :global(.chip),
+  .meta-row :global(.chip) {
+    flex-shrink: 0;
+  }
+
   .name {
     font-size: 13px;
     font-weight: 600;
@@ -335,29 +359,6 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .kind-badge {
-    font-size: 9px;
-    font-weight: 600;
-    text-transform: uppercase;
-    padding: 1px 5px;
-    border-radius: 3px;
-    flex-shrink: 0;
-  }
-
-  .root-badge {
-    background: color-mix(
-      in srgb, var(--accent-blue) 15%, transparent
-    );
-    color: var(--accent-blue);
-  }
-
-  .tmux-badge {
-    background: color-mix(
-      in srgb, var(--accent-amber) 15%, transparent
-    );
-    color: var(--accent-amber);
   }
 
   .stale-icon {
@@ -396,46 +397,6 @@
     gap: 6px;
     padding-left: 0;
     font-size: 11px;
-  }
-
-  .pr-badge {
-    display: flex;
-    align-items: center;
-    gap: 3px;
-    font-size: 10px;
-    font-weight: 600;
-    background: none;
-    border: none;
-    padding: 1px 6px;
-    border-radius: 3px;
-  }
-
-  .pr-open {
-    color: var(--accent-green);
-    background: color-mix(
-      in srgb, var(--accent-green) 12%, transparent
-    );
-  }
-
-  .pr-merged {
-    color: var(--accent-purple);
-    background: color-mix(
-      in srgb, var(--accent-purple) 12%, transparent
-    );
-  }
-
-  .pr-closed {
-    color: var(--accent-red);
-    background: color-mix(
-      in srgb, var(--accent-red) 12%, transparent
-    );
-  }
-
-  .pr-draft {
-    color: var(--text-muted);
-    background: color-mix(
-      in srgb, var(--text-muted) 12%, transparent
-    );
   }
 
   .checks-icon {

--- a/packages/ui/src/components/workspace/WorktreeRow.svelte
+++ b/packages/ui/src/components/workspace/WorktreeRow.svelte
@@ -179,11 +179,9 @@
           <Chip
             size="xs"
             tone={linkedPRTone(worktree.linkedPR.state)}
-            interactive
             uppercase={false}
             class={`workspace-pr-chip chip--state-${worktree.linkedPR.state}`}
             title="PR #{worktree.linkedPR.number}"
-            onclick={(e: MouseEvent) => e.stopPropagation()}
           >
             #{worktree.linkedPR.number} {worktree.linkedPR.state.toUpperCase()}
             {#if worktree.linkedPR.checksStatus === "success"}

--- a/packages/ui/src/components/workspace/WorktreeRow.test.ts
+++ b/packages/ui/src/components/workspace/WorktreeRow.test.ts
@@ -1,0 +1,70 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { WorkspaceWorktree } from "../../api/types.js";
+import WorktreeRow from "./WorktreeRow.svelte";
+
+function createWorktree(): WorkspaceWorktree {
+  return {
+    key: "worktree-1",
+    name: "feature-auth",
+    branch: "feature/auth",
+    isPrimary: false,
+    isHidden: false,
+    isStale: false,
+    sessionBackend: null,
+    linkedPR: {
+      number: 42,
+      title: "Add auth middleware",
+      state: "open",
+      checksStatus: "success",
+      updatedAt: "2026-04-10T12:00:00Z",
+    },
+    activity: {
+      state: "idle",
+      lastOutputAt: null,
+    },
+    diff: {
+      added: 12,
+      removed: 3,
+    },
+  };
+}
+
+describe("WorktreeRow", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the linked PR chip as passive metadata that still activates the row", async () => {
+    const onCommand = vi.fn();
+
+    render(WorktreeRow, {
+      props: {
+        worktree: createWorktree(),
+        hostKey: "local",
+        projectKey: "middleman",
+        isSelected: false,
+        onCommand,
+      },
+    });
+
+    const chip = screen.getByTitle("PR #42");
+
+    expect(chip.tagName).toBe("SPAN");
+    expect(chip.getAttribute("tabindex")).toBeNull();
+
+    await fireEvent.click(chip);
+
+    expect(onCommand).toHaveBeenCalledWith("selectWorktree", {
+      hostKey: "local",
+      projectKey: "middleman",
+      worktreeKey: "worktree-1",
+    });
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -119,6 +119,12 @@ export {
   default as Chip,
 } from "./components/shared/Chip.svelte";
 export {
+  default as ItemKindChip,
+} from "./components/shared/ItemKindChip.svelte";
+export {
+  default as ItemStateChip,
+} from "./components/shared/ItemStateChip.svelte";
+export {
   default as CollapsibleResizableSidebar,
 } from "./components/shared/CollapsibleResizableSidebar.svelte";
 export {


### PR DESCRIPTION
## Summary
- extend the shared Chip primitive with reusable tones, sizes, dot, and interactive states
- add semantic item-kind and item-state chip wrappers
- replace local badge/chip markup in activity, roborev, and workspace rows
- document the shared chip convention in the UI context notes

## How this makes the code better
- gives compact status UI one implementation path instead of repeated local badge CSS
- lets callers express domain meaning, such as item kind or state, instead of hand-picking styles
- keeps future badge changes uniform across activity feeds, review status, and workspace rows