### PR TITLE
Simplify module helper flows

### DIFF
--- a/.agents/skills/code-simplifier
+++ b/.agents/skills/code-simplifier
@@ -1,0 +1,1 @@
+../../skills/code-simplifier

--- a/.claude/skills/code-simplifier
+++ b/.claude/skills/code-simplifier
@@ -1,0 +1,1 @@
+../../skills/code-simplifier

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -157,11 +157,8 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		return stacks, make(map[int64][]StackMemberWithPR), nil
 	}
 
-	// Fetch members for all stacks.
-	placeholders := make([]string, len(stackIDs))
 	memberArgs := make([]any, len(stackIDs))
 	for i, id := range stackIDs {
-		placeholders[i] = "?"
 		memberArgs[i] = id
 	}
 	memberQuery := `
@@ -169,7 +166,7 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		       p.number, p.title, p.state, p.ci_status, p.review_decision, p.is_draft, p.base_branch
 		FROM middleman_stack_members sm
 		JOIN middleman_merge_requests p ON p.id = sm.merge_request_id
-		WHERE sm.stack_id IN (` + strings.Join(placeholders, ",") + `)
+		WHERE sm.stack_id IN (` + sqlPlaceholders(len(stackIDs)) + `)
 		ORDER BY sm.stack_id, sm.position`
 
 	mRows, err := d.ro.QueryContext(ctx, memberQuery, memberArgs...)
@@ -202,16 +199,14 @@ func (d *DB) DeleteStaleStacks(ctx context.Context, repoID int64, activeStackIDs
 		}
 		return nil
 	}
-	placeholders := make([]string, len(activeStackIDs))
 	args := make([]any, 0, len(activeStackIDs)+1)
 	args = append(args, repoID)
