### PR TITLE
Add testing tautology skill

### DIFF
--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -45,6 +45,12 @@ Apply these checks to every new or modified test:
    - Test your contract at the boundary: that you registered the route you intend, pass the values you received into your domain code correctly, handle errors, and shape responses according to your API contract.
    - If an upstream behavior is surprising or previously regressed in your usage, write a narrow characterization test around your integration point and name the upstream assumption explicitly.
 
+8. **Avoid blindingly obvious current-code assertions**
+   - Do not write tests that only assert the implementation is written the way it is currently written.
+   - Examples: a constructor assigns constructor arguments to fields; a getter returns its backing field; a trivial wrapper forwards one argument unchanged; a constant equals its literal; a data-only struct stores the values you just set.
+   - Test these only when there is behavior beyond storage or forwarding: validation, normalization, defaulting, derived values, defensive copying, side effects, permissions, error handling, compatibility guarantees, or a public contract that has regressed before.
+   - Prefer testing the first meaningful consumer-visible behavior that depends on those fields instead of testing the field assignment directly.
+
 ## Mutation Thought Experiment
 
 Before finishing, mentally mutate the production code:
@@ -55,6 +61,7 @@ Before finishing, mentally mutate the production code:
 - Return an empty or default value.
 - Remove one important side effect.
 - Replace an upstream library with a broken fake only where your code's boundary handling should notice.
+- Rename or rearrange private fields while preserving behavior.
 
 At least one relevant test should fail for each realistic mutation. If none would fail, the test is probably tautological.
 
@@ -67,6 +74,8 @@ At least one relevant test should fail for each realistic mutation. If none woul
 - The test changed after a failure but the production behavior was not investigated.
 - The test would still be meaningful if your application code were deleted and only the framework/library remained.
 - The test asserts documented upstream mechanics, such as route parsing, JSON decoding, SQL placeholder behavior, or generated client serialization, without asserting your code's decision or contract.
+- The test would fail after a harmless refactor that leaves all public behavior unchanged.
+- The test is mostly a line-by-line translation of the constructor, getter, setter, mapper, or wrapper it claims to verify.
 
 ## Practical Pattern
 

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -11,6 +11,15 @@ Tests should fail when the behavior they protect is broken. A passing test is on
 
 Before writing or changing a test, ask: "What production change should make this test fail?" If the answer is unclear, redesign the test.
 
+## Quality Gate
+
+Before writing the test body, answer these:
+
+- **Who uses this behavior?** Prefer the public API, HTTP contract, rendered UI, CLI output, persisted data, or caller-visible result over private state and helper internals.
+- **What exact example proves it?** Use concrete inputs and literal expected outputs. Do not compute expected values with the same logic as production code.
+- **What meaningful mutation would this catch?** Name the broken branch, missing side effect, wrong argument, bad boundary case, or contract violation that should fail the test.
+- **Is this our responsibility?** Test our decisions at framework, SDK, database, and service boundaries. Do not re-test the dependency's documented mechanics.
+
 ## Required Checks
 
 Apply these checks to every new or modified test:
@@ -30,6 +39,7 @@ Apply these checks to every new or modified test:
 4. **Never mock the behavior under test**
    - Mock dependencies, boundaries, and slow or nondeterministic collaborators.
    - Do not replace the method, component, handler, query, reducer, or workflow whose behavior the test claims to verify.
+   - Prefer real in-process collaborators and framework-provided test utilities when they keep the test fast and focused.
 
 5. **Investigate failures before changing expectations**
    - Do not flip expected values just to make a failing test pass.
@@ -38,12 +48,14 @@ Apply these checks to every new or modified test:
 6. **Avoid mirror assertions**
    - Do not compute the expected value with the same production logic being tested.
    - Use literals, independently constructed fixtures, small hand-checked examples, or invariant/property assertions.
