### PR TITLE
feat: read Forgejo and Gitea through shared provider core

### DIFF
--- a/internal/platform/forgejo/client.go
+++ b/internal/platform/forgejo/client.go
@@ -8,6 +8,7 @@ import (
 
 	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
 )
 
@@ -24,6 +25,7 @@ type Client struct {
 	host              string
 	baseURL           string
 	transport         *transport
+	provider          *gitealike.Provider
 	api               *forgejosdk.Client
 	foregroundTimeout time.Duration
 }
@@ -82,11 +84,13 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	transport := &transport{api: api}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
 		api:               api,
-		transport:         &transport{api: api},
+		transport:         transport,
+		provider:          gitealike.NewProvider(platform.KindForgejo, host, transport, gitealike.Options{ReadActions: true}),
 		foregroundTimeout: opts.foregroundTimeout,
 	}, nil
 }
@@ -100,7 +104,7 @@ func (c *Client) Host() string {
 }
 
 func (c *Client) Capabilities() platform.Capabilities {
-	return platform.Capabilities{}
+	return c.provider.Capabilities()
 }
 
 type transport struct {

--- a/internal/platform/forgejo/client.go
+++ b/internal/platform/forgejo/client.go
@@ -8,6 +8,7 @@ import (
 
 	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
 )
 
@@ -24,6 +25,7 @@ type Client struct {
 	host              string
 	baseURL           string
 	transport         *transport
+	provider          *gitealike.Provider
 	api               *forgejosdk.Client
 	foregroundTimeout time.Duration
 }
@@ -82,11 +84,13 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	transport := &transport{api: api, requestContextLock: make(chan struct{}, 1)}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
 		api:               api,
-		transport:         &transport{api: api, requestContextLock: make(chan struct{}, 1)},
+		transport:         transport,
+		provider:          gitealike.NewProvider(platform.KindForgejo, host, transport, gitealike.WithReadActions()),
 		foregroundTimeout: opts.foregroundTimeout,
 	}, nil
 }
@@ -100,7 +104,7 @@ func (c *Client) Host() string {
 }
 
 func (c *Client) Capabilities() platform.Capabilities {
-	return platform.Capabilities{}
+	return c.provider.Capabilities()
 }
 
 type transport struct {

--- a/internal/platform/forgejo/client_test.go
+++ b/internal/platform/forgejo/client_test.go
@@ -282,6 +282,53 @@ func TestClientReadsOpenPullRequestsIssuesAndCIChecks(t *testing.T) {
 	assert.Len(checks, 2)
 }
 
+func TestClientReadsCommitStatusesWhenActionsEndpointUnavailable(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	testCases := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "not found", statusCode: http.StatusNotFound},
+		{name: "method not allowed", statusCode: http.StatusMethodNotAllowed},
+		{name: "not implemented", statusCode: http.StatusNotImplemented},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal("token forgejo-token", r.Header.Get("Authorization"))
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v1/repos/owner/repo/commits/abc/statuses":
+					assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+						"id": 31, "context": "build", "status": "success", "target_url": "https://ci.test/build",
+					}}))
+				case "/api/v1/repos/owner/repo/actions/runs":
+					assert.Equal("abc", r.URL.Query().Get("head_sha"))
+					w.WriteHeader(testCase.statusCode)
+					assert.NoError(json.NewEncoder(w).Encode(map[string]string{"message": "actions unavailable"}))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewClient("codeberg.test", "forgejo-token", WithBaseURLForTesting(server.URL))
+			require.NoError(err)
+			ref := platform.RepoRef{Owner: "owner", Name: "repo"}
+
+			checks, err := client.ListCIChecks(context.Background(), ref, "abc")
+
+			require.NoError(err)
+			require.Len(checks, 1)
+			assert.Equal("build", checks[0].Name)
+			assert.Equal("success", checks[0].Conclusion)
+		})
+	}
+}
+
 func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)

--- a/internal/platform/forgejo/client_test.go
+++ b/internal/platform/forgejo/client_test.go
@@ -11,6 +11,18 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+var (
+	_ gitealike.Transport         = (*transport)(nil)
+	_ gitealike.ActionsTransport  = (*transport)(nil)
+	_ platform.RepositoryReader   = (*Client)(nil)
+	_ platform.MergeRequestReader = (*Client)(nil)
+	_ platform.IssueReader        = (*Client)(nil)
+	_ platform.ReleaseReader      = (*Client)(nil)
+	_ platform.TagReader          = (*Client)(nil)
+	_ platform.CIReader           = (*Client)(nil)
 )
 
 func TestClientLooksUpRepositoryAndSendsToken(t *testing.T) {
@@ -177,7 +189,7 @@ func TestTransportGetRepositoryRawCancelsWhileWaitingForRequestContext(t *testin
 	}
 }
 
-func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
+func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
 	server := httptest.NewServer(http.NotFoundHandler())
@@ -192,5 +204,103 @@ func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
 
 	assert.Equal(platform.KindForgejo, client.Platform())
 	assert.Equal("codeberg.test", client.Host())
-	assert.Equal(platform.Capabilities{}, client.Capabilities())
+	assert.Equal(platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReleases:      true,
+		ReadCI:            true,
+	}, client.Capabilities())
+}
+
+func TestClientReadsOpenPullRequestsIssuesAndCIChecks(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	var sawPulls, sawIssues, sawStatuses, sawActions bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("token forgejo-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/pulls":
+			sawPulls = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.Equal("1", r.URL.Query().Get("page"))
+			assert.Equal("100", r.URL.Query().Get("limit"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 11, "number": 3, "url": "https://codeberg.test/owner/repo/pulls/3",
+				"title": "review me", "state": "open", "user": map[string]any{"login": "alice"},
+				"head": map[string]any{"ref": "feature", "sha": "abc"},
+				"base": map[string]any{"ref": "main", "sha": "def"},
+			}}))
+		case "/api/v1/repos/owner/repo/issues":
+			sawIssues = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 21, "number": 4, "url": "https://codeberg.test/owner/repo/issues/4",
+				"title": "bug", "state": "open", "user": map[string]any{"login": "bob"},
+			}}))
+		case "/api/v1/repos/owner/repo/commits/abc/statuses":
+			sawStatuses = true
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 31, "context": "build", "state": "success", "target_url": "https://ci.test/build",
+			}}))
+		case "/api/v1/repos/owner/repo/actions/runs":
+			sawActions = true
+			assert.Equal("abc", r.URL.Query().Get("head_sha"))
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"workflow_runs": []map[string]any{{
+					"id": 41, "workflow_id": "ci.yml", "title": "CI", "status": "success",
+					"commit_sha": "abc", "html_url": "https://codeberg.test/owner/repo/actions/runs/41",
+				}},
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient("codeberg.test", "forgejo-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	ref := platform.RepoRef{Owner: "owner", Name: "repo"}
+
+	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
+	require.NoError(err)
+	issues, err := client.ListOpenIssues(context.Background(), ref)
+	require.NoError(err)
+	checks, err := client.ListCIChecks(context.Background(), ref, "abc")
+	require.NoError(err)
+
+	assert.True(sawPulls)
+	assert.True(sawIssues)
+	assert.True(sawStatuses)
+	assert.True(sawActions)
+	assert.Len(mrs, 1)
+	assert.Len(issues, 1)
+	assert.Len(checks, 2)
+}
+
+func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/repos/owner/repo/pulls/99", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		assert.NoError(json.NewEncoder(w).Encode(map[string]string{"message": "not found"}))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("codeberg.test", "forgejo-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+
+	_, err = client.GetMergeRequest(
+		context.Background(),
+		platform.RepoRef{Owner: "owner", Name: "repo"},
+		99,
+	)
+	require.Error(err)
+	assert.ErrorIs(err, platform.ErrNotFound)
 }

--- a/internal/platform/forgejo/client_test.go
+++ b/internal/platform/forgejo/client_test.go
@@ -11,6 +11,18 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+var (
+	_ gitealike.Transport         = (*transport)(nil)
+	_ gitealike.ActionsTransport  = (*transport)(nil)
+	_ platform.RepositoryReader   = (*Client)(nil)
+	_ platform.MergeRequestReader = (*Client)(nil)
+	_ platform.IssueReader        = (*Client)(nil)
+	_ platform.ReleaseReader      = (*Client)(nil)
+	_ platform.TagReader          = (*Client)(nil)
+	_ platform.CIReader           = (*Client)(nil)
 )
 
 func TestClientLooksUpRepositoryAndSendsToken(t *testing.T) {
@@ -69,7 +81,7 @@ func TestClientLookupUsesForegroundTimeout(t *testing.T) {
 	require.Error(err)
 }
 
-func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
+func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
 	server := httptest.NewServer(http.NotFoundHandler())
@@ -84,5 +96,103 @@ func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
 
 	assert.Equal(platform.KindForgejo, client.Platform())
 	assert.Equal("codeberg.test", client.Host())
-	assert.Equal(platform.Capabilities{}, client.Capabilities())
+	assert.Equal(platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReleases:      true,
+		ReadCI:            true,
+	}, client.Capabilities())
+}
+
+func TestClientReadsOpenPullRequestsIssuesAndCIChecks(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	var sawPulls, sawIssues, sawStatuses, sawActions bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("token forgejo-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/pulls":
+			sawPulls = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.Equal("1", r.URL.Query().Get("page"))
+			assert.Equal("100", r.URL.Query().Get("limit"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 11, "number": 3, "url": "https://codeberg.test/owner/repo/pulls/3",
+				"title": "review me", "state": "open", "user": map[string]any{"login": "alice"},
+				"head": map[string]any{"ref": "feature", "sha": "abc"},
+				"base": map[string]any{"ref": "main", "sha": "def"},
+			}}))
+		case "/api/v1/repos/owner/repo/issues":
+			sawIssues = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 21, "number": 4, "url": "https://codeberg.test/owner/repo/issues/4",
+				"title": "bug", "state": "open", "user": map[string]any{"login": "bob"},
+			}}))
+		case "/api/v1/repos/owner/repo/commits/abc/statuses":
+			sawStatuses = true
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 31, "context": "build", "state": "success", "target_url": "https://ci.test/build",
+			}}))
+		case "/api/v1/repos/owner/repo/actions/runs":
+			sawActions = true
+			assert.Equal("abc", r.URL.Query().Get("head_sha"))
+			assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"workflow_runs": []map[string]any{{
+					"id": 41, "workflow_id": "ci.yml", "title": "CI", "status": "success",
+					"commit_sha": "abc", "html_url": "https://codeberg.test/owner/repo/actions/runs/41",
+				}},
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient("codeberg.test", "forgejo-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	ref := platform.RepoRef{Owner: "owner", Name: "repo"}
+
+	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
+	require.NoError(err)
+	issues, err := client.ListOpenIssues(context.Background(), ref)
+	require.NoError(err)
+	checks, err := client.ListCIChecks(context.Background(), ref, "abc")
+	require.NoError(err)
+
+	assert.True(sawPulls)
+	assert.True(sawIssues)
+	assert.True(sawStatuses)
+	assert.True(sawActions)
+	assert.Len(mrs, 1)
+	assert.Len(issues, 1)
+	assert.Len(checks, 2)
+}
+
+func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/repos/owner/repo/pulls/99", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		assert.NoError(json.NewEncoder(w).Encode(map[string]string{"message": "not found"}))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("codeberg.test", "forgejo-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+
+	_, err = client.GetMergeRequest(
+		context.Background(),
+		platform.RepoRef{Owner: "owner", Name: "repo"},
+		99,
+	)
+	require.Error(err)
+	assert.ErrorIs(err, platform.ErrNotFound)
 }