-	for i, id := range activeStackIDs {
-		placeholders[i] = "?"
+	for _, id := range activeStackIDs {
 		args = append(args, id)
 	}
 	_, err := d.rw.ExecContext(ctx,
 		`DELETE FROM middleman_stacks WHERE repo_id = ? AND id NOT IN (`+
-			strings.Join(placeholders, ",")+`)`,
+			sqlPlaceholders(len(activeStackIDs))+`)`,
 		args...,
 	)
 	if err != nil {

--- a/internal/gitclone/diff.go
+++ b/internal/gitclone/diff.go
@@ -112,14 +112,7 @@ func (m *Manager) Diff(
 	}
 
 	// Step 2: Get file metadata from --raw -z (with rename/copy detection).
-	rawArgs := []string{
-		"diff", "--raw", "-z", "-M", "-C",
-		"--find-copies-harder", mergeBase, headSHA,
-	}
-	if hideWhitespace {
-		rawArgs = append(rawArgs[:2],
-			append([]string{"-w"}, rawArgs[2:]...)...)
-	}
+	rawArgs := diffRawArgs(mergeBase, headSHA, hideWhitespace)
 	rawOut, err := m.git(ctx, host, clonePath, rawArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("git diff --raw: %w", err)
@@ -165,43 +158,33 @@ func (m *Manager) Diff(
 func (m *Manager) computeWhitespaceOnlyCount(
 	ctx context.Context, host, clonePath, mergeBase, headSHA string,
 ) (int, error) {
-	// Non-whitespace-ignoring pass.
-	out1, err := m.git(ctx, host, clonePath,
-		"diff", "--raw", "-z", "--no-renames", mergeBase, headSHA)
+	whitespaceOnlyFiles, err := m.whitespaceOnlyFiles(ctx, host, clonePath, mergeBase, headSHA)
 	if err != nil {
 		return 0, err
 	}
-	// Whitespace-ignoring pass.
-	out2, err := m.git(ctx, host, clonePath,
-		"diff", "--raw", "-z", "--no-renames", "-w", mergeBase, headSHA)
-	if err != nil {
-		return 0, err
-	}
-
-	allFiles := parseRawZPaths(out1)
-	wFiles := parseRawZPaths(out2)
-
-	count := 0
-	for f := range allFiles {
-		if !wFiles[f] {
-			count++
-		}
-	}
-	return count, nil
+	return len(whitespaceOnlyFiles), nil
 }
 
 func (m *Manager) getWhitespaceOnlyFiles(
 	ctx context.Context, host, clonePath, mergeBase, headSHA string,
 ) map[string]bool {
-	out1, err := m.git(ctx, host, clonePath,
-		"diff", "--raw", "-z", "--no-renames", mergeBase, headSHA)
+	files, err := m.whitespaceOnlyFiles(ctx, host, clonePath, mergeBase, headSHA)
 	if err != nil {
 		return nil
 	}
-	out2, err := m.git(ctx, host, clonePath,
-		"diff", "--raw", "-z", "--no-renames", "-w", mergeBase, headSHA)
+	return files
+}
+
+func (m *Manager) whitespaceOnlyFiles(
+	ctx context.Context, host, clonePath, mergeBase, headSHA string,
+) (map[string]bool, error) {
+	out1, err := m.git(ctx, host, clonePath, diffRawNoRenameArgs(mergeBase, headSHA, false)...)
 	if err != nil {
-		return nil
+		return nil, err
+	}
+	out2, err := m.git(ctx, host, clonePath, diffRawNoRenameArgs(mergeBase, headSHA, true)...)
+	if err != nil {
+		return nil, err
 	}
 
 	allFiles := parseRawZPaths(out1)
@@ -213,7 +196,26 @@ func (m *Manager) getWhitespaceOnlyFiles(
 			result[f] = true
 		}
 	}
-	return result
+	return result, nil
+}
+
+func diffRawArgs(mergeBase, headSHA string, hideWhitespace bool) []string {
+	args := []string{
+		"diff", "--raw", "-z", "-M", "-C",
+		"--find-copies-harder", mergeBase, headSHA,
+	}
+	if hideWhitespace {
+		return append(args[:2], append([]string{"-w"}, args[2:]...)...)
+	}
+	return args
+}
+
+func diffRawNoRenameArgs(mergeBase, headSHA string, hideWhitespace bool) []string {
+	args := []string{"diff", "--raw", "-z", "--no-renames", mergeBase, headSHA}
+	if hideWhitespace {
+		return append(args[:4], append([]string{"-w"}, args[4:]...)...)
+	}
+	return args
 }
 
 // parseRawZPaths extracts just the file paths from --raw -z output.

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -295,14 +295,7 @@ func adaptPR(gql *gqlPR) *gh.PullRequest {
 		t := gh.Timestamp{Time: *gql.ClosedAt}
 		pr.ClosedAt = &t
 	}
-	for _, l := range gql.Labels.Nodes {
-		pr.Labels = append(pr.Labels, &gh.Label{
-			Name:        new(l.Name),
-			Color:       new(l.Color),
-			Description: new(l.Description),
-			Default:     new(l.IsDefault),
-		})
-	}
+	pr.Labels = adaptLabels(gql.Labels.Nodes)
 
 	if gql.HeadRepository != nil {
 		cloneURL := gql.HeadRepository.URL
@@ -339,16 +332,22 @@ func adaptIssue(gql *gqlIssue) *gh.Issue {
 		t := gh.Timestamp{Time: *gql.ClosedAt}
 		issue.ClosedAt = &t
 	}
-	for _, l := range gql.Labels.Nodes {
-		issue.Labels = append(issue.Labels, &gh.Label{
-			Name:        new(l.Name),
-			Color:       new(l.Color),
-			Description: new(l.Description),
-			Default:     new(l.IsDefault),
-		})
-	}
+	issue.Labels = adaptLabels(gql.Labels.Nodes)
 
 	return issue
+}
+
+func adaptLabels(labels []gqlLabel) []*gh.Label {
+	out := make([]*gh.Label, 0, len(labels))
+	for _, label := range labels {
+		out = append(out, &gh.Label{
+			Name:        new(label.Name),
+			Color:       new(label.Color),
+			Description: new(label.Description),
+			Default:     new(label.IsDefault),
+		})
+	}
+	return out
 }
 
 func stateToREST(graphqlState string) string {

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	gh "github.com/google/go-github/v84/github"
 	"github.com/wesm/middleman/internal/config"
 )
 
@@ -157,16 +158,8 @@ func resolveConfiguredRepo(
 				ErrConfiguredRepoArchived, raw.Owner, raw.Name,
 			)
 		}
-		canonicalOwner := repo.GetOwner().GetLogin()
-		if canonicalOwner == "" {
-			canonicalOwner = raw.Owner
-		}
 		status.MatchedRepoCount = 1
-		return status, []RepoRef{{
-			Owner:        canonicalRepoOwner(canonicalOwner),
-			Name:         canonicalRepoName(repo.GetName()),
-			PlatformHost: canonicalRepoHost(host),
-		}}, nil
+		return status, []RepoRef{repoRefFromRepository(raw, host, repo)}, nil
 	}
 
 	repos, err := client.ListRepositoriesByOwner(ctx, raw.Owner)
@@ -195,18 +188,22 @@ func resolveConfiguredRepo(
 		if !matched {
 			continue
 		}
-		canonicalOwner := repo.GetOwner().GetLogin()
-		if canonicalOwner == "" {
-			canonicalOwner = raw.Owner
-		}
-		matches = append(matches, RepoRef{
-			Owner:        canonicalRepoOwner(canonicalOwner),
-			Name:         canonicalRepoName(repo.GetName()),
-			PlatformHost: canonicalRepoHost(host),
-		})
+		matches = append(matches, repoRefFromRepository(raw, host, repo))
 	}
 	status.MatchedRepoCount = len(matches)
 	return status, matches, nil
+}
+
+func repoRefFromRepository(raw config.Repo, host string, repo *gh.Repository) RepoRef {
+	owner := repo.GetOwner().GetLogin()
+	if owner == "" {
+		owner = raw.Owner
+	}
+	return RepoRef{
+		Owner:        canonicalRepoOwner(owner),
+		Name:         canonicalRepoName(repo.GetName()),
+		PlatformHost: canonicalRepoHost(host),
+	}
 }
 
 func appendExpandedRepo(

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -79,19 +79,20 @@ func walkChain(
 		if len(children) == 0 {
 			break
 		}
-		// Prefer open child over merged; within same state, lowest number wins.
-		current = children[0]
-		if current.State != "open" {
-			for _, c := range children[1:] {
-				if c.State == "open" {
-					current = c
-					break
-				}
-			}
-		}
+		current = preferredChild(children)
 	}
 
 	return chain
+}
+
+func preferredChild(children []db.MergeRequest) db.MergeRequest {
+	// Children inherit deterministic number ordering from DetectChains.
+	for _, child := range children {
+		if child.State == "open" {
+			return child
+		}
+	}
+	return children[0]
 }
 
 func hasOpenMember(chain []db.MergeRequest) bool {

--- a/packages/ui/src/components/RepoTypeahead.svelte
+++ b/packages/ui/src/components/RepoTypeahead.svelte
@@ -144,7 +144,7 @@
         onmousedown={() => select(undefined)}
         onmouseenter={() => (highlightIndex = 0)}
       >All repos</li>
-      {#each filtered as option, i}
+      {#each filtered as option, i (option.value)}
         <li
           class="typeahead-option"
           class:highlighted={i + 1 === highlightIndex}
@@ -154,7 +154,7 @@
           onmousedown={() => select(option.value)}
           onmouseenter={() => (highlightIndex = i + 1)}
         >
-          {#each highlightSegments(option.value, query) as seg}{#if seg.match}<mark class="match">{seg.text}</mark>{:else}{seg.text}{/if}{/each}
+          {#each highlightSegments(option.value, query) as seg, segmentIndex (`${segmentIndex}:${seg.text}`)}{#if seg.match}<mark class="match">{seg.text}</mark>{:else}{seg.text}{/if}{/each}
         </li>
       {:else}
         <li class="typeahead-empty">No matching repos</li>

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -65,6 +65,32 @@
   }
 </script>
 
+{#snippet checkRow(check: CICheck)}
+  {#if check.url}
+    <a
+      class="ci-check"
+      href={check.url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+      <span class="ci-name">{check.name}</span>
+      {#if check.app}
+        <span class="ci-app">{check.app}</span>
+      {/if}
+      <span class="ci-arrow">→</span>
+    </a>
+  {:else}
+    <div class="ci-check ci-check--static">
+      <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+      <span class="ci-name">{check.name}</span>
+      {#if check.app}
+        <span class="ci-app">{check.app}</span>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
 {#if hasCI}
   <div class="ci-status">
     {#if showButton}
@@ -100,56 +126,12 @@
           <div class="ci-checks">
             {#if failedChecks.length > 0}
               <div class="ci-section-label ci-section-label--red">Failed ({failedChecks.length})</div>
-              {#each failedChecks as check}
-                {#if check.url}
-                  <a
-                    class="ci-check"
-                    href={check.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-                    <span class="ci-name">{check.name}</span>
-                    {#if check.app}
-                      <span class="ci-app">{check.app}</span>
-                    {/if}
-                    <span class="ci-arrow">→</span>
-                  </a>
-                {:else}
-                  <div class="ci-check ci-check--static">
-                    <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-                    <span class="ci-name">{check.name}</span>
-                    {#if check.app}
-                      <span class="ci-app">{check.app}</span>
-                    {/if}
-                  </div>
-                {/if}
+              {#each failedChecks as check (check)}
+                {@render checkRow(check)}
               {/each}
             {/if}
-            {#each nonFailedChecks as check}
-              {#if check.url}
-                <a
-                  class="ci-check"
-                  href={check.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-                  <span class="ci-name">{check.name}</span>
-                  {#if check.app}
-                    <span class="ci-app">{check.app}</span>
-                  {/if}
-                  <span class="ci-arrow">→</span>
-                </a>
-              {:else}
-                <div class="ci-check ci-check--static">
-                  <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
-                  <span class="ci-name">{check.name}</span>
-                  {#if check.app}
-                    <span class="ci-app">{check.app}</span>
-                  {/if}
-                </div>
-              {/if}
+            {#each nonFailedChecks as check (check)}
+              {@render checkRow(check)}
             {/each}
           </div>
         {/if}

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -34,9 +34,7 @@
     method: Method;
   };
 
-  // Props are stable for the lifetime of this modal, so we
-  // intentionally capture their initial values for editable fields.
-  const methods: MethodOption[] = $derived.by(() => {
+  function buildMethods(): MethodOption[] {
     const out: MethodOption[] = [];
     if (allowSquash) {
       out.push({ value: "squash", label: "Squash and merge" });
@@ -51,28 +49,29 @@
       out.push({ value: "rebase", label: "Rebase and merge" });
     }
     return out;
-  });
+  }
 
-  const coAuthorName = $derived(prAuthorDisplayName || prAuthor);
-  const coAuthor = $derived(
-    `Co-authored-by: ${coAuthorName} <${prAuthor}@users.noreply.github.com>`
-  );
+  const methods = buildMethods();
 
-  let selectedMethod = $state<Method>("squash");
-  let commitTitle = $state("");
-  let commitMessage = $state("");
-  let initialized = $state(false);
+  function initialCommitTitle(): string {
+    return `${prTitle} (#${number})`;
+  }
 
-  // Seed editable fields once on first render.
-  $effect(() => {
-    if (initialized) return;
-    selectedMethod = methods[0]?.value ?? "squash";
-    commitTitle = `${prTitle} (#${number})`;
-    commitMessage = prBody
-      ? `${prBody}\n\n${coAuthor}`
-      : coAuthor;
-    initialized = true;
-  });
+  function initialCoAuthor(): string {
+    const coAuthorName = prAuthorDisplayName || prAuthor;
+    return `Co-authored-by: ${coAuthorName} <${prAuthor}@users.noreply.github.com>`;
+  }
+
+  function initialCommitMessage(): string {
+    const coAuthor = initialCoAuthor();
+    return prBody ? `${prBody}\n\n${coAuthor}` : coAuthor;
+  }
+
+  // Props are stable for the lifetime of this modal, so these
+  // editable fields intentionally capture their initial values.
+  let selectedMethod = $state<Method>(methods[0]?.value ?? "squash");
+  let commitTitle = $state(initialCommitTitle());
+  let commitMessage = $state(initialCommitMessage());
 
   let merging = $state(false);
   let error = $state<string | null>(null);
@@ -148,7 +147,7 @@
         <div class="field" role="group" aria-label="Merge method">
           <span class="field-label">Merge method</span>
           <div class="method-options">
-            {#each methods as m}
+            {#each methods as m (m.value)}
               <label
                 class="method-option"
                 class:method-option--active={selectedMethod === m.value}

--- a/packages/ui/src/components/roborev/LogViewer.svelte
+++ b/packages/ui/src/components/roborev/LogViewer.svelte
@@ -11,6 +11,10 @@
   const stores = getStores();
   const logStore = stores.roborevLog;
   let container: HTMLElement | undefined;
+  const lines = $derived(logStore?.getLines() ?? []);
+  const lineCount = $derived(lines.length);
+  const isStreaming = $derived(logStore?.isStreaming() ?? false);
+  const followMode = $derived(logStore?.getFollowMode() ?? false);
 
   $effect(() => {
     if (!logStore) return;
@@ -27,8 +31,8 @@
 
   $effect(() => {
     if (!logStore || !container) return;
-    void logStore.getLines().length;
-    if (logStore.getFollowMode()) {
+    void lineCount;
+    if (followMode) {
       container.scrollTop = container.scrollHeight;
     }
   });
@@ -46,16 +50,16 @@
 <div class="log-viewer">
   <div class="log-toolbar">
     <span class="log-status">
-      {#if logStore?.isStreaming()}
+      {#if isStreaming}
         <span class="streaming-dot"></span>
         Streaming...
       {:else}
-        {logStore?.getLines().length ?? 0} lines
+        {lineCount} lines
       {/if}
     </span>
     <button
       class="follow-btn"
-      class:active={logStore?.getFollowMode()}
+      class:active={followMode}
       onclick={() => logStore?.toggleFollow()}
       title="Auto-scroll to bottom"
     >
@@ -67,12 +71,12 @@
     bind:this={container}
   >
     {#if logStore}
-      {#each logStore.getLines() as line}
+      {#each lines as line, index (`${line.ts}:${index}`)}
         <div class="log-line {lineClass(line.lineType)}">
           <span class="log-text">{line.text}</span>
         </div>
       {/each}
-      {#if !logStore.isStreaming() && logStore.getLines().length === 0}
+      {#if !isStreaming && lineCount === 0}
         <div class="log-empty">
           No log output available.
         </div>

--- a/skills/code-simplifier/README.md
+++ b/skills/code-simplifier/README.md
@@ -1,0 +1,3 @@
+Adapted from https://github.com/addyosmani/agent-skills/blob/main/skills/code-simplification/SKILL.md
+
+which itself is > Inspired by the [Claude Code Simplifier plugin](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/code-simplifier/agents/code-simplifier.md). Adapted here as a model-agnostic, process-driven skill for any AI coding agent.

--- a/skills/code-simplifier/SKILL.md
+++ b/skills/code-simplifier/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: code-simplification
+description: Simplifies code for clarity. Use when refactoring code for clarity without changing behavior. Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity.
+---
+
+# Code Simplification
+
+## Overview
+
+Simplify code by reducing complexity while preserving exact behavior. The goal is not fewer lines — it's code that is easier to read, understand, modify, and debug. Every simplification must pass a simple test: "Would a new team member understand this faster than the original?"
+
+## When to Use
+
+- After a feature is working and tests pass, but the implementation feels heavier than it needs to be
+- During code review when readability or complexity issues are flagged
+- When you encounter deeply nested logic, long functions, or unclear names
+- When refactoring code written under time pressure
+- When consolidating related logic scattered across files
+- After merging changes that introduced duplication or inconsistency
+
+**When NOT to use:**
+
+- Code is already clean and readable — don't simplify for the sake of it
+- You don't understand what the code does yet — comprehend before you simplify
+- The code is performance-critical and the "simpler" version would be measurably slower
+- You're about to rewrite the module entirely — simplifying throwaway code wastes effort
+
+## The Five Principles
+
+### 1. Preserve Behavior Exactly
+
+Don't change what the code does — only how it expresses it. All inputs, outputs, side effects, error behavior, and edge cases must remain identical. If you're not sure a simplification preserves behavior, don't make it.
+
+```
+ASK BEFORE EVERY CHANGE:
+→ Does this produce the same output for every input?
+→ Does this maintain the same error behavior?
+→ Does this preserve the same side effects and ordering?
+→ Do all existing tests still pass without modification?
+```
+
+### 2. Follow Project Conventions
+
+Simplification means making code more consistent with the codebase, not imposing external preferences. Before simplifying:
+
+```
+1. Read CLAUDE.md / project conventions
+2. Study how neighboring code handles similar patterns
+3. Match the project's style for:
+   - Import ordering and module system
+   - Function declaration style
+   - Naming conventions
+   - Error handling patterns
+   - Type annotation depth
+```
+
+Simplification that breaks project consistency is not simplification — it's churn.
+
+### 3. Prefer Clarity Over Cleverness
+
+Explicit code is better than compact code when the compact version requires a mental pause to parse.
+
+```typescript
+// UNCLEAR: Dense ternary chain
+const label = isNew ? 'New' : isUpdated ? 'Updated' : isArchived ? 'Archived' : 'Active';
+
+// CLEAR: Readable mapping
+function getStatusLabel(item: Item): string {
+  if (item.isNew) return 'New';
+  if (item.isUpdated) return 'Updated';
+  if (item.isArchived) return 'Archived';
+  return 'Active';
+}
+```
+
+```typescript
+// UNCLEAR: Chained reduces with inline logic
+const result = items.reduce((acc, item) => ({
+  ...acc,
+  [item.id]: { ...acc[item.id], count: (acc[item.id]?.count ?? 0) + 1 }
+}), {});
+
+// CLEAR: Named intermediate step
+const countById = new Map<string, number>();
+for (const item of items) {
+  countById.set(item.id, (countById.get(item.id) ?? 0) + 1);
+}
+```
+
+### 4. Maintain Balance
+
+Simplification has a failure mode: over-simplification. Watch for these traps:
+
+- **Inlining too aggressively** — removing a helper that gave a concept a name makes the call site harder to read
+- **Combining unrelated logic** — two simple functions merged into one complex function is not simpler
+- **Removing "unnecessary" abstraction** — some abstractions exist for extensibility or testability, not complexity
+- **Optimizing for line count** — fewer lines is not the goal; easier comprehension is
+
+### 5. Scope to What Changed
+
+Default to simplifying recently modified code. Avoid drive-by refactors of unrelated code unless explicitly asked to broaden scope. Unscoped simplification creates noise in diffs and risks unintended regressions.
+
+## The Simplification Process
+
+### Step 1: Understand Before Touching (Chesterton's Fence)
+
+Before changing or removing anything, understand why it exists. This is Chesterton's Fence: if you see a fence across a road and don't understand why it's there, don't tear it down. First understand the reason, then decide if the reason still applies.
+
+```
+BEFORE SIMPLIFYING, ANSWER:
+- What is this code's responsibility?
+- What calls it? What does it call?
+- What are the edge cases and error paths?
+- Are there tests that define the expected behavior?
+- Why might it have been written this way? (Performance? Platform constraint? Historical reason?)
+- Check git blame: what was the original context for this code?
+```
+
+If you can't answer these, you're not ready to simplify. Read more context first.
+
+### Step 2: Identify Simplification Opportunities
+
+Scan for these patterns — each one is a concrete signal, not a vague smell:
+
+**Structural complexity:**
+
+| Pattern | Signal | Simplification |
+|---------|--------|----------------|
+| Deep nesting (3+ levels) | Hard to follow control flow | Extract conditions into guard clauses or helper functions |
+| Long functions (50+ lines) | Multiple responsibilities | Split into focused functions with descriptive names |
+| Nested ternaries | Requires mental stack to parse | Replace with if/else chains, switch, or lookup objects |
+| Boolean parameter flags | `doThing(true, false, true)` | Replace with options objects or separate functions |
+| Repeated conditionals | Same `if` check in multiple places | Extract to a well-named predicate function |
+
+**Naming and readability:**
+
+| Pattern | Signal | Simplification |
+|---------|--------|----------------|
+| Generic names | `data`, `result`, `temp`, `val`, `item` | Rename to describe the content: `userProfile`, `validationErrors` |
+| Abbreviated names | `usr`, `cfg`, `btn`, `evt` | Use full words unless the abbreviation is universal (`id`, `url`, `api`) |
+| Misleading names | Function named `get` that also mutates state | Rename to reflect actual behavior |
+| Comments explaining "what" | `// increment counter` above `count++` | Delete the comment — the code is clear enough |
+| Comments explaining "why" | `// Retry because the API is flaky under load` | Keep these — they carry intent the code can't express |
+
+**Redundancy:**
+
+| Pattern | Signal | Simplification |
+|---------|--------|----------------|
+| Duplicated logic | Same 5+ lines in multiple places | Extract to a shared function |
+| Dead code | Unreachable branches, unused variables, commented-out blocks | Remove (after confirming it's truly dead) |
+| Unnecessary abstractions | Wrapper that adds no value | Inline the wrapper, call the underlying function directly |
+| Over-engineered patterns | Factory-for-a-factory, strategy-with-one-strategy | Replace with the simple direct approach |
+| Redundant type assertions | Casting to a type that's already inferred | Remove the assertion |
+
+### Step 3: Apply Changes Incrementally
+
+Make one simplification at a time. Run tests after each change. **Submit refactoring changes separately from feature or bug fix changes.** A PR that refactors and adds a feature is two PRs — split them.
+
+```
+FOR EACH SIMPLIFICATION:
+1. Make the change
+2. Run the test suite
+3. If tests pass → commit (or continue to next simplification)
+4. If tests fail → revert and reconsider
+```
+
+Avoid batching multiple simplifications into a single untested change. If something breaks, you need to know which simplification caused it.
+
+**The Rule of 500:** If a refactoring would touch more than 500 lines, invest in automation (codemods, sed scripts, AST transforms) rather than making the changes by hand. Manual edits at that scale are error-prone and exhausting to review.
+
+### Step 4: Verify the Result
+
+After all simplifications, step back and evaluate the whole:
+
+```
+COMPARE BEFORE AND AFTER:
+- Is the simplified version genuinely easier to understand?
+- Did you introduce any new patterns inconsistent with the codebase?
+- Is the diff clean and reviewable?
+- Would a teammate approve this change?
+```
+
+If the "simplified" version is harder to understand or review, revert. Not every simplification attempt succeeds.
+
+## Language-Specific Guidance
+
+### Go
+
+```go
+// SIMPLIFY: Nested conditionals with guard clauses.
+// Before
+func normalizePullRequest(pr PullRequest) (PullRequest, error) {
+	if pr.Number > 0 {
+		if pr.RepositoryID != 0 {
+			pr.UpdatedAt = pr.UpdatedAt.UTC()
+			return pr, nil
+		}
+		return PullRequest{}, errors.New("repository id is required")
+	}
+	return PullRequest{}, errors.New("pull request number is required")
+}
+
+// After
+func normalizePullRequest(pr PullRequest) (PullRequest, error) {
+	if pr.Number <= 0 {
+		return PullRequest{}, errors.New("pull request number is required")
+	}
+	if pr.RepositoryID == 0 {
+		return PullRequest{}, errors.New("repository id is required")
+	}
+	pr.UpdatedAt = pr.UpdatedAt.UTC()
+	return pr, nil
+}
+
+// SIMPLIFY: Repeated string construction.
+// Before
+func repoKey(owner, name string) string {
+	return strings.ToLower(owner) + "/" + strings.ToLower(name)
+}
+
+// After
+func repoKey(owner, name string) string {
+	return strings.ToLower(owner + "/" + name)
+}
+```
+
+### TypeScript
+
+```typescript
+// SIMPLIFY: Unnecessary async wrapper.
+// Before
+async function loadPullRequest(id: string): Promise<PullRequest> {
+  return await api.getPullRequest(id);
+}
+
+// After
+function loadPullRequest(id: string): Promise<PullRequest> {
+  return api.getPullRequest(id);
+}
+
+// SIMPLIFY: Chained array transforms hiding intent.
+// Before
+const staleOpenItems = items
+  .filter((item) => item.state === 'open')
+  .filter((item) => item.reviewDecision !== 'approved')
+  .filter((item) => Date.now() - Date.parse(item.updatedAt) > staleAfterMs);
+
+// After
+function needsReview(item: PullRequestSummary): boolean {
+  const ageMs = Date.now() - Date.parse(item.updatedAt);
+  return item.state === 'open' && item.reviewDecision !== 'approved' && ageMs > staleAfterMs;
+}
+
+const staleOpenItems = items.filter(needsReview);
+
+// SIMPLIFY: Redundant boolean return.
+// Before
+function isMergeable(pr: PullRequestSummary): boolean {
+  if (pr.state === 'open' && pr.mergeState === 'clean') {
+    return true;
+  }
+  return false;
+}
+
+// After
+function isMergeable(pr: PullRequestSummary): boolean {
+  return pr.state === 'open' && pr.mergeState === 'clean';
+}
+```
+
+### Svelte
+
+```svelte
+<!-- SIMPLIFY: Duplicated conditional markup. -->
+<!-- Before -->
+{#if pr.state === 'open'}
+  <Chip tone="success">Open</Chip>
+{:else if pr.state === 'closed'}
+  <Chip tone="neutral">Closed</Chip>
+{:else if pr.state === 'merged'}
+  <Chip tone="accent">Merged</Chip>
+{/if}
+
+<!-- After -->
+<script lang="ts">
+  const stateTone = {
+    open: 'success',
+    closed: 'neutral',
+    merged: 'accent',
+  } satisfies Record<PullRequestState, ChipTone>;
+</script>
+
+<Chip tone={stateTone[pr.state]}>{pr.state}</Chip>
+
+<!-- SIMPLIFY: Repeated event handlers with inline state updates. -->
+<!-- Before -->
+<button onclick={() => (view = 'triage')}>Triage</button>
+<button onclick={() => (view = 'review')}>Review</button>
+<button onclick={() => (view = 'merged')}>Merged</button>
+
+<!-- After -->
+<script lang="ts">
+  const views = ['triage', 'review', 'merged'] as const;
+</script>
+
+{#each views as nextView}
+  <button onclick={() => (view = nextView)}>{nextView}</button>
+{/each}
+```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's working, no need to touch it" | Working code that's hard to read will be hard to fix when it breaks. Simplifying now saves time on every future change. |
+| "Fewer lines is always simpler" | A 1-line nested ternary is not simpler than a 5-line if/else. Simplicity is about comprehension speed, not line count. |
+| "I'll just quickly simplify this unrelated code too" | Unscoped simplification creates noisy diffs and risks regressions in code you didn't intend to change. Stay focused. |
+| "The types make it self-documenting" | Types document structure, not intent. A well-named function explains *why* better than a type signature explains *what*. |
+| "This abstraction might be useful later" | Don't preserve speculative abstractions. If it's not used now, it's complexity without value. Remove it and re-add when needed. |
+| "The original author must have had a reason" | Maybe. Check git blame — apply Chesterton's Fence. But accumulated complexity often has no reason; it's just the residue of iteration under pressure. |
+| "I'll refactor while adding this feature" | Separate refactoring from feature work. Mixed changes are harder to review, revert, and understand in history. |
+
+## Red Flags
+
+- Simplification that requires modifying tests to pass (you likely changed behavior)
+- "Simplified" code that is longer and harder to follow than the original
+- Renaming things to match your preferences rather than project conventions
+- Removing error handling because "it makes the code cleaner"
+- Simplifying code you don't fully understand
+- Batching many simplifications into one large, hard-to-review commit
+- Refactoring code outside the scope of the current task without being asked
+
+## Verification
+
+After completing a simplification pass:
+
+- [ ] All existing tests pass without modification
+- [ ] Build succeeds with no new warnings
+- [ ] Linter/formatter passes (no style regressions)
+- [ ] Each simplification is a reviewable, incremental change
+- [ ] The diff is clean — no unrelated changes mixed in
+- [ ] Simplified code follows project conventions (checked against CLAUDE.md or equivalent)
+- [ ] No error handling was removed or weakened
+- [ ] No dead code was left behind (unused imports, unreachable branches)
+- [ ] A teammate or review agent would approve the change as a net improvement


### PR DESCRIPTION
- Add the code simplifier skill and expose it through agent skill discovery.
- Simplify repeated helper logic in Go modules and Svelte components without changing behavior.
- Keep broader shared UI primitive extraction out of this pass.

Validation:
- go test ./internal/gitclone ./internal/github ./internal/stacks ./internal/db -shuffle=on
- go test ./internal/gitclone ./internal/server -short -shuffle=on
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/ui lint
- focused Vitest run for touched UI components
- commit hooks