+   - Keep test logic simple enough that a reviewer can verify the expected value by inspection.
 
 7. **Do not test upstream functionality**
    - Do not write tests whose real claim is that a trusted framework, SDK, standard library, database, parser, router, or generated client works as documented.
    - For example, do not test that Huma parses URL path parameters, query strings, status codes, or OpenAPI wiring correctly unless your code adds behavior around that parsing.
    - Test your contract at the boundary: that you registered the route you intend, pass the values you received into your domain code correctly, handle errors, and shape responses according to your API contract.
    - If an upstream behavior is surprising or previously regressed in your usage, write a narrow characterization test around your integration point and name the upstream assumption explicitly.
+   - When a fake external service stands in for a real one, test the consumer behavior and prefer a contract/verified fake check for the fake itself.
 
 8. **Avoid blindingly obvious current-code assertions**
    - Do not write tests that only assert the implementation is written the way it is currently written.
@@ -62,6 +74,7 @@ Before finishing, mentally mutate the production code:
 - Remove one important side effect.
 - Replace an upstream library with a broken fake only where your code's boundary handling should notice.
 - Rename or rearrange private fields while preserving behavior.
+- Remove validation for a boundary value such as zero, empty, nil, unauthorized, or malformed input.
 
 At least one relevant test should fail for each realistic mutation. If none would fail, the test is probably tautological.
 
@@ -76,6 +89,8 @@ At least one relevant test should fail for each realistic mutation. If none woul
 - The test asserts documented upstream mechanics, such as route parsing, JSON decoding, SQL placeholder behavior, or generated client serialization, without asserting your code's decision or contract.
 - The test would fail after a harmless refactor that leaves all public behavior unchanged.
 - The test is mostly a line-by-line translation of the constructor, getter, setter, mapper, or wrapper it claims to verify.
+- The test exists mainly to raise coverage numbers, but it does not check side effects, boundaries, or observable outcomes.
+- The expected value is assembled through loops, conditionals, formatters, builders, or helpers that hide what the test is actually proving.
 
 ## Practical Pattern
 

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -39,6 +39,12 @@ Apply these checks to every new or modified test:
    - Do not compute the expected value with the same production logic being tested.
    - Use literals, independently constructed fixtures, small hand-checked examples, or invariant/property assertions.
 
+7. **Do not test upstream functionality**
+   - Do not write tests whose real claim is that a trusted framework, SDK, standard library, database, parser, router, or generated client works as documented.
+   - For example, do not test that Huma parses URL path parameters, query strings, status codes, or OpenAPI wiring correctly unless your code adds behavior around that parsing.
+   - Test your contract at the boundary: that you registered the route you intend, pass the values you received into your domain code correctly, handle errors, and shape responses according to your API contract.
+   - If an upstream behavior is surprising or previously regressed in your usage, write a narrow characterization test around your integration point and name the upstream assumption explicitly.
+
 ## Mutation Thought Experiment
 
 Before finishing, mentally mutate the production code:
@@ -48,6 +54,7 @@ Before finishing, mentally mutate the production code:
 - Skip the state change.
 - Return an empty or default value.
 - Remove one important side effect.
+- Replace an upstream library with a broken fake only where your code's boundary handling should notice.
 
 At least one relevant test should fail for each realistic mutation. If none would fail, the test is probably tautological.
 
@@ -58,6 +65,8 @@ At least one relevant test should fail for each realistic mutation. If none woul
 - The test name promises behavior that is not asserted.
 - The only possible failure is a panic, thrown exception, missing selector, or server crash.
 - The test changed after a failure but the production behavior was not investigated.
+- The test would still be meaningful if your application code were deleted and only the framework/library remained.
+- The test asserts documented upstream mechanics, such as route parsing, JSON decoding, SQL placeholder behavior, or generated client serialization, without asserting your code's decision or contract.
 
 ## Practical Pattern
 

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -15,7 +15,7 @@ Before writing or changing a test, ask: "What production change should make this
 
 Before writing the test body, answer these:
 
-- **Who uses this?** Prefer the public API, HTTP contract, rendered UI, CLI output, persisted data, or caller-visible result. Avoid private state and helper internals.
+- **Who uses this?** Prefer public APIs, HTTP contracts, UI, CLI output, persisted data, or caller-visible results. Avoid private state.
 - **What example proves it?** Use concrete inputs and literal expected outputs. Do not compute expected values with production logic.
 - **What break would this catch?** Name the wrong branch, missing side effect, wrong argument, boundary case, or contract violation.
 - **Do we own it?** Test our choices at framework, SDK, database, and service boundaries. Do not re-test documented dependency mechanics.
