### PR TITLE
Fix Rust PTY manager on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,36 @@ jobs:
           reporter: golang-json
           fail-on-error: false
 
+  pty-windows:
+    name: PTY tests (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Stub frontend embed dir
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force internal/web/dist | Out-Null
+          Set-Content -Path internal/web/dist/stub.html -Value ok
+
+      - name: Run Go PTY owner tests
+        run: go test ./internal/ptyowner/... -shuffle=on
+
+      - name: Run localruntime PTY owner smoke test
+        run: go test ./internal/workspace/localruntime -run TestManagerLaunchUsesPtyOwnerWhenConfigured -shuffle=on
+
+      - name: Run Rust PTY manager server e2e tests
+        run: go test ./internal/server -run 'TestWorkspaceCreatesRustPtyManagerSessionE2E|TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E' -shuffle=on
+
+      - name: Run Rust PTY manager tests
+        run: cargo test -p middleman-pty-manager
+
   race:
     name: go test -race
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -669,6 +670,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/frontend/src/lib/utils/e2eServerOwnership.test.ts
+++ b/frontend/src/lib/utils/e2eServerOwnership.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer } from "node:http";
 import { readFile, stat } from "node:fs/promises";
 import os from "node:os";
@@ -10,6 +17,77 @@ import * as e2eServerModule from "../../../tests/e2e-full/support/e2eServer";
 const { stopE2EServer } = e2eServerModule;
 
 const originalEnv = { ...process.env };
