### PR TITLE
fix: preserve project provider identity

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -439,14 +439,14 @@ func run(
 	)
 	for _, repo := range startupResolved.Expanded {
 		if _, err := database.UpsertRepo(
-			ctx, repo.PlatformHost, repo.Owner, repo.Name,
+			ctx, db.GitHubRepoIdentity(repo.PlatformHost, repo.Owner, repo.Name),
 		); err != nil {
 			return fmt.Errorf("seed startup repo %s/%s: %w", repo.Owner, repo.Name, err)
 		}
 	}
 	if !strings.EqualFold(defaultPlatformHost, "github.com") {
 		if _, err := database.UpsertRepo(
-			ctx, defaultPlatformHost, "enterprise", "service",
+			ctx, db.GitHubRepoIdentity(defaultPlatformHost, "enterprise", "service"),
 		); err != nil {
 			return fmt.Errorf("seed default-host repo: %w", err)
 		}

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -88,9 +88,9 @@ func TestResolveStartupReposFallsBackToDBForOfflineGlobs(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 
 	ctx := t.Context()
-	_, err = database.UpsertRepo(ctx, "github.com", "acme", "widgets")
+	_, err = database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"))
 	require.NoError(err)
-	_, err = database.UpsertRepo(ctx, "github.com", "acme", "tools")
+	_, err = database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "tools"))
 	require.NoError(err)
 
 	cfg := &config.Config{
@@ -271,11 +271,11 @@ func TestStartupFallbackKeepsPersistedGlobMatchesInAPIs(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 
 	_, err = database.UpsertRepo(
-		t.Context(), "github.com", "roborev-dev", "middleman",
+		t.Context(), db.GitHubRepoIdentity("github.com", "roborev-dev", "middleman"),
 	)
 	require.NoError(err)
 	_, err = database.UpsertRepo(
-		t.Context(), "github.com", "roborev-dev", "worker",
+		t.Context(), db.GitHubRepoIdentity("github.com", "roborev-dev", "worker"),
 	)
 	require.NoError(err)
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1673,9 +1673,12 @@ components:
           type: string
         owner:
           type: string
+        platform:
+          type: string
         platform_host:
           type: string
       required:
+        - platform
         - platform_host
         - owner
         - name

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -665,6 +665,7 @@ type MrImportMetadataResponse struct {
 type PlatformIdentityPayload struct {
 	Name         string `json:"name"`
 	Owner        string `json:"owner"`
+	Platform     string `json:"platform"`
 	PlatformHost string `json:"platform_host"`
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -525,7 +525,7 @@ func TestOpenRepairsLegacyTimestampStorage(t *testing.T) {
 	d, err := Open(path)
 	require.NoError(err)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	mrID, err := d.UpsertMergeRequest(ctx, &MergeRequest{
 		RepoID:            repoID,
@@ -836,7 +836,7 @@ func TestRepoTimestampWritesStoreUTC(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	//nolint:forbidigo // Test fixture intentionally uses a non-UTC zone to verify normalization.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -534,42 +534,9 @@ func (d *DB) PurgeOtherHosts(ctx context.Context, keepHost string) error {
 
 // --- Repos ---
 
-// UpsertRepo inserts a repo if it does not exist, then returns its ID.
-// It accepts either a RepoIdentity or the legacy (host, owner, name) string
-// triple, which is treated as a GitHub identity.
-func (d *DB) UpsertRepo(ctx context.Context, args ...any) (int64, error) {
-	identity, err := repoIdentityFromUpsertArgs(args)
-	if err != nil {
-		return 0, err
-	}
+// UpsertRepo inserts a repo identity if it does not exist, then returns its ID.
+func (d *DB) UpsertRepo(ctx context.Context, identity RepoIdentity) (int64, error) {
 	return d.upsertRepoIdentity(ctx, identity)
-}
-
-func repoIdentityFromUpsertArgs(args []any) (RepoIdentity, error) {
-	switch len(args) {
-	case 1:
-		identity, ok := args[0].(RepoIdentity)
-		if !ok {
-			return RepoIdentity{}, fmt.Errorf("upsert repo: expected RepoIdentity")
-		}
-		return canonicalRepoIdentity(identity), nil
-	case 3:
-		host, ok := args[0].(string)
-		if !ok {
-			return RepoIdentity{}, fmt.Errorf("upsert repo: expected host string")
-		}
-		owner, ok := args[1].(string)
-		if !ok {
-			return RepoIdentity{}, fmt.Errorf("upsert repo: expected owner string")
-		}
-		name, ok := args[2].(string)
-		if !ok {
-			return RepoIdentity{}, fmt.Errorf("upsert repo: expected name string")
-		}
-		return GitHubRepoIdentity(host, owner, name), nil
-	default:
-		return RepoIdentity{}, fmt.Errorf("upsert repo: expected RepoIdentity or host/owner/name")
-	}
 }
 
 func (d *DB) upsertRepoIdentity(ctx context.Context, identity RepoIdentity) (int64, error) {

--- a/internal/db/queries_projects.go
+++ b/internal/db/queries_projects.go
@@ -17,9 +17,10 @@ import (
 // linked repo (a local-only directory with no parseable remote), in which case
 // PlatformIdentity is nil.
 type PlatformIdentity struct {
-	Host  string `json:"platform_host"`
-	Owner string `json:"owner"`
-	Name  string `json:"name"`
+	Platform string `json:"platform"`
+	Host     string `json:"platform_host"`
+	Owner    string `json:"owner"`
+	Name     string `json:"name"`
 }
 
 // Project is the registry record for a local repository checkout middleman
@@ -104,7 +105,7 @@ func (d *DB) CreateProject(ctx context.Context, in CreateProjectInput) (*Project
 
 const projectSelectColumns = `p.id, p.display_name, p.local_path,
         p.default_branch, p.created_at, p.updated_at,
-        r.platform_host, r.owner, r.name`
+        r.platform, r.platform_host, r.owner, r.name`
 
 const projectFromJoin = `FROM middleman_projects p
         LEFT JOIN middleman_repos r ON r.id = p.repo_id`
@@ -270,6 +271,7 @@ func scanProjectFields(scanner interface{ Scan(...any) error }) (*Project, error
 	var (
 		p            Project
 		defaultBr    sql.NullString
+		platform     sql.NullString
 		platformHost sql.NullString
 		repoOwner    sql.NullString
 		repoName     sql.NullString
@@ -277,7 +279,7 @@ func scanProjectFields(scanner interface{ Scan(...any) error }) (*Project, error
 	err := scanner.Scan(
 		&p.ID, &p.DisplayName, &p.LocalPath,
 		&defaultBr, &p.CreatedAt, &p.UpdatedAt,
-		&platformHost, &repoOwner, &repoName,
+		&platform, &platformHost, &repoOwner, &repoName,
 	)
 	if err != nil {
 		return nil, err
@@ -287,9 +289,10 @@ func scanProjectFields(scanner interface{ Scan(...any) error }) (*Project, error
 	}
 	if platformHost.Valid {
 		p.PlatformIdentity = &PlatformIdentity{
-			Host:  platformHost.String,
-			Owner: repoOwner.String,
-			Name:  repoName.String,
+			Platform: platform.String,
+			Host:     platformHost.String,
+			Owner:    repoOwner.String,
+			Name:     repoName.String,
 		}
 	}
 	return &p, nil

--- a/internal/db/queries_projects_test.go
+++ b/internal/db/queries_projects_test.go
@@ -41,7 +41,7 @@ func TestCreateProjectLinkedToRepo(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "wesm", "examplerepo")
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "wesm", "examplerepo"))
 	require.NoError(err)
 
 	project, err := d.CreateProject(ctx, CreateProjectInput{
@@ -71,7 +71,7 @@ func TestCreateProjectFKSetNullOnRepoDelete(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "wesm", "examplerepo")
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "wesm", "examplerepo"))
 	require.NoError(err)
 
 	project, err := d.CreateProject(ctx, CreateProjectInput{

--- a/internal/db/queries_resolve_test.go
+++ b/internal/db/queries_resolve_test.go
@@ -13,7 +13,7 @@ func TestResolveItemNumber(t *testing.T) {
 	database := openTestDB(t)
 	ctx := t.Context()
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	// Seed a PR at number 10

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -113,7 +113,7 @@ func TestStartWorkspaceRetryPreservesBranchUntilCleanupSucceeds(t *testing.T) {
 
 func insertTestRepo(t *testing.T, d *DB, owner, name string) int64 {
 	t.Helper()
-	id, err := d.UpsertRepo(t.Context(), "github.com", owner, name)
+	id, err := d.UpsertRepo(t.Context(), GitHubRepoIdentity("github.com", owner, name))
 	require.NoErrorf(t, err, "UpsertRepo(%s/%s)", owner, name)
 	return id
 }
@@ -529,14 +529,14 @@ func TestUpsertAndListRepos(t *testing.T) {
 	d := openTestDB(t)
 	ctx := t.Context()
 
-	id1, err := d.UpsertRepo(ctx, "github.com", "alice", "alpha")
+	id1, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "alice", "alpha"))
 	require.NoError(err)
-	id2, err := d.UpsertRepo(ctx, "github.com", "bob", "beta")
+	id2, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "bob", "beta"))
 	require.NoError(err)
 	assert.NotEqual(id1, id2)
 
 	// Idempotency: re-inserting should return the same ID.
-	id1Again, err := d.UpsertRepo(ctx, "github.com", "alice", "alpha")
+	id1Again, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "alice", "alpha"))
 	require.NoError(err)
 	assert.Equal(id1, id1Again)
 
@@ -556,7 +556,7 @@ func TestUpsertRepoDefaultsToGitHubIdentity(t *testing.T) {
 	d := openTestDB(t)
 	ctx := t.Context()
 
-	id, err := d.UpsertRepo(ctx, "github.com", "Alice", "Alpha")
+	id, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "Alice", "Alpha"))
 	require.NoError(err)
 
 	repo, err := d.GetRepoByID(ctx, id)
@@ -1202,10 +1202,10 @@ func TestUpsertRepoCasefoldsOwnerAndName(t *testing.T) {
 	d := openTestDB(t)
 	ctx := t.Context()
 
-	id, err := d.UpsertRepo(ctx, "github.com", "Org", "Foo")
+	id, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "Org", "Foo"))
 	require.NoError(err)
 
-	sameID, err := d.UpsertRepo(ctx, "github.com", "org", "foo")
+	sameID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "org", "foo"))
 	require.NoError(err)
 	assert.Equal(id, sameID)
 
@@ -1542,7 +1542,7 @@ func TestListMergeRequests_AttachesLabels(t *testing.T) {
 	ctx := t.Context()
 	now := baseTime()
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	_, err = d.UpsertMergeRequest(ctx, &MergeRequest{
@@ -2319,7 +2319,7 @@ func TestListIssues_AttachesLabels(t *testing.T) {
 	ctx := t.Context()
 	now := baseTime()
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	issueID, err := d.UpsertIssue(ctx, &Issue{
@@ -2498,9 +2498,9 @@ func TestListIssues_UsesRepoScopedLabels(t *testing.T) {
 	ctx := t.Context()
 	now := baseTime()
 
-	repoA, err := d.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoA, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
-	repoB, err := d.UpsertRepo(ctx, "github.com", "acme", "gadget")
+	repoB, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "gadget"))
 	require.NoError(err)
 
 	issueID, err := d.UpsertIssue(ctx, &Issue{

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -712,7 +712,7 @@ func TestSyncRepoOverviewPreservesTimelineWhenCloneUnavailable(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 	d := openTestDB(t)
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	oldPublishedAt := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
@@ -792,7 +792,7 @@ func TestSyncRepoOverviewUsesTagsWhenRepoHasNoReleases(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 	d := openTestDB(t)
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	tagName := "v1.2.3"
@@ -844,7 +844,7 @@ func TestSyncRepoOverviewClearsReleasesWhenTagFallbackFails(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 	d := openTestDB(t)
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	publishedAt := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
@@ -4685,7 +4685,7 @@ func TestRefreshCIStatusAlwaysFetchesCombined(t *testing.T) {
 		nil,
 	)
 
-	repoID, _ := d.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	repoID, _ := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	err := syncer.refreshCIStatus(
 		t.Context(),
 		RepoRef{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
@@ -4722,7 +4722,7 @@ func TestRefreshCIStatusFallsBackToCombinedWhenNoCheckRuns(t *testing.T) {
 		nil,
 	)
 
-	repoID, _ := d.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	repoID, _ := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	err := syncer.refreshCIStatus(
 		t.Context(),
 		RepoRef{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
@@ -4744,7 +4744,7 @@ func TestSyncer_OnStatusChangeCallback(t *testing.T) {
 	assert := Assert.New(t)
 	mock := &mockClient{openPRs: []*gh.PullRequest{}}
 	d := openTestDB(t)
-	_, err := d.UpsertRepo(t.Context(), "github.com", "o", "n")
+	_, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "o", "n"))
 	require.NoError(t, err)
 	repos := []RepoRef{{Owner: "o", Name: "n", PlatformHost: "github.com"}}
 	s := NewSyncer(
@@ -4779,7 +4779,7 @@ func TestSyncer_TriggerRunRunsRunOnce(t *testing.T) {
 	assert := Assert.New(t)
 	mock := &mockClient{openPRs: []*gh.PullRequest{}}
 	d := openTestDB(t)
-	_, err := d.UpsertRepo(t.Context(), "github.com", "o", "n")
+	_, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "o", "n"))
 	require.NoError(t, err)
 	repos := []RepoRef{{Owner: "o", Name: "n", PlatformHost: "github.com"}}
 	s := NewSyncer(
@@ -5089,7 +5089,7 @@ func TestFetchAndUpdateClosedRefreshesPRLabels(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
 	pr := buildOpenPR(7, now)
@@ -5131,9 +5131,9 @@ func TestFetchAndUpdateClosedRefreshesPRLabelsWithSameRepoOnAnotherHost(t *testi
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	otherRepoID, err := d.UpsertRepo(ctx, "ghe.corp.com", "owner", "repo")
+	otherRepoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("ghe.corp.com", "owner", "repo"))
 	require.NoError(err)
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
 
@@ -5202,7 +5202,7 @@ func TestFetchAndUpdateClosedRefreshesIssueLabels(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	now := time.Date(2024, 6, 6, 12, 0, 0, 0, time.UTC)
 	issueNumber := 9
@@ -5241,9 +5241,9 @@ func TestFetchAndUpdateClosedRefreshesIssueLabelsWithSameRepoOnAnotherHost(t *te
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	otherRepoID, err := d.UpsertRepo(ctx, "ghe.corp.com", "owner", "repo")
+	otherRepoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("ghe.corp.com", "owner", "repo"))
 	require.NoError(err)
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	now := time.Date(2024, 6, 6, 12, 0, 0, 0, time.UTC)
 	issueNumber := 9
@@ -5308,7 +5308,7 @@ func TestBackfillRepoPersistsPRLabels(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
 	require.NoError(err)
@@ -5338,7 +5338,7 @@ func TestBackfillRepoPersistsIssueLabels(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	_, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	_, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
 	require.NoError(err)
@@ -5467,7 +5467,7 @@ func TestBackfillRepoStoresCompletionTimestampsInUTC(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	_, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	_, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
 	require.NoError(err)
@@ -5512,7 +5512,7 @@ func TestBackfillRepoDoesNotAdvancePRCursorWhenLabelPersistenceFails(t *testing.
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
 	require.NoError(err)
@@ -5563,7 +5563,7 @@ func TestBackfillRepoDoesNotAdvanceIssueCursorWhenLabelPersistenceFails(t *testi
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
 	require.NoError(err)
@@ -6289,7 +6289,7 @@ func TestFetchMRDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC)
@@ -6365,7 +6365,7 @@ func TestFetchIssueDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Date(2024, 6, 2, 12, 0, 0, 0, time.UTC)
@@ -6455,7 +6455,7 @@ func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *test
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Date(2024, 6, 3, 12, 0, 0, 0, time.UTC)
@@ -6530,7 +6530,7 @@ func TestSyncOpenMRFromBulkUpdatesCommentFieldsWhenOnlyCommentsAreComplete(t *te
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Date(2024, 6, 3, 13, 0, 0, 0, time.UTC)
@@ -6601,7 +6601,7 @@ func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Date(2024, 6, 3, 14, 0, 0, 0, time.UTC)
@@ -6658,7 +6658,7 @@ func TestSyncOpenMRFromBulkClearsCIWhenHeadSHAChanges(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	// Seed an existing MR with the old head SHA and stored CI status.
@@ -6718,7 +6718,7 @@ func TestSyncOpenMRFromBulkPreservesCIWhenHeadSHAUnchanged(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	// Same head SHA as buildOpenPR uses by default.
@@ -6778,7 +6778,7 @@ func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *t
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Date(2024, 6, 3, 12, 0, 0, 0, time.UTC)
@@ -6871,7 +6871,7 @@ func TestSyncRepoGraphQLIssues(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -7187,7 +7187,7 @@ func TestSyncRepoGraphQLIssuesCommentsIncomplete(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -7265,7 +7265,7 @@ func TestSyncRepoGraphQLIssuesClosureDetection(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -7336,7 +7336,7 @@ func TestSyncRepoGraphQLIssuesPreservesExistingFields(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -7415,7 +7415,7 @@ func TestSyncRepoGraphQLIssuesClearsDetailFetchedAtOnFailedFallback(t *testing.T
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -7693,7 +7693,7 @@ func TestRefreshRepoPRCommentsUsesFullFetchForLargeThreads(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -7744,7 +7744,7 @@ func TestRefreshRepoIssueCommentsUsesFullFetchForLargeThreads(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)
 
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -8055,7 +8055,7 @@ func TestDeferredCommentRefreshYieldsBudgetToDetailDrain(t *testing.T) {
 
 	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
 	budget := testBudget(11)
-	repoID, err := d.UpsertRepo(ctx, "github.com", "owner", "repo")
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
 

--- a/internal/projects/identity.go
+++ b/internal/projects/identity.go
@@ -16,7 +16,13 @@ import (
 
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitenv"
+	platformpkg "github.com/wesm/middleman/internal/platform"
 )
+
+type KnownPlatformHost struct {
+	Platform string
+	Host     string
+}
 
 // ResolveIdentityFromPath runs `git remote get-url origin` in path and parses
 // the result into an optional PlatformIdentity. Returns (nil, nil) when no
@@ -26,6 +32,14 @@ import (
 // responsibility. Per the consolidation spec's Decision 7, unknown identity
 // is allowed and does not block registration.
 func ResolveIdentityFromPath(ctx context.Context, path string) (*db.PlatformIdentity, error) {
+	return ResolveIdentityFromPathWithKnownPlatforms(ctx, path, nil)
+}
+
+func ResolveIdentityFromPathWithKnownPlatforms(
+	ctx context.Context,
+	path string,
+	known []KnownPlatformHost,
+) (*db.PlatformIdentity, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, fmt.Errorf("path is required")
 	}
@@ -46,14 +60,18 @@ func ResolveIdentityFromPath(ctx context.Context, path string) (*db.PlatformIden
 		}
 		return nil, fmt.Errorf("git remote get-url origin: %w", err)
 	}
-	return ParseRemoteURL(string(out)), nil
+	return ParseRemoteURLWithKnownPlatforms(string(out), known), nil
 }
 
 // ParseRemoteURL recognizes the common remote URL shapes (HTTPS, SSH SCP-style,
 // ssh://) and extracts a PlatformIdentity. Returns nil for anything it does
-// not recognize, including local paths, file:// URLs, and remotes whose path
-// does not contain exactly two segments (owner/name).
+// not recognize, including local paths, file:// URLs, unknown self-hosted
+// hosts, and nested owner paths on platforms that do not support them.
 func ParseRemoteURL(remote string) *db.PlatformIdentity {
+	return ParseRemoteURLWithKnownPlatforms(remote, nil)
+}
+
+func ParseRemoteURLWithKnownPlatforms(remote string, known []KnownPlatformHost) *db.PlatformIdentity {
 	remote = strings.TrimSpace(remote)
 	if remote == "" {
 		return nil
@@ -64,22 +82,48 @@ func ParseRemoteURL(remote string) *db.PlatformIdentity {
 		return nil
 	}
 
+	host = strings.ToLower(host)
 	path = strings.TrimSuffix(path, "/")
 	path = strings.TrimSuffix(path, ".git")
 	parts := strings.Split(path, "/")
-	if len(parts) != 2 {
+	platform, ok := resolvePlatform(host, known)
+	if !ok {
 		return nil
 	}
-	owner, name := parts[0], parts[1]
+	if len(parts) < 2 || (len(parts) > 2 && !platformpkg.AllowsNestedOwner(platformpkg.Kind(platform))) {
+		return nil
+	}
+	owner, name := strings.Join(parts[:len(parts)-1], "/"), parts[len(parts)-1]
 	if owner == "" || name == "" {
 		return nil
 	}
 
 	return &db.PlatformIdentity{
-		Host:  strings.ToLower(host),
-		Owner: strings.ToLower(owner),
-		Name:  strings.ToLower(name),
+		Platform: platform,
+		Host:     host,
+		Owner:    strings.ToLower(owner),
+		Name:     strings.ToLower(name),
 	}
+}
+
+func resolvePlatform(host string, known []KnownPlatformHost) (string, bool) {
+	for _, candidate := range known {
+		if strings.EqualFold(candidate.Host, host) && strings.TrimSpace(candidate.Platform) != "" {
+			return strings.ToLower(strings.TrimSpace(candidate.Platform)), true
+		}
+	}
+	for _, kind := range []platformpkg.Kind{
+		platformpkg.KindGitHub,
+		platformpkg.KindGitLab,
+		platformpkg.KindForgejo,
+		platformpkg.KindGitea,
+	} {
+		defaultHost, ok := platformpkg.DefaultHost(kind)
+		if ok && strings.EqualFold(defaultHost, host) {
+			return string(kind), true
+		}
+	}
+	return "", false
 }
 
 // splitRemote separates a remote URL into (host, path) without hard-coding
@@ -97,7 +141,10 @@ func splitRemote(remote string) (host, path string) {
 		if u.Scheme == "file" {
 			return "", ""
 		}
-		return u.Hostname(), strings.TrimPrefix(u.Path, "/")
+		if u.Scheme == "ssh" && u.Port() == "22" {
+			return u.Hostname(), strings.TrimPrefix(u.Path, "/")
+		}
+		return u.Host, strings.TrimPrefix(u.Path, "/")
 	}
 
 	atIdx := strings.Index(remote, "@")

--- a/internal/projects/identity_test.go
+++ b/internal/projects/identity_test.go
@@ -48,7 +48,6 @@ func TestParseRemoteURL_OtherHosts(t *testing.T) {
 	}{
 		{"gitlab", "git@gitlab.com:group/project.git", "gitlab.com/group/project"},
 		{"codeberg", "https://codeberg.org/owner/repo.git", "codeberg.org/owner/repo"},
-		{"self_hosted", "git@git.example.com:team/svc.git", "git.example.com/team/svc"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -59,6 +58,57 @@ func TestParseRemoteURL_OtherHosts(t *testing.T) {
 			assert.Equal(tc.want, got.Host+"/"+got.Owner+"/"+got.Name)
 		})
 	}
+}
+
+func TestParseRemoteURL_ConfiguredSelfHostedGitLab(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	got := ParseRemoteURLWithKnownPlatforms(
+		"git@code.example.com:group/project.git",
+		[]KnownPlatformHost{{Platform: "gitlab", Host: "code.example.com"}},
+	)
+
+	require.NotNil(got)
+	assert.Equal("gitlab", got.Platform)
+	assert.Equal("code.example.com", got.Host)
+	assert.Equal("group", got.Owner)
+	assert.Equal("project", got.Name)
+}
+
+func TestParseRemoteURL_ConfiguredSelfHostedGitLabWithURLPort(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	got := ParseRemoteURLWithKnownPlatforms(
+		"https://gitlab.example.com:8443/group/project.git",
+		[]KnownPlatformHost{{Platform: "gitlab", Host: "gitlab.example.com:8443"}},
+	)
+
+	require.NotNil(got)
+	assert.Equal("gitlab", got.Platform)
+	assert.Equal("gitlab.example.com:8443", got.Host)
+	assert.Equal("group", got.Owner)
+	assert.Equal("project", got.Name)
+}
+
+func TestParseRemoteURL_NestedGitLabRepoPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	got := ParseRemoteURL("git@gitlab.com:group/subgroup/project.git")
+
+	require.NotNil(got)
+	assert.Equal("gitlab", got.Platform)
+	assert.Equal("gitlab.com", got.Host)
+	assert.Equal("group/subgroup", got.Owner)
+	assert.Equal("project", got.Name)
+}
+
+func TestParseRemoteURL_UnknownSelfHostedRemoteIsLocalOnly(t *testing.T) {
+	assert := Assert.New(t)
+
+	assert.Nil(ParseRemoteURL("git@code.example.com:group/project.git"))
 }
 
 func TestParseRemoteURL_Unrecognized(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -705,7 +705,7 @@ func seedPR(t *testing.T, database *db.DB, owner, name string, number int, opts 
 	t.Helper()
 	ctx := t.Context()
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", owner, name)
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
 
 	numberText := strconv.Itoa(number)
@@ -1875,7 +1875,7 @@ func TestAPIGetPullNoDiffWarningWhenSHAsPresent(t *testing.T) {
 
 	seedPR(t, database, "acme", "widget", 2)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	headSHA := "deadbeef00000000000000000000000000000001"
 	baseSHA := "deadbeef00000000000000000000000000000010"
@@ -1927,7 +1927,7 @@ func TestAPIGetPullEmitsStaleDiffWarning(t *testing.T) {
 
 	seedPR(t, database, "acme", "widget", 3)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	// Platform reports the latest head; the recorded diff SHAs are from
 	// an earlier push that no longer matches.
@@ -1981,7 +1981,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnBaseDrift(t *testing.T) {
 
 	seedPR(t, database, "acme", "widget", 4)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	// Head matches, but the platform base advanced past the recorded
 	// diff base — for example a merge landed on main after the diff
@@ -2038,7 +2038,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnMergedPR(t *testing.T) {
 
 	seedPR(t, database, "acme", "widget", 5)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	now := time.Now().UTC().Truncate(time.Second)
 	mergedAt := now
@@ -2094,7 +2094,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissingClosed(t *testing.T) {
 
 	seedPR(t, database, "acme", "widget", 6)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	now := time.Now().UTC().Truncate(time.Second)
 	closedAt := now
@@ -2144,7 +2144,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnClosedPR(t *testing.T) {
 
 	seedPR(t, database, "acme", "widget", 7)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	now := time.Now().UTC().Truncate(time.Second)
 	closedAt := now
@@ -2198,7 +2198,7 @@ func TestAPIGetPullNoDiffWarningOnMergedPRWithBaseDrift(t *testing.T) {
 
 	seedPR(t, database, "acme", "widget", 8)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	now := time.Now().UTC().Truncate(time.Second)
 	mergedAt := now
@@ -2296,7 +2296,7 @@ func TestAPISyncPRSanitizesDiffFailureWarning(t *testing.T) {
 	t.Cleanup(syncer.Stop)
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
-	_, err = database.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
@@ -2367,7 +2367,7 @@ func TestAPIListRepos(t *testing.T) {
 	srv, database := setupTestServer(t)
 	client := setupTestClient(t, srv)
 
-	_, err := database.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	resp, err := client.HTTP.ListReposWithResponse(t.Context())
@@ -3141,7 +3141,7 @@ platform_host = "ghe.example.com"
 `, &mockGH{})
 
 	_, err := database.UpsertRepo(
-		t.Context(), "ghe.example.com", "acme", "widgets",
+		t.Context(), db.GitHubRepoIdentity("ghe.example.com", "acme", "widgets"),
 	)
 	require.NoError(err)
 	srv.syncer.SetRepos([]ghclient.RepoRef{{
@@ -3357,7 +3357,7 @@ func TestAPIListRepoSummariesClearsStaleOverviewWhenTagFallbackFails(t *testing.
 	require.NoError(err)
 	t.Cleanup(func() { require.NoError(database.Close()) })
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "tagless")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "tagless"))
 	require.NoError(err)
 
 	publishedAt := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
@@ -3484,7 +3484,7 @@ func TestAPICreateIssue(t *testing.T) {
 	)
 	client := setupTestClient(t, srv)
 
-	_, err := database.UpsertRepo(context.Background(), "github.com", "acme", "widgets")
+	_, err := database.UpsertRepo(context.Background(), db.GitHubRepoIdentity("github.com", "acme", "widgets"))
 	require.NoError(err)
 
 	resp, err := client.HTTP.CreateIssueWithResponse(
@@ -3540,7 +3540,7 @@ func TestAPICreateIssueRejectsNilProviderPayload(t *testing.T) {
 	)
 	client := setupTestClient(t, srv)
 
-	repoID, err := database.UpsertRepo(t.Context(), "github.com", "acme", "widgets")
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"))
 	require.NoError(err)
 
 	resp, err := client.HTTP.CreateIssueWithResponse(
@@ -3850,9 +3850,9 @@ func TestAPICreateIssueUsesPlatformHost(t *testing.T) {
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	_, err = database.UpsertRepo(context.Background(), "github.com", "acme", "widgets")
+	_, err = database.UpsertRepo(context.Background(), db.GitHubRepoIdentity("github.com", "acme", "widgets"))
 	require.NoError(err)
-	enterpriseRepoID, err := database.UpsertRepo(context.Background(), "ghe.example.com", "acme", "widgets")
+	enterpriseRepoID, err := database.UpsertRepo(context.Background(), db.GitHubRepoIdentity("ghe.example.com", "acme", "widgets"))
 	require.NoError(err)
 
 	client := setupTestClient(t, srv)
@@ -4096,7 +4096,7 @@ func TestAPICommentAutocomplete(t *testing.T) {
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	prID, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:         repoID,
@@ -4165,7 +4165,7 @@ func TestAPICommentAutocompleteUsesRepoPlatformHost(t *testing.T) {
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
 
-	githubRepoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	githubRepoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:         githubRepoID,
@@ -4183,7 +4183,7 @@ func TestAPICommentAutocompleteUsesRepoPlatformHost(t *testing.T) {
 	})
 	require.NoError(err)
 
-	repoID, err := database.UpsertRepo(ctx, "ghe.example.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("ghe.example.com", "acme", "widget"))
 	require.NoError(err)
 	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:         repoID,
@@ -4365,7 +4365,7 @@ func TestAPIReadyForReview(t *testing.T) {
 	)
 	client := setupTestClient(t, srv)
 
-	repoID, err := database.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -4487,7 +4487,7 @@ func TestOpenAPIEndpointReflectsHumaContract(t *testing.T) {
 func seedIssue(t *testing.T, database *db.DB, owner, name string, number int, state string) int64 {
 	t.Helper()
 	ctx := t.Context()
-	repoID, err := database.UpsertRepo(ctx, "github.com", owner, name)
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -4523,7 +4523,7 @@ func seedIssueOnHost(
 	t.Helper()
 	ctx := context.Background()
 
-	repoID, err := database.UpsertRepo(ctx, host, owner, name)
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity(host, owner, name))
 	require.NoError(t, err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -5127,7 +5127,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 	srv, database := setupTestServerWithMock(t, mock)
 	client := setupTestClient(t, srv)
 
-	repoID, err := database.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	prID, err := database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
@@ -6040,7 +6040,7 @@ func TestAPIIssueDataFromGraphQLSync(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	// Seed DB directly — same shape as GraphQL sync output.
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -6293,7 +6293,7 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 	// detector's slower execution) the fresh GraphQL data would be
 	// blocked and the assertion below would read back the stale 5
 	// — a test-only flake, not a production bug.
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	stale := now.Add(-time.Second)
 	_, err = database.UpsertIssue(ctx, &db.Issue{
@@ -7702,7 +7702,7 @@ func TestAPISetIssueGitHubStateReturns404WhenNoClientConfigured(t *testing.T) {
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, repos)
 	ctx := t.Context()
 
-	repoID, err := database.UpsertRepo(ctx, "ghe.corp.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("ghe.corp.com", "acme", "widget"))
 	require.NoError(err)
 	_, err = database.UpsertIssue(ctx, &db.Issue{
 		RepoID:         repoID,
@@ -8089,7 +8089,7 @@ func TestResolveItem_NotFoundOnGitHub(t *testing.T) {
 	}
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "widget"}}
 	srv, database := setupTestServerWithRepos(t, mock, repos)
-	_, err := database.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	client := setupTestClient(t, srv)
 
@@ -8112,7 +8112,7 @@ func TestResolveItem_GitHubServerError(t *testing.T) {
 	}
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "widget"}}
 	srv, database := setupTestServerWithRepos(t, mock, repos)
-	_, err := database.UpsertRepo(t.Context(), "github.com", "acme", "widget")
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	client := setupTestClient(t, srv)
 
@@ -8162,7 +8162,7 @@ func TestAPIGetMRImportMetadata(t *testing.T) {
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -10174,7 +10174,12 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	seedPR(t, database, "acme", "widget", 1)
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
 	require.NoError(err)
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, mergeBase, mergeBase))
 
@@ -10680,7 +10685,7 @@ func TestAPIGetPullDetailLoaded(t *testing.T) {
 	// Insert a second PR with DetailFetchedAt set.
 	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:          repoID,
@@ -10715,7 +10720,7 @@ func TestAPIGetPullDetailIncludesDiffSummaryRevisionFields(t *testing.T) {
 
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -10806,7 +10811,7 @@ func TestAPIActivityStartupRepairsLegacyTimestampStorage(t *testing.T) {
 	database, err := db.Open(path)
 	require.NoError(err)
 
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	prID, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:            repoID,
@@ -11088,7 +11093,7 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 
 	seedPR(t, database, "acme", "widget", 1)
 	ctx := t.Context()
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(t, err)
 	require.NoError(t, database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, mergeBase, mergeBase))
 
@@ -11299,7 +11304,7 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 
 	seedPR(t, database, "acme", "rootrepo", 1)
 	ctx := t.Context()
-	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "rootrepo")
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "rootrepo"))
 	require.NoError(err)
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"))
 
@@ -11411,7 +11416,7 @@ func seedStackedPRDraft(
 ) int64 {
 	t.Helper()
 	ctx := t.Context()
-	repoID, err := database.UpsertRepo(ctx, "github.com", owner, name)
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
 	now := time.Now().UTC().Truncate(time.Second)
 	pr := &db.MergeRequest{
@@ -15687,7 +15692,7 @@ func seedPROnHost(
 	t.Helper()
 	ctx := t.Context()
 
-	repoID, err := database.UpsertRepo(ctx, host, owner, name)
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity(host, owner, name))
 	require.NoError(t, err)
 
 	now := time.Now().UTC().Truncate(time.Second)

--- a/internal/server/projects_handlers.go
+++ b/internal/server/projects_handlers.go
@@ -17,6 +17,7 @@ import (
 )
 
 type platformIdentityPayload struct {
+	Platform     string `json:"platform"`
 	PlatformHost string `json:"platform_host"`
 	Owner        string `json:"owner"`
 	Name         string `json:"name"`
@@ -141,7 +142,12 @@ func (s *Server) registerProject(
 
 	var repoID sql.NullInt64
 	if identity != nil {
-		id, upsertErr := s.db.UpsertRepo(ctx, identity.Host, identity.Owner, identity.Name)
+		id, upsertErr := s.db.UpsertRepo(ctx, db.RepoIdentity{
+			Platform:     identity.Platform,
+			PlatformHost: identity.Host,
+			Owner:        identity.Owner,
+			Name:         identity.Name,
+		})
 		if upsertErr != nil {
 			return nil, huma.Error500InternalServerError(
 				"upsert repo identity: " + upsertErr.Error(),
@@ -178,23 +184,50 @@ func (s *Server) resolveProjectIdentity(
 	abs string,
 ) (*db.PlatformIdentity, error) {
 	if caller != nil {
+		platform := strings.TrimSpace(caller.Platform)
 		host := strings.TrimSpace(caller.PlatformHost)
 		owner := strings.TrimSpace(caller.Owner)
 		name := strings.TrimSpace(caller.Name)
-		if host == "" || owner == "" || name == "" {
+		if platform == "" || host == "" || owner == "" || name == "" {
 			return nil, huma.Error400BadRequest(
-				"platform_identity requires platform_host, owner, and name",
+				"platform_identity requires platform, platform_host, owner, and name",
 			)
 		}
-		return &db.PlatformIdentity{Host: host, Owner: owner, Name: name}, nil
+		return &db.PlatformIdentity{Platform: platform, Host: host, Owner: owner, Name: name}, nil
 	}
-	resolved, err := projects.ResolveIdentityFromPath(ctx, abs)
+	resolved, err := projects.ResolveIdentityFromPathWithKnownPlatforms(
+		ctx, abs, s.knownProjectPlatformHosts(),
+	)
 	if err != nil {
 		return nil, huma.Error500InternalServerError(
 			"resolve platform identity: " + err.Error(),
 		)
 	}
 	return resolved, nil
+}
+
+func (s *Server) knownProjectPlatformHosts() []projects.KnownPlatformHost {
+	if s.cfg == nil {
+		return nil
+	}
+	known := make([]projects.KnownPlatformHost, 0, len(s.cfg.Platforms)+len(s.cfg.Repos)+1)
+	known = append(known, projects.KnownPlatformHost{
+		Platform: "github",
+		Host:     s.cfg.DefaultPlatformHost,
+	})
+	for _, platform := range s.cfg.Platforms {
+		known = append(known, projects.KnownPlatformHost{
+			Platform: platform.Type,
+			Host:     platform.Host,
+		})
+	}
+	for _, repo := range s.cfg.Repos {
+		known = append(known, projects.KnownPlatformHost{
+			Platform: repo.PlatformOrDefault(),
+			Host:     repo.PlatformHostOrDefault(),
+		})
+	}
+	return known
 }
 
 func (s *Server) listProjects(
@@ -310,6 +343,7 @@ func projectResponseFromDB(p *db.Project) projectResponse {
 	}
 	if p.PlatformIdentity != nil {
 		resp.PlatformIdentity = &platformIdentityPayload{
+			Platform:     p.PlatformIdentity.Platform,
 			PlatformHost: p.PlatformIdentity.Host,
 			Owner:        p.PlatformIdentity.Owner,
 			Name:         p.PlatformIdentity.Name,

--- a/internal/server/projects_handlers_test.go
+++ b/internal/server/projects_handlers_test.go
@@ -15,6 +15,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/db"
 )
 
 // TestW1SliceAGate is the falsifiable capability gate from the convergence
@@ -207,6 +208,132 @@ func TestRegisterProject_RejectsMissingPath(t *testing.T) {
 	assert.Contains(string(payload), "local_path")
 }
 
+func TestRegisterProject_PreservesExplicitProviderIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(repoDir))
+
+	body := mustMarshal(t, map[string]any{
+		"local_path": repoDir,
+		"platform_identity": map[string]string{
+			"platform":      "gitlab",
+			"platform_host": "git.example.com",
+			"owner":         "platform",
+			"name":          "runner",
+		},
+	})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	defer resp.Body.Close()
+
+	var registered struct {
+		ID               string `json:"id"`
+		PlatformIdentity struct {
+			Platform     string `json:"platform"`
+			PlatformHost string `json:"platform_host"`
+			Owner        string `json:"owner"`
+			Name         string `json:"name"`
+		} `json:"platform_identity"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&registered))
+	assert.Equal("gitlab", registered.PlatformIdentity.Platform)
+	assert.Equal("git.example.com", registered.PlatformIdentity.PlatformHost)
+
+	project, err := database.GetProjectByID(t.Context(), registered.ID)
+	require.NoError(err)
+	require.NotNil(project.PlatformIdentity)
+	assert.Equal(&db.PlatformIdentity{
+		Platform: "gitlab",
+		Host:     "git.example.com",
+		Owner:    "platform",
+		Name:     "runner",
+	}, project.PlatformIdentity)
+}
+
+func TestRegisterProject_UsesConfiguredProviderForRemoteIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[platforms]]
+type = "gitlab"
+host = "code.example.com"
+`, &mockGH{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q")
+	runGit(t, repoDir, "remote", "add", "origin", "git@code.example.com:group/subgroup/project.git")
+
+	body := mustMarshal(t, map[string]any{"local_path": repoDir})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	defer resp.Body.Close()
+
+	var registered map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&registered))
+	identity, ok := registered["platform_identity"].(map[string]any)
+	require.True(ok, "platform_identity must be present")
+	assert.Equal("gitlab", identity["platform"])
+	assert.Equal("code.example.com", identity["platform_host"])
+	assert.Equal("group/subgroup", identity["owner"])
+	assert.Equal("project", identity["name"])
+}
+
+func TestRegisterProject_UsesDefaultPlatformHostForRemoteIdentity(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+default_platform_host = "ghe.example.com"
+host = "127.0.0.1"
+port = 8091
+`, &mockGH{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q")
+	runGit(t, repoDir, "remote", "add", "origin", "git@ghe.example.com:acme/widget.git")
+
+	body := mustMarshal(t, map[string]any{"local_path": repoDir})
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	defer resp.Body.Close()
+
+	var registered map[string]any
+	require.NoError(json.NewDecoder(resp.Body).Decode(&registered))
+	identity, ok := registered["platform_identity"].(map[string]any)
+	require.True(ok, "platform_identity must be present")
+	assert.Equal("github", identity["platform"])
+	assert.Equal("ghe.example.com", identity["platform_host"])
+	assert.Equal("acme", identity["owner"])
+	assert.Equal("widget", identity["name"])
+}
+
 func TestRegisterProject_RejectsNonexistentPath(t *testing.T) {
 	require := require.New(t)
 
@@ -267,6 +394,7 @@ func TestRegisterProject_AcceptsCallerProvidedIdentity(t *testing.T) {
 	body := mustMarshal(t, map[string]any{
 		"local_path": repoDir,
 		"platform_identity": map[string]string{
+			"platform":      "github",
 			"platform_host": "github.com",
 			"owner":         "acme",
 			"name":          "widget",
@@ -279,6 +407,7 @@ func TestRegisterProject_AcceptsCallerProvidedIdentity(t *testing.T) {
 	resp.Body.Close()
 	identity, _ := got["platform_identity"].(map[string]any)
 	require.NotNil(identity)
+	assert.Equal("github", identity["platform"])
 	assert.Equal("github.com", identity["platform_host"])
 	assert.NotContains(identity, "host")
 	assert.Equal("acme", identity["owner"])
@@ -296,6 +425,7 @@ func TestRegisterProject_AcceptsCallerProvidedIdentity(t *testing.T) {
 	resp.Body.Close()
 	identity2, _ := fetched["platform_identity"].(map[string]any)
 	require.NotNil(identity2)
+	assert.Equal("github", identity2["platform"])
 	assert.Equal("github.com", identity2["platform_host"])
 	assert.NotContains(identity2, "host")
 	assert.Equal("acme", identity2["owner"])
@@ -333,6 +463,7 @@ func TestRegisterProject_DoesNotSubscribeRepoToSync(t *testing.T) {
 	body := mustMarshal(t, map[string]any{
 		"local_path": repoDir,
 		"platform_identity": map[string]string{
+			"platform":      "github",
 			"platform_host": "github.com",
 			"owner":         "stranger",
 			"name":          "not-in-toml",
@@ -451,6 +582,7 @@ func TestRegisterProject_RejectsPartialPlatformIdentity(t *testing.T) {
 	missingFieldBody := mustMarshal(t, map[string]any{
 		"local_path": repoDir,
 		"platform_identity": map[string]string{
+			"platform":      "github",
 			"platform_host": "github.com",
 			"owner":         "acme",
 			// missing "name" — Huma's schema rejects with 422
@@ -463,6 +595,7 @@ func TestRegisterProject_RejectsPartialPlatformIdentity(t *testing.T) {
 	whitespaceBody := mustMarshal(t, map[string]any{
 		"local_path": repoDir,
 		"platform_identity": map[string]string{
+			"platform":      "github",
 			"platform_host": "github.com",
 			"owner":         "acme",
 			"name":          "   ",

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -167,7 +167,7 @@ func TestRunDetection(t *testing.T) {
 	d := openTestDB(t)
 	ctx := t.Context()
 
-	repoID, err := d.UpsertRepo(ctx, "", "org", "repo")
+	repoID, err := d.UpsertRepo(ctx, realdb.GitHubRepoIdentity("", "org", "repo"))
 	require.NoError(err)
 
 	// Create a 3-PR chain.
@@ -207,7 +207,7 @@ func TestRunDetection_FullyMergedStackDeleted(t *testing.T) {
 	d := openTestDB(t)
 	ctx := t.Context()
 
-	repoID, err := d.UpsertRepo(ctx, "", "org", "repo")
+	repoID, err := d.UpsertRepo(ctx, realdb.GitHubRepoIdentity("", "org", "repo"))
 	require.NoError(err)
 
 	now := time.Now()

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -29,7 +29,7 @@ func seedRepo(
 ) int64 {
 	t.Helper()
 	id, err := d.UpsertRepo(
-		t.Context(), host, owner, name,
+		t.Context(), db.GitHubRepoIdentity(host, owner, name),
 	)
 	require.NoError(t, err)
 	return id

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -167,7 +167,7 @@ func SetupDiffRepo(
 
 	// Seed database with the real SHAs for acme/widgets PR #1.
 	repoID, err := d.UpsertRepo(
-		ctx, "github.com", "acme", "widgets")
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"))
 	if err != nil {
 		return nil, fmt.Errorf("upsert repo: %w", err)
 	}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -25,15 +25,15 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	now := time.Now().UTC()
 
 	// --- Repos ---
-	widgetsID, err := d.UpsertRepo(ctx, "github.com", "acme", "widgets")
+	widgetsID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"))
 	if err != nil {
 		return nil, fmt.Errorf("upsert acme/widgets: %w", err)
 	}
-	toolsID, err := d.UpsertRepo(ctx, "github.com", "acme", "tools")
+	toolsID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "tools"))
 	if err != nil {
 		return nil, fmt.Errorf("upsert acme/tools: %w", err)
 	}
-	_, err = d.UpsertRepo(ctx, "github.com", "acme", "archived")
+	_, err = d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "archived"))
 	if err != nil {
 		return nil, fmt.Errorf("upsert acme/archived: %w", err)
 	}

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -34,7 +34,7 @@ func seedRepo(
 ) int64 {
 	t.Helper()
 	id, err := d.UpsertRepo(
-		t.Context(), host, owner, name,
+		t.Context(), db.GitHubRepoIdentity(host, owner, name),
 	)
 	require.NoError(t, err)
 	return id

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2219,6 +2219,7 @@ export interface components {
         PlatformIdentityPayload: {
             name: string;
             owner: string;
+            platform: string;
             platform_host: string;
         };
         PostCommentHostInputBody: {


### PR DESCRIPTION
Project registration now requires explicit provider identity when linking a platform repo, so GitLab projects cannot be silently recorded through the old GitHub-only host/owner/name compatibility path. The legacy varargs UpsertRepo API was removed and call sites now pass RepoIdentity values.