### PR TITLE
Make PR/issue description checkboxes clickable and reorderable

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -545,6 +545,36 @@ components:
       required:
         - body
       type: object
+    EditIssueContentHostInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/EditIssueContentHostInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        body:
+          type: string
+        title:
+          type: string
+      type: object
+    EditIssueContentInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/EditIssueContentInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        body:
+          type: string
+        title:
+          type: string
+      type: object
     EditPRContentHostInputBody:
       additionalProperties: false
       properties:
@@ -2987,6 +3017,54 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Get host by platform host issues by provider by owner by name by number
+    patch:
+      operationId: edit-issue-content-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EditIssueContentHostInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IssueDetailResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-issue-comment-on-host
@@ -4487,6 +4565,49 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Get issues by provider by owner by name by number
+    patch:
+      operationId: edit-issue-content
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EditIssueContentInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IssueDetailResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
   /issues/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-issue-comment

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -338,14 +338,26 @@ a:hover {
   list-style: none;
   padding-left: 0;
 }
+/* The <li> is a flex row so the checkbox aligns with the first line of
+   the label, but `flex-wrap: wrap` plus `flex-basis: 100%` on nested
+   lists pushes them onto their own row — otherwise a nested `<ul>` or
+   `<ol>` would render as a flex row sibling of the checkbox and
+   collapse the visible hierarchy. */
 .markdown-body .task-list-item {
   position: relative;
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
-  gap: 6px;
+  column-gap: 6px;
+  row-gap: 0;
   padding: 1px 4px 1px 22px;
   margin: 0;
   border-radius: var(--radius-sm);
+}
+.markdown-body .task-list-item > ul,
+.markdown-body .task-list-item > ol {
+  flex-basis: 100%;
+  margin: 0;
 }
 .markdown-body .task-list-item input[type="checkbox"] {
   margin: 0 4px 0 0;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -329,6 +329,79 @@ a:hover {
   background: color-mix(in srgb, var(--bg-surface-hover) 42%, transparent);
 }
 
+/* GFM task lists. Non-interactive items keep the default flow; the
+   interactive variant gets a hover-revealed drag handle, an enabled
+   checkbox, and a drop indicator when another item is being dragged
+   over it. */
+.markdown-body ul:has(> .task-list-item),
+.markdown-body ol:has(> .task-list-item) {
+  list-style: none;
+  padding-left: 0;
+}
+.markdown-body .task-list-item {
+  position: relative;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 1px 4px 1px 22px;
+  margin: 0;
+  border-radius: var(--radius-sm);
+}
+.markdown-body .task-list-item input[type="checkbox"] {
+  margin: 0 4px 0 0;
+  flex-shrink: 0;
+  cursor: default;
+}
+.markdown-body .task-list-item--interactive input[type="checkbox"] {
+  cursor: pointer;
+}
+.markdown-body .task-drag-handle {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 3px;
+  color: var(--text-muted);
+  opacity: 0;
+  cursor: grab;
+  transition: opacity 0.12s, background 0.12s;
+  user-select: none;
+}
+.markdown-body .task-list-item--interactive:hover .task-drag-handle,
+.markdown-body .task-drag-handle:focus-visible {
+  opacity: 0.7;
+}
+.markdown-body .task-drag-handle:hover {
+  opacity: 1 !important;
+  background: var(--bg-surface-hover);
+  color: var(--text-secondary);
+}
+.markdown-body .task-drag-handle:active {
+  cursor: grabbing;
+}
+.markdown-body.dragging .task-list-item--interactive {
+  transition: padding-top 0.08s, padding-bottom 0.08s;
+}
+.markdown-body.dragging
+  .task-list-item--interactive.task-drop-before {
+  box-shadow: inset 0 2px 0 0 var(--accent-blue);
+}
+.markdown-body.dragging
+  .task-list-item--interactive.task-drop-after {
+  box-shadow: inset 0 -2px 0 0 var(--accent-blue);
+}
+@media (hover: none) {
+  /* Touch devices: always show the handle since there's no hover. */
+  .markdown-body .task-drag-handle {
+    opacity: 0.7;
+  }
+}
+
 /* Item reference links (#123, owner/repo#456) */
 a.item-ref {
   color: var(--text-link, var(--accent-blue));

--- a/frontend/tests/e2e-full/description-task-list.spec.ts
+++ b/frontend/tests/e2e-full/description-task-list.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+
+// Honor PLAYWRIGHT_CHROMIUM_BINARY when set so contributors on systems
+// where Playwright's bundled Chromium can't launch (missing host libs)
+// can point at a system Chromium. CI uses the bundled binary.
+const chromiumBinary = process.env.PLAYWRIGHT_CHROMIUM_BINARY;
+if (chromiumBinary) {
+  test.use({ launchOptions: { executablePath: chromiumBinary } });
+}
+
+// Run sequentially: each test mutates the shared fixture body, so a
+// parallel run would race on the same upstream PR state.
+test.describe.serial("PR description task list", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/pulls/github/acme/widgets/1");
+    await page
+      .locator(".pull-detail")
+      .waitFor({ state: "visible", timeout: 15_000 });
+    await page
+      .locator(".body-section .markdown-body")
+      .waitFor({ state: "visible" });
+    // Give the page-load background sync time to settle so it can't
+    // race with our optimistic click and clobber the local body.
+    await page.waitForTimeout(1500);
+  });
+
+  test("checkbox clicks toggle locally and persist on reload", async ({
+    page,
+  }) => {
+    const body = page.locator(".body-section .markdown-body");
+    const cb0 = body.locator('input[type="checkbox"][data-task-index="0"]');
+    const cb1 = body.locator('input[type="checkbox"][data-task-index="1"]');
+
+    await expect(cb0).not.toBeChecked();
+    await cb0.click();
+    await expect(cb0).toBeChecked();
+    await cb1.click();
+    await expect(cb1).toBeChecked();
+
+    // Allow the debounced PATCH (~400ms) to land.
+    await page.waitForTimeout(900);
+    await page.reload();
+    const reloadedBody = page.locator(".body-section .markdown-body");
+    await reloadedBody.waitFor({ state: "visible" });
+
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="0"]'),
+    ).toBeChecked();
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="1"]'),
+    ).toBeChecked();
+  });
+
+  test("drag handle reorders a task item and persists on reload", async ({
+    page,
+  }) => {
+    const body = page.locator(".body-section .markdown-body");
+    const firstLabel = await body
+      .locator('.task-list-item--interactive[data-task-index="0"]')
+      .textContent();
+    expect(firstLabel ?? "").toMatch(/Cmd\+K/);
+
+    const handle0 = body.locator(
+      '.task-drag-handle[data-task-index="0"]',
+    );
+    const item2 = body.locator(
+      '.task-list-item--interactive[data-task-index="2"]',
+    );
+    const handleBox = await handle0.boundingBox();
+    const targetBox = await item2.boundingBox();
+    if (!handleBox || !targetBox) {
+      throw new Error("missing bounding boxes for drag");
+    }
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+    const targetX = targetBox.x + 20;
+    // Below the midpoint -> "drop after" so the item lands at index 2.
+    const targetY = targetBox.y + targetBox.height * 0.85;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    const steps = 8;
+    for (let i = 1; i <= steps; i++) {
+      await page.mouse.move(
+        startX + ((targetX - startX) * i) / steps,
+        startY + ((targetY - startY) * i) / steps,
+        { steps: 4 },
+      );
+    }
+    await page.mouse.up();
+
+    await page.waitForTimeout(900);
+    await page.reload();
+    const reloadedBody = page.locator(".body-section .markdown-body");
+    await reloadedBody.waitFor({ state: "visible" });
+
+    // The originally-first item ("Cmd+K …") now sits at index 2 after
+    // the drag; the originally-second item ("Tab/Shift+Tab …") is now
+    // at index 0.
+    const slot0 = await reloadedBody
+      .locator('.task-list-item--interactive[data-task-index="0"]')
+      .textContent();
+    const slot2 = await reloadedBody
+      .locator('.task-list-item--interactive[data-task-index="2"]')
+      .textContent();
+    expect(slot0 ?? "").toMatch(/Tab\/Shift\+Tab/);
+    expect(slot2 ?? "").toMatch(/Cmd\+K/);
+  });
+});

--- a/frontend/tests/e2e-full/description-task-list.spec.ts
+++ b/frontend/tests/e2e-full/description-task-list.spec.ts
@@ -105,4 +105,76 @@ test.describe.serial("PR description task list", () => {
     expect(slot0 ?? "").toMatch(/Tab\/Shift\+Tab/);
     expect(slot2 ?? "").toMatch(/Cmd\+K/);
   });
+
+  test("queued body save wins when an older PATCH finishes after a newer click", async ({
+    page,
+  }) => {
+    // Hold the first PATCH response so we can queue a newer body
+    // while it's in flight. This exercises the single-flight body-
+    // save queue: out-of-order responses must NOT clobber the
+    // newer body, and the final persisted body must include both
+    // toggles.
+    const body = page.locator(".body-section .markdown-body");
+    const cb0 = body.locator('input[type="checkbox"][data-task-index="0"]');
+    const cb1 = body.locator('input[type="checkbox"][data-task-index="1"]');
+    const cb0Initial = await cb0.isChecked();
+    const cb1Initial = await cb1.isChecked();
+
+    let patchCount = 0;
+    let releaseFirstPatch: () => void = () => undefined;
+    const firstPatchHeld = new Promise<void>((resolve) => {
+      releaseFirstPatch = resolve;
+    });
+    const patchRoute = /\/api\/v1\/pulls\/[^/]+\/[^/]+\/[^/]+\/1$/;
+    await page.route(patchRoute, async (route) => {
+      if (route.request().method() !== "PATCH") {
+        await route.fallback();
+        return;
+      }
+      patchCount++;
+      if (patchCount === 1) {
+        await firstPatchHeld;
+      }
+      await route.continue();
+    });
+
+    // Toggle the first checkbox; debounce fires and starts PATCH A
+    // (which the route intercept holds).
+    await cb0.click();
+    await expect(cb0).toBeChecked({ checked: !cb0Initial });
+    // Wait past the 400ms debounce so PATCH A has been dispatched
+    // and is now blocked on firstPatchHeld.
+    await expect
+      .poll(() => patchCount, { timeout: 3_000 })
+      .toBe(1);
+
+    // Toggle the second checkbox while PATCH A is in flight. Its
+    // debounced save lands in the per-target queue, holding the
+    // body with BOTH toggles.
+    await cb1.click();
+    await expect(cb1).toBeChecked({ checked: !cb1Initial });
+    // Give the debounce a chance to fire and queue PATCH B. The
+    // queue must hold it back until A returns.
+    await page.waitForTimeout(800);
+    expect(patchCount).toBe(1);
+
+    // Release PATCH A. The queue then drains and fires PATCH B
+    // with the latest body (both toggles).
+    releaseFirstPatch();
+    await expect.poll(() => patchCount, { timeout: 5_000 }).toBe(2);
+
+    // Reload and confirm BOTH toggles persisted server-side. If
+    // serialization regressed (PATCH A overwrote B's body via an
+    // out-of-order response), the second checkbox would revert.
+    await page.unroute(patchRoute);
+    await page.reload();
+    const reloadedBody = page.locator(".body-section .markdown-body");
+    await reloadedBody.waitFor({ state: "visible" });
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="0"]'),
+    ).toBeChecked({ checked: !cb0Initial });
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="1"]'),
+    ).toBeChecked({ checked: !cb1Initial });
+  });
 });

--- a/frontend/tests/e2e-full/description-task-list.spec.ts
+++ b/frontend/tests/e2e-full/description-task-list.spec.ts
@@ -120,7 +120,7 @@ test.describe.serial("PR description task list", () => {
     const cb0Initial = await cb0.isChecked();
     const cb1Initial = await cb1.isChecked();
 
-    let patchCount = 0;
+    let patchRequests = 0;
     let releaseFirstPatch: () => void = () => undefined;
     const firstPatchHeld = new Promise<void>((resolve) => {
       releaseFirstPatch = resolve;
@@ -131,12 +131,25 @@ test.describe.serial("PR description task list", () => {
         await route.fallback();
         return;
       }
-      patchCount++;
-      if (patchCount === 1) {
+      patchRequests++;
+      if (patchRequests === 1) {
         await firstPatchHeld;
       }
       await route.continue();
     });
+    // Separate counter for completed responses — route.continue()
+    // returns before the server replies, so request counts alone
+    // can't tell us a PATCH has actually persisted.
+    let patchResponses = 0;
+    const onResponse = (resp: import("@playwright/test").Response) => {
+      if (
+        resp.request().method() === "PATCH"
+        && patchRoute.test(resp.url())
+      ) {
+        patchResponses++;
+      }
+    };
+    page.on("response", onResponse);
 
     // Toggle the first checkbox; debounce fires and starts PATCH A
     // (which the route intercept holds).
@@ -145,7 +158,7 @@ test.describe.serial("PR description task list", () => {
     // Wait past the 400ms debounce so PATCH A has been dispatched
     // and is now blocked on firstPatchHeld.
     await expect
-      .poll(() => patchCount, { timeout: 3_000 })
+      .poll(() => patchRequests, { timeout: 3_000 })
       .toBe(1);
 
     // Toggle the second checkbox while PATCH A is in flight. Its
@@ -156,16 +169,22 @@ test.describe.serial("PR description task list", () => {
     // Give the debounce a chance to fire and queue PATCH B. The
     // queue must hold it back until A returns.
     await page.waitForTimeout(800);
-    expect(patchCount).toBe(1);
+    expect(patchRequests).toBe(1);
+    expect(patchResponses).toBe(0);
 
     // Release PATCH A. The queue then drains and fires PATCH B
-    // with the latest body (both toggles).
+    // with the latest body (both toggles). Wait for BOTH PATCH
+    // responses to come back from the server before reloading,
+    // otherwise the reload could race the second save and see
+    // stale data.
     releaseFirstPatch();
-    await expect.poll(() => patchCount, { timeout: 5_000 }).toBe(2);
+    await expect.poll(() => patchResponses, { timeout: 5_000 }).toBe(2);
+    expect(patchRequests).toBe(2);
 
     // Reload and confirm BOTH toggles persisted server-side. If
     // serialization regressed (PATCH A overwrote B's body via an
     // out-of-order response), the second checkbox would revert.
+    page.off("response", onResponse);
     await page.unroute(patchRoute);
     await page.reload();
     const reloadedBody = page.locator(".body-section .markdown-body");

--- a/frontend/tests/e2e-full/issue-task-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-task-list.spec.ts
@@ -104,4 +104,60 @@ test.describe.serial("issue description task list", () => {
     expect(slot0 ?? "").toMatch(/Manual toggle/);
     expect(slot2 ?? "").toMatch(/System preference/);
   });
+
+  test("queued body save wins when an older PATCH finishes after a newer click", async ({
+    page,
+  }) => {
+    // Hold the first PATCH response so we can queue a newer body
+    // while it's in flight. Mirrors the PR test — verifies the
+    // single-flight body-save queue for the issue path.
+    const body = page.locator(".body-section .markdown-body");
+    const cb0 = body.locator('input[type="checkbox"][data-task-index="0"]');
+    const cb1 = body.locator('input[type="checkbox"][data-task-index="1"]');
+    const cb0Initial = await cb0.isChecked();
+    const cb1Initial = await cb1.isChecked();
+
+    let patchCount = 0;
+    let releaseFirstPatch: () => void = () => undefined;
+    const firstPatchHeld = new Promise<void>((resolve) => {
+      releaseFirstPatch = resolve;
+    });
+    const patchRoute = /\/api\/v1\/issues\/[^/]+\/[^/]+\/[^/]+\/11$/;
+    await page.route(patchRoute, async (route) => {
+      if (route.request().method() !== "PATCH") {
+        await route.fallback();
+        return;
+      }
+      patchCount++;
+      if (patchCount === 1) {
+        await firstPatchHeld;
+      }
+      await route.continue();
+    });
+
+    await cb0.click();
+    await expect(cb0).toBeChecked({ checked: !cb0Initial });
+    await expect
+      .poll(() => patchCount, { timeout: 3_000 })
+      .toBe(1);
+
+    await cb1.click();
+    await expect(cb1).toBeChecked({ checked: !cb1Initial });
+    await page.waitForTimeout(800);
+    expect(patchCount).toBe(1);
+
+    releaseFirstPatch();
+    await expect.poll(() => patchCount, { timeout: 5_000 }).toBe(2);
+
+    await page.unroute(patchRoute);
+    await page.reload();
+    const reloadedBody = page.locator(".body-section .markdown-body");
+    await reloadedBody.waitFor({ state: "visible" });
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="0"]'),
+    ).toBeChecked({ checked: !cb0Initial });
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="1"]'),
+    ).toBeChecked({ checked: !cb1Initial });
+  });
 });

--- a/frontend/tests/e2e-full/issue-task-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-task-list.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+// Honor PLAYWRIGHT_CHROMIUM_BINARY when set so contributors on systems
+// where Playwright's bundled Chromium can't launch (missing host libs)
+// can point at a system Chromium. CI uses the bundled binary.
+const chromiumBinary = process.env.PLAYWRIGHT_CHROMIUM_BINARY;
+if (chromiumBinary) {
+  test.use({ launchOptions: { executablePath: chromiumBinary } });
+}
+
+// Run sequentially: each test mutates the shared fixture body, so a
+// parallel run would race on the same upstream issue state.
+test.describe.serial("issue description task list", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/issues/github/acme/widgets/11");
+    await page
+      .locator(".issue-detail")
+      .waitFor({ state: "visible", timeout: 15_000 });
+    await page
+      .locator(".body-section .markdown-body")
+      .waitFor({ state: "visible" });
+    // Give the page-load background sync time to settle so it can't
+    // race with our optimistic click and clobber the local body.
+    await page.waitForTimeout(1500);
+  });
+
+  test("checkbox clicks toggle locally and persist on reload", async ({
+    page,
+  }) => {
+    const body = page.locator(".body-section .markdown-body");
+    const cb0 = body.locator('input[type="checkbox"][data-task-index="0"]');
+    const cb1 = body.locator('input[type="checkbox"][data-task-index="1"]');
+
+    await expect(cb0).not.toBeChecked();
+    await cb0.click();
+    await expect(cb0).toBeChecked();
+    await cb1.click();
+    await expect(cb1).toBeChecked();
+
+    await page.waitForTimeout(900);
+    await page.reload();
+    const reloadedBody = page.locator(".body-section .markdown-body");
+    await reloadedBody.waitFor({ state: "visible" });
+
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="0"]'),
+    ).toBeChecked();
+    await expect(
+      reloadedBody.locator('input[type="checkbox"][data-task-index="1"]'),
+    ).toBeChecked();
+  });
+
+  test("drag handle reorders a task item and persists on reload", async ({
+    page,
+  }) => {
+    const body = page.locator(".body-section .markdown-body");
+    const firstLabel = await body
+      .locator('.task-list-item--interactive[data-task-index="0"]')
+      .textContent();
+    expect(firstLabel ?? "").toMatch(/System preference/);
+
+    const handle0 = body.locator(
+      '.task-drag-handle[data-task-index="0"]',
+    );
+    const item2 = body.locator(
+      '.task-list-item--interactive[data-task-index="2"]',
+    );
+    const handleBox = await handle0.boundingBox();
+    const targetBox = await item2.boundingBox();
+    if (!handleBox || !targetBox) {
+      throw new Error("missing bounding boxes for drag");
+    }
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+    const targetX = targetBox.x + 20;
+    // Below the midpoint -> "drop after" so the item lands at index 2.
+    const targetY = targetBox.y + targetBox.height * 0.85;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    const steps = 8;
+    for (let i = 1; i <= steps; i++) {
+      await page.mouse.move(
+        startX + ((targetX - startX) * i) / steps,
+        startY + ((targetY - startY) * i) / steps,
+        { steps: 4 },
+      );
+    }
+    await page.mouse.up();
+
+    await page.waitForTimeout(900);
+    await page.reload();
+    const reloadedBody = page.locator(".body-section .markdown-body");
+    await reloadedBody.waitFor({ state: "visible" });
+
+    // The originally-first item ("System preference …") now sits at
+    // index 2 after the drag; the originally-second item ("Manual
+    // toggle …") is now at index 0.
+    const slot0 = await reloadedBody
+      .locator('.task-list-item--interactive[data-task-index="0"]')
+      .textContent();
+    const slot2 = await reloadedBody
+      .locator('.task-list-item--interactive[data-task-index="2"]')
+      .textContent();
+    expect(slot0 ?? "").toMatch(/Manual toggle/);
+    expect(slot2 ?? "").toMatch(/System preference/);
+  });
+});

