### PR TITLE
Add merge-target workspace diff scope

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -4041,12 +4041,12 @@ paths:
           required: true
           schema:
             type: string
-        - description: "Diff base: head or origin"
+        - description: "Diff base: head, pushed, or merge-target"
           explode: false
           in: query
           name: base
           schema:
-            description: "Diff base: head or origin"
+            description: "Diff base: head, pushed, or merge-target"
             type: string
         - description: Set to hide to ignore whitespace-only changes
           explode: false
@@ -4078,12 +4078,12 @@ paths:
           required: true
           schema:
             type: string
-        - description: "Diff base: head or origin"
+        - description: "Diff base: head, pushed, or merge-target"
           explode: false
           in: query
           name: base
           schema:
-            description: "Diff base: head or origin"
+            description: "Diff base: head, pushed, or merge-target"
             type: string
         - description: Set to hide to ignore whitespace-only changes
           explode: false

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -130,10 +130,10 @@ describe("createDiffStore loadDiff", () => {
 
     const store = createDiffStore({ client: testClient() });
 
-    await store.loadWorkspaceDiff("ws-1", "origin");
+    await store.loadWorkspaceDiff("ws-1", "pushed");
 
-    expect(calls).toContain("/api/v1/workspaces/ws-1/files?base=origin");
-    expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=origin");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/files?base=pushed");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=pushed");
     expect(store.getFileCategoryCounts()).toEqual({
       all: 3,
       plansDocs: 1,
@@ -141,6 +141,42 @@ describe("createDiffStore loadDiff", () => {
       tests: 1,
       other: 0,
     });
+  });
+
+  it("loads workspace diffs against the merge target", async () => {
+    const calls: string[] = [];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        calls.push(url);
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(files);
+        }
+        if (url.includes("/workspaces/ws-1/diff")) {
+          return Response.json(diff);
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+
+    await store.loadWorkspaceDiff("ws-1", "merge-target");
+
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/files?base=merge-target",
+    );
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/diff?base=merge-target",
+    );
   });
 
   it("refetches workspace files when toggling whitespace hiding", async () => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -995,7 +995,7 @@ type DeleteWorkspaceParams struct {
 
 // GetWorkspacesByIdDiffParams defines parameters for GetWorkspacesByIdDiff.
 type GetWorkspacesByIdDiffParams struct {
-	// Base Diff base: head or origin
+	// Base Diff base: head, pushed, or merge-target
 	Base *string `form:"base,omitempty" json:"base,omitempty"`
 
 	// Whitespace Set to hide to ignore whitespace-only changes
@@ -1004,7 +1004,7 @@ type GetWorkspacesByIdDiffParams struct {
 
 // GetWorkspacesByIdFilesParams defines parameters for GetWorkspacesByIdFiles.
 type GetWorkspacesByIdFilesParams struct {
-	// Base Diff base: head or origin
+	// Base Diff base: head, pushed, or merge-target
 	Base *string `form:"base,omitempty" json:"base,omitempty"`
 
 	// Whitespace Set to hide to ignore whitespace-only changes

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10471,13 +10471,21 @@ func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
 		[]byte("package dirty\n"), 0o644,
 	))
 
+	mergeTargetFiles := requestWorkspaceFiles(t, srv, ws.Id, "merge-target")
+	require.NotNil(mergeTargetFiles.Files)
+	filePaths := workspaceDiffPaths(*mergeTargetFiles.Files)
+	assert.Contains(filePaths, "new.txt")
+	assert.Contains(filePaths, "committed.go")
+	assert.Contains(filePaths, "dirty.go")
+	assert.NotContains(filePaths, "target-only.txt")
+
 	mergeTargetDiff := requestWorkspaceDiff(t, srv, ws.Id, "merge-target")
 	require.NotNil(mergeTargetDiff.Files)
-	paths := workspaceDiffPaths(*mergeTargetDiff.Files)
-	assert.Contains(paths, "new.txt")
-	assert.Contains(paths, "committed.go")
-	assert.Contains(paths, "dirty.go")
-	assert.NotContains(paths, "target-only.txt")
+	diffPaths := workspaceDiffPaths(*mergeTargetDiff.Files)
+	assert.Contains(diffPaths, "new.txt")
+	assert.Contains(diffPaths, "committed.go")
+	assert.Contains(diffPaths, "dirty.go")
+	assert.NotContains(diffPaths, "target-only.txt")
 }
 
 func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10364,7 +10364,7 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 	assert.Equal(int64(0), *found.CommitsBehind)
 }
 
-func TestWorkspaceDiffEndpointsReportHeadAndUpstreamE2E(t *testing.T) {
+func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -10427,14 +10427,81 @@ func TestWorkspaceDiffEndpointsReportHeadAndUpstreamE2E(t *testing.T) {
 		[]string{"dirty.go", "z-empty.txt"},
 	)
 
-	originDiff := requestWorkspaceDiff(t, srv, ws.Id, "origin")
-	require.NotNil(originDiff.Files)
+	pushedDiff := requestWorkspaceDiff(t, srv, ws.Id, "pushed")
+	require.NotNil(pushedDiff.Files)
 	assertWorkspaceDiffPaths(
 		t,
-		*originDiff.Files,
+		*pushedDiff.Files,
 		[]string{"base.txt", "committed.go", "dirty.go", "z-blank.txt", "z-empty.txt"},
 	)
-	assert.Equal(int64(1), originDiff.WhitespaceOnlyCount)
+	assert.Equal(int64(1), pushedDiff.WhitespaceOnlyCount)
+}
+
+func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	client, _, _, remote, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	targetWork := filepath.Join(t.TempDir(), "target")
+	runGit(t, filepath.Dir(targetWork), "clone", remote, targetWork)
+	runGit(t, targetWork, "config", "user.email", "test@test.com")
+	runGit(t, targetWork, "config", "user.name", "Test")
+	require.NoError(os.WriteFile(
+		filepath.Join(targetWork, "target-only.txt"),
+		[]byte("target\n"), 0o644,
+	))
+	runGit(t, targetWork, "add", ".")
+	runGit(t, targetWork, "commit", "-m", "advance main")
+	runGit(t, targetWork, "push", "origin", "main")
+	runGit(t, ws.WorktreePath, "fetch", "origin", "main")
+
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "committed.go"),
+		[]byte("package committed\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "local workspace commit")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "dirty.go"),
+		[]byte("package dirty\n"), 0o644,
+	))
+
+	mergeTargetDiff := requestWorkspaceDiff(t, srv, ws.Id, "merge-target")
+	require.NotNil(mergeTargetDiff.Files)
+	paths := workspaceDiffPaths(*mergeTargetDiff.Files)
+	assert.Contains(paths, "new.txt")
+	assert.Contains(paths, "committed.go")
+	assert.Contains(paths, "dirty.go")
+	assert.NotContains(paths, "target-only.txt")
+}
+
+func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {
+	require := require.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/workspaces/"+ws.Id+"/diff?base=origin",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var body rawProblemDetail
+	require.NoError(json.NewDecoder(resp.Body).Decode(&body))
+	require.Contains(body.Detail, "base must be head, pushed, or merge-target")
 }
 
 func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.T) {
@@ -10562,11 +10629,15 @@ func assertWorkspaceDiffPaths(
 ) {
 	t.Helper()
 
+	Assert.Equal(t, want, workspaceDiffPaths(files))
+}
+
+func workspaceDiffPaths(files []generated.DiffFile) []string {
 	paths := make([]string, 0, len(files))
 	for _, file := range files {
 		paths = append(paths, file.Path)
 	}
-	Assert.Equal(t, want, paths)
+	return paths
 }
 
 func TestWorkspaceListPrunesMissingTmuxSessionsE2E(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -273,7 +273,7 @@ type getWorkspaceInput struct {
 
 type getWorkspaceDiffInput struct {
 	ID         string `path:"id"`
-	Base       string `query:"base"      doc:"Diff base: head or origin"`
+	Base       string `query:"base"      doc:"Diff base: head, pushed, or merge-target"`
 	Whitespace string `query:"whitespace" doc:"Set to hide to ignore whitespace-only changes"`
 }
 
@@ -318,6 +318,12 @@ type getWorkspaceRuntimeOutput = bodyOutput[workspaceRuntimeResponse]
 type workspaceRuntimeSessionOutput = bodyOutput[localruntime.SessionInfo]
 
 type createWorkspaceOutput = acceptedBodyOutput[workspaceResponse]
+
+type workspaceDiffRequest struct {
+	Summary           *db.WorkspaceSummary
+	Base              workspace.WorktreeDiffBase
+	MergeTargetBranch string
+}
 
 type listActivityInput struct {
 	Repo   string   `query:"repo"`
@@ -3027,20 +3033,20 @@ func (s *Server) getWorkspace(
 func (s *Server) getWorkspaceFiles(
 	ctx context.Context, input *getWorkspaceDiffInput,
 ) (*getWorkspaceFilesOutput, error) {
-	summary, base, err := s.workspaceDiffRequest(ctx, input)
+	req, err := s.workspaceDiffRequest(ctx, input)
 	if err != nil {
 		return nil, err
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
-	files, ok, diffErr := workspace.WorktreeDiffFiles(
-		ctx, summary.WorktreePath, base, hideWhitespace,
+	files, ok, diffErr := s.workspaceDiffFiles(
+		ctx, req, hideWhitespace,
 	)
 	if diffErr != nil {
 		slog.Error(
 			"failed to list workspace diff files",
 			"workspace_id", input.ID,
-			"base", base,
+			"base", req.Base,
 			"err", diffErr,
 		)
 		return nil, huma.Error502BadGateway(
@@ -3048,9 +3054,7 @@ func (s *Server) getWorkspaceFiles(
 		)
 	}
 	if !ok {
-		return nil, huma.Error404NotFound(
-			"workspace origin branch not available",
-		)
+		return nil, workspaceDiffBaseUnavailable(req.Base)
 	}
 	return &getWorkspaceFilesOutput{Body: filesResponse{
 		Stale: false,
@@ -3061,20 +3065,20 @@ func (s *Server) getWorkspaceFiles(
 func (s *Server) getWorkspaceDiff(
 	ctx context.Context, input *getWorkspaceDiffInput,
 ) (*getWorkspaceDiffOutput, error) {
-	summary, base, err := s.workspaceDiffRequest(ctx, input)
+	req, err := s.workspaceDiffRequest(ctx, input)
 	if err != nil {
 		return nil, err
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
-	result, ok, diffErr := workspace.WorktreeDiff(
-		ctx, summary.WorktreePath, base, hideWhitespace,
+	result, ok, diffErr := s.workspaceDiff(
+		ctx, req, hideWhitespace,
 	)
 	if diffErr != nil {
 		slog.Error(
 			"failed to compute workspace diff",
 			"workspace_id", input.ID,
-			"base", base,
+			"base", req.Base,
 			"err", diffErr,
 		)
 		return nil, huma.Error502BadGateway(
@@ -3082,9 +3086,7 @@ func (s *Server) getWorkspaceDiff(
 		)
 	}
 	if !ok {
-		return nil, huma.Error404NotFound(
-			"workspace origin branch not available",
-		)
+		return nil, workspaceDiffBaseUnavailable(req.Base)
 	}
 	return &getWorkspaceDiffOutput{Body: diffResponse{
 		Stale:               false,
@@ -3096,24 +3098,24 @@ func (s *Server) getWorkspaceDiff(
 func (s *Server) workspaceDiffRequest(
 	ctx context.Context,
 	input *getWorkspaceDiffInput,
-) (*db.WorkspaceSummary, workspace.WorktreeDiffBase, error) {
+) (workspaceDiffRequest, error) {
 	if s.workspaces == nil {
-		return nil, "", huma.Error503ServiceUnavailable(
+		return workspaceDiffRequest{}, huma.Error503ServiceUnavailable(
 			"workspace manager not configured",
 		)
 	}
 
 	summary, err := s.workspaces.GetSummary(ctx, input.ID)
 	if err != nil {
-		return nil, "", huma.Error500InternalServerError(
+		return workspaceDiffRequest{}, huma.Error500InternalServerError(
 			"get workspace failed",
 		)
 	}
 	if summary == nil {
-		return nil, "", huma.Error404NotFound("workspace not found")
+		return workspaceDiffRequest{}, huma.Error404NotFound("workspace not found")
 	}
 	if summary.Status != "ready" {
-		return nil, "", huma.Error409Conflict(
+		return workspaceDiffRequest{}, huma.Error409Conflict(
 			"workspace is not ready",
 		)
 	}
@@ -3123,13 +3125,116 @@ func (s *Server) workspaceDiffRequest(
 		base = workspace.WorktreeDiffBaseHead
 	}
 	switch base {
-	case workspace.WorktreeDiffBaseHead, workspace.WorktreeDiffBaseUpstream:
-		return summary, base, nil
+	case workspace.WorktreeDiffBaseHead, workspace.WorktreeDiffBasePushed:
+		return workspaceDiffRequest{Summary: summary, Base: base}, nil
+	case workspace.WorktreeDiffBaseMergeTarget:
+		targetBranch, ok, err := s.workspaceMergeTargetBranch(ctx, summary)
+		if err != nil {
+			return workspaceDiffRequest{}, err
+		}
+		if !ok {
+			return workspaceDiffRequest{}, workspaceDiffBaseUnavailable(base)
+		}
+		return workspaceDiffRequest{
+			Summary:           summary,
+			Base:              base,
+			MergeTargetBranch: targetBranch,
+		}, nil
 	default:
-		return nil, "", huma.Error400BadRequest(
-			"base must be head or origin",
+		return workspaceDiffRequest{}, huma.Error400BadRequest(
+			"base must be head, pushed, or merge-target",
 		)
 	}
+}
+
+func (s *Server) workspaceDiffFiles(
+	ctx context.Context,
+	req workspaceDiffRequest,
+	hideWhitespace bool,
+) ([]gitclone.DiffFile, bool, error) {
+	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
+		return workspace.WorktreeDiffFilesAgainstMergeTarget(
+			ctx,
+			req.Summary.WorktreePath,
+			req.MergeTargetBranch,
+			hideWhitespace,
+		)
+	}
+	return workspace.WorktreeDiffFiles(
+		ctx, req.Summary.WorktreePath, req.Base, hideWhitespace,
+	)
+}
+
+func (s *Server) workspaceDiff(
+	ctx context.Context,
+	req workspaceDiffRequest,
+	hideWhitespace bool,
+) (*gitclone.DiffResult, bool, error) {
+	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
+		return workspace.WorktreeDiffAgainstMergeTarget(
+			ctx,
+			req.Summary.WorktreePath,
+			req.MergeTargetBranch,
+			hideWhitespace,
+		)
+	}
+	return workspace.WorktreeDiff(
+		ctx, req.Summary.WorktreePath, req.Base, hideWhitespace,
+	)
+}
+
+func (s *Server) workspaceMergeTargetBranch(
+	ctx context.Context,
+	summary *db.WorkspaceSummary,
+) (string, bool, error) {
+	prNumber := summary.ItemNumber
+	if summary.ItemType == db.WorkspaceItemTypeIssue {
+		if summary.AssociatedPRNumber == nil {
+			return "", false, nil
+		}
+		prNumber = *summary.AssociatedPRNumber
+	}
+
+	repo, err := s.db.GetRepoByHostOwnerName(
+		ctx,
+		summary.PlatformHost,
+		summary.RepoOwner,
+		summary.RepoName,
+	)
+	if err != nil {
+		return "", false, huma.Error500InternalServerError(
+			"get workspace repo failed",
+		)
+	}
+	if repo == nil {
+		return "", false, nil
+	}
+
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(
+		ctx, repo.ID, prNumber,
+	)
+	if err != nil {
+		return "", false, huma.Error500InternalServerError(
+			"get workspace pull request failed",
+		)
+	}
+	if mr == nil || strings.TrimSpace(mr.BaseBranch) == "" {
+		return "", false, nil
+	}
+	return strings.TrimSpace(mr.BaseBranch), true, nil
+}
+
+func workspaceDiffBaseUnavailable(
+	base workspace.WorktreeDiffBase,
+) error {
+	if base == workspace.WorktreeDiffBaseMergeTarget {
+		return huma.Error404NotFound(
+			"workspace merge target branch not available",
+		)
+	}
+	return huma.Error404NotFound(
+		"workspace pushed branch not available",
+	)
 }
 
 func (s *Server) retryWorkspace(

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -20,8 +20,9 @@ import (
 type WorktreeDiffBase string
 
 const (
-	WorktreeDiffBaseHead     WorktreeDiffBase = "head"
-	WorktreeDiffBaseUpstream WorktreeDiffBase = "origin"
+	WorktreeDiffBaseHead        WorktreeDiffBase = "head"
+	WorktreeDiffBasePushed      WorktreeDiffBase = "pushed"
+	WorktreeDiffBaseMergeTarget WorktreeDiffBase = "merge-target"
 )
 
 const maxUntrackedTextFileBytes = 1 << 20
@@ -37,6 +38,29 @@ func WorktreeDiffFiles(
 		return nil, ok, err
 	}
 
+	return worktreeDiffFilesFromRef(ctx, dir, baseRef, hideWhitespace)
+}
+
+func WorktreeDiffFilesAgainstMergeTarget(
+	ctx context.Context,
+	dir string,
+	targetBranch string,
+	hideWhitespace bool,
+) ([]gitclone.DiffFile, bool, error) {
+	baseRef, ok, err := worktreeMergeTargetBaseRef(ctx, dir, targetBranch)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	return worktreeDiffFilesFromRef(ctx, dir, baseRef, hideWhitespace)
+}
+
+func worktreeDiffFilesFromRef(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	hideWhitespace bool,
+) ([]gitclone.DiffFile, bool, error) {
 	rawArgs := addWorktreeWhitespaceFlag([]string{
 		"diff", "--raw", "-z", "-M", "-C", "--find-copies-harder",
 		baseRef,
@@ -74,6 +98,29 @@ func WorktreeDiff(
 		return nil, ok, err
 	}
 
+	return worktreeDiffFromRef(ctx, dir, baseRef, hideWhitespace)
+}
+
+func WorktreeDiffAgainstMergeTarget(
+	ctx context.Context,
+	dir string,
+	targetBranch string,
+	hideWhitespace bool,
+) (*gitclone.DiffResult, bool, error) {
+	baseRef, ok, err := worktreeMergeTargetBaseRef(ctx, dir, targetBranch)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	return worktreeDiffFromRef(ctx, dir, baseRef, hideWhitespace)
+}
+
+func worktreeDiffFromRef(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	hideWhitespace bool,
+) (*gitclone.DiffResult, bool, error) {
 	wsCount, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef)
 	if err != nil {
 		return nil, false, fmt.Errorf("whitespace count: %w", err)
@@ -370,7 +417,7 @@ func worktreeDiffBaseRef(
 	switch base {
 	case WorktreeDiffBaseHead:
 		return "HEAD", true, nil
-	case WorktreeDiffBaseUpstream:
+	case WorktreeDiffBasePushed:
 		_, ok, err := WorktreeDivergence(ctx, dir)
 		if err != nil || !ok {
 			return "", ok, err
@@ -379,6 +426,41 @@ func worktreeDiffBaseRef(
 	default:
 		return "", false, fmt.Errorf("unknown worktree diff base %q", base)
 	}
+}
+
+func worktreeMergeTargetBaseRef(
+	ctx context.Context,
+	dir string,
+	targetBranch string,
+) (string, bool, error) {
+	targetBranch = strings.TrimSpace(targetBranch)
+	if targetBranch == "" {
+		return "", false, nil
+	}
+	if _, err := worktreeGitOutput(
+		ctx, dir, "check-ref-format", "--branch", targetBranch,
+	); err != nil {
+		return "", false, nil
+	}
+
+	targetRef := "refs/remotes/origin/" + targetBranch
+	if _, err := worktreeGitOutput(
+		ctx, dir, "rev-parse", "--verify", "--quiet",
+		targetRef+"^{commit}",
+	); err != nil {
+		return "", false, nil
+	}
+	out, err := worktreeGitOutput(
+		ctx, dir, "merge-base", targetRef, "HEAD",
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("git merge-base: %w", err)
+	}
+	baseRef := strings.TrimSpace(string(out))
+	if baseRef == "" {
+		return "", false, nil
+	}
+	return baseRef, true, nil
 }
 
 func worktreeGitOutput(

--- a/internal/workspace/diff_test.go
+++ b/internal/workspace/diff_test.go
@@ -82,7 +82,7 @@ func TestWorktreeDiffFilesHidesWhitespaceOnlyUntrackedFiles(t *testing.T) {
 	assert.Equal("z-empty.txt", files[1].Path)
 }
 
-func TestWorktreeDiffAgainstUpstreamIncludesLocalCommitsAndDirtyChanges(t *testing.T) {
+func TestWorktreeDiffAgainstPushedBranchIncludesLocalCommitsAndDirtyChanges(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
 	work := setupDivergenceWorktree(t)
@@ -97,7 +97,7 @@ func TestWorktreeDiffAgainstUpstreamIncludesLocalCommitsAndDirtyChanges(t *testi
 	))
 
 	diff, ok, err := WorktreeDiff(
-		t.Context(), work, WorktreeDiffBaseUpstream, false,
+		t.Context(), work, WorktreeDiffBasePushed, false,
 	)
 	require.NoError(err)
 	require.True(ok)
@@ -112,7 +112,51 @@ func TestWorktreeDiffAgainstUpstreamIncludesLocalCommitsAndDirtyChanges(t *testi
 	assert.Equal(0, diff.WhitespaceOnlyCount)
 }
 
-func TestWorktreeDiffAgainstUpstreamWithoutTrackingBranch(t *testing.T) {
+func TestWorktreeDiffAgainstMergeTargetUsesMergeBase(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	work := setupDivergenceWorktree(t)
+
+	other := filepath.Join(filepath.Dir(work), "other")
+	remote := filepath.Join(filepath.Dir(work), "remote.git")
+	runWorkspaceTestGit(t, filepath.Dir(work), "clone", remote, other)
+	runWorkspaceTestGit(t, other, "config", "user.email", "o@test.com")
+	runWorkspaceTestGit(t, other, "config", "user.name", "Other")
+	require.NoError(os.WriteFile(
+		filepath.Join(other, "target-only.txt"), []byte("target\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, other, "add", ".")
+	runWorkspaceTestGit(t, other, "commit", "-m", "target branch advance")
+	runWorkspaceTestGit(t, other, "push", "origin", "main")
+	runWorkspaceTestGit(t, work, "fetch", "origin", "main")
+
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "committed.go"), []byte("package committed\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "local commit")
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "dirty.go"), []byte("package dirty\n"), 0o644,
+	))
+
+	diff, ok, err := WorktreeDiffAgainstMergeTarget(
+		t.Context(), work, "main", false,
+	)
+	require.NoError(err)
+	require.True(ok)
+	require.NotNil(diff)
+
+	paths := make([]string, 0, len(diff.Files))
+	for _, file := range diff.Files {
+		paths = append(paths, file.Path)
+	}
+	assert.Contains(paths, "f.txt")
+	assert.Contains(paths, "committed.go")
+	assert.Contains(paths, "dirty.go")
+	assert.NotContains(paths, "target-only.txt")
+}
+
+func TestWorktreeDiffAgainstPushedBranchWithoutTrackingBranch(t *testing.T) {
 	require := require.New(t)
 	root := t.TempDir()
 	work := filepath.Join(root, "work")
@@ -126,7 +170,7 @@ func TestWorktreeDiffAgainstUpstreamWithoutTrackingBranch(t *testing.T) {
 	runWorkspaceTestGit(t, work, "commit", "-m", "init")
 
 	diff, ok, err := WorktreeDiff(
-		t.Context(), work, WorktreeDiffBaseUpstream, false,
+		t.Context(), work, WorktreeDiffBasePushed, false,
 	)
 	require.NoError(err)
 	require.False(ok)

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -3761,7 +3761,7 @@ export interface operations {
     "get-workspaces-by-id-diff": {
         parameters: {
             query?: {
-                /** @description Diff base: head or origin */
+                /** @description Diff base: head, pushed, or merge-target */
                 base?: string;
                 /** @description Set to hide to ignore whitespace-only changes */
                 whitespace?: string;
@@ -3797,7 +3797,7 @@ export interface operations {
     "get-workspaces-by-id-files": {
         parameters: {
             query?: {
-                /** @description Diff base: head or origin */
+                /** @description Diff base: head, pushed, or merge-target */
                 base?: string;
                 /** @description Set to hide to ignore whitespace-only changes */
                 whitespace?: string;

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -52,12 +52,20 @@
         HEAD
       </button>
       <button
-        class="scope-btn"
-        class:scope-btn--active={base === "origin"}
-        aria-pressed={base === "origin"}
-        onclick={() => selectBase("origin")}
+        class="scope-btn scope-btn--wide"
+        class:scope-btn--active={base === "pushed"}
+        aria-pressed={base === "pushed"}
+        onclick={() => selectBase("pushed")}
       >
-        Origin
+        Pushed branch
+      </button>
+      <button
+        class="scope-btn scope-btn--wide"
+        class:scope-btn--active={base === "merge-target"}
+        aria-pressed={base === "merge-target"}
+        onclick={() => selectBase("merge-target")}
+      >
+        Merge target
       </button>
     </div>
   </div>
@@ -110,6 +118,7 @@
 
   .scope-toggle {
     display: inline-flex;
+    flex-wrap: wrap;
     padding: 2px;
     border: 1px solid var(--border-muted);
     border-radius: 4px;
@@ -127,6 +136,10 @@
     font-size: 11px;
     font-weight: 600;
     cursor: pointer;
+  }
+
+  .scope-btn--wide {
+    min-width: 92px;
   }
 
   .scope-btn:hover {

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -19,7 +19,7 @@ export type DiffScope =
   | { kind: "commit"; sha: string }
   | { kind: "range"; fromSha: string; toSha: string };
 
-export type WorkspaceDiffBase = "head" | "origin";
+export type WorkspaceDiffBase = "head" | "pushed" | "merge-target";
 
 export interface DiffStoreOptions {
   client?: MiddlemanClient;


### PR DESCRIPTION
- add a merge-target workspace diff mode that compares against the target branch merge base
- rename the pushed-branch comparison from `origin` to `pushed` in the API and UI
- reject the old `origin` base so the workspace diff vocabulary stays consistent