### PR TITLE
Use stdlib slice and map helpers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -625,7 +626,7 @@ func (c *Config) TmuxCommand() []string {
 	if c == nil || len(c.Tmux.Command) == 0 {
 		return []string{"tmux"}
 	}
-	return append([]string(nil), c.Tmux.Command...)
+	return slices.Clone(c.Tmux.Command)
 }
 
 // TmuxAgentSessionsEnabled reports whether runtime agent launches

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1,6 +1,10 @@
 package db
 
-import "time"
+import (
+	"cmp"
+	"strings"
+	"time"
+)
 
 type Label struct {
 	ID          int64     `json:"-"`
@@ -127,6 +131,10 @@ type MergeRequest struct {
 	Labels            []Label `json:"labels,omitempty"`
 }
 
+func (mr MergeRequest) Compare(other MergeRequest) int {
+	return cmp.Compare(mr.Number, other.Number)
+}
+
 // CICheck represents a single CI check run.
 type CICheck struct {
 	Name       string `json:"name"`
@@ -134,6 +142,15 @@ type CICheck struct {
 	Conclusion string `json:"conclusion"` // success, failure, neutral, cancelled, skipped, timed_out, action_required, or empty
 	URL        string `json:"url"`        // link to the check run details page
 	App        string `json:"app"`        // app name (e.g., "GitHub Actions")
+}
+
+func (c CICheck) Compare(other CICheck) int {
+	leftFolded := strings.ToLower(c.Name)
+	rightFolded := strings.ToLower(other.Name)
+	if leftFolded != rightFolded {
+		return cmp.Compare(leftFolded, rightFolded)
+	}
+	return cmp.Compare(c.Name, other.Name)
 }
 
 type MREvent struct {

--- a/internal/gitenv/gitenv.go
+++ b/internal/gitenv/gitenv.go
@@ -18,7 +18,10 @@
 // inherited transport config to remain visible.
 package gitenv
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // StripInherited returns env with every GIT_* variable that could
 // rebind a child git process to an inherited parent context removed.
@@ -38,14 +41,7 @@ import "strings"
 // SSL, HTTP) are preserved so that developers can still observe
 // child git behavior without losing visibility.
 func StripInherited(env []string) []string {
-	out := make([]string, 0, len(env))
-	for _, e := range env {
-		if isInherited(e) {
-			continue
-		}
-		out = append(out, e)
-	}
-	return out
+	return slices.DeleteFunc(slices.Clone(env), isInherited)
 }
 
 // StripAll removes every GIT_* variable and SSH_ASKPASS from env.
@@ -55,15 +51,10 @@ func StripInherited(env []string) []string {
 // build throwaway repos (where GIT_DEFAULT_HASH could create SHA-256
 // repos instead of the expected SHA-1 layout).
 func StripAll(env []string) []string {
-	out := make([]string, 0, len(env))
-	for _, e := range env {
+	return slices.DeleteFunc(slices.Clone(env), func(e string) bool {
 		key, _, _ := strings.Cut(e, "=")
-		if strings.HasPrefix(key, "GIT_") || key == "SSH_ASKPASS" {
-			continue
-		}
-		out = append(out, e)
-	}
-	return out
+		return strings.HasPrefix(key, "GIT_") || key == "SSH_ASKPASS"
+	})
 }
 
 func isInherited(e string) bool {

--- a/internal/gitenv/gitenv.go
+++ b/internal/gitenv/gitenv.go
@@ -41,7 +41,7 @@ import (
 // SSL, HTTP) are preserved so that developers can still observe
 // child git behavior without losing visibility.
 func StripInherited(env []string) []string {
-	return slices.DeleteFunc(slices.Clone(env), isInherited)
+	return slices.DeleteFunc(cloneEnv(env), isInherited)
 }
 
 // StripAll removes every GIT_* variable and SSH_ASKPASS from env.
@@ -51,10 +51,17 @@ func StripInherited(env []string) []string {
 // build throwaway repos (where GIT_DEFAULT_HASH could create SHA-256
 // repos instead of the expected SHA-1 layout).
 func StripAll(env []string) []string {
-	return slices.DeleteFunc(slices.Clone(env), func(e string) bool {
+	return slices.DeleteFunc(cloneEnv(env), func(e string) bool {
 		key, _, _ := strings.Cut(e, "=")
 		return strings.HasPrefix(key, "GIT_") || key == "SSH_ASKPASS"
 	})
+}
+
+func cloneEnv(env []string) []string {
+	if env == nil {
+		return []string{}
+	}
+	return slices.Clone(env)
 }
 
 func isInherited(e string) bool {

--- a/internal/gitenv/gitenv_test.go
+++ b/internal/gitenv/gitenv_test.go
@@ -101,3 +101,15 @@ func TestStripAllRemovesEveryGitVar(t *testing.T) {
 	assert.Contains(out, "HOME=/Users/test")
 	assert.Contains(out, "HTTPS_PROXY=http://proxy:8080")
 }
+
+func TestStripNilReturnsExplicitEmptyEnv(t *testing.T) {
+	assert := assert.New(t)
+
+	inherited := StripInherited(nil)
+	assert.NotNil(inherited)
+	assert.Empty(inherited)
+
+	all := StripAll(nil)
+	assert.NotNil(all)
+	assert.Empty(all)
+}

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -545,14 +545,7 @@ func repoStatusConclusion(s *gh.RepoStatus) string {
 }
 
 func sortCIChecksByName(checks []db.CICheck) {
-	sort.SliceStable(checks, func(i, j int) bool {
-		leftFolded := strings.ToLower(checks[i].Name)
-		rightFolded := strings.ToLower(checks[j].Name)
-		if leftFolded != rightFolded {
-			return leftFolded < rightFolded
-		}
-		return checks[i].Name < checks[j].Name
-	})
+	slices.SortStableFunc(checks, db.CICheck.Compare)
 }
 
 func shortSHA(sha string) string {

--- a/internal/github/queue.go
+++ b/internal/github/queue.go
@@ -1,7 +1,8 @@
 package github
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"time"
 )
 
@@ -42,6 +43,10 @@ func (qi *QueueItem) WorstCaseCost() int {
 	return IssueDetailWorstCase
 }
 
+func (qi QueueItem) Compare(other QueueItem) int {
+	return cmp.Compare(other.Score, qi.Score)
+}
+
 // Staleness thresholds.
 const (
 	defaultRefetchInterval = 30 * time.Minute
@@ -62,9 +67,7 @@ func BuildQueue(
 		items[i].Score = score(&items[i], now)
 		eligible = append(eligible, items[i])
 	}
-	sort.Slice(eligible, func(i, j int) bool {
-		return eligible[i].Score > eligible[j].Score
-	})
+	slices.SortFunc(eligible, QueueItem.Compare)
 	return eligible
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -405,8 +406,7 @@ func (s *Syncer) HasDiffSync() bool {
 // the bulk sync cycle.
 func (s *Syncer) SetWatchedMRs(mrs []WatchedMR) {
 	s.watchMu.Lock()
-	s.watchedMRs = make([]WatchedMR, len(mrs))
-	copy(s.watchedMRs, mrs)
+	s.watchedMRs = slices.Clone(mrs)
 	s.watchMu.Unlock()
 }
 
@@ -573,8 +573,7 @@ func (s *Syncer) HostForRepo(owner, name string) string {
 // SetRepos atomically replaces the list of repositories to sync.
 func (s *Syncer) SetRepos(repos []RepoRef) {
 	s.reposMu.Lock()
-	s.repos = make([]RepoRef, len(repos))
-	copy(s.repos, repos)
+	s.repos = slices.Clone(repos)
 	s.reposMu.Unlock()
 }
 
@@ -698,8 +697,7 @@ func (s *Syncer) syncWatchedMRs(ctx context.Context) {
 	ctx = WithSyncBudget(ctx)
 
 	s.watchMu.Lock()
-	mrs := make([]WatchedMR, len(s.watchedMRs))
-	copy(mrs, s.watchedMRs)
+	mrs := slices.Clone(s.watchedMRs)
 	s.watchMu.Unlock()
 
 	if len(mrs) == 0 {
@@ -1020,8 +1018,7 @@ func (s *Syncer) runOnce(
 	ctx = WithSyncBudget(ctx)
 
 	s.reposMu.Lock()
-	repos := make([]RepoRef, len(s.repos))
-	copy(repos, s.repos)
+	repos := slices.Clone(s.repos)
 	s.reposMu.Unlock()
 
 	total := len(repos)
@@ -1827,8 +1824,8 @@ func (s *Syncer) drainPendingCommentSyncs(
 	eligibleHosts map[string]bool,
 ) {
 	s.commentRefreshMu.Lock()
-	prs := append([]queuedPRCommentSync(nil), s.pendingPRCommentSyncs...)
-	issues := append([]queuedIssueCommentSync(nil), s.pendingIssueCommentSyncs...)
+	prs := slices.Clone(s.pendingPRCommentSyncs)
+	issues := slices.Clone(s.pendingIssueCommentSyncs)
 	s.pendingPRCommentSyncs = nil
 	s.pendingIssueCommentSyncs = nil
 	s.commentRefreshMu.Unlock()
@@ -3765,9 +3762,7 @@ func (s *Syncer) TrackedRepos() []RepoRef {
 	s.reposMu.Lock()
 	defer s.reposMu.Unlock()
 
-	repos := make([]RepoRef, len(s.repos))
-	copy(repos, s.repos)
-	return repos
+	return slices.Clone(s.repos)
 }
 
 // isTrackedRepoOnHost checks whether the given repo on a specific host

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -204,7 +205,7 @@ func (s *Server) previewRepos(
 	}
 
 	s.cfgMu.Lock()
-	repos := append([]config.Repo(nil), s.cfg.Repos...)
+	repos := slices.Clone(s.cfg.Repos)
 	s.cfgMu.Unlock()
 
 	rows, err := buildRepoPreviewRows(
@@ -283,7 +284,7 @@ func (s *Server) applyBulkExactRepos(
 			fmt.Errorf("all selected repositories are already configured")
 	}
 
-	prev := append([]config.Repo(nil), s.cfg.Repos...)
+	prev := slices.Clone(s.cfg.Repos)
 	s.cfg.Repos = append(s.cfg.Repos, addConfigs...)
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Repos = prev

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -49,7 +50,7 @@ func (s *Server) configuredClients(
 // in-memory state (syncer tracked repos) without calling GitHub.
 func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	s.cfgMu.Lock()
-	repos := append([]config.Repo(nil), s.cfg.Repos...)
+	repos := slices.Clone(s.cfg.Repos)
 	activity := s.cfg.Activity
 	terminal := s.cfg.Terminal
 	agents := cloneConfigAgents(s.cfg.Agents)
@@ -338,7 +339,7 @@ func cloneConfigAgents(agents []config.Agent) []config.Agent {
 	cloned := make([]config.Agent, len(agents))
 	for i, agent := range agents {
 		cloned[i] = agent
-		cloned[i].Command = append([]string(nil), agent.Command...)
+		cloned[i].Command = slices.Clone(agent.Command)
 	}
 	return cloned
 }
@@ -375,9 +376,7 @@ func (s *Server) addConfiguredRepo(
 					" is already configured")
 		}
 	}
-	allRepos := append(
-		append([]config.Repo(nil), s.cfg.Repos...), newRepo,
-	)
+	allRepos := append(slices.Clone(s.cfg.Repos), newRepo)
 	s.cfgMu.Unlock()
 
 	_, expanded, err := ghclient.ResolveConfiguredRepo(
@@ -429,7 +428,7 @@ func (s *Server) refreshConfiguredRepo(
 	name := input.Name
 
 	s.cfgMu.Lock()
-	repos := append([]config.Repo(nil), s.cfg.Repos...)
+	repos := slices.Clone(s.cfg.Repos)
 	s.cfgMu.Unlock()
 
 	var target *config.Repo
@@ -466,7 +465,7 @@ func (s *Server) refreshConfiguredRepo(
 	// and the stale expansion would resurrect removed repos.
 	s.cfgMu.Lock()
 	stillExists := false
-	currentRepos := append([]config.Repo(nil), s.cfg.Repos...)
+	currentRepos := slices.Clone(s.cfg.Repos)
 	for _, rp := range currentRepos {
 		if sameConfiguredRepo(
 			rp,
@@ -520,7 +519,7 @@ func (s *Server) deleteConfiguredRepo(
 			owner + "/" + name + " is not configured")
 	}
 
-	prev := append([]config.Repo(nil), s.cfg.Repos...)
+	prev := slices.Clone(s.cfg.Repos)
 	s.cfg.Repos = append(
 		s.cfg.Repos[:idx], s.cfg.Repos[idx+1:]...,
 	)

--- a/internal/server/terminal_routes.go
+++ b/internal/server/terminal_routes.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
@@ -19,7 +20,7 @@ func terminalAPIConfig() huma.Config {
 func (s *Server) registerTerminalAPI(api huma.API, tmuxCmd []string) {
 	handler := &terminal.Handler{
 		Workspaces:  s.workspaces,
-		TmuxCommand: append([]string(nil), tmuxCmd...),
+		TmuxCommand: slices.Clone(tmuxCmd),
 	}
 	op := &huma.Operation{
 		OperationID: "connect-workspace-terminal",

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -2,7 +2,7 @@ package stacks
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/wesm/middleman/internal/db"
@@ -12,11 +12,8 @@ import (
 // Returns chains of length >= 2, ordered base-to-tip.
 func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
 	// Sort by number for deterministic tie-breaking.
-	sorted := make([]db.MergeRequest, len(prs))
-	copy(sorted, prs)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Number < sorted[j].Number
-	})
+	sorted := slices.Clone(prs)
+	slices.SortFunc(sorted, db.MergeRequest.Compare)
 
 	// head_branch -> PR. Prefer open over merged; within same state, lowest number wins.
 	headMap := make(map[string]db.MergeRequest, len(sorted))

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -100,9 +101,7 @@ func (c *FixtureClient) ListRepositoriesByOwner(
 	if len(repos) == 0 {
 		return nil, nil
 	}
-	out := make([]*gh.Repository, len(repos))
-	copy(out, repos)
-	return out, nil
+	return slices.Clone(repos), nil
 }
 
 func (c *FixtureClient) ListReleases(
@@ -115,9 +114,7 @@ func (c *FixtureClient) ListReleases(
 	if perPage > 0 && perPage < len(releases) {
 		releases = releases[:perPage]
 	}
-	out := make([]*gh.RepositoryRelease, len(releases))
-	copy(out, releases)
-	return out, nil
+	return slices.Clone(releases), nil
 }
 
 func (c *FixtureClient) ListTags(
@@ -130,9 +127,7 @@ func (c *FixtureClient) ListTags(
 	if perPage > 0 && perPage < len(tags) {
 		tags = tags[:perPage]
 	}
-	out := make([]*gh.RepositoryTag, len(tags))
-	copy(out, tags)
-	return out, nil
+	return slices.Clone(tags), nil
 }
 
 // GetRepository returns a repository with all merge methods enabled.
@@ -278,9 +273,7 @@ func (c *FixtureClient) ListIssueComments(
 	if len(comments) == 0 {
 		return nil, nil
 	}
-	out := make([]*gh.IssueComment, len(comments))
-	copy(out, comments)
-	return out, nil
+	return slices.Clone(comments), nil
 }
 
 func (c *FixtureClient) ListIssueCommentsIfChanged(
@@ -337,9 +330,7 @@ func (c *FixtureClient) ListCheckRunsForRef(
 	if len(runs) == 0 {
 		return nil, nil
 	}
-	out := make([]*gh.CheckRun, len(runs))
-	copy(out, runs)
-	return out, nil
+	return slices.Clone(runs), nil
 }
 
 // ListWorkflowRunsForHeadSHA returns nil (read-only stub).

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -49,6 +48,10 @@ type SessionInfo struct {
 	ExitedAt    *time.Time       `json:"exited_at,omitempty"`
 	ExitCode    *int             `json:"exit_code,omitempty"`
 	TmuxSession string           `json:"-"`
+}
+
+func (s SessionInfo) Compare(other SessionInfo) int {
+	return s.CreatedAt.Compare(other.CreatedAt)
 }
 
 type RestoredTmuxSession struct {
@@ -164,8 +167,8 @@ func NewManager(options Options) *Manager {
 		targetsList:      targetsList,
 		sessions:         make(map[string]*session),
 		shells:           make(map[string]*session),
-		shellCommand:     append([]string(nil), options.ShellCommand...),
-		tmuxCommand:      append([]string(nil), options.TmuxCommand...),
+		shellCommand:     slices.Clone(options.ShellCommand),
+		tmuxCommand:      slices.Clone(options.TmuxCommand),
 		tmuxOwnerMarker:  options.TmuxOwnerMarker,
 		wrapAgentsInTmux: options.WrapAgentSessionsInTmux,
 		stripEnvVars:     dedupeStrings(options.StripEnvVars),
@@ -398,7 +401,7 @@ func (m *Manager) restoreTmuxSession(
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
 	}
-	command := append([]string(nil), m.tmuxCommand...)
+	command := slices.Clone(m.tmuxCommand)
 	if len(command) == 0 {
 		command = []string{"tmux"}
 	}
@@ -491,9 +494,7 @@ func (m *Manager) ListSessions(workspaceID string) []SessionInfo {
 			sessions = append(sessions, info)
 		}
 	}
-	sort.Slice(sessions, func(i, j int) bool {
-		return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
-	})
+	slices.SortFunc(sessions, SessionInfo.Compare)
 	return sessions
 }
 
@@ -512,7 +513,7 @@ func (m *Manager) TmuxSessions(workspaceID string) []string {
 			sessions = append(sessions, s.tmuxSession)
 		}
 	}
-	sort.Strings(sessions)
+	slices.Sort(sessions)
 	return sessions
 }
 
@@ -632,7 +633,7 @@ func (m *Manager) killTmuxSession(
 	if session == "" {
 		return nil
 	}
-	command := append([]string(nil), m.tmuxCommand...)
+	command := slices.Clone(m.tmuxCommand)
 	if len(command) == 0 {
 		command = []string{"tmux"}
 	}
@@ -675,7 +676,7 @@ func (m *Manager) refreshTmuxSessionClients(
 	if session == "" {
 		return nil
 	}
-	command := append([]string(nil), m.tmuxCommand...)
+	command := slices.Clone(m.tmuxCommand)
 	if len(command) == 0 {
 		command = []string{"tmux"}
 	}
@@ -909,7 +910,7 @@ func (m *Manager) EnsureShell(
 		return existing.snapshot(), nil
 	}
 
-	command := append([]string(nil), m.shellCommand...)
+	command := slices.Clone(m.shellCommand)
 	if len(command) == 0 {
 		command = defaultShellCommand()
 	}
@@ -1110,7 +1111,7 @@ func (m *Manager) launchCommand(
 	workspaceID string,
 	cwd string,
 ) (launchCommand, error) {
-	command := append([]string(nil), target.Command...)
+	command := slices.Clone(target.Command)
 	if target.Kind != LaunchTargetAgent || !m.wrapAgentsInTmux {
 		return launchCommand{Command: command}, nil
 	}
@@ -1119,14 +1120,14 @@ func (m *Manager) launchCommand(
 	if err != nil || !tmux.Available {
 		return launchCommand{Command: command}, nil
 	}
-	tmuxCommand := append([]string(nil), m.tmuxCommand...)
+	tmuxCommand := slices.Clone(m.tmuxCommand)
 	if len(tmuxCommand) == 0 {
-		tmuxCommand = append([]string(nil), tmux.Command...)
+		tmuxCommand = slices.Clone(tmux.Command)
 	}
 	if len(tmuxCommand) == 0 {
 		tmuxCommand = []string{"tmux"}
 	}
-	resolvedAgentCommand := append([]string(nil), command...)
+	resolvedAgentCommand := slices.Clone(command)
 	resolvedPath, err := resolveExecutable(resolvedAgentCommand[0])
 	if err != nil {
 		return launchCommand{}, err
@@ -1170,11 +1171,11 @@ func (m *Manager) launchTmuxOwnedCommand(
 	agentCommand string,
 ) []string {
 	hasSession := shellCommand(append(
-		append([]string(nil), tmuxCommand...),
+		slices.Clone(tmuxCommand),
 		"has-session", "-t", tmuxSession,
 	))
 	newSessionArgs := append(
-		append([]string(nil), tmuxCommand...),
+		slices.Clone(tmuxCommand),
 		"new-session", "-d", "-s", tmuxSession,
 	)
 	if cwd != "" {
@@ -1189,16 +1190,16 @@ func (m *Manager) launchTmuxOwnedCommand(
 	)
 	newSession := shellCommand(newSessionArgs)
 	setOwner := shellCommand(append(
-		append([]string(nil), tmuxCommand...),
+		slices.Clone(tmuxCommand),
 		"set-option", "-q", "-t", tmuxSession,
 		"@middleman_owner", m.tmuxOwnerMarker,
 	))
 	killSession := shellCommand(append(
-		append([]string(nil), tmuxCommand...),
+		slices.Clone(tmuxCommand),
 		"kill-session", "-t", tmuxSession,
 	))
 	attachSession := shellCommand(append(
-		append([]string(nil), tmuxCommand...),
+		slices.Clone(tmuxCommand),
 		"attach-session", "-t", tmuxSession,
 	))
 	script := fmt.Sprintf(
@@ -1522,7 +1523,7 @@ func (s *session) drainOutput() {
 }
 
 func (s *session) broadcast(data []byte) {
-	chunk := append([]byte(nil), data...)
+	chunk := slices.Clone(data)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1581,7 +1582,7 @@ func (s *session) appendReplayOutputLocked(chunk []byte) {
 func (s *session) appendOutputBufferLocked(chunk []byte) {
 	s.outputBuffer = append(s.outputBuffer, chunk...)
 	if extra := len(s.outputBuffer) - maxSessionOutputReplay; extra > 0 {
-		s.outputBuffer = append([]byte(nil), s.outputBuffer[extra:]...)
+		s.outputBuffer = slices.Clone(s.outputBuffer[extra:])
 	}
 }
 
@@ -1632,7 +1633,7 @@ func (s *session) subscribe() (<-chan []byte, func()) {
 	s.mu.Lock()
 	info := s.info
 	if len(s.outputBuffer) > 0 && !s.alternateScreenActive {
-		replay := append([]byte(nil), s.outputBuffer...)
+		replay := slices.Clone(s.outputBuffer)
 		ch <- replay
 		slog.Debug(
 			"runtime terminal replay queued",

--- a/internal/workspace/localruntime/targets.go
+++ b/internal/workspace/localruntime/targets.go
@@ -3,6 +3,7 @@ package localruntime
 import (
 	"fmt"
 	"os/exec"
+	"slices"
 
 	"github.com/wesm/middleman/internal/config"
 )
@@ -50,7 +51,7 @@ func ResolveLaunchTargets(
 			Label:   agent.Label,
 			Kind:    LaunchTargetAgent,
 			Source:  "config",
-			Command: append([]string(nil), agent.Command...),
+			Command: slices.Clone(agent.Command),
 		}
 		if agent.EnabledOrDefault() {
 			target.Available = true
@@ -93,7 +94,7 @@ func tmuxTarget(
 	tmuxCommand []string,
 	lookPath lookPathFunc,
 ) LaunchTarget {
-	command := append([]string(nil), tmuxCommand...)
+	command := slices.Clone(tmuxCommand)
 	if len(command) == 0 {
 		command = []string{"tmux"}
 	}
@@ -116,6 +117,6 @@ func tmuxTarget(
 }
 
 func cloneTarget(target LaunchTarget) LaunchTarget {
-	target.Command = append([]string(nil), target.Command...)
+	target.Command = slices.Clone(target.Command)
 	return target
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -111,7 +112,7 @@ func (m *Manager) SetClones(clones *gitclone.Manager) {
 // invocation the manager issues. When nil/empty, the manager uses
 // ["tmux"] — preserving today's behavior.
 func (m *Manager) SetTmuxCommand(cmd []string) {
-	m.tmuxCmd = append([]string(nil), cmd...)
+	m.tmuxCmd = slices.Clone(cmd)
 }
 
 // tmuxExec builds an *exec.Cmd for a tmux invocation: the

--- a/tools/migrationhistorycheck/main.go
+++ b/tools/migrationhistorycheck/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,6 +116,10 @@ type duplicateNumberViolation struct {
 	names  []string
 }
 
+func (v duplicateNumberViolation) Compare(other duplicateNumberViolation) int {
+	return strings.Compare(v.number, other.number)
+}
+
 func duplicateMigrationNumberViolations(baseRef, migrationDir, diff string) ([]duplicateNumberViolation, error) {
 	baseByNumber, err := migrationNamesByNumberOnRef(baseRef, migrationDir)
 	if err != nil {
@@ -135,13 +140,8 @@ func duplicateMigrationNumberViolations(baseRef, migrationDir, diff string) ([]d
 
 	var violations []duplicateNumberViolation
 	for number, stagedNames := range stagedByNumber {
-		allNames := map[string]struct{}{}
-		for name := range baseByNumber[number] {
-			allNames[name] = struct{}{}
-		}
-		for name := range stagedNames {
-			allNames[name] = struct{}{}
-		}
+		allNames := maps.Clone(stagedNames)
+		maps.Copy(allNames, baseByNumber[number])
 		if len(allNames) <= 1 {
 			continue
 		}
@@ -153,9 +153,7 @@ func duplicateMigrationNumberViolations(baseRef, migrationDir, diff string) ([]d
 		})
 	}
 
-	slices.SortFunc(violations, func(a, b duplicateNumberViolation) int {
-		return strings.Compare(a.number, b.number)
-	})
+	slices.SortFunc(violations, duplicateNumberViolation.Compare)
 	return violations, nil
 }
 
@@ -231,12 +229,7 @@ func migrationIdentityFromPath(path string) (string, string, bool) {
 }
 
 func sortedKeys(values map[string]struct{}) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
+	return slices.Sorted(maps.Keys(values))
 }
 
 func getenvDefault(key, fallback string) string {

--- a/tools/nohttpmux/main.go
+++ b/tools/nohttpmux/main.go
@@ -43,15 +43,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		diagnostics = append(diagnostics, fileDiagnostics...)
 	}
 
-	slices.SortFunc(diagnostics, func(a, b Diagnostic) int {
-		if a.Path != b.Path {
-			return strings.Compare(a.Path, b.Path)
-		}
-		if a.Line != b.Line {
-			return a.Line - b.Line
-		}
-		return a.Column - b.Column
-	})
+	slices.SortFunc(diagnostics, Diagnostic.Compare)
 
 	for _, diagnostic := range diagnostics {
 		fmt.Fprintf(
@@ -70,6 +62,16 @@ type Diagnostic struct {
 	Line    int
 	Column  int
 	Message string
+}
+
+func (d Diagnostic) Compare(other Diagnostic) int {
+	if d.Path != other.Path {
+		return strings.Compare(d.Path, other.Path)
+	}
+	if d.Line != other.Line {
+		return d.Line - other.Line
+	}
+	return d.Column - other.Column
 }
 
 func checkFile(path string) ([]Diagnostic, error) {


### PR DESCRIPTION
- Replace hand-written clone, filter, merge, and key-sort loops with Go stdlib slices/maps helpers.
- Move sortable struct ordering into Compare methods and use slices sort helpers at call sites.