### PR TITLE
Run e2e job inside the Playwright container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,10 +220,12 @@ jobs:
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      # The Playwright image is minimal; setup-bun needs unzip to extract the
-      # bun tarball. apt-get update is a tiny metadata fetch (cached layer).
-      - name: Install unzip for setup-bun
-        run: apt-get update && apt-get install -y --no-install-recommends unzip
+      # The Playwright image is minimal; install the few extras the e2e
+      # server and setup-bun need:
+      #   - unzip: setup-bun shells out to it to extract the bun tarball
+      #   - tmux:  the e2e workspace runtime spawns tmux sessions
+      - name: Install missing OS deps for the e2e job
+        run: apt-get update && apt-get install -y --no-install-recommends unzip tmux
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,16 @@ jobs:
       - name: Build E2E server
         run: go build -o ./cmd/e2e-server/e2e-server ./cmd/e2e-server
 
+      # Firefox/WebKit refuse to launch when $HOME isn't owned by the running
+      # user. Actions sets HOME=/github/home (owned by pwuser, the image's
+      # default user) but starts the container as root, so Playwright bails
+      # with "Firefox is unable to launch if the $HOME folder isn't owned by
+      # the current user". Override HOME for the test run as Playwright's
+      # docs recommend; the rest of the job keeps /github/home so setup-go's
+      # cache paths still resolve.
       - name: Run E2E tests
+        env:
+          HOME: /root
         run: cd frontend && bun run playwright test --config=playwright-e2e.config.ts --project=${{ matrix.browser }}
 
       - name: Upload Playwright report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # actions/checkout sets safe.directory in a temporary HOME, so the
+      # config is gone by the time later steps run. go build's VCS stamping
+      # shells out to git and fails ("error obtaining VCS status: exit
+      # status 128") without this. Re-register against the persistent
+      # /github/home for the rest of the job.
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       # The Playwright image is minimal; setup-bun needs unzip to extract the
       # bun tarball. apt-get update is a tiny metadata fetch (cached layer).
       - name: Install unzip for setup-bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,13 @@ jobs:
     # entirely. The image tag must track @playwright/test in bun.lock.
     container:
       image: mcr.microsoft.com/playwright:v1.55.1-noble
+    # setup-go folds ImageOS into its cache key. Hosted runners set this to
+    # ubuntu24; container jobs don't, so without this the e2e job misses the
+    # host jobs' shared 178 MB Go cache. The Playwright image is also noble
+    # on amd64, so the host's content-addressed build/module entries are
+    # safe to reuse.
+    env:
+      ImageOS: ubuntu24
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,18 @@ jobs:
     # host jobs' shared 178 MB Go cache. The Playwright image is also noble
     # on amd64, so the host's content-addressed build/module entries are
     # safe to reuse.
+    #
+    # GOCACHE / GOMODCACHE pin the build and module caches to the same
+    # absolute paths the host jobs use. setup-go's cache tarball stores
+    # absolute paths, so even with a matching key the restore lands at
+    # /home/runner/... — which doesn't exist in the container. By
+    # overriding go env to point at those paths (and mkdir'ing them in
+    # the first step), the restored entries end up where Go looks for
+    # them, dropping ~30 s off the e2e-server build per browser.
     env:
       ImageOS: ubuntu24
+      GOCACHE: /home/runner/.cache/go-build
+      GOMODCACHE: /home/runner/go/pkg/mod
     strategy:
       fail-fast: false
       matrix:
@@ -226,6 +236,12 @@ jobs:
       #   - tmux:  the e2e workspace runtime spawns tmux sessions
       - name: Install missing OS deps for the e2e job
         run: apt-get update && apt-get install -y --no-install-recommends unzip tmux
+
+      # Pre-create the Go cache dirs at the host paths configured via
+      # GOCACHE / GOMODCACHE so setup-go's restore (which extracts to
+      # absolute paths from the host save) has somewhere to land.
+      - name: Pre-create host-aligned Go cache dirs
+        run: mkdir -p /home/runner/.cache/go-build /home/runner/go/pkg/mod
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,8 +234,14 @@ jobs:
       # server and setup-bun need:
       #   - unzip: setup-bun shells out to it to extract the bun tarball
       #   - tmux:  the e2e workspace runtime spawns tmux sessions
+      #   - zstd:  @actions/cache prefers zstd when present and falls back
+      #            to gzip otherwise. The compression method is part of the
+      #            cache version, so without zstd the container's lookup
+      #            (gzip) doesn't match the host's saved cache (zstd) even
+      #            for an identical key. Installing zstd brings the two
+      #            into alignment so the host-warmed Go cache restores.
       - name: Install missing OS deps for the e2e job
