### PR TITLE
refactor: consolidate activity status chips

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -47,6 +47,8 @@ Do not create new local `.badge`, `.pill`, or `.chip` geometry when `Chip` fits.
 
 In this repo, the standard term is **chip**, not pill.
 
+When a screen needs semantic chip color, extend `Chip` with a named tone class such as `chip--blue`, `chip--green`, or `chip--red` instead of redefining local badge geometry. Screens may keep legacy class names for test selectors during migration, but sizing, casing, and spacing should come from `Chip`.
+
 ### ActionButton
 
 Use `ActionButton` for repeated action styling.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10447,6 +10447,11 @@ func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
 	require := require.New(t)
+	// This intentionally goes through the generated HTTP client, the real
+	// httptest server, and the terminal websocket rather than attaching to
+	// localruntime directly. The helper exits quickly after printing the
+	// observed PTY size, so receiving size:41:177 exercises the full path
+	// that must preserve final terminal output before the exit frame wins.
 	disableTmuxAgentSessions := false
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "helper",

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -253,6 +253,10 @@ func bridgeRuntimeAttachment(
 
 	select {
 	case <-attachment.Done:
+		select {
+		case <-outputDone:
+		case <-time.After(100 * time.Millisecond):
+		}
 		cancel()
 		writeRuntimeExit(conn, attachment.Info())
 		return true

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -253,6 +253,12 @@ func bridgeRuntimeAttachment(
 
 	select {
 	case <-attachment.Done:
+		// attachment.Done reports process exit, not that every byte read
+		// from the PTY has reached the websocket. Give the output goroutine
+		// a short chance to observe the closed output channel first so a
+		// fast-exiting command can still deliver its final terminal repaint.
+		// Keep this bounded: a slow or disconnected browser must not hold the
+		// session exit frame forever.
 		select {
 		case <-outputDone:
 		case <-time.After(100 * time.Millisecond):

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -1496,6 +1496,14 @@ func (s *session) watch() SessionInfo {
 	info.TmuxSession = s.tmuxSession
 	s.mu.Unlock()
 
+	// Do not close ptmx here. cmd.Wait only tells us the session leader
+	// exited; the PTY reader may still have kernel-buffered output to
+	// broadcast. Closing the master at this point races that final output.
+	// drainOutput owns the natural EOF path and explicit Stop/Detach still
+	// close ptmx when callers intentionally tear down a live terminal. A
+	// process that daemonizes while holding the slave PTY open will keep the
+	// terminal stream alive until it releases the slave, which is preferable
+	// to timing out and truncating ordinary final output.
 	close(s.done)
 	slog.Debug(
 		"runtime session exited",

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -108,6 +108,12 @@ type Manager struct {
 // startup output entirely.
 const maxSessionOutputReplay = 64 * 1024
 
+// postExitPTYDrainTimeout bounds how long a naturally exited session can keep
+// the PTY master open after cmd.Wait returns. Normal exits should reach PTY EOF
+// immediately after the kernel buffer is drained; the timeout exists for the
+// daemonized-child case where a descendant keeps the slave side open forever.
+const postExitPTYDrainTimeout = 250 * time.Millisecond
+
 var (
 	alternateScreenEnterSequences = [][]byte{
 		[]byte("\x1b[?47h"),
@@ -134,6 +140,7 @@ type session struct {
 	ptmx                  *os.File
 	tmuxSession           string
 	done                  chan struct{}
+	outputDone            chan struct{}
 	subscribers           map[chan []byte]struct{}
 	outputBuffer          []byte
 	outputClosed          bool
@@ -1461,6 +1468,7 @@ func startSession(
 		cmd:         cmd,
 		ptmx:        ptmx,
 		done:        make(chan struct{}),
+		outputDone:  make(chan struct{}),
 		subscribers: make(map[chan []byte]struct{}),
 	}
 	go s.drainOutput()
@@ -1496,14 +1504,13 @@ func (s *session) watch() SessionInfo {
 	info.TmuxSession = s.tmuxSession
 	s.mu.Unlock()
 
-	// Do not close ptmx here. cmd.Wait only tells us the session leader
-	// exited; the PTY reader may still have kernel-buffered output to
-	// broadcast. Closing the master at this point races that final output.
-	// drainOutput owns the natural EOF path and explicit Stop/Detach still
-	// close ptmx when callers intentionally tear down a live terminal. A
-	// process that daemonizes while holding the slave PTY open will keep the
-	// terminal stream alive until it releases the slave, which is preferable
-	// to timing out and truncating ordinary final output.
+	// Do not close ptmx immediately. cmd.Wait only tells us the session
+	// leader exited; the PTY reader may still have kernel-buffered output to
+	// broadcast, and closing the master here races that final output. The
+	// natural EOF path belongs to drainOutput, but keep it bounded so a
+	// daemonized child that holds the slave PTY open cannot leak this session's
+	// reader goroutine and master descriptor forever.
+	s.closePTYAfterPostExitDrainDeadline()
 	close(s.done)
 	slog.Debug(
 		"runtime session exited",
@@ -1516,6 +1523,9 @@ func (s *session) watch() SessionInfo {
 }
 
 func (s *session) drainOutput() {
+	if s.outputDone != nil {
+		defer close(s.outputDone)
+	}
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := s.ptmx.Read(buf)
@@ -1528,6 +1538,19 @@ func (s *session) drainOutput() {
 			return
 		}
 	}
+}
+
+func (s *session) closePTYAfterPostExitDrainDeadline() {
+	if s.ptmx == nil || s.outputDone == nil {
+		return
+	}
+	go func() {
+		select {
+		case <-s.outputDone:
+		case <-time.After(postExitPTYDrainTimeout):
+			_ = s.ptmx.Close()
+		}
+	}()
 }
 
 func (s *session) broadcast(data []byte) {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -1496,7 +1496,6 @@ func (s *session) watch() SessionInfo {
 	info.TmuxSession = s.tmuxSession
 	s.mu.Unlock()
 
-	_ = s.ptmx.Close()
 	close(s.done)
 	slog.Debug(
 		"runtime session exited",
@@ -1516,6 +1515,7 @@ func (s *session) drainOutput() {
 			s.broadcast(buf[:n])
 		}
 		if err != nil {
+			_ = s.ptmx.Close()
 			s.closeSubscribers()
 			return
 		}

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -810,10 +810,12 @@ func TestSessionWatchLeavesOutputOpenForDrain(t *testing.T) {
 
 	cmd := exec.Command("sh", "-c", "exit 0")
 	require.NoError(cmd.Start())
+	outputDone := make(chan struct{})
 	s := &session{
-		cmd:  cmd,
-		ptmx: readEnd,
-		done: make(chan struct{}),
+		cmd:        cmd,
+		ptmx:       readEnd,
+		done:       make(chan struct{}),
+		outputDone: outputDone,
 	}
 
 	s.watch()
@@ -821,7 +823,35 @@ func TestSessionWatchLeavesOutputOpenForDrain(t *testing.T) {
 	buf := make([]byte, len("final output"))
 	_, err = readEnd.Read(buf)
 	require.NoError(err)
+	close(outputDone)
 	require.Equal("final output", string(buf))
+}
+
+func TestSessionWatchClosesPTYAfterPostExitDrainTimeout(t *testing.T) {
+	require := require.New(t)
+
+	readEnd, writeEnd, err := os.Pipe()
+	require.NoError(err)
+	defer readEnd.Close()
+	defer writeEnd.Close()
+
+	cmd := exec.Command("sh", "-c", "exit 0")
+	require.NoError(cmd.Start())
+	outputDone := make(chan struct{})
+	s := &session{
+		cmd:        cmd,
+		ptmx:       readEnd,
+		done:       make(chan struct{}),
+		outputDone: outputDone,
+	}
+
+	s.watch()
+	defer close(outputDone)
+
+	require.Eventually(func() bool {
+		_, err := readEnd.Stat()
+		return err != nil
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestManagerRemovesNaturallyExitedSession(t *testing.T) {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -797,6 +797,33 @@ func TestManagerStopKillsDescendantProcesses(t *testing.T) {
 		"descendant child should die with the session leader")
 }
 
+func TestSessionWatchLeavesOutputOpenForDrain(t *testing.T) {
+	require := require.New(t)
+
+	readEnd, writeEnd, err := os.Pipe()
+	require.NoError(err)
+	defer writeEnd.Close()
+	defer readEnd.Close()
+
+	_, err = writeEnd.WriteString("final output")
+	require.NoError(err)
+
+	cmd := exec.Command("sh", "-c", "exit 0")
+	require.NoError(cmd.Start())
+	s := &session{
+		cmd:  cmd,
+		ptmx: readEnd,
+		done: make(chan struct{}),
+	}
+
+	s.watch()
+
+	buf := make([]byte, len("final output"))
+	_, err = readEnd.Read(buf)
+	require.NoError(err)
+	require.Equal("final output", string(buf))
+}
+
 func TestManagerRemovesNaturallyExitedSession(t *testing.T) {
 	requirePTYAvailable(t)
 	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -13,6 +13,7 @@
     localDateLabel,
     parseAPITimestamp,
   } from "../utils/time.js";
+  import Chip from "./shared/Chip.svelte";
 
   const { activity, settings, sync, grouping } = getStores();
   const navigate = getNavigate();
@@ -171,6 +172,26 @@
     return item.item_type === "pr" ? "badge-pr" : "badge-issue";
   }
 
+  function kindChipClass(item: ActivityItem): string {
+    const legacyClass = badgeClass(item);
+    const toneClass =
+      legacyClass === "badge-pr" ? "chip--blue"
+      : legacyClass === "badge-closed" ? "chip--red"
+      : "chip--purple";
+    return `badge ${legacyClass} ${toneClass}`;
+  }
+
+  function itemTypeChipClass(itemType: string): string {
+    return itemType === "pr"
+      ? "badge badge-pr chip--blue"
+      : "badge badge-issue chip--purple";
+  }
+
+  function stateChipClass(state: string): string {
+    const toneClass = state === "merged" ? "chip--purple" : "chip--red";
+    return `state-badge state-${state} ${toneClass}`;
+  }
+
   function stateLabel(item: ActivityItem): string | null {
     if (item.item_state === "merged") return "Merged";
     if (item.item_state === "closed") return "Closed";
@@ -303,6 +324,16 @@
     }
   }
 
+  function eventChipClass(type: string): string {
+    const toneClass =
+      type === "comment" ? "chip--amber"
+      : type === "review" ? "chip--green"
+      : type === "commit" ? "chip--teal"
+      : type === "force_push" ? "chip--red"
+      : "chip--muted";
+    return `evt-label ${eventClass(type)} ${toneClass}`;
+  }
+
   function relativeTime(iso: string): string {
     const diff = Date.now() - parseAPITimestamp(iso).getTime();
     const mins = Math.floor(diff / 60000);
@@ -429,14 +460,21 @@
                 type="button"
               >
                 <span class="compact-row-top">
-                  <span class="badge {row.representative.item_type === 'pr' ? 'badge-pr' : 'badge-issue'}">{row.representative.item_type === "pr" ? "PR" : "Issue"}</span>
+                  <Chip
+                    size="sm"
+                    class={itemTypeChipClass(row.representative.item_type)}
+                  >{row.representative.item_type === "pr" ? "PR" : "Issue"}</Chip>
                   <span class="item-number">#{row.representative.item_number}</span>
                   <span class="compact-time">{relativeTime(row.latest)}</span>
                 </span>
                 <span class="compact-title">{row.representative.item_title}</span>
                 <span class="compact-meta">
                   <span>{row.representative.repo_owner}/{row.representative.repo_name}</span>
-                  <span class="evt-label evt-commit">{row.count} commits</span>
+                  <Chip
+                    size="sm"
+                    uppercase={false}
+                    class="evt-label evt-commit chip--teal"
+                  >{row.count} commits</Chip>
                   <span>{row.author}</span>
                 </span>
               </button>
@@ -448,17 +486,21 @@
                 type="button"
               >
                 <span class="compact-row-top">
-                  <span class="badge {badgeClass(row)}">{itemTypeLabel(row)}</span>
+                  <Chip size="sm" class={kindChipClass(row)}>{itemTypeLabel(row)}</Chip>
                   <span class="item-number">#{row.item_number}</span>
                   {#if stateLabel(row)}
-                    <span class="state-badge state-{row.item_state}">{stateLabel(row)}</span>
+                    <Chip size="sm" class={stateChipClass(row.item_state)}>{stateLabel(row)}</Chip>
                   {/if}
                   <span class="compact-time">{relativeTime(row.created_at)}</span>
                 </span>
                 <span class="compact-title">{row.item_title}</span>
                 <span class="compact-meta">
                   <span>{row.repo_owner}/{row.repo_name}</span>
-                  <span class="evt-label {eventClass(row.activity_type)}">{eventLabel(row)}</span>
+                  <Chip
+                    size="sm"
+                    uppercase={false}
+                    class={eventChipClass(row.activity_type)}
+                  >{eventLabel(row)}</Chip>
                   <span>{row.author}</span>
                 </span>
               </button>
@@ -483,10 +525,17 @@
               {#if isCollapsedActivityRow(row)}
                 <tr class="activity-row collapsed-row" onclick={() => handleRowClick(row.representative)}>
                   <td class="col-kind">
-                    <span class="badge {row.representative.item_type === 'pr' ? 'badge-pr' : 'badge-issue'}">{row.representative.item_type === "pr" ? "PR" : "Issue"}</span>
+                    <Chip
+                      size="sm"
+                      class={itemTypeChipClass(row.representative.item_type)}
+                    >{row.representative.item_type === "pr" ? "PR" : "Issue"}</Chip>
                   </td>
                   <td class="col-event">
-                    <span class="evt-label evt-commit">{row.count} commits</span>
+                    <Chip
+                      size="sm"
+                      uppercase={false}
+                      class="evt-label evt-commit chip--teal"
+                    >{row.count} commits</Chip>
                   </td>
                   <td class="col-repo">{row.representative.repo_owner}/{row.representative.repo_name}</td>
                   <td class="col-item">
@@ -506,13 +555,17 @@
               {:else}
                 <tr class="activity-row" onclick={() => handleRowClick(row)}>
                   <td class="col-kind">
-                    <span class="badge {badgeClass(row)}">{itemTypeLabel(row)}</span>
+                    <Chip size="sm" class={kindChipClass(row)}>{itemTypeLabel(row)}</Chip>
                     {#if stateLabel(row)}
-                      <span class="state-badge state-{row.item_state}">{stateLabel(row)}</span>
+                      <Chip size="sm" class={stateChipClass(row.item_state)}>{stateLabel(row)}</Chip>
                     {/if}
                   </td>
                   <td class="col-event">
-                    <span class="evt-label {eventClass(row.activity_type)}">{eventLabel(row)}</span>
+                    <Chip
+                      size="sm"
+                      uppercase={false}
+                      class={eventChipClass(row.activity_type)}
+                    >{eventLabel(row)}</Chip>
                   </td>
                   <td class="col-repo">{row.repo_owner}/{row.repo_name}</td>
                   <td class="col-item">
@@ -768,63 +821,6 @@
   .collapsed-row {
     background: var(--bg-inset);
   }
-
-  .badge {
-    display: inline-block;
-    padding: 1px 5px;
-    border-radius: 3px;
-    font-size: 10px;
-    font-weight: 600;
-    white-space: nowrap;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-  }
-
-  .badge-pr {
-    background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-    color: var(--accent-blue);
-  }
-  .badge-issue {
-    background: color-mix(in srgb, var(--accent-purple) 15%, transparent);
-    color: var(--accent-purple);
-  }
-  .badge-merged {
-    background: color-mix(in srgb, var(--accent-purple) 15%, transparent);
-    color: var(--accent-purple);
-  }
-  .badge-closed {
-    background: color-mix(in srgb, var(--accent-red) 15%, transparent);
-    color: var(--accent-red);
-  }
-
-  .state-badge {
-    display: inline-block;
-    padding: 1px 4px;
-    border-radius: 3px;
-    font-size: 9px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    margin-left: 3px;
-  }
-  .state-merged {
-    background: color-mix(in srgb, var(--accent-purple) 20%, transparent);
-    color: var(--accent-purple);
-  }
-  .state-closed {
-    background: color-mix(in srgb, var(--accent-red) 15%, transparent);
-    color: var(--accent-red);
-  }
-
-  .evt-label {
-    font-size: 12px;
-    color: var(--text-secondary);
-  }
-
-  .evt-label.evt-comment { color: var(--accent-amber); }
-  .evt-label.evt-review { color: var(--accent-green); }
-  .evt-label.evt-commit { color: var(--accent-teal); }
-  .evt-label.evt-force-push { color: var(--accent-red); }
 
   .col-repo {
     color: var(--text-muted);

--- a/packages/ui/src/components/shared/Chip.svelte
+++ b/packages/ui/src/components/shared/Chip.svelte
@@ -139,6 +139,11 @@
     color: var(--accent-amber);
   }
 
+  .chip--blue {
+    background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+    color: var(--accent-blue);
+  }
+
   .chip--purple,
   .chip--closed {
     background: color-mix(in srgb, var(--accent-purple) 15%, transparent);


### PR DESCRIPTION
- Replacement for #218, recreated against main instead of critique-interface.
- Migrate activity feed item, state, and event markers onto the shared Chip primitive.
- Add a blue Chip tone and document semantic Chip tone usage in the UI design-system guide.

Validation:
- bunx @sveltejs/mcp@0.1.22 svelte-autofixer packages/ui/src/components/ActivityFeed.svelte --svelte-version 5
- bun run --cwd packages/ui typecheck
- bun run --cwd frontend typecheck
- git diff --check origin/main...HEAD

Note: root-level `bunx vitest run packages/ui/src/components/ActivityFeed.test.ts` was attempted but hit the repo's unconfigured root Vitest/Svelte transform path before collecting tests.