### PR TITLE
fix: route embed details with explicit provider

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -495,9 +495,7 @@
           activeTab={r.tab ??
             (r.itemType === "issue" ? "issue" : "pr")}
           workspaceID=""
-          provider={r.platformHost.toLowerCase().includes("gitlab")
-            ? "gitlab"
-            : "github"}
+          provider={r.provider}
           platformHost={r.platformHost}
           repoOwner={r.owner}
           repoName={r.name}

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -43,6 +43,7 @@ export type Route =
   | { page: "embed-workspace-terminal"; workspaceId: string }
   | {
       page: "embed-workspace-detail";
+      provider: string;
       itemType: "pr" | "issue";
       platformHost: string;
       owner: string;
@@ -142,6 +143,10 @@ function parseHostProviderNumberedPath(
     return parseProviderNumberedPath(parts, start + 3, platformHost);
   }
   return undefined;
+}
+
+function inferLegacyEmbedProvider(platformHost: string): string {
+  return platformHost.toLowerCase().includes("gitlab") ? "gitlab" : "github";
 }
 
 function parseRoute(fullPath: string): Route {
@@ -269,7 +274,7 @@ function parseRoute(fullPath: string): Route {
     };
   }
   const embedDetailMatch = path.match(
-    /^\/workspaces\/embed\/detail\/(pr|issue)\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/,
+    /^\/workspaces\/embed\/detail\/([^/]+)\/(pr|issue)\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/,
   );
   if (embedDetailMatch) {
     const sp = new URLSearchParams(search);
@@ -281,11 +286,37 @@ function parseRoute(fullPath: string): Route {
         : undefined;
     const r: Route = {
       page: "embed-workspace-detail",
-      itemType: embedDetailMatch[1] as "pr" | "issue",
-      platformHost: embedDetailMatch[2]!,
-      owner: embedDetailMatch[3]!,
-      name: embedDetailMatch[4]!,
-      number: parseInt(embedDetailMatch[5]!, 10),
+      provider: embedDetailMatch[1]!,
+      itemType: embedDetailMatch[2] as "pr" | "issue",
+      platformHost: embedDetailMatch[3]!,
+      owner: embedDetailMatch[4]!,
+      name: embedDetailMatch[5]!,
+      number: parseInt(embedDetailMatch[6]!, 10),
+    };
+    if (branch) r.branch = branch;
+    if (tab) r.tab = tab;
+    return r;
+  }
+  const legacyEmbedDetailMatch = path.match(
+    /^\/workspaces\/embed\/detail\/(pr|issue)\/([^/]+)\/([^/]+)\/([^/]+)\/(\d+)$/,
+  );
+  if (legacyEmbedDetailMatch) {
+    const sp = new URLSearchParams(search);
+    const branch = sp.get("branch") ?? undefined;
+    const tabParam = sp.get("tab");
+    const tab: EmbedDetailTab | undefined =
+      tabParam === "pr" || tabParam === "issue" || tabParam === "reviews"
+        ? tabParam
+        : undefined;
+    const platformHost = legacyEmbedDetailMatch[2]!;
+    const r: Route = {
+      page: "embed-workspace-detail",
+      provider: inferLegacyEmbedProvider(platformHost),
+      itemType: legacyEmbedDetailMatch[1] as "pr" | "issue",
+      platformHost,
+      owner: legacyEmbedDetailMatch[3]!,
+      name: legacyEmbedDetailMatch[4]!,
+      number: parseInt(legacyEmbedDetailMatch[5]!, 10),
     };
     if (branch) r.branch = branch;
     if (tab) r.tab = tab;

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -245,12 +245,13 @@ describe("router embed-workspace routes", () => {
     });
   });
 
