### PR TITLE
Show CI check durations

### DIFF
--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -52,7 +52,7 @@ test.describe("CI dropdown", () => {
     await chip.click();
 
     const checks = detail.locator(".ci-checks");
-    await expect(checks).toBeVisible();
+    await expect(checks).toBeVisible({ timeout: 15_000 });
     await expect(detail.locator(".ci-check")).toHaveCount(4);
 
     const checksBox = await checks.boundingBox();
@@ -80,6 +80,11 @@ test.describe("CI dropdown", () => {
       "lint",
       "roborev",
       "test",
+    ]);
+    await expect(detail.locator(".ci-duration")).toHaveText([
+      "1m 30s",
+      "45s",
+      "2m",
     ]);
     const roborevRow = detail.locator(".ci-check", { hasText: "roborev" });
     await expect(roborevRow).toHaveCount(1);

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -167,11 +167,12 @@ func (mr MergeRequest) Compare(other MergeRequest) int {
 
 // CICheck represents a single CI check run.
 type CICheck struct {
-	Name       string `json:"name"`
-	Status     string `json:"status"`     // queued, in_progress, completed
-	Conclusion string `json:"conclusion"` // success, failure, neutral, cancelled, skipped, timed_out, action_required, or empty
-	URL        string `json:"url"`        // link to the check run details page
-	App        string `json:"app"`        // app name (e.g., "GitHub Actions")
+	Name            string `json:"name"`
+	Status          string `json:"status"`     // queued, in_progress, completed
+	Conclusion      string `json:"conclusion"` // success, failure, neutral, cancelled, skipped, timed_out, action_required, or empty
+	URL             string `json:"url"`        // link to the check run details page
+	App             string `json:"app"`        // app name (e.g., "GitHub Actions")
+	DurationSeconds *int64 `json:"duration_seconds,omitempty"`
 }
 
 func (c CICheck) Compare(other CICheck) int {

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -357,20 +357,7 @@ func dbLabels(labels []platform.Label, updatedAt time.Time) []db.Label {
 }
 
 func dbCIChecks(checks []platform.CICheck) []db.CICheck {
-	if len(checks) == 0 {
-		return nil
-	}
-	out := make([]db.CICheck, 0, len(checks))
-	for _, check := range checks {
-		out = append(out, db.CICheck{
-			Name:       check.Name,
-			Status:     check.Status,
-			Conclusion: check.Conclusion,
-			URL:        check.URL,
-			App:        check.App,
-		})
-	}
-	return out
+	return platform.DBCIChecks(checks)
 }
 
 // NormalizeIssueCommentEvent converts a GitHub IssueComment to a db.IssueEvent.

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -669,6 +669,37 @@ func TestNormalizeCheckRuns_SortsByCasefoldedName(t *testing.T) {
 	assert.Equal("Zebra", checks[2].Name)
 }
 
+func TestNormalizeCheckRunsIncludesDurationWhenTimestampsPresent(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	name := "build"
+	status := "completed"
+	conclusion := "success"
+	started := time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC)
+	completed := started.Add(2*time.Minute + 15*time.Second)
+
+	raw := NormalizeCheckRuns([]*gh.CheckRun{{
+		Name:        &name,
+		Status:      &status,
+		Conclusion:  &conclusion,
+		StartedAt:   ghTimestamp(started),
+		CompletedAt: ghTimestamp(completed),
+	}})
+	require.NotEmpty(raw)
+
+	var checks []struct {
+		Name            string `json:"name"`
+		DurationSeconds *int64 `json:"duration_seconds,omitempty"`
+	}
+	require.NoError(json.Unmarshal([]byte(raw), &checks))
+	require.Len(checks, 1)
+
+	assert.Equal("build", checks[0].Name)
+	require.NotNil(checks[0].DurationSeconds)
+	assert.Equal(int64(135), *checks[0].DurationSeconds)
+}
+
 func TestNormalizeCIChecks_LatestCheckRunPerNameWins(t *testing.T) {
 	assert := Assert.New(t)
 

--- a/internal/platform/persist.go
+++ b/internal/platform/persist.go
@@ -144,14 +144,27 @@ func DBCIChecks(checks []CICheck) []db.CICheck {
 	out := make([]db.CICheck, 0, len(checks))
 	for _, check := range checks {
 		out = append(out, db.CICheck{
-			Name:       check.Name,
-			Status:     check.Status,
-			Conclusion: check.Conclusion,
-			URL:        check.URL,
-			App:        check.App,
+			Name:            check.Name,
+			Status:          check.Status,
+			Conclusion:      check.Conclusion,
+			URL:             check.URL,
+			App:             check.App,
+			DurationSeconds: CICheckDurationSeconds(check),
 		})
 	}
 	return out
+}
+
+func CICheckDurationSeconds(check CICheck) *int64 {
+	if check.StartedAt == nil || check.CompletedAt == nil {
+		return nil
+	}
+	duration := check.CompletedAt.Sub(*check.StartedAt)
+	if duration < 0 {
+		return nil
+	}
+	seconds := int64(duration.Seconds())
+	return &seconds
 }
 
 func itemLabelUpdatedAt(updatedAt, createdAt time.Time) time.Time {

--- a/internal/platform/persist_test.go
+++ b/internal/platform/persist_test.go
@@ -1,0 +1,33 @@
+package platform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBCIChecksComputesDurationFromProviderTimestamps(t *testing.T) {
+	assert := assert.New(t)
+	started := time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC)
+	completed := started.Add(90 * time.Second)
+
+	checks := DBCIChecks([]CICheck{{
+		Name:        "build",
+		Status:      "completed",
+		Conclusion:  "success",
+		StartedAt:   &started,
+		CompletedAt: &completed,
+	}, {
+		Name:        "pending",
+		Status:      "in_progress",
+		StartedAt:   &started,
+		CompletedAt: nil,
+	}})
+
+	require.Len(t, checks, 2)
+	require.NotNil(t, checks[0].DurationSeconds)
+	assert.Equal(int64(90), *checks[0].DurationSeconds)
+	assert.Nil(checks[1].DurationSeconds)
+}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -41,21 +41,27 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	// --- Pull Requests ---
 
 	const widgetsPR1HeadSHA = "1111111111111111111111111111111111111111"
+	buildDuration := int64(90)
+	lintDuration := int64(45)
+	testDuration := int64(120)
+	checkStarted := now.Add(-10 * time.Minute)
 
 	ciChecksJSON, err := json.Marshal([]db.CICheck{
 		{
-			Name:       "build",
-			Status:     "completed",
-			Conclusion: "success",
-			URL:        "https://github.com/acme/widgets/actions/runs/1/job/1",
-			App:        "GitHub Actions",
+			Name:            "build",
+			Status:          "completed",
+			Conclusion:      "success",
+			URL:             "https://github.com/acme/widgets/actions/runs/1/job/1",
+			App:             "GitHub Actions",
+			DurationSeconds: &buildDuration,
 		},
 		{
-			Name:       "lint",
-			Status:     "completed",
-			Conclusion: "success",
-			URL:        "https://github.com/acme/widgets/actions/runs/1/job/3",
-			App:        "GitHub Actions",
+			Name:            "lint",
+			Status:          "completed",
+			Conclusion:      "success",
+			URL:             "https://github.com/acme/widgets/actions/runs/1/job/3",
+			App:             "GitHub Actions",
+			DurationSeconds: &lintDuration,
 		},
 		{
 			Name:       "roborev",
@@ -65,11 +71,12 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			App:        "roborev",
 		},
 		{
-			Name:       "test",
-			Status:     "completed",
-			Conclusion: "success",
-			URL:        "https://github.com/acme/widgets/actions/runs/1/job/2",
-			App:        "GitHub Actions",
+			Name:            "test",
+			Status:          "completed",
+			Conclusion:      "success",
+			URL:             "https://github.com/acme/widgets/actions/runs/1/job/2",
+			App:             "GitHub Actions",
+			DurationSeconds: &testDuration,
 		},
 	})
 	if err != nil {
@@ -734,25 +741,31 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 				CheckRuns: map[string][]*gh.CheckRun{
 					refKey("acme", "widgets", widgetsPR1HeadSHA): {
 						{
-							Name:       new("build"),
-							Status:     new("completed"),
-							Conclusion: new("success"),
-							HTMLURL:    new("https://github.com/acme/widgets/actions/runs/1/job/1"),
-							App:        &gh.App{Name: new("GitHub Actions")},
+							Name:        new("build"),
+							Status:      new("completed"),
+							Conclusion:  new("success"),
+							HTMLURL:     new("https://github.com/acme/widgets/actions/runs/1/job/1"),
+							StartedAt:   &gh.Timestamp{Time: checkStarted},
+							CompletedAt: &gh.Timestamp{Time: checkStarted.Add(time.Duration(buildDuration) * time.Second)},
+							App:         &gh.App{Name: new("GitHub Actions")},
 						},
 						{
-							Name:       new("test"),
-							Status:     new("completed"),
-							Conclusion: new("success"),
-							HTMLURL:    new("https://github.com/acme/widgets/actions/runs/1/job/2"),
-							App:        &gh.App{Name: new("GitHub Actions")},
+							Name:        new("test"),
+							Status:      new("completed"),
+							Conclusion:  new("success"),
+							HTMLURL:     new("https://github.com/acme/widgets/actions/runs/1/job/2"),
+							StartedAt:   &gh.Timestamp{Time: checkStarted},
+							CompletedAt: &gh.Timestamp{Time: checkStarted.Add(time.Duration(testDuration) * time.Second)},
+							App:         &gh.App{Name: new("GitHub Actions")},
 						},
 						{
-							Name:       new("lint"),
-							Status:     new("completed"),
-							Conclusion: new("success"),
-							HTMLURL:    new("https://github.com/acme/widgets/actions/runs/1/job/3"),
-							App:        &gh.App{Name: new("GitHub Actions")},
+							Name:        new("lint"),
+							Status:      new("completed"),
+							Conclusion:  new("success"),
+							HTMLURL:     new("https://github.com/acme/widgets/actions/runs/1/job/3"),
+							StartedAt:   &gh.Timestamp{Time: checkStarted},
+							CompletedAt: &gh.Timestamp{Time: checkStarted.Add(time.Duration(lintDuration) * time.Second)},
+							App:         &gh.App{Name: new("GitHub Actions")},
 						},
 						{
 							Name:       new("roborev"),

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -55,6 +55,7 @@ export interface CICheck {
   conclusion: string;
   url: string;
   app: string;
+  duration_seconds?: number;
 }
 
 export interface ActivitySettings {

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -63,9 +63,28 @@
     if (chipStatus === "pending") return "chip--amber";
     return "chip--muted";
   }
+
+  function formatDuration(seconds: number | undefined): string {
+    if (seconds === undefined || seconds < 0 || !Number.isFinite(seconds)) {
+      return "";
+    }
+    const wholeSeconds = Math.floor(seconds);
+    if (wholeSeconds < 60) return `${wholeSeconds}s`;
+    const minutes = Math.floor(wholeSeconds / 60);
+    const remainingSeconds = wholeSeconds % 60;
+    if (minutes < 60) {
+      return remainingSeconds === 0
+        ? `${minutes}m`
+        : `${minutes}m ${remainingSeconds}s`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+  }
 </script>
 
 {#snippet checkRow(check: CICheck)}
+  {@const duration = formatDuration(check.duration_seconds)}
   {#if check.url}
     <a
       class="ci-check"
@@ -75,6 +94,9 @@
     >
       <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
       <span class="ci-name">{check.name}</span>
+      {#if duration}
+        <span class="ci-duration">{duration}</span>
+      {/if}
       {#if check.app}
         <span class="ci-app">{check.app}</span>
       {/if}
@@ -84,6 +106,9 @@
     <div class="ci-check ci-check--static">
       <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
       <span class="ci-name">{check.name}</span>
+      {#if duration}
+        <span class="ci-duration">{duration}</span>
+      {/if}
       {#if check.app}
         <span class="ci-app">{check.app}</span>
       {/if}
@@ -230,6 +255,13 @@
   }
 
   .ci-app {
+    font-size: 10px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .ci-duration {
+    font-variant-numeric: tabular-nums;
     font-size: 10px;
     color: var(--text-muted);
     flex-shrink: 0;

--- a/packages/ui/src/components/detail/CIStatus.test.ts
+++ b/packages/ui/src/components/detail/CIStatus.test.ts
@@ -18,6 +18,7 @@ describe("CIStatus", () => {
             conclusion: "success",
             url: "https://example.com/build",
             app: "GitHub Actions",
+            duration_seconds: 135,
           },
           {
             name: "test",
@@ -57,5 +58,6 @@ describe("CIStatus", () => {
     expect(document.querySelectorAll(".ci-check")).toHaveLength(4);
     expect(document.querySelectorAll("a.ci-check")).toHaveLength(3);
     expect(document.querySelector(".ci-check--static")).toBeTruthy();
+    expect(screen.getByText("2m 15s")).toBeTruthy();
   });
 });


### PR DESCRIPTION
- Adds compact duration labels to CI checks when provider timing data is available.
- Keeps checks without start/completion timestamps unchanged.
- Covers GitHub/provider normalization plus the PR detail CI dropdown.