-        run: apt-get update && apt-get install -y --no-install-recommends unzip tmux
+        run: apt-get update && apt-get install -y --no-install-recommends unzip tmux zstd
 
       # Pre-create the Go cache dirs at the host paths configured via
       # GOCACHE / GOMODCACHE so setup-go's restore (which extracts to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,10 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Browsers and their OS deps are preinstalled here, so apt-get is skipped
+    # entirely. The image tag must track @playwright/test in bun.lock.
+    container:
+      image: mcr.microsoft.com/playwright:v1.55.1-noble
     strategy:
       fail-fast: false
       matrix:
@@ -219,9 +223,6 @@ jobs:
 
       - name: Build E2E server
         run: go build -o ./cmd/e2e-server/e2e-server ./cmd/e2e-server
-
-      - name: Install Playwright browser
-        run: cd frontend && bunx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run E2E tests
         run: cd frontend && bun run playwright test --config=playwright-e2e.config.ts --project=${{ matrix.browser }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # The Playwright image is minimal; setup-bun needs unzip to extract the
+      # bun tarball. apt-get update is a tiny metadata fetch (cached layer).
+      - name: Install unzip for setup-bun
+        run: apt-get update && apt-get install -y --no-install-recommends unzip
+
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
           go-version-file: go.mod

--- a/internal/gitclone/diff.go
+++ b/internal/gitclone/diff.go
@@ -148,10 +148,24 @@ func (m *Manager) Diff(
 		files = []DiffFile{}
 	}
 
-	// Step 4: Mark whitespace-only files (only in default mode).
-	if !hideWhitespace {
-		wsFiles := m.getWhitespaceOnlyFiles(
-			ctx, host, clonePath, mergeBase, headSHA)
+	// Step 4: Tag or drop whitespace-only modifications.
+	// In default mode they stay in the list and get tagged so the UI can
+	// surface them; in hide mode they leave the list entirely. Both modes
+	// need this server-side filter because git before 2.50 doesn't honor
+	// -w in --raw output, so step 2 returns whitespace-only files even
+	// when the caller asked to hide them.
+	wsFiles := m.getWhitespaceOnlyFiles(
+		ctx, host, clonePath, mergeBase, headSHA)
+	if hideWhitespace {
+		filtered := files[:0]
+		for i := range files {
+			if files[i].Status == "modified" && wsFiles[files[i].Path] {
+				continue
+			}
+			filtered = append(filtered, files[i])
+		}
+		files = filtered
+	} else {
 		for i := range files {
 			if wsFiles[files[i].Path] {
 				files[i].IsWhitespaceOnly = true
@@ -188,21 +202,30 @@ func (m *Manager) getWhitespaceOnlyFiles(
 func (m *Manager) whitespaceOnlyFiles(
 	ctx context.Context, host, clonePath, mergeBase, headSHA string,
 ) (map[string]bool, error) {
-	out1, err := m.git(ctx, host, clonePath, diffRawNoRenameArgs(mergeBase, headSHA, false)...)
+	// Compare --raw (full file list) against --numstat -w (files with
+	// non-whitespace changes). --raw -w would be more symmetric, but git
+	// before 2.50 ignores -w in --raw mode (it compares blob SHAs), so the
+	// two outputs match and we conclude no file is whitespace-only — wrong
+	// on every Ubuntu image that ships an older git, including the
+	// Playwright noble image used by the e2e job (git 2.43). --numstat
+	// honors -w in every supported git version, so we pivot through it.
+	rawOut, err := m.git(ctx, host, clonePath, diffRawNoRenameArgs(mergeBase, headSHA, false)...)
 	if err != nil {
 		return nil, err
 	}
-	out2, err := m.git(ctx, host, clonePath, diffRawNoRenameArgs(mergeBase, headSHA, true)...)
+	numstatOut, err := m.git(ctx, host, clonePath,
+		"diff", "--numstat", "-z", "--no-renames", "-w", mergeBase, headSHA,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	allFiles := parseRawZPaths(out1)
-	wFiles := parseRawZPaths(out2)
+	allFiles := parseRawZPaths(rawOut)
+	nonWhitespace := parseNumstatZ(numstatOut)
 
 	result := make(map[string]bool)
 	for f := range allFiles {
-		if !wFiles[f] {
+		if _, ok := nonWhitespace[f]; !ok {
 			result[f] = true
 		}
 	}


### PR DESCRIPTION
- Run e2e job inside the Playwright container image
- Install the container tools needed by CI and Playwright
- Keep older Git whitespace filtering behavior covered