### PR TITLE
Separate generated files in diff summaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 frontend/openapi/openapi.json linguist-generated=true
+frontend/openapi/openapi.yaml linguist-generated=true
 packages/ui/src/api/generated/* linguist-generated=true
+packages/ui/src/api/roborev/generated/* linguist-generated=true
 internal/apiclient/spec/openapi.json linguist-generated=true
 internal/apiclient/generated/* linguist-generated=true

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -438,6 +438,8 @@ components:
             - "null"
         is_binary:
           type: boolean
+        is_generated:
+          type: boolean
         is_whitespace_only:
           type: boolean
         old_path:
@@ -451,6 +453,7 @@ components:
         - old_path
         - status
         - is_binary
+        - is_generated
         - is_whitespace_only
         - additions
         - deletions

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -145,6 +145,7 @@ describe("createDiffStore loadDiff", () => {
     expect(store.getFileCategoryCounts()).toEqual({
       all: 3,
       plansDocs: 1,
+      generated: 0,
       code: 1,
       tests: 1,
       other: 0,
@@ -804,9 +805,10 @@ describe("createDiffStore loadDiff", () => {
     ]);
     expect(store.getFileCategoryCounts()).toEqual({
       plansDocs: 1,
+      generated: 1,
       code: 1,
       tests: 1,
-      other: 1,
+      other: 0,
       all: 4,
     });
 

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -209,6 +209,7 @@ type DiffFile struct {
 	Deletions        int64   `json:"deletions"`
 	Hunks            *[]Hunk `json:"hunks"`
 	IsBinary         bool    `json:"is_binary"`
+	IsGenerated      bool    `json:"is_generated"`
 	IsWhitespaceOnly bool    `json:"is_whitespace_only"`
 	OldPath          string  `json:"old_path"`
 	Path             string  `json:"path"`

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -294,9 +294,18 @@ func normalizeCloneHost(host string) string {
 func (m *Manager) git(
 	ctx context.Context, host, dir string, args ...string,
 ) ([]byte, error) {
+	return m.gitWithInput(ctx, host, dir, nil, args...)
+}
+
+func (m *Manager) gitWithInput(
+	ctx context.Context, host, dir string, input []byte, args ...string,
+) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
+	}
+	if input != nil {
+		cmd.Stdin = bytes.NewReader(input)
 	}
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_TERMINAL_PROMPT=0",

--- a/internal/gitclone/diff.go
+++ b/internal/gitclone/diff.go
@@ -51,6 +51,7 @@ func (m *Manager) DiffFiles(
 			files[i].Hunks = []Hunk{}
 		}
 	}
+	m.markGenerated(ctx, host, clonePath, headSHA, files)
 	return files, nil
 }
 
@@ -172,11 +173,37 @@ func (m *Manager) Diff(
 			}
 		}
 	}
+	m.markGenerated(ctx, host, clonePath, headSHA, files)
 
 	return &DiffResult{
 		WhitespaceOnlyCount: wsCount,
 		Files:               files,
 	}, nil
+}
+
+func (m *Manager) markGenerated(
+	ctx context.Context,
+	host string,
+	clonePath string,
+	attrSource string,
+	files []DiffFile,
+) {
+	if len(files) == 0 {
+		return
+	}
+	generated := map[string]bool{}
+	input := GeneratedAttributeInput(files)
+	if len(input) > 0 {
+		args := []string{"check-attr", "-z", "--stdin"}
+		if attrSource != "" {
+			args = append(args, "--source", attrSource)
+		}
+		args = append(args, "linguist-generated")
+		if out, err := m.gitWithInput(ctx, host, clonePath, input, args...); err == nil {
+			generated = ParseLinguistGeneratedAttributes(out)
+		}
+	}
+	MarkGeneratedFiles(files, generated)
 }
 
 func (m *Manager) computeWhitespaceOnlyCount(

--- a/internal/gitclone/generated.go
+++ b/internal/gitclone/generated.go
@@ -1,0 +1,89 @@
+package gitclone
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+)
+
+var generatedBasenames = map[string]bool{
+	"bun.lock":            true,
+	"bun.lockb":           true,
+	"cargo.lock":          true,
+	"composer.lock":       true,
+	"deno.lock":           true,
+	"flake.lock":          true,
+	"gemfile.lock":        true,
+	"go.sum":              true,
+	"gradle.lockfile":     true,
+	"mix.lock":            true,
+	"npm-shrinkwrap.json": true,
+	"package-lock.json":   true,
+	"pipfile.lock":        true,
+	"pnpm-lock.yaml":      true,
+	"poetry.lock":         true,
+	"pubspec.lock":        true,
+	".terraform.lock.hcl": true,
+	"terraform.lock.hcl":  true,
+	"uv.lock":             true,
+	"yarn.lock":           true,
+}
+
+// GeneratedAttributeInput returns NUL-delimited paths for git check-attr.
+func GeneratedAttributeInput(files []DiffFile) []byte {
+	var input bytes.Buffer
+	seen := make(map[string]bool, len(files))
+	for _, file := range files {
+		path := file.Path
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		input.WriteString(path)
+		input.WriteByte(0)
+	}
+	return input.Bytes()
+}
+
+// ParseLinguistGeneratedAttributes parses `git check-attr -z` triples.
+func ParseLinguistGeneratedAttributes(out []byte) map[string]bool {
+	parts := bytes.Split(out, []byte{0})
+	generated := make(map[string]bool)
+	for i := 0; i+2 < len(parts); i += 3 {
+		path := string(parts[i])
+		attr := string(parts[i+1])
+		value := string(parts[i+2])
+		if path == "" || attr != "linguist-generated" {
+			continue
+		}
+		if value == "unspecified" {
+			continue
+		}
+		generated[path] = value == "set" || value == "true"
+	}
+	return generated
+}
+
+// MarkGeneratedFiles applies Linguist metadata and local generated heuristics.
+func MarkGeneratedFiles(files []DiffFile, linguistGenerated map[string]bool) {
+	for i := range files {
+		if generated, ok := linguistGenerated[files[i].Path]; ok {
+			files[i].IsGenerated = generated
+			continue
+		}
+		files[i].IsGenerated = IsGeneratedPath(files[i].Path)
+	}
+}
+
+// IsGeneratedPath recognizes generated artifacts that are useful even without
+// repository-specific Linguist attributes.
+func IsGeneratedPath(path string) bool {
+	base := strings.ToLower(filepath.Base(filepath.ToSlash(path)))
+	if generatedBasenames[base] {
+		return true
+	}
+	return strings.HasSuffix(base, ".lock") ||
+		strings.HasSuffix(base, ".lock.json") ||
+		strings.HasSuffix(base, ".lock.yaml") ||
+		strings.HasSuffix(base, ".lock.yml")
+}

--- a/internal/gitclone/generated.go
+++ b/internal/gitclone/generated.go
@@ -29,6 +29,13 @@ var generatedBasenames = map[string]bool{
 	"yarn.lock":           true,
 }
 
+var generatedSuffixes = []string{
+	".lock",
+	".lock.json",
+	".lock.yaml",
+	".lock.yml",
+}
+
 // GeneratedAttributeInput returns NUL-delimited paths for git check-attr.
 func GeneratedAttributeInput(files []DiffFile) []byte {
 	var input bytes.Buffer
@@ -82,8 +89,10 @@ func IsGeneratedPath(path string) bool {
 	if generatedBasenames[base] {
 		return true
 	}
-	return strings.HasSuffix(base, ".lock") ||
-		strings.HasSuffix(base, ".lock.json") ||
-		strings.HasSuffix(base, ".lock.yaml") ||
-		strings.HasSuffix(base, ".lock.yml")
+	for _, suffix := range generatedSuffixes {
+		if strings.HasSuffix(base, suffix) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/gitclone/generated_test.go
+++ b/internal/gitclone/generated_test.go
@@ -1,0 +1,39 @@
+package gitclone
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLinguistGeneratedAttributesKeepsExplicitStates(t *testing.T) {
+	assert := assert.New(t)
+
+	attrs := ParseLinguistGeneratedAttributes([]byte(
+		"dist/api.ts\x00linguist-generated\x00set\x00" +
+			"bun.lock\x00linguist-generated\x00unset\x00" +
+			"src/app.ts\x00linguist-generated\x00unspecified\x00",
+	))
+
+	assert.Equal(map[string]bool{
+		"dist/api.ts": true,
+		"bun.lock":    false,
+	}, attrs)
+}
+
+func TestMarkGeneratedFilesHonorsExplicitLinguistUnset(t *testing.T) {
+	files := []DiffFile{
+		{Path: "dist/api.ts"},
+		{Path: "bun.lock"},
+		{Path: "src/app.ts"},
+	}
+
+	MarkGeneratedFiles(files, map[string]bool{
+		"dist/api.ts": true,
+		"bun.lock":    false,
+	})
+
+	assert.True(t, files[0].IsGenerated)
+	assert.False(t, files[1].IsGenerated)
+	assert.False(t, files[2].IsGenerated)
+}

--- a/internal/gitclone/types.go
+++ b/internal/gitclone/types.go
@@ -20,6 +20,7 @@ type DiffFile struct {
 	OldPath          string `json:"old_path"`
 	Status           string `json:"status"` // added, modified, deleted, renamed, copied
 	IsBinary         bool   `json:"is_binary"`
+	IsGenerated      bool   `json:"is_generated"`
 	IsWhitespaceOnly bool   `json:"is_whitespace_only"`
 	Additions        int    `json:"additions"`
 	Deletions        int    `json:"deletions"`

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -13640,6 +13640,45 @@ func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.
 	assert.Empty(*large.Hunks)
 }
 
+func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, ".gitattributes"),
+		[]byte("dist/** linguist-generated\n"), 0o644,
+	))
+	require.NoError(os.MkdirAll(filepath.Join(ws.WorktreePath, "dist"), 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "dist", "api.ts"),
+		[]byte("export const generated = true;\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "bun.lock"),
+		[]byte("# lock\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "src.ts"),
+		[]byte("export const source = true;\n"), 0o644,
+	))
+
+	files := requestWorkspaceFiles(t, srv, ws.Id, "head")
+	require.NotNil(files.Files)
+	assert.True(requireWorkspaceDiffFile(t, *files.Files, "dist/api.ts").IsGenerated)
+	assert.True(requireWorkspaceDiffFile(t, *files.Files, "bun.lock").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *files.Files, "src.ts").IsGenerated)
+
+	diff := requestWorkspaceDiff(t, srv, ws.Id, "head")
+	require.NotNil(diff.Files)
+	assert.True(requireWorkspaceDiffFile(t, *diff.Files, "dist/api.ts").IsGenerated)
+	assert.True(requireWorkspaceDiffFile(t, *diff.Files, "bun.lock").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *diff.Files, "src.ts").IsGenerated)
+}
+
 func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -13650,7 +13650,7 @@ func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
 
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, ".gitattributes"),
-		[]byte("dist/** linguist-generated\n"), 0o644,
+		[]byte("dist/** linguist-generated\nbun.lock -linguist-generated\n"), 0o644,
 	))
 	require.NoError(os.MkdirAll(filepath.Join(ws.WorktreePath, "dist"), 0o755))
 	require.NoError(os.WriteFile(
@@ -13669,13 +13669,13 @@ func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
 	files := requestWorkspaceFiles(t, srv, ws.Id, "head")
 	require.NotNil(files.Files)
 	assert.True(requireWorkspaceDiffFile(t, *files.Files, "dist/api.ts").IsGenerated)
-	assert.True(requireWorkspaceDiffFile(t, *files.Files, "bun.lock").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *files.Files, "bun.lock").IsGenerated)
 	assert.False(requireWorkspaceDiffFile(t, *files.Files, "src.ts").IsGenerated)
 
 	diff := requestWorkspaceDiff(t, srv, ws.Id, "head")
 	require.NotNil(diff.Files)
 	assert.True(requireWorkspaceDiffFile(t, *diff.Files, "dist/api.ts").IsGenerated)
-	assert.True(requireWorkspaceDiffFile(t, *diff.Files, "bun.lock").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *diff.Files, "bun.lock").IsGenerated)
 	assert.False(requireWorkspaceDiffFile(t, *diff.Files, "src.ts").IsGenerated)
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10111,6 +10111,97 @@ func TestAPIGetFiles503WhenCloneManagerNil(t *testing.T) {
 	require.Equal(http.StatusServiceUnavailable, resp.StatusCode())
 }
 
+func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(err)
+	t.Cleanup(func() { database.Close() })
+
+	bareDir := filepath.Join(dir, "clones")
+	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	require.NoError(os.MkdirAll(filepath.Dir(bare), 0o755))
+
+	work := filepath.Join(dir, "work")
+	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	runGit(t, dir, "clone", bare, work)
+	runGit(t, work, "config", "user.email", "test@test.com")
+	runGit(t, work, "config", "user.name", "Test")
+
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "base.txt"),
+		[]byte("base\n"), 0o644,
+	))
+	runGit(t, work, "add", ".")
+	runGit(t, work, "commit", "-m", "base commit")
+	runGit(t, work, "push", "origin", "main")
+	mergeBase := testGitSHA(t, work, "HEAD")
+
+	runGit(t, work, "checkout", "-b", "feature")
+	require.NoError(os.WriteFile(
+		filepath.Join(work, ".gitattributes"),
+		[]byte("dist/** linguist-generated\nbun.lock -linguist-generated\n"), 0o644,
+	))
+	require.NoError(os.MkdirAll(filepath.Join(work, "dist"), 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "dist", "api.ts"),
+		[]byte("export const generated = true;\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "bun.lock"),
+		[]byte("# lock\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "src.ts"),
+		[]byte("export const source = true;\n"), 0o644,
+	))
+	runGit(t, work, "add", ".")
+	runGit(t, work, "commit", "-m", "feature commit")
+	runGit(t, work, "push", "origin", "feature")
+	headSHA := testGitSHA(t, work, "HEAD")
+
+	clones := gitclone.New(bareDir, nil)
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": &mockGH{}},
+		database, nil, defaultTestRepos, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{Clones: clones})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	seedPR(t, database, "acme", "widget", 1)
+	repoID, err := database.UpsertRepo(ctx, "github.com", "acme", "widget")
+	require.NoError(err)
+	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, mergeBase, mergeBase))
+
+	filesResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberFilesWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, filesResp.StatusCode(), string(filesResp.Body))
+	require.NotNil(filesResp.JSON200)
+	require.NotNil(filesResp.JSON200.Files)
+	assert.True(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "dist/api.ts").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "bun.lock").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "src.ts").IsGenerated)
+
+	diffResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+		nil,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, diffResp.StatusCode(), string(diffResp.Body))
+	require.NotNil(diffResp.JSON200)
+	require.NotNil(diffResp.JSON200.Files)
+	assert.True(requireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "dist/api.ts").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "bun.lock").IsGenerated)
+	assert.False(requireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "src.ts").IsGenerated)
+}
+
 func TestSetActiveWorktreeKey(t *testing.T) {
 	assert := Assert.New(t)
 	srv, _ := setupTestServer(t)

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -116,6 +116,7 @@ func worktreeDiffFilesFromRef(
 		files = dropWhitespaceOnlyModifications(files, counts)
 	}
 	files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
+	markWorktreeGeneratedFiles(ctx, dir, files)
 	return files, true, nil
 }
 
@@ -257,11 +258,34 @@ func worktreeDiffFromRefPath(
 	); ok {
 		files = append(files, file)
 	}
+	markWorktreeGeneratedFiles(ctx, dir, files)
 
 	return &gitclone.DiffResult{
 		WhitespaceOnlyCount: wsCount,
 		Files:               files,
 	}, true, nil
+}
+
+func markWorktreeGeneratedFiles(
+	ctx context.Context,
+	dir string,
+	files []gitclone.DiffFile,
+) {
+	if len(files) == 0 {
+		return
+	}
+	generated := map[string]bool{}
+	input := gitclone.GeneratedAttributeInput(files)
+	if len(input) > 0 {
+		out, err := worktreeGitOutputWithInput(
+			ctx, dir, input,
+			"check-attr", "-z", "--stdin", "linguist-generated",
+		)
+		if err == nil {
+			generated = gitclone.ParseLinguistGeneratedAttributes(out)
+		}
+	}
+	gitclone.MarkGeneratedFiles(files, generated)
 }
 
 func applyWorktreeNumstat(
@@ -668,11 +692,23 @@ func worktreeGitOutput(
 	dir string,
 	args ...string,
 ) ([]byte, error) {
+	return worktreeGitOutputWithInput(ctx, dir, nil, args...)
+}
+
+func worktreeGitOutputWithInput(
+	ctx context.Context,
+	dir string,
+	input []byte,
+	args ...string,
+) ([]byte, error) {
 	if dir == "" {
 		return nil, errors.New("empty worktree dir")
 	}
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	if input != nil {
+		cmd.Stdin = bytes.NewReader(input)
+	}
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_TERMINAL_PROMPT=0",
 		"GIT_CONFIG_NOSYSTEM=1",

--- a/internal/workspace/diff_test.go
+++ b/internal/workspace/diff_test.go
@@ -82,6 +82,39 @@ func TestWorktreeDiffFilesHidesWhitespaceOnlyUntrackedFiles(t *testing.T) {
 	assert.Equal("z-empty.txt", files[1].Path)
 }
 
+func TestWorktreeDiffFilesMarksGeneratedFiles(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	work := setupDivergenceWorktree(t)
+
+	require.NoError(os.WriteFile(
+		filepath.Join(work, ".gitattributes"),
+		[]byte("dist/** linguist-generated\n"), 0o644,
+	))
+	require.NoError(os.MkdirAll(filepath.Join(work, "dist"), 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "dist", "api.ts"), []byte("export const api = 1;\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "src.ts"), []byte("export const src = 1;\n"), 0o644,
+	))
+
+	files, ok, err := WorktreeDiffFiles(
+		t.Context(), work, WorktreeDiffBaseHead, false,
+	)
+	require.NoError(err)
+	require.True(ok)
+	require.Len(files, 3)
+
+	generated := map[string]bool{}
+	for _, file := range files {
+		generated[file.Path] = file.IsGenerated
+	}
+	assert.False(generated[".gitattributes"])
+	assert.True(generated["dist/api.ts"])
+	assert.False(generated["src.ts"])
+}
+
 func TestWorktreeFileDiffAgainstHeadScopesPatchToOnePath(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1590,6 +1590,7 @@ export interface components {
             deletions: number;
             hunks: components["schemas"]["Hunk"][] | null;
             is_binary: boolean;
+            is_generated: boolean;
             is_whitespace_only: boolean;
             old_path: string;
             path: string;

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -114,6 +114,7 @@ export interface DiffFile {
   old_path: string;
   status: "added" | "modified" | "deleted" | "renamed" | "copied";
   is_binary: boolean;
+  is_generated?: boolean;
   is_whitespace_only: boolean;
   additions: number;
   deletions: number;

--- a/packages/ui/src/components/detail/DiffSummaryChip.svelte
+++ b/packages/ui/src/components/detail/DiffSummaryChip.svelte
@@ -33,10 +33,10 @@
 
   const rows = $derived([
     { key: "plansDocs" as const, label: "Plans/docs" },
-    { key: "generated" as const, label: "Generated" },
     { key: "code" as const, label: "Code" },
     { key: "tests" as const, label: "Tests" },
     { key: "other" as const, label: "Other" },
+    { key: "generated" as const, label: "Generated" },
   ]);
   const visibleRows = $derived(
     summary === null

--- a/packages/ui/src/components/detail/DiffSummaryChip.svelte
+++ b/packages/ui/src/components/detail/DiffSummaryChip.svelte
@@ -33,6 +33,7 @@
 
   const rows = $derived([
     { key: "plansDocs" as const, label: "Plans/docs" },
+    { key: "generated" as const, label: "Generated" },
     { key: "code" as const, label: "Code" },
     { key: "tests" as const, label: "Tests" },
     { key: "other" as const, label: "Other" },

--- a/packages/ui/src/components/detail/DiffSummaryChip.test.ts
+++ b/packages/ui/src/components/detail/DiffSummaryChip.test.ts
@@ -39,6 +39,7 @@ describe("DiffSummaryChip", () => {
       file("src/App.svelte", 40, 6),
       file("src/App.test.ts", 20, 8),
       file("bun.lock", 1, 1),
+      { ...file("src/api/generated/schema.ts", 2, 2), is_generated: true },
     ]);
 
     render(DiffSummaryChip, {
@@ -61,8 +62,8 @@ describe("DiffSummaryChip", () => {
     expect(screen.getByText("+40/-6")).toBeTruthy();
     expect(screen.getByText("Tests")).toBeTruthy();
     expect(screen.getByText("+20/-8")).toBeTruthy();
-    expect(screen.getByText("Other")).toBeTruthy();
-    expect(screen.getByText("+1/-1")).toBeTruthy();
+    expect(screen.getByText("Generated")).toBeTruthy();
+    expect(screen.getByText("+3/-3")).toBeTruthy();
     expect(loadFiles).toHaveBeenCalledTimes(1);
   });
 
@@ -91,6 +92,7 @@ describe("DiffSummaryChip", () => {
     expect(screen.getByText("Tests")).toBeTruthy();
     expect(screen.getByText("+20/-8")).toBeTruthy();
     expect(screen.queryByText("Plans/docs")).toBeNull();
+    expect(screen.queryByText("Generated")).toBeNull();
     expect(screen.queryByText("Other")).toBeNull();
   });
 

--- a/packages/ui/src/components/detail/DiffSummaryChip.test.ts
+++ b/packages/ui/src/components/detail/DiffSummaryChip.test.ts
@@ -38,30 +38,37 @@ describe("DiffSummaryChip", () => {
       file("docs/plan.md", 10, 2),
       file("src/App.svelte", 40, 6),
       file("src/App.test.ts", 20, 8),
+      file("mise.toml", 1, 1),
       file("bun.lock", 1, 1),
       { ...file("src/api/generated/schema.ts", 2, 2), is_generated: true },
     ]);
 
     render(DiffSummaryChip, {
       props: {
-        additions: 71,
-        deletions: 17,
+        additions: 74,
+        deletions: 20,
         loadFiles: async () =>
           new DiffSummaryFilesResult(false, await loadFiles()),
       },
     });
 
     await fireEvent.mouseEnter(
-      screen.getByRole("button", { name: /\+71\/-17/i }),
+      screen.getByRole("button", { name: /\+74\/-20/i }),
     );
 
-    expect(await screen.findByText("Plans/docs")).toBeTruthy();
+    const popover = await screen.findByRole("status");
+    const labels = Array.from(popover.querySelectorAll(".diff-summary-row span:first-child"))
+      .map((label) => label.textContent);
+    expect(labels).toEqual(["Plans/docs", "Code", "Tests", "Other", "Generated"]);
+    expect(screen.getByText("Plans/docs")).toBeTruthy();
     expect(screen.queryByText("Total")).toBeNull();
     expect(screen.getByText("+10/-2")).toBeTruthy();
     expect(screen.getByText("Code")).toBeTruthy();
     expect(screen.getByText("+40/-6")).toBeTruthy();
     expect(screen.getByText("Tests")).toBeTruthy();
     expect(screen.getByText("+20/-8")).toBeTruthy();
+    expect(screen.getByText("Other")).toBeTruthy();
+    expect(screen.getByText("+1/-1")).toBeTruthy();
     expect(screen.getByText("Generated")).toBeTruthy();
     expect(screen.getByText("+3/-3")).toBeTruthy();
     expect(loadFiles).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/components/detail/diff-summary.test.ts
+++ b/packages/ui/src/components/detail/diff-summary.test.ts
@@ -30,6 +30,11 @@ describe("diff summary categorization", () => {
     expect(categorizeDiffFile(file("package-lock.json", 1, 1))).toBe("generated");
   });
 
+  it("honors explicit non-generated API metadata before filename heuristics", () => {
+    expect(categorizeDiffFile({ ...file("bun.lock", 1, 1), is_generated: false }))
+      .toBe("other");
+  });
+
   it("puts documentation and planning paths into plans/docs", () => {
     expect(categorizeDiffFile("docs/rollout-plan.md")).toBe("plansDocs");
     expect(categorizeDiffFile("context/ui-design-system.md")).toBe("plansDocs");

--- a/packages/ui/src/components/detail/diff-summary.test.ts
+++ b/packages/ui/src/components/detail/diff-summary.test.ts
@@ -23,6 +23,13 @@ function file(
 }
 
 describe("diff summary categorization", () => {
+  it("puts generated files into generated", () => {
+    expect(categorizeDiffFile({ ...file("src/api/client.ts", 1, 1), is_generated: true }))
+      .toBe("generated");
+    expect(categorizeDiffFile(file("bun.lock", 1, 1))).toBe("generated");
+    expect(categorizeDiffFile(file("package-lock.json", 1, 1))).toBe("generated");
+  });
+
   it("puts documentation and planning paths into plans/docs", () => {
     expect(categorizeDiffFile("docs/rollout-plan.md")).toBe("plansDocs");
     expect(categorizeDiffFile("context/ui-design-system.md")).toBe("plansDocs");
@@ -43,15 +50,17 @@ describe("diff summary categorization", () => {
   it("summarizes added and deleted lines by category", () => {
     const summary = summarizeDiffFiles([
       file("docs/plan.md", 10, 2),
+      file("bun.lock", 5, 1),
       file("internal/server/api.go", 30, 4),
       file("internal/server/api_test.go", 20, 8),
       file("mise.toml", 1, 1),
     ]);
 
     expect(summary.plansDocs).toEqual({ additions: 10, deletions: 2 });
+    expect(summary.generated).toEqual({ additions: 5, deletions: 1 });
     expect(summary.code).toEqual({ additions: 30, deletions: 4 });
     expect(summary.tests).toEqual({ additions: 20, deletions: 8 });
     expect(summary.other).toEqual({ additions: 1, deletions: 1 });
-    expect(summary.total).toEqual({ additions: 61, deletions: 15 });
+    expect(summary.total).toEqual({ additions: 66, deletions: 16 });
   });
 });

--- a/packages/ui/src/components/detail/diff-summary.ts
+++ b/packages/ui/src/components/detail/diff-summary.ts
@@ -39,6 +39,7 @@ const ZERO_TOTALS: DiffLineTotals = { additions: 0, deletions: 0 };
 function emptySummary(): DiffLineSummary {
   return {
     plansDocs: { ...ZERO_TOTALS },
+    generated: { ...ZERO_TOTALS },
     code: { ...ZERO_TOTALS },
     tests: { ...ZERO_TOTALS },
     other: { ...ZERO_TOTALS },
@@ -49,7 +50,7 @@ function emptySummary(): DiffLineSummary {
 export function summarizeDiffFiles(files: DiffFile[]): DiffLineSummary {
   const summary = emptySummary();
   for (const file of files) {
-    const category = categorizeDiffFile(file.path);
+    const category = categorizeDiffFile(file);
     summary[category].additions += file.additions;
     summary[category].deletions += file.deletions;
     summary.total.additions += file.additions;

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -38,10 +38,10 @@ describe("DiffToolbar", () => {
       .map((button) => button.textContent?.replace(/\s+/g, " ").trim());
     expect(labels).toEqual([
       "Plans/docs (0)",
-      "Generated (0)",
       "Code (0)",
       "Tests (0)",
       "Other (0)",
+      "Generated (0)",
       "All (0)",
     ]);
 

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -38,6 +38,7 @@ describe("DiffToolbar", () => {
       .map((button) => button.textContent?.replace(/\s+/g, " ").trim());
     expect(labels).toEqual([
       "Plans/docs (0)",
+      "Generated (0)",
       "Code (0)",
       "Tests (0)",
       "Other (0)",

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -1,14 +1,16 @@
 import type { DiffFile } from "../api/types.js";
 
-export type DiffFileCategory = "plansDocs" | "code" | "tests" | "other";
+export type DiffFileCategory = "plansDocs" | "generated" | "code" | "tests" | "other";
 export type DiffFileCategoryFilter = DiffFileCategory | "all";
 export type DiffFileCategoryCounts = Record<DiffFileCategoryFilter, number>;
+type CategorizableDiffFile = Pick<DiffFile, "path"> & { is_generated?: boolean };
 
 export const diffFileCategoryOptions: {
   value: DiffFileCategoryFilter;
   label: string;
 }[] = [
   { value: "plansDocs", label: "Plans/docs" },
+  { value: "generated", label: "Generated" },
   { value: "code", label: "Code" },
   { value: "tests", label: "Tests" },
   { value: "other", label: "Other" },
@@ -59,6 +61,28 @@ const docsExtensions = new Set([
 ]);
 
 const docsDirectoryNames = new Set(["doc", "docs", "documentation"]);
+const generatedBasenames = new Set([
+  "bun.lock",
+  "bun.lockb",
+  "cargo.lock",
+  "composer.lock",
+  "deno.lock",
+  "flake.lock",
+  "gemfile.lock",
+  "go.sum",
+  "gradle.lockfile",
+  "mix.lock",
+  "npm-shrinkwrap.json",
+  "package-lock.json",
+  "pipfile.lock",
+  "pnpm-lock.yaml",
+  "poetry.lock",
+  "pubspec.lock",
+  ".terraform.lock.hcl",
+  "terraform.lock.hcl",
+  "uv.lock",
+  "yarn.lock",
+]);
 
 function pathParts(path: string): string[] {
   return path.toLowerCase().split(/[\\/]+/).filter(Boolean);
@@ -109,11 +133,28 @@ function hasDocsSignal(parts: string[], base: string, ext: string): boolean {
   );
 }
 
-export function categorizeDiffFile(path: string): DiffFileCategory {
+function hasGeneratedSignal(base: string): boolean {
+  return (
+    generatedBasenames.has(base) ||
+    base.endsWith(".lock") ||
+    base.endsWith(".lock.json") ||
+    base.endsWith(".lock.yaml") ||
+    base.endsWith(".lock.yml")
+  );
+}
+
+function diffFilePath(file: string | CategorizableDiffFile): string {
+  return typeof file === "string" ? file : file.path;
+}
+
+export function categorizeDiffFile(file: string | CategorizableDiffFile): DiffFileCategory {
+  const path = diffFilePath(file);
   const parts = pathParts(path);
   const base = basename(path);
   const ext = extension(path);
 
+  if (typeof file !== "string" && file.is_generated) return "generated";
+  if (hasGeneratedSignal(base)) return "generated";
   if (hasTestSignal(parts, base)) return "tests";
   if (hasDocsSignal(parts, base, ext)) return "plansDocs";
   if (codeExtensions.has(ext)) return "code";
@@ -125,12 +166,13 @@ export function filterDiffFilesByCategory(
   filter: DiffFileCategoryFilter,
 ): DiffFile[] {
   if (filter === "all") return files;
-  return files.filter((file) => categorizeDiffFile(file.path) === filter);
+  return files.filter((file) => categorizeDiffFile(file) === filter);
 }
 
 export function countDiffFilesByCategory(files: DiffFile[]): DiffFileCategoryCounts {
   const counts: DiffFileCategoryCounts = {
     plansDocs: 0,
+    generated: 0,
     code: 0,
     tests: 0,
     other: 0,
@@ -138,7 +180,7 @@ export function countDiffFilesByCategory(files: DiffFile[]): DiffFileCategoryCou
   };
 
   for (const file of files) {
-    counts[categorizeDiffFile(file.path)] += 1;
+    counts[categorizeDiffFile(file)] += 1;
   }
 
   return counts;

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -10,10 +10,10 @@ export const diffFileCategoryOptions: {
   label: string;
 }[] = [
   { value: "plansDocs", label: "Plans/docs" },
-  { value: "generated", label: "Generated" },
   { value: "code", label: "Code" },
   { value: "tests", label: "Tests" },
   { value: "other", label: "Other" },
+  { value: "generated", label: "Generated" },
   { value: "all", label: "All" },
 ];
 

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -149,9 +149,10 @@ export function categorizeDiffFile(file: string | CategorizableDiffFile): DiffFi
   const parts = pathParts(path);
   const base = basename(path);
   const ext = extension(path);
+  const generatedMetadata = typeof file === "string" ? undefined : file.is_generated;
 
-  if (typeof file !== "string" && file.is_generated) return "generated";
-  if (hasGeneratedSignal(base)) return "generated";
+  if (generatedMetadata === true) return "generated";
+  if (generatedMetadata !== false && hasGeneratedSignal(base)) return "generated";
   if (hasTestSignal(parts, base)) return "tests";
   if (hasDocsSignal(parts, base, ext)) return "plansDocs";
   if (codeExtensions.has(ext)) return "code";

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -83,6 +83,12 @@ const generatedBasenames = new Set([
   "uv.lock",
   "yarn.lock",
 ]);
+const generatedSuffixes = [
+  ".lock",
+  ".lock.json",
+  ".lock.yaml",
+  ".lock.yml",
+];
 
 function pathParts(path: string): string[] {
   return path.toLowerCase().split(/[\\/]+/).filter(Boolean);
@@ -134,21 +140,12 @@ function hasDocsSignal(parts: string[], base: string, ext: string): boolean {
 }
 
 function hasGeneratedSignal(base: string): boolean {
-  return (
-    generatedBasenames.has(base) ||
-    base.endsWith(".lock") ||
-    base.endsWith(".lock.json") ||
-    base.endsWith(".lock.yaml") ||
-    base.endsWith(".lock.yml")
-  );
-}
-
-function diffFilePath(file: string | CategorizableDiffFile): string {
-  return typeof file === "string" ? file : file.path;
+  return generatedBasenames.has(base) ||
+    generatedSuffixes.some((suffix) => base.endsWith(suffix));
 }
 
 export function categorizeDiffFile(file: string | CategorizableDiffFile): DiffFileCategory {
-  const path = diffFilePath(file);
+  const path = typeof file === "string" ? file : file.path;
   const parts = pathParts(path);
   const base = basename(path);
   const ext = extension(path);


### PR DESCRIPTION
- Adds a Generated diff category for Linguist-marked files and common generated artifacts such as lockfiles.
- Carries generated-file metadata through the diff API and generated clients.
- Marks checked-in generated API artifacts with Linguist attributes so they land in the generated bucket.