### PR TITLE
refactor: isolate workspace embed shell

### DIFF
--- a/context/embeds.md
+++ b/context/embeds.md
@@ -1,0 +1,17 @@
+# Embeds
+
+Middleman embed routes are intended to run in an isolated browser context, such
+as an iframe, WebView, or host-owned panel that loads one Middleman document per
+surface. They are not designed for multiple Middleman instances mounted into the
+same `window`.
+
+The embed shell is intentionally smaller than the standalone app shell. It
+initializes theme handling, the workspace bridge, the shared API provider, and
+the single requested workspace surface. It does not run standalone startup work:
+settings hydration, sync polling, pull/issue preloads, event-stream connection,
+container/sidebar setup, or global keyboard shortcuts.
+
+Hosts communicate with embeds through the `window.__middleman_*` bridge on that
+isolated browsing context. Because the bridge and browser history are
+document-global, callers that need more than one embed at a time should allocate
+one iframe/WebView per embed instance rather than sharing a single document.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
   import {
     Provider,
     PRListView,
@@ -23,11 +23,7 @@
   import RepoSummaryPage from "./lib/components/repositories/RepoSummaryPage.svelte";
   import SettingsPage from "./lib/components/settings/SettingsPage.svelte";
   import WorkspaceTerminalView from "./lib/components/terminal/WorkspaceTerminalView.svelte";
-  import WorkspaceListSidebar from "./lib/components/terminal/WorkspaceListSidebar.svelte";
-  import WorkspaceEmbedEmptyState from "./lib/components/terminal/WorkspaceEmbedEmptyState.svelte";
-  import WorkspaceFirstRunPanel from "./lib/components/terminal/WorkspaceFirstRunPanel.svelte";
-  import WorkspaceProjectCard from "./lib/components/terminal/WorkspaceProjectCard.svelte";
-  import { WorkspaceRightSidebar } from "@middleman/ui";
+  import WorkspaceEmbedShell from "./lib/components/terminal/WorkspaceEmbedShell.svelte";
   import DesignSystemPage from "./lib/components/design-system/DesignSystemPage.svelte";
   import FlashBanner from "./lib/components/FlashBanner.svelte";
   import { SpinnerIcon } from "./lib/icons.ts";
@@ -63,7 +59,6 @@
     isDiffView,
     getDetailTab,
     getSelectedPRFromRoute,
-    isWorkspaceEmbedPage,
   } from "./lib/stores/router.svelte.ts";
   import {
     buildActivitySelectionSearch,
@@ -84,23 +79,32 @@
     emitWorkspaceCommand,
     isHeaderHidden,
     isStatusBarHidden,
-    getInitialRoute,
     emitLayoutChanged,
     initWorkspaceBridge,
   } from "./lib/stores/embed-config.svelte.js";
   import { getSettings } from "./lib/api/settings.js";
+  import { shouldUseFullAppShell } from "./lib/utils/appShell.js";
 
   let stores = $state<StoreInstances | undefined>();
   let appReady = $state(false);
+  let cleanupFullAppShell: (() => void) | undefined;
+  let fullShellStores: StoreInstances | undefined;
 
