### PR TITLE
test: add Forgejo and Gitea container fixtures

### DIFF
--- a/internal/server/gitealike_container_e2e_test.go
+++ b/internal/server/gitealike_container_e2e_test.go
@@ -231,7 +231,11 @@ func runGiteaLikeContainerFixture(
 		t.Logf("keeping %s Compose stack %s at http://127.0.0.1:%s", cfg.TitlePrefix, cfg.StackID, cfg.HTTPPort)
 	} else {
 		t.Cleanup(func() {
-			assert.NoError(composeStack.Down(context.Background(), compose.RemoveOrphans(true)))
+			assert.NoError(composeStack.Down(
+				context.Background(),
+				compose.RemoveOrphans(true),
+				compose.RemoveVolumes(true),
+			))
 		})
 	}
 

--- a/internal/server/gitealike_container_e2e_test.go
+++ b/internal/server/gitealike_container_e2e_test.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/compose"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/wesm/middleman/internal/db"
+	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/platform"
+	platformforgejo "github.com/wesm/middleman/internal/platform/forgejo"
+	platformgitea "github.com/wesm/middleman/internal/platform/gitea"
+)
+
+type giteaLikeContainerClient interface {
+	platform.Provider
+	platform.RepositoryReader
+	platform.MergeRequestReader
+	platform.IssueReader
+	platform.ReleaseReader
+	platform.TagReader
+	platform.CIReader
+}
+
+type giteaLikeFixtureConfig struct {
+	Kind        platform.Kind
+	Service     string
+	ScriptDir   string
+	StackID     compose.StackIdentifier
+	Image       string
+	HTTPPort    string
+	KeepEnv     string
+	EnvPrefix   string
+	TitlePrefix string
+}
+
+type giteaLikeContainerManifest struct {
+	BaseURL            string `json:"base_url"`
+	APIURL             string `json:"api_url"`
+	Host               string `json:"host"`
+	Token              string `json:"token"`
+	Owner              string `json:"owner"`
+	Name               string `json:"name"`
+	RepoPath           string `json:"repo_path"`
+	WebURL             string `json:"web_url"`
+	CloneURL           string `json:"clone_url"`
+	DefaultBranch      string `json:"default_branch"`
+	RepositoryID       int64  `json:"repository_id"`
+	RepositoryIDString string `json:"repository_id_string"`
+	PullRequestIndex   int    `json:"pull_request_index"`
+	IssueIndex         int    `json:"issue_index"`
+	Label              string `json:"label"`
+	ReleaseTag         string `json:"release_tag"`
+	StatusContext      string `json:"status_context"`
+}
+
+func TestForgejoContainerSync(t *testing.T) {
+	if os.Getenv("MIDDLEMAN_FORGEJO_CONTAINER_TESTS") != "1" {
+		t.Skip("set MIDDLEMAN_FORGEJO_CONTAINER_TESTS=1 to run Forgejo container e2e")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+	manifest := runGiteaLikeContainerFixture(t, ctx, giteaLikeFixtureConfig{
+		Kind:        platform.KindForgejo,
+		Service:     "forgejo",
+		ScriptDir:   "forgejo",
+		StackID:     compose.StackIdentifier(envOrDefault("MIDDLEMAN_FORGEJO_COMPOSE_PROJECT", "middleman-forgejo-e2e")),
+		Image:       envOrDefault("MIDDLEMAN_FORGEJO_IMAGE", "codeberg.org/forgejo/forgejo:12"),
+		HTTPPort:    envOrDefault("FORGEJO_HTTP_PORT", freeLoopbackPort(t)),
+		KeepEnv:     "MIDDLEMAN_KEEP_FORGEJO_FIXTURE",
+		EnvPrefix:   "FORGEJO",
+		TitlePrefix: "Forgejo",
+	})
+
+	client, err := platformforgejo.NewClient(
+		manifest.Host,
+		manifest.Token,
+		platformforgejo.WithBaseURLForTesting(manifest.BaseURL),
+		platformforgejo.WithForegroundTimeoutForTesting(time.Minute),
+	)
+	require.NoError(t, err)
+	assertGiteaLikeContainerSync(t, ctx, platform.KindForgejo, manifest, client)
+}
+
+func TestGiteaContainerSync(t *testing.T) {
+	if os.Getenv("MIDDLEMAN_GITEA_CONTAINER_TESTS") != "1" {
+		t.Skip("set MIDDLEMAN_GITEA_CONTAINER_TESTS=1 to run Gitea container e2e")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+	manifest := runGiteaLikeContainerFixture(t, ctx, giteaLikeFixtureConfig{
+		Kind:        platform.KindGitea,
+		Service:     "gitea",
+		ScriptDir:   "gitea",
+		StackID:     compose.StackIdentifier(envOrDefault("MIDDLEMAN_GITEA_COMPOSE_PROJECT", "middleman-gitea-e2e")),
+		Image:       envOrDefault("MIDDLEMAN_GITEA_IMAGE", "gitea/gitea:1.24.6"),
+		HTTPPort:    envOrDefault("GITEA_HTTP_PORT", freeLoopbackPort(t)),
+		KeepEnv:     "MIDDLEMAN_KEEP_GITEA_FIXTURE",
+		EnvPrefix:   "GITEA",
+		TitlePrefix: "Gitea",
+	})
+
+	client, err := platformgitea.NewClient(
+		manifest.Host,
+		manifest.Token,
+		platformgitea.WithBaseURLForTesting(manifest.BaseURL),
+		platformgitea.WithForegroundTimeoutForTesting(time.Minute),
+	)
+	require.NoError(t, err)
+	assertGiteaLikeContainerSync(t, ctx, platform.KindGitea, manifest, client)
+}
+
+func assertGiteaLikeContainerSync(
+	t *testing.T,
+	ctx context.Context,
+	kind platform.Kind,
+	manifest giteaLikeContainerManifest,
+	client giteaLikeContainerClient,
+) {
+	t.Helper()
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	registry, err := platform.NewRegistry(client)
+	require.NoError(err)
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+	repo := ghclient.RepoRef{
+		Platform:           kind,
+		PlatformHost:       manifest.Host,
+		Owner:              manifest.Owner,
+		Name:               manifest.Name,
+		RepoPath:           manifest.RepoPath,
+		PlatformRepoID:     manifest.RepositoryID,
+		PlatformExternalID: manifest.RepositoryIDString,
+		WebURL:             manifest.WebURL,
+		CloneURL:           manifest.CloneURL,
+		DefaultBranch:      manifest.DefaultBranch,
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	syncer.RunOnce(ctx)
+	require.NoError(syncer.SyncMROnProvider(ctx, kind, manifest.Host, manifest.Owner, manifest.Name, manifest.PullRequestIndex))
+	require.NoError(syncer.SyncIssueOnProvider(ctx, kind, manifest.Host, manifest.Owner, manifest.Name, manifest.IssueIndex))
+
+	repoRow, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:       string(kind),
+		PlatformHost:   manifest.Host,
+		PlatformRepoID: manifest.RepositoryIDString,
+		Owner:          manifest.Owner,
+		Name:           manifest.Name,
+		RepoPath:       manifest.RepoPath,
+	})
+	require.NoError(err)
+	require.NotNil(repoRow)
+	assert.Equal(manifest.RepoPath, repoRow.RepoPath)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoRow.ID, manifest.PullRequestIndex)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(string(kind)+" container PR", mr.Title)
+	assert.Equal("success", mr.CIStatus)
+	assert.Contains(mr.CIChecksJSON, manifest.StatusContext)
+	require.NotEmpty(mr.Labels)
+	assert.Equal(manifest.Label, mr.Labels[0].Name)
+	mrEvents, err := database.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	assert.NotEmpty(mrEvents)
+
+	issue, err := database.GetIssueByRepoIDAndNumber(ctx, repoRow.ID, manifest.IssueIndex)
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.Equal(string(kind)+" container issue", issue.Title)
+	issueEvents, err := database.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	assert.NotEmpty(issueEvents)
+
+	summaries, err := database.ListRepoSummaries(ctx)
+	require.NoError(err)
+	require.Len(summaries, 1)
+	require.NotNil(summaries[0].Overview.LatestRelease)
+	assert.Equal(manifest.ReleaseTag, summaries[0].Overview.LatestRelease.TagName)
+	assert.NotEmpty(summaries[0].Overview.Releases)
+}
+
+func runGiteaLikeContainerFixture(
+	t *testing.T,
+	ctx context.Context,
+	cfg giteaLikeFixtureConfig,
+) giteaLikeContainerManifest {
+	t.Helper()
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	stack, err := compose.NewDockerComposeWith(
+		compose.WithStackFiles(filepath.Join(repoRoot(t), "scripts/e2e", cfg.ScriptDir, "docker-compose.yml")),
+		cfg.StackID,
+	)
+	require.NoError(err)
+	composeStack := stack.
+		WithEnv(map[string]string{
+			"MIDDLEMAN_" + cfg.EnvPrefix + "_IMAGE": cfg.Image,
+			cfg.EnvPrefix + "_HTTP_PORT":            cfg.HTTPPort,
+		}).
+		WaitForService(cfg.Service, waitForGiteaLikeHTTP())
+	err = composeStack.Up(ctx, compose.Wait(true))
+	container, containerErr := composeStack.ServiceContainer(ctx, cfg.Service)
+	if err != nil {
+		if containerErr == nil {
+			require.NoError(err, containerLogs(ctx, container))
+		}
+		require.NoError(err)
+	}
+	require.NoError(containerErr)
+	if os.Getenv(cfg.KeepEnv) == "1" {
+		t.Logf("keeping %s Compose stack %s at http://127.0.0.1:%s", cfg.TitlePrefix, cfg.StackID, cfg.HTTPPort)
+	} else {
+		t.Cleanup(func() {
+			assert.NoError(composeStack.Down(context.Background(), compose.RemoveOrphans(true)))
+		})
+	}
+
+	baseURL, err := container.PortEndpoint(ctx, "3000/tcp", "http")
+	require.NoError(err)
+
+	manifestPath := filepath.Join(t.TempDir(), cfg.ScriptDir+"-manifest.json")
+	cmd := exec.CommandContext(
+		ctx,
+		filepath.Join(repoRoot(t), "scripts/e2e", cfg.ScriptDir, "bootstrap.sh"),
+		manifestPath,
+	)
+	cmd.Env = append(os.Environ(),
+		cfg.EnvPrefix+"_URL="+baseURL,
+		cfg.EnvPrefix+"_CONTAINER_ID="+container.GetContainerID(),
+		cfg.EnvPrefix+"_TITLE_PREFIX="+cfg.TitlePrefix,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		require.NoError(err, string(output)+"\n"+containerLogs(ctx, container))
+	}
+
+	return readGiteaLikeManifest(t, manifestPath)
+}
+
+func waitForGiteaLikeHTTP() *wait.HTTPStrategy {
+	return wait.ForHTTP("/api/v1/version").
+		WithPort("3000/tcp").
+		WithStartupTimeout(5 * time.Minute).
+		WithStatusCodeMatcher(func(status int) bool {
+			return status == http.StatusOK
+		})
+}
+
+func readGiteaLikeManifest(t *testing.T, manifestPath string) giteaLikeContainerManifest {
+	t.Helper()
+	manifestFile, err := os.Open(manifestPath)
+	require.NoError(t, err)
+	defer manifestFile.Close()
+	var manifest giteaLikeContainerManifest
+	require.NoError(t, json.NewDecoder(manifestFile).Decode(&manifest))
+	require.NotEmpty(t, manifest.BaseURL)
+	require.NotEmpty(t, manifest.APIURL)
+	return manifest
+}