--- a/internal/platform/forgejo/convert.go
+++ b/internal/platform/forgejo/convert.go
@@ -165,6 +165,21 @@ func safeStatusTargetURL(rawURL string) string {
 	}
 }
 
+func convertCommit(commit *forgejosdk.Commit) gitealike.CommitDTO {
+	if commit == nil {
+		return gitealike.CommitDTO{}
+	}
+	out := convertCommitMeta(commit.CommitMeta)
+	out.URL = commit.HTMLURL
+	if commit.RepoCommit != nil {
+		out.Message = commit.RepoCommit.Message
+		if commit.RepoCommit.Author != nil {
+			out.AuthorName = commit.RepoCommit.Author.Name
+		}
+	}
+	return out
+}
+
 func convertActionRun(run *forgejosdk.ActionRun) gitealike.ActionRunDTO {
 	if run == nil {
 		return gitealike.ActionRunDTO{}
@@ -180,6 +195,93 @@ func convertActionRun(run *forgejosdk.ActionRun) gitealike.ActionRunDTO {
 		Stopped:      nonZeroTimePtr(run.Stopped),
 		NeedApproval: run.NeedApproval,
 	}
+}
+
+func convertRepositories(
+	repos []*forgejosdk.Repository,
+	page gitealike.Page,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	out := make([]gitealike.RepositoryDTO, 0, len(repos))
+	for _, repo := range repos {
+		item, err := convertRepository(repo)
+		if err != nil {
+			return nil, gitealike.Page{}, err
+		}
+		out = append(out, item)
+	}
+	return out, page, nil
+}
+
+func convertPullRequests(prs []*forgejosdk.PullRequest) []gitealike.PullRequestDTO {
+	out := make([]gitealike.PullRequestDTO, 0, len(prs))
+	for _, pr := range prs {
+		out = append(out, convertPullRequest(pr))
+	}
+	return out
+}
+
+func convertIssues(issues []*forgejosdk.Issue) []gitealike.IssueDTO {
+	out := make([]gitealike.IssueDTO, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, convertIssue(issue))
+	}
+	return out
+}
+
+func convertComments(comments []*forgejosdk.Comment) []gitealike.CommentDTO {
+	out := make([]gitealike.CommentDTO, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, convertComment(comment))
+	}
+	return out
+}
+
+func convertReviews(reviews []*forgejosdk.PullReview) []gitealike.ReviewDTO {
+	out := make([]gitealike.ReviewDTO, 0, len(reviews))
+	for _, review := range reviews {
+		out = append(out, convertReview(review))
+	}
+	return out
+}
+
+func convertCommits(commits []*forgejosdk.Commit) []gitealike.CommitDTO {
+	out := make([]gitealike.CommitDTO, 0, len(commits))
+	for _, commit := range commits {
+		out = append(out, convertCommit(commit))
+	}
+	return out
+}
+
+func convertReleases(releases []*forgejosdk.Release) []gitealike.ReleaseDTO {
+	out := make([]gitealike.ReleaseDTO, 0, len(releases))
+	for _, release := range releases {
+		out = append(out, convertRelease(release))
+	}
+	return out
+}
+
+func convertTags(tags []*forgejosdk.Tag) []gitealike.TagDTO {
+	out := make([]gitealike.TagDTO, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, convertTag(tag))
+	}
+	return out
+}
+
+func convertStatuses(statuses []*forgejosdk.Status) []gitealike.StatusDTO {
+	out := make([]gitealike.StatusDTO, 0, len(statuses))
+	for _, status := range statuses {
+		out = append(out, convertStatus(status))
+	}
+	return out
+}
+
+func convertActionRuns(runs []*forgejosdk.ActionRun) []gitealike.ActionRunDTO {
+	out := make([]gitealike.ActionRunDTO, 0, len(runs))
+	for _, run := range runs {
+		out = append(out, convertActionRun(run))
+	}
+	return out
 }
 
 func convertUser(user *forgejosdk.User) gitealike.UserDTO {

--- a/internal/platform/forgejo/convert.go
+++ b/internal/platform/forgejo/convert.go
@@ -151,6 +151,21 @@ func convertStatus(status *forgejosdk.Status) gitealike.StatusDTO {
 	}
 }
 
+func convertCommit(commit *forgejosdk.Commit) gitealike.CommitDTO {
+	if commit == nil {
+		return gitealike.CommitDTO{}
+	}
+	out := convertCommitMeta(commit.CommitMeta)
+	out.URL = commit.HTMLURL
+	if commit.RepoCommit != nil {
+		out.Message = commit.RepoCommit.Message
+		if commit.RepoCommit.Author != nil {
+			out.AuthorName = commit.RepoCommit.Author.Name
+		}
+	}
+	return out
+}
+
 func convertActionRun(run *forgejosdk.ActionRun) gitealike.ActionRunDTO {
 	if run == nil {
 		return gitealike.ActionRunDTO{}
@@ -166,6 +181,93 @@ func convertActionRun(run *forgejosdk.ActionRun) gitealike.ActionRunDTO {
 		Stopped:      nonZeroTimePtr(run.Stopped),
 		NeedApproval: run.NeedApproval,
 	}
+}
+
+func convertRepositories(
+	repos []*forgejosdk.Repository,
+	page gitealike.Page,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	out := make([]gitealike.RepositoryDTO, 0, len(repos))
+	for _, repo := range repos {
+		item, err := convertRepository(repo)
+		if err != nil {
+			return nil, gitealike.Page{}, err
+		}
+		out = append(out, item)
+	}
+	return out, page, nil
+}
+
+func convertPullRequests(prs []*forgejosdk.PullRequest) []gitealike.PullRequestDTO {
+	out := make([]gitealike.PullRequestDTO, 0, len(prs))
+	for _, pr := range prs {
+		out = append(out, convertPullRequest(pr))
+	}
+	return out
+}
+
+func convertIssues(issues []*forgejosdk.Issue) []gitealike.IssueDTO {
+	out := make([]gitealike.IssueDTO, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, convertIssue(issue))
+	}
+	return out
+}
+
+func convertComments(comments []*forgejosdk.Comment) []gitealike.CommentDTO {
+	out := make([]gitealike.CommentDTO, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, convertComment(comment))
+	}
+	return out
+}
+
+func convertReviews(reviews []*forgejosdk.PullReview) []gitealike.ReviewDTO {
+	out := make([]gitealike.ReviewDTO, 0, len(reviews))
+	for _, review := range reviews {
+		out = append(out, convertReview(review))
+	}
+	return out
+}
+
+func convertCommits(commits []*forgejosdk.Commit) []gitealike.CommitDTO {
+	out := make([]gitealike.CommitDTO, 0, len(commits))
+	for _, commit := range commits {
+		out = append(out, convertCommit(commit))
+	}
+	return out
+}
+
+func convertReleases(releases []*forgejosdk.Release) []gitealike.ReleaseDTO {
+	out := make([]gitealike.ReleaseDTO, 0, len(releases))
+	for _, release := range releases {
+		out = append(out, convertRelease(release))
+	}
+	return out
+}
+
+func convertTags(tags []*forgejosdk.Tag) []gitealike.TagDTO {
+	out := make([]gitealike.TagDTO, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, convertTag(tag))
+	}
+	return out
+}
+
+func convertStatuses(statuses []*forgejosdk.Status) []gitealike.StatusDTO {
+	out := make([]gitealike.StatusDTO, 0, len(statuses))
+	for _, status := range statuses {
+		out = append(out, convertStatus(status))
+	}
+	return out
+}
+
+func convertActionRuns(runs []*forgejosdk.ActionRun) []gitealike.ActionRunDTO {
+	out := make([]gitealike.ActionRunDTO, 0, len(runs))
+	for _, run := range runs {
+		out = append(out, convertActionRun(run))
+	}
+	return out
 }
 
 func convertUser(user *forgejosdk.User) gitealike.UserDTO {

--- a/internal/platform/forgejo/read.go
+++ b/internal/platform/forgejo/read.go
@@ -2,6 +2,8 @@ package forgejo
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/wesm/middleman/internal/platform"
@@ -365,12 +367,29 @@ func (t *transport) ListActionRuns(
 		return err
 	})
 	if err != nil {
-		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+		mappedErr := forgejoHTTPError(resp, err)
+		if actionRunsUnavailable(mappedErr) {
+			return nil, forgejoPage(resp), nil
+		}
+		return nil, gitealike.Page{}, mappedErr
 	}
 	if runs == nil {
 		return nil, forgejoPage(resp), nil
 	}
 	return convertActionRuns(runs.WorkflowRuns), forgejoPage(resp), nil
