### PR TITLE
Run Go tests through gotestsum with dorny/test-reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  checks: read
+  checks: write
   contents: read
   issues: read
   pull-requests: read
@@ -86,17 +86,50 @@ jobs:
         run: cd frontend && bun run test
 
       - name: Run tests
-        run: go test ./... -v -shuffle=on
+        run: |
+          mkdir -p tmp
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-output.json -- ./... -shuffle=on
+
+      - name: Publish unit test report
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
+        with:
+          name: Go unit tests
+          path: tmp/test-output.json
+          reporter: golang-json
+          fail-on-error: false
 
       - name: Run live GraphQL validation
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MIDDLEMAN_LIVE_GITHUB_TESTS: "1"
-        run: go test ./internal/github -run TestLiveGraphQLQueriesValidateAgainstGitHub -shuffle=on
+        run: |
+          mkdir -p tmp
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-graphql-output.json -- ./internal/github -run TestLiveGraphQLQueriesValidateAgainstGitHub -shuffle=on
+
+      - name: Publish live GraphQL test report
+        if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
+        with:
+          name: Go live GraphQL tests
+          path: tmp/test-graphql-output.json
+          reporter: golang-json
+          fail-on-error: false
 
       - name: Run integration tests (git-dependent)
-        run: go test -tags integration ./... -v -shuffle=on
+        run: |
+          mkdir -p tmp
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -shuffle=on
+
+      - name: Publish integration test report
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
+        with:
+          name: Go integration tests
+          path: tmp/test-integration-output.json
+          reporter: golang-json
+          fail-on-error: false
 
   race:
     name: go test -race
@@ -116,7 +149,18 @@ jobs:
           echo ok > internal/web/dist/stub.html
 
       - name: Run tests (race detector)
-        run: go test -race ./... -shuffle=on
+        run: |
+          mkdir -p tmp
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-race-output.json -- -race ./... -shuffle=on
+
+      - name: Publish race test report
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
+        with:
+          name: Go race tests
+          path: tmp/test-race-output.json
+          reporter: golang-json
+          fail-on-error: false
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-output.json -- ./... -shuffle=on
 
       - name: Publish unit test report
-        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
         with:
           name: Go unit tests
@@ -109,7 +109,7 @@ jobs:
           go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-graphql-output.json -- ./internal/github -run TestLiveGraphQLQueriesValidateAgainstGitHub -shuffle=on
 
       - name: Publish live GraphQL test report
