### PR TITLE
Fix aggressive tmux mouse copy

### DIFF
--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
@@ -14,6 +14,7 @@
   import { getStores } from "@middleman/ui";
   import { FitAddon, Terminal } from "ghostty-web";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
+  import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
   interface TerminalPaneProps {
     workspaceId?: string;
@@ -51,6 +52,7 @@
   let disposed = false;
   let exited = false;
   const encoder = new TextEncoder();
+  const tmuxMouseDragFilter = createTmuxMouseDragFilter();
 
   type TerminalInputData = string | ArrayBuffer | ArrayBufferView;
 
@@ -156,7 +158,10 @@
     if (ws?.readyState !== WebSocket.OPEN) return;
 
     if (typeof data === "string") {
-      ws.send(encoder.encode(data));
+      const filteredData = tmuxMouseDragFilter.filter(data);
+      if (filteredData) {
+        ws.send(encoder.encode(filteredData));
+      }
       return;
     }
     if (data instanceof ArrayBuffer) {

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
@@ -226,6 +226,19 @@ describe("GhosttyTerminalPane", () => {
     );
   });
 
+  it("filters tiny tmux mouse drags before sending terminal input", async () => {
+    await renderStarted({ workspaceId: "ws-123" });
+    const dataHandler = mockOnData.mock.calls[0]?.[0] as
+      | ((data: string) => void)
+      | undefined;
+    expect(dataHandler).toBeDefined();
+
+    socketAt(0).sent = [];
+    dataHandler?.("\x1b[<0;10;5M\x1b[<32;12;5M\x1b[<0;12;5m");
+
+    expect(sentText(socketAt(0), 0)).toBe("\x1b[<0;10;5M\x1b[<0;12;5m");
+  });
+
   it("sends terminal byte payloads as raw WebSocket bytes", async () => {
     await renderStarted({ workspaceId: "ws-123" });
     const dataHandler = mockOnData.mock.calls[0]?.[0] as
@@ -304,3 +317,12 @@ describe("GhosttyTerminalPane", () => {
     vi.useRealTimers();
   });
 });
+
+function sentText(socket: MockWebSocket, index: number): string {
+  const value = socket.sent[index];
+  if (typeof value === "string") return value;
+  if (value instanceof ArrayBuffer) {
+    return new TextDecoder().decode(value);
+  }
+  return new TextDecoder().decode(value as ArrayBufferView);
+}

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -4,17 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   ghosttyTerminalCtor,
   mockGhosttyInit,
+  xtermOnDataHandlers,
   xtermTerminalCtor,
   xtermOpen,
 } = vi.hoisted(() => ({
   ghosttyTerminalCtor: vi.fn(),
   mockGhosttyInit: vi.fn().mockResolvedValue(undefined),
+  xtermOnDataHandlers: [] as Array<(data: string) => void>,
   xtermTerminalCtor: vi.fn(),
   xtermOpen: vi.fn(),
 }));
 
 let configuredRenderer: "xterm" | "ghostty-web" = "xterm";
 let configuredFontFamily = "";
