### PR TITLE
docs: codify sync and runtime context invariants

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -1,0 +1,109 @@
+# GitHub Sync Invariants
+
+Use this document for changes in `internal/github/`, sync-triggering server
+handlers, fixture clients, and tests that rely on GitHub-derived freshness.
+
+## Purpose
+
+- Keep sync correctness rules explicit.
+- Preserve the distinction between identity, freshness, and optional fallback
+  data.
+- Prevent review-only regressions around `platform_host`, head-SHA drift,
+  timeline parity, and fallback fetch paths.
+
+## Identity Rules
+
+GitHub entities in middleman are not identified by owner/name/number alone.
+
+- Repository identity is `(platform_host, owner, name)`.
+- PR and issue identity is `(platform_host, owner, name, number)`.
+- Workspace association repair and list filtering must preserve that host-aware
+  identity.
+
+Rules:
+
+- Treat `platform_host` as part of every persisted GitHub object identity.
+- When a caller explicitly supplies `platform_host`, honor it all the way
+  through query, sync, and response shaping.
+- Only fall back to the default host when the request truly omits host and the
+  route semantics allow an implied GitHub host.
+- Do not constrain repo-scoped listing queries to one host unless the caller
+  asked for that host.
+
+## Freshness Rules
+
+Bulk sync and detail sync have different jobs, but they must not disagree about
+what "current" means.
+
+- Bulk sync keeps tracked repos, open PRs/issues, and cheap derived state fresh.
+- Detail sync populates comments, reviews, commits, and richer timeline data for
+  one item.
+- If a PR or issue is marked as detail-fetched, the persisted fields that power
+  the user-visible detail view must match that claim.
+
+For pull requests, that means:
+
+- Detail freshness must cover comments, reviews, commits, and stored PR system
+  timeline events together.
+- `last_activity_at` and similar derived fields must follow the freshest
+  persisted activity, not just one subset of the detail payload.
+- Background sync cooldowns are allowed, but user-initiated refreshes must still
+  be able to promote a stronger sync intent over an in-flight background fetch.
+
+## Timeline Event Rules
+
+PR timeline storage is intentionally selective.
+
+- Keep the existing event families stable: comments, reviews, commits, force
+  pushes, and the currently supported PR system events.
+- Review comments are UI-aware but are not part of the stored sync model unless
+  they can be fetched within the supported timeline path.
+- If bulk sync persists PR system events, detail sync must persist the same
+  family so filters and `detail_fetched_at` do not lie.
+- Optional timeline fetch failures may degrade that event family, but should not
+  drop the entire PR detail refresh when the rest of the detail payload is still
+  usable.
+
+## SHA-Sensitive Rules
+
+Some PR-derived state is only valid for one head commit.
+
+- Never carry CI status, check runs, or similar head-derived summaries forward
+  when the PR head SHA changed underneath the refresh.
+- Workflow-approval decisions must be tied to the correct PR identity, not just
+  the head SHA. Shared SHAs across forks or sibling PRs must not leak approval
+  state between items.
+- When a refresh cannot prove the state belongs to the current head SHA, clear
+  the stale derived state instead of preserving it.
+
+## Fallback Data Rules
+
+GitHub data sources are intentionally layered.
+
+- Repos without usable releases may fall back to tags for version-like timeline
+  context.
+- Repository import for the authenticated owner may need a different GitHub API
+  path than generic org/user repo listing so private owned repos are included.
+- Fallbacks must preserve the same response shape and user-visible semantics as
+  the primary path whenever possible.
+
+Use fallback paths to keep user-visible features working, not to silently change
+what a field means.
+
+## Testing Expectations
+
+Changes in this area should usually add or update tests at the boundary where
+the regression would show up.
+
+- `internal/github/*_test.go` for GraphQL parsing, normalization, optional
+  failure handling, and sync sequencing.
+- `internal/server/api_test.go` when the bug would surface through HTTP payloads
+  or sync-triggering handlers.
+- Fixture-client coverage when a fake GitHub path needs to model private repos,
+  edited comments, or timeline families consistently.
+
+Also see [`context/testing.md`](./testing.md):
+
+- Run the normal Go tests with `-shuffle=on`.
+- If you change GraphQL query shape in `internal/github/graphql.go`, run the
+  gated live GitHub validation as well.

--- a/context/testing.md
+++ b/context/testing.md
@@ -13,3 +13,9 @@ The test uses `MIDDLEMAN_GITHUB_TOKEN` first, then `GITHUB_TOKEN`. It intentiona
 When changing structs, fields, aliases, fragments, pagination arguments, or nested selections used by `internal/github/graphql.go`, enable `MIDDLEMAN_LIVE_GITHUB_TESTS=1` and run the live validation test in addition to the normal Go tests.
 
 CI runs the live GraphQL validation as a separate Go test step using the workflow `GITHUB_TOKEN` only in trusted contexts, such as pushes to `main`, manual `workflow_dispatch` runs, and same-repository pull requests. The general pull request Go test step does not receive a GitHub token.
