### PR TITLE
Deliver exit frame and reject zombie sessions on shell drawer reopen

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14298,6 +14298,86 @@ func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
 	assert.Equal(string(localruntime.SessionStatusRunning), second.JSON200.Status)
 }
 
+// TestBridgeRuntimeAttachmentSubscriberDropDoesNotEmitExitFrame
+// pins the bridge's branch that distinguishes a subscriber drop from
+// a real session exit. broadcast closes a subscriber's Output channel
+// when its 64-slot buffer fills (slow client); without this branch
+// the bridge would emit "exited" on a healthy shell and auto-close
+// the drawer in front of a still-running session.
+//
+// We exercise the bridge directly with an Attachment whose Output is
+// pre-closed and whose SessionOutputClosed reports false — exactly
+// the post-broadcast-drop state. Constructing that state via real
+// PTY traffic would be timing-fragile (it requires saturating the
+// TCP send buffer faster than the bridge can drain it), so this is
+// a focused unit test on the bridge's branching logic.
+func TestBridgeRuntimeAttachmentSubscriberDropDoesNotEmitExitFrame(t *testing.T) {
+	require := require.New(t)
+	closedOutput := make(chan []byte)
+	close(closedOutput)
+	stillRunning := make(chan struct{}) // never closed
+	attach := localruntime.NewAttachmentForTesting(
+		localruntime.AttachmentForTestingOptions{
+			Output:              closedOutput,
+			Done:                stillRunning,
+			SessionOutputClosed: func() bool { return false },
+		},
+	)
+
+	bridgeReturn := make(chan bool, 1)
+	acceptErr := make(chan error, 1)
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+				InsecureSkipVerify: true,
+			})
+			if err != nil {
+				acceptErr <- err
+				return
+			}
+			exited := bridgeRuntimeAttachment(r.Context(), conn, attach)
+			bridgeReturn <- exited
+			conn.Close(websocket.StatusNormalClosure, "test done")
+		},
+	))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 4*time.Second,
+	)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	// Read until close. With the bug present (always-emit on
+	// outputDone), we'd see a MessageText "exited" frame here.
+	for {
+		typ, data, readErr := conn.Read(ctx)
+		if readErr != nil {
+			break
+		}
+		if typ == websocket.MessageText {
+			require.Failf(
+				"unexpected exit frame on subscriber drop",
+				"frame: %s", data,
+			)
+		}
+	}
+
+	select {
+	case exited := <-bridgeReturn:
+		require.False(exited,
+			"bridge must report not-exited when only the "+
+				"subscriber's Output closed")
+	case err := <-acceptErr:
+		require.NoError(err, "websocket accept failed")
+	case <-time.After(2 * time.Second):
+		require.Fail("bridge did not return")
+	}
+}
+
 func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14185,14 +14185,18 @@ func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
