### PR TITLE
Fix sidebar filter collapse at narrow widths

### DIFF
--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -32,6 +32,22 @@ async function selectActivityViewItem(
   await dropdown.locator(".filter-item", { hasText: label }).click();
 }
 
+async function selectPullGrouping(
+  page: Page,
+  label: string | RegExp,
+): Promise<void> {
+  const groupButton = page.locator(".group-btn", { hasText: label });
+  if (await groupButton.isVisible()) {
+    await groupButton.click();
+    return;
+  }
+
+  await page.getByRole("button", { name: "Filters" }).click();
+  await page.locator(".filter-dropdown .filter-item", { hasText: label })
+    .last()
+    .click();
+}
+
 test.describe("grouping toggle", () => {
   test.beforeEach(async ({ page }) => {
     // Clear persisted grouping once before first app bootstrap so tests start
@@ -56,7 +72,7 @@ test.describe("grouping toggle", () => {
 
   test("PR list ungrouped shows repo badges and no headers", async ({ page }) => {
     // Click "All" in group toggle.
-    await page.locator(".group-btn", { hasText: "All" }).click();
+    await selectPullGrouping(page, "All");
 
     // Repo headers should disappear.
     await expect(page.locator(".repo-header")).toHaveCount(0, { timeout: 5_000 });
@@ -73,7 +89,7 @@ test.describe("grouping toggle", () => {
 
   test("toggle persists across page reload", async ({ page }) => {
     // Switch to ungrouped.
-    await page.locator(".group-btn", { hasText: "All" }).click();
+    await selectPullGrouping(page, "All");
     await expect(page.locator(".repo-header")).toHaveCount(0, { timeout: 5_000 });
 
     // Verify persisted state in a fresh page in same browser context.
@@ -90,7 +106,7 @@ test.describe("grouping toggle", () => {
 
   test("toggle syncs from PRs to issues", async ({ page }) => {
     // Switch to ungrouped in PR list.
-    await page.locator(".group-btn", { hasText: "All" }).click();
+    await selectPullGrouping(page, "All");
     await expect(page.locator(".repo-header")).toHaveCount(0, { timeout: 5_000 });
 
     // Navigate to issues.
@@ -104,7 +120,7 @@ test.describe("grouping toggle", () => {
 
   test("toggle syncs to activity threaded view", async ({ page }) => {
     // Switch to ungrouped in PR list.
-    await page.locator(".group-btn", { hasText: "All" }).click();
+    await selectPullGrouping(page, "All");
     await expect(page.locator(".repo-header")).toHaveCount(0, { timeout: 5_000 });
 
     // Navigate to activity.
@@ -189,7 +205,7 @@ test.describe("grouping toggle", () => {
 
   test("j/k navigation follows flat order in ungrouped mode", async ({ page }) => {
     // Switch to ungrouped.
-    await page.locator(".group-btn", { hasText: "All" }).click();
+    await selectPullGrouping(page, "All");
     await expect(page.locator(".repo-header")).toHaveCount(0, { timeout: 5_000 });
 
     // Capture the visible flat order of items.

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -14,6 +14,32 @@ async function waitForIssueList(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function selectIssueState(page: Page, label: string): Promise<void> {
+  const stateButton = page.locator(".state-btn", { hasText: label });
+  if (await stateButton.isVisible()) {
+    await stateButton.click();
+    return;
+  }
+
+  await page.getByRole("button", { name: "Filters" }).click();
+  await page.locator(".filter-dropdown .filter-item", { hasText: label })
+    .first()
+    .click();
+}
+
+async function selectIssueGrouping(page: Page, label: string): Promise<void> {
+  const groupButton = page.locator(".group-btn", { hasText: label });
+  if (await groupButton.isVisible()) {
+    await groupButton.click();
+    return;
+  }
+
+  await page.getByRole("button", { name: "Filters" }).click();
+  await page.locator(".filter-dropdown .filter-item", { hasText: label })
+    .last()
+    .click();
+}
+
 test.describe("issue list view", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/issues");
@@ -32,14 +58,14 @@ test.describe("issue list view", () => {
       /^4 issues$/,
     );
 
-    await page.locator(".group-btn", { hasText: "All" }).click();
+    await selectIssueGrouping(page, "All");
     const firstItem = page.locator(".issue-item").first();
     await expect(firstItem.locator(".repo-chip")).toBeVisible();
     await expect(firstItem.locator(".state-chip")).toBeVisible();
   });
 
   test("closed state shows closed issues", async ({ page }) => {
-    await page.locator(".state-btn", { hasText: "Closed" }).click();
+    await selectIssueState(page, "Closed");
 
     const countBadge = page.locator(".filter-bar .list-count-chip");
     await expect(countBadge).toHaveText(/^1 issues?$/, { timeout: 5_000 });

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -12,6 +12,32 @@ async function waitForPullList(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function selectPullState(page: Page, label: string): Promise<void> {
+  const stateButton = page.locator(".state-btn", { hasText: label });
+  if (await stateButton.isVisible()) {
+    await stateButton.click();
+    return;
+  }
+
+  await page.getByRole("button", { name: "Filters" }).click();
+  await page.locator(".filter-dropdown .filter-item", { hasText: label })
+    .first()
+    .click();
+}
+
+async function selectPullGrouping(page: Page, label: string): Promise<void> {
+  const groupButton = page.locator(".group-btn", { hasText: label });
+  if (await groupButton.isVisible()) {
+    await groupButton.click();
+    return;
+  }
+
+  await page.getByRole("button", { name: "Filters" }).click();
+  await page.locator(".filter-dropdown .filter-item", { hasText: label })
+    .last()
+    .click();
+}
+
 test.describe("PR list view", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/pulls");
@@ -41,7 +67,7 @@ test.describe("PR list view", () => {
     await page.goto("/pulls");
     await waitForPullList(page);
 
-    await page.locator(".group-btn", { hasText: "All" }).click();
+    await selectPullGrouping(page, "All");
     const firstItem = page.locator(".pull-item").first();
     await expect(firstItem.locator(".repo-chip")).toBeVisible();
     await expect(firstItem.locator(".status-chip")).toBeVisible();
@@ -50,7 +76,7 @@ test.describe("PR list view", () => {
   test("closed state shows closed and merged PRs with correct count", async ({
     page,
   }) => {
-    await page.locator(".state-btn", { hasText: "Closed" }).click();
+    await selectPullState(page, "Closed");
 
     const countBadge = page.locator(".filter-bar .list-count-chip");
     await expect(countBadge).toHaveText(/^4 PRs$/, { timeout: 5_000 });

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -148,6 +148,13 @@ async function expectCompactFilterBar(
   );
 }
 
+async function openCompactFilters(filterBar: Locator): Promise<Locator> {
+  await filterBar.getByRole("button", { name: "Filters" }).click();
+  const dropdown = filterBar.page().locator(".filter-dropdown");
+  await expect(dropdown).toBeVisible();
+  return dropdown;
+}
+
 async function expectExpandedFilterBar(
   filterBar: Locator,
 ): Promise<void> {
@@ -339,5 +346,52 @@ test.describe("collapsible sidebar", () => {
         waitForIssueList,
       ),
     );
+  });
+
+  test("pull compact filters update state and grouping", async ({ page }) => {
+    const filterBar = await setPersistedSidebarWidth(
+      page,
+      "/pulls",
+      395,
+      waitForPRList,
+    );
+    await expectCompactFilterBar(filterBar);
+
+    let dropdown = await openCompactFilters(filterBar);
+    await dropdown.locator(".filter-item", { hasText: "Closed" }).click();
+    await expect(filterBar.locator(".list-count-chip")).toHaveText(/^4 PRs$/, {
+      timeout: 5_000,
+    });
+
+    dropdown = await openCompactFilters(filterBar);
+    await dropdown.locator(".filter-item", { hasText: "All" }).last().click();
+    await expect(page.locator(".repo-header")).toHaveCount(0, {
+      timeout: 5_000,
+    });
+    await expect(page.locator(".repo-chip").first()).toBeVisible();
+  });
+
+  test("issue compact filters update state and grouping", async ({ page }) => {
+    const filterBar = await setPersistedSidebarWidth(
+      page,
+      "/issues",
+      372,
+      waitForIssueList,
+    );
+    await expectCompactFilterBar(filterBar);
+
+    let dropdown = await openCompactFilters(filterBar);
+    await dropdown.locator(".filter-item", { hasText: "Closed" }).click();
+    await expect(filterBar.locator(".list-count-chip")).toHaveText(
+      /^1 issues?$/,
+      { timeout: 5_000 },
+    );
+
+    dropdown = await openCompactFilters(filterBar);
+    await dropdown.locator(".filter-item", { hasText: "All" }).last().click();
+    await expect(page.locator(".repo-header")).toHaveCount(0, {
+      timeout: 5_000,
+    });
+    await expect(page.locator(".repo-chip").first()).toBeVisible();
   });
 });

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -282,12 +282,12 @@ test.describe("collapsible sidebar", () => {
     );
   });
 
-  test("pull filters switch at the measured 382px fit point", async ({ page }) => {
+  test("pull filters switch at the buffered 396px fit point", async ({ page }) => {
     await expectCompactFilterBar(
       await setPersistedSidebarWidth(
         page,
         "/pulls",
-        381,
+        395,
         waitForPRList,
       ),
     );
@@ -295,18 +295,18 @@ test.describe("collapsible sidebar", () => {
       await setPersistedSidebarWidth(
         page,
         "/pulls",
-        382,
+        396,
         waitForPRList,
       ),
     );
   });
 
-  test("issue filters switch at the measured 363px fit point", async ({ page }) => {
+  test("issue filters switch at the buffered 373px fit point", async ({ page }) => {
     await expectCompactFilterBar(
       await setPersistedSidebarWidth(
         page,
         "/issues",
-        362,
+        372,
         waitForIssueList,
       ),
     );
@@ -314,7 +314,7 @@ test.describe("collapsible sidebar", () => {
       await setPersistedSidebarWidth(
         page,
         "/issues",
-        363,
+        373,
         waitForIssueList,
       ),
     );

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -101,6 +101,67 @@ async function expectCompactFiltersAtMinimumWidth(
   );
 }
 
+async function expectCompactFiltersInNarrowViewport(
+  page: Page,
+  path: string,
+  waitForList: (page: Page) => Promise<void>,
+): Promise<void> {
+  await page.setViewportSize({ width: 545, height: 954 });
+  await page.goto(path);
+  await waitForList(page);
+
+  const sidebar = page.locator(".sidebar").first();
+  const filterBar = sidebar.locator(".filter-bar").first();
+  await expect(
+    filterBar.getByRole("button", { name: "Filters" }),
+  ).toBeVisible();
+  await expect(filterBar.locator(".state-toggle")).toBeHidden();
+  await expect(filterBar.locator(".group-toggle")).toBeHidden();
+}
+
+async function setPersistedSidebarWidth(
+  page: Page,
+  path: string,
+  width: number,
+  waitForList: (page: Page) => Promise<void>,
+): Promise<Locator> {
+  await page.goto(path);
+  await page.evaluate((value) => {
+    localStorage.setItem("middleman-sidebar-width", String(value));
+    localStorage.removeItem("middleman-sidebar");
+  }, width);
+  await page.reload();
+  await waitForList(page);
+  return page.locator(".sidebar").first().locator(".filter-bar").first();
+}
+
+async function expectCompactFilterBar(
+  filterBar: Locator,
+): Promise<void> {
+  await expect(
+    filterBar.getByRole("button", { name: "Filters" }),
+  ).toBeVisible();
+  await expect(filterBar.locator(".state-toggle")).toBeHidden();
+  await expect(filterBar.locator(".group-toggle")).toBeHidden();
+}
+
+async function expectExpandedFilterBar(
+  filterBar: Locator,
+): Promise<void> {
+  await expect(
+    filterBar.getByRole("button", { name: "Filters" }),
+  ).toBeHidden();
+  await expect(filterBar.locator(".state-toggle")).toBeVisible();
+  await expect(filterBar.locator(".group-toggle")).toBeVisible();
+  const filterMetrics = await filterBar.evaluate((node) => ({
+    clientWidth: node.clientWidth,
+    scrollWidth: node.scrollWidth,
+  }));
+  expect(filterMetrics.scrollWidth).toBeLessThanOrEqual(
+    filterMetrics.clientWidth,
+  );
+}
+
 test.describe("collapsible sidebar", () => {
   test("collapse and expand via strip on pulls", async ({ page }) => {
     await page.goto("/pulls");
@@ -202,6 +263,60 @@ test.describe("collapsible sidebar", () => {
       page,
       "/issues",
       waitForIssueList,
+    );
+  });
+
+  test("pull filters stay compact when a narrow viewport sidebar is opened", async ({ page }) => {
+    await expectCompactFiltersInNarrowViewport(
+      page,
+      "/pulls",
+      waitForPRList,
+    );
+  });
+
+  test("issue filters stay compact when a narrow viewport sidebar is opened", async ({ page }) => {
+    await expectCompactFiltersInNarrowViewport(
+      page,
+      "/issues",
+      waitForIssueList,
+    );
+  });
+
+  test("pull filters switch at the measured 382px fit point", async ({ page }) => {
+    await expectCompactFilterBar(
+      await setPersistedSidebarWidth(
+        page,
+        "/pulls",
+        381,
+        waitForPRList,
+      ),
+    );
+    await expectExpandedFilterBar(
+      await setPersistedSidebarWidth(
+        page,
+        "/pulls",
+        382,
+        waitForPRList,
+      ),
+    );
+  });
+
+  test("issue filters switch at the measured 363px fit point", async ({ page }) => {
+    await expectCompactFilterBar(
+      await setPersistedSidebarWidth(
+        page,
+        "/issues",
+        362,
+        waitForIssueList,
+      ),
+    );
+    await expectExpandedFilterBar(
+      await setPersistedSidebarWidth(
+        page,
+        "/issues",
+        363,
+        waitForIssueList,
+      ),
     );
   });
 });

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -70,6 +70,37 @@ async function expectResizedSidebar(
   ).toBe(420);
 }
 
+async function expectCompactFiltersAtMinimumWidth(
+  page: Page,
+  path: string,
+  waitForList: (page: Page) => Promise<void>,
+): Promise<void> {
+  await page.goto(path);
+  await waitForList(page);
+
+  const sidebar = page.locator(".sidebar").first();
+  const handle = page.locator(".resize-handle");
+
+  await dragResizeHandle(page, handle, -220);
+  await expect.poll(async () => sidebarWidth(sidebar)).toBe(200);
+
+  const filterBar = sidebar.locator(".filter-bar").first();
+  const compactFilters = filterBar.getByRole("button", {
+    name: "Filters",
+  });
+  await expect(compactFilters).toBeVisible();
+  await expect(filterBar.locator(".state-toggle")).toBeHidden();
+  await expect(filterBar.locator(".group-toggle")).toBeHidden();
+
+  const filterMetrics = await filterBar.evaluate((node) => ({
+    clientWidth: node.clientWidth,
+    scrollWidth: node.scrollWidth,
+  }));
+  expect(filterMetrics.scrollWidth).toBeLessThanOrEqual(
+    filterMetrics.clientWidth,
+  );
+}
+
 test.describe("collapsible sidebar", () => {
   test("collapse and expand via strip on pulls", async ({ page }) => {
     await page.goto("/pulls");
@@ -156,5 +187,21 @@ test.describe("collapsible sidebar", () => {
 
   test("sidebar can be resized on issues and keeps the new width after reload", async ({ page }) => {
     await expectResizedSidebar(page, "/issues", waitForIssueList);
+  });
+
+  test("pull filters collapse into a compact menu when sidebar is tight", async ({ page }) => {
+    await expectCompactFiltersAtMinimumWidth(
+      page,
+      "/pulls",
+      waitForPRList,
+    );
+  });
+
+  test("issue filters collapse into a compact menu when sidebar is tight", async ({ page }) => {
+    await expectCompactFiltersAtMinimumWidth(
+      page,
+      "/issues",
+      waitForIssueList,
+    );
   });
 });

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -143,6 +143,9 @@ async function expectCompactFilterBar(
   ).toBeVisible();
   await expect(filterBar.locator(".state-toggle")).toBeHidden();
   await expect(filterBar.locator(".group-toggle")).toBeHidden();
+  await expectFastAnimation(
+    filterBar.locator(".compact-filter-menu"),
+  );
 }
 
 async function expectExpandedFilterBar(
@@ -153,6 +156,7 @@ async function expectExpandedFilterBar(
   ).toBeHidden();
   await expect(filterBar.locator(".state-toggle")).toBeVisible();
   await expect(filterBar.locator(".group-toggle")).toBeVisible();
+  await expectFastAnimation(filterBar.locator(".state-toggle"));
   const filterMetrics = await filterBar.evaluate((node) => ({
     clientWidth: node.clientWidth,
     scrollWidth: node.scrollWidth,
@@ -160,6 +164,23 @@ async function expectExpandedFilterBar(
   expect(filterMetrics.scrollWidth).toBeLessThanOrEqual(
     filterMetrics.clientWidth,
   );
+}
+
+async function expectFastAnimation(locator: Locator): Promise<void> {
+  const durationMs = await locator.evaluate((node) => {
+    const durations = getComputedStyle(node)
+      .animationDuration.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) =>
+        value.endsWith("ms")
+          ? Number.parseFloat(value)
+          : Number.parseFloat(value) * 1000
+      );
+    return Math.max(...durations);
+  });
+  expect(durationMs).toBeGreaterThan(0);
+  expect(durationMs).toBeLessThanOrEqual(150);
 }
 
 test.describe("collapsible sidebar", () => {

--- a/packages/ui/src/components/shared/FilterDropdown.svelte
+++ b/packages/ui/src/components/shared/FilterDropdown.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import FunnelIcon from "@lucide/svelte/icons/funnel";
   import ArrowUpDownIcon from "@lucide/svelte/icons/arrow-up-down";
+  import EllipsisIcon from "@lucide/svelte/icons/ellipsis";
   import { tick } from "svelte";
 
   interface FilterDropdownItem {
@@ -31,7 +32,7 @@
     onReset?: () => void;
     minWidth?: string;
     align?: "start" | "end";
-    icon?: "filter" | "sort";
+    icon?: "filter" | "sort" | "more";
   }
 
   let {
@@ -165,12 +166,15 @@
     class:filter-active={isActive}
     bind:this={buttonRef}
     onclick={toggleOpen}
+    aria-label={label}
     {title}
     {disabled}
     type="button"
   >
     {#if icon === "sort"}
       <ArrowUpDownIcon size={12} strokeWidth={2} aria-hidden="true" />
+    {:else if icon === "more"}
+      <EllipsisIcon size={14} strokeWidth={2.2} aria-hidden="true" />
     {:else}
       <FunnelIcon size={12} strokeWidth={2} aria-hidden="true" />
     {/if}

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -25,8 +25,9 @@
     { byRepo: true, label: "By Repo" },
     { byRepo: false, label: "All" },
   ];
-  // Playwright-measured: the full issue filter row first fits at 363px.
-  const COMPACT_FILTER_MAX_WIDTH = 362;
+  // Playwright-measured with a buffered "9999 issues" count label:
+  // the full issue filter row first fits at 373px.
+  const COMPACT_FILTER_MAX_WIDTH = 372;
 
   let searchInput = $state(issues.getIssueSearchQuery() ?? "");
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -2,6 +2,7 @@
   import { getStores, getNavigate, getSidebar } from "../../context.js";
   import IssueItem from "./IssueItem.svelte";
   import Chip from "../shared/Chip.svelte";
+  import FilterDropdown from "../shared/FilterDropdown.svelte";
   import LeftSidebarToggle from "../shared/LeftSidebarToggle.svelte";
   import type { Issue } from "../../api/types.js";
   import {
@@ -12,6 +13,18 @@
   const { issues, sync, grouping, collapsedRepos, settings } = getStores();
   const navigate = getNavigate();
   const { isEmbedded, isSidebarToggleEnabled, toggleSidebar } = getSidebar();
+
+  interface Props {
+    sidebarWidth?: number;
+  }
+
+  const { sidebarWidth = 340 }: Props = $props();
+
+  const issueStateOptions = ["open", "closed", "all"] as const;
+  const groupingOptions = [
+    { byRepo: true, label: "By Repo" },
+    { byRepo: false, label: "All" },
+  ];
 
   let searchInput = $state(issues.getIssueSearchQuery() ?? "");
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;
@@ -44,6 +57,45 @@
     }, 300);
   }
 
+  function issueStateLabel(state: string): string {
+    if (state === "open") return "Open";
+    if (state === "closed") return "Closed";
+    return "All";
+  }
+
+  function setIssueState(state: string): void {
+    issues.setIssueFilterState(state);
+    void issues.loadIssues();
+  }
+
+  const compactFilterSections = $derived.by(() => [
+    {
+      title: "State",
+      items: issueStateOptions.map((state) => ({
+        id: `state-${state}`,
+        label: issueStateLabel(state),
+        active: issues.getIssueFilterState() === state,
+        closeOnSelect: true,
+        onSelect: () => setIssueState(state),
+      })),
+    },
+    {
+      title: "Group",
+      items: groupingOptions.map((option) => ({
+        id: `group-${option.byRepo ? "byRepo" : "all"}`,
+        label: option.label,
+        active: grouping.getGroupByRepo() === option.byRepo,
+        closeOnSelect: true,
+        onSelect: () => grouping.setGroupByRepo(option.byRepo),
+      })),
+    },
+  ]);
+
+  const hasCompactFilterChanges = $derived(
+    issues.getIssueFilterState() !== "open" || !grouping.getGroupByRepo(),
+  );
+  const useCompactFilters = $derived(sidebarWidth <= 280);
+
   function routeRefForIssue(issue: Issue): IssueRouteRef {
     return {
       owner: issue.repo_owner ?? "",
@@ -69,30 +121,38 @@
 </script>
 
 <div class="issue-list">
-  <div class="filter-bar">
+  <div class="filter-bar" class:filter-bar--compact={useCompactFilters}>
     <Chip size="sm" uppercase={false} class="chip--muted list-count-chip">
       {issues.getIssues().length} issues
     </Chip>
     <div class="state-toggle">
-      {#each ["open", "closed", "all"] as s (s)}
+      {#each issueStateOptions as s (s)}
         <button
           class="state-btn"
           class:state-btn--active={issues.getIssueFilterState() === s}
-          onclick={() => { issues.setIssueFilterState(s); void issues.loadIssues(); }}
-        >{s === "open" ? "Open" : s === "closed" ? "Closed" : "All"}</button>
+          onclick={() => setIssueState(s)}
+        >{issueStateLabel(s)}</button>
       {/each}
     </div>
     <div class="group-toggle">
-      <button
-        class="group-btn"
-        class:group-btn--active={grouping.getGroupByRepo()}
-        onclick={() => grouping.setGroupByRepo(true)}
-      >By Repo</button>
-      <button
-        class="group-btn"
-        class:group-btn--active={!grouping.getGroupByRepo()}
-        onclick={() => grouping.setGroupByRepo(false)}
-      >All</button>
+      {#each groupingOptions as option (option.label)}
+        <button
+          class="group-btn"
+          class:group-btn--active={grouping.getGroupByRepo() === option.byRepo}
+          onclick={() => grouping.setGroupByRepo(option.byRepo)}
+        >{option.label}</button>
+      {/each}
+    </div>
+    <div class="compact-filter-menu">
+      <FilterDropdown
+        label="Filters"
+        title="Filters"
+        icon="more"
+        active={hasCompactFilterChanges}
+        showBadge={false}
+        sections={compactFilterSections}
+        minWidth="160px"
+      />
     </div>
     {#if isSidebarToggleEnabled()}
       <LeftSidebarToggle
@@ -228,6 +288,7 @@
     border-bottom: 1px solid var(--border-muted);
     flex-shrink: 0;
     background: var(--bg-surface);
+    overflow: hidden;
   }
 
   .search-bar {
@@ -432,6 +493,23 @@
     border-radius: 6px;
     padding: 2px;
   }
+
+  .compact-filter-menu {
+    display: none;
+    flex-shrink: 0;
+  }
+
+  .compact-filter-menu :global(.filter-btn) {
+    width: 26px;
+    justify-content: center;
+    padding: 3px;
+  }
+
+  .compact-filter-menu :global(.filter-trigger-label),
+  .compact-filter-menu :global(.filter-trigger-detail) {
+    display: none;
+  }
+
   .state-btn {
     font-size: 11px;
     padding: 2px 8px;
@@ -475,5 +553,14 @@
     background: var(--bg-surface);
     color: var(--text-primary);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+  .filter-bar--compact .state-toggle,
+  .filter-bar--compact .group-toggle {
+    display: none;
+  }
+
+  .filter-bar--compact .compact-filter-menu {
+    display: block;
   }
 </style>

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -497,11 +497,14 @@
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
+    animation: sidebar-filter-pop-out 120ms ease-out;
+    transform-origin: right center;
   }
 
   .compact-filter-menu {
     display: none;
     flex-shrink: 0;
+    transform-origin: left center;
   }
 
   .compact-filter-menu :global(.filter-btn) {
@@ -543,6 +546,8 @@
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
+    animation: sidebar-filter-pop-out 120ms ease-out;
+    transform-origin: right center;
   }
   .group-btn {
     font-size: 11px;
@@ -567,5 +572,36 @@
 
   .filter-bar--compact .compact-filter-menu {
     display: block;
+    animation: sidebar-filter-collapse-in 120ms ease-out;
+  }
+
+  @keyframes sidebar-filter-collapse-in {
+    from {
+      opacity: 0.2;
+      transform: translateX(-10px) scale(0.82);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+  }
+
+  @keyframes sidebar-filter-pop-out {
+    from {
+      opacity: 0;
+      transform: translateX(8px) scale(0.92);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .state-toggle,
+    .group-toggle,
+    .filter-bar--compact .compact-filter-menu {
+      animation: none;
+    }
   }
 </style>

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -25,6 +25,8 @@
     { byRepo: true, label: "By Repo" },
     { byRepo: false, label: "All" },
   ];
+  // Playwright-measured: the full issue filter row first fits at 363px.
+  const COMPACT_FILTER_MAX_WIDTH = 362;
 
   let searchInput = $state(issues.getIssueSearchQuery() ?? "");
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;
@@ -94,7 +96,9 @@
   const hasCompactFilterChanges = $derived(
     issues.getIssueFilterState() !== "open" || !grouping.getGroupByRepo(),
   );
-  const useCompactFilters = $derived(sidebarWidth <= 280);
+  const useCompactFilters = $derived(
+    sidebarWidth <= COMPACT_FILTER_MAX_WIDTH,
+  );
 
   function routeRefForIssue(issue: Issue): IssueRouteRef {
     return {

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -643,11 +643,14 @@
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
+    animation: sidebar-filter-pop-out 120ms ease-out;
+    transform-origin: right center;
   }
 
   .compact-filter-menu {
     display: none;
     flex-shrink: 0;
+    transform-origin: left center;
   }
 
   .compact-filter-menu :global(.filter-btn) {
@@ -689,6 +692,8 @@
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
+    animation: sidebar-filter-pop-out 120ms ease-out;
+    transform-origin: right center;
   }
   .group-btn {
     font-size: 11px;
@@ -713,6 +718,37 @@
 
   .filter-bar--compact .compact-filter-menu {
     display: block;
+    animation: sidebar-filter-collapse-in 120ms ease-out;
+  }
+
+  @keyframes sidebar-filter-collapse-in {
+    from {
+      opacity: 0.2;
+      transform: translateX(-10px) scale(0.82);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+  }
+
+  @keyframes sidebar-filter-pop-out {
+    from {
+      opacity: 0;
+      transform: translateX(8px) scale(0.92);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .state-toggle,
+    .group-toggle,
+    .filter-bar--compact .compact-filter-menu {
+      animation: none;
+    }
   }
 
   .diff-files-wrap {

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -43,6 +43,8 @@
     { value: "byWorkflow", label: "Status" },
     { value: "flat", label: "All" },
   ];
+  // Playwright-measured: the full PR filter row first fits at 382px.
+  const COMPACT_FILTER_MAX_WIDTH = 381;
 
   interface Props {
     getDetailTab?: () => string;
@@ -124,7 +126,9 @@
   const hasCompactFilterChanges = $derived(
     pulls.getFilterState() !== "open" || groupingMode !== "byRepo",
   );
-  const useCompactFilters = $derived(sidebarWidth <= 280);
+  const useCompactFilters = $derived(
+    sidebarWidth <= COMPACT_FILTER_MAX_WIDTH,
+  );
 
   function routeRefForPull(pr: PullRequest): PullRequestRouteRef {
     return {

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -43,8 +43,9 @@
     { value: "byWorkflow", label: "Status" },
     { value: "flat", label: "All" },
   ];
-  // Playwright-measured: the full PR filter row first fits at 382px.
-  const COMPACT_FILTER_MAX_WIDTH = 381;
+  // Playwright-measured with a buffered "9999 PRs" count label:
+  // the full PR filter row first fits at 396px.
+  const COMPACT_FILTER_MAX_WIDTH = 395;
 
   interface Props {
     getDetailTab?: () => string;

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -4,8 +4,10 @@
   import DiffSidebar from "../diff/DiffSidebar.svelte";
   import PullItem from "./PullItem.svelte";
   import Chip from "../shared/Chip.svelte";
+  import FilterDropdown from "../shared/FilterDropdown.svelte";
   import LeftSidebarToggle from "../shared/LeftSidebarToggle.svelte";
   import type { PullRequest } from "../../api/types.js";
+  import type { GroupingMode } from "../../stores/grouping.svelte.js";
   import {
     buildPullRequestFilesRoute,
     buildPullRequestRoute,
@@ -32,14 +34,25 @@
   const workflowGroups = $derived(
     groupByWorkflow(pulls.getPulls(), activeWorktreeKey),
   );
+  const pullStateOptions = ["open", "closed", "all"] as const;
+  const groupingOptions: {
+    value: GroupingMode;
+    label: string;
+  }[] = [
+    { value: "byRepo", label: "Repo" },
+    { value: "byWorkflow", label: "Status" },
+    { value: "flat", label: "All" },
+  ];
 
   interface Props {
     getDetailTab?: () => string;
     showSelectedDiffSidebar?: boolean;
+    sidebarWidth?: number;
   }
   const {
     getDetailTab: _getDetailTab = () => "conversation",
     showSelectedDiffSidebar = true,
+    sidebarWidth = 340,
   }: Props = $props();
 
   let searchInput = $state(pulls.getSearchQuery() ?? "");
@@ -73,6 +86,45 @@
       void pulls.loadPulls();
     }, 300);
   }
+
+  function pullStateLabel(state: string): string {
+    if (state === "open") return "Open";
+    if (state === "closed") return "Closed";
+    return "All";
+  }
+
+  function setPullState(state: string): void {
+    pulls.setFilterState(state);
+    void pulls.loadPulls();
+  }
+
+  const compactFilterSections = $derived.by(() => [
+    {
+      title: "State",
+      items: pullStateOptions.map((state) => ({
+        id: `state-${state}`,
+        label: pullStateLabel(state),
+        active: pulls.getFilterState() === state,
+        closeOnSelect: true,
+        onSelect: () => setPullState(state),
+      })),
+    },
+    {
+      title: "Group",
+      items: groupingOptions.map((option) => ({
+        id: `group-${option.value}`,
+        label: option.label,
+        active: groupingMode === option.value,
+        closeOnSelect: true,
+        onSelect: () => grouping.setGroupingMode(option.value),
+      })),
+    },
+  ]);
+
+  const hasCompactFilterChanges = $derived(
+    pulls.getFilterState() !== "open" || groupingMode !== "byRepo",
+  );
+  const useCompactFilters = $derived(sidebarWidth <= 280);
 
   function routeRefForPull(pr: PullRequest): PullRequestRouteRef {
     return {
@@ -143,35 +195,38 @@
 </script>
 
 <div class="pull-list">
-  <div class="filter-bar">
+  <div class="filter-bar" class:filter-bar--compact={useCompactFilters}>
     <Chip size="sm" uppercase={false} class="chip--muted list-count-chip">
       {pulls.getPulls().length} PRs
     </Chip>
     <div class="state-toggle">
-      {#each ["open", "closed", "all"] as s (s)}
+      {#each pullStateOptions as s (s)}
         <button
           class="state-btn"
           class:state-btn--active={pulls.getFilterState() === s}
-          onclick={() => { pulls.setFilterState(s); void pulls.loadPulls(); }}
-        >{s === "open" ? "Open" : s === "closed" ? "Closed" : "All"}</button>
+          onclick={() => setPullState(s)}
+        >{pullStateLabel(s)}</button>
       {/each}
     </div>
     <div class="group-toggle">
-      <button
-        class="group-btn"
-        class:group-btn--active={groupingMode === "byRepo"}
-        onclick={() => grouping.setGroupingMode("byRepo")}
-      >Repo</button>
-      <button
-        class="group-btn"
-        class:group-btn--active={groupingMode === "byWorkflow"}
-        onclick={() => grouping.setGroupingMode("byWorkflow")}
-      >Status</button>
-      <button
-        class="group-btn"
-        class:group-btn--active={groupingMode === "flat"}
-        onclick={() => grouping.setGroupingMode("flat")}
-      >All</button>
+      {#each groupingOptions as option (option.value)}
+        <button
+          class="group-btn"
+          class:group-btn--active={groupingMode === option.value}
+          onclick={() => grouping.setGroupingMode(option.value)}
+        >{option.label}</button>
+      {/each}
+    </div>
+    <div class="compact-filter-menu">
+      <FilterDropdown
+        label="Filters"
+        title="Filters"
+        icon="more"
+        active={hasCompactFilterChanges}
+        showBadge={false}
+        sections={compactFilterSections}
+        minWidth="160px"
+      />
     </div>
     {#if isSidebarToggleEnabled()}
       <LeftSidebarToggle
@@ -354,6 +409,7 @@
     border-bottom: 1px solid var(--border-muted);
     flex-shrink: 0;
     background: var(--bg-surface);
+    overflow: hidden;
   }
 
   .search-bar {
@@ -583,6 +639,23 @@
     border-radius: 6px;
     padding: 2px;
   }
+
+  .compact-filter-menu {
+    display: none;
+    flex-shrink: 0;
+  }
+
+  .compact-filter-menu :global(.filter-btn) {
+    width: 26px;
+    justify-content: center;
+    padding: 3px;
+  }
+
+  .compact-filter-menu :global(.filter-trigger-label),
+  .compact-filter-menu :global(.filter-trigger-detail) {
+    display: none;
+  }
+
   .state-btn {
     font-size: 11px;
     padding: 2px 8px;
@@ -626,6 +699,15 @@
     background: var(--bg-surface);
     color: var(--text-primary);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+  .filter-bar--compact .state-toggle,
+  .filter-bar--compact .group-toggle {
+    display: none;
+  }
+
+  .filter-bar--compact .compact-filter-menu {
+    display: block;
   }
 
   .diff-files-wrap {

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -39,7 +39,7 @@
   mainEmpty={selectedIssue === null}
 >
   {#snippet sidebar()}
-    <IssueList />
+    <IssueList {sidebarWidth} />
   {/snippet}
 
   {#if selectedIssue !== null}

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -72,6 +72,7 @@
     <PullList
       getDetailTab={() => detailTab}
       showSelectedDiffSidebar={false}
+      {sidebarWidth}
     />
   {/snippet}
 


### PR DESCRIPTION
- Collapse PR and issue sidebar filters into the shared Filters menu before the segmented controls clip.
- Use measured breakpoints with buffer for wider count labels.
- Add a brief resize transition so the controls fold into and pop out of the compact menu.

Video:
https://github.com/user-attachments/assets/6b5ef45e-7e34-4b51-941b-887384ceb9d9