### PR TITLE
Keep same-repo workspace branches on real upstreams

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -546,6 +546,10 @@ func withSeedPRHeadSHA(headSHA string) seedPROpt {
 	return func(pr *db.MergeRequest) { pr.PlatformHeadSHA = headSHA }
 }
 
+func withSeedPRHeadRepoCloneURL(cloneURL string) seedPROpt {
+	return func(pr *db.MergeRequest) { pr.HeadRepoCloneURL = cloneURL }
+}
+
 // seedPR inserts a repo and a PR into the DB, returning the PR's internal ID.
 func seedPR(t *testing.T, database *db.DB, owner, name string, number int, opts ...seedPROpt) int64 {
 	t.Helper()
@@ -11990,6 +11994,60 @@ func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
 	assert.Equal(
 		testGitSHA(t, ws1.WorktreePath, "HEAD"),
 		testGitSHA(t, ws2.WorktreePath, "HEAD"),
+	)
+}
+
+func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	client, database, clonePath, remotePath := setupTestServerWithWorkspaces(t)
+	ctx := t.Context()
+
+	headSHA := testGitSHA(t, remotePath, "refs/heads/feature")
+	runGit(t, remotePath, "update-ref", "refs/pull/2/head", headSHA)
+	runGit(t, clonePath, "update-ref", "refs/pull/2/head", headSHA)
+	seedPR(
+		t,
+		database,
+		"acme", "widget", 2,
+		withSeedPRHeadRepoCloneURL("https://github.com/acme/widget.git"),
+	)
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     2,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	ws := waitForWorkspaceReady(t, ctx, client, createResp.JSON202.Id)
+	stored, err := database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Nil(stored.MRHeadRepo)
+	assert.Empty(stored.WorkspaceBranch)
+	assert.Equal("feature", gitOutput(t, ws.WorktreePath, "branch", "--show-current"))
+	assert.Equal(headSHA, testGitSHA(t, ws.WorktreePath, "HEAD"))
+	assert.Equal(
+		"origin/feature",
+		gitOutput(
+			t, ws.WorktreePath,
+			"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}",
+		),
+	)
+	assert.Equal(
+		"refs/heads/feature",
+		gitOutput(
+			t, ws.WorktreePath,
+			"config", "--get", "branch.feature.merge",
+		),
 	)
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8751,6 +8751,15 @@ func setupWorkspaceServerFixture(
 	cfg *config.Config,
 ) workspaceServerFixture {
 	t.Helper()
+	return setupWorkspaceServerFixtureWithHost(t, cfg, "github.com")
+}
+
+func setupWorkspaceServerFixtureWithHost(
+	t *testing.T,
+	cfg *config.Config,
+	platformHost string,
+) workspaceServerFixture {
+	t.Helper()
 
 	if testing.Short() {
 		t.Skip("workspace e2e tests skipped in short mode")
@@ -8793,7 +8802,7 @@ func setupWorkspaceServerFixture(
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
 	bare := filepath.Join(
-		bareDir, "github.com", "acme", "widget.git",
+		bareDir, platformHost, "acme", "widget.git",
 	)
 	runGit(t, dir, "clone", "--bare", remote, bare)
 
@@ -8801,7 +8810,7 @@ func setupWorkspaceServerFixture(
 	worktreeDir := filepath.Join(dir, "worktrees")
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{
-		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		{Owner: "acme", Name: "widget", PlatformHost: platformHost},
 	}
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": mock},
@@ -8823,7 +8832,7 @@ func setupWorkspaceServerFixture(
 	t.Cleanup(func() { cleanupWorkspaceServerFixtureArtifacts(t, srv, database) })
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	seedPR(t, database, "acme", "widget", 1)
+	seedPROnHost(t, database, platformHost, "acme", "widget", 1)
 
 	clientBaseURL := "http://middleman.test"
 	if basePath != "/" {
@@ -12047,6 +12056,54 @@ func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) 
 		gitOutput(
 			t, ws.WorktreePath,
 			"config", "--get", "branch.feature.merge",
+		),
+	)
+}
+
+func TestWorkspaceCreatePortQualifiedHostTracksOriginBranchE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	fixture := setupWorkspaceServerFixtureWithHost(
+		t, nil, "ghe.example.com:8443",
+	)
+	ctx := t.Context()
+
+	headSHA := testGitSHA(t, fixture.remote, "refs/heads/feature")
+	runGit(t, fixture.remote, "update-ref", "refs/pull/1/head", headSHA)
+	_, err := fixture.database.WriteDB().ExecContext(
+		ctx,
+		`UPDATE middleman_merge_requests
+		 SET head_repo_clone_url = ?
+		 WHERE number = ?`,
+		"https://ghe.example.com:8443/acme/widget.git", 1,
+	)
+	require.NoError(err)
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "ghe.example.com:8443",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	ws := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Nil(stored.MRHeadRepo)
+	assert.Equal("feature", gitOutput(t, ws.WorktreePath, "branch", "--show-current"))
+	assert.Equal(
+		"origin/feature",
+		gitOutput(
+			t, ws.WorktreePath,
+			"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}",
 		),
 	)
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -324,7 +324,7 @@ func workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string {
 	// compare clone identities before treating a non-empty URL as fork metadata.
 	headRepo := normalizeCloneRepoIdentity(cloneURL)
 	baseRepo := strings.ToLower(strings.Join([]string{
-		strings.TrimSpace(platformHost),
+		normalizePlatformHostIdentity(platformHost),
 		strings.TrimSpace(owner),
 		strings.TrimSpace(name),
 	}, "/"))

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -319,6 +319,9 @@ func workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string {
 	if cloneURL == "" {
 		return nil
 	}
+	// MRHeadRepo means "this PR head must be resolved through fork-safe refs"
+	// in setup. GitHub also fills head.repo.clone_url for same-repo PRs, so
+	// compare clone identities before treating a non-empty URL as fork metadata.
 	headRepo := normalizeCloneRepoIdentity(cloneURL)
 	baseRepo := strings.ToLower(strings.Join([]string{
 		strings.TrimSpace(platformHost),

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -180,7 +180,7 @@ func (m *Manager) Create(
 		ItemType:        db.WorkspaceItemTypePullRequest,
 		ItemNumber:      mrNumber,
 		GitHeadRef:      mr.HeadBranch,
-		MRHeadRepo:      workspaceHeadRepo(mr.HeadRepoCloneURL),
+		MRHeadRepo:      workspaceHeadRepo(platformHost, owner, name, mr.HeadRepoCloneURL),
 		WorkspaceBranch: workspaceBranchUnknown,
 		WorktreePath: filepath.Join(
 			m.worktreeDir, platformHost, owner, name,
@@ -315,8 +315,17 @@ func newWorkspaceID() (string, error) {
 	return hex.EncodeToString(idBytes), nil
 }
 
-func workspaceHeadRepo(cloneURL string) *string {
+func workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string {
 	if cloneURL == "" {
+		return nil
+	}
+	headRepo := normalizeCloneRepoIdentity(cloneURL)
+	baseRepo := strings.ToLower(strings.Join([]string{
+		strings.TrimSpace(platformHost),
+		strings.TrimSpace(owner),
+		strings.TrimSpace(name),
+	}, "/"))
+	if headRepo != "" && headRepo == baseRepo {
 		return nil
 	}
 	s := cloneURL

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -63,7 +63,7 @@ func seedMR(
 	require.NoError(t, err)
 }
 
-func seedMRWithFork(
+func seedMRWithHeadRepo(
 	t *testing.T, d *db.DB,
 	repoID int64, number int,
 	headBranch, cloneURL string,
@@ -74,7 +74,7 @@ func seedMRWithFork(
 		RepoID:           repoID,
 		PlatformID:       repoID*10000 + int64(number),
 		Number:           number,
-		Title:            "Fork PR",
+		Title:            "PR with head repo",
 		Author:           "contributor",
 		State:            "open",
 		HeadBranch:       headBranch,
@@ -137,7 +137,7 @@ func TestCreateForkPR(t *testing.T) {
 	repoID := seedRepo(
 		t, d, "github.com", "acme", "widget",
 	)
-	seedMRWithFork(
+	seedMRWithHeadRepo(
 		t, d, repoID, 99, "fix/typo",
 		"https://github.com/contributor/widget.git",
 	)
@@ -165,7 +165,7 @@ func TestCreateSameRepoPRWithPopulatedHeadRepoIsNotFork(t *testing.T) {
 	repoID := seedRepo(
 		t, d, "github.com", "acme", "widget",
 	)
-	seedMRWithFork(
+	seedMRWithHeadRepo(
 		t, d, repoID, 244, "feature/thing",
 		"git@GitHub.com:Acme/Widget.git",
 	)
@@ -178,6 +178,9 @@ func TestCreateSameRepoPRWithPopulatedHeadRepoIsNotFork(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ws)
 
+	// Same-repo PRs still have head repo clone URLs in GitHub payloads. Keeping
+	// MRHeadRepo nil is what sends workspace setup down the origin/<branch> path
+	// instead of the refs/pull/<number>/head path reserved for forks.
 	assert.Nil(ws.MRHeadRepo)
 }
 
@@ -388,11 +391,15 @@ func TestAddPreferredWorktreeSameRepoHeadRepoTracksRemoteBranch(t *testing.T) {
 	require := require.New(t)
 
 	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	// Reproduce the dangerous repo state from issue #256: the real branch and
+	// GitHub's synthetic pull ref both exist and point at the same commit.
+	// Starting a branch from refs/pull/<number>/head lets Git auto-configure
+	// that synthetic ref as the upstream, which breaks tools that inspect @{u}.
 	configureSameRepoPRRefs(t, cloneDir, "feature/thing", 244)
 
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithFork(
+	seedMRWithHeadRepo(
 		t, d, repoID, 244, "feature/thing",
 		"https://github.com/acme/widget.git",
 	)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -424,15 +424,17 @@ func TestAddPreferredWorktreeSameRepoHeadRepoTracksRemoteBranch(t *testing.T) {
 	assert.Equal("refs/heads/feature/thing", mergeRef)
 }
 
-func TestAddPreferredWorktreeForkHeadRepoUsesPullRef(t *testing.T) {
+func TestAddPreferredWorktreeForkHeadRepoUsesPullRefOverOriginBranch(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
 	cloneDir := setupBareCloneForWorkspaceGitTest(t)
-	// True fork PRs do not have an origin/<head-branch> in the base repo clone.
-	// The pull ref is the only guaranteed local ref that can materialize the
-	// fork head without adding another remote.
-	pullSHA := configureForkPRRef(t, cloneDir, 245)
+	// A base repo can have a branch with the same name as a fork PR branch, but
+	// that origin branch is not the fork head. Fork workspaces must prefer the
+	// GitHub pull ref over any same-named origin branch.
+	originSHA, pullSHA := configureForkPRRefs(
+		t, cloneDir, "fork/thing", 245,
+	)
 
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
@@ -445,11 +447,13 @@ func TestAddPreferredWorktreeForkHeadRepoUsesPullRef(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(ws.MRHeadRepo)
 
-	_, exists, err := gitRefSHA(
+	gotOriginSHA, exists, err := gitRefSHA(
 		t.Context(), cloneDir, "refs/remotes/origin/fork/thing",
 	)
 	require.NoError(err)
-	require.False(exists)
+	require.True(exists)
+	require.NotEqual(originSHA, pullSHA)
+	require.Equal(originSHA, gotOriginSHA)
 
 	branch, err := mgr.addPreferredWorktree(t.Context(), cloneDir, ws)
 	require.NoError(err)
@@ -576,17 +580,34 @@ func configureSameRepoPRRefs(
 	)
 }
 
-func configureForkPRRef(t *testing.T, cloneDir string, prNumber int) string {
+func configureForkPRRefs(
+	t *testing.T, cloneDir, branch string, prNumber int,
+) (originSHA, pullSHA string) {
 	t.Helper()
 	out, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main")
 	require.NoError(t, err)
-	sha := strings.TrimSpace(out)
-	require.NotEmpty(t, sha)
+	originSHA = strings.TrimSpace(out)
+	require.NotEmpty(t, originSHA)
+	treeOut, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main^{tree}")
+	require.NoError(t, err)
+	runWorkspaceTestGit(t, cloneDir, "config", "user.email", "test@test.com")
+	runWorkspaceTestGit(t, cloneDir, "config", "user.name", "Test")
+	commitOut, err := gitOutput(
+		t.Context(), cloneDir,
+		"commit-tree", strings.TrimSpace(treeOut),
+		"-p", originSHA, "-m", "fork head",
+	)
+	require.NoError(t, err)
+	pullSHA = strings.TrimSpace(commitOut)
+	require.NotEmpty(t, pullSHA)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "refs/remotes/origin/"+branch, originSHA,
+	)
 	runWorkspaceTestGit(
 		t, cloneDir, "update-ref",
-		fmt.Sprintf("refs/pull/%d/head", prNumber), sha,
+		fmt.Sprintf("refs/pull/%d/head", prNumber), pullSHA,
 	)
-	return sha
+	return originSHA, pullSHA
 }
 
 func runWorkspaceTestGit(t *testing.T, dir string, args ...string) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -154,6 +155,30 @@ func TestCreateForkPR(t *testing.T) {
 		"https://github.com/contributor/widget.git",
 		*ws.MRHeadRepo,
 	)
+}
+
+func TestCreateSameRepoPRWithPopulatedHeadRepoIsNotFork(t *testing.T) {
+	assert := Assert.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	repoID := seedRepo(
+		t, d, "github.com", "acme", "widget",
+	)
+	seedMRWithFork(
+		t, d, repoID, 244, "feature/thing",
+		"git@GitHub.com:Acme/Widget.git",
+	)
+
+	mgr := NewManager(d, wtDir)
+
+	ws, err := mgr.Create(
+		t.Context(), "github.com", "acme", "widget", 244,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+
+	assert.Nil(ws.MRHeadRepo)
 }
 
 func TestCreateRepoNotTracked(t *testing.T) {
@@ -358,6 +383,40 @@ func TestAddPreferredWorktreeRejectsUnsafeBranchName(t *testing.T) {
 	require.Contains(err.Error(), "invalid branch name")
 }
 
+func TestAddPreferredWorktreeSameRepoHeadRepoTracksRemoteBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	configureSameRepoPRRefs(t, cloneDir, "feature/thing", 244)
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithFork(
+		t, d, repoID, 244, "feature/thing",
+		"https://github.com/acme/widget.git",
+	)
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(t.Context(), "github.com", "acme", "widget", 244)
+	require.NoError(err)
+
+	branch, err := mgr.addPreferredWorktree(t.Context(), cloneDir, ws)
+	require.NoError(err)
+	assert.Equal("feature/thing", branch)
+
+	remote, err := gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch.feature/thing.remote",
+	)
+	require.NoError(err)
+	mergeRef, err := gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch.feature/thing.merge",
+	)
+	require.NoError(err)
+
+	assert.Equal("origin", remote)
+	assert.Equal("refs/heads/feature/thing", mergeRef)
+}
+
 func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -455,6 +514,23 @@ func setupBareCloneForWorkspaceGitTest(t *testing.T) string {
 	runWorkspaceTestGit(t, dir, "clone", "--bare", remote, cloneDir)
 
 	return cloneDir
+}
+
+func configureSameRepoPRRefs(
+	t *testing.T, cloneDir, branch string, prNumber int,
+) {
+	t.Helper()
+	out, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main")
+	require.NoError(t, err)
+	sha := strings.TrimSpace(out)
+	require.NotEmpty(t, sha)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "refs/remotes/origin/"+branch, sha,
+	)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref",
+		fmt.Sprintf("refs/pull/%d/head", prNumber), sha,
+	)
 }
 
 func runWorkspaceTestGit(t *testing.T, dir string, args ...string) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -424,6 +424,42 @@ func TestAddPreferredWorktreeSameRepoHeadRepoTracksRemoteBranch(t *testing.T) {
 	assert.Equal("refs/heads/feature/thing", mergeRef)
 }
 
+func TestAddPreferredWorktreeForkHeadRepoUsesPullRef(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	// True fork PRs do not have an origin/<head-branch> in the base repo clone.
+	// The pull ref is the only guaranteed local ref that can materialize the
+	// fork head without adding another remote.
+	pullSHA := configureForkPRRef(t, cloneDir, 245)
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(
+		t, d, repoID, 245, "fork/thing",
+		"https://github.com/contributor/widget.git",
+	)
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(t.Context(), "github.com", "acme", "widget", 245)
+	require.NoError(err)
+	require.NotNil(ws.MRHeadRepo)
+
+	_, exists, err := gitRefSHA(
+		t.Context(), cloneDir, "refs/remotes/origin/fork/thing",
+	)
+	require.NoError(err)
+	require.False(exists)
+
+	branch, err := mgr.addPreferredWorktree(t.Context(), cloneDir, ws)
+	require.NoError(err)
+	assert.Equal("fork/thing", branch)
+
+	headSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(pullSHA, headSHA)
+}
+
 func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -538,6 +574,19 @@ func configureSameRepoPRRefs(
 		t, cloneDir, "update-ref",
 		fmt.Sprintf("refs/pull/%d/head", prNumber), sha,
 	)
+}
+
+func configureForkPRRef(t *testing.T, cloneDir string, prNumber int) string {
+	t.Helper()
+	out, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main")
+	require.NoError(t, err)
+	sha := strings.TrimSpace(out)
+	require.NotEmpty(t, sha)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref",
+		fmt.Sprintf("refs/pull/%d/head", prNumber), sha,
+	)
+	return sha
 }
 
 func runWorkspaceTestGit(t *testing.T, dir string, args ...string) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -132,6 +132,7 @@ func TestCreate(t *testing.T) {
 func TestCreatePRHeadRepoClassification(t *testing.T) {
 	tests := []struct {
 		name           string
+		platformHost   string
 		number         int
 		headBranch     string
 		headRepoURL    string
@@ -150,14 +151,25 @@ func TestCreatePRHeadRepoClassification(t *testing.T) {
 			headBranch:  "feature/thing",
 			headRepoURL: "git@GitHub.com:Acme/Widget.git",
 		},
+		{
+			name:         "same-repo PR on enterprise host with port is not fork",
+			platformHost: "ghe.example.com:8443",
+			number:       246,
+			headBranch:   "feature/enterprise",
+			headRepoURL:  "https://GHE.example.com:8443/Acme/Widget.git",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := Assert.New(t)
 			d := openTestDB(t)
+			platformHost := tt.platformHost
+			if platformHost == "" {
+				platformHost = "github.com"
+			}
 			repoID := seedRepo(
-				t, d, "github.com", "acme", "widget",
+				t, d, platformHost, "acme", "widget",
 			)
 			seedMRWithHeadRepo(
 				t, d, repoID, tt.number, tt.headBranch, tt.headRepoURL,
@@ -165,7 +177,7 @@ func TestCreatePRHeadRepoClassification(t *testing.T) {
 
 			mgr := NewManager(d, t.TempDir())
 			ws, err := mgr.Create(
-				t.Context(), "github.com", "acme", "widget", tt.number,
+				t.Context(), platformHost, "acme", "widget", tt.number,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, ws)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -129,59 +129,59 @@ func TestCreate(t *testing.T) {
 	assert.Equal("creating", got.Status)
 }
 
-func TestCreateForkPR(t *testing.T) {
-	assert := Assert.New(t)
-	d := openTestDB(t)
-	wtDir := t.TempDir()
+func TestCreatePRHeadRepoClassification(t *testing.T) {
+	tests := []struct {
+		name           string
+		number         int
+		headBranch     string
+		headRepoURL    string
+		wantMRHeadRepo string
+	}{
+		{
+			name:           "fork PR keeps head repo",
+			number:         99,
+			headBranch:     "fix/typo",
+			headRepoURL:    "https://github.com/contributor/widget.git",
+			wantMRHeadRepo: "https://github.com/contributor/widget.git",
+		},
+		{
+			name:        "same-repo PR with populated head repo is not fork",
+			number:      244,
+			headBranch:  "feature/thing",
+			headRepoURL: "git@GitHub.com:Acme/Widget.git",
+		},
+	}
 
-	repoID := seedRepo(
-		t, d, "github.com", "acme", "widget",
-	)
-	seedMRWithHeadRepo(
-		t, d, repoID, 99, "fix/typo",
-		"https://github.com/contributor/widget.git",
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			d := openTestDB(t)
+			repoID := seedRepo(
+				t, d, "github.com", "acme", "widget",
+			)
+			seedMRWithHeadRepo(
+				t, d, repoID, tt.number, tt.headBranch, tt.headRepoURL,
+			)
 
-	mgr := NewManager(d, wtDir)
+			mgr := NewManager(d, t.TempDir())
+			ws, err := mgr.Create(
+				t.Context(), "github.com", "acme", "widget", tt.number,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, ws)
 
-	ws, err := mgr.Create(
-		t.Context(), "github.com", "acme", "widget", 99,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, ws)
-
-	assert.NotNil(ws.MRHeadRepo)
-	assert.Equal(
-		"https://github.com/contributor/widget.git",
-		*ws.MRHeadRepo,
-	)
-}
-
-func TestCreateSameRepoPRWithPopulatedHeadRepoIsNotFork(t *testing.T) {
-	assert := Assert.New(t)
-	d := openTestDB(t)
-	wtDir := t.TempDir()
-
-	repoID := seedRepo(
-		t, d, "github.com", "acme", "widget",
-	)
-	seedMRWithHeadRepo(
-		t, d, repoID, 244, "feature/thing",
-		"git@GitHub.com:Acme/Widget.git",
-	)
-
-	mgr := NewManager(d, wtDir)
-
-	ws, err := mgr.Create(
-		t.Context(), "github.com", "acme", "widget", 244,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, ws)
-
-	// Same-repo PRs still have head repo clone URLs in GitHub payloads. Keeping
-	// MRHeadRepo nil is what sends workspace setup down the origin/<branch> path
-	// instead of the refs/pull/<number>/head path reserved for forks.
-	assert.Nil(ws.MRHeadRepo)
+			if tt.wantMRHeadRepo == "" {
+				// Same-repo PRs still have head repo clone URLs in GitHub
+				// payloads. Keeping MRHeadRepo nil sends workspace setup down
+				// the origin/<branch> path instead of the refs/pull/<number>/head
+				// path reserved for forks.
+				assert.Nil(ws.MRHeadRepo)
+				return
+			}
+			require.NotNil(t, ws.MRHeadRepo)
+			assert.Equal(tt.wantMRHeadRepo, *ws.MRHeadRepo)
+		})
+	}
 }
 
 func TestCreateRepoNotTracked(t *testing.T) {
@@ -386,82 +386,113 @@ func TestAddPreferredWorktreeRejectsUnsafeBranchName(t *testing.T) {
 	require.Contains(err.Error(), "invalid branch name")
 }
 
-func TestAddPreferredWorktreeSameRepoHeadRepoTracksRemoteBranch(t *testing.T) {
-	assert := Assert.New(t)
-	require := require.New(t)
+func TestAddPreferredWorktreeHeadRepoRouting(t *testing.T) {
+	type worktreeExpectation struct {
+		headSHA  string
+		remote   string
+		mergeRef string
+	}
 
-	cloneDir := setupBareCloneForWorkspaceGitTest(t)
-	// Reproduce the dangerous repo state from issue #256: the real branch and
-	// GitHub's synthetic pull ref both exist and point at the same commit.
-	// Starting a branch from refs/pull/<number>/head lets Git auto-configure
-	// that synthetic ref as the upstream, which breaks tools that inspect @{u}.
-	configureSameRepoPRRefs(t, cloneDir, "feature/thing", 244)
+	tests := []struct {
+		name        string
+		number      int
+		headBranch  string
+		headRepoURL string
+		configure   func(*testing.T, string, string, int) worktreeExpectation
+	}{
+		{
+			name:        "same-repo PR tracks real remote branch",
+			number:      244,
+			headBranch:  "feature/thing",
+			headRepoURL: "https://github.com/acme/widget.git",
+			configure: func(
+				t *testing.T, cloneDir, branch string, prNumber int,
+			) worktreeExpectation {
+				// Reproduce the dangerous repo state from issue #256: the real
+				// branch and GitHub's synthetic pull ref both exist and point at
+				// the same commit. Starting from refs/pull/<number>/head lets Git
+				// auto-configure that synthetic ref as the upstream, which breaks
+				// tools that inspect @{u}.
+				sha := configureSameRepoPRRefs(
+					t, cloneDir, branch, prNumber,
+				)
+				return worktreeExpectation{
+					headSHA:  sha,
+					remote:   "origin",
+					mergeRef: "refs/heads/" + branch,
+				}
+			},
+		},
+		{
+			name:        "fork PR prefers pull ref over same-named origin branch",
+			number:      245,
+			headBranch:  "fork/thing",
+			headRepoURL: "https://github.com/contributor/widget.git",
+			configure: func(
+				t *testing.T, cloneDir, branch string, prNumber int,
+			) worktreeExpectation {
+				// A base repo can have a branch with the same name as a fork PR
+				// branch, but that origin branch is not the fork head. Fork
+				// workspaces must prefer the GitHub pull ref over any same-named
+				// origin branch.
+				originSHA, pullSHA := configureForkPRRefs(
+					t, cloneDir, branch, prNumber,
+				)
+				gotOriginSHA, exists, err := gitRefSHA(
+					t.Context(), cloneDir, "refs/remotes/origin/"+branch,
+				)
+				require.NoError(t, err)
+				require.True(t, exists)
+				require.NotEqual(t, originSHA, pullSHA)
+				require.Equal(t, originSHA, gotOriginSHA)
+				return worktreeExpectation{headSHA: pullSHA}
+			},
+		},
+	}
 
-	d := openTestDB(t)
-	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithHeadRepo(
-		t, d, repoID, 244, "feature/thing",
-		"https://github.com/acme/widget.git",
-	)
-	mgr := NewManager(d, t.TempDir())
-	ws, err := mgr.Create(t.Context(), "github.com", "acme", "widget", 244)
-	require.NoError(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			require := require.New(t)
+			cloneDir := setupBareCloneForWorkspaceGitTest(t)
+			want := tt.configure(t, cloneDir, tt.headBranch, tt.number)
 
-	branch, err := mgr.addPreferredWorktree(t.Context(), cloneDir, ws)
-	require.NoError(err)
-	assert.Equal("feature/thing", branch)
+			d := openTestDB(t)
+			repoID := seedRepo(t, d, "github.com", "acme", "widget")
+			seedMRWithHeadRepo(
+				t, d, repoID, tt.number, tt.headBranch, tt.headRepoURL,
+			)
+			mgr := NewManager(d, t.TempDir())
+			ws, err := mgr.Create(
+				t.Context(), "github.com", "acme", "widget", tt.number,
+			)
+			require.NoError(err)
 
-	remote, err := gitConfigValue(
-		t.Context(), ws.WorktreePath, "branch.feature/thing.remote",
-	)
-	require.NoError(err)
-	mergeRef, err := gitConfigValue(
-		t.Context(), ws.WorktreePath, "branch.feature/thing.merge",
-	)
-	require.NoError(err)
+			branch, err := mgr.addPreferredWorktree(t.Context(), cloneDir, ws)
+			require.NoError(err)
+			assert.Equal(tt.headBranch, branch)
 
-	assert.Equal("origin", remote)
-	assert.Equal("refs/heads/feature/thing", mergeRef)
-}
+			headSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+			require.NoError(err)
+			assert.Equal(want.headSHA, headSHA)
 
-func TestAddPreferredWorktreeForkHeadRepoUsesPullRefOverOriginBranch(t *testing.T) {
-	assert := Assert.New(t)
-	require := require.New(t)
-
-	cloneDir := setupBareCloneForWorkspaceGitTest(t)
-	// A base repo can have a branch with the same name as a fork PR branch, but
-	// that origin branch is not the fork head. Fork workspaces must prefer the
-	// GitHub pull ref over any same-named origin branch.
-	originSHA, pullSHA := configureForkPRRefs(
-		t, cloneDir, "fork/thing", 245,
-	)
-
-	d := openTestDB(t)
-	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithHeadRepo(
-		t, d, repoID, 245, "fork/thing",
-		"https://github.com/contributor/widget.git",
-	)
-	mgr := NewManager(d, t.TempDir())
-	ws, err := mgr.Create(t.Context(), "github.com", "acme", "widget", 245)
-	require.NoError(err)
-	require.NotNil(ws.MRHeadRepo)
-
-	gotOriginSHA, exists, err := gitRefSHA(
-		t.Context(), cloneDir, "refs/remotes/origin/fork/thing",
-	)
-	require.NoError(err)
-	require.True(exists)
-	require.NotEqual(originSHA, pullSHA)
-	require.Equal(originSHA, gotOriginSHA)
-
-	branch, err := mgr.addPreferredWorktree(t.Context(), cloneDir, ws)
-	require.NoError(err)
-	assert.Equal("fork/thing", branch)
-
-	headSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
-	require.NoError(err)
-	assert.Equal(pullSHA, headSHA)
+			if want.remote == "" && want.mergeRef == "" {
+				return
+			}
+			remote, err := gitConfigValue(
+				t.Context(), ws.WorktreePath,
+				"branch."+tt.headBranch+".remote",
+			)
+			require.NoError(err)
+			mergeRef, err := gitConfigValue(
+				t.Context(), ws.WorktreePath,
+				"branch."+tt.headBranch+".merge",
+			)
+			require.NoError(err)
+			assert.Equal(want.remote, remote)
+			assert.Equal(want.mergeRef, mergeRef)
+		})
+	}
 }
 
 func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {
@@ -565,7 +596,7 @@ func setupBareCloneForWorkspaceGitTest(t *testing.T) string {
 
 func configureSameRepoPRRefs(
 	t *testing.T, cloneDir, branch string, prNumber int,
-) {
+) string {
 	t.Helper()
 	out, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main")
 	require.NoError(t, err)
@@ -578,6 +609,7 @@ func configureSameRepoPRRefs(
 		t, cloneDir, "update-ref",
 		fmt.Sprintf("refs/pull/%d/head", prNumber), sha,
 	)
+	return sha
 }
 
 func configureForkPRRefs(

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -346,7 +346,7 @@ func normalizePlatformHostIdentity(platformHost string) string {
 	}
 	host, port, err := net.SplitHostPort(platformHost)
 	if err == nil {
-		return normalizeHostPortIdentity("", host, port)
+		return normalizeHostPortIdentity("https", host, port)
 	}
 	return strings.ToLower(platformHost)
 }

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -314,7 +315,9 @@ func normalizeCloneURLHost(cloneURL string) string {
 		if err != nil {
 			return ""
 		}
-		return parsed.Hostname()
+		return normalizeHostPortIdentity(
+			parsed.Scheme, parsed.Hostname(), parsed.Port(),
+		)
 	}
 	beforePath, _, ok := strings.Cut(cloneURL, ":")
 	if !ok {
@@ -324,5 +327,50 @@ func normalizeCloneURLHost(cloneURL string) string {
 	if !ok {
 		return ""
 	}
-	return host
+	return strings.ToLower(host)
+}
+
+func normalizePlatformHostIdentity(platformHost string) string {
+	platformHost = strings.TrimSpace(platformHost)
+	if platformHost == "" {
+		return ""
+	}
+	if strings.Contains(platformHost, "://") {
+		parsed, err := url.Parse(platformHost)
+		if err != nil {
+			return ""
+		}
+		return normalizeHostPortIdentity(
+			parsed.Scheme, parsed.Hostname(), parsed.Port(),
+		)
+	}
+	host, port, err := net.SplitHostPort(platformHost)
+	if err == nil {
+		return normalizeHostPortIdentity("", host, port)
+	}
+	return strings.ToLower(platformHost)
+}
+
+func normalizeHostPortIdentity(scheme, host, port string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return ""
+	}
+	if port == "" || isDefaultCloneURLPort(scheme, port) {
+		return host
+	}
+	return strings.ToLower(net.JoinHostPort(host, port))
+}
+
+func isDefaultCloneURLPort(scheme, port string) bool {
+	switch strings.ToLower(scheme) {
+	case "http":
+		return port == "80"
+	case "https":
+		return port == "443"
+	case "ssh":
+		return port == "22"
+	default:
+		return false
+	}
 }

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -419,3 +419,11 @@ func TestNormalizeCloneRepoIdentity(t *testing.T) {
 	assert.Empty(normalizeCloneRepoIdentity("/tmp/workspace/remote.git"))
 	assert.Empty(normalizeCloneRepoIdentity("not a clone url"))
 }
+
+func TestNormalizePlatformHostIdentity(t *testing.T) {
+	assert := Assert.New(t)
+
+	assert.Equal("ghe.example.com:8443", normalizePlatformHostIdentity("GHE.example.com:8443"))
+	assert.Equal("ghe.example.com", normalizePlatformHostIdentity("ghe.example.com:443"))
+	assert.Equal("ghe.example.com", normalizePlatformHostIdentity("ghe.example.com"))
+}

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -93,7 +93,7 @@ func TestPRMonitorRunOnceUsesUpstreamBranchMatch(t *testing.T) {
 
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
 	seedIssue(t, d, repoID, 7, "Track workspace association")
-	seedMRWithFork(
+	seedMRWithHeadRepo(
 		t, d, repoID, 42,
 		"feature/issue-7", "https://github.com/acme/widget.git",
 	)
@@ -243,11 +243,11 @@ func TestPRMonitorRunOnceUsesUpstreamRemoteIdentity(t *testing.T) {
 
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
 	seedIssue(t, d, repoID, 7, "Track workspace association")
-	seedMRWithFork(
+	seedMRWithHeadRepo(
 		t, d, repoID, 41,
 		"shared-branch", "https://github.com/Fork-One/Widget.git",
 	)
-	seedMRWithFork(
+	seedMRWithHeadRepo(
 		t, d, repoID, 42,
 		"shared-branch", "https://github.com/fork-two/widget.git",
 	)

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -412,6 +412,10 @@ func TestNormalizeCloneRepoIdentity(t *testing.T) {
 		"github.com/fork/widget",
 		normalizeCloneRepoIdentity("ssh://git@github.com:22/Fork/Widget.git"),
 	)
+	assert.Equal(
+		"ghe.example.com:8443/fork/widget",
+		normalizeCloneRepoIdentity("https://ghe.example.com:8443/Fork/Widget.git"),
+	)
 	assert.Empty(normalizeCloneRepoIdentity("/tmp/workspace/remote.git"))
 	assert.Empty(normalizeCloneRepoIdentity("not a clone url"))
 }


### PR DESCRIPTION
- Treat same-repo PR head clone URLs as the base repo instead of fork metadata.
- Keep workspace branches tracking origin/<head-branch> instead of refs/pull/<number>/head.

Closes #256.