+}
+
+func actionRunsUnavailable(err error) bool {
+	var httpErr *gitealike.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	switch httpErr.StatusCode {
+	case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented:
+		return true
+	default:
+		return false
+	}
 }
 
 func forgejoListOptions(opts gitealike.PageOptions) forgejosdk.ListOptions {

--- a/internal/platform/forgejo/read.go
+++ b/internal/platform/forgejo/read.go
@@ -367,6 +367,9 @@ func (t *transport) ListActionRuns(
 	if err != nil {
 		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
 	}
+	if runs == nil {
+		return nil, forgejoPage(resp), nil
+	}
 	return convertActionRuns(runs.WorkflowRuns), forgejoPage(resp), nil
 }
 

--- a/internal/platform/forgejo/read.go
+++ b/internal/platform/forgejo/read.go
@@ -1,0 +1,308 @@
+package forgejo
+
+import (
+	"context"
+
+	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+func (c *Client) GetRepository(ctx context.Context, ref platform.RepoRef) (platform.Repository, error) {
+	return c.provider.GetRepository(ctx, ref)
+}
+
+func (c *Client) ListRepositories(
+	ctx context.Context,
+	owner string,
+	opts platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	return c.provider.ListRepositories(ctx, owner, opts)
+}
+
+func (c *Client) ListOpenMergeRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.MergeRequest, error) {
+	return c.provider.ListOpenMergeRequests(ctx, ref)
+}
+
+func (c *Client) GetMergeRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.MergeRequest, error) {
+	return c.provider.GetMergeRequest(ctx, ref, number)
+}
+
+func (c *Client) ListMergeRequestEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestEvent, error) {
+	return c.provider.ListMergeRequestEvents(ctx, ref, number)
+}
+
+func (c *Client) ListOpenIssues(ctx context.Context, ref platform.RepoRef) ([]platform.Issue, error) {
+	return c.provider.ListOpenIssues(ctx, ref)
+}
+
+func (c *Client) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.Issue, error) {
+	return c.provider.GetIssue(ctx, ref, number)
+}
+
+func (c *Client) ListIssueEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.IssueEvent, error) {
+	return c.provider.ListIssueEvents(ctx, ref, number)
+}
+
+func (c *Client) ListReleases(ctx context.Context, ref platform.RepoRef) ([]platform.Release, error) {
+	return c.provider.ListReleases(ctx, ref)
+}
+
+func (c *Client) ListTags(ctx context.Context, ref platform.RepoRef) ([]platform.Tag, error) {
+	return c.provider.ListTags(ctx, ref)
+}
+
+func (c *Client) ListCIChecks(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+) ([]platform.CICheck, error) {
+	return c.provider.ListCIChecks(ctx, ref, sha)
+}
+
+func (t *transport) GetRepository(
+	ctx context.Context,
+	owner, repo string,
+) (gitealike.RepositoryDTO, error) {
+	repository, resp, err := t.api.GetRepo(owner, repo)
+	if err != nil {
+		return gitealike.RepositoryDTO{}, forgejoHTTPError(resp, err)
+	}
+	return convertRepository(repository)
+}
+
+func (t *transport) ListUserRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	repos, resp, err := t.api.ListUserRepos(owner, forgejosdk.ListReposOptions{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertRepositories(repos, forgejoPage(resp))
+}
+
+func (t *transport) ListOrgRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	repos, resp, err := t.api.ListOrgRepos(owner, forgejosdk.ListOrgReposOptions{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertRepositories(repos, forgejoPage(resp))
+}
+
+func (t *transport) ListOpenPullRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	prs, resp, err := t.api.ListRepoPullRequests(ref.Owner, ref.Name, forgejosdk.ListPullRequestsOptions{
+		ListOptions: forgejoListOptions(opts),
+		State:       forgejosdk.StateOpen,
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertPullRequests(prs), forgejoPage(resp), nil
+}
+
+func (t *transport) GetPullRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.PullRequestDTO, error) {
+	pr, resp, err := t.api.GetPullRequest(ref.Owner, ref.Name, int64(number))
+	if err != nil {
+		return gitealike.PullRequestDTO{}, forgejoHTTPError(resp, err)
+	}
+	return convertPullRequest(pr), nil
+}
+
+func (t *transport) ListPullRequestComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	comments, resp, err := t.api.ListIssueComments(ref.Owner, ref.Name, int64(number), forgejosdk.ListIssueCommentOptions{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertComments(comments), forgejoPage(resp), nil
+}
+
+func (t *transport) ListPullRequestReviews(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	reviews, resp, err := t.api.ListPullReviews(ref.Owner, ref.Name, int64(number), forgejosdk.ListPullReviewsOptions{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertReviews(reviews), forgejoPage(resp), nil
+}
+
+func (t *transport) ListPullRequestCommits(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	commits, resp, err := t.api.ListPullRequestCommits(ref.Owner, ref.Name, int64(number), forgejosdk.ListPullRequestCommitsOptions{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertCommits(commits), forgejoPage(resp), nil
+}
+
+func (t *transport) ListOpenIssues(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	issues, resp, err := t.api.ListRepoIssues(ref.Owner, ref.Name, forgejosdk.ListIssueOption{
+		ListOptions: forgejoListOptions(opts),
+		State:       forgejosdk.StateOpen,
+		Type:        forgejosdk.IssueTypeIssue,
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertIssues(issues), forgejoPage(resp), nil
+}
+
+func (t *transport) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.IssueDTO, error) {
+	issue, resp, err := t.api.GetIssue(ref.Owner, ref.Name, int64(number))
+	if err != nil {
+		return gitealike.IssueDTO{}, forgejoHTTPError(resp, err)
+	}
+	return convertIssue(issue), nil
+}
+
+func (t *transport) ListIssueComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.ListPullRequestComments(ctx, ref, number, opts)
+}
+
+func (t *transport) ListReleases(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	releases, resp, err := t.api.ListReleases(ref.Owner, ref.Name, forgejosdk.ListReleasesOptions{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertReleases(releases), forgejoPage(resp), nil
+}
+
+func (t *transport) ListTags(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.TagDTO, gitealike.Page, error) {
+	tags, resp, err := t.api.ListRepoTags(ref.Owner, ref.Name, forgejosdk.ListRepoTagsOptions{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertTags(tags), forgejoPage(resp), nil
+}
+
+func (t *transport) ListStatuses(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+	opts gitealike.PageOptions,
+) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	statuses, resp, err := t.api.ListStatuses(ref.Owner, ref.Name, sha, forgejosdk.ListStatusesOption{
+		ListOptions: forgejoListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertStatuses(statuses), forgejoPage(resp), nil
+}
+
+func (t *transport) ListActionRuns(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+	opts gitealike.PageOptions,
+) ([]gitealike.ActionRunDTO, gitealike.Page, error) {
+	runs, resp, err := t.api.ListRepoActionRuns(ref.Owner, ref.Name, forgejosdk.ListActionRunsOption{
+		ListOptions: forgejoListOptions(opts),
+		HeadSHA:     sha,
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertActionRuns(runs.WorkflowRuns), forgejoPage(resp), nil
+}
+
+func forgejoListOptions(opts gitealike.PageOptions) forgejosdk.ListOptions {
+	return forgejosdk.ListOptions{Page: opts.Page, PageSize: opts.PageSize}
+}
+
+func forgejoPage(resp *forgejosdk.Response) gitealike.Page {
+	if resp == nil {
+		return gitealike.Page{}
+	}
+	return gitealike.Page{Next: resp.NextPage}
+}
+
+func forgejoHTTPError(resp *forgejosdk.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+	if resp != nil && resp.Response != nil {
+		return &gitealike.HTTPError{StatusCode: resp.StatusCode, Err: err}
+	}
+	return err
+}

--- a/internal/platform/forgejo/read.go
+++ b/internal/platform/forgejo/read.go
@@ -1,0 +1,392 @@
+package forgejo
+
+import (
+	"context"
+
+	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+func (c *Client) GetRepository(ctx context.Context, ref platform.RepoRef) (platform.Repository, error) {
+	return c.provider.GetRepository(ctx, ref)
+}
+
+func (c *Client) ListRepositories(
+	ctx context.Context,
+	owner string,
+	opts platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	return c.provider.ListRepositories(ctx, owner, opts)
+}
+
+func (c *Client) ListOpenMergeRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.MergeRequest, error) {
+	return c.provider.ListOpenMergeRequests(ctx, ref)
+}
+
+func (c *Client) GetMergeRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.MergeRequest, error) {
+	return c.provider.GetMergeRequest(ctx, ref, number)
+}
+
+func (c *Client) ListMergeRequestEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestEvent, error) {
+	return c.provider.ListMergeRequestEvents(ctx, ref, number)
+}
+
+func (c *Client) ListOpenIssues(ctx context.Context, ref platform.RepoRef) ([]platform.Issue, error) {
+	return c.provider.ListOpenIssues(ctx, ref)
+}
+
+func (c *Client) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.Issue, error) {
+	return c.provider.GetIssue(ctx, ref, number)
+}
+
+func (c *Client) ListIssueEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.IssueEvent, error) {
+	return c.provider.ListIssueEvents(ctx, ref, number)
+}
+
+func (c *Client) ListReleases(ctx context.Context, ref platform.RepoRef) ([]platform.Release, error) {
+	return c.provider.ListReleases(ctx, ref)
+}
+
+func (c *Client) ListTags(ctx context.Context, ref platform.RepoRef) ([]platform.Tag, error) {
+	return c.provider.ListTags(ctx, ref)
+}
+
+func (c *Client) ListCIChecks(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+) ([]platform.CICheck, error) {
+	return c.provider.ListCIChecks(ctx, ref, sha)
+}
+
+func (t *transport) GetRepository(
+	ctx context.Context,
+	owner, repo string,
+) (gitealike.RepositoryDTO, error) {
+	var repository *forgejosdk.Repository
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		repository, resp, err = t.api.GetRepo(owner, repo)
+		return err
+	})
+	if err != nil {
+		return gitealike.RepositoryDTO{}, forgejoHTTPError(resp, err)
+	}
+	return convertRepository(repository)
+}
+
+func (t *transport) ListUserRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	var repos []*forgejosdk.Repository
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		repos, resp, err = t.api.ListUserRepos(owner, forgejosdk.ListReposOptions{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertRepositories(repos, forgejoPage(resp))
+}
+
+func (t *transport) ListOrgRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	var repos []*forgejosdk.Repository
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		repos, resp, err = t.api.ListOrgRepos(owner, forgejosdk.ListOrgReposOptions{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertRepositories(repos, forgejoPage(resp))
+}
+
+func (t *transport) ListOpenPullRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	var prs []*forgejosdk.PullRequest
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		prs, resp, err = t.api.ListRepoPullRequests(ref.Owner, ref.Name, forgejosdk.ListPullRequestsOptions{
+			ListOptions: forgejoListOptions(opts),
+			State:       forgejosdk.StateOpen,
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertPullRequests(prs), forgejoPage(resp), nil
+}
+
+func (t *transport) GetPullRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.PullRequestDTO, error) {
+	var pr *forgejosdk.PullRequest
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		pr, resp, err = t.api.GetPullRequest(ref.Owner, ref.Name, int64(number))
+		return err
+	})
+	if err != nil {
+		return gitealike.PullRequestDTO{}, forgejoHTTPError(resp, err)
+	}
+	return convertPullRequest(pr), nil
+}
+
+func (t *transport) ListPullRequestComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	var comments []*forgejosdk.Comment
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		comments, resp, err = t.api.ListIssueComments(ref.Owner, ref.Name, int64(number), forgejosdk.ListIssueCommentOptions{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertComments(comments), forgejoPage(resp), nil
+}
+
+func (t *transport) ListPullRequestReviews(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	var reviews []*forgejosdk.PullReview
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		reviews, resp, err = t.api.ListPullReviews(ref.Owner, ref.Name, int64(number), forgejosdk.ListPullReviewsOptions{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertReviews(reviews), forgejoPage(resp), nil
+}
+
+func (t *transport) ListPullRequestCommits(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	var commits []*forgejosdk.Commit
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		commits, resp, err = t.api.ListPullRequestCommits(ref.Owner, ref.Name, int64(number), forgejosdk.ListPullRequestCommitsOptions{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertCommits(commits), forgejoPage(resp), nil
+}
+
+func (t *transport) ListOpenIssues(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	var issues []*forgejosdk.Issue
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		issues, resp, err = t.api.ListRepoIssues(ref.Owner, ref.Name, forgejosdk.ListIssueOption{
+			ListOptions: forgejoListOptions(opts),
+			State:       forgejosdk.StateOpen,
+			Type:        forgejosdk.IssueTypeIssue,
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertIssues(issues), forgejoPage(resp), nil
+}
+
+func (t *transport) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.IssueDTO, error) {
+	var issue *forgejosdk.Issue
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		issue, resp, err = t.api.GetIssue(ref.Owner, ref.Name, int64(number))
+		return err
+	})
+	if err != nil {
+		return gitealike.IssueDTO{}, forgejoHTTPError(resp, err)
+	}
+	return convertIssue(issue), nil
+}
+
+func (t *transport) ListIssueComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.ListPullRequestComments(ctx, ref, number, opts)
+}
+
+func (t *transport) ListReleases(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	var releases []*forgejosdk.Release
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		releases, resp, err = t.api.ListReleases(ref.Owner, ref.Name, forgejosdk.ListReleasesOptions{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertReleases(releases), forgejoPage(resp), nil
+}
+
+func (t *transport) ListTags(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.TagDTO, gitealike.Page, error) {
+	var tags []*forgejosdk.Tag
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		tags, resp, err = t.api.ListRepoTags(ref.Owner, ref.Name, forgejosdk.ListRepoTagsOptions{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertTags(tags), forgejoPage(resp), nil
+}
+
+func (t *transport) ListStatuses(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+	opts gitealike.PageOptions,
+) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	var statuses []*forgejosdk.Status
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		statuses, resp, err = t.api.ListStatuses(ref.Owner, ref.Name, sha, forgejosdk.ListStatusesOption{
+			ListOptions: forgejoListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertStatuses(statuses), forgejoPage(resp), nil
+}
+
+func (t *transport) ListActionRuns(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+	opts gitealike.PageOptions,
+) ([]gitealike.ActionRunDTO, gitealike.Page, error) {
+	var runs *forgejosdk.ListActionRunsResponse
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		runs, resp, err = t.api.ListRepoActionRuns(ref.Owner, ref.Name, forgejosdk.ListActionRunsOption{
+			ListOptions: forgejoListOptions(opts),
+			HeadSHA:     sha,
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, forgejoHTTPError(resp, err)
+	}
+	return convertActionRuns(runs.WorkflowRuns), forgejoPage(resp), nil
+}
+
+func forgejoListOptions(opts gitealike.PageOptions) forgejosdk.ListOptions {
+	return forgejosdk.ListOptions{Page: opts.Page, PageSize: opts.PageSize}
+}
+
+func forgejoPage(resp *forgejosdk.Response) gitealike.Page {
+	if resp == nil {
+		return gitealike.Page{}
+	}
+	return gitealike.Page{Next: resp.NextPage}
+}
+
+func forgejoHTTPError(resp *forgejosdk.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+	if resp != nil && resp.Response != nil {
+		return &gitealike.HTTPError{StatusCode: resp.StatusCode, Err: err}
+	}
+	return err
+}

--- a/internal/platform/gitea/client.go
+++ b/internal/platform/gitea/client.go
@@ -8,6 +8,7 @@ import (
 
 	giteasdk "code.gitea.io/sdk/gitea"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
 )
 
@@ -24,6 +25,7 @@ type Client struct {
 	host              string
 	baseURL           string
 	transport         *transport
+	provider          *gitealike.Provider
 	api               *giteasdk.Client
 	foregroundTimeout time.Duration
 }
@@ -79,11 +81,13 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	transport := &transport{api: api, requestContextLock: make(chan struct{}, 1)}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
 		api:               api,
-		transport:         &transport{api: api, requestContextLock: make(chan struct{}, 1)},
+		transport:         transport,
+		provider:          gitealike.NewProvider(platform.KindGitea, host, transport),
 		foregroundTimeout: opts.foregroundTimeout,
 	}, nil
 }
@@ -97,7 +101,7 @@ func (c *Client) Host() string {
 }
 
 func (c *Client) Capabilities() platform.Capabilities {
-	return platform.Capabilities{}
+	return c.provider.Capabilities()
 }
 
 type transport struct {

--- a/internal/platform/gitea/client.go
+++ b/internal/platform/gitea/client.go
@@ -8,6 +8,7 @@ import (
 
 	giteasdk "code.gitea.io/sdk/gitea"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
 )
 
@@ -24,6 +25,7 @@ type Client struct {
 	host              string
 	baseURL           string
 	transport         *transport
+	provider          *gitealike.Provider
 	api               *giteasdk.Client
 	foregroundTimeout time.Duration
 }
@@ -79,11 +81,13 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	transport := &transport{api: api}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
 		api:               api,
-		transport:         &transport{api: api},
+		transport:         transport,
+		provider:          gitealike.NewProvider(platform.KindGitea, host, transport, gitealike.Options{}),
 		foregroundTimeout: opts.foregroundTimeout,
 	}, nil
 }
@@ -97,7 +101,7 @@ func (c *Client) Host() string {
 }
 
 func (c *Client) Capabilities() platform.Capabilities {
-	return platform.Capabilities{}
+	return c.provider.Capabilities()
 }
 
 type transport struct {

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -11,6 +11,17 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+var (
+	_ gitealike.Transport         = (*transport)(nil)
+	_ platform.RepositoryReader   = (*Client)(nil)
+	_ platform.MergeRequestReader = (*Client)(nil)
+	_ platform.IssueReader        = (*Client)(nil)
+	_ platform.ReleaseReader      = (*Client)(nil)
+	_ platform.TagReader          = (*Client)(nil)
+	_ platform.CIReader           = (*Client)(nil)
 )
 
 func TestClientLooksUpRepositoryAndSendsToken(t *testing.T) {
@@ -177,7 +188,7 @@ func TestTransportGetRepositoryRawCancelsWhileWaitingForRequestContext(t *testin
 	}
 }
 
-func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
+func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
 	server := httptest.NewServer(http.NotFoundHandler())
@@ -192,5 +203,92 @@ func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
 
 	assert.Equal(platform.KindGitea, client.Platform())
 	assert.Equal("gitea.test", client.Host())
-	assert.Equal(platform.Capabilities{}, client.Capabilities())
+	assert.Equal(platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReleases:      true,
+		ReadCI:            true,
+	}, client.Capabilities())
+}
+
+func TestClientReadsOpenPullRequestsIssuesAndStatusChecks(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	var sawPulls, sawIssues, sawStatuses bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("token gitea-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/pulls":
+			sawPulls = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.Equal("1", r.URL.Query().Get("page"))
+			assert.Equal("100", r.URL.Query().Get("limit"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 11, "number": 3, "url": "https://gitea.test/owner/repo/pulls/3",
+				"title": "review me", "state": "open", "user": map[string]any{"login": "alice"},
+				"head": map[string]any{"ref": "feature", "sha": "abc"},
+				"base": map[string]any{"ref": "main", "sha": "def"},
+			}}))
+		case "/api/v1/repos/owner/repo/issues":
+			sawIssues = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 21, "number": 4, "url": "https://gitea.test/owner/repo/issues/4",
+				"title": "bug", "state": "open", "user": map[string]any{"login": "bob"},
+			}}))
+		case "/api/v1/repos/owner/repo/commits/abc/statuses":
+			sawStatuses = true
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 31, "context": "build", "state": "success", "target_url": "https://ci.test/build",
+			}}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient("gitea.test", "gitea-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	ref := platform.RepoRef{Owner: "owner", Name: "repo"}
+
+	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
+	require.NoError(err)
+	issues, err := client.ListOpenIssues(context.Background(), ref)
+	require.NoError(err)
+	checks, err := client.ListCIChecks(context.Background(), ref, "abc")
+	require.NoError(err)
+
+	assert.True(sawPulls)
+	assert.True(sawIssues)
+	assert.True(sawStatuses)
+	assert.Len(mrs, 1)
+	assert.Len(issues, 1)
+	assert.Len(checks, 1)
+}
+
+func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/repos/owner/repo/pulls/99", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		assert.NoError(json.NewEncoder(w).Encode(map[string]string{"message": "not found"}))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("gitea.test", "gitea-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+
+	_, err = client.GetMergeRequest(
+		context.Background(),
+		platform.RepoRef{Owner: "owner", Name: "repo"},
+		99,
+	)
+	require.Error(err)
+	assert.ErrorIs(err, platform.ErrNotFound)
 }

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -11,6 +11,17 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+var (
+	_ gitealike.Transport         = (*transport)(nil)
+	_ platform.RepositoryReader   = (*Client)(nil)
+	_ platform.MergeRequestReader = (*Client)(nil)
+	_ platform.IssueReader        = (*Client)(nil)
+	_ platform.ReleaseReader      = (*Client)(nil)
+	_ platform.TagReader          = (*Client)(nil)
+	_ platform.CIReader           = (*Client)(nil)
 )
 
 func TestClientLooksUpRepositoryAndSendsToken(t *testing.T) {
@@ -69,7 +80,7 @@ func TestClientLookupUsesForegroundTimeout(t *testing.T) {
 	require.Error(err)
 }
 
-func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
+func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
 	server := httptest.NewServer(http.NotFoundHandler())
@@ -84,5 +95,92 @@ func TestClientProviderIdentityHasNoReadCapabilitiesYet(t *testing.T) {
 
 	assert.Equal(platform.KindGitea, client.Platform())
 	assert.Equal("gitea.test", client.Host())
-	assert.Equal(platform.Capabilities{}, client.Capabilities())
+	assert.Equal(platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReleases:      true,
+		ReadCI:            true,
+	}, client.Capabilities())
+}
+
+func TestClientReadsOpenPullRequestsIssuesAndStatusChecks(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	var sawPulls, sawIssues, sawStatuses bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("token gitea-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/pulls":
+			sawPulls = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.Equal("1", r.URL.Query().Get("page"))
+			assert.Equal("100", r.URL.Query().Get("limit"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 11, "number": 3, "url": "https://gitea.test/owner/repo/pulls/3",
+				"title": "review me", "state": "open", "user": map[string]any{"login": "alice"},
+				"head": map[string]any{"ref": "feature", "sha": "abc"},
+				"base": map[string]any{"ref": "main", "sha": "def"},
+			}}))
+		case "/api/v1/repos/owner/repo/issues":
+			sawIssues = true
+			assert.Equal("open", r.URL.Query().Get("state"))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 21, "number": 4, "url": "https://gitea.test/owner/repo/issues/4",
+				"title": "bug", "state": "open", "user": map[string]any{"login": "bob"},
+			}}))
+		case "/api/v1/repos/owner/repo/commits/abc/statuses":
+			sawStatuses = true
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 31, "context": "build", "state": "success", "target_url": "https://ci.test/build",
+			}}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient("gitea.test", "gitea-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	ref := platform.RepoRef{Owner: "owner", Name: "repo"}
+
+	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
+	require.NoError(err)
+	issues, err := client.ListOpenIssues(context.Background(), ref)
+	require.NoError(err)
+	checks, err := client.ListCIChecks(context.Background(), ref, "abc")
+	require.NoError(err)
+
+	assert.True(sawPulls)
+	assert.True(sawIssues)
+	assert.True(sawStatuses)
+	assert.Len(mrs, 1)
+	assert.Len(issues, 1)
+	assert.Len(checks, 1)
+}
+
+func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/repos/owner/repo/pulls/99", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		assert.NoError(json.NewEncoder(w).Encode(map[string]string{"message": "not found"}))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("gitea.test", "gitea-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+
+	_, err = client.GetMergeRequest(
+		context.Background(),
+		platform.RepoRef{Owner: "owner", Name: "repo"},
+		99,
+	)
+	require.Error(err)
+	assert.ErrorIs(err, platform.ErrNotFound)
 }