@@ -24,77 +24,77 @@ Before writing the test body, answer these:
 
 Apply these checks to every new or modified test:
 
-1. **Assert observable behavior**
-   - Verify returned values, persisted state, rendered output, emitted events, API calls, errors, permissions, or other externally meaningful effects.
-   - A test with no assertions is acceptable only when the failure mode is the subject, such as "this constructor rejects invalid input." Prefer explicit assertions even then.
+1. **Assert observable effects**
+   - Check returned values, persisted state, UI, events, API calls, errors, permissions, or other visible effects.
+   - A no-assertion test is acceptable only when the failure mode is the subject, such as "this constructor rejects invalid input." Prefer explicit assertions anyway.
 
-2. **Make mocks specific enough to detect regressions**
-   - Verify important arguments, call counts, order, and branches when they are part of the contract.
+2. **Make mocks specific**
+   - Verify arguments, call counts, order, and branches when they are part of the contract.
    - Do not let a mock accept any input when the code must pass one value.
 
-3. **Use distinct doubles for distinct branches**
+3. **Separate branch doubles**
    - Do not reuse one mock handler for success, error, incomplete, unauthorized, or other mutually exclusive paths.
-   - Each branch should have its own spy/mock so the wrong branch cannot satisfy the expectation.
+   - Give each branch its own spy/mock so the wrong branch cannot satisfy the expectation.
 
-4. **Never mock the behavior under test**
+4. **Do not mock the subject**
    - Mock dependencies, boundaries, and slow or nondeterministic collaborators.
-   - Do not replace the method, component, handler, query, reducer, or workflow whose behavior the test claims to verify.
-   - Prefer real in-process collaborators and framework-provided test utilities when they keep the test fast and focused.
+   - Do not replace the method, component, handler, query, reducer, or workflow under test.
+   - Prefer real in-process collaborators and framework test utilities when they keep the test fast.
 
 5. **Investigate failures before changing expectations**
    - Do not flip expected values just to make a failing test pass.
-   - First determine whether the production change is intended, then update the test to describe the new contract.
+   - First decide whether the production change is intended. Then update the test to describe the new contract.
 
 6. **Avoid mirror assertions**
-   - Do not compute the expected value with the same production logic being tested.
-   - Use literals, independently constructed fixtures, small hand-checked examples, or invariant/property assertions.
-   - Keep test logic simple enough that a reviewer can verify the expected value by inspection.
+   - Do not compute expected values with the same logic under test.
+   - Use literals, hand-checked fixtures, small examples, or invariant/property assertions.
+   - Keep test logic simple enough to review by inspection.
 
 7. **Do not test upstream functionality**
-   - Do not write tests whose real claim is that a trusted framework, SDK, standard library, database, parser, router, or generated client works as documented.
-   - For example, do not test that Huma parses URL path parameters, query strings, status codes, or OpenAPI wiring correctly unless your code adds behavior around that parsing.
-   - Test your contract at the boundary: that you registered the route you intend, pass the values you received into your domain code correctly, handle errors, and shape responses according to your API contract.
-   - If upstream behavior is surprising or has regressed in your usage, write a narrow characterization test around your integration point. Name the upstream assumption.
-   - When a fake external service stands in for a real one, test the consumer behavior and prefer a contract/verified fake check for the fake itself.
+   - Do not prove that a framework, SDK, standard library, database, parser, router, or generated client works as documented.
+   - Example: do not test Huma URL params, query strings, status codes, or OpenAPI wiring unless your code adds behavior there.
+   - Test your boundary contract instead: route registration, value handoff to domain code, errors, permissions, and response shape.
+   - For surprising upstream behavior, write a narrow characterization test around your integration point. Name the upstream assumption.
+   - For fake external services, test consumer behavior and prefer a contract/verified fake check for the fake itself.
 
 8. **Avoid blindingly obvious current-code assertions**
    - Do not test that the implementation is written the way it is written now.
