### PR TITLE
fix: expand PR commit details

### DIFF
--- a/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
+++ b/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
@@ -35,6 +35,10 @@ async function openTimelineFilters(page: Page): Promise<void> {
   await expect(page.locator(".filter-dropdown")).toBeVisible();
 }
 
+function cacheCommitRow(page: Page) {
+  return page.locator(".event--compact", { hasText: "abc1111" }).first();
+}
+
 test.describe("PR timeline filters", () => {
   test.beforeEach(async ({ page }) => {
     await gotoWithWebKitRetry(page, "/");
@@ -62,13 +66,15 @@ test.describe("PR timeline filters", () => {
   test("keeps commit rows while hiding and restoring system event buckets", async ({ page }) => {
     await openPRTimeline(page);
     await openTimelineFilters(page);
+    const commitRow = cacheCommitRow(page);
 
     await page.getByRole("button", { name: "Commit details" }).click();
-    await expect(page.getByText("feat: add cache store")).toBeVisible();
-    await expect(page.getByText("Cache entries now expire")).not.toBeVisible();
+    await expect(commitRow.locator(".commit-title")).toHaveText("feat: add cache store");
+    await expect(commitRow.locator(".commit-body-details")).toHaveCount(0);
     await page.getByRole("button", { name: "Commit details" }).click();
-    await expect(page.getByText("feat: add cache store")).toBeVisible();
-    await expect(page.getByText("Cache entries now expire")).toBeVisible();
+    await expect(commitRow.locator(".commit-title")).toHaveCount(0);
+    await expect(commitRow.locator(".commit-body-details"))
+      .toContainText("Cache entries now expire");
 
     await page.getByRole("button", { name: "Events" }).click();
     await expect(page.getByText("Widget rendering broken on Safari"))
@@ -118,9 +124,10 @@ test.describe("PR timeline filters", () => {
     await page.getByRole("button", { name: "Commit details" }).click();
     await page.getByRole("button", { name: "Events" }).click();
     await page.getByRole("button", { name: "Force pushes" }).click();
+    const commitRow = cacheCommitRow(page);
 
-    await expect(page.getByText("feat: add cache store")).toBeVisible();
-    await expect(page.getByText("Cache entries now expire")).not.toBeVisible();
+    await expect(commitRow.locator(".commit-title")).toHaveText("feat: add cache store");
+    await expect(commitRow.locator(".commit-body-details")).toHaveCount(0);
     await expect(page.getByText("No activity matches the current filters"))
       .not.toBeVisible();
   });

--- a/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
+++ b/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
@@ -25,6 +25,7 @@ async function openPRTimeline(page: Page): Promise<void> {
   await page.locator(".pull-detail")
     .waitFor({ state: "visible", timeout: 10_000 });
   await expect(page.getByText("feat: add cache store")).toBeVisible();
+  await expect(page.getByText("Cache entries now expire")).toBeVisible();
   await expect(page.getByText("Widget rendering broken on Safari"))
     .toBeVisible();
 }
@@ -58,14 +59,16 @@ test.describe("PR timeline filters", () => {
     await expect(page.getByText("develop -> main")).toBeVisible();
   });
 
-  test("hides and restores commit and system event buckets", async ({ page }) => {
+  test("keeps commit rows while hiding and restoring system event buckets", async ({ page }) => {
     await openPRTimeline(page);
     await openTimelineFilters(page);
 
     await page.getByRole("button", { name: "Commit details" }).click();
-    await expect(page.getByText("feat: add cache store")).not.toBeVisible();
+    await expect(page.getByText("feat: add cache store")).toBeVisible();
+    await expect(page.getByText("Cache entries now expire")).not.toBeVisible();
     await page.getByRole("button", { name: "Commit details" }).click();
     await expect(page.getByText("feat: add cache store")).toBeVisible();
+    await expect(page.getByText("Cache entries now expire")).toBeVisible();
 
     await page.getByRole("button", { name: "Events" }).click();
     await expect(page.getByText("Widget rendering broken on Safari"))
@@ -107,19 +110,18 @@ test.describe("PR timeline filters", () => {
       .toContainText("1");
   });
 
-  test(
-    "shows a filtered-empty state when every event bucket is hidden",
-    async ({ page }) => {
-      await openPRTimeline(page);
-      await openTimelineFilters(page);
+  test("keeps commit rows when other event buckets are hidden", async ({ page }) => {
+    await openPRTimeline(page);
+    await openTimelineFilters(page);
 
-      await page.getByRole("button", { name: "Messages" }).click();
-      await page.getByRole("button", { name: "Commit details" }).click();
-      await page.getByRole("button", { name: "Events" }).click();
-      await page.getByRole("button", { name: "Force pushes" }).click();
+    await page.getByRole("button", { name: "Messages" }).click();
+    await page.getByRole("button", { name: "Commit details" }).click();
+    await page.getByRole("button", { name: "Events" }).click();
+    await page.getByRole("button", { name: "Force pushes" }).click();
 
-      await expect(page.getByText("No activity matches the current filters"))
-        .toBeVisible();
-    },
-  );
+    await expect(page.getByText("feat: add cache store")).toBeVisible();
+    await expect(page.getByText("Cache entries now expire")).not.toBeVisible();
+    await expect(page.getByText("No activity matches the current filters"))
+      .not.toBeVisible();
+  });
 });

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -488,7 +488,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			EventType:      "commit",
 			Author:         "alice",
 			Summary:        "abc1111",
-			Body:           "feat: add cache store",
+			Body:           "feat: add cache store\n\nCache entries now expire when pull request detail data is refreshed.",
 			CreatedAt:      commitBase,
 			DedupeKey:      "w1-commit-1",
 		},

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -72,9 +72,8 @@
     return body.split(/\r?\n/, 1)[0] ?? "";
   }
 
-  function commitBodyDetails(body: string): string {
-    const lines = body.split(/\r?\n/);
-    return lines.slice(1).join("\n").trim();
+  function commitDetailsBody(body: string): string {
+    return body.trim();
   }
 
   function systemEventLabel(eventType: string): string {
@@ -191,7 +190,7 @@
         </div>
         {#if isCompactEvent(event.EventType)}
           {@const metadata = parseMetadata(event)}
-          {@const commitDetails = event.EventType === "commit" ? commitBodyDetails(event.Body) : ""}
+          {@const commitDetails = event.EventType === "commit" ? commitDetailsBody(event.Body) : ""}
           <div class="event-card event-card--compact">
             <div class="event-header event-header--compact">
               <span
@@ -205,7 +204,9 @@
               {/if}
               {#if event.EventType === "commit"}
                 <span class="commit-sha">{shortCommit(event.Summary)}</span>
-                <span class="commit-title">{commitTitle(event.Body)}</span>
+                {#if !showCommitDetails}
+                  <span class="commit-title">{commitTitle(event.Body)}</span>
+                {/if}
                 <span class="event-time">{timeAgo(event.CreatedAt)}</span>
               {:else if event.EventType === "cross_referenced"}
                 {@const sourceUrl = metadataString(metadata, "source_url")}

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -110,7 +110,7 @@ describe("EventTimeline", () => {
     expect(bodyStyle.getPropertyValue("border-radius")).toBe("");
   });
 
-  it("renders commit events as compact one-line commit detail rows", () => {
+  it("renders commit events as expanded commit detail rows", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-06-01T16:00:00Z"));
 
@@ -127,11 +127,12 @@ describe("EventTimeline", () => {
     });
 
     expect(screen.getByText("abcdef1")).toBeTruthy();
-    expect(screen.getByText("feat: add timeline filters")).toBeTruthy();
-    expect(screen.getByText("Long body")).toBeTruthy();
+    expect(
+      document.querySelector(".commit-body-details")?.textContent?.trim(),
+    ).toBe("feat: add timeline filters\n\nLong body");
     expect(screen.getByText("4h ago")).toBeTruthy();
     expect(document.querySelector(".event--compact")).toBeTruthy();
-    expect(document.querySelector(".commit-title")).toBeTruthy();
+    expect(document.querySelector(".commit-title")).toBeNull();
     expect(
       document.querySelector(".commit-body-details")?.classList.contains("event-body"),
     ).toBe(true);
@@ -141,6 +142,29 @@ describe("EventTimeline", () => {
         ?.lastElementChild
         ?.classList.contains("event-time"),
     ).toBe(true);
+  });
+
+  it("expands single-line commit messages when commit details are shown", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T16:00:00Z"));
+
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            EventType: "commit",
+            Summary: "abcdef1234567890",
+            Body: "refactor: simplify worktree mapping application",
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getByText("abcdef1")).toBeTruthy();
+    expect(
+      document.querySelector(".commit-body-details")?.textContent?.trim(),
+    ).toBe("refactor: simplify worktree mapping application");
+    expect(document.querySelector(".commit-title")).toBeNull();
   });
 
   it("can hide commit body details while keeping the title row", () => {

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -160,7 +160,7 @@ describe("prTimelineFilter", () => {
         showForcePushes: true,
         hideBots: false,
       }).map((item) => item.ID),
-    ).toEqual([2]);
+    ).toEqual([1, 2]);
   });
 
   it("filters by disabled buckets and bots", () => {
@@ -180,7 +180,7 @@ describe("prTimelineFilter", () => {
         showForcePushes: false,
         hideBots: true,
       }).map((item) => item.ID),
-    ).toEqual([1, 5]);
+    ).toEqual([1, 3, 5]);
   });
 
   it("counts active timeline filters", () => {

--- a/packages/ui/src/components/detail/prTimelineFilter.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.ts
@@ -111,7 +111,7 @@ export function filterPREvents(
       case "messages":
         return filter.showMessages;
       case "commitDetails":
-        return filter.showCommitDetails;
+        return true;
       case "events":
         return filter.showEvents;
       case "forcePushes":


### PR DESCRIPTION
- keep PR commit rows visible when Commit details is toggled off
- render the full commit message in the detail body when Commit details is toggled on
- add unit and e2e coverage for single-line and multi-line commit messages

Validation:
- bun run test packages/ui/src/components/detail/EventTimeline.test.ts packages/ui/src/components/detail/prTimelineFilter.test.ts
- bun run test:e2e pr-timeline-filters.spec.ts
- bun run typecheck