### PR TITLE
Fix repo selector after repository imports

### DIFF
--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -20,10 +20,20 @@
   let highlightIndex = $state(0);
   let inputEl = $state<HTMLInputElement>();
   let containerEl = $state<HTMLDivElement>();
+  let repoFetchVersion = 0;
+  let latestRepoFetchKey = "";
 
   $effect(() => {
+    const configuredRepoKey = configuredRepos
+      .map((repo) => `${repo.provider}/${repo.platform_host}/${repo.repo_path || `${repo.owner}/${repo.name}`}`)
+      .join("\0");
+    const fetchKey = `${++repoFetchVersion}:${settingsLoaded}:${configuredRepoKey}`;
+
+    latestRepoFetchKey = fetchKey;
+    fetchedRepos = [];
+
     void client.GET("/repos").then(({ data, error }) => {
-      if (error) return;
+      if (error || fetchKey !== latestRepoFetchKey) return;
       fetchedRepos = data ?? [];
     });
   });

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -15,6 +15,7 @@
   const stores = getStores();
 
   let fetchedRepos = $state<Repo[]>([]);
+  let reposLoading = $state(false);
   let query = $state("");
   let open = $state(false);
   let highlightIndex = $state(0);
@@ -30,10 +31,13 @@
     const fetchKey = `${++repoFetchVersion}:${settingsLoaded}:${configuredRepoKey}`;
 
     latestRepoFetchKey = fetchKey;
+    reposLoading = true;
     fetchedRepos = [];
 
     void client.GET("/repos").then(({ data, error }) => {
-      if (error || fetchKey !== latestRepoFetchKey) return;
+      if (fetchKey !== latestRepoFetchKey) return;
+      reposLoading = false;
+      if (error) return;
       fetchedRepos = data ?? [];
     });
   });
@@ -99,6 +103,12 @@
   const displayValue = $derived(
     selected ?? "All repos",
   );
+
+  $effect(() => {
+    if (!selected || reposLoading) return;
+    if (options.some((option) => option.value === selected)) return;
+    onchange(undefined);
+  });
 
   async function openDropdown() {
     query = "";

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -52,11 +52,28 @@
     };
   }
 
+  function mergeOptions(
+    configured: ConfigRepo[],
+    fetched: Repo[],
+  ): { value: string; owner: string; name: string }[] {
+    const merged = new Map<string, { value: string; owner: string; name: string }>();
+
+    for (const repo of configured.filter((entry) => !entry.is_glob)) {
+      const option = optionFromConfigRepo(repo);
+      merged.set(option.value, option);
+    }
+
+    for (const repo of fetched) {
+      const option = optionFromRepo(repo);
+      merged.set(option.value, option);
+    }
+
+    return Array.from(merged.values());
+  }
+
   const options = $derived.by(() => {
     if (settingsLoaded || configuredRepos.length > 0) {
-      return configuredRepos
-        .filter((repo) => !repo.is_glob)
-        .map(optionFromConfigRepo);
+      return mergeOptions(configuredRepos, fetchedRepos);
     }
     return fetchedRepos.map(optionFromRepo);
   });

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { tick } from "svelte";
+  import { getStores } from "@middleman/ui";
   import { client } from "../api/runtime.js";
