### PR TITLE
Add embed-targetable workspace surfaces and project/worktree registry

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1103,6 +1103,44 @@ components:
         - type
         - content
       type: object
+    ListLaunchTargetsOutputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/ListLaunchTargetsOutputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        launch_targets:
+          items:
+            $ref: "#/components/schemas/LaunchTarget"
+          type:
+            - array
+            - "null"
+      required:
+        - launch_targets
+      type: object
+    ListProjectsOutputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/ListProjectsOutputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        projects:
+          items:
+            $ref: "#/components/schemas/ProjectResponse"
+          type:
+            - array
+            - "null"
+      required:
+        - projects
+      type: object
     ListWorkspacesOutputBody:
       additionalProperties: false
       properties:
@@ -1121,6 +1159,25 @@ components:
             - "null"
       required:
         - workspaces
+      type: object
+    ListWorktreesOutputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/ListWorktreesOutputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        worktrees:
+          items:
+            $ref: "#/components/schemas/WorktreeResponse"
+          type:
+            - array
+            - "null"
+      required:
+        - worktrees
       type: object
     MREvent:
       additionalProperties: false
@@ -1609,6 +1666,20 @@ components:
         - is_draft
         - title
       type: object
+    PlatformIdentityPayload:
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        owner:
+          type: string
+        platform_host:
+          type: string
+      required:
+        - platform_host
+        - owner
+        - name
+      type: object
     PostCommentHostInputBody:
       additionalProperties: false
       properties:
@@ -1668,6 +1739,39 @@ components:
           type: string
       required:
         - body
+      type: object
+    ProjectResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/ProjectResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        default_branch:
+          type: string
+        display_name:
+          type: string
+        id:
+          type: string
+        local_path:
+          type: string
+        platform_identity:
+          $ref: "#/components/schemas/PlatformIdentityPayload"
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - id
+        - display_name
+        - local_path
+        - created_at
+        - updated_at
       type: object
     ProviderCapabilitiesResponse:
       additionalProperties: false
@@ -1798,6 +1902,45 @@ components:
           type: object
       required:
         - hosts
+      type: object
+    RegisterProjectInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RegisterProjectInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        default_branch:
+          type: string
+        display_name:
+          type: string
+        local_path:
+          type: string
+        platform_identity:
+          $ref: "#/components/schemas/PlatformIdentityPayload"
+      required:
+        - local_path
+      type: object
+    RegisterWorktreeInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RegisterWorktreeInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        branch:
+          type: string
+        path:
+          type: string
+      required:
+        - branch
+        - path
       type: object
     RepoPreviewRequest:
       additionalProperties: false
@@ -2655,6 +2798,38 @@ components:
           type: string
       required:
         - worktree_key
+      type: object
+    WorktreeResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/WorktreeResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        branch:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        id:
+          type: string
+        path:
+          type: string
+        project_id:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - id
+        - project_id
+        - branch
+        - path
+        - created_at
+        - updated_at
       type: object
 info:
   title: middleman API
@@ -4558,6 +4733,136 @@ paths:
               schema:
                 $ref: "#/components/schemas/WorkspaceResponse"
           description: Accepted
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+  /projects:
+    get:
+      operationId: list-projects
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListProjectsOutputBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+    post:
+      operationId: register-project
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterProjectInputBody"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResponse"
+          description: Created
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+  /projects/{project_id}:
+    get:
+      operationId: get-project
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+  /projects/{project_id}/launch-targets:
+    get:
+      operationId: list-launch-targets
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListLaunchTargetsOutputBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+  /projects/{project_id}/worktrees:
+    get:
+      operationId: list-worktrees
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListWorktreesOutputBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+    post:
+      operationId: register-worktree
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterWorktreeInputBody"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorktreeResponse"
+          description: Created
         default:
           content:
             application/problem+json:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -23,6 +23,11 @@
   import RepoSummaryPage from "./lib/components/repositories/RepoSummaryPage.svelte";
   import SettingsPage from "./lib/components/settings/SettingsPage.svelte";
   import WorkspaceTerminalView from "./lib/components/terminal/WorkspaceTerminalView.svelte";
+  import WorkspaceListSidebar from "./lib/components/terminal/WorkspaceListSidebar.svelte";
+  import WorkspaceEmbedEmptyState from "./lib/components/terminal/WorkspaceEmbedEmptyState.svelte";
+  import WorkspaceFirstRunPanel from "./lib/components/terminal/WorkspaceFirstRunPanel.svelte";
+  import WorkspaceProjectCard from "./lib/components/terminal/WorkspaceProjectCard.svelte";
+  import { WorkspaceRightSidebar } from "@middleman/ui";
   import DesignSystemPage from "./lib/components/design-system/DesignSystemPage.svelte";
   import FlashBanner from "./lib/components/FlashBanner.svelte";
   import { SpinnerIcon } from "./lib/icons.ts";
@@ -58,6 +63,7 @@
     isDiffView,
     getDetailTab,
     getSelectedPRFromRoute,
+    isWorkspaceEmbedPage,
   } from "./lib/stores/router.svelte.ts";
   import {
     buildActivitySelectionSearch,
@@ -473,7 +479,45 @@
   }}
   bind:stores
 >