-   - Examples: a constructor assigns constructor arguments to fields; a getter returns its backing field; a trivial wrapper forwards one argument unchanged; a constant equals its literal; a data-only struct stores the values you just set.
-   - Test these only when there is behavior beyond storage or forwarding: validation, normalization, defaulting, derived values, defensive copying, side effects, permissions, error handling, compatibility guarantees, or a public contract that has regressed before.
-   - Prefer the first consumer-visible result that depends on those fields.
+   - Skip tests for plain constructor assignment, getters, trivial forwarding, constants, and data-only structs.
+   - Test them only when they validate, normalize, default, derive, copy, enforce permissions, handle errors, cause side effects, or protect compatibility.
+   - Prefer the first consumer-visible result that depends on the fields.
 
 ## Mutation Thought Experiment
 
 Before finishing, mentally mutate the production code:
 
-- Pass the wrong constant or argument.
-- Call the wrong branch handler.
-- Skip the state change.
-- Return an empty or default value.
-- Remove one important side effect.
-- Replace an upstream library with a broken fake only where your code's boundary handling should notice.
-- Rename or rearrange private fields while preserving behavior.
-- Remove validation for a boundary value such as zero, empty, nil, unauthorized, or malformed input.
+- Wrong constant or argument.
+- Wrong branch handler.
+- Missing state change.
+- Empty/default return.
+- Missing side effect.
+- Broken fake at a boundary your code should notice.
+- Renamed or rearranged private fields with behavior preserved.
+- Missing validation for zero, empty, nil, unauthorized, or malformed input.
 
 At least one relevant test should fail for each realistic mutation. If none fail, the test is probably tautological.
 
 ## Red Flags
 
-- The test only proves that a mock was called, but not that the right dependency, argument, or branch was used.
-- The setup and assertion both reuse the same object or helper in a way that guarantees equality.
-- The test name promises behavior that is not asserted.
-- The only possible failure is a panic, thrown exception, missing selector, or server crash.
-- The test changed after a failure but the production behavior was not investigated.
-- The test would still be meaningful if your application code were deleted and only the framework/library remained.
-- The test asserts upstream mechanics, such as route parsing, JSON decoding, SQL placeholder behavior, or generated client serialization, without asserting your decision or contract.
-- The test would fail after a harmless refactor that leaves all public behavior unchanged.
-- The test is mostly a line-by-line translation of the constructor, getter, setter, mapper, or wrapper it claims to verify.
-- The test exists mainly to raise coverage numbers, but it does not check side effects, boundaries, or observable outcomes.
-- The expected value is assembled through loops, conditionals, formatters, builders, or helpers that hide what the test is actually proving.
+- Only proves a mock was called, not the dependency, argument, or branch.
+- Reuses the same setup/assertion object, guaranteeing equality.
+- Promises behavior the test never asserts.
+- Can fail only through panic, exception, missing selector, or server crash.
+- Changes expectations without investigating production behavior.
+- Still matters if only the framework/library remains.
+- Asserts upstream mechanics, not your decision or contract.
+- Fails after a harmless behavior-preserving refactor.
+- Translates a constructor, getter, setter, mapper, or wrapper line by line.
+- Exists for coverage without checking side effects, boundaries, or outcomes.
+- Hides expected values behind loops, formatters, builders, or helpers.
 
 ## Practical Pattern
 
-For each test, write a short intent sentence in your head:
+For each test, write this sentence:
 
 > Given this setup, when the user/system does X, then Y observable behavior changes.
 

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -19,6 +19,7 @@ Before writing the test body, answer these:
 - **What example proves it?** Use concrete inputs and literal expected outputs. Do not compute expected values with production logic.
 - **What break would this catch?** Name the wrong branch, missing side effect, wrong argument, boundary case, or contract violation.
 - **Do we own it?** Test our choices at framework, SDK, database, and service boundaries. Do not re-test documented dependency mechanics.
+- **Can you state it?** Given this setup, when the user/system does X, then Y observable behavior changes. If Y is not assertable, the test is not ready.
 
 ## Required Checks
 
