### PR TITLE
feat: publish inline reviews with forgejo

### DIFF
--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -196,11 +196,50 @@ const diffResponse = {
   ],
 };
 
+const multiHunkDiffResponse = {
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "src/main.ts",
+      old_path: "src/main.ts",
+      status: "modified",
+      additions: 2,
+      deletions: 0,
+      is_binary: false,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 1,
+          new_start: 1,
+          new_count: 1,
+          section: "",
+          lines: [
+            { type: "add", old_num: null, new_num: 1, content: "const first = 1;" },
+          ],
+        },
+        {
+          old_start: 20,
+          old_count: 1,
+          new_start: 20,
+          new_count: 1,
+          section: "",
+          lines: [
+            { type: "add", old_num: null, new_num: 20, content: "const second = 2;" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 async function mockInlineReviewAPI(
   page: Page,
   capabilities = baseCapabilities,
   provider = "github",
   platformHost = "github.com",
+  filesResponse: typeof diffResponse = diffResponse,
+  onCreateDraft?: (body: { body: string; range: Record<string, unknown> }) => void,
 ): Promise<void> {
   let draftComments: Array<Record<string, unknown>> = [];
   let reviewThreadResolved = false;
@@ -220,10 +259,10 @@ async function mockInlineReviewAPI(
     );
   });
   await page.route(`**${path}/files`, async (route) => {
-    await fulfillJson(route, diffResponse);
+    await fulfillJson(route, filesResponse);
   });
   await page.route(`**${path}/diff`, async (route) => {
-    await fulfillJson(route, diffResponse);
+    await fulfillJson(route, filesResponse);
   });
   await page.route(`**${path}/review-draft`, async (route) => {
     if (route.request().method() === "DELETE") {
@@ -243,6 +282,7 @@ async function mockInlineReviewAPI(
       body: string;
       range: Record<string, unknown>;
     };
+    onCreateDraft?.(body);
     draftComments = [{
       id: "1",
       body: body.body,
@@ -315,4 +355,38 @@ test("enables inline review on public Forgejo and Gitea files routes", async ({ 
   await mockInlineReviewAPI(page, baseCapabilities, "gitea", "gitea.com");
   await page.goto("/pulls/gitea/acme/widgets/42/files");
   await expect(page.getByRole("button", { name: "Comment on new line 2" })).toBeVisible();
+});
+
+test("does not create multiline draft ranges across separate PR diff hunks", async ({ page }) => {
+  let createdRange: Record<string, unknown> | undefined;
+  await mockInlineReviewAPI(
+    page,
+    baseCapabilities,
+    "github",
+    "github.com",
+    multiHunkDiffResponse,
+    (body) => { createdRange = body.range; },
+  );
+
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  await page.getByRole("button", { name: "Comment on new line 1" }).click();
+  await page.getByRole("button", { name: "Comment on new line 20" }).click({
+    modifiers: ["Shift"],
+  });
+
+  const selected = page.locator(".gutter-new.gutter--selected");
+  await expect(selected).toHaveCount(1);
+  await expect(selected).toHaveText("20");
+
+  await page.getByPlaceholder("Leave a comment").fill("Only the second hunk.");
+  await page.getByRole("button", { name: "Add comment" }).click();
+
+  expect(createdRange).toMatchObject({
+    path: "src/main.ts",
+    side: "right",
+    line: 20,
+    new_line: 20,
+  });
+  expect(createdRange).not.toHaveProperty("start_line");
+  expect(createdRange).not.toHaveProperty("start_side");
 });

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4622,6 +4622,12 @@ func (s *Syncer) syncProviderMRDetailExtras(
 		}
 	}
 
+	reviewThreadCalls, err := s.syncProviderMRReviewThreads(ctx, repo, mrID, number)
+	calls += reviewThreadCalls
+	if err != nil {
+		return calls, false, fmt.Errorf("sync review threads for MR #%d: %w", number, err)
+	}
+
 	pending := false
 	if headSHA == "" {
 		return calls, pending, nil
@@ -4652,6 +4658,96 @@ func (s *Syncer) syncProviderMRDetailExtras(
 	}
 	pending = ciHasPending(string(ciJSON))
 	return calls, pending, nil
+}
+
+func (s *Syncer) syncProviderMRReviewThreads(
+	ctx context.Context,
+	repo RepoRef,
+	mrID int64,
+	number int,
+) (int, error) {
+	caps, err := s.clients.Capabilities(repoPlatform(repo), repoHost(repo))
+	if err != nil {
+		if errors.Is(err, platform.ErrUnsupportedCapability) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !caps.ReadReviewThreads {
+		return 0, nil
+	}
+	reader, err := s.clients.MergeRequestReviewThreadReader(repoPlatform(repo), repoHost(repo))
+	if err != nil {
+		return 0, err
+	}
+	threads, err := reader.ListMergeRequestReviewThreads(ctx, platformRepoRef(repo), number)
+	calls := 1
+	if err != nil {
+		return calls, err
+	}
+
+	dbThreads := make([]db.MRReviewThread, 0, len(threads))
+	events := make([]db.MREvent, 0, len(threads))
+	for _, thread := range threads {
+		providerThreadID := thread.ProviderThreadID
+		if providerThreadID == "" {
+			providerThreadID = thread.ProviderCommentID
+		}
+		if providerThreadID == "" {
+			continue
+		}
+		dbThreads = append(dbThreads, db.MRReviewThread{
+			ProviderThreadID:  providerThreadID,
+			ProviderReviewID:  thread.ProviderReviewID,
+			ProviderCommentID: thread.ProviderCommentID,
+			Body:              thread.Body,
+			AuthorLogin:       thread.AuthorLogin,
+			Range:             dbReviewLineRangeFromPlatform(thread.Range),
+			Resolved:          thread.Resolved,
+			CreatedAt:         thread.CreatedAt,
+			UpdatedAt:         thread.UpdatedAt,
+			ResolvedAt:        thread.ResolvedAt,
+			MetadataJSON:      thread.MetadataJSON,
+		})
+		createdAt := thread.CreatedAt
+		if createdAt.IsZero() {
+			createdAt = time.Now().UTC()
+		}
+		events = append(events, db.MREvent{
+			MergeRequestID:     mrID,
+			PlatformExternalID: providerThreadID,
+			EventType:          "review_comment",
+			Author:             thread.AuthorLogin,
+			Body:               thread.Body,
+			CreatedAt:          createdAt,
+			DedupeKey:          "review_comment:" + providerThreadID,
+		})
+	}
+	if err := s.db.UpsertMRReviewThreads(ctx, mrID, dbThreads); err != nil {
+		return calls, err
+	}
+	if len(events) > 0 {
+		if err := s.db.UpsertMREvents(ctx, events); err != nil {
+			return calls, err
+		}
+	}
+	return calls, nil
+}
+
+func dbReviewLineRangeFromPlatform(input platform.DiffReviewLineRange) db.ReviewLineRange {
+	return db.ReviewLineRange{
+		Path:        input.Path,
+		OldPath:     input.OldPath,
+		Side:        input.Side,
+		StartSide:   input.StartSide,
+		StartLine:   input.StartLine,
+		Line:        input.Line,
+		OldLine:     input.OldLine,
+		NewLine:     input.NewLine,
+		LineType:    input.LineType,
+		DiffHeadSHA: input.DiffHeadSHA,
+		CommitSHA:   input.CommitSHA,
+	}
 }
 
 // fetchIssueDetail performs a full detail fetch for a single
@@ -6478,6 +6574,9 @@ func (s *Syncer) syncMRForRepo(
 
 		if err := s.refreshTimeline(ctx, repo, repoID, mrID, ghPR); err != nil {
 			return fmt.Errorf("refresh timeline for MR #%d: %w", number, err)
+		}
+		if _, err := s.syncProviderMRReviewThreads(ctx, repo, mrID, number); err != nil {
+			return fmt.Errorf("sync review threads for MR #%d: %w", number, err)
 		}
 
 		syncMRHeadSHA := ""

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -480,8 +480,11 @@ type syncTestReadProvider struct {
 	listIssueCalls      atomic.Int32
 	getMRCalls          atomic.Int32
 	getIssueCalls       atomic.Int32
+	listReviewThreads   atomic.Int32
 	listMRMergeEvents   []platform.MergeRequestEvent
+	reviewThreads       []platform.MergeRequestReviewThread
 	listIssueReadEvents []platform.IssueEvent
+	readReviewThreads   bool
 }
 
 type syncTestRepositoryReadProvider struct {
@@ -567,6 +570,7 @@ func (p *syncTestReadProvider) Capabilities() platform.Capabilities {
 	return platform.Capabilities{
 		ReadMergeRequests: true,
 		ReadIssues:        true,
+		ReadReviewThreads: p.readReviewThreads,
 	}
 }
 
@@ -614,6 +618,15 @@ func (p *syncTestReadProvider) ListMergeRequestEvents(
 	int,
 ) ([]platform.MergeRequestEvent, error) {
 	return p.listMRMergeEvents, nil
+}
+
+func (p *syncTestReadProvider) ListMergeRequestReviewThreads(
+	context.Context,
+	platform.RepoRef,
+	int,
+) ([]platform.MergeRequestReviewThread, error) {
+	p.listReviewThreads.Add(1)
+	return p.reviewThreads, nil
 }
 
 func (p *syncTestReadProvider) ListOpenIssues(
@@ -3514,6 +3527,96 @@ func TestFetchMRDetailPersistsWorkflowApproval(t *testing.T) {
 	assert.Equal(headSHA, got.WorkflowApprovalHeadSHA)
 	assert.True(got.WorkflowApprovalRequired)
 	assert.Equal(1, got.WorkflowApprovalCount)
+}
+
+func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+
+	ref := platform.RepoRef{
+		Platform:      platform.KindForgejo,
+		Host:          "codeberg.org",
+		Owner:         "acme",
+		Name:          "widgets",
+		RepoPath:      "acme/widgets",
+		DefaultBranch: "main",
+	}
+	repo := RepoRef{
+		Platform:      platform.KindForgejo,
+		PlatformHost:  "codeberg.org",
+		Owner:         "acme",
+		Name:          "widgets",
+		RepoPath:      "acme/widgets",
+		DefaultBranch: "main",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+
+	line := 12
+	provider := &syncTestReadProvider{
+		syncTestProvider:  syncTestProvider{kind: platform.KindForgejo, host: "codeberg.org"},
+		readReviewThreads: true,
+		mergeRequests: []platform.MergeRequest{{
+			Repo:               ref,
+			PlatformID:         9001,
+			PlatformExternalID: "9001",
+			Number:             42,
+			URL:                "https://codeberg.org/acme/widgets/pulls/42",
+			Title:              "inline review",
+			Author:             "ada",
+			State:              "open",
+			HeadBranch:         "feature",
+			BaseBranch:         "main",
+			HeadSHA:            "head-sha",
+			BaseSHA:            "base-sha",
+			CreatedAt:          now,
+			UpdatedAt:          now,
+			LastActivityAt:     now,
+		}},
+		reviewThreads: []platform.MergeRequestReviewThread{{
+			ProviderThreadID:  "thread-42",
+			ProviderReviewID:  "review-42",
+			ProviderCommentID: "comment-42",
+			Body:              "synced inline note",
+			AuthorLogin:       "reviewer",
+			Range: platform.DiffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        line,
+				NewLine:     &line,
+				LineType:    "add",
+				DiffHeadSHA: "head-sha",
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(registry, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
+
+	calls, err := syncer.fetchProviderMRDetail(ctx, provider, repo, repoID, 42)
+	require.NoError(err)
+	assert.Equal(3, calls)
+	assert.Equal(int32(1), provider.listReviewThreads.Load())
+
+	mr, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 42)
+	require.NoError(err)
+	require.NotNil(mr)
+	threads, err := d.ListMRReviewThreads(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("thread-42", threads[0].ProviderThreadID)
+	assert.Equal("synced inline note", threads[0].Body)
+
+	events, err := d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("review_comment", events[0].EventType)
+	assert.Equal("thread-42", events[0].PlatformExternalID)
 }
 
 func TestSyncOpenIssueReadsExistingByRepoID(t *testing.T) {

--- a/internal/platform/forgejo/client.go
+++ b/internal/platform/forgejo/client.go
@@ -128,7 +128,16 @@ func (c *Client) Host() string {
 }
 
 func (c *Client) Capabilities() platform.Capabilities {
-	return c.provider.Capabilities()
+	caps := c.provider.Capabilities()
+	caps.ReviewDraftMutation = true
+	caps.ReadReviewThreads = true
+	caps.NativeMultilineRanges = false
+	caps.SupportedReviewActions = []platform.ReviewAction{
+		platform.ReviewActionComment,
+		platform.ReviewActionApprove,
+		platform.ReviewActionRequestChanges,
+	}
+	return caps
 }
 
 type transport struct {

--- a/internal/platform/forgejo/client_test.go
+++ b/internal/platform/forgejo/client_test.go
@@ -16,19 +16,21 @@ import (
 )
 
 var (
-	_ gitealike.Transport         = (*transport)(nil)
-	_ gitealike.ActionsTransport  = (*transport)(nil)
-	_ platform.RepositoryReader   = (*Client)(nil)
-	_ platform.MergeRequestReader = (*Client)(nil)
-	_ platform.IssueReader        = (*Client)(nil)
-	_ platform.ReleaseReader      = (*Client)(nil)
-	_ platform.TagReader          = (*Client)(nil)
-	_ platform.CIReader           = (*Client)(nil)
-	_ platform.CommentMutator     = (*Client)(nil)
-	_ platform.StateMutator       = (*Client)(nil)
-	_ platform.MergeMutator       = (*Client)(nil)
-	_ platform.ReviewMutator      = (*Client)(nil)
-	_ platform.IssueMutator       = (*Client)(nil)
+	_ gitealike.Transport                     = (*transport)(nil)
+	_ gitealike.ActionsTransport              = (*transport)(nil)
+	_ platform.RepositoryReader               = (*Client)(nil)
+	_ platform.MergeRequestReader             = (*Client)(nil)
+	_ platform.IssueReader                    = (*Client)(nil)
+	_ platform.ReleaseReader                  = (*Client)(nil)
+	_ platform.TagReader                      = (*Client)(nil)
+	_ platform.CIReader                       = (*Client)(nil)
+	_ platform.CommentMutator                 = (*Client)(nil)
+	_ platform.StateMutator                   = (*Client)(nil)
+	_ platform.MergeMutator                   = (*Client)(nil)
+	_ platform.ReviewMutator                  = (*Client)(nil)
+	_ platform.IssueMutator                   = (*Client)(nil)
+	_ platform.DiffReviewDraftMutator         = (*Client)(nil)
+	_ platform.MergeRequestReviewThreadReader = (*Client)(nil)
 )
 
 func TestClientLooksUpRepositoryAndSendsToken(t *testing.T) {
@@ -243,17 +245,25 @@ func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 	assert.Equal(platform.KindForgejo, client.Platform())
 	assert.Equal("codeberg.test", client.Host())
 	assert.Equal(platform.Capabilities{
-		ReadRepositories:  true,
-		ReadMergeRequests: true,
-		ReadIssues:        true,
-		ReadComments:      true,
-		ReadReleases:      true,
-		ReadCI:            true,
-		CommentMutation:   true,
-		StateMutation:     true,
-		MergeMutation:     true,
-		ReviewMutation:    true,
-		IssueMutation:     true,
+		ReadRepositories:      true,
+		ReadMergeRequests:     true,
+		ReadIssues:            true,
+		ReadComments:          true,
+		ReadReleases:          true,
+		ReadCI:                true,
+		CommentMutation:       true,
+		StateMutation:         true,
+		MergeMutation:         true,
+		ReviewMutation:        true,
+		IssueMutation:         true,
+		ReviewDraftMutation:   true,
+		ReadReviewThreads:     true,
+		NativeMultilineRanges: false,
+		SupportedReviewActions: []platform.ReviewAction{
+			platform.ReviewActionComment,
+			platform.ReviewActionApprove,
+			platform.ReviewActionRequestChanges,
+		},
 	}, client.Capabilities())
 }
 

--- a/internal/platform/forgejo/diff_review.go
+++ b/internal/platform/forgejo/diff_review.go
@@ -1,0 +1,217 @@
+package forgejo
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	"github.com/wesm/middleman/internal/platform"
+)
+
+func (c *Client) PublishDiffReviewDraft(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	input platform.PublishDiffReviewDraftInput,
+) (*platform.PublishedDiffReview, error) {
+	return c.transport.PublishDiffReviewDraft(ctx, ref, number, input)
+}
+
+func (c *Client) ListMergeRequestReviewThreads(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestReviewThread, error) {
+	return c.transport.ListMergeRequestReviewThreads(ctx, ref, number)
+}
+
+func (t *transport) PublishDiffReviewDraft(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	input platform.PublishDiffReviewDraftInput,
+) (*platform.PublishedDiffReview, error) {
+	comments := make([]forgejosdk.CreatePullReviewComment, 0, len(input.Comments))
+	commitID := ""
+	for _, comment := range input.Comments {
+		if commitID == "" {
+			commitID = comment.Range.CommitSHA
+			if commitID == "" {
+				commitID = comment.Range.DiffHeadSHA
+			}
+		}
+		comments = append(comments, forgejoReviewComments(comment)...)
+	}
+
+	var review *forgejosdk.PullReview
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		review, resp, err = t.api.CreatePullReview(ref.Owner, ref.Name, int64(number), forgejosdk.CreatePullReviewOptions{
+			State:    forgejoReviewState(input.Action),
+			Body:     input.Body,
+			CommitID: commitID,
+			Comments: comments,
+		})
+		return err
+	})
+	if err != nil {
+		return nil, forgejoHTTPError(resp, err)
+	}
+	if review == nil {
+		return nil, fmt.Errorf("forgejo create pull review returned nil review")
+	}
+	return &platform.PublishedDiffReview{
+		ProviderReviewID: strconv.FormatInt(review.ID, 10),
+		SubmittedAt:      review.Submitted.UTC(),
+	}, nil
+}
+
+func (t *transport) ListMergeRequestReviewThreads(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestReviewThread, error) {
+	reviews, err := t.listAllPullReviews(ctx, ref, number)
+	if err != nil {
+		return nil, err
+	}
+	threads := make([]platform.MergeRequestReviewThread, 0)
+	for _, review := range reviews {
+		comments, err := t.listPullReviewComments(ctx, ref, number, review.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, comment := range comments {
+			threads = append(threads, forgejoReviewThread(review, comment))
+		}
+	}
+	return threads, nil
+}
+
+func (t *transport) listAllPullReviews(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]*forgejosdk.PullReview, error) {
+	t.spendSyncBudget(ctx)
+	var out []*forgejosdk.PullReview
+	page := 1
+	for {
+		var reviews []*forgejosdk.PullReview
+		var resp *forgejosdk.Response
+		err := t.withRequestContext(ctx, func() error {
+			var err error
+			reviews, resp, err = t.api.ListPullReviews(ref.Owner, ref.Name, int64(number), forgejosdk.ListPullReviewsOptions{
+				ListOptions: forgejosdk.ListOptions{Page: page, PageSize: 100},
+			})
+			return err
+		})
+		if err != nil {
+			return nil, forgejoHTTPError(resp, err)
+		}
+		out = append(out, reviews...)
+		if resp == nil || resp.NextPage == 0 {
+			return out, nil
+		}
+		page = resp.NextPage
+	}
+}
+
+func (t *transport) listPullReviewComments(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	reviewID int64,
+) ([]*forgejosdk.PullReviewComment, error) {
+	t.spendSyncBudget(ctx)
+	var comments []*forgejosdk.PullReviewComment
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		comments, resp, err = t.api.ListPullReviewComments(ref.Owner, ref.Name, int64(number), reviewID)
+		return err
+	})
+	if err != nil {
+		return nil, forgejoHTTPError(resp, err)
+	}
+	return comments, nil
+}
+
+func forgejoReviewState(action platform.ReviewAction) forgejosdk.ReviewStateType {
+	switch action {
+	case platform.ReviewActionApprove:
+		return forgejosdk.ReviewStateApproved
+	case platform.ReviewActionRequestChanges:
+		return forgejosdk.ReviewStateRequestChanges
+	default:
+		return forgejosdk.ReviewStateComment
+	}
+}
+
+func forgejoReviewComments(comment platform.LocalDiffReviewDraftComment) []forgejosdk.CreatePullReviewComment {
+	next := forgejosdk.CreatePullReviewComment{
+		Path: comment.Range.Path,
+		Body: comment.Body,
+	}
+	if comment.Range.Side == "left" {
+		next.OldLineNum = int64(comment.Range.Line)
+	} else {
+		next.NewLineNum = int64(comment.Range.Line)
+	}
+	return []forgejosdk.CreatePullReviewComment{next}
+}
+
+func forgejoReviewThread(
+	review *forgejosdk.PullReview,
+	comment *forgejosdk.PullReviewComment,
+) platform.MergeRequestReviewThread {
+	if review == nil {
+		review = &forgejosdk.PullReview{}
+	}
+	if comment == nil {
+		comment = &forgejosdk.PullReviewComment{}
+	}
+	line := int(comment.LineNum)
+	side := "right"
+	lineType := "add"
+	var oldLine *int
+	var newLine *int
+	if comment.OldLineNum > 0 {
+		line = int(comment.OldLineNum)
+		side = "left"
+		lineType = "delete"
+		oldLine = &line
+	} else {
+		newLine = &line
+	}
+	resolvedAt := (*time.Time)(nil)
+	resolved := comment.Resolver != nil
+	if resolved {
+		updated := comment.Updated.UTC()
+		resolvedAt = &updated
+	}
+	return platform.MergeRequestReviewThread{
+		ProviderThreadID:  strconv.FormatInt(comment.ID, 10),
+		ProviderReviewID:  strconv.FormatInt(review.ID, 10),
+		ProviderCommentID: strconv.FormatInt(comment.ID, 10),
+		Body:              comment.Body,
+		AuthorLogin:       convertUser(comment.Reviewer).UserName,
+		Range: platform.DiffReviewLineRange{
+			Path:        comment.Path,
+			Side:        side,
+			Line:        line,
+			OldLine:     oldLine,
+			NewLine:     newLine,
+			LineType:    lineType,
+			DiffHeadSHA: comment.CommitID,
+			CommitSHA:   comment.CommitID,
+		},
+		Resolved:   resolved,
+		CreatedAt:  comment.Created.UTC(),
+		UpdatedAt:  comment.Updated.UTC(),
+		ResolvedAt: resolvedAt,
+	}
+}

--- a/internal/platform/forgejo/diff_review.go
+++ b/internal/platform/forgejo/diff_review.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
-	"github.com/wesm/middleman/internal/platform"
+	"go.kenn.io/middleman/internal/platform"
 )
 
 func (c *Client) PublishDiffReviewDraft(

--- a/internal/platform/forgejo/diff_review_test.go
+++ b/internal/platform/forgejo/diff_review_test.go
@@ -1,0 +1,132 @@
+package forgejo
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	Require "github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/platform"
+)
+
+func TestPublishDiffReviewDraftCreatesForgejoReview(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	submitted := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/api/v1/repos/acme/widgets/pulls/42/reviews", r.URL.Path)
+		var body struct {
+			Event    string `json:"event"`
+			Body     string `json:"body"`
+			CommitID string `json:"commit_id"`
+			Comments []struct {
+				Path        string `json:"path"`
+				Body        string `json:"body"`
+				NewPosition int64  `json:"new_position"`
+				OldPosition int64  `json:"old_position"`
+			} `json:"comments"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		assert.Equal("REQUEST_CHANGES", body.Event)
+		assert.Equal("summary", body.Body)
+		assert.Equal("head-sha", body.CommitID)
+		if assert.Len(body.Comments, 1) {
+			assert.Equal(int64(5), body.Comments[0].NewPosition)
+			assert.Zero(body.Comments[0].OldPosition)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id":           99,
+			"state":        "REQUEST_CHANGES",
+			"body":         "summary",
+			"submitted_at": submitted.Format(time.RFC3339),
+			"user":         map[string]any{"login": "reviewer"},
+		}))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("codeberg.test", "token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		Owner: "acme",
+		Name:  "widgets",
+	}, 42, platform.PublishDiffReviewDraftInput{
+		Body:   "summary",
+		Action: platform.ReviewActionRequestChanges,
+		Comments: []platform.LocalDiffReviewDraftComment{{
+			Body: "range note",
+			Range: platform.DiffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        5,
+				DiffHeadSHA: "head-sha",
+			},
+		}},
+	})
+
+	require.NoError(err)
+	require.NotNil(result)
+	assert.Equal("99", result.ProviderReviewID)
+	assert.Equal(submitted, result.SubmittedAt)
+}
+
+func TestListMergeRequestReviewThreadsReadsForgejoReviewComments(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	created := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/acme/widgets/pulls/42/reviews":
+			assert.Equal(http.MethodGet, r.Method)
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id":           99,
+				"state":        "COMMENT",
+				"submitted_at": created.Format(time.RFC3339),
+				"user":         map[string]any{"login": "reviewer"},
+			}}))
+		case "/api/v1/repos/acme/widgets/pulls/42/reviews/99/comments":
+			assert.Equal(http.MethodGet, r.Method)
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id":                     101,
+				"body":                   "inline note",
+				"user":                   map[string]any{"login": "reviewer"},
+				"pull_request_review_id": 99,
+				"path":                   "src/main.go",
+				"commit_id":              "head-sha",
+				"position":               7,
+				"created_at":             created.Format(time.RFC3339),
+				"updated_at":             created.Add(time.Minute).Format(time.RFC3339),
+			}}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient("codeberg.test", "token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	threads, err := client.ListMergeRequestReviewThreads(context.Background(), platform.RepoRef{
+		Owner: "acme",
+		Name:  "widgets",
+	}, 42)
+
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("101", threads[0].ProviderThreadID)
+	assert.Equal("99", threads[0].ProviderReviewID)
+	assert.Equal("inline note", threads[0].Body)
+	assert.Equal("reviewer", threads[0].AuthorLogin)
+	assert.Equal("right", threads[0].Range.Side)
+	assert.Equal(7, threads[0].Range.Line)
+	assert.Equal("head-sha", threads[0].Range.CommitSHA)
+}

--- a/internal/platform/forgejo/diff_review_test.go
+++ b/internal/platform/forgejo/diff_review_test.go
@@ -10,7 +10,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
-	"github.com/wesm/middleman/internal/platform"
+	"go.kenn.io/middleman/internal/platform"
 )
 
 func TestPublishDiffReviewDraftCreatesForgejoReview(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -19780,8 +19780,13 @@ func TestWorkspaceIssueMonitorAssociatesPRAndKeepsIssueOwnership(t *testing.T) {
 
 	fixture, created := prepareIssueWorkspaceAssociationFixture(t)
 
-	updates, err := fixture.server.workspacePRMonitor.RunOnce(ctx)
-	require.NoError(err)
+	var updates []workspace.PRAssociationUpdate
+	require.Eventually(func() bool {
+		var runErr error
+		updates, runErr = fixture.server.workspacePRMonitor.RunOnce(ctx)
+		require.NoError(runErr)
+		return len(updates) == 1
+	}, 5*time.Second, 25*time.Millisecond)
 	require.Len(updates, 1)
 	assert.Equal(created.ID, updates[0].WorkspaceID)
 	assert.Equal(42, updates[0].PRNumber)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18815,12 +18815,17 @@ done
 		require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("size\n")))
 	}
 	requestSize()
-	readCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
-	defer cancel()
+	deadline := time.Now().Add(8 * time.Second)
 	var got strings.Builder
-	for {
+	for time.Now().Before(deadline) {
+		readCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
 		typ, data, readErr := conn.Read(readCtx)
+		cancel()
 		if readErr != nil {
+			if errors.Is(readErr, context.DeadlineExceeded) {
+				requestSize()
+				continue
+			}
 			break
 		}
 		if typ != websocket.MessageBinary {
@@ -18833,9 +18838,7 @@ done
 		if strings.Contains(got.String(), "size:40:177:size") {
 			return
 		}
-		if strings.Contains(got.String(), "size:") {
-			requestSize()
-		}
+		requestSize()
 	}
 	require.Contains(got.String(), "size:40:177:size")
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18755,13 +18755,17 @@ func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
 	dir := t.TempDir()
 	agentPath := filepath.Join(dir, "size-agent")
 	require.NoError(os.WriteFile(agentPath, []byte(`#!/bin/sh
-while IFS= read -r line; do
+attempt=0
+while [ "$attempt" -lt 80 ]; do
 	set -- $(stty size 2>/dev/null || printf '0 0')
-	printf 'size:%s:%s:%s\n' "$1" "$2" "$line"
-	if [ "$1:$2:$line" = "40:177:size" ]; then
+	printf 'size:%s:%s:probe\n' "$1" "$2"
+	if [ "$1:$2" = "40:177" ]; then
 		exit 0
 	fi
+	attempt=$((attempt + 1))
+	sleep 0.1
 done
+exit 1
 `), 0o755))
 	cfg := &config.Config{
 		Agents: []config.Agent{{
@@ -18803,7 +18807,7 @@ done
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
-	requestSize := func() {
+	requestResize := func() {
 		t.Helper()
 		resize, err := json.Marshal(map[string]any{
 			"type": "resize",
@@ -18812,9 +18816,8 @@ done
 		})
 		require.NoError(err)
 		require.NoError(conn.Write(ctx, websocket.MessageText, resize))
-		require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("size\n")))
 	}
-	requestSize()
+	requestResize()
 	deadline := time.Now().Add(8 * time.Second)
 	var got strings.Builder
 	for time.Now().Before(deadline) {
@@ -18823,7 +18826,7 @@ done
 		cancel()
 		if readErr != nil {
 			if errors.Is(readErr, context.DeadlineExceeded) {
-				requestSize()
+				requestResize()
 				continue
 			}
 			break
@@ -18835,12 +18838,12 @@ done
 		// tmux keeps one row for its status line by default, so the
 		// pane sees one fewer row than the attached terminal while
 		// preserving the requested column count.
-		if strings.Contains(got.String(), "size:40:177:size") {
+		if strings.Contains(got.String(), "size:40:177:probe") {
 			return
 		}
-		requestSize()
+		requestResize()
 	}
-	require.Contains(got.String(), "size:40:177:size")
+	require.Contains(got.String(), "size:40:177:probe")
 }
 
 func createReadyWorkspace(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10867,10 +10867,10 @@ func TestAPIForgejoPublishReviewDraftIngestsTimelineThread(t *testing.T) {
 	var detail mergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
 	require.Len(detail.Events, 1)
-	require.NotNil(detail.Events[0].ReviewThread)
-	assert.Equal("Forgejo inline note", detail.Events[0].ReviewThread.Body)
-	assert.Equal("src/main.go", detail.Events[0].ReviewThread.Path)
-	assert.Equal(7, detail.Events[0].ReviewThread.Line)
+	require.NotNil(detail.Events[0].DiffThread)
+	assert.Equal("Forgejo inline note", detail.Events[0].DiffThread.Body)
+	assert.Equal("src/main.go", detail.Events[0].DiffThread.Path)
+	assert.Equal(7, detail.Events[0].DiffThread.Line)
 }
 
 func TestAPIForgejoSyncRecoversReviewThreadTimelineMetadata(t *testing.T) {
@@ -10931,10 +10931,10 @@ func TestAPIForgejoSyncRecoversReviewThreadTimelineMetadata(t *testing.T) {
 	var detail mergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
 	require.Len(detail.Events, 1)
-	require.NotNil(detail.Events[0].ReviewThread)
+	require.NotNil(detail.Events[0].DiffThread)
 	assert.Equal("review_comment", detail.Events[0].EventType)
-	assert.Equal("Recovered inline note", detail.Events[0].ReviewThread.Body)
-	assert.Equal("src/recovered.go", detail.Events[0].ReviewThread.Path)
+	assert.Equal("Recovered inline note", detail.Events[0].DiffThread.Body)
+	assert.Equal("src/recovered.go", detail.Events[0].DiffThread.Path)
 }
 
 func TestAPIPublishReviewDraftDeletesDraftBeforeReviewThreadIngest(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -498,7 +498,7 @@ type apiTestGitLabProvider struct {
 }
 
 func (p *apiTestGitLabProvider) Platform() platform.Kind {
-	return platform.KindGitLab
+	return p.ref.Platform
 }
 
 func (p *apiTestGitLabProvider) Host() string {
@@ -10488,12 +10488,29 @@ func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
 
 func TestAPIDiffReviewDraftRejectsInvalidLineCoordinates(t *testing.T) {
 	require := require.New(t)
-	srv, _ := setupGitLabCapabilityServer(t)
+	assert := Assert.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:       true,
+		ReadMergeRequests:      true,
+		ReadIssues:             true,
+		ReadComments:           true,
+		ReviewDraftMutation:    true,
+		SupportedReviewActions: []platform.ReviewAction{platform.ReviewActionComment},
+	}
+	srv, database := setupGitLabCapabilityServerWithCaps(t, &caps)
+	ctx := t.Context()
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	rr := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
-		"body": "Invalid legacy line type.",
-		"range": map[string]any{
+	validRange := map[string]any{
+		"path":          "internal/server/api_test.go",
+		"side":          "right",
+		"line":          42,
+		"new_line":      42,
+		"line_type":     "add",
+		"diff_head_sha": "abc123",
+	}
+	invalidRanges := []map[string]any{
+		{
 			"path":          "internal/server/api_test.go",
 			"side":          "right",
 			"line":          42,
@@ -10501,20 +10518,94 @@ func TestAPIDiffReviewDraftRejectsInvalidLineCoordinates(t *testing.T) {
 			"line_type":     "added",
 			"diff_head_sha": "abc123",
 		},
-	})
-	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
-
-	rr = doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
-		"body": "Missing diff head.",
-		"range": map[string]any{
+		{
 			"path":      "internal/server/api_test.go",
 			"side":      "right",
 			"line":      42,
 			"new_line":  42,
 			"line_type": "add",
 		},
+		{
+			"path":          "internal/server/api_test.go",
+			"side":          "right",
+			"start_line":    41,
+			"line":          42,
+			"new_line":      42,
+			"line_type":     "add",
+			"diff_head_sha": "abc123",
+		},
+		{
+			"path":          "internal/server/api_test.go",
+			"side":          "right",
+			"start_side":    "right",
+			"line":          42,
+			"new_line":      42,
+			"line_type":     "add",
+			"diff_head_sha": "abc123",
+		},
+		{
+			"path":          "internal/server/api_test.go",
+			"side":          "right",
+			"start_side":    "right",
+			"start_line":    43,
+			"line":          42,
+			"new_line":      42,
+			"line_type":     "add",
+			"diff_head_sha": "abc123",
+		},
+	}
+	for _, lineRange := range invalidRanges {
+		rr := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+			"body":  "Invalid range.",
+			"range": lineRange,
+		})
+		require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
 	})
-	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	storedDraft, err := database.GetMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	assert.Nil(storedDraft)
+
+	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		"body":  "Valid draft.",
+		"range": validRange,
+	})
+	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+	var created map[string]any
+	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
+	commentID, ok := created["id"].(string)
+	require.True(ok)
+
+	patchRR := doJSON(t, srv, http.MethodPatch, basePath+"/comments/"+commentID, map[string]any{
+		"body": "Invalid patch.",
+		"range": map[string]any{
+			"path":          "internal/server/api_test.go",
+			"side":          "right",
+			"start_side":    "right",
+			"line":          42,
+			"new_line":      42,
+			"line_type":     "add",
+			"diff_head_sha": "abc123",
+		},
+	})
+	require.Equal(http.StatusBadRequest, patchRR.Code, patchRR.Body.String())
+	storedDraft, err = database.GetMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	require.NotNil(storedDraft)
+	comments, err := database.ListMRReviewDraftComments(ctx, storedDraft.ID)
+	require.NoError(err)
+	require.Len(comments, 1)
+	assert.Equal("Valid draft.", comments[0].Body)
 }
 
 func TestAPIPublishReviewDraftRejectsStoredCommentWithoutDiffHeadSHA(t *testing.T) {
@@ -10703,6 +10794,149 @@ func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
 	assert.Equal("thread-7", events[0].PlatformExternalID)
 }
 
+func TestAPIForgejoPublishReviewDraftIngestsTimelineThread(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:       true,
+		ReadMergeRequests:      true,
+		ReadIssues:             true,
+		ReadComments:           true,
+		ReadReviewThreads:      true,
+		ReviewDraftMutation:    true,
+		SupportedReviewActions: []platform.ReviewAction{platform.ReviewActionComment},
+	}
+	srv, database, provider := setupForgejoCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "forgejo",
+		PlatformHost: "codeberg.org",
+		RepoPath:     "acme/widgets",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 42)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NoError(database.UpdateDiffSHAs(ctx, repo.ID, 42, "forgejo-head", "base", "merge"))
+	now := time.Now().UTC().Truncate(time.Second)
+	line := 7
+	provider.reviewThreads = []platform.MergeRequestReviewThread{{
+		ProviderThreadID:  "comment-42",
+		ProviderReviewID:  "review-42",
+		ProviderCommentID: "comment-42",
+		Body:              "Forgejo inline note",
+		AuthorLogin:       "ada",
+		Range: platform.DiffReviewLineRange{
+			Path:        "src/main.go",
+			Side:        "right",
+			Line:        7,
+			NewLine:     &line,
+			LineType:    "add",
+			DiffHeadSHA: "forgejo-head",
+			CommitSHA:   "forgejo-head",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}
+
+	basePath := "/api/v1/pulls/forgejo/acme/widgets/42/review-draft"
+	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		"body": "Forgejo inline note",
+		"range": map[string]any{
+			"path":          "src/main.go",
+			"side":          "right",
+			"line":          7,
+			"new_line":      7,
+			"line_type":     "add",
+			"diff_head_sha": "forgejo-head",
+			"commit_sha":    "forgejo-head",
+		},
+	})
+	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+
+	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+		"action": "comment",
+	})
+	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
+	require.Len(provider.publishedReviews, 1)
+
+	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/forgejo/acme/widgets/42", nil)
+	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
+	var detail mergeRequestDetailResponse
+	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
+	require.Len(detail.Events, 1)
+	require.NotNil(detail.Events[0].ReviewThread)
+	assert.Equal("Forgejo inline note", detail.Events[0].ReviewThread.Body)
+	assert.Equal("src/main.go", detail.Events[0].ReviewThread.Path)
+	assert.Equal(7, detail.Events[0].ReviewThread.Line)
+}
+
+func TestAPIForgejoSyncRecoversReviewThreadTimelineMetadata(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:       true,
+		ReadMergeRequests:      true,
+		ReadIssues:             true,
+		ReadComments:           true,
+		ReadReviewThreads:      true,
+		ReviewDraftMutation:    true,
+		SupportedReviewActions: []platform.ReviewAction{platform.ReviewActionComment},
+	}
+	srv, database, provider := setupForgejoCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "forgejo",
+		PlatformHost: "codeberg.org",
+		RepoPath:     "acme/widgets",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 42)
+	require.NoError(err)
+	require.NotNil(mr)
+	events, err := database.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Empty(events)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	line := 8
+	provider.reviewThreads = []platform.MergeRequestReviewThread{{
+		ProviderThreadID:  "comment-99",
+		ProviderReviewID:  "review-99",
+		ProviderCommentID: "comment-99",
+		Body:              "Recovered inline note",
+		AuthorLogin:       "ada",
+		Range: platform.DiffReviewLineRange{
+			Path:        "src/recovered.go",
+			Side:        "right",
+			Line:        line,
+			NewLine:     &line,
+			LineType:    "add",
+			DiffHeadSHA: "abc123",
+			CommitSHA:   "abc123",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}
+
+	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/forgejo/acme/widgets/42/sync", nil)
+	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
+
+	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/forgejo/acme/widgets/42", nil)
+	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
+	var detail mergeRequestDetailResponse
+	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
+	require.Len(detail.Events, 1)
+	require.NotNil(detail.Events[0].ReviewThread)
+	assert.Equal("review_comment", detail.Events[0].EventType)
+	assert.Equal("Recovered inline note", detail.Events[0].ReviewThread.Body)
+	assert.Equal("src/recovered.go", detail.Events[0].ReviewThread.Path)
+}
+
 func TestAPIPublishReviewDraftDeletesDraftBeforeReviewThreadIngest(t *testing.T) {
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -10829,6 +11063,70 @@ func TestAPIResolveReviewThreadPersistsProviderState(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(thread)
 	assert.False(thread.Resolved)
+}
+
+func TestAPIResolveReviewThreadReturnsServerErrorForCorruptStoredThread(t *testing.T) {
+	require := require.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:       true,
+		ReadMergeRequests:      true,
+		ReadIssues:             true,
+		ReadComments:           true,
+		ReviewThreadResolution: true,
+		ReviewDraftMutation:    true,
+		SupportedReviewActions: []platform.ReviewAction{platform.ReviewActionComment},
+		NativeMultilineRanges:  true,
+		ReadReviewThreads:      true,
+	}
+	srv, database, _ := setupGitLabCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	now := time.Now().UTC().Truncate(time.Second)
+	line := 42
+	require.NoError(database.UpsertMRReviewThreads(ctx, mr.ID, []db.MRReviewThread{{
+		ProviderThreadID:  "thread-corrupt",
+		ProviderCommentID: "comment-corrupt",
+		Body:              "corrupt thread",
+		Range: db.ReviewLineRange{
+			Path:        "internal/server/api_test.go",
+			Side:        "right",
+			Line:        42,
+			NewLine:     &line,
+			LineType:    "add",
+			DiffHeadSHA: "head",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}))
+	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(threads, 1)
+	_, err = database.WriteDB().ExecContext(
+		ctx,
+		`UPDATE middleman_mr_review_threads SET line = 'not-an-int' WHERE id = ?`,
+		threads[0].ID,
+	)
+	require.NoError(err)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-threads/"+
+			strconv.FormatInt(threads[0].ID, 10)+"/resolve",
+		nil,
+	)
+	require.Equal(http.StatusInternalServerError, rr.Code, rr.Body.String())
 }
 
 func TestAPIPullDetailAttachesReviewThreadMetadata(t *testing.T) {
@@ -12126,6 +12424,76 @@ func setupGitLabCapabilityServerWithProvider(
 		PlatformExternalID: "gid://gitlab/Project/4242",
 		WebURL:             "https://gitlab.example.com/group/project",
 		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	syncer.RunOnce(ctx)
+	return srv, database, provider
+}
+
+func setupForgejoCapabilityServerWithProvider(
+	t *testing.T,
+	caps *platform.Capabilities,
+) (*Server, *db.DB, *apiTestGitLabProvider) {
+	t.Helper()
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	database := dbtest.Open(t)
+
+	ref := platform.RepoRef{
+		Platform:           platform.KindForgejo,
+		Host:               "codeberg.org",
+		Owner:              "acme",
+		Name:               "widgets",
+		RepoPath:           "acme/widgets",
+		PlatformID:         5252,
+		PlatformExternalID: "5252",
+		WebURL:             "https://codeberg.org/acme/widgets",
+		CloneURL:           "https://codeberg.org/acme/widgets.git",
+		DefaultBranch:      "main",
+	}
+	provider := &apiTestGitLabProvider{
+		ref:          ref,
+		capabilities: caps,
+		mergeRequests: []platform.MergeRequest{{
+			Repo:               ref,
+			PlatformID:         9001,
+			PlatformExternalID: "9001",
+			Number:             42,
+			URL:                "https://codeberg.org/acme/widgets/pulls/42",
+			Title:              "Forgejo provider PR",
+			Author:             "ada",
+			State:              "open",
+			HeadBranch:         "feature/forgejo",
+			BaseBranch:         "main",
+			HeadSHA:            "abc123",
+			BaseSHA:            "def456",
+			CreatedAt:          now,
+			UpdatedAt:          now,
+			LastActivityAt:     now,
+		}},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	repo := ghclient.RepoRef{
+		Platform:           platform.KindForgejo,
+		Owner:              "acme",
+		Name:               "widgets",
+		PlatformHost:       "codeberg.org",
+		RepoPath:           "acme/widgets",
+		PlatformRepoID:     5252,
+		PlatformExternalID: "5252",
+		WebURL:             "https://codeberg.org/acme/widgets",
+		CloneURL:           "https://codeberg.org/acme/widgets.git",
 		DefaultBranch:      "main",
 	}
 	syncer := ghclient.NewSyncerWithRegistry(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -19787,15 +19787,25 @@ func TestWorkspaceIssueMonitorAssociatesPRAndKeepsIssueOwnership(t *testing.T) {
 	fixture, created := prepareIssueWorkspaceAssociationFixture(t)
 
 	var updates []workspace.PRAssociationUpdate
+	var sawUpdate bool
 	require.Eventually(func() bool {
 		var runErr error
 		updates, runErr = fixture.server.workspacePRMonitor.RunOnce(ctx)
 		require.NoError(runErr)
-		return len(updates) == 1
-	}, 5*time.Second, 25*time.Millisecond)
-	require.Len(updates, 1)
-	assert.Equal(created.ID, updates[0].WorkspaceID)
-	assert.Equal(42, updates[0].PRNumber)
+		if len(updates) == 1 {
+			sawUpdate = true
+			return true
+		}
+		stored, getErr := fixture.database.GetWorkspace(ctx, created.ID)
+		require.NoError(getErr)
+		return stored != nil &&
+			stored.AssociatedPRNumber != nil &&
+			*stored.AssociatedPRNumber == 42
+	}, 30*time.Second, 100*time.Millisecond)
+	if sawUpdate {
+		assert.Equal(created.ID, updates[0].WorkspaceID)
+		assert.Equal(42, updates[0].PRNumber)
+	}
 
 	getRR := doJSON(
 		t,

--- a/internal/server/diff_review_handlers.go
+++ b/internal/server/diff_review_handlers.go
@@ -273,11 +273,14 @@ func (s *Server) setDiffReviewThreadResolved(
 		return nil, huma.Error404NotFound("pull request not found")
 	}
 	thread, err := s.db.GetMRReviewThread(ctx, mr.ID, threadID)
-	if errors.Is(err, sql.ErrNoRows) || thread == nil {
-		return nil, huma.Error404NotFound("review thread not found")
-	}
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, huma.Error404NotFound("review thread not found")
+		}
 		return nil, huma.Error500InternalServerError("get review thread failed")
+	}
+	if thread == nil {
+		return nil, huma.Error404NotFound("review thread not found")
 	}
 	resolver, err := s.syncer.DiffReviewThreadResolver(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -562,8 +565,19 @@ func dbReviewLineRange(input diffReviewLineRange) (db.ReviewLineRange, error) {
 		return db.ReviewLineRange{}, huma.Error400BadRequest("review range diff_head_sha is required")
 	}
 	startSide := strings.ToLower(strings.TrimSpace(input.StartSide))
+	if input.StartLine != nil && *input.StartLine <= 0 {
+		return db.ReviewLineRange{}, huma.Error400BadRequest("review range start_line must be positive")
+	}
+	if (startSide == "") != (input.StartLine == nil) {
+		return db.ReviewLineRange{}, huma.Error400BadRequest(
+			"review range start_side and start_line must be supplied together",
+		)
+	}
 	if startSide != "" && startSide != side {
 		return db.ReviewLineRange{}, huma.Error400BadRequest("review range must stay on one side")
+	}
+	if input.StartLine != nil && *input.StartLine > input.Line {
+		return db.ReviewLineRange{}, huma.Error400BadRequest("review range start_line must be before line")
 	}
 	return db.ReviewLineRange{
 		Path:        path,

--- a/internal/server/diff_review_handlers_test.go
+++ b/internal/server/diff_review_handlers_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBReviewLineRangeRejectsMalformedMultilineRanges(t *testing.T) {
+	validLine := 10
+	cases := []struct {
+		name  string
+		patch func(*diffReviewLineRange)
+	}{
+		{
+			name: "non-positive start line",
+			patch: func(input *diffReviewLineRange) {
+				startLine := 0
+				input.StartSide = "right"
+				input.StartLine = &startLine
+			},
+		},
+		{
+			name: "start line without start side",
+			patch: func(input *diffReviewLineRange) {
+				input.StartLine = &validLine
+			},
+		},
+		{
+			name: "start side without start line",
+			patch: func(input *diffReviewLineRange) {
+				input.StartSide = "right"
+			},
+		},
+		{
+			name: "start line after end line",
+			patch: func(input *diffReviewLineRange) {
+				startLine := 11
+				input.StartSide = "right"
+				input.StartLine = &startLine
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			input := diffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        10,
+				NewLine:     &validLine,
+				LineType:    "add",
+				DiffHeadSHA: "head-sha",
+			}
+			tc.patch(&input)
+
+			_, err := dbReviewLineRange(input)
+			require.Error(err)
+		})
+	}
+}

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -247,6 +247,7 @@
   type ReviewLineRef = {
     side: ReviewSide;
     order: number;
+    hunkIndex: number;
     line: number;
     oldLine?: number | undefined;
     newLine?: number | undefined;
@@ -261,12 +262,14 @@
     line: DiffFileType["hunks"][number]["lines"][number],
     side: ReviewSide,
     order: number,
+    hunkIndex: number,
   ): ReviewLineRef | null {
     const lineNumber = side === "right" ? line.new_num : line.old_num;
     if (lineNumber == null) return null;
     return {
       side,
       order,
+      hunkIndex,
       line: lineNumber,
       oldLine: line.old_num,
       newLine: line.new_num,
@@ -277,9 +280,10 @@
   function selectableLines(side: ReviewSide): ReviewLineRef[] {
     const refs: ReviewLineRef[] = [];
     let order = 0;
-    for (const hunk of renderedFile.hunks) {
+    for (let hunkIndex = 0; hunkIndex < renderedFile.hunks.length; hunkIndex++) {
+      const hunk = renderedFile.hunks[hunkIndex]!;
       for (const line of hunk.lines) {
-        const ref = lineRef(line, side, order);
+        const ref = lineRef(line, side, order, hunkIndex);
         if (ref) refs.push(ref);
         order += 1;
       }
@@ -309,14 +313,21 @@
     line: DiffFileType["hunks"][number]["lines"][number],
     side: ReviewSide,
     order: number,
+    hunkIndex: number,
     event: MouseEvent,
   ): void {
     if (!reviewEnabled || !diffHeadSHA) return;
-    const current = lineRef(line, side, order);
+    const current = lineRef(line, side, order, hunkIndex);
     if (!current) return;
-    if (nativeMultilineRanges && event.shiftKey && selectionAnchor?.side === side) {
+    const anchor = selectionAnchor;
+    if (
+      nativeMultilineRanges &&
+      event.shiftKey &&
+      anchor?.side === side &&
+      anchor.hunkIndex === current.hunkIndex
+    ) {
       const refs = selectableLines(side);
-      const anchorIndex = refs.findIndex((ref) => ref.order === selectionAnchor?.order);
+      const anchorIndex = refs.findIndex((ref) => ref.order === anchor.order);
       const currentIndex = refs.findIndex((ref) => ref.order === current.order);
       if (anchorIndex !== -1 && currentIndex !== -1) {
         const [startIndex, endIndex] = anchorIndex <= currentIndex
@@ -338,10 +349,12 @@
     line: DiffFileType["hunks"][number]["lines"][number],
     side: ReviewSide,
     order: number,
+    hunkIndex: number,
   ): boolean {
     if (!selectedRange) return false;
-    const current = lineRef(line, side, order);
+    const current = lineRef(line, side, order, hunkIndex);
     if (!current || current.side !== selectedRange.start.side) return false;
+    if (current.hunkIndex !== selectedRange.start.hunkIndex) return false;
     const min = Math.min(selectedRange.start.order, selectedRange.end.order);
     const max = Math.max(selectedRange.start.order, selectedRange.end.order);
     return current.order >= min && current.order <= max;
@@ -350,10 +363,11 @@
   function composerAfter(
     line: DiffFileType["hunks"][number]["lines"][number],
     order: number,
+    hunkIndex: number,
   ): boolean {
     if (!composerRange || !selectedRange) return false;
     const max = Math.max(selectedRange.start.order, selectedRange.end.order);
-    return order === max && lineRef(line, selectedRange.end.side, order) !== null;
+    return order === max && lineRef(line, selectedRange.end.side, order, hunkIndex) !== null;
   }
 
   function closeComposer(): void {
@@ -422,11 +436,11 @@
                 {...(line.no_newline ? { noNewline: line.no_newline } : {})}
                 tokens={getTokens(hunkIdx, lineIdx)}
                 {reviewEnabled}
-                oldSelected={isSelected(line, "left", order)}
-                newSelected={isSelected(line, "right", order)}
-                onselectside={(side, event) => handleLineSelect(line, side, order, event)}
+                oldSelected={isSelected(line, "left", order, hunkIdx)}
+                newSelected={isSelected(line, "right", order, hunkIdx)}
+                onselectside={(side, event) => handleLineSelect(line, side, order, hunkIdx, event)}
               />
-              {#if composerRange && composerAfter(line, order)}
+              {#if composerRange && composerAfter(line, order, hunkIdx)}
                 <DiffInlineCommentComposer
                   range={composerRange}
                   onclose={closeComposer}

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -202,4 +202,44 @@ describe("DiffFile", () => {
 
     expect(document.querySelectorAll(".gutter-new.gutter--selected")).toHaveLength(1);
   });
+
+  it("does not create multiline review ranges across separate hunks", async () => {
+    renderDiffFile(makeFile({
+      additions: 2,
+      deletions: 0,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 1,
+          new_start: 1,
+          new_count: 1,
+          lines: [
+            { type: "add", content: "first hunk", new_num: 1 },
+          ],
+        },
+        {
+          old_start: 20,
+          old_count: 1,
+          new_start: 20,
+          new_count: 1,
+          lines: [
+            { type: "add", content: "second hunk", new_num: 20 },
+          ],
+        },
+      ],
+    }), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+      nativeMultilineRanges: true,
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Comment on new line 1" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Comment on new line 20" }), {
+      shiftKey: true,
+    });
+
+    const selected = Array.from(document.querySelectorAll(".gutter-new.gutter--selected"));
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.textContent?.trim()).toBe("20");
+  });
 });

--- a/packages/ui/src/stores/diff-review-draft.svelte.test.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.test.ts
@@ -14,10 +14,12 @@ interface MockDraftLoad {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 describe("createDiffReviewDraftStore", () => {
@@ -205,6 +207,83 @@ describe("createDiffReviewDraftStore", () => {
     await staleLoad.promise;
     await Promise.resolve();
 
+    expect(store.getComments()).toEqual([]);
+  });
+
+  it("does not stay loading when a mutation fails during an in-flight load", async () => {
+    const staleLoad = deferred<unknown>();
+    const client = {
+      GET: vi.fn().mockReturnValueOnce(staleLoad.promise),
+      POST: vi.fn(() => Promise.resolve({
+        error: { title: "failed" },
+        response: { status: 502, ok: false },
+      })),
+    } as unknown as MiddlemanClient;
+    const store = createDiffReviewDraftStore({ client });
+
+    store.setContext({
+      provider: "forgejo",
+      platformHost: "codeberg.org",
+      owner: "acme",
+      name: "widgets",
+      repoPath: "acme/widgets",
+    }, 42, true);
+    await Promise.resolve();
+    expect(store.isLoading()).toBe(true);
+
+    await expect(store.publish("comment", "summary")).resolves.toBe(false);
+    expect(store.isLoading()).toBe(false);
+
+    staleLoad.resolve({
+      data: {
+        comments: [{ id: "stale", body: "old draft" }],
+        supported_actions: ["comment"],
+        native_multiline_ranges: true,
+      },
+      response: { status: 200, ok: true },
+    });
+    await staleLoad.promise;
+    await Promise.resolve();
+
+    expect(store.isLoading()).toBe(false);
+    expect(store.getComments()).toEqual([]);
+  });
+
+  it("does not stay loading when discard succeeds during an in-flight load", async () => {
+    const staleLoad = deferred<unknown>();
+    const client = {
+      GET: vi.fn().mockReturnValueOnce(staleLoad.promise),
+      DELETE: vi.fn(() => Promise.resolve({
+        response: { status: 200, ok: true },
+      })),
+    } as unknown as MiddlemanClient;
+    const store = createDiffReviewDraftStore({ client });
+
+    store.setContext({
+      provider: "forgejo",
+      platformHost: "codeberg.org",
+      owner: "acme",
+      name: "widgets",
+      repoPath: "acme/widgets",
+    }, 42, true);
+    await Promise.resolve();
+    expect(store.isLoading()).toBe(true);
+
+    await expect(store.discard()).resolves.toBe(true);
+    expect(store.isLoading()).toBe(false);
+
+    staleLoad.resolve({
+      data: {
+        comments: [{ id: "stale", body: "old draft" }],
+        supported_actions: ["comment"],
+        native_multiline_ranges: true,
+      },
+      response: { status: 200, ok: true },
+    });
+    await staleLoad.promise;
+    await Promise.resolve();
+
+    expect(store.isLoading()).toBe(false);
     expect(store.getComments()).toEqual([]);
   });
 });

--- a/packages/ui/src/stores/diff-review-draft.svelte.test.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.test.ts
@@ -14,8 +14,8 @@ interface MockDraftLoad {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
   });
   return { promise, resolve };
 }
@@ -160,5 +160,51 @@ describe("createDiffReviewDraftStore", () => {
     expect(client.GET).toHaveBeenCalledTimes(2);
     expect(store.getComments()).toEqual([{ id: "new", body: "new draft" }]);
     expect(store.isLoading()).toBe(false);
+  });
+
+  it("ignores an older same-PR load after publish refreshes the draft", async () => {
+    const staleLoad = deferred<MockDraftLoad>();
+    const client = {
+      GET: vi
+        .fn()
+        .mockReturnValueOnce(staleLoad.promise)
+        .mockResolvedValueOnce({
+          data: {
+            comments: [],
+            supported_actions: ["comment"],
+            native_multiline_ranges: true,
+          },
+          response: { status: 200, ok: true },
+        }),
+      POST: vi.fn(() => Promise.resolve({
+        response: { status: 200, ok: true },
+      })),
+    } as unknown as MiddlemanClient;
+    const store = createDiffReviewDraftStore({ client });
+
+    store.setContext({
+      provider: "forgejo",
+      platformHost: "codeberg.org",
+      owner: "acme",
+      name: "widgets",
+      repoPath: "acme/widgets",
+    }, 42, true);
+    await Promise.resolve();
+
+    await expect(store.publish("comment", "summary")).resolves.toBe(true);
+    expect(store.getComments()).toEqual([]);
+
+    staleLoad.resolve({
+      data: {
+        comments: [{ id: "stale", body: "old draft" }],
+        supported_actions: ["comment"],
+        native_multiline_ranges: true,
+      },
+      response: { status: 200, ok: true },
+    });
+    await staleLoad.promise;
+    await Promise.resolve();
+
+    expect(store.getComments()).toEqual([]);
   });
 });

--- a/packages/ui/src/stores/diff-review-draft.svelte.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.ts
@@ -37,6 +37,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
   let submitting = $state(false);
   let storeError = $state<string | null>(null);
   let wasEnabled = false;
+  let draftVersion = 0;
 
   function isEnabled(): boolean {
     return enabled;
@@ -120,6 +121,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
   }
 
   function clear(): void {
+    draftVersion += 1;
     enabled = false;
     wasEnabled = false;
     ref = null;
@@ -136,6 +138,8 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     const params = currentParams();
     if (!params) return;
     const key = requestKey();
+    const version = ++draftVersion;
+    const isCurrent = () => requestKey() === key && draftVersion === version;
     loading = true;
     storeError = null;
     try {
@@ -146,17 +150,17 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       if (!data) {
         throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
-      if (requestKey() !== key) return;
+      if (!isCurrent()) return;
       draft = {
         ...data,
         comments: data.comments ?? [],
         supported_actions: data.supported_actions ?? [],
       };
     } catch (err) {
-      if (requestKey() !== key) return;
+      if (!isCurrent()) return;
       storeError = err instanceof Error ? err.message : String(err);
     } finally {
-      if (requestKey() === key) {
+      if (isCurrent()) {
         loading = false;
       }
     }
@@ -169,6 +173,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
+    draftVersion += 1;
     submitting = true;
     storeError = null;
     try {
@@ -196,6 +201,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
+    draftVersion += 1;
     submitting = true;
     storeError = null;
     try {
@@ -230,6 +236,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     const publishedRef = ref;
     const publishedNumber = number;
     const key = requestKey();
+    draftVersion += 1;
     submitting = true;
     storeError = null;
     try {
@@ -262,6 +269,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
+    draftVersion += 1;
     submitting = true;
     storeError = null;
     try {

--- a/packages/ui/src/stores/diff-review-draft.svelte.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.ts
@@ -120,8 +120,13 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     number = nextNumber;
   }
 
-  function clear(): void {
+  function invalidateDraftLoad(): void {
     draftVersion += 1;
+    loading = false;
+  }
+
+  function clear(): void {
+    invalidateDraftLoad();
     enabled = false;
     wasEnabled = false;
     ref = null;
@@ -173,7 +178,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
-    draftVersion += 1;
+    invalidateDraftLoad();
     submitting = true;
     storeError = null;
     try {
@@ -201,7 +206,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
-    draftVersion += 1;
+    invalidateDraftLoad();
     submitting = true;
     storeError = null;
     try {
@@ -236,7 +241,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     const publishedRef = ref;
     const publishedNumber = number;
     const key = requestKey();
-    draftVersion += 1;
+    invalidateDraftLoad();
     submitting = true;
     storeError = null;
     try {
@@ -269,7 +274,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
-    draftVersion += 1;
+    invalidateDraftLoad();
     submitting = true;
     storeError = null;
     try {


### PR DESCRIPTION
Adds Forgejo inline review support on top of the shared draft flow:

- Publish local inline draft comments through Forgejo pull-review APIs.
- Ingest provider review comments back into timeline review-thread metadata during publish and sync.
- Keep range support aligned with Forgejo's current single-line publishing behavior.
- Tighten range validation and stale draft handling around publish, refresh, and navigation.
