### PR TITLE
feat: start Forgejo and Gitea providers at runtime

### DIFF
--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -155,6 +155,76 @@ func TestValidateProviderHostKeysAllowsMixedProvidersOnSameHostWithSameToken(t *
 	require.NoError(t, err)
 }
 
+func TestDefaultProviderFactoriesRegisterForgejoAndGitea(t *testing.T) {
+	factories := defaultProviderFactories()
+
+	assert := Assert.New(t)
+	assert.Contains(factories, string(platform.KindForgejo))
+	assert.Contains(factories, string(platform.KindGitea))
+}
+
+func TestBuildProviderStartupKeepsForgeProviderHostsDistinct(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	callsByProvider := map[string][]providerFactoryInput{}
+	factories := map[string]providerFactory{
+		string(platform.KindForgejo): func(input providerFactoryInput) (providerFactoryOutput, error) {
+			callsByProvider[string(platform.KindForgejo)] = append(
+				callsByProvider[string(platform.KindForgejo)], input,
+			)
+			return providerFactoryOutput{provider: mainTestRepositoryReader{
+				kind: platform.KindForgejo,
+				host: input.host,
+			}}, nil
+		},
+		string(platform.KindGitea): func(input providerFactoryInput) (providerFactoryOutput, error) {
+			callsByProvider[string(platform.KindGitea)] = append(
+				callsByProvider[string(platform.KindGitea)], input,
+			)
+			return providerFactoryOutput{provider: mainTestRepositoryReader{
+				kind: platform.KindGitea,
+				host: input.host,
+			}}, nil
+		},
+	}
+
+	startup, err := buildProviderStartup(
+		database,
+		&config.Config{SyncBudgetPerHour: 200},
+		map[string]string{
+			providerHostKey(string(platform.KindForgejo), "codeberg.org"):    "codeberg-token",
+			providerHostKey(string(platform.KindGitea), "gitea.example.com"): "gitea-token",
+		},
+		factories,
+	)
+	require.NoError(err)
+
+	forgejoCalls := callsByProvider[string(platform.KindForgejo)]
+	giteaCalls := callsByProvider[string(platform.KindGitea)]
+	require.Len(forgejoCalls, 1)
+	require.Len(giteaCalls, 1)
+	assert.Equal("codeberg.org", forgejoCalls[0].host)
+	assert.Equal("codeberg-token", forgejoCalls[0].token)
+	assert.Equal("gitea.example.com", giteaCalls[0].host)
+	assert.Equal("gitea-token", giteaCalls[0].token)
+	assert.NotSame(forgejoCalls[0].rateTracker, giteaCalls[0].rateTracker)
+	assert.NotSame(forgejoCalls[0].budget, giteaCalls[0].budget)
+	assert.Equal("codeberg-token", startup.cloneTokens["codeberg.org"])
+	assert.Equal("gitea-token", startup.cloneTokens["gitea.example.com"])
+
+	forgejoReader, err := startup.registry.RepositoryReader(platform.KindForgejo, "codeberg.org")
+	require.NoError(err)
+	giteaReader, err := startup.registry.RepositoryReader(platform.KindGitea, "gitea.example.com")
+	require.NoError(err)
+	assert.NotNil(forgejoReader)
+	assert.NotNil(giteaReader)
+}
+
 func TestBuildProviderStartupUsesRegisteredFactoryForFutureProvider(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/cmd/middleman/provider_startup.go
+++ b/cmd/middleman/provider_startup.go
@@ -63,6 +63,7 @@ func defaultProviderFactories() map[string]providerFactory {
 			client, err := forgejoclient.NewClient(
 				input.host, input.token,
 				forgejoclient.WithRateTracker(input.rateTracker),
+				forgejoclient.WithSyncBudget(input.budget),
 			)
 			if err != nil {
 				return providerFactoryOutput{}, err
@@ -73,6 +74,7 @@ func defaultProviderFactories() map[string]providerFactory {
 			client, err := giteaclient.NewClient(
 				input.host, input.token,
 				giteaclient.WithRateTracker(input.rateTracker),
+				giteaclient.WithSyncBudget(input.budget),
 			)
 			if err != nil {
 				return providerFactoryOutput{}, err

--- a/cmd/middleman/provider_startup.go
+++ b/cmd/middleman/provider_startup.go
@@ -7,6 +7,8 @@ import (
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
+	forgejoclient "github.com/wesm/middleman/internal/platform/forgejo"
+	giteaclient "github.com/wesm/middleman/internal/platform/gitea"
 	gitlabclient "github.com/wesm/middleman/internal/platform/gitlab"
 )
 
@@ -51,6 +53,26 @@ func defaultProviderFactories() map[string]providerFactory {
 			client, err := gitlabclient.NewClient(
 				input.host, input.token,
 				gitlabclient.WithRateTracker(input.rateTracker),
+			)
+			if err != nil {
+				return providerFactoryOutput{}, err
+			}
+			return providerFactoryOutput{provider: client}, nil
+		},
+		string(platform.KindForgejo): func(input providerFactoryInput) (providerFactoryOutput, error) {
+			client, err := forgejoclient.NewClient(
+				input.host, input.token,
+				forgejoclient.WithRateTracker(input.rateTracker),
+			)
+			if err != nil {
+				return providerFactoryOutput{}, err
+			}
+			return providerFactoryOutput{provider: client}, nil
+		},
+		string(platform.KindGitea): func(input providerFactoryInput) (providerFactoryOutput, error) {
+			client, err := giteaclient.NewClient(
+				input.host, input.token,
+				giteaclient.WithRateTracker(input.rateTracker),
 			)
 			if err != nil {
 				return providerFactoryOutput{}, err

--- a/internal/github/budget_transport.go
+++ b/internal/github/budget_transport.go
@@ -15,6 +15,11 @@ func WithSyncBudget(ctx context.Context) context.Context {
 	return context.WithValue(ctx, syncBudgetKey{}, true)
 }
 
+func IsSyncBudgetContext(ctx context.Context) bool {
+	_, ok := ctx.Value(syncBudgetKey{}).(bool)
+	return ok
+}
+
 // budgetTransport wraps an http.RoundTripper and increments a
 // SyncBudget for every RoundTrip invocation whose request
 // context carries the sync-budget key. This captures paginated
@@ -31,7 +36,7 @@ type budgetTransport struct {
 func (t *budgetTransport) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
-	if _, ok := req.Context().Value(syncBudgetKey{}).(bool); ok {
+	if IsSyncBudgetContext(req.Context()) {
 		t.budget.Spend(1)
 	}
 	return t.base.RoundTrip(req)

--- a/internal/platform/forgejo/client.go
+++ b/internal/platform/forgejo/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
@@ -18,6 +19,7 @@ type clientOptions struct {
 	baseURL           string
 	foregroundTimeout time.Duration
 	rateTracker       *ratelimit.RateTracker
+	budget            *ghsync.SyncBudget
 	skipVersionProbe  bool
 }
 
@@ -46,6 +48,12 @@ func WithForegroundTimeoutForTesting(timeout time.Duration) ClientOption {
 func WithRateTracker(rateTracker *ratelimit.RateTracker) ClientOption {
 	return func(opts *clientOptions) {
 		opts.rateTracker = rateTracker
+	}
+}
+
+func WithSyncBudget(budget *ghsync.SyncBudget) ClientOption {
+	return func(opts *clientOptions) {
+		opts.budget = budget
 	}
 }
 
@@ -84,7 +92,11 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	transport := &transport{api: api, requestContextLock: make(chan struct{}, 1)}
+	transport := &transport{
+		api:                api,
+		budget:             opts.budget,
+		requestContextLock: make(chan struct{}, 1),
+	}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
@@ -109,12 +121,14 @@ func (c *Client) Capabilities() platform.Capabilities {
 
 type transport struct {
 	api                *forgejosdk.Client
+	budget             *ghsync.SyncBudget
 	requestContextLock chan struct{}
 }
 
 func (t *transport) getRepositoryRaw(
 	ctx context.Context, owner, repo string,
 ) (*forgejosdk.Repository, error) {
+	t.spendSyncBudget(ctx)
 	var repository *forgejosdk.Repository
 	err := t.withRequestContext(ctx, func() error {
 		var err error
@@ -141,6 +155,12 @@ func (t *transport) withRequestContext(ctx context.Context, request func() error
 	t.api.SetContext(ctx)
 	defer t.api.SetContext(context.Background())
 	return request()
+}
+
+func (t *transport) spendSyncBudget(ctx context.Context) {
+	if t.budget != nil && ghsync.IsSyncBudgetContext(ctx) {
+		t.budget.Spend(1)
+	}
 }
 
 type rateTrackingTransport struct {

--- a/internal/platform/forgejo/client.go
+++ b/internal/platform/forgejo/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
@@ -18,6 +19,7 @@ type clientOptions struct {
 	baseURL           string
 	foregroundTimeout time.Duration
 	rateTracker       *ratelimit.RateTracker
+	budget            *ghsync.SyncBudget
 	skipVersionProbe  bool
 }
 
@@ -46,6 +48,12 @@ func WithForegroundTimeoutForTesting(timeout time.Duration) ClientOption {
 func WithRateTracker(rateTracker *ratelimit.RateTracker) ClientOption {
 	return func(opts *clientOptions) {
 		opts.rateTracker = rateTracker
+	}
+}
+
+func WithSyncBudget(budget *ghsync.SyncBudget) ClientOption {
+	return func(opts *clientOptions) {
+		opts.budget = budget
 	}
 }
 
@@ -84,7 +92,7 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	transport := &transport{api: api}
+	transport := &transport{api: api, budget: opts.budget}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
@@ -108,12 +116,14 @@ func (c *Client) Capabilities() platform.Capabilities {
 }
 
 type transport struct {
-	api *forgejosdk.Client
+	api    *forgejosdk.Client
+	budget *ghsync.SyncBudget
 }
 
 func (t *transport) getRepositoryRaw(
 	ctx context.Context, owner, repo string,
 ) (*forgejosdk.Repository, error) {
+	t.spendSyncBudget(ctx)
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -121,6 +131,12 @@ func (t *transport) getRepositoryRaw(
 	}
 	repository, _, err := t.api.GetRepo(owner, repo)
 	return repository, err
+}
+
+func (t *transport) spendSyncBudget(ctx context.Context) {
+	if t.budget != nil && ghsync.IsSyncBudgetContext(ctx) {
+		t.budget.Spend(1)
+	}
 }
 
 type rateTrackingTransport struct {

--- a/internal/platform/forgejo/client_test.go
+++ b/internal/platform/forgejo/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 )
@@ -187,6 +188,38 @@ func TestTransportGetRepositoryRawCancelsWhileWaitingForRequestContext(t *testin
 	case <-time.After(time.Second):
 		require.FailNow("first request did not finish")
 	}
+}
+
+func TestClientLookupCountsSyncBudget(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id":        1,
+			"name":      "repo",
+			"full_name": "owner/repo",
+			"owner":     map[string]any{"login": "owner"},
+		}))
+	}))
+	defer server.Close()
+
+	budget := ghsync.NewSyncBudget(20)
+	client, err := NewClient(
+		"codeberg.test",
+		"forgejo-token",
+		WithBaseURLForTesting(server.URL),
+		WithSyncBudget(budget),
+	)
+	require.NoError(err)
+
+	_, err = client.transport.getRepositoryRaw(
+		ghsync.WithSyncBudget(context.Background()),
+		"owner",
+		"repo",
+	)
+	require.NoError(err)
+	require.Equal(1, budget.Spent())
 }
 
 func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {

--- a/internal/platform/forgejo/client_test.go
+++ b/internal/platform/forgejo/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 )
@@ -79,6 +80,38 @@ func TestClientLookupUsesForegroundTimeout(t *testing.T) {
 
 	_, err = client.transport.getRepositoryRaw(context.Background(), "owner", "repo")
 	require.Error(err)
+}
+
+func TestClientLookupCountsSyncBudget(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id":        1,
+			"name":      "repo",
+			"full_name": "owner/repo",
+			"owner":     map[string]any{"login": "owner"},
+		}))
+	}))
+	defer server.Close()
+
+	budget := ghsync.NewSyncBudget(20)
+	client, err := NewClient(
+		"codeberg.test",
+		"forgejo-token",
+		WithBaseURLForTesting(server.URL),
+		WithSyncBudget(budget),
+	)
+	require.NoError(err)
+
+	_, err = client.transport.getRepositoryRaw(
+		ghsync.WithSyncBudget(context.Background()),
+		"owner",
+		"repo",
+	)
+	require.NoError(err)
+	require.Equal(1, budget.Spent())
 }
 
 func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {

--- a/internal/platform/forgejo/read.go
+++ b/internal/platform/forgejo/read.go
@@ -85,6 +85,7 @@ func (t *transport) GetRepository(
 	ctx context.Context,
 	owner, repo string,
 ) (gitealike.RepositoryDTO, error) {
+	t.spendSyncBudget(ctx)
 	var repository *forgejosdk.Repository
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -103,6 +104,7 @@ func (t *transport) ListUserRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var repos []*forgejosdk.Repository
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -123,6 +125,7 @@ func (t *transport) ListOrgRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var repos []*forgejosdk.Repository
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -143,6 +146,7 @@ func (t *transport) ListOpenPullRequests(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var prs []*forgejosdk.PullRequest
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -164,6 +168,7 @@ func (t *transport) GetPullRequest(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.PullRequestDTO, error) {
+	t.spendSyncBudget(ctx)
 	var pr *forgejosdk.PullRequest
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -183,6 +188,7 @@ func (t *transport) ListPullRequestComments(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var comments []*forgejosdk.Comment
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -204,6 +210,7 @@ func (t *transport) ListPullRequestReviews(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var reviews []*forgejosdk.PullReview
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -225,6 +232,7 @@ func (t *transport) ListPullRequestCommits(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var commits []*forgejosdk.Commit
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -245,6 +253,7 @@ func (t *transport) ListOpenIssues(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var issues []*forgejosdk.Issue
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -267,6 +276,7 @@ func (t *transport) GetIssue(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.IssueDTO, error) {
+	t.spendSyncBudget(ctx)
 	var issue *forgejosdk.Issue
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -294,6 +304,7 @@ func (t *transport) ListReleases(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var releases []*forgejosdk.Release
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -314,6 +325,7 @@ func (t *transport) ListTags(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.TagDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var tags []*forgejosdk.Tag
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -335,6 +347,7 @@ func (t *transport) ListStatuses(
 	sha string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var statuses []*forgejosdk.Status
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -356,6 +369,7 @@ func (t *transport) ListActionRuns(
 	sha string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ActionRunDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var runs *forgejosdk.ListActionRunsResponse
 	var resp *forgejosdk.Response
 	err := t.withRequestContext(ctx, func() error {

--- a/internal/platform/forgejo/read.go
+++ b/internal/platform/forgejo/read.go
@@ -83,6 +83,7 @@ func (t *transport) GetRepository(
 	ctx context.Context,
 	owner, repo string,
 ) (gitealike.RepositoryDTO, error) {
+	t.spendSyncBudget(ctx)
 	repository, resp, err := t.api.GetRepo(owner, repo)
 	if err != nil {
 		return gitealike.RepositoryDTO{}, forgejoHTTPError(resp, err)
@@ -95,6 +96,7 @@ func (t *transport) ListUserRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	repos, resp, err := t.api.ListUserRepos(owner, forgejosdk.ListReposOptions{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -109,6 +111,7 @@ func (t *transport) ListOrgRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	repos, resp, err := t.api.ListOrgRepos(owner, forgejosdk.ListOrgReposOptions{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -123,6 +126,7 @@ func (t *transport) ListOpenPullRequests(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	prs, resp, err := t.api.ListRepoPullRequests(ref.Owner, ref.Name, forgejosdk.ListPullRequestsOptions{
 		ListOptions: forgejoListOptions(opts),
 		State:       forgejosdk.StateOpen,
@@ -138,6 +142,7 @@ func (t *transport) GetPullRequest(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.PullRequestDTO, error) {
+	t.spendSyncBudget(ctx)
 	pr, resp, err := t.api.GetPullRequest(ref.Owner, ref.Name, int64(number))
 	if err != nil {
 		return gitealike.PullRequestDTO{}, forgejoHTTPError(resp, err)
@@ -151,6 +156,7 @@ func (t *transport) ListPullRequestComments(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	comments, resp, err := t.api.ListIssueComments(ref.Owner, ref.Name, int64(number), forgejosdk.ListIssueCommentOptions{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -166,6 +172,7 @@ func (t *transport) ListPullRequestReviews(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	reviews, resp, err := t.api.ListPullReviews(ref.Owner, ref.Name, int64(number), forgejosdk.ListPullReviewsOptions{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -181,6 +188,7 @@ func (t *transport) ListPullRequestCommits(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	commits, resp, err := t.api.ListPullRequestCommits(ref.Owner, ref.Name, int64(number), forgejosdk.ListPullRequestCommitsOptions{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -195,6 +203,7 @@ func (t *transport) ListOpenIssues(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	issues, resp, err := t.api.ListRepoIssues(ref.Owner, ref.Name, forgejosdk.ListIssueOption{
 		ListOptions: forgejoListOptions(opts),
 		State:       forgejosdk.StateOpen,
@@ -211,6 +220,7 @@ func (t *transport) GetIssue(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.IssueDTO, error) {
+	t.spendSyncBudget(ctx)
 	issue, resp, err := t.api.GetIssue(ref.Owner, ref.Name, int64(number))
 	if err != nil {
 		return gitealike.IssueDTO{}, forgejoHTTPError(resp, err)
@@ -232,6 +242,7 @@ func (t *transport) ListReleases(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	releases, resp, err := t.api.ListReleases(ref.Owner, ref.Name, forgejosdk.ListReleasesOptions{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -246,6 +257,7 @@ func (t *transport) ListTags(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.TagDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	tags, resp, err := t.api.ListRepoTags(ref.Owner, ref.Name, forgejosdk.ListRepoTagsOptions{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -261,6 +273,7 @@ func (t *transport) ListStatuses(
 	sha string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	statuses, resp, err := t.api.ListStatuses(ref.Owner, ref.Name, sha, forgejosdk.ListStatusesOption{
 		ListOptions: forgejoListOptions(opts),
 	})
@@ -276,6 +289,7 @@ func (t *transport) ListActionRuns(
 	sha string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ActionRunDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	runs, resp, err := t.api.ListRepoActionRuns(ref.Owner, ref.Name, forgejosdk.ListActionRunsOption{
 		ListOptions: forgejoListOptions(opts),
 		HeadSHA:     sha,

--- a/internal/platform/gitea/client.go
+++ b/internal/platform/gitea/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	giteasdk "code.gitea.io/sdk/gitea"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
@@ -18,6 +19,7 @@ type clientOptions struct {
 	baseURL           string
 	foregroundTimeout time.Duration
 	rateTracker       *ratelimit.RateTracker
+	budget            *ghsync.SyncBudget
 	skipVersionProbe  bool
 }
 
@@ -46,6 +48,12 @@ func WithForegroundTimeoutForTesting(timeout time.Duration) ClientOption {
 func WithRateTracker(rateTracker *ratelimit.RateTracker) ClientOption {
 	return func(opts *clientOptions) {
 		opts.rateTracker = rateTracker
+	}
+}
+
+func WithSyncBudget(budget *ghsync.SyncBudget) ClientOption {
+	return func(opts *clientOptions) {
+		opts.budget = budget
 	}
 }
 
@@ -81,7 +89,11 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	transport := &transport{api: api, requestContextLock: make(chan struct{}, 1)}
+	transport := &transport{
+		api:                api,
+		budget:             opts.budget,
+		requestContextLock: make(chan struct{}, 1),
+	}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
@@ -106,12 +118,14 @@ func (c *Client) Capabilities() platform.Capabilities {
 
 type transport struct {
 	api                *giteasdk.Client
+	budget             *ghsync.SyncBudget
 	requestContextLock chan struct{}
 }
 
 func (t *transport) getRepositoryRaw(
 	ctx context.Context, owner, repo string,
 ) (*giteasdk.Repository, error) {
+	t.spendSyncBudget(ctx)
 	var repository *giteasdk.Repository
 	err := t.withRequestContext(ctx, func() error {
 		var err error
@@ -138,6 +152,12 @@ func (t *transport) withRequestContext(ctx context.Context, request func() error
 	t.api.SetContext(ctx)
 	defer t.api.SetContext(context.Background())
 	return request()
+}
+
+func (t *transport) spendSyncBudget(ctx context.Context) {
+	if t.budget != nil && ghsync.IsSyncBudgetContext(ctx) {
+		t.budget.Spend(1)
+	}
 }
 
 type rateTrackingTransport struct {

--- a/internal/platform/gitea/client.go
+++ b/internal/platform/gitea/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	giteasdk "code.gitea.io/sdk/gitea"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 	"github.com/wesm/middleman/internal/ratelimit"
@@ -18,6 +19,7 @@ type clientOptions struct {
 	baseURL           string
 	foregroundTimeout time.Duration
 	rateTracker       *ratelimit.RateTracker
+	budget            *ghsync.SyncBudget
 	skipVersionProbe  bool
 }
 
@@ -46,6 +48,12 @@ func WithForegroundTimeoutForTesting(timeout time.Duration) ClientOption {
 func WithRateTracker(rateTracker *ratelimit.RateTracker) ClientOption {
 	return func(opts *clientOptions) {
 		opts.rateTracker = rateTracker
+	}
+}
+
+func WithSyncBudget(budget *ghsync.SyncBudget) ClientOption {
+	return func(opts *clientOptions) {
+		opts.budget = budget
 	}
 }
 
@@ -81,7 +89,7 @@ func NewClient(host, token string, options ...ClientOption) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	transport := &transport{api: api}
+	transport := &transport{api: api, budget: opts.budget}
 	return &Client{
 		host:              host,
 		baseURL:           opts.baseURL,
@@ -105,12 +113,14 @@ func (c *Client) Capabilities() platform.Capabilities {
 }
 
 type transport struct {
-	api *giteasdk.Client
+	api    *giteasdk.Client
+	budget *ghsync.SyncBudget
 }
 
 func (t *transport) getRepositoryRaw(
 	ctx context.Context, owner, repo string,
 ) (*giteasdk.Repository, error) {
+	t.spendSyncBudget(ctx)
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -118,6 +128,12 @@ func (t *transport) getRepositoryRaw(
 	}
 	repository, _, err := t.api.GetRepo(owner, repo)
 	return repository, err
+}
+
+func (t *transport) spendSyncBudget(ctx context.Context) {
+	if t.budget != nil && ghsync.IsSyncBudgetContext(ctx) {
+		t.budget.Spend(1)
+	}
 }
 
 type rateTrackingTransport struct {

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 )
@@ -186,6 +187,38 @@ func TestTransportGetRepositoryRawCancelsWhileWaitingForRequestContext(t *testin
 	case <-time.After(time.Second):
 		require.FailNow("first request did not finish")
 	}
+}
+
+func TestClientLookupCountsSyncBudget(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id":        1,
+			"name":      "repo",
+			"full_name": "owner/repo",
+			"owner":     map[string]any{"login": "owner"},
+		}))
+	}))
+	defer server.Close()
+
+	budget := ghsync.NewSyncBudget(20)
+	client, err := NewClient(
+		"gitea.test",
+		"gitea-token",
+		WithBaseURLForTesting(server.URL),
+		WithSyncBudget(budget),
+	)
+	require.NoError(err)
+
+	_, err = client.transport.getRepositoryRaw(
+		ghsync.WithSyncBudget(context.Background()),
+		"owner",
+		"repo",
+	)
+	require.NoError(err)
+	require.Equal(1, budget.Spent())
 }
 
 func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
+	ghsync "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/platform/gitealike"
 )
@@ -78,6 +79,38 @@ func TestClientLookupUsesForegroundTimeout(t *testing.T) {
 
 	_, err = client.transport.getRepositoryRaw(context.Background(), "owner", "repo")
 	require.Error(err)
+}
+
+func TestClientLookupCountsSyncBudget(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id":        1,
+			"name":      "repo",
+			"full_name": "owner/repo",
+			"owner":     map[string]any{"login": "owner"},
+		}))
+	}))
+	defer server.Close()
+
+	budget := ghsync.NewSyncBudget(20)
+	client, err := NewClient(
+		"gitea.test",
+		"gitea-token",
+		WithBaseURLForTesting(server.URL),
+		WithSyncBudget(budget),
+	)
+	require.NoError(err)
+
+	_, err = client.transport.getRepositoryRaw(
+		ghsync.WithSyncBudget(context.Background()),
+		"owner",
+		"repo",
+	)
+	require.NoError(err)
+	require.Equal(1, budget.Spent())
 }
 
 func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {

--- a/internal/platform/gitea/read.go
+++ b/internal/platform/gitea/read.go
@@ -83,6 +83,7 @@ func (t *transport) GetRepository(
 	ctx context.Context,
 	owner, repo string,
 ) (gitealike.RepositoryDTO, error) {
+	t.spendSyncBudget(ctx)
 	repository, resp, err := t.api.GetRepo(owner, repo)
 	if err != nil {
 		return gitealike.RepositoryDTO{}, giteaHTTPError(resp, err)
@@ -95,6 +96,7 @@ func (t *transport) ListUserRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	repos, resp, err := t.api.ListUserRepos(owner, giteasdk.ListReposOptions{
 		ListOptions: giteaListOptions(opts),
 	})
@@ -109,6 +111,7 @@ func (t *transport) ListOrgRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	repos, resp, err := t.api.ListOrgRepos(owner, giteasdk.ListOrgReposOptions{
 		ListOptions: giteaListOptions(opts),
 	})
@@ -123,6 +126,7 @@ func (t *transport) ListOpenPullRequests(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	prs, resp, err := t.api.ListRepoPullRequests(ref.Owner, ref.Name, giteasdk.ListPullRequestsOptions{
 		ListOptions: giteaListOptions(opts),
 		State:       giteasdk.StateOpen,
@@ -138,6 +142,7 @@ func (t *transport) GetPullRequest(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.PullRequestDTO, error) {
+	t.spendSyncBudget(ctx)
 	pr, resp, err := t.api.GetPullRequest(ref.Owner, ref.Name, int64(number))
 	if err != nil {
 		return gitealike.PullRequestDTO{}, giteaHTTPError(resp, err)
@@ -151,6 +156,7 @@ func (t *transport) ListPullRequestComments(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	comments, resp, err := t.api.ListIssueComments(ref.Owner, ref.Name, int64(number), giteasdk.ListIssueCommentOptions{
 		ListOptions: giteaListOptions(opts),
 	})
@@ -166,6 +172,7 @@ func (t *transport) ListPullRequestReviews(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	reviews, resp, err := t.api.ListPullReviews(ref.Owner, ref.Name, int64(number), giteasdk.ListPullReviewsOptions{
 		ListOptions: giteaListOptions(opts),
 	})
@@ -181,6 +188,7 @@ func (t *transport) ListPullRequestCommits(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	commits, resp, err := t.api.ListPullRequestCommits(ref.Owner, ref.Name, int64(number), giteasdk.ListPullRequestCommitsOptions{
 		ListOptions: giteaListOptions(opts),
 	})
@@ -195,6 +203,7 @@ func (t *transport) ListOpenIssues(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	issues, resp, err := t.api.ListRepoIssues(ref.Owner, ref.Name, giteasdk.ListIssueOption{
 		ListOptions: giteaListOptions(opts),
 		State:       giteasdk.StateOpen,
@@ -211,6 +220,7 @@ func (t *transport) GetIssue(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.IssueDTO, error) {
+	t.spendSyncBudget(ctx)
 	issue, resp, err := t.api.GetIssue(ref.Owner, ref.Name, int64(number))
 	if err != nil {
 		return gitealike.IssueDTO{}, giteaHTTPError(resp, err)
@@ -232,6 +242,7 @@ func (t *transport) ListReleases(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	releases, resp, err := t.api.ListReleases(ref.Owner, ref.Name, giteasdk.ListReleasesOptions{
 		ListOptions: giteaListOptions(opts),
 	})
@@ -246,6 +257,7 @@ func (t *transport) ListTags(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.TagDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	tags, resp, err := t.api.ListRepoTags(ref.Owner, ref.Name, giteasdk.ListRepoTagsOptions{
 		ListOptions: giteaListOptions(opts),
 	})
@@ -261,6 +273,7 @@ func (t *transport) ListStatuses(
 	sha string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	statuses, resp, err := t.api.ListStatuses(ref.Owner, ref.Name, sha, giteasdk.ListStatusesOption{
 		ListOptions: giteaListOptions(opts),
 	})

--- a/internal/platform/gitea/read.go
+++ b/internal/platform/gitea/read.go
@@ -83,6 +83,7 @@ func (t *transport) GetRepository(
 	ctx context.Context,
 	owner, repo string,
 ) (gitealike.RepositoryDTO, error) {
+	t.spendSyncBudget(ctx)
 	var repository *giteasdk.Repository
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -101,6 +102,7 @@ func (t *transport) ListUserRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var repos []*giteasdk.Repository
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -121,6 +123,7 @@ func (t *transport) ListOrgRepositories(
 	owner string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.RepositoryDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var repos []*giteasdk.Repository
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -141,6 +144,7 @@ func (t *transport) ListOpenPullRequests(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.PullRequestDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var prs []*giteasdk.PullRequest
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -162,6 +166,7 @@ func (t *transport) GetPullRequest(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.PullRequestDTO, error) {
+	t.spendSyncBudget(ctx)
 	var pr *giteasdk.PullRequest
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -181,6 +186,7 @@ func (t *transport) ListPullRequestComments(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommentDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var comments []*giteasdk.Comment
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -202,6 +208,7 @@ func (t *transport) ListPullRequestReviews(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReviewDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var reviews []*giteasdk.PullReview
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -223,6 +230,7 @@ func (t *transport) ListPullRequestCommits(
 	number int,
 	opts gitealike.PageOptions,
 ) ([]gitealike.CommitDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var commits []*giteasdk.Commit
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -243,6 +251,7 @@ func (t *transport) ListOpenIssues(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.IssueDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var issues []*giteasdk.Issue
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -265,6 +274,7 @@ func (t *transport) GetIssue(
 	ref platform.RepoRef,
 	number int,
 ) (gitealike.IssueDTO, error) {
+	t.spendSyncBudget(ctx)
 	var issue *giteasdk.Issue
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -292,6 +302,7 @@ func (t *transport) ListReleases(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.ReleaseDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var releases []*giteasdk.Release
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -312,6 +323,7 @@ func (t *transport) ListTags(
 	ref platform.RepoRef,
 	opts gitealike.PageOptions,
 ) ([]gitealike.TagDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var tags []*giteasdk.Tag
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {
@@ -333,6 +345,7 @@ func (t *transport) ListStatuses(
 	sha string,
 	opts gitealike.PageOptions,
 ) ([]gitealike.StatusDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
 	var statuses []*giteasdk.Status
 	var resp *giteasdk.Response
 	err := t.withRequestContext(ctx, func() error {


### PR DESCRIPTION
Register Forgejo and Gitea startup factories so configured hosts build real provider instances with their host-scoped tokens. Add focused startup coverage that keeps provider host rate trackers, budgets, registry entries, and clone tokens distinct.