-	// Helper closes its PTY end immediately, then sleeps 750ms before
-	// exiting. The bridge's outputDone fires within milliseconds; an
-	// exit frame must still be delivered well before the helper's
-	// cmd.Wait return. 4 s is generous slack for slow CI without
-	// risking the test masking a frame that comes ONLY after cmd.Wait.
-	readCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	// Helper closes its PTY end immediately, then sleeps long enough
+	// before exiting that a regression which gates the exit frame on
+	// cmd.Wait would push delivery well past our promptness budget.
+	// The bridge's outputDone path must deliver the frame within a
+	// few hundred ms of attach; cmd.Wait can only return when the
+	// helper finishes its sleep, so the gap between "right" and
+	// "wrong" is the helper's sleep duration. Helper sleeps 2 s; we
+	// allow up to 800 ms for the PTY-EOF path even on slow CI.
+	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	frameDeadline := time.Now().Add(400 * time.Millisecond)
+	const exitFrameBudget = 800 * time.Millisecond
+	attachStart := time.Now()
 	for {
 		typ, data, readErr := conn.Read(readCtx)
 		if readErr != nil {
@@ -14204,10 +14208,13 @@ func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
 		if typ != websocket.MessageText {
 			continue
 		}
-		require.LessOrEqualf(
-			time.Now().Unix(), frameDeadline.Unix()+1,
-			"exit frame must arrive promptly after PTY EOF, "+
-				"not gated on the wrapper's cmd.Wait",
+		elapsed := time.Since(attachStart)
+		require.Lessf(elapsed, exitFrameBudget,
+			"exit frame took %s after attach; bridge appears "+
+				"gated on cmd.Wait rather than PTY EOF (helper "+
+				"sleeps 2 s, so a regression would clock in "+
+				"around there)",
+			elapsed,
 		)
 		var msg struct {
 			Type string `json:"type"`
@@ -14828,12 +14835,15 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 		// close — without that, the kernel SIGHUPs the session leader
 		// and cmd.Wait returns alongside drainOutput, which hides the
 		// race we're trying to exercise. Closing stdin/stdout/stderr
-		// drops every slave fd; the master sees EOF immediately.
+		// drops every slave fd; the master sees EOF immediately. The
+		// 2 s sleep gives the exit-frame promptness assertion clear
+		// daylight: a regression that gates on cmd.Wait would deliver
+		// at ~2 s, well past the test's promptness budget.
 		signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
 		_ = os.Stdin.Close()
 		_ = os.Stdout.Close()
 		_ = os.Stderr.Close()
-		time.Sleep(750 * time.Millisecond)
+		time.Sleep(2 * time.Second)
 		os.Exit(7)
 	default:
 		os.Exit(2)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18,12 +18,14 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -14143,24 +14145,25 @@ func TestWorkspaceRuntimeShellTerminalWebSocketE2E(t *testing.T) {
 }
 
 // TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E pins the
-// websocket "exited" text frame contract. Without it, the frontend's
-// ShellDrawer never fires its onExit handler, so the drawer doesn't
-// auto-close on shell exit and the user is stranded on a dead session
-// (TerminalPane reconnect-loops on a still-listed-but-output-dead
-// session, which looks like a hang).
+// websocket "exited" text frame contract. The frontend's ShellDrawer
+// only fires onExit when this frame arrives; without it the drawer
+// doesn't auto-close on shell exit and the user is stranded on a dead
+// session (TerminalPane reconnect-loops on a still-listed-but-
+// output-dead session, which looks like a hang).
 //
-// The frame is the only client-visible signal that the shell ended;
-// the existing WebSocket test pair (this and the runtime-session
-// variant below) prove only that bytes flow during the session. They
-// silently passed when the bridge dropped the exit frame on the
-// outputDone path.
+// Uses the "pty-close-then-sleep" helper to deterministically open the
+// race window where drainOutput's PTY EOF precedes watchSession's
+// cmd.Wait return by hundreds of milliseconds. Without the bridge fix
+// (always send exit frame on outputDone), this test fails because the
+// 100ms timeout fires before attachment.Done — exactly the systemd-
+// run-wrapped shell case the user hit.
 func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
 	require := require.New(t)
 	cfg := &config.Config{
 		Shell: config.Shell{
-			Command: serverRuntimeHelperCommand("exit"),
+			Command: serverRuntimeHelperCommand("pty-close-then-sleep"),
 		},
 	}
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
@@ -14182,8 +14185,14 @@ func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
+	// Helper closes its PTY end immediately, then sleeps 750ms before
+	// exiting. The bridge's outputDone fires within milliseconds; an
+	// exit frame must still be delivered well before the helper's
+	// cmd.Wait return. 4 s is generous slack for slow CI without
+	// risking the test masking a frame that comes ONLY after cmd.Wait.
 	readCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
+	frameDeadline := time.Now().Add(400 * time.Millisecond)
 	for {
 		typ, data, readErr := conn.Read(readCtx)
 		if readErr != nil {
@@ -14195,25 +14204,41 @@ func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
 		if typ != websocket.MessageText {
 			continue
 		}
+		require.LessOrEqualf(
+			time.Now().Unix(), frameDeadline.Unix()+1,
+			"exit frame must arrive promptly after PTY EOF, "+
+				"not gated on the wrapper's cmd.Wait",
+		)
 		var msg struct {
 			Type string `json:"type"`
 			Code int    `json:"code"`
 		}
 		require.NoError(json.Unmarshal(data, &msg))
 		require.Equal("exited", msg.Type)
-		require.Equal(3, msg.Code)
+		// ExitCode may be 7 (cmd.Wait completed before writeRuntimeExit
+		// reads the snapshot) or -1 (writeRuntimeExit read snapshot
+		// before watchSession populated ExitCode). Both are "the
+		// session ended" signals the frontend treats identically;
+		// pinning a specific value would be timing-dependent. Reject
+		// 0 (success) — that would mean the frame leaked from a
+		// successful exit path that doesn't apply here.
+		require.NotEqual(0, msg.Code, "non-success exit must report non-zero (or -1)")
 		return
 	}
 }
 
 // TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E pins the
-// behavior that an EnsureShell call following a previous shell's exit
-// always returns a fresh session, never the dead one. Without the
-// runningSession outputClosed check, drainOutput's PTY EOF is observed
-// before watchSession's cmd.Wait returns; during that window the
-// session sits in m.shells with Status=Running but no live PTY, and
-// EnsureShell would reuse it — yielding a "starting" session whose
-// terminal never produces a single byte.
+// behavior that an EnsureShell call hitting the post-PTY-EOF /
+// pre-cmd.Wait-return window returns a fresh session, never the
+// zombie. Without the runningSession outputClosed check, EnsureShell
+// would hand the next caller a Status=Running snapshot whose Output
+// channel was already closed; the frontend would mount a TerminalPane
+// against it, immediately receive the exit frame (per the bridge
+// fix), auto-close — and on the next click do it all over again.
+//
+// Uses the "pty-close-then-sleep" helper so the zombie window is
+// deterministic (~750ms) and the second EnsureShell is guaranteed to
+// land inside it.
 func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 
@@ -14221,7 +14246,7 @@ func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
 	assert := Assert.New(t)
 	cfg := &config.Config{
 		Shell: config.Shell{
-			Command: serverRuntimeHelperCommand("exit"),
+			Command: serverRuntimeHelperCommand("pty-close-then-sleep"),
 		},
 	}
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
@@ -14236,9 +14261,10 @@ func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
 	require.NotNil(first.JSON200)
 	firstCreatedAt := first.JSON200.CreatedAt
 
-	// Drive the first shell to exit by attaching once. The "exit"
-	// helper exits immediately with code 3; bridgeRuntimeAttachment
-	// observes outputDone and closes.
+	// Attach + drain to drive the helper through its PTY-close. The
+	// helper then sleeps ~750 ms before exiting; we want EnsureShell
+	// to fire inside that sleep, when m.shells[key] still holds the
+	// zombie (Status=Running, outputClosed=true).
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
@@ -14246,6 +14272,7 @@ func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
 		"/runtime/shell/terminal?cols=80&rows=24"
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	require.NoError(err)
+	// Read until WS closes (server sends exit frame and drops conn).
 	for {
 		readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		_, _, readErr := conn.Read(readCtx)
@@ -14256,9 +14283,8 @@ func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
 	}
 	conn.Close(websocket.StatusNormalClosure, "done")
 
-	// Re-ensure right away — within the watchSession-completes window
-	// where the previous session can still be sitting in the manager
-	// map. The new shell must be a fresh one.
+	// Inside the zombie window: helper still sleeping, so cmd.Wait
+	// hasn't returned and watchSession hasn't run.
 	second, err := client.HTTP.EnsureWorkspaceRuntimeShellWithResponse(
 		ctx, ws.Id,
 	)
@@ -14267,7 +14293,7 @@ func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
 	require.NotNil(second.JSON200)
 	assert.NotEqual(
 		firstCreatedAt, second.JSON200.CreatedAt,
-		"second EnsureShell must return a fresh session, not the just-exited one",
+		"second EnsureShell must return a fresh session, not the zombie",
 	)
 	assert.Equal(string(localruntime.SessionStatusRunning), second.JSON200.Status)
 }
@@ -14714,6 +14740,21 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 		return
 	case "exit":
 		os.Exit(3)
+	case "pty-close-then-sleep":
+		// Simulate the systemd-run-wrapper window the bridge has to
+		// survive: PTY EOF observed (drainOutput exits) well before
+		// cmd.Wait returns. Ignoring SIGHUP keeps us alive when the
+		// runtime closes the PTY master in response to our slave
+		// close — without that, the kernel SIGHUPs the session leader
+		// and cmd.Wait returns alongside drainOutput, which hides the
+		// race we're trying to exercise. Closing stdin/stdout/stderr
+		// drops every slave fd; the master sees EOF immediately.
+		signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+		_ = os.Stdin.Close()
+		_ = os.Stdout.Close()
+		_ = os.Stderr.Close()
+		time.Sleep(750 * time.Millisecond)
+		os.Exit(7)
 	default:
 		os.Exit(2)
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14945,6 +14945,12 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	assert.Equal(db.WorkspaceItemTypePullRequest, createResp.JSON202.ItemType)
 	assert.Equal(int64(1), createResp.JSON202.ItemNumber)
 
+	// Wait for the async clone to finish before exercising the rest of the
+	// flow. Deleting (or letting the test end) while the clone subprocess is
+	// still writing into the workspace's TempDir races t.TempDir cleanup,
+	// which then fails with "directory not empty".
+	waitForWorkspaceReady(t, ctx, client, wsID)
+
 	// 3. Get workspace by ID.
 	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(
 		ctx, wsID,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14142,6 +14142,136 @@ func TestWorkspaceRuntimeShellTerminalWebSocketE2E(t *testing.T) {
 	require.Contains(got.String(), "echo:ping")
 }
 
+// TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E pins the
+// websocket "exited" text frame contract. Without it, the frontend's
+// ShellDrawer never fires its onExit handler, so the drawer doesn't
+// auto-close on shell exit and the user is stranded on a dead session
+// (TerminalPane reconnect-loops on a still-listed-but-output-dead
+// session, which looks like a hang).
+//
+// The frame is the only client-visible signal that the shell ended;
+// the existing WebSocket test pair (this and the runtime-session
+// variant below) prove only that bytes flow during the session. They
+// silently passed when the bridge dropped the exit frame on the
+// outputDone path.
+func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	cfg := &config.Config{
+		Shell: config.Shell{
+			Command: serverRuntimeHelperCommand("exit"),
+		},
+	}
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	shellResp, err := client.HTTP.EnsureWorkspaceRuntimeShellWithResponse(
+		ctx, ws.Id,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, shellResp.StatusCode())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/shell/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	readCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			require.Failf(
+				"never received exit frame",
+				"read err before exit frame: %v", readErr,
+			)
+		}
+		if typ != websocket.MessageText {
+			continue
+		}
+		var msg struct {
+			Type string `json:"type"`
+			Code int    `json:"code"`
+		}
+		require.NoError(json.Unmarshal(data, &msg))
+		require.Equal("exited", msg.Type)
+		require.Equal(3, msg.Code)
+		return
+	}
+}
+
+// TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E pins the
+// behavior that an EnsureShell call following a previous shell's exit
+// always returns a fresh session, never the dead one. Without the
+// runningSession outputClosed check, drainOutput's PTY EOF is observed
+// before watchSession's cmd.Wait returns; during that window the
+// session sits in m.shells with Status=Running but no live PTY, and
+// EnsureShell would reuse it — yielding a "starting" session whose
+// terminal never produces a single byte.
+func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	cfg := &config.Config{
+		Shell: config.Shell{
+			Command: serverRuntimeHelperCommand("exit"),
+		},
+	}
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	first, err := client.HTTP.EnsureWorkspaceRuntimeShellWithResponse(
+		ctx, ws.Id,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, first.StatusCode())
+	require.NotNil(first.JSON200)
+	firstCreatedAt := first.JSON200.CreatedAt
+
+	// Drive the first shell to exit by attaching once. The "exit"
+	// helper exits immediately with code 3; bridgeRuntimeAttachment
+	// observes outputDone and closes.
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/shell/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	for {
+		readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		_, _, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			break
+		}
+	}
+	conn.Close(websocket.StatusNormalClosure, "done")
+
+	// Re-ensure right away — within the watchSession-completes window
+	// where the previous session can still be sitting in the manager
+	// map. The new shell must be a fresh one.
+	second, err := client.HTTP.EnsureWorkspaceRuntimeShellWithResponse(
+		ctx, ws.Id,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, second.StatusCode())
+	require.NotNil(second.JSON200)
+	assert.NotEqual(
+		firstCreatedAt, second.JSON200.CreatedAt,
+		"second EnsureShell must return a fresh session, not the just-exited one",
+	)
+	assert.Equal(string(localruntime.SessionStatusRunning), second.JSON200.Status)
+}
+
 func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -270,15 +270,18 @@ func bridgeRuntimeAttachment(
 		cancel()
 		return false
 	case <-outputDone:
-		select {
-		case <-attachment.Done:
-			cancel()
-			writeRuntimeExit(conn, attachment.Info())
-			return true
-		case <-time.After(100 * time.Millisecond):
-			cancel()
-			return false
-		}
+		// Output channel closed = drainOutput observed PTY EOF, which
+		// is the client-visible "session is over" signal. Process exit
+		// (attachment.Done) follows in a separate goroutine and can lag
+		// noticeably when the session is wrapped (e.g. systemd-run
+		// --wait collecting the transient unit), so don't gate the exit
+		// frame on it — clients that miss the frame reconnect-loop on a
+		// dead session and never fire their onExit handler. ExitCode
+		// may not be populated yet; writeRuntimeExit emits -1 in that
+		// case, which the frontend treats the same as any other exit.
+		cancel()
+		writeRuntimeExit(conn, attachment.Info())
+		return true
 	case <-ctx.Done():
 		return false
 	}

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -270,18 +270,31 @@ func bridgeRuntimeAttachment(
 		cancel()
 		return false
 	case <-outputDone:
-		// Output channel closed = drainOutput observed PTY EOF, which
-		// is the client-visible "session is over" signal. Process exit
-		// (attachment.Done) follows in a separate goroutine and can lag
-		// noticeably when the session is wrapped (e.g. systemd-run
-		// --wait collecting the transient unit), so don't gate the exit
-		// frame on it — clients that miss the frame reconnect-loop on a
-		// dead session and never fire their onExit handler. ExitCode
-		// may not be populated yet; writeRuntimeExit emits -1 in that
-		// case, which the frontend treats the same as any other exit.
+		// outputDone fires when the per-subscriber Output channel
+		// closes. There are two distinct reasons that can happen:
+		//
+		//   1. drainOutput observed PTY EOF and closed every
+		//      subscriber via closeSubscribers. The session itself
+		//      is over; send the "exited" frame so the client's
+		//      onExit fires. attachment.Done follows in a separate
+		//      goroutine and can lag noticeably for wrapped sessions
+		//      (systemd-run --wait collecting the transient unit),
+		//      so we do NOT gate the frame on attachment.Done —
+		//      ExitCode may be nil and writeRuntimeExit emits -1,
+		//      which the frontend treats identically.
+		//
+		//   2. broadcast dropped this subscriber because its 64-slot
+		//      buffer filled (slow client, congested writer, etc.).
+		//      The session is still running, and reporting "exited"
+		//      here would auto-close the drawer on a healthy shell.
+		//      Close the websocket without an exit frame; the client
+		//      can reconnect and resubscribe from the replay buffer.
 		cancel()
-		writeRuntimeExit(conn, attachment.Info())
-		return true
+		if attachment.SessionOutputClosed() {
+			writeRuntimeExit(conn, attachment.Info())
+			return true
+		}
+		return false
 	case <-ctx.Done():
 		return false
 	}

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -263,8 +263,11 @@ func bridgeRuntimeAttachment(
 		case <-outputDone:
 		case <-time.After(100 * time.Millisecond):
 		}