-  onMount(() => {
+  function stopFullAppShell() {
+    fullShellStores?.events.disconnect();
+    cleanupFullAppShell?.();
+    cleanupFullAppShell = undefined;
+    fullShellStores = undefined;
+    appReady = false;
+  }
+
+  function startFullAppShell(startupStores: StoreInstances) {
+    if (cleanupFullAppShell) return;
+    fullShellStores = startupStores;
+    appReady = false;
     initTheme();
     initSidebar();
     initWorkspaceBridge();
-    const initialRoute = getInitialRoute();
-    if (initialRoute) {
-      replaceUrl(initialRoute);
-    }
     const ui = getUIConfig();
     applyConfigRepo(ui.repo, ui.hideRepoSelector);
     const appEl = document.getElementById("app")!;
@@ -108,7 +112,7 @@
     const cleanupItemRefs = initItemRefHandler();
     const cancelStartup = runAppStartup({
       getSettings,
-      getStores: () => stores,
+      getStores: () => startupStores,
       onReady: () => {
         appReady = true;
       },
@@ -117,7 +121,7 @@
       stores?.events.disconnect();
     };
     window.addEventListener("beforeunload", onBeforeUnload);
-    return () => {
+    cleanupFullAppShell = () => {
       cancelStartup();
       cleanupTheme();
       cleanupContainer();
@@ -127,11 +131,23 @@
         onBeforeUnload,
       );
     };
+  }
+
+  $effect(() => {
+    if (!shouldUseFullAppShell(getPage())) {
+      stopFullAppShell();
+      return;
+    }
+    if (stores && stores !== fullShellStores) {
+      stopFullAppShell();
+      startFullAppShell(stores);
+    }
   });
 
   let lastRepo: string | undefined;
 
   onDestroy(() => {
+    stopFullAppShell();
     stores?.events.disconnect();
   });
 
@@ -157,6 +173,7 @@
   });
 
   $effect(() => {
+    if (!shouldUseFullAppShell(getPage())) return;
     reapplyTheme();
   });
 
@@ -421,6 +438,7 @@
   }
 
   $effect(() => {
+    if (!shouldUseFullAppShell(getPage())) return;
     window.addEventListener("keydown", handleKeydown);
     return () =>
       window.removeEventListener(
@@ -430,92 +448,59 @@
   });
 </script>
 
-<Provider
-  {client}
-  roborevBaseUrl="/api/roborev"
-  onError={showFlash}
-  onNavigate={(e) =>
-    navigate(typeof e === "string" ? e : e.path)}
-  onWorkspaceCommand={emitWorkspaceCommand}
-  actions={{
-    pull: getPullRequestActions().map((a) => ({
-      id: a.id,
-      label: a.label,
-      handler: (ctx) => invokeAction(a, {
-        surface: ctx.surface,
-        owner: ctx.owner,
-        name: ctx.name,
-        number: ctx.number,
-        ...ctx.meta != null && { meta: ctx.meta },
-      }),
-    })),
-    issue: getIssueActions().map((a) => ({
-      id: a.id,
-      label: a.label,
-      handler: (ctx) => invokeAction(a, {
-        surface: ctx.surface,
-        owner: ctx.owner,
-        name: ctx.name,
-        number: ctx.number,
-        ...ctx.meta != null && { meta: ctx.meta },
-      }),
-    })),
-  }}
-  hostState={{
-    getGlobalRepo,
-    getGroupByRepo: () => stores?.grouping.getGroupByRepo() ?? true,
-    getView,
-    getActiveWorktreeKey,
-  }}
-  config={{
-    hideStar: getUIConfig().hideStar,
-    basePath: getBasePath(),
-  }}
-  {getPage}
-  sidebar={{
-    isEmbedded,
-    isSidebarToggleEnabled,
-    toggleSidebar,
-  }}
-  bind:stores
->
-  {#if isWorkspaceEmbedPage(getPage())}
-    {@const r = getRoute()}
-    <main class="embed-layout">
-      {#if r.page === "embed-workspace-list"}
-        <WorkspaceListSidebar selectedId="" />
-      {:else if r.page === "embed-workspace-terminal"}
-        <WorkspaceTerminalView
-          workspaceId={r.workspaceId}
-          hideWorkspaceList={true}
-          hideRightSidebar={true}
-        />
-      {:else if r.page === "embed-workspace-detail"}
-        <WorkspaceRightSidebar
-          activeTab={r.tab ??
-            (r.itemType === "issue" ? "issue" : "pr")}
-          workspaceID=""
-          provider={r.provider}
-          platformHost={r.platformHost}
-          repoOwner={r.owner}
-          repoName={r.name}
-          repoPath={r.repoPath}
-          ownerItemType={r.itemType === "issue" ? "issue" : "pull_request"}
-          ownerItemNumber={r.number}
-          associatedPRNumber={r.itemType === "pr" ? r.number : null}
-          branch={r.branch ?? ""}
-          roborevBaseUrl={getBasePath().replace(/\/$/, "") +
-            "/api/roborev"}
-        />
-      {:else if r.page === "embed-workspace-empty"}
-        <WorkspaceEmbedEmptyState reason={r.reason} />
-      {:else if r.page === "embed-workspace-first-run"}
-        <WorkspaceFirstRunPanel />
-      {:else if r.page === "embed-workspace-project"}
-        <WorkspaceProjectCard projectId={r.projectId} />
-      {/if}
-    </main>
-  {:else if getPage() === "focus"}
+{#if !shouldUseFullAppShell(getPage())}
+  <WorkspaceEmbedShell />
+{:else}
+  <Provider
+    {client}
+    roborevBaseUrl="/api/roborev"
+    onError={showFlash}
+    onNavigate={(e) =>
+      navigate(typeof e === "string" ? e : e.path)}
+    onWorkspaceCommand={emitWorkspaceCommand}
+    actions={{
+      pull: getPullRequestActions().map((a) => ({
+        id: a.id,
+        label: a.label,
+        handler: (ctx) => invokeAction(a, {
+          surface: ctx.surface,
+          owner: ctx.owner,
+          name: ctx.name,
+          number: ctx.number,
+          ...ctx.meta != null && { meta: ctx.meta },
+        }),
+      })),
+      issue: getIssueActions().map((a) => ({
+        id: a.id,
+        label: a.label,
+        handler: (ctx) => invokeAction(a, {
+          surface: ctx.surface,
+          owner: ctx.owner,
+          name: ctx.name,
+          number: ctx.number,
+          ...ctx.meta != null && { meta: ctx.meta },
+        }),
+      })),
+    }}
+    hostState={{
+      getGlobalRepo,
+      getGroupByRepo: () => stores?.grouping.getGroupByRepo() ?? true,
+      getView,
+      getActiveWorktreeKey,
+    }}
+    config={{
+      hideStar: getUIConfig().hideStar,
+      basePath: getBasePath(),
+    }}
+    {getPage}
+    sidebar={{
+      isEmbedded,
+      isSidebarToggleEnabled,
+      toggleSidebar,
+    }}
+    bind:stores
+  >
+  {#if getPage() === "focus"}
     {@const r = getRoute()}
     {#if r.page === "focus"}
       <main class="focus-layout">
@@ -646,7 +631,8 @@
       <StatusBar />
     {/if}
   {/if}
-</Provider>
+  </Provider>
+{/if}
 
 <style>
   .focus-layout {
@@ -655,19 +641,6 @@
     background: var(--bg-primary);
     display: flex;
     flex-direction: column;
-  }
-
-  /* Embed routes render a single workspace component at full
-     bleed. The host (e.g. a WKWebView) provides the surrounding
-     chrome. Hidden overflow lets the inner component manage its
-     own scrolling without leaking onto the host. */
-  .embed-layout {
-    flex: 1;
-    overflow: hidden;
-    background: var(--bg-primary);
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
   }
 
   .app-main {

--- a/frontend/src/lib/components/terminal/WorkspaceEmbedShell.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceEmbedShell.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import { Provider, WorkspaceRightSidebar } from "@middleman/ui";
+  import type { StoreInstances } from "@middleman/ui";
+
+  import { client } from "../../api/runtime.js";
+  import {
+    getBasePath,
+    getPage,
+    getRoute,
+    getView,
+    navigate,
+  } from "../../stores/router.svelte.ts";
+  import {
+    cleanupTheme,
+    initTheme,
+    reapplyTheme,
+  } from "../../stores/theme.svelte.js";
+  import {
+    emitWorkspaceCommand,
+    getActiveWorktreeKey,
+    getIssueActions,
+    getPullRequestActions,
+    getUIConfig,
+    initWorkspaceBridge,
+    invokeAction,
+  } from "../../stores/embed-config.svelte.js";
+  import { getGlobalRepo } from "../../stores/filter.svelte.js";
+  import WorkspaceTerminalView from "./WorkspaceTerminalView.svelte";
+  import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
+  import WorkspaceEmbedEmptyState from "./WorkspaceEmbedEmptyState.svelte";
+  import WorkspaceFirstRunPanel from "./WorkspaceFirstRunPanel.svelte";
+  import WorkspaceProjectCard from "./WorkspaceProjectCard.svelte";
+  import { showFlash } from "../../stores/flash.svelte.js";
+
+  let stores = $state<StoreInstances | undefined>();
+
+  onMount(() => {
+    initTheme();
+    initWorkspaceBridge();
+    return () => {
+      cleanupTheme();
+    };
+  });
+
+  onDestroy(() => {
+    stores?.events.disconnect();
+  });
+
+  $effect(() => {
+    reapplyTheme();
+  });
+</script>
+
+<Provider
+  {client}
+  roborevBaseUrl="/api/roborev"
+  onError={showFlash}
+  onNavigate={(e) =>
+    navigate(typeof e === "string" ? e : e.path)}
+  onWorkspaceCommand={emitWorkspaceCommand}
+  actions={{
+    pull: getPullRequestActions().map((a) => ({
+      id: a.id,
+      label: a.label,
+      handler: (ctx) => invokeAction(a, {
+        surface: ctx.surface,
+        owner: ctx.owner,
+        name: ctx.name,
+        number: ctx.number,
+        ...ctx.meta != null && { meta: ctx.meta },
+      }),
+    })),
+    issue: getIssueActions().map((a) => ({
+      id: a.id,
+      label: a.label,
+      handler: (ctx) => invokeAction(a, {
+        surface: ctx.surface,
+        owner: ctx.owner,
+        name: ctx.name,
+        number: ctx.number,
+        ...ctx.meta != null && { meta: ctx.meta },
+      }),
+    })),
+  }}
+  config={{
+    hideStar: getUIConfig().hideStar,
+    basePath: getBasePath(),
+  }}
+  hostState={{
+    getGlobalRepo,
+    getGroupByRepo: () => stores?.grouping.getGroupByRepo() ?? true,
+    getView,
+    getActiveWorktreeKey,
+  }}
+  {getPage}
+  sidebar={{
+    isEmbedded: () => true,
+    isSidebarToggleEnabled: () => false,
+    toggleSidebar: () => {},
+  }}
+  bind:stores
+>
+  {@const r = getRoute()}
+  <main class="embed-layout">
+    {#if r.page === "embed-workspace-list"}
+      <WorkspaceListSidebar selectedId="" />
+    {:else if r.page === "embed-workspace-terminal"}
+      <WorkspaceTerminalView
+        workspaceId={r.workspaceId}
+        hideWorkspaceList={true}
+        hideRightSidebar={true}
+      />
+    {:else if r.page === "embed-workspace-detail"}
+      <WorkspaceRightSidebar
+        activeTab={r.tab ??
+          (r.itemType === "issue" ? "issue" : "pr")}
+        workspaceID=""
+        provider={r.provider}
+        platformHost={r.platformHost}
+        repoOwner={r.owner}
+        repoName={r.name}
+        repoPath={r.repoPath}
+        ownerItemType={r.itemType === "issue" ? "issue" : "pull_request"}
+        ownerItemNumber={r.number}
+        associatedPRNumber={r.itemType === "pr" ? r.number : null}
+        branch={r.branch ?? ""}
+        roborevBaseUrl={getBasePath().replace(/\/$/, "") +
+          "/api/roborev"}
+      />
+    {:else if r.page === "embed-workspace-empty"}
+      <WorkspaceEmbedEmptyState reason={r.reason} />
+    {:else if r.page === "embed-workspace-first-run"}
+      <WorkspaceFirstRunPanel />
+    {:else if r.page === "embed-workspace-project"}
+      <WorkspaceProjectCard projectId={r.projectId} />
+    {/if}
+  </main>
+</Provider>
+
+<style>
+  .embed-layout {
+    flex: 1;
+    overflow: hidden;
+    background: var(--bg-primary);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+</style>

--- a/frontend/src/lib/stores/router.initialization.test.ts
+++ b/frontend/src/lib/stores/router.initialization.test.ts
@@ -11,6 +11,7 @@ async function importRouterAt(path: string) {
 
 describe("router initialization", () => {
   afterEach(() => {
+    delete window.__middleman_config;
     window.history.replaceState(null, "", "/");
     vi.resetModules();
   });
@@ -29,6 +30,32 @@ describe("router initialization", () => {
         platformHost: "ghe.example.com",
       },
     });
+  });
+
+  it("uses embed initialRoute before the first app render", async () => {
+    window.__middleman_config = {
+      embed: {
+        initialRoute:
+          "/workspaces/embed/detail/gitlab/pr/git.example.com/42" +
+          "?repo_path=group%2Fproject",
+      },
+    };
+    const { getRoute } = await importRouterAt("/");
+
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-detail",
+      provider: "gitlab",
+      itemType: "pr",
+      platformHost: "git.example.com",
+      repoPath: "group/project",
+      owner: "group",
+      name: "project",
+      number: 42,
+    });
+    expect(window.location.pathname + window.location.search).toBe(
+      "/workspaces/embed/detail/gitlab/pr/git.example.com/42" +
+        "?repo_path=group%2Fproject",
+    );
   });
 
   it("preserves provider issue route state on popstate", async () => {

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -65,6 +65,7 @@ import {
   getOnRouteChange,
   getUIConfig as getEmbedUIConfig,
   getHost,
+  getInitialRoute,
 } from "./embed-config.svelte.js";
 
 // Runtime base path injected by the Go server (e.g., "/" or "/middleman/").
@@ -395,7 +396,18 @@ function parseRoute(fullPath: string): Route {
   return { page: "activity" };
 }
 
-let route = $state<Route>(parseRoute(currentLocationPath()));
+const configuredInitialRoute = getInitialRoute();
+if (configuredInitialRoute) {
+  history.replaceState(
+    null,
+    "",
+    basePrefix + configuredInitialRoute,
+  );
+}
+
+let route = $state<Route>(
+  parseRoute(configuredInitialRoute ?? currentLocationPath()),
+);
 
 // Fire onRouteChange for the initial route after the module loads.
 // Deferred so the embedder has time to set up the callback.

--- a/frontend/src/lib/utils/appShell.test.ts
+++ b/frontend/src/lib/utils/appShell.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldUseFullAppShell } from "./appShell.js";
+
+describe("app shell selection", () => {
+  it("does not use full app startup for workspace embed pages", () => {
+    expect(shouldUseFullAppShell("embed-workspace-list")).toBe(false);
+    expect(shouldUseFullAppShell("embed-workspace-terminal")).toBe(false);
+    expect(shouldUseFullAppShell("embed-workspace-detail")).toBe(false);
+    expect(shouldUseFullAppShell("embed-workspace-empty")).toBe(false);
+    expect(shouldUseFullAppShell("embed-workspace-first-run")).toBe(false);
+    expect(shouldUseFullAppShell("embed-workspace-project")).toBe(false);
+  });
+
+  it("uses the full app shell for standalone pages", () => {
+    expect(shouldUseFullAppShell("activity")).toBe(true);
+    expect(shouldUseFullAppShell("workspaces")).toBe(true);
+    expect(shouldUseFullAppShell("terminal")).toBe(true);
+  });
+});

--- a/frontend/src/lib/utils/appShell.ts
+++ b/frontend/src/lib/utils/appShell.ts
@@ -1,0 +1,8 @@
+import {
+  isWorkspaceEmbedPage,
+  type Page,
+} from "../stores/router.svelte.js";
+
+export function shouldUseFullAppShell(page: Page): boolean {
+  return !isWorkspaceEmbedPage(page);
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -230,6 +230,7 @@ interface Window {
   __BASE_PATH__?: string;
   __MIDDLEMAN_DEV_API_URL__?: string;
   __middleman_config?: MiddlemanConfig;
+  __middleman_event_source_counts?: () => { created: number; closed: number };
   __middleman_notify_config_changed?: () => void;
   __middleman_update_workspace?: (data: WorkspaceData) => void;
   __middleman_navigate_to_route?: (route: string) => void;

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -224,3 +224,193 @@ test("nested repo_path embed detail route loads matching detail content", async 
   await detailRequest;
   await expect(page.getByText("Nested GitLab issue")).toBeVisible();
 });
+
+test("embed initialRoute opens detail surface without full app chrome", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: {
+        initialRoute:
+          "/workspaces/embed/detail/gitlab/issue/git.example.com/7" +
+          "?repo_path=group%2Fproject",
+      },
+    };
+  });
+
+  const detailRequest = page.waitForRequest(
+    (request) =>
+      request.method() === "GET" &&
+      new URL(request.url()).pathname ===
+        "/api/v1/host/git.example.com/issues/gitlab/group/project/7",
+  );
+  await page.route(
+    "**/api/v1/host/git.example.com/issues/gitlab/group/project/7",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          issue: {
+            ID: 7,
+            RepoID: 7,
+            GitHubID: 7007,
+            Number: 7,
+            URL: "https://git.example.com/group/project/-/issues/7",
+            Title: "Initial route GitLab issue",
+            Author: "marius",
+            State: "open",
+            Body: "",
+            CommentCount: 0,
+            LabelsJSON: "[]",
+            CreatedAt: "2026-03-28T14:00:00Z",
+            UpdatedAt: "2026-03-30T14:00:00Z",
+            LastActivityAt: "2026-03-30T14:00:00Z",
+            ClosedAt: null,
+            Starred: false,
+          },
+          repo: {
+            provider: "gitlab",
+            platform_host: "git.example.com",
+            owner: "group",
+            name: "project",
+            repo_path: "group/project",
+          },
+          events: [],
+          platform_host: "git.example.com",
+          repo_owner: "group",
+          repo_name: "project",
+          detail_loaded: true,
+          detail_fetched_at: "2026-03-30T14:00:00Z",
+        }),
+      });
+    },
+  );
+
+  await page.goto("/");
+
+  await detailRequest;
+  await expect(page.locator("header.app-header")).toHaveCount(0);
+  await expect(page).toHaveURL(
+    /\/workspaces\/embed\/detail\/gitlab\/issue\/git\.example\.com\/7\?repo_path=group%2Fproject$/,
+  );
+  await expect(page.getByText("Initial route GitLab issue")).toBeVisible();
+});
+
+test("full app initializes after navigating away from an initial embed route", async ({ page }) => {
+  await page.route("**/api/v1/settings", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repos: [],
+        activity: {
+          view_mode: "threaded",
+          time_range: "7d",
+          hide_closed: false,
+          hide_bots: false,
+        },
+        terminal: {
+          font_family: '"Fira Code", monospace',
+          renderer: "xterm",
+        },
+        agents: [],
+      }),
+    });
+  });
+
+  await page.addInitScript(() => {
+    window.__middleman_config = {
+      embed: {
+        initialRoute: "/workspaces/embed/list",
+      },
+    };
+  });
+
+  await page.goto("/");
+  await expect(page.locator("header.app-header")).toHaveCount(0);
+
+  const pullsResponse = page.waitForResponse(
+    (response) => new URL(response.url()).pathname === "/api/v1/pulls",
+  );
+  await page.evaluate(() => {
+    window.__middleman_navigate_to_route?.("/pulls");
+  });
+
+  await expect(page).toHaveURL(/\/pulls$/);
+  await pullsResponse;
+  await expect(page.locator("header.app-header")).toBeVisible();
+});
+
+test("full app reinitializes after navigating through an embed route", async ({ page }) => {
+  let settingsRequests = 0;
+  await page.addInitScript(() => {
+    const OriginalEventSource = window.EventSource;
+    const created: EventSource[] = [];
+    const closed: EventSource[] = [];
+    class TrackingEventSource extends OriginalEventSource {
+      constructor(url: string | URL, eventSourceInitDict?: EventSourceInit) {
+        super(url, eventSourceInitDict);
+        created.push(this);
+      }
+
+      close(): void {
+        closed.push(this);
+        super.close();
+      }
+    }
+    window.EventSource = TrackingEventSource;
+    Object.defineProperty(window, "__middleman_event_source_counts", {
+      value: () => ({ created: created.length, closed: closed.length }),
+    });
+  });
+  await page.route("**/api/v1/settings", async (route) => {
+    settingsRequests += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repos: [],
+        activity: {
+          view_mode: "threaded",
+          time_range: "7d",
+          hide_closed: false,
+          hide_bots: false,
+        },
+        terminal: {
+          font_family: '"Fira Code", monospace',
+          renderer: "xterm",
+        },
+        agents: [],
+      }),
+    });
+  });
+
+  await page.goto("/pulls");
+  await expect(page.locator("header.app-header")).toBeVisible();
+  await expect.poll(() => settingsRequests).toBe(1);
+  const initialEventSources = await page.evaluate(() =>
+    window.__middleman_event_source_counts?.().created ?? 0,
+  );
+  expect(initialEventSources).toBeGreaterThan(0);
+
+  await page.evaluate(() => {
+    window.__middleman_navigate_to_route?.("/workspaces/embed/list");
+  });
+  await expect(page).toHaveURL(/\/workspaces\/embed\/list$/);
+  await expect(page.locator("header.app-header")).toHaveCount(0);
+  await expect.poll(async () => page.evaluate(() =>
+    window.__middleman_event_source_counts?.().closed ?? 0,
+  )).toBeGreaterThanOrEqual(initialEventSources);
+
+  await page.evaluate(() => {
+    window.__middleman_navigate_to_route?.("/pulls");
+  });
+  await expect(page).toHaveURL(/\/pulls$/);
+  await expect(page.locator("header.app-header")).toBeVisible();
+  await expect.poll(() => settingsRequests).toBe(2);
+  await expect.poll(async () => page.evaluate(() =>
+    window.__middleman_event_source_counts?.().created ?? 0,
+  )).toBeGreaterThan(initialEventSources);
+  await expect.poll(async () => page.evaluate(() =>
+    window.__middleman_event_source_counts?.().closed ?? 0,
+  )).toBeGreaterThanOrEqual(initialEventSources);
+});


### PR DESCRIPTION
Embed routes now render through a smaller shell that skips standalone settings startup, sync/event preload behavior, sidebar/container setup, and global shortcuts. The embed contract documents one isolated browsing context per Middleman embed instance.