### PR TITLE
Add word wrap to diff view

### DIFF
--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -540,7 +540,7 @@ describe("createDiffStore loadDiff", () => {
       },
     );
 
-    const store = createDiffStore({ getBasePath: () => "/" });
+    const store = createDiffStore({ client: testClient() });
     await store.loadDiff("owner", "repo", 1);
 
     expect(store.getFileCategoryFilter()).toBe("all");

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -441,7 +441,7 @@ test.describe("diff view", () => {
     const initialCount = fetchCount;
 
     // Toggle hide whitespace on.
-    await page.locator(".toggle-switch").click();
+    await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
 
     // Wait for the re-fetch to land and assert it actually happened.
     await expect.poll(() => fetchCount).toBeGreaterThan(initialCount);
@@ -818,7 +818,7 @@ test.describe("diff view performance", () => {
 
     // Toggle whitespace -- triggers a re-fetch with ?whitespace=hide
     // which returns fewer files.
-    await page.locator(".toggle-switch").click();
+    await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
 
     // Count should drop to 45, proving the re-fetch and re-render completed.
     await expect(page.locator(".diff-file .file-header")).toHaveCount(45, { timeout: 15_000 });
@@ -1032,7 +1032,7 @@ test.describe("diff view (git-backed)", () => {
     await expect(page.locator(".diff-file")).toHaveCount(4);
 
     // Toggle hide whitespace.
-    await page.locator(".toggle-switch").click();
+    await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
 
     // README.md is whitespace-only and should be hidden.
     await expect(page.locator(".diff-file")).toHaveCount(3, { timeout: 10_000 });

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -226,6 +226,7 @@ test.describe("diff view", () => {
     await page.addInitScript(() => {
       localStorage.removeItem("diff-tab-width");
       localStorage.removeItem("diff-hide-whitespace");
+      localStorage.removeItem("diff-word-wrap");
       localStorage.removeItem("diff-collapsed-files");
     });
   });
@@ -355,6 +356,23 @@ test.describe("diff view", () => {
     await segments.nth(1).click();
     await expect(segments.nth(1)).toHaveClass(/segment--active/);
     await expect(segments.nth(2)).not.toHaveClass(/segment--active/);
+  });
+
+  test("word wrap toggle changes diff line wrapping", async ({ page }) => {
+    await mockDiffApi(page, smallDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+
+    const wrapToggle = page.getByRole("switch", { name: "Word wrap" });
+    const firstCodeLine = page.locator(".diff-line .code").first();
+
+    await expect(wrapToggle).toHaveAttribute("aria-checked", "false");
+    await expect(firstCodeLine).toHaveCSS("white-space", "pre");
+
+    await wrapToggle.click();
+
+    await expect(wrapToggle).toHaveAttribute("aria-checked", "true");
+    await expect(firstCodeLine).toHaveCSS("white-space", "pre-wrap");
   });
 
   test("changed file category filter narrows the sidebar and rendered diff", async ({ page }) => {
@@ -734,6 +752,7 @@ test.describe("diff view performance", () => {
     await page.addInitScript(() => {
       localStorage.removeItem("diff-tab-width");
       localStorage.removeItem("diff-hide-whitespace");
+      localStorage.removeItem("diff-word-wrap");
       localStorage.removeItem("diff-collapsed-files");
     });
   });

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -193,7 +193,7 @@
         <div class="binary-notice">Binary file changed</div>
       {:else}
         <div class="file-rows">
-          {#each renderedFile.hunks as hunk, hunkIdx}
+          {#each renderedFile.hunks as hunk, hunkIdx (`${hunk.old_start}:${hunk.new_start}:${hunkIdx}`)}
             {#if hunkIdx > 0}
               {@const gap = computeCollapsedLines(renderedFile.hunks, hunkIdx)}
               {#if gap > 0}
@@ -205,7 +205,7 @@
               <span class="hunk-gutter"></span>
               <span class="hunk-text">@@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@{hunk.section ? ` ${hunk.section}` : ""}</span>
             </div>
-            {#each hunk.lines as line, lineIdx}
+            {#each hunk.lines as line, lineIdx (`${hunkIdx}:${line.old_num ?? ""}:${line.new_num ?? ""}:${lineIdx}`)}
               <DiffLineComponent
                 type={line.type}
                 content={line.content}
@@ -302,9 +302,17 @@
     overflow-x: auto;
   }
 
+  :global(.diff-area--word-wrap) .file-content {
+    overflow-x: hidden;
+  }
+
   .file-rows {
     min-width: 100%;
     width: max-content;
+  }
+
+  :global(.diff-area--word-wrap) .file-rows {
+    width: 100%;
   }
 
   .binary-notice {
@@ -334,5 +342,10 @@
   .hunk-text {
     padding: 2px 12px;
     white-space: pre;
+  }
+
+  :global(.diff-area--word-wrap) .hunk-text {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 </style>

--- a/packages/ui/src/components/diff/DiffLine.svelte
+++ b/packages/ui/src/components/diff/DiffLine.svelte
@@ -35,7 +35,7 @@
     class:marker--add={type === "add"}
     class:marker--del={type === "delete"}
   >{marker}</span>
-  <pre class="code">{#each tokens as span}<span style:--dc={span.darkColor} style:--lc={span.lightColor}>{span.content}</span>{/each}{#if noNewline}<span class="no-newline"> (no newline at end of file)</span>{/if}</pre>
+  <pre class="code">{#each tokens as span, index (index)}<span style:--dc={span.darkColor} style:--lc={span.lightColor}>{span.content}</span>{/each}{#if noNewline}<span class="no-newline"> (no newline at end of file)</span>{/if}</pre>
 </div>
 
 <style>
@@ -106,6 +106,13 @@
     white-space: pre;
     background: transparent;
     border: none;
+  }
+
+  :global(.diff-area--word-wrap) .code {
+    flex-basis: 0;
+    min-width: 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 
   /* Token colors via CSS custom properties — theme switch is pure CSS,

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -58,6 +58,20 @@
         <span class="toggle-knob"></span>
       </button>
     </div>
+    <div class="toolbar-group">
+      <span class="toolbar-label">Word wrap</span>
+      <button
+        class="toggle-switch"
+        class:toggle-switch--on={diff.getWordWrap()}
+        role="switch"
+        aria-label="Word wrap"
+        aria-checked={diff.getWordWrap()}
+        title={diff.getWordWrap() ? "Disable word wrap" : "Enable word wrap"}
+        onclick={() => diff.setWordWrap(!diff.getWordWrap())}
+      >
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
   </div>
 </div>
 

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -21,6 +21,7 @@ function renderToolbar() {
 describe("DiffToolbar", () => {
   afterEach(() => {
     cleanup();
+    localStorage.removeItem("diff-word-wrap");
   });
 
   it("defaults the changed file category filter to all and renders category buttons", async () => {
@@ -52,5 +53,19 @@ describe("DiffToolbar", () => {
     expect(diff.getFileCategoryFilter()).toBe("code");
     expect(screen.getByRole("button", { name: "Code (0)" })
       .getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("toggles the word wrap preference", async () => {
+    const { diff } = renderToolbar();
+    const wordWrap = screen.getByRole("switch", { name: "Word wrap" });
+
+    expect(diff.getWordWrap()).toBe(false);
+    expect(wordWrap.getAttribute("aria-checked")).toBe("false");
+
+    await fireEvent.click(wordWrap);
+
+    expect(diff.getWordWrap()).toBe(true);
+    expect(wordWrap.getAttribute("aria-checked")).toBe("true");
+    expect(localStorage.getItem("diff-word-wrap")).toBe("true");
   });
 });

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -30,6 +30,7 @@
   const loading = $derived(diffStore.isDiffLoading());
   const error = $derived(diffStore.getDiffError());
   const tabWidth = $derived(diffStore.getTabWidth());
+  const wordWrap = $derived(diffStore.getWordWrap());
 
   function scrollToFile(path: string): void {
     if (!diffArea) return;
@@ -137,6 +138,7 @@
       <div class="diff-main">
         <div
           class="diff-area"
+          class:diff-area--word-wrap={wordWrap}
           bind:this={diffArea}
           onscroll={onDiffScroll}
           style:tab-size={tabWidth}

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -133,6 +133,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let fileListAbortController: AbortController | null = null;
 
   let tabWidth = $state(loadTabWidth());
+  let wordWrap = $state(
+    safeGetItem("diff-word-wrap") === "true",
+  );
   let hideWhitespace = $state(
     safeGetItem("diff-hide-whitespace") === "true",
   );
@@ -199,6 +202,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   function getTabWidth(): number {
     return tabWidth;
   }
+  function getWordWrap(): boolean {
+    return wordWrap;
+  }
   function getHideWhitespace(): boolean {
     return hideWhitespace;
   }
@@ -255,6 +261,11 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   function setTabWidth(w: number): void {
     tabWidth = w;
     safeSetItem("diff-tab-width", String(w));
+  }
+
+  function setWordWrap(v: boolean): void {
+    wordWrap = v;
+    safeSetItem("diff-word-wrap", String(v));
   }
 
   function setHideWhitespace(v: boolean): void {
@@ -611,6 +622,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     getFileCategoryCounts,
     isFileListLoading,
     getTabWidth,
+    getWordWrap,
     getHideWhitespace,
     getFileCategoryFilter,
     getActiveFile,
@@ -622,6 +634,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     getScrollTarget,
     consumeScrollTarget,
     setTabWidth,
+    setWordWrap,
     setHideWhitespace,
     isFileCollapsed,
     toggleFileCollapsed,


### PR DESCRIPTION
- Adds a persisted Word wrap toggle to the diff toolbar.
- Lets long diff lines wrap in the file view while keeping the default scroll behavior off.