### PR TITLE
Allow wrapping the workspace shell command via [shell] config

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -86,6 +86,50 @@ stale tabs.
   unintended navigation when the user is targeting a nested control.
 - Persisted "last active tab" state must be scoped per workspace.
 
+## Shell Command Override
+
+The plain shell session is launched as a direct child of middleman via
+`pty.StartWithSize`, which means it inherits middleman's seccomp filter,
+namespace restrictions, and resource limits. Hardened deployments
+(systemd services with `SystemCallFilter=~@privileged`, `LockPersonality=`,
+`MemoryDenyWriteExecute=`, etc.) will SIGSYS the shell almost immediately:
+zsh and bash both call `setresuid(uid, uid, uid)` during startup to drop
+saved-uid privileges, and that syscall is in `@privileged`.
+
+For these deployments, set `[shell] command = [...]` to wrap the launch
+in something that escapes the parent unit's filter. On systemd hosts,
+`systemd-run --user` spawns a fresh transient unit with its own
+(unfiltered) policy:
+
+```toml
+[shell]
+command = [
+  "systemd-run", "--user", "--quiet", "--collect", "--wait", "--pipe",
+  "--service-type=exec",
+  "--property=KillMode=process",
+  "--description=middleman shell",
+  "--",
+  "zsh",  # absolute path or PATH-resolvable name; see below
+]
+```
+
+Notes:
+
+- `cwd` is propagated by the runtime via `cmd.Dir` — your wrapper must
+  forward it to the actual shell. With `systemd-run`, that's
+  `--working-directory=$PWD` (or a fixed path); without an explicit
+  flag the transient unit does not inherit the launcher's working
+  directory.
+- The configured argv is invoked verbatim (no shell expansion). The
+  first element must be an absolute path or a `PATH`-resolvable name;
+  relative paths are rejected so a malicious worktree cannot drop a
+  binary into itself and gain code execution.
+- When unset, the runtime falls back to `$SHELL`, then `/bin/sh`. This
+  is the safe default for unhardened single-user installs.
+
+The `[tmux] command` setting follows the same wrap-it-in-systemd-run
+pattern for similar reasons; the two are independent.
+
 ## Testing Expectations
 
 Prefer full-stack coverage when the bug crosses backend lifecycle and frontend

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -492,6 +492,18 @@ type Tmux struct {
 	AgentSessions *bool    `toml:"agent_sessions,omitempty"`
 }
 
+// Shell configures the command middleman runs when ensuring the
+// per-workspace plain shell session. Hardened middleman deployments
+// (e.g. systemd services with SystemCallFilter=~@privileged) must
+// wrap the shell so it escapes the parent's seccomp filter — zsh
+// calls setresuid during startup and is killed by SIGSYS otherwise.
+// The configured command is invoked with the workspace worktree as
+// its working directory; provide a command that propagates that to
+// the spawned shell (e.g. `systemd-run --working-directory=...`).
+type Shell struct {
+	Command []string `toml:"command,omitempty"`
+}
+
 type Config struct {
 	SyncInterval        string           `toml:"sync_interval"`
 	GitHubTokenEnv      string           `toml:"github_token_env"`
@@ -508,6 +520,7 @@ type Config struct {
 	Agents              []Agent          `toml:"agents"`
 	Roborev             Roborev          `toml:"roborev"`
 	Tmux                Tmux             `toml:"tmux"`
+	Shell               Shell            `toml:"shell"`
 }
 
 func DefaultConfigPath() string {
@@ -841,6 +854,13 @@ func (c *Config) Validate() error {
 		)
 	}
 
+	if len(c.Shell.Command) > 0 &&
+		strings.TrimSpace(c.Shell.Command[0]) == "" {
+		return fmt.Errorf(
+			"config: invalid shell.command: first element must be non-empty",
+		)
+	}
+
 	return nil
 }
 
@@ -1108,6 +1128,17 @@ func (c *Config) TmuxCommand() []string {
 	return slices.Clone(c.Tmux.Command)
 }
 
+// ShellCommand returns the configured shell command + argv prefix
+// used when ensuring a workspace's plain shell session, or nil when
+// unset. nil means the runtime falls back to the user's $SHELL (or
+// /bin/sh). The returned slice is a copy, safe to append to.
+func (c *Config) ShellCommand() []string {
+	if c == nil || len(c.Shell.Command) == 0 {
+		return nil
+	}
+	return slices.Clone(c.Shell.Command)
+}
+
 // TmuxAgentSessionsEnabled reports whether runtime agent launches
 // should prefer tmux-backed sessions. Defaults to true so agent
 // activity is visible to tmux-based workspace fingerprinting.
@@ -1152,6 +1183,7 @@ type configFile struct {
 	Agents              []Agent          `toml:"agents,omitempty"`
 	Roborev             Roborev          `toml:"roborev,omitempty"`
 	Tmux                Tmux             `toml:"tmux,omitempty"`
+	Shell               Shell            `toml:"shell,omitempty"`
 }
 
 // Save writes the current config to the given path.
@@ -1169,6 +1201,7 @@ func (c *Config) Save(path string) error {
 		Agents:              c.Agents,
 		Roborev:             c.Roborev,
 		Tmux:                c.Tmux,
+		Shell:               c.Shell,
 	}
 	if c.DefaultPlatformHost == defaultPlatformHost {
 		f.DefaultPlatformHost = ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1748,6 +1748,115 @@ command = ["   ", "extra"]
 	)
 }
 