-		cancel()
+		// Write the frame BEFORE cancel: coder/websocket tears down
+		// the underlying connection when the input goroutine's
+		// Read context is canceled, which races our Write.
 		writeRuntimeExit(conn, attachment.Info())
+		cancel()
 		return true
 	case <-inputDone:
 		cancel()
@@ -289,12 +292,19 @@ func bridgeRuntimeAttachment(
 		//      here would auto-close the drawer on a healthy shell.
 		//      Close the websocket without an exit frame; the client
 		//      can reconnect and resubscribe from the replay buffer.
-		cancel()
-		if attachment.SessionOutputClosed() {
+		//
+		// Order matters: write the exit frame BEFORE cancel(). The
+		// input goroutine's conn.Read uses ctx, and coder/websocket
+		// tears down the underlying TCP connection when that ctx is
+		// canceled. Cancelling first races writeRuntimeExit's Write
+		// against socket teardown — the Write loses ~25 % of the
+		// time and the frame never reaches the client.
+		closed := attachment.SessionOutputClosed()
+		if closed {
 			writeRuntimeExit(conn, attachment.Info())
-			return true
 		}
-		return false
+		cancel()
+		return closed
 	case <-ctx.Done():
 		return false
 	}

--- a/internal/server/workspace_runtime_terminal.go
+++ b/internal/server/workspace_runtime_terminal.go
@@ -115,6 +115,26 @@ func (s *Server) serveRuntimeTerminal(
 		if err := attachment.Resize(cols, rows); err != nil {
 			slog.Warn("runtime terminal initial resize", "err", err)
 		}
+		// pty.Setsize SIGWINCHs the foreground process of the master,
+		// but for tmux-backed sessions the pane refit happens via
+		// async client-to-server IPC. If the bridge starts forwarding
+		// client input before that refit lands, the agent inside the
+		// pane sees the pre-resize geometry. Refresh runs
+		// `tmux refresh-client` against the attached client, which
+		// is a synchronous round-trip to the tmux server and forces
+		// it to drain any pending resize messages from the client
+		// before returning. For non-tmux sessions, refresh is a
+		// no-op. The 2 s budget mirrors the bridge's resize/refresh
+		// control handler.
+		refreshCtx, refreshCancel := context.WithTimeout(
+			r.Context(), 2*time.Second,
+		)
+		if err := attachment.Refresh(refreshCtx); err != nil {
+			slog.Warn(
+				"runtime terminal initial refresh", "err", err,
+			)
+		}
+		refreshCancel()
 	}
 
 	exited := bridgeRuntimeAttachment(r.Context(), conn, attachment)

--- a/internal/workspace/localruntime/attachment_testing.go
+++ b/internal/workspace/localruntime/attachment_testing.go
@@ -1,0 +1,37 @@
+package localruntime
+
+// AttachmentForTestingOptions configures NewAttachmentForTesting.
+// Output and Done are required; sessionOutputClosed lets callers
+// distinguish a real session exit from a per-subscriber drop, which
+// is the contract bridge code in internal/server depends on. Other
+// fields default to no-ops; tests that exercise resize / refresh /
+// write callbacks should set them explicitly.
+type AttachmentForTestingOptions struct {
+	Output              <-chan []byte
+	Done                <-chan struct{}
+	Info                func() SessionInfo
+	SessionOutputClosed func() bool
+}
+
+// NewAttachmentForTesting constructs an Attachment with caller-
+// controlled channels and inspector funcs. Test-only escape hatch:
+// the bridge code in internal/server has to be exercised against
+// channel/lifecycle scenarios that are awkward to drive end-to-end
+// (slow-subscriber drops, ordered close races), and the production
+// constructor (attachToSession) hides too much state for that.
+func NewAttachmentForTesting(opts AttachmentForTestingOptions) *Attachment {
+	info := opts.Info
+	if info == nil {
+		info = func() SessionInfo { return SessionInfo{} }
+	}
+	sessionOutputClosed := opts.SessionOutputClosed
+	if sessionOutputClosed == nil {
+		sessionOutputClosed = func() bool { return false }
+	}
+	return &Attachment{
+		Output:              opts.Output,
+		Done:                opts.Done,
+		info:                info,
+		sessionOutputClosed: sessionOutputClosed,
+	}
+}

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -159,6 +159,13 @@ type Attachment struct {
 	resize  func(cols, rows int) error
 	refresh func(context.Context) error
 	close   func()
+
+	// sessionOutputClosed reports whether the underlying session's
+	// PTY EOF has been observed by drainOutput (s.outputClosed=true).
+	// The Output channel can also close because broadcast dropped
+	// this subscriber for falling behind; that is not a session exit
+	// and bridges must not propagate it as one.
+	sessionOutputClosed func() bool
 }
 
 func NewManager(options Options) *Manager {
@@ -1009,6 +1016,19 @@ func (a *Attachment) Close() {
 	}
 }
 
+// SessionOutputClosed reports whether the session's drainOutput has
+// observed PTY EOF — i.e. the session itself ended, not merely this
+// attachment's per-subscriber channel. Bridges use it to tell a real
+// session exit (send the "exited" frame) from a slow-subscriber drop
+// (broadcast closed our channel because we fell behind; the session
+// is still running and any reconnect should resubscribe).
+func (a *Attachment) SessionOutputClosed() bool {
+	if a == nil || a.sessionOutputClosed == nil {
+		return false
+	}
+	return a.sessionOutputClosed()
+}
+
 func (m *Manager) ShellSession(workspaceID string) *SessionInfo {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1328,19 +1348,28 @@ func (m *Manager) runningSession(
 		delete(sessions, key)
 		return nil
 	}
-	// drainOutput closes outputClosed as soon as the PTY hits EOF, but
-	// watchSession only marks Status=Exited once cmd.Wait returns —
-	// which can lag noticeably for wrapped commands (systemd-run
-	// --wait, etc.). Treating those output-dead sessions as still
-	// "running" hands callers a zombie they can attach to but never
-	// receive any bytes from. Reject them so EnsureShell/Launch start
-	// a fresh session; the lingering watchSession will overwrite-or-
-	// skip the map entry on its own (removeExitedSession's identity
-	// check guards against double-cleanup).
+	// drainOutput closes outputClosed as soon as the PTY hits EOF,
+	// but watchSession only marks Status=Exited once cmd.Wait
+	// returns — which can lag noticeably for wrapped commands
+	// (systemd-run --wait, etc.). Treating those output-dead
+	// sessions as still "running" hands callers a zombie they can
+	// attach to but never receive any bytes from. Reject the zombie
+	// so EnsureShell/Launch start a fresh session.
+	//
+	// The caller will overwrite our map entry with the new session,
+	// which means we are about to lose our only handle to the old
+	// process. If its wrapper is still in cmd.Wait (zsh exited but
+	// systemd-run is still tearing down the transient unit), or
+	// worse, hung indefinitely, Manager.Shutdown can no longer
+	// reach it. stop() it now: SIGKILL the process group and close
+	// the master so cmd.Wait returns and the goroutine can finish.
+	// removeExitedSession's identity check (current != s) guards
+	// against double-cleanup once the new session is in place.
 	s.mu.Lock()
 	outputClosed := s.outputClosed
 	s.mu.Unlock()
 	if outputClosed {
+		s.stop()
 		return nil
 	}
 	return s
@@ -1935,5 +1964,10 @@ func attachToSession(
 			return refresh(ctx, s)
 		},
 		close: unsubscribe,
+		sessionOutputClosed: func() bool {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			return s.outputClosed
+		},
 	}, nil
 }

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -1323,12 +1323,27 @@ func (m *Manager) runningSession(
 		return nil
 	}
 	info := s.snapshot()