--- a/internal/platform/gitea/convert.go
+++ b/internal/platform/gitea/convert.go
@@ -156,6 +156,100 @@ func safeStatusTargetURL(rawURL string) string {
 	}
 }
 
+func convertCommit(commit *giteasdk.Commit) gitealike.CommitDTO {
+	if commit == nil {
+		return gitealike.CommitDTO{}
+	}
+	out := convertCommitMeta(commit.CommitMeta)
+	out.URL = commit.HTMLURL
+	if commit.RepoCommit != nil {
+		out.Message = commit.RepoCommit.Message
+		if commit.RepoCommit.Author != nil {
+			out.AuthorName = commit.RepoCommit.Author.Name
+		}
+	}
+	return out
+}
+
+func convertRepositories(
+	repos []*giteasdk.Repository,
+	page gitealike.Page,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	out := make([]gitealike.RepositoryDTO, 0, len(repos))
+	for _, repo := range repos {
+		item, err := convertRepository(repo)
+		if err != nil {
+			return nil, gitealike.Page{}, err
+		}
+		out = append(out, item)
+	}
+	return out, page, nil
+}
+
+func convertPullRequests(prs []*giteasdk.PullRequest) []gitealike.PullRequestDTO {
+	out := make([]gitealike.PullRequestDTO, 0, len(prs))
+	for _, pr := range prs {
+		out = append(out, convertPullRequest(pr))
+	}
+	return out
+}
+
+func convertIssues(issues []*giteasdk.Issue) []gitealike.IssueDTO {
+	out := make([]gitealike.IssueDTO, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, convertIssue(issue))
+	}
+	return out
+}
+
+func convertComments(comments []*giteasdk.Comment) []gitealike.CommentDTO {
+	out := make([]gitealike.CommentDTO, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, convertComment(comment))
+	}
+	return out
+}
+
+func convertReviews(reviews []*giteasdk.PullReview) []gitealike.ReviewDTO {
+	out := make([]gitealike.ReviewDTO, 0, len(reviews))
+	for _, review := range reviews {
+		out = append(out, convertReview(review))
+	}
+	return out
+}
+
+func convertCommits(commits []*giteasdk.Commit) []gitealike.CommitDTO {
+	out := make([]gitealike.CommitDTO, 0, len(commits))
+	for _, commit := range commits {
+		out = append(out, convertCommit(commit))
+	}
+	return out
+}
+
+func convertReleases(releases []*giteasdk.Release) []gitealike.ReleaseDTO {
+	out := make([]gitealike.ReleaseDTO, 0, len(releases))
+	for _, release := range releases {
+		out = append(out, convertRelease(release))
+	}
+	return out
+}
+
+func convertTags(tags []*giteasdk.Tag) []gitealike.TagDTO {
+	out := make([]gitealike.TagDTO, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, convertTag(tag))
+	}
+	return out
+}
+
+func convertStatuses(statuses []*giteasdk.Status) []gitealike.StatusDTO {
+	out := make([]gitealike.StatusDTO, 0, len(statuses))
+	for _, status := range statuses {
+		out = append(out, convertStatus(status))
+	}
+	return out
+}
+
 func convertUser(user *giteasdk.User) gitealike.UserDTO {
 	if user == nil {
 		return gitealike.UserDTO{}

--- a/internal/platform/gitea/convert.go
+++ b/internal/platform/gitea/convert.go
@@ -142,6 +142,100 @@ func convertStatus(status *giteasdk.Status) gitealike.StatusDTO {
 	}
 }
 
+func convertCommit(commit *giteasdk.Commit) gitealike.CommitDTO {
+	if commit == nil {
+		return gitealike.CommitDTO{}
+	}
+	out := convertCommitMeta(commit.CommitMeta)
+	out.URL = commit.HTMLURL
+	if commit.RepoCommit != nil {
+		out.Message = commit.RepoCommit.Message
+		if commit.RepoCommit.Author != nil {
+			out.AuthorName = commit.RepoCommit.Author.Name
+		}
+	}
+	return out
+}
+
+func convertRepositories(
+	repos []*giteasdk.Repository,
+	page gitealike.Page,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	out := make([]gitealike.RepositoryDTO, 0, len(repos))
+	for _, repo := range repos {
+		item, err := convertRepository(repo)
+		if err != nil {
+			return nil, gitealike.Page{}, err
+		}
+		out = append(out, item)
+	}
+	return out, page, nil
+}
+
+func convertPullRequests(prs []*giteasdk.PullRequest) []gitealike.PullRequestDTO {
+	out := make([]gitealike.PullRequestDTO, 0, len(prs))
+	for _, pr := range prs {
+		out = append(out, convertPullRequest(pr))
+	}
+	return out
+}
+
+func convertIssues(issues []*giteasdk.Issue) []gitealike.IssueDTO {
+	out := make([]gitealike.IssueDTO, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, convertIssue(issue))
+	}
+	return out
+}
+
+func convertComments(comments []*giteasdk.Comment) []gitealike.CommentDTO {
+	out := make([]gitealike.CommentDTO, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, convertComment(comment))
+	}
+	return out
+}
+
+func convertReviews(reviews []*giteasdk.PullReview) []gitealike.ReviewDTO {
+	out := make([]gitealike.ReviewDTO, 0, len(reviews))
+	for _, review := range reviews {
+		out = append(out, convertReview(review))
+	}
+	return out
+}
+
+func convertCommits(commits []*giteasdk.Commit) []gitealike.CommitDTO {
+	out := make([]gitealike.CommitDTO, 0, len(commits))
+	for _, commit := range commits {
+		out = append(out, convertCommit(commit))
+	}
+	return out
+}
+
+func convertReleases(releases []*giteasdk.Release) []gitealike.ReleaseDTO {
+	out := make([]gitealike.ReleaseDTO, 0, len(releases))
+	for _, release := range releases {
+		out = append(out, convertRelease(release))
+	}
+	return out
+}
+
+func convertTags(tags []*giteasdk.Tag) []gitealike.TagDTO {
+	out := make([]gitealike.TagDTO, 0, len(tags))
+	for _, tag := range tags {
+		out = append(out, convertTag(tag))
+	}
+	return out
+}
+
+func convertStatuses(statuses []*giteasdk.Status) []gitealike.StatusDTO {
+	out := make([]gitealike.StatusDTO, 0, len(statuses))
+	for _, status := range statuses {
+		out = append(out, convertStatus(status))
+	}
+	return out
+}
+
 func convertUser(user *giteasdk.User) gitealike.UserDTO {
 	if user == nil {
 		return gitealike.UserDTO{}

--- a/internal/platform/gitea/read.go
+++ b/internal/platform/gitea/read.go
@@ -1,0 +1,292 @@
+package gitea
+
+import (
+	"context"
+
+	giteasdk "code.gitea.io/sdk/gitea"
+	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+func (c *Client) GetRepository(ctx context.Context, ref platform.RepoRef) (platform.Repository, error) {
+	return c.provider.GetRepository(ctx, ref)
+}
+
+func (c *Client) ListRepositories(
+	ctx context.Context,
+	owner string,
+	opts platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	return c.provider.ListRepositories(ctx, owner, opts)
+}
+
+func (c *Client) ListOpenMergeRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.MergeRequest, error) {
+	return c.provider.ListOpenMergeRequests(ctx, ref)
+}
+
+func (c *Client) GetMergeRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.MergeRequest, error) {
+	return c.provider.GetMergeRequest(ctx, ref, number)
+}
+
+func (c *Client) ListMergeRequestEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestEvent, error) {
+	return c.provider.ListMergeRequestEvents(ctx, ref, number)
+}
+
+func (c *Client) ListOpenIssues(ctx context.Context, ref platform.RepoRef) ([]platform.Issue, error) {
+	return c.provider.ListOpenIssues(ctx, ref)
+}
+
+func (c *Client) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.Issue, error) {
+	return c.provider.GetIssue(ctx, ref, number)
+}
+
+func (c *Client) ListIssueEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.IssueEvent, error) {
+	return c.provider.ListIssueEvents(ctx, ref, number)
+}
+
+func (c *Client) ListReleases(ctx context.Context, ref platform.RepoRef) ([]platform.Release, error) {
+	return c.provider.ListReleases(ctx, ref)
+}
+
+func (c *Client) ListTags(ctx context.Context, ref platform.RepoRef) ([]platform.Tag, error) {
+	return c.provider.ListTags(ctx, ref)
+}
+
+func (c *Client) ListCIChecks(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+) ([]platform.CICheck, error) {
+	return c.provider.ListCIChecks(ctx, ref, sha)
+}
+
+func (t *transport) GetRepository(
+	ctx context.Context,
+	owner, repo string,
+) (gitealike.RepositoryDTO, error) {
+	repository, resp, err := t.api.GetRepo(owner, repo)
+	if err != nil {
+		return gitealike.RepositoryDTO{}, giteaHTTPError(resp, err)
+	}
+	return convertRepository(repository)
+}
+
+func (t *transport) ListUserRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	repos, resp, err := t.api.ListUserRepos(owner, giteasdk.ListReposOptions{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertRepositories(repos, giteaPage(resp))
+}
+
+func (t *transport) ListOrgRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	repos, resp, err := t.api.ListOrgRepos(owner, giteasdk.ListOrgReposOptions{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertRepositories(repos, giteaPage(resp))
+}
+
+func (t *transport) ListOpenPullRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	prs, resp, err := t.api.ListRepoPullRequests(ref.Owner, ref.Name, giteasdk.ListPullRequestsOptions{
+		ListOptions: giteaListOptions(opts),
+		State:       giteasdk.StateOpen,
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertPullRequests(prs), giteaPage(resp), nil
+}
+
+func (t *transport) GetPullRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.PullRequestDTO, error) {
+	pr, resp, err := t.api.GetPullRequest(ref.Owner, ref.Name, int64(number))
+	if err != nil {
+		return gitealike.PullRequestDTO{}, giteaHTTPError(resp, err)
+	}
+	return convertPullRequest(pr), nil
+}
+
+func (t *transport) ListPullRequestComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	comments, resp, err := t.api.ListIssueComments(ref.Owner, ref.Name, int64(number), giteasdk.ListIssueCommentOptions{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertComments(comments), giteaPage(resp), nil
+}
+
+func (t *transport) ListPullRequestReviews(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	reviews, resp, err := t.api.ListPullReviews(ref.Owner, ref.Name, int64(number), giteasdk.ListPullReviewsOptions{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertReviews(reviews), giteaPage(resp), nil
+}
+
+func (t *transport) ListPullRequestCommits(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	commits, resp, err := t.api.ListPullRequestCommits(ref.Owner, ref.Name, int64(number), giteasdk.ListPullRequestCommitsOptions{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertCommits(commits), giteaPage(resp), nil
+}
+
+func (t *transport) ListOpenIssues(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	issues, resp, err := t.api.ListRepoIssues(ref.Owner, ref.Name, giteasdk.ListIssueOption{
+		ListOptions: giteaListOptions(opts),
+		State:       giteasdk.StateOpen,
+		Type:        giteasdk.IssueTypeIssue,
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertIssues(issues), giteaPage(resp), nil
+}
+
+func (t *transport) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.IssueDTO, error) {
+	issue, resp, err := t.api.GetIssue(ref.Owner, ref.Name, int64(number))
+	if err != nil {
+		return gitealike.IssueDTO{}, giteaHTTPError(resp, err)
+	}
+	return convertIssue(issue), nil
+}
+
+func (t *transport) ListIssueComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.ListPullRequestComments(ctx, ref, number, opts)
+}
+
+func (t *transport) ListReleases(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	releases, resp, err := t.api.ListReleases(ref.Owner, ref.Name, giteasdk.ListReleasesOptions{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertReleases(releases), giteaPage(resp), nil
+}
+
+func (t *transport) ListTags(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.TagDTO, gitealike.Page, error) {
+	tags, resp, err := t.api.ListRepoTags(ref.Owner, ref.Name, giteasdk.ListRepoTagsOptions{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertTags(tags), giteaPage(resp), nil
+}
+
+func (t *transport) ListStatuses(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+	opts gitealike.PageOptions,
+) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	statuses, resp, err := t.api.ListStatuses(ref.Owner, ref.Name, sha, giteasdk.ListStatusesOption{
+		ListOptions: giteaListOptions(opts),
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertStatuses(statuses), giteaPage(resp), nil
+}
+
+func giteaListOptions(opts gitealike.PageOptions) giteasdk.ListOptions {
+	return giteasdk.ListOptions{Page: opts.Page, PageSize: opts.PageSize}
+}
+
+func giteaPage(resp *giteasdk.Response) gitealike.Page {
+	if resp == nil {
+		return gitealike.Page{}
+	}
+	return gitealike.Page{Next: resp.NextPage}
+}
+
+func giteaHTTPError(resp *giteasdk.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+	if resp != nil && resp.Response != nil {
+		return &gitealike.HTTPError{StatusCode: resp.StatusCode, Err: err}
+	}
+	return err
+}

--- a/internal/platform/gitea/read.go
+++ b/internal/platform/gitea/read.go
@@ -1,0 +1,370 @@
+package gitea
+
+import (
+	"context"
+
+	giteasdk "code.gitea.io/sdk/gitea"
+	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
+)
+
+func (c *Client) GetRepository(ctx context.Context, ref platform.RepoRef) (platform.Repository, error) {
+	return c.provider.GetRepository(ctx, ref)
+}
+
+func (c *Client) ListRepositories(
+	ctx context.Context,
+	owner string,
+	opts platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	return c.provider.ListRepositories(ctx, owner, opts)
+}
+
+func (c *Client) ListOpenMergeRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.MergeRequest, error) {
+	return c.provider.ListOpenMergeRequests(ctx, ref)
+}
+
+func (c *Client) GetMergeRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.MergeRequest, error) {
+	return c.provider.GetMergeRequest(ctx, ref, number)
+}
+
+func (c *Client) ListMergeRequestEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestEvent, error) {
+	return c.provider.ListMergeRequestEvents(ctx, ref, number)
+}
+
+func (c *Client) ListOpenIssues(ctx context.Context, ref platform.RepoRef) ([]platform.Issue, error) {
+	return c.provider.ListOpenIssues(ctx, ref)
+}
+
+func (c *Client) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (platform.Issue, error) {
+	return c.provider.GetIssue(ctx, ref, number)
+}
+
+func (c *Client) ListIssueEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.IssueEvent, error) {
+	return c.provider.ListIssueEvents(ctx, ref, number)
+}
+
+func (c *Client) ListReleases(ctx context.Context, ref platform.RepoRef) ([]platform.Release, error) {
+	return c.provider.ListReleases(ctx, ref)
+}
+
+func (c *Client) ListTags(ctx context.Context, ref platform.RepoRef) ([]platform.Tag, error) {
+	return c.provider.ListTags(ctx, ref)
+}
+
+func (c *Client) ListCIChecks(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+) ([]platform.CICheck, error) {
+	return c.provider.ListCIChecks(ctx, ref, sha)
+}
+
+func (t *transport) GetRepository(
+	ctx context.Context,
+	owner, repo string,
+) (gitealike.RepositoryDTO, error) {
+	var repository *giteasdk.Repository
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		repository, resp, err = t.api.GetRepo(owner, repo)
+		return err
+	})
+	if err != nil {
+		return gitealike.RepositoryDTO{}, giteaHTTPError(resp, err)
+	}
+	return convertRepository(repository)
+}
+
+func (t *transport) ListUserRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	var repos []*giteasdk.Repository
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		repos, resp, err = t.api.ListUserRepos(owner, giteasdk.ListReposOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertRepositories(repos, giteaPage(resp))
+}
+
+func (t *transport) ListOrgRepositories(
+	ctx context.Context,
+	owner string,
+	opts gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	var repos []*giteasdk.Repository
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		repos, resp, err = t.api.ListOrgRepos(owner, giteasdk.ListOrgReposOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertRepositories(repos, giteaPage(resp))
+}
+
+func (t *transport) ListOpenPullRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	var prs []*giteasdk.PullRequest
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		prs, resp, err = t.api.ListRepoPullRequests(ref.Owner, ref.Name, giteasdk.ListPullRequestsOptions{
+			ListOptions: giteaListOptions(opts),
+			State:       giteasdk.StateOpen,
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertPullRequests(prs), giteaPage(resp), nil
+}
+
+func (t *transport) GetPullRequest(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.PullRequestDTO, error) {
+	var pr *giteasdk.PullRequest
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		pr, resp, err = t.api.GetPullRequest(ref.Owner, ref.Name, int64(number))
+		return err
+	})
+	if err != nil {
+		return gitealike.PullRequestDTO{}, giteaHTTPError(resp, err)
+	}
+	return convertPullRequest(pr), nil
+}
+
+func (t *transport) ListPullRequestComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	var comments []*giteasdk.Comment
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		comments, resp, err = t.api.ListIssueComments(ref.Owner, ref.Name, int64(number), giteasdk.ListIssueCommentOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertComments(comments), giteaPage(resp), nil
+}
+
+func (t *transport) ListPullRequestReviews(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	var reviews []*giteasdk.PullReview
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		reviews, resp, err = t.api.ListPullReviews(ref.Owner, ref.Name, int64(number), giteasdk.ListPullReviewsOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertReviews(reviews), giteaPage(resp), nil
+}
+
+func (t *transport) ListPullRequestCommits(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	var commits []*giteasdk.Commit
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		commits, resp, err = t.api.ListPullRequestCommits(ref.Owner, ref.Name, int64(number), giteasdk.ListPullRequestCommitsOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertCommits(commits), giteaPage(resp), nil
+}
+
+func (t *transport) ListOpenIssues(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	var issues []*giteasdk.Issue
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		issues, resp, err = t.api.ListRepoIssues(ref.Owner, ref.Name, giteasdk.ListIssueOption{
+			ListOptions: giteaListOptions(opts),
+			State:       giteasdk.StateOpen,
+			Type:        giteasdk.IssueTypeIssue,
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertIssues(issues), giteaPage(resp), nil
+}
+
+func (t *transport) GetIssue(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) (gitealike.IssueDTO, error) {
+	var issue *giteasdk.Issue
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		issue, resp, err = t.api.GetIssue(ref.Owner, ref.Name, int64(number))
+		return err
+	})
+	if err != nil {
+		return gitealike.IssueDTO{}, giteaHTTPError(resp, err)
+	}
+	return convertIssue(issue), nil
+}
+
+func (t *transport) ListIssueComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.ListPullRequestComments(ctx, ref, number, opts)
+}
+
+func (t *transport) ListReleases(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	var releases []*giteasdk.Release
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		releases, resp, err = t.api.ListReleases(ref.Owner, ref.Name, giteasdk.ListReleasesOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertReleases(releases), giteaPage(resp), nil
+}
+
+func (t *transport) ListTags(
+	ctx context.Context,
+	ref platform.RepoRef,
+	opts gitealike.PageOptions,
+) ([]gitealike.TagDTO, gitealike.Page, error) {
+	var tags []*giteasdk.Tag
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		tags, resp, err = t.api.ListRepoTags(ref.Owner, ref.Name, giteasdk.ListRepoTagsOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertTags(tags), giteaPage(resp), nil
+}
+
+func (t *transport) ListStatuses(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+	opts gitealike.PageOptions,
+) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	var statuses []*giteasdk.Status
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		statuses, resp, err = t.api.ListStatuses(ref.Owner, ref.Name, sha, giteasdk.ListStatusesOption{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertStatuses(statuses), giteaPage(resp), nil
+}
+
+func giteaListOptions(opts gitealike.PageOptions) giteasdk.ListOptions {
+	return giteasdk.ListOptions{Page: opts.Page, PageSize: opts.PageSize}
+}
+
+func giteaPage(resp *giteasdk.Response) gitealike.Page {
+	if resp == nil {
+		return gitealike.Page{}
+	}
+	return gitealike.Page{Next: resp.NextPage}
+}
+
+func giteaHTTPError(resp *giteasdk.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+	if resp != nil && resp.Response != nil {
+		return &gitealike.HTTPError{StatusCode: resp.StatusCode, Err: err}
+	}
+	return err
+}

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -14,17 +14,17 @@ type Provider struct {
 	kind      platform.Kind
 	host      string
 	transport Transport
-	options   Options
+	options   options
 }
 
-type Options struct {
+type options struct {
 	ReadActions bool
 }
 
-type Option func(*Options)
+type Option func(*options)
 
 func WithReadActions() Option {
-	return func(options *Options) {
+	return func(options *options) {
 		options.ReadActions = true
 	}
 }
@@ -35,7 +35,7 @@ func NewProvider(
 	transport Transport,
 	opts ...Option,
 ) *Provider {
-	var options Options
+	var options options
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8494,6 +8494,282 @@ func TestAPIGitLabUnsupportedMutationsReturnCodedCapabilityErrors(t *testing.T) 
 	}
 }
 
+func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	transport := &apiTestGitealikeTransport{
+		repo: gitealike.RepositoryDTO{
+			ID:            101,
+			Owner:         gitealike.UserDTO{UserName: "forgejo"},
+			Name:          "tea",
+			FullName:      "forgejo/tea",
+			HTMLURL:       "https://codeberg.test/forgejo/tea",
+			CloneURL:      "https://codeberg.test/forgejo/tea.git",
+			DefaultBranch: "main",
+			Created:       base,
+			Updated:       base,
+		},
+		pulls: []gitealike.PullRequestDTO{{
+			ID:       201,
+			Index:    7,
+			HTMLURL:  "https://codeberg.test/forgejo/tea/pulls/7",
+			Title:    "Add tea",
+			User:     gitealike.UserDTO{UserName: "alice"},
+			State:    "open",
+			IsLocked: true,
+			Head:     gitealike.BranchDTO{Ref: "feature", SHA: "abc123"},
+			Base:     gitealike.BranchDTO{Ref: "main", SHA: "def456"},
+			Created:  base,
+			Updated:  base.Add(time.Minute),
+		}},
+		pullComments: []gitealike.CommentDTO{{
+			ID:      301,
+			User:    gitealike.UserDTO{UserName: "reviewer"},
+			Body:    "looks good",
+			Created: base.Add(2 * time.Minute),
+			Updated: base.Add(2 * time.Minute),
+		}},
+		issues: []gitealike.IssueDTO{{
+			ID:      401,
+			Index:   8,
+			HTMLURL: "https://codeberg.test/forgejo/tea/issues/8",
+			Title:   "Missing cup",
+			User:    gitealike.UserDTO{UserName: "bob"},
+			State:   "open",
+			Created: base,
+			Updated: base.Add(time.Minute),
+		}},
+		issueComments: []gitealike.CommentDTO{{
+			ID:      501,
+			User:    gitealike.UserDTO{UserName: "triager"},
+			Body:    "confirmed",
+			Created: base.Add(3 * time.Minute),
+			Updated: base.Add(3 * time.Minute),
+		}},
+		statuses: []gitealike.StatusDTO{{
+			ID:        601,
+			Context:   "build",
+			State:     "success",
+			TargetURL: "https://ci.test/build",
+			Created:   base.Add(time.Minute),
+			Updated:   base.Add(time.Minute),
+		}},
+	}
+	provider := gitealike.NewProvider(
+		platform.KindForgejo,
+		"codeberg.test",
+		transport,
+		gitealike.Options{},
+	)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindForgejo,
+			PlatformHost: "codeberg.test",
+			Owner:        "forgejo",
+			Name:         "tea",
+			RepoPath:     "forgejo/tea",
+		}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+	require.NoError(syncer.SyncMR(ctx, "forgejo", "tea", 7))
+	require.NoError(syncer.SyncIssue(ctx, "forgejo", "tea", 8))
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "forgejo",
+		PlatformHost: "codeberg.test",
+		RepoPath:     "forgejo/tea",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.True(mr.IsLocked)
+	assert.Equal("success", mr.CIStatus)
+
+	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pullResp.StatusCode())
+	require.NotNil(pullResp.JSON200)
+	assert.True(pullResp.JSON200.MergeRequest.IsLocked)
+	assert.Equal("forgejo", pullResp.JSON200.Repo.Provider)
+	assert.True(pullResp.JSON200.Repo.Capabilities.ReadMergeRequests)
+	assert.True(pullResp.JSON200.Repo.Capabilities.ReadCi)
+	require.NotNil(pullResp.JSON200.Events)
+	require.Len(*pullResp.JSON200.Events, 1)
+	assert.Equal("looks good", (*pullResp.JSON200.Events)[0].Body)
+
+	issueResp, err := client.HTTP.GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(
+		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 8,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, issueResp.StatusCode())
+	require.NotNil(issueResp.JSON200)
+	assert.Equal("Missing cup", issueResp.JSON200.Issue.Title)
+	require.NotNil(issueResp.JSON200.Events)
+	require.Len(*issueResp.JSON200.Events, 1)
+	assert.Equal("confirmed", (*issueResp.JSON200.Events)[0].Body)
+}
+
+type apiTestGitealikeTransport struct {
+	repo          gitealike.RepositoryDTO
+	pulls         []gitealike.PullRequestDTO
+	pullComments  []gitealike.CommentDTO
+	issues        []gitealike.IssueDTO
+	issueComments []gitealike.CommentDTO
+	statuses      []gitealike.StatusDTO
+}
+
+func (t *apiTestGitealikeTransport) GetRepository(
+	context.Context,
+	string,
+	string,
+) (gitealike.RepositoryDTO, error) {
+	return t.repo, nil
+}
+
+func (t *apiTestGitealikeTransport) ListUserRepositories(
+	context.Context,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	return []gitealike.RepositoryDTO{t.repo}, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListOrgRepositories(
+	context.Context,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	return []gitealike.RepositoryDTO{t.repo}, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListOpenPullRequests(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	return t.pulls, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) GetPullRequest(
+	_ context.Context,
+	_ platform.RepoRef,
+	number int,
+) (gitealike.PullRequestDTO, error) {
+	for _, pr := range t.pulls {
+		if pr.Index == number {
+			return pr, nil
+		}
+	}
+	return gitealike.PullRequestDTO{}, platform.ErrNotFound
+}
+
+func (t *apiTestGitealikeTransport) ListPullRequestComments(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.pullComments, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListPullRequestReviews(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListPullRequestCommits(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListOpenIssues(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	return t.issues, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) GetIssue(
+	_ context.Context,
+	_ platform.RepoRef,
+	number int,
+) (gitealike.IssueDTO, error) {
+	for _, issue := range t.issues {
+		if issue.Index == number {
+			return issue, nil
+		}
+	}
+	return gitealike.IssueDTO{}, platform.ErrNotFound
+}
+
+func (t *apiTestGitealikeTransport) ListIssueComments(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.issueComments, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListReleases(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListTags(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.TagDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListStatuses(
+	context.Context,
+	platform.RepoRef,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	return t.statuses, gitealike.Page{}, nil
+}
+
 func setupGitLabCapabilityServer(t *testing.T) (*Server, *db.DB) {
 	t.Helper()
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8561,7 +8561,6 @@ func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
 		platform.KindForgejo,
 		"codeberg.test",
 		transport,
-		gitealike.Options{},
 	)
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/wesm/middleman/internal/gitenv"
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/stacks"
 	"github.com/wesm/middleman/internal/testutil"
 	"github.com/wesm/middleman/internal/workspace"
@@ -8491,6 +8492,282 @@ func TestAPIGitLabUnsupportedMutationsReturnCodedCapabilityErrors(t *testing.T) 
 			)
 		})
 	}
+}
+
+func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	transport := &apiTestGitealikeTransport{
+		repo: gitealike.RepositoryDTO{
+			ID:            101,
+			Owner:         gitealike.UserDTO{UserName: "forgejo"},
+			Name:          "tea",
+			FullName:      "forgejo/tea",
+			HTMLURL:       "https://codeberg.test/forgejo/tea",
+			CloneURL:      "https://codeberg.test/forgejo/tea.git",
+			DefaultBranch: "main",
+			Created:       base,
+			Updated:       base,
+		},
+		pulls: []gitealike.PullRequestDTO{{
+			ID:       201,
+			Index:    7,
+			HTMLURL:  "https://codeberg.test/forgejo/tea/pulls/7",
+			Title:    "Add tea",
+			User:     gitealike.UserDTO{UserName: "alice"},
+			State:    "open",
+			IsLocked: true,
+			Head:     gitealike.BranchDTO{Ref: "feature", SHA: "abc123"},
+			Base:     gitealike.BranchDTO{Ref: "main", SHA: "def456"},
+			Created:  base,
+			Updated:  base.Add(time.Minute),
+		}},
+		pullComments: []gitealike.CommentDTO{{
+			ID:      301,
+			User:    gitealike.UserDTO{UserName: "reviewer"},
+			Body:    "looks good",
+			Created: base.Add(2 * time.Minute),
+			Updated: base.Add(2 * time.Minute),
+		}},
+		issues: []gitealike.IssueDTO{{
+			ID:      401,
+			Index:   8,
+			HTMLURL: "https://codeberg.test/forgejo/tea/issues/8",
+			Title:   "Missing cup",
+			User:    gitealike.UserDTO{UserName: "bob"},
+			State:   "open",
+			Created: base,
+			Updated: base.Add(time.Minute),
+		}},
+		issueComments: []gitealike.CommentDTO{{
+			ID:      501,
+			User:    gitealike.UserDTO{UserName: "triager"},
+			Body:    "confirmed",
+			Created: base.Add(3 * time.Minute),
+			Updated: base.Add(3 * time.Minute),
+		}},
+		statuses: []gitealike.StatusDTO{{
+			ID:        601,
+			Context:   "build",
+			State:     "success",
+			TargetURL: "https://ci.test/build",
+			Created:   base.Add(time.Minute),
+			Updated:   base.Add(time.Minute),
+		}},
+	}
+	provider := gitealike.NewProvider(
+		platform.KindForgejo,
+		"codeberg.test",
+		transport,
+		gitealike.Options{},
+	)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindForgejo,
+			PlatformHost: "codeberg.test",
+			Owner:        "forgejo",
+			Name:         "tea",
+			RepoPath:     "forgejo/tea",
+		}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+	require.NoError(syncer.SyncMR(ctx, "forgejo", "tea", 7))
+	require.NoError(syncer.SyncIssue(ctx, "forgejo", "tea", 8))
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "forgejo",
+		PlatformHost: "codeberg.test",
+		RepoPath:     "forgejo/tea",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.True(mr.IsLocked)
+	assert.Equal("success", mr.CIStatus)
+
+	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pullResp.StatusCode())
+	require.NotNil(pullResp.JSON200)
+	assert.True(pullResp.JSON200.MergeRequest.IsLocked)
+	assert.Equal("forgejo", pullResp.JSON200.Repo.Provider)
+	assert.True(pullResp.JSON200.Repo.Capabilities.ReadMergeRequests)
+	assert.True(pullResp.JSON200.Repo.Capabilities.ReadCi)
+	require.NotNil(pullResp.JSON200.Events)
+	require.Len(*pullResp.JSON200.Events, 1)
+	assert.Equal("looks good", (*pullResp.JSON200.Events)[0].Body)
+
+	issueResp, err := client.HTTP.GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(
+		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 8,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, issueResp.StatusCode())
+	require.NotNil(issueResp.JSON200)
+	assert.Equal("Missing cup", issueResp.JSON200.Issue.Title)
+	require.NotNil(issueResp.JSON200.Events)
+	require.Len(*issueResp.JSON200.Events, 1)
+	assert.Equal("confirmed", (*issueResp.JSON200.Events)[0].Body)
+}
+
+type apiTestGitealikeTransport struct {
+	repo          gitealike.RepositoryDTO
+	pulls         []gitealike.PullRequestDTO
+	pullComments  []gitealike.CommentDTO
+	issues        []gitealike.IssueDTO
+	issueComments []gitealike.CommentDTO
+	statuses      []gitealike.StatusDTO
+}
+
+func (t *apiTestGitealikeTransport) GetRepository(
+	context.Context,
+	string,
+	string,
+) (gitealike.RepositoryDTO, error) {
+	return t.repo, nil
+}
+
+func (t *apiTestGitealikeTransport) ListUserRepositories(
+	context.Context,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	return []gitealike.RepositoryDTO{t.repo}, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListOrgRepositories(
+	context.Context,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	return []gitealike.RepositoryDTO{t.repo}, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListOpenPullRequests(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	return t.pulls, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) GetPullRequest(
+	_ context.Context,
+	_ platform.RepoRef,
+	number int,
+) (gitealike.PullRequestDTO, error) {
+	for _, pr := range t.pulls {
+		if pr.Index == number {
+			return pr, nil
+		}
+	}
+	return gitealike.PullRequestDTO{}, platform.ErrNotFound
+}
+
+func (t *apiTestGitealikeTransport) ListPullRequestComments(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.pullComments, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListPullRequestReviews(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListPullRequestCommits(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListOpenIssues(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	return t.issues, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) GetIssue(
+	_ context.Context,
+	_ platform.RepoRef,
+	number int,
+) (gitealike.IssueDTO, error) {
+	for _, issue := range t.issues {
+		if issue.Index == number {
+			return issue, nil
+		}
+	}
+	return gitealike.IssueDTO{}, platform.ErrNotFound
+}
+
+func (t *apiTestGitealikeTransport) ListIssueComments(
+	context.Context,
+	platform.RepoRef,
+	int,
+	gitealike.PageOptions,
+) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	return t.issueComments, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListReleases(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListTags(
+	context.Context,
+	platform.RepoRef,
+	gitealike.PageOptions,
+) ([]gitealike.TagDTO, gitealike.Page, error) {
+	return nil, gitealike.Page{}, nil
+}
+
+func (t *apiTestGitealikeTransport) ListStatuses(
+	context.Context,
+	platform.RepoRef,
+	string,
+	gitealike.PageOptions,
+) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	return t.statuses, gitealike.Page{}, nil
 }
 
 func setupGitLabCapabilityServer(t *testing.T) (*Server, *db.DB) {


### PR DESCRIPTION
Wire the Forgejo and Gitea SDK clients into the shared gitealike provider so repository, merge request, issue, release, tag, and CI read paths use the same pagination and typed error behavior. Forgejo includes action runs in CI checks where the SDK exposes them; Gitea stays on commit statuses only.