+let mockSockets: MockWebSocket[] = [];
 
 class MockWebSocket {
   static OPEN = 1;
@@ -24,9 +27,14 @@ class MockWebSocket {
   onmessage: ((event: MessageEvent) => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
+  sent: Array<string | ArrayBuffer | ArrayBufferView> = [];
 
-  constructor(public url: string) {}
-  send(): void {}
+  constructor(public url: string) {
+    mockSockets.push(this);
+  }
+  send(data: string | ArrayBuffer | ArrayBufferView): void {
+    this.sent.push(data);
+  }
   close(): void {}
 }
 
@@ -50,7 +58,10 @@ vi.mock("@xterm/xterm", () => ({
       dispose: vi.fn(),
       loadAddon: vi.fn(),
       onBinary: vi.fn(),
-      onData: vi.fn(),
+      onData: vi.fn((handler: (data: string) => void) => {
+        xtermOnDataHandlers.push(handler);
+        return { dispose: vi.fn() };
+      }),
       open: xtermOpen,
       refresh: vi.fn(),
       write: vi.fn(),
@@ -103,6 +114,8 @@ describe("TerminalPane", () => {
     mockGhosttyInit.mockClear();
     xtermTerminalCtor.mockReset();
     xtermOpen.mockReset();
+    xtermOnDataHandlers.length = 0;
+    mockSockets = [];
 
     vi.stubGlobal("ResizeObserver", class {
       observe(): void {}
@@ -143,4 +156,39 @@ describe("TerminalPane", () => {
     expect(xtermTerminalCtor).not.toHaveBeenCalled();
     expect(mockGhosttyInit).toHaveBeenCalledTimes(1);
   });
+
+  it("filters tiny tmux mouse drags before sending terminal input", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(xtermOnDataHandlers).toHaveLength(1));
+    expect(mockSockets).toHaveLength(1);
+
+    xtermOnDataHandlers[0]!("\x1b[<0;10;5M\x1b[<32;12;5M\x1b[<0;12;5m");
+
+    expect(sentText(mockSockets[0]!, mockSockets[0]!.sent.length - 1)).toBe("\x1b[<0;10;5M\x1b[<0;12;5m");
+  });
+
+  it("does not update drag filter state while disconnected", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(xtermOnDataHandlers).toHaveLength(1));
+    const socket = mockSockets[0]!;
+    socket.readyState = 0;
+    socket.sent = [];
+
+    xtermOnDataHandlers[0]!("\x1b[<0;10;5M");
+    socket.readyState = MockWebSocket.OPEN;
+    xtermOnDataHandlers[0]!("\x1b[<32;12;5M");
+
+    expect(sentText(socket, 0)).toBe("\x1b[<32;12;5M");
+  });
 });
+
+function sentText(socket: MockWebSocket, index: number): string {
+  const value = socket.sent[index];
+  if (typeof value === "string") return value;
+  if (value instanceof ArrayBuffer) {
+    return new TextDecoder().decode(value);
+  }
+  return new TextDecoder().decode(value);
+}

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -6,6 +6,7 @@
   import { WebglAddon } from "@xterm/addon-webgl";
   import "@xterm/xterm/css/xterm.css";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
+  import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
   interface TerminalPaneProps {
     workspaceId?: string;
@@ -43,6 +44,7 @@
   let disposed = false;
   let exited = false;
   const encoder = new TextEncoder();
+  const tmuxMouseDragFilter = createTmuxMouseDragFilter();
 
   const MAX_RECONNECT_DELAY = 30000;
 
@@ -332,8 +334,11 @@
       fit.fit();
 
       term.onData((data: string) => {
-        if (ws?.readyState === WebSocket.OPEN) {
-          ws.send(encoder.encode(data));
+        if (ws?.readyState !== WebSocket.OPEN) return;
+
+        const filteredData = tmuxMouseDragFilter.filter(data);
+        if (filteredData) {
+          ws.send(encoder.encode(filteredData));
         }
       });
 

--- a/frontend/src/lib/components/terminal/tmuxMouseDragFilter.test.ts
+++ b/frontend/src/lib/components/terminal/tmuxMouseDragFilter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter";
+
+const mouseDown = "\x1b[<0;10;5M";
+const smallDrag = "\x1b[<32;12;5M";
+const thresholdDrag = "\x1b[<32;13;5M";
+const largeDrag = "\x1b[<32;14;5M";
+const laterDrag = "\x1b[<32;15;5M";
+const mouseUp = "\x1b[<0;14;5m";
+
+function collect(filter: ReturnType<typeof createTmuxMouseDragFilter>, input: string[]): string {
+  return input.map((chunk) => filter.filter(chunk)).join("");
+}
+
+describe("tmux mouse drag filter", () => {
+  it("suppresses left-button drag reports until selection exceeds threshold", () => {
+    const filter = createTmuxMouseDragFilter({ thresholdCells: 3 });
+
+    const output = collect(filter, [mouseDown, smallDrag, thresholdDrag, mouseUp]);
+
+    expect(output).toBe(mouseDown + mouseUp);
+  });
+
+  it("flushes buffered drag reports once selection exceeds threshold", () => {
+    const filter = createTmuxMouseDragFilter({ thresholdCells: 3 });
+
+    const output = collect(filter, [mouseDown, smallDrag, thresholdDrag, largeDrag, laterDrag, mouseUp]);
+
+    expect(output).toBe(mouseDown + smallDrag + thresholdDrag + largeDrag + laterDrag + mouseUp);
+  });
+
+  it("passes through non-mouse terminal data around suppressed drag reports", () => {
+    const filter = createTmuxMouseDragFilter({ thresholdCells: 3 });
+
+    const output = filter.filter(`paste:${mouseDown}x${smallDrag}y${mouseUp}:done`);
+
+    expect(output).toBe(`paste:${mouseDown}xy${mouseUp}:done`);
+  });
+
+  it("passes through Escape without waiting for more input", () => {
+    const filter = createTmuxMouseDragFilter({ thresholdCells: 3 });
+
+    expect(filter.filter("\x1b")).toBe("\x1b");
+  });
+
+  it("passes through wheel reports without applying drag threshold", () => {
+    const filter = createTmuxMouseDragFilter({ thresholdCells: 3 });
+    const wheelUp = "\x1b[<64;10;5M";
+
+    expect(filter.filter(wheelUp)).toBe(wheelUp);
+  });
+
+  it("does not let wheel reports start drag filtering", () => {
+    const filter = createTmuxMouseDragFilter({ thresholdCells: 3 });
+    const wheelUp = "\x1b[<64;10;5M";
+    const dragWithoutDown = "\x1b[<32;12;5M";
+
+    expect(filter.filter(wheelUp + dragWithoutDown)).toBe(wheelUp + dragWithoutDown);
+  });
+});

--- a/frontend/src/lib/components/terminal/tmuxMouseDragFilter.ts
+++ b/frontend/src/lib/components/terminal/tmuxMouseDragFilter.ts
@@ -1,0 +1,206 @@
+export interface TmuxMouseDragFilterOptions {
+  thresholdCells?: number;
+}
+
+interface SgrMouseReport {
+  raw: string;
+  code: number;
+  x: number;
+  y: number;
+  final: "M" | "m";
+}
+
+interface PendingDrag {
+  startX: number;
+  startY: number;
+  bufferedReports: string[];
+  thresholdExceeded: boolean;
+}
+
+const DEFAULT_THRESHOLD_CELLS = 3;
+const SGR_MOUSE_PREFIX = "\x1b[<";
+
+export interface TmuxMouseDragFilter {
+  filter(data: string): string;
+}
+
+export function createTmuxMouseDragFilter(
+  options: TmuxMouseDragFilterOptions = {},
+): TmuxMouseDragFilter {
+  const thresholdCells = options.thresholdCells ?? DEFAULT_THRESHOLD_CELLS;
+  let pendingDrag: PendingDrag | null = null;
+
+  function filter(data: string): string {
+    const parseResult = parseReports(data);
+    let output = "";
+
+    for (const part of parseResult.parts) {
+      if (typeof part === "string") {
+        output += part;
+        continue;
+      }
+      output += filterReport(part);
+    }
+
+    return output;
+  }
+
+  function filterReport(report: SgrMouseReport): string {
+    if (isLeftButtonDown(report)) {
+      pendingDrag = {
+        startX: report.x,
+        startY: report.y,
+        bufferedReports: [],
+        thresholdExceeded: false,
+      };
+      return report.raw;
+    }
+
+    if (pendingDrag && isLeftButtonDrag(report)) {
+      if (!pendingDrag.thresholdExceeded) {
+        pendingDrag.bufferedReports.push(report.raw);
+        pendingDrag.thresholdExceeded = dragExceededThreshold(
+          pendingDrag,
+          report,
+        );
+        if (!pendingDrag.thresholdExceeded) return "";
+
+        const buffered = pendingDrag.bufferedReports.join("");
+        pendingDrag.bufferedReports = [];
+        return buffered;
+      }
+      return report.raw;
+    }
+
+    if (pendingDrag && isMouseRelease(report)) {
+      const output = pendingDrag.thresholdExceeded
+        ? pendingDrag.bufferedReports.join("") + report.raw
+        : report.raw;
+      pendingDrag = null;
+      return output;
+    }
+
+    return report.raw;
+  }
+
+  function dragExceededThreshold(
+    drag: PendingDrag,
+    report: SgrMouseReport,
+  ): boolean {
+    return Math.max(
+      Math.abs(report.x - drag.startX),
+      Math.abs(report.y - drag.startY),
+    ) > thresholdCells;
+  }
+
+  return { filter };
+}
+
+function parseReports(input: string): {
+  parts: Array<string | SgrMouseReport>;
+} {
+  const parts: Array<string | SgrMouseReport> = [];
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const start = input.indexOf(SGR_MOUSE_PREFIX, cursor);
+    if (start === -1) break;
+
+    if (start > cursor) {
+      parts.push(input.slice(cursor, start));
+    }
+
+    const parsed = parseReportAt(input, start);
+    if (!parsed) {
+      parts.push(input[start]!);
+      cursor = start + 1;
+      continue;
+    }
+
+    parts.push(parsed.report);
+    cursor = parsed.end;
+  }
+
+  if (cursor < input.length) {
+    parts.push(input.slice(cursor));
+  }
+
+  return { parts };
+}
+
+function parseReportAt(
+  input: string,
+  start: number,
+): { report: SgrMouseReport; end: number } | null {
+  let cursor = start + SGR_MOUSE_PREFIX.length;
+  const fields: number[] = [];
+
+  for (let fieldIndex = 0; fieldIndex < 3; fieldIndex++) {
+    const fieldStart = cursor;
+    while (cursor < input.length && isDigit(input[cursor]!)) cursor++;
+    if (cursor === input.length) return null;
+    if (cursor === fieldStart) return null;
+
+    fields.push(Number(input.slice(fieldStart, cursor)));
+
+    if (fieldIndex < 2) {
+      if (input[cursor] !== ";") return null;
+      cursor++;
+      continue;
+    }
+
+    const final = input[cursor];
+    if (final !== "M" && final !== "m") return null;
+    cursor++;
+    return {
+      report: {
+        raw: input.slice(start, cursor),
+        code: fields[0]!,
+        x: fields[1]!,
+        y: fields[2]!,
+        final,
+      },
+      end: cursor,
+    };
+  }
+
+  return null;
+}
+
+function isDigit(value: string): boolean {
+  return value >= "0" && value <= "9";
+}
+
+function isLeftButtonDown(report: SgrMouseReport): boolean {
+  return (
+    report.final === "M" &&
+    !isMotion(report) &&
+    !isWheel(report) &&
+    button(report) === 0
+  );
+}
+
+function isLeftButtonDrag(report: SgrMouseReport): boolean {
+  return (
+    report.final === "M" &&
+    isMotion(report) &&
+    !isWheel(report) &&
+    button(report) === 0
+  );
+}
+
+function isMouseRelease(report: SgrMouseReport): boolean {
+  return report.final === "m";
+}
+
+function isMotion(report: SgrMouseReport): boolean {
+  return (report.code & 32) !== 0;
+}
+
+function isWheel(report: SgrMouseReport): boolean {
+  return (report.code & 64) !== 0;
+}
+
+function button(report: SgrMouseReport): number {
+  return report.code & 3;
+}


### PR DESCRIPTION
- Suppress tiny tmux mouse drags before they enter copy mode.
- Preserve tmux mouse scrolling, real drag selection, Escape, paste, and binary input.

Closes #180.