### PR TITLE
Pin WebKit e2e density to native scale

### DIFF
--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       testIgnore: /roborev/,
       use: {
         ...devices["Desktop Safari"],
+        deviceScaleFactor: 1,
       },
     },
     {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
       name: "webkit",
       use: {
         ...devices["Desktop Safari"],
+        deviceScaleFactor: 1,
       },
     },
   ],


### PR DESCRIPTION
- Pin WebKit Playwright projects to deviceScaleFactor 1 to reduce rendering cost during e2e runs.