-  it("parses /workspaces/embed/detail/pr/:host/:owner/:name/:number", () => {
+  it("parses /workspaces/embed/detail/:provider/pr/:host/:owner/:name/:number", () => {
     navigate(
-      "/workspaces/embed/detail/pr/github.com/acme/widgets/42",
+      "/workspaces/embed/detail/github/pr/github.com/acme/widgets/42",
     );
     expect(getRoute()).toEqual({
       page: "embed-workspace-detail",
+      provider: "github",
       itemType: "pr",
       platformHost: "github.com",
       owner: "acme",
@@ -259,15 +260,47 @@ describe("router embed-workspace routes", () => {
     });
   });
 
+  it("parses legacy /workspaces/embed/detail/:type/:host/:owner/:name/:number", () => {
+    navigate(
+      "/workspaces/embed/detail/issue/gitlab.example.com/acme/widgets/7?tab=issue",
+    );
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-detail",
+      provider: "gitlab",
+      itemType: "issue",
+      platformHost: "gitlab.example.com",
+      owner: "acme",
+      name: "widgets",
+      number: 7,
+      tab: "issue",
+    });
+  });
+
+  it("keeps legacy GitHub Enterprise embed detail URLs on GitHub", () => {
+    navigate(
+      "/workspaces/embed/detail/pr/ghe.example.com/acme/widgets/42",
+    );
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-detail",
+      provider: "github",
+      itemType: "pr",
+      platformHost: "ghe.example.com",
+      owner: "acme",
+      name: "widgets",
+      number: 42,
+    });
+  });
+
   it("parses /workspaces/embed/detail with branch and tab query", () => {
     navigate(
-      "/workspaces/embed/detail/issue/ghe.example.com/org/repo/7" +
+      "/workspaces/embed/detail/gitlab/issue/git.example.com/org/repo/7" +
         "?branch=feature%2Fx&tab=reviews",
     );
     expect(getRoute()).toEqual({
       page: "embed-workspace-detail",
+      provider: "gitlab",
       itemType: "issue",
-      platformHost: "ghe.example.com",
+      platformHost: "git.example.com",
       owner: "org",
       name: "repo",
       number: 7,
@@ -278,11 +311,12 @@ describe("router embed-workspace routes", () => {
 
   it("ignores unknown tab values on the detail route", () => {
     navigate(
-      "/workspaces/embed/detail/pr/github.com/o/n/1?tab=garbage",
+      "/workspaces/embed/detail/github/pr/github.com/o/n/1?tab=garbage",
     );
     const route = getRoute();
     expect(route).toEqual({
       page: "embed-workspace-detail",
+      provider: "github",
       itemType: "pr",
       platformHost: "github.com",
       owner: "o",
@@ -406,7 +440,7 @@ describe("router navigation events", () => {
     const embedPaths = [
       "/workspaces/embed/list",
       "/workspaces/embed/terminal/ws-1",
-      "/workspaces/embed/detail/pr/github.com/acme/widget/42",
+      "/workspaces/embed/detail/github/pr/github.com/acme/widget/42",
       "/workspaces/embed/empty/noWorkspace",
       "/workspaces/embed/first-run",
       "/workspaces/embed/project/prj_abc123",

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -107,3 +107,61 @@ test("workspace bridge methods are registered on startup", async ({ page }) => {
     updateHostState: "function",
   });
 });
+
+test("provider-explicit embed detail route uses provider in detail request", async ({ page }) => {
+  const detailRequest = page.waitForRequest(
+    (request) =>
+      request.method() === "GET" &&
+      new URL(request.url()).pathname ===
+        "/api/v1/host/git.example.com/issues/gitlab/group/project/7",
+  );
+  await page.route(
+    "**/api/v1/host/git.example.com/issues/gitlab/group/project/7",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          issue: {
+            ID: 7,
+            RepoID: 7,
+            GitHubID: 7007,
+            Number: 7,
+            URL: "https://git.example.com/group/project/-/issues/7",
+            Title: "Provider-explicit GitLab issue",
+            Author: "marius",
+            State: "open",
+            Body: "",
+            CommentCount: 0,
+            LabelsJSON: "[]",
+            CreatedAt: "2026-03-28T14:00:00Z",
+            UpdatedAt: "2026-03-30T14:00:00Z",
+            LastActivityAt: "2026-03-30T14:00:00Z",
+            ClosedAt: null,
+            Starred: false,
+          },
+          repo: {
+            provider: "gitlab",
+            platform_host: "git.example.com",
+            owner: "group",
+            name: "project",
+            repo_path: "group/project",
+          },
+          events: [],
+          platform_host: "git.example.com",
+          repo_owner: "group",
+          repo_name: "project",
+          detail_loaded: true,
+          detail_fetched_at: "2026-03-30T14:00:00Z",
+        }),
+      });
+    },
+  );
+
+  await page.goto(
+    "/workspaces/embed/detail/gitlab/issue/git.example.com/group/project/7",
+  );
+
+  await detailRequest;
+  await expect(page.getByText("Provider-explicit GitLab issue")).toBeVisible();
+});


### PR DESCRIPTION
Embed detail surfaces now carry provider in the route contract and pass it directly into the workspace sidebar. This avoids classifying self-hosted GitLab instances by hostname text.