### PR TITLE
Use readable routes for PR and issue details

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -230,7 +230,7 @@ describe("AppHeader", () => {
     await fireEvent.click(screen.getByRole("button", { name: "PRs" }));
 
     expect(window.location.pathname + window.location.search).toBe(
-      "/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1",
+      "/pulls/github/acme/widgets/1/files",
     );
   });
 
@@ -242,7 +242,7 @@ describe("AppHeader", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Issues" }));
 
     expect(window.location.pathname + window.location.search).toBe(
-      "/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=10",
+      "/host/ghe.example.com/issues/github/acme/widgets/10",
     );
   });
 

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -630,7 +630,7 @@ describe("RepoSummaryPage", () => {
         "github.com/acme/widgets",
       );
       expect(mockNavigate).toHaveBeenCalledWith(
-        "/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=27",
+        "/issues/github/acme/widgets/27",
       );
     });
   });
@@ -698,7 +698,7 @@ describe("RepoSummaryPage", () => {
     });
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        "/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=27",
+        "/issues/github/acme/widgets/27",
       );
     });
   });
@@ -827,7 +827,7 @@ describe("RepoSummaryPage", () => {
         "ghe.example.com/acme/widgets",
       );
       expect(mockNavigate).toHaveBeenCalledWith(
-        "/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=42",
+        "/host/ghe.example.com/issues/github/acme/widgets/42",
       );
     });
   });

