### PR TITLE
Reset API budgets after rate windows expire

### DIFF
--- a/internal/ratelimit/rate.go
+++ b/internal/ratelimit/rate.go
@@ -121,10 +121,14 @@ func (rt *RateTracker) BucketKey() string {
 // persists to DB.
 func (rt *RateTracker) RecordRequest() {
 	rt.mu.Lock()
-	defer rt.mu.Unlock()
-	rt.rollIfNeeded()
+	resetFn := rt.rollIfNeeded()
 	rt.count++
 	rt.persist()
+	rt.mu.Unlock()
+
+	if resetFn != nil {
+		resetFn()
+	}
 }
 
 // SetOnWindowReset registers a callback invoked when a provider
@@ -238,9 +242,14 @@ func (rt *RateTracker) Known() bool {
 // the current hour window.
 func (rt *RateTracker) RequestsThisHour() int {
 	rt.mu.Lock()
-	defer rt.mu.Unlock()
-	rt.rollIfNeeded()
-	return rt.count
+	resetFn := rt.rollIfNeeded()
+	count := rt.count
+	rt.mu.Unlock()
+
+	if resetFn != nil {
+		resetFn()
+	}
+	return count
 }
 
 // ResetAt returns a copy of the reset time, or nil if unknown.
@@ -285,7 +294,7 @@ func (rt *RateTracker) isQuotaStale() bool {
 // rate window has expired. When the provider's resetAt is known, it
 // defines the window; otherwise falls back to clock-hour
 // boundaries. Must be called with mu held.
-func (rt *RateTracker) rollIfNeeded() {
+func (rt *RateTracker) rollIfNeeded() func() {
 	if rt.resetAt != nil {
 		if !time.Now().Before(*rt.resetAt) && !rt.lastRolledAt.Equal(*rt.resetAt) {
 			rt.lastRolledAt = *rt.resetAt
@@ -296,8 +305,9 @@ func (rt *RateTracker) rollIfNeeded() {
 			// does not change between windows.
 			rt.resetAt = nil
 			rt.persist()
+			return rt.onWindowReset
 		}
-		return
+		return nil
 	}
 	now := truncateHour(time.Now().UTC())
 	if now.After(rt.hourStart) {
@@ -305,7 +315,10 @@ func (rt *RateTracker) rollIfNeeded() {
 		rt.hourStart = now
 		rt.remaining = -1
 		// Keep rt.limit — same reasoning as above.
+		rt.persist()
+		return rt.onWindowReset
 	}
+	return nil
 }
 
 // persist writes current state to DB. Must be called with mu held.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8864,6 +8864,58 @@ func TestAPIRateLimitsWithBudget(t *testing.T) {
 	assert.Equal(458, gh.BudgetRemaining)
 }
 
+func TestAPIRateLimitsResetExpiredBudgetWindow(t *testing.T) {
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	rt := ghclient.NewRateTracker(database, "github.com", "rest")
+	budget := ghclient.NewSyncBudget(500)
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": &mockGH{}},
+		database, nil,
+		[]ghclient.RepoRef{{
+			Owner: "acme", Name: "widget",
+			PlatformHost: "github.com",
+		}},
+		time.Minute,
+		map[string]*ghclient.RateTracker{"github.com": rt},
+		map[string]*ghclient.SyncBudget{"github.com": budget},
+	)
+	t.Cleanup(syncer.Stop)
+
+	budget.Spend(42)
+	rt.UpdateFromRate(ghclient.Rate{
+		Limit:     5000,
+		Remaining: 3000,
+		Reset:     time.Now().Add(time.Hour),
+	})
+	rt.SetResetAtForTesting(time.Now().Add(-time.Second))
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/rate-limits")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(200, resp.StatusCode)
+
+	var body rateLimitsResponse
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.NoError(t, err)
+
+	gh, ok := body.Hosts["github.com"]
+	assert.True(ok)
+	assert.Equal(500, gh.BudgetLimit)
+	assert.Equal(0, gh.BudgetSpent)
+	assert.Equal(500, gh.BudgetRemaining)
+}
+
 func TestAPIRateLimitsWithGQL(t *testing.T) {
 	assert := Assert.New(t)
 


### PR DESCRIPTION
- Reset sync API budget counters when the provider rate-limit window expires.
- Keep `/api/v1/rate-limits` budget fields fresh after rollover.