@@ -65,7 +66,7 @@ Apply these checks to every new or modified test:
 
 ## Mutation Thought Experiment
 
-Before finishing, mentally mutate the production code:
+Before finishing, mentally mutate the production code. At least one relevant test should fail for each realistic mutation.
 
 - Wrong constant or argument.
 - Wrong branch handler.
@@ -76,26 +77,13 @@ Before finishing, mentally mutate the production code:
 - Renamed or rearranged private fields with behavior preserved.
 - Missing validation for zero, empty, nil, unauthorized, or malformed input.
 
-At least one relevant test should fail for each realistic mutation. If none fail, the test is probably tautological.
+If none fail, the test is probably tautological.
 
 ## Red Flags
 
-- Only proves a mock was called, not the dependency, argument, or branch.
 - Reuses the same setup/assertion object, guaranteeing equality.
-- Promises behavior the test never asserts.
 - Can fail only through panic, exception, missing selector, or server crash.
-- Changes expectations without investigating production behavior.
 - Still matters if only the framework/library remains.
-- Asserts upstream mechanics, not your decision or contract.
-- Fails after a harmless behavior-preserving refactor.
 - Translates a constructor, getter, setter, mapper, or wrapper line by line.
 - Exists for coverage without checking side effects, boundaries, or outcomes.
 - Hides expected values behind loops, formatters, builders, or helpers.
-
-## Practical Pattern
-
-For each test, write this sentence:
-
-> Given this setup, when the user/system does X, then Y observable behavior changes.
-
-If Y is not assertable, the test is not ready.

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -64,6 +64,10 @@ Apply these checks to every new or modified test:
    - Test them only when they validate, normalize, default, derive, copy, enforce permissions, handle errors, cause side effects, or protect compatibility.
    - Prefer the first consumer-visible result that depends on the fields.
 
+## Test Level
+
+Use the narrowest test that can catch the break, but honor repo rules. In middleman, e2e tests are required for API behavior, data flow across HTTP and SQLite, and user-visible workflows. Keep those e2e tests non-tautological: assert the workflow result, stored state, rendered UI, or API contract, not just that the server, router, or page did not crash.
+
 ## Mutation Check
 
 Before finishing, mentally mutate the production code. At least one relevant test should fail for each realistic mutation.

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: testing-without-tautologies
+description: Use when creating, editing, fixing, or reviewing tests; when adding mocks, assertions, smoke tests, unit tests, integration tests, e2e tests, or changing tests after failures.
+---
+
+# Testing Without Tautologies
+
+## Core Idea
+
+Tests should fail when the behavior they protect is broken. A passing test is only useful if it can reveal a meaningful problem.
+
+Before writing or changing a test, ask: "What production change should make this test fail?" If the answer is unclear, redesign the test.
+
+## Required Checks
+
+Apply these checks to every new or modified test:
+
+1. **Assert observable behavior**
+   - Verify returned values, persisted state, rendered output, emitted events, API calls, errors, permissions, or other externally meaningful effects.
+   - A test with no assertions is acceptable only when the failure mode is the behavior under test, such as "this constructor rejects invalid input." Prefer explicit assertions even then.
+
+2. **Make mocks specific enough to detect regressions**
+   - Mock expectations must verify important arguments, call counts, order, and branches when those details are part of the contract.
+   - Avoid mocks that accept any input when the code must pass a particular value.
+
+3. **Use distinct doubles for distinct branches**
+   - Do not reuse one mock handler for success, error, incomplete, unauthorized, or other mutually exclusive paths.
+   - Each branch should have its own spy/mock so the wrong branch cannot satisfy the expectation.
+
+4. **Never mock the behavior under test**
+   - Mock dependencies, boundaries, and slow or nondeterministic collaborators.
+   - Do not replace the method, component, handler, query, reducer, or workflow whose behavior the test claims to verify.
+
+5. **Investigate failures before changing expectations**
+   - Do not flip expected values just to make a failing test pass.
+   - First determine whether the production change is intended, then update the test to describe the new contract.
+
+6. **Avoid mirror assertions**
+   - Do not compute the expected value with the same production logic being tested.
+   - Use literals, independently constructed fixtures, small hand-checked examples, or invariant/property assertions.
+
+## Mutation Thought Experiment
+
+Before finishing, mentally mutate the production code:
+
+- Pass the wrong constant or argument.
+- Call the wrong branch handler.
+- Skip the state change.
+- Return an empty or default value.
+- Remove one important side effect.
+
+At least one relevant test should fail for each realistic mutation. If none would fail, the test is probably tautological.
+
+## Red Flags
+
+- The test only proves that a mock was called, but not that the right dependency, argument, or branch was used.
+- The setup and assertion both reuse the same object or helper in a way that guarantees equality.
+- The test name promises behavior that is not asserted.
+- The only possible failure is a panic, thrown exception, missing selector, or server crash.
+- The test changed after a failure but the production behavior was not investigated.
+
+## Practical Pattern
+
+For each test, write a short intent sentence in your head:
+
+> Given this setup, when the user/system does X, then Y observable behavior changes.
+
+If you cannot fill in Y with something assertable, the test is not ready.

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -64,7 +64,7 @@ Apply these checks to every new or modified test:
    - Test them only when they validate, normalize, default, derive, copy, enforce permissions, handle errors, cause side effects, or protect compatibility.
    - Prefer the first consumer-visible result that depends on the fields.
 