-  import type { Repo } from "@middleman/ui/api/types";
+  import type { ConfigRepo, Repo } from "@middleman/ui/api/types";
   import { ChevronDownIcon } from "../icons.ts";
 
   interface Props {
@@ -11,7 +12,9 @@
 
   let { selected, onchange }: Props = $props();
 
-  let repos = $state<Repo[]>([]);
+  const stores = getStores();
+
+  let fetchedRepos = $state<Repo[]>([]);
   let query = $state("");
   let open = $state(false);
   let highlightIndex = $state(0);
@@ -21,16 +24,41 @@
   $effect(() => {
     void client.GET("/repos").then(({ data, error }) => {
       if (error) return;
-      repos = data ?? [];
+      fetchedRepos = data ?? [];
     });
   });
 
+  const configuredRepos = $derived(
+    stores?.settings?.getConfiguredRepos?.() ?? [],
+  );
+  const settingsLoaded = $derived(
+    stores?.settings?.isSettingsLoaded?.() ?? false,
+  );
+
+  function optionFromRepo(repo: Repo): { value: string; owner: string; name: string } {
+    return {
+      value: `${repo.PlatformHost}/${repo.Owner}/${repo.Name}`,
+      owner: repo.Owner,
+      name: repo.Name,
+    };
+  }
+
+  function optionFromConfigRepo(repo: ConfigRepo): { value: string; owner: string; name: string } {
+    const path = repo.repo_path || `${repo.owner}/${repo.name}`;
+    return {
+      value: `${repo.platform_host}/${path}`,
+      owner: repo.owner,
+      name: repo.name,
+    };
+  }
+
   const options = $derived.by(() => {
-    return repos.map((r) => ({
-      value: `${r.PlatformHost}/${r.Owner}/${r.Name}`,
-      owner: r.Owner,
-      name: r.Name,
-    }));
+    if (settingsLoaded || configuredRepos.length > 0) {
+      return configuredRepos
+        .filter((repo) => !repo.is_glob)
+        .map(optionFromConfigRepo);
+    }
+    return fetchedRepos.map(optionFromRepo);
   });
 
   const filtered = $derived.by(() => {
@@ -143,7 +171,7 @@
         onmousedown={() => select(undefined)}
         onmouseenter={() => (highlightIndex = 0)}
       >All repos</li>
-      {#each filtered as option, i}
+      {#each filtered as option, i (option.value)}
         <li
           class="typeahead-option"
           class:highlighted={i + 1 === highlightIndex}
@@ -153,7 +181,7 @@
           onmousedown={() => select(option.value)}
           onmouseenter={() => (highlightIndex = i + 1)}
         >
-          {#each highlightSegments(option.value, query) as seg}{#if seg.match}<mark class="match">{seg.text}</mark>{:else}{seg.text}{/if}{/each}
+          {#each highlightSegments(option.value, query) as seg, segIndex (`${option.value}-${segIndex}-${seg.text}-${seg.match}`)}{#if seg.match}<mark class="match">{seg.text}</mark>{:else}{seg.text}{/if}{/each}
         </li>
       {:else}
         <li class="typeahead-empty">No matching repos</li>

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -2,11 +2,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/sv
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import type { Repo } from "@middleman/ui/api/types";
-import { createSettingsStore } from "../../../../packages/ui/src/stores/settings.svelte.ts";
+import { createSettingsStore } from "@middleman/ui/stores/settings";
 import { client } from "../api/runtime.js";
 import RepoTypeahead from "./RepoTypeahead.svelte";
 
-const settingsStore = createSettingsStore();
+let settingsStore: ReturnType<typeof createSettingsStore>;
 
 vi.mock("@middleman/ui", () => ({
   getStores: () => ({
@@ -24,13 +24,13 @@ const getRepos = client.GET as unknown as Mock<() => Promise<{ data: Repo[]; err
 
 describe("RepoTypeahead", () => {
   beforeEach(() => {
+    settingsStore = createSettingsStore();
     settingsStore.setConfiguredRepos([]);
     getRepos.mockResolvedValue({ data: [], error: undefined });
   });
 
   afterEach(() => {
     cleanup();
-    settingsStore.setConfiguredRepos([]);
   });
 
   it("updates dropdown options when configured repos change", async () => {
@@ -118,6 +118,7 @@ describe("RepoTypeahead", () => {
         Name: "middleman",
       },
     ] as unknown as Repo[];
+    const onchange = vi.fn();
 
     getRepos
       .mockResolvedValueOnce({
@@ -143,12 +144,12 @@ describe("RepoTypeahead", () => {
 
     render(RepoTypeahead, {
       props: {
-        selected: undefined,
-        onchange: vi.fn(),
+        selected: "github.com/roborev-dev/middleman",
+        onchange,
       },
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /github.com\/roborev-dev\/middleman/i }));
 
     await waitFor(() => {
       expect(screen.getByRole("option", { name: /roborev-dev\/middleman/i })).toBeTruthy();
@@ -158,6 +159,7 @@ describe("RepoTypeahead", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("option", { name: /roborev-dev\/middleman/i })).toBeNull();
+      expect(onchange).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -108,4 +108,56 @@ describe("RepoTypeahead", () => {
       expect(screen.getByRole("option", { name: /roborev-dev\/worker/i })).toBeTruthy();
     });
   });
+
+  it("drops removed repos after settings remove matching entries", async () => {
+    const fetchedRepos = [
+      {
+        Platform: "github",
+        PlatformHost: "github.com",
+        Owner: "roborev-dev",
+        Name: "middleman",
+      },
+    ] as unknown as Repo[];
+
+    getRepos
+      .mockResolvedValueOnce({
+        data: fetchedRepos,
+        error: undefined,
+      })
+      .mockResolvedValueOnce({
+        data: [],
+        error: undefined,
+      });
+
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "roborev-dev",
+        name: "*",
+        repo_path: "roborev-dev/*",
+        is_glob: true,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, {
+      props: {
+        selected: undefined,
+        onchange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /roborev-dev\/middleman/i })).toBeTruthy();
+    });
+
+    settingsStore.setConfiguredRepos([]);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("option", { name: /roborev-dev\/middleman/i })).toBeNull();
+    });
+  });
 });

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -1,7 +1,10 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
+import type { Repo } from "@middleman/ui/api/types";
 import { createSettingsStore } from "../../../../packages/ui/src/stores/settings.svelte.ts";
+import { client } from "../api/runtime.js";
+import RepoTypeahead from "./RepoTypeahead.svelte";
 
 const settingsStore = createSettingsStore();
 
@@ -17,11 +20,12 @@ vi.mock("../api/runtime.js", () => ({
   },
 }));
 
-import RepoTypeahead from "./RepoTypeahead.svelte";
+const getRepos = client.GET as unknown as Mock<() => Promise<{ data: Repo[]; error: undefined }>>;
 
 describe("RepoTypeahead", () => {
   beforeEach(() => {
     settingsStore.setConfiguredRepos([]);
+    getRepos.mockResolvedValue({ data: [], error: undefined });
   });
 
   afterEach(() => {
@@ -54,6 +58,54 @@ describe("RepoTypeahead", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("option", { name: /import-lab\/api/i })).toBeTruthy();
+    });
+  });
+
+  it("keeps fetched repos for glob-backed settings entries", async () => {
+    const fetchedRepos = [
+      {
+        Platform: "github",
+        PlatformHost: "github.com",
+        Owner: "roborev-dev",
+        Name: "middleman",
+      },
+      {
+        Platform: "github",
+        PlatformHost: "github.com",
+        Owner: "roborev-dev",
+        Name: "worker",
+      },
+    ] as unknown as Repo[];
+
+    getRepos.mockResolvedValue({
+      data: fetchedRepos,
+      error: undefined,
+    });
+
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "roborev-dev",
+        name: "*",
+        repo_path: "roborev-dev/*",
+        is_glob: true,
+        matched_repo_count: 2,
+      },
+    ]);
+
+    render(RepoTypeahead, {
+      props: {
+        selected: undefined,
+        onchange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /roborev-dev\/middleman/i })).toBeTruthy();
+      expect(screen.getByRole("option", { name: /roborev-dev\/worker/i })).toBeTruthy();
     });
   });
 });

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSettingsStore } from "../../../../packages/ui/src/stores/settings.svelte.ts";
+
+const settingsStore = createSettingsStore();
+
+vi.mock("@middleman/ui", () => ({
+  getStores: () => ({
+    settings: settingsStore,
+  }),
+}));
+
+vi.mock("../api/runtime.js", () => ({
+  client: {
+    GET: vi.fn(() => Promise.resolve({ data: [], error: undefined })),
+  },
+}));
+
+import RepoTypeahead from "./RepoTypeahead.svelte";
+
+describe("RepoTypeahead", () => {
+  beforeEach(() => {
+    settingsStore.setConfiguredRepos([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    settingsStore.setConfiguredRepos([]);
+  });
+
+  it("updates dropdown options when configured repos change", async () => {
+    render(RepoTypeahead, {
+      props: {
+        selected: undefined,
+        onchange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    expect(screen.queryByRole("option", { name: /import-lab\/api/i })).toBeNull();
+
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "api",
+        repo_path: "import-lab/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /import-lab\/api/i })).toBeTruthy();
+    });
+  });
+});

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -46,6 +46,13 @@ test("settings shows glob match counts and refresh updates tracked repos", async
       .join(",");
   }).toBe("middleman,worker");
 
+  const selector = page.getByTitle("Select repository");
+  await expect(selector).toBeVisible();
+  await selector.click();
+  await expect(page.getByRole("option", { name: /roborev-dev\/middleman/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /roborev-dev\/worker/ })).toBeVisible();
+  await page.keyboard.press("Escape");
+
   await row.getByRole("button", { name: "Refresh" }).click();
 
   await expect(row).toContainText("(3)");

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -120,6 +120,26 @@ test("settings imports a selected subset from a repository glob", async ({ page 
       .sort()
       .join(",");
   }).toBe("api");
+
+  await selector.click();
+  await page.getByRole("option", { name: /import-lab\/api/ }).click();
+  await expect(selector).toContainText("github.com/import-lab/api");
+
+  const repoRow = page.locator(".repo-row", { hasText: "import-lab/api" });
+  await repoRow.getByTitle("Remove github/github.com/import-lab/api").click();
+  await repoRow.getByRole("button", { name: "Yes" }).click();
+
+  await expect(repoRow).toHaveCount(0);
+  await expect(selector).toContainText("All repos");
+  await expect.poll(async () => {
+    const response = await api!.get("/api/v1/repos");
+    const repos = await response.json() as RepoSummary[];
+    return repos
+      .filter((repo) => repo.Owner === "import-lab")
+      .map((repo) => repo.Name)
+      .sort()
+      .join(",");
+  }).toBe("");
 });
 
 test("repository import can hide forks and private repositories before adding", async ({ page }) => {

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -100,8 +100,11 @@ test("settings imports a selected subset from a repository glob", async ({ page 
   const selector = page.getByTitle("Select repository");
   await expect(selector).toBeVisible();
   await selector.click();
-  await expect(page.getByRole("option", { name: /import-lab\/api/ })).toBeVisible();
+  const apiOption = page.getByRole("option", { name: /import-lab\/api/ });
+  await expect(apiOption).toBeVisible();
   await expect(page.getByRole("option", { name: /import-lab\/worker/ })).toHaveCount(0);
+  await apiOption.click();
+  await expect(selector).toContainText("github.com/import-lab/api");
 
   if (!api) throw new Error("settings-globs API context not initialized");
   const settingsResponse = await api.get("/api/v1/settings");
@@ -120,10 +123,6 @@ test("settings imports a selected subset from a repository glob", async ({ page 
       .sort()
       .join(",");
   }).toBe("api");
-
-  await selector.click();
-  await page.getByRole("option", { name: /import-lab\/api/ }).click();
-  await expect(selector).toContainText("github.com/import-lab/api");
 
   const repoRow = page.locator(".repo-row", { hasText: "import-lab/api" });
   await repoRow.getByTitle("Remove github/github.com/import-lab/api").click();

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -90,6 +90,12 @@ test("settings imports a selected subset from a repository glob", async ({ page 
   await expect(page.locator(".repo-row", { hasText: "import-lab/api" })).toBeVisible();
   await expect(page.locator(".repo-row", { hasText: "import-lab/worker" })).toHaveCount(0);
 
+  const selector = page.getByTitle("Select repository");
+  await expect(selector).toBeVisible();
+  await selector.click();
+  await expect(page.getByRole("option", { name: /import-lab\/api/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /import-lab\/worker/ })).toHaveCount(0);
+
   if (!api) throw new Error("settings-globs API context not initialized");
   const settingsResponse = await api.get("/api/v1/settings");
   const settings = await settingsResponse.json() as { repos: Array<{ owner: string; name: string; is_glob: boolean }> };


### PR DESCRIPTION
- Refresh header repo selector as soon as settings imports add new exact repositories.
- Keep startup fallback behavior for the initial `/repos` bootstrap response.
- Add component and full-stack regression coverage for import-without-refresh flow.

Closes #300