--- a/scripts/e2e/forgejo/README.md
+++ b/scripts/e2e/forgejo/README.md
@@ -1,0 +1,11 @@
+# Forgejo Container Fixture
+
+This opt-in fixture starts a real Forgejo instance on loopback, runs an idempotent bootstrap script, and lets the Go e2e test sync seeded data into SQLite.
+
+Run:
+
+```sh
+MIDDLEMAN_FORGEJO_CONTAINER_TESTS=1 go test ./internal/server -run TestForgejoContainerSync -shuffle=on
+```
+
+The manifest emitted by `bootstrap.sh` includes both `base_url` and `api_url`. The provider test intentionally configures the SDK with `base_url`; `api_url` is only for script/API diagnostics.

--- a/scripts/e2e/forgejo/bootstrap.sh
+++ b/scripts/e2e/forgejo/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GITEALIKE_ENV_PREFIX=FORGEJO
+export GITEALIKE_BINARY=forgejo
+"$(dirname "$0")/../gitealike/bootstrap.py" "$@"

--- a/scripts/e2e/forgejo/docker-compose.yml
+++ b/scripts/e2e/forgejo/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  forgejo:
+    image: ${MIDDLEMAN_FORGEJO_IMAGE:-codeberg.org/forgejo/forgejo:12}
+    ports:
+      - "127.0.0.1:${FORGEJO_HTTP_PORT:-13000}:3000"
+    environment:
+      USER_UID: "1000"
+      USER_GID: "1000"
+      FORGEJO__database__DB_TYPE: sqlite3
+      FORGEJO__security__INSTALL_LOCK: "true"
+      FORGEJO__server__DOMAIN: 127.0.0.1
+      FORGEJO__server__ROOT_URL: http://127.0.0.1:${FORGEJO_HTTP_PORT:-13000}/
+      FORGEJO__service__DISABLE_REGISTRATION: "false"
+      FORGEJO__repository__DEFAULT_BRANCH: main
+    volumes:
+      - forgejo-data:/data
+
+volumes:
+  forgejo-data:

--- a/scripts/e2e/forgejo/wait.sh
+++ b/scripts/e2e/forgejo/wait.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FORGEJO_URL:?FORGEJO_URL is required}"
+
+python3 - <<'PY'
+import json
+import os
+import time
+import urllib.request
+
+base_url = os.environ["FORGEJO_URL"].rstrip("/")
+deadline = time.monotonic() + int(os.environ.get("FORGEJO_READY_TIMEOUT_SECONDS", "300"))
+while time.monotonic() < deadline:
+    try:
+        with urllib.request.urlopen(f"{base_url}/api/v1/version", timeout=10) as resp:
+            if resp.status == 200 and json.loads(resp.read().decode()):
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(2)
+raise SystemExit(f"Forgejo did not become ready at {base_url}")
+PY

--- a/scripts/e2e/gitea/README.md
+++ b/scripts/e2e/gitea/README.md
@@ -1,0 +1,11 @@
+# Gitea Container Fixture
+
+This opt-in fixture starts a real Gitea instance on loopback, runs an idempotent bootstrap script, and lets the Go e2e test sync seeded data into SQLite.
+
+Run:
+
+```sh
+MIDDLEMAN_GITEA_CONTAINER_TESTS=1 go test ./internal/server -run TestGiteaContainerSync -shuffle=on
+```
+
+The manifest emitted by `bootstrap.sh` includes both `base_url` and `api_url`. The provider test intentionally configures the SDK with `base_url`; `api_url` is only for script/API diagnostics.