--- a/frontend/src/lib/stores/router.initialization.test.ts
+++ b/frontend/src/lib/stores/router.initialization.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const issueRoute =
-  "/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidget&number=7";
+  "/host/ghe.example.com/issues/github/acme/widget/7";
 
 async function importRouterAt(path: string) {
   vi.resetModules();
@@ -15,7 +15,7 @@ describe("router initialization", () => {
     vi.resetModules();
   });
 
-  it("preserves provider issue query state on initial load", async () => {
+  it("preserves provider issue route state on initial load", async () => {
     const { getRoute } = await importRouterAt(issueRoute);
 
     expect(getRoute()).toEqual({
@@ -31,7 +31,7 @@ describe("router initialization", () => {
     });
   });
 
-  it("preserves provider issue query state on popstate", async () => {
+  it("preserves provider issue route state on popstate", async () => {
     const { getRoute } = await importRouterAt("/issues");
 
     window.history.pushState(null, "", issueRoute);

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -5,6 +5,7 @@ import {
   type RepositoryRouteRef,
   type RoutedItemRef,
 } from "@middleman/ui/routes";
+import { canonicalProvider } from "@middleman/ui/api/provider-routes";
 
 export type RepoRef = RepositoryRouteRef;
 export type NumberedItemRef = NumberedRouteItemRef;
@@ -52,27 +53,64 @@ function currentLocationPath(): string {
   return window.location.pathname + window.location.search;
 }
 
-function parseProviderNumberedRef(search: string): NumberedItemRef | undefined {
-  const sp = new URLSearchParams(search);
-  const provider = sp.get("provider")?.trim();
-  const repoPath = sp.get("repo_path")?.replace(/^\/+|\/+$/g, "");
-  const numberText = sp.get("number");
-  if (!provider || !repoPath || !numberText) return undefined;
+const defaultPlatformHosts: Record<string, string> = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+};
+
+function defaultPlatformHost(provider: string): string | undefined {
+  return defaultPlatformHosts[canonicalProvider(provider)];
+}
+
+function decodeRouteSegment(segment: string): string | undefined {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseProviderNumberedPath(
+  parts: string[],
+  start: number,
+  platformHost?: string | undefined,
+): NumberedItemRef | undefined {
+  if (parts.length < start + 4) return undefined;
+  const provider = decodeRouteSegment(parts[start] ?? "")?.trim();
+  const owner = decodeRouteSegment(parts[start + 1] ?? "")?.replace(/^\/+|\/+$/g, "");
+  const name = decodeRouteSegment(parts[start + 2] ?? "")?.replace(/^\/+|\/+$/g, "");
+  const numberText = decodeRouteSegment(parts[start + 3] ?? "");
+  if (!provider || !owner || !name || !numberText) return undefined;
 
   const number = parseInt(numberText, 10);
-  const pathParts = repoPath.split("/").filter(Boolean);
-  if (!Number.isFinite(number) || number <= 0 || pathParts.length < 2) return undefined;
+  if (!Number.isFinite(number) || number <= 0) return undefined;
 
-  const platformHost = sp.get("platform_host") ?? undefined;
+  const resolvedPlatformHost = platformHost ?? defaultPlatformHost(provider);
   const ref: NumberedItemRef = {
     provider,
-    owner: pathParts.slice(0, -1).join("/"),
-    name: pathParts[pathParts.length - 1]!,
+    owner,
+    name,
     number,
-    repoPath,
-    ...(platformHost && { platformHost }),
+    repoPath: `${owner}/${name}`,
+    ...(resolvedPlatformHost && { platformHost: resolvedPlatformHost }),
   };
   return ref;
+}
+
+function parseHostProviderNumberedPath(
+  parts: string[],
+  kind: "pulls" | "issues",
+  start = 0,
+): NumberedItemRef | undefined {
+  if (parts[start] === kind) {
+    return parseProviderNumberedPath(parts, start + 1);
+  }
+  if (parts[start] === "host" && parts[start + 2] === kind) {
+    const platformHost = decodeRouteSegment(parts[start + 1] ?? "")?.trim();
+    if (!platformHost) return undefined;
+    return parseProviderNumberedPath(parts, start + 3, platformHost);
+  }
+  return undefined;
 }
 
 function parseRoute(fullPath: string): Route {
@@ -80,6 +118,7 @@ function parseRoute(fullPath: string): Route {
   const pathname = qIdx >= 0 ? fullPath.slice(0, qIdx) : fullPath;
   const search = qIdx >= 0 ? fullPath.slice(qIdx + 1) : "";
   const path = stripBase(pathname).replace(/\/+$/, "") || "/";
+  const parts = path.split("/").filter(Boolean);
   if (path.startsWith("/focus/")) {
     if (path === "/focus/mrs") {
       const sp = new URLSearchParams(search);
@@ -95,25 +134,21 @@ function parseRoute(fullPath: string): Route {
       if (repo) r.repo = repo;
       return r;
     }
-    if (path === "/focus/pr") {
-      const selected = parseProviderNumberedRef(search);
-      if (selected) {
-        return {
-          page: "focus",
-          itemType: "pr",
-          ...selected,
-        };
-      }
+    const pull = parseHostProviderNumberedPath(parts, "pulls", 1);
+    if (pull && parts.length === (parts[1] === "host" ? 8 : 6)) {
+      return {
+        page: "focus",
+        itemType: "pr",
+        ...pull,
+      };
     }
-    if (path === "/focus/issue") {
-      const selected = parseProviderNumberedRef(search);
-      if (selected) {
-        return {
-          page: "focus",
-          itemType: "issue",
-          ...selected,
-        };
-      }
+    const issue = parseHostProviderNumberedPath(parts, "issues", 1);
+    if (issue && parts.length === (parts[1] === "host" ? 8 : 6)) {
+      return {
+        page: "focus",
+        itemType: "issue",
+        ...issue,
+      };
     }
   }
   if (path === "/design-system") {
@@ -121,14 +156,15 @@ function parseRoute(fullPath: string): Route {
   }
   if (path.startsWith("/pulls")) {
     const rest = path.slice("/pulls".length);
-    if (rest === "/detail" || rest === "/detail/files") {
-      const selected = parseProviderNumberedRef(search);
-      if (selected) {
+    if (rest !== "" && rest !== "/board") {
+      const selected = parseHostProviderNumberedPath(parts, "pulls");
+      const isFiles = parts[parts.length - 1] === "files";
+      if (selected && (parts.length === 5 || (parts.length === 6 && isFiles))) {
         return {
           page: "pulls",
           view: "list",
           selected,
-          ...(rest === "/detail/files" && { tab: "files" as const }),
+          ...(isFiles && { tab: "files" as const }),
         };
       }
     }
@@ -140,9 +176,9 @@ function parseRoute(fullPath: string): Route {
   }
   if (path === "/settings" && !isEmbedded()) return { page: "settings" };
   if (path.startsWith("/issues")) {
-    if (path === "/issues/detail") {
-      const selected = parseProviderNumberedRef(search);
-      if (selected) {
+    if (path !== "/issues") {
+      const selected = parseHostProviderNumberedPath(parts, "issues");
+      if (selected && parts.length === 5) {
         return {
           page: "issues",
           selected,
@@ -150,6 +186,25 @@ function parseRoute(fullPath: string): Route {
       }
     }
     return { page: "issues" };
+  }
+  if (path.startsWith("/host/")) {
+    const pull = parseHostProviderNumberedPath(parts, "pulls");
+    const isPullFiles = parts[parts.length - 1] === "files";
+    if (pull && (parts.length === 7 || (parts.length === 8 && isPullFiles))) {
+      return {
+        page: "pulls",
+        view: "list",
+        selected: pull,
+        ...(isPullFiles && { tab: "files" as const }),
+      };
+    }
+    const issue = parseHostProviderNumberedPath(parts, "issues");
+    if (issue && parts.length === 7) {
+      return {
+        page: "issues",
+        selected: issue,
+      };
+    }
   }
   const reviewsMatch = path.match(/^\/reviews(?:\/(\d+))?$/);
   if (reviewsMatch) {

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -8,8 +8,8 @@ import {
   getPage,
 } from "./router.svelte.js";
 
-const prRoute = "/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42";
-const prFilesRoute = "/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42";
+const prRoute = "/pulls/github/acme/widgets/42";
+const prFilesRoute = "/pulls/github/acme/widgets/42/files";
 const prRef = {
   provider: "github",
   platformHost: "github.com",
@@ -19,7 +19,7 @@ const prRef = {
   number: 42,
 };
 
-describe("router /pulls/detail files route", () => {
+describe("router /pulls files route", () => {
   beforeEach(() => {
     navigate("/pulls");
   });
@@ -97,14 +97,19 @@ describe("router basic routes", () => {
     expect(getRoute()).toEqual({ page: "pulls", view: "board" });
   });
 
-  it("does not parse legacy pull detail routes", () => {
+  it("does not parse legacy owner/name pull detail routes", () => {
     navigate("/pulls/org/repo/7");
+    expect(getRoute()).toEqual({ page: "pulls", view: "list" });
+  });
+
+  it("does not parse old query-param pull detail routes", () => {
+    navigate("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
     expect(getRoute()).toEqual({ page: "pulls", view: "list" });
   });
 
   it("parses provider pull routes with escaped nested repo paths", () => {
     navigate(
-      "/pulls/detail?provider=gitlab&platform_host=gitlab.example.com%3A8443&repo_path=Group%2FSubGroup%2FSubGroup%202%2FMy_Project.v2&number=12",
+      "/host/gitlab.example.com%3A8443/pulls/gitlab/Group%2FSubGroup%2FSubGroup%202/My_Project.v2/12",
     );
 
     expect(getRoute()).toEqual({
@@ -123,7 +128,7 @@ describe("router basic routes", () => {
 
   it("parses provider pull files routes with escaped nested repo paths", () => {
     navigate(
-      "/pulls/detail/files?provider=gitlab&platform_host=gitlab.example.com%3A8443&repo_path=Group%2FSubGroup%2FSubGroup%202%2FMy_Project.v2&number=12",
+      "/host/gitlab.example.com%3A8443/pulls/gitlab/Group%2FSubGroup%2FSubGroup%202/My_Project.v2/12/files",
     );
 
     expect(getRoute()).toEqual({
@@ -161,9 +166,14 @@ describe("router basic routes", () => {
     expect(getRoute()).toEqual({ page: "issues" });
   });
 
+  it("does not parse old query-param issue detail routes", () => {
+    navigate("/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+    expect(getRoute()).toEqual({ page: "issues" });
+  });
+
   it("parses provider issue routes with special characters in repo paths", () => {
     navigate(
-      "/issues/detail?provider=gitlab&platform_host=gitlab.example.test%3A8443&repo_path=Team%20One%2FSub%20Team%2Fproject%2B%231&number=7",
+      "/host/gitlab.example.test%3A8443/issues/gitlab/Team%20One%2FSub%20Team/project%2B%231/7",
     );
 
     expect(getRoute()).toEqual({
@@ -177,6 +187,32 @@ describe("router basic routes", () => {
         number: 7,
       },
     });
+  });
+
+  it("parses focus provider pull and issue routes", () => {
+    navigate("/focus/pulls/github/acme/widgets/42");
+    expect(getRoute()).toEqual({
+      page: "focus",
+      itemType: "pr",
+      ...prRef,
+    });
+
+    navigate("/focus/host/ghe.example.com/issues/github/acme/widgets/7");
+    expect(getRoute()).toEqual({
+      page: "focus",
+      itemType: "issue",
+      provider: "github",
+      platformHost: "ghe.example.com",
+      owner: "acme",
+      name: "widgets",
+      repoPath: "acme/widgets",
+      number: 7,
+    });
+  });
+
+  it("does not parse old query-param focus detail routes", () => {
+    navigate("/focus/pr?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+    expect(getRoute()).toEqual({ page: "activity" });
   });
 
   it("treats legacy /workspaces/panel routes as workspaces page", () => {

--- a/frontend/src/lib/utils/activitySelection.test.ts
+++ b/frontend/src/lib/utils/activitySelection.test.ts
@@ -162,7 +162,7 @@ describe("activity selection URL state", () => {
     };
 
     expect(activitySelectionToRoute(pr, "pulls")).toBe(
-      "/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1",
+      "/pulls/github/acme/widgets/1/files",
     );
     expect(activitySelectionToRoute(pr, "issues")).toBeNull();
   });
@@ -177,7 +177,7 @@ describe("activity selection URL state", () => {
     };
 
     expect(activitySelectionToRoute(issue, "issues")).toBe(
-      "/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=10",
+      "/host/ghe.example.com/issues/github/acme/widgets/10",
     );
     expect(activitySelectionToRoute(issue, "pulls")).toBeNull();
   });

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -805,7 +805,7 @@ test.describe("activity split view and detail drawers", () => {
     await page.locator(".view-tab", { hasText: "PRs" }).click();
 
     await expect(page).toHaveURL(
-      /\/pulls\/detail\/files\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=1$/,
+      /\/pulls\/github\/acme\/widgets\/1\/files$/,
     );
   });
 
@@ -819,7 +819,7 @@ test.describe("activity split view and detail drawers", () => {
     await page.locator(".view-tab", { hasText: "Issues" }).click();
 
     await expect(page).toHaveURL(
-      /\/issues\/detail\?provider=github&platform_host=ghe\.example\.com&repo_path=acme%2Fwidgets&number=10$/,
+      /\/host\/ghe\.example\.com\/issues\/github\/acme\/widgets\/10$/,
     );
   });
 
@@ -1463,7 +1463,7 @@ test.describe("PR list tabs", () => {
     await mockDiffForAllPRs(page, tinyDiff);
 
     await page.goto(
-      "/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1",
+      "/pulls/github/acme/widgets/1",
     );
 
     // Wait for the PRListView tab bar (scoped to .main-area) to
@@ -1495,7 +1495,7 @@ test.describe("PR list tabs", () => {
       { hasText: "Files changed" },
     ).click();
     await expect(page).toHaveURL(
-      /\/pulls\/detail\/files\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=1$/,
+      /\/pulls\/github\/acme\/widgets\/1\/files$/,
     );
     await expect(page.locator(".diff-view")).toBeVisible();
     await expect(page.locator(".main-area .detail-tabs")).toHaveCount(1);
@@ -1507,7 +1507,7 @@ test.describe("PR list tabs", () => {
       { hasText: "Conversation" },
     ).click();
     await expect(page).toHaveURL(
-      /\/pulls\/detail\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=1$/,
+      /\/pulls\/github\/acme\/widgets\/1$/,
     );
     await expect(page.locator(".main-area .detail-tabs")).toHaveCount(1);
   });
@@ -1520,7 +1520,7 @@ test.describe("PR list tabs", () => {
     await mockDiffForAllPRs(page, tinyDiff);
 
     await page.goto(
-      "/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1",
+      "/pulls/github/acme/widgets/1/files",
     );
 
     await page.locator(".main-area .detail-tabs").first()

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test.describe("CI dropdown", () => {
   test("detail chips use the shared centered chip layout", async ({ page }) => {
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
 
     const chips = page.locator(".pull-detail .chips-row .chip");
     await expect(chips.first()).toBeVisible();
@@ -29,7 +29,7 @@ test.describe("CI dropdown", () => {
   });
 
   test("expanded CI checks stay below chip without stretching sibling chips", async ({ page }) => {
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
 
     const detail = page.locator(".pull-detail");
     const chip = detail.getByRole("button", { name: /CI:\s*(success|pending)/i });

--- a/frontend/tests/e2e-full/comment-editor.spec.ts
+++ b/frontend/tests/e2e-full/comment-editor.spec.ts
@@ -98,7 +98,7 @@ test.describe("comment editor autocomplete", () => {
   });
 
   test("PR comment editor accepts @ mention and submits end-to-end", async ({ page }) => {
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=5");
+    await page.goto("/pulls/github/acme/widgets/5");
     await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 10_000 });
     await expect(page.getByText("Detail not yet loaded")).toHaveCount(0, { timeout: 10_000 });
 
@@ -126,7 +126,7 @@ test.describe("comment editor autocomplete", () => {
   });
 
   test("issue comment editor accepts # reference and submits end-to-end", async ({ page }) => {
-    await page.goto("/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=12");
+    await page.goto("/issues/github/acme/widgets/12");
     await page.locator(".issue-detail").waitFor({ state: "visible", timeout: 10_000 });
     await expect(page.getByText("Detail not yet loaded")).toHaveCount(0, { timeout: 10_000 });
 

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -81,7 +81,7 @@ test.describe("detail action buttons", () => {
       const server = isolatedServer;
       const apiContext = api;
 
-      await page.goto(`${server.info.base_url}/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=10`);
+      await page.goto(`${server.info.base_url}/issues/github/acme/widgets/10`);
       await expect(page.locator(".issue-detail")).toBeVisible();
 
       const createResponsePromise = page.waitForResponse((response) => {
@@ -193,7 +193,7 @@ test.describe("detail action buttons", () => {
         && url.endsWith("/api/v1/issues/github/acme/widgets/10/workspace");
     });
 
-    await page.goto("/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=10");
+    await page.goto("/issues/github/acme/widgets/10");
     await expect(page.locator(".issue-detail")).toBeVisible();
 
     // Background sync enqueues asynchronously; the server returns 202
@@ -302,7 +302,7 @@ test.describe("detail action buttons", () => {
       },
     );
 
-    await page.goto("/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=10");
+    await page.goto("/issues/github/acme/widgets/10");
     await expect(page.locator(".issue-detail")).toBeVisible();
 
     await page.locator(".btn--workspace").click();
@@ -418,7 +418,7 @@ test.describe("detail action buttons", () => {
       },
     );
 
-    await page.goto("/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=10");
+    await page.goto("/issues/github/acme/widgets/10");
     await expect(page.locator(".issue-detail")).toBeVisible();
 
     await page.locator(".btn--workspace").click();
@@ -464,7 +464,7 @@ test.describe("detail action buttons", () => {
       isolatedServer = await startIsolatedE2EServer();
       const baseURL = isolatedServer.info.base_url;
 
-      await page.goto(`${baseURL}/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=2`);
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/2`);
       await expect(page.locator(".pull-detail")).toBeVisible();
       await expect(page.locator(".detail-title")).toContainText(
         "Fix race condition in event loop",
@@ -484,7 +484,7 @@ test.describe("detail action buttons", () => {
 
   test("narrow actions menu closes when clicking outside", async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 720 });
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
     await expect(page.locator(".pull-detail")).toBeVisible();
 
     await page.locator(".actions-menu-trigger").click();
@@ -504,7 +504,7 @@ test.describe("detail action buttons", () => {
       });
     });
 
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
     await expect(page.locator(".pull-detail")).toBeVisible();
 
     await page.locator(".actions-menu-trigger").click();
@@ -519,7 +519,7 @@ test.describe("detail action buttons", () => {
 
   test("approve form stays visible in the narrow actions menu", async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 720 });
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
     await expect(page.locator(".pull-detail")).toBeVisible();
 
     await page.locator(".actions-menu-trigger").click();
@@ -540,7 +540,7 @@ test.describe("detail action buttons", () => {
       const baseURL = isolatedServer.info.base_url;
 
       await page.setViewportSize({ width: 320, height: 720 });
-      await page.goto(`${baseURL}/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=6`);
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/6`);
       await expect(page.locator(".pull-detail")).toBeVisible();
 
       await page.locator(".actions-menu-trigger").click();
@@ -559,7 +559,7 @@ test.describe("detail action buttons", () => {
   });
 
   test("draft pull request actions keep exactly the same height", async ({ page }) => {
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=6");
+    await page.goto("/pulls/github/acme/widgets/6");
     await expect(page.locator(".pull-detail")).toBeVisible();
 
     const ready = page.locator(".btn--ready");
@@ -614,7 +614,7 @@ test.describe("detail action buttons", () => {
       const server = isolatedServer;
       const apiContext = api;
 
-      await page.goto(`${server.info.base_url}/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=6`);
+      await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/6`);
       await expect(page.locator(".pull-detail")).toBeVisible();
 
       const readyResponsePromise = page.waitForResponse((response) => {

--- a/frontend/tests/e2e-full/detail-number-copy.spec.ts
+++ b/frontend/tests/e2e-full/detail-number-copy.spec.ts
@@ -9,7 +9,7 @@ test.describe("detail number link copy", () => {
   }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
     await page.locator(".pull-detail")
       .waitFor({ state: "visible", timeout: 10_000 });
 
@@ -28,7 +28,7 @@ test.describe("detail number link copy", () => {
   }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
-    await page.goto("/issues/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=10");
+    await page.goto("/issues/github/acme/widgets/10");
     await page.locator(".issue-detail")
       .waitFor({ state: "visible", timeout: 10_000 });
 

--- a/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
+++ b/frontend/tests/e2e-full/diff-highlight-screenshot.spec.ts
@@ -75,7 +75,7 @@ test.describe("diff highlight backgrounds on horizontal scroll", () => {
       });
     });
 
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -276,7 +276,7 @@ async function mockDiffApiError(page: Page, status: number, detail: string): Pro
 }
 
 async function navigateToDiff(page: Page): Promise<void> {
-  await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+  await page.goto("/pulls/github/acme/widgets/1/files");
 }
 
 async function waitForDiffLoaded(page: Page): Promise<void> {
@@ -482,7 +482,7 @@ test.describe("diff view", () => {
       hasText: "Conversation",
     }).click();
     await expect(page).toHaveURL(
-      /\/pulls\/detail\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=1$/,
+      /\/pulls\/github\/acme\/widgets\/1$/,
     );
   });
 
@@ -904,7 +904,7 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-file-row")).toHaveCount(11);
 
     // Switch to PR 2.
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=2");
+    await page.goto("/pulls/github/acme/widgets/2/files");
     await waitForSidebarFilesLoaded(page);
 
     // Filter input is empty and full list shows.
@@ -941,7 +941,7 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-file-row")).toHaveCount(0);
 
     // Switch to PR 2 (small diff — filter input hidden).
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=2");
+    await page.goto("/pulls/github/acme/widgets/2/files");
     await waitForSidebarFilesLoaded(page);
 
     // Filter input is hidden and all 4 files show (stale query doesn't apply).
@@ -1013,7 +1013,7 @@ test.describe("diff view", () => {
     await expect(page.locator(".commit-item").first()).toBeVisible();
 
     // Switch to PR 2.
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=2");
+    await page.goto("/pulls/github/acme/widgets/2/files");
     await waitForSidebarFilesLoaded(page);
 
     // Commit section should be collapsed on new PR (body hidden).
@@ -1134,7 +1134,7 @@ test.describe("diff view (git-backed)", () => {
   });
 
   test("diff is not marked as stale", async ({ page }) => {
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
@@ -1142,7 +1142,7 @@ test.describe("diff view (git-backed)", () => {
   });
 
   test("real diff loads and renders all changed files", async ({ page }) => {
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
     await page.locator(".diff-file-row").first()
@@ -1161,7 +1161,7 @@ test.describe("diff view (git-backed)", () => {
       );
       expect(response.ok()).toBe(true);
 
-      await page.goto(`${server.info.base_url}/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1`);
+      await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1/files`);
       await waitForDiffLoaded(page);
       await waitForSidebarFilesLoaded(page);
 
@@ -1220,7 +1220,7 @@ test.describe("diff view (git-backed)", () => {
       );
       expect(advanceResponse.ok()).toBe(true);
 
-      await page.goto(`${server.info.base_url}/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1`);
+      await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1/files`);
       await waitForDiffLoaded(page);
       await waitForSidebarFilesLoaded(page);
 
@@ -1257,7 +1257,7 @@ test.describe("diff view (git-backed)", () => {
   });
 
   test("modified file has multiple hunks with correct content", async ({ page }) => {
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
@@ -1287,7 +1287,7 @@ test.describe("diff view (git-backed)", () => {
   });
 
   test("added file shows A status in sidebar and only addition lines", async ({ page }) => {
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
     await page.locator(".diff-file-row").first()
@@ -1317,7 +1317,7 @@ test.describe("diff view (git-backed)", () => {
   });
 
   test("deleted file shows D status in sidebar and only deletion lines", async ({ page }) => {
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
     await page.locator(".diff-file-row").first()
@@ -1346,7 +1346,7 @@ test.describe("diff view (git-backed)", () => {
   });
 
   test("hide whitespace toggle filters whitespace-only files", async ({ page }) => {
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
@@ -1362,7 +1362,7 @@ test.describe("diff view (git-backed)", () => {
   });
 
   test("collapsed region appears between hunks in modified file", async ({ page }) => {
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 
@@ -1383,7 +1383,7 @@ test.describe("diff view (git-backed)", () => {
       Date.now = () => originalNow() + offsetMs;
     }, 20 * 24 * 60 * 60 * 1000);
 
-    await page.goto("/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".commit-section__toggle").click();
     await page.locator(".commit-item").first()
       .waitFor({ state: "visible", timeout: 10_000 });

--- a/frontend/tests/e2e-full/focus-mode.spec.ts
+++ b/frontend/tests/e2e-full/focus-mode.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test.describe("focus mode", () => {
   test("PR focus route renders detail without shell chrome", async ({ page }) => {
-    await page.goto("/focus/pr?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/focus/pulls/github/acme/widgets/1");
     await page.locator(".focus-layout").waitFor({ state: "visible", timeout: 10_000 });
 
     await expect(page.locator(".pull-detail")).toBeVisible();
@@ -12,7 +12,7 @@ test.describe("focus mode", () => {
   });
 
   test("issue focus route renders detail without shell chrome", async ({ page }) => {
-    await page.goto("/focus/issue?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=10");
+    await page.goto("/focus/issues/github/acme/widgets/10");
     await page.locator(".focus-layout").waitFor({ state: "visible", timeout: 10_000 });
 
     await expect(page.locator(".issue-detail")).toBeVisible();
@@ -22,28 +22,28 @@ test.describe("focus mode", () => {
   });
 
   test("browser back/forward works between focus routes", async ({ page }) => {
-    await page.goto("/focus/pr?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/focus/pulls/github/acme/widgets/1");
     await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 10_000 });
 
     // Navigate forward to an issue focus route.
-    await page.goto("/focus/issue?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=10");
+    await page.goto("/focus/issues/github/acme/widgets/10");
     await page.locator(".issue-detail").waitFor({ state: "visible", timeout: 10_000 });
     await expect(page).toHaveURL(
-      /\/focus\/issue\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=10$/,
+      /\/focus\/issues\/github\/acme\/widgets\/10$/,
     );
 
     // Go back to the PR focus route.
     await page.goBack();
     await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 10_000 });
     await expect(page).toHaveURL(
-      /\/focus\/pr\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=1$/,
+      /\/focus\/pulls\/github\/acme\/widgets\/1$/,
     );
 
     // Go forward to the issue focus route.
     await page.goForward();
     await page.locator(".issue-detail").waitFor({ state: "visible", timeout: 10_000 });
     await expect(page).toHaveURL(
-      /\/focus\/issue\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=10$/,
+      /\/focus\/issues\/github\/acme\/widgets\/10$/,
     );
   });
 });

--- a/frontend/tests/e2e-full/pr-detail-branches.spec.ts
+++ b/frontend/tests/e2e-full/pr-detail-branches.spec.ts
@@ -3,7 +3,7 @@ import { startIsolatedE2EServer } from "./support/e2eServer";
 
 test.describe("PR detail branch info", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
     await page.locator(".pull-detail")
       .waitFor({ state: "visible", timeout: 10_000 });
   });
@@ -84,7 +84,7 @@ test.describe("PR detail branch info", () => {
       });
     });
 
-    await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+    await page.goto("/pulls/github/acme/widgets/1");
     await page.locator(".pull-detail")
       .waitFor({ state: "visible", timeout: 10_000 });
 
@@ -110,7 +110,7 @@ test("diff summary uses real files after the PR head advances", async ({ page })
       window.setInterval = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
         realSetInterval(handler, timeout === 60_000 ? 100 : timeout, ...args)) as typeof window.setInterval;
     });
-    await page.goto(`${server.info.base_url}/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1`);
+    await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
     await page.locator(".pull-detail")
       .waitFor({ state: "visible", timeout: 10_000 });
     await expect(page.locator(".sync-indicator")).toHaveCount(0);

--- a/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
+++ b/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
@@ -21,7 +21,7 @@ async function gotoWithWebKitRetry(page: Page, url: string): Promise<void> {
 }
 
 async function openPRTimeline(page: Page): Promise<void> {
-  await gotoWithWebKitRetry(page, "/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1");
+  await gotoWithWebKitRetry(page, "/pulls/github/acme/widgets/1");
   await page.locator(".pull-detail")
     .waitFor({ state: "visible", timeout: 10_000 });
   await expect(page.getByText("feat: add cache store")).toBeVisible();

--- a/frontend/tests/e2e-full/provider-capabilities.spec.ts
+++ b/frontend/tests/e2e-full/provider-capabilities.spec.ts
@@ -10,7 +10,7 @@ test.describe("provider capabilities", () => {
     });
 
     await page.goto(
-      "/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=1",
+      "/pulls/github/acme/widgets/1",
     );
 
     await expect(page.locator(".pull-detail")).toBeVisible();
@@ -21,7 +21,7 @@ test.describe("provider capabilities", () => {
 
   test("GitLab issue detail hides timeline edit controls when comments are read-only", async ({ page }) => {
     await page.goto(
-      "/issues/detail?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fproject&number=11",
+      "/host/gitlab.example.com/issues/gitlab/group/project/11",
     );
 
     const detail = page.locator(".issue-detail");

--- a/frontend/tests/e2e-full/repo-summaries.spec.ts
+++ b/frontend/tests/e2e-full/repo-summaries.spec.ts
@@ -147,7 +147,7 @@ test.describe("repository summaries", () => {
     await dialog.getByRole("button", { name: "Create issue" }).click();
 
     await expect(page).toHaveURL(
-      /\/issues\/detail\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=\d+$/,
+      /\/issues\/github\/acme\/widgets\/\d+$/,
     );
     await page.locator(".issue-detail").waitFor({
       state: "visible",

--- a/frontend/tests/e2e-full/routed-items.spec.ts
+++ b/frontend/tests/e2e-full/routed-items.spec.ts
@@ -38,7 +38,7 @@ test.describe("routed item builders through the UI", () => {
     await page.locator(".pull-item").filter({ hasText: prTitle }).first().click();
 
     await expect(page).toHaveURL(
-      /\/pulls\/detail\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=1$/,
+      /\/pulls\/github\/acme\/widgets\/1$/,
     );
     await expect(page.locator(".pull-detail .detail-title")).toContainText(prTitle);
     await expect((await detailLoaded).ok()).toBe(true);
@@ -56,7 +56,7 @@ test.describe("routed item builders through the UI", () => {
     await page.locator(".issue-item").filter({ hasText: issueTitle }).first().click();
 
     await expect(page).toHaveURL(
-      /\/issues\/detail\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=10$/,
+      /\/issues\/github\/acme\/widgets\/10$/,
     );
     await expect(page.locator(".issue-detail .detail-title")).toContainText(issueTitle);
     await expect((await detailLoaded).ok()).toBe(true);
@@ -74,7 +74,7 @@ test.describe("routed item builders through the UI", () => {
     await page.locator(".focus-list .pull-item").filter({ hasText: prTitle }).first().click();
 
     await expect(page).toHaveURL(
-      /\/focus\/pr\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=1$/,
+      /\/focus\/pulls\/github\/acme\/widgets\/1$/,
     );
     await expect(page.locator(".focus-layout .pull-detail .detail-title"))
       .toContainText(prTitle);
@@ -94,7 +94,7 @@ test.describe("routed item builders through the UI", () => {
     await page.locator(".focus-list .issue-item").filter({ hasText: issueTitle }).first().click();
 
     await expect(page).toHaveURL(
-      /\/focus\/issue\?provider=github&platform_host=github\.com&repo_path=acme%2Fwidgets&number=10$/,
+      /\/focus\/issues\/github\/acme\/widgets\/10$/,
     );
     await expect(page.locator(".focus-layout .issue-detail .detail-title"))
       .toContainText(issueTitle);

--- a/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
+++ b/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
@@ -96,7 +96,7 @@ test.describe("UTC maintainer flows", () => {
   test("closing and reopening a pull request keeps API timestamps canonical UTC", async ({ page, browserName }) => {
     const pull = closeReopenPullTarget(browserName);
 
-    await page.goto(`/pulls/detail?provider=github&platform_host=github.com&repo_path=${pull.owner}%2F${pull.repo}&number=${pull.number}`);
+    await page.goto(`/pulls/github/${pull.owner}/${pull.repo}/${pull.number}`);
     await expect(page.locator(".btn--close")).toBeVisible();
 
     await page.locator(".btn--close").click();
@@ -117,7 +117,7 @@ test.describe("UTC maintainer flows", () => {
   test("merging a pull request stores UTC timestamps and updates the detail view", async ({ page, browserName }) => {
     const pull = mergeTarget(browserName);
 
-    await page.goto(`/pulls/detail?provider=github&platform_host=github.com&repo_path=${pull.owner}%2F${pull.repo}&number=${pull.number}`);
+    await page.goto(`/pulls/github/${pull.owner}/${pull.repo}/${pull.number}`);
     await expect(page.locator(".btn--merge")).toBeVisible();
 
     await page.locator(".btn--merge").click();
@@ -135,7 +135,7 @@ test.describe("UTC maintainer flows", () => {
   test("closing and reopening an issue keeps API timestamps canonical UTC", async ({ page, browserName }) => {
     const issue = closeReopenIssueTarget(browserName);
 
-    await page.goto(`/issues/detail?provider=github&platform_host=github.com&repo_path=${issue.owner}%2F${issue.repo}&number=${issue.number}`);
+    await page.goto(`/issues/github/${issue.owner}/${issue.repo}/${issue.number}`);
     await expect(page.locator(".btn--close")).toBeVisible();
 
     await page.locator(".btn--close").click();

--- a/frontend/tests/e2e-full/workflow-status.spec.ts
+++ b/frontend/tests/e2e-full/workflow-status.spec.ts
@@ -43,7 +43,7 @@ test("workflow status dropdown persists through API and database", async ({
   const server = await startIsolatedE2EServer();
 
   try {
-    const detailPath = `/pulls/detail?provider=github&platform_host=github.com&repo_path=${target.owner}%2F${target.repo}&number=${target.number}`;
+    const detailPath = `/pulls/github/${target.owner}/${target.repo}/${target.number}`;
     await page.goto(`${server.info.base_url}${detailPath}`);
     await expect(page.locator(".pull-detail")).toBeVisible();
 

--- a/frontend/tests/e2e/comment-editing.spec.ts
+++ b/frontend/tests/e2e/comment-editing.spec.ts
@@ -139,14 +139,14 @@ test("edits a pull request timeline comment", async ({ page }) => {
       await fulfillJson(route, prDetail(commentBody, event));
     },
   );
-  await page.route("**/api/v1/repos/acme/widgets/pulls/detail?provider=github&platform_host=github.com&repo_path=42%2Fcomments&number=9101", async (route) => {
+  await page.route("**/api/v1/pulls/github/acme/widgets/42/comments/9101", async (route) => {
     const reqBody = JSON.parse(route.request().postData() ?? "{}") as { body?: string };
     patchedBody = reqBody.body ?? "";
     commentBody = patchedBody;
     await fulfillJson(route, { ...event, Body: patchedBody });
   });
 
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
   await expect(page.getByText("Original PR comment")).toBeVisible();
 
   await editVisibleTimelineComment(page, "Edited PR comment");
@@ -181,14 +181,14 @@ test("edits an issue timeline comment", async ({ page }) => {
       await fulfillJson(route, issueDetail(commentBody, event));
     },
   );
-  await page.route("**/api/v1/repos/acme/widgets/issues/detail?provider=github&platform_host=github.com&repo_path=7%2Fcomments&number=9202", async (route) => {
+  await page.route("**/api/v1/issues/github/acme/widgets/7/comments/9202", async (route) => {
     const reqBody = JSON.parse(route.request().postData() ?? "{}") as { body?: string };
     patchedBody = reqBody.body ?? "";
     commentBody = patchedBody;
     await fulfillJson(route, { ...event, Body: patchedBody });
   });
 
-  await page.goto("/focus/issue?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=7");
+  await page.goto("/focus/issues/github/acme/widgets/7");
   await expect(page.getByText("Original issue comment")).toBeVisible();
 
   await editVisibleTimelineComment(page, "Edited issue comment");

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -285,7 +285,7 @@ test.describe("PR detail merge modal route reset", () => {
     );
 
     await page.goto(
-      `/pulls/detail?provider=github&platform_host=github.com&repo_path=${conflictedPR.repo_owner}%2F${conflictedPR.repo_name}&number=${conflictedPR.Number}`,
+      `/pulls/github/${conflictedPR.repo_owner}/${conflictedPR.repo_name}/${conflictedPR.Number}`,
     );
 
     await expect(page.locator(".detail-title")).toContainText(
@@ -323,7 +323,7 @@ test.describe("PR detail merge modal route reset", () => {
     }
 
     await page.goto(
-      `/pulls/detail?provider=github&platform_host=github.com&repo_path=${prA.repo_owner}%2F${prA.repo_name}&number=${prA.Number}`,
+      `/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`,
     );
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
 
@@ -339,7 +339,7 @@ test.describe("PR detail merge modal route reset", () => {
       window.history.pushState(
         null,
         "",
-        `/pulls/detail?provider=github&platform_host=github.com&repo_path=${owner}%2F${name}&number=${number}`,
+        `/pulls/github/${owner}/${name}/${number}`,
       );
       window.dispatchEvent(new PopStateEvent("popstate"));
     }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
@@ -404,7 +404,7 @@ test.describe("PR detail merge modal route reset", () => {
     );
 
     await page.goto(
-      `/pulls/detail?provider=github&platform_host=github.com&repo_path=${prA.repo_owner}%2F${prA.repo_name}&number=${prA.Number}`,
+      `/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`,
     );
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
     await expect(page.locator(".btn--merge")).toBeVisible();
@@ -413,7 +413,7 @@ test.describe("PR detail merge modal route reset", () => {
       window.history.pushState(
         null,
         "",
-        `/pulls/detail?provider=github&platform_host=github.com&repo_path=${owner}%2F${name}&number=${number}`,
+        `/pulls/github/${owner}/${name}/${number}`,
       );
       window.dispatchEvent(new PopStateEvent("popstate"));
     }, [prSquashOnly.repo_owner, prSquashOnly.repo_name, prSquashOnly.Number] as const);
@@ -478,7 +478,7 @@ test.describe("detail load-error banner", () => {
     );
 
     await page.goto(
-      `/pulls/detail?provider=github&platform_host=github.com&repo_path=${prA.repo_owner}%2F${prA.repo_name}&number=${prA.Number}`,
+      `/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`,
     );
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
 
@@ -486,7 +486,7 @@ test.describe("detail load-error banner", () => {
       window.history.pushState(
         null,
         "",
-        `/pulls/detail?provider=github&platform_host=github.com&repo_path=${owner}%2F${name}&number=${number}`,
+        `/pulls/github/${owner}/${name}/${number}`,
       );
       window.dispatchEvent(new PopStateEvent("popstate"));
     }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
@@ -531,7 +531,7 @@ test.describe("detail load-error banner", () => {
     );
 
     await page.goto(
-      `/issues/detail?provider=github&platform_host=github.com&repo_path=${issueX.repo_owner}%2F${issueX.repo_name}&number=${issueX.Number}`,
+      `/issues/github/${issueX.repo_owner}/${issueX.repo_name}/${issueX.Number}`,
     );
     await expect(page.locator(".issue-detail .detail-title")).toContainText(
       issueX.Title,
@@ -541,7 +541,7 @@ test.describe("detail load-error banner", () => {
       window.history.pushState(
         null,
         "",
-        `/issues/detail?provider=github&platform_host=github.com&repo_path=${owner}%2F${name}&number=${number}`,
+        `/issues/github/${owner}/${name}/${number}`,
       );
       window.dispatchEvent(new PopStateEvent("popstate"));
     }, [issueY.repo_owner, issueY.repo_name, issueY.Number] as const);
@@ -560,7 +560,7 @@ test.describe("PR detail stale-action gating", () => {
     const userMutations = recordUserMutations(page);
     const { release } = await setupHeldPR(page, prA, prB);
 
-    await page.goto(`/pulls/detail?provider=github&platform_host=github.com&repo_path=${prA.repo_owner}%2F${prA.repo_name}&number=${prA.Number}`);
+    await page.goto(`/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`);
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
 
     // Trigger an in-place navigation to the slow PR via popstate.
@@ -568,7 +568,7 @@ test.describe("PR detail stale-action gating", () => {
       window.history.pushState(
         null,
         "",
-        `/pulls/detail?provider=github&platform_host=github.com&repo_path=${owner}%2F${name}&number=${number}`,
+        `/pulls/github/${owner}/${name}/${number}`,
       );
       window.dispatchEvent(new PopStateEvent("popstate"));
     }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
@@ -611,7 +611,7 @@ test.describe("issue detail stale-action gating", () => {
     const { release } = await setupHeldIssue(page, issueX, issueY);
 
     await page.goto(
-      `/issues/detail?provider=github&platform_host=github.com&repo_path=${issueX.repo_owner}%2F${issueX.repo_name}&number=${issueX.Number}`,
+      `/issues/github/${issueX.repo_owner}/${issueX.repo_name}/${issueX.Number}`,
     );
     await expect(page.locator(".issue-detail .detail-title")).toContainText(
       issueX.Title,
@@ -621,7 +621,7 @@ test.describe("issue detail stale-action gating", () => {
       window.history.pushState(
         null,
         "",
-        `/issues/detail?provider=github&platform_host=github.com&repo_path=${owner}%2F${name}&number=${number}`,
+        `/issues/github/${owner}/${name}/${number}`,
       );
       window.dispatchEvent(new PopStateEvent("popstate"));
     }, [issueY.repo_owner, issueY.repo_name, issueY.Number] as const);

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("edit title: click Edit, type, save", async ({ page }) => {
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
   await expect(page.locator(".detail-title")).toContainText("Add browser regression coverage");
   await page.locator(".edit-title-btn").click();
 
@@ -20,7 +20,7 @@ test("edit title: click Edit, type, save", async ({ page }) => {
 });
 
 test("edit title: cancel with Escape", async ({ page }) => {
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
   await page.locator(".edit-title-btn").click();
 
   const input = page.locator(".title-edit-input");
@@ -33,7 +33,7 @@ test("edit title: cancel with Escape", async ({ page }) => {
 });
 
 test("edit title: save disabled when blank", async ({ page }) => {
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
   await page.locator(".edit-title-btn").click();
 
   const input = page.locator(".title-edit-input");
@@ -42,7 +42,7 @@ test("edit title: save disabled when blank", async ({ page }) => {
 });
 
 test("edit body: click Edit, type, save", async ({ page }) => {
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
   await page.locator(".edit-body-btn").click();
 
   const textarea = page.locator(".body-edit-textarea");
@@ -54,7 +54,7 @@ test("edit body: click Edit, type, save", async ({ page }) => {
 });
 
 test("edit body: cancel preserves original", async ({ page }) => {
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
   await page.locator(".edit-body-btn").click();
 
   await page.locator(".body-edit-textarea").fill("discarded");
@@ -119,7 +119,7 @@ test("markdown tables keep compact columns readable", async ({ page }) => {
     });
   });
 
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
 
   const taskHeader = page
     .locator(".markdown-body th")
@@ -187,7 +187,7 @@ test("add description to empty-body PR shows add-description-btn", async ({ page
     });
   });
 
-  await page.goto("/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42");
+  await page.goto("/pulls/github/acme/widgets/42");
 
   const addBtn = page.locator(".add-description-btn");
   await expect(addBtn).toBeVisible();

--- a/frontend/tests/e2e/issue-routing.spec.ts
+++ b/frontend/tests/e2e/issue-routing.spec.ts
@@ -71,7 +71,7 @@ test.describe("issue route platform host", () => {
   test("direct issue load preserves platform_host in detail requests", async ({ page }) => {
     const seenHosts = await mockIssueDetailAndTrackHosts(page);
 
-    await page.goto("/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=7");
+    await page.goto("/host/ghe.example.com/issues/github/acme/widgets/7");
 
     await expect(page.locator(".issue-detail .detail-title"))
       .toContainText("Mirror host issue");
@@ -86,7 +86,7 @@ test.describe("issue route platform host", () => {
       window.history.pushState(
         null,
         "",
-        "/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=7",
+        "/host/ghe.example.com/issues/github/acme/widgets/7",
       );
       window.dispatchEvent(new PopStateEvent("popstate"));
     });

--- a/packages/ui/src/routes.test.ts
+++ b/packages/ui/src/routes.test.ts
@@ -25,10 +25,10 @@ describe("route item builders", () => {
     const ref = { ...githubWidgets, number: 42 };
 
     expect(buildPullRequestRoute(ref)).toBe(
-      "/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42",
+      "/pulls/github/acme/widgets/42",
     );
     expect(buildPullRequestFilesRoute(ref)).toBe(
-      "/pulls/detail/files?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42",
+      "/pulls/github/acme/widgets/42/files",
     );
   });
 
@@ -40,7 +40,7 @@ describe("route item builders", () => {
         number: 7,
       }),
     ).toBe(
-      "/issues/detail?provider=github&platform_host=ghe.example.com%2Fteam%20one&repo_path=acme%2Fwidgets&number=7",
+      "/host/ghe.example.com%2Fteam%20one/issues/github/acme/widgets/7",
     );
   });
 
@@ -54,7 +54,7 @@ describe("route item builders", () => {
         number: 7,
       }),
     ).toBe(
-      "/issues/detail?provider=github&repo_path=acme%2Fwidgets&number=7",
+      "/issues/github/acme/widgets/7",
     );
   });
 
@@ -67,13 +67,13 @@ describe("route item builders", () => {
     };
 
     expect(buildProviderPullRequestRoute(deep)).toBe(
-      "/pulls/detail?provider=gitlab&platform_host=gitlab.example.com%3A8443&repo_path=Group%2FSubGroup%2FSubGroup%202%2FMy_Project.v2&number=12",
+      "/host/gitlab.example.com%3A8443/pulls/gitlab/Group%2FSubGroup%2FSubGroup%202/My_Project.v2/12",
     );
     expect(buildProviderPullRequestFilesRoute(deep)).toBe(
-      "/pulls/detail/files?provider=gitlab&platform_host=gitlab.example.com%3A8443&repo_path=Group%2FSubGroup%2FSubGroup%202%2FMy_Project.v2&number=12",
+      "/host/gitlab.example.com%3A8443/pulls/gitlab/Group%2FSubGroup%2FSubGroup%202/My_Project.v2/12/files",
     );
     expect(buildProviderIssueRoute(deep)).toBe(
-      "/issues/detail?provider=gitlab&platform_host=gitlab.example.com%3A8443&repo_path=Group%2FSubGroup%2FSubGroup%202%2FMy_Project.v2&number=12",
+      "/host/gitlab.example.com%3A8443/issues/gitlab/Group%2FSubGroup%2FSubGroup%202/My_Project.v2/12",
     );
   });
 
@@ -84,7 +84,7 @@ describe("route item builders", () => {
         number: 42,
       }),
     ).toBe(
-      "/focus/pr?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42",
+      "/focus/pulls/github/acme/widgets/42",
     );
     expect(
       buildFocusIssueRoute({
@@ -93,7 +93,7 @@ describe("route item builders", () => {
         number: 7,
       }),
     ).toBe(
-      "/focus/issue?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=7",
+      "/focus/host/ghe.example.com/issues/github/acme/widgets/7",
     );
     expect(buildFocusListRoute({ itemType: "mrs" })).toBe("/focus/mrs");
     expect(buildFocusListRoute({ itemType: "issues" })).toBe("/focus/issues");
@@ -112,16 +112,16 @@ describe("route item builders", () => {
     } as const;
 
     expect(buildRoutedItemRoute(pr)).toBe(
-      "/pulls/detail?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42",
+      "/pulls/github/acme/widgets/42",
     );
     expect(buildRoutedItemRoute(issue)).toBe(
-      "/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=7",
+      "/host/ghe.example.com/issues/github/acme/widgets/7",
     );
     expect(buildRoutedItemRoute(pr, { focus: true })).toBe(
-      "/focus/pr?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&number=42",
+      "/focus/pulls/github/acme/widgets/42",
     );
     expect(buildRoutedItemRoute(issue, { focus: true })).toBe(
-      "/focus/issue?provider=github&platform_host=ghe.example.com&repo_path=acme%2Fwidgets&number=7",
+      "/focus/host/ghe.example.com/issues/github/acme/widgets/7",
     );
   });
 });

--- a/packages/ui/src/routes.ts
+++ b/packages/ui/src/routes.ts
@@ -1,3 +1,8 @@
+import {
+  providerRouteParams,
+  type ProviderRouteRef as APIProviderRouteRef,
+} from "./api/provider-routes.js";
+
 export type RepositoryRouteRef = {
   provider: string;
   platformHost?: string | undefined;
@@ -38,13 +43,13 @@ export function buildPullRequestFilesRoute(ref: PullRequestRouteRef): string {
 }
 
 export function buildProviderPullRequestRoute(ref: ProviderRouteRef & { number: number }): string {
-  return `/pulls/detail${providerItemQuery(ref)}`;
+  return providerItemPath("pulls", ref);
 }
 
 export function buildProviderPullRequestFilesRoute(
   ref: ProviderRouteRef & { number: number },
 ): string {
-  return `/pulls/detail/files${providerItemQuery(ref)}`;
+  return `${providerItemPath("pulls", ref)}/files`;
 }
 
 export function buildIssueRoute(ref: IssueRouteRef): string {
@@ -52,15 +57,15 @@ export function buildIssueRoute(ref: IssueRouteRef): string {
 }
 
 export function buildProviderIssueRoute(ref: ProviderRouteRef & { number: number }): string {
-  return `/issues/detail${providerItemQuery(ref)}`;
+  return providerItemPath("issues", ref);
 }
 
 export function buildFocusPullRequestRoute(ref: PullRequestRouteRef): string {
-  return `/focus/pr${providerItemQuery(providerRouteRef(ref))}`;
+  return `/focus${buildProviderPullRequestRoute(providerRouteRef(ref))}`;
 }
 
 export function buildFocusIssueRoute(ref: IssueRouteRef): string {
-  return `/focus/issue${providerItemQuery(providerRouteRef(ref))}`;
+  return `/focus${buildProviderIssueRoute(providerRouteRef(ref))}`;
 }
 
 export function buildFocusListRoute(ref: FocusListRouteRef): string {
@@ -85,18 +90,6 @@ function requireRouteText(value: string, field: string): string {
   return value;
 }
 
-function providerItemQuery(ref: ProviderRouteRef & { number: number }): string {
-  const params: Array<[string, string]> = [
-    ["provider", requireRouteText(ref.provider, "provider")],
-    ["repo_path", requireRouteText(ref.repoPath, "repoPath")],
-    ["number", ref.number.toString()],
-  ];
-  if (ref.platformHost) {
-    params.splice(1, 0, ["platform_host", ref.platformHost]);
-  }
-  return `?${params.map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join("&")}`;
-}
-
 function providerRouteRef(ref: NumberedRouteItemRef): ProviderRouteRef & { number: number } {
   return {
     provider: ref.provider,
@@ -104,4 +97,35 @@ function providerRouteRef(ref: NumberedRouteItemRef): ProviderRouteRef & { numbe
     repoPath: ref.repoPath,
     number: ref.number,
   };
+}
+
+function providerItemPath(kind: "pulls" | "issues", ref: ProviderRouteRef & { number: number }): string {
+  const routeRef = providerRouteParts(ref);
+  const encodedProvider = encodeURIComponent(routeRef.provider);
+  const encodedOwner = encodeURIComponent(routeRef.owner);
+  const encodedName = encodeURIComponent(routeRef.name);
+  const encodedNumber = encodeURIComponent(ref.number.toString());
+  if (routeRef.platform_host) {
+    return `/host/${encodeURIComponent(routeRef.platform_host)}/${kind}/${encodedProvider}/${encodedOwner}/${encodedName}/${encodedNumber}`;
+  }
+  return `/${kind}/${encodedProvider}/${encodedOwner}/${encodedName}/${encodedNumber}`;
+}
+
+function providerRouteParts(
+  ref: ProviderRouteRef,
+): ReturnType<typeof providerRouteParams> {
+  const repoPath = requireRouteText(ref.repoPath, "repoPath").replace(/^\/+|\/+$/g, "");
+  const pathParts = repoPath.split("/").filter(Boolean);
+  if (pathParts.length < 2) {
+    throw new Error("missing route repoPath owner/name");
+  }
+  const owner = pathParts.slice(0, -1).join("/");
+  const name = pathParts[pathParts.length - 1]!;
+  return providerRouteParams({
+    provider: requireRouteText(ref.provider, "provider"),
+    platformHost: ref.platformHost,
+    owner,
+    name,
+    repoPath,
+  } satisfies APIProviderRouteRef);
 }


### PR DESCRIPTION
## Summary
- Switched PR and issue detail URLs from query-param routes to readable path-based routes, including files views and focus mode.
- Updated router parsing and route generation to support the new canonical paths while rejecting the old detail URL shapes.
- Refreshed frontend coverage around navigation, deep links, back/forward behavior, and detail actions.

## URL changes
| Old | New |
|---|---|
| `/pulls/detail?provider=github&platform_host=github.com&repo_path=wesm%2Fagentsview&number=481` | `/pulls/github/wesm/agentsview/481` |
| `/pulls/detail/files?provider=github&platform_host=github.com&repo_path=wesm%2Fagentsview&number=481` | `/pulls/github/wesm/agentsview/481/files` |
| `/issues/detail?provider=github&platform_host=github.com&repo_path=wesm%2Fagentsview&number=481` | `/issues/github/wesm/agentsview/481` |
| `/pulls/detail?provider=github&platform_host=ghe.example.com&repo_path=wesm%2Fagentsview&number=481` | `/host/ghe.example.com/pulls/github/wesm/agentsview/481` |
| `/issues/detail?provider=github&platform_host=ghe.example.com&repo_path=wesm%2Fagentsview&number=481` | `/host/ghe.example.com/issues/github/wesm/agentsview/481` |
| `/focus/pr?provider=github&platform_host=github.com&repo_path=wesm%2Fagentsview&number=481` | `/focus/pulls/github/wesm/agentsview/481` |
| `/focus/issue?provider=github&platform_host=github.com&repo_path=wesm%2Fagentsview&number=481` | `/focus/issues/github/wesm/agentsview/481` |
| `/focus/pr?provider=github&platform_host=ghe.example.com&repo_path=wesm%2Fagentsview&number=481` | `/focus/host/ghe.example.com/pulls/github/wesm/agentsview/481` |
| `/focus/issue?provider=github&platform_host=ghe.example.com&repo_path=wesm%2Fagentsview&number=481` | `/focus/host/ghe.example.com/issues/github/wesm/agentsview/481` |

Default provider hosts are omitted. Nested repo owners stay encoded as one path segment, for example `Group/SubGroup/Project` becomes `/pulls/gitlab/Group%2FSubGroup/Project/12`.