+func TestLoadShellCommand(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[shell]
+command = ["systemd-run", "--user", "--scope", "zsh"]
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "--scope", "zsh"},
+		cfg.Shell.Command,
+	)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "--scope", "zsh"},
+		cfg.ShellCommand(),
+	)
+}
+
+func TestLoadShellCommandOmitted(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, ``)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(cfg.Shell.Command)
+	// Unset returns nil, signalling the runtime to fall back to $SHELL.
+	assert.Nil(cfg.ShellCommand())
+}
+
+func TestLoadShellCommandEmptyArray(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[shell]
+command = []
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Nil(cfg.ShellCommand())
+}
+
+func TestShellCommandDefensiveCopy(t *testing.T) {
+	assert := Assert.New(t)
+	cfg := &Config{Shell: Shell{Command: []string{"zsh"}}}
+	first := cfg.ShellCommand()
+	first[0] = "hacked"
+	second := cfg.ShellCommand()
+	assert.Equal([]string{"zsh"}, second)
+}
+
+func TestShellCommandNilReceiver(t *testing.T) {
+	assert := Assert.New(t)
+	var cfg *Config
+	assert.Nil(cfg.ShellCommand())
+}
+
+func TestLoadShellCommandRejectsEmptyFirstElement(t *testing.T) {
+	path := writeConfig(t, `
+[shell]
+command = ["", "zsh"]
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(),
+		`config: invalid shell.command`,
+	)
+}
+
+// Whitespace-only first element sneaks past a plain == "" check and
+// exec("   ") fails with a confusing shell-level error rather than
+// the config-load validation message operators actually want.
+func TestLoadShellCommandRejectsWhitespaceFirstElement(t *testing.T) {
+	path := writeConfig(t, `
+[shell]
+command = ["   ", "zsh"]
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(),
+		`config: invalid shell.command`,
+	)
+}
+
+func TestSavePreservesShellCommand(t *testing.T) {
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := &Config{
+		SyncInterval:   "5m",
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Host:           "127.0.0.1",
+		Port:           8091,
+		DataDir:        dir,
+		Activity:       Activity{ViewMode: "threaded", TimeRange: "7d"},
+		Shell: Shell{
+			Command: []string{"systemd-run", "--user", "zsh"},
+		},
+	}
+	require.NoError(t, cfg.Save(path))
+
+	reloaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(
+		[]string{"systemd-run", "--user", "zsh"},
+		reloaded.Shell.Command,
+	)
+}
+
 func TestSavePreservesTmuxCommand(t *testing.T) {
 	assert := Assert.New(t)
 	dir := t.TempDir()

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14085,6 +14085,63 @@ func TestWorkspaceRuntimeEnsureShellE2E(t *testing.T) {
 	assert.Empty(*getResp.JSON200.Sessions)
 }
 
+// TestWorkspaceRuntimeShellTerminalWebSocketE2E exercises the
+// /ws/v1/.../runtime/shell/terminal upgrade path end-to-end with a
+// custom Shell.Command. Hardened deployments (e.g. systemd services
+// with SystemCallFilter=~@privileged) need the override so that
+// zsh's startup setresuid is not SIGSYS'd by the parent's seccomp
+// filter; this test guards both the websocket route and the
+// config.Shell.Command -> manager.Options.ShellCommand wiring.
+func TestWorkspaceRuntimeShellTerminalWebSocketE2E(t *testing.T) {
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	cfg := &config.Config{
+		Shell: config.Shell{
+			Command: serverRuntimeHelperCommand("echo"),
+		},
+	}
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	shellResp, err := client.HTTP.EnsureWorkspaceRuntimeShellWithResponse(
+		ctx, ws.Id,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, shellResp.StatusCode())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/shell/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageBinary, []byte("ping\n"),
+	))
+	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var got strings.Builder
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+		if typ != websocket.MessageBinary {
+			continue
+		}
+		got.WriteString(string(data))
+		if strings.Contains(got.String(), "echo:ping") {
+			return
+		}
+	}
+	require.Contains(got.String(), "echo:ping")
+}
+
 func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -441,6 +441,7 @@ func newServer(
 			TmuxOwnerMarker:         s.workspaces.TmuxOwnerMarker(),
 			WrapAgentSessionsInTmux: cfg.TmuxAgentSessionsEnabled(),
 			StripEnvVars:            cfg.TokenEnvNames(),
+			ShellCommand:            cfg.ShellCommand(),
 			OnSessionExit:           s.handleRuntimeSessionExit,
 		})
 		if err := s.restoreRuntimeTmuxSessions(context.Background()); err != nil {


### PR DESCRIPTION
## Summary

- Adds a `[shell] command = [...]` config section parallel to the existing `[tmux] command` override, threaded into `localruntime.NewManager` via `Options.ShellCommand`.
- Lets hardened deployments wrap the per-workspace plain shell (e.g. in `systemd-run --user`) so it escapes the parent service's seccomp filter. Without this, services with `SystemCallFilter=~@privileged` saw the Shell drawer attach, immediately receive `{"code":-1,"type":"exited"}`, and render blank — zsh's startup `setresuid` was SIGSYS'd before the drawer could draw a single byte.
- Unset preserves the existing `\$SHELL` / `/bin/sh` fallback. `context/workspace-runtime-lifecycle.md` documents when to reach for the override.