-## Mutation Thought Experiment
+## Mutation Check
 
 Before finishing, mentally mutate the production code. At least one relevant test should fail for each realistic mutation.
 

--- a/skills/testing-without-tautologies/SKILL.md
+++ b/skills/testing-without-tautologies/SKILL.md
@@ -7,18 +7,18 @@ description: Use when creating, editing, fixing, or reviewing tests; when adding
 
 ## Core Idea
 
-Tests should fail when the behavior they protect is broken. A passing test is only useful if it can reveal a meaningful problem.
+Tests should fail when protected behavior breaks. A passing test helps only if it can catch a real problem.
 
-Before writing or changing a test, ask: "What production change should make this test fail?" If the answer is unclear, redesign the test.
+Before writing or changing a test, ask: "What production change should make this test fail?" If you cannot answer, redesign the test.
 
 ## Quality Gate
 
 Before writing the test body, answer these:
 
-- **Who uses this behavior?** Prefer the public API, HTTP contract, rendered UI, CLI output, persisted data, or caller-visible result over private state and helper internals.
-- **What exact example proves it?** Use concrete inputs and literal expected outputs. Do not compute expected values with the same logic as production code.
-- **What meaningful mutation would this catch?** Name the broken branch, missing side effect, wrong argument, bad boundary case, or contract violation that should fail the test.
-- **Is this our responsibility?** Test our decisions at framework, SDK, database, and service boundaries. Do not re-test the dependency's documented mechanics.
+- **Who uses this?** Prefer the public API, HTTP contract, rendered UI, CLI output, persisted data, or caller-visible result. Avoid private state and helper internals.
+- **What example proves it?** Use concrete inputs and literal expected outputs. Do not compute expected values with production logic.
+- **What break would this catch?** Name the wrong branch, missing side effect, wrong argument, boundary case, or contract violation.
+- **Do we own it?** Test our choices at framework, SDK, database, and service boundaries. Do not re-test documented dependency mechanics.
 
 ## Required Checks
 
@@ -26,11 +26,11 @@ Apply these checks to every new or modified test:
 
 1. **Assert observable behavior**
    - Verify returned values, persisted state, rendered output, emitted events, API calls, errors, permissions, or other externally meaningful effects.
-   - A test with no assertions is acceptable only when the failure mode is the behavior under test, such as "this constructor rejects invalid input." Prefer explicit assertions even then.
+   - A test with no assertions is acceptable only when the failure mode is the subject, such as "this constructor rejects invalid input." Prefer explicit assertions even then.
 
 2. **Make mocks specific enough to detect regressions**