-  {#if getPage() === "focus"}
+  {#if isWorkspaceEmbedPage(getPage())}
+    {@const r = getRoute()}
+    <main class="embed-layout">
+      {#if r.page === "embed-workspace-list"}
+        <WorkspaceListSidebar selectedId="" />
+      {:else if r.page === "embed-workspace-terminal"}
+        <WorkspaceTerminalView
+          workspaceId={r.workspaceId}
+          hideWorkspaceList={true}
+          hideRightSidebar={true}
+        />
+      {:else if r.page === "embed-workspace-detail"}
+        <WorkspaceRightSidebar
+          activeTab={r.tab ??
+            (r.itemType === "issue" ? "issue" : "pr")}
+          workspaceID=""
+          provider={r.platformHost.toLowerCase().includes("gitlab")
+            ? "gitlab"
+            : "github"}
+          platformHost={r.platformHost}
+          repoOwner={r.owner}
+          repoName={r.name}
+          repoPath={`${r.owner}/${r.name}`}
+          ownerItemType={r.itemType === "issue" ? "issue" : "pull_request"}
+          ownerItemNumber={r.number}
+          associatedPRNumber={r.itemType === "pr" ? r.number : null}
+          branch={r.branch ?? ""}
+          roborevBaseUrl={getBasePath().replace(/\/$/, "") +
+            "/api/roborev"}
+        />
+      {:else if r.page === "embed-workspace-empty"}
+        <WorkspaceEmbedEmptyState reason={r.reason} />
+      {:else if r.page === "embed-workspace-first-run"}
+        <WorkspaceFirstRunPanel />
+      {:else if r.page === "embed-workspace-project"}
+        <WorkspaceProjectCard projectId={r.projectId} />
+      {/if}
+    </main>
+  {:else if getPage() === "focus"}
     {@const r = getRoute()}
     {#if r.page === "focus"}
       <main class="focus-layout">
@@ -613,6 +657,19 @@
     background: var(--bg-primary);
     display: flex;
     flex-direction: column;
+  }
+
+  /* Embed routes render a single workspace component at full
+     bleed. The host (e.g. a WKWebView) provides the surrounding
+     chrome. Hidden overflow lets the inner component manage its
+     own scrolling without leaking onto the host. */
+  .embed-layout {
+    flex: 1;
+    overflow: hidden;
+    background: var(--bg-primary);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
 
   .app-main {

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -2,7 +2,6 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/sv
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mockRefreshSyncStatus = vi.fn();
-let mockEmbedded = false;
 
 vi.mock("@middleman/ui", () => ({
   getStores: () => ({
@@ -21,13 +20,16 @@ vi.mock("../../api/settings.js", () => ({
   bulkAddRepos: vi.fn(),
 }));
 
-vi.mock("../../stores/embed-config.svelte.js", () => ({
-  isEmbedded: () => mockEmbedded,
-}));
-
-import { bulkAddRepos, previewRepos } from "../../api/settings.js";
+import {
+  addRepo,
+  bulkAddRepos,
+  previewRepos,
+  refreshRepo,
+} from "../../api/settings.js";
 import RepoSettings from "./RepoSettings.svelte";
 
+const mockAddRepo = vi.mocked(addRepo);
+const mockRefreshRepo = vi.mocked(refreshRepo);
 const mockPreviewRepos = vi.mocked(previewRepos);
 const mockBulkAddRepos = vi.mocked(bulkAddRepos);
 
@@ -35,9 +37,10 @@ describe("RepoSettings", () => {
   afterEach(() => {
     cleanup();
     mockRefreshSyncStatus.mockReset();
+    mockAddRepo.mockReset();
+    mockRefreshRepo.mockReset();
     mockPreviewRepos.mockReset();
     mockBulkAddRepos.mockReset();
-    mockEmbedded = false;
   });
 
   it("renders the glob count and refresh action", () => {
@@ -91,17 +94,57 @@ describe("RepoSettings", () => {
     expect(summary.closest("details")?.hasAttribute("open")).toBe(false);
   });
 
-  it("hides import and direct add controls in embedded mode", () => {
-    mockEmbedded = true;
+  it("forwards add/refresh through the settings API", async () => {
+    mockAddRepo.mockResolvedValue({
+      repos: [],
+      activity: {
+        view_mode: "threaded",
+        time_range: "7d",
+        hide_closed: false,
+        hide_bots: false,
+      },
+      terminal: { font_family: "", renderer: "xterm" },
+      agents: [],
+    });
+    mockRefreshRepo.mockResolvedValue({
+      repos: [],
+      activity: {
+        view_mode: "threaded",
+        time_range: "7d",
+        hide_closed: false,
+        hide_bots: false,
+      },
+      terminal: { font_family: "", renderer: "xterm" },
+      agents: [],
+    });
+
     render(RepoSettings, {
       props: {
-        repos: [],
+        repos: [{
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "*",
+          repo_path: "acme/*",
+          is_glob: true,
+          matched_repo_count: 1,
+        }],
         onUpdate: vi.fn(),
       },
     });
 
-    expect(screen.queryByRole("button", { name: "Add repositories…" })).toBeNull();
-    expect(screen.queryByText("Advanced: add exact repo or tracking glob directly")).toBeNull();
+    const input = screen.getByPlaceholderText("owner/name");
+    await fireEvent.input(input, { target: { value: "github/acme/widget" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(mockAddRepo).toHaveBeenCalledWith("acme", "widget", {
+      provider: "github",
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(mockRefreshRepo).toHaveBeenCalledWith("acme", "*", {
+      provider: "github",
+      host: "github.com",
+    });
   });
 
   it("updates repos and refreshes sync status after import", async () => {

--- a/frontend/src/lib/components/terminal/ToolingStatusBlock.svelte
+++ b/frontend/src/lib/components/terminal/ToolingStatusBlock.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+  // ToolingStatusBlock renders the embedding host's view of git and
+  // provider CLI availability/authentication. It is consumed by the
+  // First Run Panel (gates provider-dependent actions) and the New
+  // Worktree sheet (gates the PR/issue source radios). The block itself
+  // is informational - it never blocks a flow, it just tells the user
+  // what is missing and how to recover.
+
+  import type { ToolingStatusValue } from "../../stores/embed-config.svelte.ts";
+
+  interface Props {
+    tooling: ToolingStatusValue | undefined;
+    provider?: string | undefined;
+    // When the embedder cannot detect tooling state at all (the
+    // /api/tooling endpoint failed, or the host has not pushed yet),
+    // hide the block entirely. The parent decides whether to fall
+    // back to a global "tooling unavailable" notice.
+    hideWhenUnknown?: boolean;
+  }
+
+  let { tooling, provider, hideWhenUnknown = false }: Props = $props();
+
+  let copied = $state<string | null>(null);
+
+  type ToolStatus = "ok" | "missing" | "unauthed" | "unknown";
+  type ProviderToolName = "gh" | "glab";
+  type ProviderTooling = NonNullable<ToolingStatusValue[ProviderToolName]>;
+
+  const providerToolName = $derived<ProviderToolName>(
+    provider?.toLowerCase() === "gitlab" ? "glab" : "gh",
+  );
+  const providerTool = $derived<ProviderTooling | undefined>(
+    tooling?.[providerToolName],
+  );
+  const installCommand = $derived(`brew install ${providerToolName}`);
+  const authCommand = $derived(`${providerToolName} auth login`);
+
+  const gitStatus = $derived<ToolStatus>(
+    tooling?.git
+      ? (tooling.git.available ? "ok" : "missing")
+      : "unknown",
+  );
+
+  const providerCliStatus = $derived<ToolStatus>(
+    providerTool
+      ? (!providerTool.available
+          ? "missing"
+          : (providerTool.authenticated ? "ok" : "unauthed"))
+      : "unknown",
+  );
+
+  const gitDetail = $derived.by(() => {
+    if (!tooling?.git) return "";
+    if (tooling.git.available) {
+      return tooling.git.version
+        ? `Available (${tooling.git.version})`
+        : "Available";
+    }
+    return "Not found on PATH";
+  });
+
+  const providerCliDetail = $derived.by(() => {
+    if (!providerTool) return "";
+    if (!providerTool.available) return "Not installed";
+    if (!providerTool.authenticated) return "Not authenticated";
+    const userPart = providerTool.user ? `as ${providerTool.user}` : "";
+    const hostPart = providerTool.host ? `on ${providerTool.host}` : "";
+    const tail = [userPart, hostPart].filter(Boolean).join(" ");
+    return tail ? `Authenticated ${tail}` : "Authenticated";
+  });
+
+  const showBlock = $derived(
+    !hideWhenUnknown ||
+      gitStatus !== "unknown" ||
+      providerCliStatus !== "unknown",
+  );
+
+  async function copyCommand(command: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(command);
+      copied = command;
+      setTimeout(() => {
+        if (copied === command) copied = null;
+      }, 1500);
+    } catch (err) {
+      console.error("Copy failed:", err);
+    }
+  }
+</script>
+
+{#if showBlock}
+  <section class="tooling-block" aria-label="Tooling status">
+    <h3 class="tooling-block__title">Tooling</h3>
+    <ul class="tooling-block__list">
+      <li class="tooling-row" data-status={gitStatus}>
+        <div class="tooling-row__main">
+          <span
+            class="tooling-row__indicator"
+            data-status={gitStatus}
+            aria-hidden="true"
+          ></span>
+          <span class="tooling-row__name">git</span>
+          <span class="tooling-row__detail">{gitDetail}</span>
+        </div>
+        {#if gitStatus === "missing"}
+          <p class="tooling-row__recovery">
+            Install Xcode Command Line Tools:
+            <code>xcode-select --install</code>
+          </p>
+        {/if}
+      </li>
+
+      <li class="tooling-row" data-status={providerCliStatus}>
+        <div class="tooling-row__main">
+          <span
+            class="tooling-row__indicator"
+            data-status={providerCliStatus}
+            aria-hidden="true"
+          ></span>
+          <span class="tooling-row__name">{providerToolName}</span>
+          <span class="tooling-row__detail">{providerCliDetail}</span>
+        </div>
+        {#if providerCliStatus === "missing"}
+          <p class="tooling-row__recovery">
+            Install with:
+            <code>{installCommand}</code>
+            <button
+              type="button"
+              class="tooling-row__copy"
+              onclick={() => copyCommand(installCommand)}
+              aria-label={providerToolName === "gh"
+                ? "Copy install command"
+                : `Copy ${providerToolName} install command`}
+            >
+              {copied === installCommand ? "Copied" : "Copy"}
+            </button>
+          </p>
+        {/if}
+        {#if providerCliStatus === "unauthed"}
+          <p class="tooling-row__recovery">
+            Authenticate with:
+            <code>{authCommand}</code>
+            <button
+              type="button"
+              class="tooling-row__copy"
+              onclick={() => copyCommand(authCommand)}
+              aria-label={providerToolName === "gh"
+                ? "Copy auth command"
+                : `Copy ${providerToolName} auth command`}
+            >
+              {copied === authCommand ? "Copied" : "Copy"}
+            </button>
+          </p>
+        {/if}
+      </li>
+    </ul>
+  </section>
+{/if}
+
+<style>
+  .tooling-block {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md, 8px);
+    background: var(--bg-surface);
+  }
+
+  .tooling-block__title {
+    margin: 0;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+
+  .tooling-block__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .tooling-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .tooling-row__main {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+  }
+
+  .tooling-row__indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .tooling-row__indicator[data-status="ok"] {
+    background: var(--accent-green);
+  }
+
+  .tooling-row__indicator[data-status="missing"] {
+    background: var(--accent-red);
+  }
+
+  .tooling-row__indicator[data-status="unauthed"] {
+    background: var(--accent-amber);
+  }
+
+  .tooling-row__indicator[data-status="unknown"] {
+    background: var(--text-muted);
+  }
+
+  .tooling-row__name {
+    font-family: var(--font-mono, monospace);
+    font-weight: 600;
+  }
+
+  .tooling-row__detail {
+    color: var(--text-secondary);
+    font-size: 12px;
+  }
+
+  .tooling-row__recovery {
+    margin: 0;
+    padding-left: 16px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .tooling-row__recovery code {
+    padding: 2px 5px;
+    border-radius: 4px;
+    background: var(--bg-inset);
+    color: var(--text-primary);
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+  }
+
+  .tooling-row__copy {
+    padding: 2px 6px;
+    border: 1px solid var(--border-muted);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 11px;
+  }
+</style>

--- a/frontend/src/lib/components/terminal/ToolingStatusBlock.test.ts
+++ b/frontend/src/lib/components/terminal/ToolingStatusBlock.test.ts
@@ -1,0 +1,165 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ToolingStatusBlock from "./ToolingStatusBlock.svelte";
+
+describe("ToolingStatusBlock", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders both git and gh rows when tooling is fully available", () => {
+    render(ToolingStatusBlock, {
+      props: {
+        tooling: {
+          git: { available: true, version: "2.45.0" },
+          gh: {
+            available: true,
+            authenticated: true,
+            user: "wesm",
+            host: "github.com",
+          },
+        },
+      },
+    });
+
+    expect(screen.getByText("git")).toBeTruthy();
+    expect(screen.getByText("Available (2.45.0)")).toBeTruthy();
+    expect(screen.getByText("gh")).toBeTruthy();
+    expect(
+      screen.getByText("Authenticated as wesm on github.com"),
+    ).toBeTruthy();
+  });
+
+  it("renders the GitLab CLI row for GitLab providers", () => {
+    render(ToolingStatusBlock, {
+      props: {
+        provider: "gitlab",
+        tooling: {
+          git: { available: true, version: "2.45.0" },
+          gh: {
+            available: true,
+            authenticated: true,
+            user: "wesm",
+            host: "github.com",
+          },
+          glab: {
+            available: true,
+            authenticated: true,
+            user: "wesm",
+            host: "gitlab.com",
+          },
+        },
+      },
+    });
+
+    expect(screen.getByText("git")).toBeTruthy();
+    expect(screen.getByText("glab")).toBeTruthy();
+    expect(screen.queryByText("gh")).toBeNull();
+    expect(
+      screen.getByText("Authenticated as wesm on gitlab.com"),
+    ).toBeTruthy();
+  });
+
+  it("surfaces GitLab CLI recovery commands for GitLab providers", async () => {
+    render(ToolingStatusBlock, {
+      props: {
+        provider: "gitlab",
+        tooling: {
+          git: { available: true },
+          glab: { available: false, authenticated: false },
+        },
+      },
+    });
+
+    expect(screen.getByText("Not installed")).toBeTruthy();
+    expect(screen.getByText("brew install glab")).toBeTruthy();
+    await fireEvent.click(screen.getByLabelText("Copy glab install command"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "brew install glab",
+    );
+  });
+
+  it("surfaces a recovery command when gh is not authenticated", () => {
+    render(ToolingStatusBlock, {
+      props: {
+        tooling: {
+          git: { available: true },
+          gh: { available: true, authenticated: false },
+        },
+      },
+    });
+
+    expect(screen.getByText("Not authenticated")).toBeTruthy();
+    const code = screen.getByText("gh auth login");
+    expect(code).toBeTruthy();
+  });
+
+  it("surfaces a brew install command when gh is missing", () => {
+    render(ToolingStatusBlock, {
+      props: {
+        tooling: {
+          git: { available: true },
+          gh: { available: false, authenticated: false },
+        },
+      },
+    });
+
+    expect(screen.getByText("Not installed")).toBeTruthy();
+    expect(screen.getByText("brew install gh")).toBeTruthy();
+  });
+
+  it("surfaces git recovery when git is missing", () => {
+    render(ToolingStatusBlock, {
+      props: {
+        tooling: {
+          git: { available: false },
+          gh: { available: true, authenticated: true },
+        },
+      },
+    });
+
+    expect(screen.getByText("Not found on PATH")).toBeTruthy();
+    expect(screen.getByText("xcode-select --install")).toBeTruthy();
+  });
+
+  it("copies the gh auth login command on button click", async () => {
+    render(ToolingStatusBlock, {
+      props: {
+        tooling: {
+          git: { available: true },
+          gh: { available: true, authenticated: false },
+        },
+      },
+    });
+
+    const button = screen.getByLabelText("Copy auth command");
+    await fireEvent.click(button);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "gh auth login",
+    );
+  });
+
+  it("renders nothing when tooling is undefined and hideWhenUnknown is set", () => {
+    const { container } = render(ToolingStatusBlock, {
+      props: { tooling: undefined, hideWhenUnknown: true },
+    });
+    expect(container.querySelector(".tooling-block")).toBeNull();
+  });
+
+  it("renders the block when tooling is undefined and hideWhenUnknown is false", () => {
+    render(ToolingStatusBlock, {
+      props: { tooling: undefined },
+    });
+    // Both rows show their unknown indicator without recovery copy.
+    expect(screen.getByText("git")).toBeTruthy();
+    expect(screen.getByText("gh")).toBeTruthy();
+    expect(screen.queryByText("brew install gh")).toBeNull();
+    expect(screen.queryByText("gh auth login")).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/terminal/WorkspaceEmbedEmptyState.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceEmbedEmptyState.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { EmbedEmptyReason } from "../../stores/router.svelte.ts";
+
+  const { reason }: { reason: EmbedEmptyReason } = $props();
+
+  const message = $derived.by(() => {
+    switch (reason) {
+      case "noRepo":
+        return "Select a repository to see workspaces";
+      case "noWorkspace":
+        return "No workspace for this item yet";
+      case "noSelection":
+      default:
+        return "Select a workspace from the sidebar";
+    }
+  });
+</script>
+
+<div class="empty">
+  <span>{message}</span>
+</div>
+
+<style>
+  .empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: var(--text-muted);
+    font-size: 13px;
+    background: var(--bg-primary);
+  }
+</style>

--- a/frontend/src/lib/components/terminal/WorkspaceEmbedEmptyState.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceEmbedEmptyState.test.ts
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+
+import WorkspaceEmbedEmptyState from "./WorkspaceEmbedEmptyState.svelte";
+
+describe("WorkspaceEmbedEmptyState", () => {
+  afterEach(() => cleanup());
+
+  it("renders the noSelection message", () => {
+    render(WorkspaceEmbedEmptyState, {
+      props: { reason: "noSelection" },
+    });
+    expect(
+      screen.getByText("Select a workspace from the sidebar"),
+    ).toBeTruthy();
+  });
+
+  it("renders the noRepo message", () => {
+    render(WorkspaceEmbedEmptyState, {
+      props: { reason: "noRepo" },
+    });
+    expect(
+      screen.getByText("Select a repository to see workspaces"),
+    ).toBeTruthy();
+  });
+
+  it("renders the noWorkspace message", () => {
+    render(WorkspaceEmbedEmptyState, {
+      props: { reason: "noWorkspace" },
+    });
+    expect(
+      screen.getByText("No workspace for this item yet"),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+  // WorkspaceFirstRunPanel is the embed surface that renders when the
+  // project registry is empty. It is the first surface a fresh
+  // installation lands on, and it must offer at least one action that
+  // progresses toward a worktree - the master spec's "no dead ends"
+  // rule. Every action returns a CommandResult so the surface can
+  // render in-flight, success, and failure states.
+
+  import {
+    getProjectAction,
+    getToolingStatus,
+    getWorkspaceData,
+    invokeProjectAction,
+  } from "../../stores/embed-config.svelte.ts";
+  import ToolingStatusBlock from "./ToolingStatusBlock.svelte";
+
+  type ActionId = "add-existing" | "clone" | "connect-github";
+
+  interface ActionDefinition {
+    id: ActionId;
+    label: string;
+    description: string;
+    requiresGh: boolean;
+  }
+
+  const ACTIONS: ActionDefinition[] = [
+    {
+      id: "add-existing",
+      label: "Add an existing local repository",
+      description: "Pick a folder you already cloned.",
+      requiresGh: false,
+    },
+    {
+      id: "clone",
+      label: "Clone a repository",
+      description: "Provide a URL and we'll clone it.",
+      requiresGh: false,
+    },
+    {
+      id: "connect-github",
+      label: "Connect a GitHub repository",
+      description: "Pick from your GitHub repos.",
+      requiresGh: true,
+    },
+  ];
+
+  let inFlight = $state<ActionId | null>(null);
+  let lastError = $state<string | null>(null);
+
+  const tooling = $derived(getToolingStatus());
+  const provider = $derived.by(() => {
+    const workspace = getWorkspaceData();
+    if (!workspace) return undefined;
+    const selectedHost = workspace.hosts.find(
+      (host) => host.key === workspace.selectedHostKey,
+    ) ?? workspace.hosts[0];
+    return selectedHost?.platform;
+  });
+  const ghAuthed = $derived(
+    tooling?.gh?.available === true &&
+      tooling.gh.authenticated === true,
+  );
+
+  function isDisabled(definition: ActionDefinition): boolean {
+    if (inFlight !== null) return true;
+    if (definition.requiresGh && !ghAuthed) return true;
+    return false;
+  }
+
+  function disabledReason(
+    definition: ActionDefinition,
+  ): string | undefined {
+    if (definition.requiresGh && !ghAuthed) {
+      if (!tooling?.gh?.available) {
+        return "Install gh to use this option.";
+      }
+      return "Run gh auth login to use this option.";
+    }
+    return undefined;
+  }
+
+  async function runAction(definition: ActionDefinition): Promise<void> {
+    if (isDisabled(definition)) return;
+    const action = getProjectAction(definition.id);
+    if (!action) {
+      lastError =
+        "This action is not available in this build. Please update " +
+        "the host application.";
+      return;
+    }
+    inFlight = definition.id;
+    lastError = null;
+    try {
+      const result = await invokeProjectAction(action, {
+        surface: "first-run-panel",
+      });
+      if (!result.ok) {
+        lastError = result.message ?? "Action failed.";
+      }
+    } finally {
+      inFlight = null;
+    }
+  }
+</script>
+
+<section class="first-run" aria-labelledby="first-run-title">
+  <div class="first-run__intro">
+    <h1 id="first-run-title" class="first-run__title">
+      Get to your first worktree.
+    </h1>
+    <p class="first-run__lede">
+      Worktrees keep one branch checked out per directory so each
+      change you start has its own working tree, terminal, and
+      agent. Pick a starting point below.
+    </p>
+  </div>
+
+  <ul class="first-run__actions">
+    {#each ACTIONS as action (action.id)}
+      {@const disabled = isDisabled(action)}
+      {@const reason = disabledReason(action)}
+      <li class="first-run-action">
+        <button
+          type="button"
+          class="first-run-action__button"
+          {disabled}
+          aria-busy={inFlight === action.id}
+          aria-describedby={reason
+            ? `first-run-action-reason-${action.id}`
+            : undefined}
+          onclick={() => runAction(action)}
+        >
+          <span class="first-run-action__label">
+            {action.label}
+            {#if inFlight === action.id}
+              <span class="first-run-action__spinner" aria-hidden="true">…</span>
+            {/if}
+          </span>
+          <span class="first-run-action__description">
+            {action.description}
+          </span>
+        </button>
+        {#if reason}
+          <p
+            class="first-run-action__reason"
+            id="first-run-action-reason-{action.id}"
+          >
+            {reason}
+          </p>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+
+  {#if lastError}
+    <p class="first-run__error" role="alert">
+      {lastError}
+    </p>
+  {/if}
+
+  <ToolingStatusBlock {tooling} {provider} />
+</section>
+
+<style>
+  .first-run {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 480px;
+    margin: 24px auto;
+    padding: 16px;
+    box-sizing: border-box;
+  }
+
+  .first-run__intro {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .first-run__title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .first-run__lede {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .first-run__actions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .first-run-action {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .first-run-action__button {
+    appearance: none;
+    border: 1px solid var(--border-default);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    text-align: left;
+    padding: 12px 14px;
+    border-radius: var(--radius-md, 8px);
+    font: inherit;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .first-run-action__button:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+  }
+
+  .first-run-action__button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .first-run-action__label {
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .first-run-action__spinner {
+    color: var(--text-muted);
+  }
+
+  .first-run-action__description {
+    color: var(--text-secondary);
+    font-size: 12px;
+  }
+
+  .first-run-action__reason {
+    margin: 0 0 0 14px;
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .first-run__error {
+    margin: 0;
+    padding: 8px 12px;
+    border: 1px solid var(--accent-red);
+    border-radius: var(--radius-md, 8px);
+    background: color-mix(in srgb, var(--accent-red) 10%, transparent);
+    color: var(--accent-red);
+    font-size: 13px;
+  }
+</style>

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
@@ -1,0 +1,198 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import WorkspaceFirstRunPanel from "./WorkspaceFirstRunPanel.svelte";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper needs dynamic window access
+const win = window as any;
+
+interface SetupArgs {
+  ghAuthed: boolean;
+  ghAvailable?: boolean;
+  handlers?: Partial<
+    Record<string, (ctx: unknown) => CommandResult | Promise<CommandResult>>
+  >;
+}
+
+function setupConfig({
+  ghAuthed,
+  ghAvailable = true,
+  handlers = {},
+}: SetupArgs): void {
+  win.__middleman_config = {
+    actions: {
+      project: [
+        {
+          id: "add-existing",
+          label: "Add Existing",
+          handler: handlers["add-existing"] ?? vi.fn().mockResolvedValue({ ok: true }),
+        },
+        {
+          id: "clone",
+          label: "Clone",
+          handler: handlers["clone"] ?? vi.fn().mockResolvedValue({ ok: true }),
+        },
+        {
+          id: "connect-github",
+          label: "Connect GH",
+          handler: handlers["connect-github"] ?? vi.fn().mockResolvedValue({ ok: true }),
+        },
+      ],
+    },
+    embed: {
+      tooling: {
+        git: { available: true, version: "2.45.0" },
+        gh: { available: ghAvailable, authenticated: ghAuthed },
+      },
+    },
+  };
+  win.__middleman_notify_config_changed?.();
+}
+
+describe("WorkspaceFirstRunPanel", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete win.__middleman_config;
+  });
+
+  it("renders the three primary actions with their descriptions", () => {
+    setupConfig({ ghAuthed: true });
+    render(WorkspaceFirstRunPanel);
+
+    expect(
+      screen.getByRole("button", {
+        name: /Add an existing local repository/i,
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Clone a repository/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Connect a GitHub repository/i,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("disables the GitHub action with a recovery hint when gh is not authenticated", () => {
+    setupConfig({ ghAuthed: false, ghAvailable: true });
+    render(WorkspaceFirstRunPanel);
+
+    const button = screen.getByRole("button", {
+      name: /Connect a GitHub repository/i,
+    });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      screen.getByText("Run gh auth login to use this option."),
+    ).toBeTruthy();
+  });
+
+  it("uses an install-gh recovery hint when gh is unavailable", () => {
+    setupConfig({ ghAuthed: false, ghAvailable: false });
+    render(WorkspaceFirstRunPanel);
+
+    expect(
+      screen.getByText("Install gh to use this option."),
+    ).toBeTruthy();
+  });
+
+  it("invokes the action handler when the user clicks", async () => {
+    const handler = vi.fn().mockResolvedValue({ ok: true });
+    setupConfig({ ghAuthed: true, handlers: { "add-existing": handler } });
+    render(WorkspaceFirstRunPanel);
+
+    const button = screen.getByRole("button", {
+      name: /Add an existing local repository/i,
+    });
+    await fireEvent.click(button);
+    expect(handler).toHaveBeenCalledWith({
+      surface: "first-run-panel",
+    });
+  });
+
+  it("renders the failure message when an action returns ok: false", async () => {
+    const handler = vi.fn().mockResolvedValue({
+      ok: false,
+      message: "Couldn't reach the remote",
+    });
+    setupConfig({ ghAuthed: true, handlers: { clone: handler } });
+    render(WorkspaceFirstRunPanel);
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Clone a repository/i }),
+    );
+    expect(
+      await screen.findByText("Couldn't reach the remote"),
+    ).toBeTruthy();
+  });
+
+  it("renders an upgrade-host hint when the action is not registered", async () => {
+    win.__middleman_config = {
+      actions: { project: [] },
+      embed: {
+        tooling: {
+          git: { available: true },
+          gh: { available: true, authenticated: true },
+        },
+      },
+    };
+    win.__middleman_notify_config_changed?.();
+    render(WorkspaceFirstRunPanel);
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Add an existing local repository/i }),
+    );
+    expect(
+      await screen.findByText(/not available in this build/i),
+    ).toBeTruthy();
+  });
+
+  it("renders the tooling status block beneath the actions", () => {
+    setupConfig({ ghAuthed: true });
+    render(WorkspaceFirstRunPanel);
+    expect(screen.getByLabelText("Tooling status")).toBeTruthy();
+  });
+
+  it("shows GitLab CLI status for a selected GitLab workspace host", () => {
+    setupConfig({ ghAuthed: true });
+    win.__middleman_config.workspace = {
+      selectedHostKey: "gitlab-main",
+      selectedWorktreeKey: null,
+      hosts: [{
+        key: "gitlab-main",
+        label: "GitLab",
+        connectionState: "connected",
+        platform: "gitlab",
+        projects: [],
+        sessions: [],
+        resources: null,
+      }],
+    };
+    win.__middleman_config.embed.tooling.glab = {
+      available: true,
+      authenticated: true,
+      user: "wesm",
+      host: "gitlab.com",
+    };
+    win.__middleman_notify_config_changed?.();
+
+    render(WorkspaceFirstRunPanel);
+
+    expect(screen.getByText("glab")).toBeTruthy();
+    expect(screen.queryByText("gh")).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/terminal/WorkspaceProjectCard.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceProjectCard.svelte
@@ -1,0 +1,370 @@
+<script lang="ts">
+  // WorkspaceProjectCard renders a single registered project with its
+  // worktrees and a primary CTA to create a new one. For the first-
+  // useful-minute flow the project is freshly registered and has zero
+  // worktrees, so the card opens straight to the New Worktree action.
+  // The actions.project["new-worktree"] handler is the embedding
+  // host's responsibility to register; we surface failure via the
+  // ack-aware runner.
+
+  import { onMount } from "svelte";
+
+  import { apiErrorMessage, client } from "../../api/runtime.ts";
+  import {
+    getProjectAction,
+    invokeProjectAction,
+  } from "../../stores/embed-config.svelte.ts";
+
+  interface Props {
+    projectId: string;
+  }
+
+  interface PlatformIdentity {
+    platform_host: string;
+    owner: string;
+    name: string;
+  }
+
+  interface Project {
+    id: string;
+    display_name: string;
+    local_path: string;
+    platform_identity?: PlatformIdentity;
+    default_branch?: string;
+  }
+
+  interface Worktree {
+    id: string;
+    project_id: string;
+    branch: string;
+    path: string;
+  }
+
+  let { projectId }: Props = $props();
+
+  let project = $state<Project | null>(null);
+  let worktrees = $state<Worktree[]>([]);
+  let loadError = $state<string | null>(null);
+  let loading = $state<boolean>(true);
+  let inFlight = $state<boolean>(false);
+  let actionError = $state<string | null>(null);
+
+  async function load(): Promise<void> {
+    loading = true;
+    loadError = null;
+    try {
+      const {
+        data: projectData,
+        error: projectError,
+      } = await client.GET("/projects/{project_id}", {
+        params: { path: { project_id: projectId } },
+      });
+      if (!projectData) {
+        loadError = apiErrorMessage(
+          projectError,
+          "Couldn't load this project.",
+        );
+        return;
+      }
+      project = projectData as Project;
+
+      const {
+        data: worktreesData,
+        error: worktreesError,
+      } = await client.GET("/projects/{project_id}/worktrees", {
+        params: { path: { project_id: projectId } },
+      });
+      if (!worktreesData) {
+        loadError = apiErrorMessage(
+          worktreesError,
+          "Couldn't load this project's worktrees.",
+        );
+        return;
+      }
+      worktrees = (worktreesData.worktrees ?? []) as Worktree[];
+    } catch (err) {
+      loadError = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    void load();
+  });
+
+  async function startNewWorktree(): Promise<void> {
+    if (inFlight) return;
+    const action = getProjectAction("new-worktree");
+    if (!action) {
+      actionError =
+        "New Worktree is not available in this build. " +
+        "Please update the host application.";
+      return;
+    }
+    inFlight = true;
+    actionError = null;
+    try {
+      const result = await invokeProjectAction(action, {
+        surface: "project-card",
+        projectId,
+      });
+      if (!result.ok) {
+        actionError = result.message ?? "Couldn't start a new worktree.";
+        return;
+      }
+      // Refresh worktree list on success so the new row shows up.
+      await load();
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  function platformChip(identity: PlatformIdentity): string {
+    return `${identity.platform_host} / ${identity.owner} / ${identity.name}`;
+  }
+</script>
+
+<section class="project-card" aria-labelledby="project-card-title">
+  {#if loading}
+    <p class="project-card__status">Loading project…</p>
+  {:else if loadError}
+    <p class="project-card__error" role="alert">{loadError}</p>
+    <button
+      type="button"
+      class="project-card__retry"
+      onclick={() => void load()}
+    >
+      Retry
+    </button>
+  {:else if project}
+    <header class="project-card__header">
+      <h2
+        id="project-card-title"
+        class="project-card__title"
+      >
+        {project.display_name}
+      </h2>
+      <p class="project-card__path">
+        <span class="project-card__path-text">{project.local_path}</span>
+      </p>
+      {#if project.platform_identity}
+        <p class="project-card__platform">
+          <span class="project-card__platform-chip">
+            {platformChip(project.platform_identity)}
+          </span>
+        </p>
+      {/if}
+      {#if project.default_branch}
+        <p class="project-card__branch">
+          Default branch:
+          <code>{project.default_branch}</code>
+        </p>
+      {/if}
+    </header>
+
+    <section class="project-card__worktrees" aria-label="Worktrees">
+      <h3 class="project-card__section-title">Worktrees</h3>
+      {#if worktrees.length === 0}
+        <p class="project-card__empty">
+          This project has no worktrees yet.
+        </p>
+      {:else}
+        <ul class="project-card__worktree-list">
+          {#each worktrees as worktree (worktree.id)}
+            <li class="project-card__worktree-row">
+              <span class="project-card__worktree-branch">
+                {worktree.branch}
+              </span>
+              <span class="project-card__worktree-path">
+                {worktree.path}
+              </span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <button
+      type="button"
+      class="project-card__cta"
+      disabled={inFlight}
+      aria-busy={inFlight}
+      onclick={() => void startNewWorktree()}
+    >
+      {worktrees.length === 0
+        ? "Create your first worktree"
+        : "Create another worktree"}
+      {#if inFlight}
+        <span aria-hidden="true">…</span>
+      {/if}
+    </button>
+
+    {#if actionError}
+      <p class="project-card__error" role="alert">{actionError}</p>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .project-card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 480px;
+    margin: 24px auto;
+    padding: 16px;
+    box-sizing: border-box;
+  }
+
+  .project-card__status {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .project-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .project-card__title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .project-card__path {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+
+  .project-card__path-text {
+    font-family: var(--font-mono, monospace);
+    word-break: break-all;
+  }
+
+  .project-card__platform {
+    margin: 0;
+  }
+
+  .project-card__platform-chip {
+    display: inline-flex;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: var(--bg-inset);
+    color: var(--text-secondary);
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+  }
+
+  .project-card__branch {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 12px;
+  }
+
+  .project-card__branch code {
+    font-family: var(--font-mono, monospace);
+    background: var(--bg-inset);
+    padding: 1px 4px;
+    border-radius: 4px;
+  }
+
+  .project-card__section-title {
+    margin: 0 0 4px 0;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+  }
+
+  .project-card__empty {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .project-card__worktree-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .project-card__worktree-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md, 8px);
+    background: var(--bg-surface);
+  }
+
+  .project-card__worktree-branch {
+    font-weight: 600;
+    font-size: 13px;
+  }
+
+  .project-card__worktree-path {
+    font-family: var(--font-mono, monospace);
+    color: var(--text-secondary);
+    font-size: 12px;
+    word-break: break-all;
+  }
+
+  .project-card__cta {
+    appearance: none;
+    border: 1px solid var(--accent-blue);
+    background: var(--accent-blue);
+    color: white;
+    font: inherit;
+    font-weight: 600;
+    padding: 10px 14px;
+    border-radius: var(--radius-md, 8px);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+
+  .project-card__cta:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .project-card__error {
+    margin: 0;
+    padding: 8px 12px;
+    border: 1px solid var(--accent-red);
+    border-radius: var(--radius-md, 8px);
+    background: color-mix(in srgb, var(--accent-red) 10%, transparent);
+    color: var(--accent-red);
+    font-size: 13px;
+  }
+
+  .project-card__retry {
+    appearance: none;
+    align-self: flex-start;
+    padding: 4px 10px;
+    border-radius: var(--radius-md, 8px);
+    border: 1px solid var(--border-default);
+    background: var(--bg-surface);
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+  }
+</style>

--- a/frontend/src/lib/components/terminal/WorkspaceProjectCard.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceProjectCard.test.ts
@@ -1,0 +1,255 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import WorkspaceProjectCard from "./WorkspaceProjectCard.svelte";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper needs dynamic window access
+const win = window as any;
+
+const projectGet = vi.fn();
+const worktreesGet = vi.fn();
+
+vi.mock("../../api/runtime.ts", () => ({
+  apiErrorMessage: (
+    error: { detail?: string; title?: string } | undefined,
+    fallback: string,
+  ) => error?.detail ?? error?.title ?? fallback,
+  client: {
+    GET: vi.fn((path: string, options) => {
+      if (path === "/projects/{project_id}") {
+        return projectGet(options);
+      }
+      if (path === "/projects/{project_id}/worktrees") {
+        return worktreesGet(options);
+      }
+      throw new Error(`unexpected GET path ${path}`);
+    }),
+  },
+}));
+
+interface ProjectFixture {
+  id: string;
+  display_name: string;
+  local_path: string;
+  default_branch?: string;
+  platform_identity?: { platform_host: string; owner: string; name: string };
+}
+
+function setProjectResponse(project: ProjectFixture | { error: string }): void {
+  projectGet.mockReset();
+  if ("error" in project) {
+    projectGet.mockResolvedValue({
+      error: { detail: project.error },
+      data: undefined,
+    });
+    return;
+  }
+  projectGet.mockResolvedValue({ data: project, error: undefined });
+}
+
+function setWorktreesResponse(
+  worktrees: Array<{ id: string; project_id: string; branch: string; path: string }>,
+): void {
+  worktreesGet.mockReset();
+  worktreesGet.mockResolvedValue({
+    data: { worktrees },
+    error: undefined,
+  });
+}
+
+describe("WorkspaceProjectCard", () => {
+  beforeEach(() => {
+    delete win.__middleman_config;
+  });
+
+  afterEach(() => {
+    cleanup();
+    projectGet.mockReset();
+    worktreesGet.mockReset();
+  });
+
+  it("renders project metadata and the create-first-worktree CTA when empty", async () => {
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "myrepo",
+      local_path: "/Users/wesm/code/myrepo",
+      default_branch: "main",
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+
+    expect(await screen.findByText("myrepo")).toBeTruthy();
+    expect(screen.getByText("/Users/wesm/code/myrepo")).toBeTruthy();
+    expect(screen.getByText("main")).toBeTruthy();
+    expect(
+      screen.getByText("This project has no worktrees yet."),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Create your first worktree/i }),
+    ).toBeTruthy();
+  });
+
+  it("hides the platform chip row when platform_identity is absent", async () => {
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "no-remote-repo",
+      local_path: "/tmp/no-remote",
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+    await screen.findByText("no-remote-repo");
+    // Chip uses platform host / owner / name format; absence is the no-platform path.
+    expect(screen.queryByText(/github\.com \/ /)).toBeNull();
+  });
+
+  it("renders platform identity from platform_host", async () => {
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "remote-repo",
+      local_path: "/tmp/remote-repo",
+      platform_identity: {
+        platform_host: "gitlab.example.com",
+        owner: "group/subgroup",
+        name: "project",
+      },
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+
+    expect(
+      await screen.findByText("gitlab.example.com / group/subgroup / project"),
+    ).toBeTruthy();
+  });
+
+  it("renders existing worktrees and switches the CTA label", async () => {
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "myrepo",
+      local_path: "/tmp/myrepo",
+    });
+    setWorktreesResponse([
+      {
+        id: "wtr_1",
+        project_id: "prj_1",
+        branch: "feature-x",
+        path: "/tmp/myrepo-worktrees/feature-x",
+      },
+    ]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+    await screen.findByText("feature-x");
+    expect(
+      screen.getByText("/tmp/myrepo-worktrees/feature-x"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Create another worktree/i }),
+    ).toBeTruthy();
+  });
+
+  it("renders an error and a retry button when the project fetch fails", async () => {
+    setProjectResponse({ error: "project not found" });
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+    expect(await screen.findByText("project not found")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Retry/i })).toBeTruthy();
+  });
+
+  it("invokes the new-worktree action with the project id when clicked", async () => {
+    const newWorktreeHandler = vi.fn().mockResolvedValue({ ok: true });
+    win.__middleman_config = {
+      actions: {
+        project: [
+          {
+            id: "new-worktree",
+            label: "New Worktree",
+            handler: newWorktreeHandler,
+          },
+        ],
+      },
+    };
+    win.__middleman_notify_config_changed?.();
+
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "myrepo",
+      local_path: "/tmp/myrepo",
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+    await screen.findByText("myrepo");
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Create your first worktree/i }),
+    );
+    expect(newWorktreeHandler).toHaveBeenCalledWith({
+      surface: "project-card",
+      projectId: "prj_1",
+    });
+  });
+
+  it("surfaces a failure message when the new-worktree action returns ok: false", async () => {
+    win.__middleman_config = {
+      actions: {
+        project: [
+          {
+            id: "new-worktree",
+            label: "New Worktree",
+            handler: () =>
+              Promise.resolve({
+                ok: false,
+                message: "user cancelled the sheet",
+              }),
+          },
+        ],
+      },
+    };
+    win.__middleman_notify_config_changed?.();
+
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "myrepo",
+      local_path: "/tmp/myrepo",
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+    await screen.findByText("myrepo");
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Create your first worktree/i }),
+    );
+    expect(
+      await screen.findByText("user cancelled the sheet"),
+    ).toBeTruthy();
+  });
+
+  it("renders an upgrade-host hint when the new-worktree action is missing", async () => {
+    win.__middleman_config = { actions: { project: [] } };
+    win.__middleman_notify_config_changed?.();
+
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "myrepo",
+      local_path: "/tmp/myrepo",
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+    await screen.findByText("myrepo");
+    await fireEvent.click(
+      screen.getByRole("button", { name: /Create your first worktree/i }),
+    );
+    expect(
+      await screen.findByText(/not available in this build/i),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -63,6 +63,12 @@
     createdAt: string;
   }
 
+  // hideWorkspaceList / hideRightSidebar let an embedding host
+  // render only the terminal/home/empty surface and compose the
+  // workspace list and per-item detail sidebar separately via
+  // the /workspaces/embed/list and /workspaces/embed/detail
+  // routes. Both default to false to preserve the standalone
+  // /workspaces and /terminal/{id} layout.
   interface Props {
     workspaceId: string;
     isSidebarCollapsed?: boolean;
@@ -70,6 +76,8 @@
     onSidebarResize?: (width: number) => void;
     isSidebarToggleEnabled?: boolean;
     onToggleSidebar?: () => void;
+    hideWorkspaceList?: boolean;
+    hideRightSidebar?: boolean;
   }
 
   const {
@@ -79,6 +87,8 @@
     onSidebarResize = undefined,
     isSidebarToggleEnabled = false,
     onToggleSidebar = undefined,
+    hideWorkspaceList = false,
+    hideRightSidebar = false,
   }: Props = $props();
 
   const basePath = (
@@ -892,24 +902,7 @@
 </script>
 
 <div class="terminal-view">
-  <CollapsibleResizableSidebar
-    isCollapsed={isSidebarCollapsed}
-    sidebarWidth={currentWorkspaceListWidth}
-    minSidebarWidth={MIN_WORKSPACE_LIST_WIDTH}
-    maxSidebarWidth={MAX_WORKSPACE_LIST_WIDTH}
-    onSidebarResize={handleWorkspaceListResize}
-    showCollapsedStrip={isSidebarToggleEnabled}
-    onExpand={onToggleSidebar}
-    mainOverflow="hidden"
-  >
-    {#snippet sidebar()}
-      <WorkspaceListSidebar
-        selectedId={workspaceId}
-        {isSidebarToggleEnabled}
-        onCollapseSidebar={onToggleSidebar}
-        onOpenItemSidebar={openItemSidebar}
-      />
-    {/snippet}
+  {#snippet terminalMainContent()}
     <div class="terminal-main">
       {#if !workspaceId}
         <div class="state-message">
@@ -984,42 +977,44 @@
             </code>
           </div>
           <div class="header-right">
-            <div class="seg-control">
-              <button
-                class="seg-btn"
-                class:active={sidebarOpen && sidebarTab === "diff"}
-                onclick={() => handleSegmentClick("diff")}
-              >
-                Diff
-              </button>
-              {#if workspace.item_type === "issue"}
+            {#if !hideRightSidebar}
+              <div class="seg-control">
                 <button
                   class="seg-btn"
-                  class:active={sidebarOpen && sidebarTab === "issue"}
-                  onclick={() => handleSegmentClick("issue")}
+                  class:active={sidebarOpen && sidebarTab === "diff"}
+                  onclick={() => handleSegmentClick("diff")}
                 >
-                  Issue
+                  Diff
                 </button>
-              {/if}
-              {#if getWorkspacePRNumber(workspace) !== null}
-                <button
-                  class="seg-btn"
-                  class:active={sidebarOpen && sidebarTab === "pr"}
-                  onclick={() => handleSegmentClick("pr")}
-                >
-                  PR
-                </button>
-              {/if}
-              {#if workspace.item_type === "pull_request"}
-                <button
-                  class="seg-btn"
-                  class:active={sidebarOpen && sidebarTab === "reviews"}
-                  onclick={() => handleSegmentClick("reviews")}
-                >
-                  Reviews
-                </button>
-              {/if}
-            </div>
+                {#if workspace.item_type === "issue"}
+                  <button
+                    class="seg-btn"
+                    class:active={sidebarOpen && sidebarTab === "issue"}
+                    onclick={() => handleSegmentClick("issue")}
+                  >
+                    Issue
+                  </button>
+                {/if}
+                {#if getWorkspacePRNumber(workspace) !== null}
+                  <button
+                    class="seg-btn"
+                    class:active={sidebarOpen && sidebarTab === "pr"}
+                    onclick={() => handleSegmentClick("pr")}
+                  >
+                    PR
+                  </button>
+                {/if}
+                {#if workspace.item_type === "pull_request"}
+                  <button
+                    class="seg-btn"
+                    class:active={sidebarOpen && sidebarTab === "reviews"}
+                    onclick={() => handleSegmentClick("reviews")}
+                  >
+                    Reviews
+                  </button>
+                {/if}
+              </div>
+            {/if}
             <button
               class="header-btn danger"
               disabled={actionsBlocked}
@@ -1143,7 +1138,7 @@
               />
             </div>
           </div>
-          {#if sidebarOpen && workspace}
+          {#if sidebarOpen && workspace && !hideRightSidebar}
             <SplitResizeHandle
               class="sidebar-resize-handle"
               ariaLabel="Resize workspace details"
@@ -1173,7 +1168,32 @@
         </div>
       {/if}
     </div>
-  </CollapsibleResizableSidebar>
+  {/snippet}
+
+  {#if hideWorkspaceList}
+    {@render terminalMainContent()}
+  {:else}
+    <CollapsibleResizableSidebar
+      isCollapsed={isSidebarCollapsed}
+      sidebarWidth={currentWorkspaceListWidth}
+      minSidebarWidth={MIN_WORKSPACE_LIST_WIDTH}
+      maxSidebarWidth={MAX_WORKSPACE_LIST_WIDTH}
+      onSidebarResize={handleWorkspaceListResize}
+      showCollapsedStrip={isSidebarToggleEnabled}
+      onExpand={onToggleSidebar}
+      mainOverflow="hidden"
+    >
+      {#snippet sidebar()}
+        <WorkspaceListSidebar
+          selectedId={workspaceId}
+          {isSidebarToggleEnabled}
+          onCollapseSidebar={onToggleSidebar}
+          onOpenItemSidebar={openItemSidebar}
+        />
+      {/snippet}
+      {@render terminalMainContent()}
+    </CollapsibleResizableSidebar>
+  {/if}
 </div>
 
 <style>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
@@ -1,0 +1,219 @@
+// Pins the embed-only props on WorkspaceTerminalView so a refactor that
+// loses the conditional rendering around the workspace list column or the
+// right detail sidebar fails loudly rather than silently breaking
+// embedders that mount the surface via /workspaces/embed/terminal.
+//
+// Lives in its own file because the broader WorkspaceTerminalView test
+// suite stubs globalThis.fetch *after* the runtime client module has
+// captured it; that's a pre-existing test-infrastructure issue
+// (introduced in #182) which affects neither this branch nor the embed
+// props themselves. Mocking the api/runtime module here avoids the
+// captured-fetch problem entirely.
+
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runtimeClient: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    DELETE: vi.fn(),
+  },
+}));
+
+vi.mock("../../api/runtime.js", () => ({
+  client: mocks.runtimeClient,
+  apiErrorMessage: (_err: unknown, fallback: string) => fallback,
+}));
+
+vi.mock("../../api/workspace-runtime.js", () => ({
+  ensureWorkspaceShell: vi.fn(),
+  getWorkspaceRuntime: vi.fn().mockResolvedValue({
+    launch_targets: [],
+    sessions: [],
+    shell_session: null,
+  }),
+  launchWorkspaceSession: vi.fn(),
+  stopWorkspaceSession: vi.fn(),
+  workspaceSessionWebSocketPath: () => "",
+  workspaceShellWebSocketPath: () => "",
+  workspaceTmuxWebSocketPath: () => "",
+}));
+
+// Stub xterm so the terminal panes don't try to render in jsdom.
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    cols: 80,
+    rows: 24,
+    open: vi.fn(),
+    loadAddon: vi.fn(),
+    onData: vi.fn(),
+    onBinary: vi.fn(),
+    dispose: vi.fn(),
+    write: vi.fn(),
+    refresh: vi.fn(),
+    clearTextureAtlas: vi.fn(),
+    options: {},
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn() })),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("@middleman/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@middleman/ui")>();
+  return {
+    ...actual,
+    getStores: () => ({
+      settings: { getTerminalFontFamily: () => "" },
+    }),
+  };
+});
+
+import WorkspaceTerminalView from "./WorkspaceTerminalView.svelte";
+
+const readyWorkspaceData = {
+  id: "ws-1",
+  platform_host: "github.com",
+  repo_owner: "acme",
+  repo_name: "widget",
+  item_type: "pull_request",
+  item_number: 7,
+  git_head_ref: "feature/embed-props",
+  worktree_path: "/tmp/worktree",
+  tmux_session: "middleman-ws-1",
+  status: "ready",
+  created_at: "2026-04-29T00:00:00Z",
+};
+
+describe("WorkspaceTerminalView embed props", () => {
+  beforeEach(() => {
+    mocks.runtimeClient.GET.mockReset();
+    mocks.runtimeClient.POST.mockReset();
+    mocks.runtimeClient.DELETE.mockReset();
+    mocks.runtimeClient.GET.mockResolvedValue({
+      data: readyWorkspaceData,
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        addEventListener(): void {}
+        close(): void {}
+      },
+    );
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe(): void {}
+        disconnect(): void {}
+      },
+    );
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("hides the workspace list column when hideWorkspaceList is true", async () => {
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        hideWorkspaceList: true,
+      },
+    });
+
+    // Wait for the header branch element that only renders once the
+    // workspace payload resolves; this confirms the component reached
+    // steady state rather than failing the load early.
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("feature/embed-props").length,
+      ).toBeGreaterThan(0),
+    );
+
+    // The workspace-list column header reads "Workspaces"; with
+    // hideWorkspaceList the entire column is skipped so the heading
+    // must not be in the DOM.
+    expect(screen.queryByText("Workspaces")).toBeNull();
+  });
+
+  it("renders the workspace list column by default", async () => {
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1" },
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("feature/embed-props").length,
+      ).toBeGreaterThan(0),
+    );
+
+    expect(screen.queryByText("Workspaces")).not.toBeNull();
+  });
+
+  it("hides the PR/Reviews segmented control when hideRightSidebar is true", async () => {
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        hideWorkspaceList: true,
+        hideRightSidebar: true,
+      },
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("feature/embed-props").length,
+      ).toBeGreaterThan(0),
+    );
+
+    expect(screen.queryByRole("button", { name: "PR" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Reviews" }),
+    ).toBeNull();
+  });
+
+  it("renders the PR/Reviews segmented control by default", async () => {
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1" },
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText("feature/embed-props").length,
+      ).toBeGreaterThan(0),
+    );
+
+    expect(screen.getByRole("button", { name: "PR" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Reviews" }),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/stores/embed-config.svelte.test.ts
+++ b/frontend/src/lib/stores/embed-config.svelte.test.ts
@@ -10,8 +10,16 @@ import {
   getIssueActions,
   invokeAction,
   getOnNavigate,
+  getProjectActions,
+  getProjectAction,
+  invokeProjectAction,
+  getToolingStatus,
+  initWorkspaceBridge,
 } from "./embed-config.svelte.js";
-import type { ActionHook } from "./embed-config.svelte.js";
+import type {
+  ActionHook,
+  ProjectActionHook,
+} from "./embed-config.svelte.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper needs dynamic window access
 const win = window as any;
@@ -216,5 +224,136 @@ describe("onNavigate callback", () => {
     delete win.__middleman_config.onNavigate;
     win.__middleman_notify_config_changed();
     expect(getOnNavigate()).toBeUndefined();
+  });
+});
+
+describe("project actions", () => {
+  it("returns empty array when not configured", () => {
+    expect(getProjectActions()).toEqual([]);
+    expect(getProjectAction("add-existing")).toBeUndefined();
+  });
+
+  it("returns project actions from config", () => {
+    const handler = vi.fn().mockResolvedValue({ ok: true });
+    win.__middleman_config = {
+      actions: {
+        project: [
+          { id: "add-existing", label: "Add existing", handler },
+        ],
+      },
+    };
+    win.__middleman_notify_config_changed();
+    expect(getProjectActions()).toHaveLength(1);
+    expect(getProjectAction("add-existing")?.id).toBe("add-existing");
+    expect(getProjectAction("missing")).toBeUndefined();
+  });
+});
+
+describe("invokeProjectAction", () => {
+  it("passes context to handler and returns its CommandResult", async () => {
+    const handler = vi.fn().mockResolvedValue({ ok: true });
+    const action: ProjectActionHook = {
+      id: "clone", label: "Clone", handler,
+    };
+    const result = await invokeProjectAction(action, {
+      surface: "first-run-panel",
+    });
+    expect(handler).toHaveBeenCalledWith({ surface: "first-run-panel" });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("propagates handler-supplied failure", async () => {
+    const action: ProjectActionHook = {
+      id: "clone", label: "Clone",
+      handler: () => ({ ok: false, message: "auth failed" }),
+    };
+    const result = await invokeProjectAction(action, {
+      surface: "first-run-panel",
+    });
+    expect(result).toEqual({ ok: false, message: "auth failed" });
+  });
+
+  it("normalizes thrown errors into a failure result", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const action: ProjectActionHook = {
+      id: "clone", label: "Clone",
+      handler: () => { throw new Error("boom"); },
+    };
+    const result = await invokeProjectAction(action, {
+      surface: "first-run-panel",
+    });
+    expect(result).toEqual({ ok: false, message: "boom" });
+    spy.mockRestore();
+  });
+
+  it("normalizes async rejections into a failure result", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const action: ProjectActionHook = {
+      id: "clone", label: "Clone",
+      handler: () => Promise.reject(new Error("async boom")),
+    };
+    const result = await invokeProjectAction(action, {
+      surface: "first-run-panel",
+    });
+    expect(result).toEqual({ ok: false, message: "async boom" });
+    spy.mockRestore();
+  });
+
+  it("treats a void return as ok: true so legacy-shaped handlers do not break", async () => {
+    const action = {
+      id: "noop", label: "Noop",
+      handler: () => undefined,
+    } as unknown as ProjectActionHook;
+    const result = await invokeProjectAction(action, {
+      surface: "test",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("tooling status", () => {
+  it("returns undefined when no tooling on embed config", () => {
+    expect(getToolingStatus()).toBeUndefined();
+  });
+
+  it("returns tooling block when set", () => {
+    win.__middleman_config = {
+      embed: {
+        tooling: {
+          git: { available: true, version: "2.45.0" },
+          gh: { available: true, authenticated: false },
+        },
+      },
+    };
+    win.__middleman_notify_config_changed();
+    const tooling = getToolingStatus();
+    expect(tooling?.git?.available).toBe(true);
+    expect(tooling?.gh?.authenticated).toBe(false);
+  });
+
+  it("__middleman_update_tooling pushes new state and notifies", () => {
+    initWorkspaceBridge();
+    win.__middleman_config = {};
+    win.__middleman_notify_config_changed();
+    expect(getToolingStatus()).toBeUndefined();
+
+    win.__middleman_update_tooling({
+      git: { available: false },
+      gh: { available: false, authenticated: false },
+    });
+    expect(getToolingStatus()?.git?.available).toBe(false);
+    expect(getToolingStatus()?.gh?.authenticated).toBe(false);
+  });
+
+  it("__middleman_update_tooling is a no-op when config is unset", () => {
+    initWorkspaceBridge();
+    delete win.__middleman_config;
+    expect(() =>
+      win.__middleman_update_tooling({
+        git: { available: true },
+        gh: { available: true, authenticated: true },
+      }),
+    ).not.toThrow();
+    expect(getToolingStatus()).toBeUndefined();
   });
 });

--- a/frontend/src/lib/stores/embed-config.svelte.ts
+++ b/frontend/src/lib/stores/embed-config.svelte.ts
@@ -23,6 +23,25 @@ export interface ActionContext {
   meta?: Record<string, unknown>;
 }
 
+export interface ProjectActionContext {
+  surface: string;
+  projectId?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface ProjectActionHook {
+  id: string;
+  label: string;
+  handler: (
+    context: ProjectActionContext,
+  ) => CommandResult | Promise<CommandResult>;
+}
+
+// Re-export ToolingStatus from the global ambient module so .svelte
+// files can import it explicitly. Lint in .svelte files does not pick
+// up ambient globals declared in vite-env.d.ts.
+export type ToolingStatusValue = ToolingStatus;
+
 interface UIDefaults {
   hideSync: boolean;
   hideRepoSelector: boolean;
@@ -115,6 +134,20 @@ export function getIssueActions(): ActionHook[] {
   return readConfig()?.actions?.issue ?? [];
 }
 
+export function getProjectActions(): ProjectActionHook[] {
+  return readConfig()?.actions?.project ?? [];
+}
+
+export function getProjectAction(
+  id: string,
+): ProjectActionHook | undefined {
+  return getProjectActions().find((action) => action.id === id);
+}
+
+export function getToolingStatus(): ToolingStatus | undefined {
+  return readConfig()?.embed?.tooling;
+}
+
 export function getOnNavigate():
   ((event: MiddlemanNavigateEvent) => void) | undefined {
   return readConfig()?.onNavigate;
@@ -136,6 +169,36 @@ export function invokeAction(
     });
   } catch (err) {
     console.error("Embedding action error:", err);
+  }
+}
+
+// invokeProjectAction is the ack-aware project-action runner. The firing
+// surface awaits the returned CommandResult to render in-flight, success,
+// and failure states - this is the contract that fixes "button click does
+// nothing" for project actions. Handlers that throw are normalized into
+// { ok: false, message } so callers never see an unhandled rejection.
+export async function invokeProjectAction(
+  action: ProjectActionHook,
+  context: ProjectActionContext,
+): Promise<CommandResult> {
+  try {
+    const result = await action.handler(context);
+    if (
+      result &&
+      typeof result === "object" &&
+      "ok" in result &&
+      typeof result.ok === "boolean"
+    ) {
+      return result;
+    }
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `Embedding project action "${action.id}" failed:`,
+      err,
+    );
+    return { ok: false, message };
   }
 }
 
@@ -278,6 +341,13 @@ export function initWorkspaceBridge(): void {
     const hosts = [...config.workspace.hosts];
     hosts[hostIdx] = updated;
     config.workspace = { ...config.workspace, hosts };
+    window.__middleman_notify_config_changed?.();
+  };
+  window.__middleman_update_tooling = (tooling: ToolingStatus) => {
+    const config = window.__middleman_config;
+    if (!config) return;
+    const embed = { ...(config.embed ?? {}), tooling };
+    config.embed = embed;
     window.__middleman_notify_config_changed?.();
   };
 }

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -12,19 +12,50 @@ export type NumberedItemRef = NumberedRouteItemRef;
 export type HostedItemRef = IssueRouteRef;
 export type RoutableItemRef = RoutedItemRef;
 
+export type EmbedEmptyReason = "noSelection" | "noRepo" | "noWorkspace";
+
+export type EmbedDetailTab = "pr" | "issue" | "reviews";
+
 export type Route =
   | { page: "activity" }
   | { page: "design-system" }
   | { page: "repos" }
   | { page: "workspaces" }
-  | { page: "pulls"; view: "list" | "board"; selected?: NumberedItemRef; tab?: "files" }
+  | {
+      page: "pulls";
+      view: "list" | "board";
+      selected?: NumberedItemRef;
+      tab?: "files";
+    }
   | { page: "issues"; selected?: HostedItemRef }
   | { page: "settings" }
   | ({ page: "focus" } & RoutableItemRef)
   | { page: "focus"; itemType: "mrs"; repo?: string }
   | { page: "focus"; itemType: "issues"; repo?: string }
   | { page: "reviews"; jobId?: number }
-  | { page: "terminal"; workspaceId: string };
+  | { page: "terminal"; workspaceId: string }
+  // Embed-targetable workspace surfaces. Hosts mount these
+  // routes to render a single component of the workspaces UX
+  // (list, terminal, per-item detail, empty placeholder, the
+  // empty-registry First Run Panel, or a per-project card)
+  // without the surrounding app chrome.
+  | { page: "embed-workspace-list" }
+  | { page: "embed-workspace-terminal"; workspaceId: string }
+  | {
+      page: "embed-workspace-detail";
+      itemType: "pr" | "issue";
+      platformHost: string;
+      owner: string;
+      name: string;
+      number: number;
+      branch?: string;
+      tab?: EmbedDetailTab;
+    }
+  | { page: "embed-workspace-empty"; reason: EmbedEmptyReason }
+  | { page: "embed-workspace-first-run" }
+  | { page: "embed-workspace-project"; projectId: string };
+
+export type Page = Route["page"];
 
 import {
   isEmbedded,
@@ -223,15 +254,71 @@ function parseRoute(fullPath: string): Route {
       workspaceId: terminalMatch[1]!,
     };
   }
+  // Embed routes must be matched before the generic /workspaces
+  // catch-all so they don't fall back to the standalone page.
+  if (path === "/workspaces/embed/list") {
+    return { page: "embed-workspace-list" };
+  }
+  const embedTerminalMatch = path.match(
+    /^\/workspaces\/embed\/terminal(?:\/([^/]+))?$/,
+  );
+  if (embedTerminalMatch) {
+    return {
+      page: "embed-workspace-terminal",
+      workspaceId: embedTerminalMatch[1] ?? "",
+    };
+  }
+  const embedDetailMatch = path.match(
+    /^\/workspaces\/embed\/detail\/(pr|issue)\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/,
+  );
+  if (embedDetailMatch) {
+    const sp = new URLSearchParams(search);
+    const branch = sp.get("branch") ?? undefined;
+    const tabParam = sp.get("tab");
+    const tab: EmbedDetailTab | undefined =
+      tabParam === "pr" || tabParam === "issue" || tabParam === "reviews"
+        ? tabParam
+        : undefined;
+    const r: Route = {
+      page: "embed-workspace-detail",
+      itemType: embedDetailMatch[1] as "pr" | "issue",
+      platformHost: embedDetailMatch[2]!,
+      owner: embedDetailMatch[3]!,
+      name: embedDetailMatch[4]!,
+      number: parseInt(embedDetailMatch[5]!, 10),
+    };
+    if (branch) r.branch = branch;
+    if (tab) r.tab = tab;
+    return r;
+  }
+  const embedEmptyMatch = path.match(
+    /^\/workspaces\/embed\/empty\/(noSelection|noRepo|noWorkspace)$/,
+  );
+  if (embedEmptyMatch) {
+    return {
+      page: "embed-workspace-empty",
+      reason: embedEmptyMatch[1] as EmbedEmptyReason,
+    };
+  }
+  if (path === "/workspaces/embed/first-run") {
+    return { page: "embed-workspace-first-run" };
+  }
+  const embedProjectMatch = path.match(
+    /^\/workspaces\/embed\/project\/([A-Za-z0-9_-]+)$/,
+  );
+  if (embedProjectMatch) {
+    return {
+      page: "embed-workspace-project",
+      projectId: embedProjectMatch[1]!,
+    };
+  }
   if (path === "/workspaces" || path.startsWith("/workspaces/")) {
     return { page: "workspaces" };
   }
   return { page: "activity" };
 }
 
-let route = $state<Route>(
-  parseRoute(currentLocationPath()),
-);
+let route = $state<Route>(parseRoute(currentLocationPath()));
 
 // Fire onRouteChange for the initial route after the module loads.
 // Deferred so the embedder has time to set up the callback.
@@ -243,9 +330,7 @@ export function getRoute(): Route {
   return route;
 }
 
-export function getPage():
-  "activity" | "design-system" | "repos" | "pulls" | "issues" | "settings"
-  | "focus" | "reviews" | "workspaces" | "terminal" {
+export function getPage(): Page {
   return route.page;
 }
 
@@ -284,10 +369,7 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
     navType = "repos";
   } else if (r.page === "reviews") {
     navType = "reviews";
-  } else if (
-    r.page === "workspaces" ||
-    r.page === "terminal"
-  ) {
+  } else if (isWorkspacePage(r.page)) {
     navType = "workspaces";
   } else if (r.page === "design-system") {
     navType = "activity";
@@ -333,6 +415,26 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
   return event;
 }
 
+export function isWorkspacePage(page: Page): boolean {
+  return (
+    page === "workspaces" || page === "terminal" || isWorkspaceEmbedPage(page)
+  );
+}
+
+export function isWorkspaceEmbedPage(page: Page): boolean {
+  switch (page) {
+    case "embed-workspace-list":
+    case "embed-workspace-terminal":
+    case "embed-workspace-detail":
+    case "embed-workspace-empty":
+    case "embed-workspace-first-run":
+    case "embed-workspace-project":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function fireMiddlemanNavigateEvent(r: Route): void {
   const cb = getOnNavigate();
   if (cb) cb(buildRouteEvent(r));
@@ -370,7 +472,8 @@ if (typeof window !== "undefined") {
 export type DetailTab = "conversation" | "files";
 
 export function getDetailTab(): DetailTab {
-  if (route.page === "pulls" && "tab" in route && route.tab === "files") return "files";
+  if (route.page === "pulls" && "tab" in route && route.tab === "files")
+    return "files";
   return "conversation";
 }
 
@@ -388,7 +491,9 @@ export type View = "list" | "board";
 export type Tab = "pulls" | "issues";
 
 export function getView(): View {
-  return route.page === "pulls" && "view" in route && route.view === "board" ? "board" : "list";
+  return route.page === "pulls" && "view" in route && route.view === "board"
+    ? "board"
+    : "list";
 }
 
 export function setView(v: View): void {

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -222,6 +222,115 @@ describe("router basic routes", () => {
   });
 });
 
+describe("router embed-workspace routes", () => {
+  it("parses /workspaces/embed/list", () => {
+    navigate("/workspaces/embed/list");
+    expect(getRoute()).toEqual({ page: "embed-workspace-list" });
+    expect(getPage()).toBe("embed-workspace-list");
+  });
+
+  it("parses /workspaces/embed/terminal without an id", () => {
+    navigate("/workspaces/embed/terminal");
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-terminal",
+      workspaceId: "",
+    });
+  });
+
+  it("parses /workspaces/embed/terminal/:workspaceId", () => {
+    navigate("/workspaces/embed/terminal/abc-123");
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-terminal",
+      workspaceId: "abc-123",
+    });
+  });
+
+  it("parses /workspaces/embed/detail/pr/:host/:owner/:name/:number", () => {
+    navigate(
+      "/workspaces/embed/detail/pr/github.com/acme/widgets/42",
+    );
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-detail",
+      itemType: "pr",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+    });
+  });
+
+  it("parses /workspaces/embed/detail with branch and tab query", () => {
+    navigate(
+      "/workspaces/embed/detail/issue/ghe.example.com/org/repo/7" +
+        "?branch=feature%2Fx&tab=reviews",
+    );
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-detail",
+      itemType: "issue",
+      platformHost: "ghe.example.com",
+      owner: "org",
+      name: "repo",
+      number: 7,
+      branch: "feature/x",
+      tab: "reviews",
+    });
+  });
+
+  it("ignores unknown tab values on the detail route", () => {
+    navigate(
+      "/workspaces/embed/detail/pr/github.com/o/n/1?tab=garbage",
+    );
+    const route = getRoute();
+    expect(route).toEqual({
+      page: "embed-workspace-detail",
+      itemType: "pr",
+      platformHost: "github.com",
+      owner: "o",
+      name: "n",
+      number: 1,
+    });
+  });
+
+  it("parses /workspaces/embed/empty/:reason for each known reason", () => {
+    for (const reason of [
+      "noSelection",
+      "noRepo",
+      "noWorkspace",
+    ] as const) {
+      navigate(`/workspaces/embed/empty/${reason}`);
+      expect(getRoute()).toEqual({
+        page: "embed-workspace-empty",
+        reason,
+      });
+    }
+  });
+
+  it("falls back to the standalone workspaces page for unknown empty reasons", () => {
+    navigate("/workspaces/embed/empty/garbage");
+    expect(getRoute()).toEqual({ page: "workspaces" });
+  });
+
+  it("parses /workspaces/embed/first-run", () => {
+    navigate("/workspaces/embed/first-run");
+    expect(getRoute()).toEqual({ page: "embed-workspace-first-run" });
+    expect(getPage()).toBe("embed-workspace-first-run");
+  });
+
+  it("parses /workspaces/embed/project/:project_id", () => {
+    navigate("/workspaces/embed/project/prj_abc123");
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-project",
+      projectId: "prj_abc123",
+    });
+    expect(getPage()).toBe("embed-workspace-project");
+  });
+
+  it("falls back to the standalone workspaces page for unknown project_id shapes", () => {
+    navigate("/workspaces/embed/project/has slash/extra");
+    expect(getRoute()).toEqual({ page: "workspaces" });
+  });
+});
+
 describe("router navigation events", () => {
   beforeEach(() => {
     navigate("/pulls");
@@ -288,5 +397,56 @@ describe("router navigation events", () => {
     const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
     expect(payload.type).toBe("activity");
     expect(payload.view).toBe("/design-system");
+  });
+
+  it("maps every embed-workspace route to a workspaces navigation event", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy);
+
+    const embedPaths = [
+      "/workspaces/embed/list",
+      "/workspaces/embed/terminal/ws-1",
+      "/workspaces/embed/detail/pr/github.com/acme/widget/42",
+      "/workspaces/embed/empty/noWorkspace",
+      "/workspaces/embed/first-run",
+      "/workspaces/embed/project/prj_abc123",
+    ];
+
+    for (const path of embedPaths) {
+      spy.mockClear();
+      navigate(path);
+      const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+      expect(payload.type, `type for ${path}`).toBe("workspaces");
+      expect(payload.focus, `focus for ${path}`).toBe(false);
+    }
+  });
+});
+
+describe("router window bridges", () => {
+  beforeEach(() => {
+    navigate("/pulls");
+  });
+
+  it("exposes __middleman_navigate_to_route as a window global", () => {
+    const bridge = (window as unknown as {
+      __middleman_navigate_to_route?: (route: string) => void;
+    }).__middleman_navigate_to_route;
+    expect(typeof bridge).toBe("function");
+  });
+
+  it("__middleman_navigate_to_route updates the SPA route", () => {
+    const bridge = (window as unknown as {
+      __middleman_navigate_to_route: (route: string) => void;
+    }).__middleman_navigate_to_route;
+
+    bridge("/workspaces/embed/first-run");
+    expect(getRoute()).toEqual({ page: "embed-workspace-first-run" });
+    expect(getPage()).toBe("embed-workspace-first-run");
+
+    bridge("/workspaces/embed/project/prj_xyz");
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-project",
+      projectId: "prj_xyz",
+    });
   });
 });

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -50,6 +50,7 @@ interface MiddlemanConfig {
   actions?: {
     pullRequest?: ActionHookDef[];
     issue?: ActionHookDef[];
+    project?: ProjectActionDef[];
   };
   workspace?: WorkspaceData;
   onWorkspaceCommand?: WorkspaceCommandHandler;
@@ -61,6 +62,7 @@ interface MiddlemanConfig {
     activePlatformHost?: string | null;
     panelMode?: boolean;
     hoverCardsEnabled?: boolean;
+    tooling?: ToolingStatus;
   };
   onLayoutChanged?: (layout: {
     sidebar: { width: number };
@@ -80,6 +82,44 @@ interface ActionHookDef {
     number: number;
     meta?: Record<string, unknown>;
   }) => void | Promise<void>;
+}
+
+// ProjectActionDef is the registry shape for project-scoped actions
+// (add-existing, clone, connect-github, new-worktree). The handler MUST
+// return a CommandResult so the firing surface can render success/failure
+// instead of a fire-and-forget click. The action ID is the identifier the
+// surface uses to look up the handler.
+interface ProjectActionDef {
+  id: string;
+  label: string;
+  handler: (context: {
+    surface: string;
+    projectId?: string;
+    meta?: Record<string, unknown>;
+  }) => CommandResult | Promise<CommandResult>;
+}
+
+// ToolingStatus reports the embedding host's view of git/gh availability.
+// The First Run Panel and the New Worktree sheet read this to gate the
+// GitHub-dependent surfaces and surface specific recovery copy when a
+// tool is missing.
+interface ToolingStatus {
+  git?: {
+    available: boolean;
+    version?: string;
+  };
+  gh?: {
+    available: boolean;
+    authenticated: boolean;
+    user?: string;
+    host?: string;
+  };
+  glab?: {
+    available: boolean;
+    authenticated: boolean;
+    user?: string;
+    host?: string;
+  };
 }
 
 interface WorkspaceHost {
@@ -209,4 +249,5 @@ interface Window {
       resources?: WorkspaceResources | null;
     },
   ) => void;
+  __middleman_update_tooling?: (tooling: ToolingStatus) => void;
 }

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -474,11 +474,32 @@ type Line struct {
 	Type      string `json:"type"`
 }
 
+// ListLaunchTargetsOutputBody defines model for ListLaunchTargetsOutputBody.
+type ListLaunchTargetsOutputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema        *string         `json:"$schema,omitempty"`
+	LaunchTargets *[]LaunchTarget `json:"launch_targets"`
+}
+
+// ListProjectsOutputBody defines model for ListProjectsOutputBody.
+type ListProjectsOutputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema   *string            `json:"$schema,omitempty"`
+	Projects *[]ProjectResponse `json:"projects"`
+}
+
 // ListWorkspacesOutputBody defines model for ListWorkspacesOutputBody.
 type ListWorkspacesOutputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema     *string              `json:"$schema,omitempty"`
 	Workspaces *[]WorkspaceResponse `json:"workspaces"`
+}
+
+// ListWorktreesOutputBody defines model for ListWorktreesOutputBody.
+type ListWorktreesOutputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema    *string             `json:"$schema,omitempty"`
+	Worktrees *[]WorktreeResponse `json:"worktrees"`
 }
 
 // MREvent defines model for MREvent.
@@ -640,6 +661,13 @@ type MrImportMetadataResponse struct {
 	Title            string  `json:"title"`
 }
 
+// PlatformIdentityPayload defines model for PlatformIdentityPayload.
+type PlatformIdentityPayload struct {
+	Name         string `json:"name"`
+	Owner        string `json:"owner"`
+	PlatformHost string `json:"platform_host"`
+}
+
 // PostCommentHostInputBody defines model for PostCommentHostInputBody.
 type PostCommentHostInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -666,6 +694,19 @@ type PostIssueCommentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema *string `json:"$schema,omitempty"`
 	Body   string  `json:"body"`
+}
+
+// ProjectResponse defines model for ProjectResponse.
+type ProjectResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema           *string                  `json:"$schema,omitempty"`
+	CreatedAt        time.Time                `json:"created_at"`
+	DefaultBranch    *string                  `json:"default_branch,omitempty"`
+	DisplayName      string                   `json:"display_name"`
+	Id               string                   `json:"id"`
+	LocalPath        string                   `json:"local_path"`
+	PlatformIdentity *PlatformIdentityPayload `json:"platform_identity,omitempty"`
+	UpdatedAt        time.Time                `json:"updated_at"`
 }
 
 // ProviderCapabilitiesResponse defines model for ProviderCapabilitiesResponse.
@@ -712,6 +753,24 @@ type RateLimitsResponse struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema *string                        `json:"$schema,omitempty"`
 	Hosts  map[string]RateLimitHostStatus `json:"hosts"`
+}
+
+// RegisterProjectInputBody defines model for RegisterProjectInputBody.
+type RegisterProjectInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema           *string                  `json:"$schema,omitempty"`
+	DefaultBranch    *string                  `json:"default_branch,omitempty"`
+	DisplayName      *string                  `json:"display_name,omitempty"`
+	LocalPath        string                   `json:"local_path"`
+	PlatformIdentity *PlatformIdentityPayload `json:"platform_identity,omitempty"`
+}
+
+// RegisterWorktreeInputBody defines model for RegisterWorktreeInputBody.
+type RegisterWorktreeInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+	Branch string  `json:"branch"`
+	Path   string  `json:"path"`
 }
 
 // RepoPreviewRequest defines model for RepoPreviewRequest.
@@ -1043,6 +1102,18 @@ type WorktreeLinkResponse struct {
 	WorktreePath   *string `json:"worktree_path,omitempty"`
 }
 
+// WorktreeResponse defines model for WorktreeResponse.
+type WorktreeResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema    *string   `json:"$schema,omitempty"`
+	Branch    string    `json:"branch"`
+	CreatedAt time.Time `json:"created_at"`
+	Id        string    `json:"id"`
+	Path      string    `json:"path"`
+	ProjectId string    `json:"project_id"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 // GetActivityParams defines parameters for GetActivity.
 type GetActivityParams struct {
 	Repo   *string   `form:"repo,omitempty" json:"repo,omitempty"`
@@ -1226,6 +1297,12 @@ type SetIssueGithubStateJSONRequestBody = GithubStateInputBody
 
 // CreateIssueWorkspaceJSONRequestBody defines body for CreateIssueWorkspace for application/json ContentType.
 type CreateIssueWorkspaceJSONRequestBody = CreateIssueWorkspaceInputBody
+
+// RegisterProjectJSONRequestBody defines body for RegisterProject for application/json ContentType.
+type RegisterProjectJSONRequestBody = RegisterProjectInputBody
+
+// RegisterWorktreeJSONRequestBody defines body for RegisterWorktree for application/json ContentType.
+type RegisterWorktreeJSONRequestBody = RegisterWorktreeInputBody
 
 // EditPrContentJSONRequestBody defines body for EditPrContent for application/json ContentType.
 type EditPrContentJSONRequestBody = EditPRContentInputBody
@@ -1504,6 +1581,28 @@ type ClientInterface interface {
 	CreateIssueWorkspaceWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CreateIssueWorkspace(ctx context.Context, provider string, owner string, name string, number int64, body CreateIssueWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProjects request
+	ListProjects(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RegisterProjectWithBody request with any body
+	RegisterProjectWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RegisterProject(ctx context.Context, body RegisterProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProject request
+	GetProject(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListLaunchTargets request
+	ListLaunchTargets(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListWorktrees request
+	ListWorktrees(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RegisterWorktreeWithBody request with any body
+	RegisterWorktreeWithBody(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RegisterWorktree(ctx context.Context, projectId string, body RegisterWorktreeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListPulls request
 	ListPulls(ctx context.Context, params *ListPullsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2384,6 +2483,102 @@ func (c *Client) CreateIssueWorkspaceWithBody(ctx context.Context, provider stri
 
 func (c *Client) CreateIssueWorkspace(ctx context.Context, provider string, owner string, name string, number int64, body CreateIssueWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreateIssueWorkspaceRequest(c.Server, provider, owner, name, number, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProjects(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProjectsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegisterProjectWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterProjectRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegisterProject(ctx context.Context, body RegisterProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterProjectRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProject(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectRequest(c.Server, projectId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListLaunchTargets(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListLaunchTargetsRequest(c.Server, projectId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListWorktrees(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListWorktreesRequest(c.Server, projectId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegisterWorktreeWithBody(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterWorktreeRequestWithBody(c.Server, projectId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegisterWorktree(ctx context.Context, projectId string, body RegisterWorktreeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterWorktreeRequest(c.Server, projectId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -6199,6 +6394,222 @@ func NewCreateIssueWorkspaceRequestWithBody(server string, provider string, owne
 	return req, nil
 }
 
+// NewListProjectsRequest generates requests for ListProjects
+func NewListProjectsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRegisterProjectRequest calls the generic RegisterProject builder with application/json body
+func NewRegisterProjectRequest(server string, body RegisterProjectJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRegisterProjectRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewRegisterProjectRequestWithBody generates requests for RegisterProject with any type of body
+func NewRegisterProjectRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetProjectRequest generates requests for GetProject
+func NewGetProjectRequest(server string, projectId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListLaunchTargetsRequest generates requests for ListLaunchTargets
+func NewListLaunchTargetsRequest(server string, projectId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/launch-targets", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListWorktreesRequest generates requests for ListWorktrees
+func NewListWorktreesRequest(server string, projectId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/worktrees", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRegisterWorktreeRequest calls the generic RegisterWorktree builder with application/json body
+func NewRegisterWorktreeRequest(server string, projectId string, body RegisterWorktreeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRegisterWorktreeRequestWithBody(server, projectId, "application/json", bodyReader)
+}
+
+// NewRegisterWorktreeRequestWithBody generates requests for RegisterWorktree with any type of body
+func NewRegisterWorktreeRequestWithBody(server string, projectId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/worktrees", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListPullsRequest generates requests for ListPulls
 func NewListPullsRequest(server string, params *ListPullsParams) (*http.Request, error) {
 	var err error
@@ -9085,6 +9496,28 @@ type ClientWithResponsesInterface interface {
 
 	CreateIssueWorkspaceWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body CreateIssueWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIssueWorkspaceResponse, error)
 
+	// ListProjectsWithResponse request
+	ListProjectsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProjectsResponse, error)
+
+	// RegisterProjectWithBodyWithResponse request with any body
+	RegisterProjectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterProjectResponse, error)
+
+	RegisterProjectWithResponse(ctx context.Context, body RegisterProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterProjectResponse, error)
+
+	// GetProjectWithResponse request
+	GetProjectWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetProjectResponse, error)
+
+	// ListLaunchTargetsWithResponse request
+	ListLaunchTargetsWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*ListLaunchTargetsResponse, error)
+
+	// ListWorktreesWithResponse request
+	ListWorktreesWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*ListWorktreesResponse, error)
+
+	// RegisterWorktreeWithBodyWithResponse request with any body
+	RegisterWorktreeWithBodyWithResponse(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterWorktreeResponse, error)
+
+	RegisterWorktreeWithResponse(ctx context.Context, projectId string, body RegisterWorktreeJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterWorktreeResponse, error)
+
 	// ListPullsWithResponse request
 	ListPullsWithResponse(ctx context.Context, params *ListPullsParams, reqEditors ...RequestEditorFn) (*ListPullsResponse, error)
 
@@ -10198,6 +10631,144 @@ func (r CreateIssueWorkspaceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CreateIssueWorkspaceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListProjectsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ListProjectsOutputBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProjectsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProjectsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RegisterProjectResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON201                       *ProjectResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r RegisterProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RegisterProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ProjectResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListLaunchTargetsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ListLaunchTargetsOutputBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r ListLaunchTargetsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListLaunchTargetsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListWorktreesResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ListWorktreesOutputBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r ListWorktreesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListWorktreesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RegisterWorktreeResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON201                       *WorktreeResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r RegisterWorktreeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RegisterWorktreeResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11849,6 +12420,76 @@ func (c *ClientWithResponses) CreateIssueWorkspaceWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseCreateIssueWorkspaceResponse(rsp)
+}
+
+// ListProjectsWithResponse request returning *ListProjectsResponse
+func (c *ClientWithResponses) ListProjectsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProjectsResponse, error) {
+	rsp, err := c.ListProjects(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProjectsResponse(rsp)
+}
+
+// RegisterProjectWithBodyWithResponse request with arbitrary body returning *RegisterProjectResponse
+func (c *ClientWithResponses) RegisterProjectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterProjectResponse, error) {
+	rsp, err := c.RegisterProjectWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterProjectResponse(rsp)
+}
+
+func (c *ClientWithResponses) RegisterProjectWithResponse(ctx context.Context, body RegisterProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterProjectResponse, error) {
+	rsp, err := c.RegisterProject(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterProjectResponse(rsp)
+}
+
+// GetProjectWithResponse request returning *GetProjectResponse
+func (c *ClientWithResponses) GetProjectWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*GetProjectResponse, error) {
+	rsp, err := c.GetProject(ctx, projectId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectResponse(rsp)
+}
+
+// ListLaunchTargetsWithResponse request returning *ListLaunchTargetsResponse
+func (c *ClientWithResponses) ListLaunchTargetsWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*ListLaunchTargetsResponse, error) {
+	rsp, err := c.ListLaunchTargets(ctx, projectId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListLaunchTargetsResponse(rsp)
+}
+
+// ListWorktreesWithResponse request returning *ListWorktreesResponse
+func (c *ClientWithResponses) ListWorktreesWithResponse(ctx context.Context, projectId string, reqEditors ...RequestEditorFn) (*ListWorktreesResponse, error) {
+	rsp, err := c.ListWorktrees(ctx, projectId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListWorktreesResponse(rsp)
+}
+
+// RegisterWorktreeWithBodyWithResponse request with arbitrary body returning *RegisterWorktreeResponse
+func (c *ClientWithResponses) RegisterWorktreeWithBodyWithResponse(ctx context.Context, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterWorktreeResponse, error) {
+	rsp, err := c.RegisterWorktreeWithBody(ctx, projectId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterWorktreeResponse(rsp)
+}
+
+func (c *ClientWithResponses) RegisterWorktreeWithResponse(ctx context.Context, projectId string, body RegisterWorktreeJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterWorktreeResponse, error) {
+	rsp, err := c.RegisterWorktree(ctx, projectId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterWorktreeResponse(rsp)
 }
 
 // ListPullsWithResponse request returning *ListPullsResponse
@@ -13726,6 +14367,204 @@ func ParseCreateIssueWorkspaceResponse(rsp *http.Response) (*CreateIssueWorkspac
 			return nil, err
 		}
 		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProjectsResponse parses an HTTP response from a ListProjectsWithResponse call
+func ParseListProjectsResponse(rsp *http.Response) (*ListProjectsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProjectsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListProjectsOutputBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRegisterProjectResponse parses an HTTP response from a RegisterProjectWithResponse call
+func ParseRegisterProjectResponse(rsp *http.Response) (*RegisterProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RegisterProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ProjectResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectResponse parses an HTTP response from a GetProjectWithResponse call
+func ParseGetProjectResponse(rsp *http.Response) (*GetProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListLaunchTargetsResponse parses an HTTP response from a ListLaunchTargetsWithResponse call
+func ParseListLaunchTargetsResponse(rsp *http.Response) (*ListLaunchTargetsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListLaunchTargetsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListLaunchTargetsOutputBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListWorktreesResponse parses an HTTP response from a ListWorktreesWithResponse call
+func ParseListWorktreesResponse(rsp *http.Response) (*ListWorktreesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListWorktreesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListWorktreesOutputBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRegisterWorktreeResponse parses an HTTP response from a RegisterWorktreeWithResponse call
+func ParseRegisterWorktreeResponse(rsp *http.Response) (*RegisterWorktreeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RegisterWorktreeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest WorktreeResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ErrorModel

--- a/internal/db/migrations/000019_add_generic_projects_and_worktrees.down.sql
+++ b/internal/db/migrations/000019_add_generic_projects_and_worktrees.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS middleman_project_worktrees_project_id_idx;
+DROP TABLE IF EXISTS middleman_project_worktrees;
+
+DROP INDEX IF EXISTS middleman_projects_repo_id_idx;
+DROP TABLE IF EXISTS middleman_projects;

--- a/internal/db/migrations/000019_add_generic_projects_and_worktrees.up.sql
+++ b/internal/db/migrations/000019_add_generic_projects_and_worktrees.up.sql
@@ -1,0 +1,38 @@
+-- middleman_projects is the registry for local repository checkouts.
+-- Each row represents a local working directory the user (or an embedder)
+-- has registered with middleman. Projects optionally link to a row in
+-- middleman_repos via repo_id; that link is the sole source of truth for
+-- platform identity (host/owner/name). Local-only projects with no
+-- parseable remote have repo_id NULL.
+--
+-- ON DELETE SET NULL on the FK: if the linked middleman_repos row is
+-- removed, the project becomes local-only rather than being deleted -
+-- the on-disk checkout is the source of truth for the project record,
+-- and unsyncing a repo should not strand the registered worktree.
+CREATE TABLE IF NOT EXISTS middleman_projects (
+    id              TEXT PRIMARY KEY,
+    display_name    TEXT NOT NULL,
+    local_path      TEXT NOT NULL UNIQUE,
+    repo_id         INTEGER REFERENCES middleman_repos(id) ON DELETE SET NULL,
+    default_branch  TEXT,
+    created_at      DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at      DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS middleman_projects_repo_id_idx
+    ON middleman_projects (repo_id) WHERE repo_id IS NOT NULL;
+
+-- middleman_project_worktrees records the worktrees the embedder has
+-- created on disk for a project. The caller performs the
+-- `git worktree add`; middleman only persists the metadata.
+CREATE TABLE IF NOT EXISTS middleman_project_worktrees (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL REFERENCES middleman_projects(id) ON DELETE CASCADE,
+    branch      TEXT NOT NULL,
+    path        TEXT NOT NULL UNIQUE,
+    created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS middleman_project_worktrees_project_id_idx
+    ON middleman_project_worktrees (project_id);

--- a/internal/db/queries_projects.go
+++ b/internal/db/queries_projects.go
@@ -1,0 +1,353 @@
+package db
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PlatformIdentity captures a project's optional VCS-platform identity. It is
+// derived from the linked middleman_repos row at read time; middleman_projects
+// itself stores only the FK in repo_id. A project may be registered without a
+// linked repo (a local-only directory with no parseable remote), in which case
+// PlatformIdentity is nil.
+type PlatformIdentity struct {
+	Host  string `json:"platform_host"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+}
+
+// Project is the registry record for a local repository checkout middleman
+// knows about. Identity (host/owner/name), when present, lives in
+// middleman_repos and is joined in via repo_id.
+type Project struct {
+	ID               string
+	DisplayName      string
+	LocalPath        string
+	PlatformIdentity *PlatformIdentity
+	DefaultBranch    string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// ProjectWorktree is the registry record for a worktree of a Project. The
+// caller performs the filesystem mutation (`git worktree add`); middleman only
+// persists the metadata.
+type ProjectWorktree struct {
+	ID        string
+	ProjectID string
+	Branch    string
+	Path      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// ErrProjectNotFound is returned by GetProject* when no record matches.
+var ErrProjectNotFound = errors.New("project not found")
+
+// ErrProjectPathTaken is returned by CreateProject when local_path is already
+// registered.
+var ErrProjectPathTaken = errors.New("project local_path already registered")
+
+// ErrWorktreePathTaken is returned by CreateProjectWorktree when path is
+// already registered for any project.
+var ErrWorktreePathTaken = errors.New("worktree path already registered")
+
+// CreateProjectInput collects the fields required to register a new project.
+// RepoID links the project to a middleman_repos row that owns the platform
+// identity; pass an unset NullInt64 to register a local-only project.
+type CreateProjectInput struct {
+	DisplayName   string
+	LocalPath     string
+	RepoID        sql.NullInt64
+	DefaultBranch string
+}
+
+// CreateProject persists a new project. The ID is generated server-side.
+func (d *DB) CreateProject(ctx context.Context, in CreateProjectInput) (*Project, error) {
+	displayName := strings.TrimSpace(in.DisplayName)
+	if displayName == "" {
+		return nil, fmt.Errorf("display_name is required")
+	}
+	localPath := strings.TrimSpace(in.LocalPath)
+	if localPath == "" {
+		return nil, fmt.Errorf("local_path is required")
+	}
+
+	id, err := newProjectID()
+	if err != nil {
+		return nil, err
+	}
+
+	defaultBranch := strings.TrimSpace(in.DefaultBranch)
+
+	_, err = d.rw.ExecContext(ctx,
+		`INSERT INTO middleman_projects (
+		    id, display_name, local_path, repo_id, default_branch
+		 ) VALUES (?, ?, ?, ?, ?)`,
+		id, displayName, localPath, in.RepoID, defaultBranch,
+	)
+	if err != nil {
+		if isUniqueConstraintErr(err, "middleman_projects.local_path") {
+			return nil, ErrProjectPathTaken
+		}
+		return nil, fmt.Errorf("insert project: %w", err)
+	}
+
+	return d.GetProjectByID(ctx, id)
+}
+
+const projectSelectColumns = `p.id, p.display_name, p.local_path,
+        p.default_branch, p.created_at, p.updated_at,
+        r.platform_host, r.owner, r.name`
+
+const projectFromJoin = `FROM middleman_projects p
+        LEFT JOIN middleman_repos r ON r.id = p.repo_id`
+
+// GetProjectByID returns one project by its server-assigned id, joining the
+// linked middleman_repos row to populate PlatformIdentity when present.
+func (d *DB) GetProjectByID(ctx context.Context, id string) (*Project, error) {
+	row := d.ro.QueryRowContext(ctx,
+		`SELECT `+projectSelectColumns+` `+projectFromJoin+`
+		 WHERE p.id = ?`,
+		id,
+	)
+	return scanProject(row)
+}
+
+// GetProjectByLocalPath returns the project registered at the given absolute
+// path, or ErrProjectNotFound if no record matches.
+func (d *DB) GetProjectByLocalPath(ctx context.Context, localPath string) (*Project, error) {
+	row := d.ro.QueryRowContext(ctx,
+		`SELECT `+projectSelectColumns+` `+projectFromJoin+`
+		 WHERE p.local_path = ?`,
+		localPath,
+	)
+	return scanProject(row)
+}
+
+// ListProjects returns all registered projects ordered by display_name.
+func (d *DB) ListProjects(ctx context.Context) ([]Project, error) {
+	rows, err := d.ro.QueryContext(ctx,
+		`SELECT `+projectSelectColumns+` `+projectFromJoin+`
+		 ORDER BY p.display_name COLLATE NOCASE, p.id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+	defer rows.Close()
+
+	var projects []Project
+	for rows.Next() {
+		project, err := scanProjectRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		projects = append(projects, *project)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate projects: %w", err)
+	}
+	return projects, nil
+}
+
+// CreateProjectWorktreeInput collects fields for registering a worktree the
+// caller has already created on disk.
+type CreateProjectWorktreeInput struct {
+	ProjectID string
+	Branch    string
+	Path      string
+}
+
+// CreateProjectWorktree persists a worktree record. The caller must have
+// already run `git worktree add`; middleman only records metadata.
+func (d *DB) CreateProjectWorktree(ctx context.Context, in CreateProjectWorktreeInput) (*ProjectWorktree, error) {
+	projectID := strings.TrimSpace(in.ProjectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	branch := strings.TrimSpace(in.Branch)
+	if branch == "" {
+		return nil, fmt.Errorf("branch is required")
+	}
+	path := strings.TrimSpace(in.Path)
+	if path == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+
+	if _, err := d.GetProjectByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+
+	id, err := newWorktreeID()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = d.rw.ExecContext(ctx,
+		`INSERT INTO middleman_project_worktrees (
+		    id, project_id, branch, path
+		 ) VALUES (?, ?, ?, ?)`,
+		id, projectID, branch, path,
+	)
+	if err != nil {
+		if isUniqueConstraintErr(err, "middleman_project_worktrees.path") {
+			return nil, ErrWorktreePathTaken
+		}
+		return nil, fmt.Errorf("insert project worktree: %w", err)
+	}
+
+	return d.GetProjectWorktreeByID(ctx, id)
+}
+
+// GetProjectWorktreeByID returns one worktree by id.
+func (d *DB) GetProjectWorktreeByID(ctx context.Context, id string) (*ProjectWorktree, error) {
+	row := d.ro.QueryRowContext(ctx,
+		`SELECT id, project_id, branch, path, created_at, updated_at
+		 FROM middleman_project_worktrees WHERE id = ?`,
+		id,
+	)
+	return scanProjectWorktree(row)
+}
+
+// ListProjectWorktrees returns the worktrees for a project ordered by
+// created_at.
+func (d *DB) ListProjectWorktrees(ctx context.Context, projectID string) ([]ProjectWorktree, error) {
+	if _, err := d.GetProjectByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+	rows, err := d.ro.QueryContext(ctx,
+		`SELECT id, project_id, branch, path, created_at, updated_at
+		 FROM middleman_project_worktrees
+		 WHERE project_id = ?
+		 ORDER BY created_at, id`,
+		projectID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list project worktrees: %w", err)
+	}
+	defer rows.Close()
+
+	var worktrees []ProjectWorktree
+	for rows.Next() {
+		wt, err := scanProjectWorktreeRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		worktrees = append(worktrees, *wt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate project worktrees: %w", err)
+	}
+	return worktrees, nil
+}
+
+func scanProject(row *sql.Row) (*Project, error) {
+	project, err := scanProjectFields(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrProjectNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan project: %w", err)
+	}
+	return project, nil
+}
+
+func scanProjectRow(rows *sql.Rows) (*Project, error) {
+	project, err := scanProjectFields(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan project: %w", err)
+	}
+	return project, nil
+}
+
+func scanProjectFields(scanner interface{ Scan(...any) error }) (*Project, error) {
+	var (
+		p            Project
+		defaultBr    sql.NullString
+		platformHost sql.NullString
+		repoOwner    sql.NullString
+		repoName     sql.NullString
+	)
+	err := scanner.Scan(
+		&p.ID, &p.DisplayName, &p.LocalPath,
+		&defaultBr, &p.CreatedAt, &p.UpdatedAt,
+		&platformHost, &repoOwner, &repoName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if defaultBr.Valid {
+		p.DefaultBranch = defaultBr.String
+	}
+	if platformHost.Valid {
+		p.PlatformIdentity = &PlatformIdentity{
+			Host:  platformHost.String,
+			Owner: repoOwner.String,
+			Name:  repoName.String,
+		}
+	}
+	return &p, nil
+}
+
+func scanProjectWorktree(row *sql.Row) (*ProjectWorktree, error) {
+	worktree, err := scanProjectWorktreeFields(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrProjectNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan project worktree: %w", err)
+	}
+	return worktree, nil
+}
+
+func scanProjectWorktreeRow(rows *sql.Rows) (*ProjectWorktree, error) {
+	worktree, err := scanProjectWorktreeFields(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan project worktree: %w", err)
+	}
+	return worktree, nil
+}
+
+func scanProjectWorktreeFields(
+	scanner interface{ Scan(...any) error },
+) (*ProjectWorktree, error) {
+	var w ProjectWorktree
+	if err := scanner.Scan(
+		&w.ID, &w.ProjectID, &w.Branch, &w.Path,
+		&w.CreatedAt, &w.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &w, nil
+}
+
+func newProjectID() (string, error) {
+	return newPrefixedID("prj_")
+}
+
+func newWorktreeID() (string, error) {
+	return newPrefixedID("wtr_")
+}
+
+func newPrefixedID(prefix string) (string, error) {
+	var buf [12]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generate id: %w", err)
+	}
+	return prefix + hex.EncodeToString(buf[:]), nil
+}
+
+func isUniqueConstraintErr(err error, suffix string) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") &&
+		strings.Contains(msg, suffix)
+}

--- a/internal/db/queries_projects_test.go
+++ b/internal/db/queries_projects_test.go
@@ -1,0 +1,329 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateProjectWithoutPlatformIdentity(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	project, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "myrepo",
+		LocalPath:   "/tmp/myrepo",
+	})
+	require.NoError(err)
+	require.NotNil(project)
+
+	assert.NotEmpty(project.ID)
+	assert.Greater(len(project.ID), len("prj_"))
+	assert.Equal("myrepo", project.DisplayName)
+	assert.Equal("/tmp/myrepo", project.LocalPath)
+	assert.Nil(project.PlatformIdentity)
+	assert.False(project.CreatedAt.IsZero())
+
+	roundTrip, err := d.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	assert.Equal(project.ID, roundTrip.ID)
+	assert.Nil(roundTrip.PlatformIdentity)
+}
+
+func TestCreateProjectLinkedToRepo(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "wesm", "examplerepo")
+	require.NoError(err)
+
+	project, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName:   "examplerepo",
+		LocalPath:     "/Users/example/code/examplerepo",
+		RepoID:        sql.NullInt64{Int64: repoID, Valid: true},
+		DefaultBranch: "main",
+	})
+	require.NoError(err)
+	require.NotNil(project.PlatformIdentity)
+	assert.Equal("github.com", project.PlatformIdentity.Host)
+	assert.Equal("wesm", project.PlatformIdentity.Owner)
+	assert.Equal("examplerepo", project.PlatformIdentity.Name)
+	assert.Equal("main", project.DefaultBranch)
+
+	// Re-fetching reads the joined identity off middleman_repos -
+	// pin that the JOIN is the source of truth.
+	roundTrip, err := d.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.NotNil(roundTrip.PlatformIdentity)
+	assert.Equal("github.com", roundTrip.PlatformIdentity.Host)
+}
+
+func TestCreateProjectFKSetNullOnRepoDelete(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID, err := d.UpsertRepo(ctx, "github.com", "wesm", "examplerepo")
+	require.NoError(err)
+
+	project, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "examplerepo",
+		LocalPath:   "/tmp/examplerepo",
+		RepoID:      sql.NullInt64{Int64: repoID, Valid: true},
+	})
+	require.NoError(err)
+	require.NotNil(project.PlatformIdentity)
+
+	// Deleting the repo row must null the project's FK rather than
+	// cascade-delete the project. The on-disk checkout is the source
+	// of truth for the project record.
+	_, err = d.WriteDB().ExecContext(ctx,
+		`DELETE FROM middleman_repos WHERE id = ?`, repoID,
+	)
+	require.NoError(err)
+
+	after, err := d.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	assert.Nil(after.PlatformIdentity,
+		"identity must clear when the linked repo row is removed")
+	assert.Equal(project.LocalPath, after.LocalPath,
+		"project record itself must survive repo deletion")
+}
+
+func TestCreateProjectRejectsBlankRequiredFields(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "",
+		LocalPath:   "/tmp/x",
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "display_name")
+
+	_, err = d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "ok",
+		LocalPath:   "",
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "local_path")
+}
+
+func TestCreateProjectDuplicateLocalPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "first",
+		LocalPath:   "/tmp/repo",
+	})
+	require.NoError(err)
+
+	_, err = d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "second",
+		LocalPath:   "/tmp/repo",
+	})
+	require.Error(err)
+	assert.ErrorIs(err, ErrProjectPathTaken)
+}
+
+func TestGetProjectByIDNotFound(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := d.GetProjectByID(ctx, "prj_doesnotexist")
+	require.Error(err)
+	assert.ErrorIs(err, ErrProjectNotFound)
+}
+
+func TestGetProjectByLocalPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	created, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "myrepo",
+		LocalPath:   "/tmp/myrepo",
+	})
+	require.NoError(err)
+
+	found, err := d.GetProjectByLocalPath(ctx, "/tmp/myrepo")
+	require.NoError(err)
+	assert.Equal(created.ID, found.ID)
+
+	_, err = d.GetProjectByLocalPath(ctx, "/tmp/nope")
+	assert.ErrorIs(err, ErrProjectNotFound)
+}
+
+func TestListProjectsOrdersByDisplayName(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	for _, p := range []CreateProjectInput{
+		{DisplayName: "Zeta", LocalPath: "/tmp/zeta"},
+		{DisplayName: "alpha", LocalPath: "/tmp/alpha"},
+		{DisplayName: "Mu", LocalPath: "/tmp/mu"},
+	} {
+		_, err := d.CreateProject(ctx, p)
+		require.NoError(err)
+	}
+
+	listed, err := d.ListProjects(ctx)
+	require.NoError(err)
+	require.Len(listed, 3)
+	assert.Equal("alpha", listed[0].DisplayName)
+	assert.Equal("Mu", listed[1].DisplayName)
+	assert.Equal("Zeta", listed[2].DisplayName)
+}
+
+func TestCreateProjectWorktreeRoundTrip(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	project, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "myrepo",
+		LocalPath:   "/tmp/myrepo",
+	})
+	require.NoError(err)
+
+	worktree, err := d.CreateProjectWorktree(ctx, CreateProjectWorktreeInput{
+		ProjectID: project.ID,
+		Branch:    "feature-x",
+		Path:      "/tmp/myrepo-worktrees/feature-x",
+	})
+	require.NoError(err)
+	assert.Greater(len(worktree.ID), len("wtr_"))
+	assert.Equal(project.ID, worktree.ProjectID)
+	assert.Equal("feature-x", worktree.Branch)
+
+	roundTrip, err := d.GetProjectWorktreeByID(ctx, worktree.ID)
+	require.NoError(err)
+	assert.Equal(worktree.ID, roundTrip.ID)
+}
+
+func TestCreateProjectWorktreeRejectsUnknownProject(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := d.CreateProjectWorktree(ctx, CreateProjectWorktreeInput{
+		ProjectID: "prj_doesnotexist",
+		Branch:    "feature-x",
+		Path:      "/tmp/x",
+	})
+	require.Error(err)
+	assert.ErrorIs(err, ErrProjectNotFound)
+}
+
+func TestCreateProjectWorktreeRejectsDuplicatePath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	project, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "myrepo",
+		LocalPath:   "/tmp/myrepo",
+	})
+	require.NoError(err)
+
+	_, err = d.CreateProjectWorktree(ctx, CreateProjectWorktreeInput{
+		ProjectID: project.ID,
+		Branch:    "feature-x",
+		Path:      "/tmp/wt",
+	})
+	require.NoError(err)
+
+	_, err = d.CreateProjectWorktree(ctx, CreateProjectWorktreeInput{
+		ProjectID: project.ID,
+		Branch:    "feature-y",
+		Path:      "/tmp/wt",
+	})
+	require.Error(err)
+	assert.ErrorIs(err, ErrWorktreePathTaken)
+}
+
+func TestListProjectWorktreesScopedToProject(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	a, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "a", LocalPath: "/tmp/a",
+	})
+	require.NoError(err)
+	b, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "b", LocalPath: "/tmp/b",
+	})
+	require.NoError(err)
+
+	for _, in := range []CreateProjectWorktreeInput{
+		{ProjectID: a.ID, Branch: "wip", Path: "/tmp/a-wt-1"},
+		{ProjectID: a.ID, Branch: "wip2", Path: "/tmp/a-wt-2"},
+		{ProjectID: b.ID, Branch: "wip", Path: "/tmp/b-wt-1"},
+	} {
+		_, err := d.CreateProjectWorktree(ctx, in)
+		require.NoError(err)
+	}
+
+	aList, err := d.ListProjectWorktrees(ctx, a.ID)
+	require.NoError(err)
+	assert.Len(aList, 2)
+
+	bList, err := d.ListProjectWorktrees(ctx, b.ID)
+	require.NoError(err)
+	assert.Len(bList, 1)
+
+	_, err = d.ListProjectWorktrees(ctx, "prj_doesnotexist")
+	assert.ErrorIs(err, ErrProjectNotFound)
+}
+
+func TestProjectWorktreeCascadesOnProjectDelete(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	project, err := d.CreateProject(ctx, CreateProjectInput{
+		DisplayName: "myrepo", LocalPath: "/tmp/myrepo",
+	})
+	require.NoError(err)
+	_, err = d.CreateProjectWorktree(ctx, CreateProjectWorktreeInput{
+		ProjectID: project.ID, Branch: "wip", Path: "/tmp/wt",
+	})
+	require.NoError(err)
+
+	_, err = d.WriteDB().ExecContext(ctx,
+		`DELETE FROM middleman_projects WHERE id = ?`, project.ID,
+	)
+	require.NoError(err)
+
+	var count int
+	err = d.ReadDB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM middleman_project_worktrees WHERE project_id = ?`,
+		project.ID,
+	).Scan(&count)
+	require.NoError(err)
+	assert.Zero(count)
+}

--- a/internal/projects/identity.go
+++ b/internal/projects/identity.go
@@ -1,0 +1,109 @@
+// Package projects holds project-registry helpers that sit between the
+// generic db layer and the HTTP/Huma handlers. The package owns identity
+// resolution from local repository paths and any other non-trivial logic
+// that does not belong directly in the db package.
+package projects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/gitenv"
+)
+
+// ResolveIdentityFromPath runs `git remote get-url origin` in path and parses
+// the result into an optional PlatformIdentity. Returns (nil, nil) when no
+// origin remote is configured, when path is not a git repository, or when
+// the URL does not match a recognized pattern. The contract is identity-
+// only: validation that path exists and is a git repository is the caller's
+// responsibility. Per the consolidation spec's Decision 7, unknown identity
+// is allowed and does not block registration.
+func ResolveIdentityFromPath(ctx context.Context, path string) (*db.PlatformIdentity, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve path: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	cmd.Dir = abs
+	cmd.Env = gitenv.StripAll(os.Environ())
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// `git remote get-url origin` exits non-zero when origin is
+			// unset; treat as a clean no-identity result.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("git remote get-url origin: %w", err)
+	}
+	return ParseRemoteURL(string(out)), nil
+}
+
+// ParseRemoteURL recognizes the common remote URL shapes (HTTPS, SSH SCP-style,
+// ssh://) and extracts a PlatformIdentity. Returns nil for anything it does
+// not recognize, including local paths, file:// URLs, and remotes whose path
+// does not contain exactly two segments (owner/name).
+func ParseRemoteURL(remote string) *db.PlatformIdentity {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return nil
+	}
+
+	host, path := splitRemote(remote)
+	if host == "" || path == "" {
+		return nil
+	}
+
+	path = strings.TrimSuffix(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 {
+		return nil
+	}
+	owner, name := parts[0], parts[1]
+	if owner == "" || name == "" {
+		return nil
+	}
+
+	return &db.PlatformIdentity{
+		Host:  strings.ToLower(host),
+		Owner: strings.ToLower(owner),
+		Name:  strings.ToLower(name),
+	}
+}
+
+// splitRemote separates a remote URL into (host, path) without hard-coding
+// any specific platform. It accepts the three common shapes:
+//
+//	scheme://[user@]host[:port]/path
+//	user@host:path     (SCP-style)
+//	host:path          (rejected — no user@ disambiguator from local paths)
+func splitRemote(remote string) (host, path string) {
+	if strings.Contains(remote, "://") {
+		u, err := url.Parse(remote)
+		if err != nil {
+			return "", ""
+		}
+		if u.Scheme == "file" {
+			return "", ""
+		}
+		return u.Hostname(), strings.TrimPrefix(u.Path, "/")
+	}
+
+	atIdx := strings.Index(remote, "@")
+	colonIdx := strings.Index(remote, ":")
+	if atIdx > 0 && colonIdx > atIdx {
+		return remote[atIdx+1 : colonIdx], remote[colonIdx+1:]
+	}
+	return "", ""
+}

--- a/internal/projects/identity_test.go
+++ b/internal/projects/identity_test.go
@@ -1,0 +1,193 @@
+package projects
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/gitenv"
+)
+
+func TestParseRemoteURL_GitHubFormats(t *testing.T) {
+	cases := []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{"scp_with_dot_git", "git@github.com:wesm/examplerepo.git", "github.com/wesm/examplerepo"},
+		{"scp_no_dot_git", "git@github.com:wesm/examplerepo", "github.com/wesm/examplerepo"},
+		{"https_with_dot_git", "https://github.com/wesm/examplerepo.git", "github.com/wesm/examplerepo"},
+		{"https_no_dot_git", "https://github.com/wesm/examplerepo", "github.com/wesm/examplerepo"},
+		{"https_with_user", "https://wesm@github.com/wesm/examplerepo.git", "github.com/wesm/examplerepo"},
+		{"ssh_full", "ssh://git@github.com/wesm/examplerepo.git", "github.com/wesm/examplerepo"},
+		{"ssh_with_port", "ssh://git@github.com:22/wesm/examplerepo.git", "github.com/wesm/examplerepo"},
+		{"git_protocol", "git://github.com/wesm/examplerepo.git", "github.com/wesm/examplerepo"},
+		{"trailing_slash", "https://github.com/wesm/examplerepo/", "github.com/wesm/examplerepo"},
+		{"casefold", "GIT@GITHUB.COM:WesM/Examplerepo.git", "github.com/wesm/examplerepo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			require := require.New(t)
+			got := ParseRemoteURL(tc.remote)
+			require.NotNil(got)
+			assert.Equal(tc.want, got.Host+"/"+got.Owner+"/"+got.Name)
+		})
+	}
+}
+
+func TestParseRemoteURL_OtherHosts(t *testing.T) {
+	cases := []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{"gitlab", "git@gitlab.com:group/project.git", "gitlab.com/group/project"},
+		{"codeberg", "https://codeberg.org/owner/repo.git", "codeberg.org/owner/repo"},
+		{"self_hosted", "git@git.example.com:team/svc.git", "git.example.com/team/svc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			require := require.New(t)
+			got := ParseRemoteURL(tc.remote)
+			require.NotNil(got)
+			assert.Equal(tc.want, got.Host+"/"+got.Owner+"/"+got.Name)
+		})
+	}
+}
+
+func TestParseRemoteURL_Unrecognized(t *testing.T) {
+	cases := []string{
+		"",
+		"   ",
+		"not-a-url",
+		"/local/path/to/repo",
+		"./relative/path",
+		"file:///tmp/repo",
+		"https://github.com/onlyone",           // missing name
+		"https://github.com/too/many/segments", // wrong arity
+		"github.com:foo/bar.git",               // SCP without user@
+		"git@github.com",                       // missing path
+		"git@github.com:",                      // empty path
+		"git@github.com:owner/.git",            // empty name after strip
+	}
+	for _, remote := range cases {
+		t.Run(remote, func(t *testing.T) {
+			assert := Assert.New(t)
+			assert.Nil(ParseRemoteURL(remote))
+		})
+	}
+}
+
+func TestResolveIdentityFromPath_NoOriginRemote(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	require.NoError(runGit(dir, "init", "-q"))
+
+	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	require.NoError(err)
+	assert.Nil(identity)
+}
+
+func TestResolveIdentityFromPath_UnrecognizableRemote(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	require.NoError(runGit(dir, "init", "-q"))
+	require.NoError(runGit(dir, "remote", "add", "origin", "/local/only/repo"))
+
+	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	require.NoError(err)
+	assert.Nil(identity)
+}
+
+func TestResolveIdentityFromPath_RecognizedRemote(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	require.NoError(runGit(dir, "init", "-q"))
+	require.NoError(runGit(dir, "remote", "add", "origin", "git@github.com:wesm/examplerepo.git"))
+
+	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	require.NoError(err)
+	require.NotNil(identity)
+	assert.Equal("github.com", identity.Host)
+	assert.Equal("wesm", identity.Owner)
+	assert.Equal("examplerepo", identity.Name)
+}
+
+func TestResolveIdentityFromPath_NotAGitRepoIsTreatedAsNoIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	// A plain directory that is not a git repo causes git to exit
+	// non-zero. The resolver's contract is identity-only, so it
+	// returns (nil, nil) and lets registration validation reject the
+	// non-repo separately.
+	dir := t.TempDir()
+	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	require.NoError(err)
+	assert.Nil(identity)
+}
+
+func TestResolveIdentityFromPath_RequiresPath(t *testing.T) {
+	require := require.New(t)
+	_, err := ResolveIdentityFromPath(context.Background(), "")
+	require.Error(err)
+}
+
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(gitenv.StripAll(os.Environ()),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	return cmd.Run()
+}
+
+// Sanity check that filepath.Abs is used; otherwise an unusual cwd could
+// hide bugs in tests that pass relative paths.
+func TestResolveIdentityFromPath_ResolvesRelativePaths(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	require.NoError(runGit(dir, "init", "-q"))
+	require.NoError(runGit(dir, "remote", "add", "origin", "git@github.com:o/n.git"))
+
+	parent := t.TempDir()
+	cwd := filepath.Join(parent, "cwd")
+	require.NoError(os.Mkdir(cwd, 0o755))
+
+	rel, err := filepath.Rel(cwd, dir)
+	require.NoError(err)
+	identity, err := ResolveIdentityFromPath(context.Background(), filepath.Join(cwd, rel))
+	require.NoError(err)
+	require.NotNil(identity)
+	assert.Equal("github.com", identity.Host)
+}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -509,6 +509,39 @@ func (s *Server) registerAPI(api huma.API) {
 		Path:          "/workspaces/{id}",
 		DefaultStatus: http.StatusNoContent,
 	}, s.deleteWorkspace)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "register-project",
+		Method:        http.MethodPost,
+		Path:          "/projects",
+		DefaultStatus: http.StatusCreated,
+	}, s.registerProject)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-projects",
+		Method:      http.MethodGet,
+		Path:        "/projects",
+	}, s.listProjects)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-project",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}",
+	}, s.getProject)
+	huma.Register(api, huma.Operation{
+		OperationID:   "register-worktree",
+		Method:        http.MethodPost,
+		Path:          "/projects/{project_id}/worktrees",
+		DefaultStatus: http.StatusCreated,
+	}, s.registerWorktree)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-worktrees",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}/worktrees",
+	}, s.listWorktrees)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-launch-targets",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}/launch-targets",
+	}, s.listLaunchTargets)
 }
 
 func (s *Server) registerProviderRepoAPI(api huma.API) {

--- a/internal/server/projects_handlers.go
+++ b/internal/server/projects_handlers.go
@@ -1,0 +1,346 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/projects"
+	"github.com/wesm/middleman/internal/workspace/localruntime"
+)
+
+type platformIdentityPayload struct {
+	PlatformHost string `json:"platform_host"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+}
+
+type registerProjectInput struct {
+	Body struct {
+		LocalPath        string                   `json:"local_path"`
+		DisplayName      string                   `json:"display_name,omitempty"`
+		DefaultBranch    string                   `json:"default_branch,omitempty"`
+		PlatformIdentity *platformIdentityPayload `json:"platform_identity,omitempty"`
+	}
+}
+
+type projectResponse struct {
+	ID               string                   `json:"id"`
+	DisplayName      string                   `json:"display_name"`
+	LocalPath        string                   `json:"local_path"`
+	PlatformIdentity *platformIdentityPayload `json:"platform_identity,omitempty"`
+	DefaultBranch    string                   `json:"default_branch,omitempty"`
+	CreatedAt        time.Time                `json:"created_at"`
+	UpdatedAt        time.Time                `json:"updated_at"`
+}
+
+type registerProjectOutput struct {
+	Body projectResponse
+}
+
+type listProjectsOutput struct {
+	Body struct {
+		Projects []projectResponse `json:"projects"`
+	}
+}
+
+type projectIDInput struct {
+	ProjectID string `path:"project_id"`
+}
+
+type getProjectOutput struct {
+	Body projectResponse
+}
+
+type registerWorktreeInput struct {
+	ProjectID string `path:"project_id"`
+	Body      struct {
+		Branch string `json:"branch"`
+		Path   string `json:"path"`
+	}
+}
+
+type worktreeResponse struct {
+	ID        string    `json:"id"`
+	ProjectID string    `json:"project_id"`
+	Branch    string    `json:"branch"`
+	Path      string    `json:"path"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type registerWorktreeOutput struct {
+	Body worktreeResponse
+}
+
+type listWorktreesOutput struct {
+	Body struct {
+		Worktrees []worktreeResponse `json:"worktrees"`
+	}
+}
+
+type listLaunchTargetsOutput struct {
+	Body struct {
+		LaunchTargets []localruntime.LaunchTarget `json:"launch_targets"`
+	}
+}
+
+// registerProject handles POST /api/v1/projects.
+//
+// Identity resolution:
+//   - If the caller passes a platform_identity payload, it wins.
+//   - Otherwise the handler runs `git remote get-url origin` against the path
+//     and parses the result. Unparseable, missing, or non-git remotes leave
+//     the project local-only.
+//
+// When an identity is established (caller-provided or parsed), the handler
+// calls db.UpsertRepo to ensure a middleman_repos row exists for it and
+// stores the row's id as the project's repo_id FK. UpsertRepo is pure DDL
+// (INSERT ON CONFLICT DO NOTHING + SELECT id) and does NOT subscribe the
+// repo to sync; sync subscription remains driven by the user's TOML config
+// and the AddRepo settings handler. The middleman_repos row exists solely
+// as a stable FK target so the project's identity cannot drift.
+func (s *Server) registerProject(
+	ctx context.Context, input *registerProjectInput,
+) (*registerProjectOutput, error) {
+	rawPath := strings.TrimSpace(input.Body.LocalPath)
+	if rawPath == "" {
+		return nil, huma.Error400BadRequest("local_path is required")
+	}
+	abs, err := filepath.Abs(rawPath)
+	if err != nil {
+		return nil, huma.Error400BadRequest("resolve local_path: " + err.Error())
+	}
+	stat, err := os.Stat(abs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, huma.Error400BadRequest("local_path does not exist: " + abs)
+		}
+		return nil, huma.Error500InternalServerError("stat local_path: " + err.Error())
+	}
+	if !stat.IsDir() {
+		return nil, huma.Error400BadRequest("local_path is not a directory: " + abs)
+	}
+
+	displayName := strings.TrimSpace(input.Body.DisplayName)
+	if displayName == "" {
+		displayName = filepath.Base(abs)
+	}
+
+	identity, err := s.resolveProjectIdentity(ctx, input.Body.PlatformIdentity, abs)
+	if err != nil {
+		return nil, err
+	}
+
+	var repoID sql.NullInt64
+	if identity != nil {
+		id, upsertErr := s.db.UpsertRepo(ctx, identity.Host, identity.Owner, identity.Name)
+		if upsertErr != nil {
+			return nil, huma.Error500InternalServerError(
+				"upsert repo identity: " + upsertErr.Error(),
+			)
+		}
+		repoID = sql.NullInt64{Int64: id, Valid: true}
+	}
+
+	created, err := s.db.CreateProject(ctx, db.CreateProjectInput{
+		DisplayName:   displayName,
+		LocalPath:     abs,
+		RepoID:        repoID,
+		DefaultBranch: strings.TrimSpace(input.Body.DefaultBranch),
+	})
+	if err != nil {
+		if errors.Is(err, db.ErrProjectPathTaken) {
+			return nil, huma.Error409Conflict(
+				"a project is already registered at " + abs,
+			)
+		}
+		return nil, huma.Error500InternalServerError("register project: " + err.Error())
+	}
+
+	return &registerProjectOutput{Body: projectResponseFromDB(created)}, nil
+}
+
+// resolveProjectIdentity returns the platform identity to associate with a
+// project. Caller-provided identity wins; otherwise the handler tries to
+// parse the path's git origin remote. Returns (nil, nil) when neither is
+// available - that path produces a local-only project.
+func (s *Server) resolveProjectIdentity(
+	ctx context.Context,
+	caller *platformIdentityPayload,
+	abs string,
+) (*db.PlatformIdentity, error) {
+	if caller != nil {
+		host := strings.TrimSpace(caller.PlatformHost)
+		owner := strings.TrimSpace(caller.Owner)
+		name := strings.TrimSpace(caller.Name)
+		if host == "" || owner == "" || name == "" {
+			return nil, huma.Error400BadRequest(
+				"platform_identity requires platform_host, owner, and name",
+			)
+		}
+		return &db.PlatformIdentity{Host: host, Owner: owner, Name: name}, nil
+	}
+	resolved, err := projects.ResolveIdentityFromPath(ctx, abs)
+	if err != nil {
+		return nil, huma.Error500InternalServerError(
+			"resolve platform identity: " + err.Error(),
+		)
+	}
+	return resolved, nil
+}
+
+func (s *Server) listProjects(
+	ctx context.Context, _ *struct{},
+) (*listProjectsOutput, error) {
+	rows, err := s.db.ListProjects(ctx)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("list projects: " + err.Error())
+	}
+	out := &listProjectsOutput{}
+	out.Body.Projects = projectResponsesFromDB(rows)
+	return out, nil
+}
+
+func (s *Server) getProject(
+	ctx context.Context, input *projectIDInput,
+) (*getProjectOutput, error) {
+	project, err := s.db.GetProjectByID(ctx, input.ProjectID)
+	if err != nil {
+		if errors.Is(err, db.ErrProjectNotFound) {
+			return nil, huma.Error404NotFound("project not found")
+		}
+		return nil, huma.Error500InternalServerError("get project: " + err.Error())
+	}
+	return &getProjectOutput{Body: projectResponseFromDB(project)}, nil
+}
+
+func (s *Server) registerWorktree(
+	ctx context.Context, input *registerWorktreeInput,
+) (*registerWorktreeOutput, error) {
+	branch := strings.TrimSpace(input.Body.Branch)
+	if branch == "" {
+		return nil, huma.Error400BadRequest("branch is required")
+	}
+	path := strings.TrimSpace(input.Body.Path)
+	if path == "" {
+		return nil, huma.Error400BadRequest("path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, huma.Error400BadRequest("resolve path: " + err.Error())
+	}
+
+	created, err := s.db.CreateProjectWorktree(ctx, db.CreateProjectWorktreeInput{
+		ProjectID: input.ProjectID,
+		Branch:    branch,
+		Path:      abs,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, db.ErrProjectNotFound):
+			return nil, huma.Error404NotFound("project not found")
+		case errors.Is(err, db.ErrWorktreePathTaken):
+			return nil, huma.Error409Conflict(
+				"a worktree is already registered at " + abs,
+			)
+		}
+		return nil, huma.Error500InternalServerError("register worktree: " + err.Error())
+	}
+	return &registerWorktreeOutput{Body: worktreeResponseFromDB(created)}, nil
+}
+
+func (s *Server) listWorktrees(
+	ctx context.Context, input *projectIDInput,
+) (*listWorktreesOutput, error) {
+	rows, err := s.db.ListProjectWorktrees(ctx, input.ProjectID)
+	if err != nil {
+		if errors.Is(err, db.ErrProjectNotFound) {
+			return nil, huma.Error404NotFound("project not found")
+		}
+		return nil, huma.Error500InternalServerError("list worktrees: " + err.Error())
+	}
+	out := &listWorktreesOutput{}
+	out.Body.Worktrees = worktreeResponsesFromDB(rows)
+	return out, nil
+}
+
+func (s *Server) listLaunchTargets(
+	ctx context.Context, input *projectIDInput,
+) (*listLaunchTargetsOutput, error) {
+	if _, err := s.db.GetProjectByID(ctx, input.ProjectID); err != nil {
+		if errors.Is(err, db.ErrProjectNotFound) {
+			return nil, huma.Error404NotFound("project not found")
+		}
+		return nil, huma.Error500InternalServerError("get project: " + err.Error())
+	}
+	// Resolve fresh on every call so PATH changes (a newly installed
+	// agent, a deleted binary) take effect without restarting the
+	// server. The runtime manager caches targets at startup and is
+	// only initialized when options.WorktreeDir is set; this endpoint
+	// must work either way.
+	var agents []config.Agent
+	if s.cfg != nil {
+		agents = s.cfg.Agents
+	}
+	targets := localruntime.ResolveLaunchTargets(agents, s.cfg.TmuxCommand(), nil)
+	if targets == nil {
+		targets = []localruntime.LaunchTarget{}
+	}
+	out := &listLaunchTargetsOutput{}
+	out.Body.LaunchTargets = targets
+	return out, nil
+}
+
+func projectResponseFromDB(p *db.Project) projectResponse {
+	resp := projectResponse{
+		ID:            p.ID,
+		DisplayName:   p.DisplayName,
+		LocalPath:     p.LocalPath,
+		DefaultBranch: p.DefaultBranch,
+		CreatedAt:     p.CreatedAt,
+		UpdatedAt:     p.UpdatedAt,
+	}
+	if p.PlatformIdentity != nil {
+		resp.PlatformIdentity = &platformIdentityPayload{
+			PlatformHost: p.PlatformIdentity.Host,
+			Owner:        p.PlatformIdentity.Owner,
+			Name:         p.PlatformIdentity.Name,
+		}
+	}
+	return resp
+}
+
+func projectResponsesFromDB(rows []db.Project) []projectResponse {
+	responses := make([]projectResponse, 0, len(rows))
+	for i := range rows {
+		responses = append(responses, projectResponseFromDB(&rows[i]))
+	}
+	return responses
+}
+
+func worktreeResponseFromDB(w *db.ProjectWorktree) worktreeResponse {
+	return worktreeResponse{
+		ID:        w.ID,
+		ProjectID: w.ProjectID,
+		Branch:    w.Branch,
+		Path:      w.Path,
+		CreatedAt: w.CreatedAt,
+		UpdatedAt: w.UpdatedAt,
+	}
+}
+
+func worktreeResponsesFromDB(rows []db.ProjectWorktree) []worktreeResponse {
+	responses := make([]worktreeResponse, 0, len(rows))
+	for i := range rows {
+		responses = append(responses, worktreeResponseFromDB(&rows[i]))
+	}
+	return responses
+}

--- a/internal/server/projects_handlers_test.go
+++ b/internal/server/projects_handlers_test.go
@@ -1,0 +1,653 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestW1SliceAGate is the falsifiable capability gate from the convergence
+// plan: it exercises the generic project + worktree registry plus
+// launch-target discovery against a path with no `gh` context and an
+// unrecognizable remote, and finishes by asserting neutral operation IDs in
+// the live OpenAPI document. If this test passes, the W1 milestone is
+// unblocked on the Middleman side.
+func TestW1SliceAGate(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	// 1) Register a project from a path with no `gh` context and no
+	//    parseable remote. The response must include a server-assigned
+	//    project_id and must omit platform_identity.
+	registerBody := mustMarshal(t, map[string]any{
+		"local_path":   repoDir,
+		"display_name": "no-remote-repo",
+	})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", registerBody)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	var registered map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&registered))
+	resp.Body.Close()
+	projectID, _ := registered["id"].(string)
+	require.NotEmpty(projectID)
+	assert.True(strings.HasPrefix(projectID, "prj_"))
+	assert.NotContains(registered, "platform_identity",
+		"platform_identity must be absent when no remote is parseable")
+	assert.Equal("no-remote-repo", registered["display_name"])
+	assert.NotContains(registered, "host",
+		"host column was speculative; the response must not include it")
+
+	// 2) GET /projects must list the registered project.
+	resp = httpDo(t, ts, http.MethodGet, "/api/v1/projects", nil)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var listed struct {
+		Projects []map[string]any `json:"projects"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&listed))
+	resp.Body.Close()
+	require.Len(listed.Projects, 1)
+	assert.Equal(projectID, listed.Projects[0]["id"])
+	assert.NotContains(listed.Projects[0], "platform_identity")
+
+	// 3) GET /projects/{project_id} must round-trip the record with
+	//    platform_identity still absent.
+	resp = httpDo(t, ts, http.MethodGet, "/api/v1/projects/"+projectID, nil)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var fetched map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&fetched))
+	resp.Body.Close()
+	assert.Equal(projectID, fetched["id"])
+	assert.NotContains(fetched, "platform_identity")
+
+	// 4) Register a worktree the daemon already created on disk.
+	//    Middleman just persists the metadata - the path validity
+	//    contract is the daemon's, not Middleman's.
+	worktreePath := filepath.Join(t.TempDir(), "wt-feature-x")
+	wtBody := mustMarshal(t, map[string]any{
+		"branch": "feature-x",
+		"path":   worktreePath,
+	})
+	resp = httpDo(t, ts, http.MethodPost,
+		"/api/v1/projects/"+projectID+"/worktrees", wtBody,
+	)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	var worktree map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&worktree))
+	resp.Body.Close()
+	worktreeID, _ := worktree["id"].(string)
+	require.NotEmpty(worktreeID)
+	assert.True(strings.HasPrefix(worktreeID, "wtr_"))
+	assert.Equal(projectID, worktree["project_id"])
+	assert.Equal("feature-x", worktree["branch"])
+	assert.Equal(worktreePath, worktree["path"])
+
+	// 5) Listing the project's worktrees must return the new record.
+	resp = httpDo(t, ts, http.MethodGet,
+		"/api/v1/projects/"+projectID+"/worktrees", nil,
+	)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var wtList struct {
+		Worktrees []map[string]any `json:"worktrees"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&wtList))
+	resp.Body.Close()
+	require.Len(wtList.Worktrees, 1)
+	assert.Equal(worktreeID, wtList.Worktrees[0]["id"])
+
+	// 6) Launch-target discovery must include plain_shell with
+	//    available: true. Configured-agent presence depends on PATH;
+	//    only plain_shell is required.
+	resp = httpDo(t, ts, http.MethodGet,
+		"/api/v1/projects/"+projectID+"/launch-targets", nil,
+	)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var ltList struct {
+		LaunchTargets []map[string]any `json:"launch_targets"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&ltList))
+	resp.Body.Close()
+	require.NotEmpty(ltList.LaunchTargets)
+
+	var plainShell map[string]any
+	for _, target := range ltList.LaunchTargets {
+		if target["key"] == "plain_shell" {
+			plainShell = target
+			break
+		}
+	}
+	require.NotNil(plainShell, "plain_shell must be present")
+	assert.Equal(true, plainShell["available"])
+	assert.Equal("plain_shell", plainShell["kind"])
+
+	// 7) The live OpenAPI document must register the gate's operation
+	//    IDs and must not bake PR/MR/issue terms into them - the
+	//    generic registry must be a generic registry.
+	resp = httpDo(t, ts, http.MethodGet, "/api/v1/openapi.json", nil)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var doc struct {
+		Paths map[string]map[string]struct {
+			OperationID string `json:"operationId"`
+		} `json:"paths"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&doc))
+	resp.Body.Close()
+
+	expectedOps := map[string]string{
+		"POST /projects":                            "register-project",
+		"GET /projects":                             "list-projects",
+		"GET /projects/{project_id}":                "get-project",
+		"POST /projects/{project_id}/worktrees":     "register-worktree",
+		"GET /projects/{project_id}/worktrees":      "list-worktrees",
+		"GET /projects/{project_id}/launch-targets": "list-launch-targets",
+	}
+	for spec, wantID := range expectedOps {
+		method, path, _ := strings.Cut(spec, " ")
+		gotPath, ok := doc.Paths[path]
+		require.Truef(ok, "OpenAPI doc missing path %q", path)
+		gotOp, ok := gotPath[strings.ToLower(method)]
+		require.Truef(ok, "OpenAPI doc missing %s on %s", method, path)
+		assert.Equalf(wantID, gotOp.OperationID,
+			"unexpected operation id for %s %s", method, path)
+	}
+
+	// 8) Negative: no operation ID on a generic project route may
+	//    contain "pull-request", "issue", or "mr" terms. This is the
+	//    "generic, not a PR fork" assertion from the convergence plan.
+	for path, methods := range doc.Paths {
+		if !strings.HasPrefix(path, "/projects") {
+			continue
+		}
+		for method, op := range methods {
+			id := op.OperationID
+			for _, banned := range []string{"pull-request", "pullrequest", "pr-", "issue", "mr-"} {
+				assert.NotContainsf(id, banned,
+					"op id %q on %s %s contains banned term %q",
+					id, method, path, banned)
+			}
+		}
+	}
+}
+
+func TestRegisterProject_RejectsMissingPath(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body := mustMarshal(t, map[string]any{"local_path": ""})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusBadRequest, resp.StatusCode)
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	assert.Contains(string(payload), "local_path")
+}
+
+func TestRegisterProject_RejectsNonexistentPath(t *testing.T) {
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body := mustMarshal(t, map[string]any{
+		"local_path": "/this/path/should/never/exist",
+	})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestRegisterProject_DuplicatePathReturns409(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	body := mustMarshal(t, map[string]any{"local_path": repoDir})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusConflict, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestRegisterProject_AcceptsCallerProvidedIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	// Even though the repo has no remote, the caller can provide
+	// platform_identity directly. Caller-provided wins, and the handler
+	// upserts a middleman_repos row to give the project a stable FK
+	// target - no sync subscription is created (sync is driven by TOML
+	// config, not by middleman_repos rows).
+	body := mustMarshal(t, map[string]any{
+		"local_path": repoDir,
+		"platform_identity": map[string]string{
+			"platform_host": "github.com",
+			"owner":         "acme",
+			"name":          "widget",
+		},
+	})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	var got map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&got))
+	resp.Body.Close()
+	identity, _ := got["platform_identity"].(map[string]any)
+	require.NotNil(identity)
+	assert.Equal("github.com", identity["platform_host"])
+	assert.NotContains(identity, "host")
+	assert.Equal("acme", identity["owner"])
+	assert.Equal("widget", identity["name"])
+
+	// Re-fetching reads the identity off the joined middleman_repos
+	// row - confirms the FK linkage is what the response is built from
+	// (not a stale duplicate copy on middleman_projects).
+	projectID, _ := got["id"].(string)
+	require.NotEmpty(projectID)
+	resp = httpDo(t, ts, http.MethodGet, "/api/v1/projects/"+projectID, nil)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var fetched map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&fetched))
+	resp.Body.Close()
+	identity2, _ := fetched["platform_identity"].(map[string]any)
+	require.NotNil(identity2)
+	assert.Equal("github.com", identity2["platform_host"])
+	assert.NotContains(identity2, "host")
+	assert.Equal("acme", identity2["owner"])
+	assert.Equal("widget", identity2["name"])
+}
+
+// TestRegisterProject_DoesNotSubscribeRepoToSync pins the load-bearing
+// invariant that registering a project does NOT subscribe the linked
+// repo to sync. registerProject calls db.UpsertRepo to give the project
+// a stable middleman_repos FK target, but UpsertRepo is pure DDL and
+// must not touch the syncer's in-memory tracked-repos list - sync
+// subscription is driven exclusively by the user's TOML config and
+// SetRepos.
+//
+// If a future refactor accidentally couples UpsertRepo (or the
+// project-registration path) to sync, this test fails and flags the
+// regression: an embedder could otherwise quietly add unwanted repos
+// to the sync set just by registering a project.
+func TestRegisterProject_DoesNotSubscribeRepoToSync(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	before := srv.syncer.TrackedRepos()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	body := mustMarshal(t, map[string]any{
+		"local_path": repoDir,
+		"platform_identity": map[string]string{
+			"platform_host": "github.com",
+			"owner":         "stranger",
+			"name":          "not-in-toml",
+		},
+	})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	after := srv.syncer.TrackedRepos()
+	assert.Equal(before, after,
+		"registering a project must not change the syncer's tracked-repos set")
+
+	// Sanity check the upsert side-effect: the middleman_repos row must
+	// exist (so the project's FK target is real), even though sync is
+	// not subscribed. Confirms the equality assertion above is not
+	// passing simply because UpsertRepo silently no-op'd.
+	var count int
+	err := database.ReadDB().QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM middleman_repos
+		   WHERE platform_host = ? AND owner = ? AND name = ?`,
+		"github.com", "stranger", "not-in-toml",
+	).Scan(&count)
+	require.NoError(err)
+	assert.Equal(1, count,
+		"UpsertRepo must persist the middleman_repos FK target row")
+}
+
+func TestGetProject_NotFoundReturns404(t *testing.T) {
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := httpDo(t, ts, http.MethodGet, "/api/v1/projects/prj_nope", nil)
+	require.Equal(http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestRegisterWorktree_DuplicatePathReturns409(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	body := mustMarshal(t, map[string]any{"local_path": repoDir})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	var registered map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&registered))
+	resp.Body.Close()
+	projectID, _ := registered["id"].(string)
+
+	wtPath := filepath.Join(t.TempDir(), "wt-1")
+	wtBody := mustMarshal(t, map[string]any{
+		"branch": "feature-x",
+		"path":   wtPath,
+	})
+	resp = httpDo(t, ts, http.MethodPost,
+		"/api/v1/projects/"+projectID+"/worktrees", wtBody,
+	)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	resp = httpDo(t, ts, http.MethodPost,
+		"/api/v1/projects/"+projectID+"/worktrees", wtBody,
+	)
+	require.Equal(http.StatusConflict, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestListLaunchTargets_NotFoundReturns404(t *testing.T) {
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := httpDo(t, ts, http.MethodGet,
+		"/api/v1/projects/prj_nope/launch-targets", nil,
+	)
+	require.Equal(http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+}
+
+// TestRegisterProject_RejectsPartialPlatformIdentity pins the contract that
+// platform_identity is all-or-nothing. Two paths reject it:
+//   - Missing field: Huma's JSON Schema validator returns 422 (the
+//     platformIdentityPayload struct fields are non-pointer and
+//     non-omitempty, so all three are required).
+//   - Whitespace-only field: passes the schema validator but fails the
+//     handler's TrimSpace check and returns 400. This is the embedder-
+//     facing failure mode for "I sent the field but the value is junk".
+func TestRegisterProject_RejectsPartialPlatformIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	missingFieldBody := mustMarshal(t, map[string]any{
+		"local_path": repoDir,
+		"platform_identity": map[string]string{
+			"platform_host": "github.com",
+			"owner":         "acme",
+			// missing "name" — Huma's schema rejects with 422
+		},
+	})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", missingFieldBody)
+	require.Equal(http.StatusUnprocessableEntity, resp.StatusCode)
+	resp.Body.Close()
+
+	whitespaceBody := mustMarshal(t, map[string]any{
+		"local_path": repoDir,
+		"platform_identity": map[string]string{
+			"platform_host": "github.com",
+			"owner":         "acme",
+			"name":          "   ",
+		},
+	})
+	resp = httpDo(t, ts, http.MethodPost, "/api/v1/projects", whitespaceBody)
+	require.Equal(http.StatusBadRequest, resp.StatusCode)
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	assert.Contains(string(payload), "platform_identity")
+}
+
+// TestRegisterProject_RejectsPathThatIsAFile guards against an embedder
+// passing a regular file as local_path (e.g. a config file or symlink the
+// host resolved to the wrong target). The handler must reject before
+// recording the row.
+func TestRegisterProject_RejectsPathThatIsAFile(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "not-a-dir.txt")
+	require.NoError(os.WriteFile(filePath, []byte(""), 0o600))
+
+	body := mustMarshal(t, map[string]any{"local_path": filePath})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusBadRequest, resp.StatusCode)
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	assert.Contains(string(payload), "not a directory")
+}
+
+// TestRegisterWorktree_RejectsBlankFields covers the two required worktree
+// fields under both Huma schema validation (missing fields → 422) and the
+// handler's TrimSpace check (whitespace-only fields → 400). Both contracts
+// are embedder-facing; pinning both guards against either layer regressing.
+func TestRegisterWorktree_RejectsBlankFields(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	regBody := mustMarshal(t, map[string]any{"local_path": repoDir})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", regBody)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	var registered map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&registered))
+	resp.Body.Close()
+	projectID, _ := registered["id"].(string)
+
+	cases := []struct {
+		name       string
+		body       map[string]any
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "missing branch returns 422 from schema",
+			body:       map[string]any{"path": "/tmp/whatever"},
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name:       "missing path returns 422 from schema",
+			body:       map[string]any{"branch": "feature-x"},
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name:       "whitespace branch returns 400 from handler",
+			body:       map[string]any{"branch": "   ", "path": "/tmp/whatever"},
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "branch",
+		},
+		{
+			name:       "whitespace path returns 400 from handler",
+			body:       map[string]any{"branch": "feature-x", "path": "   "},
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "path",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustMarshal(t, tc.body)
+			resp := httpDo(t, ts, http.MethodPost,
+				"/api/v1/projects/"+projectID+"/worktrees", body,
+			)
+			defer resp.Body.Close()
+			require.Equal(tc.wantStatus, resp.StatusCode)
+			if tc.wantBody != "" {
+				payload, err := io.ReadAll(resp.Body)
+				require.NoError(err)
+				assert.Contains(string(payload), tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestRegisterWorktree_NotFoundReturns404 pins the failure mode an embedder
+// hits if the project_id is wrong or the project was deleted between
+// register-project and register-worktree.
+func TestRegisterWorktree_NotFoundReturns404(t *testing.T) {
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body := mustMarshal(t, map[string]any{
+		"branch": "feature-x",
+		"path":   "/tmp/wt-1",
+	})
+	resp := httpDo(t, ts, http.MethodPost,
+		"/api/v1/projects/prj_nope/worktrees", body,
+	)
+	require.Equal(http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+}
+
+// TestListProjects_ReturnsEmptyArrayNotNull pins that the JSON response
+// always emits an empty array when no projects are registered. An embedder
+// iterating the response with `for (const p of resp.projects)` would crash
+// on null but works on []. The Go side initializes the slice non-nil; this
+// test catches a regression that lets the empty case marshal to null.
+func TestListProjects_ReturnsEmptyArrayNotNull(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := httpDo(t, ts, http.MethodGet, "/api/v1/projects", nil)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+	var listed map[string]json.RawMessage
+	require.NoError(json.NewDecoder(resp.Body).Decode(&listed))
+	raw, ok := listed["projects"]
+	require.True(ok, "response must include a projects key")
+	assert.Equal("[]", string(raw),
+		"empty list must serialize as [] for embedder iteration safety")
+}
+
+// initLocalOnlyGitRepo runs `git init` in dir without configuring any remote,
+// matching the no-`gh` Add Existing path.
+func initLocalOnlyGitRepo(dir string) error {
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	out, err := json.Marshal(v)
+	require.NoError(t, err)
+	return out
+}
+
+func httpDo(t *testing.T, ts *httptest.Server, method, path string, body []byte) *http.Response {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, ts.URL+path, bodyReader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	return resp
+}

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -665,6 +665,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list-projects"];
+        put?: never;
+        post: operations["register-project"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{project_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get-project"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{project_id}/launch-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list-launch-targets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{project_id}/worktrees": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list-worktrees"];
+        put?: never;
+        post: operations["register-worktree"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/pulls": {
         parameters: {
             query?: never;
@@ -1919,6 +1983,24 @@ export interface components {
             old_num?: number;
             type: string;
         };
+        ListLaunchTargetsOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/ListLaunchTargetsOutputBody.json
+             */
+            readonly $schema?: string;
+            launch_targets: components["schemas"]["LaunchTarget"][] | null;
+        };
+        ListProjectsOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/ListProjectsOutputBody.json
+             */
+            readonly $schema?: string;
+            projects: components["schemas"]["ProjectResponse"][] | null;
+        };
         ListWorkspacesOutputBody: {
             /**
              * Format: uri
@@ -1927,6 +2009,15 @@ export interface components {
              */
             readonly $schema?: string;
             workspaces: components["schemas"]["WorkspaceResponse"][] | null;
+        };
+        ListWorktreesOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/ListWorktreesOutputBody.json
+             */
+            readonly $schema?: string;
+            worktrees: components["schemas"]["WorktreeResponse"][] | null;
         };
         MREvent: {
             /**
@@ -2125,6 +2216,11 @@ export interface components {
             state: string;
             title: string;
         };
+        PlatformIdentityPayload: {
+            name: string;
+            owner: string;
+            platform_host: string;
+        };
         PostCommentHostInputBody: {
             /**
              * Format: uri
@@ -2160,6 +2256,23 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
+        };
+        ProjectResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/ProjectResponse.json
+             */
+            readonly $schema?: string;
+            /** Format: date-time */
+            created_at: string;
+            default_branch?: string;
+            display_name: string;
+            id: string;
+            local_path: string;
+            platform_identity?: components["schemas"]["PlatformIdentityPayload"];
+            /** Format: date-time */
+            updated_at: string;
         };
         ProviderCapabilitiesResponse: {
             comment_mutation: boolean;
@@ -2216,6 +2329,28 @@ export interface components {
             hosts: {
                 [key: string]: components["schemas"]["RateLimitHostStatus"];
             };
+        };
+        RegisterProjectInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RegisterProjectInputBody.json
+             */
+            readonly $schema?: string;
+            default_branch?: string;
+            display_name?: string;
+            local_path: string;
+            platform_identity?: components["schemas"]["PlatformIdentityPayload"];
+        };
+        RegisterWorktreeInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RegisterWorktreeInputBody.json
+             */
+            readonly $schema?: string;
+            branch: string;
+            path: string;
         };
         RepoPreviewRequest: {
             /**
@@ -2586,6 +2721,22 @@ export interface components {
             worktree_branch?: string;
             worktree_key: string;
             worktree_path?: string;
+        };
+        WorktreeResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/WorktreeResponse.json
+             */
+            readonly $schema?: string;
+            branch: string;
+            /** Format: date-time */
+            created_at: string;
+            id: string;
+            path: string;
+            project_id: string;
+            /** Format: date-time */
+            updated_at: string;
         };
     };
     responses: never;
@@ -4116,6 +4267,196 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkspaceResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "list-projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListProjectsOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "register-project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterProjectInputBody"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "list-launch-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListLaunchTargetsOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "list-worktrees": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListWorktreesOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "register-worktree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterWorktreeInputBody"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorktreeResponse"];
                 };
             };
             /** @description Error */


### PR DESCRIPTION
## Summary

- Adds `/workspaces/embed/*` routes that mount individual pieces of the workspaces UX (list, terminal, per-item detail sidebar, empty placeholder, first-run panel, project card) without the surrounding app chrome. Standalone `/workspaces` is unchanged.
- Adds two new `WorkspaceTerminalView` props, `hideWorkspaceList` and `hideRightSidebar`, that an embedder can pass to skip the workspace list column, the right detail sidebar, and the segmented Diff/Issue/PR/Reviews button group.
- Adds a project/worktree registry (migration `000017`) backing six Huma endpoints under `/api/v1`: `register-project`, `list-projects`, `get-project`, `register-worktree`, `list-worktrees`, `list-launch-targets`. Project identity links to `middleman_repos` via FK; registering a project does not subscribe its repo to sync.
- Embed config gains `embed.tooling` (git/gh availability and gh auth state pushed via `__middleman_update_tooling`) and a separate `actions.project[]` registry whose handler returns `CommandResult` so project-scoped surfaces can render in-flight, success, and failure states.
- `RepoSettings` add/remove/refresh actions no longer short-circuit when running inside an embedder; the underlying settings API works the same way embedded or standalone.

The standalone `/workspaces` page is unchanged. Embedders opt in by routing to a `/workspaces/embed/...` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)