### PR TITLE
feat: share Forgejo and Gitea provider core

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1281,6 +1281,8 @@ components:
           type: integer
         IsDraft:
           type: boolean
+        IsLocked:
+          type: boolean
         KanbanStatus:
           type: string
         LastActivityAt:
@@ -1335,6 +1337,7 @@ components:
         - AuthorDisplayName
         - State
         - IsDraft
+        - IsLocked
         - Body
         - HeadBranch
         - BaseBranch
@@ -1468,6 +1471,8 @@ components:
           type: integer
         IsDraft:
           type: boolean
+        IsLocked:
+          type: boolean
         KanbanStatus:
           type: string
         LastActivityAt:
@@ -1546,6 +1551,7 @@ components:
         - AuthorDisplayName
         - State
         - IsDraft
+        - IsLocked
         - Body
         - HeadBranch
         - BaseBranch

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -543,6 +543,7 @@ type MergeRequest struct {
 	HeadRepoCloneURL   string     `json:"HeadRepoCloneURL"`
 	ID                 int64      `json:"ID"`
 	IsDraft            bool       `json:"IsDraft"`
+	IsLocked           bool       `json:"IsLocked"`
 	KanbanStatus       string     `json:"KanbanStatus"`
 	LastActivityAt     time.Time  `json:"LastActivityAt"`
 	MergeableState     string     `json:"MergeableState"`
@@ -600,6 +601,7 @@ type MergeRequestResponse struct {
 	HeadRepoCloneURL   string                  `json:"HeadRepoCloneURL"`
 	ID                 int64                   `json:"ID"`
 	IsDraft            bool                    `json:"IsDraft"`
+	IsLocked           bool                    `json:"IsLocked"`
 	KanbanStatus       string                  `json:"KanbanStatus"`
 	LastActivityAt     time.Time               `json:"LastActivityAt"`
 	MergeableState     string                  `json:"MergeableState"`

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -623,6 +623,7 @@ func TestOpenRepairsLegacyTimestampStorage(t *testing.T) {
 	)
 	require.NoError(err)
 	require.NoError(rewriteWorkspacesToVersion9ForTest(raw))
+	require.NoError(removeMergeRequestLockedColumnForTest(raw))
 	require.NoError(removeProviderIdentityColumnsForTest(raw))
 	_, err = raw.ExecContext(ctx,
 		`UPDATE schema_migrations SET version = ?, dirty = FALSE`,
@@ -725,6 +726,7 @@ func TestOpenRepairsBrokenWorkspaceMigrationVersion11(t *testing.T) {
 	raw, err := sql.Open("sqlite", path)
 	require.NoError(err)
 	require.NoError(rewriteWorkspacesToVersion11ForTest(raw))
+	require.NoError(removeMergeRequestLockedColumnForTest(raw))
 	require.NoError(removeProviderIdentityColumnsForTest(raw))
 	_, err = raw.Exec(`UPDATE schema_migrations SET version = 11, dirty = FALSE`)
 	require.NoError(err)
@@ -796,6 +798,7 @@ func TestOpenMigratesWorkspaceUniquenessAndPreservesSetupEvents(t *testing.T) {
 	raw, err := sql.Open("sqlite", path)
 	require.NoError(err)
 	require.NoError(rewriteWorkspacesToVersion11ForTest(raw))
+	require.NoError(removeMergeRequestLockedColumnForTest(raw))
 	require.NoError(removeProviderIdentityColumnsForTest(raw))
 	_, err = raw.Exec(`UPDATE schema_migrations SET version = 11, dirty = FALSE`)
 	require.NoError(err)
@@ -1216,6 +1219,11 @@ func removeProviderIdentityColumnsForTest(raw *sql.DB) error {
 		    SELECT RAISE(ABORT, 'repo identifiers must be lowercase');
 		END;
 	`)
+	return err
+}
+
+func removeMergeRequestLockedColumnForTest(raw *sql.DB) error {
+	_, err := raw.Exec(`ALTER TABLE middleman_merge_requests DROP COLUMN is_locked`)
 	return err
 }
 

--- a/internal/db/migrations/000018_add_merge_request_locked.down.sql
+++ b/internal/db/migrations/000018_add_merge_request_locked.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE middleman_merge_requests DROP COLUMN is_locked;

--- a/internal/db/migrations/000018_add_merge_request_locked.up.sql
+++ b/internal/db/migrations/000018_add_merge_request_locked.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE middleman_merge_requests
+ADD COLUMN is_locked INTEGER NOT NULL DEFAULT 0;

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1444,7 +1444,7 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 	_, err := d.rw.ExecContext(ctx, `
 		INSERT INTO middleman_merge_requests
 		    (repo_id, platform_id, platform_external_id, number, url, title, author, author_display_name,
-		     state, is_draft, body, head_branch, base_branch,
+		     state, is_draft, is_locked, body, head_branch, base_branch,
 		     platform_head_sha, platform_base_sha,
 		     head_repo_clone_url,
 		     additions, deletions, comment_count,
@@ -1452,7 +1452,7 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		     detail_fetched_at, ci_had_pending,
 		     created_at, updated_at,
 		     last_activity_at, merged_at, closed_at, mergeable_state)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo_id, number) DO UPDATE SET
 		    platform_id          = excluded.platform_id,
 		    platform_external_id = COALESCE(NULLIF(excluded.platform_external_id, ''), middleman_merge_requests.platform_external_id),
@@ -1462,6 +1462,7 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		    author_display_name  = excluded.author_display_name,
 		    state                = excluded.state,
 		    is_draft             = excluded.is_draft,
+		    is_locked            = excluded.is_locked,
 		    body                 = excluded.body,
 		    head_branch          = excluded.head_branch,
 		    base_branch          = excluded.base_branch,
@@ -1484,7 +1485,7 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		WHERE excluded.updated_at >= middleman_merge_requests.updated_at`,
 		mr.RepoID, mr.PlatformID, mr.PlatformExternalID, mr.Number, mr.URL, mr.Title,
 		mr.Author, mr.AuthorDisplayName,
-		mr.State, mr.IsDraft, mr.Body, mr.HeadBranch, mr.BaseBranch,
+		mr.State, mr.IsDraft, mr.IsLocked, mr.Body, mr.HeadBranch, mr.BaseBranch,
 		mr.PlatformHeadSHA, mr.PlatformBaseSHA,
 		mr.HeadRepoCloneURL,
 		mr.Additions, mr.Deletions, mr.CommentCount, mr.ReviewDecision,
@@ -1513,7 +1514,7 @@ func (d *DB) GetMergeRequest(ctx context.Context, owner, name string, number int
 	var mr MergeRequest
 	err := d.ro.QueryRowContext(ctx, `
 		SELECT p.id, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
-		       p.author, p.author_display_name, p.state, p.is_draft,
+		       p.author, p.author_display_name, p.state, p.is_draft, p.is_locked,
 		       p.body, p.head_branch, p.base_branch,
 		       p.platform_head_sha, p.platform_base_sha,
 		       p.diff_head_sha, p.diff_base_sha, p.merge_base_sha,
@@ -1534,7 +1535,7 @@ func (d *DB) GetMergeRequest(ctx context.Context, owner, name string, number int
 		owner, name, number,
 	).Scan(
 		&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.PlatformExternalID, &mr.Number, &mr.URL, &mr.Title,
-		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft,
+		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft, &mr.IsLocked,
 		&mr.Body, &mr.HeadBranch, &mr.BaseBranch,
 		&mr.PlatformHeadSHA, &mr.PlatformBaseSHA,
 		&mr.DiffHeadSHA, &mr.DiffBaseSHA, &mr.MergeBaseSHA,
@@ -1565,7 +1566,7 @@ func (d *DB) GetMergeRequestByRepoIDAndNumber(ctx context.Context, repoID int64,
 	var mr MergeRequest
 	err := d.ro.QueryRowContext(ctx, `
 		SELECT p.id, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
-		       p.author, p.author_display_name, p.state, p.is_draft,
+		       p.author, p.author_display_name, p.state, p.is_draft, p.is_locked,
 		       p.body, p.head_branch, p.base_branch,
 		       p.platform_head_sha, p.platform_base_sha,
 		       p.diff_head_sha, p.diff_base_sha, p.merge_base_sha,
@@ -1585,7 +1586,7 @@ func (d *DB) GetMergeRequestByRepoIDAndNumber(ctx context.Context, repoID int64,
 		repoID, number,
 	).Scan(
 		&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.PlatformExternalID, &mr.Number, &mr.URL, &mr.Title,
-		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft,
+		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft, &mr.IsLocked,
 		&mr.Body, &mr.HeadBranch, &mr.BaseBranch,
 		&mr.PlatformHeadSHA, &mr.PlatformBaseSHA,
 		&mr.DiffHeadSHA, &mr.DiffBaseSHA, &mr.MergeBaseSHA,
@@ -1663,7 +1664,7 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 
 	query := fmt.Sprintf(`
 		SELECT p.id, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
-		       p.author, p.author_display_name, p.state, p.is_draft,
+		       p.author, p.author_display_name, p.state, p.is_draft, p.is_locked,
 		       p.body, p.head_branch, p.base_branch,
 		       p.platform_head_sha, p.platform_base_sha,
 		       p.diff_head_sha, p.diff_base_sha, p.merge_base_sha,
@@ -1695,7 +1696,7 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 		var mr MergeRequest
 		if err := rows.Scan(
 			&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.PlatformExternalID, &mr.Number, &mr.URL, &mr.Title,
-			&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft,
+			&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft, &mr.IsLocked,
 			&mr.Body, &mr.HeadBranch, &mr.BaseBranch,
 			&mr.PlatformHeadSHA, &mr.PlatformBaseSHA,
 			&mr.DiffHeadSHA, &mr.DiffBaseSHA, &mr.MergeBaseSHA,

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1313,6 +1313,7 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 		Author:         "alice",
 		State:          "open",
 		IsDraft:        false,
+		IsLocked:       true,
 		Body:           "body text",
 		HeadBranch:     "fix/something",
 		BaseBranch:     "main",
@@ -1337,6 +1338,7 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 	assert.Equal(pr.Title, got.Title)
 	assert.Equal(pr.Author, got.Author)
 	assert.Equal(pr.Additions, got.Additions)
+	assert.True(got.IsLocked)
 	assert.Empty(got.KanbanStatus)
 
 	// Update via upsert — change title and additions.
@@ -1353,6 +1355,7 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 	require.NotNil(got2)
 	assert.Equal("fix: something updated", got2.Title)
 	assert.Equal(20, got2.Additions)
+	assert.True(got2.IsLocked)
 	// created_at must not change.
 	assert.True(got2.CreatedAt.Equal(now))
 

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -132,6 +132,7 @@ type MergeRequest struct {
 	AuthorDisplayName  string
 	State              string
 	IsDraft            bool
+	IsLocked           bool
 	Body               string
 	HeadBranch         string
 	BaseBranch         string

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -302,6 +302,7 @@ mutation($pullRequestId: ID!) {
       title
       state
       isDraft
+      locked
       body
       url
       author {

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -39,6 +39,7 @@ type gqlPR struct {
 	Title          string
 	State          string
 	IsDraft        bool
+	Locked         bool
 	Body           string
 	URL            string
 	Author         struct{ Login string }
@@ -265,6 +266,7 @@ func adaptPR(gql *gqlPR) *gh.PullRequest {
 		Title:     new(gql.Title),
 		State:     new(state),
 		Draft:     new(gql.IsDraft),
+		Locked:    new(gql.Locked),
 		Body:      new(gql.Body),
 		HTMLURL:   new(gql.URL),
 		Additions: new(gql.Additions),

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -27,6 +27,7 @@ func TestAdaptPR(t *testing.T) {
 		Title:          "Fix bug",
 		State:          "OPEN",
 		IsDraft:        true,
+		Locked:         true,
 		Body:           "Fixes #1",
 		URL:            "https://github.com/o/r/pull/42",
 		Additions:      10,
@@ -51,6 +52,7 @@ func TestAdaptPR(t *testing.T) {
 	assert.Equal("Fix bug", pr.GetTitle())
 	assert.Equal("open", pr.GetState())
 	assert.True(pr.GetDraft())
+	assert.True(pr.GetLocked())
 	assert.Equal("Fixes #1", pr.GetBody())
 	assert.Equal("https://github.com/o/r/pull/42", pr.GetHTMLURL())
 	assert.Equal(10, pr.GetAdditions())

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -55,6 +55,7 @@ func NormalizePR(repoID int64, ghPR *gh.PullRequest) (*db.MergeRequest, error) {
 		AuthorDisplayName:  platformMR.AuthorDisplayName,
 		State:              platformMR.State,
 		IsDraft:            platformMR.IsDraft,
+		IsLocked:           platformMR.IsLocked,
 		Body:               platformMR.Body,
 		HeadBranch:         platformMR.HeadBranch,
 		BaseBranch:         platformMR.BaseBranch,

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -50,6 +50,7 @@ func TestNormalizePR_OpenPR(t *testing.T) {
 		User:      &gh.User{Login: new("alice")},
 		State:     new("open"),
 		Draft:     new(false),
+		Locked:    new(true),
 		Body:      new("description"),
 		Additions: new(10),
 		Deletions: new(5),
@@ -75,6 +76,7 @@ func TestNormalizePR_OpenPR(t *testing.T) {
 	assert.Equal("alice", pr.Author)
 	assert.Equal("open", pr.State)
 	assert.False(pr.IsDraft)
+	assert.True(pr.IsLocked)
 	assert.Equal("description", pr.Body)
 	assert.Equal(10, pr.Additions)
 	assert.Equal(5, pr.Deletions)

--- a/internal/platform/gitealike/normalize.go
+++ b/internal/platform/gitealike/normalize.go
@@ -65,6 +65,7 @@ func NormalizePullRequest(repo platform.RepoRef, pr PullRequestDTO) platform.Mer
 		AuthorDisplayName:  pr.User.FullName,
 		State:              state,
 		IsDraft:            pr.Draft,
+		IsLocked:           pr.IsLocked,
 		Body:               pr.Body,
 		HeadBranch:         pr.Head.Ref,
 		BaseBranch:         pr.Base.Ref,

--- a/internal/platform/gitealike/normalize.go
+++ b/internal/platform/gitealike/normalize.go
@@ -64,7 +64,7 @@ func NormalizePullRequest(repo platform.RepoRef, pr PullRequestDTO) platform.Mer
 		Author:             pr.User.UserName,
 		AuthorDisplayName:  pr.User.FullName,
 		State:              state,
-		IsDraft:            pr.IsLocked,
+		IsDraft:            pr.Draft,
 		Body:               pr.Body,
 		HeadBranch:         pr.Head.Ref,
 		BaseBranch:         pr.Base.Ref,

--- a/internal/platform/gitealike/normalize.go
+++ b/internal/platform/gitealike/normalize.go
@@ -1,0 +1,346 @@
+package gitealike
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/wesm/middleman/internal/platform"
+)
+
+func NormalizeRepository(
+	kind platform.Kind,
+	host string,
+	repo RepositoryDTO,
+) (platform.Repository, error) {
+	repoPath := strings.TrimSpace(repo.FullName)
+	if repoPath == "" {
+		repoPath = OwnerRepoPath(repo.Owner.UserName, repo.Name)
+	}
+	owner, name, err := splitRepoPath(repoPath, repo.Name)
+	if err != nil {
+		return platform.Repository{}, err
+	}
+	ref := platform.RepoRef{
+		Platform:           kind,
+		Host:               host,
+		Owner:              owner,
+		Name:               name,
+		RepoPath:           repoPath,
+		PlatformID:         repo.ID,
+		PlatformExternalID: strconv.FormatInt(repo.ID, 10),
+		WebURL:             repo.HTMLURL,
+		CloneURL:           repo.CloneURL,
+		DefaultBranch:      repo.DefaultBranch,
+	}
+	return platform.Repository{
+		Ref:                ref,
+		PlatformID:         repo.ID,
+		PlatformExternalID: strconv.FormatInt(repo.ID, 10),
+		Description:        repo.Description,
+		Private:            repo.Private,
+		Archived:           repo.Archived,
+		DefaultBranch:      repo.DefaultBranch,
+		WebURL:             repo.HTMLURL,
+		CloneURL:           repo.CloneURL,
+		CreatedAt:          repo.Created.UTC(),
+		UpdatedAt:          repo.Updated.UTC(),
+	}, nil
+}
+
+func NormalizePullRequest(repo platform.RepoRef, pr PullRequestDTO) platform.MergeRequest {
+	state := NormalizeState(pr.State)
+	if pr.Merged || pr.MergedAt != nil {
+		state = "merged"
+	}
+	return platform.MergeRequest{
+		Repo:               repo,
+		PlatformID:         pr.ID,
+		PlatformExternalID: strconv.FormatInt(pr.ID, 10),
+		Number:             pr.Index,
+		URL:                pr.HTMLURL,
+		Title:              pr.Title,
+		Author:             pr.User.UserName,
+		AuthorDisplayName:  pr.User.FullName,
+		State:              state,
+		IsDraft:            pr.IsLocked,
+		Body:               pr.Body,
+		HeadBranch:         pr.Head.Ref,
+		BaseBranch:         pr.Base.Ref,
+		HeadSHA:            pr.Head.SHA,
+		BaseSHA:            pr.Base.SHA,
+		HeadRepoCloneURL:   pr.Head.RepoCloneURL,
+		CommentCount:       pr.Comments,
+		CreatedAt:          pr.Created.UTC(),
+		UpdatedAt:          pr.Updated.UTC(),
+		LastActivityAt:     pr.Updated.UTC(),
+		MergedAt:           timePtrUTC(pr.MergedAt),
+		ClosedAt:           timePtrUTC(pr.Closed),
+		Labels:             NormalizeLabels(repo, pr.Labels),
+	}
+}
+
+func NormalizeIssue(repo platform.RepoRef, issue IssueDTO) platform.Issue {
+	return platform.Issue{
+		Repo:               repo,
+		PlatformID:         issue.ID,
+		PlatformExternalID: strconv.FormatInt(issue.ID, 10),
+		Number:             issue.Index,
+		URL:                issue.HTMLURL,
+		Title:              issue.Title,
+		Author:             issue.User.UserName,
+		State:              NormalizeState(issue.State),
+		Body:               issue.Body,
+		CommentCount:       issue.Comments,
+		CreatedAt:          issue.Created.UTC(),
+		UpdatedAt:          issue.Updated.UTC(),
+		LastActivityAt:     issue.Updated.UTC(),
+		ClosedAt:           timePtrUTC(issue.Closed),
+		Labels:             NormalizeLabels(repo, issue.Labels),
+	}
+}
+
+func NormalizeLabels(repo platform.RepoRef, labels []LabelDTO) []platform.Label {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]platform.Label, 0, len(labels))
+	for _, label := range labels {
+		out = append(out, platform.Label{
+			Repo:               repo,
+			PlatformID:         label.ID,
+			PlatformExternalID: strconv.FormatInt(label.ID, 10),
+			Name:               label.Name,
+			Description:        label.Description,
+			Color:              label.Color,
+			IsDefault:          label.IsDefault,
+		})
+	}
+	return out
+}
+
+func NormalizeIssueComments(
+	kind platform.Kind,
+	repo platform.RepoRef,
+	number int,
+	comments []CommentDTO,
+) []platform.IssueEvent {
+	events := make([]platform.IssueEvent, 0, len(comments))
+	for _, comment := range comments {
+		events = append(events, platform.IssueEvent{
+			Repo:               repo,
+			PlatformID:         comment.ID,
+			PlatformExternalID: strconv.FormatInt(comment.ID, 10),
+			IssueNumber:        number,
+			EventType:          "issue_comment",
+			Author:             comment.User.UserName,
+			Body:               comment.Body,
+			CreatedAt:          comment.Created.UTC(),
+			DedupeKey: NoteDedupeKey(
+				kind, repo.Host, repo.RepoPath, "issue", number, "issue_comment",
+				strconv.FormatInt(comment.ID, 10),
+			),
+		})
+	}
+	return events
+}
+
+func NormalizeMergeRequestEvents(
+	kind platform.Kind,
+	repo platform.RepoRef,
+	number int,
+	comments []CommentDTO,
+	reviews []ReviewDTO,
+	commits []CommitDTO,
+) []platform.MergeRequestEvent {
+	events := make([]platform.MergeRequestEvent, 0, len(comments)+len(reviews)+len(commits))
+	for _, comment := range comments {
+		externalID := strconv.FormatInt(comment.ID, 10)
+		events = append(events, platform.MergeRequestEvent{
+			Repo:               repo,
+			PlatformID:         comment.ID,
+			PlatformExternalID: externalID,
+			MergeRequestNumber: number,
+			EventType:          "issue_comment",
+			Author:             comment.User.UserName,
+			Body:               comment.Body,
+			CreatedAt:          comment.Created.UTC(),
+			DedupeKey:          NoteDedupeKey(kind, repo.Host, repo.RepoPath, "mr", number, "issue_comment", externalID),
+		})
+	}
+	for _, review := range reviews {
+		externalID := strconv.FormatInt(review.ID, 10)
+		events = append(events, platform.MergeRequestEvent{
+			Repo:               repo,
+			PlatformID:         review.ID,
+			PlatformExternalID: externalID,
+			MergeRequestNumber: number,
+			EventType:          "review",
+			Author:             review.User.UserName,
+			Summary:            review.State,
+			Body:               review.Body,
+			CreatedAt:          review.Submitted.UTC(),
+			DedupeKey:          NoteDedupeKey(kind, repo.Host, repo.RepoPath, "mr", number, "review", externalID),
+		})
+	}
+	for _, commit := range commits {
+		events = append(events, platform.MergeRequestEvent{
+			Repo:               repo,
+			PlatformExternalID: commit.SHA,
+			MergeRequestNumber: number,
+			EventType:          "commit",
+			Author:             commit.AuthorName,
+			Summary:            commit.Message,
+			CreatedAt:          commit.Created.UTC(),
+			DedupeKey:          NoteDedupeKey(kind, repo.Host, repo.RepoPath, "mr", number, "commit", commit.SHA),
+		})
+	}
+	return events
+}
+
+func NormalizeRelease(repo platform.RepoRef, release ReleaseDTO) platform.Release {
+	return platform.Release{
+		Repo:               repo,
+		PlatformID:         release.ID,
+		PlatformExternalID: strconv.FormatInt(release.ID, 10),
+		TagName:            release.TagName,
+		Name:               release.Title,
+		URL:                release.HTMLURL,
+		TargetCommitish:    release.Target,
+		Prerelease:         release.Prerelease,
+		PublishedAt:        timePtrUTC(release.PublishedAt),
+		CreatedAt:          release.CreatedAt.UTC(),
+	}
+}
+
+func NormalizeTag(repo platform.RepoRef, tag TagDTO) platform.Tag {
+	return platform.Tag{
+		Repo:               repo,
+		PlatformExternalID: tag.Commit.SHA,
+		Name:               tag.Name,
+		SHA:                tag.Commit.SHA,
+		URL:                tag.URL,
+	}
+}
+
+func NormalizeStatuses(
+	repo platform.RepoRef,
+	statuses []StatusDTO,
+	actionRuns []ActionRunDTO,
+) []platform.CICheck {
+	checks := make([]platform.CICheck, 0, len(statuses)+len(actionRuns))
+	for _, status := range statuses {
+		checkStatus, conclusion := NormalizeCommitStatus(status.State)
+		checks = append(checks, platform.CICheck{
+			Repo:               repo,
+			PlatformID:         status.ID,
+			PlatformExternalID: strconv.FormatInt(status.ID, 10),
+			Name:               status.Context,
+			Status:             checkStatus,
+			Conclusion:         conclusion,
+			URL:                status.TargetURL,
+			App:                "status",
+			StartedAt:          timePtr(status.Created),
+			CompletedAt:        timePtr(status.Updated),
+		})
+	}
+	for _, run := range actionRuns {
+		checkStatus, conclusion := NormalizeCommitStatus(run.Status)
+		checks = append(checks, platform.CICheck{
+			Repo:               repo,
+			PlatformID:         run.ID,
+			PlatformExternalID: strconv.FormatInt(run.ID, 10),
+			Name:               run.Title,
+			Status:             checkStatus,
+			Conclusion:         conclusion,
+			URL:                run.HTMLURL,
+			App:                "action",
+			StartedAt:          timePtrUTC(run.Started),
+			CompletedAt:        timePtrUTC(run.Stopped),
+		})
+	}
+	return checks
+}
+
+func NormalizeState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "opened":
+		return "open"
+	case "closed":
+		return "closed"
+	case "merged":
+		return "merged"
+	default:
+		return strings.TrimSpace(state)
+	}
+}
+
+func OwnerRepoPath(owner, name string) string {
+	if owner == "" {
+		return name
+	}
+	return owner + "/" + name
+}
+
+func NoteDedupeKey(
+	kind platform.Kind,
+	host string,
+	repoPath string,
+	parentKind string,
+	number int,
+	eventKind string,
+	externalID string,
+) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%d/%s/%s", kind, host, repoPath, parentKind, number, eventKind, externalID)
+}
+
+func NormalizeCommitStatus(state string) (status string, conclusion string) {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "pending", "running", "queued", "waiting":
+		return "pending", ""
+	case "success", "successful", "passed":
+		return "completed", "success"
+	case "failure", "failed", "error", "cancelled", "canceled":
+		return "completed", "failure"
+	case "skipped":
+		return "completed", "skipped"
+	default:
+		return NormalizeState(state), ""
+	}
+}
+
+func NextPage(next int) int {
+	if next < 0 {
+		return 0
+	}
+	return next
+}
+
+func splitRepoPath(repoPath, fallbackName string) (string, string, error) {
+	parts := strings.Split(repoPath, "/")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("invalid repository path %q", repoPath)
+	}
+	name := fallbackName
+	if name == "" {
+		name = parts[len(parts)-1]
+	}
+	return strings.Join(parts[:len(parts)-1], "/"), name, nil
+}
+
+func timePtrUTC(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	utc := t.UTC()
+	return &utc
+}
+
+func timePtr(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	utc := t.UTC()
+	return &utc
+}

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -1,0 +1,198 @@
+package gitealike
+
+import (
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	Require "github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/platform"
+)
+
+func TestNormalizeRepositoryMapsSharedDTO(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	created := time.Date(2026, 5, 1, 2, 3, 4, 0, time.UTC)
+	updated := created.Add(time.Hour)
+
+	repo, err := NormalizeRepository(platform.KindForgejo, "codeberg.org", RepositoryDTO{
+		ID:            42,
+		Owner:         UserDTO{UserName: "forgejo"},
+		Name:          "forgejo",
+		FullName:      "forgejo/forgejo",
+		HTMLURL:       "https://codeberg.org/forgejo/forgejo",
+		CloneURL:      "https://codeberg.org/forgejo/forgejo.git",
+		DefaultBranch: "forgejo",
+		Private:       true,
+		Archived:      true,
+		Description:   "git forge",
+		Created:       created,
+		Updated:       updated,
+	})
+	require.NoError(err)
+
+	assert.Equal(platform.KindForgejo, repo.Ref.Platform)
+	assert.Equal("codeberg.org", repo.Ref.Host)
+	assert.Equal("forgejo", repo.Ref.Owner)
+	assert.Equal("forgejo", repo.Ref.Name)
+	assert.Equal("forgejo/forgejo", repo.Ref.RepoPath)
+	assert.Equal(int64(42), repo.Ref.PlatformID)
+	assert.Equal("42", repo.Ref.PlatformExternalID)
+	assert.Equal("https://codeberg.org/forgejo/forgejo", repo.Ref.WebURL)
+	assert.Equal("https://codeberg.org/forgejo/forgejo.git", repo.Ref.CloneURL)
+	assert.Equal("forgejo", repo.Ref.DefaultBranch)
+	assert.Equal("git forge", repo.Description)
+	assert.True(repo.Private)
+	assert.True(repo.Archived)
+	assert.Equal(created, repo.CreatedAt)
+	assert.Equal(updated, repo.UpdatedAt)
+}
+
+func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
+	assert := Assert.New(t)
+	base := time.Date(2026, 5, 1, 2, 3, 4, 0, time.UTC)
+	closed := base.Add(2 * time.Hour)
+	repo := platform.RepoRef{
+		Platform: platform.KindGitea,
+		Host:     "gitea.com",
+		Owner:    "gitea",
+		Name:     "tea",
+		RepoPath: "gitea/tea",
+	}
+
+	pr := NormalizePullRequest(repo, PullRequestDTO{
+		ID:       100,
+		Index:    7,
+		HTMLURL:  "https://gitea.com/gitea/tea/pulls/7",
+		Title:    "Add tea",
+		User:     UserDTO{UserName: "alice", FullName: "Alice"},
+		State:    "closed",
+		Body:     "body",
+		Head:     BranchDTO{Ref: "feature", SHA: "abc123", RepoCloneURL: "https://example/head.git"},
+		Base:     BranchDTO{Ref: "main", SHA: "def456"},
+		Labels:   []LabelDTO{{ID: 1, Name: "kind/feature", Color: "00ff00", Description: "feature", IsDefault: true}},
+		Created:  base,
+		Updated:  base.Add(time.Hour),
+		Merged:   true,
+		MergedAt: &closed,
+		Closed:   &closed,
+	})
+	assert.Equal("merged", pr.State)
+	assert.Equal(7, pr.Number)
+	assert.Equal("alice", pr.Author)
+	assert.Equal("Alice", pr.AuthorDisplayName)
+	assert.Equal("feature", pr.HeadBranch)
+	assert.Equal("abc123", pr.HeadSHA)
+	assert.Equal("main", pr.BaseBranch)
+	assert.Equal("def456", pr.BaseSHA)
+	assert.Equal("https://example/head.git", pr.HeadRepoCloneURL)
+	assert.Equal("kind/feature", pr.Labels[0].Name)
+	assert.Equal(&closed, pr.MergedAt)
+	assert.Equal(&closed, pr.ClosedAt)
+
+	issue := NormalizeIssue(repo, IssueDTO{
+		ID:       200,
+		Index:    9,
+		HTMLURL:  "https://gitea.com/gitea/tea/issues/9",
+		Title:    "Bug",
+		User:     UserDTO{UserName: "bob"},
+		State:    "closed",
+		Body:     "issue body",
+		Comments: 3,
+		Labels:   []LabelDTO{{ID: 2, Name: "bug"}},
+		Created:  base,
+		Updated:  base.Add(time.Hour),
+		Closed:   &closed,
+	})
+	assert.Equal("closed", issue.State)
+	assert.Equal(9, issue.Number)
+	assert.Equal("bob", issue.Author)
+	assert.Equal(3, issue.CommentCount)
+	assert.Equal(&closed, issue.ClosedAt)
+
+	mrEvents := NormalizeMergeRequestEvents(
+		platform.KindGitea,
+		repo,
+		7,
+		[]CommentDTO{{ID: 300, User: UserDTO{UserName: "carol"}, Body: "comment", Created: base}},
+		[]ReviewDTO{{ID: 301, User: UserDTO{UserName: "dave"}, State: "APPROVED", Body: "review", Submitted: base.Add(time.Minute)}},
+		[]CommitDTO{{SHA: "abc123", AuthorName: "eve", Message: "commit", Created: base.Add(2 * time.Minute)}},
+	)
+	assert.Len(mrEvents, 3)
+	assert.Equal("issue_comment", mrEvents[0].EventType)
+	assert.Equal("review", mrEvents[1].EventType)
+	assert.Equal("commit", mrEvents[2].EventType)
+	assert.Contains(mrEvents[0].DedupeKey, "gitea/gitea.com/gitea/tea")
+
+	issueEvents := NormalizeIssueComments(
+		platform.KindGitea,
+		repo,
+		9,
+		[]CommentDTO{{ID: 400, User: UserDTO{UserName: "frank"}, Body: "issue comment", Created: base}},
+	)
+	assert.Len(issueEvents, 1)
+	assert.Equal("issue_comment", issueEvents[0].EventType)
+	assert.Equal("frank", issueEvents[0].Author)
+
+	release := NormalizeRelease(repo, ReleaseDTO{
+		ID:          500,
+		TagName:     "v1.0.0",
+		Title:       "One",
+		HTMLURL:     "https://gitea.com/gitea/tea/releases/v1.0.0",
+		Target:      "main",
+		Prerelease:  true,
+		PublishedAt: &closed,
+		CreatedAt:   base,
+	})
+	assert.Equal("v1.0.0", release.TagName)
+	assert.Equal("One", release.Name)
+	assert.Equal(&closed, release.PublishedAt)
+
+	tag := NormalizeTag(repo, TagDTO{Name: "v1.0.0", Commit: CommitDTO{SHA: "abc123"}})
+	assert.Equal("v1.0.0", tag.Name)
+	assert.Equal("abc123", tag.SHA)
+}
+
+func TestNormalizeStatusesMapsCommitStatusesAndActionRuns(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	started := time.Date(2026, 5, 1, 2, 3, 4, 0, time.UTC)
+	stopped := started.Add(time.Minute)
+	repo := platform.RepoRef{Platform: platform.KindForgejo, Host: "codeberg.org", RepoPath: "forgejo/forgejo"}
+
+	checks := NormalizeStatuses(repo, []StatusDTO{
+		{ID: 1, Context: "ci/success", State: "success", TargetURL: "https://ci/success", Description: "ok", Created: started, Updated: stopped},
+		{ID: 2, Context: "ci/pending", State: "pending", TargetURL: "https://ci/pending", Created: started},
+		{ID: 3, Context: "ci/error", State: "error", TargetURL: "https://ci/error", Created: started},
+	}, []ActionRunDTO{
+		{ID: 4, WorkflowID: "build", Title: "Build", Status: "failure", CommitSHA: "abc123", HTMLURL: "https://actions/build", Started: &started, Stopped: &stopped, NeedApproval: true},
+	})
+
+	require.Len(checks, 4)
+	assert.Equal("ci/success", checks[0].Name)
+	assert.Equal("completed", checks[0].Status)
+	assert.Equal("success", checks[0].Conclusion)
+	assert.Equal("pending", checks[1].Status)
+	assert.Empty(checks[1].Conclusion)
+	assert.Equal("failure", checks[2].Conclusion)
+	assert.Equal("Build", checks[3].Name)
+	assert.Equal("action", checks[3].App)
+	assert.Equal(&started, checks[3].StartedAt)
+	assert.Equal(&stopped, checks[3].CompletedAt)
+}
+
+func TestSharedHelpersNormalizeStateDedupeAndPagination(t *testing.T) {
+	assert := Assert.New(t)
+
+	assert.Equal("open", NormalizeState("opened"))
+	assert.Equal("closed", NormalizeState("closed"))
+	assert.Equal("merged", NormalizeState("merged"))
+	assert.Equal("custom", NormalizeState(" custom "))
+	assert.Equal("owner/repo", OwnerRepoPath("owner", "repo"))
+	assert.Equal(0, NextPage(0))
+	assert.Equal(3, NextPage(3))
+	assert.Equal(
+		"forgejo/codeberg.org/forgejo/forgejo/mr/7/issue_comment/123",
+		NoteDedupeKey(platform.KindForgejo, "codeberg.org", "forgejo/forgejo", "mr", 7, "issue_comment", "123"),
+	)
+}

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -109,6 +109,7 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 		Updated:  base,
 	})
 	assert.False(lockedPR.IsDraft)
+	assert.True(lockedPR.IsLocked)
 	assert.Equal("main", pr.BaseBranch)
 	assert.Equal("def456", pr.BaseSHA)
 	assert.Equal("https://example/head.git", pr.HeadRepoCloneURL)

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -83,6 +83,32 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 	assert.Equal("Alice", pr.AuthorDisplayName)
 	assert.Equal("feature", pr.HeadBranch)
 	assert.Equal("abc123", pr.HeadSHA)
+	assert.False(pr.IsDraft)
+
+	draftPR := NormalizePullRequest(repo, PullRequestDTO{
+		ID:       101,
+		Index:    8,
+		Title:    "Draft tea",
+		User:     UserDTO{UserName: "alice"},
+		State:    "open",
+		Draft:    true,
+		IsLocked: true,
+		Created:  base,
+		Updated:  base,
+	})
+	assert.True(draftPR.IsDraft)
+
+	lockedPR := NormalizePullRequest(repo, PullRequestDTO{
+		ID:       102,
+		Index:    9,
+		Title:    "Locked tea",
+		User:     UserDTO{UserName: "alice"},
+		State:    "open",
+		IsLocked: true,
+		Created:  base,
+		Updated:  base,
+	})
+	assert.False(lockedPR.IsDraft)
 	assert.Equal("main", pr.BaseBranch)
 	assert.Equal("def456", pr.BaseSHA)
 	assert.Equal("https://example/head.git", pr.HeadRepoCloneURL)

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -1,0 +1,307 @@
+package gitealike
+
+import (
+	"context"
+	"errors"
+
+	"github.com/wesm/middleman/internal/platform"
+)
+
+type Provider struct {
+	kind      platform.Kind
+	host      string
+	transport Transport
+	options   Options
+}
+
+type Options struct {
+	ReadActions bool
+}
+
+func NewProvider(
+	kind platform.Kind,
+	host string,
+	transport Transport,
+	options Options,
+) *Provider {
+	return &Provider{
+		kind:      kind,
+		host:      host,
+		transport: transport,
+		options:   options,
+	}
+}
+
+func (p *Provider) Platform() platform.Kind {
+	return p.kind
+}
+
+func (p *Provider) Host() string {
+	return p.host
+}
+
+func (p *Provider) Capabilities() platform.Capabilities {
+	return platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReleases:      true,
+		ReadCI:            true,
+	}
+}
+
+func (p *Provider) GetRepository(
+	ctx context.Context,
+	ref platform.RepoRef,
+) (platform.Repository, error) {
+	repo, err := p.transport.GetRepository(ctx, ref.Owner, ref.Name)
+	if err != nil {
+		return platform.Repository{}, p.mapError(err)
+	}
+	return NormalizeRepository(p.kind, p.host, repo)
+}
+
+func (p *Provider) ListRepositories(
+	ctx context.Context,
+	owner string,
+	opts platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	repos, err := p.listRepositories(ctx, owner, p.transport.ListUserRepositories)
+	if err != nil {
+		if errors.Is(err, platform.ErrNotFound) {
+			repos, err = p.listRepositories(ctx, owner, p.transport.ListOrgRepositories)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if opts.Limit <= 0 && opts.Offset <= 0 {
+		return repos, nil
+	}
+	return applyRepositoryListOptions(repos, opts), nil
+}
+
+func (p *Provider) ListOpenMergeRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.MergeRequest, error) {
+	items, err := collectPages(ctx, func(opts PageOptions) ([]PullRequestDTO, Page, error) {
+		return p.transport.ListOpenPullRequests(ctx, ref, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	out := make([]platform.MergeRequest, 0, len(items))
+	for _, item := range items {
+		out = append(out, NormalizePullRequest(ref, item))
+	}
+	return out, nil
+}
+
+func (p *Provider) GetMergeRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.MergeRequest, error) {
+	pr, err := p.transport.GetPullRequest(ctx, ref, number)
+	if err != nil {
+		return platform.MergeRequest{}, p.mapError(err)
+	}
+	return NormalizePullRequest(ref, pr), nil
+}
+
+func (p *Provider) ListMergeRequestEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestEvent, error) {
+	comments, err := collectPages(ctx, func(opts PageOptions) ([]CommentDTO, Page, error) {
+		return p.transport.ListPullRequestComments(ctx, ref, number, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	reviews, err := collectPages(ctx, func(opts PageOptions) ([]ReviewDTO, Page, error) {
+		return p.transport.ListPullRequestReviews(ctx, ref, number, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	commits, err := collectPages(ctx, func(opts PageOptions) ([]CommitDTO, Page, error) {
+		return p.transport.ListPullRequestCommits(ctx, ref, number, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	return NormalizeMergeRequestEvents(p.kind, ref, number, comments, reviews, commits), nil
+}
+
+func (p *Provider) ListOpenIssues(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.Issue, error) {
+	items, err := collectPages(ctx, func(opts PageOptions) ([]IssueDTO, Page, error) {
+		return p.transport.ListOpenIssues(ctx, ref, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	out := make([]platform.Issue, 0, len(items))
+	for _, item := range items {
+		if item.IsPullRequest {
+			continue
+		}
+		out = append(out, NormalizeIssue(ref, item))
+	}
+	return out, nil
+}
+
+func (p *Provider) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.Issue, error) {
+	issue, err := p.transport.GetIssue(ctx, ref, number)
+	if err != nil {
+		return platform.Issue{}, p.mapError(err)
+	}
+	return NormalizeIssue(ref, issue), nil
+}
+
+func (p *Provider) ListIssueEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.IssueEvent, error) {
+	comments, err := collectPages(ctx, func(opts PageOptions) ([]CommentDTO, Page, error) {
+		return p.transport.ListIssueComments(ctx, ref, number, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	return NormalizeIssueComments(p.kind, ref, number, comments), nil
+}
+
+func (p *Provider) ListReleases(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.Release, error) {
+	items, err := collectPages(ctx, func(opts PageOptions) ([]ReleaseDTO, Page, error) {
+		return p.transport.ListReleases(ctx, ref, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	out := make([]platform.Release, 0, len(items))
+	for _, item := range items {
+		out = append(out, NormalizeRelease(ref, item))
+	}
+	return out, nil
+}
+
+func (p *Provider) ListTags(ctx context.Context, ref platform.RepoRef) ([]platform.Tag, error) {
+	items, err := collectPages(ctx, func(opts PageOptions) ([]TagDTO, Page, error) {
+		return p.transport.ListTags(ctx, ref, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	out := make([]platform.Tag, 0, len(items))
+	for _, item := range items {
+		out = append(out, NormalizeTag(ref, item))
+	}
+	return out, nil
+}
+
+func (p *Provider) ListCIChecks(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+) ([]platform.CICheck, error) {
+	statuses, err := collectPages(ctx, func(opts PageOptions) ([]StatusDTO, Page, error) {
+		return p.transport.ListStatuses(ctx, ref, sha, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	var actionRuns []ActionRunDTO
+	if p.options.ReadActions {
+		if actionsTransport, ok := p.transport.(ActionsTransport); ok {
+			actionRuns, err = collectPages(ctx, func(opts PageOptions) ([]ActionRunDTO, Page, error) {
+				return actionsTransport.ListActionRuns(ctx, ref, sha, opts)
+			})
+			if err != nil {
+				return nil, p.mapError(err)
+			}
+		}
+	}
+	return NormalizeStatuses(ref, statuses, actionRuns), nil
+}
+
+func (p *Provider) listRepositories(
+	ctx context.Context,
+	owner string,
+	list func(context.Context, string, PageOptions) ([]RepositoryDTO, Page, error),
+) ([]platform.Repository, error) {
+	items, err := collectPages(ctx, func(opts PageOptions) ([]RepositoryDTO, Page, error) {
+		return list(ctx, owner, opts)
+	})
+	if err != nil {
+		return nil, p.mapError(err)
+	}
+	out := make([]platform.Repository, 0, len(items))
+	for _, item := range items {
+		repo, err := NormalizeRepository(p.kind, p.host, item)
+		if err != nil {
+			return nil, err
+		}
+		if repo.Ref.Owner == owner {
+			out = append(out, repo)
+		}
+	}
+	return out, nil
+}
+
+func (p *Provider) mapError(err error) error {
+	return mapTransportError(p.kind, p.host, err)
+}
+
+func collectPages[T any](
+	ctx context.Context,
+	fetch func(PageOptions) ([]T, Page, error),
+) ([]T, error) {
+	var out []T
+	page := 1
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		items, next, err := fetch(PageOptions{Page: page, PageSize: defaultPageSize})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, items...)
+		page = NextPage(next.Next)
+		if page == 0 {
+			return out, nil
+		}
+	}
+}
+
+func applyRepositoryListOptions(
+	repos []platform.Repository,
+	opts platform.RepositoryListOptions,
+) []platform.Repository {
+	start := max(opts.Offset, 0)
+	if start >= len(repos) {
+		return nil
+	}
+	end := len(repos)
+	if opts.Limit > 0 && start+opts.Limit < end {
+		end = start + opts.Limit
+	}
+	return repos[start:end]
+}

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -3,9 +3,12 @@ package gitealike
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/wesm/middleman/internal/platform"
 )
+
+const maxCollectedPages = 1000
 
 type Provider struct {
 	kind      platform.Kind
@@ -285,21 +288,33 @@ func collectPages[T any](
 ) ([]T, error) {
 	var out []T
 	page := 1
+	seen := make(map[int]bool)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
+		if seen[page] {
+			return nil, fmt.Errorf("gitealike pagination did not advance: page %d repeated", page)
+		}
+		if len(seen) >= maxCollectedPages {
+			return nil, fmt.Errorf("gitealike pagination exceeded %d pages", maxCollectedPages)
+		}
+		seen[page] = true
 		items, next, err := fetch(PageOptions{Page: page, PageSize: defaultPageSize})
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, items...)
-		page = NextPage(next.Next)
-		if page == 0 {
+		nextPage := NextPage(next.Next)
+		if nextPage == 0 {
 			return out, nil
 		}
+		if nextPage <= page {
+			return nil, fmt.Errorf("gitealike pagination did not advance: next page %d after page %d", nextPage, page)
+		}
+		page = nextPage
 	}
 }
 

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -18,12 +18,24 @@ type Options struct {
 	ReadActions bool
 }
 
+type Option func(*Options)
+
+func WithReadActions() Option {
+	return func(options *Options) {
+		options.ReadActions = true
+	}
+}
+
 func NewProvider(
 	kind platform.Kind,
 	host string,
 	transport Transport,
-	options Options,
+	opts ...Option,
 ) *Provider {
+	var options Options
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return &Provider{
 		kind:      kind,
 		host:      host,

--- a/internal/platform/gitealike/provider_test.go
+++ b/internal/platform/gitealike/provider_test.go
@@ -1,0 +1,261 @@
+package gitealike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	Require "github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/platform"
+)
+
+func TestProviderCapabilitiesEnableSharedReadBehavior(t *testing.T) {
+	provider := NewProvider(platform.KindForgejo, "codeberg.org", &fakeTransport{}, Options{ReadActions: true})
+
+	Assert.Equal(t, platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReleases:      true,
+		ReadCI:            true,
+	}, provider.Capabilities())
+}
+
+func TestProviderPaginatesAndNormalizesReadMethods(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	base := time.Date(2026, 5, 1, 2, 3, 4, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform: platform.KindForgejo,
+		Host:     "codeberg.org",
+		Owner:    "forgejo",
+		Name:     "forgejo",
+		RepoPath: "forgejo/forgejo",
+	}
+	transport := &fakeTransport{
+		repo: RepositoryDTO{
+			ID:            1,
+			Owner:         UserDTO{UserName: "forgejo"},
+			Name:          "forgejo",
+			FullName:      "forgejo/forgejo",
+			DefaultBranch: "main",
+			Created:       base,
+			Updated:       base,
+		},
+		userRepos: [][]RepositoryDTO{
+			{{ID: 2, Owner: UserDTO{UserName: "forgejo"}, Name: "one", FullName: "forgejo/one"}},
+			{{ID: 3, Owner: UserDTO{UserName: "forgejo"}, Name: "two", FullName: "forgejo/two"}},
+		},
+		pulls: [][]PullRequestDTO{
+			{{ID: 4, Index: 1, Title: "one", User: UserDTO{UserName: "alice"}, State: "open", Created: base, Updated: base}},
+			{{ID: 5, Index: 2, Title: "two", User: UserDTO{UserName: "bob"}, State: "open", Created: base, Updated: base}},
+		},
+		issues: [][]IssueDTO{
+			{
+				{ID: 6, Index: 3, Title: "issue", User: UserDTO{UserName: "carol"}, State: "open", Created: base, Updated: base},
+				{ID: 7, Index: 4, Title: "pull duplicate", User: UserDTO{UserName: "dan"}, State: "open", Created: base, Updated: base, IsPullRequest: true},
+			},
+		},
+		releases: [][]ReleaseDTO{{{ID: 8, TagName: "v1", Title: "one", CreatedAt: base}}},
+		tags:     [][]TagDTO{{{Name: "v1", Commit: CommitDTO{SHA: "abc"}}}},
+		statuses: [][]StatusDTO{{{ID: 9, Context: "ci", State: "success", Created: base}}},
+	}
+	provider := NewProvider(platform.KindForgejo, "codeberg.org", transport, Options{})
+
+	repo, err := provider.GetRepository(context.Background(), ref)
+	require.NoError(err)
+	assert.Equal("forgejo/forgejo", repo.Ref.RepoPath)
+
+	repos, err := provider.ListRepositories(context.Background(), "forgejo", platform.RepositoryListOptions{})
+	require.NoError(err)
+	assert.Equal([]string{"one", "two"}, []string{repos[0].Ref.Name, repos[1].Ref.Name})
+	assert.Equal([]int{1, 2}, transport.userRepoPages)
+
+	mrs, err := provider.ListOpenMergeRequests(context.Background(), ref)
+	require.NoError(err)
+	assert.Equal([]int{1, 2}, []int{mrs[0].Number, mrs[1].Number})
+	assert.Equal([]int{1, 2}, transport.pullPages)
+
+	issues, err := provider.ListOpenIssues(context.Background(), ref)
+	require.NoError(err)
+	require.Len(issues, 1)
+	assert.Equal(3, issues[0].Number)
+
+	releases, err := provider.ListReleases(context.Background(), ref)
+	require.NoError(err)
+	require.Len(releases, 1)
+	assert.Equal("v1", releases[0].TagName)
+
+	tags, err := provider.ListTags(context.Background(), ref)
+	require.NoError(err)
+	require.Len(tags, 1)
+	assert.Equal("abc", tags[0].SHA)
+
+	checks, err := provider.ListCIChecks(context.Background(), ref, "abc")
+	require.NoError(err)
+	require.Len(checks, 1)
+	assert.Equal("success", checks[0].Conclusion)
+}
+
+func TestProviderFallsBackFromUserToOrgRepositoryImport(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	transport := &fakeTransport{
+		userRepoErr: &HTTPError{StatusCode: 404, Message: "user missing"},
+		orgRepos: [][]RepositoryDTO{
+			{{ID: 10, Owner: UserDTO{UserName: "org"}, Name: "repo", FullName: "org/repo"}},
+		},
+	}
+	provider := NewProvider(platform.KindGitea, "gitea.com", transport, Options{})
+
+	repos, err := provider.ListRepositories(context.Background(), "org", platform.RepositoryListOptions{})
+	require.NoError(err)
+
+	require.Len(repos, 1)
+	assert.Equal("org/repo", repos[0].Ref.RepoPath)
+	assert.Equal([]int{1}, transport.userRepoPages)
+	assert.Equal([]int{1}, transport.orgRepoPages)
+}
+
+func TestProviderMapsHTTPStatusErrorsToTypedPlatformErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		target     error
+		code       platform.PlatformErrorCode
+	}{
+		{"unauthorized", 401, platform.ErrPermissionDenied, platform.ErrCodePermissionDenied},
+		{"forbidden", 403, platform.ErrPermissionDenied, platform.ErrCodePermissionDenied},
+		{"not found", 404, platform.ErrNotFound, platform.ErrCodeNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			require := Require.New(t)
+			provider := NewProvider(platform.KindForgejo, "codeberg.org", &fakeTransport{
+				repoErr: &HTTPError{StatusCode: tt.statusCode, Message: "failed"},
+			}, Options{})
+
+			_, err := provider.GetRepository(context.Background(), platform.RepoRef{
+				Owner: "forgejo",
+				Name:  "forgejo",
+			})
+
+			require.Error(err)
+			require.ErrorIs(err, tt.target)
+			var platformErr *platform.Error
+			require.ErrorAs(err, &platformErr)
+			assert.Equal(tt.code, platformErr.Code)
+			assert.Equal(platform.KindForgejo, platformErr.Provider)
+			assert.Equal("codeberg.org", platformErr.PlatformHost)
+		})
+	}
+}
+
+type fakeTransport struct {
+	repo        RepositoryDTO
+	repoErr     error
+	userRepos   [][]RepositoryDTO
+	userRepoErr error
+	orgRepos    [][]RepositoryDTO
+	orgRepoErr  error
+	pulls       [][]PullRequestDTO
+	issues      [][]IssueDTO
+	releases    [][]ReleaseDTO
+	tags        [][]TagDTO
+	statuses    [][]StatusDTO
+
+	userRepoPages []int
+	orgRepoPages  []int
+	pullPages     []int
+}
+
+func (t *fakeTransport) GetRepository(context.Context, string, string) (RepositoryDTO, error) {
+	return t.repo, t.repoErr
+}
+
+func (t *fakeTransport) ListUserRepositories(
+	_ context.Context,
+	_ string,
+	opts PageOptions,
+) ([]RepositoryDTO, Page, error) {
+	t.userRepoPages = append(t.userRepoPages, opts.Page)
+	if t.userRepoErr != nil {
+		return nil, Page{}, t.userRepoErr
+	}
+	return pageFor(t.userRepos, opts.Page)
+}
+
+func (t *fakeTransport) ListOrgRepositories(
+	_ context.Context,
+	_ string,
+	opts PageOptions,
+) ([]RepositoryDTO, Page, error) {
+	t.orgRepoPages = append(t.orgRepoPages, opts.Page)
+	if t.orgRepoErr != nil {
+		return nil, Page{}, t.orgRepoErr
+	}
+	return pageFor(t.orgRepos, opts.Page)
+}
+
+func (t *fakeTransport) ListOpenPullRequests(
+	_ context.Context,
+	_ platform.RepoRef,
+	opts PageOptions,
+) ([]PullRequestDTO, Page, error) {
+	t.pullPages = append(t.pullPages, opts.Page)
+	return pageFor(t.pulls, opts.Page)
+}
+
+func (t *fakeTransport) GetPullRequest(context.Context, platform.RepoRef, int) (PullRequestDTO, error) {
+	return PullRequestDTO{}, nil
+}
+
+func (t *fakeTransport) ListPullRequestComments(context.Context, platform.RepoRef, int, PageOptions) ([]CommentDTO, Page, error) {
+	return nil, Page{}, nil
+}
+
+func (t *fakeTransport) ListPullRequestReviews(context.Context, platform.RepoRef, int, PageOptions) ([]ReviewDTO, Page, error) {
+	return nil, Page{}, nil
+}
+
+func (t *fakeTransport) ListPullRequestCommits(context.Context, platform.RepoRef, int, PageOptions) ([]CommitDTO, Page, error) {
+	return nil, Page{}, nil
+}
+
+func (t *fakeTransport) ListOpenIssues(_ context.Context, _ platform.RepoRef, opts PageOptions) ([]IssueDTO, Page, error) {
+	return pageFor(t.issues, opts.Page)
+}
+
+func (t *fakeTransport) GetIssue(context.Context, platform.RepoRef, int) (IssueDTO, error) {
+	return IssueDTO{}, nil
+}
+
+func (t *fakeTransport) ListIssueComments(context.Context, platform.RepoRef, int, PageOptions) ([]CommentDTO, Page, error) {
+	return nil, Page{}, nil
+}
+
+func (t *fakeTransport) ListReleases(_ context.Context, _ platform.RepoRef, opts PageOptions) ([]ReleaseDTO, Page, error) {
+	return pageFor(t.releases, opts.Page)
+}
+
+func (t *fakeTransport) ListTags(_ context.Context, _ platform.RepoRef, opts PageOptions) ([]TagDTO, Page, error) {
+	return pageFor(t.tags, opts.Page)
+}
+
+func (t *fakeTransport) ListStatuses(_ context.Context, _ platform.RepoRef, _ string, opts PageOptions) ([]StatusDTO, Page, error) {
+	return pageFor(t.statuses, opts.Page)
+}
+
+func pageFor[T any](pages [][]T, page int) ([]T, Page, error) {
+	if page < 1 || page > len(pages) {
+		return nil, Page{}, nil
+	}
+	next := 0
+	if page < len(pages) {
+		next = page + 1
+	}
+	return pages[page-1], Page{Next: next}, nil
+}

--- a/internal/platform/gitealike/provider_test.go
+++ b/internal/platform/gitealike/provider_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestProviderCapabilitiesEnableSharedReadBehavior(t *testing.T) {
-	provider := NewProvider(platform.KindForgejo, "codeberg.org", &fakeTransport{}, Options{ReadActions: true})
+	provider := NewProvider(platform.KindForgejo, "codeberg.org", &fakeTransport{}, WithReadActions())
 
 	Assert.Equal(t, platform.Capabilities{
 		ReadRepositories:  true,
@@ -62,7 +62,7 @@ func TestProviderPaginatesAndNormalizesReadMethods(t *testing.T) {
 		tags:     [][]TagDTO{{{Name: "v1", Commit: CommitDTO{SHA: "abc"}}}},
 		statuses: [][]StatusDTO{{{ID: 9, Context: "ci", State: "success", Created: base}}},
 	}
-	provider := NewProvider(platform.KindForgejo, "codeberg.org", transport, Options{})
+	provider := NewProvider(platform.KindForgejo, "codeberg.org", transport)
 
 	repo, err := provider.GetRepository(context.Background(), ref)
 	require.NoError(err)
@@ -108,7 +108,7 @@ func TestProviderFallsBackFromUserToOrgRepositoryImport(t *testing.T) {
 			{{ID: 10, Owner: UserDTO{UserName: "org"}, Name: "repo", FullName: "org/repo"}},
 		},
 	}
-	provider := NewProvider(platform.KindGitea, "gitea.com", transport, Options{})
+	provider := NewProvider(platform.KindGitea, "gitea.com", transport)
 
 	repos, err := provider.ListRepositories(context.Background(), "org", platform.RepositoryListOptions{})
 	require.NoError(err)
@@ -136,7 +136,7 @@ func TestProviderMapsHTTPStatusErrorsToTypedPlatformErrors(t *testing.T) {
 			require := Require.New(t)
 			provider := NewProvider(platform.KindForgejo, "codeberg.org", &fakeTransport{
 				repoErr: &HTTPError{StatusCode: tt.statusCode, Message: "failed"},
-			}, Options{})
+			})
 
 			_, err := provider.GetRepository(context.Background(), platform.RepoRef{
 				Owner: "forgejo",

--- a/internal/platform/gitealike/provider_test.go
+++ b/internal/platform/gitealike/provider_test.go
@@ -99,6 +99,26 @@ func TestProviderPaginatesAndNormalizesReadMethods(t *testing.T) {
 	assert.Equal("success", checks[0].Conclusion)
 }
 
+func TestCollectPagesRejectsNonAdvancingPagination(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	_, err := collectPages(context.Background(), func(opts PageOptions) ([]int, Page, error) {
+		return []int{opts.Page}, Page{Next: opts.Page}, nil
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "did not advance")
+}
+
+func TestCollectPagesRejectsExcessivePagination(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	_, err := collectPages(context.Background(), func(opts PageOptions) ([]int, Page, error) {
+		return []int{opts.Page}, Page{Next: opts.Page + 1}, nil
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "exceeded")
+}
+
 func TestProviderFallsBackFromUserToOrgRepositoryImport(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)

--- a/internal/platform/gitealike/types.go
+++ b/internal/platform/gitealike/types.go
@@ -1,0 +1,241 @@
+package gitealike
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/wesm/middleman/internal/platform"
+)
+
+const defaultPageSize = 100
+
+type Transport interface {
+	GetRepository(ctx context.Context, owner, repo string) (RepositoryDTO, error)
+	ListUserRepositories(ctx context.Context, owner string, opts PageOptions) ([]RepositoryDTO, Page, error)
+	ListOrgRepositories(ctx context.Context, owner string, opts PageOptions) ([]RepositoryDTO, Page, error)
+	ListOpenPullRequests(ctx context.Context, ref platform.RepoRef, opts PageOptions) ([]PullRequestDTO, Page, error)
+	GetPullRequest(ctx context.Context, ref platform.RepoRef, number int) (PullRequestDTO, error)
+	ListPullRequestComments(ctx context.Context, ref platform.RepoRef, number int, opts PageOptions) ([]CommentDTO, Page, error)
+	ListPullRequestReviews(ctx context.Context, ref platform.RepoRef, number int, opts PageOptions) ([]ReviewDTO, Page, error)
+	ListPullRequestCommits(ctx context.Context, ref platform.RepoRef, number int, opts PageOptions) ([]CommitDTO, Page, error)
+	ListOpenIssues(ctx context.Context, ref platform.RepoRef, opts PageOptions) ([]IssueDTO, Page, error)
+	GetIssue(ctx context.Context, ref platform.RepoRef, number int) (IssueDTO, error)
+	ListIssueComments(ctx context.Context, ref platform.RepoRef, number int, opts PageOptions) ([]CommentDTO, Page, error)
+	ListReleases(ctx context.Context, ref platform.RepoRef, opts PageOptions) ([]ReleaseDTO, Page, error)
+	ListTags(ctx context.Context, ref platform.RepoRef, opts PageOptions) ([]TagDTO, Page, error)
+	ListStatuses(ctx context.Context, ref platform.RepoRef, sha string, opts PageOptions) ([]StatusDTO, Page, error)
+}
+
+type ActionsTransport interface {
+	ListActionRuns(ctx context.Context, ref platform.RepoRef, sha string, opts PageOptions) ([]ActionRunDTO, Page, error)
+}
+
+type PageOptions struct {
+	Page     int
+	PageSize int
+}
+
+type Page struct {
+	Next int
+}
+
+type UserDTO struct {
+	ID       int64
+	UserName string
+	FullName string
+}
+
+type RepositoryDTO struct {
+	ID            int64
+	Owner         UserDTO
+	Name          string
+	FullName      string
+	HTMLURL       string
+	CloneURL      string
+	DefaultBranch string
+	Private       bool
+	Archived      bool
+	Description   string
+	Created       time.Time
+	Updated       time.Time
+}
+
+type BranchDTO struct {
+	Ref          string
+	SHA          string
+	RepoCloneURL string
+}
+
+type LabelDTO struct {
+	ID          int64
+	Name        string
+	Description string
+	Color       string
+	IsDefault   bool
+}
+
+type PullRequestDTO struct {
+	ID       int64
+	Index    int
+	HTMLURL  string
+	Title    string
+	User     UserDTO
+	State    string
+	IsLocked bool
+	Body     string
+	Head     BranchDTO
+	Base     BranchDTO
+	Labels   []LabelDTO
+	Comments int
+	Created  time.Time
+	Updated  time.Time
+	Merged   bool
+	MergedAt *time.Time
+	Closed   *time.Time
+}
+
+type IssueDTO struct {
+	ID            int64
+	Index         int
+	HTMLURL       string
+	Title         string
+	User          UserDTO
+	State         string
+	Body          string
+	Comments      int
+	Labels        []LabelDTO
+	Created       time.Time
+	Updated       time.Time
+	Closed        *time.Time
+	IsPullRequest bool
+}
+
+type CommentDTO struct {
+	ID      int64
+	User    UserDTO
+	Body    string
+	Created time.Time
+	Updated time.Time
+}
+
+type ReviewDTO struct {
+	ID        int64
+	User      UserDTO
+	State     string
+	Body      string
+	Submitted time.Time
+}
+
+type CommitDTO struct {
+	SHA        string
+	AuthorName string
+	Message    string
+	URL        string
+	Created    time.Time
+}
+
+type ReleaseDTO struct {
+	ID          int64
+	TagName     string
+	Title       string
+	HTMLURL     string
+	Target      string
+	Prerelease  bool
+	PublishedAt *time.Time
+	CreatedAt   time.Time
+}
+
+type TagDTO struct {
+	Name   string
+	Commit CommitDTO
+	URL    string
+}
+
+type StatusDTO struct {
+	ID          int64
+	Context     string
+	State       string
+	TargetURL   string
+	Description string
+	Created     time.Time
+	Updated     time.Time
+}
+
+type ActionRunDTO struct {
+	ID           int64
+	WorkflowID   string
+	Title        string
+	Status       string
+	CommitSHA    string
+	HTMLURL      string
+	Started      *time.Time
+	Stopped      *time.Time
+	NeedApproval bool
+}
+
+type HTTPError struct {
+	StatusCode int
+	Message    string
+	Err        error
+}
+
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	message := e.Message
+	if message == "" {
+		message = httpStatusMessage(e.StatusCode)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", message, e.Err)
+	}
+	return message
+}
+
+func (e *HTTPError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func mapTransportError(kind platform.Kind, host string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		return err
+	}
+	var code platform.PlatformErrorCode
+	switch httpErr.StatusCode {
+	case 401, 403:
+		code = platform.ErrCodePermissionDenied
+	case 404:
+		code = platform.ErrCodeNotFound
+	default:
+		return err
+	}
+	return &platform.Error{
+		Code:         code,
+		Provider:     kind,
+		PlatformHost: host,
+		Err:          err,
+	}
+}
+
+func httpStatusMessage(statusCode int) string {
+	switch statusCode {
+	case 401:
+		return "unauthorized"
+	case 403:
+		return "forbidden"
+	case 404:
+		return "not found"
+	default:
+		return fmt.Sprintf("http status %d", statusCode)
+	}
+}

--- a/internal/platform/gitealike/types.go
+++ b/internal/platform/gitealike/types.go
@@ -83,6 +83,7 @@ type PullRequestDTO struct {
 	Title    string
 	User     UserDTO
 	State    string
+	Draft    bool
 	IsLocked bool
 	Body     string
 	Head     BranchDTO

--- a/internal/platform/github/normalize.go
+++ b/internal/platform/github/normalize.go
@@ -29,6 +29,7 @@ func NormalizePullRequest(repo platform.RepoRef, ghPR *gh.PullRequest) (platform
 		AuthorDisplayName:  nameOrEmpty(ghPR.GetUser()),
 		State:              ghPR.GetState(),
 		IsDraft:            ghPR.GetDraft(),
+		IsLocked:           ghPR.GetLocked(),
 		Body:               ghPR.GetBody(),
 		Additions:          ghPR.GetAdditions(),
 		Deletions:          ghPR.GetDeletions(),

--- a/internal/platform/persist.go
+++ b/internal/platform/persist.go
@@ -37,6 +37,7 @@ func DBMergeRequest(repoID int64, mr MergeRequest) *db.MergeRequest {
 		AuthorDisplayName:  mr.AuthorDisplayName,
 		State:              mr.State,
 		IsDraft:            mr.IsDraft,
+		IsLocked:           mr.IsLocked,
 		Body:               mr.Body,
 		HeadBranch:         mr.HeadBranch,
 		BaseBranch:         mr.BaseBranch,

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -69,6 +69,7 @@ type MergeRequest struct {
 	AuthorDisplayName  string
 	State              string
 	IsDraft            bool
+	IsLocked           bool
 	Body               string
 	HeadBranch         string
 	BaseBranch         string

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9421,6 +9421,7 @@ func TestAPIActivityStartupRepairsLegacyTimestampStorage(t *testing.T) {
 			DROP INDEX IF EXISTS idx_merge_requests_repo_platform_external_id;
 			DROP INDEX IF EXISTS idx_repos_provider_path_key;
 			DROP INDEX IF EXISTS idx_repos_platform_repo_id;
+			ALTER TABLE middleman_merge_requests DROP COLUMN is_locked;
 			ALTER TABLE middleman_mr_events DROP COLUMN platform_external_id;
 			ALTER TABLE middleman_labels DROP COLUMN platform_external_id;
 			ALTER TABLE middleman_issues DROP COLUMN platform_external_id;

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/wesm/middleman/internal/gitenv"
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/stacks"
 	"github.com/wesm/middleman/internal/testutil"
 	"github.com/wesm/middleman/internal/workspace"
@@ -8606,6 +8607,215 @@ func assertUnsupportedCapabilityProblem(
 	assert.Equal(provider, problem.Errors[0].Value["provider"])
 	assert.Equal(host, problem.Errors[0].Value["platform_host"])
 	assert.Equal(capability, problem.Errors[0].Value["capability"])
+}
+
+func TestAPIGitealikeLockedPRPersistsThroughServer(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	transport := &lockedGitealikeTransport{
+		repo: gitealike.RepositoryDTO{
+			ID:            101,
+			Owner:         gitealike.UserDTO{UserName: "forgejo"},
+			Name:          "tea",
+			FullName:      "forgejo/tea",
+			HTMLURL:       "https://codeberg.test/forgejo/tea",
+			CloneURL:      "https://codeberg.test/forgejo/tea.git",
+			DefaultBranch: "main",
+			Created:       base,
+			Updated:       base,
+		},
+		pull: gitealike.PullRequestDTO{
+			ID:       201,
+			Index:    7,
+			HTMLURL:  "https://codeberg.test/forgejo/tea/pulls/7",
+			Title:    "Locked tea",
+			User:     gitealike.UserDTO{UserName: "alice"},
+			State:    "open",
+			Draft:    false,
+			IsLocked: true,
+			Head:     gitealike.BranchDTO{Ref: "feature", SHA: "abc123"},
+			Base:     gitealike.BranchDTO{Ref: "main", SHA: "def456"},
+			Created:  base,
+			Updated:  base.Add(time.Minute),
+		},
+	}
+	provider := gitealike.NewProvider(platform.KindForgejo, "codeberg.test", transport)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindForgejo,
+			PlatformHost: "codeberg.test",
+			Owner:        "forgejo",
+			Name:         "tea",
+			RepoPath:     "forgejo/tea",
+		}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+	require.NoError(syncer.SyncMR(ctx, "forgejo", "tea", 7))
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "forgejo",
+		PlatformHost: "codeberg.test",
+		RepoPath:     "forgejo/tea",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.False(mr.IsDraft)
+	assert.True(mr.IsLocked)
+
+	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pullResp.StatusCode(), string(pullResp.Body))
+	require.NotNil(pullResp.JSON200)
+	assert.False(pullResp.JSON200.MergeRequest.IsDraft)
+	assert.True(pullResp.JSON200.MergeRequest.IsLocked)
+}
+
+type lockedGitealikeTransport struct {
+	repo gitealike.RepositoryDTO
+	pull gitealike.PullRequestDTO
+}
+
+func (t *lockedGitealikeTransport) GetRepository(
+	context.Context,
+	string,
+	string,
+) (gitealike.RepositoryDTO, error) {
+	return t.repo, nil
+}
+
+func (t *lockedGitealikeTransport) ListUserRepositories(
+	context.Context,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	return []gitealike.RepositoryDTO{t.repo}, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListOrgRepositories(
+	context.Context,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	return []gitealike.RepositoryDTO{t.repo}, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListOpenPullRequests(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	return []gitealike.PullRequestDTO{t.pull}, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) GetPullRequest(
+	context.Context,
+	platform.RepoRef,
+	int,
+) (gitealike.PullRequestDTO, error) {
+	return t.pull, nil
+}
+
+func (t *lockedGitealikeTransport) ListPullRequestComments(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListPullRequestReviews(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListPullRequestCommits(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListOpenIssues(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) GetIssue(
+	context.Context,
+	platform.RepoRef,
+	int,
+) (gitealike.IssueDTO, error) {
+	return gitealike.IssueDTO{}, platform.ErrNotFound
+}
+
+func (t *lockedGitealikeTransport) ListIssueComments(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListReleases(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListTags(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.TagDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *lockedGitealikeTransport) ListStatuses(
+	context.Context,
+	platform.RepoRef,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
 }
 
 func TestProviderIssueRouteGeneratedClientEscapesGitLabRepoPath(t *testing.T) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
     "./api/types": { "default": "./src/api/types.ts" },
     "./api/client": { "default": "./src/api/generated/client.ts" },
     "./api/schema": { "default": "./src/api/generated/schema.ts" },
+    "./api/provider-capabilities": { "default": "./src/api/provider-capabilities.ts" },
     "./api/provider-routes": { "default": "./src/api/provider-routes.ts" },
     "./utils/time": { "default": "./src/utils/time.ts" },
     "./utils/markdown": { "default": "./src/utils/markdown.ts" },

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2008,6 +2008,7 @@ export interface components {
             /** Format: int64 */
             ID: number;
             IsDraft: boolean;
+            IsLocked: boolean;
             KanbanStatus: string;
             /** Format: date-time */
             LastActivityAt: string;
@@ -2077,6 +2078,7 @@ export interface components {
             /** Format: int64 */
             ID: number;
             IsDraft: boolean;
+            IsLocked: boolean;
             KanbanStatus: string;
             /** Format: date-time */
             LastActivityAt: string;

--- a/packages/ui/src/api/provider-capabilities.test.ts
+++ b/packages/ui/src/api/provider-capabilities.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { supportsLocked } from "./provider-capabilities.js";
+
+describe("supportsLocked", () => {
+  it("reports locked support for providers that expose lock state", () => {
+    expect(supportsLocked("github", "github.com", "acme", "widgets")).toBe(true);
+    expect(supportsLocked("forgejo", "codeberg.org", "forgejo", "forgejo")).toBe(true);
+    expect(supportsLocked("gitea", "gitea.com", "gitea", "tea")).toBe(true);
+  });
+
+  it("does not report locked support for read-only GitLab data", () => {
+    expect(supportsLocked("gitlab", "gitlab.com", "group", "project")).toBe(false);
+  });
+});

--- a/packages/ui/src/api/provider-capabilities.ts
+++ b/packages/ui/src/api/provider-capabilities.ts
@@ -1,0 +1,10 @@
+const lockedProviders = new Set(["github", "forgejo", "gitea"]);
+
+export function supportsLocked(
+  provider: string,
+  _host: string,
+  _org: string,
+  _repo: string,
+): boolean {
+  return lockedProviders.has(provider.trim().toLowerCase());
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -49,6 +49,7 @@ export {
   buildPullRequestRoute,
   buildRoutedItemRoute,
 } from "./routes.js";
+export { supportsLocked } from "./api/provider-capabilities.js";
 export type {
   FocusListRouteRef,
   IssueRouteRef,


### PR DESCRIPTION
Adds a shared gitea-like provider core for SDK-free normalization, pagination, read capabilities, and typed transport error mapping before SDK converters wire into it.