### PR TITLE
Standardize left sidebar collapse controls

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -68,6 +68,18 @@ Intent:
 
 If a new repeated button treatment is needed, extend `ActionButton` rather than creating another local button pattern.
 
+### LeftSidebarToggle
+
+Use `LeftSidebarToggle` for collapse and expand controls on left-side navigation rails.
+
+Intent:
+
+- one shared icon, size, hover, and accessible label contract for left-sidebar collapse affordances
+- consistent expanded/collapsed direction across PR, issue, activity, and workspace sidebars
+- avoid one-off SVG buttons or local `.sidebar-toggle` styling in each rail
+
+Use it inside left sidebar headers and collapsed strips. Pass a specific label such as `Workspaces sidebar` when the generic `sidebar` label would be ambiguous.
+
 ### SelectDropdown
 
 Use `SelectDropdown` for single-value selection controls in the UI.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -572,7 +572,14 @@
         <!-- Single mount across /workspaces and /terminal/{id};
              WorkspaceTerminalView reacts to workspaceId changes
              internally so the page doesn't flash on navigation. -->
-        <WorkspaceTerminalView workspaceId={wsId} />
+        <WorkspaceTerminalView
+          workspaceId={wsId}
+          isSidebarCollapsed={isSidebarCollapsed()}
+          sidebarWidth={getSidebarWidth()}
+          onSidebarResize={handleSidebarResize}
+          isSidebarToggleEnabled={isSidebarToggleEnabled()}
+          onToggleSidebar={toggleSidebar}
+        />
       {/if}
     </main>
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -320,19 +320,3 @@ a.item-ref {
 a.item-ref:hover {
   text-decoration: underline;
 }
-
-/* Sidebar collapse toggle (used in PullList, IssueList, AppHeader) */
-.sidebar-toggle {
-  width: 26px;
-  height: 26px;
-  border-radius: var(--radius-sm);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-.sidebar-toggle:hover {
-  background: var(--bg-surface-hover);
-  color: var(--text-primary);
-}

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -27,7 +27,9 @@
 
   const hasSidebarStrip = $derived(
     getPage() === "issues"
-    || (getPage() === "pulls" && getView() === "list"),
+    || (getPage() === "pulls" && getView() === "list")
+    || getPage() === "workspaces"
+    || getPage() === "terminal",
   );
 
   const stores = getStores();

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -9,6 +9,7 @@
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
   import { client } from "../../api/runtime.js";
+  import { LeftSidebarToggle } from "@middleman/ui";
 
   interface Workspace {
     id: string;
@@ -46,9 +47,16 @@
   interface Props {
     selectedId: string;
     onOpenItemSidebar?: (workspaceId: string, tab: "pr" | "issue") => void;
+    isSidebarToggleEnabled?: boolean;
+    onCollapseSidebar?: (() => void) | undefined;
   }
 
-  const { selectedId, onOpenItemSidebar }: Props = $props();
+  const {
+    selectedId,
+    onOpenItemSidebar,
+    isSidebarToggleEnabled = false,
+    onCollapseSidebar,
+  }: Props = $props();
 
   const basePath = (
     window.__BASE_PATH__ ?? "/"
@@ -190,6 +198,14 @@
   <div class="sidebar-header">
     <span class="sidebar-header-label">Workspaces</span>
     <span class="sidebar-header-count">{workspaces.length}</span>
+    {#if isSidebarToggleEnabled && onCollapseSidebar}
+      <LeftSidebarToggle
+        state="expanded"
+        label="Workspaces sidebar"
+        onclick={onCollapseSidebar}
+        class="left-sidebar-toggle--push left-sidebar-toggle--compact"
+      />
+    {/if}
   </div>
   <div class="sidebar-list">
     {#each [...grouped] as [repoKey, items] (repoKey)}
@@ -217,7 +233,6 @@
           {@const ahead = ws.commits_ahead ?? 0}
           {@const behind = ws.commits_behind ?? 0}
           {@const showPush = ahead > 0 || behind > 0}
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
           <div
             class={["ws-row", { selected: ws.id === selectedId }]}
             onclick={(e) => {
@@ -355,10 +370,10 @@
 
   .sidebar-header {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 6px;
     height: 28px;
-    padding: 0 12px;
+    padding: 0 4px 0 12px;
     border-bottom: 1px solid var(--border-muted);
     flex-shrink: 0;
   }

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -262,6 +262,19 @@
     }
   }
 
+  function openItemSidebar(targetId: string, tab: SidebarTab): void {
+    // Cross-workspace click: navigate first, then ensure
+    // the sidebar is open for the target tab.
+    if (targetId !== workspaceId) {
+      sidebarTab = tab;
+      sidebarOpen = true;
+      navigate(`/terminal/${targetId}`);
+      return;
+    }
+
+    handleSegmentClick(tab);
+  }
+
   function toggleRightSidebar(): void {
     sidebarOpen = !sidebarOpen;
   }
@@ -881,24 +894,7 @@
         selectedId={workspaceId}
         {isSidebarToggleEnabled}
         onCollapseSidebar={onToggleSidebar}
-        onOpenItemSidebar={(targetId, tab) => {
-          // Cross-workspace click: navigate first, then ensure
-          // the sidebar is open for the target tab.
-          if (targetId !== workspaceId) {
-            sidebarTab = tab;
-            sidebarOpen = true;
-            navigate(`/terminal/${targetId}`);
-            return;
-          }
-          // Same-workspace click: toggle, mirroring the seg-btn
-          // behavior in handleSegmentClick.
-          if (sidebarOpen && sidebarTab === tab) {
-            sidebarOpen = false;
-            return;
-          }
-          sidebarTab = tab;
-          sidebarOpen = true;
-        }}
+        onOpenItemSidebar={openItemSidebar}
       />
     {/snippet}
     <div class="terminal-main">

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -54,9 +54,23 @@
     createdAt: string;
   }
 
+  interface Props {
+    workspaceId: string;
+    isSidebarCollapsed?: boolean;
+    sidebarWidth?: number;
+    onSidebarResize?: (width: number) => void;
+    isSidebarToggleEnabled?: boolean;
+    onToggleSidebar?: () => void;
+  }
+
   const {
     workspaceId,
-  }: { workspaceId: string } = $props();
+    isSidebarCollapsed = false,
+    sidebarWidth: externalWorkspaceListWidth = undefined,
+    onSidebarResize = undefined,
+    isSidebarToggleEnabled = false,
+    onToggleSidebar = undefined,
+  }: Props = $props();
 
   const basePath = (
     window.__BASE_PATH__ ?? "/"
@@ -154,6 +168,11 @@
   let sidebarOpen = $state(loadSidebarOpen());
   let sidebarWidth = $state(loadSidebarWidth());
   let workspaceListWidth = $state(loadWorkspaceListWidth());
+  const currentWorkspaceListWidth = $derived(
+    clampWorkspaceListWidth(
+      externalWorkspaceListWidth ?? workspaceListWidth,
+    ),
+  );
 
   // Runtime is only "live" when both the runtime fetch and the
   // workspace fetch resolve for the current route. Without the
@@ -227,6 +246,7 @@
     );
   });
   $effect(() => {
+    if (externalWorkspaceListWidth !== undefined) return;
     localStorage.setItem(
       WORKSPACE_LIST_WIDTH_KEY,
       String(workspaceListWidth),
@@ -242,8 +262,22 @@
     }
   }
 
-  function toggleSidebar(): void {
+  function toggleRightSidebar(): void {
     sidebarOpen = !sidebarOpen;
+  }
+
+  function handleWorkspaceListResize(width: number): void {
+    const clamped = clampWorkspaceListWidth(width);
+    if (onSidebarResize) {
+      onSidebarResize(clamped);
+    } else {
+      workspaceListWidth = clamped;
+    }
+    requestAnimationFrame(() => {
+      if (containerEl) {
+        clampRightSidebarWidth(containerEl.clientWidth);
+      }
+    });
   }
 
   let containerEl = $state<HTMLElement | null>(null);
@@ -324,7 +358,7 @@
         !e.defaultPrevented
       ) {
         e.preventDefault();
-        toggleSidebar();
+        toggleRightSidebar();
       }
     }
     window.addEventListener("keydown", onKeydown);
@@ -833,22 +867,20 @@
 
 <div class="terminal-view">
   <CollapsibleResizableSidebar
-    sidebarWidth={workspaceListWidth}
+    isCollapsed={isSidebarCollapsed}
+    sidebarWidth={currentWorkspaceListWidth}
     minSidebarWidth={MIN_WORKSPACE_LIST_WIDTH}
     maxSidebarWidth={MAX_WORKSPACE_LIST_WIDTH}
-    onSidebarResize={(width) => {
-      workspaceListWidth = clampWorkspaceListWidth(width);
-      requestAnimationFrame(() => {
-        if (containerEl) {
-          clampRightSidebarWidth(containerEl.clientWidth);
-        }
-      });
-    }}
+    onSidebarResize={handleWorkspaceListResize}
+    showCollapsedStrip={isSidebarToggleEnabled}
+    onExpand={onToggleSidebar}
     mainOverflow="hidden"
   >
     {#snippet sidebar()}
       <WorkspaceListSidebar
         selectedId={workspaceId}
+        {isSidebarToggleEnabled}
+        onCollapseSidebar={onToggleSidebar}
         onOpenItemSidebar={(targetId, tab) => {
           // Cross-workspace click: navigate first, then ensure
           // the sidebar is open for the target tab.

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -393,4 +393,24 @@ describe("WorkspaceTerminalView", () => {
 
     expect(sockets).toHaveLength(1);
   });
+
+  it("shows a workspace sidebar collapse button", async () => {
+    const onToggleSidebar = vi.fn();
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        isSidebarToggleEnabled: true,
+        onToggleSidebar,
+      },
+    });
+
+    const collapseButton = await screen.findByRole("button", {
+      name: "Collapse Workspaces sidebar",
+    });
+
+    await fireEvent.click(collapseButton);
+
+    expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -72,11 +72,15 @@ test.describe("collapsible sidebar", () => {
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
 
     // Click the collapse button inside the sidebar.
-    await sidebar.locator(".sidebar-toggle").click();
+    await sidebar
+      .getByRole("button", { name: "Collapse sidebar" })
+      .click();
     await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
     // The expand button should now appear in the collapsed strip.
-    const expandBtn = sidebar.locator(".expand-btn");
+    const expandBtn = sidebar.getByRole("button", {
+      name: "Expand sidebar",
+    });
     await expect(expandBtn).toBeVisible();
 
     // Click the expand button to restore the sidebar.
@@ -92,10 +96,14 @@ test.describe("collapsible sidebar", () => {
     await expect(sidebar).toBeVisible();
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
 
-    await sidebar.locator(".sidebar-toggle").click();
+    await sidebar
+      .getByRole("button", { name: "Collapse sidebar" })
+      .click();
     await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
-    const expandBtn = sidebar.locator(".expand-btn");
+    const expandBtn = sidebar.getByRole("button", {
+      name: "Expand sidebar",
+    });
     await expect(expandBtn).toBeVisible();
 
     await expandBtn.click();
@@ -108,7 +116,9 @@ test.describe("collapsible sidebar", () => {
 
     // Collapse sidebar on list view.
     const sidebar = page.locator(".sidebar");
-    await sidebar.locator(".sidebar-toggle").click();
+    await sidebar
+      .getByRole("button", { name: "Collapse sidebar" })
+      .click();
     await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
     // Navigate to board view (no sidebar strip).

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 async function waitForPRList(page: Page): Promise<void> {
   await page.locator(".pull-item").first()
@@ -10,15 +10,23 @@ async function waitForIssueList(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
-async function sidebarWidth(sidebar: ReturnType<Page["locator"]>): Promise<number> {
+async function sidebarWidth(sidebar: Locator): Promise<number> {
   return Math.round(await sidebar.evaluate((node) =>
     node.getBoundingClientRect().width
   ));
 }
 
+function collapseToggle(sidebar: Locator): Locator {
+  return sidebar.getByRole("button", { name: "Collapse sidebar" });
+}
+
+function expandToggle(sidebar: Locator): Locator {
+  return sidebar.getByRole("button", { name: "Expand sidebar" });
+}
+
 async function dragResizeHandle(
   page: Page,
-  handle: ReturnType<Page["locator"]>,
+  handle: Locator,
   deltaX: number,
 ): Promise<void> {
   const box = await handle.boundingBox();
@@ -71,19 +79,12 @@ test.describe("collapsible sidebar", () => {
     await expect(sidebar).toBeVisible();
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
 
-    // Click the collapse button inside the sidebar.
-    await sidebar
-      .getByRole("button", { name: "Collapse sidebar" })
-      .click();
+    await collapseToggle(sidebar).click();
     await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
-    // The expand button should now appear in the collapsed strip.
-    const expandBtn = sidebar.getByRole("button", {
-      name: "Expand sidebar",
-    });
+    const expandBtn = expandToggle(sidebar);
     await expect(expandBtn).toBeVisible();
 
-    // Click the expand button to restore the sidebar.
     await expandBtn.click();
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
   });
@@ -96,14 +97,10 @@ test.describe("collapsible sidebar", () => {
     await expect(sidebar).toBeVisible();
     await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
 
-    await sidebar
-      .getByRole("button", { name: "Collapse sidebar" })
-      .click();
+    await collapseToggle(sidebar).click();
     await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
-    const expandBtn = sidebar.getByRole("button", {
-      name: "Expand sidebar",
-    });
+    const expandBtn = expandToggle(sidebar);
     await expect(expandBtn).toBeVisible();
 
     await expandBtn.click();
@@ -114,11 +111,8 @@ test.describe("collapsible sidebar", () => {
     await page.goto("/pulls");
     await waitForPRList(page);
 
-    // Collapse sidebar on list view.
     const sidebar = page.locator(".sidebar");
-    await sidebar
-      .getByRole("button", { name: "Collapse sidebar" })
-      .click();
+    await collapseToggle(sidebar).click();
     await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
     // Navigate to board view (no sidebar strip).

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -13,6 +13,23 @@ test("workspaces route renders the terminal workspace list shell", async ({ page
   ).toBeVisible();
 });
 
+test("workspaces sidebar collapses and expands through the shared control", async ({ page }) => {
+  await page.goto("/workspaces");
+
+  const sidebar = page.locator(".sidebar").first();
+  await expect(sidebar).toBeVisible();
+
+  await sidebar
+    .getByRole("button", { name: "Collapse Workspaces sidebar" })
+    .click();
+  await expect(sidebar).toHaveClass(/sidebar--collapsed/);
+
+  await sidebar
+    .getByRole("button", { name: "Expand sidebar" })
+    .click();
+  await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
+});
+
 test("AppHeader workspaces tab navigates to /workspaces", async ({ page }) => {
   await page.goto("/pulls");
   await page

--- a/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
+++ b/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
+  import LeftSidebarToggle from "./LeftSidebarToggle.svelte";
 
   interface Props {
     children?: Snippet | undefined;
@@ -93,15 +94,12 @@
     {/if}
   {:else if !hideSidebar && showCollapsedStrip}
     <aside class="sidebar sidebar--collapsed">
-      <button class="expand-btn" onclick={onExpand} title="Expand sidebar">
-        <svg width="14" height="14" viewBox="0 0 16 16"
-          fill="none" stroke="currentColor" stroke-width="1.5">
-          <rect x="1" y="1" width="14" height="14" rx="2" />
-          <line x1="6" y1="1" x2="6" y2="15" />
-          <polyline points="8,6 10,8 8,10"
-            stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
+      <LeftSidebarToggle
+        state="collapsed"
+        label="sidebar"
+        onclick={onExpand}
+        class="left-sidebar-toggle--compact"
+      />
     </aside>
   {/if}
 
@@ -143,23 +141,6 @@
     width: 28px;
     align-items: center;
     padding-top: 6px;
-  }
-
-  .expand-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 22px;
-    height: 22px;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: color 0.1s, background 0.1s;
-  }
-
-  .expand-btn:hover {
-    color: var(--text-primary);
-    background: var(--bg-surface-hover);
   }
 
   .resize-handle {

--- a/packages/ui/src/components/shared/LeftSidebarToggle.svelte
+++ b/packages/ui/src/components/shared/LeftSidebarToggle.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import PanelLeftCloseIcon from "@lucide/svelte/icons/panel-left-close";
+  import PanelLeftOpenIcon from "@lucide/svelte/icons/panel-left-open";
+  import type { ClassValue } from "svelte/elements";
+
+  type SidebarToggleState = "expanded" | "collapsed";
+
+  interface Props {
+    state?: SidebarToggleState;
+    label?: string;
+    onclick?: ((event: MouseEvent) => void) | undefined;
+    class?: ClassValue;
+  }
+
+  let {
+    state = "expanded",
+    label = "sidebar",
+    onclick,
+    class: className = undefined,
+  }: Props = $props();
+
+  const action = $derived(
+    state === "collapsed" ? "Expand" : "Collapse",
+  );
+  const accessibleLabel = $derived(`${action} ${label}`);
+</script>
+
+<button
+  class={[
+    "left-sidebar-toggle",
+    `left-sidebar-toggle--${state}`,
+    className,
+  ]}
+  {onclick}
+  title={accessibleLabel}
+  aria-label={accessibleLabel}
+  type="button"
+>
+  {#if state === "collapsed"}
+    <PanelLeftOpenIcon
+      size="14"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    />
+  {:else}
+    <PanelLeftCloseIcon
+      size="14"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    />
+  {/if}
+</button>
+
+<style>
+  .left-sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .left-sidebar-toggle:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+  }
+
+  .left-sidebar-toggle--compact {
+    width: 22px;
+    height: 22px;
+  }
+
+  .left-sidebar-toggle--push {
+    margin-left: auto;
+  }
+</style>

--- a/packages/ui/src/components/shared/LeftSidebarToggle.svelte
+++ b/packages/ui/src/components/shared/LeftSidebarToggle.svelte
@@ -19,6 +19,9 @@
     class: className = undefined,
   }: Props = $props();
 
+  const ToggleIcon = $derived(
+    state === "collapsed" ? PanelLeftOpenIcon : PanelLeftCloseIcon,
+  );
   const action = $derived(
     state === "collapsed" ? "Expand" : "Collapse",
   );
@@ -36,19 +39,11 @@
   aria-label={accessibleLabel}
   type="button"
 >
-  {#if state === "collapsed"}
-    <PanelLeftOpenIcon
-      size="14"
-      strokeWidth="1.5"
-      aria-hidden="true"
-    />
-  {:else}
-    <PanelLeftCloseIcon
-      size="14"
-      strokeWidth="1.5"
-      aria-hidden="true"
-    />
-  {/if}
+  <ToggleIcon
+    size="14"
+    strokeWidth="1.5"
+    aria-hidden="true"
+  />
 </button>
 
 <style>

--- a/packages/ui/src/components/shared/LeftSidebarToggle.test.ts
+++ b/packages/ui/src/components/shared/LeftSidebarToggle.test.ts
@@ -1,0 +1,56 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LeftSidebarToggle from "./LeftSidebarToggle.svelte";
+
+describe("LeftSidebarToggle", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the expanded-state collapse control", async () => {
+    const onclick = vi.fn();
+
+    render(LeftSidebarToggle, {
+      props: {
+        state: "expanded",
+        label: "Workspaces sidebar",
+        onclick,
+      },
+    });
+
+    const button = screen.getByRole("button", {
+      name: "Collapse Workspaces sidebar",
+    });
+    expect(button.getAttribute("title")).toBe(
+      "Collapse Workspaces sidebar",
+    );
+    expect(button.classList.contains("left-sidebar-toggle")).toBe(true);
+
+    await fireEvent.click(button);
+
+    expect(onclick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the collapsed-state expand control", () => {
+    render(LeftSidebarToggle, {
+      props: {
+        state: "collapsed",
+        label: "sidebar",
+        class: "left-sidebar-toggle--push",
+      },
+    });
+
+    const button = screen.getByRole("button", {
+      name: "Expand sidebar",
+    });
+    expect(button.getAttribute("title")).toBe("Expand sidebar");
+    expect(
+      button.classList.contains("left-sidebar-toggle--push"),
+    ).toBe(true);
+  });
+});

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -2,6 +2,7 @@
   import { getStores, getNavigate, getSidebar } from "../../context.js";
   import IssueItem from "./IssueItem.svelte";
   import Chip from "../shared/Chip.svelte";
+  import LeftSidebarToggle from "../shared/LeftSidebarToggle.svelte";
 
   const { issues, sync, grouping, collapsedRepos, settings } = getStores();
   const navigate = getNavigate();
@@ -92,15 +93,12 @@
       >All</button>
     </div>
     {#if isSidebarToggleEnabled()}
-      <button class="sidebar-toggle" onclick={toggleSidebar} title="Collapse sidebar">
-        <svg width="14" height="14" viewBox="0 0 16 16"
-          fill="none" stroke="currentColor" stroke-width="1.5">
-          <rect x="1" y="1" width="14" height="14" rx="2" />
-          <line x1="6" y1="1" x2="6" y2="15" />
-          <polyline points="10,6 8,8 10,10"
-            stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
+      <LeftSidebarToggle
+        state="expanded"
+        label="sidebar"
+        onclick={toggleSidebar}
+        class="left-sidebar-toggle--push"
+      />
     {/if}
   </div>
   <div class="search-bar">
@@ -226,25 +224,6 @@
     border-bottom: 1px solid var(--border-muted);
     flex-shrink: 0;
     background: var(--bg-surface);
-  }
-
-  .sidebar-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    margin-left: auto;
-    flex-shrink: 0;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: color 0.1s, background 0.1s;
-  }
-
-  .sidebar-toggle:hover {
-    color: var(--text-primary);
-    background: var(--bg-surface-hover);
   }
 
   .search-bar {

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -4,6 +4,7 @@
   import DiffSidebar from "../diff/DiffSidebar.svelte";
   import PullItem from "./PullItem.svelte";
   import Chip from "../shared/Chip.svelte";
+  import LeftSidebarToggle from "../shared/LeftSidebarToggle.svelte";
 
   const { pulls, sync, grouping, collapsedRepos, settings } = getStores();
   const navigate = getNavigate();
@@ -156,15 +157,12 @@
       >All</button>
     </div>
     {#if isSidebarToggleEnabled()}
-      <button class="sidebar-toggle" onclick={toggleSidebar} title="Collapse sidebar">
-        <svg width="14" height="14" viewBox="0 0 16 16"
-          fill="none" stroke="currentColor" stroke-width="1.5">
-          <rect x="1" y="1" width="14" height="14" rx="2" />
-          <line x1="6" y1="1" x2="6" y2="15" />
-          <polyline points="10,6 8,8 10,10"
-            stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
+      <LeftSidebarToggle
+        state="expanded"
+        label="sidebar"
+        onclick={toggleSidebar}
+        class="left-sidebar-toggle--push"
+      />
     {/if}
   </div>
   <div class="search-bar">
@@ -338,25 +336,6 @@
     border-bottom: 1px solid var(--border-muted);
     flex-shrink: 0;
     background: var(--bg-surface);
-  }
-
-  .sidebar-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    margin-left: auto;
-    flex-shrink: 0;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: color 0.1s, background 0.1s;
-  }
-
-  .sidebar-toggle:hover {
-    color: var(--text-primary);
-    background: var(--bg-surface-hover);
   }
 
   .search-bar {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -128,6 +128,9 @@ export {
   default as CollapsibleResizableSidebar,
 } from "./components/shared/CollapsibleResizableSidebar.svelte";
 export {
+  default as LeftSidebarToggle,
+} from "./components/shared/LeftSidebarToggle.svelte";
+export {
   default as FilterDropdown,
 } from "./components/shared/FilterDropdown.svelte";
 export {

--- a/packages/ui/src/views/ActivityFeedView.svelte
+++ b/packages/ui/src/views/ActivityFeedView.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import PanelLeftCloseIcon from "@lucide/svelte/icons/panel-left-close";
-  import PanelLeftOpenIcon from "@lucide/svelte/icons/panel-left-open";
   import { onDestroy } from "svelte";
   import type { ActivityItem } from "../api/types.js";
   import ActivityFeed
     from "../components/ActivityFeed.svelte";
+  import LeftSidebarToggle
+    from "../components/shared/LeftSidebarToggle.svelte";
   import PRListView from "./PRListView.svelte";
   import IssueListView from "./IssueListView.svelte";
 
@@ -181,34 +181,22 @@
   >
     {#if activeDrawer && activityPaneCollapsed}
       <div class="activity-collapsed-strip">
-        <button
-          class="activity-sidebar-toggle"
+        <LeftSidebarToggle
+          state="collapsed"
+          label="Activity sidebar"
           onclick={expandActivityPane}
-          title="Expand Activity sidebar"
-          type="button"
-        >
-          <PanelLeftOpenIcon
-            size="14"
-            strokeWidth="1.5"
-            aria-hidden="true"
-          />
-        </button>
+          class="left-sidebar-toggle--compact"
+        />
       </div>
     {:else if activeDrawer}
       <div class="activity-rail-header">
         <span>Activity</span>
-        <button
-          class="activity-sidebar-toggle"
+        <LeftSidebarToggle
+          state="expanded"
+          label="Activity sidebar"
           onclick={collapseActivityPane}
-          title="Collapse Activity sidebar"
-          type="button"
-        >
-          <PanelLeftCloseIcon
-            size="14"
-            strokeWidth="1.5"
-            aria-hidden="true"
-          />
-        </button>
+          class="left-sidebar-toggle--compact"
+        />
       </div>
     {/if}
     <div class="activity-feed-wrap">
@@ -340,21 +328,6 @@
     justify-content: center;
     padding-top: 6px;
     background: var(--bg-surface);
-  }
-
-  .activity-sidebar-toggle {
-    width: 22px;
-    height: 22px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-  }
-
-  .activity-sidebar-toggle:hover {
-    color: var(--text-primary);
-    background: var(--bg-surface-hover);
   }
 
   .activity-detail-header span {

--- a/skills/code-simplifier/SKILL.md
+++ b/skills/code-simplifier/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: code-simplification
+name: code-simplifier
 description: Simplifies code for clarity. Use when refactoring code for clarity without changing behavior. Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity.
 ---
 


### PR DESCRIPTION
- Add a shared left-sidebar collapse/expand control for PR, issue, activity, and workspace rails.
- Wire the workspaces rail into the same collapse state and collapsed strip behavior as the other left sidebars.
- Update sidebar regression coverage to use the shared accessible control contract.