### PR TITLE
Avoid eager full workspace patches

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -4055,6 +4055,13 @@ paths:
           schema:
             description: Set to hide to ignore whitespace-only changes
             type: string
+        - description: Optional file path to limit the returned patch
+          explode: false
+          in: query
+          name: path
+          schema:
+            description: Optional file path to limit the returned patch
+            type: string
       responses:
         "200":
           content:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -566,8 +566,12 @@ components:
             - "null"
         stale:
           type: boolean
+        whitespace_only_count:
+          format: int64
+          type: integer
       required:
         - stale
+        - whitespace_only_count
         - files
       type: object
     GithubStateInputBody:

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -30,7 +30,10 @@ function makeDiffResult(files: string[]): DiffResult {
   };
 }
 
-function makeFilesResult(files: string[]): FilesResult {
+function makeFilesResult(
+  files: string[],
+  overrides: Partial<FilesResult & { whitespace_only_count: number }> = {},
+): FilesResult {
   return {
     stale: false,
     files: files.map((path) => ({
@@ -43,6 +46,7 @@ function makeFilesResult(files: string[]): FilesResult {
       deletions: 0,
       hunks: [],
     })),
+    ...overrides,
   };
 }
 
@@ -281,6 +285,65 @@ describe("createDiffStore loadDiff", () => {
     expect(calls).toContain(
       "/api/v1/workspaces/ws-1/diff?base=head&path=b.ts",
     );
+  });
+
+  it("keeps the workspace-wide whitespace count while loading scoped patches", async () => {
+    const files = makeFilesResult(["a.ts", "whitespace.ts"], {
+      whitespace_only_count: 7,
+    });
+    const scopedDiff = makeDiffResult(["a.ts"]);
+    scopedDiff.whitespace_only_count = 0;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(files);
+        }
+        if (url.includes("/workspaces/ws-1/diff")) {
+          return Response.json(scopedDiff);
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+
+    expect(store.getDiff()?.whitespace_only_count).toBe(7);
+  });
+
+  it("clears workspace diff loading when the file list fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(
+            { title: "workspace files failed" },
+            { status: 502 },
+          );
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+
+    expect(store.isDiffLoading()).toBe(false);
+    expect(store.getDiffError()).toBe("workspace files failed");
   });
 
   it("clears stale data when switching PRs", async () => {

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -96,18 +96,14 @@ afterEach(() => {
 });
 
 describe("createDiffStore loadDiff", () => {
-  it("loads workspace diffs with the selected base", async () => {
+  it("loads workspace files and only the active workspace patch", async () => {
     const calls: string[] = [];
     const files = makeFilesResult([
       "src/app.go",
       "src/app_test.go",
       "docs/plan.md",
     ]);
-    const diff = makeDiffResult([
-      "src/app.go",
-      "src/app_test.go",
-      "docs/plan.md",
-    ]);
+    const diff = makeDiffResult(["src/app.go"]);
 
     vi.spyOn(globalThis, "fetch").mockImplementation(
       async (input: RequestInfo | URL) => {
@@ -133,7 +129,13 @@ describe("createDiffStore loadDiff", () => {
     await store.loadWorkspaceDiff("ws-1", "pushed");
 
     expect(calls).toContain("/api/v1/workspaces/ws-1/files?base=pushed");
-    expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=pushed");
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/diff?base=pushed&path=src%2Fapp.go",
+    );
+    expect(calls).not.toContain("/api/v1/workspaces/ws-1/diff?base=pushed");
+    expect(store.getVisibleDiffFiles().map((file) => file.path)).toEqual([
+      "src/app.go",
+    ]);
     expect(store.getFileCategoryCounts()).toEqual({
       all: 3,
       plansDocs: 1,
@@ -175,6 +177,9 @@ describe("createDiffStore loadDiff", () => {
       "/api/v1/workspaces/ws-1/files?base=merge-target",
     );
     expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/diff?base=merge-target&path=src%2Fapp.go",
+    );
+    expect(calls).not.toContain(
       "/api/v1/workspaces/ws-1/diff?base=merge-target",
     );
   });
@@ -230,6 +235,51 @@ describe("createDiffStore loadDiff", () => {
 
     expect(calls).toContain(
       "/api/v1/workspaces/ws-1/files?base=head&whitespace=hide",
+    );
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/diff?base=head&whitespace=hide&path=a.ts",
+    );
+  });
+
+  it("loads the selected workspace file patch on demand", async () => {
+    const calls: string[] = [];
+    const files = makeFilesResult(["a.ts", "b.ts"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        calls.push(url);
+
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(files);
+        }
+        if (url.includes("path=a.ts")) {
+          return Response.json(makeDiffResult(["a.ts"]));
+        }
+        if (url.includes("path=b.ts")) {
+          return Response.json(makeDiffResult(["b.ts"]));
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+
+    store.requestScrollToFile("b.ts");
+    await vi.waitFor(() => {
+      expect(store.getVisibleDiffFiles().map((file) => file.path)).toEqual([
+        "b.ts",
+      ]);
+    });
+
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/diff?base=head&path=b.ts",
     );
   });
 

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -265,9 +265,10 @@ type FilePreviewResponse struct {
 // FilesResponse defines model for FilesResponse.
 type FilesResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema *string     `json:"$schema,omitempty"`
-	Files  *[]DiffFile `json:"files"`
-	Stale  bool        `json:"stale"`
+	Schema              *string     `json:"$schema,omitempty"`
+	Files               *[]DiffFile `json:"files"`
+	Stale               bool        `json:"stale"`
+	WhitespaceOnlyCount int64       `json:"whitespace_only_count"`
 }
 
 // GithubStateInputBody defines model for GithubStateInputBody.

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1000,6 +1000,9 @@ type GetWorkspacesByIdDiffParams struct {
 
 	// Whitespace Set to hide to ignore whitespace-only changes
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
+
+	// Path Optional file path to limit the returned patch
+	Path *string `form:"path,omitempty" json:"path,omitempty"`
 }
 
 // GetWorkspacesByIdFilesParams defines parameters for GetWorkspacesByIdFiles.
@@ -5363,6 +5366,22 @@ func NewGetWorkspacesByIdDiffRequest(server string, id string, params *GetWorksp
 		if params.Whitespace != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "whitespace", *params.Whitespace, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10556,6 +10557,35 @@ func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.
 	assert.Empty(*large.Hunks)
 }
 
+func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "first.go"),
+		[]byte("package first\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "second.go"),
+		[]byte("package second\n"), 0o644,
+	))
+
+	diff := requestWorkspaceDiffForPath(t, srv, ws.Id, "head", "first.go")
+	require.NotNil(diff.Files)
+	require.Len(*diff.Files, 1)
+
+	file := (*diff.Files)[0]
+	assert.Equal("first.go", file.Path)
+	assert.Equal("added", file.Status)
+	require.NotNil(file.Hunks)
+	require.Len(*file.Hunks, 1)
+	assert.NotContains(workspaceDiffPaths(*diff.Files), "second.go")
+}
+
 func requestWorkspaceFiles(
 	t *testing.T,
 	srv *Server,
@@ -10598,6 +10628,33 @@ func requestWorkspaceDiff(
 	if len(whitespace) > 0 {
 		query += "&whitespace=" + whitespace[0]
 	}
+	req := httptest.NewRequest(
+		http.MethodGet,
+		query,
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body generated.DiffResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return body
+}
+
+func requestWorkspaceDiffForPath(
+	t *testing.T,
+	srv *Server,
+	workspaceID string,
+	base string,
+	path string,
+) generated.DiffResponse {
+	t.Helper()
+
+	query := "/api/v1/workspaces/" + workspaceID +
+		"/diff?base=" + base + "&path=" + url.QueryEscape(path)
 	req := httptest.NewRequest(
 		http.MethodGet,
 		query,

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -146,8 +146,9 @@ type diffResponse struct {
 }
 
 type filesResponse struct {
-	Stale bool                `json:"stale"`
-	Files []gitclone.DiffFile `json:"files"`
+	Stale               bool                `json:"stale"`
+	WhitespaceOnlyCount int                 `json:"whitespace_only_count"`
+	Files               []gitclone.DiffFile `json:"files"`
 }
 
 type filePreviewResponse struct {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3063,9 +3063,24 @@ func (s *Server) getWorkspaceFiles(
 	if !ok {
 		return nil, workspaceDiffBaseUnavailable(req.Base)
 	}
+	whitespaceOnlyCount, countOK, countErr := s.workspaceDiffWhitespaceOnlyCount(
+		ctx, req,
+	)
+	if countErr != nil {
+		slog.Warn(
+			"failed to count workspace whitespace-only diff files",
+			"workspace_id", input.ID,
+			"base", req.Base,
+			"err", countErr,
+		)
+	}
+	if !countOK {
+		return nil, workspaceDiffBaseUnavailable(req.Base)
+	}
 	return &getWorkspaceFilesOutput{Body: filesResponse{
-		Stale: false,
-		Files: files,
+		Stale:               false,
+		WhitespaceOnlyCount: whitespaceOnlyCount,
+		Files:               files,
 	}}, nil
 }
 
@@ -3203,6 +3218,22 @@ func (s *Server) workspaceDiff(
 	}
 	return workspace.WorktreeDiff(
 		ctx, req.Summary.WorktreePath, req.Base, hideWhitespace,
+	)
+}
+
+func (s *Server) workspaceDiffWhitespaceOnlyCount(
+	ctx context.Context,
+	req workspaceDiffRequest,
+) (int, bool, error) {
+	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
+		return workspace.WorktreeDiffWhitespaceOnlyCountAgainstMergeTarget(
+			ctx,
+			req.Summary.WorktreePath,
+			req.MergeTargetBranch,
+		)
+	}
+	return workspace.WorktreeDiffWhitespaceOnlyCount(
+		ctx, req.Summary.WorktreePath, req.Base,
 	)
 }
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -271,10 +271,17 @@ type getWorkspaceInput struct {
 	ID string `path:"id"`
 }
 
+type getWorkspaceFilesInput struct {
+	ID         string `path:"id"`
+	Base       string `query:"base"      doc:"Diff base: head, pushed, or merge-target"`
+	Whitespace string `query:"whitespace" doc:"Set to hide to ignore whitespace-only changes"`
+}
+
 type getWorkspaceDiffInput struct {
 	ID         string `path:"id"`
 	Base       string `query:"base"      doc:"Diff base: head, pushed, or merge-target"`
 	Whitespace string `query:"whitespace" doc:"Set to hide to ignore whitespace-only changes"`
+	Path       string `query:"path"      doc:"Optional file path to limit the returned patch"`
 }
 
 type retryWorkspaceInput struct {
@@ -3031,9 +3038,9 @@ func (s *Server) getWorkspace(
 }
 
 func (s *Server) getWorkspaceFiles(
-	ctx context.Context, input *getWorkspaceDiffInput,
+	ctx context.Context, input *getWorkspaceFilesInput,
 ) (*getWorkspaceFilesOutput, error) {
-	req, err := s.workspaceDiffRequest(ctx, input)
+	req, err := s.workspaceDiffRequest(ctx, input.ID, input.Base)
 	if err != nil {
 		return nil, err
 	}
@@ -3065,14 +3072,14 @@ func (s *Server) getWorkspaceFiles(
 func (s *Server) getWorkspaceDiff(
 	ctx context.Context, input *getWorkspaceDiffInput,
 ) (*getWorkspaceDiffOutput, error) {
-	req, err := s.workspaceDiffRequest(ctx, input)
+	req, err := s.workspaceDiffRequest(ctx, input.ID, input.Base)
 	if err != nil {
 		return nil, err
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
 	result, ok, diffErr := s.workspaceDiff(
-		ctx, req, hideWhitespace,
+		ctx, req, hideWhitespace, input.Path,
 	)
 	if diffErr != nil {
 		slog.Error(
@@ -3097,7 +3104,8 @@ func (s *Server) getWorkspaceDiff(
 
 func (s *Server) workspaceDiffRequest(
 	ctx context.Context,
-	input *getWorkspaceDiffInput,
+	id string,
+	baseInput string,
 ) (workspaceDiffRequest, error) {
 	if s.workspaces == nil {
 		return workspaceDiffRequest{}, huma.Error503ServiceUnavailable(
@@ -3105,7 +3113,7 @@ func (s *Server) workspaceDiffRequest(
 		)
 	}
 
-	summary, err := s.workspaces.GetSummary(ctx, input.ID)
+	summary, err := s.workspaces.GetSummary(ctx, id)
 	if err != nil {
 		return workspaceDiffRequest{}, huma.Error500InternalServerError(
 			"get workspace failed",
@@ -3120,7 +3128,7 @@ func (s *Server) workspaceDiffRequest(
 		)
 	}
 
-	base := workspace.WorktreeDiffBase(input.Base)
+	base := workspace.WorktreeDiffBase(baseInput)
 	if base == "" {
 		base = workspace.WorktreeDiffBaseHead
 	}
@@ -3169,13 +3177,28 @@ func (s *Server) workspaceDiff(
 	ctx context.Context,
 	req workspaceDiffRequest,
 	hideWhitespace bool,
+	path string,
 ) (*gitclone.DiffResult, bool, error) {
 	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
+		if path != "" {
+			return workspace.WorktreeFileDiffAgainstMergeTarget(
+				ctx,
+				req.Summary.WorktreePath,
+				req.MergeTargetBranch,
+				hideWhitespace,
+				path,
+			)
+		}
 		return workspace.WorktreeDiffAgainstMergeTarget(
 			ctx,
 			req.Summary.WorktreePath,
 			req.MergeTargetBranch,
 			hideWhitespace,
+		)
+	}
+	if path != "" {
+		return workspace.WorktreeFileDiff(
+			ctx, req.Summary.WorktreePath, req.Base, hideWhitespace, path,
 		)
 	}
 	return workspace.WorktreeDiff(

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -101,6 +101,21 @@ func WorktreeDiff(
 	return worktreeDiffFromRef(ctx, dir, baseRef, hideWhitespace)
 }
 
+func WorktreeFileDiff(
+	ctx context.Context,
+	dir string,
+	base WorktreeDiffBase,
+	hideWhitespace bool,
+	path string,
+) (*gitclone.DiffResult, bool, error) {
+	baseRef, ok, err := worktreeDiffBaseRef(ctx, dir, base)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	return worktreeDiffFromRefPath(ctx, dir, baseRef, hideWhitespace, path)
+}
+
 func WorktreeDiffAgainstMergeTarget(
 	ctx context.Context,
 	dir string,
@@ -115,13 +130,43 @@ func WorktreeDiffAgainstMergeTarget(
 	return worktreeDiffFromRef(ctx, dir, baseRef, hideWhitespace)
 }
 
+func WorktreeFileDiffAgainstMergeTarget(
+	ctx context.Context,
+	dir string,
+	targetBranch string,
+	hideWhitespace bool,
+	path string,
+) (*gitclone.DiffResult, bool, error) {
+	baseRef, ok, err := worktreeMergeTargetBaseRef(ctx, dir, targetBranch)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	return worktreeDiffFromRefPath(ctx, dir, baseRef, hideWhitespace, path)
+}
+
 func worktreeDiffFromRef(
 	ctx context.Context,
 	dir string,
 	baseRef string,
 	hideWhitespace bool,
 ) (*gitclone.DiffResult, bool, error) {
-	wsCount, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef)
+	return worktreeDiffFromRefPath(ctx, dir, baseRef, hideWhitespace, "")
+}
+
+func worktreeDiffFromRefPath(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	hideWhitespace bool,
+	path string,
+) (*gitclone.DiffResult, bool, error) {
+	path, err := cleanWorktreeDiffPath(path)
+	if err != nil {
+		return nil, false, err
+	}
+
+	wsCount, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, path)
 	if err != nil {
 		return nil, false, fmt.Errorf("whitespace count: %w", err)
 	}
@@ -130,15 +175,27 @@ func worktreeDiffFromRef(
 		"diff", "--raw", "-z", "-M", "-C", "--find-copies-harder",
 		baseRef,
 	}, hideWhitespace)
+	rawArgs = appendWorktreePathspec(rawArgs, path)
 	rawOut, err := worktreeGitOutput(ctx, dir, rawArgs...)
 	if err != nil {
 		return nil, false, fmt.Errorf("git diff --raw: %w", err)
 	}
 	files := gitclone.ParseRawZ(rawOut)
 
+	numstatArgs := addWorktreeWhitespaceFlag([]string{
+		"diff", "--numstat", "-z", "-M", "-C", "--find-copies-harder",
+		baseRef,
+	}, hideWhitespace)
+	numstatArgs = appendWorktreePathspec(numstatArgs, path)
+	numstatOut, err := worktreeGitOutput(ctx, dir, numstatArgs...)
+	if err != nil {
+		return nil, false, fmt.Errorf("git diff --numstat: %w", err)
+	}
+
 	patchArgs := addWorktreeWhitespaceFlag([]string{
 		"diff", "-M", "-C", "--find-copies-harder", "-U3", baseRef,
 	}, hideWhitespace)
+	patchArgs = appendWorktreePathspec(patchArgs, path)
 	patchOut, err := worktreeGitOutput(ctx, dir, patchArgs...)
 	if err != nil {
 		return nil, false, fmt.Errorf("git diff patch: %w", err)
@@ -147,16 +204,23 @@ func worktreeDiffFromRef(
 	if files == nil {
 		files = []gitclone.DiffFile{}
 	}
+	applyWorktreeNumstat(files, parseWorktreeNumstatZ(numstatOut))
 
 	if !hideWhitespace {
-		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef)
+		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, path)
 		if err == nil {
 			for i := range files {
 				files[i].IsWhitespaceOnly = wsFiles[files[i].Path]
 			}
 		}
 	}
-	files = append(files, worktreeUntrackedFiles(ctx, dir, true, hideWhitespace)...)
+	if path == "" {
+		files = append(files, worktreeUntrackedFiles(ctx, dir, true, hideWhitespace)...)
+	} else if file, ok := worktreeUntrackedFile(
+		ctx, dir, path, true, hideWhitespace,
+	); ok {
+		files = append(files, file)
+	}
 
 	return &gitclone.DiffResult{
 		WhitespaceOnlyCount: wsCount,
@@ -193,6 +257,33 @@ func addWorktreeWhitespaceFlag(
 	return withWhitespace
 }
 
+func appendWorktreePathspec(args []string, path string) []string {
+	if path == "" {
+		return args
+	}
+	return append(args, "--", path)
+}
+
+func cleanWorktreeDiffPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if strings.Contains(path, "\x00") {
+		return "", errors.New("diff path contains NUL byte")
+	}
+	path = filepath.ToSlash(path)
+	if strings.HasPrefix(path, "/") {
+		return "", errors.New("diff path must be relative")
+	}
+	clean := filepath.ToSlash(filepath.Clean(path))
+	if clean == "." ||
+		clean == ".." ||
+		strings.HasPrefix(clean, "../") {
+		return "", errors.New("diff path must stay inside worktree")
+	}
+	return clean, nil
+}
+
 func worktreeUntrackedFiles(
 	ctx context.Context,
 	dir string,
@@ -206,9 +297,56 @@ func worktreeUntrackedFiles(
 		return nil
 	}
 	parts := bytes.Split(out, []byte{0})
-	files := make([]gitclone.DiffFile, 0, len(parts))
+	paths := make([]string, 0, len(parts))
 	for _, part := range parts {
 		path := string(part)
+		if path == "" {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return worktreeUntrackedFilesFromPaths(
+		dir, paths, withHunks, hideWhitespace,
+	)
+}
+
+func worktreeUntrackedFile(
+	ctx context.Context,
+	dir string,
+	path string,
+	withHunks bool,
+	hideWhitespace bool,
+) (gitclone.DiffFile, bool) {
+	out, err := worktreeGitOutput(
+		ctx, dir, "ls-files", "--others", "--exclude-standard", "-z",
+		"--", path,
+	)
+	if err != nil {
+		return gitclone.DiffFile{}, false
+	}
+	for part := range bytes.SplitSeq(out, []byte{0}) {
+		if string(part) != path {
+			continue
+		}
+		files := worktreeUntrackedFilesFromPaths(
+			dir, []string{path}, withHunks, hideWhitespace,
+		)
+		if len(files) == 0 {
+			return gitclone.DiffFile{}, false
+		}
+		return files[0], true
+	}
+	return gitclone.DiffFile{}, false
+}
+
+func worktreeUntrackedFilesFromPaths(
+	dir string,
+	paths []string,
+	withHunks bool,
+	hideWhitespace bool,
+) []gitclone.DiffFile {
+	files := make([]gitclone.DiffFile, 0, len(paths))
+	for _, path := range paths {
 		if path == "" {
 			continue
 		}
@@ -364,9 +502,9 @@ func parseWorktreeNumstatInt(value string) int {
 }
 
 func worktreeWhitespaceOnlyCount(
-	ctx context.Context, dir string, baseRef string,
+	ctx context.Context, dir string, baseRef string, path string,
 ) (int, error) {
-	files, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef)
+	files, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, path)
 	if err != nil {
 		return 0, err
 	}
@@ -374,16 +512,20 @@ func worktreeWhitespaceOnlyCount(
 }
 
 func worktreeWhitespaceOnlyFiles(
-	ctx context.Context, dir string, baseRef string,
+	ctx context.Context, dir string, baseRef string, path string,
 ) (map[string]bool, error) {
-	outAll, err := worktreeGitOutput(ctx, dir,
+	allArgs := appendWorktreePathspec([]string{
 		"diff", "--raw", "-z", "--no-renames", baseRef,
-	)
+	}, path)
+	outAll, err := worktreeGitOutput(ctx, dir, allArgs...)
 	if err != nil {
 		return nil, err
 	}
-	outNoWhitespace, err := worktreeGitOutput(ctx, dir,
+	noWhitespaceArgs := appendWorktreePathspec([]string{
 		"diff", "--raw", "-z", "--no-renames", "-w", baseRef,
+	}, path)
+	outNoWhitespace, err := worktreeGitOutput(
+		ctx, dir, noWhitespaceArgs...,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -41,6 +41,20 @@ func WorktreeDiffFiles(
 	return worktreeDiffFilesFromRef(ctx, dir, baseRef, hideWhitespace)
 }
 
+func WorktreeDiffWhitespaceOnlyCount(
+	ctx context.Context,
+	dir string,
+	base WorktreeDiffBase,
+) (int, bool, error) {
+	baseRef, ok, err := worktreeDiffBaseRef(ctx, dir, base)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+
+	count, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, "")
+	return count, true, err
+}
+
 func WorktreeDiffFilesAgainstMergeTarget(
 	ctx context.Context,
 	dir string,
@@ -53,6 +67,20 @@ func WorktreeDiffFilesAgainstMergeTarget(
 	}
 
 	return worktreeDiffFilesFromRef(ctx, dir, baseRef, hideWhitespace)
+}
+
+func WorktreeDiffWhitespaceOnlyCountAgainstMergeTarget(
+	ctx context.Context,
+	dir string,
+	targetBranch string,
+) (int, bool, error) {
+	baseRef, ok, err := worktreeMergeTargetBaseRef(ctx, dir, targetBranch)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+
+	count, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, "")
+	return count, true, err
 }
 
 func worktreeDiffFilesFromRef(

--- a/internal/workspace/diff_test.go
+++ b/internal/workspace/diff_test.go
@@ -82,6 +82,35 @@ func TestWorktreeDiffFilesHidesWhitespaceOnlyUntrackedFiles(t *testing.T) {
 	assert.Equal("z-empty.txt", files[1].Path)
 }
 
+func TestWorktreeFileDiffAgainstHeadScopesPatchToOnePath(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	work := setupDivergenceWorktree(t)
+
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "f.txt"), []byte("dirty\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "dirty-test.txt"), []byte("test\n"), 0o644,
+	))
+
+	diff, ok, err := WorktreeFileDiff(
+		t.Context(), work, WorktreeDiffBaseHead, false, "f.txt",
+	)
+	require.NoError(err)
+	require.True(ok)
+	require.NotNil(diff)
+	require.Len(diff.Files, 1)
+
+	file := diff.Files[0]
+	assert.Equal("f.txt", file.Path)
+	assert.Equal("modified", file.Status)
+	assert.Equal(1, file.Additions)
+	assert.Equal(1, file.Deletions)
+	require.Len(file.Hunks, 1)
+	assert.NotEmpty(file.Hunks[0].Lines)
+}
+
 func TestWorktreeDiffAgainstPushedBranchIncludesLocalCommitsAndDirtyChanges(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1187,6 +1187,8 @@ export interface components {
             readonly $schema?: string;
             files: components["schemas"]["DiffFile"][] | null;
             stale: boolean;
+            /** Format: int64 */
+            whitespace_only_count: number;
         };
         GithubStateInputBody: {
             /**

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -3765,6 +3765,8 @@ export interface operations {
                 base?: string;
                 /** @description Set to hide to ignore whitespace-only changes */
                 whitespace?: string;
+                /** @description Optional file path to limit the returned patch */
+                path?: string;
             };
             header?: never;
             path: {

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -98,6 +98,7 @@ export interface DiffResult {
 
 export interface FilesResult {
   stale: boolean;
+  whitespace_only_count?: number;
   files: DiffFile[];
 }
 

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -39,20 +39,26 @@
 
   const diff = $derived(diffStore.getDiff());
   const visibleFiles = $derived(diffStore.getVisibleDiffFiles());
+  const navigationFiles = $derived(
+    diffStore.getVisibleFileList()?.files ?? visibleFiles,
+  );
   const loading = $derived(diffStore.isDiffLoading());
   const error = $derived(diffStore.getDiffError());
   const tabWidth = $derived(diffStore.getTabWidth());
   const wordWrap = $derived(diffStore.getWordWrap());
 
-  function scrollToFile(path: string): void {
-    if (!diffArea) return;
+  function scrollToFile(path: string): boolean {
+    if (!diffArea) return false;
     const el = diffArea.querySelector(`[data-file-path="${CSS.escape(path)}"]`);
     if (el) {
       el.scrollIntoView({ behavior: "instant", block: "start" });
+    } else {
+      return false;
     }
     // Clear the scrolling flag after the instant scroll so the next user-initiated
     // scroll event resumes active file tracking.
     scrollRaf = requestAnimationFrame(() => diffStore.clearScrolling());
+    return true;
   }
 
   // Watch for scroll requests from the sidebar file list (via the store).
@@ -61,8 +67,9 @@
   $effect(() => {
     const target = diffStore.getScrollTarget();
     if (target && diffArea && diff) {
-      diffStore.consumeScrollTarget();
-      scrollToFile(target);
+      if (scrollToFile(target)) {
+        diffStore.consumeScrollTarget();
+      }
     }
   });
 
@@ -95,9 +102,9 @@
     if ((e.target as HTMLElement).isContentEditable) return;
 
     if (e.key === "j" || e.key === "k") {
-      if (!diff || visibleFiles.length === 0) return;
+      if (!diff || navigationFiles.length === 0) return;
       e.preventDefault();
-      const paths = visibleFiles.map((f) => f.path);
+      const paths = navigationFiles.map((f) => f.path);
       const currentIdx = diffStore.getActiveFile() ? paths.indexOf(diffStore.getActiveFile()!) : -1;
       let nextIdx: number;
       if (e.key === "j") {

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -1,0 +1,119 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+} from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  DiffFile,
+  DiffResult,
+  FilesResult,
+} from "../../api/types.js";
+import { STORES_KEY } from "../../context.js";
+import type { DiffStore } from "../../stores/diff.svelte.js";
+
+vi.mock("./DiffFile.svelte", async () => ({
+  default: (await import("./DiffViewTestFile.svelte")).default,
+}));
+
+import DiffView from "./DiffView.svelte";
+
+if (!globalThis.CSS) {
+  globalThis.CSS = {} as typeof CSS;
+}
+globalThis.CSS.escape ??= (value: string) => value.replace(/"/g, '\\"');
+
+function makeFile(path: string): DiffFile {
+  return {
+    path,
+    old_path: path,
+    status: "modified",
+    is_binary: false,
+    is_whitespace_only: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [],
+  };
+}
+
+function makeDiffStore(
+  overrides: Partial<DiffStore> = {},
+): DiffStore {
+  const activeFile = overrides.getActiveFile?.() ?? "a.ts";
+  const diff: DiffResult = {
+    stale: false,
+    whitespace_only_count: 0,
+    files: [makeFile(activeFile)],
+  };
+  const fileList: FilesResult = {
+    stale: false,
+    files: [makeFile("a.ts"), makeFile("b.ts")],
+  };
+
+  return {
+    getDiff: () => diff,
+    getVisibleDiffFiles: () => diff.files,
+    getVisibleFileList: () => fileList,
+    isDiffLoading: () => false,
+    getDiffError: () => null,
+    getTabWidth: () => 4,
+    getWordWrap: () => false,
+    getRichPreview: () => false,
+    getFilePreviewGeneration: () => 0,
+    getScrollTarget: () => null,
+    consumeScrollTarget: vi.fn(),
+    clearScrolling: vi.fn(),
+    isScrolling: () => false,
+    isFileCollapsed: () => false,
+    toggleFileCollapsed: vi.fn(),
+    setActiveFile: vi.fn(),
+    getActiveFile: () => activeFile,
+    requestScrollToFile: vi.fn(),
+    stepPrev: vi.fn(),
+    stepNext: vi.fn(),
+    loadDiff: vi.fn(),
+    clearDiff: vi.fn(),
+    ...overrides,
+  } as unknown as DiffStore;
+}
+
+function renderDiffView(diff: DiffStore) {
+  return render(DiffView, {
+    props: {
+      owner: "acme",
+      name: "widgets",
+      number: 1,
+      loadOnMount: false,
+    },
+    context: new Map([[STORES_KEY, { diff }]]),
+  });
+}
+
+describe("DiffView", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the workspace file list for keyboard navigation", async () => {
+    const requestScrollToFile = vi.fn();
+    const diff = makeDiffStore({ requestScrollToFile });
+
+    renderDiffView(diff);
+    await fireEvent.keyDown(window, { key: "j" });
+
+    expect(requestScrollToFile).toHaveBeenCalledWith("b.ts");
+  });
+
+  it("keeps a scroll target pending until the file is rendered", async () => {
+    const consumeScrollTarget = vi.fn();
+    const diff = makeDiffStore({
+      getScrollTarget: () => "b.ts",
+      consumeScrollTarget,
+    });
+
+    renderDiffView(diff);
+    await Promise.resolve();
+
+    expect(consumeScrollTarget).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/diff/DiffViewTestFile.svelte
+++ b/packages/ui/src/components/diff/DiffViewTestFile.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import type { DiffFile } from "../../api/types.js";
+
+  interface Props {
+    file: DiffFile;
+  }
+
+  const { file }: Props = $props();
+</script>
+
+<div data-file-path={file.path}>{file.path}</div>

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -164,6 +164,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let currentNumber = $state(0);
   let currentWorkspaceID = $state("");
   let currentWorkspaceBase = $state<WorkspaceDiffBase>("head");
+  let workspaceWhitespaceOnlyCount = $state(0);
 
   function getCurrentPR(): { owner: string; name: string; number: number } | null {
     if (!currentOwner) return null;
@@ -268,11 +269,12 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
   function requestScrollToFile(path: string): void {
     activeFile = path;
-    scrollTarget = path;
     scrolling = true;
     if (currentWorkspaceID) {
-      void loadWorkspaceFileDiff(path);
+      void loadWorkspaceFileDiff(path, undefined, true);
+      return;
     }
+    scrollTarget = path;
   }
 
   function getScrollTarget(): string | null {
@@ -533,6 +535,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
   function applyFilesResult(data: FilesResponse): void {
     fileList = normalizeFilesResult(data);
+    if (currentWorkspaceID) {
+      workspaceWhitespaceOnlyCount = data.whitespace_only_count ?? 0;
+    }
     setActiveIfNeeded(getVisibleFileList()?.files);
   }
 
@@ -547,7 +552,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     const files = file ? [file] : result.files.slice(0, 1);
     diff = {
       stale: result.stale,
-      whitespace_only_count: result.whitespace_only_count,
+      whitespace_only_count: workspaceWhitespaceOnlyCount,
       files,
     };
   }
@@ -565,6 +570,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     fileListAbortController = null;
     filesAc.abort();
     fileListLoading = false;
+    finishDiffLoad(diffAc);
   }
 
   async function loadDiff(
@@ -684,7 +690,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     if (!selectedPath) {
       diff = {
         stale: fileList?.stale ?? false,
-        whitespace_only_count: 0,
+        whitespace_only_count: workspaceWhitespaceOnlyCount,
         files: [],
       };
       finishDiffLoad(diffAc);
@@ -697,6 +703,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   async function loadWorkspaceFileDiff(
     path: string,
     existingAc?: AbortController,
+    scrollAfterLoad = false,
   ): Promise<void> {
     if (!currentWorkspaceID) return;
     const ac = existingAc ?? new AbortController();
@@ -705,6 +712,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       abortController = ac;
       loading = true;
       storeError = null;
+      diff = null;
     }
     const workspaceID = currentWorkspaceID;
     const base = currentWorkspaceBase;
@@ -730,6 +738,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         return;
       }
       applyWorkspaceFileDiffResult(path, data);
+      if (scrollAfterLoad) {
+        scrollTarget = path;
+      }
     } catch (_err) {
       if (ac.signal.aborted || !diffLoadIsCurrent(ac)) return;
       storeError = _err instanceof Error ? _err.message : String(_err);
@@ -763,6 +774,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentNumber = 0;
     currentWorkspaceID = "";
     currentWorkspaceBase = "head";
+    workspaceWhitespaceOnlyCount = 0;
   }
 
   async function loadCommits(): Promise<void> {

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -182,6 +182,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     return storeError;
   }
   function getFileList(): FilesResult | null {
+    if (currentWorkspaceID && fileList) {
+      return { stale: fileList.stale, files: fileList.files ?? [] };
+    }
     // Prefer diff.files once available — it respects hideWhitespace
     // and is authoritative. The lightweight /files response is a fast
     // preview used only until the full diff arrives.
@@ -254,6 +257,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     fileCategoryFilter = nextFilter;
     const visibleFiles = getVisibleFileList()?.files ?? getVisibleDiffFiles();
     setActiveIfNeeded(visibleFiles);
+    if (currentWorkspaceID && activeFile) {
+      void loadWorkspaceFileDiff(activeFile);
+    }
   }
 
   function clearScrolling(): void {
@@ -264,6 +270,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     activeFile = path;
     scrollTarget = path;
     scrolling = true;
+    if (currentWorkspaceID) {
+      void loadWorkspaceFileDiff(path);
+    }
   }
 
   function getScrollTarget(): string | null {
@@ -453,6 +462,17 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     };
   }
 
+  function workspaceFileDiffQuery(base: WorkspaceDiffBase, path: string): {
+    base: WorkspaceDiffBase;
+    whitespace?: string;
+    path: string;
+  } {
+    return {
+      ...workspaceDiffQuery(base),
+      path,
+    };
+  }
+
   function setActiveIfNeeded(
     files: { path: string }[] | undefined,
   ): void {
@@ -519,6 +539,17 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   function applyDiffResult(data: DiffResponse): void {
     diff = normalizeDiffResult(data);
     setActiveIfNeeded(getVisibleDiffFiles());
+  }
+
+  function applyWorkspaceFileDiffResult(path: string, data: DiffResponse): void {
+    const result = normalizeDiffResult(data);
+    const file = result.files.find((candidate) => candidate.path === path);
+    const files = file ? [file] : result.files.slice(0, 1);
+    diff = {
+      stale: result.stale,
+      whitespace_only_count: result.whitespace_only_count,
+      files,
+    };
   }
 
   function failDiffLoad(
@@ -622,55 +653,90 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
     const { diffAc, filesAc } = startDiffLoad();
 
-    const filesPromise = (async () => {
-      try {
-        const { data } = await apiClient.GET(
-          "/workspaces/{id}/files",
-          {
-            params: {
-              path: { id: workspaceID },
-              query: workspaceDiffQuery(base),
-            },
-            signal: filesAc.signal,
+    try {
+      const { data, error, response } = await apiClient.GET(
+        "/workspaces/{id}/files",
+        {
+          params: {
+            path: { id: workspaceID },
+            query: workspaceDiffQuery(base),
           },
-        );
-        if (!filesLoadIsCurrent(filesAc)) return;
-        if (!data) return;
-        applyFilesResult(data);
-      } catch {
-        if (filesAc.signal.aborted) return;
-        if (!filesLoadIsCurrent(filesAc)) return;
-        fileList = null;
-      } finally {
-        finishFilesLoad(filesAc);
+          signal: filesAc.signal,
+        },
+      );
+      if (!filesLoadIsCurrent(filesAc)) return;
+      if (!data) {
+        throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
-    })();
+      applyFilesResult(data);
+    } catch (_err) {
+      if (filesAc.signal.aborted || !filesLoadIsCurrent(filesAc)) return;
+      failDiffLoad(_err, diffAc, filesAc);
+      return;
+    } finally {
+      finishFilesLoad(filesAc);
+    }
 
-    const diffPromise = (async () => {
-      try {
-        const { data, error, response } = await apiClient.GET(
-          "/workspaces/{id}/diff",
-          {
-            params: {
-              path: { id: workspaceID },
-              query: workspaceDiffQuery(base),
-            },
-            signal: diffAc.signal,
+    const visibleFiles = getVisibleFileList()?.files ?? [];
+    const selectedPath =
+      visibleFiles.find((file) => file.path === activeFile)?.path ??
+      visibleFiles[0]?.path;
+    if (!selectedPath) {
+      diff = {
+        stale: fileList?.stale ?? false,
+        whitespace_only_count: 0,
+        files: [],
+      };
+      finishDiffLoad(diffAc);
+      return;
+    }
+
+    await loadWorkspaceFileDiff(selectedPath, diffAc);
+  }
+
+  async function loadWorkspaceFileDiff(
+    path: string,
+    existingAc?: AbortController,
+  ): Promise<void> {
+    if (!currentWorkspaceID) return;
+    const ac = existingAc ?? new AbortController();
+    if (!existingAc) {
+      abortController?.abort();
+      abortController = ac;
+      loading = true;
+      storeError = null;
+    }
+    const workspaceID = currentWorkspaceID;
+    const base = currentWorkspaceBase;
+    try {
+      const { data, error, response } = await apiClient.GET(
+        "/workspaces/{id}/diff",
+        {
+          params: {
+            path: { id: workspaceID },
+            query: workspaceFileDiffQuery(base, path),
           },
-        );
-        if (!diffLoadIsCurrent(diffAc)) return;
-        if (!data) {
-          throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
-        }
-        applyDiffResult(data);
-      } catch (_err) {
-        failDiffLoad(_err, diffAc, filesAc);
-      } finally {
-        finishDiffLoad(diffAc);
+          signal: ac.signal,
+        },
+      );
+      if (!diffLoadIsCurrent(ac)) return;
+      if (!data) {
+        throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
-    })();
-
-    await Promise.allSettled([filesPromise, diffPromise]);
+      if (
+        currentWorkspaceID !== workspaceID ||
+        currentWorkspaceBase !== base
+      ) {
+        return;
+      }
+      applyWorkspaceFileDiffResult(path, data);
+    } catch (_err) {
+      if (ac.signal.aborted || !diffLoadIsCurrent(ac)) return;
+      storeError = _err instanceof Error ? _err.message : String(_err);
+      diff = null;
+    } finally {
+      finishDiffLoad(ac);
+    }
   }
 
   function clearDiff(): void {


### PR DESCRIPTION
Why:
- Large workspace comparisons can produce multi-megabyte patches, which made switching into provider-sized branches slow before the user selected a file to inspect.
- The UI only needs the changed-file index immediately; patch bodies should be requested for the active file instead of computed and sent for the whole workspace.

What changed:
- Added a scoped workspace diff query for a single file path.
- Changed workspace diff loading to fetch file metadata first and load selected-file patches on demand.
- Regenerated API clients for the new query parameter.