### PR TITLE
Show provider icons in multi-provider views

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "marked": "17.0.5",
         "openapi-fetch": "^0.17.0",
         "shiki": "^4.0.2",
+        "simple-icons": "^16.19.0",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -841,6 +842,8 @@
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "simple-icons": ["simple-icons@16.19.0", "", {}, "sha512-muxcz/FDvWFPrKJdsjaz79qsBjtZeVKUVIFl7wLVOwb+yqAag8FPe8+hFlMVRnmAXYQIm4eUDDm2+dhOj0cFgQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"slices"
@@ -20,6 +22,7 @@ import (
 	gh "github.com/google/go-github/v84/github"
 	"github.com/wesm/middleman/internal/config"
 	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/gitenv"
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	"github.com/wesm/middleman/internal/server"
@@ -164,7 +167,60 @@ func (p e2eStaticProvider) ListIssueEvents(
 
 type globRefreshContextKey struct{}
 
-func gitLabReadOnlyRepoRef() platform.RepoRef {
+func e2eGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(gitenv.StripAll(os.Environ()),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_AUTHOR_DATE=2026-04-28T12:00:00Z",
+		"GIT_COMMITTER_DATE=2026-04-28T12:00:00Z",
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git %s: %w: %s", args[0], err, stderr.String())
+	}
+	return nil
+}
+
+func createBareRepoFixture(tmpDir, host, owner, name string) (string, error) {
+	workDir := filepath.Join(tmpDir, "fixture-work", host, owner, name)
+	barePath := filepath.Join(tmpDir, "clones", host, owner, name+".git")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir fixture workdir: %w", err)
+	}
+	if err := e2eGit(workDir, "init", "-b", "main"); err != nil {
+		return "", fmt.Errorf("init fixture repo: %w", err)
+	}
+	if err := e2eGit(workDir, "config", "user.email", "e2e@example.com"); err != nil {
+		return "", fmt.Errorf("config fixture repo email: %w", err)
+	}
+	if err := e2eGit(workDir, "config", "user.name", "E2E Fixture"); err != nil {
+		return "", fmt.Errorf("config fixture repo name: %w", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(workDir, "README.md"),
+		[]byte("# GitLab fixture\n"),
+		0o644,
+	); err != nil {
+		return "", fmt.Errorf("write fixture file: %w", err)
+	}
+	if err := e2eGit(workDir, "add", "README.md"); err != nil {
+		return "", fmt.Errorf("stage fixture repo: %w", err)
+	}
+	if err := e2eGit(workDir, "commit", "-m", "fixture: seed gitlab repo"); err != nil {
+		return "", fmt.Errorf("commit fixture repo: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(barePath), 0o755); err != nil {
+		return "", fmt.Errorf("mkdir bare fixture parent: %w", err)
+	}
+	if err := e2eGit("", "clone", "--bare", workDir, barePath); err != nil {
+		return "", fmt.Errorf("clone bare fixture repo: %w", err)
+	}
+	return barePath, nil
+}
+
+func gitLabReadOnlyRepoRef(cloneURL string) platform.RepoRef {
 	return platform.RepoRef{
 		Platform:      platform.KindGitLab,
 		Host:          "gitlab.example.com",
@@ -172,13 +228,16 @@ func gitLabReadOnlyRepoRef() platform.RepoRef {
 		Name:          "project",
 		RepoPath:      "group/project",
 		WebURL:        "https://gitlab.example.com/group/project",
-		CloneURL:      "https://gitlab.example.com/group/project.git",
+		CloneURL:      cloneURL,
 		DefaultBranch: "main",
 	}
 }
 
-func gitLabReadOnlyIssueFixture(now time.Time) (platform.Issue, []platform.IssueEvent) {
-	ref := gitLabReadOnlyRepoRef()
+func gitLabReadOnlyIssueFixture(
+	now time.Time,
+	cloneURL string,
+) (platform.Issue, []platform.IssueEvent) {
+	ref := gitLabReadOnlyRepoRef(cloneURL)
 	issue := platform.Issue{
 		Repo:         ref,
 		PlatformID:   7101,
@@ -207,9 +266,13 @@ func gitLabReadOnlyIssueFixture(now time.Time) (platform.Issue, []platform.Issue
 	return issue, events
 }
 
-func seedGitLabReadOnlyCapabilityFixture(ctx context.Context, database *db.DB) error {
+func seedGitLabReadOnlyCapabilityFixture(
+	ctx context.Context,
+	database *db.DB,
+	cloneURL string,
+) error {
 	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
-	issue, events := gitLabReadOnlyIssueFixture(now)
+	issue, events := gitLabReadOnlyIssueFixture(now, cloneURL)
 	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
 		Platform:       "gitlab",
 		PlatformHost:   "gitlab.example.com",
@@ -284,7 +347,16 @@ func run(
 	if err != nil {
 		return fmt.Errorf("seed fixtures: %w", err)
 	}
-	if err := seedGitLabReadOnlyCapabilityFixture(ctx, database); err != nil {
+	gitLabCloneURL, err := createBareRepoFixture(
+		tmpDir,
+		"gitlab.example.com",
+		"group",
+		"project",
+	)
+	if err != nil {
+		return fmt.Errorf("create gitlab fixture repo: %w", err)
+	}
+	if err := seedGitLabReadOnlyCapabilityFixture(ctx, database, gitLabCloneURL); err != nil {
 		return fmt.Errorf("seed gitlab capability fixture: %w", err)
 	}
 
@@ -472,6 +544,7 @@ func run(
 
 	gitLabIssue, gitLabIssueEvents := gitLabReadOnlyIssueFixture(
 		time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+		gitLabCloneURL,
 	)
 	forgeUpdated := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
 	giteaUpdated := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -168,6 +168,9 @@ func (p e2eStaticProvider) ListIssueEvents(
 type globRefreshContextKey struct{}
 
 func e2eGit(dir string, args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("git: no args")
+	}
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()),

--- a/docs/superpowers/plans/2026-05-12-provider-brand-icons.md
+++ b/docs/superpowers/plans/2026-05-12-provider-brand-icons.md
@@ -1,0 +1,65 @@
+# Provider Brand Icons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show provider brand icons for GitHub, GitLab, Forgejo, and Gitea when more than one provider is present.
+
+**Architecture:** Add one focused Svelte component that renders Simple Icons SVG path data by provider id. Each surface computes whether its local data includes multiple providers and only passes icons through in that state.
+
+**Tech Stack:** Svelte 5, TypeScript, Bun, Vitest, Testing Library, `simple-icons`.
+
+---
+
+### Task 1: Provider Icon Component
+
+**Files:**
+- Create: `frontend/src/lib/components/provider/ProviderIcon.svelte`
+- Create: `frontend/src/lib/components/provider/provider-icons.ts`
+- Test: `frontend/src/lib/components/provider/ProviderIcon.test.ts`
+
+- [ ] Write a failing component test for GitHub/GitLab rendering and unknown-provider fallback.
+- [ ] Add `simple-icons` to `frontend/package.json` with Bun.
+- [ ] Implement a typed provider-to-icon map using `siGithub`, `siGitlab`, `siForgejo`, and `siGitea`.
+- [ ] Render a 24x24 SVG with `role="img"` and an accessible label.
+
+### Task 2: Repository Cards
+
+**Files:**
+- Modify: `frontend/src/lib/components/repositories/RepoSummaryPage.svelte`
+- Modify: `frontend/src/lib/components/repositories/RepoSummaryCard.svelte`
+- Test: `frontend/src/lib/components/repositories/RepoSummaryPage.test.ts`
+
+- [ ] Add a failing test that multi-provider repo summaries show provider icons on cards.
+- [ ] Add a failing test that single-provider summaries do not show provider icons.
+- [ ] Compute `showProviderIcons` from distinct `summary.repo.provider` values on the page.
+- [ ] Pass `showProviderIcon` to `RepoSummaryCard` and render the icon before the repo name.
+
+### Task 3: Workspace Sidebar
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte`
+- Test: `frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts`
+
+- [ ] Add provider to the workspace row type if the API response already provides it.
+- [ ] Add a failing test that multiple workspace providers show icons in repo group headers.
+- [ ] Add a failing test that a single provider hides icons.
+- [ ] Compute `showProviderIcons` from distinct workspace providers and render the icon in group headers.
+
+### Task 4: Settings and Project Identity
+
+**Files:**
+- Modify: `frontend/src/lib/components/settings/RepoSettings.svelte`
+- Modify: `frontend/src/lib/components/terminal/WorkspaceProjectCard.svelte`
+- Test: `frontend/src/lib/components/terminal/WorkspaceProjectCard.test.ts`
+
+- [ ] Add a failing settings test that multiple configured providers show row icons.
+- [ ] Add a failing project-card test that a multi-provider context shows the linked project icon.
+- [ ] Render provider icons beside configured repo rows when multiple providers are configured.
+- [ ] Render provider icons beside project identity when a provider id is available.
+
+### Task 5: Verification and Commit
+
+- [ ] Run focused Vitest tests for touched components.
+- [ ] Run `bun run typecheck`.
+- [ ] Run Svelte autofixer on touched `.svelte` files.
+- [ ] Commit with hooks using a conventional commit message explaining the provider-disambiguation outcome.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -13,6 +13,7 @@
         "marked": "17.0.5",
         "openapi-fetch": "^0.17.0",
         "shiki": "^4.0.2",
+        "simple-icons": "^16.19.0",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -677,6 +678,8 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
+
+    "simple-icons": ["simple-icons@16.19.0", "", {}, "sha512-muxcz/FDvWFPrKJdsjaz79qsBjtZeVKUVIFl7wLVOwb+yqAag8FPe8+hFlMVRnmAXYQIm4eUDDm2+dhOj0cFgQ=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,8 @@
     "js-toml": "^1.0.3",
     "marked": "17.0.5",
     "openapi-fetch": "^0.17.0",
-    "shiki": "^4.0.2"
+    "shiki": "^4.0.2",
+    "simple-icons": "^16.19.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/lib/components/provider/ProviderIcon.svelte
+++ b/frontend/src/lib/components/provider/ProviderIcon.svelte
@@ -18,7 +18,7 @@
 
 {#if icon}
   <svg
-    class={["provider-icon", className]}
+    class={["provider-icon", className].filter(Boolean).join(" ")}
     role="img"
     aria-label={icon.title}
     viewBox="0 0 24 24"

--- a/frontend/src/lib/components/provider/ProviderIcon.svelte
+++ b/frontend/src/lib/components/provider/ProviderIcon.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { providerIcon } from "./provider-icons.ts";
+
+  interface Props {
+    provider: string;
+    size?: number;
+    class?: string;
+  }
+
+  let {
+    provider,
+    size = 16,
+    class: className = "",
+  }: Props = $props();
+
+  const icon = $derived(providerIcon(provider));
+</script>
+
+{#if icon}
+  <svg
+    class={["provider-icon", className]}
+    role="img"
+    aria-label={icon.title}
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>{icon.title}</title>
+    <path d={icon.path}></path>
+  </svg>
+{/if}
+
+<style>
+  .provider-icon {
+    display: inline-block;
+    flex: 0 0 auto;
+    color: currentColor;
+    vertical-align: -0.125em;
+  }
+</style>

--- a/frontend/src/lib/components/provider/ProviderIcon.test.ts
+++ b/frontend/src/lib/components/provider/ProviderIcon.test.ts
@@ -1,0 +1,22 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+
+import ProviderIcon from "./ProviderIcon.svelte";
+
+describe("ProviderIcon", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders known provider brand icons with accessible labels", () => {
+    render(ProviderIcon, { props: { provider: "github" } });
+    expect(screen.getByRole("img", { name: "GitHub" })).toBeTruthy();
+  });
+
+  it("renders nothing for unknown providers", () => {
+    const { container } = render(ProviderIcon, {
+      props: { provider: "unknown" },
+    });
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/provider/provider-icons.ts
+++ b/frontend/src/lib/components/provider/provider-icons.ts
@@ -1,0 +1,18 @@
+import {
+  siForgejo,
+  siGitea,
+  siGithub,
+  siGitlab,
+  type SimpleIcon,
+} from "simple-icons";
+
+export const providerIcons: Record<string, SimpleIcon> = {
+  forgejo: siForgejo,
+  gitea: siGitea,
+  github: siGithub,
+  gitlab: siGitlab,
+};
+
+export function providerIcon(provider: string): SimpleIcon | undefined {
+  return providerIcons[provider.trim().toLowerCase()];
+}

--- a/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
@@ -2,6 +2,7 @@
   import { ActionButton, Chip } from "@middleman/ui";
   import { timeAgo } from "@middleman/ui/utils/time";
   import { ExternalLinkIcon } from "../../icons.js";
+  import ProviderIcon from "../provider/ProviderIcon.svelte";
   import RepoMetricGrid from "./RepoMetricGrid.svelte";
   import {
     displayReleaseName,
@@ -25,6 +26,7 @@
 
   interface Props {
     summary: RepoSummaryCard;
+    showProviderIcon?: boolean;
     onviewprs: () => void;
     onviewissues: () => void;
     onopencomposer: () => void;
@@ -33,6 +35,7 @@
 
   let {
     summary,
+    showProviderIcon = false,
     onviewprs,
     onviewissues,
     onopencomposer,
@@ -179,8 +182,15 @@
 
 <article class="repo-card" aria-labelledby={`repo-${stateKey}`} bind:this={cardElement}>
   <div class="repo-card__header">
-    <div class="repo-card__identity">
+      <div class="repo-card__identity">
       <div class="repo-card__name-row">
+        {#if showProviderIcon}
+          <ProviderIcon
+            provider={summary.repo.provider}
+            size={16}
+            class="repo-card__provider-icon"
+          />
+        {/if}
         <button
           id={`repo-${stateKey}`}
           class="repo-card__name"
@@ -393,6 +403,10 @@
     min-width: 0;
     gap: 6px;
     color: var(--text-muted);
+  }
+
+  :global(.repo-card__provider-icon) {
+    color: var(--text-secondary);
   }
 
   .repo-card__name {

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
@@ -150,6 +150,13 @@
     });
   });
 
+  const showProviderIcons = $derived.by(() => {
+    const providers = new Set(
+      summaries.map((summary) => summary.repo.provider.toLowerCase()),
+    );
+    return providers.size > 1;
+  });
+
   function dateValue(value: string | undefined): number {
     if (!value) return 0;
     return new Date(value).getTime();
@@ -449,6 +456,7 @@
       {#each filteredSummaries as summary (repoStateKey(summary))}
         <RepoSummaryCard
           {summary}
+          showProviderIcon={showProviderIcons}
           onviewprs={() =>
             filterAndNavigate(summary, "/pulls")}
           onviewissues={() =>

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -62,6 +62,38 @@ vi.mock("@middleman/ui", async (importOriginal) => {
 
 import RepoSummaryPage from "./RepoSummaryPage.svelte";
 
+function repoSummaryFixture({
+  provider,
+  platformHost,
+  owner,
+  name,
+}: {
+  provider: string;
+  platformHost: string;
+  owner: string;
+  name: string;
+}) {
+  return {
+    owner,
+    name,
+    platform_host: platformHost,
+    repo: {
+      provider,
+      platform_host: platformHost,
+      owner,
+      name,
+      repo_path: `${owner}/${name}`,
+    },
+    cached_pr_count: 0,
+    open_pr_count: 0,
+    draft_pr_count: 0,
+    cached_issue_count: 0,
+    open_issue_count: 0,
+    active_authors: [],
+    recent_issues: [],
+  };
+}
+
 describe("RepoSummaryPage", () => {
   beforeEach(() => {
     mockGet.mockReset();
@@ -246,6 +278,57 @@ describe("RepoSummaryPage", () => {
     await screen.findByRole("button", { name: /acme\s*\/\s*widgets/ });
     expect(screen.queryByText("github.com")).toBeNull();
     expect(screen.getByText("ghe.example.com")).toBeTruthy();
+  });
+
+  it("shows provider brand icons on repo cards when multiple providers are present", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        repoSummaryFixture({
+          provider: "github",
+          platformHost: "github.com",
+          owner: "acme",
+          name: "widgets",
+        }),
+        repoSummaryFixture({
+          provider: "gitlab",
+          platformHost: "gitlab.com",
+          owner: "platform",
+          name: "api",
+        }),
+      ],
+      error: undefined,
+    });
+
+    render(RepoSummaryPage);
+
+    await screen.findByRole("button", { name: /acme\s*\/\s*widgets/ });
+    expect(screen.getByRole("img", { name: "GitHub" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "GitLab" })).toBeTruthy();
+  });
+
+  it("hides provider brand icons on repo cards for a single provider", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        repoSummaryFixture({
+          provider: "github",
+          platformHost: "github.com",
+          owner: "acme",
+          name: "widgets",
+        }),
+        repoSummaryFixture({
+          provider: "github",
+          platformHost: "ghe.example.com",
+          owner: "enterprise",
+          name: "service",
+        }),
+      ],
+      error: undefined,
+    });
+
+    render(RepoSummaryPage);
+
+    await screen.findByRole("button", { name: /acme\s*\/\s*widgets/ });
+    expect(screen.queryByRole("img", { name: "GitHub" })).toBeNull();
   });
 
   it("keeps cached output visible when a sync issue exists", async () => {

--- a/frontend/src/lib/components/settings/RepoSettings.svelte
+++ b/frontend/src/lib/components/settings/RepoSettings.svelte
@@ -3,6 +3,7 @@
   import { getStores } from "@middleman/ui";
   import type { ConfigRepo } from "@middleman/ui/api/types";
   import { addRepo, removeRepo, getSettings, refreshRepo } from "../../api/settings.js";
+  import ProviderIcon from "../provider/ProviderIcon.svelte";
   import RepoImportModal from "./RepoImportModal.svelte";
 
   const { sync } = getStores();
@@ -27,12 +28,24 @@
   let refreshingByKey = $state<Record<string, boolean>>({});
   let refreshErrors = $state<Record<string, string>>({});
 
+  const showProviderIcons = $derived.by(() => {
+    const providers = new Set(
+      repos.map((repo) => repo.provider.trim().toLowerCase()),
+    );
+    return providers.size > 1;
+  });
+
   function repoKey(repo: ConfigRepo): string {
     return `${repo.provider}/${repo.platform_host}/${repo.repo_path || `${repo.owner}/${repo.name}`}`.toLowerCase();
   }
 
   function repoLabel(repo: ConfigRepo): string {
     return repo.repo_path || `${repo.owner}/${repo.name}`;
+  }
+
+  function repoDisplayLabel(repo: ConfigRepo): string {
+    const label = repoLabel(repo);
+    return repo.is_glob ? `${label} (${repo.matched_repo_count})` : label;
   }
 
   async function handleAdd(): Promise<void> {
@@ -136,15 +149,9 @@
 <div class="repo-list">
   {#each repos as repo (repoKey(repo))}
     {@const key = repoKey(repo)}
-    {@const label = repoLabel(repo)}
     <div class="repo-row">
       <div class="repo-main">
-        <span class="repo-name">
-          {label}
-          {#if repo.is_glob}
-            <span class="repo-count">({repo.matched_repo_count})</span>
-          {/if}
-        </span>
+        <span class="repo-name">{#if showProviderIcons}<ProviderIcon provider={repo.provider} size={16} class="repo-provider-icon" />{/if}{repoDisplayLabel(repo)}</span>
         {#if refreshErrors[key]}
           <div class="error-msg row-error">{refreshErrors[key]}</div>
         {/if}
@@ -222,8 +229,8 @@
   }
   .repo-row:last-child { border-bottom: none; }
   .repo-main { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-  .repo-name { font-size: 13px; color: var(--text-primary); font-weight: 500; }
-  .repo-count { color: var(--text-muted); margin-left: 4px; }
+  .repo-name { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-primary); font-weight: 500; }
+  :global(.repo-provider-icon) { color: var(--text-secondary); }
   .repo-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
   .refresh-btn {
     padding: 4px 10px; font-size: 12px; font-weight: 500;

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -63,6 +63,67 @@ describe("RepoSettings", () => {
     expect(screen.getByRole("button", { name: "Refresh" })).toBeTruthy();
   });
 
+  it("shows provider icons when configured repos use multiple providers", () => {
+    render(RepoSettings, {
+      props: {
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "widgets",
+            repo_path: "acme/widgets",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+          {
+            provider: "forgejo",
+            platform_host: "codeberg.org",
+            owner: "forge",
+            name: "service",
+            repo_path: "forge/service",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+        ],
+        onUpdate: vi.fn(),
+      },
+    });
+
+    expect(screen.getByRole("img", { name: "GitHub" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Forgejo" })).toBeTruthy();
+  });
+
+  it("hides provider icons when configured repos use one provider", () => {
+    render(RepoSettings, {
+      props: {
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "widgets",
+            repo_path: "acme/widgets",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+          {
+            provider: "github",
+            platform_host: "ghe.example.com",
+            owner: "enterprise",
+            name: "service",
+            repo_path: "enterprise/service",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+        ],
+        onUpdate: vi.fn(),
+      },
+    });
+
+    expect(screen.queryByRole("img", { name: "GitHub" })).toBeNull();
+  });
+
   it("opens the repository import modal and restores focus on close", async () => {
     render(RepoSettings, {
       props: {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -7,9 +7,17 @@
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
   import { client } from "../../api/runtime.js";
   import { LeftSidebarToggle } from "@middleman/ui";
+  import ProviderIcon from "../provider/ProviderIcon.svelte";
 
   interface Workspace {
     id: string;
+    repo?: {
+      provider: string;
+      platform_host: string;
+      owner: string;
+      name: string;
+      repo_path: string;
+    };
     platform_host: string;
     repo_owner: string;
     repo_name: string;
@@ -78,6 +86,15 @@
       }
     }
     return map;
+  });
+
+  const showProviderIcons = $derived.by(() => {
+    const providers = new Set<string>();
+    for (const ws of workspaces) {
+      const provider = workspaceProvider(ws);
+      if (provider) providers.add(provider.toLowerCase());
+    }
+    return providers.size > 1;
   });
 
   async function fetchWorkspaces(): Promise<void> {
@@ -154,6 +171,10 @@
     return repoKey;
   }
 
+  function workspaceProvider(ws: Workspace): string | undefined {
+    return ws.repo?.provider;
+  }
+
   function handleItemBubbleClick(
     e: MouseEvent | KeyboardEvent,
     ws: Workspace,
@@ -217,6 +238,13 @@
           strokeWidth="2.25"
           aria-hidden="true"
         />
+        {#if showProviderIcons && workspaceProvider(items[0]!)}
+          <ProviderIcon
+            provider={workspaceProvider(items[0]!)!}
+            size={14}
+            class="group-provider-icon"
+          />
+        {/if}
         <span class="group-label">{shortRepo(repoKey)}</span>
         <span class="group-count">{items.length}</span>
       </button>
@@ -441,6 +469,10 @@
     color: var(--text-muted);
     flex-shrink: 0;
     transition: transform 100ms ease;
+  }
+
+  :global(.group-provider-icon) {
+    color: var(--text-secondary);
   }
 
   .group-header.collapsed :global(.group-chevron) {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -1,0 +1,139 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
+
+const mockGet = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("../../api/runtime.js", () => ({
+  client: {
+    GET: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+vi.mock("../../stores/router.svelte.ts", () => ({
+  navigate: (path: string) => mockNavigate(path),
+}));
+
+class MockEventSource {
+  addEventListener = vi.fn();
+  close = vi.fn();
+
+  constructor(readonly url: string) {}
+}
+
+interface WorkspaceFixtureOptions {
+  id: string;
+  provider: string;
+  platformHost: string;
+  owner: string;
+  name: string;
+  number: number;
+}
+
+function workspaceFixture({
+  id,
+  provider,
+  platformHost,
+  owner,
+  name,
+  number,
+}: WorkspaceFixtureOptions) {
+  return {
+    id,
+    repo: {
+      provider,
+      platform_host: platformHost,
+      owner,
+      name,
+      repo_path: `${owner}/${name}`,
+    },
+    platform_host: platformHost,
+    repo_owner: owner,
+    repo_name: name,
+    item_type: "pull_request",
+    item_number: number,
+    git_head_ref: `feature-${number}`,
+    worktree_path: `/tmp/${id}`,
+    tmux_session: id,
+    status: "ready",
+    created_at: "2026-05-12T12:00:00Z",
+    mr_title: `PR ${number}`,
+    mr_state: "open",
+  };
+}
+
+describe("WorkspaceListSidebar", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockNavigate.mockReset();
+    vi.stubGlobal("EventSource", MockEventSource);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows provider icons in repo groups when multiple providers are present", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-github",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widgets",
+            number: 42,
+          }),
+          workspaceFixture({
+            id: "ws-gitlab",
+            provider: "gitlab",
+            platformHost: "gitlab.com",
+            owner: "platform",
+            name: "api",
+            number: 7,
+          }),
+        ],
+      },
+    });
+
+    render(WorkspaceListSidebar, { props: { selectedId: "ws-github" } });
+
+    await screen.findByText("acme/widgets");
+    expect(screen.getByRole("img", { name: "GitHub" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "GitLab" })).toBeTruthy();
+  });
+
+  it("hides provider icons in repo groups when one provider is present", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-github",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widgets",
+            number: 42,
+          }),
+          workspaceFixture({
+            id: "ws-ghe",
+            provider: "github",
+            platformHost: "ghe.example.com",
+            owner: "enterprise",
+            name: "service",
+            number: 9,
+          }),
+        ],
+      },
+    });
+
+    render(WorkspaceListSidebar, { props: { selectedId: "ws-github" } });
+
+    await screen.findByText("acme/widgets");
+    expect(screen.queryByRole("img", { name: "GitHub" })).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/terminal/WorkspaceProjectCard.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceProjectCard.svelte
@@ -10,6 +10,7 @@
   import { onMount } from "svelte";
 
   import { apiErrorMessage, client } from "../../api/runtime.ts";
+  import ProviderIcon from "../provider/ProviderIcon.svelte";
   import {
     getProjectAction,
     invokeProjectAction,
@@ -20,6 +21,7 @@
   }
 
   interface PlatformIdentity {
+    platform?: string;
     platform_host: string;
     owner: string;
     name: string;
@@ -151,6 +153,13 @@
       {#if project.platform_identity}
         <p class="project-card__platform">
           <span class="project-card__platform-chip">
+            {#if project.platform_identity.platform}
+              <ProviderIcon
+                provider={project.platform_identity.platform}
+                size={14}
+                class="project-card__platform-icon"
+              />
+            {/if}
             {platformChip(project.platform_identity)}
           </span>
         </p>
@@ -258,12 +267,18 @@
 
   .project-card__platform-chip {
     display: inline-flex;
+    align-items: center;
+    gap: 6px;
     padding: 2px 8px;
     border-radius: 10px;
     background: var(--bg-inset);
     color: var(--text-secondary);
     font-family: var(--font-mono, monospace);
     font-size: 11px;
+  }
+
+  :global(.project-card__platform-icon) {
+    color: var(--text-secondary);
   }
 
   .project-card__branch {

--- a/frontend/src/lib/components/terminal/WorkspaceProjectCard.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceProjectCard.test.ts
@@ -39,7 +39,12 @@ interface ProjectFixture {
   display_name: string;
   local_path: string;
   default_branch?: string;
-  platform_identity?: { platform_host: string; owner: string; name: string };
+  platform_identity?: {
+    platform?: string;
+    platform_host: string;
+    owner: string;
+    name: string;
+  };
 }
 
 function setProjectResponse(project: ProjectFixture | { error: string }): void {
@@ -128,6 +133,27 @@ describe("WorkspaceProjectCard", () => {
 
     expect(
       await screen.findByText("gitlab.example.com / group/subgroup / project"),
+    ).toBeTruthy();
+  });
+
+  it("renders provider brand icon beside platform identity when platform is present", async () => {
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "remote-repo",
+      local_path: "/tmp/remote-repo",
+      platform_identity: {
+        platform: "gitlab",
+        platform_host: "gitlab.example.com",
+        owner: "group/subgroup",
+        name: "project",
+      },
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
+
+    expect(
+      await screen.findByRole("img", { name: "GitLab" }),
     ).toBeTruthy();
   });
 

--- a/frontend/tests/e2e-full/provider-icons.spec.ts
+++ b/frontend/tests/e2e-full/provider-icons.spec.ts
@@ -1,0 +1,62 @@
+import { expect, request as playwrightRequest, test } from "@playwright/test";
+import { startIsolatedE2EServer } from "./support/e2eServer";
+
+type RepoSummary = {
+  repo: {
+    provider: string;
+    owner: string;
+    name: string;
+  };
+};
+
+test("provider icons disambiguate multi-provider repository views", async ({ page }) => {
+  const server = await startIsolatedE2EServer();
+  const api = await playwrightRequest.newContext({
+    baseURL: server.info.base_url,
+  });
+
+  try {
+    const summariesResponse = await api.get("/api/v1/repos/summary");
+    expect(summariesResponse.ok()).toBe(true);
+    const summaries = await summariesResponse.json() as RepoSummary[];
+    expect(
+      new Set(summaries.map((summary) => summary.repo.provider.toLowerCase())).size,
+    ).toBeGreaterThan(1);
+
+    await page.goto(`${server.info.base_url}/repos`);
+    const repoCards = page.locator(".repo-card");
+    await expect(
+      repoCards.filter({
+        has: page.getByRole("button", { name: /acme\s*\/\s*widgets/ }),
+      }).first(),
+    ).toBeVisible();
+    await expect(repoCards.getByRole("img", { name: "GitHub" }).first()).toBeVisible();
+    await expect(repoCards.getByRole("img", { name: "GitLab" })).toBeVisible();
+
+    await page.goto(`${server.info.base_url}/settings`);
+    await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+    await expect(page.locator(".repo-row").getByRole("img")).toHaveCount(0);
+
+    const addResponse = await api.post("/api/v1/repos/bulk", {
+      data: {
+        repos: [{
+          provider: "forgejo",
+          platform_host: "codeberg.org",
+          owner: "forge-lab",
+          name: "service",
+          repo_path: "forge-lab/service",
+        }],
+      },
+    });
+    expect(addResponse.ok()).toBe(true);
+
+    await page.reload();
+    await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+    const repoRows = page.locator(".repo-row");
+    await expect(repoRows.getByRole("img", { name: "GitHub" }).first()).toBeVisible();
+    await expect(repoRows.getByRole("img", { name: "Forgejo" })).toBeVisible();
+  } finally {
+    await api.dispose();
+    await server.stop();
+  }
+});

--- a/frontend/tests/e2e-full/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/workspace-sidebar.spec.ts
@@ -94,6 +94,71 @@ async function waitForWorkspaceReady(
 test.describe("workspace sidebar full-stack", () => {
   test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
 
+  test("shows provider icons in group headers when workspaces span multiple providers", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const githubResponse = await api.post(
+        "/api/v1/issues/github/acme/widgets/10/workspace",
+        {
+          data: {},
+        },
+      );
+      expect(githubResponse.status()).toBe(202);
+      const githubWorkspace = await githubResponse.json() as WorkspaceStatusResponse;
+      await waitForWorkspaceReady(api, githubWorkspace.id);
+
+      const gitlabResponse = await api.post(
+        "/api/v1/host/gitlab.example.com/issues/gitlab/group/project/11/workspace",
+        {
+          data: {},
+        },
+      );
+      expect(gitlabResponse.status()).toBe(202);
+      const gitlabWorkspace = await gitlabResponse.json() as WorkspaceStatusResponse;
+      await waitForWorkspaceReady(api, gitlabWorkspace.id);
+
+      const workspacesResponse = await api.get("/api/v1/workspaces");
+      expect(workspacesResponse.ok()).toBe(true);
+      const workspacesPayload = await workspacesResponse.json() as {
+        workspaces: Array<{ repo: { provider: string } }>;
+      };
+      expect(
+        new Set(workspacesPayload.workspaces.map((workspace) => workspace.repo.provider)),
+      ).toEqual(new Set(["github", "gitlab"]));
+
+      await page.goto(
+        `${isolatedServer.info.base_url}/terminal/${githubWorkspace.id}`,
+      );
+
+      const githubGroup = page.locator(
+        ".workspace-list-sidebar .group-header",
+      ).filter({
+        has: page.locator(".group-label", { hasText: "acme/widgets" }),
+      });
+      await expect(
+        githubGroup.getByRole("img", { name: "GitHub" }),
+      ).toBeVisible();
+
+      const gitlabGroup = page.locator(
+        ".workspace-list-sidebar .group-header",
+      ).filter({
+        has: page.locator(".group-label", { hasText: "group/project" }),
+      });
+      await expect(
+        gitlabGroup.getByRole("img", { name: "GitLab" }),
+      ).toBeVisible();
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("issue workspaces expose the Issue tab and hide Reviews", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1678,14 +1678,16 @@ func TestManagerRequestRetryConsumesQueuedRetryWhenCleanupFails(t *testing.T) {
 		firstResult <- retryResult{ws: next, startNow: startNow, err: err}
 	}()
 
+	const retryWait = 3 * time.Second
+
 	require.Eventually(func() bool {
 		_, err := os.Stat(started)
 		return err == nil
-	}, time.Second, 10*time.Millisecond)
+	}, retryWait, 10*time.Millisecond)
 	require.Eventually(func() bool {
 		got, err := d.GetWorkspace(ctx, ws.ID)
 		return err == nil && got != nil && got.Status == "creating"
-	}, time.Second, 10*time.Millisecond)
+	}, retryWait, 10*time.Millisecond)
 
 	queuedWS, startNow, err := mgr.RequestRetry(ctx, ws.ID)
 	require.NoError(err)
@@ -1702,7 +1704,7 @@ func TestManagerRequestRetryConsumesQueuedRetryWhenCleanupFails(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, 10*time.Millisecond)
+	}, retryWait, 10*time.Millisecond)
 	assert.Nil(first.ws)
 	assert.False(first.startNow)
 	require.Error(first.err)


### PR DESCRIPTION
- Show provider brand icons on repository cards, workspace sidebar groups, and configured repository rows when multiple providers are present.
- Keep single-provider views visually unchanged.
- Add Simple Icons-backed provider icon coverage for GitHub, GitLab, Forgejo, and Gitea.

![provider-brand-icons-repos.png](https://github.com/user-attachments/assets/5da7b935-120f-44cb-aed2-54ae6acbfaa7)