--- a/frontend/tests/e2e-full/issue-task-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-task-list.spec.ts
@@ -117,7 +117,7 @@ test.describe.serial("issue description task list", () => {
     const cb0Initial = await cb0.isChecked();
     const cb1Initial = await cb1.isChecked();
 
-    let patchCount = 0;
+    let patchRequests = 0;
     let releaseFirstPatch: () => void = () => undefined;
     const firstPatchHeld = new Promise<void>((resolve) => {
       releaseFirstPatch = resolve;
@@ -128,27 +128,46 @@ test.describe.serial("issue description task list", () => {
         await route.fallback();
         return;
       }
-      patchCount++;
-      if (patchCount === 1) {
+      patchRequests++;
+      if (patchRequests === 1) {
         await firstPatchHeld;
       }
       await route.continue();
     });
+    // Separate counter for completed responses — route.continue()
+    // returns before the server replies, so request counts alone
+    // can't tell us a PATCH has actually persisted.
+    let patchResponses = 0;
+    const onResponse = (resp: import("@playwright/test").Response) => {
+      if (
+        resp.request().method() === "PATCH"
+        && patchRoute.test(resp.url())
+      ) {
+        patchResponses++;
+      }
+    };
+    page.on("response", onResponse);
 
     await cb0.click();
     await expect(cb0).toBeChecked({ checked: !cb0Initial });
     await expect
-      .poll(() => patchCount, { timeout: 3_000 })
+      .poll(() => patchRequests, { timeout: 3_000 })
       .toBe(1);
 
     await cb1.click();
     await expect(cb1).toBeChecked({ checked: !cb1Initial });
     await page.waitForTimeout(800);
-    expect(patchCount).toBe(1);
+    expect(patchRequests).toBe(1);
+    expect(patchResponses).toBe(0);
 
+    // Release PATCH A. Wait for BOTH PATCH responses to come back
+    // from the server before reloading, so the reload doesn't race
+    // the second save.
     releaseFirstPatch();
-    await expect.poll(() => patchCount, { timeout: 5_000 }).toBe(2);
+    await expect.poll(() => patchResponses, { timeout: 5_000 }).toBe(2);
+    expect(patchRequests).toBe(2);
 
+    page.off("response", onResponse);
     await page.unroute(patchRoute);
     await page.reload();
     const reloadedBody = page.locator(".body-section .markdown-body");

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -253,6 +253,22 @@ type EditIssueCommentInputBody struct {
 	Body   string  `json:"body"`
 }
 
+// EditIssueContentHostInputBody defines model for EditIssueContentHostInputBody.
+type EditIssueContentHostInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+	Body   *string `json:"body,omitempty"`
+	Title  *string `json:"title,omitempty"`
+}
+
+// EditIssueContentInputBody defines model for EditIssueContentInputBody.
+type EditIssueContentInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+	Body   *string `json:"body,omitempty"`
+	Title  *string `json:"title,omitempty"`
+}
+
 // EditPRContentHostInputBody defines model for EditPRContentHostInputBody.
 type EditPRContentHostInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -1251,6 +1267,9 @@ type GetWorkspacesByIdFilesParams struct {
 // CreateIssueOnHostJSONRequestBody defines body for CreateIssueOnHost for application/json ContentType.
 type CreateIssueOnHostJSONRequestBody = CreateIssueHostInputBody
 
+// EditIssueContentOnHostJSONRequestBody defines body for EditIssueContentOnHost for application/json ContentType.
+type EditIssueContentOnHostJSONRequestBody = EditIssueContentHostInputBody
+
 // PostIssueCommentOnHostJSONRequestBody defines body for PostIssueCommentOnHost for application/json ContentType.
 type PostIssueCommentOnHostJSONRequestBody = PostIssueCommentHostInputBody
 
@@ -1286,6 +1305,9 @@ type SetKanbanStateOnHostJSONRequestBody = SetKanbanStateHostInputBody
 
 // CreateIssueJSONRequestBody defines body for CreateIssue for application/json ContentType.
 type CreateIssueJSONRequestBody = CreateIssueInputBody
+
+// EditIssueContentJSONRequestBody defines body for EditIssueContent for application/json ContentType.
+type EditIssueContentJSONRequestBody = EditIssueContentInputBody
 
 // PostIssueCommentJSONRequestBody defines body for PostIssueComment for application/json ContentType.
 type PostIssueCommentJSONRequestBody = PostIssueCommentInputBody
@@ -1437,6 +1459,11 @@ type ClientInterface interface {
 	// GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber request
 	GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EditIssueContentOnHostWithBody request with any body
+	EditIssueContentOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EditIssueContentOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body EditIssueContentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostIssueCommentOnHostWithBody request with any body
 	PostIssueCommentOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1556,6 +1583,11 @@ type ClientInterface interface {
 
 	// GetIssuesByProviderByOwnerByNameByNumber request
 	GetIssuesByProviderByOwnerByNameByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EditIssueContentWithBody request with any body
+	EditIssueContentWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EditIssueContent(ctx context.Context, provider string, owner string, name string, number int64, body EditIssueContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostIssueCommentWithBody request with any body
 	PostIssueCommentWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1836,6 +1868,30 @@ func (c *Client) CreateIssueOnHost(ctx context.Context, platformHost string, pro
 
 func (c *Client) GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberRequest(c.Server, platformHost, provider, owner, name, number)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditIssueContentOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditIssueContentOnHostRequestWithBody(c.Server, platformHost, provider, owner, name, number, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditIssueContentOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body EditIssueContentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditIssueContentOnHostRequest(c.Server, platformHost, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2364,6 +2420,30 @@ func (c *Client) CreateIssue(ctx context.Context, provider string, owner string,
 
 func (c *Client) GetIssuesByProviderByOwnerByNameByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetIssuesByProviderByOwnerByNameByNumberRequest(c.Server, provider, owner, name, number)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditIssueContentWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditIssueContentRequestWithBody(c.Server, provider, owner, name, number, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditIssueContent(ctx context.Context, provider string, owner string, name string, number int64, body EditIssueContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditIssueContentRequest(c.Server, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3636,6 +3716,81 @@ func NewGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberRequest(server
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewEditIssueContentOnHostRequest calls the generic EditIssueContentOnHost builder with application/json body
+func NewEditIssueContentOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64, body EditIssueContentOnHostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEditIssueContentOnHostRequestWithBody(server, platformHost, provider, owner, name, number, "application/json", bodyReader)
+}
+
+// NewEditIssueContentOnHostRequestWithBody generates requests for EditIssueContentOnHost with any type of body
+func NewEditIssueContentOnHostRequestWithBody(server string, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam4 string
+
+	pathParam4, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/issues/%s/%s/%s/%s", pathParam0, pathParam1, pathParam2, pathParam3, pathParam4)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -6002,6 +6157,74 @@ func NewGetIssuesByProviderByOwnerByNameByNumberRequest(server string, provider 
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewEditIssueContentRequest calls the generic EditIssueContent builder with application/json body
+func NewEditIssueContentRequest(server string, provider string, owner string, name string, number int64, body EditIssueContentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEditIssueContentRequestWithBody(server, provider, owner, name, number, "application/json", bodyReader)
+}
+
+// NewEditIssueContentRequestWithBody generates requests for EditIssueContent with any type of body
+func NewEditIssueContentRequestWithBody(server string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/issues/%s/%s/%s/%s", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -9351,6 +9574,11 @@ type ClientWithResponsesInterface interface {
 	// GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse request
 	GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse, error)
 
+	// EditIssueContentOnHostWithBodyWithResponse request with any body
+	EditIssueContentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueContentOnHostResponse, error)
+
+	EditIssueContentOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body EditIssueContentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueContentOnHostResponse, error)
+
 	// PostIssueCommentOnHostWithBodyWithResponse request with any body
 	PostIssueCommentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostIssueCommentOnHostResponse, error)
 
@@ -9470,6 +9698,11 @@ type ClientWithResponsesInterface interface {
 
 	// GetIssuesByProviderByOwnerByNameByNumberWithResponse request
 	GetIssuesByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetIssuesByProviderByOwnerByNameByNumberResponse, error)
+
+	// EditIssueContentWithBodyWithResponse request with any body
+	EditIssueContentWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueContentResponse, error)
+
+	EditIssueContentWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body EditIssueContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueContentResponse, error)
 
 	// PostIssueCommentWithBodyWithResponse request with any body
 	PostIssueCommentWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostIssueCommentResponse, error)
@@ -9763,6 +9996,29 @@ func (r GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse) Stat
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EditIssueContentOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *IssueDetailResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r EditIssueContentOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditIssueContentOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -10495,6 +10751,29 @@ func (r GetIssuesByProviderByOwnerByNameByNumberResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetIssuesByProviderByOwnerByNameByNumberResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EditIssueContentResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *IssueDetailResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r EditIssueContentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditIssueContentResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11953,6 +12232,23 @@ func (c *ClientWithResponses) GetHostByPlatformHostIssuesByProviderByOwnerByName
 	return ParseGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse(rsp)
 }
 
+// EditIssueContentOnHostWithBodyWithResponse request with arbitrary body returning *EditIssueContentOnHostResponse
+func (c *ClientWithResponses) EditIssueContentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueContentOnHostResponse, error) {
+	rsp, err := c.EditIssueContentOnHostWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditIssueContentOnHostResponse(rsp)
+}
+
+func (c *ClientWithResponses) EditIssueContentOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body EditIssueContentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueContentOnHostResponse, error) {
+	rsp, err := c.EditIssueContentOnHost(ctx, platformHost, provider, owner, name, number, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditIssueContentOnHostResponse(rsp)
+}
+
 // PostIssueCommentOnHostWithBodyWithResponse request with arbitrary body returning *PostIssueCommentOnHostResponse
 func (c *ClientWithResponses) PostIssueCommentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostIssueCommentOnHostResponse, error) {
 	rsp, err := c.PostIssueCommentOnHostWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
@@ -12335,6 +12631,23 @@ func (c *ClientWithResponses) GetIssuesByProviderByOwnerByNameByNumberWithRespon
 		return nil, err
 	}
 	return ParseGetIssuesByProviderByOwnerByNameByNumberResponse(rsp)
+}
+
+// EditIssueContentWithBodyWithResponse request with arbitrary body returning *EditIssueContentResponse
+func (c *ClientWithResponses) EditIssueContentWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueContentResponse, error) {
+	rsp, err := c.EditIssueContentWithBody(ctx, provider, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditIssueContentResponse(rsp)
+}
+
+func (c *ClientWithResponses) EditIssueContentWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body EditIssueContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditIssueContentResponse, error) {
+	rsp, err := c.EditIssueContent(ctx, provider, owner, name, number, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditIssueContentResponse(rsp)
 }
 
 // PostIssueCommentWithBodyWithResponse request with arbitrary body returning *PostIssueCommentResponse
@@ -13138,6 +13451,39 @@ func ParseGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse(rsp
 	}
 
 	response := &GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IssueDetailResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEditIssueContentOnHostResponse parses an HTTP response from a EditIssueContentOnHostWithResponse call
+func ParseEditIssueContentOnHostResponse(rsp *http.Response) (*EditIssueContentOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditIssueContentOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -14166,6 +14512,39 @@ func ParseGetIssuesByProviderByOwnerByNameByNumberResponse(rsp *http.Response) (
 	}
 
 	response := &GetIssuesByProviderByOwnerByNameByNumberResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest IssueDetailResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEditIssueContentResponse parses an HTTP response from a EditIssueContentWithResponse call
+func ParseEditIssueContentResponse(rsp *http.Response) (*EditIssueContentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditIssueContentResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1989,6 +1989,28 @@ func (d *DB) UpdateMRTitleBody(
 	return nil
 }
 
+// UpdateIssueTitleBody updates only the title, body, updated_at, and
+// last_activity_at fields on an issue. last_activity_at advances to
+// MAX(existing, updatedAt) so list ordering reflects the edit.
+func (d *DB) UpdateIssueTitleBody(
+	ctx context.Context,
+	id int64,
+	title, body string,
+	updatedAt time.Time,
+) error {
+	_, err := d.rw.ExecContext(ctx, `
+		UPDATE middleman_issues
+		SET title = ?, body = ?, updated_at = ?,
+		    last_activity_at = MAX(last_activity_at, ?)
+		WHERE id = ? AND updated_at <= ?`,
+		title, body, updatedAt, updatedAt, id, updatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("update issue title/body: %w", err)
+	}
+	return nil
+}
+
 // UpdateMRDerivedFields writes computed fields back to the merge_requests row.
 func (d *DB) UpdateMRDerivedFields(
 	ctx context.Context,

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -82,6 +82,7 @@ type Client interface {
 	MergePullRequest(ctx context.Context, owner, repo string, number int, commitTitle, commitMessage, method string) (*gh.PullRequestMergeResult, error)
 	EditPullRequest(ctx context.Context, owner, repo string, number int, opts EditPullRequestOpts) (*gh.PullRequest, error)
 	EditIssue(ctx context.Context, owner, repo string, number int, state string) (*gh.Issue, error)
+	EditIssueContent(ctx context.Context, owner, repo string, number int, title *string, body *string) (*gh.Issue, error)
 	ListPullRequestsPage(ctx context.Context, owner, repo, state string, page int) ([]*gh.PullRequest, bool, error)
 	ListIssuesPage(ctx context.Context, owner, repo, state string, page int) ([]*gh.Issue, bool, error)
 	// InvalidateListETagsForRepo drops cached conditional-GET
@@ -1198,6 +1199,27 @@ func (c *liveClient) EditIssue(
 	issue, resp, err := c.gh.Issues.Edit(
 		ctx, owner, repo, number, &gh.IssueRequest{State: &state},
 	)
+	c.trackRate(resp)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"editing issue %s/%s#%d: %w",
+			owner, repo, number, err,
+		)
+	}
+	return issue, nil
+}
+
+func (c *liveClient) EditIssueContent(
+	ctx context.Context, owner, repo string, number int, title *string, body *string,
+) (*gh.Issue, error) {
+	req := &gh.IssueRequest{}
+	if title != nil {
+		req.Title = title
+	}
+	if body != nil {
+		req.Body = body
+	}
+	issue, resp, err := c.gh.Issues.Edit(ctx, owner, repo, number, req)
 	c.trackRate(resp)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -873,6 +873,25 @@ func (p gitHubClientProvider) EditMergeRequestContent(
 	return platformgithub.NormalizePullRequest(ref, pr)
 }
 
+func (p gitHubClientProvider) EditIssueContent(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	title *string,
+	body *string,
+) (platform.Issue, error) {
+	ghIssue, err := p.client.EditIssueContent(
+		ctx, ref.Owner, ref.Name, number, title, body,
+	)
+	if err != nil {
+		return platform.Issue{}, err
+	}
+	if ghIssue == nil {
+		return platform.Issue{}, fmt.Errorf("provider returned no issue")
+	}
+	return platformgithub.NormalizeIssue(ref, ghIssue)
+}
+
 // SetWatchInterval sets the fast-sync interval for watched MRs.
 // Must be called before Start.
 func (s *Syncer) SetWatchInterval(d time.Duration) {
@@ -1195,6 +1214,13 @@ func (s *Syncer) MergeRequestContentMutator(
 	host string,
 ) (platform.MergeRequestContentMutator, error) {
 	return s.clients.MergeRequestContentMutator(kind, canonicalRepoHost(host))
+}
+
+func (s *Syncer) IssueContentMutator(
+	kind platform.Kind,
+	host string,
+) (platform.IssueContentMutator, error) {
+	return s.clients.IssueContentMutator(kind, canonicalRepoHost(host))
 }
 
 func (s *Syncer) ResolveConfiguredRepo(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -535,6 +535,20 @@ func (m *mockClient) EditIssue(
 	return &gh.Issue{State: &state}, nil
 }
 
+func (m *mockClient) EditIssueContent(
+	_ context.Context, _, _ string, _ int, title *string, body *string,
+) (*gh.Issue, error) {
+	m.trackCall()
+	out := &gh.Issue{}
+	if title != nil {
+		out.Title = title
+	}
+	if body != nil {
+		out.Body = body
+	}
+	return out, nil
+}
+
 func (m *mockClient) ListPullRequestsPage(
 	ctx context.Context, owner, repo, state string, page int,
 ) ([]*gh.PullRequest, bool, error) {

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -132,6 +132,9 @@ func (m *mockClient) EditPullRequest(context.Context, string, string, int, ghcli
 func (m *mockClient) EditIssue(context.Context, string, string, int, string) (*gh.Issue, error) {
 	return nil, nil
 }
+func (m *mockClient) EditIssueContent(context.Context, string, string, int, *string, *string) (*gh.Issue, error) {
+	return nil, nil
+}
 func (m *mockClient) ListPullRequestsPage(context.Context, string, string, string, int) ([]*gh.PullRequest, bool, error) {
 	return nil, false, nil
 }

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -104,3 +104,13 @@ type MergeRequestContentMutator interface {
 		body *string,
 	) (MergeRequest, error)
 }
+
+type IssueContentMutator interface {
+	EditIssueContent(
+		ctx context.Context,
+		ref RepoRef,
+		number int,
+		title *string,
+		body *string,
+	) (Issue, error)
+}

--- a/internal/platform/forgejo/mutation.go
+++ b/internal/platform/forgejo/mutation.go
@@ -103,6 +103,16 @@ func (c *Client) EditMergeRequestContent(
 	return c.provider.EditMergeRequestContent(ctx, ref, number, title, body)
 }
 
+func (c *Client) EditIssueContent(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	title *string,
+	body *string,
+) (platform.Issue, error) {
+	return c.provider.EditIssueContent(ctx, ref, number, title, body)
+}
+
 func (t *transport) CreateIssueComment(
 	ctx context.Context,
 	ref platform.RepoRef,

--- a/internal/platform/gitea/mutation.go
+++ b/internal/platform/gitea/mutation.go
@@ -103,6 +103,16 @@ func (c *Client) EditMergeRequestContent(
 	return c.provider.EditMergeRequestContent(ctx, ref, number, title, body)
 }
 
+func (c *Client) EditIssueContent(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	title *string,
+	body *string,
+) (platform.Issue, error) {
+	return c.provider.EditIssueContent(ctx, ref, number, title, body)
+}
+
 func (t *transport) CreateIssueComment(
 	ctx context.Context,
 	ref platform.RepoRef,

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -448,6 +448,24 @@ func (p *Provider) EditMergeRequestContent(
 	return NormalizePullRequest(ref, pr), nil
 }
 
+func (p *Provider) EditIssueContent(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	title *string,
+	body *string,
+) (platform.Issue, error) {
+	transport, err := p.mutationTransport("state_mutation")
+	if err != nil {
+		return platform.Issue{}, err
+	}
+	issue, err := transport.EditIssue(ctx, ref, number, IssueMutationOptions{Title: title, Body: body})
+	if err != nil {
+		return platform.Issue{}, p.mapError(err)
+	}
+	return NormalizeIssue(ref, issue), nil
+}
+
 func (p *Provider) listRepositories(
 	ctx context.Context,
 	owner string,

--- a/internal/platform/registry.go
+++ b/internal/platform/registry.go
@@ -231,3 +231,18 @@ func (r *Registry) MergeRequestContentMutator(
 	}
 	return mutator, nil
 }
+
+func (r *Registry) IssueContentMutator(
+	kind Kind,
+	host string,
+) (IssueContentMutator, error) {
+	provider, err := r.Provider(kind, host)
+	if err != nil {
+		return nil, err
+	}
+	mutator, ok := provider.(IssueContentMutator)
+	if !ok {
+		return nil, UnsupportedCapability(kind, host, "state_mutation")
+	}
+	return mutator, nil
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -83,6 +83,7 @@ type mockGH struct {
 	markReadyForReviewFn      func(context.Context, string, string, int) (*gh.PullRequest, error)
 	editPullRequestFn         func(context.Context, string, string, int, ghclient.EditPullRequestOpts) (*gh.PullRequest, error)
 	editIssueFn               func(context.Context, string, string, int, string) (*gh.Issue, error)
+	editIssueContentFn        func(context.Context, string, string, int, *string, *string) (*gh.Issue, error)
 	createIssueCommentFn      func(context.Context, string, string, int, string) (*gh.IssueComment, error)
 	editIssueCommentFn        func(context.Context, string, string, int64, string) (*gh.IssueComment, error)
 	createReviewFn            func(context.Context, string, string, int, string, string) (*gh.PullRequestReview, error)
@@ -384,6 +385,22 @@ func (m *mockGH) EditIssue(
 		return m.editIssueFn(ctx, owner, repo, number, state)
 	}
 	return &gh.Issue{State: &state}, nil
+}
+
+func (m *mockGH) EditIssueContent(
+	ctx context.Context, owner, repo string, number int, title *string, body *string,
+) (*gh.Issue, error) {
+	if m.editIssueContentFn != nil {
+		return m.editIssueContentFn(ctx, owner, repo, number, title, body)
+	}
+	out := &gh.Issue{}
+	if title != nil {
+		out.Title = title
+	}
+	if body != nil {
+		out.Body = body
+	}
+	return out, nil
 }
 
 func (m *mockGH) ListPullRequestsPage(
@@ -15879,4 +15896,78 @@ func TestAPIEditPRPreservesDerivedFields(t *testing.T) {
 	require.Equal("success", after.CIStatus)
 	require.Equal("APPROVED", after.ReviewDecision)
 	require.Equal("open", after.State)
+}
+
+// --- edit-issue-content (PATCH) tests ---
+
+func TestAPIEditIssueBodyOnly(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	seedIssue(t, database, "acme", "widget", 5, "open")
+
+	rr := doJSON(t, srv, http.MethodPatch,
+		"/api/v1/issues/gh/acme/widget/5",
+		map[string]string{"body": "- [x] task done"})
+	require.Equal(http.StatusOK, rr.Code)
+
+	issue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	require.NoError(err)
+	require.NotNil(issue)
+	require.Equal("Test Issue", issue.Title)
+	require.Equal("- [x] task done", issue.Body)
+}
+
+func TestAPIEditIssueTitleAndBody(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	seedIssue(t, database, "acme", "widget", 5, "open")
+
+	rr := doJSON(t, srv, http.MethodPatch,
+		"/api/v1/issues/gh/acme/widget/5",
+		map[string]string{"title": "new title", "body": "new body"})
+	require.Equal(http.StatusOK, rr.Code)
+
+	issue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	require.NoError(err)
+	require.NotNil(issue)
+	require.Equal("new title", issue.Title)
+	require.Equal("new body", issue.Body)
+}
+
+func TestAPIEditIssueNoFields400(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	seedIssue(t, database, "acme", "widget", 5, "open")
+
+	rr := doJSON(t, srv, http.MethodPatch,
+		"/api/v1/issues/gh/acme/widget/5",
+		map[string]any{})
+	require.Equal(http.StatusBadRequest, rr.Code)
+}
+
+func TestAPIEditIssueBlankTitle400(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	seedIssue(t, database, "acme", "widget", 5, "open")
+
+	rr := doJSON(t, srv, http.MethodPatch,
+		"/api/v1/issues/gh/acme/widget/5",
+		map[string]string{"title": "   "})
+	require.Equal(http.StatusBadRequest, rr.Code)
+}
+
+func TestAPIEditIssueMissing404(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	// Register the repo without the issue.
+	_, err := database.UpsertRepo(
+		t.Context(),
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodPatch,
+		"/api/v1/issues/gh/acme/widget/999",
+		map[string]string{"body": "anything"})
+	require.Equal(http.StatusNotFound, rr.Code)
 }

--- a/internal/server/e2etest/fixtures_test.go
+++ b/internal/server/e2etest/fixtures_test.go
@@ -209,6 +209,9 @@ func (m *mockGH) EditPullRequest(context.Context, string, string, int, ghclient.
 func (m *mockGH) EditIssue(context.Context, string, string, int, string) (*gh.Issue, error) {
 	return nil, nil
 }
+func (m *mockGH) EditIssueContent(context.Context, string, string, int, *string, *string) (*gh.Issue, error) {
+	return nil, nil
+}
 func (m *mockGH) ListPullRequestsPage(context.Context, string, string, string, int) ([]*gh.PullRequest, bool, error) {
 	return nil, false, nil
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -242,6 +242,20 @@ type editPRContentInput struct {
 
 type editPRContentOutput = bodyOutput[mergeRequestDetailResponse]
 
+type editIssueContentInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	Body         struct {
+		Title *string `json:"title,omitempty"`
+		Body  *string `json:"body,omitempty"`
+	}
+}
+
+type editIssueContentOutput = bodyOutput[issueDetailResponse]
+
 type githubStateInput struct {
 	Provider     string `path:"provider"`
 	PlatformHost string
@@ -575,6 +589,8 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 	huma.Get(api, hostIssuePath, s.getIssueOnHost)
 	huma.Register(api, huma.Operation{OperationID: "post-issue-comment", Method: http.MethodPost, Path: issuePath + "/comments", DefaultStatus: http.StatusCreated}, s.postIssueComment)
 	huma.Register(api, huma.Operation{OperationID: "post-issue-comment-on-host", Method: http.MethodPost, Path: hostIssuePath + "/comments", DefaultStatus: http.StatusCreated}, s.postIssueCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content", Method: http.MethodPatch, Path: issuePath, DefaultStatus: http.StatusOK}, s.editIssueContent)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content-on-host", Method: http.MethodPatch, Path: hostIssuePath, DefaultStatus: http.StatusOK}, s.editIssueContentOnHost)
 	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment", Method: http.MethodPatch, Path: issuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editIssueComment)
 	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment-on-host", Method: http.MethodPatch, Path: hostIssuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editIssueCommentOnHost)
 
@@ -1036,6 +1052,90 @@ func (s *Server) editPRContent(
 	}
 
 	return &editPRContentOutput{Body: body}, nil
+}
+
+func (s *Server) editIssueContent(
+	ctx context.Context, input *editIssueContentInput,
+) (*editIssueContentOutput, error) {
+	if input.Body.Title == nil && input.Body.Body == nil {
+		return nil, huma.Error400BadRequest(
+			"at least one of title or body must be provided",
+		)
+	}
+	if input.Body.Title != nil && strings.TrimSpace(*input.Body.Title) == "" {
+		return nil, huma.Error400BadRequest("title must not be blank")
+	}
+
+	repo, err := s.requireRepoRouteCapability(
+		ctx,
+		input.Provider, input.PlatformHost, input.Owner, input.Name,
+		capabilityStateMutation,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	mutator, err := s.syncer.IssueContentMutator(
+		repoProviderKind(*repo), repoProviderHost(*repo),
+	)
+	if err != nil {
+		return nil, huma.Error404NotFound(err.Error())
+	}
+
+	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("get issue failed")
+	}
+	if issue == nil {
+		return nil, huma.Error404NotFound("issue not found")
+	}
+
+	updatedIssue, err := mutator.EditIssueContent(
+		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Title, input.Body.Body,
+	)
+	if err != nil {
+		return nil, huma.Error502BadGateway(
+			"provider API error: " + err.Error(),
+		)
+	}
+
+	newTitle := issue.Title
+	if updatedIssue.Title != "" {
+		newTitle = updatedIssue.Title
+	} else if input.Body.Title != nil {
+		newTitle = *input.Body.Title
+	}
+	newBody := issue.Body
+	if updatedIssue.Body != "" {
+		newBody = updatedIssue.Body
+	} else if input.Body.Body != nil {
+		newBody = *input.Body.Body
+	}
+	updatedAt := s.now().UTC()
+	if !updatedIssue.UpdatedAt.IsZero() {
+		updatedAt = updatedIssue.UpdatedAt.UTC()
+	}
+	if err := s.db.UpdateIssueTitleBody(
+		ctx, issue.ID, newTitle, newBody, updatedAt,
+	); err != nil {
+		return nil, huma.Error500InternalServerError(
+			"update title/body failed",
+		)
+	}
+
+	issue, err = s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	if err != nil || issue == nil {
+		return nil, huma.Error500InternalServerError(
+			"re-read issue failed",
+		)
+	}
+
+	body, err := s.buildIssueDetailResponse(ctx, repo, issue)
+	if err != nil {
+		return nil, err
+	}
+
+	return &editIssueContentOutput{Body: body}, nil
 }
 
 func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*postCommentOutput, error) {

--- a/internal/server/provider_route_wrappers.go
+++ b/internal/server/provider_route_wrappers.go
@@ -133,6 +133,18 @@ type editPRContentHostInput struct {
 	}
 }
 
+type editIssueContentHostInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	Body         struct {
+		Title *string `json:"title,omitempty"`
+		Body  *string `json:"body,omitempty"`
+	}
+}
+
 type githubStateHostInput struct {
 	Provider     string `path:"provider"`
 	PlatformHost string `path:"platform_host"`
@@ -222,6 +234,18 @@ func (s *Server) editPRContentOnHost(ctx context.Context, input *editPRContentHo
 		Body:         input.Body,
 	}
 	return s.editPRContent(ctx, &next)
+}
+
+func (s *Server) editIssueContentOnHost(ctx context.Context, input *editIssueContentHostInput) (*editIssueContentOutput, error) {
+	next := editIssueContentInput{
+		Provider:     input.Provider,
+		PlatformHost: input.PlatformHost,
+		Owner:        input.Owner,
+		Name:         input.Name,
+		Number:       input.Number,
+		Body:         input.Body,
+	}
+	return s.editIssueContent(ctx, &next)
 }
 
 func (s *Server) postCommentOnHost(ctx context.Context, input *postCommentHostInput) (*postCommentOutput, error) {

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -258,15 +258,6 @@ func (c *FixtureClient) CreateIssue(
 	return issue, nil
 }
 
-func (c *FixtureClient) findIssue(owner, repo string, number int) *gh.Issue {
-	for _, issue := range c.OpenIssues[repoKey(owner, repo)] {
-		if issue.GetNumber() == number {
-			return issue
-		}
-	}
-	return nil
-}
-
 // ListIssueComments returns nil (read-only stub).
 func (c *FixtureClient) ListIssueComments(
 	_ context.Context, owner, repo string, number int,
@@ -450,51 +441,100 @@ func (c *FixtureClient) MergePullRequest(
 }
 
 // EditPullRequest updates seeded PR fields for E2E mutations.
+// Mutates the PR in BOTH the OpenPRs and PRs maps so a follow-up
+// GetPullRequest (used by sync) returns the new state instead of the
+// pristine seed.
 func (c *FixtureClient) EditPullRequest(
 	_ context.Context, owner, repo string, number int, opts ghclient.EditPullRequestOpts,
 ) (*gh.PullRequest, error) {
-	pr := c.findPullRequest(owner, repo, number)
-	if pr == nil {
-		return nil, nil
-	}
 	now := gh.Timestamp{Time: time.Now().UTC()}
-	if opts.State != nil {
-		pr.State = opts.State
-		if *opts.State == "closed" {
-			pr.ClosedAt = &now
-		} else {
-			pr.ClosedAt = nil
-			pr.MergedAt = nil
-			merged := false
-			pr.Merged = &merged
+	var updated *gh.PullRequest
+	for _, prs := range []map[string][]*gh.PullRequest{c.OpenPRs, c.PRs} {
+		for _, pr := range prs[repoKey(owner, repo)] {
+			if pr.GetNumber() != number {
+				continue
+			}
+			if opts.State != nil {
+				pr.State = opts.State
+				if *opts.State == "closed" {
+					pr.ClosedAt = &now
+				} else {
+					pr.ClosedAt = nil
+					pr.MergedAt = nil
+					merged := false
+					pr.Merged = &merged
+				}
+			}
+			if opts.Title != nil {
+				pr.Title = opts.Title
+			}
+			if opts.Body != nil {
+				pr.Body = opts.Body
+			}
+			pr.UpdatedAt = &now
+			if updated == nil {
+				updated = pr
+			}
 		}
 	}
-	if opts.Title != nil {
-		pr.Title = opts.Title
-	}
-	if opts.Body != nil {
-		pr.Body = opts.Body
-	}
-	pr.UpdatedAt = &now
-	return pr, nil
+	return updated, nil
 }
 
 // EditIssue updates the seeded issue state for E2E mutations.
+// Mutates the issue in BOTH the OpenIssues and Issues maps so a
+// follow-up GetIssue (used by sync) sees the new state instead of
+// the pristine seed.
 func (c *FixtureClient) EditIssue(
 	_ context.Context, owner, repo string, number int, state string,
 ) (*gh.Issue, error) {
-	issue := c.findIssue(owner, repo, number)
-	if issue == nil {
-		return nil, nil
-	}
 	now := gh.Timestamp{Time: time.Now().UTC()}
-	issue.State = &state
-	if state == "closed" {
-		issue.ClosedAt = &now
-	} else {
-		issue.ClosedAt = nil
+	var updated *gh.Issue
+	for _, issues := range []map[string][]*gh.Issue{c.OpenIssues, c.Issues} {
+		for _, issue := range issues[repoKey(owner, repo)] {
+			if issue.GetNumber() != number {
+				continue
+			}
+			issue.State = &state
+			if state == "closed" {
+				issue.ClosedAt = &now
+			} else {
+				issue.ClosedAt = nil
+			}
+			if updated == nil {
+				updated = issue
+			}
+		}
 	}
-	return issue, nil
+	return updated, nil
+}
+
+// EditIssueContent updates the seeded issue's title and/or body so e2e
+// tests exercising body edits (checkbox toggling, etc.) see persisted
+// state on the next read. Mutates BOTH OpenIssues and Issues so the
+// sync path observes the edit.
+func (c *FixtureClient) EditIssueContent(
+	_ context.Context, owner, repo string, number int, title *string, body *string,
+) (*gh.Issue, error) {
+	now := gh.Timestamp{Time: time.Now().UTC()}
+	var updated *gh.Issue
+	for _, issues := range []map[string][]*gh.Issue{c.OpenIssues, c.Issues} {
+		for _, issue := range issues[repoKey(owner, repo)] {
+			if issue.GetNumber() != number {
+				continue
+			}
+			if title != nil {
+				issue.Title = title
+			}
+			if body != nil {
+				issue.Body = body
+			}
+			issue.UpdatedAt = &now
+			if updated == nil {
+				updated = issue
+			}
+		}
+	}
+	return updated, nil
 }
 
 // ListPullRequestsPage returns nil (read-only stub).

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -85,6 +85,13 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	// widgets#1: open, alice, has reviews+comments+4 commits
 	w1Created := now.Add(-10 * 24 * time.Hour)
+	w1Body := "## Summary\n\n" +
+		"Introduce an LRU cache in front of the widget store.\n\n" +
+		"## Test plan\n\n" +
+		"- [ ] Cmd+K opens palette, focus lands in the search input\n" +
+		"- [ ] Tab/Shift+Tab cycles within the palette dialog only\n" +
+		"- [ ] `>settings` + Enter navigates to /settings\n" +
+		"- [x] Cache invalidates on widget update\n"
 	w1ID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:            widgetsID,
 		PlatformID:        1001,
@@ -94,6 +101,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Author:            "alice",
 		AuthorDisplayName: "Alice",
 		State:             "open",
+		Body:              w1Body,
 		HeadBranch:        "feature/caching",
 		BaseBranch:        "main",
 		Additions:         240,
@@ -717,7 +725,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	openPRs := map[string][]*gh.PullRequest{
 		"acme/widgets": {
-			setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA),
+			setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1006, 6, "WIP: new dashboard layout", "carol", "open", true, "", w6Created, now.Add(-12*time.Hour)), 150, 40),
 			setPRStats(buildGHPR("acme", "widgets", 1007, 7, "Bump lodash from 4.17.20 to 4.17.21", "dependabot[bot]", "open", false, "", w7Created, now.Add(-6*time.Hour)), 1, 1),
@@ -732,7 +740,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	allPRs := map[string][]*gh.PullRequest{
 		"acme/widgets": {
-			setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA),
+			setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1003, 3, "Upgrade dependency versions", "carol", "merged", false, "", now.Add(-10*24*time.Hour), w3Merged), 80, 80),
 			setPRStats(buildGHPR("acme", "widgets", 1004, 4, "Refactor storage backend", "alice", "merged", false, "", now.Add(-30*24*time.Hour), w4Merged), 420, 310),
@@ -879,6 +887,14 @@ func buildGHPR(
 	if mergeableState != "" {
 		pr.MergeableState = new(mergeableState)
 	}
+	return pr
+}
+
+// setPRBody sets a Body on a *gh.PullRequest so the fixture client
+// returns prose for sync paths exercising body persistence (e.g.
+// task-list checkboxes).
+func setPRBody(pr *gh.PullRequest, body string) *gh.PullRequest {
+	pr.Body = &body
 	return pr
 }
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -437,6 +437,11 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	// widgets#11: open, alice, older (20d ago)
 	wi11Created := now.Add(-20 * 24 * time.Hour)
+	wi11Body := "## Acceptance criteria\n\n" +
+		"- [ ] System preference detected on first launch\n" +
+		"- [ ] Manual toggle in settings overrides system\n" +
+		"- [ ] Choice persists across reloads\n" +
+		"- [x] Theme tokens defined in design system\n"
 	wi11ID, err := d.UpsertIssue(ctx, &db.Issue{
 		RepoID:         widgetsID,
 		PlatformID:     3011,
@@ -445,6 +450,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Title:          "Add dark mode support",
 		Author:         "alice",
 		State:          "open",
+		Body:           wi11Body,
 		CommentCount:   0,
 		CreatedAt:      wi11Created,
 		UpdatedAt:      wi11Created,
@@ -760,7 +766,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	openIssues := map[string][]*gh.Issue{
 		"acme/widgets": {
 			buildGHIssue("acme", "widgets", 3010, 10, "Widget rendering broken on Safari", "eve", "open", wi10Created, now.Add(-4*time.Hour)),
-			buildGHIssue("acme", "widgets", 3011, 11, "Add dark mode support", "alice", "open", wi11Created, wi11Created),
+			setIssueBody(buildGHIssue("acme", "widgets", 3011, 11, "Add dark mode support", "alice", "open", wi11Created, wi11Created), wi11Body),
 			buildGHIssue("acme", "widgets", 3013, 13, "Security advisory: prototype pollution", "dependabot[bot]", "open", wi13Created, wi13Created),
 		},
 		"acme/tools": {
@@ -780,7 +786,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	allIssues := map[string][]*gh.Issue{
 		"acme/widgets": {
 			buildGHIssue("acme", "widgets", 3010, 10, "Widget rendering broken on Safari", "eve", "open", wi10Created, now.Add(-4*time.Hour)),
-			buildGHIssue("acme", "widgets", 3011, 11, "Add dark mode support", "alice", "open", wi11Created, wi11Created),
+			setIssueBody(buildGHIssue("acme", "widgets", 3011, 11, "Add dark mode support", "alice", "open", wi11Created, wi11Created), wi11Body),
 			buildGHIssue("acme", "widgets", 3012, 12, "Crash on empty input", "carol", "closed", now.Add(-7*24*time.Hour), wi12Closed),
 			buildGHIssue("acme", "widgets", 3013, 13, "Security advisory: prototype pollution", "dependabot[bot]", "open", wi13Created, wi13Created),
 		},
@@ -896,6 +902,13 @@ func buildGHPR(
 func setPRBody(pr *gh.PullRequest, body string) *gh.PullRequest {
 	pr.Body = &body
 	return pr
+}
+
+// setIssueBody sets a Body on a *gh.Issue. Mirrors setPRBody for
+// issue-side body edits (task-list checkboxes on issue descriptions).
+func setIssueBody(issue *gh.Issue, body string) *gh.Issue {
+	issue.Body = &body
+	return issue
 }
 
 // setPRStats sets Additions and Deletions on a *gh.PullRequest so the

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -67,7 +67,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["edit-issue-content-on-host"];
         trace?: never;
     };
     "/host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/comments": {
@@ -565,7 +565,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["edit-issue-content"];
         trace?: never;
     };
     "/issues/{provider}/{owner}/{name}/{number}/comments": {
@@ -1707,6 +1707,26 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
+        };
+        EditIssueContentHostInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/EditIssueContentHostInputBody.json
+             */
+            readonly $schema?: string;
+            body?: string;
+            title?: string;
+        };
+        EditIssueContentInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/EditIssueContentInputBody.json
+             */
+            readonly $schema?: string;
+            body?: string;
+            title?: string;
         };
         EditPRContentHostInputBody: {
             /**
@@ -2885,6 +2905,45 @@ export interface operations {
             };
         };
     };
+    "edit-issue-content-on-host": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EditIssueContentHostInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IssueDetailResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "post-issue-comment-on-host": {
         parameters: {
             query?: never;
@@ -4041,6 +4100,44 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IssueDetailResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "edit-issue-content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EditIssueContentInputBody"];
+            };
+        };
         responses: {
             /** @description OK */
             200: {

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -403,20 +403,38 @@
 
   // Task-list checkbox clicks update the body locally for instant
   // feedback, then debounce a PATCH so a flurry of clicks collapses
-  // into a single save.
+  // into a single save. Target and body are captured at schedule
+  // time so a route change before the timer fires can't redirect
+  // the save to a different issue or lose the edit.
+  type PendingBodySave = {
+    owner: string;
+    name: string;
+    number: number;
+    body: string;
+  };
   let bodySaveTimeout: ReturnType<typeof setTimeout> | null = null;
+  let pendingBodySave: PendingBodySave | null = null;
   const BODY_SAVE_DEBOUNCE_MS = 400;
 
-  function scheduleBodySave(): void {
+  function scheduleBodySave(body: string): void {
+    pendingBodySave = { owner, name, number, body };
     if (bodySaveTimeout !== null) clearTimeout(bodySaveTimeout);
     bodySaveTimeout = setTimeout(() => {
-      bodySaveTimeout = null;
-      const latest = issues.getIssueDetail()?.issue?.Body;
-      if (latest === undefined) return;
-      void issues.saveIssueBodyInBackground(
-        owner, name, number, latest,
-      );
+      flushBodySave();
     }, BODY_SAVE_DEBOUNCE_MS);
+  }
+
+  function flushBodySave(): void {
+    if (bodySaveTimeout !== null) {
+      clearTimeout(bodySaveTimeout);
+      bodySaveTimeout = null;
+    }
+    const target = pendingBodySave;
+    pendingBodySave = null;
+    if (target === null) return;
+    void issues.saveIssueBodyInBackground(
+      target.owner, target.name, target.number, target.body,
+    );
   }
 
   function onBodyClick(event: MouseEvent): void {
@@ -438,7 +456,7 @@
     if (newBody === detail.issue.Body) return;
     event.preventDefault();
     issues.setLocalIssueBody(owner, name, number, newBody);
-    scheduleBodySave();
+    scheduleBodySave(newBody);
   }
 
   // Drag-to-reorder for task-list items. See PullDetail.svelte for the
@@ -534,7 +552,7 @@
     const newBody = moveTaskListItem(detail.issue.Body, from, target);
     if (newBody === detail.issue.Body) return;
     issues.setLocalIssueBody(owner, name, number, newBody);
-    scheduleBodySave();
+    scheduleBodySave(newBody);
   }
 
   function onBodyDragEnd(event: DragEvent): void {
@@ -573,15 +591,14 @@
   }
 
   // Drop any pending checkbox save when navigating to a different
-  // issue so a stale toggle doesn't land on the new target.
+  // issue so a stale toggle doesn't land on the new target. The
+  // pending save still fires against the originally-captured target
+  // so a fast click + navigate sequence persists.
   $effect(() => {
     void owner;
     void name;
     void number;
-    if (bodySaveTimeout !== null) {
-      clearTimeout(bodySaveTimeout);
-      bodySaveTimeout = null;
-    }
+    flushBodySave();
     clearDragState();
   });
 </script>

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -466,7 +466,9 @@
     const newBody = toggleTaskListItem(detail.issue.Body, index);
     if (newBody === detail.issue.Body) return;
     event.preventDefault();
-    issues.setLocalIssueBody(owner, name, number, newBody);
+    issues.setLocalIssueBody(
+      provider, platformHost, owner, name, number, newBody,
+    );
     scheduleBodySave(newBody);
   }
 
@@ -562,7 +564,9 @@
     if (target === from) return;
     const newBody = moveTaskListItem(detail.issue.Body, from, target);
     if (newBody === detail.issue.Body) return;
-    issues.setLocalIssueBody(owner, name, number, newBody);
+    issues.setLocalIssueBody(
+      provider, platformHost, owner, name, number, newBody,
+    );
     scheduleBodySave(newBody);
   }
 

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -9,6 +9,7 @@
   import { pushModalFrame } from "../../stores/keyboard/modal-stack.svelte.js";
   import type { IssueDetailSyncMode } from "../../stores/issues.svelte.js";
   import { renderMarkdown } from "../../utils/markdown.js";
+  import { moveTaskListItem, toggleTaskListItem } from "../../utils/task-list.js";
   import { timeAgo } from "../../utils/time.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import EventTimeline from "./EventTimeline.svelte";
@@ -399,6 +400,190 @@
     if (workspaceCreating) return;
     branchConflict = null;
   }
+
+  // Task-list checkbox clicks update the body locally for instant
+  // feedback, then debounce a PATCH so a flurry of clicks collapses
+  // into a single save.
+  let bodySaveTimeout: ReturnType<typeof setTimeout> | null = null;
+  const BODY_SAVE_DEBOUNCE_MS = 400;
+
+  function scheduleBodySave(): void {
+    if (bodySaveTimeout !== null) clearTimeout(bodySaveTimeout);
+    bodySaveTimeout = setTimeout(() => {
+      bodySaveTimeout = null;
+      const latest = issues.getIssueDetail()?.issue?.Body;
+      if (latest === undefined) return;
+      void issues.saveIssueBodyInBackground(
+        owner, name, number, latest,
+      );
+    }, BODY_SAVE_DEBOUNCE_MS);
+  }
+
+  function onBodyClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    if (target.tagName !== "INPUT") return;
+    if ((target as HTMLInputElement).type !== "checkbox") return;
+    const raw = target.getAttribute("data-task-index");
+    if (raw === null) return;
+    if (staleIssue || !currentCapabilities().state_mutation) {
+      event.preventDefault();
+      return;
+    }
+    const index = parseInt(raw, 10);
+    if (Number.isNaN(index)) return;
+    const detail = issues.getIssueDetail();
+    if (!detail) return;
+    const newBody = toggleTaskListItem(detail.issue.Body, index);
+    if (newBody === detail.issue.Body) return;
+    event.preventDefault();
+    issues.setLocalIssueBody(owner, name, number, newBody);
+    scheduleBodySave();
+  }
+
+  // Drag-to-reorder for task-list items. See PullDetail.svelte for the
+  // mirror implementation — the only difference is the store getter.
+  let dragSourceIndex = $state<number | null>(null);
+  let dropTargetIndex = $state<number | null>(null);
+  let dropTargetSide = $state<"before" | "after">("before");
+
+  function findTaskItemIndex(el: HTMLElement | null): number | null {
+    let cur: HTMLElement | null = el;
+    while (cur) {
+      if (cur.classList && cur.classList.contains("task-list-item")) {
+        const raw = cur.getAttribute("data-task-index");
+        if (raw === null) return null;
+        const idx = parseInt(raw, 10);
+        return Number.isNaN(idx) ? null : idx;
+      }
+      cur = cur.parentElement;
+    }
+    return null;
+  }
+
+  function onBodyDragStart(event: DragEvent): void {
+    if (staleIssue || !currentCapabilities().state_mutation) return;
+    const target = event.target as HTMLElement | null;
+    if (!target?.classList?.contains("task-drag-handle")) return;
+    const raw = target.getAttribute("data-task-index");
+    if (raw === null) return;
+    const idx = parseInt(raw, 10);
+    if (Number.isNaN(idx)) return;
+    dragSourceIndex = idx;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", String(idx));
+    }
+  }
+
+  function onBodyDragOver(event: DragEvent): void {
+    if (dragSourceIndex === null) return;
+    const target = event.target as HTMLElement | null;
+    const idx = findTaskItemIndex(target);
+    if (idx === null) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    let li: HTMLElement | null = target;
+    while (li && !(li.classList && li.classList.contains("task-list-item"))) {
+      li = li.parentElement;
+    }
+    let side: "before" | "after" = "before";
+    if (li) {
+      const rect = li.getBoundingClientRect();
+      side = event.clientY < rect.top + rect.height / 2
+        ? "before"
+        : "after";
+    }
+    dropTargetSide = side;
+    dropTargetIndex = idx;
+    updateDropIndicatorClasses(
+      event.currentTarget as HTMLElement,
+      idx,
+      side,
+    );
+  }
+
+  function onBodyDragLeave(event: DragEvent): void {
+    const related = event.relatedTarget as HTMLElement | null;
+    const body = event.currentTarget as HTMLElement;
+    if (!related || !body.contains(related)) {
+      dropTargetIndex = null;
+      clearDropIndicatorClasses(body);
+    }
+  }
+
+  function onBodyDrop(event: DragEvent): void {
+    const body = event.currentTarget as HTMLElement;
+    if (dragSourceIndex === null) {
+      clearDragState(body);
+      return;
+    }
+    event.preventDefault();
+    const from = dragSourceIndex;
+    const to = dropTargetIndex;
+    const side = dropTargetSide;
+    clearDragState(body);
+    if (to === null || to === from) return;
+    if (staleIssue || !currentCapabilities().state_mutation) return;
+    const detail = issues.getIssueDetail();
+    if (!detail) return;
+    let target = to;
+    if (from < to && side === "before") target = to - 1;
+    else if (from > to && side === "after") target = to + 1;
+    if (target === from) return;
+    const newBody = moveTaskListItem(detail.issue.Body, from, target);
+    if (newBody === detail.issue.Body) return;
+    issues.setLocalIssueBody(owner, name, number, newBody);
+    scheduleBodySave();
+  }
+
+  function onBodyDragEnd(event: DragEvent): void {
+    clearDragState(event.currentTarget as HTMLElement);
+  }
+
+  function updateDropIndicatorClasses(
+    root: HTMLElement,
+    idx: number,
+    side: "before" | "after",
+  ): void {
+    clearDropIndicatorClasses(root);
+    const li = root.querySelector(
+      `.task-list-item--interactive[data-task-index="${idx}"]`,
+    );
+    if (!li) return;
+    li.classList.add(
+      side === "before" ? "task-drop-before" : "task-drop-after",
+    );
+  }
+
+  function clearDropIndicatorClasses(root: HTMLElement): void {
+    root.querySelectorAll(".task-drop-before").forEach((el) =>
+      el.classList.remove("task-drop-before"),
+    );
+    root.querySelectorAll(".task-drop-after").forEach((el) =>
+      el.classList.remove("task-drop-after"),
+    );
+  }
+
+  function clearDragState(root?: HTMLElement | null): void {
+    dragSourceIndex = null;
+    dropTargetIndex = null;
+    dropTargetSide = "before";
+    if (root) clearDropIndicatorClasses(root);
+  }
+
+  // Drop any pending checkbox save when navigating to a different
+  // issue so a stale toggle doesn't land on the new target.
+  $effect(() => {
+    void owner;
+    void name;
+    void number;
+    if (bodySaveTimeout !== null) {
+      clearTimeout(bodySaveTimeout);
+      bodySaveTimeout = null;
+    }
+    clearDragState();
+  });
 </script>
 
 {#if issues.isIssueDetailLoading() && (issues.getIssueDetail() === null || staleIssue)}
@@ -507,7 +692,18 @@
                 </svg>
               {/if}
             </button>
-            <div class="inset-box markdown-body">{@html renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath })}</div>
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="inset-box markdown-body"
+              class:dragging={dragSourceIndex !== null}
+              onclick={onBodyClick}
+              ondragstart={onBodyDragStart}
+              ondragover={onBodyDragOver}
+              ondragleave={onBodyDragLeave}
+              ondrop={onBodyDrop}
+              ondragend={onBodyDragEnd}
+            >{@html renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation })}</div>
           </div>
         </div>
       {/if}

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -411,13 +411,19 @@
     name: string;
     number: number;
     body: string;
+    provider: string;
+    platformHost?: string | undefined;
+    repoPath: string;
   };
   let bodySaveTimeout: ReturnType<typeof setTimeout> | null = null;
   let pendingBodySave: PendingBodySave | null = null;
   const BODY_SAVE_DEBOUNCE_MS = 400;
 
   function scheduleBodySave(body: string): void {
-    pendingBodySave = { owner, name, number, body };
+    pendingBodySave = {
+      owner, name, number, body,
+      provider, platformHost, repoPath,
+    };
     if (bodySaveTimeout !== null) clearTimeout(bodySaveTimeout);
     bodySaveTimeout = setTimeout(() => {
       flushBodySave();
@@ -434,6 +440,11 @@
     if (target === null) return;
     void issues.saveIssueBodyInBackground(
       target.owner, target.name, target.number, target.body,
+      {
+        provider: target.provider,
+        platformHost: target.platformHost,
+        repoPath: target.repoPath,
+      },
     );
   }
 

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -11,6 +11,7 @@
     getUIConfig, getNavigate,
   } from "../../context.js";
   import { renderMarkdown } from "../../utils/markdown.js";
+  import { moveTaskListItem, toggleTaskListItem } from "../../utils/task-list.js";
   import { timeAgo } from "../../utils/time.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import EventTimeline from "./EventTimeline.svelte";
@@ -205,6 +206,13 @@
     editingBody = false;
     titleDraft = "";
     bodyDraft = "";
+    // A pending checkbox save from the previous PR must not fire
+    // against the new one; drop it.
+    if (bodySaveTimeout !== null) {
+      clearTimeout(bodySaveTimeout);
+      bodySaveTimeout = null;
+    }
+    clearDragState();
   });
 
   let copied = $state(false);
@@ -575,6 +583,186 @@
     } finally {
       wsCreating = false;
     }
+  }
+
+  // Task-list checkbox clicks update the body locally for instant
+  // feedback, then debounce a PATCH so a flurry of clicks collapses
+  // into a single save. Avoids GitHub-style per-click blocking saves.
+  let bodySaveTimeout: ReturnType<typeof setTimeout> | null = null;
+  const BODY_SAVE_DEBOUNCE_MS = 400;
+
+  function scheduleBodySave(): void {
+    if (bodySaveTimeout !== null) clearTimeout(bodySaveTimeout);
+    bodySaveTimeout = setTimeout(() => {
+      bodySaveTimeout = null;
+      const latest = detailStore.getDetail()?.merge_request?.Body;
+      if (latest === undefined) return;
+      void detailStore.savePRBodyInBackground(
+        owner, name, number, latest,
+      );
+    }, BODY_SAVE_DEBOUNCE_MS);
+  }
+
+  function onBodyClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    if (target.tagName !== "INPUT") return;
+    if ((target as HTMLInputElement).type !== "checkbox") return;
+    const raw = target.getAttribute("data-task-index");
+    if (raw === null) return;
+    if (stalePR || !currentCapabilities().state_mutation) {
+      event.preventDefault();
+      return;
+    }
+    const index = parseInt(raw, 10);
+    if (Number.isNaN(index)) return;
+    const mr = currentPR();
+    if (!mr) return;
+    const newBody = toggleTaskListItem(mr.Body, index);
+    if (newBody === mr.Body) return;
+    // We manage state ourselves; let the visual flip persist via the
+    // optimistic store update rather than the browser's default toggle
+    // (which would race with our re-render).
+    event.preventDefault();
+    detailStore.setLocalPRBody(owner, name, number, newBody);
+    scheduleBodySave();
+  }
+
+  // Drag-to-reorder for task-list items. The handle (rendered by the
+  // markdown layer as `<span class="task-drag-handle" draggable>`) is
+  // the drag source; the enclosing `<li class="task-list-item">` is
+  // the drop target. Drop position relative to the target's vertical
+  // midpoint decides before/after placement.
+  let dragSourceIndex = $state<number | null>(null);
+  let dropTargetIndex = $state<number | null>(null);
+  let dropTargetSide = $state<"before" | "after">("before");
+
+  function findTaskItemIndex(el: HTMLElement | null): number | null {
+    let cur: HTMLElement | null = el;
+    while (cur) {
+      if (cur.classList && cur.classList.contains("task-list-item")) {
+        const raw = cur.getAttribute("data-task-index");
+        if (raw === null) return null;
+        const idx = parseInt(raw, 10);
+        return Number.isNaN(idx) ? null : idx;
+      }
+      cur = cur.parentElement;
+    }
+    return null;
+  }
+
+  function onBodyDragStart(event: DragEvent): void {
+    if (stalePR || !currentCapabilities().state_mutation) return;
+    const target = event.target as HTMLElement | null;
+    if (!target?.classList?.contains("task-drag-handle")) return;
+    const raw = target.getAttribute("data-task-index");
+    if (raw === null) return;
+    const idx = parseInt(raw, 10);
+    if (Number.isNaN(idx)) return;
+    dragSourceIndex = idx;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      // Firefox requires a non-empty payload to start a drag.
+      event.dataTransfer.setData("text/plain", String(idx));
+    }
+  }
+
+  function onBodyDragOver(event: DragEvent): void {
+    if (dragSourceIndex === null) return;
+    const target = event.target as HTMLElement | null;
+    const idx = findTaskItemIndex(target);
+    if (idx === null) return;
+    event.preventDefault(); // allow drop
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    let li: HTMLElement | null = target;
+    while (li && !(li.classList && li.classList.contains("task-list-item"))) {
+      li = li.parentElement;
+    }
+    let side: "before" | "after" = "before";
+    if (li) {
+      const rect = li.getBoundingClientRect();
+      side = event.clientY < rect.top + rect.height / 2
+        ? "before"
+        : "after";
+    }
+    dropTargetSide = side;
+    dropTargetIndex = idx;
+    updateDropIndicatorClasses(
+      event.currentTarget as HTMLElement,
+      idx,
+      side,
+    );
+  }
+
+  function onBodyDragLeave(event: DragEvent): void {
+    const related = event.relatedTarget as HTMLElement | null;
+    const body = event.currentTarget as HTMLElement;
+    if (!related || !body.contains(related)) {
+      dropTargetIndex = null;
+      clearDropIndicatorClasses(body);
+    }
+  }
+
+  function updateDropIndicatorClasses(
+    root: HTMLElement,
+    idx: number,
+    side: "before" | "after",
+  ): void {
+    clearDropIndicatorClasses(root);
+    const li = root.querySelector(
+      `.task-list-item--interactive[data-task-index="${idx}"]`,
+    );
+    if (!li) return;
+    li.classList.add(
+      side === "before" ? "task-drop-before" : "task-drop-after",
+    );
+  }
+
+  function clearDropIndicatorClasses(root: HTMLElement): void {
+    root.querySelectorAll(".task-drop-before").forEach((el) =>
+      el.classList.remove("task-drop-before"),
+    );
+    root.querySelectorAll(".task-drop-after").forEach((el) =>
+      el.classList.remove("task-drop-after"),
+    );
+  }
+
+  function onBodyDrop(event: DragEvent): void {
+    const body = event.currentTarget as HTMLElement;
+    if (dragSourceIndex === null) {
+      clearDragState(body);
+      return;
+    }
+    event.preventDefault();
+    const from = dragSourceIndex;
+    const to = dropTargetIndex;
+    const side = dropTargetSide;
+    clearDragState(body);
+    if (to === null || to === from) return;
+    if (stalePR || !currentCapabilities().state_mutation) return;
+    const mr = currentPR();
+    if (!mr) return;
+    // "before X" with from < X means landing one slot earlier than X
+    // after the splice; "after X" means landing on X. Adjust target.
+    let target = to;
+    if (from < to && side === "before") target = to - 1;
+    else if (from > to && side === "after") target = to + 1;
+    if (target === from) return;
+    const newBody = moveTaskListItem(mr.Body, from, target);
+    if (newBody === mr.Body) return;
+    detailStore.setLocalPRBody(owner, name, number, newBody);
+    scheduleBodySave();
+  }
+
+  function onBodyDragEnd(event: DragEvent): void {
+    clearDragState(event.currentTarget as HTMLElement);
+  }
+
+  function clearDragState(root?: HTMLElement | null): void {
+    dragSourceIndex = null;
+    dropTargetIndex = null;
+    dropTargetSide = "before";
+    if (root) clearDropIndicatorClasses(root);
   }
 
   async function loadDiffSummaryFiles(): Promise<DiffSummaryFilesResult> {
@@ -1182,7 +1370,18 @@
                 </svg>
               {/if}
             </button>
-            <div class="inset-box markdown-body">{@html renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath })}</div>
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="inset-box markdown-body"
+              class:dragging={dragSourceIndex !== null}
+              onclick={onBodyClick}
+              ondragstart={onBodyDragStart}
+              ondragover={onBodyDragOver}
+              ondragleave={onBodyDragLeave}
+              ondrop={onBodyDrop}
+              ondragend={onBodyDragEnd}
+            >{@html renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation })}</div>
           </div>
         {:else if capabilities.state_mutation}
           <button class="add-description-btn" onclick={startEditBody}>

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -206,12 +206,11 @@
     editingBody = false;
     titleDraft = "";
     bodyDraft = "";
-    // A pending checkbox save from the previous PR must not fire
-    // against the new one; drop it.
-    if (bodySaveTimeout !== null) {
-      clearTimeout(bodySaveTimeout);
-      bodySaveTimeout = null;
-    }
+    // Flush any pending checkbox/reorder save before clearing state.
+    // pendingBodySave captures the previous PR's identity at schedule
+    // time, so this fires against the correct target even though
+    // owner/name/number have already changed.
+    flushBodySave();
     clearDragState();
   });
 
@@ -588,19 +587,38 @@
   // Task-list checkbox clicks update the body locally for instant
   // feedback, then debounce a PATCH so a flurry of clicks collapses
   // into a single save. Avoids GitHub-style per-click blocking saves.
+  // The target (owner/name/number) AND the body to save are captured
+  // when scheduling so a route change before the timer fires can't
+  // redirect the save or lose the edit.
+  type PendingBodySave = {
+    owner: string;
+    name: string;
+    number: number;
+    body: string;
+  };
   let bodySaveTimeout: ReturnType<typeof setTimeout> | null = null;
+  let pendingBodySave: PendingBodySave | null = null;
   const BODY_SAVE_DEBOUNCE_MS = 400;
 
-  function scheduleBodySave(): void {
+  function scheduleBodySave(body: string): void {
+    pendingBodySave = { owner, name, number, body };
     if (bodySaveTimeout !== null) clearTimeout(bodySaveTimeout);
     bodySaveTimeout = setTimeout(() => {
-      bodySaveTimeout = null;
-      const latest = detailStore.getDetail()?.merge_request?.Body;
-      if (latest === undefined) return;
-      void detailStore.savePRBodyInBackground(
-        owner, name, number, latest,
-      );
+      flushBodySave();
     }, BODY_SAVE_DEBOUNCE_MS);
+  }
+
+  function flushBodySave(): void {
+    if (bodySaveTimeout !== null) {
+      clearTimeout(bodySaveTimeout);
+      bodySaveTimeout = null;
+    }
+    const target = pendingBodySave;
+    pendingBodySave = null;
+    if (target === null) return;
+    void detailStore.savePRBodyInBackground(
+      target.owner, target.name, target.number, target.body,
+    );
   }
 
   function onBodyClick(event: MouseEvent): void {
@@ -625,7 +643,7 @@
     // (which would race with our re-render).
     event.preventDefault();
     detailStore.setLocalPRBody(owner, name, number, newBody);
-    scheduleBodySave();
+    scheduleBodySave(newBody);
   }
 
   // Drag-to-reorder for task-list items. The handle (rendered by the
@@ -751,7 +769,7 @@
     const newBody = moveTaskListItem(mr.Body, from, target);
     if (newBody === mr.Body) return;
     detailStore.setLocalPRBody(owner, name, number, newBody);
-    scheduleBodySave();
+    scheduleBodySave(newBody);
   }
 
   function onBodyDragEnd(event: DragEvent): void {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -653,7 +653,9 @@
     // optimistic store update rather than the browser's default toggle
     // (which would race with our re-render).
     event.preventDefault();
-    detailStore.setLocalPRBody(owner, name, number, newBody);
+    detailStore.setLocalPRBody(
+      provider, platformHost, owner, name, number, newBody,
+    );
     scheduleBodySave(newBody);
   }
 
@@ -779,7 +781,9 @@
     if (target === from) return;
     const newBody = moveTaskListItem(mr.Body, from, target);
     if (newBody === mr.Body) return;
-    detailStore.setLocalPRBody(owner, name, number, newBody);
+    detailStore.setLocalPRBody(
+      provider, platformHost, owner, name, number, newBody,
+    );
     scheduleBodySave(newBody);
   }
 

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -595,13 +595,19 @@
     name: string;
     number: number;
     body: string;
+    provider: string;
+    platformHost?: string | undefined;
+    repoPath: string;
   };
   let bodySaveTimeout: ReturnType<typeof setTimeout> | null = null;
   let pendingBodySave: PendingBodySave | null = null;
   const BODY_SAVE_DEBOUNCE_MS = 400;
 
   function scheduleBodySave(body: string): void {
-    pendingBodySave = { owner, name, number, body };
+    pendingBodySave = {
+      owner, name, number, body,
+      provider, platformHost, repoPath,
+    };
     if (bodySaveTimeout !== null) clearTimeout(bodySaveTimeout);
     bodySaveTimeout = setTimeout(() => {
       flushBodySave();
@@ -618,6 +624,11 @@
     if (target === null) return;
     void detailStore.savePRBodyInBackground(
       target.owner, target.name, target.number, target.body,
+      {
+        provider: target.provider,
+        platformHost: target.platformHost,
+        repoPath: target.repoPath,
+      },
     );
   }
 

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -97,6 +97,8 @@ export function createDetailStore(
   // THIS specific PR — a poll on a different PR is unaffected, and
   // navigating away doesn't strand the flag on the wrong target.
   type UnsavedTarget = {
+    provider: string;
+    platformHost: string | undefined;
     owner: string;
     name: string;
     number: number;
@@ -189,11 +191,16 @@ export function createDetailStore(
 
   // Apply a fresh PullDetail from the server. When the user has an
   // unsynced local body edit on the same PR, keep that body so a
-  // polling refresh can't revert a pending optimistic toggle.
+  // polling refresh can't revert a pending optimistic toggle. Match on
+  // provider + platformHost too so an unrelated repo with the same
+  // owner/name/number (different host or provider) doesn't inherit
+  // another repo's pending body.
   function withPreservedLocalBody(next: PullDetail): PullDetail {
     if (!unsavedLocalBody) return next;
     if (!detail) return next;
     if (
+      unsavedLocalBody.provider !== next.repo?.provider ||
+      unsavedLocalBody.platformHost !== next.repo?.platform_host ||
       unsavedLocalBody.owner !== next.repo_owner ||
       unsavedLocalBody.name !== next.repo_name ||
       unsavedLocalBody.number !== next.merge_request?.Number
@@ -665,6 +672,8 @@ export function createDetailStore(
         detail = data as PullDetail;
         if (
           unsavedLocalBody &&
+          unsavedLocalBody.provider === ref.provider &&
+          unsavedLocalBody.platformHost === ref.platformHost &&
           unsavedLocalBody.owner === owner &&
           unsavedLocalBody.name === name &&
           unsavedLocalBody.number === number
@@ -703,13 +712,15 @@ export function createDetailStore(
   // the body as unsaved so a background refresh can't revert it
   // before the debounced PATCH lands.
   function setLocalPRBody(
+    provider: string,
+    platformHost: string | undefined,
     owner: string,
     name: string,
     number: number,
     body: string,
   ): void {
     if (!detail || !isDetailShowing(owner, name, number)) return;
-    unsavedLocalBody = { owner, name, number };
+    unsavedLocalBody = { provider, platformHost, owner, name, number };
     detail = {
       ...detail,
       merge_request: { ...detail.merge_request, Body: body },
@@ -734,12 +745,20 @@ export function createDetailStore(
   const inflightSaves = new Map<string, Promise<void>>();
   const queuedSaves = new Map<string, QueuedSave>();
   function saveQueueKey(
-    owner: string, name: string, number: number,
+    provider: string,
+    platformHost: string | undefined,
+    owner: string,
+    name: string,
+    number: number,
   ): string {
     // JSON encoding stores each field as its own array element, so
     // an owner or name that contains a delimiter character can't
-    // forge a collision with a different (owner, name, number).
-    return JSON.stringify([owner, name, number]);
+    // forge a collision with a different target. provider and
+    // platformHost are part of the key so the same owner/name/number
+    // on different hosts or providers can't share a queue slot.
+    return JSON.stringify([
+      provider, platformHost ?? "", owner, name, number,
+    ]);
   }
 
   async function runPRBodyPatch(
@@ -796,6 +815,8 @@ export function createDetailStore(
     if (
       succeeded &&
       unsavedLocalBody &&
+      unsavedLocalBody.provider === routeRef.provider &&
+      unsavedLocalBody.platformHost === routeRef.platformHost &&
       unsavedLocalBody.owner === owner &&
       unsavedLocalBody.name === name &&
       unsavedLocalBody.number === number
@@ -831,7 +852,9 @@ export function createDetailStore(
       repoPath: string;
     },
   ): Promise<void> {
-    const key = saveQueueKey(owner, name, number);
+    const key = saveQueueKey(
+      routeRef.provider, routeRef.platformHost, owner, name, number,
+    );
     queuedSaves.set(key, { body, routeRef });
     const existing = inflightSaves.get(key);
     if (existing) return existing;

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -91,6 +91,11 @@ export function createDetailStore(
   let storeError = $state<string | null>(null);
   let detailLoaded = $state(false);
   let syncGeneration = 0;
+  // Tracks whether the local PR body has been edited since the last
+  // server confirmation. While set, background sync paths preserve
+  // the local body when applying refreshed server data, so a poll
+  // can't clobber a pending optimistic checkbox/reorder edit.
+  let unsavedLocalBody = false;
   let activeLoad: {
     key: string;
     promise: Promise<void> | null;
@@ -176,6 +181,33 @@ export function createDetailStore(
     );
   }
 
+  // Apply a fresh PullDetail from the server. When the user has an
+  // unsynced local body edit on the same PR, keep that body so a
+  // polling refresh can't revert a pending optimistic toggle.
+  function withPreservedLocalBody(next: PullDetail): PullDetail {
+    if (!unsavedLocalBody) return next;
+    if (!detail) return next;
+    if (
+      detail.repo_owner !== next.repo_owner ||
+      detail.repo_name !== next.repo_name ||
+      detail.merge_request?.Number !==
+        next.merge_request?.Number
+    ) {
+      return next;
+    }
+    return {
+      ...next,
+      merge_request: {
+        ...next.merge_request,
+        Body: detail.merge_request.Body,
+      },
+    };
+  }
+
+  function hasUnsavedLocalBody(): boolean {
+    return unsavedLocalBody;
+  }
+
   function currentDetailRef(
     owner: string,
     name: string,
@@ -219,10 +251,10 @@ export function createDetailStore(
       // the new selection's data from being clobbered.
       if (expectedGen !== syncGeneration) return;
       if (data !== undefined) {
-        detail = {
+        detail = withPreservedLocalBody({
           ...data,
           events: data.events ?? [],
-        } as PullDetail;
+        } as PullDetail);
         detailLoaded = data.detail_loaded ?? detailLoaded;
       }
     } catch {
@@ -257,10 +289,10 @@ export function createDetailStore(
       }
       if (data) {
         storeError = null;
-        detail = {
+        detail = withPreservedLocalBody({
           ...data,
           events: data.events ?? [],
-        } as PullDetail;
+        } as PullDetail);
         detailLoaded =
           data.detail_loaded ?? detailLoaded;
       }
@@ -287,6 +319,7 @@ export function createDetailStore(
     syncing = false;
     storeError = null;
     detailLoaded = false;
+    unsavedLocalBody = false;
   }
 
   async function loadDetail(
@@ -355,7 +388,7 @@ export function createDetailStore(
           );
         }
         detail = data
-          ? ({
+          ? withPreservedLocalBody({
               ...data,
               events: data.events ?? [],
             } as PullDetail)
@@ -617,6 +650,7 @@ export function createDetailStore(
       // Apply server-canonical response.
       if (data && isDetailShowing(owner, name, number)) {
         detail = data as PullDetail;
+        unsavedLocalBody = false;
       }
     } catch (err) {
       storeError =
@@ -645,7 +679,9 @@ export function createDetailStore(
   // Replaces the in-memory PR body without touching the server. Pair
   // with savePRBodyInBackground for instant-feedback edits (e.g. task-
   // list checkbox clicks): apply the change locally first, then push
-  // it asynchronously so the click never blocks on the network.
+  // it asynchronously so the click never blocks on the network. Marks
+  // the body as unsaved so a background refresh can't revert it
+  // before the debounced PATCH lands.
   function setLocalPRBody(
     owner: string,
     name: string,
@@ -653,6 +689,7 @@ export function createDetailStore(
     body: string,
   ): void {
     if (!detail || !isDetailShowing(owner, name, number)) return;
+    unsavedLocalBody = true;
     detail = {
       ...detail,
       merge_request: { ...detail.merge_request, Body: body },
@@ -691,7 +728,9 @@ export function createDetailStore(
       }
       // Apply server-canonical response only when the user is still
       // looking at the same PR AND hasn't toggled again since this
-      // request was sent (server body matches what we sent).
+      // request was sent (server body matches what we sent). When it
+      // does match, the local edit has been confirmed by the server
+      // so the unsaved-body flag clears.
       if (
         data &&
         isDetailShowing(owner, name, number) &&
@@ -699,6 +738,7 @@ export function createDetailStore(
         detail.merge_request.Body === body
       ) {
         detail = data as PullDetail;
+        unsavedLocalBody = false;
       }
     } catch (err) {
       storeError =
@@ -903,6 +943,7 @@ export function createDetailStore(
     updatePRContent,
     setLocalPRBody,
     savePRBodyInBackground,
+    hasUnsavedLocalBody,
     startDetailPolling,
     stopDetailPolling,
     toggleDetailPRStar,

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -716,23 +716,35 @@ export function createDetailStore(
     };
   }
 
-  // Fire-and-forget PATCH for the PR body. Does NOT apply an optimistic
-  // update or revert on failure — the caller already owns local state.
-  // On error, storeError is set so the surface can surface a banner.
-  //
-  // The caller passes the full route ref so the PATCH always targets
-  // the captured PR even if the user has since navigated away. Only
-  // the response is gated on the currently displayed detail.
-  async function savePRBodyInBackground(
-    owner: string,
-    name: string,
-    number: number,
-    body: string,
+  // Single-flight body-save state, keyed per PR. Each entry tracks
+  // the in-flight PATCH and the latest queued body waiting to send
+  // once the in-flight save completes. The queue collapses to a
+  // single pending body — if the user toggles many times while a
+  // save is in flight, only the latest body lands. This prevents
+  // out-of-order PATCH responses from clobbering a newer body with
+  // an older one.
+  type QueuedSave = {
+    body: string;
     routeRef: {
       provider: string;
       platformHost?: string | undefined;
       repoPath: string;
-    },
+    };
+  };
+  const inflightSaves = new Map<string, Promise<void>>();
+  const queuedSaves = new Map<string, QueuedSave>();
+  function saveQueueKey(
+    owner: string, name: string, number: number,
+  ): string {
+    return `${owner} ${name} ${number}`;
+  }
+
+  async function runPRBodyPatch(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+    routeRef: QueuedSave["routeRef"],
   ): Promise<void> {
     const ref = detailRequestRef(owner, name, number, routeRef);
     let succeeded = false;
@@ -794,6 +806,47 @@ export function createDetailStore(
       }
     }
     refreshPullsIfActive().catch(() => {});
+  }
+
+  // Fire-and-forget PATCH for the PR body. Does NOT apply an optimistic
+  // update or revert on failure — the caller already owns local state.
+  // On error, storeError is set so the surface can surface a banner.
+  //
+  // The caller passes the full route ref so the PATCH always targets
+  // the captured PR even if the user has since navigated away. Only
+  // the response is gated on the currently displayed detail. Saves
+  // for the same PR are serialized so older requests can't overwrite
+  // newer bodies via out-of-order responses.
+  function savePRBodyInBackground(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+    routeRef: {
+      provider: string;
+      platformHost?: string | undefined;
+      repoPath: string;
+    },
+  ): Promise<void> {
+    const key = saveQueueKey(owner, name, number);
+    queuedSaves.set(key, { body, routeRef });
+    const existing = inflightSaves.get(key);
+    if (existing) return existing;
+    const flight = (async () => {
+      try {
+        while (queuedSaves.has(key)) {
+          const next = queuedSaves.get(key)!;
+          queuedSaves.delete(key);
+          await runPRBodyPatch(
+            owner, name, number, next.body, next.routeRef,
+          );
+        }
+      } finally {
+        inflightSaves.delete(key);
+      }
+    })();
+    inflightSaves.set(key, flight);
+    return flight;
   }
 
   function startDetailPolling(

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -642,6 +642,71 @@ export function createDetailStore(
     refreshPullsIfActive().catch(() => {});
   }
 
+  // Replaces the in-memory PR body without touching the server. Pair
+  // with savePRBodyInBackground for instant-feedback edits (e.g. task-
+  // list checkbox clicks): apply the change locally first, then push
+  // it asynchronously so the click never blocks on the network.
+  function setLocalPRBody(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+  ): void {
+    if (!detail || !isDetailShowing(owner, name, number)) return;
+    detail = {
+      ...detail,
+      merge_request: { ...detail.merge_request, Body: body },
+    };
+  }
+
+  // Fire-and-forget PATCH for the PR body. Does NOT apply an optimistic
+  // update or revert on failure — the caller already owns local state.
+  // On error, storeError is set so the surface can surface a banner.
+  async function savePRBodyInBackground(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+  ): Promise<void> {
+    if (!isDetailShowing(owner, name, number)) return;
+    const ref = currentDetailRef(owner, name, number);
+    try {
+      const { data, error: requestError } =
+        await apiClient.PATCH(
+          providerItemPath("pulls", ref, ""),
+          {
+            params: {
+              path: { ...providerRouteParams(ref), number },
+            },
+            body: { body },
+          },
+        );
+      if (requestError) {
+        throw new Error(
+          apiErrorMessage(
+            requestError,
+            "failed to update PR",
+          ),
+        );
+      }
+      // Apply server-canonical response only when the user is still
+      // looking at the same PR AND hasn't toggled again since this
+      // request was sent (server body matches what we sent).
+      if (
+        data &&
+        isDetailShowing(owner, name, number) &&
+        detail &&
+        detail.merge_request.Body === body
+      ) {
+        detail = data as PullDetail;
+      }
+    } catch (err) {
+      storeError =
+        err instanceof Error ? err.message : String(err);
+    }
+    refreshPullsIfActive().catch(() => {});
+  }
+
   function startDetailPolling(
     owner: string,
     name: string,
@@ -836,6 +901,8 @@ export function createDetailStore(
     refreshDetailOnly,
     updateKanbanState,
     updatePRContent,
+    setLocalPRBody,
+    savePRBodyInBackground,
     startDetailPolling,
     stopDetailPolling,
     toggleDetailPRStar,

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -771,9 +771,13 @@ export function createDetailStore(
       storeError =
         err instanceof Error ? err.message : String(err);
     }
-    // On a successful save, the captured target is now in sync with
-    // the server. Clear the unsaved flag if it pointed here, even
-    // when the user has since navigated away.
+    // On a successful save, the captured target may be in sync with
+    // the server — but only if the user hasn't typed more since the
+    // request went out. If `detail` is still showing this PR AND the
+    // local body diverges from the body we sent, treat the new edits
+    // as still pending and keep the flag set so the next polling
+    // refresh preserves them. Otherwise (matching body, or user
+    // navigated away), the saved body is canonical and we can clear.
     if (
       succeeded &&
       unsavedLocalBody &&
@@ -781,7 +785,13 @@ export function createDetailStore(
       unsavedLocalBody.name === name &&
       unsavedLocalBody.number === number
     ) {
-      unsavedLocalBody = null;
+      const newerEditInFlight =
+        detail !== null &&
+        isDetailShowing(owner, name, number) &&
+        detail.merge_request.Body !== body;
+      if (!newerEditInFlight) {
+        unsavedLocalBody = null;
+      }
     }
     refreshPullsIfActive().catch(() => {});
   }

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -736,7 +736,10 @@ export function createDetailStore(
   function saveQueueKey(
     owner: string, name: string, number: number,
   ): string {
-    return `${owner} ${name} ${number}`;
+    // JSON encoding stores each field as its own array element, so
+    // an owner or name that contains a delimiter character can't
+    // forge a collision with a different (owner, name, number).
+    return JSON.stringify([owner, name, number]);
   }
 
   async function runPRBodyPatch(

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -770,6 +770,15 @@ export function createDetailStore(
   ): Promise<void> {
     const ref = detailRequestRef(owner, name, number, routeRef);
     let succeeded = false;
+    // Capture whether the locally-displayed body still equals what we
+    // sent BEFORE we overwrite `detail` with the server response. If
+    // the server normalizes the body (e.g. line endings), a post-
+    // overwrite comparison would falsely look like a newer user edit
+    // and strand `unsavedLocalBody` indefinitely. Also include
+    // provider + platform host so a save response that returns after
+    // the user navigated to the same owner/name/number on another
+    // host doesn't replace the new repo's detail.
+    let localBodyMatchesSent = false;
     try {
       const { data, error: requestError } =
         await apiClient.PATCH(
@@ -790,30 +799,27 @@ export function createDetailStore(
         );
       }
       succeeded = true;
-      // Apply server-canonical response only when the user is still
-      // looking at the same PR AND hasn't toggled again since this
-      // request was sent (server body matches what we sent).
-      if (
-        data &&
+      localBodyMatchesSent =
+        detail !== null &&
         isDetailShowing(owner, name, number) &&
-        detail &&
-        detail.merge_request.Body === body
-      ) {
+        detail.repo?.provider === routeRef.provider &&
+        detail.repo?.platform_host === routeRef.platformHost &&
+        detail.merge_request.Body === body;
+      if (data && localBodyMatchesSent) {
         detail = data as PullDetail;
       }
     } catch (err) {
       storeError =
         err instanceof Error ? err.message : String(err);
     }
-    // On a successful save, the captured target may be in sync with
-    // the server — but only if the user hasn't typed more since the
-    // request went out. If `detail` is still showing this PR AND the
-    // local body diverges from the body we sent, treat the new edits
-    // as still pending and keep the flag set so the next polling
-    // refresh preserves them. Otherwise (matching body, or user
-    // navigated away), the saved body is canonical and we can clear.
+    // Clear the unsaved-body flag only when the captured local body
+    // matched what we sent — i.e. no newer toggle landed during the
+    // request. Using the captured value (rather than a fresh check)
+    // is what keeps a server-normalized body from masquerading as a
+    // newer edit and leaving the flag stuck.
     if (
       succeeded &&
+      localBodyMatchesSent &&
       unsavedLocalBody &&
       unsavedLocalBody.provider === routeRef.provider &&
       unsavedLocalBody.platformHost === routeRef.platformHost &&
@@ -821,13 +827,7 @@ export function createDetailStore(
       unsavedLocalBody.name === name &&
       unsavedLocalBody.number === number
     ) {
-      const newerEditInFlight =
-        detail !== null &&
-        isDetailShowing(owner, name, number) &&
-        detail.merge_request.Body !== body;
-      if (!newerEditInFlight) {
-        unsavedLocalBody = null;
-      }
+      unsavedLocalBody = null;
     }
     refreshPullsIfActive().catch(() => {});
   }

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -91,11 +91,17 @@ export function createDetailStore(
   let storeError = $state<string | null>(null);
   let detailLoaded = $state(false);
   let syncGeneration = 0;
-  // Tracks whether the local PR body has been edited since the last
-  // server confirmation. While set, background sync paths preserve
-  // the local body when applying refreshed server data, so a poll
-  // can't clobber a pending optimistic checkbox/reorder edit.
-  let unsavedLocalBody = false;
+  // Tracks the PR (if any) whose local body has been edited since
+  // the last server confirmation. While set, background sync paths
+  // preserve the local body when applying refreshed server data for
+  // THIS specific PR — a poll on a different PR is unaffected, and
+  // navigating away doesn't strand the flag on the wrong target.
+  type UnsavedTarget = {
+    owner: string;
+    name: string;
+    number: number;
+  };
+  let unsavedLocalBody = $state<UnsavedTarget | null>(null);
   let activeLoad: {
     key: string;
     promise: Promise<void> | null;
@@ -188,6 +194,13 @@ export function createDetailStore(
     if (!unsavedLocalBody) return next;
     if (!detail) return next;
     if (
+      unsavedLocalBody.owner !== next.repo_owner ||
+      unsavedLocalBody.name !== next.repo_name ||
+      unsavedLocalBody.number !== next.merge_request?.Number
+    ) {
+      return next;
+    }
+    if (
       detail.repo_owner !== next.repo_owner ||
       detail.repo_name !== next.repo_name ||
       detail.merge_request?.Number !==
@@ -205,7 +218,7 @@ export function createDetailStore(
   }
 
   function hasUnsavedLocalBody(): boolean {
-    return unsavedLocalBody;
+    return unsavedLocalBody !== null;
   }
 
   function currentDetailRef(
@@ -319,7 +332,7 @@ export function createDetailStore(
     syncing = false;
     storeError = null;
     detailLoaded = false;
-    unsavedLocalBody = false;
+    unsavedLocalBody = null;
   }
 
   async function loadDetail(
@@ -650,7 +663,14 @@ export function createDetailStore(
       // Apply server-canonical response.
       if (data && isDetailShowing(owner, name, number)) {
         detail = data as PullDetail;
-        unsavedLocalBody = false;
+        if (
+          unsavedLocalBody &&
+          unsavedLocalBody.owner === owner &&
+          unsavedLocalBody.name === name &&
+          unsavedLocalBody.number === number
+        ) {
+          unsavedLocalBody = null;
+        }
       }
     } catch (err) {
       storeError =
@@ -689,7 +709,7 @@ export function createDetailStore(
     body: string,
   ): void {
     if (!detail || !isDetailShowing(owner, name, number)) return;
-    unsavedLocalBody = true;
+    unsavedLocalBody = { owner, name, number };
     detail = {
       ...detail,
       merge_request: { ...detail.merge_request, Body: body },
@@ -699,14 +719,23 @@ export function createDetailStore(
   // Fire-and-forget PATCH for the PR body. Does NOT apply an optimistic
   // update or revert on failure — the caller already owns local state.
   // On error, storeError is set so the surface can surface a banner.
+  //
+  // The caller passes the full route ref so the PATCH always targets
+  // the captured PR even if the user has since navigated away. Only
+  // the response is gated on the currently displayed detail.
   async function savePRBodyInBackground(
     owner: string,
     name: string,
     number: number,
     body: string,
+    routeRef: {
+      provider: string;
+      platformHost?: string | undefined;
+      repoPath: string;
+    },
   ): Promise<void> {
-    if (!isDetailShowing(owner, name, number)) return;
-    const ref = currentDetailRef(owner, name, number);
+    const ref = detailRequestRef(owner, name, number, routeRef);
+    let succeeded = false;
     try {
       const { data, error: requestError } =
         await apiClient.PATCH(
@@ -726,11 +755,10 @@ export function createDetailStore(
           ),
         );
       }
+      succeeded = true;
       // Apply server-canonical response only when the user is still
       // looking at the same PR AND hasn't toggled again since this
-      // request was sent (server body matches what we sent). When it
-      // does match, the local edit has been confirmed by the server
-      // so the unsaved-body flag clears.
+      // request was sent (server body matches what we sent).
       if (
         data &&
         isDetailShowing(owner, name, number) &&
@@ -738,11 +766,22 @@ export function createDetailStore(
         detail.merge_request.Body === body
       ) {
         detail = data as PullDetail;
-        unsavedLocalBody = false;
       }
     } catch (err) {
       storeError =
         err instanceof Error ? err.message : String(err);
+    }
+    // On a successful save, the captured target is now in sync with
+    // the server. Clear the unsaved flag if it pointed here, even
+    // when the user has since navigated away.
+    if (
+      succeeded &&
+      unsavedLocalBody &&
+      unsavedLocalBody.owner === owner &&
+      unsavedLocalBody.name === name &&
+      unsavedLocalBody.number === number
+    ) {
+      unsavedLocalBody = null;
     }
     refreshPullsIfActive().catch(() => {});
   }

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -96,11 +96,17 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   let detailSyncing = $state(false);
   let detailError = $state<string | null>(null);
   let issueDetailLoaded = $state(false);
-  // Tracks whether the local issue body has been edited since the
-  // last server confirmation. While set, background sync paths
-  // preserve the local body so a poll can't revert a pending
-  // optimistic checkbox/reorder edit.
-  let unsavedLocalBody = false;
+  // Tracks the issue (if any) whose local body has been edited since
+  // the last server confirmation. While set, background sync paths
+  // preserve the local body for THIS specific issue — a poll on a
+  // different issue is unaffected, and navigating away doesn't
+  // strand the flag on the wrong target.
+  type UnsavedIssueTarget = {
+    owner: string;
+    name: string;
+    number: number;
+  };
+  let unsavedLocalBody = $state<UnsavedIssueTarget | null>(null);
   let detailPollHandle: ReturnType<typeof setInterval> | null = null;
   let issueSyncGeneration = 0;
   let activeDetailLoad: {
@@ -246,6 +252,13 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     if (!unsavedLocalBody) return next;
     if (!issueDetail) return next;
     if (
+      unsavedLocalBody.owner !== next.repo_owner ||
+      unsavedLocalBody.name !== next.repo_name ||
+      unsavedLocalBody.number !== next.issue?.Number
+    ) {
+      return next;
+    }
+    if (
       issueDetail.repo_owner !== next.repo_owner ||
       issueDetail.repo_name !== next.repo_name ||
       issueDetail.issue?.Number !== next.issue?.Number
@@ -259,7 +272,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   }
 
   function hasUnsavedLocalBody(): boolean {
-    return unsavedLocalBody;
+    return unsavedLocalBody !== null;
   }
 
   function currentIssuePlatformHost(
@@ -565,7 +578,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     detailSyncing = false;
     detailError = null;
     issueDetailLoaded = false;
-    unsavedLocalBody = false;
+    unsavedLocalBody = null;
   }
 
   async function submitIssueComment(
@@ -666,7 +679,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     ) {
       return;
     }
-    unsavedLocalBody = true;
+    unsavedLocalBody = { owner, name, number };
     issueDetail = {
       ...issueDetail,
       issue: { ...issueDetail.issue, Body: body },
@@ -676,21 +689,23 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   // Fire-and-forget PATCH for the issue body. Does NOT apply an
   // optimistic update or revert on failure — the caller already owns
   // local state. On error, detailError surfaces a banner.
+  //
+  // The caller passes the full route ref so the PATCH always targets
+  // the captured issue even if the user has since navigated away.
+  // Only the response is gated on the currently displayed detail.
   async function saveIssueBodyInBackground(
     owner: string,
     name: string,
     number: number,
     body: string,
+    routeRef: {
+      provider: string;
+      platformHost?: string | undefined;
+      repoPath: string;
+    },
   ): Promise<void> {
-    if (!issueDetail) return;
-    if (
-      issueDetail.repo_owner !== owner ||
-      issueDetail.repo_name !== name ||
-      issueDetail.issue.Number !== number
-    ) {
-      return;
-    }
-    const ref = currentIssueDetailRef(owner, name, number);
+    const ref = issueDetailRequestRef(owner, name, number, routeRef);
+    let succeeded = false;
     try {
       const { data, error: requestError } =
         await apiClient.PATCH(
@@ -710,10 +725,10 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
           apiErrorMessage(requestError, "failed to update issue"),
         );
       }
+      succeeded = true;
       // Only adopt the server-canonical issue when the user is still
       // viewing the same issue AND no newer toggle has shifted the
-      // local body away from what we just persisted. When it does
-      // match, the local edit has been confirmed so the flag clears.
+      // local body away from what we just persisted.
       if (
         data &&
         issueDetail &&
@@ -723,11 +738,22 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
         issueDetail.issue.Body === body
       ) {
         issueDetail = data as IssueDetail;
-        unsavedLocalBody = false;
       }
     } catch (err) {
       detailError =
         err instanceof Error ? err.message : String(err);
+    }
+    // On a successful save, the captured target is now in sync with
+    // the server. Clear the unsaved flag if it pointed here, even
+    // when the user has since navigated away.
+    if (
+      succeeded &&
+      unsavedLocalBody &&
+      unsavedLocalBody.owner === owner &&
+      unsavedLocalBody.name === name &&
+      unsavedLocalBody.number === number
+    ) {
+      unsavedLocalBody = null;
     }
     refreshIssuesIfActive().catch(() => {});
   }

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -686,23 +686,33 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     };
   }
 
-  // Fire-and-forget PATCH for the issue body. Does NOT apply an
-  // optimistic update or revert on failure — the caller already owns
-  // local state. On error, detailError surfaces a banner.
-  //
-  // The caller passes the full route ref so the PATCH always targets
-  // the captured issue even if the user has since navigated away.
-  // Only the response is gated on the currently displayed detail.
-  async function saveIssueBodyInBackground(
-    owner: string,
-    name: string,
-    number: number,
-    body: string,
+  // Single-flight body-save state, keyed per issue. Each entry
+  // tracks the in-flight PATCH and the latest queued body waiting
+  // to send once the in-flight save completes. The queue collapses
+  // to a single pending body so out-of-order PATCH responses can't
+  // overwrite a newer body with an older one.
+  type QueuedIssueSave = {
+    body: string;
     routeRef: {
       provider: string;
       platformHost?: string | undefined;
       repoPath: string;
-    },
+    };
+  };
+  const inflightIssueSaves = new Map<string, Promise<void>>();
+  const queuedIssueSaves = new Map<string, QueuedIssueSave>();
+  function issueSaveQueueKey(
+    owner: string, name: string, number: number,
+  ): string {
+    return `${owner} ${name} ${number}`;
+  }
+
+  async function runIssueBodyPatch(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+    routeRef: QueuedIssueSave["routeRef"],
   ): Promise<void> {
     const ref = issueDetailRequestRef(owner, name, number, routeRef);
     let succeeded = false;
@@ -769,6 +779,47 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       }
     }
     refreshIssuesIfActive().catch(() => {});
+  }
+
+  // Fire-and-forget PATCH for the issue body. Does NOT apply an
+  // optimistic update or revert on failure — the caller already owns
+  // local state. On error, detailError surfaces a banner.
+  //
+  // The caller passes the full route ref so the PATCH always targets
+  // the captured issue even if the user has since navigated away.
+  // Only the response is gated on the currently displayed detail.
+  // Saves for the same issue are serialized so older requests can't
+  // overwrite newer bodies via out-of-order responses.
+  function saveIssueBodyInBackground(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+    routeRef: {
+      provider: string;
+      platformHost?: string | undefined;
+      repoPath: string;
+    },
+  ): Promise<void> {
+    const key = issueSaveQueueKey(owner, name, number);
+    queuedIssueSaves.set(key, { body, routeRef });
+    const existing = inflightIssueSaves.get(key);
+    if (existing) return existing;
+    const flight = (async () => {
+      try {
+        while (queuedIssueSaves.has(key)) {
+          const next = queuedIssueSaves.get(key)!;
+          queuedIssueSaves.delete(key);
+          await runIssueBodyPatch(
+            owner, name, number, next.body, next.routeRef,
+          );
+        }
+      } finally {
+        inflightIssueSaves.delete(key);
+      }
+    })();
+    inflightIssueSaves.set(key, flight);
+    return flight;
   }
 
   async function toggleIssueStar(

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -102,6 +102,8 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   // different issue is unaffected, and navigating away doesn't
   // strand the flag on the wrong target.
   type UnsavedIssueTarget = {
+    provider: string;
+    platformHost: string | undefined;
     owner: string;
     name: string;
     number: number;
@@ -247,11 +249,16 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   // Apply a fresh IssueDetail from the server. When the user has an
   // unsynced local body edit on the same issue, keep that body so a
-  // polling refresh can't revert a pending optimistic toggle.
+  // polling refresh can't revert a pending optimistic toggle. Match on
+  // provider + platformHost too so an unrelated repo with the same
+  // owner/name/number (different host or provider) doesn't inherit
+  // another repo's pending body.
   function withPreservedLocalBody(next: IssueDetail): IssueDetail {
     if (!unsavedLocalBody) return next;
     if (!issueDetail) return next;
     if (
+      unsavedLocalBody.provider !== next.repo?.provider ||
+      unsavedLocalBody.platformHost !== next.repo?.platform_host ||
       unsavedLocalBody.owner !== next.repo_owner ||
       unsavedLocalBody.name !== next.repo_name ||
       unsavedLocalBody.number !== next.issue?.Number
@@ -666,6 +673,8 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   // background refresh can't revert it before the debounced PATCH
   // lands.
   function setLocalIssueBody(
+    provider: string,
+    platformHost: string | undefined,
     owner: string,
     name: string,
     number: number,
@@ -679,7 +688,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     ) {
       return;
     }
-    unsavedLocalBody = { owner, name, number };
+    unsavedLocalBody = { provider, platformHost, owner, name, number };
     issueDetail = {
       ...issueDetail,
       issue: { ...issueDetail.issue, Body: body },
@@ -702,12 +711,20 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   const inflightIssueSaves = new Map<string, Promise<void>>();
   const queuedIssueSaves = new Map<string, QueuedIssueSave>();
   function issueSaveQueueKey(
-    owner: string, name: string, number: number,
+    provider: string,
+    platformHost: string | undefined,
+    owner: string,
+    name: string,
+    number: number,
   ): string {
     // JSON encoding stores each field as its own array element, so
     // an owner or name that contains a delimiter character can't
-    // forge a collision with a different (owner, name, number).
-    return JSON.stringify([owner, name, number]);
+    // forge a collision with a different target. provider and
+    // platformHost are part of the key so the same owner/name/number
+    // on different hosts or providers can't share a queue slot.
+    return JSON.stringify([
+      provider, platformHost ?? "", owner, name, number,
+    ]);
   }
 
   async function runIssueBodyPatch(
@@ -767,6 +784,8 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     if (
       succeeded &&
       unsavedLocalBody &&
+      unsavedLocalBody.provider === routeRef.provider &&
+      unsavedLocalBody.platformHost === routeRef.platformHost &&
       unsavedLocalBody.owner === owner &&
       unsavedLocalBody.name === name &&
       unsavedLocalBody.number === number
@@ -804,7 +823,9 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       repoPath: string;
     },
   ): Promise<void> {
-    const key = issueSaveQueueKey(owner, name, number);
+    const key = issueSaveQueueKey(
+      routeRef.provider, routeRef.platformHost, owner, name, number,
+    );
     queuedIssueSaves.set(key, { body, routeRef });
     const existing = inflightIssueSaves.get(key);
     if (existing) return existing;

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -743,9 +743,14 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       detailError =
         err instanceof Error ? err.message : String(err);
     }
-    // On a successful save, the captured target is now in sync with
-    // the server. Clear the unsaved flag if it pointed here, even
-    // when the user has since navigated away.
+    // On a successful save, the captured target may be in sync with
+    // the server — but only if the user hasn't typed more since the
+    // request went out. If `issueDetail` is still showing this issue
+    // AND the local body diverges from the body we sent, treat the
+    // new edits as still pending and keep the flag set so the next
+    // polling refresh preserves them. Otherwise (matching body, or
+    // user navigated away), the saved body is canonical and we can
+    // clear.
     if (
       succeeded &&
       unsavedLocalBody &&
@@ -753,7 +758,15 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       unsavedLocalBody.name === name &&
       unsavedLocalBody.number === number
     ) {
-      unsavedLocalBody = null;
+      const newerEditInFlight =
+        issueDetail !== null &&
+        issueDetail.repo_owner === owner &&
+        issueDetail.repo_name === name &&
+        issueDetail.issue.Number === number &&
+        issueDetail.issue.Body !== body;
+      if (!newerEditInFlight) {
+        unsavedLocalBody = null;
+      }
     }
     refreshIssuesIfActive().catch(() => {});
   }

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -96,6 +96,11 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   let detailSyncing = $state(false);
   let detailError = $state<string | null>(null);
   let issueDetailLoaded = $state(false);
+  // Tracks whether the local issue body has been edited since the
+  // last server confirmation. While set, background sync paths
+  // preserve the local body so a poll can't revert a pending
+  // optimistic checkbox/reorder edit.
+  let unsavedLocalBody = false;
   let detailPollHandle: ReturnType<typeof setInterval> | null = null;
   let issueSyncGeneration = 0;
   let activeDetailLoad: {
@@ -234,6 +239,29 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   // --- detail writes ---
 
+  // Apply a fresh IssueDetail from the server. When the user has an
+  // unsynced local body edit on the same issue, keep that body so a
+  // polling refresh can't revert a pending optimistic toggle.
+  function withPreservedLocalBody(next: IssueDetail): IssueDetail {
+    if (!unsavedLocalBody) return next;
+    if (!issueDetail) return next;
+    if (
+      issueDetail.repo_owner !== next.repo_owner ||
+      issueDetail.repo_name !== next.repo_name ||
+      issueDetail.issue?.Number !== next.issue?.Number
+    ) {
+      return next;
+    }
+    return {
+      ...next,
+      issue: { ...next.issue, Body: issueDetail.issue.Body },
+    };
+  }
+
+  function hasUnsavedLocalBody(): boolean {
+    return unsavedLocalBody;
+  }
+
   function currentIssuePlatformHost(
     owner: string,
     name: string,
@@ -345,7 +373,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
           throw new Error(apiErrorMessage(requestError, "failed to load issue"));
         }
         issueDetail = data
-          ? ({
+          ? withPreservedLocalBody({
               ...data,
               events: data.events ?? [],
             } as IssueDetail)
@@ -458,10 +486,10 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       }
       if (data) {
         detailError = null;
-        issueDetail = {
+        issueDetail = withPreservedLocalBody({
           ...data,
           events: data.events ?? [],
-        } as IssueDetail;
+        } as IssueDetail);
         issueDetailLoaded = data.detail_loaded ?? issueDetailLoaded;
       }
     } catch {
@@ -498,10 +526,10 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       // keeps the new selection's data from being clobbered.
       if (expectedGen !== issueSyncGeneration) return;
       if (data !== undefined) {
-        issueDetail = {
+        issueDetail = withPreservedLocalBody({
           ...data,
           events: data.events ?? [],
-        } as IssueDetail;
+        } as IssueDetail);
         issueDetailLoaded = data.detail_loaded ?? issueDetailLoaded;
       }
     } catch {
@@ -537,6 +565,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     detailSyncing = false;
     detailError = null;
     issueDetailLoaded = false;
+    unsavedLocalBody = false;
   }
 
   async function submitIssueComment(
@@ -620,7 +649,9 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   // Replaces the in-memory issue body without touching the server. Pair
   // with saveIssueBodyInBackground for instant-feedback edits like
-  // task-list checkbox clicks.
+  // task-list checkbox clicks. Marks the body as unsaved so a
+  // background refresh can't revert it before the debounced PATCH
+  // lands.
   function setLocalIssueBody(
     owner: string,
     name: string,
@@ -635,6 +666,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     ) {
       return;
     }
+    unsavedLocalBody = true;
     issueDetail = {
       ...issueDetail,
       issue: { ...issueDetail.issue, Body: body },
@@ -680,7 +712,8 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       }
       // Only adopt the server-canonical issue when the user is still
       // viewing the same issue AND no newer toggle has shifted the
-      // local body away from what we just persisted.
+      // local body away from what we just persisted. When it does
+      // match, the local edit has been confirmed so the flag clears.
       if (
         data &&
         issueDetail &&
@@ -690,6 +723,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
         issueDetail.issue.Body === body
       ) {
         issueDetail = data as IssueDetail;
+        unsavedLocalBody = false;
       }
     } catch (err) {
       detailError =
@@ -880,6 +914,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     editIssueComment,
     setLocalIssueBody,
     saveIssueBodyInBackground,
+    hasUnsavedLocalBody,
     toggleIssueStar,
     selectNextIssue,
     selectPrevIssue,

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -736,6 +736,15 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   ): Promise<void> {
     const ref = issueDetailRequestRef(owner, name, number, routeRef);
     let succeeded = false;
+    // Capture whether the locally-displayed body still equals what we
+    // sent BEFORE we overwrite `issueDetail` with the server response.
+    // A server-side body normalization (e.g. line endings) would
+    // otherwise masquerade as a newer user edit on a post-overwrite
+    // check and strand `unsavedLocalBody`. Also include provider +
+    // platform host so a stale response from a since-navigated-away
+    // host can't replace the now-displayed issue from another host
+    // that happens to share owner/name/number.
+    let localBodyMatchesSent = false;
     try {
       const { data, error: requestError } =
         await apiClient.PATCH(
@@ -756,33 +765,24 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
         );
       }
       succeeded = true;
-      // Only adopt the server-canonical issue when the user is still
-      // viewing the same issue AND no newer toggle has shifted the
-      // local body away from what we just persisted.
-      if (
-        data &&
-        issueDetail &&
+      localBodyMatchesSent =
+        issueDetail !== null &&
+        issueDetail.repo?.provider === routeRef.provider &&
+        issueDetail.repo?.platform_host === routeRef.platformHost &&
         issueDetail.repo_owner === owner &&
         issueDetail.repo_name === name &&
         issueDetail.issue.Number === number &&
-        issueDetail.issue.Body === body
-      ) {
+        issueDetail.issue.Body === body;
+      if (data && localBodyMatchesSent) {
         issueDetail = data as IssueDetail;
       }
     } catch (err) {
       detailError =
         err instanceof Error ? err.message : String(err);
     }
-    // On a successful save, the captured target may be in sync with
-    // the server — but only if the user hasn't typed more since the
-    // request went out. If `issueDetail` is still showing this issue
-    // AND the local body diverges from the body we sent, treat the
-    // new edits as still pending and keep the flag set so the next
-    // polling refresh preserves them. Otherwise (matching body, or
-    // user navigated away), the saved body is canonical and we can
-    // clear.
     if (
       succeeded &&
+      localBodyMatchesSent &&
       unsavedLocalBody &&
       unsavedLocalBody.provider === routeRef.provider &&
       unsavedLocalBody.platformHost === routeRef.platformHost &&
@@ -790,15 +790,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       unsavedLocalBody.name === name &&
       unsavedLocalBody.number === number
     ) {
-      const newerEditInFlight =
-        issueDetail !== null &&
-        issueDetail.repo_owner === owner &&
-        issueDetail.repo_name === name &&
-        issueDetail.issue.Number === number &&
-        issueDetail.issue.Body !== body;
-      if (!newerEditInFlight) {
-        unsavedLocalBody = null;
-      }
+      unsavedLocalBody = null;
     }
     refreshIssuesIfActive().catch(() => {});
   }

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -704,7 +704,10 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   function issueSaveQueueKey(
     owner: string, name: string, number: number,
   ): string {
-    return `${owner} ${name} ${number}`;
+    // JSON encoding stores each field as its own array element, so
+    // an owner or name that contains a delimiter character can't
+    // forge a collision with a different (owner, name, number).
+    return JSON.stringify([owner, name, number]);
   }
 
   async function runIssueBodyPatch(

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -618,6 +618,86 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     return true;
   }
 
+  // Replaces the in-memory issue body without touching the server. Pair
+  // with saveIssueBodyInBackground for instant-feedback edits like
+  // task-list checkbox clicks.
+  function setLocalIssueBody(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+  ): void {
+    if (!issueDetail) return;
+    if (
+      issueDetail.repo_owner !== owner ||
+      issueDetail.repo_name !== name ||
+      issueDetail.issue.Number !== number
+    ) {
+      return;
+    }
+    issueDetail = {
+      ...issueDetail,
+      issue: { ...issueDetail.issue, Body: body },
+    };
+  }
+
+  // Fire-and-forget PATCH for the issue body. Does NOT apply an
+  // optimistic update or revert on failure — the caller already owns
+  // local state. On error, detailError surfaces a banner.
+  async function saveIssueBodyInBackground(
+    owner: string,
+    name: string,
+    number: number,
+    body: string,
+  ): Promise<void> {
+    if (!issueDetail) return;
+    if (
+      issueDetail.repo_owner !== owner ||
+      issueDetail.repo_name !== name ||
+      issueDetail.issue.Number !== number
+    ) {
+      return;
+    }
+    const ref = currentIssueDetailRef(owner, name, number);
+    try {
+      const { data, error: requestError } =
+        await apiClient.PATCH(
+          providerItemPath("issues", ref, ""),
+          {
+            params: {
+              path: {
+                ...providerRouteParams(ref),
+                number,
+              },
+            },
+            body: { body },
+          },
+        );
+      if (requestError) {
+        throw new Error(
+          apiErrorMessage(requestError, "failed to update issue"),
+        );
+      }
+      // Only adopt the server-canonical issue when the user is still
+      // viewing the same issue AND no newer toggle has shifted the
+      // local body away from what we just persisted.
+      if (
+        data &&
+        issueDetail &&
+        issueDetail.repo_owner === owner &&
+        issueDetail.repo_name === name &&
+        issueDetail.issue.Number === number &&
+        issueDetail.issue.Body === body
+      ) {
+        issueDetail = data as IssueDetail;
+      }
+    } catch (err) {
+      detailError =
+        err instanceof Error ? err.message : String(err);
+    }
+    refreshIssuesIfActive().catch(() => {});
+  }
+
   async function toggleIssueStar(
     owner: string,
     name: string,
@@ -798,6 +878,8 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     clearIssueDetail,
     submitIssueComment,
     editIssueComment,
+    setLocalIssueBody,
+    saveIssueBodyInBackground,
     toggleIssueStar,
     selectNextIssue,
     selectPrevIssue,

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -74,4 +74,43 @@ describe("renderMarkdown task lists", () => {
     const matches = html.match(/<input/g) ?? [];
     expect(matches.length).toBe(1);
   });
+
+  it("preserves per-listitem indices when task items are nested", () => {
+    // Each <li> and its drag handle MUST carry the same index as the
+    // checkbox that lives directly inside that <li>. A nested child
+    // must not leak its index back up to its parent's wrapper.
+    const html = renderMarkdown(
+      "- [ ] outer\n  - [ ] inner\n- [x] sibling",
+      undefined,
+      { interactiveTasks: true },
+    );
+    // The outer <li> wraps both the outer checkbox AND the nested
+    // list — its data-task-index must match its OWN checkbox (0),
+    // not the nested child's (1).
+    expect(html).toContain(
+      '<li class="task-list-item task-list-item--interactive" data-task-index="0">',
+    );
+    expect(html).toContain(
+      '<li class="task-list-item task-list-item--interactive" data-task-index="1">',
+    );
+    expect(html).toContain(
+      '<li class="task-list-item task-list-item--interactive" data-task-index="2">',
+    );
+    expect(html).toContain(
+      '<span class="task-drag-handle" data-task-index="0"',
+    );
+    expect(html).toContain(
+      '<span class="task-drag-handle" data-task-index="1"',
+    );
+    expect(html).toContain(
+      '<span class="task-drag-handle" data-task-index="2"',
+    );
+    // Sanity-check pairing: the outer <li> contains the nested <li>
+    // in its inner content, and the outer's drag handle precedes
+    // the outer's checkbox.
+    const outerOpen = html.indexOf(
+      'data-task-index="0"><span class="task-drag-handle" data-task-index="0"',
+    );
+    expect(outerOpen).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -75,6 +75,26 @@ describe("renderMarkdown task lists", () => {
     expect(matches.length).toBe(1);
   });
 
+  it("renders blockquoted task items as non-interactive even when interactiveTasks is set", () => {
+    // Source-side TASK_LINE doesn't match `> - [ ]` so the renderer
+    // must NOT emit interactive checkboxes for them — otherwise
+    // data-task-index would drift from the source helpers and
+    // clicking would mutate the wrong line.
+    const html = renderMarkdown(
+      "> - [ ] inside blockquote\n\n- [ ] outside",
+      undefined,
+      { interactiveTasks: true },
+    );
+    // The blockquoted checkbox stays disabled with no data-task-index.
+    expect(html).toMatch(
+      /<blockquote>[\s\S]*<input disabled="" type="checkbox">[\s\S]*<\/blockquote>/,
+    );
+    // The plain task outside the blockquote keeps interactivity at
+    // index 0 (the blockquoted one didn't consume an index).
+    expect(html).toContain('data-task-index="0"');
+    expect(html).not.toContain('data-task-index="1"');
+  });
+
   it("preserves per-listitem indices when task items are nested", () => {
     // Each <li> and its drag handle MUST carry the same index as the
     // checkbox that lives directly inside that <li>. A nested child

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "./markdown.js";
+
+describe("renderMarkdown task lists", () => {
+  it("renders disabled checkboxes by default", () => {
+    const html = renderMarkdown("- [ ] one\n- [x] two");
+    expect(html).toContain('disabled=""');
+    expect(html).not.toContain("data-task-index");
+  });
+
+  it("renders enabled checkboxes with sequential indices when interactiveTasks is set", () => {
+    const html = renderMarkdown(
+      "- [ ] alpha\n- [x] beta\n- [ ] gamma",
+      undefined,
+      { interactiveTasks: true },
+    );
+    expect(html).not.toContain('disabled=""');
+    expect(html).toContain('data-task-index="0"');
+    expect(html).toContain('data-task-index="1"');
+    expect(html).toContain('data-task-index="2"');
+  });
+
+  it("starts the task index at zero for every render", () => {
+    const opts = { interactiveTasks: true } as const;
+    const first = renderMarkdown("- [ ] a", undefined, opts);
+    const second = renderMarkdown("- [ ] b", undefined, opts);
+    expect(first).toContain('data-task-index="0"');
+    expect(second).toContain('data-task-index="0"');
+  });
+
+  it("preserves checked state when interactiveTasks is set", () => {
+    const html = renderMarkdown("- [x] done", undefined, {
+      interactiveTasks: true,
+    });
+    expect(html).toContain('checked=""');
+  });
+
+  it("caches interactive and non-interactive renders separately", () => {
+    const src = "- [ ] task";
+    const plain = renderMarkdown(src);
+    const interactive = renderMarkdown(src, undefined, {
+      interactiveTasks: true,
+    });
+    expect(plain).toContain('disabled=""');
+    expect(interactive).toContain('data-task-index="0"');
+  });
+
+  it("emits a drag handle and item-level data-task-index for interactive tasks", () => {
+    const html = renderMarkdown("- [ ] a\n- [ ] b", undefined, {
+      interactiveTasks: true,
+    });
+    expect(html).toContain(
+      '<li class="task-list-item task-list-item--interactive" data-task-index="0">',
+    );
+    expect(html).toContain(
+      '<span class="task-drag-handle" data-task-index="0"',
+    );
+    expect(html).toContain(
+      '<span class="task-drag-handle" data-task-index="1"',
+    );
+    expect(html).toContain('draggable="true"');
+  });
+
+  it("does not emit drag handles in non-interactive mode", () => {
+    const html = renderMarkdown("- [ ] a");
+    expect(html).not.toContain("task-drag-handle");
+    expect(html).not.toContain("draggable");
+  });
+
+  it("emits only one input per task item in interactive mode", () => {
+    const html = renderMarkdown("- [ ] a", undefined, {
+      interactiveTasks: true,
+    });
+    const matches = html.match(/<input/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+});

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -110,10 +110,18 @@ let renderState: {
   taskIndex: number;
   interactiveTasks: boolean;
   itemStack: ListItemFrame[];
+  // Counts blockquote nesting depth so listitem can detect when it
+  // sits inside `> ...`. The source-side task helpers don't see
+  // blockquoted task lines (TASK_LINE matches column-0 bullets),
+  // so the renderer must skip interactivity inside blockquotes —
+  // otherwise data-task-index values would drift from the source
+  // and clicks would mutate the wrong line.
+  blockquoteDepth: number;
 } = {
   taskIndex: 0,
   interactiveTasks: false,
   itemStack: [],
+  blockquoteDepth: 0,
 };
 
 const htmlCache = new Map<string, string>();
@@ -139,19 +147,36 @@ function getMarked(repo?: RepoContext): Marked {
     instance.use({ extensions: [itemRefExtension(repo)] });
     instance.use({
       renderer: {
+        blockquote(token: { tokens?: unknown[] }): string {
+          const self = this as unknown as {
+            parser: { parse(toks: unknown[]): string };
+          };
+          renderState.blockquoteDepth++;
+          const inner = self.parser.parse(
+            (token.tokens ?? []) as unknown[],
+          );
+          renderState.blockquoteDepth--;
+          return `<blockquote>\n${inner}</blockquote>\n`;
+        },
         // The checkbox renderer is called during the recursive parse
         // of a listitem's inner tokens. It allocates the next task
         // index and writes it onto the top frame of itemStack so the
         // enclosing listitem can pick up THIS item's index — even if
         // nested children push and pop frames of their own first.
+        // Inside a blockquote, the source-side helpers can't see the
+        // task line (TASK_LINE doesn't match `> -` prefixes), so
+        // emit the default disabled checkbox to keep indices aligned.
         checkbox({ checked }: { checked: boolean }): string {
-          const index = renderState.taskIndex++;
-          const stack = renderState.itemStack;
-          if (stack.length > 0) {
-            stack[stack.length - 1]!.checkboxIndex = index;
-          }
+          const inBlockquote = renderState.blockquoteDepth > 0;
+          const interactive = renderState.interactiveTasks
+            && !inBlockquote;
           const checkedAttr = checked ? ' checked=""' : "";
-          if (renderState.interactiveTasks) {
+          if (interactive) {
+            const index = renderState.taskIndex++;
+            const stack = renderState.itemStack;
+            if (stack.length > 0) {
+              stack[stack.length - 1]!.checkboxIndex = index;
+            }
             return `<input${checkedAttr} type="checkbox" data-task-index="${index}">`;
           }
           return `<input${checkedAttr} disabled="" type="checkbox">`;
@@ -172,7 +197,9 @@ function getMarked(repo?: RepoContext): Marked {
           );
           renderState.itemStack.pop();
           if (!token.task) return `<li>${inner}</li>\n`;
-          if (!renderState.interactiveTasks) {
+          const interactive = renderState.interactiveTasks
+            && renderState.blockquoteDepth === 0;
+          if (!interactive) {
             return `<li class="task-list-item">${inner}</li>\n`;
           }
           const index = frame.checkboxIndex;
@@ -212,7 +239,12 @@ export function renderMarkdown(
   const cached = htmlCache.get(key);
   if (cached !== undefined) return cached;
 
-  renderState = { taskIndex: 0, interactiveTasks, itemStack: [] };
+  renderState = {
+    taskIndex: 0,
+    interactiveTasks,
+    itemStack: [],
+    blockquoteDepth: 0,
+  };
   const html = DOMPurify.sanitize(
     getMarked(repo).parse(raw) as string,
     {

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -98,13 +98,22 @@ export interface RenderMarkdownOpts {
 
 // Per-render state for the custom checkbox renderer. Marked is single-
 // threaded synchronous, so a module-level variable is safe.
-let renderState = {
+//
+// `itemStack` is a stack of pending listitem invocation scopes. When a
+// listitem fires, it pushes a fresh frame; the checkbox renderer (for
+// THIS item's `[ ]`) writes its allocated index to the top frame; the
+// listitem reads the same frame back on its way out and pops. Nested
+// task children push their own frames on top, so a parent's frame is
+// preserved while inner items emit their own checkboxes.
+type ListItemFrame = { checkboxIndex: number };
+let renderState: {
+  taskIndex: number;
+  interactiveTasks: boolean;
+  itemStack: ListItemFrame[];
+} = {
   taskIndex: 0,
   interactiveTasks: false,
-  // Set by the checkbox renderer to the index it just emitted, then
-  // read by the listitem renderer (which fires AFTER its inner tokens)
-  // so a single task carries the same index on both elements.
-  lastCheckboxIndex: -1,
+  itemStack: [],
 };
 
 const htmlCache = new Map<string, string>();
@@ -130,13 +139,17 @@ function getMarked(repo?: RepoContext): Marked {
     instance.use({ extensions: [itemRefExtension(repo)] });
     instance.use({
       renderer: {
-        // The checkbox renderer runs first (as the parser walks the
-        // inner tokens of a task list item) and owns the index; the
-        // listitem renderer reads that index back to attach a matching
-        // drag handle and wrapper data attribute.
+        // The checkbox renderer is called during the recursive parse
+        // of a listitem's inner tokens. It allocates the next task
+        // index and writes it onto the top frame of itemStack so the
+        // enclosing listitem can pick up THIS item's index — even if
+        // nested children push and pop frames of their own first.
         checkbox({ checked }: { checked: boolean }): string {
           const index = renderState.taskIndex++;
-          renderState.lastCheckboxIndex = index;
+          const stack = renderState.itemStack;
+          if (stack.length > 0) {
+            stack[stack.length - 1]!.checkboxIndex = index;
+          }
           const checkedAttr = checked ? ' checked=""' : "";
           if (renderState.interactiveTasks) {
             return `<input${checkedAttr} type="checkbox" data-task-index="${index}">`;
@@ -151,18 +164,18 @@ function getMarked(repo?: RepoContext): Marked {
           const self = this as unknown as {
             parser: { parse(toks: unknown[], loose: boolean): string };
           };
-          // Reset the checkbox index sentinel so the listitem renderer
-          // can detect whether the inner parse actually emitted one.
-          renderState.lastCheckboxIndex = -1;
+          const frame: ListItemFrame = { checkboxIndex: -1 };
+          renderState.itemStack.push(frame);
           const inner = self.parser.parse(
             (token.tokens ?? []) as unknown[],
             !!token.loose,
           );
+          renderState.itemStack.pop();
           if (!token.task) return `<li>${inner}</li>\n`;
           if (!renderState.interactiveTasks) {
             return `<li class="task-list-item">${inner}</li>\n`;
           }
-          const index = renderState.lastCheckboxIndex;
+          const index = frame.checkboxIndex;
           const handle =
             `<span class="task-drag-handle" `
             + `data-task-index="${index}" `
@@ -199,7 +212,7 @@ export function renderMarkdown(
   const cached = htmlCache.get(key);
   if (cached !== undefined) return cached;
 
-  renderState = { taskIndex: 0, interactiveTasks, lastCheckboxIndex: -1 };
+  renderState = { taskIndex: 0, interactiveTasks, itemStack: [] };
   const html = DOMPurify.sanitize(
     getMarked(repo).parse(raw) as string,
     {

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -88,8 +88,39 @@ function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
   };
 }
 
+export interface RenderMarkdownOpts {
+  // When true, GFM task-list checkboxes render as enabled <input> elements
+  // tagged with data-task-index="N" (zero-based, in document order). The
+  // caller is responsible for intercepting clicks and persisting state —
+  // unhandled clicks toggle visually but do not save.
+  interactiveTasks?: boolean;
+}
+
+// Per-render state for the custom checkbox renderer. Marked is single-
+// threaded synchronous, so a module-level variable is safe.
+let renderState = {
+  taskIndex: 0,
+  interactiveTasks: false,
+  // Set by the checkbox renderer to the index it just emitted, then
+  // read by the listitem renderer (which fires AFTER its inner tokens)
+  // so a single task carries the same index on both elements.
+  lastCheckboxIndex: -1,
+};
+
 const htmlCache = new Map<string, string>();
 const markedCache = new Map<string, Marked>();
+
+// Six-dot drag handle SVG used to grab a task-list item. Inlined so
+// the rendered markdown is self-contained and no extra fetch is needed.
+const DRAG_HANDLE_SVG =
+  `<svg viewBox="0 0 12 16" width="12" height="16" aria-hidden="true">`
+  + `<circle cx="3" cy="3" r="1.2"/>`
+  + `<circle cx="9" cy="3" r="1.2"/>`
+  + `<circle cx="3" cy="8" r="1.2"/>`
+  + `<circle cx="9" cy="8" r="1.2"/>`
+  + `<circle cx="3" cy="13" r="1.2"/>`
+  + `<circle cx="9" cy="13" r="1.2"/>`
+  + `</svg>`;
 
 function getMarked(repo?: RepoContext): Marked {
   const key = repo ? `${repo.provider}/${repo.platformHost ?? ""}/${repo.repoPath}` : "";
@@ -97,6 +128,58 @@ function getMarked(repo?: RepoContext): Marked {
   if (!instance) {
     instance = new Marked({ breaks: true, gfm: true });
     instance.use({ extensions: [itemRefExtension(repo)] });
+    instance.use({
+      renderer: {
+        // The checkbox renderer runs first (as the parser walks the
+        // inner tokens of a task list item) and owns the index; the
+        // listitem renderer reads that index back to attach a matching
+        // drag handle and wrapper data attribute.
+        checkbox({ checked }: { checked: boolean }): string {
+          const index = renderState.taskIndex++;
+          renderState.lastCheckboxIndex = index;
+          const checkedAttr = checked ? ' checked=""' : "";
+          if (renderState.interactiveTasks) {
+            return `<input${checkedAttr} type="checkbox" data-task-index="${index}">`;
+          }
+          return `<input${checkedAttr} disabled="" type="checkbox">`;
+        },
+        listitem(token: {
+          task?: boolean;
+          loose?: boolean;
+          tokens?: unknown[];
+        }): string {
+          const self = this as unknown as {
+            parser: { parse(toks: unknown[], loose: boolean): string };
+          };
+          // Reset the checkbox index sentinel so the listitem renderer
+          // can detect whether the inner parse actually emitted one.
+          renderState.lastCheckboxIndex = -1;
+          const inner = self.parser.parse(
+            (token.tokens ?? []) as unknown[],
+            !!token.loose,
+          );
+          if (!token.task) return `<li>${inner}</li>\n`;
+          if (!renderState.interactiveTasks) {
+            return `<li class="task-list-item">${inner}</li>\n`;
+          }
+          const index = renderState.lastCheckboxIndex;
+          const handle =
+            `<span class="task-drag-handle" `
+            + `data-task-index="${index}" `
+            + `draggable="true" `
+            + `role="button" `
+            + `tabindex="-1" `
+            + `aria-label="Drag to reorder">`
+            + DRAG_HANDLE_SVG
+            + `</span>`;
+          return (
+            `<li class="task-list-item task-list-item--interactive" `
+            + `data-task-index="${index}">`
+            + `${handle}${inner}</li>\n`
+          );
+        },
+      },
+    });
     markedCache.set(key, instance);
   }
   return instance;
@@ -105,12 +188,18 @@ function getMarked(repo?: RepoContext): Marked {
 export function renderMarkdown(
   raw: string,
   repo?: RepoContext,
+  opts: RenderMarkdownOpts = {},
 ): string {
   if (!raw) return "";
-  const key = repo ? `${repo.provider}/${repo.platformHost ?? ""}/${repo.repoPath}\0${raw}` : raw;
+  const interactiveTasks = !!opts.interactiveTasks;
+  const repoKey = repo
+    ? `${repo.provider}/${repo.platformHost ?? ""}/${repo.repoPath}`
+    : "";
+  const key = `${repoKey}\0${interactiveTasks ? 1 : 0}\0${raw}`;
   const cached = htmlCache.get(key);
   if (cached !== undefined) return cached;
 
+  renderState = { taskIndex: 0, interactiveTasks, lastCheckboxIndex: -1 };
   const html = DOMPurify.sanitize(
     getMarked(repo).parse(raw) as string,
     {
@@ -122,6 +211,8 @@ export function renderMarkdown(
         "data-name",
         "data-repo-path",
         "data-number",
+        "data-task-index",
+        "draggable",
       ],
     },
   );

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -196,4 +196,73 @@ describe("moveTaskListItem", () => {
       ].join("\n"),
     );
   });
+
+  it("carries continuation lines along with the moved task", () => {
+    const src = [
+      "- [ ] first",
+      "- [ ] second",
+      "  continued text",
+      "  more continuation",
+      "- [ ] third",
+    ].join("\n");
+    expect(moveTaskListItem(src, 1, 2)).toBe(
+      [
+        "- [ ] first",
+        "- [ ] third",
+        "- [ ] second",
+        "  continued text",
+        "  more continuation",
+      ].join("\n"),
+    );
+  });
+
+  it("carries nested sub-task children along with the moved task", () => {
+    const src = [
+      "- [ ] outer first",
+      "  - [ ] inner a",
+      "  - [ ] inner b",
+      "- [ ] outer second",
+    ].join("\n");
+    // Move outer-first (index 0) to outer-second's slot (index 3).
+    expect(moveTaskListItem(src, 0, 3)).toBe(
+      [
+        "- [ ] outer second",
+        "- [ ] outer first",
+        "  - [ ] inner a",
+        "  - [ ] inner b",
+      ].join("\n"),
+    );
+  });
+
+  it("returns source unchanged when dragging a task onto its own nested child", () => {
+    const src = "- [ ] outer\n  - [ ] inner\n- [ ] sibling";
+    // index 0 is outer, index 1 is inner. inner sits inside outer's
+    // block, so moving outer to land on inner is a no-op.
+    expect(moveTaskListItem(src, 0, 1)).toBe(src);
+  });
+
+  it("preserves blank lines and prose outside the moved block", () => {
+    const src = [
+      "Intro line",
+      "",
+      "- [ ] A",
+      "- [ ] B",
+      "  with continuation",
+      "",
+      "Trailing prose",
+    ].join("\n");
+    // Move A (index 0) to B's slot (index 1). B carries its
+    // continuation; A becomes a single-line block.
+    expect(moveTaskListItem(src, 0, 1)).toBe(
+      [
+        "Intro line",
+        "",
+        "- [ ] B",
+        "  with continuation",
+        "- [ ] A",
+        "",
+        "Trailing prose",
+      ].join("\n"),
+    );
+  });
 });

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  listTaskItems,
+  moveTaskListItem,
+  toggleTaskListItem,
+} from "./task-list.js";
+
+describe("listTaskItems", () => {
+  it("returns an empty list for empty input", () => {
+    expect(listTaskItems("")).toEqual([]);
+  });
+
+  it("returns an empty list when there are no tasks", () => {
+    expect(listTaskItems("plain prose\nno tasks here")).toEqual([]);
+  });
+
+  it("captures index, checked state, and line number in document order", () => {
+    const src = [
+      "intro line",
+      "- [ ] first",
+      "  text",
+      "- [x] second",
+      "* [X] third (uppercase)",
+      "1. [ ] fourth (ordered)",
+    ].join("\n");
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 1 },
+      { index: 1, checked: true, line: 3 },
+      { index: 2, checked: true, line: 4 },
+      { index: 3, checked: false, line: 5 },
+    ]);
+  });
+
+  it("ignores task-shaped lines inside fenced code blocks", () => {
+    const src = [
+      "- [ ] real one",
+      "```",
+      "- [ ] not a task",
+      "- [x] also fenced",
+      "```",
+      "- [x] real two",
+    ].join("\n");
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 0 },
+      { index: 1, checked: true, line: 5 },
+    ]);
+  });
+
+  it("handles indented (nested) task list items", () => {
+    const src = "- [ ] outer\n  - [x] inner";
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 0 },
+      { index: 1, checked: true, line: 1 },
+    ]);
+  });
+});
+
+describe("toggleTaskListItem", () => {
+  it("flips an unchecked box to checked", () => {
+    expect(toggleTaskListItem("- [ ] a", 0)).toBe("- [x] a");
+  });
+
+  it("flips a checked box to unchecked", () => {
+    expect(toggleTaskListItem("- [x] a", 0)).toBe("- [ ] a");
+  });
+
+  it("normalizes uppercase X to space when unchecking", () => {
+    expect(toggleTaskListItem("- [X] a", 0)).toBe("- [ ] a");
+  });
+
+  it("returns source unchanged when the index is out of range", () => {
+    expect(toggleTaskListItem("- [ ] a", 5)).toBe("- [ ] a");
+  });
+
+  it("returns source unchanged when the index is negative", () => {
+    expect(toggleTaskListItem("- [ ] a", -1)).toBe("- [ ] a");
+  });
+
+  it("toggles only the targeted item and leaves others intact", () => {
+    const src = "- [ ] first\n- [ ] second\n- [x] third";
+    expect(toggleTaskListItem(src, 1)).toBe(
+      "- [ ] first\n- [x] second\n- [x] third",
+    );
+  });
+
+  it("preserves line content after the checkbox", () => {
+    const src = "- [ ] item with **bold** and `code`";
+    expect(toggleTaskListItem(src, 0)).toBe(
+      "- [x] item with **bold** and `code`",
+    );
+  });
+
+  it("ignores task-shaped lines inside fenced code blocks when counting", () => {
+    const src = [
+      "- [ ] outer one",
+      "```",
+      "- [ ] fenced",
+      "```",
+      "- [ ] outer two",
+    ].join("\n");
+    const out = toggleTaskListItem(src, 1);
+    // index 1 is "outer two", not the fenced line
+    expect(out).toBe(
+      [
+        "- [ ] outer one",
+        "```",
+        "- [ ] fenced",
+        "```",
+        "- [x] outer two",
+      ].join("\n"),
+    );
+  });
+
+  it("supports ordered-list task markers", () => {
+    expect(toggleTaskListItem("1. [ ] step one", 0)).toBe(
+      "1. [x] step one",
+    );
+  });
+
+  it("supports nested task items by document order", () => {
+    const src = "- [ ] outer\n  - [ ] inner";
+    expect(toggleTaskListItem(src, 1)).toBe(
+      "- [ ] outer\n  - [x] inner",
+    );
+  });
+});
+
+describe("moveTaskListItem", () => {
+  it("moves an item downward to a later position", () => {
+    const src = "- [ ] A\n- [ ] B\n- [ ] C";
+    expect(moveTaskListItem(src, 0, 2)).toBe(
+      "- [ ] B\n- [ ] C\n- [ ] A",
+    );
+  });
+
+  it("moves an item upward to an earlier position", () => {
+    const src = "- [ ] A\n- [ ] B\n- [ ] C";
+    expect(moveTaskListItem(src, 2, 0)).toBe(
+      "- [ ] C\n- [ ] A\n- [ ] B",
+    );
+  });
+
+  it("swaps two adjacent items", () => {
+    const src = "- [ ] A\n- [ ] B\n- [ ] C";
+    expect(moveTaskListItem(src, 0, 1)).toBe(
+      "- [ ] B\n- [ ] A\n- [ ] C",
+    );
+    expect(moveTaskListItem(src, 1, 0)).toBe(
+      "- [ ] B\n- [ ] A\n- [ ] C",
+    );
+  });
+
+  it("returns source unchanged when from === to", () => {
+    const src = "- [ ] A\n- [ ] B";
+    expect(moveTaskListItem(src, 0, 0)).toBe(src);
+  });
+
+  it("returns source unchanged when an index is out of range", () => {
+    const src = "- [ ] A\n- [ ] B";
+    expect(moveTaskListItem(src, 0, 5)).toBe(src);
+    expect(moveTaskListItem(src, 5, 0)).toBe(src);
+    expect(moveTaskListItem(src, -1, 0)).toBe(src);
+  });
+
+  it("preserves checked state of the moved item", () => {
+    const src = "- [ ] A\n- [x] B\n- [ ] C";
+    expect(moveTaskListItem(src, 1, 0)).toBe(
+      "- [x] B\n- [ ] A\n- [ ] C",
+    );
+  });
+
+  it("preserves non-task content between task items", () => {
+    const src = "- [ ] A\nsome prose\n- [ ] B\n- [ ] C";
+    expect(moveTaskListItem(src, 0, 2)).toBe(
+      "some prose\n- [ ] B\n- [ ] C\n- [ ] A",
+    );
+  });
+
+  it("skips fenced task-shaped lines when counting", () => {
+    const src = [
+      "- [ ] real one",
+      "```",
+      "- [ ] fenced",
+      "```",
+      "- [ ] real two",
+      "- [ ] real three",
+    ].join("\n");
+    expect(moveTaskListItem(src, 0, 2)).toBe(
+      [
+        "```",
+        "- [ ] fenced",
+        "```",
+        "- [ ] real two",
+        "- [ ] real three",
+        "- [ ] real one",
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -52,6 +52,23 @@ describe("listTaskItems", () => {
     ]);
   });
 
+  it("does not treat 4-space-indented fence syntax as a real fence", () => {
+    // CommonMark: at top level, 4+ leading spaces means indented code,
+    // even if the rest of the line is `` ``` ``. The `` ``` `` inside
+    // the indented block must NOT open a fence — if it did, the real
+    // task that follows would be hidden inside the bogus fenced
+    // block and the index would drift.
+    const src = [
+      "    ```",
+      "    - [ ] indented code line",
+      "    ```",
+      "- [ ] real task after indented code",
+    ].join("\n");
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 3 },
+    ]);
+  });
+
   it("does not close a backtick fence with a tilde fence", () => {
     const src = [
       "```",

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -53,6 +53,38 @@ describe("listTaskItems", () => {
       { index: 1, checked: true, line: 1 },
     ]);
   });
+
+  it("skips task-shaped lines inside indented code blocks", () => {
+    // Top-level indented (4-space) code block. Marked treats this
+    // as a code block, so the inner `- [ ]` is plain text, not a
+    // task. listTaskItems must agree.
+    const src = [
+      "    - [ ] in indented code block",
+      "    - [x] still in code block",
+      "",
+      "- [ ] real task",
+    ].join("\n");
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 3 },
+    ]);
+  });
+
+  it("treats tab-indented task-shaped lines at top level as code", () => {
+    const src = "\t- [ ] tab indented\n- [ ] real task";
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 1 },
+    ]);
+  });
+
+  it("keeps nested task items inside a list (not as code blocks)", () => {
+    // The 4-space indent here is continuation of the list, NOT
+    // a code block — list context preserves the nesting rules.
+    const src = "- [ ] outer\n    - [ ] inner";
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 0 },
+      { index: 1, checked: false, line: 1 },
+    ]);
+  });
 });
 
 describe("toggleTaskListItem", () => {
@@ -114,6 +146,20 @@ describe("toggleTaskListItem", () => {
   it("supports ordered-list task markers", () => {
     expect(toggleTaskListItem("1. [ ] step one", 0)).toBe(
       "1. [x] step one",
+    );
+  });
+
+  it("does not flip task-shaped lines inside indented code blocks", () => {
+    const src = [
+      "    - [ ] in indented code block",
+      "- [ ] real task",
+    ].join("\n");
+    // Index 0 is the real task on line 1, not the code-block line.
+    expect(toggleTaskListItem(src, 0)).toBe(
+      [
+        "    - [ ] in indented code block",
+        "- [x] real task",
+      ].join("\n"),
     );
   });
 
@@ -230,6 +276,21 @@ describe("moveTaskListItem", () => {
         "- [ ] outer first",
         "  - [ ] inner a",
         "  - [ ] inner b",
+      ].join("\n"),
+    );
+  });
+
+  it("does not see indented-code task-shaped lines as targets", () => {
+    const src = [
+      "    - [ ] in indented code block",
+      "- [ ] real first",
+      "- [ ] real second",
+    ].join("\n");
+    expect(moveTaskListItem(src, 0, 1)).toBe(
+      [
+        "    - [ ] in indented code block",
+        "- [ ] real second",
+        "- [ ] real first",
       ].join("\n"),
     );
   });

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -31,6 +31,39 @@ describe("listTaskItems", () => {
     ]);
   });
 
+  it("keeps a longer fence open across shorter inner fences", () => {
+    // A 4-backtick fence is allowed to contain a literal 3-backtick
+    // line; the close fence must match the opener's char and have at
+    // least as many backticks. Without this rule, the inner ``` would
+    // prematurely close the block and the second `[ ] inside` would
+    // wrongly count as a task, shifting indices for the real task.
+    const src = [
+      "````",
+      "```",
+      "- [ ] inside fenced block",
+      "```",
+      "````",
+      "- [ ] real task after fence",
+    ].join("\n");
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 5 },
+    ]);
+  });
+
+  it("does not close a backtick fence with a tilde fence", () => {
+    const src = [
+      "```",
+      "- [ ] inside backtick fence",
+      "~~~",
+      "- [ ] still inside backtick fence",
+      "```",
+      "- [ ] real task after fence",
+    ].join("\n");
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 5 },
+    ]);
+  });
+
   it("ignores task-shaped lines inside fenced code blocks", () => {
     const src = [
       "- [ ] real one",

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -76,6 +76,15 @@ describe("listTaskItems", () => {
     ]);
   });
 
+  it("rejects checkbox markers without a trailing space (matches marked)", () => {
+    // Marked treats `- [ ]nospace` as plain text, not a task — the
+    // source helper must agree or data-task-index would drift.
+    const src = "- [ ]nospace\n- [ ] withspace";
+    expect(listTaskItems(src)).toEqual([
+      { index: 0, checked: false, line: 1 },
+    ]);
+  });
+
   it("keeps nested task items inside a list (not as code blocks)", () => {
     // The 4-space indent here is continuation of the list, NOT
     // a code block — list context preserves the nesting rules.
@@ -332,6 +341,26 @@ describe("moveTaskListItem", () => {
         "- [ ] outer B",
         "  - [ ] child B1",
         "  - [ ] child A1",
+      ].join("\n"),
+    );
+  });
+
+  it("carries blank-separated continuation paragraphs along with the task", () => {
+    // Markdown allows a list item's body to span blank-separated
+    // paragraphs as long as continuation stays indented. moveTask
+    // must drag the whole multi-paragraph item together.
+    const src = [
+      "- [ ] first",
+      "",
+      "  paragraph two of first",
+      "- [ ] second",
+    ].join("\n");
+    expect(moveTaskListItem(src, 0, 1)).toBe(
+      [
+        "- [ ] second",
+        "- [ ] first",
+        "",
+        "  paragraph two of first",
       ].join("\n"),
     );
   });

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -22,12 +22,14 @@ describe("listTaskItems", () => {
       "- [x] second",
       "* [X] third (uppercase)",
       "1. [ ] fourth (ordered)",
+      "2) [x] fifth (ordered with paren)",
     ].join("\n");
     expect(listTaskItems(src)).toEqual([
       { index: 0, checked: false, line: 1 },
       { index: 1, checked: true, line: 3 },
       { index: 2, checked: true, line: 4 },
       { index: 3, checked: false, line: 5 },
+      { index: 4, checked: true, line: 6 },
     ]);
   });
 
@@ -188,6 +190,14 @@ describe("toggleTaskListItem", () => {
   it("supports ordered-list task markers", () => {
     expect(toggleTaskListItem("1. [ ] step one", 0)).toBe(
       "1. [x] step one",
+    );
+  });
+
+  it("supports ordered-list task markers using ')' (CommonMark)", () => {
+    // marked accepts `1)` as an ordered-list marker, so the source
+    // helpers must too — otherwise data-task-index would drift.
+    expect(toggleTaskListItem("1) [ ] step one", 0)).toBe(
+      "1) [x] step one",
     );
   });
 

--- a/packages/ui/src/utils/task-list.test.ts
+++ b/packages/ui/src/utils/task-list.test.ts
@@ -302,6 +302,40 @@ describe("moveTaskListItem", () => {
     expect(moveTaskListItem(src, 0, 1)).toBe(src);
   });
 
+  it("rejects cross-hierarchy moves between different indent levels", () => {
+    const src = [
+      "- [ ] outer",
+      "  - [ ] inner",
+      "- [ ] another outer",
+    ].join("\n");
+    // inner (index 1, indent 2) onto outer (index 0, indent 0) —
+    // different indents, refuse the move so we don't reparent it.
+    expect(moveTaskListItem(src, 1, 0)).toBe(src);
+    // Same direction: outer onto inner — also rejected.
+    expect(moveTaskListItem(src, 2, 1)).toBe(src);
+  });
+
+  it("allows moves between same-level siblings under different parents", () => {
+    // Both nested tasks live at indent 2 — even though they sit
+    // under different parents, the moved indentation matches so
+    // the markdown structure stays well-formed.
+    const src = [
+      "- [ ] outer A",
+      "  - [ ] child A1",
+      "- [ ] outer B",
+      "  - [ ] child B1",
+    ].join("\n");
+    // child A1 (index 1) to child B1 (index 3) — same indent.
+    expect(moveTaskListItem(src, 1, 3)).toBe(
+      [
+        "- [ ] outer A",
+        "- [ ] outer B",
+        "  - [ ] child B1",
+        "  - [ ] child A1",
+      ].join("\n"),
+    );
+  });
+
   it("preserves blank lines and prose outside the moved block", () => {
     const src = [
       "Intro line",

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -14,7 +14,12 @@
 // shift indices.
 const TASK_LINE = /^([\t ]*(?:[-*+]|\d+\.)[\t ]+\[)([ xX])(\])(?:[\t ]|$)/;
 const BULLET_LINE = /^[\t ]*(?:[-*+]|\d+\.)[\t ]+/;
-const FENCE_LINE = /^[\t ]*(```|~~~)/;
+// Fenced code block opener: 3+ matching characters (` or ~) with
+// optional leading whitespace. Captures the character and run so the
+// close fence can be validated against the same marker and length per
+// CommonMark — e.g. a four-backtick fence can contain a literal
+// three-backtick line without ending the block.
+const FENCE_LINE = /^[\t ]*(`{3,}|~{3,})/;
 
 export interface TaskItem {
   // Zero-based index of this task in document order.
@@ -53,22 +58,37 @@ type TaskLineVisitor = (
 // context is tracked so an indented task line under a parent bullet
 // is recognized as a nested task rather than a code-block line.
 function walkTaskLines(lines: string[], visitor: TaskLineVisitor): void {
-  let inFence = false;
+  // `openFence` is null outside a fenced code block; while inside,
+  // it records the opener's marker character and minimum length, so
+  // the close fence has to match (same char, at least as long).
+  let openFence: { char: string; length: number } | null = null;
   let listIndent: number | null = null;
   let taskIndex = 0;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
-    if (FENCE_LINE.test(line)) {
-      inFence = !inFence;
-      // A fenced block at the same indent as the list bullet ends
-      // the list — Markdown treats the fence as block-level content.
-      if (!inFence && listIndent !== null
-        && leadingWhitespaceCount(line) <= listIndent) {
-        listIndent = null;
+    const fenceMatch = line.match(FENCE_LINE);
+    if (fenceMatch) {
+      const run = fenceMatch[1]!;
+      const char = run[0]!;
+      if (openFence === null) {
+        openFence = { char, length: run.length };
+        continue;
       }
+      if (char === openFence.char && run.length >= openFence.length) {
+        openFence = null;
+        // A fenced block at the same indent as the list bullet ends
+        // the list — Markdown treats the fence as block-level content.
+        if (listIndent !== null
+          && leadingWhitespaceCount(line) <= listIndent) {
+          listIndent = null;
+        }
+        continue;
+      }
+      // Mismatched marker or shorter run: this line stays inside the
+      // current code block as plain content.
       continue;
     }
-    if (inFence) continue;
+    if (openFence !== null) continue;
     if (line.trim() === "") continue;
 
     const indent = leadingWhitespaceCount(line);

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -5,10 +5,14 @@
 
 // A line is a task-list item when it begins with optional leading
 // whitespace, a bullet (-, *, +) or ordered marker (1.), at least one
-// space, and then a checkbox token `[ ]`, `[x]`, or `[X]`. Anything
-// inside a fenced code block is ignored so `[ ]` shown in code samples
-// doesn't shift indices.
-const TASK_LINE = /^([\t ]*(?:[-*+]|\d+\.)[\t ]+\[)([ xX])(\])/;
+// space, the checkbox token `[ ]`, `[x]`, or `[X]`, AND a whitespace
+// character (or end-of-line) after the closing bracket. Marked's
+// renderer applies the same trailing-whitespace rule — without it
+// `- [ ]text` lexes as plain prose, so the source helpers must
+// agree or data-task-index would drift. Anything inside a fenced
+// code block is ignored so `[ ]` shown in code samples doesn't
+// shift indices.
+const TASK_LINE = /^([\t ]*(?:[-*+]|\d+\.)[\t ]+\[)([ xX])(\])(?:[\t ]|$)/;
 const BULLET_LINE = /^[\t ]*(?:[-*+]|\d+\.)[\t ]+/;
 const FENCE_LINE = /^[\t ]*(```|~~~)/;
 
@@ -119,22 +123,40 @@ export function listTaskItems(source: string): TaskItem[] {
 
 // A task block spans the task line plus any immediately-following
 // continuation lines that belong to the same item — more-indented
-// content (multi-line description, nested sub-tasks) is carried along
-// with the task when it moves. The block ends at the first line that
-// is blank or at the same/lower indent than the bullet.
+// content (multi-line description, nested sub-tasks) is carried
+// along with the task when it moves. Blank lines do NOT terminate
+// the block on their own: Markdown allows blank-separated
+// paragraphs that remain part of a list item as long as the next
+// non-blank line is still indented past the bullet. The block ends
+// at the first non-blank line that sits at or below the bullet's
+// indentation.
 function findTaskBlockEnd(
   lines: string[],
   start: number,
 ): number {
   const bulletIndent = leadingWhitespaceCount(lines[start]!);
   let end = start + 1;
+  let pendingBlankRun = 0;
   while (end < lines.length) {
     const line = lines[end]!;
-    if (line.trim() === "") break;
-    if (leadingWhitespaceCount(line) <= bulletIndent) break;
+    if (line.trim() === "") {
+      pendingBlankRun++;
+      end++;
+      continue;
+    }
+    if (leadingWhitespaceCount(line) <= bulletIndent) {
+      // The next non-blank line dedents out of the item — strip
+      // the buffered blank lines, they belong to the separator
+      // between this item and what follows.
+      return end - pendingBlankRun;
+    }
+    // Indented content continues the block, including any blank
+    // lines we buffered on the way here.
+    pendingBlankRun = 0;
     end++;
   }
-  return end;
+  // Reached EOF; drop trailing blanks from the block.
+  return end - pendingBlankRun;
 }
 
 // Returns a new source string with the Nth task-list item moved to

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -9,6 +9,7 @@
 // inside a fenced code block is ignored so `[ ]` shown in code samples
 // doesn't shift indices.
 const TASK_LINE = /^([\t ]*(?:[-*+]|\d+\.)[\t ]+\[)([ xX])(\])/;
+const BULLET_LINE = /^[\t ]*(?:[-*+]|\d+\.)[\t ]+/;
 const FENCE_LINE = /^[\t ]*(```|~~~)/;
 
 export interface TaskItem {
@@ -20,34 +21,100 @@ export interface TaskItem {
   line: number;
 }
 
-export function listTaskItems(source: string): TaskItem[] {
-  if (!source) return [];
-  const out: TaskItem[] = [];
-  let inFence = false;
-  let count = 0;
-  const lines = source.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (FENCE_LINE.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    const m = line.match(TASK_LINE);
-    if (!m) continue;
-    out.push({
-      index: count++,
-      checked: m[2] !== " ",
-      line: i,
-    });
-  }
-  return out;
-}
-
 function leadingWhitespaceCount(line: string): number {
   let i = 0;
   while (i < line.length && (line[i] === " " || line[i] === "\t")) i++;
   return i;
+}
+
+// CommonMark indented code block start: 4+ leading spaces or a leading
+// tab, at a position where a code block can begin (i.e. outside a list
+// context). Inside a list, the same indentation continues the list
+// item rather than starting a code block.
+function isIndentedCodeStart(line: string): boolean {
+  if (line.startsWith("\t")) return true;
+  if (line.startsWith("    ")) return true;
+  return false;
+}
+
+type TaskLineVisitor = (
+  match: RegExpMatchArray,
+  lineIndex: number,
+  taskIndex: number,
+) => void;
+
+// Walks `lines` and invokes `visitor` for every task-list line that
+// the markdown renderer would treat as such. Skips lines inside
+// fenced code blocks and top-level indented code blocks. List
+// context is tracked so an indented task line under a parent bullet
+// is recognized as a nested task rather than a code-block line.
+function walkTaskLines(lines: string[], visitor: TaskLineVisitor): void {
+  let inFence = false;
+  let listIndent: number | null = null;
+  let taskIndex = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (FENCE_LINE.test(line)) {
+      inFence = !inFence;
+      // A fenced block at the same indent as the list bullet ends
+      // the list — Markdown treats the fence as block-level content.
+      if (!inFence && listIndent !== null
+        && leadingWhitespaceCount(line) <= listIndent) {
+        listIndent = null;
+      }
+      continue;
+    }
+    if (inFence) continue;
+    if (line.trim() === "") continue;
+
+    const indent = leadingWhitespaceCount(line);
+    // Outside a list, a 4-space (or tab) indent opens a code block:
+    // any task-shaped line in it is plain code, not a task.
+    if (listIndent === null && isIndentedCodeStart(line)) continue;
+
+    // Dedent out of the list when a non-blank line sits at or below
+    // the list bullet indent and isn't itself a bullet at that level.
+    if (
+      listIndent !== null &&
+      indent < listIndent
+    ) {
+      listIndent = null;
+    }
+
+    const taskMatch = line.match(TASK_LINE);
+    if (taskMatch) {
+      visitor(taskMatch, i, taskIndex++);
+      if (listIndent === null || indent < listIndent) {
+        listIndent = indent;
+      }
+      continue;
+    }
+
+    // Non-task bullet still establishes/preserves list context so
+    // a subsequent indented task line is recognized as nested.
+    if (BULLET_LINE.test(line)) {
+      if (listIndent === null) listIndent = indent;
+      continue;
+    }
+
+    // Non-bullet line at or below list indent terminates the list.
+    if (listIndent !== null && indent <= listIndent) {
+      listIndent = null;
+    }
+  }
+}
+
+export function listTaskItems(source: string): TaskItem[] {
+  if (!source) return [];
+  const out: TaskItem[] = [];
+  walkTaskLines(source.split("\n"), (m, lineIndex, taskIndex) => {
+    out.push({
+      index: taskIndex,
+      checked: m[2] !== " ",
+      line: lineIndex,
+    });
+  });
+  return out;
 }
 
 // A task block spans the task line plus any immediately-following
@@ -85,16 +152,9 @@ export function moveTaskListItem(
   if (fromIndex < 0 || toIndex < 0) return source;
   const lines = source.split("\n");
   const taskLines: number[] = [];
-  let inFence = false;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (FENCE_LINE.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    if (TASK_LINE.test(line)) taskLines.push(i);
-  }
+  walkTaskLines(lines, (_m, lineIndex) => {
+    taskLines.push(lineIndex);
+  });
   if (fromIndex >= taskLines.length) return source;
   if (toIndex >= taskLines.length) return source;
   const fromStart = taskLines[fromIndex]!;
@@ -132,25 +192,18 @@ export function toggleTaskListItem(source: string, index: number): string {
   if (!source) return source;
   if (index < 0) return source;
   const lines = source.split("\n");
-  let inFence = false;
-  let count = 0;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (FENCE_LINE.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    const m = line.match(TASK_LINE);
-    if (!m) continue;
-    if (count === index) {
-      const prefix = m[1]!;
-      const ch = m[2]!;
-      const next = ch === " " ? "x" : " ";
-      lines[i] = `${prefix}${next}${line.slice(prefix.length + 1)}`;
-      return lines.join("\n");
-    }
-    count++;
-  }
-  return source;
+  let result = source;
+  let mutated = false;
+  walkTaskLines(lines, (m, lineIndex, taskIndex) => {
+    if (mutated) return;
+    if (taskIndex !== index) return;
+    const prefix = m[1]!;
+    const ch = m[2]!;
+    const next = ch === " " ? "x" : " ";
+    const original = lines[lineIndex]!;
+    lines[lineIndex] = `${prefix}${next}${original.slice(prefix.length + 1)}`;
+    result = lines.join("\n");
+    mutated = true;
+  });
+  return result;
 }

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -1,0 +1,119 @@
+// GFM task list helpers. Mirrors the same recognition rules the marked
+// renderer applies — see RenderMarkdownOpts.interactiveTasks — so that
+// data-task-index attributes emitted there line up with the source-
+// position-based toggling here.
+
+// A line is a task-list item when it begins with optional leading
+// whitespace, a bullet (-, *, +) or ordered marker (1.), at least one
+// space, and then a checkbox token `[ ]`, `[x]`, or `[X]`. Anything
+// inside a fenced code block is ignored so `[ ]` shown in code samples
+// doesn't shift indices.
+const TASK_LINE = /^([\t ]*(?:[-*+]|\d+\.)[\t ]+\[)([ xX])(\])/;
+const FENCE_LINE = /^[\t ]*(```|~~~)/;
+
+export interface TaskItem {
+  // Zero-based index of this task in document order.
+  index: number;
+  // Whether the checkbox is currently checked.
+  checked: boolean;
+  // Line number (zero-based) where the checkbox lives.
+  line: number;
+}
+
+export function listTaskItems(source: string): TaskItem[] {
+  if (!source) return [];
+  const out: TaskItem[] = [];
+  let inFence = false;
+  let count = 0;
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (FENCE_LINE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = line.match(TASK_LINE);
+    if (!m) continue;
+    out.push({
+      index: count++,
+      checked: m[2] !== " ",
+      line: i,
+    });
+  }
+  return out;
+}
+
+// Returns a new source string with the Nth task-list line moved to
+// the position currently occupied by the Mth task-list line. Other
+// lines shift accordingly, like Array.prototype.splice. Only the task
+// line itself moves — continuation lines under a multi-line task item
+// are NOT carried along (a known limitation). If either index is out
+// of range, or they're equal, the source is returned unchanged.
+export function moveTaskListItem(
+  source: string,
+  fromIndex: number,
+  toIndex: number,
+): string {
+  if (!source) return source;
+  if (fromIndex === toIndex) return source;
+  if (fromIndex < 0 || toIndex < 0) return source;
+  const lines = source.split("\n");
+  const positions: number[] = [];
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (FENCE_LINE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (TASK_LINE.test(line)) positions.push(i);
+  }
+  if (fromIndex >= positions.length) return source;
+  if (toIndex >= positions.length) return source;
+  const fromLine = positions[fromIndex]!;
+  const toLine = positions[toIndex]!;
+  const moved = lines[fromLine]!;
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (i === fromLine) continue;
+    if (fromIndex < toIndex) {
+      out.push(lines[i]!);
+      if (i === toLine) out.push(moved);
+    } else {
+      if (i === toLine) out.push(moved);
+      out.push(lines[i]!);
+    }
+  }
+  return out.join("\n");
+}
+
+// Returns a new source string with the Nth task-list checkbox toggled.
+// If `index` is out of range, the source is returned unchanged.
+export function toggleTaskListItem(source: string, index: number): string {
+  if (!source) return source;
+  if (index < 0) return source;
+  const lines = source.split("\n");
+  let inFence = false;
+  let count = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (FENCE_LINE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = line.match(TASK_LINE);
+    if (!m) continue;
+    if (count === index) {
+      const prefix = m[1]!;
+      const ch = m[2]!;
+      const next = ch === " " ? "x" : " ";
+      lines[i] = `${prefix}${next}${line.slice(prefix.length + 1)}`;
+      return lines.join("\n");
+    }
+    count++;
+  }
+  return source;
+}

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -44,12 +44,37 @@ export function listTaskItems(source: string): TaskItem[] {
   return out;
 }
 
-// Returns a new source string with the Nth task-list line moved to
-// the position currently occupied by the Mth task-list line. Other
-// lines shift accordingly, like Array.prototype.splice. Only the task
-// line itself moves — continuation lines under a multi-line task item
-// are NOT carried along (a known limitation). If either index is out
-// of range, or they're equal, the source is returned unchanged.
+function leadingWhitespaceCount(line: string): number {
+  let i = 0;
+  while (i < line.length && (line[i] === " " || line[i] === "\t")) i++;
+  return i;
+}
+
+// A task block spans the task line plus any immediately-following
+// continuation lines that belong to the same item — more-indented
+// content (multi-line description, nested sub-tasks) is carried along
+// with the task when it moves. The block ends at the first line that
+// is blank or at the same/lower indent than the bullet.
+function findTaskBlockEnd(
+  lines: string[],
+  start: number,
+): number {
+  const bulletIndent = leadingWhitespaceCount(lines[start]!);
+  let end = start + 1;
+  while (end < lines.length) {
+    const line = lines[end]!;
+    if (line.trim() === "") break;
+    if (leadingWhitespaceCount(line) <= bulletIndent) break;
+    end++;
+  }
+  return end;
+}
+
+// Returns a new source string with the Nth task-list item moved to
+// the position currently occupied by the Mth task-list item. The
+// moved item carries its continuation lines and nested sub-tasks
+// with it. If either index is out of range, or they're equal, the
+// source is returned unchanged.
 export function moveTaskListItem(
   source: string,
   fromIndex: number,
@@ -59,7 +84,7 @@ export function moveTaskListItem(
   if (fromIndex === toIndex) return source;
   if (fromIndex < 0 || toIndex < 0) return source;
   const lines = source.split("\n");
-  const positions: number[] = [];
+  const taskLines: number[] = [];
   let inFence = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
@@ -68,25 +93,37 @@ export function moveTaskListItem(
       continue;
     }
     if (inFence) continue;
-    if (TASK_LINE.test(line)) positions.push(i);
+    if (TASK_LINE.test(line)) taskLines.push(i);
   }
-  if (fromIndex >= positions.length) return source;
-  if (toIndex >= positions.length) return source;
-  const fromLine = positions[fromIndex]!;
-  const toLine = positions[toIndex]!;
-  const moved = lines[fromLine]!;
-  const out: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (i === fromLine) continue;
-    if (fromIndex < toIndex) {
-      out.push(lines[i]!);
-      if (i === toLine) out.push(moved);
-    } else {
-      if (i === toLine) out.push(moved);
-      out.push(lines[i]!);
-    }
+  if (fromIndex >= taskLines.length) return source;
+  if (toIndex >= taskLines.length) return source;
+  const fromStart = taskLines[fromIndex]!;
+  const fromEnd = findTaskBlockEnd(lines, fromStart);
+  const toStart = taskLines[toIndex]!;
+  const toEnd = findTaskBlockEnd(lines, toStart);
+  // Refuse no-ops: dragging a task onto something inside its own
+  // block would either be a no-op or self-overlap, both of which we
+  // pass through unchanged.
+  if (toStart >= fromStart && toStart < fromEnd) return source;
+  const moved = lines.slice(fromStart, fromEnd);
+  const without = [
+    ...lines.slice(0, fromStart),
+    ...lines.slice(fromEnd),
+  ];
+  // Where to insert depends on direction: moving down lands the block
+  // where the target block ended (minus the removed block's length);
+  // moving up lands it where the target block started.
+  let insertAt: number;
+  if (fromIndex < toIndex) {
+    insertAt = toEnd - (fromEnd - fromStart);
+  } else {
+    insertAt = toStart;
   }
-  return out.join("\n");
+  return [
+    ...without.slice(0, insertAt),
+    ...moved,
+    ...without.slice(insertAt),
+  ].join("\n");
 }
 
 // Returns a new source string with the Nth task-list checkbox toggled.

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -12,8 +12,12 @@
 // agree or data-task-index would drift. Anything inside a fenced
 // code block is ignored so `[ ]` shown in code samples doesn't
 // shift indices.
-const TASK_LINE = /^([\t ]*(?:[-*+]|\d+\.)[\t ]+\[)([ xX])(\])(?:[\t ]|$)/;
-const BULLET_LINE = /^[\t ]*(?:[-*+]|\d+\.)[\t ]+/;
+// CommonMark accepts both `1.` and `1)` as ordered-list markers, and
+// marked renders either shape as a task-list item — accept both here
+// or `1) [ ]` lexes as a task on render but plain prose in source,
+// drifting data-task-index out of sync.
+const TASK_LINE = /^([\t ]*(?:[-*+]|\d+[.)])[\t ]+\[)([ xX])(\])(?:[\t ]|$)/;
+const BULLET_LINE = /^[\t ]*(?:[-*+]|\d+[.)])[\t ]+/;
 // Fenced code block opener: 3+ matching characters (` or ~) with
 // optional leading whitespace. Captures the character and run so the
 // close fence can be validated against the same marker and length per

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -161,6 +161,17 @@ export function moveTaskListItem(
   const fromEnd = findTaskBlockEnd(lines, fromStart);
   const toStart = taskLines[toIndex]!;
   const toEnd = findTaskBlockEnd(lines, toStart);
+  // Refuse cross-hierarchy moves: dropping a nested item onto a
+  // top-level sibling (or vice versa) would silently change the
+  // markdown structure — the moved block keeps its original indent
+  // and would reparent or orphan itself. Only same-indent moves
+  // (true siblings under the same parent list) are allowed.
+  if (
+    leadingWhitespaceCount(lines[fromStart]!) !==
+    leadingWhitespaceCount(lines[toStart]!)
+  ) {
+    return source;
+  }
   // Refuse no-ops: dragging a task onto something inside its own
   // block would either be a no-op or self-overlap, both of which we
   // pass through unchanged.

--- a/packages/ui/src/utils/task-list.ts
+++ b/packages/ui/src/utils/task-list.ts
@@ -70,6 +70,22 @@ function walkTaskLines(lines: string[], visitor: TaskLineVisitor): void {
   let taskIndex = 0;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
+    // At top level (outside a list), a line starting with 4 spaces or
+    // a tab is an indented code block per CommonMark — it can't open
+    // a fence, even if the rest of the line is `` ``` ``. Skip it
+    // before fence detection so the `` ``` `` inside doesn't open a
+    // bogus block and shift downstream task indices. Inside a fenced
+    // block (openFence !== null) we still need to fall through so a
+    // matching close-fence line can end the block; inside a list, the
+    // same indent continues the list item and may legitimately open a
+    // fence as part of the item's content.
+    if (
+      openFence === null
+      && listIndent === null
+      && isIndentedCodeStart(line)
+    ) {
+      continue;
+    }
     const fenceMatch = line.match(FENCE_LINE);
     if (fenceMatch) {
       const run = fenceMatch[1]!;
@@ -96,9 +112,6 @@ function walkTaskLines(lines: string[], visitor: TaskLineVisitor): void {
     if (line.trim() === "") continue;
 
     const indent = leadingWhitespaceCount(line);
-    // Outside a list, a 4-space (or tab) indent opens a code block:
-    // any task-shaped line in it is plain code, not a task.
-    if (listIndent === null && isIndentedCodeStart(line)) continue;
 
     // Dedent out of the list when a non-blank line sits at or below
     // the list bullet indent and isn't itself a bullet at that level.


### PR DESCRIPTION
## Summary

- Task-list checkboxes in PR descriptions and issue bodies now toggle on click. Clicks apply locally for instant feedback; a 400ms debounce coalesces a flurry of clicks into one PATCH.
- Each task item gets a hover-revealed six-dot grip; dragging it reorders the items within the body.
- New `edit-issue-content` PATCH endpoint mirrors the existing PR variant via a fresh `IssueContentMutator` platform interface (GitHub and gitealike implementations).
- Unit tests cover the markdown renderer, toggle/move helpers, and the new server endpoint. Playwright e2e exercises checkbox toggle and drag-reorder persistence across reload.

## Test plan

- [ ] Make sure clicking checkboxes feels instant — no waiting on the network
- [ ] Hover a task item, drag by the grip to a new position; release lands the item there
- [ ] Reload the page; new state survives
- [ ] Same flow works on an issue body, not just PR descriptions