### PR TITLE
Refactor Huma response wrappers

### DIFF
--- a/internal/server/health_routes.go
+++ b/internal/server/health_routes.go
@@ -6,9 +6,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
-type healthOutput struct {
-	Body healthResponse
-}
+type healthOutput = bodyOutput[healthResponse]
 
 type healthResponse struct {
 	Status string `json:"status"`

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -30,9 +30,7 @@ type listPullsInput struct {
 	Offset  int    `query:"offset"`
 }
 
-type listPullsOutput struct {
-	Body []mergeRequestResponse
-}
+type listPullsOutput = bodyOutput[[]mergeRequestResponse]
 
 type repoNumberInput struct {
 	Owner  string `path:"owner"`
@@ -40,13 +38,9 @@ type repoNumberInput struct {
 	Number int    `path:"number"`
 }
 
-type getPullOutput struct {
-	Body mergeRequestDetailResponse
-}
+type getPullOutput = bodyOutput[mergeRequestDetailResponse]
 
-type getMRImportMetadataOutput struct {
-	Body mrImportMetadataResponse
-}
+type getMRImportMetadataOutput = bodyOutput[mrImportMetadataResponse]
 
 type setKanbanStateInput struct {
 	Owner  string `path:"owner"`
@@ -57,9 +51,7 @@ type setKanbanStateInput struct {
 	}
 }
 
-type statusOnlyOutput struct {
-	Status int `status:"200"`
-}
+type statusOnlyOutput = okStatusOutput
 
 type postCommentInput struct {
 	Owner  string `path:"owner"`
@@ -70,10 +62,7 @@ type postCommentInput struct {
 	}
 }
 
-type postCommentOutput struct {
-	Status int `status:"201"`
-	Body   db.MREvent
-}
+type postCommentOutput = createdOutput[db.MREvent]
 
 type editCommentInput struct {
 	Owner     string `path:"owner"`
@@ -85,9 +74,7 @@ type editCommentInput struct {
 	}
 }
 
-type editCommentOutput struct {
-	Body db.MREvent
-}
+type editCommentOutput = bodyOutput[db.MREvent]
 
 type listIssuesInput struct {
 	Repo    string `query:"repo"`
@@ -98,9 +85,7 @@ type listIssuesInput struct {
 	Offset  int    `query:"offset"`
 }
 
-type listIssuesOutput struct {
-	Body []issueResponse
-}
+type listIssuesOutput = bodyOutput[[]issueResponse]
 
 type issueRepoNumberInput struct {
 	Owner        string `path:"owner"`
@@ -109,9 +94,7 @@ type issueRepoNumberInput struct {
 	PlatformHost string `query:"platform_host"`
 }
 
-type getIssueOutput struct {
-	Body issueDetailResponse
-}
+type getIssueOutput = bodyOutput[issueDetailResponse]
 
 type postIssueCommentInput struct {
 	Owner  string `path:"owner"`
@@ -123,10 +106,7 @@ type postIssueCommentInput struct {
 	}
 }
 
-type postIssueCommentOutput struct {
-	Status int `status:"201"`
-	Body   db.IssueEvent
-}
+type postIssueCommentOutput = createdOutput[db.IssueEvent]
 
 type editIssueCommentInput struct {
 	Owner     string `path:"owner"`
@@ -139,9 +119,7 @@ type editIssueCommentInput struct {
 	}
 }
 
-type editIssueCommentOutput struct {
-	Body db.IssueEvent
-}
+type editIssueCommentOutput = bodyOutput[db.IssueEvent]
 
 type createIssueInput struct {
 	Owner string `path:"owner"`
@@ -153,10 +131,7 @@ type createIssueInput struct {
 	}
 }
 
-type createIssueOutput struct {
-	Status int `status:"201"`
-	Body   issueResponse
-}
+type createIssueOutput = createdOutput[issueResponse]
 
 type starredInput struct {
 	Body starredRequest
@@ -167,9 +142,7 @@ type getRepoInput struct {
 	Name  string `path:"name"`
 }
 
-type getRepoOutput struct {
-	Body db.Repo
-}
+type getRepoOutput = bodyOutput[db.Repo]
 
 type commentAutocompleteInput struct {
 	Owner        string `path:"owner"`
@@ -180,9 +153,7 @@ type commentAutocompleteInput struct {
 	Limit        int    `query:"limit"`
 }
 
-type commentAutocompleteOutput struct {
-	Body commentAutocompleteResponse
-}
+type commentAutocompleteOutput = bodyOutput[commentAutocompleteResponse]
 
 type approvePRInput struct {
 	Owner  string `path:"owner"`
@@ -198,9 +169,7 @@ type actionStatusBody struct {
 	ApprovedCount int    `json:"approved_count,omitempty"`
 }
 
-type actionStatusOutput struct {
-	Body actionStatusBody
-}
+type actionStatusOutput = bodyOutput[actionStatusBody]
 
 type mergePRInput struct {
 	Owner  string `path:"owner"`
@@ -219,9 +188,7 @@ type mergePRBody struct {
 	Message string `json:"message"`
 }
 
-type mergePROutput struct {
-	Body mergePRBody
-}
+type mergePROutput = bodyOutput[mergePRBody]
 
 type editPRContentInput struct {
 	Owner  string `path:"owner"`
@@ -233,9 +200,7 @@ type editPRContentInput struct {
 	}
 }
 
-type editPRContentOutput struct {
-	Body mergeRequestDetailResponse
-}
+type editPRContentOutput = bodyOutput[mergeRequestDetailResponse]
 
 type githubStateInput struct {
 	Owner  string `path:"owner"`
@@ -247,55 +212,35 @@ type githubStateInput struct {
 	}
 }
 
-type githubStateOutput struct {
-	Body struct {
-		State string `json:"state"`
-	}
+type githubStateOutputBody struct {
+	State string `json:"state"`
 }
 
-type listReposOutput struct {
-	Body []db.Repo
-}
+type githubStateOutput = bodyOutput[githubStateOutputBody]
 
-type listRepoSummariesOutput struct {
-	Body []repoSummaryResponse
-}
+type listReposOutput = bodyOutput[[]db.Repo]
 
-type acceptedOutput struct {
-	Status int `status:"202"`
-}
+type listRepoSummariesOutput = bodyOutput[[]repoSummaryResponse]
 
-type syncPROutput struct {
-	Body mergeRequestDetailResponse
-}
+type acceptedOutput = acceptedStatusOutput
 
-type syncIssueOutput struct {
-	Body issueDetailResponse
-}
+type syncPROutput = bodyOutput[mergeRequestDetailResponse]
 
-type resolveItemOutput struct {
-	Body resolveItemResponse
-}
+type syncIssueOutput = bodyOutput[issueDetailResponse]
 
-type syncStatusOutput struct {
-	Body *ghclient.SyncStatus
-}
+type resolveItemOutput = bodyOutput[resolveItemResponse]
 
-type rateLimitsOutput struct {
-	Body rateLimitsResponse
-}
+type syncStatusOutput = bodyOutput[*ghclient.SyncStatus]
+
+type rateLimitsOutput = bodyOutput[rateLimitsResponse]
 
 type listStacksInput struct {
 	Repo string `query:"repo"`
 }
 
-type listStacksOutput struct {
-	Body []stackResponse
-}
+type listStacksOutput = bodyOutput[[]stackResponse]
 
-type getStackForPROutput struct {
-	Body stackContextResponse
-}
+type getStackForPROutput = bodyOutput[stackContextResponse]
 
 type createWorkspaceInput struct {
 	Body struct {
@@ -348,28 +293,19 @@ type deleteWorkspaceInput struct {
 	Force bool   `query:"force"`
 }
 
-type listWorkspacesOutput struct {
-	Body struct {
-		Workspaces []workspaceResponse `json:"workspaces"`
-	}
+type listWorkspacesOutputBody struct {
+	Workspaces []workspaceResponse `json:"workspaces"`
 }
 
-type getWorkspaceOutput struct {
-	Body workspaceResponse
-}
+type listWorkspacesOutput = bodyOutput[listWorkspacesOutputBody]
 
-type getWorkspaceRuntimeOutput struct {
-	Body workspaceRuntimeResponse
-}
+type getWorkspaceOutput = bodyOutput[workspaceResponse]
 
-type workspaceRuntimeSessionOutput struct {
-	Body localruntime.SessionInfo
-}
+type getWorkspaceRuntimeOutput = bodyOutput[workspaceRuntimeResponse]
 
-type createWorkspaceOutput struct {
-	Status int `status:"202"`
-	Body   workspaceResponse
-}
+type workspaceRuntimeSessionOutput = bodyOutput[localruntime.SessionInfo]
+
+type createWorkspaceOutput = acceptedBodyOutput[workspaceResponse]
 
 type listActivityInput struct {
 	Repo   string   `query:"repo"`
@@ -379,9 +315,7 @@ type listActivityInput struct {
 	Since  string   `query:"since"`
 }
 
-type listActivityOutput struct {
-	Body activityResponse
-}
+type listActivityOutput = bodyOutput[activityResponse]
 
 func apiConfig(basePath string) huma.Config {
 	config := huma.DefaultConfig("middleman API", "0.1.0")
@@ -2273,9 +2207,7 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 
 // --- Commits ---
 
-type getCommitsOutput struct {
-	Body commitsResponse
-}
+type getCommitsOutput = bodyOutput[commitsResponse]
 
 func (s *Server) getCommits(ctx context.Context, input *repoNumberInput) (*getCommitsOutput, error) {
 	if s.clones == nil {
@@ -2326,9 +2258,7 @@ type getDiffInput struct {
 	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
 }
 
-type getDiffOutput struct {
-	Body diffResponse
-}
+type getDiffOutput = bodyOutput[diffResponse]
 
 func (s *Server) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOutput, error) {
 	if s.clones == nil {
@@ -2418,9 +2348,7 @@ type getFilesInput struct {
 	Number int    `path:"number"`
 }
 
-type getFilesOutput struct {
-	Body filesResponse
-}
+type getFilesOutput = bodyOutput[filesResponse]
 
 func (s *Server) getFiles(ctx context.Context, input *getFilesInput) (*getFilesOutput, error) {
 	if s.clones == nil {

--- a/internal/server/output_wrappers.go
+++ b/internal/server/output_wrappers.go
@@ -1,0 +1,23 @@
+package server
+
+type bodyOutput[T any] struct {
+	Body T
+}
+
+type createdOutput[T any] struct {
+	Status int `status:"201"`
+	Body   T
+}
+
+type acceptedBodyOutput[T any] struct {
+	Status int `status:"202"`
+	Body   T
+}
+
+type okStatusOutput struct {
+	Status int `status:"200"`
+}
+
+type acceptedStatusOutput struct {
+	Status int `status:"202"`
+}

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -24,9 +24,7 @@ type repoPreviewRequest struct {
 	Pattern string `json:"pattern"`
 }
 
-type repoPreviewOutput struct {
-	Body repoPreviewResponse
-}
+type repoPreviewOutput = bodyOutput[repoPreviewResponse]
 
 type repoPreviewResponse struct {
 	Owner   string           `json:"owner"`
@@ -52,10 +50,7 @@ type bulkAddReposRequest struct {
 	Repos []bulkAddRepoRequest `json:"repos"`
 }
 
-type bulkAddReposOutput struct {
-	Status int `status:"201"`
-	Body   settingsResponse
-}
+type bulkAddReposOutput = createdOutput[settingsResponse]
 
 type bulkAddRepoRequest struct {
 	Owner string `json:"owner"`

--- a/internal/server/roborev_proxy.go
+++ b/internal/server/roborev_proxy.go
@@ -47,9 +47,7 @@ type roborevStatusResponse struct {
 	Endpoint  string `json:"endpoint"`
 }
 
-type roborevStatusOutput struct {
-	Body roborevStatusResponse
-}
+type roborevStatusOutput = bodyOutput[roborevStatusResponse]
 
 // getRoborevStatus probes the roborev daemon and reports whether
 // it is reachable and what version it advertises.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,11 +50,11 @@ type RepoRef struct {
 	Name  string `json:"name"`
 }
 
-type versionOutput struct {
-	Body struct {
-		Version string `json:"version"`
-	}
+type versionOutputBody struct {
+	Version string `json:"version"`
 }
+
+type versionOutput = bodyOutput[versionOutputBody]
 
 type ServerOptions struct {
 	EmbedConfig *EmbedConfig

--- a/internal/server/settings_routes.go
+++ b/internal/server/settings_routes.go
@@ -6,9 +6,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
-type getSettingsOutput struct {
-	Body settingsResponse
-}
+type getSettingsOutput = bodyOutput[settingsResponse]
 
 type updateSettingsInput struct {
 	Body updateSettingsRequest
@@ -26,9 +24,7 @@ type repoConfigInput struct {
 	Name  string `path:"name"`
 }
 
-type settingsOutput struct {
-	Body settingsResponse
-}
+type settingsOutput = bodyOutput[settingsResponse]
 
 func (s *Server) registerSettingsAPI(api huma.API) {
 	huma.Register(api, huma.Operation{


### PR DESCRIPTION
- Add shared generic response wrappers for Huma route outputs.
- Replace repeated one-off Body/Status output structs while preserving generated OpenAPI schema names.