### PR TITLE
clarify advanced repo add provider scoping

### DIFF
--- a/frontend/src/lib/components/settings/RepoSettings.svelte
+++ b/frontend/src/lib/components/settings/RepoSettings.svelte
@@ -191,10 +191,10 @@
 
 {#if !embedded}
   <details class="advanced-add">
-    <summary>Advanced: add exact repo or tracking glob directly</summary>
+    <summary>Advanced: add provider-scoped repo or tracking glob directly</summary>
     <div class="advanced-body">
       <div class="add-form">
-        <input class="add-input" type="text" placeholder="owner/name" bind:value={inputValue} onkeydown={handleInputKeydown} disabled={adding} />
+        <input class="add-input" type="text" placeholder="provider/owner/name" bind:value={inputValue} onkeydown={handleInputKeydown} disabled={adding} />
         <button class="add-btn" onclick={() => void handleAdd()} disabled={adding || !inputValue.trim()}>
           {adding ? "Adding..." : "Add"}
         </button>

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -89,7 +89,7 @@ describe("RepoSettings", () => {
       },
     });
 
-    const summary = screen.getByText("Advanced: add exact repo or tracking glob directly");
+    const summary = screen.getByText("Advanced: add provider-scoped repo or tracking glob directly");
     expect(summary).toBeTruthy();
     expect(summary.closest("details")?.hasAttribute("open")).toBe(false);
   });
@@ -133,7 +133,7 @@ describe("RepoSettings", () => {
       },
     });
 
-    const input = screen.getByPlaceholderText("owner/name");
+    const input = screen.getByPlaceholderText("provider/owner/name");
     await fireEvent.input(input, { target: { value: "github/acme/widget" } });
     await fireEvent.click(screen.getByRole("button", { name: "Add" }));
     expect(mockAddRepo).toHaveBeenCalledWith("acme", "widget", {


### PR DESCRIPTION
## Summary
- Update the advanced repo add UI copy to make provider scoping explicit.
- Change the input placeholder to `provider/owner/name` so the required format is clearer.
- Adjust the component test to match the new label and placeholder.

## Testing
- Not run (not requested).