### PR TITLE
feat: support gitlab inline review publishing

### DIFF
--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -233,6 +233,11 @@ const multiHunkDiffResponse = {
   ],
 };
 
+type MockInlineReviewOptions = {
+  publishStatus?: "published" | "partially_published";
+  remainingDraftComments?: Array<Record<string, unknown>>;
+};
+
 async function mockInlineReviewAPI(
   page: Page,
   capabilities = baseCapabilities,
@@ -240,6 +245,7 @@ async function mockInlineReviewAPI(
   platformHost = "github.com",
   filesResponse: typeof diffResponse = diffResponse,
   onCreateDraft?: (body: { body: string; range: Record<string, unknown> }) => void,
+  options: MockInlineReviewOptions = {},
 ): Promise<void> {
   let draftComments: Array<Record<string, unknown>> = [];
   let reviewThreadResolved = false;
@@ -298,8 +304,8 @@ async function mockInlineReviewAPI(
     await fulfillJson(route, draftComments[0], 201);
   });
   await page.route(`**${path}/review-draft/publish`, async (route) => {
-    draftComments = [];
-    await fulfillJson(route, { status: "published" });
+    draftComments = options.remainingDraftComments ?? [];
+    await fulfillJson(route, { status: options.publishStatus ?? "published" });
   });
   await page.route(`**${path}/review-threads/1/resolve`, async (route) => {
     reviewThreadResolved = true;
@@ -324,6 +330,46 @@ test("adds and publishes an inline draft review comment", async ({ page }) => {
   await expect(page.getByText("Please cover this line.")).toBeVisible();
   await page.getByRole("button", { name: "Publish review" }).click();
   await expect(page.getByText("1 draft comment")).toBeHidden();
+});
+
+test("keeps remaining GitLab draft state visible after a partial publish", async ({ page }) => {
+  await mockInlineReviewAPI(
+    page,
+    baseCapabilities,
+    "gitlab",
+    "gitlab.com",
+    diffResponse,
+    undefined,
+    {
+      publishStatus: "partially_published",
+      remainingDraftComments: [{
+        id: "remaining-1",
+        body: "Still needs follow-up.",
+        path: "src/main.ts",
+        side: "right",
+        line: 2,
+        new_line: 2,
+        line_type: "add",
+        diff_head_sha: "diff-head",
+        created_at: "2026-03-30T14:02:00Z",
+        updated_at: "2026-03-30T14:02:00Z",
+      }],
+    },
+  );
+
+  await page.goto("/pulls/gitlab/acme/widgets/42/files");
+  await page.getByRole("button", { name: "Comment on new line 2" }).click();
+  await page.getByPlaceholder("Leave a comment").fill("Please cover this line.");
+  await page.getByRole("button", { name: "Add comment" }).click();
+
+  const summary = page.getByPlaceholder("Review summary");
+  await summary.fill("Summary should not stay in the composer.");
+  await page.getByRole("button", { name: "Publish review" }).click();
+
+  await expect(summary).toHaveValue("");
+  await expect(page.locator(".review-warning")).toContainText("Review was partially published");
+  await expect(page.getByText("1 draft comment")).toBeVisible();
+  await expect(page.getByText("Still needs follow-up.")).toBeVisible();
 });
 
 test("hides inline review controls when provider draft review is unsupported", async ({ page }) => {

--- a/internal/db/queries_review.go
+++ b/internal/db/queries_review.go
@@ -330,6 +330,32 @@ func (d *DB) UpsertMRReviewThreads(ctx context.Context, mrID int64, threads []MR
 	})
 }
 
+// DeleteMissingMRReviewThreads removes review-thread metadata and generated
+// review_comment timeline rows that are absent from the latest provider read.
+func (d *DB) DeleteMissingMRReviewThreads(ctx context.Context, mrID int64, providerThreadIDs []string) error {
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		threadQuery := `DELETE FROM middleman_mr_review_threads WHERE merge_request_id = ?`
+		threadArgs := []any{mrID}
+		eventQuery := `DELETE FROM middleman_mr_events WHERE merge_request_id = ? AND event_type = 'review_comment'`
+		eventArgs := []any{mrID}
+		if len(providerThreadIDs) > 0 {
+			threadQuery += ` AND provider_thread_id NOT IN (` + sqlPlaceholders(len(providerThreadIDs)) + `)`
+			eventQuery += ` AND dedupe_key NOT IN (` + sqlPlaceholders(len(providerThreadIDs)) + `)`
+			for _, providerThreadID := range providerThreadIDs {
+				threadArgs = append(threadArgs, providerThreadID)
+				eventArgs = append(eventArgs, "review_comment:"+providerThreadID)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, threadQuery, threadArgs...); err != nil {
+			return fmt.Errorf("delete missing mr review threads: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, eventQuery, eventArgs...); err != nil {
+			return fmt.Errorf("delete missing mr review thread events: %w", err)
+		}
+		return nil
+	})
+}
+
 func (d *DB) ListMRReviewThreads(ctx context.Context, mrID int64) ([]MRReviewThread, error) {
 	rows, err := d.ro.QueryContext(ctx, `
 		SELECT id, merge_request_id, provider_thread_id, provider_review_id,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4479,7 +4479,8 @@ func (s *Syncer) fetchMRDetail(
 	if err := s.refreshTimeline(
 		ctx, repo, repoID, mrID, fullPR,
 	); err != nil {
-		// Timeline = 4 calls (comments + reviews + commits + force-push).
+		// Timeline = 4 base calls (comments + reviews + commits + force-push);
+		// provider review-thread sync is handled inside refreshTimeline.
 		calls += 4
 		return calls, err
 	}
@@ -4712,8 +4713,16 @@ func (s *Syncer) syncProviderMRDetailExtras(
 	}
 	if err == nil {
 		dbEvents := make([]db.MREvent, 0, len(events))
+		commentDedupeKeys := make([]string, 0, len(events))
 		for _, event := range events {
-			dbEvents = append(dbEvents, platform.DBMREvent(mrID, event))
+			dbEvent := platform.DBMREvent(mrID, event)
+			dbEvents = append(dbEvents, dbEvent)
+			if dbEvent.EventType == "issue_comment" {
+				commentDedupeKeys = append(commentDedupeKeys, dbEvent.DedupeKey)
+			}
+		}
+		if err := s.db.DeleteMissingMRCommentEvents(ctx, mrID, commentDedupeKeys); err != nil {
+			return calls, false, fmt.Errorf("delete missing comment events for MR #%d: %w", number, err)
 		}
 		if err := s.db.UpsertMREvents(ctx, dbEvents); err != nil {
 			return calls, false, fmt.Errorf("upsert events for MR #%d: %w", number, err)
@@ -4786,6 +4795,8 @@ func (s *Syncer) syncProviderMRReviewThreads(
 
 	dbThreads := make([]db.MRReviewThread, 0, len(threads))
 	events := make([]db.MREvent, 0, len(threads))
+	providerThreadIDs := make([]string, 0, len(threads))
+	seenProviderThreadIDs := make(map[string]struct{}, len(threads))
 	for _, thread := range threads {
 		providerThreadID := thread.ProviderThreadID
 		if providerThreadID == "" {
@@ -4794,6 +4805,11 @@ func (s *Syncer) syncProviderMRReviewThreads(
 		if providerThreadID == "" {
 			continue
 		}
+		if _, ok := seenProviderThreadIDs[providerThreadID]; ok {
+			continue
+		}
+		seenProviderThreadIDs[providerThreadID] = struct{}{}
+		providerThreadIDs = append(providerThreadIDs, providerThreadID)
 		dbThreads = append(dbThreads, db.MRReviewThread{
 			ProviderThreadID:  providerThreadID,
 			ProviderReviewID:  thread.ProviderReviewID,
@@ -4820,6 +4836,9 @@ func (s *Syncer) syncProviderMRReviewThreads(
 			CreatedAt:          createdAt,
 			DedupeKey:          "review_comment:" + providerThreadID,
 		})
+	}
+	if err := s.db.DeleteMissingMRReviewThreads(ctx, mrID, providerThreadIDs); err != nil {
+		return calls, err
 	}
 	if err := s.db.UpsertMRReviewThreads(ctx, mrID, dbThreads); err != nil {
 		return calls, err
@@ -5115,6 +5134,9 @@ func (s *Syncer) refreshTimeline(
 	}
 	if err := s.db.UpsertMREvents(ctx, events); err != nil {
 		return fmt.Errorf("upsert events for MR #%d: %w", number, err)
+	}
+	if _, err := s.syncProviderMRReviewThreads(ctx, repo, mrID, number); err != nil {
+		return fmt.Errorf("sync review threads for MR #%d: %w", number, err)
 	}
 
 	reviewDecision := DeriveReviewDecision(reviews)
@@ -6708,9 +6730,6 @@ func (s *Syncer) syncMRForRepo(
 
 		if err := s.refreshTimeline(ctx, repo, repoID, mrID, ghPR); err != nil {
 			return fmt.Errorf("refresh timeline for MR #%d: %w", number, err)
-		}
-		if _, err := s.syncProviderMRReviewThreads(ctx, repo, mrID, number); err != nil {
-			return fmt.Errorf("sync review threads for MR #%d: %w", number, err)
 		}
 
 		syncMRHeadSHA := ""

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -3617,6 +3617,18 @@ func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
 	require.Len(events, 1)
 	assert.Equal("review_comment", events[0].EventType)
 	assert.Equal("thread-42", events[0].PlatformExternalID)
+
+	provider.reviewThreads = nil
+	calls, err = syncer.fetchProviderMRDetail(ctx, provider, repo, repoID, 42)
+	require.NoError(err)
+	assert.Equal(3, calls)
+
+	threads, err = d.ListMRReviewThreads(ctx, mr.ID)
+	require.NoError(err)
+	assert.Empty(threads)
+	events, err = d.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	assert.Empty(events)
 }
 
 func TestSyncOpenIssueReadsExistingByRepoID(t *testing.T) {

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -179,14 +179,22 @@ func (c *Client) Host() string {
 
 func (c *Client) Capabilities() platform.Capabilities {
 	return platform.Capabilities{
-		ReadRepositories:  true,
-		ReadMergeRequests: true,
-		ReadIssues:        true,
-		ReadComments:      true,
-		ReadReleases:      true,
-		ReadCI:            true,
-		ThreadReply:       true,
-		ThreadResolve:     true,
+		ReadRepositories:       true,
+		ReadMergeRequests:      true,
+		ReadIssues:             true,
+		ReadComments:           true,
+		ReadReleases:           true,
+		ReadCI:                 true,
+		ThreadReply:            true,
+		ThreadResolve:          true,
+		ReviewDraftMutation:    true,
+		ReviewThreadResolution: true,
+		ReadReviewThreads:      true,
+		NativeMultilineRanges:  false,
+		SupportedReviewActions: []platform.ReviewAction{
+			platform.ReviewActionComment,
+			platform.ReviewActionApprove,
+		},
 	}
 }
 

--- a/internal/platform/gitlab/diff_review.go
+++ b/internal/platform/gitlab/diff_review.go
@@ -254,7 +254,13 @@ func gitlabReviewLineRange(position *gitlab.NotePosition) platform.DiffReviewLin
 		MergeBaseSHA: position.StartSHA,
 		CommitSHA:    position.HeadSHA,
 	}
-	if position.OldLine > 0 && position.NewLine == 0 {
+	if position.OldLine > 0 && position.NewLine > 0 {
+		lineRange.LineType = "context"
+		oldLine := int(position.OldLine)
+		newLine := int(position.NewLine)
+		lineRange.OldLine = &oldLine
+		lineRange.NewLine = &newLine
+	} else if position.OldLine > 0 && position.NewLine == 0 {
 		lineRange.Side = "left"
 		lineRange.Line = int(position.OldLine)
 		lineRange.LineType = "delete"

--- a/internal/platform/gitlab/diff_review.go
+++ b/internal/platform/gitlab/diff_review.go
@@ -23,6 +23,7 @@ func (c *Client) PublishDiffReviewDraft(
 		return nil, err
 	}
 	createdDraftIDs := make([]int64, 0, len(input.Comments))
+	publishedCommentIDs := make([]int64, 0, len(input.Comments))
 	submittedAt := time.Now().UTC()
 	for _, comment := range input.Comments {
 		draftNote, _, err := c.api.DraftNotes.CreateDraftNote(
@@ -54,7 +55,8 @@ func (c *Client) PublishDiffReviewDraft(
 					mappedErr = fmt.Errorf("%w; cleanup failed: %v", mappedErr, cleanupErr)
 				}
 				return &platform.PublishedDiffReview{SubmittedAt: submittedAt}, &platform.DiffReviewPublishPartialError{
-					Err: mappedErr,
+					Err:                 mappedErr,
+					PublishedCommentIDs: publishedCommentIDs,
 				}
 			}
 			if cleanupErr := c.deleteDraftNotes(ctx, pid, int64(number), createdDraftIDs); cleanupErr != nil {
@@ -63,6 +65,9 @@ func (c *Client) PublishDiffReviewDraft(
 			return nil, mapGitLabError("publish_draft_note", err)
 		}
 		publishedAnyDraft = true
+		if i < len(input.Comments) && input.Comments[i].ID > 0 {
+			publishedCommentIDs = append(publishedCommentIDs, input.Comments[i].ID)
+		}
 	}
 	publishedAny := publishedAnyDraft
 	if body := strings.TrimSpace(input.Body); body != "" {
@@ -72,14 +77,14 @@ func (c *Client) PublishDiffReviewDraft(
 			&gitlab.CreateMergeRequestNoteOptions{Body: &body},
 			gitlab.WithContext(ctx),
 		); err != nil {
-			return gitlabPublishFailure(submittedAt, publishedAny, mapGitLabError("create_merge_request_note", err))
+			return gitlabPublishFailure(submittedAt, publishedAny, publishedCommentIDs, mapGitLabError("create_merge_request_note", err))
 		}
 		publishedAny = true
 	}
 	if input.Action == platform.ReviewActionApprove {
 		sha := reviewHeadSHA(input)
 		if sha == "" {
-			return gitlabPublishFailure(submittedAt, publishedAny, fmt.Errorf("approve_merge_request: missing review head sha"))
+			return gitlabPublishFailure(submittedAt, publishedAny, publishedCommentIDs, fmt.Errorf("approve_merge_request: missing review head sha"))
 		}
 		_, _, err := c.api.MergeRequestApprovals.ApproveMergeRequest(
 			pid,
@@ -88,15 +93,23 @@ func (c *Client) PublishDiffReviewDraft(
 			gitlab.WithContext(ctx),
 		)
 		if err != nil {
-			return gitlabPublishFailure(submittedAt, publishedAny, mapGitLabError("approve_merge_request", err))
+			return gitlabPublishFailure(submittedAt, publishedAny, publishedCommentIDs, mapGitLabError("approve_merge_request", err))
 		}
 	}
 	return &platform.PublishedDiffReview{SubmittedAt: submittedAt}, nil
 }
 
-func gitlabPublishFailure(submittedAt time.Time, publishedAny bool, err error) (*platform.PublishedDiffReview, error) {
+func gitlabPublishFailure(
+	submittedAt time.Time,
+	publishedAny bool,
+	publishedCommentIDs []int64,
+	err error,
+) (*platform.PublishedDiffReview, error) {
 	if publishedAny {
-		return &platform.PublishedDiffReview{SubmittedAt: submittedAt}, &platform.DiffReviewPublishPartialError{Err: err}
+		return &platform.PublishedDiffReview{SubmittedAt: submittedAt}, &platform.DiffReviewPublishPartialError{
+			Err:                 err,
+			PublishedCommentIDs: publishedCommentIDs,
+		}
 	}
 	return nil, err
 }

--- a/internal/platform/gitlab/diff_review.go
+++ b/internal/platform/gitlab/diff_review.go
@@ -1,0 +1,313 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"go.kenn.io/middleman/internal/platform"
+)
+
+func (c *Client) PublishDiffReviewDraft(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	input platform.PublishDiffReviewDraftInput,
+) (*platform.PublishedDiffReview, error) {
+	pid, err := projectLookupArg(ref)
+	if err != nil {
+		return nil, err
+	}
+	createdDraftIDs := make([]int64, 0, len(input.Comments))
+	submittedAt := time.Now().UTC()
+	for _, comment := range input.Comments {
+		draftNote, _, err := c.api.DraftNotes.CreateDraftNote(
+			pid,
+			int64(number),
+			&gitlab.CreateDraftNoteOptions{
+				Note:     new(comment.Body),
+				CommitID: nonEmptyStringPtr(comment.Range.CommitSHA, comment.Range.DiffHeadSHA),
+				Position: gitlabPositionOptions(comment.Range),
+			},
+			gitlab.WithContext(ctx),
+		)
+		if err != nil {
+			if cleanupErr := c.deleteDraftNotes(ctx, pid, int64(number), createdDraftIDs); cleanupErr != nil {
+				return nil, fmt.Errorf("%w; cleanup failed: %v", mapGitLabError("create_draft_note", err), cleanupErr)
+			}
+			return nil, mapGitLabError("create_draft_note", err)
+		}
+		if draftNote != nil && draftNote.ID > 0 {
+			createdDraftIDs = append(createdDraftIDs, draftNote.ID)
+		}
+	}
+	publishedAnyDraft := false
+	for i, draftID := range createdDraftIDs {
+		if _, err := c.api.DraftNotes.PublishDraftNote(pid, int64(number), draftID, gitlab.WithContext(ctx)); err != nil {
+			if publishedAnyDraft {
+				mappedErr := mapGitLabError("publish_draft_note", err)
+				if cleanupErr := c.deleteDraftNotes(ctx, pid, int64(number), createdDraftIDs[i:]); cleanupErr != nil {
+					mappedErr = fmt.Errorf("%w; cleanup failed: %v", mappedErr, cleanupErr)
+				}
+				return &platform.PublishedDiffReview{SubmittedAt: submittedAt}, &platform.DiffReviewPublishPartialError{
+					Err: mappedErr,
+				}
+			}
+			if cleanupErr := c.deleteDraftNotes(ctx, pid, int64(number), createdDraftIDs); cleanupErr != nil {
+				return nil, fmt.Errorf("%w; cleanup failed: %v", mapGitLabError("publish_draft_note", err), cleanupErr)
+			}
+			return nil, mapGitLabError("publish_draft_note", err)
+		}
+		publishedAnyDraft = true
+	}
+	publishedAny := publishedAnyDraft
+	if body := strings.TrimSpace(input.Body); body != "" {
+		if _, _, err := c.api.Notes.CreateMergeRequestNote(
+			pid,
+			int64(number),
+			&gitlab.CreateMergeRequestNoteOptions{Body: &body},
+			gitlab.WithContext(ctx),
+		); err != nil {
+			return gitlabPublishFailure(submittedAt, publishedAny, mapGitLabError("create_merge_request_note", err))
+		}
+		publishedAny = true
+	}
+	if input.Action == platform.ReviewActionApprove {
+		sha := reviewHeadSHA(input)
+		if sha == "" {
+			return gitlabPublishFailure(submittedAt, publishedAny, fmt.Errorf("approve_merge_request: missing review head sha"))
+		}
+		_, _, err := c.api.MergeRequestApprovals.ApproveMergeRequest(
+			pid,
+			int64(number),
+			&gitlab.ApproveMergeRequestOptions{SHA: nonEmptyStringPtr(sha)},
+			gitlab.WithContext(ctx),
+		)
+		if err != nil {
+			return gitlabPublishFailure(submittedAt, publishedAny, mapGitLabError("approve_merge_request", err))
+		}
+	}
+	return &platform.PublishedDiffReview{SubmittedAt: submittedAt}, nil
+}
+
+func gitlabPublishFailure(submittedAt time.Time, publishedAny bool, err error) (*platform.PublishedDiffReview, error) {
+	if publishedAny {
+		return &platform.PublishedDiffReview{SubmittedAt: submittedAt}, &platform.DiffReviewPublishPartialError{Err: err}
+	}
+	return nil, err
+}
+
+func (c *Client) deleteDraftNotes(ctx context.Context, pid any, number int64, draftIDs []int64) error {
+	errs := make([]error, 0)
+	for _, draftID := range draftIDs {
+		if _, err := c.api.DraftNotes.DeleteDraftNote(pid, number, draftID, gitlab.WithContext(ctx)); err != nil {
+			errs = append(errs, mapGitLabError("delete_draft_note", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Client) ListMergeRequestReviewThreads(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]platform.MergeRequestReviewThread, error) {
+	pid, err := projectLookupArg(ref)
+	if err != nil {
+		return nil, err
+	}
+	var out []platform.MergeRequestReviewThread
+	page := int64(1)
+	for {
+		discussions, resp, err := c.api.Discussions.ListMergeRequestDiscussions(
+			pid,
+			int64(number),
+			&gitlab.ListMergeRequestDiscussionsOptions{
+				ListOptions: gitlab.ListOptions{Page: page, PerPage: defaultPageSize},
+			},
+			gitlab.WithContext(ctx),
+		)
+		if err != nil {
+			return nil, mapGitLabError("list_merge_request_discussions", err)
+		}
+		for _, discussion := range discussions {
+			out = append(out, gitlabReviewThreads(discussion)...)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return out, nil
+		}
+		page = resp.NextPage
+	}
+}
+
+func (c *Client) ResolveDiffReviewThread(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	providerThreadID string,
+) error {
+	return c.ResolveThread(ctx, ref, number, providerThreadID, true)
+}
+
+func (c *Client) UnresolveDiffReviewThread(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	providerThreadID string,
+) error {
+	return c.ResolveThread(ctx, ref, number, providerThreadID, false)
+}
+
+func gitlabPositionOptions(lineRange platform.DiffReviewLineRange) *gitlab.PositionOptions {
+	positionType := "text"
+	headSHA := firstNonEmpty(lineRange.DiffHeadSHA, lineRange.CommitSHA)
+	baseSHA := firstNonEmpty(lineRange.DiffBaseSHA, lineRange.MergeBaseSHA, headSHA)
+	startSHA := firstNonEmpty(lineRange.MergeBaseSHA, lineRange.DiffBaseSHA, baseSHA)
+	next := &gitlab.PositionOptions{
+		PositionType: &positionType,
+		HeadSHA:      nonEmptyStringPtr(headSHA),
+		BaseSHA:      nonEmptyStringPtr(baseSHA),
+		StartSHA:     nonEmptyStringPtr(startSHA),
+		NewPath:      new(lineRange.Path),
+		OldPath:      new(firstNonEmpty(lineRange.OldPath, lineRange.Path)),
+	}
+	if lineRange.Side == "left" {
+		next.OldLine = new(int64(lineRange.Line))
+	} else {
+		next.NewLine = new(int64(lineRange.Line))
+	}
+	if lineRange.StartLine != nil && lineRange.StartSide != "" {
+		next.LineRange = &gitlab.LineRangeOptions{
+			Start: gitlabLinePosition(lineRange.StartSide, *lineRange.StartLine),
+			End:   gitlabLinePosition(lineRange.Side, lineRange.Line),
+		}
+	}
+	return next
+}
+
+func gitlabLinePosition(side string, line int) *gitlab.LinePositionOptions {
+	positionType := "new"
+	next := &gitlab.LinePositionOptions{Type: &positionType}
+	if side == "left" {
+		positionType = "old"
+		next.OldLine = new(int64(line))
+	} else {
+		next.NewLine = new(int64(line))
+	}
+	return next
+}
+
+func gitlabReviewThreads(discussion *gitlab.Discussion) []platform.MergeRequestReviewThread {
+	if discussion == nil {
+		return nil
+	}
+	for _, note := range discussion.Notes {
+		if note == nil || note.System || note.Position == nil {
+			continue
+		}
+		return []platform.MergeRequestReviewThread{gitlabReviewThread(discussion.ID, note)}
+	}
+	return nil
+}
+
+func gitlabReviewThread(discussionID string, note *gitlab.Note) platform.MergeRequestReviewThread {
+	lineRange := gitlabReviewLineRange(note.Position)
+	resolvedAt := (*time.Time)(nil)
+	if note.Resolved && note.UpdatedAt != nil {
+		updated := note.UpdatedAt.UTC()
+		resolvedAt = &updated
+	}
+	createdAt := time.Time{}
+	if note.CreatedAt != nil {
+		createdAt = note.CreatedAt.UTC()
+	}
+	updatedAt := createdAt
+	if note.UpdatedAt != nil {
+		updatedAt = note.UpdatedAt.UTC()
+	}
+	return platform.MergeRequestReviewThread{
+		ProviderThreadID:  discussionID,
+		ProviderCommentID: strconv.FormatInt(note.ID, 10),
+		Body:              note.Body,
+		AuthorLogin:       note.Author.Username,
+		Range:             lineRange,
+		Resolved:          note.Resolved,
+		CreatedAt:         createdAt,
+		UpdatedAt:         updatedAt,
+		ResolvedAt:        resolvedAt,
+	}
+}
+
+func gitlabReviewLineRange(position *gitlab.NotePosition) platform.DiffReviewLineRange {
+	lineRange := platform.DiffReviewLineRange{
+		Path:         firstNonEmpty(position.NewPath, position.OldPath),
+		OldPath:      position.OldPath,
+		Side:         "right",
+		Line:         int(position.NewLine),
+		LineType:     "add",
+		DiffHeadSHA:  position.HeadSHA,
+		DiffBaseSHA:  position.BaseSHA,
+		MergeBaseSHA: position.StartSHA,
+		CommitSHA:    position.HeadSHA,
+	}
+	if position.OldLine > 0 && position.NewLine == 0 {
+		lineRange.Side = "left"
+		lineRange.Line = int(position.OldLine)
+		lineRange.LineType = "delete"
+		oldLine := int(position.OldLine)
+		lineRange.OldLine = &oldLine
+	} else if position.NewLine > 0 {
+		newLine := int(position.NewLine)
+		lineRange.NewLine = &newLine
+	}
+	if position.LineRange != nil && position.LineRange.StartRange != nil {
+		start := position.LineRange.StartRange
+		startSide := "right"
+		startLine := int(start.NewLine)
+		if start.Type == "old" {
+			startSide = "left"
+			startLine = int(start.OldLine)
+		}
+		if startLine > 0 {
+			lineRange.StartSide = startSide
+			lineRange.StartLine = &startLine
+		}
+	}
+	return lineRange
+}
+
+func reviewHeadSHA(input platform.PublishDiffReviewDraftInput) string {
+	if input.HeadSHA != "" {
+		return input.HeadSHA
+	}
+	for _, comment := range input.Comments {
+		if comment.Range.DiffHeadSHA != "" {
+			return comment.Range.DiffHeadSHA
+		}
+		if comment.Range.CommitSHA != "" {
+			return comment.Range.CommitSHA
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nonEmptyStringPtr(values ...string) *string {
+	value := firstNonEmpty(values...)
+	if value == "" {
+		return nil
+	}
+	return &value
+}

--- a/internal/platform/gitlab/diff_review_test.go
+++ b/internal/platform/gitlab/diff_review_test.go
@@ -144,6 +144,7 @@ func TestGitLabPublishDiffReviewDraftReturnsPartialErrorWhenApproveFails(t *test
 	}, 7, platform.PublishDiffReviewDraftInput{
 		Action: platform.ReviewActionApprove,
 		Comments: []platform.LocalDiffReviewDraftComment{{
+			ID:   123,
 			Body: "range note",
 			Range: platform.DiffReviewLineRange{
 				Path:        "src/main.go",
@@ -157,6 +158,7 @@ func TestGitLabPublishDiffReviewDraftReturnsPartialErrorWhenApproveFails(t *test
 	require.Error(err)
 	var partialErr *platform.DiffReviewPublishPartialError
 	require.ErrorAs(err, &partialErr)
+	assert.Equal([]int64{123}, partialErr.PublishedCommentIDs)
 	assert.True(published)
 }
 

--- a/internal/platform/gitlab/diff_review_test.go
+++ b/internal/platform/gitlab/diff_review_test.go
@@ -564,6 +564,60 @@ func TestGitLabListMergeRequestReviewThreadsReadsDiscussions(t *testing.T) {
 	assert.Equal(updated, *threads[0].ResolvedAt)
 }
 
+func TestGitLabListMergeRequestReviewThreadsReadsContextLinePositions(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	created := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/api/v4/projects/group%2Fproject/merge_requests/7/discussions", r.URL.EscapedPath())
+		writeJSON(w, `[
+			{
+				"id": "discussion-1",
+				"individual_note": false,
+				"notes": [{
+					"id": 101,
+					"type": "DiscussionNote",
+					"body": "context note",
+					"author": {"username": "reviewer"},
+					"system": false,
+					"resolvable": true,
+					"resolved": false,
+					"created_at": "`+created.Format(time.RFC3339)+`",
+					"updated_at": "`+created.Format(time.RFC3339)+`",
+					"position": {
+						"base_sha": "base",
+						"start_sha": "merge-base",
+						"head_sha": "head",
+						"position_type": "text",
+						"old_path": "src/main.go",
+						"new_path": "src/main.go",
+						"old_line": 8,
+						"new_line": 9
+					}
+				}]
+			}
+		]`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	threads, err := client.ListMergeRequestReviewThreads(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7)
+
+	require.NoError(err)
+	require.Len(threads, 1)
+	lineRange := threads[0].Range
+	assert.Equal("right", lineRange.Side)
+	assert.Equal(9, lineRange.Line)
+	assert.Equal("context", lineRange.LineType)
+	require.NotNil(lineRange.OldLine)
+	require.NotNil(lineRange.NewLine)
+	assert.Equal(8, *lineRange.OldLine)
+	assert.Equal(9, *lineRange.NewLine)
+}
+
 func TestGitLabListMergeRequestReviewThreadsCollapsesDiscussionReplies(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)

--- a/internal/platform/gitlab/diff_review_test.go
+++ b/internal/platform/gitlab/diff_review_test.go
@@ -1,0 +1,661 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	Require "github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/platform"
+)
+
+func TestGitLabPublishDiffReviewDraftCreatesDraftNotesAndApproves(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	var createdDrafts int
+	var published bool
+	var summaryCreated bool
+	var approved bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			createdDrafts++
+			var body struct {
+				Note     string `json:"note"`
+				CommitID string `json:"commit_id"`
+				Position struct {
+					PositionType string `json:"position_type"`
+					NewPath      string `json:"new_path"`
+					NewLine      int64  `json:"new_line"`
+					BaseSHA      string `json:"base_sha"`
+					StartSHA     string `json:"start_sha"`
+					HeadSHA      string `json:"head_sha"`
+				} `json:"position"`
+			}
+			if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			assert.Equal("range note", body.Note)
+			assert.Equal("head-sha", body.CommitID)
+			assert.Equal("text", body.Position.PositionType)
+			assert.Equal("src/main.go", body.Position.NewPath)
+			assert.Equal(int64(5), body.Position.NewLine)
+			assert.Equal("base-sha", body.Position.BaseSHA)
+			assert.Equal("merge-base-sha", body.Position.StartSHA)
+			assert.Equal("head-sha", body.Position.HeadSHA)
+			writeJSON(w, `{"id": 55, "note": "range note"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			published = true
+			writeJSON(w, `{}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/notes":
+			assert.Equal(http.MethodPost, r.Method)
+			summaryCreated = true
+			var body struct {
+				Body string `json:"body"`
+			}
+			if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			assert.Equal("review summary", body.Body)
+			writeJSON(w, `{"id": 77, "body": "review summary"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/approve":
+			assert.Equal(http.MethodPost, r.Method)
+			approved = true
+			var body struct {
+				SHA string `json:"sha"`
+			}
+			if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			assert.Equal("head-sha", body.SHA)
+			writeJSON(w, `{"approved": true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionApprove,
+		Body:   " review summary ",
+		Comments: []platform.LocalDiffReviewDraftComment{{
+			Body: "range note",
+			Range: platform.DiffReviewLineRange{
+				Path:         "src/main.go",
+				Side:         "right",
+				Line:         5,
+				DiffHeadSHA:  "head-sha",
+				DiffBaseSHA:  "base-sha",
+				MergeBaseSHA: "merge-base-sha",
+				CommitSHA:    "head-sha",
+			},
+		}},
+	})
+
+	require.NoError(err)
+	require.NotNil(result)
+	assert.Equal(1, createdDrafts)
+	assert.True(published)
+	assert.True(summaryCreated)
+	assert.True(approved)
+	assert.False(result.SubmittedAt.IsZero())
+}
+
+func TestGitLabPublishDiffReviewDraftReturnsPartialErrorWhenApproveFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	var published bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			writeJSON(w, `{"id": 55, "note": "range note"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			published = true
+			writeJSON(w, `{}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/approve":
+			assert.Equal(http.MethodPost, r.Method)
+			http.Error(w, `{"message": "approval failed"}`, http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionApprove,
+		Comments: []platform.LocalDiffReviewDraftComment{{
+			Body: "range note",
+			Range: platform.DiffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        5,
+				DiffHeadSHA: "head-sha",
+			},
+		}},
+	})
+
+	require.Error(err)
+	var partialErr *platform.DiffReviewPublishPartialError
+	require.ErrorAs(err, &partialErr)
+	assert.True(published)
+}
+
+func TestGitLabPublishDiffReviewDraftUsesHeadSHAForSummaryApproval(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	var approved bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/notes":
+			assert.Equal(http.MethodPost, r.Method)
+			writeJSON(w, `{"id": 77, "body": "summary"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/approve":
+			assert.Equal(http.MethodPost, r.Method)
+			approved = true
+			var body struct {
+				SHA string `json:"sha"`
+			}
+			if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			assert.Equal("review-head", body.SHA)
+			writeJSON(w, `{"approved": true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action:  platform.ReviewActionApprove,
+		Body:    "summary",
+		HeadSHA: "review-head",
+	})
+
+	require.NoError(err)
+	require.NotNil(result)
+	assert.True(approved)
+}
+
+func TestGitLabPublishDiffReviewDraftRejectsApprovalWithoutHeadSHA(t *testing.T) {
+	require := Require.New(t)
+	var calledProvider bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calledProvider = true
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionApprove,
+	})
+
+	require.Error(err)
+	require.Nil(result)
+	Assert.New(t).False(calledProvider)
+}
+
+func TestGitLabPublishDiffReviewDraftDoesNotApproveWhenPublishFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	var approved bool
+	var deleted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			writeJSON(w, `{"id": 55, "note": "range note"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/approve":
+			assert.Equal(http.MethodPost, r.Method)
+			approved = true
+			writeJSON(w, `{"approved": true}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55":
+			assert.Equal(http.MethodDelete, r.Method)
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionApprove,
+		Comments: []platform.LocalDiffReviewDraftComment{{
+			Body: "range note",
+			Range: platform.DiffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        5,
+				DiffHeadSHA: "head-sha",
+			},
+		}},
+	})
+
+	require.Error(err)
+	assert.Nil(result)
+	assert.False(approved)
+	assert.True(deleted)
+}
+
+func TestGitLabPublishDiffReviewDraftReturnsNormalErrorWhenFirstPublishCleanupFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			writeJSON(w, `{"id": 55, "note": "range note"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55":
+			assert.Equal(http.MethodDelete, r.Method)
+			http.Error(w, `{"message": "delete failed"}`, http.StatusBadRequest)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionComment,
+		Comments: []platform.LocalDiffReviewDraftComment{{
+			Body: "range note",
+			Range: platform.DiffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        5,
+				DiffHeadSHA: "head-sha",
+			},
+		}},
+	})
+
+	require.Error(err)
+	assert.Nil(result)
+	var partialErr *platform.DiffReviewPublishPartialError
+	assert.NotErrorAs(err, &partialErr)
+	assert.Contains(err.Error(), "cleanup failed")
+}
+
+func TestGitLabPublishDiffReviewDraftReturnsPartialErrorAfterSomeDraftsPublish(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	var createdDrafts int
+	var approved bool
+	var deleted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			createdDrafts++
+			writeJSON(w, `{"id": `+strconv.Itoa(54+createdDrafts)+`, "note": "range note"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			writeJSON(w, `{}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56":
+			assert.Equal(http.MethodDelete, r.Method)
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/approve":
+			approved = true
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionApprove,
+		Comments: []platform.LocalDiffReviewDraftComment{
+			{
+				Body: "first note",
+				Range: platform.DiffReviewLineRange{
+					Path:        "src/main.go",
+					Side:        "right",
+					Line:        5,
+					DiffHeadSHA: "head-sha",
+				},
+			},
+			{
+				Body: "second note",
+				Range: platform.DiffReviewLineRange{
+					Path:        "src/main.go",
+					Side:        "right",
+					Line:        6,
+					DiffHeadSHA: "head-sha",
+				},
+			},
+		},
+	})
+
+	require.Error(err)
+	require.NotNil(result)
+	var partialErr *platform.DiffReviewPublishPartialError
+	require.ErrorAs(err, &partialErr)
+	assert.Equal(2, createdDrafts)
+	assert.False(approved)
+	assert.True(deleted)
+}
+
+func TestGitLabPublishDiffReviewDraftKeepsPartialErrorWhenRemainingCleanupFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	var createdDrafts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			createdDrafts++
+			writeJSON(w, `{"id": `+strconv.Itoa(54+createdDrafts)+`, "note": "range note"}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			writeJSON(w, `{}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56":
+			assert.Equal(http.MethodDelete, r.Method)
+			http.Error(w, `{"message": "delete failed"}`, http.StatusBadRequest)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionComment,
+		Comments: []platform.LocalDiffReviewDraftComment{
+			{
+				Body: "first note",
+				Range: platform.DiffReviewLineRange{
+					Path:        "src/main.go",
+					Side:        "right",
+					Line:        5,
+					DiffHeadSHA: "head-sha",
+				},
+			},
+			{
+				Body: "second note",
+				Range: platform.DiffReviewLineRange{
+					Path:        "src/main.go",
+					Side:        "right",
+					Line:        6,
+					DiffHeadSHA: "head-sha",
+				},
+			},
+		},
+	})
+
+	require.Error(err)
+	require.NotNil(result)
+	var partialErr *platform.DiffReviewPublishPartialError
+	require.ErrorAs(err, &partialErr)
+	assert.Contains(err.Error(), "cleanup failed")
+}
+
+func TestGitLabPublishDiffReviewDraftDeletesCreatedDraftsWhenLaterCreateFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	var createAttempts int
+	var deleted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			createAttempts++
+			if createAttempts == 1 {
+				writeJSON(w, `{"id": 55, "note": "first note"}`)
+				return
+			}
+			http.Error(w, `{"message": "create failed"}`, http.StatusBadRequest)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55":
+			assert.Equal(http.MethodDelete, r.Method)
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, platform.PublishDiffReviewDraftInput{
+		Action: platform.ReviewActionComment,
+		Comments: []platform.LocalDiffReviewDraftComment{
+			{
+				Body: "first note",
+				Range: platform.DiffReviewLineRange{
+					Path:        "src/main.go",
+					Side:        "right",
+					Line:        5,
+					DiffHeadSHA: "head-sha",
+				},
+			},
+			{
+				Body: "second note",
+				Range: platform.DiffReviewLineRange{
+					Path:        "src/main.go",
+					Side:        "right",
+					Line:        6,
+					DiffHeadSHA: "head-sha",
+				},
+			},
+		},
+	})
+
+	require.Error(err)
+	assert.Nil(result)
+	assert.Equal(2, createAttempts)
+	assert.True(deleted)
+}
+
+func TestGitLabListMergeRequestReviewThreadsReadsDiscussions(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	created := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	updated := created.Add(time.Minute)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/api/v4/projects/group%2Fproject/merge_requests/7/discussions", r.URL.EscapedPath())
+		writeJSON(w, `[
+			{
+				"id": "discussion-1",
+				"individual_note": false,
+				"notes": [{
+					"id": 101,
+					"type": "DiscussionNote",
+					"body": "inline note",
+					"author": {"username": "reviewer"},
+					"system": false,
+					"resolvable": true,
+					"resolved": true,
+					"created_at": "`+created.Format(time.RFC3339)+`",
+					"updated_at": "`+updated.Format(time.RFC3339)+`",
+					"position": {
+						"base_sha": "base",
+						"start_sha": "base",
+						"head_sha": "head",
+						"position_type": "text",
+						"new_path": "src/main.go",
+						"new_line": 9
+					}
+				}]
+			}
+		]`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	threads, err := client.ListMergeRequestReviewThreads(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7)
+
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("discussion-1", threads[0].ProviderThreadID)
+	assert.Equal("101", threads[0].ProviderCommentID)
+	assert.Equal("inline note", threads[0].Body)
+	assert.Equal("reviewer", threads[0].AuthorLogin)
+	assert.True(threads[0].Resolved)
+	assert.Equal("src/main.go", threads[0].Range.Path)
+	assert.Equal("right", threads[0].Range.Side)
+	assert.Equal(9, threads[0].Range.Line)
+	assert.Equal("head", threads[0].Range.DiffHeadSHA)
+	assert.Equal("base", threads[0].Range.DiffBaseSHA)
+	assert.Equal("base", threads[0].Range.MergeBaseSHA)
+	assert.Equal(created, threads[0].CreatedAt)
+	assert.Equal(updated, threads[0].UpdatedAt)
+	require.NotNil(threads[0].ResolvedAt)
+	assert.Equal(updated, *threads[0].ResolvedAt)
+}
+
+func TestGitLabListMergeRequestReviewThreadsCollapsesDiscussionReplies(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	created := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/api/v4/projects/group%2Fproject/merge_requests/7/discussions", r.URL.EscapedPath())
+		writeJSON(w, `[
+			{
+				"id": "discussion-1",
+				"individual_note": false,
+				"notes": [
+					{
+						"id": 101,
+						"type": "DiscussionNote",
+						"body": "original inline note",
+						"author": {"username": "reviewer"},
+						"system": false,
+						"resolvable": true,
+						"resolved": false,
+						"created_at": "`+created.Format(time.RFC3339)+`",
+						"updated_at": "`+created.Format(time.RFC3339)+`",
+						"position": {
+							"base_sha": "base",
+							"start_sha": "base",
+							"head_sha": "head",
+							"position_type": "text",
+							"new_path": "src/main.go",
+							"new_line": 9
+						}
+					},
+					{
+						"id": 102,
+						"type": "DiscussionNote",
+						"body": "reply should not replace original",
+						"author": {"username": "other-reviewer"},
+						"system": false,
+						"resolvable": true,
+						"resolved": false,
+						"created_at": "`+created.Add(time.Minute).Format(time.RFC3339)+`",
+						"updated_at": "`+created.Add(time.Minute).Format(time.RFC3339)+`",
+						"position": {
+							"base_sha": "base",
+							"start_sha": "base",
+							"head_sha": "head",
+							"position_type": "text",
+							"new_path": "src/main.go",
+							"new_line": 10
+						}
+					}
+				]
+			}
+		]`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	threads, err := client.ListMergeRequestReviewThreads(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7)
+
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("discussion-1", threads[0].ProviderThreadID)
+	assert.Equal("101", threads[0].ProviderCommentID)
+	assert.Equal("original inline note", threads[0].Body)
+	assert.Equal("reviewer", threads[0].AuthorLogin)
+	assert.Equal(9, threads[0].Range.Line)
+}
+
+func TestGitLabResolveDiffReviewThreadUpdatesDiscussion(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPut, r.Method)
+		assert.Equal("/api/v4/projects/group%2Fproject/merge_requests/7/discussions/discussion-1", r.URL.EscapedPath())
+		var body struct {
+			Resolved bool `json:"resolved"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		assert.True(body.Resolved)
+		writeJSON(w, `{"id": "discussion-1", "notes": []}`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	err := client.ResolveDiffReviewThread(context.Background(), platform.RepoRef{
+		RepoPath: "group/project",
+	}, 7, "discussion-1")
+
+	require.NoError(err)
+}

--- a/internal/platform/gitlab/diff_review_test.go
+++ b/internal/platform/gitlab/diff_review_test.go
@@ -693,9 +693,18 @@ func TestGitLabListMergeRequestReviewThreadsCollapsesDiscussionReplies(t *testin
 func TestGitLabResolveDiffReviewThreadUpdatesDiscussion(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
+	discussionID := "0123456789abcdef0123456789abcdef01234567"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.EscapedPath() == "/api/v4/projects/group%2Fproject" {
+			writeJSON(w, `{"id": 42, "path_with_namespace": "group/project", "path": "project"}`)
+			return
+		}
 		assert.Equal(http.MethodPut, r.Method)
-		assert.Equal("/api/v4/projects/group%2Fproject/merge_requests/7/discussions/discussion-1", r.URL.EscapedPath())
+		assert.Equal(
+			"/api/v4/projects/42/merge_requests/7/discussions/"+discussionID,
+			r.URL.EscapedPath(),
+		)
 		var body struct {
 			Resolved bool `json:"resolved"`
 		}
@@ -704,14 +713,14 @@ func TestGitLabResolveDiffReviewThreadUpdatesDiscussion(t *testing.T) {
 			return
 		}
 		assert.True(body.Resolved)
-		writeJSON(w, `{"id": "discussion-1", "notes": []}`)
+		writeJSON(w, `{"id": "`+discussionID+`", "notes": []}`)
 	}))
 	defer server.Close()
 
 	client := newTestClient(t, server.URL)
 	err := client.ResolveDiffReviewThread(context.Background(), platform.RepoRef{
 		RepoPath: "group/project",
-	}, 7, "discussion-1")
+	}, 7, discussionID)
 
 	require.NoError(err)
 }

--- a/internal/platform/gitlab/normalize.go
+++ b/internal/platform/gitlab/normalize.go
@@ -273,6 +273,9 @@ func NormalizeMergeRequestNotes(
 			}
 			continue
 		}
+		if note.Position != nil {
+			continue
+		}
 		events = append(events, platform.MergeRequestEvent{
 			Repo:               repo,
 			PlatformID:         note.ID,

--- a/internal/platform/gitlab/normalize_test.go
+++ b/internal/platform/gitlab/normalize_test.go
@@ -289,6 +289,37 @@ func TestNormalizeNotesKeepsAssignmentSystemNotes(t *testing.T) {
 	assert.Equal("gitlab:gitlab.example.com:group/project:issue:5:system_note:2", issueEvents[1].DedupeKey)
 }
 
+func TestNormalizeMergeRequestNotesDropsPositionedDiffNotes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	createdAt := time.Date(2026, 4, 4, 10, 0, 0, 0, time.UTC)
+	notes := []*gitlab.Note{
+		{
+			ID:        1,
+			Body:      "top-level note",
+			Author:    gitlab.NoteAuthor{Username: "alice"},
+			CreatedAt: &createdAt,
+		},
+		{
+			ID:        2,
+			Body:      "inline diff note",
+			Author:    gitlab.NoteAuthor{Username: "reviewer"},
+			CreatedAt: &createdAt,
+			Position: &gitlab.NotePosition{
+				NewPath: "src/main.go",
+				NewLine: 9,
+			},
+		},
+	}
+
+	events := NormalizeMergeRequestNotes(testGitLabRepoRef(), 7, notes)
+
+	require.Len(events, 1)
+	assert.Equal("issue_comment", events[0].EventType)
+	assert.Equal("top-level note", events[0].Body)
+	assert.Equal("gitlab:gitlab.example.com:group/project:mr:7:note:1", events[0].DedupeKey)
+}
+
 func TestNormalizeNotesDedupeKeyIncludesRepositoryAndParent(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -249,7 +249,8 @@ type PublishedDiffReview struct {
 }
 
 type DiffReviewPublishPartialError struct {
-	Err error
+	Err                 error
+	PublishedCommentIDs []int64
 }
 
 func (e *DiffReviewPublishPartialError) Error() string {

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -213,17 +213,19 @@ const (
 )
 
 type DiffReviewLineRange struct {
-	Path        string
-	OldPath     string
-	Side        string
-	StartSide   string
-	StartLine   *int
-	Line        int
-	OldLine     *int
-	NewLine     *int
-	LineType    string
-	DiffHeadSHA string
-	CommitSHA   string
+	Path         string
+	OldPath      string
+	Side         string
+	StartSide    string
+	StartLine    *int
+	Line         int
+	OldLine      *int
+	NewLine      *int
+	LineType     string
+	DiffHeadSHA  string
+	DiffBaseSHA  string
+	MergeBaseSHA string
+	CommitSHA    string
 }
 
 type LocalDiffReviewDraftComment struct {
@@ -237,12 +239,31 @@ type LocalDiffReviewDraftComment struct {
 type PublishDiffReviewDraftInput struct {
 	Body     string
 	Action   ReviewAction
+	HeadSHA  string
 	Comments []LocalDiffReviewDraftComment
 }
 
 type PublishedDiffReview struct {
 	ProviderReviewID string
 	SubmittedAt      time.Time
+}
+
+type DiffReviewPublishPartialError struct {
+	Err error
+}
+
+func (e *DiffReviewPublishPartialError) Error() string {
+	if e == nil || e.Err == nil {
+		return "diff review partially published"
+	}
+	return e.Err.Error()
+}
+
+func (e *DiffReviewPublishPartialError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
 }
 
 type MergeRequestReviewThread struct {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -48,6 +48,7 @@ import (
 	forgejoplatform "go.kenn.io/middleman/internal/platform/forgejo"
 	giteaplatform "go.kenn.io/middleman/internal/platform/gitea"
 	"go.kenn.io/middleman/internal/platform/gitealike"
+	platformgitlab "go.kenn.io/middleman/internal/platform/gitlab"
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/ptyowner"
 	"go.kenn.io/middleman/internal/stacks"
@@ -493,6 +494,7 @@ type apiTestGitLabProvider struct {
 	reviewThreads      []platform.MergeRequestReviewThread
 	reviewThreadsErr   error
 	publishedReviews   []platform.PublishDiffReviewDraftInput
+	publishReviewErr   error
 	resolvedThreads    []string
 	unresolvedThreads  []string
 }
@@ -526,7 +528,7 @@ func (p *apiTestGitLabProvider) PublishDiffReviewDraft(
 	input platform.PublishDiffReviewDraftInput,
 ) (*platform.PublishedDiffReview, error) {
 	p.publishedReviews = append(p.publishedReviews, input)
-	return &platform.PublishedDiffReview{SubmittedAt: time.Now().UTC()}, nil
+	return &platform.PublishedDiffReview{SubmittedAt: time.Now().UTC()}, p.publishReviewErr
 }
 
 func (p *apiTestGitLabProvider) ListMergeRequestReviewThreads(
@@ -10709,6 +10711,507 @@ func TestAPIPublishReviewDraftRejectsMultilineRangeWithoutCapability(t *testing.
 	require.Empty(provider.publishedReviews)
 }
 
+func TestAPIGitLabPublishReviewDraftApprovesWithDiffPositionSHAs(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:      true,
+		ReadMergeRequests:     true,
+		ReadIssues:            true,
+		ReadComments:          true,
+		ReviewDraftMutation:   true,
+		NativeMultilineRanges: false,
+		SupportedReviewActions: []platform.ReviewAction{
+			platform.ReviewActionComment,
+			platform.ReviewActionApprove,
+		},
+	}
+	srv, database, provider := setupGitLabCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	require.NoError(database.UpdateDiffSHAs(ctx, repo.ID, 7, "gitlab-head", "gitlab-base", "gitlab-merge-base"))
+
+	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
+	getRR := doJSON(t, srv, http.MethodGet, basePath, nil)
+	require.Equal(http.StatusOK, getRR.Code, getRR.Body.String())
+	var draft map[string]any
+	require.NoError(json.NewDecoder(getRR.Body).Decode(&draft))
+	assert.Equal([]any{"comment", "approve"}, draft["supported_actions"])
+	assert.Equal(false, draft["native_multiline_ranges"])
+
+	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		"body": "Please tighten this line.",
+		"range": map[string]any{
+			"path":          "internal/server/api_test.go",
+			"side":          "right",
+			"line":          42,
+			"new_line":      42,
+			"line_type":     "add",
+			"diff_head_sha": "gitlab-head",
+			"commit_sha":    "gitlab-head",
+		},
+	})
+	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+
+	rejectRR := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		basePath+"/publish",
+		map[string]string{"action": "request_changes"},
+	)
+	require.Equal(http.StatusBadRequest, rejectRR.Code, rejectRR.Body.String())
+	require.Empty(provider.publishedReviews)
+
+	publishRR := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		basePath+"/publish",
+		map[string]string{"action": "approve", "body": "approved"},
+	)
+	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
+	require.Len(provider.publishedReviews, 1)
+	published := provider.publishedReviews[0]
+	assert.Equal(platform.ReviewActionApprove, published.Action)
+	assert.Equal("approved", published.Body)
+	require.Len(published.Comments, 1)
+	lineRange := published.Comments[0].Range
+	assert.Equal("gitlab-head", lineRange.DiffHeadSHA)
+	assert.Equal("gitlab-base", lineRange.DiffBaseSHA)
+	assert.Equal("gitlab-merge-base", lineRange.MergeBaseSHA)
+	assert.Empty(lineRange.StartSide)
+	assert.Nil(lineRange.StartLine)
+}
+
+func TestAPIPublishReviewDraftClearsPartialPublishedDraft(t *testing.T) {
+	require := require.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:       true,
+		ReadMergeRequests:      true,
+		ReadIssues:             true,
+		ReadComments:           true,
+		ReviewDraftMutation:    true,
+		SupportedReviewActions: []platform.ReviewAction{platform.ReviewActionComment},
+	}
+	srv, database, provider := setupGitLabCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+	provider.publishReviewErr = &platform.DiffReviewPublishPartialError{Err: errors.New("approval failed")}
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NoError(database.UpdateDiffSHAs(ctx, repo.ID, 7, "gitlab-head", "gitlab-base", "gitlab-merge-base"))
+
+	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
+	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		"body": "Please tighten this line.",
+		"range": map[string]any{
+			"path":          "internal/server/api_test.go",
+			"side":          "right",
+			"line":          42,
+			"new_line":      42,
+			"line_type":     "add",
+			"diff_head_sha": "gitlab-head",
+			"commit_sha":    "gitlab-head",
+		},
+	})
+	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+
+	publishRR := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		basePath+"/publish",
+		map[string]string{"action": "comment"},
+	)
+	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
+	var publishStatus actionStatusBody
+	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
+	require.Equal("partially_published", publishStatus.Status)
+	require.Len(provider.publishedReviews, 1)
+	draft, err := database.GetMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	require.Nil(draft)
+}
+
+func TestAPIGitLabPublishReviewDraftSurfacesCleanupFailureAsPartial(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	var createAttempts atomic.Int32
+	var publishAttempts atomic.Int32
+	var deleteAttempts atomic.Int32
+	writeRawJSON := func(w http.ResponseWriter, body string) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			next := createAttempts.Add(1)
+			var body struct {
+				Note     string `json:"note"`
+				CommitID string `json:"commit_id"`
+				Position struct {
+					NewPath string `json:"new_path"`
+					NewLine int64  `json:"new_line"`
+				} `json:"position"`
+			}
+			if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			assert.Equal("gitlab-head", body.CommitID)
+			assert.Equal("src/main.go", body.Position.NewPath)
+			assert.Equal(int64(40+next), body.Position.NewLine)
+			writeRawJSON(w, fmt.Sprintf(`{"id": %d, "note": %q}`, 54+next, body.Note))
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			publishAttempts.Add(1)
+			writeRawJSON(w, `{}`)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			publishAttempts.Add(1)
+			http.Error(w, "publish failed", http.StatusBadRequest)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56":
+			assert.Equal(http.MethodDelete, r.Method)
+			deleteAttempts.Add(1)
+			http.Error(w, "delete failed", http.StatusBadRequest)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/discussions":
+			assert.Equal(http.MethodGet, r.Method)
+			writeRawJSON(w, `[
+				{
+					"id": "discussion-55",
+					"individual_note": false,
+					"notes": [{
+						"id": 55,
+						"type": "DiscussionNote",
+						"body": "first line",
+						"author": {"username": "reviewer"},
+						"system": false,
+						"resolvable": true,
+						"resolved": false,
+						"created_at": "`+now.Format(time.RFC3339)+`",
+						"updated_at": "`+now.Format(time.RFC3339)+`",
+						"position": {
+							"base_sha": "base",
+							"start_sha": "merge-base",
+							"head_sha": "gitlab-head",
+							"position_type": "text",
+							"new_path": "src/main.go",
+							"new_line": 41
+						}
+					}]
+				}
+			]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer gitlabServer.Close()
+
+	database := dbtest.Open(t)
+	client, err := platformgitlab.NewClient(
+		"gitlab.example.com",
+		"token",
+		platformgitlab.WithBaseURLForTesting(gitlabServer.URL+"/api/v4"),
+	)
+	require.NoError(err)
+	registry, err := platform.NewRegistry(client)
+	require.NoError(err)
+	repoRef := ghclient.RepoRef{
+		Platform:           platform.KindGitLab,
+		PlatformHost:       "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformRepoID:     4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repoRef}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.example.com",
+		PlatformRepoID: "4242",
+		Owner:          "group",
+		Name:           "project",
+		RepoPath:       "group/project",
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(ctx, repoID, db.RepoProviderMetadata{
+		PlatformRepoID: "4242",
+		WebURL:         "https://gitlab.example.com/group/project",
+		CloneURL:       "https://gitlab.example.com/group/project.git",
+		DefaultBranch:  "main",
+	}))
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             repoID,
+		PlatformID:         7001,
+		PlatformExternalID: "gid://gitlab/MergeRequest/7001",
+		Number:             7,
+		URL:                "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:              "GitLab provider MR",
+		Author:             "ada",
+		State:              "open",
+		HeadBranch:         "feature/gitlab",
+		BaseBranch:         "main",
+		PlatformHeadSHA:    "gitlab-head",
+		PlatformBaseSHA:    "base",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		LastActivityAt:     now,
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 7, "gitlab-head", "base", "merge-base"))
+
+	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
+	for _, line := range []int{41, 42} {
+		createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+			"body": fmt.Sprintf("line %d", line),
+			"range": map[string]any{
+				"path":          "src/main.go",
+				"side":          "right",
+				"line":          line,
+				"new_line":      line,
+				"line_type":     "add",
+				"diff_head_sha": "gitlab-head",
+			},
+		})
+		require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+	}
+
+	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+		"action": "comment",
+	})
+	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
+	var publishStatus actionStatusBody
+	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
+	assert.Equal("partially_published", publishStatus.Status)
+	assert.Equal(int32(2), createAttempts.Load())
+	assert.Equal(int32(2), publishAttempts.Load())
+	assert.Equal(int32(1), deleteAttempts.Load())
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	draft, err := database.GetMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	assert.Nil(draft)
+	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("discussion-55", threads[0].ProviderThreadID)
+}
+
+func TestAPIGitLabPublishReviewDraftSendsSummaryThroughServer(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	var order []string
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes":
+			assert.Equal(http.MethodPost, r.Method)
+			order = append(order, "create-draft")
+			writeJSON(w, http.StatusOK, map[string]any{"id": 55, "note": "inline note"})
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
+			assert.Equal(http.MethodPut, r.Method)
+			order = append(order, "publish-draft")
+			writeJSON(w, http.StatusOK, map[string]any{})
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/notes":
+			assert.Equal(http.MethodPost, r.Method)
+			order = append(order, "summary-note")
+			var body struct {
+				Body string `json:"body"`
+			}
+			if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			assert.Equal("review summary from ui", body.Body)
+			writeJSON(w, http.StatusOK, map[string]any{"id": 77, "body": body.Body})
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/approve":
+			assert.Equal(http.MethodPost, r.Method)
+			order = append(order, "approve")
+			http.Error(w, "approval failed", http.StatusBadRequest)
+		case "/api/v4/projects/group%2Fproject/merge_requests/7/discussions":
+			assert.Equal(http.MethodGet, r.Method)
+			writeRawJSONForTest(w, `[
+				{
+					"id": "discussion-55",
+					"individual_note": false,
+					"notes": [{
+						"id": 55,
+						"type": "DiscussionNote",
+						"body": "inline note",
+						"author": {"username": "reviewer"},
+						"system": false,
+						"resolvable": true,
+						"resolved": false,
+						"created_at": "`+now.Format(time.RFC3339)+`",
+						"updated_at": "`+now.Format(time.RFC3339)+`",
+						"position": {
+							"base_sha": "base",
+							"start_sha": "merge-base",
+							"head_sha": "gitlab-head",
+							"position_type": "text",
+							"new_path": "src/main.go",
+							"new_line": 41
+						}
+					}]
+				}
+			]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer gitlabServer.Close()
+
+	srv, database, repoID := setupActualGitLabReviewServer(t, gitlabServer.URL, now)
+	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 7, "gitlab-head", "base", "merge-base"))
+
+	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
+	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		"body": "inline note",
+		"range": map[string]any{
+			"path":          "src/main.go",
+			"side":          "right",
+			"line":          41,
+			"new_line":      41,
+			"line_type":     "add",
+			"diff_head_sha": "gitlab-head",
+		},
+	})
+	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+
+	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+		"action": "approve",
+		"body":   " review summary from ui ",
+	})
+	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
+	var publishStatus actionStatusBody
+	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
+	assert.Equal("partially_published", publishStatus.Status)
+	assert.Equal([]string{"create-draft", "publish-draft", "summary-note", "approve"}, order)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	draft, err := database.GetMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	assert.Nil(draft)
+	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("discussion-55", threads[0].ProviderThreadID)
+}
+
+func setupActualGitLabReviewServer(
+	t *testing.T,
+	gitlabServerURL string,
+	now time.Time,
+) (*Server, *db.DB, int64) {
+	t.Helper()
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	client, err := platformgitlab.NewClient(
+		"gitlab.example.com",
+		"token",
+		platformgitlab.WithBaseURLForTesting(gitlabServerURL+"/api/v4"),
+	)
+	require.NoError(err)
+	registry, err := platform.NewRegistry(client)
+	require.NoError(err)
+	repoRef := ghclient.RepoRef{
+		Platform:           platform.KindGitLab,
+		PlatformHost:       "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformRepoID:     4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repoRef}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.example.com",
+		PlatformRepoID: "4242",
+		Owner:          "group",
+		Name:           "project",
+		RepoPath:       "group/project",
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(ctx, repoID, db.RepoProviderMetadata{
+		PlatformRepoID: "4242",
+		WebURL:         "https://gitlab.example.com/group/project",
+		CloneURL:       "https://gitlab.example.com/group/project.git",
+		DefaultBranch:  "main",
+	}))
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             repoID,
+		PlatformID:         7001,
+		PlatformExternalID: "gid://gitlab/MergeRequest/7001",
+		Number:             7,
+		URL:                "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:              "GitLab provider MR",
+		Author:             "ada",
+		State:              "open",
+		HeadBranch:         "feature/gitlab",
+		BaseBranch:         "main",
+		PlatformHeadSHA:    "gitlab-head",
+		PlatformBaseSHA:    "base",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		LastActivityAt:     now,
+	})
+	require.NoError(err)
+	return srv, database, repoID
+}
+
+func writeRawJSONForTest(w http.ResponseWriter, body string) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, body)
+}
+
 func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -10735,24 +11238,69 @@ func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(mr)
 	require.NoError(database.UpdateDiffSHAs(ctx, repo.ID, 7, "current-head", "base", "merge"))
-	now := time.Now().UTC().Truncate(time.Second)
-	line := 42
-	provider.reviewThreads = []platform.MergeRequestReviewThread{{
-		ProviderThreadID:  "thread-7",
-		ProviderCommentID: "comment-7",
-		Body:              "Published inline comment",
-		AuthorLogin:       "ada",
-		Range: platform.DiffReviewLineRange{
+	staleLine := 41
+	require.NoError(database.UpsertMRReviewThreads(ctx, mr.ID, []db.MRReviewThread{{
+		ProviderThreadID:  "stale-thread",
+		ProviderCommentID: "stale-comment",
+		Body:              "stale inline comment",
+		AuthorLogin:       "grace",
+		Range: db.ReviewLineRange{
 			Path:        "internal/server/api_test.go",
 			Side:        "right",
-			Line:        42,
-			NewLine:     &line,
+			Line:        staleLine,
+			NewLine:     &staleLine,
 			LineType:    "add",
 			DiffHeadSHA: "current-head",
 		},
-		CreatedAt: now,
-		UpdatedAt: now,
-	}}
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}}))
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID:     mr.ID,
+		PlatformExternalID: "stale-thread",
+		EventType:          "review_comment",
+		Author:             "grace",
+		Body:               "stale inline comment",
+		CreatedAt:          time.Now().UTC(),
+		DedupeKey:          "review_comment:stale-thread",
+	}}))
+	now := time.Now().UTC().Truncate(time.Second)
+	line := 42
+	replyLine := 43
+	provider.reviewThreads = []platform.MergeRequestReviewThread{
+		{
+			ProviderThreadID:  "thread-7",
+			ProviderCommentID: "comment-7",
+			Body:              "Published inline comment",
+			AuthorLogin:       "ada",
+			Range: platform.DiffReviewLineRange{
+				Path:        "internal/server/api_test.go",
+				Side:        "right",
+				Line:        42,
+				NewLine:     &line,
+				LineType:    "add",
+				DiffHeadSHA: "current-head",
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		{
+			ProviderThreadID:  "thread-7",
+			ProviderCommentID: "comment-reply",
+			Body:              "Reply should not replace original",
+			AuthorLogin:       "grace",
+			Range: platform.DiffReviewLineRange{
+				Path:        "internal/server/api_test.go",
+				Side:        "right",
+				Line:        43,
+				NewLine:     &replyLine,
+				LineType:    "add",
+				DiffHeadSHA: "current-head",
+			},
+			CreatedAt: now.Add(time.Minute),
+			UpdatedAt: now.Add(time.Minute),
+		},
+	}
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
 	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please fix this.",
@@ -10787,9 +11335,14 @@ func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
 	require.NoError(err)
 	require.Len(threads, 1)
 	assert.Equal("thread-7", threads[0].ProviderThreadID)
+	assert.Equal("comment-7", threads[0].ProviderCommentID)
+	assert.Equal("Published inline comment", threads[0].Body)
+	assert.Equal("ada", threads[0].AuthorLogin)
+	assert.Equal(42, threads[0].Range.Line)
 	events, err := database.ListMREvents(ctx, mr.ID)
 	require.NoError(err)
 	require.NotEmpty(events)
+	require.Len(events, 1)
 	assert.Equal("review_comment", events[0].EventType)
 	assert.Equal("thread-7", events[0].PlatformExternalID)
 }
@@ -10935,6 +11488,229 @@ func TestAPIForgejoSyncRecoversReviewThreadTimelineMetadata(t *testing.T) {
 	assert.Equal("review_comment", detail.Events[0].EventType)
 	assert.Equal("Recovered inline note", detail.Events[0].DiffThread.Body)
 	assert.Equal("src/recovered.go", detail.Events[0].DiffThread.Path)
+}
+
+func TestAPIGitLabSyncKeepsCanonicalReviewThreadWhenProviderReturnsReplies(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReviewThreads: true,
+	}
+	srv, database, provider := setupGitLabCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	originalLine := 9
+	replyLine := 10
+	provider.reviewThreads = []platform.MergeRequestReviewThread{
+		{
+			ProviderThreadID:  "discussion-1",
+			ProviderCommentID: "101",
+			Body:              "original inline note",
+			AuthorLogin:       "reviewer",
+			Range: platform.DiffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        originalLine,
+				NewLine:     &originalLine,
+				LineType:    "add",
+				DiffHeadSHA: "abc123",
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		{
+			ProviderThreadID:  "discussion-1",
+			ProviderCommentID: "102",
+			Body:              "reply should not replace original",
+			AuthorLogin:       "other-reviewer",
+			Range: platform.DiffReviewLineRange{
+				Path:        "src/main.go",
+				Side:        "right",
+				Line:        replyLine,
+				NewLine:     &replyLine,
+				LineType:    "add",
+				DiffHeadSHA: "abc123",
+			},
+			CreatedAt: now.Add(time.Minute),
+			UpdatedAt: now.Add(time.Minute),
+		},
+	}
+
+	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
+	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
+
+	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
+	require.NoError(err)
+	require.Len(threads, 1)
+	assert.Equal("discussion-1", threads[0].ProviderThreadID)
+	assert.Equal("101", threads[0].ProviderCommentID)
+	assert.Equal("original inline note", threads[0].Body)
+	assert.Equal("reviewer", threads[0].AuthorLogin)
+	assert.Equal(originalLine, threads[0].Range.Line)
+
+	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
+	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
+	var detail mergeRequestDetailResponse
+	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
+	require.Len(detail.Events, 1)
+	require.NotNil(detail.Events[0].ReviewThread)
+	assert.Equal("review_comment", detail.Events[0].EventType)
+	assert.Equal("original inline note", detail.Events[0].ReviewThread.Body)
+	assert.Equal("reviewer", detail.Events[0].ReviewThread.AuthorLogin)
+	assert.Equal("101", detail.Events[0].ReviewThread.ProviderCommentID)
+	assert.Equal(originalLine, detail.Events[0].ReviewThread.Line)
+}
+
+func TestAPIGitLabSyncPrunesMissingReviewThreadTimelineEvents(t *testing.T) {
+	require := require.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReviewThreads: true,
+	}
+	srv, database, provider := setupGitLabCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+
+	line := 12
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(database.UpsertMRReviewThreads(ctx, mr.ID, []db.MRReviewThread{{
+		ProviderThreadID:  "stale-thread",
+		ProviderCommentID: "stale-comment",
+		Body:              "stale inline note",
+		AuthorLogin:       "reviewer",
+		Range: db.ReviewLineRange{
+			Path:        "src/stale.go",
+			Side:        "right",
+			Line:        line,
+			NewLine:     &line,
+			LineType:    "add",
+			DiffHeadSHA: "abc123",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}))
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID:     mr.ID,
+		PlatformExternalID: "stale-thread",
+		EventType:          "review_comment",
+		Author:             "reviewer",
+		Body:               "stale inline note",
+		CreatedAt:          now,
+		DedupeKey:          "review_comment:stale-thread",
+	}}))
+	provider.reviewThreads = nil
+
+	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
+	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
+
+	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
+	require.NoError(err)
+	require.Empty(threads)
+	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
+	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
+	var detail mergeRequestDetailResponse
+	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
+	require.Empty(detail.Events)
+}
+
+func TestAPIGitLabSyncPrunesLegacyPositionedNoteCommentEvents(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReviewThreads: true,
+	}
+	srv, database, provider := setupGitLabCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID:     mr.ID,
+		PlatformExternalID: "2",
+		EventType:          "issue_comment",
+		Author:             "reviewer",
+		Body:               "legacy inline diff note",
+		CreatedAt:          now,
+		DedupeKey:          "gitlab:gitlab.example.com:group/project:mr:7:note:2",
+	}}))
+	line := 9
+	provider.reviewThreads = []platform.MergeRequestReviewThread{{
+		ProviderThreadID:  "discussion-2",
+		ProviderCommentID: "2",
+		Body:              "canonical inline diff note",
+		AuthorLogin:       "reviewer",
+		Range: platform.DiffReviewLineRange{
+			Path:        "src/main.go",
+			Side:        "right",
+			Line:        line,
+			NewLine:     &line,
+			LineType:    "add",
+			DiffHeadSHA: "abc123",
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}
+
+	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
+	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
+
+	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
+	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
+	var detail mergeRequestDetailResponse
+	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
+	require.Len(detail.Events, 1)
+	assert.Equal("review_comment", detail.Events[0].EventType)
+	require.NotNil(detail.Events[0].ReviewThread)
+	assert.Equal("canonical inline diff note", detail.Events[0].ReviewThread.Body)
+
+	events, err := database.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	for _, event := range events {
+		assert.NotEqual("issue_comment", event.EventType)
+	}
 }
 
 func TestAPIPublishReviewDraftDeletesDraftBeforeReviewThreadIngest(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10661,6 +10661,59 @@ func TestAPIPublishReviewDraftRejectsStoredCommentWithoutDiffHeadSHA(t *testing.
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 }
 
+func TestAPIPublishReviewDraftUsesPlatformHeadSHAWhenDiffHeadIsUnavailable(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	caps := platform.Capabilities{
+		ReadRepositories:       true,
+		ReadMergeRequests:      true,
+		ReadIssues:             true,
+		ReadComments:           true,
+		ReviewDraftMutation:    true,
+		SupportedReviewActions: []platform.ReviewAction{platform.ReviewActionComment, platform.ReviewActionApprove},
+	}
+	srv, database, provider := setupGitLabCapabilityServerWithProvider(t, &caps)
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		RepoPath:     "group/project",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	draft, err := database.GetOrCreateMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	line := 42
+	_, err = database.CreateMRReviewDraftComment(ctx, draft.ID, db.MRReviewDraftCommentInput{
+		Body: "ready to approve",
+		Range: db.ReviewLineRange{
+			Path:        "internal/server/api_test.go",
+			Side:        "right",
+			Line:        42,
+			NewLine:     &line,
+			LineType:    "add",
+			DiffHeadSHA: mr.PlatformHeadSHA,
+		},
+	})
+	require.NoError(err)
+
+	publishRR := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft/publish",
+		map[string]string{"action": "approve", "body": "looks good"},
+	)
+
+	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
+	require.Len(provider.publishedReviews, 1)
+	assert.Equal(mr.PlatformHeadSHA, provider.publishedReviews[0].HeadSHA)
+}
+
 func TestAPIPublishReviewDraftRejectsMultilineRangeWithoutCapability(t *testing.T) {
 	require := require.New(t)
 	caps := platform.Capabilities{

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -11630,12 +11630,12 @@ func TestAPIGitLabSyncKeepsCanonicalReviewThreadWhenProviderReturnsReplies(t *te
 	var detail mergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
 	require.Len(detail.Events, 1)
-	require.NotNil(detail.Events[0].ReviewThread)
+	require.NotNil(detail.Events[0].DiffThread)
 	assert.Equal("review_comment", detail.Events[0].EventType)
-	assert.Equal("original inline note", detail.Events[0].ReviewThread.Body)
-	assert.Equal("reviewer", detail.Events[0].ReviewThread.AuthorLogin)
-	assert.Equal("101", detail.Events[0].ReviewThread.ProviderCommentID)
-	assert.Equal(originalLine, detail.Events[0].ReviewThread.Line)
+	assert.Equal("original inline note", detail.Events[0].DiffThread.Body)
+	assert.Equal("reviewer", detail.Events[0].DiffThread.AuthorLogin)
+	assert.Equal("101", detail.Events[0].DiffThread.ProviderCommentID)
+	assert.Equal(originalLine, detail.Events[0].DiffThread.Line)
 }
 
 func TestAPIGitLabSyncPrunesMissingReviewThreadTimelineEvents(t *testing.T) {
@@ -11764,8 +11764,8 @@ func TestAPIGitLabSyncPrunesLegacyPositionedNoteCommentEvents(t *testing.T) {
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
 	require.Len(detail.Events, 1)
 	assert.Equal("review_comment", detail.Events[0].EventType)
-	require.NotNil(detail.Events[0].ReviewThread)
-	assert.Equal("canonical inline diff note", detail.Events[0].ReviewThread.Body)
+	require.NotNil(detail.Events[0].DiffThread)
+	assert.Equal("canonical inline diff note", detail.Events[0].DiffThread.Body)
 
 	events, err := database.ListMREvents(ctx, mr.ID)
 	require.NoError(err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10844,7 +10844,7 @@ func TestAPIGitLabPublishReviewDraftApprovesWithDiffPositionSHAs(t *testing.T) {
 	assert.Nil(lineRange.StartLine)
 }
 
-func TestAPIPublishReviewDraftClearsPartialPublishedDraft(t *testing.T) {
+func TestAPIPublishReviewDraftPreservesDraftWhenPartialStatusIsUnknown(t *testing.T) {
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:       true,
@@ -10899,7 +10899,11 @@ func TestAPIPublishReviewDraftClearsPartialPublishedDraft(t *testing.T) {
 	require.Len(provider.publishedReviews, 1)
 	draft, err := database.GetMRReviewDraft(ctx, mr.ID)
 	require.NoError(err)
-	require.Nil(draft)
+	require.NotNil(draft)
+	comments, err := database.ListMRReviewDraftComments(ctx, draft.ID)
+	require.NoError(err)
+	require.Len(comments, 1)
+	require.Equal("Please tighten this line.", comments[0].Body)
 }
 
 func TestAPIGitLabPublishReviewDraftSurfacesCleanupFailureAsPartial(t *testing.T) {
@@ -11076,7 +11080,11 @@ func TestAPIGitLabPublishReviewDraftSurfacesCleanupFailureAsPartial(t *testing.T
 	require.NotNil(mr)
 	draft, err := database.GetMRReviewDraft(ctx, mr.ID)
 	require.NoError(err)
-	assert.Nil(draft)
+	require.NotNil(draft)
+	comments, err := database.ListMRReviewDraftComments(ctx, draft.ID)
+	require.NoError(err)
+	require.Len(comments, 1)
+	assert.Equal("line 42", comments[0].Body)
 	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
 	require.NoError(err)
 	require.Len(threads, 1)

--- a/internal/server/diff_review_handlers.go
+++ b/internal/server/diff_review_handlers.go
@@ -191,11 +191,15 @@ func (s *Server) publishDiffReviewDraft(
 	if draft == nil || len(draft.Comments) == 0 {
 		return nil, huma.Error400BadRequest("review draft has no comments")
 	}
-	if mr.DiffHeadSHA == "" {
+	reviewHeadSHA := mr.DiffHeadSHA
+	if reviewHeadSHA == "" {
+		reviewHeadSHA = mr.PlatformHeadSHA
+	}
+	if reviewHeadSHA == "" {
 		return nil, huma.Error409Conflict("review diff is unavailable")
 	}
 	for _, comment := range draft.Comments {
-		if comment.Range.DiffHeadSHA == "" || comment.Range.DiffHeadSHA != mr.DiffHeadSHA {
+		if comment.Range.DiffHeadSHA == "" || comment.Range.DiffHeadSHA != reviewHeadSHA {
 			return nil, huma.Error409Conflict("review draft is stale")
 		}
 		if !caps.NativeMultilineRanges && (comment.Range.StartLine != nil || comment.Range.StartSide != "") {
@@ -224,7 +228,7 @@ func (s *Server) publishDiffReviewDraft(
 	if _, err := mutator.PublishDiffReviewDraft(ctx, platformRepoRefFromDB(*repo), input.Number, platform.PublishDiffReviewDraftInput{
 		Body:     strings.TrimSpace(input.Body.Body),
 		Action:   action,
-		HeadSHA:  mr.DiffHeadSHA,
+		HeadSHA:  reviewHeadSHA,
 		Comments: comments,
 	}); err != nil {
 		var partialErr *platform.DiffReviewPublishPartialError

--- a/internal/server/diff_review_handlers.go
+++ b/internal/server/diff_review_handlers.go
@@ -210,10 +210,13 @@ func (s *Server) publishDiffReviewDraft(
 	}
 	comments := make([]platform.LocalDiffReviewDraftComment, 0, len(draft.Comments))
 	for _, comment := range draft.Comments {
+		lineRange := platformReviewLineRange(comment.Range)
+		lineRange.DiffBaseSHA = mr.DiffBaseSHA
+		lineRange.MergeBaseSHA = mr.MergeBaseSHA
 		comments = append(comments, platform.LocalDiffReviewDraftComment{
 			ID:        comment.ID,
 			Body:      comment.Body,
-			Range:     platformReviewLineRange(comment.Range),
+			Range:     lineRange,
 			CreatedAt: comment.CreatedAt,
 			UpdatedAt: comment.UpdatedAt,
 		})
@@ -221,8 +224,19 @@ func (s *Server) publishDiffReviewDraft(
 	if _, err := mutator.PublishDiffReviewDraft(ctx, platformRepoRefFromDB(*repo), input.Number, platform.PublishDiffReviewDraftInput{
 		Body:     strings.TrimSpace(input.Body.Body),
 		Action:   action,
+		HeadSHA:  mr.DiffHeadSHA,
 		Comments: comments,
 	}); err != nil {
+		var partialErr *platform.DiffReviewPublishPartialError
+		if errors.As(err, &partialErr) {
+			if discardErr := s.db.DeleteMRReviewDraft(ctx, mr.ID); discardErr != nil {
+				return nil, huma.Error500InternalServerError("discard partially published review draft failed")
+			}
+			if capabilityEnabled(s.capabilitiesForRepo(*repo), capabilityReadReviewThreads) {
+				_ = s.ingestDiffReviewThreads(ctx, *repo, *mr)
+			}
+			return &actionStatusOutput{Body: actionStatusBody{Status: "partially_published"}}, nil
+		}
 		return nil, huma.Error502BadGateway("publish review draft on provider failed")
 	}
 	if err := s.db.DeleteMRReviewDraft(ctx, mr.ID); err != nil {
@@ -372,6 +386,8 @@ func (s *Server) ingestDiffReviewThreads(
 	}
 	dbThreads := make([]db.MRReviewThread, 0, len(threads))
 	events := make([]db.MREvent, 0, len(threads))
+	providerThreadIDs := make([]string, 0, len(threads))
+	seenProviderThreadIDs := make(map[string]struct{}, len(threads))
 	for _, thread := range threads {
 		providerThreadID := thread.ProviderThreadID
 		if providerThreadID == "" {
@@ -380,6 +396,11 @@ func (s *Server) ingestDiffReviewThreads(
 		if providerThreadID == "" {
 			continue
 		}
+		if _, ok := seenProviderThreadIDs[providerThreadID]; ok {
+			continue
+		}
+		seenProviderThreadIDs[providerThreadID] = struct{}{}
+		providerThreadIDs = append(providerThreadIDs, providerThreadID)
 		dbThread := db.MRReviewThread{
 			ProviderThreadID:  providerThreadID,
 			ProviderReviewID:  thread.ProviderReviewID,
@@ -410,6 +431,9 @@ func (s *Server) ingestDiffReviewThreads(
 				DedupeKey:          "review_comment:" + eventExternalID,
 			})
 		}
+	}
+	if err := s.db.DeleteMissingMRReviewThreads(ctx, mr.ID, providerThreadIDs); err != nil {
+		return huma.Error500InternalServerError("delete missing review threads failed")
 	}
 	if err := s.db.UpsertMRReviewThreads(ctx, mr.ID, dbThreads); err != nil {
 		return huma.Error500InternalServerError("persist review threads failed")

--- a/internal/server/diff_review_handlers.go
+++ b/internal/server/diff_review_handlers.go
@@ -233,8 +233,10 @@ func (s *Server) publishDiffReviewDraft(
 	}); err != nil {
 		var partialErr *platform.DiffReviewPublishPartialError
 		if errors.As(err, &partialErr) {
-			if discardErr := s.db.DeleteMRReviewDraft(ctx, mr.ID); discardErr != nil {
-				return nil, huma.Error500InternalServerError("discard partially published review draft failed")
+			if len(partialErr.PublishedCommentIDs) > 0 {
+				if discardErr := s.deletePublishedReviewDraftComments(ctx, draft.ID, mr.ID, partialErr.PublishedCommentIDs); discardErr != nil {
+					return nil, huma.Error500InternalServerError("discard partially published review draft comments failed")
+				}
 			}
 			if capabilityEnabled(s.capabilitiesForRepo(*repo), capabilityReadReviewThreads) {
 				_ = s.ingestDiffReviewThreads(ctx, *repo, *mr)
@@ -250,6 +252,27 @@ func (s *Server) publishDiffReviewDraft(
 		_ = s.ingestDiffReviewThreads(ctx, *repo, *mr)
 	}
 	return &actionStatusOutput{Body: actionStatusBody{Status: "published"}}, nil
+}
+
+func (s *Server) deletePublishedReviewDraftComments(
+	ctx context.Context,
+	draftID int64,
+	mrID int64,
+	commentIDs []int64,
+) error {
+	for _, commentID := range commentIDs {
+		if err := s.db.DeleteMRReviewDraftComment(ctx, draftID, commentID); err != nil {
+			return err
+		}
+	}
+	remaining, err := s.db.ListMRReviewDraftComments(ctx, draftID)
+	if err != nil {
+		return err
+	}
+	if len(remaining) == 0 {
+		return s.db.DeleteMRReviewDraft(ctx, mrID)
+	}
+	return nil
 }
 
 func (s *Server) resolveDiffReviewThread(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1925,7 +1925,7 @@ func TestManagerRequestRetryConsumesQueuedRetryWhenCleanupFails(t *testing.T) {
 		firstResult <- retryResult{ws: next, startNow: startNow, err: err}
 	}()
 
-	const retryWait = 3 * time.Second
+	const retryWait = 5 * time.Second
 
 	require.Eventually(func() bool {
 		_, err := os.Stat(started)

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -5,6 +5,7 @@
   import CopyIcon from "@lucide/svelte/icons/copy";
   import PencilIcon from "@lucide/svelte/icons/pencil";
   import XIcon from "@lucide/svelte/icons/x";
+  import { untrack } from "svelte";
   import { slide } from "svelte/transition";
   import type { IssueEvent, PREvent } from "../../api/types.js";
   import type { components } from "../../api/generated/schema.js";
@@ -54,10 +55,11 @@
 
   $effect(() => {
     if (!provider || !repoOwner || !repoName || !repoPath || number == null) return;
-    diffReviewDraft?.setRouteContext(
-      { provider, platformHost, owner: repoOwner, name: repoName, repoPath },
-      number,
-    );
+    const nextRef = { provider, platformHost, owner: repoOwner, name: repoName, repoPath };
+    const nextNumber = number;
+    untrack(() => {
+      diffReviewDraft?.setRouteContext(nextRef, nextNumber);
+    });
   });
 
   const typeLabels: Record<string, string> = {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -375,6 +375,19 @@
     selectedRange = null;
     selectionAnchor = null;
   }
+
+  let reviewContextKey = "";
+  $effect(() => {
+    const nextKey = reviewEnabled && diffHeadSHA
+      ? `${file.path}:${file.old_path ?? ""}:${diffHeadSHA}`
+      : "";
+    if (nextKey !== reviewContextKey) {
+      reviewContextKey = nextKey;
+      composerRange = null;
+      selectedRange = null;
+      selectionAnchor = null;
+    }
+  });
 </script>
 
 <div class="diff-file" data-file-path={file.path} bind:this={fileEl}>
@@ -440,7 +453,7 @@
                 newSelected={isSelected(line, "right", order, hunkIdx)}
                 onselectside={(side, event) => handleLineSelect(line, side, order, hunkIdx, event)}
               />
-              {#if composerRange && composerAfter(line, order, hunkIdx)}
+              {#if reviewEnabled && composerRange && composerAfter(line, order, hunkIdx)}
                 <DiffInlineCommentComposer
                   range={composerRange}
                   onclose={closeComposer}

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -98,6 +98,7 @@ function renderDiffFile(
     reviewEnabled?: boolean;
     diffHeadSHA?: string;
     nativeMultilineRanges?: boolean;
+    owner?: string;
   } = {},
 ) {
   const diff = createDiffStore();
@@ -110,7 +111,7 @@ function renderDiffFile(
   return render(DiffFile, {
     props: {
       file,
-      owner: uniqueOwner(),
+      owner: options.owner ?? uniqueOwner(),
       name: "n",
       number: 1,
       ...(options.richPreviewEnabled !== undefined && {
@@ -241,5 +242,54 @@ describe("DiffFile", () => {
     const selected = Array.from(document.querySelectorAll(".gutter-new.gutter--selected"));
     expect(selected).toHaveLength(1);
     expect(selected[0]?.textContent?.trim()).toBe("20");
+  });
+
+  it("clears an open inline composer when review context changes", async () => {
+    const file = makeFile();
+    const owner = uniqueOwner();
+    const { rerender } = renderDiffFile(file, {
+      owner,
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Comment on new line 1" }));
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+    expect(document.querySelectorAll(".gutter-new.gutter--selected")).toHaveLength(1);
+
+    await rerender({
+      file,
+      owner,
+      name: "n",
+      number: 1,
+      reviewEnabled: false,
+      diffHeadSHA: "diff-head",
+    });
+
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+    expect(document.querySelectorAll(".gutter-new.gutter--selected")).toHaveLength(0);
+
+    await rerender({
+      file,
+      owner,
+      name: "n",
+      number: 1,
+      reviewEnabled: true,
+      diffHeadSHA: "new-diff-head",
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Comment on new line 1" }));
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+
+    await rerender({
+      file,
+      owner,
+      name: "n",
+      number: 1,
+      reviewEnabled: true,
+      diffHeadSHA: "another-diff-head",
+    });
+
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+    expect(document.querySelectorAll(".gutter-new.gutter--selected")).toHaveLength(0);
   });
 });

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -70,6 +70,7 @@
   );
   const loading = $derived(diffStore.isDiffLoading());
   const error = $derived(diffStore.getDiffError());
+  const reviewWarning = $derived(diffReviewDraft?.getWarning() ?? null);
   const tabWidth = $derived(diffStore.getTabWidth());
   const wordWrap = $derived(diffStore.getWordWrap());
   const scopeKind = $derived(
@@ -238,6 +239,9 @@
             />
           {/each}
           {#if reviewEnabled && diffReviewDraft}
+            {#if reviewWarning}
+              <div class="review-warning">{reviewWarning}</div>
+            {/if}
             <DiffReviewDraftTray />
           {/if}
         </div>
@@ -262,6 +266,15 @@
     border-bottom: 1px solid var(--diff-stale-border);
     font-size: var(--font-size-sm);
     flex-shrink: 0;
+  }
+
+  .review-warning {
+    flex-shrink: 0;
+    padding: 8px 12px;
+    border-top: 1px solid var(--diff-stale-border);
+    background: var(--diff-stale-bg);
+    color: var(--diff-stale-text);
+    font-size: var(--font-size-sm);
   }
 
   .diff-body {

--- a/packages/ui/src/stores/diff-review-draft.svelte.test.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.test.ts
@@ -164,6 +164,41 @@ describe("createDiffReviewDraftStore", () => {
     expect(store.isLoading()).toBe(false);
   });
 
+  it("surfaces partial publish status while clearing the draft", async () => {
+    const client = {
+      GET: vi.fn(() => Promise.resolve({
+        data: {
+          comments: [],
+          supported_actions: ["comment"],
+          native_multiline_ranges: false,
+        },
+        response: { status: 200, ok: true },
+      })),
+      POST: vi.fn(() => Promise.resolve({
+        data: { status: "partially_published" },
+        response: { status: 200, ok: true },
+      })),
+    } as unknown as MiddlemanClient;
+    const onPublished = vi.fn();
+    const store = createDiffReviewDraftStore({ client, onPublished });
+    const ref = {
+      provider: "gitlab",
+      platformHost: "gitlab.example.com",
+      owner: "group",
+      name: "project",
+      repoPath: "group/project",
+    };
+
+    store.setContext(ref, 7, true);
+    await Promise.resolve();
+    const ok = await store.publish("approve", "summary");
+
+    expect(ok).toBe(true);
+    expect(store.getDraft()?.comments).toEqual([]);
+    expect(store.getWarning()).toContain("partially published");
+    expect(onPublished).toHaveBeenCalledWith(ref, 7);
+  });
+
   it("ignores an older same-PR load after publish refreshes the draft", async () => {
     const staleLoad = deferred<MockDraftLoad>();
     const client = {
@@ -211,7 +246,7 @@ describe("createDiffReviewDraftStore", () => {
   });
 
   it("does not stay loading when a mutation fails during an in-flight load", async () => {
-    const staleLoad = deferred<unknown>();
+    const staleLoad = deferred<MockDraftLoad>();
     const client = {
       GET: vi.fn().mockReturnValueOnce(staleLoad.promise),
       POST: vi.fn(() => Promise.resolve({
@@ -250,7 +285,7 @@ describe("createDiffReviewDraftStore", () => {
   });
 
   it("does not stay loading when discard succeeds during an in-flight load", async () => {
-    const staleLoad = deferred<unknown>();
+    const staleLoad = deferred<MockDraftLoad>();
     const client = {
       GET: vi.fn().mockReturnValueOnce(staleLoad.promise),
       DELETE: vi.fn(() => Promise.resolve({

--- a/packages/ui/src/stores/diff-review-draft.svelte.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.ts
@@ -36,8 +36,10 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
   let loading = $state(false);
   let submitting = $state(false);
   let storeError = $state<string | null>(null);
+  let storeWarning = $state<string | null>(null);
   let wasEnabled = false;
   let draftVersion = 0;
+  let submitVersion = 0;
 
   function isEnabled(): boolean {
     return enabled;
@@ -63,6 +65,10 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     return storeError;
   }
 
+  function getWarning(): string | null {
+    return storeWarning;
+  }
+
   function currentParams() {
     if (!ref || !number) return null;
     return {
@@ -80,6 +86,23 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       number,
       diffHeadSHA ?? "",
     ].join(":");
+  }
+
+  function beginSubmit(): number {
+    const token = ++submitVersion;
+    submitting = true;
+    return token;
+  }
+
+  function finishSubmit(token: number): void {
+    if (submitVersion === token) {
+      submitting = false;
+    }
+  }
+
+  function cancelSubmit(): void {
+    submitVersion += 1;
+    submitting = false;
   }
 
   function setContext(
@@ -104,10 +127,14 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled) {
       draft = null;
       storeError = null;
+      storeWarning = null;
+      cancelSubmit();
       return;
     }
     if (changed || enabling) {
       draft = null;
+      storeWarning = null;
+      cancelSubmit();
       void loadDraft();
     }
   }
@@ -116,8 +143,20 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     nextRef: ProviderRouteRef,
     nextNumber: number,
   ): void {
+    const changed =
+      !ref ||
+      ref.provider !== nextRef.provider ||
+      ref.platformHost !== nextRef.platformHost ||
+      ref.repoPath !== nextRef.repoPath ||
+      number !== nextNumber;
     ref = nextRef;
     number = nextNumber;
+    if (changed) {
+      draftVersion += 1;
+      cancelSubmit();
+      storeError = null;
+      storeWarning = null;
+    }
   }
 
   function invalidateDraftLoad(): void {
@@ -127,6 +166,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
 
   function clear(): void {
     invalidateDraftLoad();
+    cancelSubmit();
     enabled = false;
     wasEnabled = false;
     ref = null;
@@ -134,8 +174,8 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     diffHeadSHA = undefined;
     draft = null;
     loading = false;
-    submitting = false;
     storeError = null;
+    storeWarning = null;
   }
 
   async function loadDraft(): Promise<void> {
@@ -178,9 +218,13 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
+    const key = requestKey();
     invalidateDraftLoad();
-    submitting = true;
+    const version = draftVersion;
+    const isCurrent = () => requestKey() === key && draftVersion === version;
+    const submitToken = beginSubmit();
     storeError = null;
+    storeWarning = null;
     try {
       const { data, error, response } = await apiClient.POST(
         providerItemPath("pulls", ref, "/review-draft/comments"),
@@ -192,13 +236,16 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       if (!data) {
         throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
+      if (!isCurrent()) return true;
       await loadDraft();
       return true;
     } catch (err) {
-      storeError = err instanceof Error ? err.message : String(err);
+      if (isCurrent()) {
+        storeError = err instanceof Error ? err.message : String(err);
+      }
       return false;
     } finally {
-      submitting = false;
+      finishSubmit(submitToken);
     }
   }
 
@@ -206,9 +253,13 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
+    const key = requestKey();
     invalidateDraftLoad();
-    submitting = true;
+    const version = draftVersion;
+    const isCurrent = () => requestKey() === key && draftVersion === version;
+    const submitToken = beginSubmit();
     storeError = null;
+    storeWarning = null;
     try {
       const { error, response } = await apiClient.DELETE(
         providerItemPath("pulls", ref, "/review-draft/comments/{draft_comment_id}"),
@@ -224,13 +275,16 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       if (!response.ok) {
         throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
+      if (!isCurrent()) return true;
       await loadDraft();
       return true;
     } catch (err) {
-      storeError = err instanceof Error ? err.message : String(err);
+      if (isCurrent()) {
+        storeError = err instanceof Error ? err.message : String(err);
+      }
       return false;
     } finally {
-      submitting = false;
+      finishSubmit(submitToken);
     }
   }
 
@@ -242,18 +296,27 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     const publishedNumber = number;
     const key = requestKey();
     invalidateDraftLoad();
-    submitting = true;
+    const version = draftVersion;
+    const isCurrent = () => requestKey() === key && draftVersion === version;
+    const submitToken = beginSubmit();
     storeError = null;
+    storeWarning = null;
     try {
-      const { error, response } = await apiClient.POST(
+      const { data, error, response } = await apiClient.POST(
         providerItemPath("pulls", ref, "/review-draft/publish"),
         { params, body: { action, body } },
       );
       if (!response.ok) {
         throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
+      const partial = data?.status === "partially_published";
+      if (!isCurrent()) return true;
       draft = null;
       await loadDraft();
+      if (partial && requestKey() === key) {
+        storeWarning =
+          "Review was partially published. Some inline comments or the selected review action may not have been submitted.";
+      }
       if (requestKey() === key) {
         try {
           await opts.onPublished?.(publishedRef, publishedNumber);
@@ -263,10 +326,12 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       }
       return true;
     } catch (err) {
-      storeError = err instanceof Error ? err.message : String(err);
+      if (isCurrent()) {
+        storeError = err instanceof Error ? err.message : String(err);
+      }
       return false;
     } finally {
-      submitting = false;
+      finishSubmit(submitToken);
     }
   }
 
@@ -274,9 +339,13 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!enabled || !ref) return false;
     const params = currentParams();
     if (!params) return false;
+    const key = requestKey();
     invalidateDraftLoad();
-    submitting = true;
+    const version = draftVersion;
+    const isCurrent = () => requestKey() === key && draftVersion === version;
+    const submitToken = beginSubmit();
     storeError = null;
+    storeWarning = null;
     try {
       const { error, response } = await apiClient.DELETE(
         providerItemPath("pulls", ref, "/review-draft"),
@@ -285,13 +354,16 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       if (!response.ok) {
         throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
+      if (!isCurrent()) return true;
       draft = null;
       return true;
     } catch (err) {
-      storeError = err instanceof Error ? err.message : String(err);
+      if (isCurrent()) {
+        storeError = err instanceof Error ? err.message : String(err);
+      }
       return false;
     } finally {
-      submitting = false;
+      finishSubmit(submitToken);
     }
   }
 
@@ -302,8 +374,12 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (!ref || !number) return false;
     const params = currentParams();
     if (!params) return false;
-    submitting = true;
+    const key = requestKey();
+    const version = ++draftVersion;
+    const isCurrent = () => requestKey() === key && draftVersion === version;
+    const submitToken = beginSubmit();
     storeError = null;
+    storeWarning = null;
     try {
       const path = resolved
         ? "/review-threads/{thread_id}/resolve"
@@ -324,10 +400,12 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       }
       return true;
     } catch (err) {
-      storeError = err instanceof Error ? err.message : String(err);
+      if (isCurrent()) {
+        storeError = err instanceof Error ? err.message : String(err);
+      }
       return false;
     } finally {
-      submitting = false;
+      finishSubmit(submitToken);
     }
   }
 
@@ -338,6 +416,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     isLoading,
     isSubmitting,
     getError,
+    getWarning,
     setContext,
     setRouteContext,
     clear,


### PR DESCRIPTION
Adds GitLab inline review support on top of the shared draft flow:

- Publish inline draft notes, review summaries, and approvals through GitLab APIs.
- Read and resolve GitLab discussions as canonical provider review threads.
- Model partial publish and cleanup failures so already-posted comments do not remain queued for retry.
- Prune stale provider thread and positioned-note timeline rows during publish and sync refreshes.