-   - Mock expectations must verify important arguments, call counts, order, and branches when those details are part of the contract.
-   - Avoid mocks that accept any input when the code must pass a particular value.
+   - Verify important arguments, call counts, order, and branches when they are part of the contract.
+   - Do not let a mock accept any input when the code must pass one value.
 
 3. **Use distinct doubles for distinct branches**
    - Do not reuse one mock handler for success, error, incomplete, unauthorized, or other mutually exclusive paths.
@@ -54,14 +54,14 @@ Apply these checks to every new or modified test:
    - Do not write tests whose real claim is that a trusted framework, SDK, standard library, database, parser, router, or generated client works as documented.
    - For example, do not test that Huma parses URL path parameters, query strings, status codes, or OpenAPI wiring correctly unless your code adds behavior around that parsing.
    - Test your contract at the boundary: that you registered the route you intend, pass the values you received into your domain code correctly, handle errors, and shape responses according to your API contract.
-   - If an upstream behavior is surprising or previously regressed in your usage, write a narrow characterization test around your integration point and name the upstream assumption explicitly.
+   - If upstream behavior is surprising or has regressed in your usage, write a narrow characterization test around your integration point. Name the upstream assumption.
    - When a fake external service stands in for a real one, test the consumer behavior and prefer a contract/verified fake check for the fake itself.
 
 8. **Avoid blindingly obvious current-code assertions**
-   - Do not write tests that only assert the implementation is written the way it is currently written.
+   - Do not test that the implementation is written the way it is written now.
    - Examples: a constructor assigns constructor arguments to fields; a getter returns its backing field; a trivial wrapper forwards one argument unchanged; a constant equals its literal; a data-only struct stores the values you just set.
    - Test these only when there is behavior beyond storage or forwarding: validation, normalization, defaulting, derived values, defensive copying, side effects, permissions, error handling, compatibility guarantees, or a public contract that has regressed before.
-   - Prefer testing the first meaningful consumer-visible behavior that depends on those fields instead of testing the field assignment directly.
+   - Prefer the first consumer-visible result that depends on those fields.
 
 ## Mutation Thought Experiment
 
@@ -76,7 +76,7 @@ Before finishing, mentally mutate the production code:
 - Rename or rearrange private fields while preserving behavior.
 - Remove validation for a boundary value such as zero, empty, nil, unauthorized, or malformed input.
 
-At least one relevant test should fail for each realistic mutation. If none would fail, the test is probably tautological.
+At least one relevant test should fail for each realistic mutation. If none fail, the test is probably tautological.
 
 ## Red Flags
 
@@ -86,7 +86,7 @@ At least one relevant test should fail for each realistic mutation. If none woul
 - The only possible failure is a panic, thrown exception, missing selector, or server crash.
 - The test changed after a failure but the production behavior was not investigated.
 - The test would still be meaningful if your application code were deleted and only the framework/library remained.
-- The test asserts documented upstream mechanics, such as route parsing, JSON decoding, SQL placeholder behavior, or generated client serialization, without asserting your code's decision or contract.
+- The test asserts upstream mechanics, such as route parsing, JSON decoding, SQL placeholder behavior, or generated client serialization, without asserting your decision or contract.
 - The test would fail after a harmless refactor that leaves all public behavior unchanged.
 - The test is mostly a line-by-line translation of the constructor, getter, setter, mapper, or wrapper it claims to verify.
 - The test exists mainly to raise coverage numbers, but it does not check side effects, boundaries, or observable outcomes.
@@ -98,4 +98,4 @@ For each test, write a short intent sentence in your head:
 
 > Given this setup, when the user/system does X, then Y observable behavior changes.
 
-If you cannot fill in Y with something assertable, the test is not ready.
+If Y is not assertable, the test is not ready.

--- a/skills/testing-without-tautologies/agents/openai.yaml
+++ b/skills/testing-without-tautologies/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Testing Without Tautologies"
+  short_description: "Write tests that can actually fail"
+  default_prompt: "Use $testing-without-tautologies to write or review tests that protect real behavior."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
Adds a Codex skill for writing and reviewing tests that can fail for the right reasons.

Covers broad mocks, missing assertions, upstream/framework mechanics, implementation-echo tests, and coverage-only cases. Includes agent metadata so the skill can trigger during test work.