### PR TITLE
Serialize workspace tmux e2e runs

### DIFF
--- a/frontend/src/lib/utils/exclusiveLock.test.ts
+++ b/frontend/src/lib/utils/exclusiveLock.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdtemp, rm, stat, symlink } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   acquireExclusiveLock,
@@ -40,8 +41,10 @@ describe("exclusive e2e lock", () => {
     }));
 
     const info = await stat(exclusiveLockPath("workspace-tmux", root));
+    const rootInfo = await stat(root);
 
     expect(info.isDirectory()).toBe(true);
+    expect(rootInfo.mode & 0o777).toBe(0o700);
   });
 
   it("waits for an existing lock file before acquiring", async () => {
@@ -68,5 +71,17 @@ describe("exclusive e2e lock", () => {
     const secondRelease = await secondReleasePromise;
     releaseFns.push(secondRelease);
     expect(secondAcquired).toBe(true);
+  });
+
+  it("rejects a symlinked lock root", async () => {
+    const target = await tempRoot();
+    const root = path.join(os.tmpdir(), `middleman-lock-link-${process.pid}`);
+    tempRoots.push(root);
+    await rm(root, { force: true, recursive: true });
+    await symlink(target, root);
+
+    await expect(acquireExclusiveLock("workspace-tmux", {
+      rootDir: root,
+    })).rejects.toThrow("lock root is not a safe directory");
   });
 });

--- a/frontend/src/lib/utils/exclusiveLock.test.ts
+++ b/frontend/src/lib/utils/exclusiveLock.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { mkdtemp, rm, stat, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -83,5 +83,22 @@ describe("exclusive e2e lock", () => {
     await expect(acquireExclusiveLock("workspace-tmux", {
       rootDir: root,
     })).rejects.toThrow("lock root is not a safe directory");
+  });
+
+  it("recovers a stale lock with a dead owner process", async () => {
+    const root = await tempRoot();
+    const lockPath = exclusiveLockPath("workspace-tmux", root);
+    await mkdir(lockPath);
+    await writeFile(path.join(lockPath, "metadata.json"), JSON.stringify({
+      created_at: new Date(Date.now() - 11 * 60 * 1000).toISOString(),
+      pid: 999_999_999,
+    }) + "\n");
+
+    releaseFns.push(await acquireExclusiveLock("workspace-tmux", {
+      rootDir: root,
+    }));
+
+    const info = await stat(lockPath);
+    expect(info.isDirectory()).toBe(true);
   });
 });