--- a/scripts/e2e/gitea/bootstrap.sh
+++ b/scripts/e2e/gitea/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GITEALIKE_ENV_PREFIX=GITEA
+export GITEALIKE_BINARY=gitea
+"$(dirname "$0")/../gitealike/bootstrap.py" "$@"

--- a/scripts/e2e/gitea/docker-compose.yml
+++ b/scripts/e2e/gitea/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  gitea:
+    image: ${MIDDLEMAN_GITEA_IMAGE:-gitea/gitea:1.24.6}
+    ports:
+      - "127.0.0.1:${GITEA_HTTP_PORT:-13001}:3000"
+    environment:
+      USER_UID: "1000"
+      USER_GID: "1000"
+      GITEA__database__DB_TYPE: sqlite3
+      GITEA__security__INSTALL_LOCK: "true"
+      GITEA__server__DOMAIN: 127.0.0.1
+      GITEA__server__ROOT_URL: http://127.0.0.1:${GITEA_HTTP_PORT:-13001}/
+      GITEA__service__DISABLE_REGISTRATION: "false"
+      GITEA__repository__DEFAULT_BRANCH: main
+    volumes:
+      - gitea-data:/data
+
+volumes:
+  gitea-data:

--- a/scripts/e2e/gitea/wait.sh
+++ b/scripts/e2e/gitea/wait.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITEA_URL:?GITEA_URL is required}"
+
+python3 - <<'PY'
+import json
+import os
+import time
+import urllib.request
+
+base_url = os.environ["GITEA_URL"].rstrip("/")
+deadline = time.monotonic() + int(os.environ.get("GITEA_READY_TIMEOUT_SECONDS", "300"))
+while time.monotonic() < deadline:
+    try:
+        with urllib.request.urlopen(f"{base_url}/api/v1/version", timeout=10) as resp:
+            if resp.status == 200 and json.loads(resp.read().decode()):
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(2)
+raise SystemExit(f"Gitea did not become ready at {base_url}")
+PY

