### PR TITLE
Add app favicon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>middleman</title>
     <style>
       /* Critical theme colors inlined to prevent flash before app.css loads */

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="middleman">
-  <rect width="512" height="512" fill="#20272d"/>
+  <rect width="512" height="512" rx="104" fill="#20272d"/>
   <path
     d="M186 120c-42 0-44 32-44 63v34c0 23-20 35-42 39 22 4 42 16 42 39v34c0 31 2 63 44 63"
     fill="none"

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="middleman">
+  <rect width="512" height="512" rx="104" fill="#20272d"/>
+  <path
+    d="M186 120c-42 0-44 32-44 63v34c0 23-20 35-42 39 22 4 42 16 42 39v34c0 31 2 63 44 63"
+    fill="none"
+    stroke="#f7fbff"
+    stroke-width="34"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M326 120c42 0 44 32 44 63v34c0 23 20 35 42 39-22 4-42 16-42 39v34c0 31-2 63-44 63"
+    fill="none"
+    stroke="#f7fbff"
+    stroke-width="34"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path d="M220 192h72" stroke="#4cc46c" stroke-linecap="round" stroke-width="24"/>
+  <path d="M220 256h72" stroke="#f3b13f" stroke-linecap="round" stroke-width="24"/>
+  <path d="M220 320h72" stroke="#e34b3f" stroke-linecap="round" stroke-width="24"/>
+</svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,22 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="middleman">
   <rect width="512" height="512" rx="104" fill="#20272d"/>
-  <path
-    d="M186 120c-42 0-44 32-44 63v34c0 23-20 35-42 39 22 4 42 16 42 39v34c0 31 2 63 44 63"
-    fill="none"
-    stroke="#f7fbff"
-    stroke-width="34"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M326 120c42 0 44 32 44 63v34c0 23 20 35 42 39-22 4-42 16-42 39v34c0 31-2 63-44 63"
-    fill="none"
-    stroke="#f7fbff"
-    stroke-width="34"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path d="M220 192h72" stroke="#4cc46c" stroke-linecap="round" stroke-width="24"/>
-  <path d="M220 256h72" stroke="#f3b13f" stroke-linecap="round" stroke-width="24"/>
-  <path d="M220 320h72" stroke="#e34b3f" stroke-linecap="round" stroke-width="24"/>
+  <g transform="translate(256 256) scale(1.153) translate(-256 -256)">
+    <path
+      d="M186 120c-42 0-44 32-44 63v34c0 23-20 35-42 39 22 4 42 16 42 39v34c0 31 2 63 44 63"
+      fill="none"
+      stroke="#f7fbff"
+      stroke-width="34"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M326 120c42 0 44 32 44 63v34c0 23 20 35 42 39-22 4-42 16-42 39v34c0 31-2 63-44 63"
+      fill="none"
+      stroke="#f7fbff"
+      stroke-width="34"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path d="M220 192h72" stroke="#4cc46c" stroke-linecap="round" stroke-width="24"/>
+    <path d="M220 256h72" stroke="#f3b13f" stroke-linecap="round" stroke-width="24"/>
+    <path d="M220 320h72" stroke="#e34b3f" stroke-linecap="round" stroke-width="24"/>
+  </g>
 </svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="middleman">
-  <rect width="512" height="512" rx="104" fill="#20272d"/>
+  <rect width="512" height="512" fill="#20272d"/>
   <path
     d="M186 120c-42 0-44 32-44 63v34c0 23-20 35-42 39 22 4 42 16 42 39v34c0 31 2 63 44 63"
     fill="none"

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { getStores } from "@middleman/ui";
-  import { getPage, getView, navigate } from "../../stores/router.svelte.ts";
+  import {
+    getBasePath,
+    getPage,
+    getView,
+    navigate,
+  } from "../../stores/router.svelte.ts";
   import {
     activitySelectionToRoute,
     parseActivitySelection,
@@ -24,6 +29,8 @@
     toggleSidebar,
     isSidebarToggleEnabled,
   } from "../../stores/sidebar.svelte.js";
+
+  const appIconSrc = `${getBasePath().replace(/\/$/, "")}/favicon.svg`;
 
   const hasSidebarStrip = $derived(
     getPage() === "issues"
@@ -90,7 +97,10 @@
         />
       </HeaderIconButton>
     {/if}
-    <span class="logo">middleman</span>
+    <span class="brand">
+      <img class="app-icon" src={appIconSrc} alt="" aria-hidden="true" />
+      <span class="logo">middleman</span>
+    </span>
     {#if !getUIConfig().hideRepoSelector}
       <RepoTypeahead
         selected={getGlobalRepo()}
@@ -215,6 +225,19 @@
     display: flex;
     align-items: center;
     gap: 12px;
+  }
+
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    flex-shrink: 0;
+  }
+
+  .app-icon {
+    display: block;
+    width: 22px;
+    height: 22px;
   }
 
   .logo {

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -184,6 +184,20 @@ describe("AppHeader", () => {
     ).toBeTruthy();
   });
 
+  it("renders the app icon next to the wordmark", () => {
+    initTheme();
+    const { container } = render(AppHeader);
+
+    const brand = container.querySelector(".brand");
+    const appIcon = brand?.querySelector("img.app-icon");
+    const wordmark = brand?.querySelector(".logo");
+
+    expect(appIcon?.getAttribute("src")).toBe("/favicon.svg");
+    expect(appIcon?.getAttribute("alt")).toBe("");
+    expect(appIcon?.nextElementSibling).toBe(wordmark);
+    expect(wordmark?.textContent).toBe("middleman");
+  });
+
   it("changes the theme toggle SVG when toggled", async () => {
     initTheme();
     render(AppHeader);

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -184,20 +184,6 @@ describe("AppHeader", () => {
     ).toBeTruthy();
   });
 
-  it("renders the app icon next to the wordmark", () => {
-    initTheme();
-    const { container } = render(AppHeader);
-
-    const brand = container.querySelector(".brand");
-    const appIcon = brand?.querySelector("img.app-icon");
-    const wordmark = brand?.querySelector(".logo");
-
-    expect(appIcon?.getAttribute("src")).toBe("/favicon.svg");
-    expect(appIcon?.getAttribute("alt")).toBe("");
-    expect(appIcon?.nextElementSibling).toBe(wordmark);
-    expect(wordmark?.textContent).toBe("middleman");
-  });
-
   it("changes the theme toggle SVG when toggled", async () => {
     initTheme();
     render(AppHeader);


### PR DESCRIPTION
- Add a branded SVG favicon based on the bracketed diff mark.
- Register it in the frontend HTML so browser/app contexts use the icon.
- Increase the inner mark size so it reads better at favicon scale.
- Show the same icon beside the middleman wordmark in the app header.

Closes #84.