-	if info.Status == SessionStatusRunning ||
-		info.Status == SessionStatusStarting {
-		return s
+	if info.Status != SessionStatusRunning &&
+		info.Status != SessionStatusStarting {
+		delete(sessions, key)
+		return nil
 	}
-	delete(sessions, key)
-	return nil
+	// drainOutput closes outputClosed as soon as the PTY hits EOF, but
+	// watchSession only marks Status=Exited once cmd.Wait returns —
+	// which can lag noticeably for wrapped commands (systemd-run
+	// --wait, etc.). Treating those output-dead sessions as still
+	// "running" hands callers a zombie they can attach to but never
+	// receive any bytes from. Reject them so EnsureShell/Launch start
+	// a fresh session; the lingering watchSession will overwrite-or-
+	// skip the map entry on its own (removeExitedSession's identity
+	// check guards against double-cleanup).
+	s.mu.Lock()
+	outputClosed := s.outputClosed
+	s.mu.Unlock()
+	if outputClosed {
+		return nil
+	}
+	return s
 }
 
 func (m *Manager) session(

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -946,6 +946,63 @@ func TestManagerShellSingletonPerWorkspace(t *testing.T) {
 	assert.Empty(mgr.ListSessions("ws-1"))
 }
 
+// TestManagerEnsureShellSkipsZombieSessions pins the runningSession
+// outputClosed check that prevents EnsureShell from returning a
+// session whose drainOutput already saw PTY EOF but whose
+// watchSession's cmd.Wait hasn't fired yet.
+//
+// Wrapped shells (systemd-run --wait, etc.) routinely sit in this
+// "output dead, status still Running" window after the inner zsh
+// exits while the wrapper does its cleanup. Without this guard,
+// EnsureShell would hand the next caller a snapshot of the zombie:
+// status=Running, but a closed Output channel that yields nothing.
+// The frontend then mounts a TerminalPane, attaches, gets the exit
+// frame instantly, auto-closes — and on the user's next click does
+// it all over again until the zombie is finally collected. From the
+// user's seat that looks like a hang.
+func TestManagerEnsureShellSkipsZombieSessions(t *testing.T) {
+	requirePTYAvailable(t)
+	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	mgr := NewManager(Options{
+		ShellCommand: helperCommand("sleep"),
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	first, err := mgr.EnsureShell(ctx, "ws-1", t.TempDir())
+	require.NoError(err)
+	require.Equal(SessionStatusRunning, first.Status)
+
+	// Reach into the manager state and synthesize the zombie window:
+	// outputClosed flipped while the watchSession goroutine is still
+	// blocked on cmd.Wait (the helperCommand("sleep") process never
+	// exits, so cmd.Wait won't return until Shutdown kills it).
+	mgr.mu.Lock()
+	s := mgr.shells[first.Key]
+	mgr.mu.Unlock()
+	require.NotNil(s, "shell session should be in m.shells")
+	s.mu.Lock()
+	s.outputClosed = true
+	s.mu.Unlock()
+
+	second, err := mgr.EnsureShell(ctx, "ws-1", t.TempDir())
+	require.NoError(err)
+	assert.Equal(SessionStatusRunning, second.Status)
+	assert.NotEqual(
+		first.CreatedAt, second.CreatedAt,
+		"EnsureShell after a zombie must return a fresh session",
+	)
+	// The new session replaces the zombie in the map.
+	mgr.mu.Lock()
+	current := mgr.shells[first.Key]
+	mgr.mu.Unlock()
+	assert.NotSame(s, current,
+		"the zombie should have been replaced, not reused")
+}
+
 func TestManagerShellConcurrentStartsOneProcess(t *testing.T) {
 	requirePTYAvailable(t)
 	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -1057,31 +1057,27 @@ func TestAttachmentSessionOutputClosedDistinguishesSubscriberDrop(t *testing.T) 
 	require.NotNil(s)
 
 	// Force the broadcast-drops-subscriber path: the channel buffer
-	// is 64. We do not consume from attach.Output, so 65+ broadcasts
-	// will eventually trigger broadcast's `default` branch (drop +
-	// close). Stop as soon as the channel is observed closed.
-	dropped := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case _, ok := <-attach.Output:
-				if !ok {
-					close(dropped)
-					return
-				}
-			case <-time.After(2 * time.Second):
-				return
-			}
-		}
-	}()
+	// is 64, so the 65th broadcast that can't enqueue takes the
+	// `default` branch and closes the channel. Run the broadcasts
+	// synchronously WITHOUT a concurrent consumer — a parallel
+	// reader could drain the buffer faster than we fill it and the
+	// drop would never trigger. Drain afterward to confirm closure.
 	for range 200 {
 		s.broadcast([]byte("x"))
 	}
-	select {
-	case <-dropped:
-	case <-time.After(2 * time.Second):
-		require.Fail("broadcast never dropped the slow subscriber")
+	drained := 0
+	for {
+		_, ok := <-attach.Output
+		if !ok {
+			break
+		}
+		drained++
+		require.Less(drained, 200,
+			"channel never closed; broadcast did not drop the "+
+				"slow subscriber")
 	}
+	assert.LessOrEqual(drained, 64,
+		"buffer is 64; drop should fire by the 65th broadcast")
 
 	// Subscriber dropped, but the session itself is still healthy
 	// (helperCommand("sleep") is still running and drainOutput has

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -1066,15 +1066,27 @@ func TestAttachmentSessionOutputClosedDistinguishesSubscriberDrop(t *testing.T) 
 		s.broadcast([]byte("x"))
 	}
 	drained := 0
+drain:
 	for {
-		_, ok := <-attach.Output
-		if !ok {
-			break
+		// Bound the receive: if broadcast regresses and never
+		// closes the channel, the buffered messages drain and the
+		// next receive would block forever, hanging the test
+		// process instead of failing it.
+		select {
+		case _, ok := <-attach.Output:
+			if !ok {
+				break drain
+			}
+			drained++
+			require.Less(drained, 200,
+				"channel never closed; broadcast did not "+
+					"drop the slow subscriber")
+		case <-time.After(2 * time.Second):
+			require.Fail(
+				"timed out waiting for channel close; " +
+					"broadcast did not drop the slow subscriber",
+			)
 		}
-		drained++
-		require.Less(drained, 200,
-			"channel never closed; broadcast did not drop the "+
-				"slow subscriber")
 	}
 	assert.LessOrEqual(drained, 64,
 		"buffer is 64; drop should fire by the 65th broadcast")

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -1001,6 +1001,101 @@ func TestManagerEnsureShellSkipsZombieSessions(t *testing.T) {
 	mgr.mu.Unlock()
 	assert.NotSame(s, current,
 		"the zombie should have been replaced, not reused")
+
+	// Once the zombie is no longer in the map, Manager.Shutdown
+	// can't reach it. EnsureShell must therefore reap it inline:
+	// SIGKILL the process group so cmd.Wait returns and the
+	// per-session watchSession goroutine completes (closing s.done).
+	// helperCommand("sleep") would otherwise block forever.
+	require.Eventually(func() bool {
+		select {
+		case <-s.done:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond,
+		"zombie's process must be killed and reaped, not orphaned")
+}
+
+// TestAttachmentSessionOutputClosedDistinguishesSubscriberDrop covers
+// the contract bridges rely on to tell a real session exit from a
+// dropped subscriber: a closed Output channel can mean either, and
+// auto-closing the drawer on the latter would hang the user out on a
+// healthy shell.
+//
+// broadcast drops a subscriber when its 64-slot buffer can't accept
+// another chunk (slow client / congested writer). drainOutput's PTY
+// EOF, in contrast, runs closeSubscribers which flips s.outputClosed
+// before closing every subscriber channel. SessionOutputClosed
+// exposes that distinction to bridge code.
+func TestAttachmentSessionOutputClosedDistinguishesSubscriberDrop(t *testing.T) {
+	requirePTYAvailable(t)
+	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	mgr := NewManager(Options{ShellCommand: helperCommand("sleep")})
+	t.Cleanup(mgr.Shutdown)
+
+	shell, err := mgr.EnsureShell(ctx, "ws-1", t.TempDir())
+	require.NoError(err)
+
+	attach, err := mgr.AttachShell("ws-1")
+	require.NoError(err)
+	t.Cleanup(attach.Close)
+	require.Equal(shell.Key, attach.Info().Key)
+
+	// Healthy session: SessionOutputClosed must report false.
+	assert.False(attach.SessionOutputClosed(),
+		"freshly-attached session should not look output-closed")
+
+	mgr.mu.Lock()
+	s := mgr.shells[shell.Key]
+	mgr.mu.Unlock()
+	require.NotNil(s)
+
+	// Force the broadcast-drops-subscriber path: the channel buffer
+	// is 64. We do not consume from attach.Output, so 65+ broadcasts
+	// will eventually trigger broadcast's `default` branch (drop +
+	// close). Stop as soon as the channel is observed closed.
+	dropped := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case _, ok := <-attach.Output:
+				if !ok {
+					close(dropped)
+					return
+				}
+			case <-time.After(2 * time.Second):
+				return
+			}
+		}
+	}()
+	for range 200 {
+		s.broadcast([]byte("x"))
+	}
+	select {
+	case <-dropped:
+	case <-time.After(2 * time.Second):
+		require.Fail("broadcast never dropped the slow subscriber")
+	}
+
+	// Subscriber dropped, but the session itself is still healthy
+	// (helperCommand("sleep") is still running and drainOutput has
+	// not seen PTY EOF). SessionOutputClosed must NOT be true here —
+	// otherwise the bridge would emit "exited" on a live shell.
+	assert.False(attach.SessionOutputClosed(),
+		"subscriber drop must not be misreported as session exit")
+
+	// Now simulate the real session-exit path. closeSubscribers is
+	// what drainOutput calls on PTY EOF; it flips outputClosed.
+	s.closeSubscribers()
+	assert.True(attach.SessionOutputClosed(),
+		"after drainOutput's closeSubscribers, the bridge must see "+
+			"the session as output-closed and emit the exit frame")
 }
 
 func TestManagerShellConcurrentStartsOneProcess(t *testing.T) {


### PR DESCRIPTION
Stacked on #289.

## Summary

- Bridge: `bridgeRuntimeAttachment` always sends the `{"type":"exited"}` text frame when `outputDone` fires. The previous 100ms race against `attachment.Done` silently dropped the frame for any session whose `cmd.Wait` lagged behind PTY EOF — the systemd-run-wrapped shell case, where the wrapper's own teardown easily exceeds 100ms. Without the frame, the frontend's TerminalPane never fired `onExit`, so the drawer didn't auto-close and the WS reconnected forever onto a dead session.
- Runtime manager: `runningSession` now also rejects sessions whose `outputClosed` flag is set. `drainOutput` flips that flag at PTY EOF, but `watchSession` only marks `Status=Exited` when `cmd.Wait` returns; in between, callers were getting a "zombie" snapshot — `Status=Running` with a closed Output channel — that mounted a TerminalPane against a session that would never produce a byte.
- New tests pin the exit-frame contract (no existing test covered it — that's how the regression slipped past the previous PR), a fresh-session-after-exit contract, and the zombie skip in `runningSession`.