### PR TITLE
Keep diff display toggles in the menu

### DIFF
--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -289,6 +289,10 @@ async function waitForSidebarFilesLoaded(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 
+async function openDiffFilterMenu(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "More diff filters" }).click();
+}
+
 // --- Functional tests ---
 
 test.describe("diff view", () => {
@@ -415,19 +419,31 @@ test.describe("diff view", () => {
     await expect(content).toBeVisible();
   });
 
-  test("toolbar tab width buttons change active state", async ({ page }) => {
+  test("toolbar keeps file filters inline and moves display settings into the menu", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
+    await expect(page.getByRole("group", { name: "Filter changed files" }))
+      .toBeVisible();
+    await expect(page.getByRole("button", { name: "More diff filters" }))
+      .toBeVisible();
+    await expect(page.getByRole("switch", { name: "Word wrap" }))
+      .toHaveCount(0);
+
+    await openDiffFilterMenu(page);
+
     // Default tab width is 4.
-    const segments = page.locator(".diff-toolbar .segment");
-    await expect(segments.nth(2)).toHaveClass(/segment--active/);
+    const tabWidth = page.getByRole("group", { name: "Tab width" });
+    await expect(tabWidth.getByRole("button", { name: "4" }))
+      .toHaveAttribute("aria-pressed", "true");
 
     // Click tab width 2.
-    await segments.nth(1).click();
-    await expect(segments.nth(1)).toHaveClass(/segment--active/);
-    await expect(segments.nth(2)).not.toHaveClass(/segment--active/);
+    await tabWidth.getByRole("button", { name: "2" }).click();
+    await expect(tabWidth.getByRole("button", { name: "2" }))
+      .toHaveAttribute("aria-pressed", "true");
+    await expect(tabWidth.getByRole("button", { name: "4" }))
+      .toHaveAttribute("aria-pressed", "false");
   });
 
   test("word wrap toggle changes diff line wrapping", async ({ page }) => {
@@ -435,8 +451,10 @@ test.describe("diff view", () => {
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
-    const wrapToggle = page.getByRole("switch", { name: "Word wrap" });
     const firstCodeLine = page.locator(".diff-line .code").first();
+
+    await openDiffFilterMenu(page);
+    const wrapToggle = page.getByRole("switch", { name: "Word wrap" });
 
     await expect(wrapToggle).toHaveAttribute("aria-checked", "false");
     await expect(firstCodeLine).toHaveCSS("white-space", "pre");
@@ -453,6 +471,7 @@ test.describe("diff view", () => {
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
+    await openDiffFilterMenu(page);
     const previewToggle = page.getByRole("switch", { name: "Rich preview" });
     await expect(previewToggle).toHaveAttribute("aria-checked", "false");
 
@@ -525,6 +544,7 @@ test.describe("diff view", () => {
     await waitForDiffLoaded(page);
     await waitForSidebarFilesLoaded(page);
 
+    await openDiffFilterMenu(page);
     await page.getByRole("switch", { name: "Rich preview" }).click();
     await page.locator(".diff-file-row", { hasText: "logo.png" }).click();
 
@@ -533,6 +553,7 @@ test.describe("diff view", () => {
     expect(previewFetchCount).toBe(1);
 
     const initialDiffFetchCount = diffFetchCount;
+    await openDiffFilterMenu(page);
     await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
     await expect.poll(() => diffFetchCount).toBeGreaterThan(initialDiffFetchCount);
     await page.locator(".diff-file-row", { hasText: "logo.png" }).click();
@@ -607,6 +628,7 @@ test.describe("diff view", () => {
     const initialCount = fetchCount;
 
     // Toggle hide whitespace on.
+    await openDiffFilterMenu(page);
     await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
 
     // Wait for the re-fetch to land and assert it actually happened.
@@ -984,6 +1006,7 @@ test.describe("diff view performance", () => {
 
     // Toggle whitespace -- triggers a re-fetch with ?whitespace=hide
     // which returns fewer files.
+    await openDiffFilterMenu(page);
     await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
 
     // Count should drop to 45, proving the re-fetch and re-render completed.
@@ -1113,6 +1136,7 @@ test.describe("diff view (git-backed)", () => {
       await waitForDiffLoaded(page);
       await waitForSidebarFilesLoaded(page);
 
+      await openDiffFilterMenu(page);
       await page.getByRole("switch", { name: "Rich preview" }).click();
 
       const handlerFile = page.locator('[data-file-path="internal/handler.go"]');
@@ -1242,6 +1266,7 @@ test.describe("diff view (git-backed)", () => {
     await expect(page.locator(".diff-file")).toHaveCount(4);
 
     // Toggle hide whitespace.
+    await openDiffFilterMenu(page);
     await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
 
     // README.md is whitespace-only and should be hidden.

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -44,6 +44,97 @@
   }
 </script>
 
+{#snippet menuContent(showFileFilters: boolean)}
+  {#if showFileFilters}
+    <div class="compact-menu-section">
+      <div class="compact-menu-title">Files</div>
+      <div class="compact-menu-grid" role="group" aria-label="Filter changed files">
+        {#each diffFileCategoryOptions as option (option.value)}
+          <button
+            class="compact-menu-item"
+            class:compact-menu-item--active={activeCategory === option.value}
+            aria-pressed={activeCategory === option.value}
+            type="button"
+            onclick={() => setFileCategoryFilter(option.value)}
+          >
+            <span>{option.label}</span>
+            <span class="category-count">({categoryCounts[option.value]})</span>
+          </button>
+        {/each}
+      </div>
+    </div>
+  {/if}
+  <div class="compact-menu-section">
+    <div class="compact-menu-title">Tab width</div>
+    <div class="compact-menu-grid" role="group" aria-label="Tab width">
+      {#each tabOptions as opt (opt)}
+        <button
+          class="compact-menu-item"
+          class:compact-menu-item--active={diff.getTabWidth() === opt}
+          aria-pressed={diff.getTabWidth() === opt}
+          type="button"
+          onclick={() => diff.setTabWidth(opt)}
+        >
+          {opt}
+        </button>
+      {/each}
+    </div>
+  </div>
+  <div class="compact-menu-section">
+    <button
+      class="compact-switch-row"
+      type="button"
+      role="switch"
+      aria-label="Hide whitespace changes"
+      aria-checked={diff.getHideWhitespace()}
+      onclick={() => diff.setHideWhitespace(!diff.getHideWhitespace())}
+    >
+      <span>Hide whitespace</span>
+      <span
+        class="toggle-switch"
+        class:toggle-switch--on={diff.getHideWhitespace()}
+        aria-hidden="true"
+      >
+        <span class="toggle-knob"></span>
+      </span>
+    </button>
+    <button
+      class="compact-switch-row"
+      type="button"
+      role="switch"
+      aria-checked={diff.getWordWrap()}
+      onclick={() => diff.setWordWrap(!diff.getWordWrap())}
+    >
+      <span>Word wrap</span>
+      <span
+        class="toggle-switch"
+        class:toggle-switch--on={diff.getWordWrap()}
+        aria-hidden="true"
+      >
+        <span class="toggle-knob"></span>
+      </span>
+    </button>
+    {#if showRichPreview}
+      <button
+        class="compact-switch-row"
+        type="button"
+        role="switch"
+        aria-checked={diff.getRichPreview()}
+        onclick={() => diff.setRichPreview(!diff.getRichPreview())}
+      >
+        <span>Rich preview</span>
+        <span
+          class="toggle-switch"
+          class:toggle-switch--on={diff.getRichPreview()}
+          aria-hidden="true"
+        >
+          <span class="toggle-knob"></span>
+        </span>
+      </button>
+    {/if}
+  </div>
+{/snippet}
+
 <svelte:document onclick={handleDocumentClick} onkeydown={handleDocumentKeydown} />
 
 <div class={["diff-toolbar", compact && "diff-toolbar--compact"]}>
@@ -55,110 +146,6 @@
         <span class="category-count">({categoryCounts[activeCategory]})</span>
       </span>
       <span class="compact-summary-detail">Tab {diff.getTabWidth()}</span>
-    </div>
-    <div class="compact-menu-wrap" bind:this={compactMenuRef}>
-      <button
-        class="compact-more-btn"
-        class:compact-more-btn--active={menuOpen}
-        type="button"
-        aria-label="More diff filters"
-        aria-expanded={menuOpen}
-        title="More diff filters"
-        onclick={() => {
-          menuOpen = !menuOpen;
-        }}
-      >
-        <MoreHorizontalIcon size={16} strokeWidth={2} aria-hidden="true" />
-      </button>
-      {#if menuOpen}
-        <div class="compact-menu">
-          <div class="compact-menu-section">
-            <div class="compact-menu-title">Files</div>
-            <div class="compact-menu-grid" role="group" aria-label="Filter changed files">
-              {#each diffFileCategoryOptions as option (option.value)}
-                <button
-                  class="compact-menu-item"
-                  class:compact-menu-item--active={activeCategory === option.value}
-                  aria-pressed={activeCategory === option.value}
-                  type="button"
-                  onclick={() => setFileCategoryFilter(option.value)}
-                >
-                  <span>{option.label}</span>
-                  <span class="category-count">({categoryCounts[option.value]})</span>
-                </button>
-              {/each}
-            </div>
-          </div>
-          <div class="compact-menu-section">
-            <div class="compact-menu-title">Tab width</div>
-            <div class="compact-menu-grid" role="group" aria-label="Tab width">
-              {#each tabOptions as opt (opt)}
-                <button
-                  class="compact-menu-item"
-                  class:compact-menu-item--active={diff.getTabWidth() === opt}
-                  aria-pressed={diff.getTabWidth() === opt}
-                  type="button"
-                  onclick={() => diff.setTabWidth(opt)}
-                >
-                  {opt}
-                </button>
-              {/each}
-            </div>
-          </div>
-          <div class="compact-menu-section">
-            <button
-              class="compact-switch-row"
-              type="button"
-              role="switch"
-              aria-checked={diff.getHideWhitespace()}
-              onclick={() => diff.setHideWhitespace(!diff.getHideWhitespace())}
-            >
-              <span>Hide whitespace</span>
-              <span
-                class="toggle-switch"
-                class:toggle-switch--on={diff.getHideWhitespace()}
-                aria-hidden="true"
-              >
-                <span class="toggle-knob"></span>
-              </span>
-            </button>
-            <button
-              class="compact-switch-row"
-              type="button"
-              role="switch"
-              aria-checked={diff.getWordWrap()}
-              onclick={() => diff.setWordWrap(!diff.getWordWrap())}
-            >
-              <span>Word wrap</span>
-              <span
-                class="toggle-switch"
-                class:toggle-switch--on={diff.getWordWrap()}
-                aria-hidden="true"
-              >
-                <span class="toggle-knob"></span>
-              </span>
-            </button>
-            {#if showRichPreview}
-              <button
-                class="compact-switch-row"
-                type="button"
-                role="switch"
-                aria-checked={diff.getRichPreview()}
-                onclick={() => diff.setRichPreview(!diff.getRichPreview())}
-              >
-                <span>Rich preview</span>
-                <span
-                  class="toggle-switch"
-                  class:toggle-switch--on={diff.getRichPreview()}
-                  aria-hidden="true"
-                >
-                  <span class="toggle-knob"></span>
-                </span>
-              </button>
-            {/if}
-          </div>
-        </div>
-      {/if}
     </div>
   {:else}
     <div class="toolbar-group toolbar-group--category">
@@ -176,66 +163,27 @@
         {/each}
       </div>
     </div>
-    <div class="toolbar-settings">
-      <div class="toolbar-group">
-        <span class="toolbar-label">Tab width</span>
-        <div class="segmented-control">
-          {#each tabOptions as opt (opt)}
-            <button
-              class="segment"
-              class:segment--active={diff.getTabWidth() === opt}
-              onclick={() => diff.setTabWidth(opt)}
-            >
-              {opt}
-            </button>
-          {/each}
-        </div>
-      </div>
-      <div class="toolbar-group">
-        <span class="toolbar-label">Hide whitespace</span>
-        <button
-          class="toggle-switch"
-          class:toggle-switch--on={diff.getHideWhitespace()}
-          role="switch"
-          aria-checked={diff.getHideWhitespace()}
-          title={diff.getHideWhitespace() ? "Show whitespace changes" : "Hide whitespace changes"}
-          onclick={() => diff.setHideWhitespace(!diff.getHideWhitespace())}
-        >
-          <span class="toggle-knob"></span>
-        </button>
-      </div>
-      <div class="toolbar-group">
-        <span class="toolbar-label">Word wrap</span>
-        <button
-          class="toggle-switch"
-          class:toggle-switch--on={diff.getWordWrap()}
-          role="switch"
-          aria-label="Word wrap"
-          aria-checked={diff.getWordWrap()}
-          title={diff.getWordWrap() ? "Disable word wrap" : "Enable word wrap"}
-          onclick={() => diff.setWordWrap(!diff.getWordWrap())}
-        >
-          <span class="toggle-knob"></span>
-        </button>
-      </div>
-      {#if showRichPreview}
-        <div class="toolbar-group">
-          <span class="toolbar-label">Rich preview</span>
-          <button
-            class="toggle-switch"
-            class:toggle-switch--on={diff.getRichPreview()}
-            role="switch"
-            aria-label="Rich preview"
-            aria-checked={diff.getRichPreview()}
-            title={diff.getRichPreview() ? "Show unified diff" : "Show rich file previews"}
-            onclick={() => diff.setRichPreview(!diff.getRichPreview())}
-          >
-            <span class="toggle-knob"></span>
-          </button>
-        </div>
-      {/if}
-    </div>
   {/if}
+  <div class="compact-menu-wrap" bind:this={compactMenuRef}>
+    <button
+      class="compact-more-btn"
+      class:compact-more-btn--active={menuOpen}
+      type="button"
+      aria-label="More diff filters"
+      aria-expanded={menuOpen}
+      title="More diff filters"
+      onclick={() => {
+        menuOpen = !menuOpen;
+      }}
+    >
+      <MoreHorizontalIcon size={16} strokeWidth={2} aria-hidden="true" />
+    </button>
+    {#if menuOpen}
+      <div class="compact-menu">
+        {@render menuContent(compact)}
+      </div>
+    {/if}
+  </div>
 </div>
 
 <style>
@@ -263,15 +211,8 @@
   }
 
   .toolbar-group--category {
+    flex: 1 1 auto;
     min-width: 0;
-  }
-
-  .toolbar-settings {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-left: auto;
-    flex-shrink: 0;
   }
 
   .toolbar-label {
@@ -302,6 +243,7 @@
 
   .compact-menu-wrap {
     position: relative;
+    margin-left: auto;
     flex-shrink: 0;
   }
 
@@ -394,41 +336,6 @@
   .compact-switch-row {
     justify-content: space-between;
   }
-
-  .segmented-control {
-    display: flex;
-    border: 1px solid var(--diff-border);
-    border-radius: var(--radius-sm);
-    overflow: hidden;
-  }
-
-  .segment {
-    font-size: 11px;
-    font-family: var(--font-mono);
-    padding: 2px 8px;
-    color: var(--text-secondary);
-    background: var(--diff-bg);
-    border-right: 1px solid var(--diff-border);
-    line-height: 18px;
-  }
-
-  .segment:last-child {
-    border-right: none;
-  }
-
-  .segment:hover {
-    background: var(--bg-surface-hover);
-  }
-
-  .segment--active {
-    background: var(--accent-blue);
-    color: #ffffff;
-  }
-
-  .segment--active:hover {
-    background: var(--accent-blue);
-  }
-
   .category-toggle {
     display: flex;
     gap: 2px;
@@ -502,9 +409,8 @@
       flex-direction: column;
     }
 
-    .toolbar-settings {
+    .compact-menu-wrap {
       margin-left: 0;
-      flex-wrap: wrap;
     }
   }
 </style>

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -58,6 +58,11 @@ describe("DiffToolbar", () => {
 
   it("toggles the word wrap preference", async () => {
     const { diff } = renderToolbar();
+    expect(screen.queryByRole("switch", { name: "Word wrap" })).toBeNull();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "More diff filters" }),
+    );
     const wordWrap = screen.getByRole("switch", { name: "Word wrap" });
 
     expect(diff.getWordWrap()).toBe(false);


### PR DESCRIPTION
- Keep changed-file category filters visible in the diff toolbar.
- Move tab width, whitespace, word wrap, and rich preview controls into the always-visible diff menu.
- Update toolbar and diff-view coverage for the menu interaction.