### PR TITLE
feat: expose Forgejo and Gitea repository imports

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -83,6 +83,7 @@ type e2eStaticProvider struct {
 	kind        platform.Kind
 	host        string
 	caps        platform.Capabilities
+	repos       []platform.Repository
 	issue       platform.Issue
 	issueEvents []platform.IssueEvent
 }
@@ -97,6 +98,33 @@ func (p e2eStaticProvider) Host() string {
 
 func (p e2eStaticProvider) Capabilities() platform.Capabilities {
 	return p.caps
+}
+
+func (p e2eStaticProvider) GetRepository(
+	_ context.Context,
+	ref platform.RepoRef,
+) (platform.Repository, error) {
+	for _, repo := range p.repos {
+		if repo.Ref.RepoPath == ref.RepoPath ||
+			(repo.Ref.Owner == ref.Owner && repo.Ref.Name == ref.Name) {
+			return repo, nil
+		}
+	}
+	return platform.Repository{}, platform.ErrNotFound
+}
+
+func (p e2eStaticProvider) ListRepositories(
+	_ context.Context,
+	owner string,
+	_ platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	repos := make([]platform.Repository, 0, len(p.repos))
+	for _, repo := range p.repos {
+		if strings.EqualFold(repo.Ref.Owner, owner) {
+			repos = append(repos, repo)
+		}
+	}
+	return repos, nil
 }
 
 func (p e2eStaticProvider) ListOpenIssues(
@@ -445,6 +473,8 @@ func run(
 	gitLabIssue, gitLabIssueEvents := gitLabReadOnlyIssueFixture(
 		time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
 	)
+	forgeUpdated := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	giteaUpdated := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
 	registry, err := ghclient.NewProviderRegistry(
 		fixtureClients,
 		e2eStaticProvider{
@@ -455,6 +485,86 @@ func run(
 			caps: platform.Capabilities{
 				ReadIssues:   true,
 				ReadComments: true,
+			},
+		},
+		e2eStaticProvider{
+			kind: platform.KindForgejo,
+			host: "codeberg.org",
+			caps: platform.Capabilities{
+				ReadRepositories: true,
+			},
+			repos: []platform.Repository{
+				{
+					Ref: platform.RepoRef{
+						Platform: platform.KindForgejo,
+						Host:     "codeberg.org",
+						Owner:    "forge-lab",
+						Name:     "service",
+						RepoPath: "forge-lab/service",
+					},
+					Description:   "Forgejo service",
+					Private:       false,
+					UpdatedAt:     forgeUpdated,
+					DefaultBranch: "main",
+					WebURL:        "https://codeberg.org/forge-lab/service",
+					CloneURL:      "https://codeberg.org/forge-lab/service.git",
+				},
+				{
+					Ref: platform.RepoRef{
+						Platform: platform.KindForgejo,
+						Host:     "codeberg.org",
+						Owner:    "forge-lab",
+						Name:     "archived",
+						RepoPath: "forge-lab/archived",
+					},
+					Archived: true,
+				},
+			},
+		},
+		e2eStaticProvider{
+			kind: platform.KindGitea,
+			host: "gitea.com",
+			caps: platform.Capabilities{
+				ReadRepositories: true,
+			},
+			repos: []platform.Repository{
+				{
+					Ref: platform.RepoRef{
+						Platform: platform.KindGitea,
+						Host:     "gitea.com",
+						Owner:    "gitea-team",
+						Name:     "service",
+						RepoPath: "gitea-team/service",
+					},
+					Description:   "Gitea service",
+					Private:       false,
+					UpdatedAt:     giteaUpdated,
+					DefaultBranch: "main",
+					WebURL:        "https://gitea.com/gitea-team/service",
+					CloneURL:      "https://gitea.com/gitea-team/service.git",
+				},
+				{
+					Ref: platform.RepoRef{
+						Platform: platform.KindGitea,
+						Host:     "gitea.com",
+						Owner:    "gitea-team",
+						Name:     "private-service",
+						RepoPath: "gitea-team/private-service",
+					},
+					Description: "Private Gitea service",
+					Private:     true,
+					UpdatedAt:   giteaUpdated.Add(-time.Hour),
+				},
+				{
+					Ref: platform.RepoRef{
+						Platform: platform.KindGitea,
+						Host:     "gitea.com",
+						Owner:    "gitea-team",
+						Name:     "archived",
+						RepoPath: "gitea-team/archived",
+					},
+					Archived: true,
+				},
 			},
 		},
 	)

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MockedFunction } from "vitest";
 import RepoImportModal from "./RepoImportModal.svelte";
 import { bulkAddRepos, previewRepos } from "../../api/settings.js";
 
@@ -8,8 +9,8 @@ vi.mock("../../api/settings.js", () => ({
   bulkAddRepos: vi.fn(),
 }));
 
-const preview = vi.mocked(previewRepos);
-const bulk = vi.mocked(bulkAddRepos);
+const preview = previewRepos as MockedFunction<typeof previewRepos>;
+const bulk = bulkAddRepos as MockedFunction<typeof bulkAddRepos>;
 
 const rows = [
   { provider: "github", platform_host: "github.com", owner: "acme", name: "worker", repo_path: "acme/worker", description: "Background jobs", private: false, fork: false, pushed_at: "2026-04-20T00:00:00Z", already_configured: false },
@@ -93,6 +94,38 @@ describe("RepoImportModal", () => {
     await fireEvent.keyDown(input, { key: "Enter" });
 
     expect(preview).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets Forgejo and Gitea default hosts and keeps owner patterns non-nested", async () => {
+    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+
+    const provider = screen.getByLabelText("Provider");
+    const host = screen.getByLabelText("Host") as HTMLInputElement;
+    const pattern = screen.getByLabelText("Repository pattern");
+
+    await fireEvent.change(provider, { target: { value: "forgejo" } });
+    expect(host.value).toBe("codeberg.org");
+    await fireEvent.input(pattern, { target: { value: "team/subgroup/project-*" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    expect((await screen.findByRole("alert")).textContent).toContain("Format: owner/pattern");
+    expect(preview).not.toHaveBeenCalled();
+
+    await fireEvent.change(provider, { target: { value: "gitea" } });
+    expect(host.value).toBe("gitea.com");
+    await fireEvent.input(pattern, { target: { value: "team/service-*" } });
+    preview.mockResolvedValueOnce({
+      provider: "gitea",
+      platform_host: "gitea.com",
+      owner: "team",
+      pattern: "service-*",
+      repos: [],
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+
+    await waitFor(() => expect(preview).toHaveBeenCalledWith("team", "service-*", {
+      provider: "gitea",
+      host: "gitea.com",
+    }));
   });
 
   it("keeps tab focus inside the modal", async () => {

--- a/frontend/src/lib/components/settings/repoImportProviders.ts
+++ b/frontend/src/lib/components/settings/repoImportProviders.ts
@@ -23,6 +23,20 @@ export const repoImportProviders: RepoImportProvider[] = [
     allowNestedOwner: true,
     ownerPatternPlaceholder: "group/subgroup/pattern",
   },
+  {
+    id: "forgejo",
+    label: "Forgejo",
+    defaultHost: "codeberg.org",
+    allowNestedOwner: false,
+    ownerPatternPlaceholder: "owner/pattern",
+  },
+  {
+    id: "gitea",
+    label: "Gitea",
+    defaultHost: "gitea.com",
+    allowNestedOwner: false,
+    ownerPatternPlaceholder: "owner/pattern",
+  },
 ];
 
 export function repoImportProvider(id: string): RepoImportProvider {

--- a/frontend/src/lib/components/settings/repoImportSelection.test.ts
+++ b/frontend/src/lib/components/settings/repoImportSelection.test.ts
@@ -9,6 +9,7 @@ import {
   sortRows,
   type RepoImportRow,
 } from "./repoImportSelection.js";
+import { repoImportProvider, repoImportProviders } from "./repoImportProviders.js";
 
 const rows: RepoImportRow[] = [
   { provider: "github", platform_host: "github.com", owner: "acme", name: "worker", repo_path: "acme/worker", description: "Background jobs", private: false, fork: false, pushed_at: "2026-04-20T00:00:00Z", already_configured: false },
@@ -29,6 +30,29 @@ describe("repo import selection helpers", () => {
       owner: "group/subgroup",
       pattern: "project-*",
     });
+  });
+
+  it("keeps Forgejo and Gitea owner patterns non-nested", () => {
+    expect(repoImportProviders.map((provider) => provider.id)).toEqual([
+      "github",
+      "gitlab",
+      "forgejo",
+      "gitea",
+    ]);
+    expect(repoImportProvider("forgejo")).toMatchObject({
+      defaultHost: "codeberg.org",
+      allowNestedOwner: false,
+      ownerPatternPlaceholder: "owner/pattern",
+    });
+    expect(repoImportProvider("gitea")).toMatchObject({
+      defaultHost: "gitea.com",
+      allowNestedOwner: false,
+      ownerPatternPlaceholder: "owner/pattern",
+    });
+    expect(() => parseImportPattern("team/subgroup/project-*", repoImportProvider("forgejo").allowNestedOwner))
+      .toThrow("Format: owner/pattern");
+    expect(() => parseImportPattern("team/subgroup/project-*", repoImportProvider("gitea").allowNestedOwner))
+      .toThrow("Format: owner/pattern");
   });
 
   it("rejects malformed patterns before the API call", () => {

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -200,28 +200,7 @@ test("repository import can hide forks and private repositories before adding", 
   }]);
 });
 
-test("repository import exposes Forgejo and Gitea provider defaults", async ({ page }) => {
-  const previewRequests: Array<{ provider: string; host: string; owner: string; pattern: string }> = [];
-  await page.route("**/api/v1/repos/preview", async (route) => {
-    const body = route.request().postDataJSON() as {
-      provider: string;
-      host: string;
-      owner: string;
-      pattern: string;
-    };
-    previewRequests.push(body);
-    await route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({
-        provider: body.provider,
-        platform_host: body.host,
-        owner: body.owner,
-        pattern: body.pattern,
-        repos: [],
-      }),
-    });
-  });
-
+test("repository import previews and adds Forgejo and Gitea repositories through the API", async ({ page }) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
   await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
   await page.getByRole("button", { name: "Add repositories…" }).click();
@@ -232,19 +211,58 @@ test("repository import exposes Forgejo and Gitea provider defaults", async ({ p
   await dialog.getByLabel("Repository pattern").fill("team/subgroup/service-*");
   await dialog.getByRole("button", { name: "Preview" }).click();
   await expect(dialog.getByRole("alert")).toContainText("Format: owner/pattern");
-  expect(previewRequests).toEqual([]);
+
+  await dialog.getByLabel("Repository pattern").fill("forge-lab/*");
+  await dialog.getByRole("button", { name: "Preview" }).click();
+  await expect(dialog.getByText("forge-lab/service")).toBeVisible();
+  await expect(dialog.getByText("forge-lab/archived")).toHaveCount(0);
 
   await dialog.getByLabel("Provider").selectOption("gitea");
   await expect(dialog.getByLabel("Host")).toHaveValue("gitea.com");
-  await dialog.getByLabel("Repository pattern").fill("team/service-*");
+  await dialog.getByLabel("Repository pattern").fill("gitea-team/*");
   await dialog.getByRole("button", { name: "Preview" }).click();
+  await expect(dialog.getByText("gitea-team/service")).toBeVisible();
+  await expect(dialog.getByText("gitea-team/private-service")).toBeVisible();
+  await expect(dialog.getByText("gitea-team/archived")).toHaveCount(0);
 
-  await expect.poll(() => previewRequests).toEqual([{
+  await dialog.getByLabel("Hide private").check();
+  await expect(dialog.getByText("gitea-team/service")).toBeVisible();
+  await expect(dialog.getByText("gitea-team/private-service")).toHaveCount(0);
+  await dialog.getByRole("button", { name: "Add selected repositories" }).click();
+
+  await expect(page.getByRole("dialog", { name: "Add repositories" })).toHaveCount(0);
+  await expect(page.locator(".repo-row", { hasText: "gitea-team/service" })).toBeVisible();
+
+  if (!api) throw new Error("settings-globs API context not initialized");
+  const settingsResponse = await api.get("/api/v1/settings");
+  const settings = await settingsResponse.json() as {
+    repos: Array<{
+      provider: string;
+      platform_host: string;
+      owner: string;
+      name: string;
+      repo_path: string;
+      is_glob: boolean;
+    }>;
+  };
+  expect(settings.repos).toContainEqual(expect.objectContaining({
     provider: "gitea",
-    host: "gitea.com",
-    owner: "team",
-    pattern: "service-*",
-  }]);
+    platform_host: "gitea.com",
+    owner: "gitea-team",
+    name: "service",
+    repo_path: "gitea-team/service",
+    is_glob: false,
+  }));
+
+  await expect.poll(async () => {
+    const response = await api!.get("/api/v1/repos");
+    const repos = await response.json() as RepoSummary[];
+    return repos
+      .filter((repo) => repo.Owner === "gitea-team")
+      .map((repo) => repo.Name)
+      .sort()
+      .join(",");
+  }).toBe("service");
 });
 
 test("repository import traps keyboard focus inside the dialog", async ({ page }) => {

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -2,6 +2,8 @@ import { expect, request as playwrightRequest, test, type APIRequestContext } fr
 import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
 
 type RepoSummary = {
+  Platform: string;
+  PlatformHost: string;
   Owner: string;
   Name: string;
 };
@@ -216,26 +218,13 @@ test("repository import previews and adds Forgejo and Gitea repositories through
   await dialog.getByRole("button", { name: "Preview" }).click();
   await expect(dialog.getByText("forge-lab/service")).toBeVisible();
   await expect(dialog.getByText("forge-lab/archived")).toHaveCount(0);
-
-  await dialog.getByLabel("Provider").selectOption("gitea");
-  await expect(dialog.getByLabel("Host")).toHaveValue("gitea.com");
-  await dialog.getByLabel("Repository pattern").fill("gitea-team/*");
-  await dialog.getByRole("button", { name: "Preview" }).click();
-  await expect(dialog.getByText("gitea-team/service")).toBeVisible();
-  await expect(dialog.getByText("gitea-team/private-service")).toBeVisible();
-  await expect(dialog.getByText("gitea-team/archived")).toHaveCount(0);
-
-  await dialog.getByLabel("Hide private").check();
-  await expect(dialog.getByText("gitea-team/service")).toBeVisible();
-  await expect(dialog.getByText("gitea-team/private-service")).toHaveCount(0);
   await dialog.getByRole("button", { name: "Add selected repositories" }).click();
-
   await expect(page.getByRole("dialog", { name: "Add repositories" })).toHaveCount(0);
-  await expect(page.locator(".repo-row", { hasText: "gitea-team/service" })).toBeVisible();
+  await expect(page.locator(".repo-row", { hasText: "forge-lab/service" })).toBeVisible();
 
   if (!api) throw new Error("settings-globs API context not initialized");
-  const settingsResponse = await api.get("/api/v1/settings");
-  const settings = await settingsResponse.json() as {
+  let settingsResponse = await api.get("/api/v1/settings");
+  let settings = await settingsResponse.json() as {
     repos: Array<{
       provider: string;
       platform_host: string;
@@ -245,6 +234,44 @@ test("repository import previews and adds Forgejo and Gitea repositories through
       is_glob: boolean;
     }>;
   };
+  expect(settings.repos).toContainEqual(expect.objectContaining({
+    provider: "forgejo",
+    platform_host: "codeberg.org",
+    owner: "forge-lab",
+    name: "service",
+    repo_path: "forge-lab/service",
+    is_glob: false,
+  }));
+  await expect.poll(async () => {
+    const response = await api!.get("/api/v1/repos");
+    const repos = await response.json() as RepoSummary[];
+    return repos
+      .filter((repo) => repo.Platform === "forgejo" && repo.PlatformHost === "codeberg.org" && repo.Owner === "forge-lab")
+      .map((repo) => repo.Name)
+      .sort()
+      .join(",");
+  }).toBe("service");
+
+  await page.getByRole("button", { name: "Add repositories…" }).click();
+  const giteaDialog = page.getByRole("dialog", { name: "Add repositories" });
+  await giteaDialog.getByLabel("Provider").selectOption("gitea");
+  await expect(giteaDialog.getByLabel("Host")).toHaveValue("gitea.com");
+  await giteaDialog.getByLabel("Repository pattern").fill("gitea-team/*");
+  await giteaDialog.getByRole("button", { name: "Preview" }).click();
+  await expect(giteaDialog.getByText("gitea-team/service")).toBeVisible();
+  await expect(giteaDialog.getByText("gitea-team/private-service")).toBeVisible();
+  await expect(giteaDialog.getByText("gitea-team/archived")).toHaveCount(0);
+
+  await giteaDialog.getByLabel("Hide private").check();
+  await expect(giteaDialog.getByText("gitea-team/service")).toBeVisible();
+  await expect(giteaDialog.getByText("gitea-team/private-service")).toHaveCount(0);
+  await giteaDialog.getByRole("button", { name: "Add selected repositories" }).click();
+
+  await expect(page.getByRole("dialog", { name: "Add repositories" })).toHaveCount(0);
+  await expect(page.locator(".repo-row", { hasText: "gitea-team/service" })).toBeVisible();
+
+  settingsResponse = await api.get("/api/v1/settings");
+  settings = await settingsResponse.json() as typeof settings;
   expect(settings.repos).toContainEqual(expect.objectContaining({
     provider: "gitea",
     platform_host: "gitea.com",

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -200,6 +200,53 @@ test("repository import can hide forks and private repositories before adding", 
   }]);
 });
 
+test("repository import exposes Forgejo and Gitea provider defaults", async ({ page }) => {
+  const previewRequests: Array<{ provider: string; host: string; owner: string; pattern: string }> = [];
+  await page.route("**/api/v1/repos/preview", async (route) => {
+    const body = route.request().postDataJSON() as {
+      provider: string;
+      host: string;
+      owner: string;
+      pattern: string;
+    };
+    previewRequests.push(body);
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        provider: body.provider,
+        platform_host: body.host,
+        owner: body.owner,
+        pattern: body.pattern,
+        repos: [],
+      }),
+    });
+  });
+
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page.getByRole("button", { name: "Add repositories…" }).click();
+  const dialog = page.getByRole("dialog", { name: "Add repositories" });
+
+  await dialog.getByLabel("Provider").selectOption("forgejo");
+  await expect(dialog.getByLabel("Host")).toHaveValue("codeberg.org");
+  await dialog.getByLabel("Repository pattern").fill("team/subgroup/service-*");
+  await dialog.getByRole("button", { name: "Preview" }).click();
+  await expect(dialog.getByRole("alert")).toContainText("Format: owner/pattern");
+  expect(previewRequests).toEqual([]);
+
+  await dialog.getByLabel("Provider").selectOption("gitea");
+  await expect(dialog.getByLabel("Host")).toHaveValue("gitea.com");
+  await dialog.getByLabel("Repository pattern").fill("team/service-*");
+  await dialog.getByRole("button", { name: "Preview" }).click();
+
+  await expect.poll(() => previewRequests).toEqual([{
+    provider: "gitea",
+    host: "gitea.com",
+    owner: "team",
+    pattern: "service-*",
+  }]);
+});
+
 test("repository import traps keyboard focus inside the dialog", async ({ page }) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
   await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });


### PR DESCRIPTION
Add Forgejo and Gitea to the settings import provider selector with public default hosts and non-nested owner patterns. Cover provider defaults, validation, and preview request payloads in component and Playwright settings import tests.