-        if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: ${{ !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
         with:
           name: Go live GraphQL tests
@@ -123,7 +123,7 @@ jobs:
           go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -shuffle=on
 
       - name: Publish integration test report
-        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
         with:
           name: Go integration tests
@@ -154,7 +154,7 @@ jobs:
           go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-race-output.json -- -race ./... -shuffle=on
 
       - name: Publish race test report
-        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451  # v2.7.0
         with:
           name: Go race tests

--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,24 @@ AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
 DEV_LOG_DIR ?= tmp/logs
 DEV_BACKEND_LOG ?= $(DEV_LOG_DIR)/backend-dev.log
 
-.PHONY: ensure-embed-dir check-air air-install build build-release install \
+.PHONY: ensure-embed-dir ensure-tmp-dir check-air air-install build build-release install \
         frontend-deps frontend frontend-dev frontend-dev-bun frontend-check api-generate roborev-api-generate \
-        dev test test-short test-e2e test-e2e-roborev test-gitlab-container gitlab-fixture-bake vet lint nilaway testify-helper-check \
+        dev test test-short test-integration test-e2e test-e2e-roborev test-gitlab-container gitlab-fixture-bake vet lint nilaway testify-helper-check \
         frontend-api-client-check huma-route-check script-tests guardrail-check tidy svelte-skills svelte-skills-sync clean install-hooks help
+
+# gotestsum prints package names on success and full output on failure,
+# while persisting raw `go test -json` events for downstream reporters.
+GOTESTSUM := go tool gotestsum --format pkgname-and-test-fails --jsonfile
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
 	@mkdir -p internal/web/dist
 	@test -n "$$(ls internal/web/dist/ 2>/dev/null)" \
 		|| echo ok > internal/web/dist/stub.html
+
+# Ensure tmp/ exists so gotestsum can write JSON output there
+ensure-tmp-dir:
+	@mkdir -p tmp
 
 # Build the binary (debug, with embedded frontend)
 build: frontend
@@ -152,16 +160,16 @@ dev: ensure-embed-dir check-air
 	fi
 
 # Run tests
-test: ensure-embed-dir
-	go test ./... -v -shuffle=on
+test: ensure-embed-dir ensure-tmp-dir
+	$(GOTESTSUM)=tmp/test-output.json -- ./... -shuffle=on
 
 # Run fast tests only
-test-short: ensure-embed-dir
-	go test ./... -short -shuffle=on
+test-short: ensure-embed-dir ensure-tmp-dir
+	$(GOTESTSUM)=tmp/test-short-output.json -- ./... -short -shuffle=on
 
 # Run integration tests that execute real git commands (excluded from test-short)
-test-integration: ensure-embed-dir
-	go test -tags integration ./... -v -shuffle=on
+test-integration: ensure-embed-dir ensure-tmp-dir
+	$(GOTESTSUM)=tmp/test-integration-output.json -- -tags integration ./... -shuffle=on
 
 # Run full-stack E2E tests (Playwright against real Go server, excludes roborev)
 test-e2e: frontend
@@ -174,12 +182,12 @@ test-e2e-roborev:
 		./scripts/run-roborev-e2e.sh
 
 # Run opt-in GitLab CE container compatibility tests.
-test-gitlab-container: ensure-embed-dir
+test-gitlab-container: ensure-embed-dir ensure-tmp-dir
 	@if [ "$${MIDDLEMAN_GITLAB_CONTAINER_E2E:-}" != "1" ]; then \
 		echo "Set MIDDLEMAN_GITLAB_CONTAINER_E2E=1 to run the GitLab CE container e2e fixture." >&2; \
 		exit 1; \
 	fi
-	GOFLAGS="$${GOFLAGS:+$$GOFLAGS }-buildvcs=false" go test ./internal/server -run TestGitLabContainerE2E -shuffle=on -timeout 40m
+	GOFLAGS="$${GOFLAGS:+$$GOFLAGS }-buildvcs=false" $(GOTESTSUM)=tmp/test-gitlab-container-output.json -- ./internal/server -run TestGitLabContainerE2E -shuffle=on -timeout 40m
 
 # Build a reusable GitLab fixture image from the idempotent bootstrap script.
 gitlab-fixture-bake:

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/buger/goterm v1.0.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/docker/buildx v0.33.0 // indirect
 	github.com/docker/cli v29.4.0+incompatible // indirect
 	github.com/docker/compose/v5 v5.1.2 // indirect
@@ -59,8 +61,10 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsevents v0.2.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/getkin/kin-openapi v0.133.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -93,6 +97,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
@@ -183,6 +188,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/gotestsum v1.13.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
@@ -190,4 +196,7 @@ require (
 	tags.cncf.io/container-device-interface v1.1.0 // indirect
 )
 
-tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
+tool (
+	github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
+	gotest.tools/gotestsum
+)

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bitfield/gotestdox v0.2.2 h1:x6RcPAbBbErKLnapz1QeAlf3ospg8efBsedU93CDsnE=
+github.com/bitfield/gotestdox v0.2.2/go.mod h1:D+gwtS0urjBrzguAkTM2wodsTQYFHdpx8eqRJ3N+9pY=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
@@ -107,6 +109,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
+github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/docker/buildx v0.33.0 h1:xuZeuQe/C/2tvLDgiIA6+Ynq3FFWSfsGNWIHM3q1hD8=
 github.com/docker/buildx v0.33.0/go.mod h1:7JVma62htERKE5iy5YD1q64PKiAHUzXuhSBd4oq3I74=
 github.com/docker/cli v29.4.0+incompatible h1:+IjXULMetlvWJiuSI0Nbor36lcJ5BTcVpUmB21KBoVM=
@@ -136,6 +140,8 @@ github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJ
 github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsevents v0.2.0 h1:BRlvlqjvNTfogHfeBOFvSC9N0Ddy+wzQCQukyoD7o/c=
@@ -671,6 +677,8 @@ gopkg.in/yaml.v3 v3.0.0-20191026110619-0b21df46bc1d/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/gotestsum v1.13.0 h1:+Lh454O9mu9AMG1APV4o0y7oDYKyik/3kBOiCqiEpRo=
+gotest.tools/gotestsum v1.13.0/go.mod h1:7f0NS5hFb0dWr4NtcsAsF0y1kzjEFfAil0HiBQJE03Q=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 modernc.org/cc/v4 v4.27.1 h1:9W30zRlYrefrDV2JE2O8VDtJ1yPGownxciz5rrbQZis=

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -110,7 +110,11 @@ func worktreeDiffFilesFromRef(
 	if err != nil {
 		return nil, false, fmt.Errorf("git diff --numstat: %w", err)
 	}
-	applyWorktreeNumstat(files, parseWorktreeNumstatZ(numstatOut))
+	counts := parseWorktreeNumstatZ(numstatOut)
+	applyWorktreeNumstat(files, counts)
+	if hideWhitespace {
+		files = dropWhitespaceOnlyModifications(files, counts)
+	}
 	files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
 	return files, true, nil
 }
@@ -232,7 +236,11 @@ func worktreeDiffFromRefPath(
 	if files == nil {
 		files = []gitclone.DiffFile{}
 	}
-	applyWorktreeNumstat(files, parseWorktreeNumstatZ(numstatOut))
+	counts := parseWorktreeNumstatZ(numstatOut)
+	applyWorktreeNumstat(files, counts)
+	if hideWhitespace {
+		files = dropWhitespaceOnlyModifications(files, counts)
+	}
 
 	if !hideWhitespace {
 		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, path)
@@ -269,6 +277,28 @@ func applyWorktreeNumstat(
 			files[i].Hunks = []gitclone.Hunk{}
 		}
 	}
+}
+
+// dropWhitespaceOnlyModifications removes "modified" entries that --raw lists
+// but --numstat omits under -w. git's --raw output ignores -w (it compares
+// blob SHAs), while --numstat honors it, so absence from the numstat map
+// reliably indicates a whitespace-only modification. Renames, copies, adds,
+// and deletes are preserved since their inclusion in --raw still represents
+// a real history change even with 0/0 counts.
+func dropWhitespaceOnlyModifications(
+	files []gitclone.DiffFile,
+	counts map[string]worktreeNumstatCount,
+) []gitclone.DiffFile {
+	out := files[:0]
+	for i := range files {
+		if files[i].Status == "modified" {
+			if _, ok := counts[files[i].Path]; !ok {
+				continue
+			}
+		}
+		out = append(out, files[i])
+	}
+	return out
 }
 
 func addWorktreeWhitespaceFlag(


### PR DESCRIPTION
## Summary
- CI Go test steps (unit, live GraphQL, integration, race) now run via `gotestsum --format pkgname-and-test-fails --jsonfile`, publishing per-suite check runs through `dorny/test-reporter@v2.7.0` (`golang-json`).
- `make test`, `test-short`, `test-integration`, and `test-gitlab-container` use the same gotestsum invocation, writing JSON event logs to `tmp/`.
- gotestsum is wired in as a Go tool (`go get -tool gotest.tools/gotestsum`), so contributors invoke it as `go tool gotestsum` without a separate install.
- Bug fix: worktree diffs with `hideWhitespace=true` no longer return whitespace-only modifications. `git diff --raw` ignores `-w` (compares blob SHAs); we now treat the `--numstat` map as ground truth and drop "modified" entries that aren't in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)