--- a/scripts/e2e/gitealike/bootstrap.py
+++ b/scripts/e2e/gitealike/bootstrap.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <manifest.json>", file=sys.stderr)
+        return 2
+
+    prefix = require_env("GITEALIKE_ENV_PREFIX")
+    binary = require_env("GITEALIKE_BINARY")
+    base_url = require_env(f"{prefix}_URL").rstrip("/")
+    container_id = os.environ.get(f"{prefix}_CONTAINER_ID", "")
+    title_prefix = os.environ.get(f"{prefix}_TITLE_PREFIX", prefix.title())
+    manifest_path = sys.argv[1]
+    fixture = Fixture(prefix, binary, base_url, container_id, title_prefix)
+    manifest = fixture.bootstrap()
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(json.dumps(manifest, sort_keys=True))
+    return 0
+
+
+class Fixture:
+    def __init__(self, prefix, binary, base_url, container_id, title_prefix):
+        self.prefix = prefix
+        self.binary = binary
+        self.base_url = base_url
+        self.api_url = f"{base_url}/api/v1"
+        self.container_id = container_id
+        self.title_prefix = title_prefix
+        self.admin_user = "middleman-admin"
+        self.admin_password = "middleman-admin-password"
+        self.fixture_user = "middleman-user"
+        self.fixture_password = "middleman-user-password"
+        self.owner = "middleman-fixture"
+        self.repo = "project-special"
+        self.label = "middleman-fixture"
+        self.branch = "feature/gitealike"
+        self.status_context = "middleman/container-fixture"
+
+    def bootstrap(self):
+        self.wait_ready()
+        self.ensure_admin_user()
+        token = self.create_token()
+        self.ensure_fixture_user(token)
+        self.ensure_org(token)
+        repo = self.ensure_repo(token)
+        label = self.ensure_label(token)
+        branch = self.ensure_branch(token)
+        self.ensure_file(token, branch)
+        branch = self.get_branch(token, self.branch)
+        self.ensure_status(token, branch["commit"]["id"])
+        pr = self.ensure_pull_request(token, label["id"])
+        issue = self.ensure_issue(token, label["id"])
+        self.ensure_comment(token, pr["number"], f"PR note from {self.title_prefix} container")
+        self.ensure_comment(token, issue["number"], f"Issue note from {self.title_prefix} container")
+        release = self.ensure_release(token)
+        parsed = urllib.parse.urlparse(self.base_url)
+        repo_path = f"{self.owner}/{self.repo}"
+        return {
+            "base_url": self.base_url,
+            "api_url": self.api_url,
+            "host": parsed.netloc,
+            "token": token,
+            "owner": self.owner,
+            "name": self.repo,
+            "repo_path": repo_path,
+            "web_url": f"{self.base_url}/{repo_path}",
+            "clone_url": f"{self.base_url}/{repo_path}.git",
+            "default_branch": "main",
+            "repository_id": repo["id"],
+            "repository_id_string": str(repo["id"]),
+            "pull_request_index": pr["number"],
+            "issue_index": issue["number"],
+            "label": label["name"],
+            "release_tag": release["tag_name"],
+            "status_context": self.status_context,
+        }
+
+    def wait_ready(self):
+        deadline = time.monotonic() + int(os.environ.get(f"{self.prefix}_READY_TIMEOUT_SECONDS", "300"))
+        last_error = None
+        while time.monotonic() < deadline:
+            try:
+                version = self.request("GET", "/version", expected=(200,))
+                if version:
+                    return
+            except Exception as exc:
+                last_error = exc
+                time.sleep(2)
+        raise RuntimeError(f"{self.prefix} did not become ready at {self.base_url}: {last_error}")
+
+    def ensure_admin_user(self):
+        if not self.container_id:
+            return
+        cmd = [
+            "docker",
+            "exec",
+            self.container_id,
+            self.binary,
+            "admin",
+            "user",
+            "create",
+            "--username",
+            self.admin_user,
+            "--password",
+            self.admin_password,
+            "--email",
+            "middleman-admin@example.invalid",
+            "--admin",
+            "--must-change-password=false",
+        ]
+        result = subprocess.run(cmd, text=True, capture_output=True, check=False)
+        output = result.stdout + result.stderr
+        if result.returncode != 0 and "already exists" not in output.lower():
+            raise RuntimeError(output)
+
+    def create_token(self):
+        name = f"middleman-e2e-{int(time.time())}"
+        token = self.request(
+            "POST",
+            f"/users/{quote(self.admin_user)}/tokens",
+            basic_auth=(self.admin_user, self.admin_password),
+            data={"name": name, "scopes": ["all"]},
+            expected=(200, 201),
+        )
+        value = token.get("sha1") or token.get("token")
+        if not value:
+            raise RuntimeError(f"token response did not include token material: {token}")
+        return value
+
+    def ensure_fixture_user(self, token):
+        try:
+            return self.request("GET", f"/users/{quote(self.fixture_user)}", token=token)
+        except Exception:
+            return self.request(
+                "POST",
+                "/admin/users",
+                token=token,
+                data={
+                    "username": self.fixture_user,
+                    "login_name": self.fixture_user,
+                    "email": "middleman-user@example.invalid",
+                    "password": self.fixture_password,
+                    "must_change_password": False,
+                    "source_id": 0,
+                },
+                expected=(201,),
+            )
+
+    def ensure_org(self, token):
+        try:
+            return self.request("GET", f"/orgs/{quote(self.owner)}", token=token)
+        except Exception:
+            return self.request(
+                "POST",
+                "/orgs",
+                token=token,
+                data={
+                    "username": self.owner,
+                    "full_name": "Middleman Fixture",
+                    "description": "Middleman Gitea-compatible e2e fixture",
+                },
+                expected=(201,),
+            )
+
+    def ensure_repo(self, token):
+        try:
+            return self.request("GET", f"/repos/{quote(self.owner)}/{quote(self.repo)}", token=token)
+        except Exception:
+            return self.request(
+                "POST",
+                f"/org/{quote(self.owner)}/repos",
+                token=token,
+                data={
+                    "name": self.repo,
+                    "auto_init": True,
+                    "default_branch": "main",
+                    "private": False,
+                    "description": "Middleman Gitea-compatible e2e fixture",
+                },
+                expected=(201,),
+            )
+
+    def ensure_label(self, token):
+        labels = self.request("GET", self.repo_path("/labels"), token=token)
+        for label in labels:
+            if label.get("name") == self.label:
+                return label
+        return self.request(
+            "POST",
+            self.repo_path("/labels"),
+            token=token,
+            data={"name": self.label, "color": "#0052cc", "description": "Middleman container fixture"},
+            expected=(201,),
+        )
+
+    def ensure_branch(self, token):
+        try:
+            return self.get_branch(token, self.branch)
+        except Exception:
+            self.request(
+                "POST",
+                self.repo_path("/branches"),
+                token=token,
+                data={"old_branch_name": "main", "new_branch_name": self.branch},
+                expected=(201,),
+            )
+            return self.get_branch(token, self.branch)
+
+    def get_branch(self, token, branch):
+        return self.request("GET", self.repo_path(f"/branches/{quote(branch)}"), token=token)
+
+    def ensure_file(self, token, branch):
+        path = "src/gitealike-fixture.txt"
+        content = f"{self.title_prefix} container fixture\n"
+        encoded_path = quote(path)
+        payload = {
+            "branch": branch["name"],
+            "content": base64.b64encode(content.encode()).decode(),
+            "message": f"Add {self.title_prefix} fixture file",
+        }
+        try:
+            existing = self.request(
+                "GET",
+                self.repo_path(f"/contents/{encoded_path}?ref={quote(branch['name'])}"),
+                token=token,
+            )
+            existing_content = base64.b64decode("".join(existing.get("content", "").split())).decode()
+            if existing_content == content:
+                return
+            payload["sha"] = existing["sha"]
+            self.request("PUT", self.repo_path(f"/contents/{encoded_path}"), token=token, data=payload)
+        except Exception as exc:
+            if " returned 404:" not in str(exc):
+                raise
+            self.request("POST", self.repo_path(f"/contents/{encoded_path}"), token=token, data=payload, expected=(201,))
+
+    def ensure_status(self, token, sha):
+        statuses = self.request("GET", self.repo_path(f"/statuses/{quote(sha)}"), token=token)
+        for status in statuses:
+            if status.get("context") == self.status_context and status.get("state") == "success":
+                return status
+        return self.request(
+            "POST",
+            self.repo_path(f"/statuses/{quote(sha)}"),
+            token=token,
+            data={
+                "state": "success",
+                "context": self.status_context,
+                "description": "Container fixture status",
+                "target_url": f"{self.base_url}/{self.owner}/{self.repo}/actions",
+            },
+            expected=(201,),
+        )
+
+    def ensure_pull_request(self, token, label_id):
+        pulls = self.request("GET", self.repo_path("/pulls?state=open"), token=token)
+        title = f"{self.prefix.lower()} container PR"
+        for pull in pulls:
+            if pull.get("title") == title:
+                self.ensure_labels(token, pull["number"], [label_id])
+                return pull
+        pull = self.request(
+            "POST",
+            self.repo_path("/pulls"),
+            token=token,
+            data={
+                "head": self.branch,
+                "base": "main",
+                "title": title,
+                "body": "Pull request seeded by middleman e2e.",
+            },
+            expected=(201,),
+        )
+        self.ensure_labels(token, pull["number"], [label_id])
+        return pull
+
+    def ensure_issue(self, token, label_id):
+        title = f"{self.prefix.lower()} container issue"
+        issues = self.request("GET", self.repo_path(f"/issues?state=open&q={quote(title)}"), token=token)
+        for issue in issues:
+            if issue.get("title") == title and not issue.get("pull_request"):
+                self.ensure_labels(token, issue["number"], [label_id])
+                return issue
+        return self.request(
+            "POST",
+            self.repo_path("/issues"),
+            token=token,
+            data={
+                "title": title,
+                "body": "Issue seeded by middleman e2e.",
+                "labels": [label_id],
+            },
+            expected=(201,),
+        )
+
+    def ensure_labels(self, token, number, label_ids):
+        self.request(
+            "POST",
+            self.repo_path(f"/issues/{number}/labels"),
+            token=token,
+            data={"labels": label_ids},
+            expected=(200, 201),
+        )
+
+    def ensure_comment(self, token, number, body):
+        comments = self.request("GET", self.repo_path(f"/issues/{number}/comments"), token=token)
+        for comment in comments:
+            if comment.get("body") == body:
+                return comment
+        return self.request(
+            "POST",
+            self.repo_path(f"/issues/{number}/comments"),
+            token=token,
+            data={"body": body},
+            expected=(201,),
+        )
+
+    def ensure_release(self, token):
+        tag = "v1.0.0"
+        releases = self.request("GET", self.repo_path("/releases"), token=token)
+        for release in releases:
+            if release.get("tag_name") == tag:
+                return release
+        return self.request(
+            "POST",
+            self.repo_path("/releases"),
+            token=token,
+            data={
+                "tag_name": tag,
+                "target_commitish": "main",
+                "name": "Version 1.0.0",
+                "body": "Release seeded by middleman e2e.",
+            },
+            expected=(201,),
+        )
+
+    def repo_path(self, suffix):
+        return f"/repos/{quote(self.owner)}/{quote(self.repo)}{suffix}"
+
+    def request(self, method, path, token=None, basic_auth=None, data=None, expected=(200,)):
+        url = path if path.startswith("http") else f"{self.api_url}{path}"
+        headers = {}
+        body = None
+        if token:
+            headers["Authorization"] = f"token {token}"
+        if basic_auth:
+            raw = f"{basic_auth[0]}:{basic_auth[1]}".encode()
+            headers["Authorization"] = "Basic " + base64.b64encode(raw).decode()
+        if data is not None:
+            body = json.dumps(data).encode()
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                raw = resp.read()
+                if resp.status not in expected:
+                    raise RuntimeError(f"{method} {url} returned {resp.status}: {raw[:400]!r}")
+                if not raw:
+                    return {}
+                return json.loads(raw.decode())
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            if exc.code in expected:
+                if not raw:
+                    return {}
+                return json.loads(raw.decode())
+            raise RuntimeError(f"{method} {url} returned {exc.code}: {raw[:800]!r}") from exc
+
+
+def quote(value):
+    return urllib.parse.quote(str(value), safe="")
+
+
+def require_env(name):
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e/gitealike/bootstrap.py
+++ b/scripts/e2e/gitealike/bootstrap.py
@@ -180,7 +180,7 @@ class Fixture:
         except Exception:
             return self.request(
                 "POST",
-                f"/org/{quote(self.owner)}/repos",
+                f"/orgs/{quote(self.owner)}/repos",
                 token=token,
                 data={
                     "name": self.repo,


### PR DESCRIPTION
Add opt-in loopback Docker Compose fixtures and bootstrap scripts for real Forgejo and Gitea compatibility checks. The gated server tests sync seeded repositories into SQLite and assert PR, issue, release, tag, comment, and CI status data while keeping the default suite skipped without env vars.