+
+function writeFakeBun(
+  binDir: string,
+  frontendDir: string,
+  body: string,
+  windowsBody?: string,
+): void {
+  if (process.platform === "win32") {
+    const bunPath = path.join(binDir, "bun.exe");
+    try {
+      linkSync(process.execPath, bunPath);
+    } catch {
+      copyFileSync(process.execPath, bunPath);
+    }
+    writeFileSync(path.join(frontendDir, "run"), windowsBody ?? body, { flag: "wx" });
+    return;
+  }
+  writeFileSync(path.join(binDir, "bun"), body, { mode: 0o755, flag: "wx" });
+}
+
+function prependExecutablePath(binDir: string): () => void {
+  const previousPATH = process.env.PATH;
+  const previousPath = process.env.Path;
+  const currentPath = previousPATH ?? previousPath ?? "";
+  const nextPath = `${binDir}${path.delimiter}${currentPath}`;
+
+  process.env.PATH = nextPath;
+  if (process.platform === "win32") {
+    process.env.Path = nextPath;
+  }
+
+  return () => {
+    if (previousPATH === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = previousPATH;
+    }
+    if (process.platform === "win32") {
+      if (previousPath === undefined) {
+        delete process.env.Path;
+      } else {
+        process.env.Path = previousPath;
+      }
+    }
+  };
+}
+
+function clearExecutablePath(): () => void {
+  const previousPATH = process.env.PATH;
+  const previousPath = process.env.Path;
+
+  process.env.PATH = "";
+  if (process.platform === "win32") {
+    process.env.Path = "";
+  }
+
+  return () => {
+    if (previousPATH === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = previousPATH;
+    }
+    if (process.platform === "win32") {
+      if (previousPath === undefined) {
+        delete process.env.Path;
+      } else {
+        process.env.Path = previousPath;
+      }
+    }
+  };
+}
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -48,9 +126,10 @@ describe("waitForServerInfo", () => {
 
     const dir = mkdtempSync(path.join(os.tmpdir(), "e2e-server-test-"));
     const infoFile = path.join(dir, "server-info.json");
-    const readyAt = Date.now() + 150;
+    let requestCount = 0;
     const server = createServer((_req, res) => {
-      if (Date.now() < readyAt) {
+      requestCount += 1;
+      if (requestCount === 1) {
         res.writeHead(503, { "content-type": "text/plain" });
         res.end("not ready");
         return;
@@ -81,11 +160,10 @@ describe("waitForServerInfo", () => {
       }),
     );
 
-    const startedAt = Date.now();
     const info = await waitForServerInfo(infoFile, { exitCode: null });
 
     expect(info.base_url).toBe(`http://127.0.0.1:${port}`);
-    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(100);
+    expect(requestCount).toBeGreaterThanOrEqual(2);
 
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
@@ -189,10 +267,11 @@ describe("ensureEmbeddedFrontend", () => {
     mkdirSync(frontendDist, { recursive: true });
     mkdirSync(embeddedDist, { recursive: true });
 
-    writeFileSync(
-      path.join(binDir, "bun"),
+    writeFakeBun(
+      binDir,
+      frontendDir,
       "#!/usr/bin/env bash\nset -euo pipefail\nmkdir -p dist\nprintf '<html><body>rebuilt</body></html>' > dist/index.html\n",
-      { mode: 0o755 },
+      "const { mkdirSync, writeFileSync } = require('node:fs');\nmkdirSync('dist', { recursive: true });\nwriteFileSync('dist/index.html', '<html><body>rebuilt</body></html>');\n",
     );
 
     const frontendIndex = path.join(frontendDist, "index.html");
@@ -208,17 +287,12 @@ describe("ensureEmbeddedFrontend", () => {
     utimesSync(embeddedIndex, oldTime, oldTime);
     utimesSync(sourceFile, newTime, newTime);
 
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+    const restorePath = prependExecutablePath(binDir);
     try {
       await ensureEmbeddedFrontend(dir);
       await expect(readFile(embeddedIndex, "utf8")).resolves.toContain("<body>rebuilt</body>");
     } finally {
-      if (previousPath === undefined) {
-        delete process.env.PATH;
-      } else {
-        process.env.PATH = previousPath;
-      }
+      restorePath();
     }
   });
 
@@ -248,10 +322,11 @@ describe("ensureEmbeddedFrontend", () => {
 
     // Fake bun that fails the build (mimics a real build error). The
     // existing dist must not be silently reused in this case.
-    writeFileSync(
-      path.join(binDir, "bun"),
+    writeFakeBun(
+      binDir,
+      frontendDir,
       "#!/usr/bin/env bash\necho 'simulated build error' >&2\nexit 1\n",
-      { mode: 0o755 },
+      "console.error('simulated build error');\nprocess.exit(1);\n",
     );
 
     const frontendIndex = path.join(frontendDist, "index.html");
@@ -267,18 +342,13 @@ describe("ensureEmbeddedFrontend", () => {
     utimesSync(embeddedIndex, oldTime, oldTime);
     utimesSync(sourceFile, newTime, newTime);
 
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ""}`;
+    const restorePath = prependExecutablePath(binDir);
     try {
       await expect(ensureEmbeddedFrontend(dir)).rejects.toThrow(
         /frontend build failed/,
       );
     } finally {
-      if (previousPath === undefined) {
-        delete process.env.PATH;
-      } else {
-        process.env.PATH = previousPath;
-      }
+      restorePath();
     }
   });
 
@@ -318,19 +388,14 @@ describe("ensureEmbeddedFrontend", () => {
     // Empty PATH so the spawned `bun` triggers ENOENT (missing tool).
     // No embedded index exists yet, so the fallback path must still
     // copy the (stale) frontend dist into the embedded location.
-    const previousPath = process.env.PATH;
-    process.env.PATH = "";
+    const restorePath = clearExecutablePath();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       await ensureEmbeddedFrontend(dir);
       await expect(readFile(embeddedIndex, "utf8")).resolves.toContain("<body>existing dist</body>");
       expect(warnSpy).toHaveBeenCalled();
     } finally {
-      if (previousPath === undefined) {
-        delete process.env.PATH;
-      } else {
-        process.env.PATH = previousPath;
-      }
+      restorePath();
     }
   });
 });

--- a/frontend/src/lib/utils/exclusiveLock.test.ts
+++ b/frontend/src/lib/utils/exclusiveLock.test.ts
@@ -44,7 +44,9 @@ describe("exclusive e2e lock", () => {
     const rootInfo = await stat(root);
 
     expect(info.isDirectory()).toBe(true);
-    expect(rootInfo.mode & 0o777).toBe(0o700);
+    if (process.platform !== "win32") {
+      expect(rootInfo.mode & 0o777).toBe(0o700);
+    }
   });
 
   it("waits for an existing lock file before acquiring", async () => {
@@ -78,7 +80,7 @@ describe("exclusive e2e lock", () => {
     const root = path.join(os.tmpdir(), `middleman-lock-link-${process.pid}`);
     tempRoots.push(root);
     await rm(root, { force: true, recursive: true });
-    await symlink(target, root);
+    await symlink(target, root, process.platform === "win32" ? "junction" : undefined);
 
     await expect(acquireExclusiveLock("workspace-tmux", {
       rootDir: root,

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -383,8 +383,16 @@ func remoteURLHost(remoteURL string) string {
 	if remoteURL == "" {
 		return ""
 	}
-	if u, err := url.Parse(remoteURL); err == nil && u.Host != "" {
-		return u.Host
+	if u, err := url.Parse(remoteURL); err == nil {
+		if u.Host != "" {
+			return u.Host
+		}
+		if u.Scheme != "" {
+			return ""
+		}
+	}
+	if filepath.VolumeName(remoteURL) != "" {
+		return ""
 	}
 	prefix, _, ok := strings.Cut(remoteURL, ":")
 	if !ok || strings.Contains(prefix, "/") {
@@ -402,8 +410,13 @@ func remoteURLRepoPath(remoteURL string) string {
 		return ""
 	}
 	var repoPath string
-	if u, err := url.Parse(remoteURL); err == nil && u.Host != "" {
+	if u, err := url.Parse(remoteURL); err == nil && (u.Host != "" || u.Scheme != "") {
+		if strings.EqualFold(u.Scheme, "file") {
+			return ""
+		}
 		repoPath = u.Path
+	} else if filepath.VolumeName(remoteURL) != "" {
+		return ""
 	} else {
 		prefix, path, ok := strings.Cut(remoteURL, ":")
 		if !ok || strings.Contains(prefix, "/") {

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -383,16 +383,13 @@ func remoteURLHost(remoteURL string) string {
 	if remoteURL == "" {
 		return ""
 	}
+	if isLocalRemoteURL(remoteURL) {
+		return ""
+	}
 	if u, err := url.Parse(remoteURL); err == nil {
 		if u.Host != "" {
 			return u.Host
 		}
-		if u.Scheme != "" {
-			return ""
-		}
-	}
-	if filepath.VolumeName(remoteURL) != "" {
-		return ""
 	}
 	prefix, _, ok := strings.Cut(remoteURL, ":")
 	if !ok || strings.Contains(prefix, "/") {
@@ -409,14 +406,12 @@ func remoteURLRepoPath(remoteURL string) string {
 	if remoteURL == "" {
 		return ""
 	}
-	var repoPath string
-	if u, err := url.Parse(remoteURL); err == nil && (u.Host != "" || u.Scheme != "") {
-		if strings.EqualFold(u.Scheme, "file") {
-			return ""
-		}
-		repoPath = u.Path
-	} else if filepath.VolumeName(remoteURL) != "" {
+	if isLocalRemoteURL(remoteURL) {
 		return ""
+	}
+	var repoPath string
+	if u, err := url.Parse(remoteURL); err == nil && u.Host != "" {
+		repoPath = u.Path
 	} else {
 		prefix, path, ok := strings.Cut(remoteURL, ":")
 		if !ok || strings.Contains(prefix, "/") {
@@ -430,6 +425,27 @@ func remoteURLRepoPath(remoteURL string) string {
 		return ""
 	}
 	return repoPath
+}
+
+func isLocalRemoteURL(remoteURL string) bool {
+	if filepath.VolumeName(remoteURL) != "" || isWindowsDrivePath(remoteURL) {
+		return true
+	}
+	if u, err := url.Parse(remoteURL); err == nil && strings.EqualFold(u.Scheme, "file") {
+		return true
+	}
+	return false
+}
+
+func isWindowsDrivePath(value string) bool {
+	if len(value) < 3 || value[1] != ':' {
+		return false
+	}
+	drive := value[0]
+	if (drive < 'A' || drive > 'Z') && (drive < 'a' || drive > 'z') {
+		return false
+	}
+	return value[2] == '\\' || value[2] == '/'
 }
 
 func normalizeCloneHost(host string) string {

--- a/internal/gitclone/clone_security_test.go
+++ b/internal/gitclone/clone_security_test.go
@@ -22,6 +22,37 @@ func TestValidateRemoteURLHostAcceptsMatchingHTTPSHost(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateRemoteURLIdentityAcceptsSCPStyleRemoteWithoutUser(t *testing.T) {
+	err := validateRemoteURLIdentity(
+		"github.com", "acme", "widget",
+		"github.com:acme/widget.git",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestValidateRemoteURLIdentityRejectsSCPStyleRemoteHostMismatch(t *testing.T) {
+	err := validateRemoteURLIdentity(
+		"github.com", "acme", "widget",
+		"evil.example.com:acme/widget.git",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evil.example.com")
+	assert.Contains(t, err.Error(), "github.com")
+}
+
+func TestValidateRemoteURLIdentityRejectsSchemeOnlyRemoteHostMismatch(t *testing.T) {
+	err := validateRemoteURLIdentity(
+		"github.com", "acme", "widget",
+		"ssh:evil.example.com/acme/widget.git",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ssh")
+	assert.Contains(t, err.Error(), "github.com")
+}
+
 func TestValidateRemoteURLHostAcceptsLocalPath(t *testing.T) {
 	err := validateRemoteURLHost("github.com", "/tmp/acme/widget.git")
 

--- a/internal/gitclone/clone_security_test.go
+++ b/internal/gitclone/clone_security_test.go
@@ -28,6 +28,27 @@ func TestValidateRemoteURLHostAcceptsLocalPath(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateRemoteURLHostAcceptsFileURL(t *testing.T) {
+	err := validateRemoteURLHost("github.com", "file:///C:/tmp/acme/widget.git")
+
+	require.NoError(t, err)
+}
+
+func TestValidateRemoteURLIdentityAcceptsFileURL(t *testing.T) {
+	err := validateRemoteURLIdentity(
+		"github.com", "acme", "widget",
+		"file:///C:/Users/RUNNER~1/AppData/Local/Temp/Test/remote/widget",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestValidateRemoteURLHostAcceptsWindowsLocalPath(t *testing.T) {
+	err := validateRemoteURLHost("github.com", `C:\tmp\acme\widget.git`)
+
+	require.NoError(t, err)
+}
+
 func TestClonePathIncludesHost(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/commits_test.go
+++ b/internal/gitclone/commits_test.go
@@ -409,7 +409,7 @@ func TestListCommits_NulInMessage(t *testing.T) {
 	mergeBase := gitSHA(t, work, "HEAD")
 
 	commitTestRun(t, work, "git", "checkout", "-b", "pr")
-	require.NoError(os.WriteFile(filepath.Join(work, "nul.txt"), []byte("nul\n"), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "nul-message.txt"), []byte("nul\n"), 0o644))
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", `message with \x00 in it`)
 	commitTestRun(t, work, "git", "push", "origin", "pr")

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -1,6 +1,7 @@
 package ptyowner
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -99,20 +100,24 @@ func (c *Client) Ensure(ctx context.Context, session, cwd string) error {
 				StripEnvVars: c.StripEnvVars,
 			})
 		}()
-		return c.waitReady(ctx, session)
+		return c.waitReady(ctx, session, nil, nil, nil)
 	}
 	exe, args := c.ownerCommand(exe, session, cwd, string(commandJSON))
 	cmd := exec.Command(exe, args...)
 	cmd.Env = c.ownerHelperEnvironment(os.Environ())
 	detachCommand(cmd)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start pty owner: %w", err)
 	}
+	exited := make(chan error, 1)
 	go func() {
-		_ = cmd.Wait()
+		exited <- cmd.Wait()
 	}()
 
-	return c.waitReady(ctx, session)
+	return c.waitReady(ctx, session, exited, &stdout, &stderr)
 }
 
 func acquireStartLock(
@@ -183,7 +188,12 @@ func (c *Client) ownerCommand(
 	return exe, args
 }
 
-func (c *Client) waitReady(ctx context.Context, session string) error {
+func (c *Client) waitReady(
+	ctx context.Context,
+	session string,
+	exited <-chan error,
+	stdout, stderr *bytes.Buffer,
+) error {
 	deadline := time.Now().Add(5 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
@@ -195,10 +205,26 @@ func (c *Client) waitReady(ctx context.Context, session string) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case err := <-exited:
+			return exitedOwnerError(err, stdout, stderr)
 		case <-time.After(25 * time.Millisecond):
 		}
 	}
 	return fmt.Errorf("pty owner did not become ready: %w", lastErr)
+}
+
+func exitedOwnerError(err error, stdout, stderr *bytes.Buffer) error {
+	msg := strings.TrimSpace(stderr.String())
+	if msg == "" {
+		msg = strings.TrimSpace(stdout.String())
+	}
+	if msg == "" {
+		msg = "no output"
+	}
+	if err != nil {
+		return fmt.Errorf("pty owner exited before ready: %w: %s", err, msg)
+	}
+	return fmt.Errorf("pty owner exited before ready: %s", msg)
 }
 
 func (c *Client) HasState(session string) bool {

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -17,12 +17,13 @@ import (
 )
 
 type Client struct {
-	Root        string
-	ExePath     string
-	ExeArgs     []string
-	ManagerPath string
-	Command     []string
-	InProcess   bool
+	Root         string
+	ExePath      string
+	ExeArgs      []string
+	ManagerPath  string
+	Command      []string
+	StripEnvVars []string
+	InProcess    bool
 }
 
 const (
@@ -91,17 +92,18 @@ func (c *Client) Ensure(ctx context.Context, session, cwd string) error {
 	if c.InProcess {
 		go func() {
 			_ = RunOwner(context.Background(), Options{
-				Root:    c.Root,
-				Session: session,
-				Cwd:     cwd,
-				Command: command,
+				Root:         c.Root,
+				Session:      session,
+				Cwd:          cwd,
+				Command:      command,
+				StripEnvVars: c.StripEnvVars,
 			})
 		}()
 		return c.waitReady(ctx, session)
 	}
 	exe, args := c.ownerCommand(exe, session, cwd, string(commandJSON))
 	cmd := exec.Command(exe, args...)
-	cmd.Env = ownerHelperEnvironment(os.Environ())
+	cmd.Env = c.ownerHelperEnvironment(os.Environ())
 	detachCommand(cmd)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start pty owner: %w", err)
@@ -231,10 +233,10 @@ func (c *Client) Ping(ctx context.Context, session string) error {
 	return nil
 }
 
-func (c *Client) Snapshot(ctx context.Context, session string) ([]byte, error) {
+func (c *Client) Snapshot(ctx context.Context, session string) (Status, error) {
 	conn, state, err := c.connect(ctx, session)
 	if err != nil {
-		return nil, err
+		return Status{}, err
 	}
 	defer conn.Close()
 	clearDeadline := applyRPCDeadline(ctx, conn)
@@ -242,16 +244,19 @@ func (c *Client) Snapshot(ctx context.Context, session string) ([]byte, error) {
 	enc := json.NewEncoder(conn)
 	dec := json.NewDecoder(conn)
 	if err := enc.Encode(Request{Type: RequestStatus, Token: state.Token}); err != nil {
-		return nil, err
+		return Status{}, err
 	}
 	var resp Response
 	if err := dec.Decode(&resp); err != nil {
-		return nil, err
+		return Status{}, err
 	}
 	if !resp.OK {
-		return nil, errors.New(resp.Error)
+		return Status{}, errors.New(resp.Error)
 	}
-	return append([]byte(nil), resp.Output...), nil
+	return Status{
+		Output: append([]byte(nil), resp.Output...),
+		Title:  resp.Title,
+	}, nil
 }
 
 func (c *Client) Attach(
@@ -387,6 +392,10 @@ func isStaleOwnerConnection(err error) bool {
 
 func ownerHelperEnvironment(env []string) []string {
 	return sessionEnvironment(env, nil)
+}
+
+func (c Client) ownerHelperEnvironment(env []string) []string {
+	return sessionEnvironment(env, c.StripEnvVars)
 }
 
 func applyRPCDeadline(ctx context.Context, conn net.Conn) func() {

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -1,7 +1,6 @@
 package ptyowner
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -31,6 +30,7 @@ const (
 	clientRPCTimeout       = 5 * time.Second
 	startLockStaleAfter    = 30 * time.Second
 	startLockRetryInterval = 25 * time.Millisecond
+	ownerOutputLimit       = 64 * 1024
 )
 
 type Attachment struct {
@@ -106,7 +106,8 @@ func (c *Client) Ensure(ctx context.Context, session, cwd string) error {
 	cmd := exec.Command(exe, args...)
 	cmd.Env = c.ownerHelperEnvironment(os.Environ())
 	detachCommand(cmd)
-	var stdout, stderr bytes.Buffer
+	stdout := newBoundedOutputBuffer(ownerOutputLimit)
+	stderr := newBoundedOutputBuffer(ownerOutputLimit)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
@@ -192,7 +193,7 @@ func (c *Client) waitReady(
 	ctx context.Context,
 	session string,
 	exited <-chan error,
-	stdout, stderr *bytes.Buffer,
+	stdout, stderr *boundedOutputBuffer,
 ) error {
 	deadline := time.Now().Add(5 * time.Second)
 	var lastErr error
@@ -213,9 +214,12 @@ func (c *Client) waitReady(
 	return fmt.Errorf("pty owner did not become ready: %w", lastErr)
 }
 
-func exitedOwnerError(err error, stdout, stderr *bytes.Buffer) error {
-	msg := strings.TrimSpace(stderr.String())
-	if msg == "" {
+func exitedOwnerError(err error, stdout, stderr *boundedOutputBuffer) error {
+	msg := ""
+	if stderr != nil {
+		msg = strings.TrimSpace(stderr.String())
+	}
+	if msg == "" && stdout != nil {
 		msg = strings.TrimSpace(stdout.String())
 	}
 	if msg == "" {
@@ -225,6 +229,38 @@ func exitedOwnerError(err error, stdout, stderr *bytes.Buffer) error {
 		return fmt.Errorf("pty owner exited before ready: %w: %s", err, msg)
 	}
 	return fmt.Errorf("pty owner exited before ready: %s", msg)
+}
+
+type boundedOutputBuffer struct {
+	mu    sync.Mutex
+	limit int
+	data  []byte
+}
+
+func newBoundedOutputBuffer(limit int) boundedOutputBuffer {
+	return boundedOutputBuffer{limit: limit}
+}
+
+func (b *boundedOutputBuffer) Write(p []byte) (int, error) {
+	if b == nil || b.limit <= 0 {
+		return len(p), nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.data = append(b.data, p...)
+	if len(b.data) > b.limit {
+		b.data = append([]byte(nil), b.data[len(b.data)-b.limit:]...)
+	}
+	return len(p), nil
+}
+
+func (b *boundedOutputBuffer) String() string {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.data)
 }
 
 func (c *Client) HasState(session string) bool {

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -29,10 +29,11 @@ const (
 )
 
 type Options struct {
-	Root    string
-	Session string
-	Cwd     string
-	Command []string
+	Root         string
+	Session      string
+	Cwd          string
+	Command      []string
+	StripEnvVars []string
 }
 
 type owner struct {
@@ -43,6 +44,8 @@ type owner struct {
 
 	mu           sync.Mutex
 	outputBuffer []byte
+	title        string
+	titleParser  terminalTitleParser
 	subscribers  map[chan []byte]struct{}
 	exitCode     int
 	exited       bool
@@ -75,7 +78,7 @@ func RunOwner(ctx context.Context, opts Options) error {
 
 	cmd := p.Command(command[0], command[1:]...)
 	cmd.Dir = opts.Cwd
-	cmd.Env = sessionEnvironment(os.Environ(), nil)
+	cmd.Env = sessionEnvironment(os.Environ(), opts.StripEnvVars)
 	configureOwnerCommand(cmd)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start pty command: %w", err)
@@ -203,8 +206,10 @@ func (o *owner) handleConn(conn net.Conn) {
 
 	switch first.Type {
 	case RequestStatus:
+		status := o.snapshotStatus()
 		_ = enc.Encode(Response{
-			Type: ResponseOK, OK: true, Output: o.snapshotOutput(),
+			Type: ResponseOK, OK: true, Output: status.Output,
+			Title: status.Title,
 		})
 	case RequestStop:
 		_ = enc.Encode(Response{Type: ResponseOK, OK: true})
@@ -383,6 +388,9 @@ func (o *owner) broadcast(data []byte) {
 	chunk := append([]byte(nil), data...)
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	if title, ok := o.titleParser.Update(chunk); ok {
+		o.title = title
+	}
 	o.outputBuffer = append(o.outputBuffer, chunk...)
 	if extra := len(o.outputBuffer) - maxOutputReplay; extra > 0 {
 		o.outputBuffer = append([]byte(nil), o.outputBuffer[extra:]...)
@@ -420,10 +428,13 @@ func (o *owner) subscribe() (<-chan []byte, func()) {
 	}
 }
 
-func (o *owner) snapshotOutput() []byte {
+func (o *owner) snapshotStatus() Status {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return append([]byte(nil), o.outputBuffer...)
+	return Status{
+		Output: append([]byte(nil), o.outputBuffer...),
+		Title:  o.title,
+	}
 }
 
 func (o *owner) currentExitCode() int {
@@ -522,4 +533,76 @@ func waitExitCode(waitErr error) int {
 		return exitErr.ExitCode()
 	}
 	return -1
+}
+
+type terminalTitleParser struct {
+	pending []byte
+}
+
+const terminalTitlePendingLimit = 4096
+
+func (p *terminalTitleParser) Update(data []byte) (string, bool) {
+	if len(data) == 0 && len(p.pending) == 0 {
+		return "", false
+	}
+	buf := append(append([]byte(nil), p.pending...), data...)
+	title, ok, consumed := parseTerminalTitle(buf)
+	if consumed < len(buf) {
+		p.pending = append([]byte(nil), buf[consumed:]...)
+		if len(p.pending) > terminalTitlePendingLimit {
+			p.pending = append(
+				[]byte(nil),
+				p.pending[len(p.pending)-terminalTitlePendingLimit:]...,
+			)
+		}
+	} else {
+		p.pending = nil
+	}
+	return title, ok
+}
+
+func parseTerminalTitle(data []byte) (string, bool, int) {
+	const esc = byte(0x1b)
+	var title string
+	ok := false
+	consumed := 0
+	for i := 0; i < len(data); i++ {
+		if data[i] == esc && i+1 >= len(data) {
+			return title, ok, i
+		}
+		if data[i] != esc || data[i+1] != ']' {
+			consumed = i + 1
+			continue
+		}
+
+		seqStart := i
+		payloadStart := i + 2
+		terminatorStart := -1
+		terminatorEnd := -1
+		for j := payloadStart; j < len(data); j++ {
+			if data[j] == 0x07 {
+				terminatorStart = j
+				terminatorEnd = j + 1
+				break
+			}
+			if data[j] == esc && j+1 < len(data) && data[j+1] == '\\' {
+				terminatorStart = j
+				terminatorEnd = j + 2
+				break
+			}
+		}
+		if terminatorStart == -1 {
+			return title, ok, seqStart
+		}
+
+		payload := string(data[payloadStart:terminatorStart])
+		code, value, found := strings.Cut(payload, ";")
+		if found && (code == "0" || code == "1" || code == "2") {
+			title = strings.TrimSpace(value)
+			ok = true
+		}
+		consumed = terminatorEnd
+		i = terminatorEnd - 1
+	}
+	return title, ok, consumed
 }

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -546,6 +546,20 @@ func TestClientEnsuresExternalManagerWithGoTestHelper(t *testing.T) {
 	require.Contains(readUntil(t, attachment.Output, "echo:ping"), "echo:ping")
 }
 
+func TestBoundedOutputBufferRetainsTail(t *testing.T) {
+	assert := Assert.New(t)
+	buf := newBoundedOutputBuffer(8)
+
+	n, err := buf.Write([]byte("hello "))
+	require.NoError(t, err)
+	assert.Equal(6, n)
+	n, err = buf.Write([]byte("world"))
+	require.NoError(t, err)
+	assert.Equal(5, n)
+
+	assert.Equal("lo world", buf.String())
+}
+
 func TestPtyOwnerEchoHelperProcess(t *testing.T) {
 	if os.Getenv("MIDDLEMAN_PTYOWNER_TEST_HELPER") != "1" {
 		return

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -98,6 +98,31 @@ func TestOwnerStopWhileRunOwnerReturns(t *testing.T) {
 	}
 }
 
+func TestTerminalTitleParserTracksOSCSequences(t *testing.T) {
+	assert := Assert.New(t)
+	var parser terminalTitleParser
+
+	title, ok := parser.Update([]byte("before\x1b]0;busy title\x07after"))
+	assert.True(ok)
+	assert.Equal("busy title", title)
+
+	title, ok = parser.Update([]byte("\x1b]2;split"))
+	assert.False(ok)
+	assert.Empty(title)
+
+	title, ok = parser.Update([]byte(" title\x1b\\tail"))
+	assert.True(ok)
+	assert.Equal("split title", title)
+
+	title, ok = parser.Update([]byte("\x1b"))
+	assert.False(ok)
+	assert.Empty(title)
+
+	title, ok = parser.Update([]byte("]0;edge title\x07"))
+	assert.True(ok)
+	assert.Equal("edge title", title)
+}
+
 func TestOwnerRejectsOversizedUnauthenticatedRequest(t *testing.T) {
 	require := require.New(t)
 	if runtime.GOOS == "windows" {
@@ -157,6 +182,20 @@ func TestOwnerHelperEnvironmentStripsCredentials(t *testing.T) {
 		"MIDDLEMAN_GITHUB_TOKEN=secret-1",
 		"GITHUB_TOKEN=secret-2",
 		"GH_TOKEN_WORK=secret-3",
+		"KEEP=value",
+	})
+
+	require.ElementsMatch(t, []string{
+		"PATH=/usr/bin",
+		"KEEP=value",
+	}, out)
+}
+
+func TestClientOwnerHelperEnvironmentStripsConfiguredVariables(t *testing.T) {
+	client := Client{StripEnvVars: []string{"WORKSPACE_TOKEN"}}
+	out := client.ownerHelperEnvironment([]string{
+		"PATH=/usr/bin",
+		"WORKSPACE_TOKEN=secret",
 		"KEEP=value",
 	})
 

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -469,6 +470,97 @@ func TestClientEnsuresExternalManager(t *testing.T) {
 	require.Contains(readUntil(t, attachment.Output, "ready"), "ready")
 	require.NoError(attachment.Write([]byte("hello\r")))
 	require.Contains(readUntil(t, attachment.Output, "got:hello"), "got:hello")
+}
+
+func TestClientEnsuresExternalManagerWithPowerShell(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell PTY manager startup coverage is Windows-specific")
+	}
+	require := require.New(t)
+	managerPath := os.Getenv("MIDDLEMAN_PTY_MANAGER_TEST")
+	if managerPath == "" {
+		t.Skip("set MIDDLEMAN_PTY_MANAGER_TEST to an external pty manager binary")
+	}
+
+	root := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
+	require.NoError(os.MkdirAll(root, 0o755))
+	client := Client{
+		Root:        root,
+		ManagerPath: managerPath,
+		Command: []string{
+			"powershell.exe", "-NoLogo", "-NoProfile", "-NoExit",
+		},
+	}
+
+	require.NoError(client.Ensure(t.Context(), "middleman-powershell-test", t.TempDir()))
+	t.Cleanup(func() {
+		_ = client.Stop(context.Background(), "middleman-powershell-test")
+	})
+
+	attachment, err := client.Attach(
+		context.Background(), "middleman-powershell-test", 120, 30,
+	)
+	require.NoError(err)
+	defer attachment.Close()
+
+	require.NoError(attachment.Write([]byte("Write-Output powershell-ready\r")))
+	require.Contains(readUntil(t, attachment.Output, "powershell-ready"), "powershell-ready")
+}
+
+func TestClientEnsuresExternalManagerWithGoTestHelper(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows ConPTY coverage for Go test helpers")
+	}
+	require := require.New(t)
+	managerPath := os.Getenv("MIDDLEMAN_PTY_MANAGER_TEST")
+	if managerPath == "" {
+		t.Skip("set MIDDLEMAN_PTY_MANAGER_TEST to an external pty manager binary")
+	}
+	t.Setenv("MIDDLEMAN_PTYOWNER_TEST_HELPER", "1")
+
+	root := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
+	require.NoError(os.MkdirAll(root, 0o755))
+	client := Client{
+		Root:        root,
+		ManagerPath: managerPath,
+		Command: []string{
+			os.Args[0],
+			"-test.run=TestPtyOwnerEchoHelperProcess",
+			"--",
+			"echo",
+		},
+	}
+
+	require.NoError(client.Ensure(t.Context(), "middleman-go-helper-test", t.TempDir()))
+	t.Cleanup(func() {
+		_ = client.Stop(context.Background(), "middleman-go-helper-test")
+	})
+
+	attachment, err := client.Attach(
+		context.Background(), "middleman-go-helper-test", 120, 30,
+	)
+	require.NoError(err)
+	defer attachment.Close()
+
+	require.NoError(attachment.Write([]byte("ping\r")))
+	require.Contains(readUntil(t, attachment.Output, "echo:ping"), "echo:ping")
+}
+
+func TestPtyOwnerEchoHelperProcess(t *testing.T) {
+	if os.Getenv("MIDDLEMAN_PTYOWNER_TEST_HELPER") != "1" {
+		return
+	}
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err == nil {
+		fmt.Print("echo:" + line)
+	}
+	blockPtyOwnerTestHelper()
+}
+
+func blockPtyOwnerTestHelper() {
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 func TestExternalManagerAttachmentWritesUseAttachConnection(t *testing.T) {

--- a/internal/ptyowner/paths.go
+++ b/internal/ptyowner/paths.go
@@ -33,7 +33,7 @@ func NewSessionPaths(root, session string) (SessionPaths, error) {
 	if err := validateSessionName(session); err != nil {
 		return SessionPaths{}, err
 	}
-	dir := filepath.Join(root, session)
+	dir := filepath.Join(root, sessionDirName(session))
 	socket := filepath.Join(root, "sock-"+sessionSocketHash(session))
 	socketDir := ""
 	if len(socket) > maxUnixSocketPathLen {
@@ -51,6 +51,13 @@ func NewSessionPaths(root, session string) (SessionPaths, error) {
 }
 
 const maxUnixSocketPathLen = 100
+
+func sessionDirName(session string) string {
+	if strings.ContainsAny(session, `<>:"|?*`) {
+		return "session-" + sessionSocketHash(session)
+	}
+	return session
+}
 
 func sessionSocketHash(session string) string {
 	sum := sha256.Sum256([]byte(session))

--- a/internal/ptyowner/protocol.go
+++ b/internal/ptyowner/protocol.go
@@ -27,4 +27,10 @@ type Response struct {
 	Error    string `json:"error,omitempty"`
 	ExitCode *int   `json:"exit_code,omitempty"`
 	Output   []byte `json:"output,omitempty"`
+	Title    string `json:"title,omitempty"`
+}
+
+type Status struct {
+	Output []byte
+	Title  string
 }

--- a/internal/ptyowner/protocol_test.go
+++ b/internal/ptyowner/protocol_test.go
@@ -36,6 +36,20 @@ func TestSessionPathsAreStable(t *testing.T) {
 	assert.Contains(paths.StatePath, "owner.json")
 }
 
+func TestSessionPathsHashFilesystemHostileNames(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	root := t.TempDir()
+
+	paths, err := NewSessionPaths(root, "ws-1:codex")
+
+	require.NoError(err)
+	assert.Equal("ws-1:codex", paths.Session)
+	assert.NotContains(filepath.Base(paths.Dir), ":")
+	assert.Contains(filepath.Base(paths.Dir), "session-")
+	assert.Equal(filepath.Join(paths.Dir, "owner.json"), paths.StatePath)
+}
+
 func TestSessionPathsUsePrivateSocketDirForLongRoots(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -76,6 +90,7 @@ func TestProtocolResponseRoundTrip(t *testing.T) {
 		OK:       true,
 		ExitCode: &code,
 		Output:   []byte("recent output"),
+		Title:    "workspace title",
 	}
 
 	var buf bytes.Buffer

--- a/internal/ptyowner/runtime/runtime.go
+++ b/internal/ptyowner/runtime/runtime.go
@@ -1,0 +1,198 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/wesm/middleman/internal/ptyowner"
+)
+
+type Owner interface {
+	Start(
+		ctx context.Context,
+		session string,
+		cwd string,
+		command []string,
+		stripEnvVars []string,
+	) (PTY, error)
+	Stop(ctx context.Context, session string) error
+}
+
+type PTY interface {
+	Output() <-chan []byte
+	Done() <-chan struct{}
+	Write([]byte) error
+	Resize(cols, rows int) error
+	ExitCode() int
+	Close()
+}
+
+type ExecutableResolver func(string) (string, error)
+
+type owner struct {
+	client  *ptyowner.Client
+	resolve ExecutableResolver
+}
+
+type ownedPTY struct {
+	attachment *ptyowner.Attachment
+}
+
+func New(client *ptyowner.Client, resolve ExecutableResolver) Owner {
+	if client == nil {
+		return nil
+	}
+	if resolve == nil {
+		resolve = ResolveExecutable
+	}
+	return owner{client: client, resolve: resolve}
+}
+
+func (o owner) Start(
+	ctx context.Context,
+	session string,
+	cwd string,
+	command []string,
+	stripEnvVars []string,
+) (PTY, error) {
+	if o.client == nil {
+		return nil, errors.New("pty owner runtime is unavailable")
+	}
+	if len(command) == 0 || command[0] == "" {
+		return nil, errors.New("session command is empty")
+	}
+	resolvedPath, err := o.resolve(command[0])
+	if err != nil {
+		return nil, err
+	}
+	resolvedCommand := append([]string{resolvedPath}, command[1:]...)
+	slog.Debug(
+		"runtime session resolving command",
+		"session_key", session,
+		"program", resolvedPath,
+		"argc", len(command),
+		"cwd", cwd,
+		"pty_backend", "pty_owner",
+	)
+	client := *o.client
+	client.ExeArgs = append([]string(nil), o.client.ExeArgs...)
+	client.Command = resolvedCommand
+	client.StripEnvVars = append(
+		append([]string(nil), o.client.StripEnvVars...),
+		stripEnvVars...,
+	)
+	if err := client.Ensure(ctx, session, cwd); err != nil {
+		return nil, err
+	}
+	// The caller's launch context may end while the runtime session continues;
+	// this attachment is the long-lived drain for the owner-managed PTY.
+	attachment, err := client.Attach(context.WithoutCancel(ctx), session, 120, 30)
+	if err != nil {
+		_ = client.Stop(ctx, session)
+		return nil, err
+	}
+	return ownedPTY{attachment: attachment}, nil
+}
+
+func (o owner) Stop(ctx context.Context, session string) error {
+	if o.client == nil {
+		return nil
+	}
+	return o.client.Stop(ctx, session)
+}
+
+func (p ownedPTY) Output() <-chan []byte {
+	if p.attachment == nil {
+		ch := make(chan []byte)
+		close(ch)
+		return ch
+	}
+	return p.attachment.Output
+}
+
+func (p ownedPTY) Done() <-chan struct{} {
+	if p.attachment == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return p.attachment.Done
+}
+
+func (p ownedPTY) Write(data []byte) error {
+	if p.attachment == nil {
+		return errors.New("pty owner attachment is closed")
+	}
+	return p.attachment.Write(data)
+}
+
+func (p ownedPTY) Resize(cols int, rows int) error {
+	if p.attachment == nil {
+		return errors.New("pty owner attachment is closed")
+	}
+	return p.attachment.Resize(cols, rows)
+}
+
+func (p ownedPTY) ExitCode() int {
+	if p.attachment == nil {
+		return -1
+	}
+	return p.attachment.ExitCode()
+}
+
+func (p ownedPTY) Close() {
+	if p.attachment != nil {
+		p.attachment.Close()
+	}
+}
+
+// ResolveExecutable returns an absolute path for name. Names that are already
+// absolute are accepted as-is; names without a path separator are looked up via
+// PATH; relative names with separators are rejected because the PTY cwd may be
+// an untrusted worktree.
+func ResolveExecutable(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("session command is empty")
+	}
+	if filepath.IsAbs(name) {
+		return name, nil
+	}
+	if !hasRelativePathSyntax(name) {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			return "", fmt.Errorf(
+				"resolve session command %q via PATH: %w",
+				name, err,
+			)
+		}
+		if !filepath.IsAbs(path) {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				return "", fmt.Errorf(
+					"resolve session command %q via PATH: %w",
+					name, err,
+				)
+			}
+			path = abs
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf(
+		"session command %q must be an absolute path or a "+
+			"PATH-resolvable name; relative paths resolve inside "+
+			"the PTY working directory, which may be untrusted",
+		name,
+	)
+}
+
+func hasRelativePathSyntax(name string) bool {
+	if strings.ContainsAny(name, `/\\`) {
+		return true
+	}
+	return len(name) >= 2 && name[1] == ':'
+}

--- a/internal/ptyowner/runtime/runtime_test.go
+++ b/internal/ptyowner/runtime/runtime_test.go
@@ -1,0 +1,41 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasRelativePathSyntaxRejectsWindowsPathForms(t *testing.T) {
+	assert := Assert.New(t)
+
+	assert.False(hasRelativePathSyntax("tool.exe"))
+	assert.True(hasRelativePathSyntax(`dir\\tool.exe`))
+	assert.True(hasRelativePathSyntax("./tool.exe"))
+	assert.True(hasRelativePathSyntax("C:tool.exe"))
+}
+
+func TestResolveExecutableRejectsPathSyntaxEvenIfPATHContainsMatch(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	dir := t.TempDir()
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cases := []string{"./tool.exe", "C:tool.exe"}
+	if runtime.GOOS != "windows" {
+		name := `dir\tool`
+		exe := filepath.Join(dir, name)
+		require.NoError(os.WriteFile(exe, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		cases = append(cases, name)
+	}
+
+	for _, name := range cases {
+		_, err := ResolveExecutable(name)
+		require.Error(err)
+		assert.Contains(err.Error(), "relative paths resolve inside")
+	}
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -12241,7 +12241,7 @@ func TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E(t *testing.T) {
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
-	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\n", "echo:ping")
+	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\r", "echo:ping")
 
 	stopResp, err := fixture.client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
 		ctx, ws.Id, session.Key,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -11664,6 +11664,7 @@ func setupWorkspaceServerFixtureWithHostAndOptions(
 		bareDir, platformHost, "acme", "widget.git",
 	)
 	runGit(t, dir, "clone", "--bare", remote, bare)
+	runGit(t, bare, "remote", "set-url", "origin", gitLocalRemoteURL(remote))
 
 	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
@@ -11690,7 +11691,10 @@ func setupWorkspaceServerFixtureWithHostAndOptions(
 	t.Cleanup(func() { cleanupWorkspaceServerFixtureArtifacts(t, srv, database) })
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	seedPROnHost(t, database, platformHost, "acme", "widget", 1)
+	seedPROnHost(
+		t, database, platformHost, "acme", "widget", 1,
+		withSeedPRHeadRepoCloneURL("https://github.com/acme/widget.git"),
+	)
 
 	clientBaseURL := "http://middleman.test"
 	if basePath != "/" {
@@ -12076,19 +12080,66 @@ func TestWorkspaceCreatesPtyOwnerSessionWhenTmuxUnavailableE2E(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 }
 
-func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
+func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("rust pty manager currently advertises Unix socket transport")
+		t.Skip("workspace clone fixture uses Unix-style local remotes")
 	}
-	requirePTYAvailable(t)
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+
+	conn, _, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	workspaceTerminalConnWriteRead(
+		t, ctx, conn, "stty -echo\rprintf '%s\\n' $((40+2))\r", "42",
+	)
+	workspaceTerminalConnWriteRead(
+		t, ctx, conn,
+		"printf 'title-sent\\n'; printf '\\033]0;⠴ t3code-b5014b03\\007'\r",
+		"t3code-b5014b03",
+	)
+
+	var got *generated.WorkspaceResponse
+	require.Eventually(func() bool {
+		resp, err := fixture.client.HTTP.GetWorkspacesByIdWithResponse(ctx, ws.Id)
+		if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return false
+		}
+		got = resp.JSON200
+		return got.TmuxWorking &&
+			got.TmuxActivitySource == tmuxActivitySourceTitle &&
+			got.TmuxPaneTitle != nil
+	}, 6*time.Second, 50*time.Millisecond)
+	require.NotNil(got)
+	assert.True(got.TmuxWorking)
+	assert.Equal(tmuxActivitySourceTitle, got.TmuxActivitySource)
+	require.NotNil(got.TmuxPaneTitle)
+	assert.Equal("⠴ t3code-b5014b03", *got.TmuxPaneTitle)
+}
+
+func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		requirePTYAvailable(t)
+	}
 	require := require.New(t)
 	assert := Assert.New(t)
 
 	managerPath := buildRustPtyManagerForTest(t)
 	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
-	cfg := &config.Config{Tmux: config.Tmux{
-		Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
-	}}
+	cfg := &config.Config{
+		Tmux: config.Tmux{
+			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+		},
+		Shell: config.Shell{Command: rustPtyManagerShellCommandForTest()},
+	}
 	fixture := setupWorkspaceServerFixtureWithOptions(t, cfg, ServerOptions{
 		PtyOwnerDir:         ptyOwnerDir,
 		PtyOwnerManagerPath: managerPath,
@@ -12110,17 +12161,23 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
-	workspaceTerminalConnWriteRead(
-		t, ctx, conn, "printf 'rust-owner-one\n'\n", "rust-owner-one",
-	)
-	require.NoError(conn.Write(
-		ctx,
-		websocket.MessageText,
-		[]byte(`{"type":"resize","cols":133,"rows":37}`),
-	))
-	workspaceTerminalConnWriteRead(
-		t, ctx, conn, "printf 'size:'; stty size\n", "size:37 133",
-	)
+	if runtime.GOOS == "windows" {
+		workspaceTerminalConnWriteRead(
+			t, ctx, conn, "Write-Output rust-owner-one\r", "rust-owner-one",
+		)
+	} else {
+		workspaceTerminalConnWriteRead(
+			t, ctx, conn, "printf 'rust-owner-one\n'\r", "rust-owner-one",
+		)
+		require.NoError(conn.Write(
+			ctx,
+			websocket.MessageText,
+			[]byte(`{"type":"resize","cols":133,"rows":37}`),
+		))
+		workspaceTerminalConnWriteRead(
+			t, ctx, conn, "printf 'size:'; stty size\r", "size:37 133",
+		)
+	}
 
 	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
 	force := true
@@ -12134,9 +12191,68 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 }
 
+func TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		requirePTYAvailable(t)
+	}
+	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	managerPath := buildRustPtyManagerForTest(t)
+	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: serverRuntimeHelperCommand("echo"),
+		}},
+		Tmux: config.Tmux{
+			Command:       []string{filepath.Join(t.TempDir(), "missing-tmux")},
+			AgentSessions: &disableTmuxAgentSessions,
+		},
+	}
+	fixture := setupWorkspaceServerFixtureWithOptions(t, cfg, ServerOptions{
+		PtyOwnerDir:         ptyOwnerDir,
+		PtyOwnerManagerPath: managerPath,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "helper"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, session.Key)
+	assert.Equal("helper", session.TargetKey)
+	assert.Equal(string(localruntime.SessionStatusRunning), session.Status)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\n", "echo:ping")
+
+	stopResp, err := fixture.client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, session.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, stopResp.StatusCode())
+}
+
 func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("rust pty manager currently advertises Unix socket transport")
+		t.Skip("concurrent attach coverage is exercised by the Rust owner tests on Windows")
 	}
 	requirePTYAvailable(t)
 	require := require.New(t)
@@ -12145,13 +12261,24 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 	managerPath := buildRustPtyManagerForTest(t)
 	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
 	session := "middleman-rust-concurrent"
+	command := []string{
+		"sh", "-c",
+		"printf ready; while IFS= read -r line; do echo got:$line; done",
+	}
+	readyNeedle := "ready"
+	firstNeedle := "got:before-second"
+	thirdNeedle := "got:after-close"
+	if runtime.GOOS == "windows" {
+		t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+		command = serverRuntimeHelperCommand("echo")
+		readyNeedle = ""
+		firstNeedle = "echo:before-second"
+		thirdNeedle = "echo:after-close"
+	}
 	client := ptyowner.Client{
 		Root:        ptyOwnerDir,
 		ManagerPath: managerPath,
-		Command: []string{
-			"sh", "-c",
-			"printf ready; while IFS= read -r line; do echo got:$line; done",
-		},
+		Command:     command,
 	}
 	require.NoError(client.Ensure(t.Context(), session, t.TempDir()))
 	t.Cleanup(func() {
@@ -12161,11 +12288,16 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 	first, err := client.Attach(context.Background(), session, 120, 30)
 	require.NoError(err)
 	defer first.Close()
-	require.Contains(readPtyOwnerOutputUntil(t, first.Output, "ready"), "ready")
+	if readyNeedle != "" {
+		require.Contains(
+			readPtyOwnerOutputUntil(t, first.Output, readyNeedle),
+			readyNeedle,
+		)
+	}
 	require.NoError(first.Write([]byte("before-second\r")))
 	require.Contains(
-		readPtyOwnerOutputUntil(t, first.Output, "got:before-second"),
-		"got:before-second",
+		readPtyOwnerOutputUntil(t, first.Output, firstNeedle),
+		firstNeedle,
 	)
 
 	second, err := client.Attach(context.Background(), session, 100, 20)
@@ -12184,6 +12316,10 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 	}, 2*time.Second, 20*time.Millisecond)
 	defer third.Close()
 	require.NoError(third.Write([]byte("after-close\n")))
+	require.Contains(
+		readPtyOwnerOutputUntil(t, third.Output, thirdNeedle),
+		thirdNeedle,
+	)
 }
 
 func readPtyOwnerOutputUntil(
@@ -12296,6 +12432,7 @@ func setupPtyOwnerWorkspaceFixture(
 	cfg := &config.Config{Tmux: config.Tmux{
 		Command: []string{filepath.Join(dir, "missing-tmux")},
 	}}
+	t.Setenv("SHELL", "/bin/sh")
 	t.Setenv("MIDDLEMAN_SERVER_PTY_OWNER_HELPER", "1")
 	return setupWorkspaceServerFixtureWithOptions(
 		t, cfg, ptyOwnerServerOptions(ptyOwnerDir),
@@ -12311,6 +12448,24 @@ func ptyOwnerServerOptions(ptyOwnerDir string) ServerOptions {
 			"--",
 		},
 	}
+}
+
+func gitLocalRemoteURL(path string) string {
+	if runtime.GOOS != "windows" {
+		return path
+	}
+	slashPath := filepath.ToSlash(path)
+	if !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
+	return (&url.URL{Scheme: "file", Path: slashPath}).String()
+}
+
+func rustPtyManagerShellCommandForTest() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"powershell.exe", "-NoLogo", "-NoProfile", "-NoExit"}
+	}
+	return []string{"/bin/sh"}
 }
 
 func buildRustPtyManagerForTest(t *testing.T) string {
@@ -12661,7 +12816,8 @@ exit 0
 	require.Len(*resp.JSON200.Sessions, 1)
 
 	session := (*resp.JSON200.Sessions)[0]
-	assert.Equal(ws.ID+":helper", session.Key)
+	assert.NotEmpty(session.Key)
+	assert.NotContains(session.Key, ":")
 	assert.Equal(ws.ID, session.WorkspaceId)
 	assert.Equal("helper", session.TargetKey)
 	assert.Equal("Helper", session.Label)
@@ -16232,6 +16388,7 @@ func TestWorkspacePRDetailPlatformHost(t *testing.T) {
 func seedPROnHost(
 	t *testing.T, database *db.DB,
 	host, owner, name string, number int,
+	opts ...seedPROpt,
 ) int64 {
 	t.Helper()
 	ctx := t.Context()
@@ -16260,6 +16417,9 @@ func seedPROnHost(
 		CreatedAt:      now,
 		UpdatedAt:      now,
 		LastActivityAt: now,
+	}
+	for _, opt := range opts {
+		opt(pr)
 	}
 
 	prID, err := database.UpsertMergeRequest(ctx, pr)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3926,7 +3926,7 @@ func (s *Server) stopWorkspaceRuntimeSession(
 		ctx, summary.ID, input.SessionKey,
 	); err != nil {
 		if errors.Is(err, localruntime.ErrSessionNotFound) {
-			if targetKey, ok := runtimeTargetKeyFromSessionKey(
+			if targetKey, ok := legacyRuntimeTargetKeyFromSessionKey(
 				summary.ID, input.SessionKey,
 			); ok {
 				stopped, stopErr := s.workspaces.StopStoredRuntimeTmuxSession(
@@ -3941,6 +3941,17 @@ func (s *Server) stopWorkspaceRuntimeSession(
 				if stopped {
 					return nil, nil
 				}
+			}
+			stopped, stopErr := s.workspaces.StopStoredRuntimeTmuxSessionByKey(
+				ctx, summary.ID, input.SessionKey,
+			)
+			if stopErr != nil {
+				return nil, huma.Error500InternalServerError(
+					"stop stored runtime tmux session: " + stopErr.Error(),
+				)
+			}
+			if stopped {
+				return nil, nil
 			}
 			return nil, huma.Error404NotFound(err.Error())
 		}
@@ -3972,7 +3983,7 @@ func runtimeSessionTmuxSession(
 	return ""
 }
 
-func runtimeTargetKeyFromSessionKey(
+func legacyRuntimeTargetKeyFromSessionKey(
 	workspaceID string,
 	key string,
 ) (string, bool) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/wesm/middleman/internal/gitclone"
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/ptyowner"
+	ptyownerruntime "github.com/wesm/middleman/internal/ptyowner/runtime"
 	"github.com/wesm/middleman/internal/workspace"
 	"github.com/wesm/middleman/internal/workspace/localruntime"
 )
@@ -438,7 +440,7 @@ func newServer(
 			ManagerPath: options.PtyOwnerManagerPath,
 			InProcess:   options.PtyOwnerInProcess,
 		}
-		if !tmuxAvailable {
+		if preferPtyOwnerForWorkspaces(runtime.GOOS, tmuxAvailable, options) {
 			s.workspaces.SetPtyOwnerClient(ptyOwnerClient)
 		} else {
 			s.workspaces.SetPtyOwnerFallbackClient(ptyOwnerClient)
@@ -462,6 +464,10 @@ func newServer(
 		if cfg != nil {
 			agents = cfg.Agents
 		}
+		var runtimePtyOwner ptyownerruntime.Owner
+		if !tmuxAvailable {
+			runtimePtyOwner = ptyownerruntime.New(ptyOwnerClient, nil)
+		}
 		s.runtime = localruntime.NewManager(localruntime.Options{
 			Targets: localruntime.ResolveLaunchTargets(
 				agents, tmuxCmd, nil,
@@ -472,6 +478,7 @@ func newServer(
 			StripEnvVars:            cfg.TokenEnvNames(),
 			ShellCommand:            cfg.ShellCommand(),
 			OnSessionExit:           s.handleRuntimeSessionExit,
+			PtyOwnerRuntime:         runtimePtyOwner,
 		})
 		if err := s.restoreRuntimeTmuxSessions(context.Background()); err != nil {
 			slog.Warn("restore runtime tmux sessions", "err", err)
@@ -626,6 +633,19 @@ func (s *Server) handleRuntimeSessionExit(info localruntime.SessionInfo) {
 			)
 		}
 	})
+}
+
+func preferPtyOwnerForWorkspaces(
+	runtimeGOOS string,
+	tmuxAvailable bool,
+	options ServerOptions,
+) bool {
+	if !tmuxAvailable {
+		return true
+	}
+	return runtimeGOOS == "windows" &&
+		(options.PtyOwnerManagerPath != "" || options.PtyOwnerExePath != "" ||
+			options.PtyOwnerInProcess)
 }
 
 func tmuxCommandAvailable(command []string) bool {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,6 +29,16 @@ func newTestServer(t *testing.T) *Server {
 	return New(openTestDB(t), nil, nil, "/", nil, ServerOptions{})
 }
 
+func TestPreferPtyOwnerForWorkspacesOnWindows(t *testing.T) {
+	require := require.New(t)
+
+	prefer := preferPtyOwnerForWorkspaces("windows", true, ServerOptions{
+		PtyOwnerManagerPath: "middleman-pty-manager.exe",
+	})
+
+	require.True(prefer)
+}
+
 func TestHealthzAndLivez_ReturnOK(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/creack/pty/v2"
+
+	ptyownerruntime "github.com/wesm/middleman/internal/ptyowner/runtime"
 )
 
 type SessionStatus string
@@ -78,6 +80,10 @@ type Options struct {
 	// OnSessionExit is called after a launched runtime session or shell exits
 	// naturally and is removed from the manager's active session maps.
 	OnSessionExit func(SessionInfo)
+	// PtyOwnerRuntime starts direct runtime PTYs through the durable PTY owner
+	// instead of github.com/creack/pty. This is required on Windows, where
+	// creack/pty does not provide a local PTY implementation.
+	PtyOwnerRuntime ptyownerruntime.Owner
 }
 
 type Manager struct {
@@ -92,6 +98,7 @@ type Manager struct {
 	wrapAgentsInTmux bool
 	stripEnvVars     []string
 	onSessionExit    func(SessionInfo)
+	ptyOwnerRuntime  ptyownerruntime.Owner
 	startLocks       map[string]*sync.Mutex
 	stoppingWS       map[string]int
 	inflightWS       map[string]int
@@ -137,6 +144,8 @@ type session struct {
 	info                  SessionInfo
 	cmd                   *exec.Cmd
 	ptmx                  *os.File
+	ptyOwner              ptyownerruntime.Owner
+	pty                   ptyownerruntime.PTY
 	tmuxSession           string
 	done                  chan struct{}
 	outputDone            chan struct{}
@@ -186,6 +195,7 @@ func NewManager(options Options) *Manager {
 		wrapAgentsInTmux: options.WrapAgentSessionsInTmux,
 		stripEnvVars:     dedupeStrings(options.StripEnvVars),
 		onSessionExit:    options.OnSessionExit,
+		ptyOwnerRuntime:  options.PtyOwnerRuntime,
 		startLocks:       make(map[string]*sync.Mutex),
 		stoppingWS:       make(map[string]int),
 		inflightWS:       make(map[string]int),
@@ -305,7 +315,7 @@ func (m *Manager) Launch(
 		"tmux_session", launch.TmuxSession,
 	)
 
-	started, err := startSession(SessionInfo{
+	started, err := m.startSession(ctx, SessionInfo{
 		Key:         key,
 		WorkspaceID: workspaceID,
 		TargetKey:   targetKey,
@@ -432,7 +442,7 @@ func (m *Manager) restoreTmuxSession(
 		"target_key", targetKey,
 		"tmux_session", tmuxSession,
 	)
-	started, err := startSession(SessionInfo{
+	started, err := m.startSession(ctx, SessionInfo{
 		Key:         key,
 		WorkspaceID: workspaceID,
 		TargetKey:   targetKey,
@@ -937,7 +947,7 @@ func (m *Manager) EnsureShell(
 	}
 	defer m.releaseInflight(workspaceID)
 
-	started, err := startSession(SessionInfo{
+	started, err := m.startSession(ctx, SessionInfo{
 		Key:         key,
 		WorkspaceID: workspaceID,
 		TargetKey:   "plain_shell",
@@ -1446,6 +1456,55 @@ func (m *Manager) removeExitedSession(
 	return true
 }
 
+func (m *Manager) startSession(
+	ctx context.Context,
+	info SessionInfo,
+	command []string,
+	cwd string,
+	extraStripVars []string,
+) (*session, error) {
+	if m.ptyOwnerRuntime != nil {
+		return startPtyOwnerSession(
+			ctx, m.ptyOwnerRuntime, info, command, cwd, extraStripVars,
+		)
+	}
+	return startSession(info, command, cwd, extraStripVars)
+}
+
+func startPtyOwnerSession(
+	ctx context.Context,
+	owner ptyownerruntime.Owner,
+	info SessionInfo,
+	command []string,
+	cwd string,
+	extraStripVars []string,
+) (*session, error) {
+	if len(command) == 0 || command[0] == "" {
+		return nil, errors.New("session command is empty")
+	}
+	ptySession, err := owner.Start(ctx, info.Key, cwd, command, extraStripVars)
+	if err != nil {
+		return nil, fmt.Errorf("start pty owner: %w", err)
+	}
+	slog.Debug(
+		"runtime session pty owner started",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"target_key", info.TargetKey,
+	)
+	info.Status = SessionStatusRunning
+	s := &session{
+		info:        info,
+		ptyOwner:    owner,
+		pty:         ptySession,
+		done:        make(chan struct{}),
+		outputDone:  make(chan struct{}),
+		subscribers: make(map[chan []byte]struct{}),
+	}
+	go s.drainOutput()
+	return s, nil
+}
+
 func startSession(
 	info SessionInfo,
 	command []string,
@@ -1536,6 +1595,9 @@ func (s *session) snapshot() SessionInfo {
 }
 
 func (s *session) watch() SessionInfo {
+	if s.pty != nil {
+		return s.watchPtyOwner()
+	}
 	exitCode := waitExitCode(s.cmd.Wait())
 	now := time.Now().UTC()
 
@@ -1565,9 +1627,44 @@ func (s *session) watch() SessionInfo {
 	return info
 }
 
+func (s *session) watchPtyOwner() SessionInfo {
+	<-s.pty.Done()
+	exitCode := s.pty.ExitCode()
+	now := time.Now().UTC()
+
+	s.mu.Lock()
+	s.info.Status = SessionStatusExited
+	s.info.ExitedAt = &now
+	s.info.ExitCode = &exitCode
+	info := s.info
+	info.TmuxSession = s.tmuxSession
+	s.mu.Unlock()
+
+	s.closeSubscribers()
+	close(s.done)
+	slog.Debug(
+		"runtime session exited",
+		"workspace_id", info.WorkspaceID,
+		"session_key", info.Key,
+		"target_key", info.TargetKey,
+		"exit_code", exitCode,
+		"pty_backend", "pty_owner",
+	)
+	return info
+}
+
 func (s *session) drainOutput() {
 	if s.outputDone != nil {
 		defer close(s.outputDone)
+	}
+	if s.pty != nil {
+		for chunk := range s.pty.Output() {
+			if len(chunk) > 0 {
+				s.broadcast(chunk)
+			}
+		}
+		s.closeSubscribers()
+		return
 	}
 	buf := make([]byte, 32*1024)
 	for {
@@ -1764,7 +1861,17 @@ func (s *session) closeSubscribers() {
 
 func (s *session) stop() {
 	s.stopOnce.Do(func() {
-		if s.cmd.Process != nil {
+		if s.pty != nil {
+			if s.ptyOwner != nil {
+				ctx, cancel := context.WithTimeout(
+					context.Background(), 2*time.Second,
+				)
+				_ = s.ptyOwner.Stop(ctx, s.info.Key)
+				cancel()
+			}
+			s.pty.Close()
+		}
+		if s.cmd != nil && s.cmd.Process != nil {
 			_ = killSessionProcess(s.cmd.Process)
 		}
 		if s.ptmx != nil {
@@ -1787,6 +1894,9 @@ func (s *session) wasStopRequested() bool {
 
 func (s *session) detach() {
 	s.stopOnce.Do(func() {
+		if s.pty != nil {
+			s.pty.Close()
+		}
 		if s.ptmx != nil {
 			_ = s.ptmx.Close()
 		}
@@ -1800,8 +1910,13 @@ func waitSessionDone(s *session) {
 	}
 }
 
+func SessionKey(workspaceID string, targetKey string) string {
+	sum := sha256.Sum256([]byte(workspaceID + "\x00" + targetKey))
+	return "session-" + hex.EncodeToString(sum[:8])
+}
+
 func sessionKey(workspaceID string, targetKey string) string {
-	return workspaceID + ":" + targetKey
+	return SessionKey(workspaceID, targetKey)
 }
 
 // resolveExecutable returns an absolute path for name. Names that
@@ -1934,12 +2049,18 @@ func attachToSession(
 		Done:   s.done,
 		info:   s.snapshot,
 		write: func(data []byte) error {
+			if s.pty != nil {
+				return s.pty.Write(data)
+			}
 			_, err := s.ptmx.Write(data)
 			return err
 		},
 		resize: func(cols, rows int) error {
 			if cols <= 0 || rows <= 0 {
 				return nil
+			}
+			if s.pty != nil {
+				return s.pty.Resize(cols, rows)
 			}
 			return pty.Setsize(s.ptmx, &pty.Winsize{
 				Rows: uint16(rows),

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -2,21 +2,21 @@ package localruntime
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
 	"github.com/creack/pty/v2"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ptyownerruntime "github.com/wesm/middleman/internal/ptyowner/runtime"
 )
 
 func requirePTYAvailable(t *testing.T) {
@@ -102,6 +102,17 @@ func TestManagerLaunchConcurrentStartsOneProcess(t *testing.T) {
 		return strings.Count(string(data), "\n") == 1
 	}, 2*time.Second, 20*time.Millisecond)
 	assert.Len(mgr.ListSessions("ws-1"), 1)
+}
+
+func TestSessionKeyIsFilesystemSafe(t *testing.T) {
+	key := sessionKey("ws:alpha", "foo:bar/baz")
+
+	assert := Assert.New(t)
+	assert.NotContains(key, ":")
+	assert.NotContains(key, "/")
+	assert.NotContains(key, `\\`)
+	assert.Equal(key, sessionKey("ws:alpha", "foo:bar/baz"))
+	assert.NotEqual(key, sessionKey("ws:alpha", "foo:bar/qux"))
 }
 
 func TestManagerLaunchUnavailableTarget(t *testing.T) {
@@ -423,6 +434,47 @@ func TestManagerLaunchCommandFallsBackWhenTmuxUnavailable(t *testing.T) {
 	assert.Empty(launch.TmuxSession)
 }
 
+func TestManagerLaunchUsesPtyOwnerWhenConfigured(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	backend := newFakeRuntimePtyOwner()
+	agent := helperTarget("codex", "exit")
+	mgr := NewManager(Options{
+		Targets:         []LaunchTarget{agent},
+		PtyOwnerRuntime: backend,
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	info, err := mgr.Launch(ctx, "ws-1", t.TempDir(), "codex")
+	require.NoError(err)
+
+	assert.Equal(SessionStatusRunning, info.Status)
+	assert.Equal(info.Key, backend.startedSession)
+	assert.NotContains(backend.startedSession, ":")
+	assert.Equal(agent.Command, backend.startedCommand)
+	assert.Len(mgr.ListSessions("ws-1"), 1)
+}
+
+func TestManagerLaunchPassesStripEnvVarsToPtyOwner(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := context.Background()
+	backend := newFakeRuntimePtyOwner()
+	agent := helperTarget("codex", "exit")
+	mgr := NewManager(Options{
+		Targets:         []LaunchTarget{agent},
+		PtyOwnerRuntime: backend,
+		StripEnvVars:    []string{"WORKSPACE_TOKEN", "WORKSPACE_TOKEN"},
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	_, err := mgr.Launch(ctx, "ws-1", t.TempDir(), "codex")
+	require.NoError(err)
+
+	assert.Equal([]string{"WORKSPACE_TOKEN"}, backend.startedStripEnvVars)
+}
+
 func TestManagerLaunchCommandDoesNotWrapWhenConfigDisabled(t *testing.T) {
 	assert := Assert.New(t)
 	agent := helperTarget("codex", "sleep")
@@ -599,12 +651,12 @@ func TestManagerShutdownTerminatesPTYManagedSessions(t *testing.T) {
 		pid = s.cmd.Process.Pid
 		return pid > 0
 	}, 2*time.Second, 20*time.Millisecond)
-	require.NoError(syscall.Kill(pid, 0), "helper should be alive")
+	require.True(processAlive(pid), "helper should be alive")
 
 	mgr.Shutdown()
 
 	assert.Eventually(func() bool {
-		return errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+		return !processAlive(pid)
 	}, 5*time.Second, 25*time.Millisecond)
 	assert.Empty(mgr.ListSessions("ws-1"))
 }
@@ -659,7 +711,7 @@ func TestManagerLaunchRejectsWhileWorkspaceStopping(t *testing.T) {
 		}
 		for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
 			pid, _ := strconv.Atoi(line)
-			if pid > 0 && syscall.Kill(pid, 0) == nil {
+			if processAlive(pid) {
 				return false
 			}
 		}
@@ -785,14 +837,13 @@ func TestManagerStopKillsDescendantProcesses(t *testing.T) {
 		return parentPID > 0 && childPID > 0
 	}, 5*time.Second, 25*time.Millisecond, "helper should record both pids")
 
-	require.NoError(syscall.Kill(parentPID, 0), "parent should be alive")
-	require.NoError(syscall.Kill(childPID, 0), "child should be alive")
+	require.True(processAlive(parentPID), "parent should be alive")
+	require.True(processAlive(childPID), "child should be alive")
 
 	require.NoError(mgr.Stop(ctx, "ws-1", session.Key))
 
 	assert.Eventually(func() bool {
-		return errors.Is(syscall.Kill(parentPID, 0), syscall.ESRCH) &&
-			errors.Is(syscall.Kill(childPID, 0), syscall.ESRCH)
+		return !processAlive(parentPID) && !processAlive(childPID)
 	}, 5*time.Second, 25*time.Millisecond,
 		"descendant child should die with the session leader")
 }
@@ -1104,6 +1155,69 @@ drain:
 	assert.True(attach.SessionOutputClosed(),
 		"after drainOutput's closeSubscribers, the bridge must see "+
 			"the session as output-closed and emit the exit frame")
+}
+
+type fakeRuntimePtyOwner struct {
+	startedSession      string
+	startedCwd          string
+	startedCommand      []string
+	startedStripEnvVars []string
+	startedPTY          *fakeRuntimePTY
+	stoppedSession      string
+}
+
+func newFakeRuntimePtyOwner() *fakeRuntimePtyOwner {
+	return &fakeRuntimePtyOwner{}
+}
+
+func (f *fakeRuntimePtyOwner) Start(
+	_ context.Context,
+	session string,
+	cwd string,
+	command []string,
+	stripEnvVars []string,
+) (ptyownerruntime.PTY, error) {
+	f.startedSession = session
+	f.startedCwd = cwd
+	f.startedCommand = slices.Clone(command)
+	f.startedStripEnvVars = slices.Clone(stripEnvVars)
+	f.startedPTY = &fakeRuntimePTY{
+		output: make(chan []byte, 64),
+		done:   make(chan struct{}),
+	}
+	return f.startedPTY, nil
+}
+
+func (f *fakeRuntimePtyOwner) Stop(_ context.Context, session string) error {
+	f.stoppedSession = session
+	if f.startedPTY != nil {
+		f.startedPTY.Close()
+	}
+	return nil
+}
+
+type fakeRuntimePTY struct {
+	output chan []byte
+	done   chan struct{}
+}
+
+func (f *fakeRuntimePTY) Output() <-chan []byte { return f.output }
+
+func (f *fakeRuntimePTY) Done() <-chan struct{} { return f.done }
+
+func (f *fakeRuntimePTY) Write([]byte) error { return nil }
+
+func (f *fakeRuntimePTY) Resize(int, int) error { return nil }
+
+func (f *fakeRuntimePTY) ExitCode() int { return 0 }
+
+func (f *fakeRuntimePTY) Close() {
+	select {
+	case <-f.done:
+	default:
+		close(f.output)
+		close(f.done)
+	}
 }
 
 func TestManagerShellConcurrentStartsOneProcess(t *testing.T) {

--- a/internal/workspace/localruntime/process_alive_unix_test.go
+++ b/internal/workspace/localruntime/process_alive_unix_test.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package localruntime
+
+import "syscall"
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}

--- a/internal/workspace/localruntime/process_alive_windows_test.go
+++ b/internal/workspace/localruntime/process_alive_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package localruntime
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	cmd := exec.Command(
+		"powershell",
+		"-NoProfile",
+		"-Command",
+		"if (Get-Process -Id "+strconv.Itoa(pid)+" -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
+	)
+	return cmd.Run() == nil
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/wesm/middleman/internal/gitclone"
 	"github.com/wesm/middleman/internal/gitenv"
 	"github.com/wesm/middleman/internal/procutil"
+	"github.com/wesm/middleman/internal/workspace/localruntime"
 )
 
 // Manager owns middleman's persisted workspace lifecycle.
@@ -87,7 +88,7 @@ var (
 	ErrWorkspaceInvalidState = errors.New("workspace invalid state")
 )
 
-type TmuxPaneSnapshot struct {
+type TerminalPaneSnapshot struct {
 	Title  string
 	Output string
 }
@@ -1393,6 +1394,30 @@ func (m *Manager) StopStoredRuntimeTmuxSession(
 	return false, nil
 }
 
+// StopStoredRuntimeTmuxSessionByKey cleans up a persisted runtime tmux session
+// addressed by the public localruntime session key.
+func (m *Manager) StopStoredRuntimeTmuxSessionByKey(
+	ctx context.Context,
+	workspaceID string,
+	sessionKey string,
+) (bool, error) {
+	if sessionKey == "" {
+		return false, nil
+	}
+	stored, err := m.db.ListWorkspaceTmuxSessions(ctx, workspaceID)
+	if err != nil {
+		return false, err
+	}
+	for _, storedSession := range stored {
+		if localruntime.SessionKey(workspaceID, storedSession.TargetKey) == sessionKey {
+			return m.StopStoredRuntimeTmuxSession(
+				ctx, workspaceID, storedSession.TargetKey,
+			)
+		}
+	}
+	return false, nil
+}
+
 // TmuxSessionsForWorkspace returns the persisted workspace tmux
 // session plus stored per-agent sessions. Runtime tmux sessions are
 // stored rather than discovered by naming convention so restart
@@ -1433,33 +1458,35 @@ func (m *Manager) TmuxPaneTitle(
 }
 
 // TerminalPaneSnapshot returns recent terminal output for the backend
-// that owns the workspace's primary terminal. Runtime sessions remain
-// tmux-backed and should use TmuxPaneSnapshot directly.
+// that owns the workspace's primary terminal.
 func (m *Manager) TerminalPaneSnapshot(
 	ctx context.Context, ws *db.Workspace,
 	session string,
-) (TmuxPaneSnapshot, error) {
+) (TerminalPaneSnapshot, error) {
 	if ws != nil && session == ws.TmuxSession && m.UsesPtyOwnerForWorkspace(ws) {
 		if m.ptyOwner == nil {
-			return TmuxPaneSnapshot{}, fmt.Errorf("pty owner backend unavailable")
+			return TerminalPaneSnapshot{}, fmt.Errorf("pty owner backend unavailable")
 		}
-		output, err := m.ptyOwner.Snapshot(ctx, session)
+		status, err := m.ptyOwner.Snapshot(ctx, session)
 		if err != nil {
-			return TmuxPaneSnapshot{}, err
+			return TerminalPaneSnapshot{}, err
 		}
-		return TmuxPaneSnapshot{Output: string(output)}, nil
+		return TerminalPaneSnapshot{
+			Title:  status.Title,
+			Output: string(status.Output),
+		}, nil
 	}
-	return m.TmuxPaneSnapshot(ctx, session)
+	return m.tmuxPaneSnapshot(ctx, session)
 }
 
-// TmuxPaneSnapshot returns the active pane title and recent pane
+// tmuxPaneSnapshot returns the active pane title and recent pane
 // output for passive activity detection.
-func (m *Manager) TmuxPaneSnapshot(
+func (m *Manager) tmuxPaneSnapshot(
 	ctx context.Context, session string,
-) (TmuxPaneSnapshot, error) {
+) (TerminalPaneSnapshot, error) {
 	title, err := m.tmuxPaneTitle(ctx, session)
 	if err != nil {
-		return TmuxPaneSnapshot{}, err
+		return TerminalPaneSnapshot{}, err
 	}
 
 	cmd := m.tmuxExec(
@@ -1477,11 +1504,11 @@ func (m *Manager) TmuxPaneSnapshot(
 		if msg == "" {
 			msg = strings.TrimSpace(stdout.String())
 		}
-		return TmuxPaneSnapshot{}, fmt.Errorf(
+		return TerminalPaneSnapshot{}, fmt.Errorf(
 			"tmux capture-pane: %w: %s", err, msg,
 		)
 	}
-	return TmuxPaneSnapshot{
+	return TerminalPaneSnapshot{
 		Title:  title,
 		Output: stdout.String(),
 	}, nil

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -819,6 +819,31 @@ func TestManagerEnsureTerminalUsesPtyOwnerWhenConfigured(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 }
 
+func TestManagerTerminalPaneSnapshotIncludesPtyOwnerTitle(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	owner := &fakePtyOwnerClient{
+		SnapshotOutput: []byte("recent output"),
+		SnapshotTitle:  "⠴ t3code-b5014b03",
+	}
+	mgr := NewManager(nil, t.TempDir())
+	mgr.SetPtyOwnerClient(owner)
+	ws := &db.Workspace{
+		ID:              "ws-1",
+		TmuxSession:     "middleman-ws-1",
+		TerminalBackend: TerminalBackendPtyOwner,
+	}
+
+	snapshot, err := mgr.TerminalPaneSnapshot(
+		context.Background(), ws, ws.TmuxSession,
+	)
+
+	require.NoError(err)
+	assert.Equal("⠴ t3code-b5014b03", snapshot.Title)
+	assert.Equal("recent output", snapshot.Output)
+}
+
 func TestManagerCleanupTerminalUsesPtyOwnerForBaseSession(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -2247,9 +2272,11 @@ type fakePtyOwnerCall struct {
 }
 
 type fakePtyOwnerClient struct {
-	Calls         []fakePtyOwnerCall
-	StateExists   bool
-	StateSessions map[string]bool
+	Calls          []fakePtyOwnerCall
+	StateExists    bool
+	StateSessions  map[string]bool
+	SnapshotOutput []byte
+	SnapshotTitle  string
 }
 
 func (f *fakePtyOwnerClient) HasState(session string) bool {
@@ -2289,6 +2316,9 @@ func (f *fakePtyOwnerClient) Stop(
 func (f *fakePtyOwnerClient) Snapshot(
 	context.Context,
 	string,
-) ([]byte, error) {
-	return nil, nil
+) (ptyowner.Status, error) {
+	return ptyowner.Status{
+		Output: f.SnapshotOutput,
+		Title:  f.SnapshotTitle,
+	}, nil
 }

--- a/internal/workspace/terminal_backend.go
+++ b/internal/workspace/terminal_backend.go
@@ -23,7 +23,7 @@ type PtyOwnerClient interface {
 		rows int,
 	) (*ptyowner.Attachment, error)
 	Stop(ctx context.Context, session string) error
-	Snapshot(ctx context.Context, session string) ([]byte, error)
+	Snapshot(ctx context.Context, session string) (ptyowner.Status, error)
 }
 
 func (m *Manager) SetPtyOwnerClient(client PtyOwnerClient) {

--- a/rust/pty-manager/Cargo.toml
+++ b/rust/pty-manager/Cargo.toml
@@ -12,3 +12,11 @@ rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_System_Threading",
+] }

--- a/rust/pty-manager/src/main.rs
+++ b/rust/pty-manager/src/main.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::env;
+#[cfg(windows)]
+use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 #[cfg(windows)]
@@ -140,6 +142,7 @@ struct Shared {
     attached: bool,
     exited: bool,
     reader_done: bool,
+    stopping: bool,
     exit_code: i32,
 }
 
@@ -367,6 +370,7 @@ fn handle_conn(
         }
         "stop" => {
             write_response(&mut response_stream, ok())?;
+            mark_stopping(&shared);
             let _ = killer.kill();
         }
         "input" => {
@@ -500,6 +504,7 @@ fn handle_attach(
                 resize_pty(&runtime.master, req.cols, req.rows);
             }
             "stop" => {
+                mark_stopping(&runtime.shared);
                 let _ = killer.kill();
             }
             _ => {}
@@ -715,7 +720,16 @@ fn add_subscriber(shared: &mut Shared, tx: mpsc::SyncSender<Vec<u8>>) -> u64 {
 
 fn owner_complete(shared: &Arc<Mutex<Shared>>) -> bool {
     let shared = shared.lock().expect("shared poisoned");
-    shared.exited && shared.reader_done
+    shared.stopping || (shared.exited && shared.reader_done)
+}
+
+fn mark_stopping(shared: &Arc<Mutex<Shared>>) {
+    let subscribers = {
+        let mut shared = shared.lock().expect("shared poisoned");
+        shared.stopping = true;
+        std::mem::take(&mut shared.subscribers)
+    };
+    drop(subscribers);
 }
 
 fn mark_child_exited(shared: &Arc<Mutex<Shared>>, exit_code: i32) {
@@ -832,18 +846,14 @@ fn private_state_file(path: &Path) -> Result<fs::File> {
 
 #[cfg(windows)]
 fn private_state_file(path: &Path) -> Result<fs::File> {
-    let file = OpenOptions::new()
+    // The session directory is created with a protected inheritable DACL, so
+    // files created inside it inherit the same current-user-only access. Calling
+    // SetFileSecurityW again for this long state-file path fails on Windows.
+    Ok(OpenOptions::new()
         .create(true)
         .truncate(true)
         .write(true)
-        .open(path)?;
-    restrict_windows_acl(path, false).with_context(|| {
-        format!(
-            "restrict permissions on pty owner state file {}",
-            path.display()
-        )
-    })?;
-    Ok(file)
+        .open(path)?)
 }
 
 fn create_private_dir(path: &Path) -> Result<()> {
@@ -981,10 +991,25 @@ fn wide_null(value: &str) -> Vec<u16> {
 
 #[cfg(windows)]
 fn wide_path_null(path: &Path) -> Vec<u16> {
-    path.as_os_str()
+    windows_acl_path(path)
         .encode_wide()
         .chain(std::iter::once(0))
         .collect()
+}
+
+#[cfg(windows)]
+fn windows_acl_path(path: &Path) -> OsString {
+    let raw = path.as_os_str().to_string_lossy();
+    if raw.starts_with(r"\\?\") || raw.starts_with(r"\??\") {
+        return path.as_os_str().to_os_string();
+    }
+    if let Some(unc) = raw.strip_prefix(r"\\") {
+        return OsString::from(format!(r"\\?\UNC\{unc}"));
+    }
+    if raw.len() >= 3 && raw.as_bytes()[1] == b':' && raw.as_bytes()[2] == b'\\' {
+        return OsString::from(format!(r"\\?\{raw}"));
+    }
+    path.as_os_str().to_os_string()
 }
 
 #[cfg(windows)]
@@ -1287,6 +1312,20 @@ mod tests {
         assert!(!paths.socket.exists());
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_acl_paths_use_extended_length_prefix() {
+        let path = Path::new(r"C:\tmp")
+            .join("long-owner-root-".repeat(8))
+            .join("middleman-abc123")
+            .join("owner.json.tmp");
+
+        assert_eq!(
+            windows_acl_path(&path).to_string_lossy(),
+            format!(r"\\?\{}", path.display())
+        );
     }
 
     #[cfg(windows)]

--- a/rust/pty-manager/src/main.rs
+++ b/rust/pty-manager/src/main.rs
@@ -10,13 +10,34 @@ use std::collections::HashMap;
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
+#[cfg(windows)]
+use std::net::{TcpListener, TcpStream};
+#[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+#[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+#[cfg(windows)]
+use std::ptr;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, LocalFree};
+#[cfg(windows)]
+use windows_sys::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+};
+#[cfg(windows)]
+use windows_sys::Win32::Security::{
+    DACL_SECURITY_INFORMATION, GetTokenInformation, PROTECTED_DACL_SECURITY_INFORMATION,
+    PSECURITY_DESCRIPTOR, SetFileSecurityW, TOKEN_QUERY, TOKEN_USER, TokenUser,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
 const MAX_OUTPUT_REPLAY: usize = 64 * 1024;
 const MAX_OWNER_FIRST_REQUEST_SIZE: usize = 8 * 1024;
@@ -24,6 +45,15 @@ const MAX_OWNER_REQUEST_SIZE: usize = 96 * 1024;
 const MAX_OWNER_INPUT_SIZE: usize = 64 * 1024;
 const MAX_UNIX_SOCKET_PATH_LEN: usize = 100;
 const SUBSCRIBER_CHANNEL_CAPACITY: usize = 64;
+
+#[cfg(windows)]
+type OwnerListener = TcpListener;
+#[cfg(unix)]
+type OwnerListener = UnixListener;
+#[cfg(windows)]
+type OwnerStream = TcpStream;
+#[cfg(unix)]
+type OwnerStream = UnixStream;
 
 #[derive(Debug, Default)]
 struct Args {
@@ -96,11 +126,15 @@ struct Response<'a> {
         serialize_with = "serialize_base64_bytes"
     )]
     output: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
 }
 
 #[derive(Default)]
 struct Shared {
     output: Vec<u8>,
+    title: Option<String>,
+    title_parser: TitleParserState,
     subscribers: Vec<Subscriber>,
     next_subscriber_id: u64,
     attached: bool,
@@ -181,12 +215,9 @@ fn run_owner(args: Args) -> Result<()> {
     if let Some(socket_dir) = &paths.socket_dir {
         create_private_dir(socket_dir).context("create fallback socket dir")?;
     }
-    let _ = fs::remove_file(&paths.socket);
     let mut cleanup = OwnerCleanup::new(paths.clone());
 
-    let listener = UnixListener::bind(&paths.socket)
-        .with_context(|| format!("listen on {}", paths.socket.display()))?;
-    listener.set_nonblocking(true)?;
+    let (listener, listener_addr) = bind_owner_listener(&paths)?;
 
     let pty_system = native_pty_system();
     let pair = pty_system
@@ -221,7 +252,7 @@ fn run_owner(args: Args) -> Result<()> {
         &paths,
         &OwnerState {
             session: &args.session,
-            addr: format!("unix://{}", paths.socket.display()),
+            addr: listener_addr,
             token: &token,
             cwd: &cwd_string,
             pid: std::process::id(),
@@ -235,12 +266,24 @@ fn run_owner(args: Args) -> Result<()> {
     }));
 
     let reader_shared = Arc::clone(&shared);
+    let reader_writer = Arc::clone(&writer);
     thread::spawn(move || {
         let mut buf = [0_u8; 32 * 1024];
+        let mut terminal_response_state = TerminalResponseState::default();
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => break,
-                Ok(n) => broadcast(&reader_shared, &buf[..n]),
+                Ok(n) => {
+                    let chunk = &buf[..n];
+                    if let Some(response) =
+                        terminal_response_for_output(&mut terminal_response_state, chunk)
+                        && let Ok(mut writer) = reader_writer.lock()
+                    {
+                        let _ = writer.write_all(response);
+                        let _ = writer.flush();
+                    }
+                    broadcast(&reader_shared, chunk);
+                }
             }
         }
         mark_reader_done(&reader_shared);
@@ -283,7 +326,7 @@ fn run_owner(args: Args) -> Result<()> {
 }
 
 fn handle_conn(
-    stream: UnixStream,
+    stream: OwnerStream,
     token: &str,
     shared: Arc<Mutex<Shared>>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
@@ -305,6 +348,7 @@ fn handle_conn(
                 error: Some("invalid pty owner token".to_string()),
                 exit_code: None,
                 output: Vec::new(),
+                title: None,
             },
         )?;
         return Ok(());
@@ -312,8 +356,14 @@ fn handle_conn(
 
     match first.kind.as_str() {
         "status" => {
-            let output = shared.lock().expect("shared poisoned").output.clone();
-            write_response(&mut response_stream, ok_with_output(output))?;
+            let (output, title) = {
+                let shared = shared.lock().expect("shared poisoned");
+                (shared.output.clone(), shared.title.clone())
+            };
+            write_response(
+                &mut response_stream,
+                ok_with_output_and_title(output, title),
+            )?;
         }
         "stop" => {
             write_response(&mut response_stream, ok())?;
@@ -352,6 +402,7 @@ fn handle_conn(
                     error: Some("unknown pty owner request".to_string()),
                     exit_code: None,
                     output: Vec::new(),
+                    title: None,
                 },
             )?;
         }
@@ -360,8 +411,8 @@ fn handle_conn(
 }
 
 fn handle_attach(
-    mut stream: UnixStream,
-    mut reader: BufReader<UnixStream>,
+    mut stream: OwnerStream,
+    mut reader: BufReader<OwnerStream>,
     token: &str,
     first: Request,
     runtime: AttachRuntime,
@@ -379,6 +430,7 @@ fn handle_attach(
                     error: Some("pty owner already has an active attachment".to_string()),
                     exit_code: None,
                     output: Vec::new(),
+                    title: None,
                 },
             )?;
             return Ok(());
@@ -503,6 +555,10 @@ fn broadcast(shared: &Arc<Mutex<Shared>>, data: &[u8]) {
     let chunk = data.to_vec();
     let subscribers = {
         let mut shared = shared.lock().expect("shared poisoned");
+        let title = update_terminal_title(&mut shared.title_parser, data);
+        if title.is_some() {
+            shared.title = title;
+        }
         shared.output.extend_from_slice(data);
         if shared.output.len() > MAX_OUTPUT_REPLAY {
             let extra = shared.output.len() - MAX_OUTPUT_REPLAY;
@@ -526,6 +582,124 @@ fn broadcast(shared: &Arc<Mutex<Shared>>, data: &[u8]) {
             .subscribers
             .retain(|subscriber| !failed_ids.contains(&subscriber.id));
     }
+}
+
+#[derive(Debug, Default)]
+struct TitleParserState {
+    pending: Vec<u8>,
+}
+
+const TITLE_PENDING_LIMIT: usize = 4096;
+
+fn update_terminal_title(state: &mut TitleParserState, data: &[u8]) -> Option<String> {
+    if data.is_empty() && state.pending.is_empty() {
+        return None;
+    }
+
+    let mut buf = Vec::with_capacity(state.pending.len() + data.len());
+    buf.extend_from_slice(&state.pending);
+    buf.extend_from_slice(data);
+
+    let (title, consumed) = parse_terminal_title(&buf);
+    if consumed < buf.len() {
+        state.pending = buf[consumed..].to_vec();
+        if state.pending.len() > TITLE_PENDING_LIMIT {
+            state
+                .pending
+                .drain(0..state.pending.len() - TITLE_PENDING_LIMIT);
+        }
+    } else {
+        state.pending.clear();
+    }
+    title
+}
+
+fn parse_terminal_title(data: &[u8]) -> (Option<String>, usize) {
+    let mut title = None;
+    let mut consumed = 0;
+    let mut i = 0;
+    while i < data.len() {
+        if data[i] == 0x1b && i + 1 >= data.len() {
+            return (title, i);
+        }
+        if data[i] != 0x1b || data[i + 1] != b']' {
+            consumed = i + 1;
+            i += 1;
+            continue;
+        }
+
+        let seq_start = i;
+        let payload_start = i + 2;
+        let mut terminator_start = None;
+        let mut terminator_end = None;
+        let mut j = payload_start;
+        while j < data.len() {
+            if data[j] == 0x07 {
+                terminator_start = Some(j);
+                terminator_end = Some(j + 1);
+                break;
+            }
+            if data[j] == 0x1b && j + 1 < data.len() && data[j + 1] == b'\\' {
+                terminator_start = Some(j);
+                terminator_end = Some(j + 2);
+                break;
+            }
+            j += 1;
+        }
+
+        let Some(term_start) = terminator_start else {
+            return (title, seq_start);
+        };
+        let term_end = terminator_end.expect("terminal title terminator end");
+        if let Some((code, value)) = split_osc_payload(&data[payload_start..term_start])
+            && matches!(code, "0" | "1" | "2")
+        {
+            title = Some(value.trim().to_string());
+        }
+        consumed = term_end;
+        i = term_end;
+    }
+    (title, consumed)
+}
+
+fn split_osc_payload(payload: &[u8]) -> Option<(&str, String)> {
+    let semicolon = payload.iter().position(|byte| *byte == b';')?;
+    let code = std::str::from_utf8(&payload[..semicolon]).ok()?;
+    let value = String::from_utf8_lossy(&payload[semicolon + 1..]).to_string();
+    Some((code, value))
+}
+
+#[derive(Default)]
+struct TerminalResponseState {
+    #[cfg(windows)]
+    pending: Vec<u8>,
+}
+
+#[cfg(windows)]
+fn terminal_response_for_output(
+    state: &mut TerminalResponseState,
+    data: &[u8],
+) -> Option<&'static [u8]> {
+    let mut combined = Vec::with_capacity(state.pending.len() + data.len());
+    combined.extend_from_slice(&state.pending);
+    combined.extend_from_slice(data);
+
+    state.pending.clear();
+    let pending_start = combined.len().saturating_sub(3);
+    state.pending.extend_from_slice(&combined[pending_start..]);
+
+    if combined.windows(4).any(|window| window == b"\x1b[6n") {
+        return Some(b"\x1b[1;1R");
+    }
+    None
+}
+
+#[cfg(not(windows))]
+fn terminal_response_for_output(
+    _state: &mut TerminalResponseState,
+    _data: &[u8],
+) -> Option<&'static [u8]> {
+    None
 }
 
 fn new_subscriber_channel() -> (mpsc::SyncSender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
@@ -578,16 +752,22 @@ fn ok<'a>() -> Response<'a> {
         error: None,
         exit_code: None,
         output: Vec::new(),
+        title: None,
     }
 }
 
 fn ok_with_output<'a>(output: Vec<u8>) -> Response<'a> {
+    ok_with_output_and_title(output, None)
+}
+
+fn ok_with_output_and_title<'a>(output: Vec<u8>, title: Option<String>) -> Response<'a> {
     Response {
         kind: "output",
         ok: true,
         error: None,
         exit_code: None,
         output,
+        title,
     }
 }
 
@@ -598,38 +778,223 @@ fn exit<'a>(exit_code: i32) -> Response<'a> {
         error: None,
         exit_code: Some(exit_code),
         output: Vec::new(),
+        title: None,
     }
 }
 
-fn write_response(stream: &mut UnixStream, response: Response<'_>) -> Result<()> {
+fn write_response(stream: &mut OwnerStream, response: Response<'_>) -> Result<()> {
     serde_json::to_writer(&mut *stream, &response)?;
     stream.write_all(b"\n")?;
     stream.flush()?;
     Ok(())
 }
 
+#[cfg(unix)]
+fn bind_owner_listener(paths: &SessionPaths) -> Result<(OwnerListener, String)> {
+    let _ = fs::remove_file(&paths.socket);
+    let listener = UnixListener::bind(&paths.socket)
+        .with_context(|| format!("listen on {}", paths.socket.display()))?;
+    listener.set_nonblocking(true)?;
+    Ok((listener, format!("unix://{}", paths.socket.display())))
+}
+
+#[cfg(windows)]
+fn bind_owner_listener(_paths: &SessionPaths) -> Result<(OwnerListener, String)> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).context("listen on tcp loopback")?;
+    listener.set_nonblocking(true)?;
+    let addr = listener.local_addr().context("read tcp listener address")?;
+    Ok((listener, format!("tcp://{addr}")))
+}
+
 fn write_state(paths: &SessionPaths, state: &OwnerState<'_>) -> Result<()> {
     let data = serde_json::to_vec_pretty(state)?;
     let tmp = paths.state_path.with_extension("json.tmp");
     {
-        let mut file = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .mode(0o600)
-            .open(&tmp)?;
+        let mut file = private_state_file(&tmp)?;
         file.write_all(&data)?;
         file.sync_all()?;
     }
     fs::rename(tmp, &paths.state_path)?;
+    #[cfg(unix)]
     fs::set_permissions(&paths.state_path, fs::Permissions::from_mode(0o600))?;
     Ok(())
 }
 
+#[cfg(unix)]
+fn private_state_file(path: &Path) -> Result<fs::File> {
+    Ok(OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?)
+}
+
+#[cfg(windows)]
+fn private_state_file(path: &Path) -> Result<fs::File> {
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
+    restrict_windows_acl(path, false).with_context(|| {
+        format!(
+            "restrict permissions on pty owner state file {}",
+            path.display()
+        )
+    })?;
+    Ok(file)
+}
+
 fn create_private_dir(path: &Path) -> Result<()> {
     fs::create_dir_all(path)?;
+    #[cfg(unix)]
     fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    #[cfg(windows)]
+    restrict_windows_acl(path, true).with_context(|| {
+        format!(
+            "restrict permissions on pty owner state directory {}",
+            path.display()
+        )
+    })?;
     Ok(())
+}
+
+#[cfg(windows)]
+fn restrict_windows_acl(path: &Path, directory: bool) -> Result<()> {
+    let current_user_sid = current_user_sid_string()?;
+    let sddl = private_windows_sddl(&current_user_sid, directory);
+    let sddl_wide = wide_null(&sddl);
+    let path_wide = wide_path_null(path);
+    let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
+
+    // SAFETY: `sddl_wide` and `path_wide` are nul-terminated UTF-16 buffers
+    // that live for the duration of the FFI calls. Windows allocates the
+    // descriptor for the SDDL conversion, and we release it with LocalFree.
+    unsafe {
+        if ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_wide.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            ptr::null_mut(),
+        ) == 0
+        {
+            bail!(
+                "build private security descriptor for {}: windows error {}",
+                path.display(),
+                GetLastError()
+            );
+        }
+
+        let security_info = DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION;
+        let ok = SetFileSecurityW(path_wide.as_ptr(), security_info, descriptor);
+        let err = GetLastError();
+        let _ = LocalFree(descriptor as _);
+        if ok == 0 {
+            bail!(
+                "apply private security descriptor to {}: windows error {}",
+                path.display(),
+                err
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn private_windows_sddl(current_user_sid: &str, directory: bool) -> String {
+    let inheritance = if directory { "OICI" } else { "" };
+    format!("D:P(A;{inheritance};FA;;;{current_user_sid})")
+}
+
+#[cfg(windows)]
+fn current_user_sid_string() -> Result<String> {
+    let mut token = ptr::null_mut();
+    // SAFETY: GetCurrentProcess returns a pseudo-handle. OpenProcessToken writes
+    // a real token handle into `token`, which we close before returning.
+    unsafe {
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            bail!("open process token: windows error {}", GetLastError());
+        }
+    }
+    let _guard = HandleGuard(token);
+
+    let mut needed = 0;
+    // SAFETY: First call asks Windows for the required buffer size.
+    unsafe {
+        let _ = GetTokenInformation(token, TokenUser, ptr::null_mut(), 0, &mut needed);
+    }
+    if needed == 0 {
+        // SAFETY: GetLastError reads thread-local Windows error state.
+        unsafe {
+            bail!(
+                "query current user token size: windows error {}",
+                GetLastError()
+            );
+        }
+    }
+
+    let mut buffer = vec![0_u8; needed as usize];
+    // SAFETY: `buffer` is sized from the previous GetTokenInformation call and
+    // is valid for writes of `needed` bytes.
+    unsafe {
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            needed,
+            &mut needed,
+        ) == 0
+        {
+            bail!("query current user token: windows error {}", GetLastError());
+        }
+
+        let user = &*(buffer.as_ptr().cast::<TOKEN_USER>());
+        let mut sid_ptr = ptr::null_mut();
+        if ConvertSidToStringSidW(user.User.Sid, &mut sid_ptr) == 0 {
+            bail!("convert current user SID: windows error {}", GetLastError());
+        }
+        let sid = wide_ptr_to_string(sid_ptr);
+        let _ = LocalFree(sid_ptr as _);
+        Ok(sid)
+    }
+}
+
+#[cfg(windows)]
+struct HandleGuard(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for HandleGuard {
+    fn drop(&mut self) {
+        // SAFETY: HandleGuard owns this handle after successful OpenProcessToken.
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn wide_null(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(windows)]
+fn wide_path_null(path: &Path) -> Vec<u16> {
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(windows)]
+unsafe fn wide_ptr_to_string(ptr: windows_sys::core::PWSTR) -> String {
+    let mut len = 0;
+    while unsafe { *ptr.add(len) } != 0 {
+        len += 1;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    String::from_utf16_lossy(slice)
 }
 
 impl OwnerCleanup {
@@ -676,7 +1041,7 @@ impl Drop for ActiveAttachment {
 
 fn session_paths(root: &Path, session: &str) -> Result<SessionPaths> {
     validate_session_name(session)?;
-    let dir = root.join(session);
+    let dir = root.join(session_dir_name(session));
     let mut socket = root.join(format!("sock-{}", socket_hash(session)));
     let mut socket_dir = None;
     if socket.to_string_lossy().len() > MAX_UNIX_SOCKET_PATH_LEN {
@@ -694,6 +1059,14 @@ fn session_paths(root: &Path, session: &str) -> Result<SessionPaths> {
         socket,
         socket_dir,
     })
+}
+
+fn session_dir_name(session: &str) -> String {
+    if session.contains(['<', '>', ':', '"', '|', '?', '*']) {
+        format!("session-{}", socket_hash(session))
+    } else {
+        session.to_string()
+    }
 }
 
 fn ensure_socket_path_fits(socket: &Path) -> Result<()> {
@@ -872,6 +1245,15 @@ mod tests {
     }
 
     #[test]
+    fn paths_hash_filesystem_hostile_sessions() {
+        let paths = session_paths(Path::new("/tmp/root"), "ws-1:codex").unwrap();
+        let dir = Path::new("/tmp/root").join("session-8dc56ff7cc3fbfcb");
+
+        assert_eq!(paths.dir, dir);
+        assert_eq!(paths.state_path, dir.join("owner.json"));
+    }
+
+    #[test]
     fn paths_use_private_temp_socket_dir_for_long_roots() {
         let root = PathBuf::from("/tmp").join("x".repeat(MAX_UNIX_SOCKET_PATH_LEN));
 
@@ -892,6 +1274,45 @@ mod tests {
         assert!(paths.socket.to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn owner_listener_uses_tcp_loopback_on_windows() {
+        let root = env::temp_dir().join(format!("mm-pty-listener-test-{}", new_token()));
+        let paths = session_paths(&root, "middleman-abc123").unwrap();
+        create_private_dir(&paths.dir).unwrap();
+
+        let (_listener, addr) = bind_owner_listener(&paths).unwrap();
+
+        assert!(addr.starts_with("tcp://127.0.0.1:"));
+        assert!(!paths.socket.exists());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn conpty_cursor_position_requests_get_default_response() {
+        let mut state = TerminalResponseState::default();
+        assert_eq!(
+            terminal_response_for_output(&mut state, b"\x1b[6n"),
+            Some(&b"\x1b[1;1R"[..])
+        );
+        assert_eq!(terminal_response_for_output(&mut state, b"ready"), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn conpty_cursor_position_requests_can_span_reads() {
+        let mut state = TerminalResponseState::default();
+        assert_eq!(terminal_response_for_output(&mut state, b"abc\x1b"), None);
+        assert_eq!(terminal_response_for_output(&mut state, b"[6"), None);
+        assert_eq!(
+            terminal_response_for_output(&mut state, b"nxyz"),
+            Some(&b"\x1b[1;1R"[..])
+        );
+    }
+
+    #[cfg(unix)]
     #[test]
     fn state_files_are_private() {
         let root = Path::new("/tmp").join(format!("mm-pty-test-{}", new_token()));
@@ -1020,5 +1441,37 @@ mod tests {
             .map(|subscriber| subscriber.id)
             .collect();
         assert_eq!(remaining_ids, vec![2]);
+    }
+
+    #[test]
+    fn terminal_title_parser_updates_from_osc_sequences() {
+        let mut state = TitleParserState::default();
+
+        assert_eq!(
+            update_terminal_title(&mut state, b"before\x1b]0;busy title\x07after"),
+            Some("busy title".to_string())
+        );
+    }
+
+    #[test]
+    fn terminal_title_parser_handles_split_st_sequences() {
+        let mut state = TitleParserState::default();
+
+        assert_eq!(update_terminal_title(&mut state, b"\x1b]2;split"), None);
+        assert_eq!(
+            update_terminal_title(&mut state, b" title\x1b\\tail"),
+            Some("split title".to_string())
+        );
+    }
+
+    #[test]
+    fn terminal_title_parser_handles_split_escape_prefix() {
+        let mut state = TitleParserState::default();
+
+        assert_eq!(update_terminal_title(&mut state, b"\x1b"), None);
+        assert_eq!(
+            update_terminal_title(&mut state, b"]0;edge title\x07"),
+            Some("edge title".to_string())
+        );
     }
 }


### PR DESCRIPTION
- Use TCP loopback for the Rust PTY manager control channel on Windows. - Answer ConPTY cursor-position probes so shell startup can continue. - Reconcile the stacked localruntime process-kill helper with the process-compose branch.