--- a/frontend/src/lib/utils/exclusiveLock.test.ts
+++ b/frontend/src/lib/utils/exclusiveLock.test.ts
@@ -32,7 +32,7 @@ describe("exclusive e2e lock", () => {
     return root;
   }
 
-  it("creates a stable lock file in the configured temp root", async () => {
+  it("creates a stable lock path in the configured temp root", async () => {
     const root = await tempRoot();
 
     releaseFns.push(await acquireExclusiveLock("workspace-tmux", {
@@ -41,7 +41,7 @@ describe("exclusive e2e lock", () => {
 
     const info = await stat(exclusiveLockPath("workspace-tmux", root));
 
-    expect(info.isFile()).toBe(true);
+    expect(info.isDirectory()).toBe(true);
   });
 
   it("waits for an existing lock file before acquiring", async () => {

--- a/frontend/src/lib/utils/exclusiveLock.test.ts
+++ b/frontend/src/lib/utils/exclusiveLock.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireExclusiveLock,
+  exclusiveLockPath,
+} from "../../../tests/e2e-full/support/exclusiveLock";
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("exclusive e2e lock", () => {
+  const releaseFns: Array<() => Promise<void>> = [];
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    while (releaseFns.length > 0) {
+      await releaseFns.pop()?.();
+    }
+    while (tempRoots.length > 0) {
+      await rm(tempRoots.pop() ?? "", { force: true, recursive: true });
+    }
+  });
+
+  async function tempRoot(): Promise<string> {
+    const root = await mkdtemp(path.join(os.tmpdir(), "middleman-lock-test-"));
+    tempRoots.push(root);
+    return root;
+  }
+
+  it("creates a stable lock file in the configured temp root", async () => {
+    const root = await tempRoot();
+
+    releaseFns.push(await acquireExclusiveLock("workspace-tmux", {
+      rootDir: root,
+    }));
+
+    const info = await stat(exclusiveLockPath("workspace-tmux", root));
+
+    expect(info.isFile()).toBe(true);
+  });
+
+  it("waits for an existing lock file before acquiring", async () => {
+    const root = await tempRoot();
+    const firstRelease = await acquireExclusiveLock("workspace-tmux", {
+      rootDir: root,
+    });
+    releaseFns.push(firstRelease);
+
+    let secondAcquired = false;
+    const secondReleasePromise = acquireExclusiveLock("workspace-tmux", {
+      rootDir: root,
+    }).then((release) => {
+      secondAcquired = true;
+      return release;
+    });
+
+    await delay(25);
+    expect(secondAcquired).toBe(false);
+
+    await firstRelease();
+    releaseFns.pop();
+
+    const secondRelease = await secondReleasePromise;
+    releaseFns.push(secondRelease);
+    expect(secondAcquired).toBe(true);
+  });
+});

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -21,6 +21,8 @@ type WorkspaceStatusResponse = {
   error_message?: string | null;
 };
 
+const lockedWorkspaceTestTimeoutMs = 120_000;
+
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {
     execFileSync(command, args, { stdio: "ignore" });
@@ -60,6 +62,8 @@ async function waitForWorkspaceReady(
 }
 
 test.describe("detail action buttons", () => {
+  test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
+
   test("issue detail creates a middleman workspace and opens its terminal", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -1,7 +1,11 @@
 import { execFileSync } from "node:child_process";
 import { access } from "node:fs/promises";
 import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
-import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+import {
+  startIsolatedE2EServer,
+  startIsolatedWorkspaceE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
 
 type WorkspaceStatusResponse = {
   id: string;
@@ -65,7 +69,7 @@ test.describe("detail action buttons", () => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
-      isolatedServer = await startIsolatedE2EServer();
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
       api = await playwrightRequest.newContext({
         baseURL: isolatedServer.info.base_url,
       });

--- a/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
+++ b/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
@@ -2,8 +2,26 @@ import { expect, test, type Page } from "@playwright/test";
 
 const storageKey = "middleman-pr-timeline-filter";
 
+async function gotoWithWebKitRetry(page: Page, url: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await page.goto(url);
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes("WebKit encountered an internal error")) {
+        throw error;
+      }
+      lastError = error;
+      await page.waitForTimeout(250);
+    }
+  }
+  throw lastError;
+}
+
 async function openPRTimeline(page: Page): Promise<void> {
-  await page.goto("/pulls/acme/widgets/1");
+  await gotoWithWebKitRetry(page, "/pulls/acme/widgets/1");
   await page.locator(".pull-detail")
     .waitFor({ state: "visible", timeout: 10_000 });
   await expect(page.getByText("feat: add cache store")).toBeVisible();
@@ -18,7 +36,7 @@ async function openTimelineFilters(page: Page): Promise<void> {
 
 test.describe("PR timeline filters", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await gotoWithWebKitRetry(page, "/");
     await page.evaluate((key) => {
       localStorage.removeItem(key);
     }, storageKey);

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { acquireExclusiveLock } from "./exclusiveLock";
 
 export type E2EServerInfo = {
   host: string;
@@ -32,6 +33,7 @@ const startupTimeoutMs = 60_000;
 const pollIntervalMs = 100;
 const reachabilityTimeoutMs = 1_000;
 const ownedServerEnvVar = "PLAYWRIGHT_E2E_SERVER_OWNED";
+const workspaceTmuxLockName = "workspace-tmux";
 
 type ManagedChildLike = {
   pid?: number | undefined;
@@ -428,6 +430,34 @@ export async function startIsolatedE2EServerWithOptions(
       cleanupManagedServerProcess(started.child, isolatedInfoFile);
       await removeServerInfo(isolatedInfoFile);
       await rm(isolatedInfoDir, { force: true, recursive: true });
+    },
+  };
+}
+
+export async function startIsolatedWorkspaceE2EServer(): Promise<IsolatedE2EServer> {
+  return startIsolatedWorkspaceE2EServerWithOptions();
+}
+
+export async function startIsolatedWorkspaceE2EServerWithOptions(
+  options: IsolatedE2EServerOptions = {},
+): Promise<IsolatedE2EServer> {
+  const releaseLock = await acquireExclusiveLock(workspaceTmuxLockName);
+  let server: IsolatedE2EServer;
+  try {
+    server = await startIsolatedE2EServerWithOptions(options);
+  } catch (error) {
+    await releaseLock();
+    throw error;
+  }
+
+  return {
+    info: server.info,
+    stop: async () => {
+      try {
+        await server.stop();
+      } finally {
+        await releaseLock();
+      }
     },
   };
 }

--- a/frontend/tests/e2e-full/support/exclusiveLock.ts
+++ b/frontend/tests/e2e-full/support/exclusiveLock.ts
@@ -31,26 +31,74 @@ function lockMetadata(): string {
   }) + "\n";
 }
 
-function spawnLockProcess(lockFile: string): ChildProcess {
+function lockWorkerScript(): string {
+  return `
+    import { mkdir, rm, writeFile } from "node:fs/promises";
+    import path from "node:path";
+
+    const [lockDir, metadata] = process.argv.slice(1);
+    const waitMs = 100;
+    let releasing = false;
+
+    if (!lockDir || metadata === undefined) {
+      throw new Error("usage: lock-worker <lock-dir> <metadata>");
+    }
+
+    const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    async function acquire() {
+      for (;;) {
+        try {
+          await mkdir(lockDir);
+          await writeFile(path.join(lockDir, "metadata.json"), metadata);
+          process.stdout.write("locked\\n");
+          return;
+        } catch (error) {
+          if (error?.code !== "EEXIST") {
+            throw error;
+          }
+          await delay(waitMs);
+        }
+      }
+    }
+
+    async function release() {
+      if (releasing) {
+        return;
+      }
+      releasing = true;
+      await rm(lockDir, { recursive: true, force: true });
+    }
+
+    process.stdin.resume();
+    process.stdin.on("end", async () => {
+      await release();
+      process.exit(0);
+    });
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      process.on(signal, async () => {
+        await release();
+        process.exit(0);
+      });
+    }
+    process.on("exit", () => {
+      if (!releasing) {
+        void rm(lockDir, { recursive: true, force: true });
+      }
+    });
+
+    await acquire();
+  `;
+}
+
+function spawnLockProcess(lockPath: string): ChildProcess {
   return spawn(
-    "perl",
+    process.execPath,
     [
-      "-MFcntl=:flock",
-      "-MIO::Handle",
+      "--input-type=module",
       "-e",
-      `
-        my ($path, $metadata) = @ARGV;
-        open(my $fh, ">>", $path) or die "open $path: $!";
-        flock($fh, LOCK_EX) or die "flock $path: $!";
-        truncate($fh, 0) or die "truncate $path: $!";
-        seek($fh, 0, 0) or die "seek $path: $!";
-        print $fh $metadata or die "write $path: $!";
-        $fh->flush();
-        print STDOUT "locked\\n";
-        STDOUT->flush();
-        while (sysread(STDIN, my $buf, 8192)) {}
-      `,
-      lockFile,
+      lockWorkerScript(),
+      lockPath,
       lockMetadata(),
     ],
     {
@@ -118,9 +166,9 @@ export async function acquireExclusiveLock(
 ): Promise<() => Promise<void>> {
   const rootDir = options.rootDir ?? LOCK_ROOT;
   await mkdir(rootDir, { recursive: true });
-  const lockFile = exclusiveLockPath(name, rootDir);
+  const lockPath = exclusiveLockPath(name, rootDir);
 
-  const child = spawnLockProcess(lockFile);
+  const child = spawnLockProcess(lockPath);
   await waitForLockProcess(child);
 
   let released = false;

--- a/frontend/tests/e2e-full/support/exclusiveLock.ts
+++ b/frontend/tests/e2e-full/support/exclusiveLock.ts
@@ -1,10 +1,13 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { chmod, lstat, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 
-const LOCK_ROOT = path.join(os.tmpdir(), "middleman-playwright-locks");
+const LOCK_ROOT = path.join(
+  os.tmpdir(),
+  `middleman-playwright-locks-${typeof os.userInfo().uid === "number" ? os.userInfo().uid : "user"}`,
+);
 export type ExclusiveLockOptions = {
   rootDir?: string;
 };
@@ -34,10 +37,15 @@ function lockMetadata(): string {
 function lockWorkerScript(): string {
   return `
     import { mkdir, rm, writeFile } from "node:fs/promises";
+    import { rmSync } from "node:fs";
     import path from "node:path";
 
-    const [lockDir, metadata] = process.argv.slice(1);
+    const args = process.argv[1] === "[eval]"
+      ? process.argv.slice(2)
+      : process.argv.slice(1);
+    const [lockDir, metadata] = args;
     const waitMs = 100;
+    let acquired = false;
     let releasing = false;
 
     if (!lockDir || metadata === undefined) {
@@ -50,6 +58,7 @@ function lockWorkerScript(): string {
       for (;;) {
         try {
           await mkdir(lockDir);
+          acquired = true;
           await writeFile(path.join(lockDir, "metadata.json"), metadata);
           process.stdout.write("locked\\n");
           return;
@@ -63,11 +72,12 @@ function lockWorkerScript(): string {
     }
 
     async function release() {
-      if (releasing) {
+      if (releasing || !acquired) {
         return;
       }
       releasing = true;
       await rm(lockDir, { recursive: true, force: true });
+      acquired = false;
     }
 
     process.stdin.resume();
@@ -82,13 +92,40 @@ function lockWorkerScript(): string {
       });
     }
     process.on("exit", () => {
-      if (!releasing) {
-        void rm(lockDir, { recursive: true, force: true });
+      if (acquired && !releasing) {
+        try {
+          rmSync(lockDir, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup during process exit.
+        }
       }
     });
 
     await acquire();
   `;
+}
+
+async function ensureLockRoot(rootDir: string): Promise<void> {
+  try {
+    const info = await lstat(rootDir);
+    if (!info.isDirectory() || info.isSymbolicLink()) {
+      throw new Error(`lock root is not a safe directory: ${rootDir}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+    await mkdir(rootDir, { recursive: true, mode: 0o700 });
+  }
+
+  const info = await lstat(rootDir);
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error(`lock root is not a safe directory: ${rootDir}`);
+  }
+  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+    throw new Error(`lock root is owned by uid ${info.uid}, expected ${process.getuid()}`);
+  }
+  await chmod(rootDir, 0o700);
 }
 
 function spawnLockProcess(lockPath: string): ChildProcess {
@@ -165,7 +202,7 @@ export async function acquireExclusiveLock(
   options: ExclusiveLockOptions = {},
 ): Promise<() => Promise<void>> {
   const rootDir = options.rootDir ?? LOCK_ROOT;
-  await mkdir(rootDir, { recursive: true });
+  await ensureLockRoot(rootDir);
   const lockPath = exclusiveLockPath(name, rootDir);
 
   const child = spawnLockProcess(lockPath);

--- a/frontend/tests/e2e-full/support/exclusiveLock.ts
+++ b/frontend/tests/e2e-full/support/exclusiveLock.ts
@@ -1,30 +1,134 @@
-import { mkdir, rm } from "node:fs/promises";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 
 const LOCK_ROOT = path.join(os.tmpdir(), "middleman-playwright-locks");
+export type ExclusiveLockOptions = {
+  rootDir?: string;
+};
 
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
+function safeLockName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed === "") {
+    throw new Error("lock name must not be empty");
+  }
+  return trimmed.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+export function exclusiveLockPath(
+  name: string,
+  rootDir: string = LOCK_ROOT,
+): string {
+  return path.join(rootDir, `${safeLockName(name)}.lock`);
+}
+
+function lockMetadata(): string {
+  return JSON.stringify({
+    created_at: new Date().toISOString(),
+    pid: process.pid,
+  }) + "\n";
+}
+
+function spawnLockProcess(lockFile: string): ChildProcess {
+  return spawn(
+    "perl",
+    [
+      "-MFcntl=:flock",
+      "-MIO::Handle",
+      "-e",
+      `
+        my ($path, $metadata) = @ARGV;
+        open(my $fh, ">>", $path) or die "open $path: $!";
+        flock($fh, LOCK_EX) or die "flock $path: $!";
+        truncate($fh, 0) or die "truncate $path: $!";
+        seek($fh, 0, 0) or die "seek $path: $!";
+        print $fh $metadata or die "write $path: $!";
+        $fh->flush();
+        print STDOUT "locked\\n";
+        STDOUT->flush();
+        while (sysread(STDIN, my $buf, 8192)) {}
+      `,
+      lockFile,
+      lockMetadata(),
+    ],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+}
+
+async function waitForLockProcess(child: ChildProcess): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let locked = false;
+    let stderr = "";
+
+    const cleanup = () => {
+      child.stdout?.off("data", onStdout);
+      child.stderr?.off("data", onStderr);
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+    const onStdout = (chunk: Buffer) => {
+      if (chunk.toString("utf8").includes("locked\n")) {
+        locked = true;
+        cleanup();
+        resolve();
+      }
+    };
+    const onStderr = (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      if (locked) {
+        return;
+      }
+      cleanup();
+      reject(new Error(
+        `lock helper exited before acquiring lock (code=${code}, signal=${signal}): ${stderr.trim()}`,
+      ));
+    };
+
+    child.stdout?.on("data", onStdout);
+    child.stderr?.on("data", onStderr);
+    child.on("error", onError);
+    child.on("exit", onExit);
+  });
+}
+
+async function stopLockProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.stdin?.end();
+  await new Promise<void>((resolve, reject) => {
+    child.once("exit", () => resolve());
+    child.once("error", reject);
+  });
 }
 
 export async function acquireExclusiveLock(
   name: string,
+  options: ExclusiveLockOptions = {},
 ): Promise<() => Promise<void>> {
-  await mkdir(LOCK_ROOT, { recursive: true });
-  const lockDir = path.join(LOCK_ROOT, name);
+  const rootDir = options.rootDir ?? LOCK_ROOT;
+  await mkdir(rootDir, { recursive: true });
+  const lockFile = exclusiveLockPath(name, rootDir);
 
-  for (;;) {
-    try {
-      await mkdir(lockDir);
-      return async () => {
-        await rm(lockDir, { recursive: true, force: true });
-      };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-      await sleep(100);
+  const child = spawnLockProcess(lockFile);
+  await waitForLockProcess(child);
+
+  let released = false;
+  return async () => {
+    if (released) {
+      return;
     }
-  }
+    released = true;
+    await stopLockProcess(child);
+  };
 }

--- a/frontend/tests/e2e-full/support/exclusiveLock.ts
+++ b/frontend/tests/e2e-full/support/exclusiveLock.ts
@@ -4,9 +4,18 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 
+function lockRootSuffix(): string {
+  try {
+    const uid = os.userInfo().uid;
+    return typeof uid === "number" ? String(uid) : "user";
+  } catch {
+    return "user";
+  }
+}
+
 const LOCK_ROOT = path.join(
   os.tmpdir(),
-  `middleman-playwright-locks-${typeof os.userInfo().uid === "number" ? os.userInfo().uid : "user"}`,
+  `middleman-playwright-locks-${lockRootSuffix()}`,
 );
 export type ExclusiveLockOptions = {
   rootDir?: string;
@@ -36,7 +45,7 @@ function lockMetadata(): string {
 
 function lockWorkerScript(): string {
   return `
-    import { mkdir, rm, writeFile } from "node:fs/promises";
+    import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
     import { rmSync } from "node:fs";
     import path from "node:path";
 
@@ -45,6 +54,8 @@ function lockWorkerScript(): string {
       : process.argv.slice(1);
     const [lockDir, metadata] = args;
     const waitMs = 100;
+    const staleLockMs = 10 * 60 * 1000;
+    const metadataGraceMs = 5_000;
     let acquired = false;
     let releasing = false;
 
@@ -54,17 +65,78 @@ function lockWorkerScript(): string {
 
     const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+    function ownerIsAlive(pid) {
+      if (!Number.isInteger(pid) || pid <= 0) {
+        return false;
+      }
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (error) {
+        return error?.code === "EPERM";
+      }
+    }
+
+    async function lockAgeMs() {
+      try {
+        const info = await stat(lockDir);
+        return Date.now() - info.mtimeMs;
+      } catch {
+        return 0;
+      }
+    }
+
+    async function removeStaleLockIfNeeded() {
+      const metadataPath = path.join(lockDir, "metadata.json");
+      let parsed;
+      try {
+        parsed = JSON.parse(await readFile(metadataPath, "utf8"));
+      } catch {
+        if (await lockAgeMs() <= metadataGraceMs) {
+          return false;
+        }
+        await rm(lockDir, { recursive: true, force: true });
+        return true;
+      }
+
+      const createdAtMs = Date.parse(parsed.created_at);
+      if (
+        Number.isFinite(createdAtMs) &&
+        Date.now() - createdAtMs > staleLockMs
+      ) {
+        await rm(lockDir, { recursive: true, force: true });
+        return true;
+      }
+
+      if (!ownerIsAlive(parsed.pid)) {
+        await rm(lockDir, { recursive: true, force: true });
+        return true;
+      }
+
+      return false;
+    }
+
+    function ownerMetadata() {
+      return JSON.stringify({
+        ...JSON.parse(metadata),
+        pid: process.pid,
+      }) + "\\n";
+    }
+
     async function acquire() {
       for (;;) {
         try {
           await mkdir(lockDir);
           acquired = true;
-          await writeFile(path.join(lockDir, "metadata.json"), metadata);
+          await writeFile(path.join(lockDir, "metadata.json"), ownerMetadata());
           process.stdout.write("locked\\n");
           return;
         } catch (error) {
           if (error?.code !== "EEXIST") {
             throw error;
+          }
+          if (await removeStaleLockIfNeeded()) {
+            continue;
           }
           await delay(waitMs);
         }
@@ -190,11 +262,28 @@ async function stopLockProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) {
     return;
   }
-  child.stdin?.end();
-  await new Promise<void>((resolve, reject) => {
-    child.once("exit", () => resolve());
-    child.once("error", reject);
+  const exitPromise = new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    const onExit = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    child.once("exit", onExit);
+    child.once("error", onError);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      onExit();
+    }
   });
+  child.stdin?.end();
+  await exitPromise;
 }
 
 export async function acquireExclusiveLock(

--- a/frontend/tests/e2e-full/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/workspace-sidebar.spec.ts
@@ -1,5 +1,8 @@
 import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
-import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+import {
+  startIsolatedWorkspaceE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
 
 type WorkspaceStatusResponse = {
   id: string;
@@ -31,7 +34,7 @@ test.describe("workspace sidebar full-stack", () => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
-      isolatedServer = await startIsolatedE2EServer();
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
       api = await playwrightRequest.newContext({
         baseURL: isolatedServer.info.base_url,
       });

--- a/frontend/tests/e2e-full/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/workspace-sidebar.spec.ts
@@ -9,6 +9,8 @@ type WorkspaceStatusResponse = {
   status: string;
 };
 
+const lockedWorkspaceTestTimeoutMs = 120_000;
+
 async function waitForWorkspaceReady(
   api: APIRequestContext,
   workspaceId: string,
@@ -30,6 +32,8 @@ async function waitForWorkspaceReady(
 }
 
 test.describe("workspace sidebar full-stack", () => {
+  test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
+
   test("issue workspaces expose the Issue tab and hide Reviews", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;

--- a/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
@@ -1,6 +1,9 @@
 import { execFileSync } from "node:child_process";
 import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
-import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+import {
+  startIsolatedWorkspaceE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
 
 type WorkspaceStatusResponse = {
   id: string;
@@ -64,7 +67,7 @@ test.describe("workspace tab persistence", () => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
-      isolatedServer = await startIsolatedE2EServer();
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
       api = await playwrightRequest.newContext({
         baseURL: isolatedServer.info.base_url,
       });
@@ -145,7 +148,7 @@ test.describe("workspace tab persistence", () => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
-      isolatedServer = await startIsolatedE2EServer();
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
       api = await playwrightRequest.newContext({
         baseURL: isolatedServer.info.base_url,
       });

--- a/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
@@ -10,6 +10,8 @@ type WorkspaceStatusResponse = {
   status: string;
 };
 
+const lockedWorkspaceTestTimeoutMs = 120_000;
+
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {
     execFileSync(command, args, { stdio: "ignore" });
@@ -58,6 +60,8 @@ async function createIssueWorkspace(
 }
 
 test.describe("workspace tab persistence", () => {
+  test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
+
   test("opening tmux tab keeps Home pane mounted across tab switches", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),


### PR DESCRIPTION
Workspace/tmux Playwright specs can be launched from multiple local worktrees at once. That can overload local tmux and process resources, so this PR gates only those real workspace server launches behind a shared /tmp advisory lock while preserving parallelism for unrelated e2e tests.

- Adds a cross-worktree advisory lock helper for e2e tests.
- Routes real workspace/tmux specs through a locked isolated server starter.