+
+## Related context
+
+- [`context/github-sync-invariants.md`](./github-sync-invariants.md) documents
+  the host-aware identity, timeline freshness, SHA-sensitive CI, and fallback
+  rules that usually determine which tests belong on a GitHub-sync change.

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -21,6 +21,7 @@ Use this document as the intent-level guide for frontend UI work in `middleman`.
 - Tokens: `frontend/src/app.css`
 - Shared primitives: `packages/ui/src/components/shared/`
 - Svelte guidance: `skills/svelte-core-bestpractices/` (`svelte-core-bestpractices`) and `skills/svelte-code-writer/` (`svelte-code-writer`)
+- Interaction contracts: `context/ui-interaction-contracts.md`
 - This guidance: `context/ui-design-system.md`
 
 ## Shared primitives

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -1,0 +1,93 @@
+# UI Interaction Contracts
+
+Use this document for frontend behavior changes where the risk is not visual
+style but stale identity, broken persistence, or surprising interaction
+semantics.
+
+## Purpose
+
+- Make behavior-level UI contracts explicit.
+- Keep route identity, persisted browser state, and keyboard/pointer semantics
+  consistent across the app.
+- Prevent narrow regressions that usually show up only after review or in e2e
+  flows.
+
+## Identity And Route State
+
+Interactive surfaces must agree on which item is selected.
+
+- Treat `platform_host` as part of PR and issue identity in route state, drawer
+  state, and stale-detail guards.
+- When host is omitted for the default GitHub host, normalize comparisons so
+  `github.com` and an omitted host do not look like different items.
+- Use shared named route/item reference types from
+  `frontend/src/lib/stores/router.svelte.ts` instead of repeating anonymous
+  `{ owner, name, number }`-style shapes.
+- When a view changes from item A to item B, reset transient action state that
+  could otherwise submit or render against the wrong item.
+
+Examples of transient state that should usually reset on identity change:
+
+- inline edit drafts
+- merge/close/reopen dialogs
+- approve/review forms
+- embedded detail-tab selection when the parent surface owns the item
+
+## Persistence Scope
+
+Persisted controls must state their scope clearly.
+
+- Browser-local preferences belong in `localStorage` only when the behavior is
+  intentionally per-browser and not worth server settings.
+- URL query state belongs in the route only when deep-linking or back/forward
+  navigation is part of the feature contract.
+- Server-backed settings belong in the API only when the preference should
+  follow the user/config rather than one browser session.
+
+Whenever a control persists, document and test:
+
+- where it persists
+- whether it is global, per-view, or per-item
+- what happens after navigating away and back
+
+## Nested Interaction Rules
+
+Rows that contain buttons, links, or toggles need clear event ownership.
+
+- Activating a nested control inside a clickable row must not also trigger the
+  row's navigation or selection behavior.
+- Escape should close drawers, split-detail panels, menus, or modals when that
+  surface is currently active.
+- Focus-visible states matter for controls that are visually subtle, such as tab
+  close buttons or compact action affordances.
+- If a component claims menu-like behavior, it must honor the keyboard and focus
+  contract of that role. Otherwise, use simpler semantics honestly.
+
+## Filtering And Visibility Rules
+
+Not every visibility control means "remove this entity entirely."
+
+- Controls that toggle detail visibility should preserve the parent row unless
+  the feature explicitly removes that category from the result set.
+- When two data sources race, prefer the source that matches the user's current
+  filter/scope rather than a stale but faster preview.
+- Empty states should make it clear when filters, not missing data, are hiding
+  results.
+
+## Testing Expectations
+
+Behavior contracts should usually be tested where the user would notice the
+breakage.
+
+- Component tests for local state transitions, event propagation, and route/item
+  identity helpers.
+- Store tests for persistence scope and normalization logic.
+- Playwright/e2e tests for navigation away/back, Escape behavior, nested button
+  activation, and other multi-surface flows.
+
+Related docs:
+
+- [`context/ui-design-system.md`](./ui-design-system.md) for visual primitives
+  and styling guidance.
+- [`context/workspace-runtime-lifecycle.md`](./workspace-runtime-lifecycle.md)
+  for runtime-specific workspace tab and shell behavior.

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -37,3 +37,9 @@ issue-backed workspaces show the issue sidebar and disable the PR/reviews path.
 - Represent arbitrary worktrees discovered on a host machine.
 - Mirror an external workspace tree or host inventory.
 - Serve as a generic Git automation API outside middleman's workspace lifecycle.
+
+## Related context
+
+- [`context/workspace-runtime-lifecycle.md`](./workspace-runtime-lifecycle.md)
+  documents runtime-session exit, tmux persistence, and destructive ordering
+  rules that sit underneath these APIs.

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -1,0 +1,105 @@
+# Workspace Runtime Lifecycle
+
+Use this document for changes in workspace delete flows, runtime session
+management, tmux persistence, and workspace terminal UI behavior.
+
+## Purpose
+
+- Keep the lifecycle of middleman-managed runtime state explicit.
+- Preserve the distinction between the durable workspace, the base tmux
+  terminal, and launched runtime sessions.
+- Prevent review regressions around destructive ordering, stale tmux rows, and
+  UI/runtime disagreement after exits.
+
+## Runtime Model
+
+Middleman manages three related but different things:
+
+- The persisted workspace record and worktree.
+- The base workspace `tmux` terminal, which is durable and reconnectable.
+- Launched runtime sessions and the shell drawer, which are disposable live
+  processes.
+
+Rules:
+
+- The base workspace `tmux` tab is part of the durable workspace experience.
+- Launched agent sessions are not durable after natural exit.
+- The shell drawer behaves like a disposable runtime process, not like the base
+  tmux tab.
+
+## Natural Exit Rules
+
+Natural process exit should collapse stale runtime state quickly.
+
+- When a launched runtime session exits naturally, remove it from backend
+  runtime state and from the workspace UI.
+- If the exited session was active, return the UI to Home rather than leaving a
+  dead terminal tab selected.
+- If the session was tmux-backed, forget the persisted runtime tmux row once the
+  backing tmux session is gone.
+- When the shell drawer process exits, close or collapse the drawer and require
+  a fresh launch on reopen.
+
+The base workspace `tmux` tab is the exception:
+
+- Keep reconnect behavior for the base `tmux` tab.
+- Do not auto-close that tab just because the websocket detached or the view
+  remounted.
+
+## Delete Ordering Rules
+
+Workspace deletion is intentionally conservative.
+
+- First decide whether deletion is allowed, including dirty-worktree checks.
+- Only after a clean preflight may runtime sessions and shells be stopped.
+- Only after runtime shutdown succeeds should destructive worktree and DB
+  teardown continue.
+
+This ordering prevents a rejected delete from silently killing the user's live
+workspace sessions.
+
+## Tmux Persistence Rules
+
+Persisted tmux-backed runtime rows are only valid while the backing tmux session
+still exists.
+
+- Restore persisted runtime tmux sessions on startup only when the backing tmux
+  session is still present.
+- Treat "tmux session is no longer running" and equivalent dead-server cases as
+  gone state to be cleaned up, not as a reason to preserve stale runtime rows.
+- During explicit delete or stop flows, forgetting the persisted row is part of
+  cleanup.
+- During middleman shutdown, detach/restart behavior is different: do not treat
+  normal server shutdown as a natural user exit that should erase recoverable
+  base runtime state.
+
+## UI Contract Rules
+
+The workspace UI should reflect runtime truth without leaving users stranded in
+stale tabs.
+
+- Runtime lists returned by `/workspaces/{id}/runtime` are the authoritative
+  backend view of live launched sessions.
+- The frontend may react immediately to terminal exit events, but should then
+  reconcile with a runtime refresh.
+- Keyboard and pointer interactions inside workspace rows must not trigger
+  unintended navigation when the user is targeting a nested control.
+- Persisted "last active tab" state must be scoped per workspace.
+
+## Testing Expectations
+
+Prefer full-stack coverage when the bug crosses backend lifecycle and frontend
+behavior.
+
+- Use real SQLite-backed server tests for delete ordering, tmux cleanup, and
+  runtime-session API behavior.
+- Use tmux wrappers/fakes for missing-session and dead-server cases.
+- Add frontend or Playwright coverage when the regression is visible in tab
+  selection, shell drawer state, or workspace navigation.
+
+Related intent docs:
+
+- [`context/workspace-apis.md`](./workspace-apis.md) for workspace API scope and
+  non-goals.
+- [`context/ui-interaction-contracts.md`](./ui-interaction-contracts.md) for
+  row/button, tab, and keyboard interaction expectations in the UI.


### PR DESCRIPTION
- add GitHub sync invariants for host-aware identity, freshness, timeline parity, and fallback data paths
- add workspace runtime lifecycle guidance for delete ordering, natural exits, and tmux persistence
- add UI interaction contract guidance and link the new docs from existing context entry points