### PR TITLE
Show approver names from approval chip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run packages/ui lint and typecheck
         run: cd packages/ui && bun run typecheck && bun run lint
 
+      - name: Run guardrail checks
+        run: make guardrail-check
+
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.10.1

--- a/frontend/tests/e2e-full/pr-detail-branches.spec.ts
+++ b/frontend/tests/e2e-full/pr-detail-branches.spec.ts
@@ -43,6 +43,18 @@ test.describe("PR detail branch info", () => {
     )).toBe(true);
   });
 
+  test("reveals current approvers from full-stack review events", async ({ page }) => {
+    const trigger = page.getByRole("button", { name: "APPROVED (2)" });
+    await expect(trigger).toBeVisible();
+
+    await trigger.click();
+
+    const popup = page.locator(".approval-popup");
+    await expect(popup).toContainText("alice");
+    await expect(popup).toContainText("bob");
+    await expect(popup).not.toContainText("carol");
+  });
+
   test("summarizes changed lines by category in the popover", async ({ page }) => {
     await page.route("**/api/v1/pulls/github/acme/widgets/1/files", async (route) => {
       await route.fulfill({

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -378,6 +378,44 @@ func TestUpsertMREventsUpdatesExistingEventBody(t *testing.T) {
 	assert.Equal("edited body", events[0].Body)
 }
 
+func TestUpsertMREventsUpdatesExistingReviewState(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	base := baseTime()
+
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mrID := insertTestMR(t, d, repoID, 1, "dismissed review", base)
+	platformID := int64(202)
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		PlatformID:     &platformID,
+		EventType:      "review",
+		Author:         "carol",
+		Summary:        "APPROVED",
+		CreatedAt:      base,
+		DedupeKey:      "review-202",
+	}}))
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		PlatformID:     &platformID,
+		EventType:      "review",
+		Author:         "carol",
+		Summary:        "DISMISSED",
+		CreatedAt:      base.Add(time.Hour),
+		DedupeKey:      "review-202",
+	}}))
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("DISMISSED", events[0].Summary)
+	assert.Equal(base.Add(time.Hour), events[0].CreatedAt)
+}
+
 func TestUpsertIssueEventsUpdatesExistingEventBody(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -33,6 +33,7 @@ type FixtureClient struct {
 	OpenIssues                map[string][]*gh.Issue
 	Issues                    map[string][]*gh.Issue
 	Comments                  map[string][]*gh.IssueComment
+	Reviews                   map[string][]*gh.PullRequestReview
 	ReposByOwner              map[string][]*gh.Repository
 	Releases                  map[string][]*gh.RepositoryRelease
 	Tags                      map[string][]*gh.RepositoryTag
@@ -51,6 +52,7 @@ func NewFixtureClient() ghclient.Client {
 		OpenIssues:       make(map[string][]*gh.Issue),
 		Issues:           make(map[string][]*gh.Issue),
 		Comments:         make(map[string][]*gh.IssueComment),
+		Reviews:          make(map[string][]*gh.PullRequestReview),
 		ReposByOwner:     make(map[string][]*gh.Repository),
 		Releases:         make(map[string][]*gh.RepositoryRelease),
 		Tags:             make(map[string][]*gh.RepositoryTag),
@@ -289,11 +291,16 @@ func (c *FixtureClient) ListIssueCommentsIfChanged(
 	return c.ListIssueComments(ctx, owner, repo, number)
 }
 
-// ListReviews returns nil (read-only stub).
 func (c *FixtureClient) ListReviews(
-	_ context.Context, _, _ string, _ int,
+	_ context.Context, owner, repo string, number int,
 ) ([]*gh.PullRequestReview, error) {
-	return nil, nil
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	reviews := c.Reviews[issueKey(owner, repo, number)]
+	if len(reviews) == 0 {
+		return nil, nil
+	}
+	return slices.Clone(reviews), nil
 }
 
 // ListCommits returns nil (read-only stub).

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -99,6 +99,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Additions:         240,
 		Deletions:         30,
 		CommentCount:      3,
+		ReviewDecision:    "approved",
 		CIStatus:          "success",
 		CIChecksJSON:      string(ciChecksJSON),
 		CreatedAt:         w1Created,
@@ -107,6 +108,55 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("upsert widgets#1: %w", err)
+	}
+	if err := d.UpsertMREvents(ctx, []db.MREvent{
+		{
+			MergeRequestID: w1ID,
+			PlatformID:     int64Ptr(5011),
+			EventType:      "review",
+			Author:         "alice",
+			Summary:        "APPROVED",
+			CreatedAt:      w1Created.Add(2 * time.Hour),
+			DedupeKey:      "widgets-1-review-alice-approved",
+		},
+		{
+			MergeRequestID: w1ID,
+			PlatformID:     int64Ptr(5012),
+			EventType:      "review",
+			Author:         "bob",
+			Summary:        "CHANGES_REQUESTED",
+			CreatedAt:      w1Created.Add(3 * time.Hour),
+			DedupeKey:      "widgets-1-review-bob-changes-requested",
+		},
+		{
+			MergeRequestID: w1ID,
+			PlatformID:     int64Ptr(5013),
+			EventType:      "review",
+			Author:         "bob",
+			Summary:        "APPROVED",
+			CreatedAt:      w1Created.Add(4 * time.Hour),
+			DedupeKey:      "widgets-1-review-bob-approved",
+		},
+		{
+			MergeRequestID: w1ID,
+			PlatformID:     int64Ptr(5014),
+			EventType:      "review",
+			Author:         "carol",
+			Summary:        "APPROVED",
+			CreatedAt:      w1Created.Add(5 * time.Hour),
+			DedupeKey:      "widgets-1-review-carol-approved",
+		},
+		{
+			MergeRequestID: w1ID,
+			PlatformID:     int64Ptr(5015),
+			EventType:      "review",
+			Author:         "carol",
+			Summary:        "DISMISSED",
+			CreatedAt:      w1Created.Add(6 * time.Hour),
+			DedupeKey:      "widgets-1-review-carol-dismissed",
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("upsert widgets#1 review events: %w", err)
 	}
 
 	// widgets#2: open, bob, dirty merge state
@@ -708,6 +758,16 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		},
 	}
 
+	reviews := map[string][]*gh.PullRequestReview{
+		issueKey("acme", "widgets", 1): {
+			buildGHReview(5011, "alice", "APPROVED", w1Created.Add(2*time.Hour)),
+			buildGHReview(5012, "bob", "CHANGES_REQUESTED", w1Created.Add(3*time.Hour)),
+			buildGHReview(5013, "bob", "APPROVED", w1Created.Add(4*time.Hour)),
+			buildGHReview(5014, "carol", "APPROVED", w1Created.Add(5*time.Hour)),
+			buildGHReview(5015, "carol", "DISMISSED", w1Created.Add(6*time.Hour)),
+		},
+	}
+
 	allIssues := map[string][]*gh.Issue{
 		"acme/widgets": {
 			buildGHIssue("acme", "widgets", 3010, 10, "Widget rendering broken on Safari", "eve", "open", wi10Created, now.Add(-4*time.Hour)),
@@ -732,6 +792,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 				OpenIssues: openIssues,
 				Issues:     allIssues,
 				Comments:   make(map[string][]*gh.IssueComment),
+				Reviews:    reviews,
 				Tags:       make(map[string][]*gh.RepositoryTag),
 				CombinedStatuses: map[string]*gh.CombinedStatus{
 					refKey("acme", "widgets", widgetsPR1HeadSHA): {
@@ -783,6 +844,15 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	return result, nil
 }
 
+func buildGHReview(id int64, login, state string, submittedAt time.Time) *gh.PullRequestReview {
+	return &gh.PullRequestReview{
+		ID:          new(id),
+		User:        &gh.User{Login: new(login)},
+		State:       new(state),
+		SubmittedAt: &gh.Timestamp{Time: submittedAt},
+	}
+}
+
 // buildGHPR creates a minimal *gh.PullRequest for the FixtureClient.
 func buildGHPR(
 	owner, repo string,
@@ -818,6 +888,11 @@ func setPRStats(pr *gh.PullRequest, additions, deletions int) *gh.PullRequest {
 	pr.Additions = &additions
 	pr.Deletions = &deletions
 	return pr
+}
+
+//go:fix inline
+func int64Ptr(value int64) *int64 {
+	return new(value)
 }
 
 func setPRHeadSHA(pr *gh.PullRequest, sha string) *gh.PullRequest {

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -117,7 +117,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			Author:         "alice",
 			Summary:        "APPROVED",
 			CreatedAt:      w1Created.Add(2 * time.Hour),
-			DedupeKey:      "widgets-1-review-alice-approved",
+			DedupeKey:      "review-5011",
 		},
 		{
 			MergeRequestID: w1ID,
@@ -126,7 +126,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			Author:         "bob",
 			Summary:        "CHANGES_REQUESTED",
 			CreatedAt:      w1Created.Add(3 * time.Hour),
-			DedupeKey:      "widgets-1-review-bob-changes-requested",
+			DedupeKey:      "review-5012",
 		},
 		{
 			MergeRequestID: w1ID,
@@ -135,7 +135,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			Author:         "bob",
 			Summary:        "APPROVED",
 			CreatedAt:      w1Created.Add(4 * time.Hour),
-			DedupeKey:      "widgets-1-review-bob-approved",
+			DedupeKey:      "review-5013",
 		},
 		{
 			MergeRequestID: w1ID,
@@ -144,19 +144,21 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			Author:         "carol",
 			Summary:        "APPROVED",
 			CreatedAt:      w1Created.Add(5 * time.Hour),
-			DedupeKey:      "widgets-1-review-carol-approved",
-		},
-		{
-			MergeRequestID: w1ID,
-			PlatformID:     int64Ptr(5015),
-			EventType:      "review",
-			Author:         "carol",
-			Summary:        "DISMISSED",
-			CreatedAt:      w1Created.Add(6 * time.Hour),
-			DedupeKey:      "widgets-1-review-carol-dismissed",
+			DedupeKey:      "review-5014",
 		},
 	}); err != nil {
 		return nil, fmt.Errorf("upsert widgets#1 review events: %w", err)
+	}
+	if err := d.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: w1ID,
+		PlatformID:     int64Ptr(5014),
+		EventType:      "review",
+		Author:         "carol",
+		Summary:        "DISMISSED",
+		CreatedAt:      w1Created.Add(6 * time.Hour),
+		DedupeKey:      "review-5014",
+	}}); err != nil {
+		return nil, fmt.Errorf("dismiss widgets#1 carol review event: %w", err)
 	}
 
 	// widgets#2: open, bob, dirty merge state
@@ -763,8 +765,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			buildGHReview(5011, "alice", "APPROVED", w1Created.Add(2*time.Hour)),
 			buildGHReview(5012, "bob", "CHANGES_REQUESTED", w1Created.Add(3*time.Hour)),
 			buildGHReview(5013, "bob", "APPROVED", w1Created.Add(4*time.Hour)),
-			buildGHReview(5014, "carol", "APPROVED", w1Created.Add(5*time.Hour)),
-			buildGHReview(5015, "carol", "DISMISSED", w1Created.Add(6*time.Hour)),
+			buildGHReview(5014, "carol", "DISMISSED", w1Created.Add(6*time.Hour)),
 		},
 	}
 

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -126,6 +126,43 @@
   const hasActiveTimelineFilters = $derived(
     activePRTimelineFilterCount(timelineFilter) > 0,
   );
+  const currentApprovers = $derived.by(() =>
+    approversFromReviewEvents(detailStore.getDetail()?.events ?? []),
+  );
+
+  type ReviewEventLike = {
+    EventType: string;
+    Author: string;
+    Summary: string;
+    CreatedAt: string;
+  };
+
+  function approversFromReviewEvents(events: ReviewEventLike[]): string[] {
+    const latestByAuthor = new Map<
+      string,
+      { state: string; createdMs: number }
+    >();
+    for (const event of events) {
+      if (event.EventType !== "review" || !event.Author) continue;
+      const state = event.Summary.toUpperCase();
+      if (
+        state !== "APPROVED" &&
+        state !== "CHANGES_REQUESTED" &&
+        state !== "DISMISSED"
+      ) {
+        continue;
+      }
+      const createdMs = Date.parse(event.CreatedAt);
+      const previous = latestByAuthor.get(event.Author);
+      if (!previous || createdMs >= previous.createdMs) {
+        latestByAuthor.set(event.Author, { state, createdMs });
+      }
+    }
+    return Array.from(latestByAuthor.entries())
+      .filter(([, review]) => review.state === "APPROVED")
+      .map(([author]) => author)
+      .sort((left, right) => left.localeCompare(right));
+  }
 
   async function editTimelineComment(
     event: { PlatformID: number | null },
@@ -435,6 +472,14 @@
     return "chip--muted";
   }
 
+  function reviewLabel(decision: string, approverCount: number): string {
+    const label = decision.replace(/_/g, " ");
+    if (decision === "APPROVED" && approverCount > 1) {
+      return `${label} (${approverCount})`;
+    }
+    return label;
+  }
+
   function onKanbanChange(value: string): void {
     if (stalePR) return;
     void detailStore.updateKanbanState(owner, name, number, value as KanbanStatus);
@@ -531,22 +576,48 @@
   let wsError = $state<string | null>(null);
   let actionMenuOpen = $state(false);
   let actionMenuWrapEl = $state<HTMLDivElement>();
+  let approvalPopupOpen = $state(false);
+  let approvalPopupWrapEl = $state<HTMLDivElement>();
 
   function closeActionMenu(): void {
     actionMenuOpen = false;
+  }
+
+  function closeApprovalPopup(): void {
+    approvalPopupOpen = false;
+  }
+
+  function toggleApprovalPopup(): void {
+    if (currentApprovers.length === 0) return;
+    approvalPopupOpen = !approvalPopupOpen;
   }
 
   function onActionMenuKeydown(e: KeyboardEvent): void {
     if (actionMenuOpen && e.key === "Escape") {
       actionMenuOpen = false;
     }
+    if (approvalPopupOpen && e.key === "Escape") {
+      approvalPopupOpen = false;
+    }
   }
 
-  function onActionMenuDocumentMousedown(e: MouseEvent): void {
-    if (!actionMenuOpen) return;
+  function onDocumentMousedown(e: MouseEvent): void {
     const target = e.target as Node;
-    if (actionMenuWrapEl?.contains(target)) return;
-    closeActionMenu();
+    if (actionMenuOpen && !actionMenuWrapEl?.contains(target)) {
+      closeActionMenu();
+    }
+    if (approvalPopupOpen && !approvalPopupWrapEl?.contains(target)) {
+      closeApprovalPopup();
+    }
+  }
+
+  function onApprovalPopupFocusout(): void {
+    queueMicrotask(() => {
+      if (!approvalPopupOpen) return;
+      const active = document.activeElement;
+      if (active && approvalPopupWrapEl?.contains(active)) return;
+      closeApprovalPopup();
+    });
   }
 
   async function createWorkspace(): Promise<void> {
@@ -603,7 +674,7 @@
 </script>
 
 <svelte:window onkeydown={onActionMenuKeydown} />
-<svelte:document onmousedown={onActionMenuDocumentMousedown} />
+<svelte:document onmousedown={onDocumentMousedown} />
 
 {#if detailStore.isDetailLoading() && (detailStore.getDetail() === null || stalePR)}
   <div class="state-center"><p class="state-msg">Loading…</p></div>
@@ -797,9 +868,38 @@
           showPanel={false}
         />
         {#if pr.ReviewDecision}
-          <Chip class={reviewColor(pr.ReviewDecision)}>
-            {pr.ReviewDecision.replace(/_/g, " ")}
-          </Chip>
+          {@const approverCount = currentApprovers.length}
+          {@const reviewText = reviewLabel(pr.ReviewDecision, approverCount)}
+          {#if pr.ReviewDecision === "APPROVED" && approverCount > 0}
+            <div
+              class="approval-chip-wrap"
+              bind:this={approvalPopupWrapEl}
+              onfocusout={onApprovalPopupFocusout}
+            >
+              <Chip
+                class={reviewColor(pr.ReviewDecision)}
+                interactive
+                expanded={approvalPopupOpen}
+                title="Show approving reviewers"
+                onclick={toggleApprovalPopup}
+              >
+                {reviewText}
+              </Chip>
+              {#if approvalPopupOpen}
+                <div class="approval-popup" role="list">
+                  {#each currentApprovers as approver (approver)}
+                    <div class="approval-popup-item" role="listitem">
+                      {approver}
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {:else}
+            <Chip class={reviewColor(pr.ReviewDecision)}>
+              {reviewText}
+            </Chip>
+          {/if}
         {/if}
         {#if pr.Additions > 0 || pr.Deletions > 0}
           <DiffSummaryChip
@@ -1542,6 +1642,40 @@
     flex-wrap: wrap;
     gap: 6px;
     min-width: 0;
+  }
+
+  .approval-chip-wrap {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .approval-popup {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 6px);
+    left: 0;
+    min-width: 120px;
+    max-width: min(220px, 70vw);
+    padding: 6px;
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    background: var(--bg-surface);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .approval-popup-item {
+    overflow: hidden;
+    padding: 4px 6px;
+    border-radius: 4px;
+    color: var(--text-primary);
+    font-size: 12px;
+    line-height: 1.3;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .approval-popup-item + .approval-popup-item {
+    margin-top: 2px;
   }
 
   :global(.kanban-select) {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -20,6 +20,7 @@
   import ApproveWorkflowsButton from "./ApproveWorkflowsButton.svelte";
   import MergeModal from "./MergeModal.svelte";
   import ReadyForReviewButton from "./ReadyForReviewButton.svelte";
+  import ReviewDecisionChip from "./ReviewDecisionChip.svelte";
   import {
     runOpenMerge,
     type PRDetailActionInput,
@@ -126,44 +127,6 @@
   const hasActiveTimelineFilters = $derived(
     activePRTimelineFilterCount(timelineFilter) > 0,
   );
-  const currentApprovers = $derived.by(() =>
-    approversFromReviewEvents(detailStore.getDetail()?.events ?? []),
-  );
-
-  type ReviewEventLike = {
-    EventType: string;
-    Author: string;
-    Summary: string;
-    CreatedAt: string;
-  };
-
-  function approversFromReviewEvents(events: ReviewEventLike[]): string[] {
-    const latestByAuthor = new Map<
-      string,
-      { state: string; createdMs: number }
-    >();
-    for (const event of events) {
-      if (event.EventType !== "review" || !event.Author) continue;
-      const state = event.Summary.toUpperCase();
-      if (
-        state !== "APPROVED" &&
-        state !== "CHANGES_REQUESTED" &&
-        state !== "DISMISSED"
-      ) {
-        continue;
-      }
-      const createdMs = Date.parse(event.CreatedAt);
-      const previous = latestByAuthor.get(event.Author);
-      if (!previous || createdMs >= previous.createdMs) {
-        latestByAuthor.set(event.Author, { state, createdMs });
-      }
-    }
-    return Array.from(latestByAuthor.entries())
-      .filter(([, review]) => review.state === "APPROVED")
-      .map(([author]) => author)
-      .sort((left, right) => left.localeCompare(right));
-  }
-
   async function editTimelineComment(
     event: { PlatformID: number | null },
     body: string,
@@ -466,20 +429,6 @@
     { value: "awaiting_merge", label: "Awaiting Merge" },
   ];
 
-  function reviewColor(decision: string): string {
-    if (decision === "APPROVED") return "chip--green";
-    if (decision === "CHANGES_REQUESTED") return "chip--red";
-    return "chip--muted";
-  }
-
-  function reviewLabel(decision: string, approverCount: number): string {
-    const label = decision.replace(/_/g, " ");
-    if (decision === "APPROVED" && approverCount > 1) {
-      return `${label} (${approverCount})`;
-    }
-    return label;
-  }
-
   function onKanbanChange(value: string): void {
     if (stalePR) return;
     void detailStore.updateKanbanState(owner, name, number, value as KanbanStatus);
@@ -576,28 +525,14 @@
   let wsError = $state<string | null>(null);
   let actionMenuOpen = $state(false);
   let actionMenuWrapEl = $state<HTMLDivElement>();
-  let approvalPopupOpen = $state(false);
-  let approvalPopupWrapEl = $state<HTMLDivElement>();
 
   function closeActionMenu(): void {
     actionMenuOpen = false;
   }
 
-  function closeApprovalPopup(): void {
-    approvalPopupOpen = false;
-  }
-
-  function toggleApprovalPopup(): void {
-    if (currentApprovers.length === 0) return;
-    approvalPopupOpen = !approvalPopupOpen;
-  }
-
   function onActionMenuKeydown(e: KeyboardEvent): void {
     if (actionMenuOpen && e.key === "Escape") {
       actionMenuOpen = false;
-    }
-    if (approvalPopupOpen && e.key === "Escape") {
-      approvalPopupOpen = false;
     }
   }
 
@@ -606,18 +541,6 @@
     if (actionMenuOpen && !actionMenuWrapEl?.contains(target)) {
       closeActionMenu();
     }
-    if (approvalPopupOpen && !approvalPopupWrapEl?.contains(target)) {
-      closeApprovalPopup();
-    }
-  }
-
-  function onApprovalPopupFocusout(): void {
-    queueMicrotask(() => {
-      if (!approvalPopupOpen) return;
-      const active = document.activeElement;
-      if (active && approvalPopupWrapEl?.contains(active)) return;
-      closeApprovalPopup();
-    });
   }
 
   async function createWorkspace(): Promise<void> {
@@ -868,38 +791,10 @@
           showPanel={false}
         />
         {#if pr.ReviewDecision}
-          {@const approverCount = currentApprovers.length}
-          {@const reviewText = reviewLabel(pr.ReviewDecision, approverCount)}
-          {#if pr.ReviewDecision === "APPROVED" && approverCount > 0}
-            <div
-              class="approval-chip-wrap"
-              bind:this={approvalPopupWrapEl}
-              onfocusout={onApprovalPopupFocusout}
-            >
-              <Chip
-                class={reviewColor(pr.ReviewDecision)}
-                interactive
-                expanded={approvalPopupOpen}
-                title="Show approving reviewers"
-                onclick={toggleApprovalPopup}
-              >
-                {reviewText}
-              </Chip>
-              {#if approvalPopupOpen}
-                <div class="approval-popup" role="list">
-                  {#each currentApprovers as approver (approver)}
-                    <div class="approval-popup-item" role="listitem">
-                      {approver}
-                    </div>
-                  {/each}
-                </div>
-              {/if}
-            </div>
-          {:else}
-            <Chip class={reviewColor(pr.ReviewDecision)}>
-              {reviewText}
-            </Chip>
-          {/if}
+          <ReviewDecisionChip
+            decision={pr.ReviewDecision}
+            events={detail.events}
+          />
         {/if}
         {#if pr.Additions > 0 || pr.Deletions > 0}
           <DiffSummaryChip
@@ -1642,40 +1537,6 @@
     flex-wrap: wrap;
     gap: 6px;
     min-width: 0;
-  }
-
-  .approval-chip-wrap {
-    position: relative;
-    display: inline-flex;
-  }
-
-  .approval-popup {
-    position: absolute;
-    z-index: 20;
-    top: calc(100% + 6px);
-    left: 0;
-    min-width: 120px;
-    max-width: min(220px, 70vw);
-    padding: 6px;
-    border: 1px solid var(--border-default);
-    border-radius: 6px;
-    background: var(--bg-surface);
-    box-shadow: var(--shadow-lg);
-  }
-
-  .approval-popup-item {
-    overflow: hidden;
-    padding: 4px 6px;
-    border-radius: 4px;
-    color: var(--text-primary);
-    font-size: 12px;
-    line-height: 1.3;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .approval-popup-item + .approval-popup-item {
-    margin-top: 2px;
   }
 
   :global(.kanban-select) {

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -1,0 +1,200 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PullDetail } from "../../api/types.js";
+import {
+  ACTIONS_KEY,
+  API_CLIENT_KEY,
+  NAVIGATE_KEY,
+  STORES_KEY,
+  UI_CONFIG_KEY,
+} from "../../context.js";
+import PullDetailComponent from "./PullDetail.svelte";
+
+const capabilities = {
+  read_repositories: true,
+  read_merge_requests: true,
+  read_issues: true,
+  read_comments: true,
+  read_releases: true,
+  read_ci: true,
+  comment_mutation: false,
+  state_mutation: true,
+  merge_mutation: false,
+  review_mutation: false,
+  workflow_approval: false,
+  ready_for_review: false,
+  issue_mutation: false,
+};
+
+function reviewEvent(author: string, summary = "APPROVED", createdAt = "2026-05-01T12:00:00Z") {
+  return {
+    ID: Math.floor(Math.random() * 1_000_000),
+    MergeRequestID: 1,
+    PlatformID: 1,
+    PlatformExternalID: "",
+    EventType: "review",
+    Author: author,
+    Summary: summary,
+    Body: "",
+    MetadataJSON: "",
+    CreatedAt: createdAt,
+    DedupeKey: `review-${author}-${summary}-${createdAt}`,
+  };
+}
+
+function pullDetail(): PullDetail {
+  return {
+    detail_loaded: true,
+    detail_fetched_at: "2026-05-01T12:05:00Z",
+    diff_head_sha: "head",
+    merge_base_sha: "base",
+    platform_base_sha: "base",
+    platform_head_sha: "head",
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widget",
+    warnings: [],
+    workflow_approval: {
+      count: 0,
+      required: false,
+      runs: [],
+    },
+    workspace: undefined,
+    worktree_links: [],
+    repo: {
+      ID: 1,
+      Owner: "acme",
+      Name: "widget",
+      Host: "github.com",
+      PlatformHost: "github.com",
+      Platform: "github",
+      URL: "https://github.com/acme/widget",
+      DefaultBranch: "main",
+      IsArchived: false,
+      AllowSquashMerge: false,
+      AllowMergeCommit: false,
+      AllowRebaseMerge: false,
+      capabilities,
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widget",
+      repo_path: "acme/widget",
+    },
+    merge_request: {
+      ID: 1,
+      RepoID: 1,
+      PlatformID: 100,
+      PlatformExternalID: "PR_1",
+      Number: 1,
+      URL: "https://github.com/acme/widget/pull/1",
+      Title: "Make approval counts visible",
+      Author: "octocat",
+      AuthorDisplayName: "Octocat",
+      State: "open",
+      IsDraft: false,
+      IsLocked: false,
+      Body: "",
+      HeadBranch: "feature",
+      BaseBranch: "main",
+      HeadRepoCloneURL: "https://github.com/acme/widget.git",
+      Additions: 0,
+      Deletions: 0,
+      CommentCount: 0,
+      ReviewDecision: "APPROVED",
+      CIStatus: "",
+      CIChecksJSON: "",
+      CIHadPending: false,
+      CreatedAt: "2026-05-01T11:00:00Z",
+      UpdatedAt: "2026-05-01T12:00:00Z",
+      LastActivityAt: "2026-05-01T12:00:00Z",
+      MergedAt: null,
+      ClosedAt: null,
+      MergeableState: "clean",
+      DetailFetchedAt: "2026-05-01T12:05:00Z",
+      KanbanStatus: "new",
+      Starred: false,
+      labels: [],
+    },
+    events: [
+      reviewEvent("alice", "APPROVED", "2026-05-01T12:00:00Z"),
+      reviewEvent("bob", "APPROVED", "2026-05-01T11:59:00Z"),
+    ],
+  };
+}
+
+function renderPullDetail(detail: PullDetail) {
+  const detailStore = {
+    loadDetail: vi.fn(async () => undefined),
+    startDetailPolling: vi.fn(),
+    stopDetailPolling: vi.fn(),
+    getDetail: () => detail,
+    isDetailLoading: () => false,
+    getDetailError: () => null,
+    isStaleRefreshing: () => false,
+    isDetailSyncing: () => false,
+    getDetailLoaded: () => true,
+    updateKanbanState: vi.fn(),
+    toggleDetailPRStar: vi.fn(),
+    updatePRContent: vi.fn(),
+    editComment: vi.fn(),
+  };
+
+  return render(PullDetailComponent, {
+    props: {
+      owner: "acme",
+      name: "widget",
+      number: 1,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      hideWorkspaceAction: true,
+    },
+    context: new Map<symbol, unknown>([
+      [
+        API_CLIENT_KEY,
+        {
+          GET: vi.fn(async () => ({
+            data: {
+              AllowSquashMerge: false,
+              AllowMergeCommit: false,
+              AllowRebaseMerge: false,
+            },
+          })),
+        },
+      ],
+      [
+        STORES_KEY,
+        {
+          detail: detailStore,
+          pulls: { loadPulls: vi.fn() },
+          activity: { loadActivity: vi.fn() },
+        },
+      ],
+      [ACTIONS_KEY, { pull: [] }],
+      [UI_CONFIG_KEY, { hideStar: true }],
+      [NAVIGATE_KEY, vi.fn()],
+    ]),
+  });
+}
+
+describe("PullDetail approvals", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows approval count and expands approver names", async () => {
+    renderPullDetail(pullDetail());
+
+    const trigger = screen.getByRole("button", { name: "APPROVED (2)" });
+    await fireEvent.click(trigger);
+
+    const popup = document.querySelector(".approval-popup");
+    expect(popup?.textContent).toContain("alice");
+    expect(popup?.textContent).toContain("bob");
+
+    await fireEvent.mouseDown(document.body);
+
+    expect(document.querySelector(".approval-popup")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -197,4 +197,18 @@ describe("PullDetail approvals", () => {
 
     expect(document.querySelector(".approval-popup")).toBeNull();
   });
+
+  it("normalizes backend review decision casing before enabling approver popup", async () => {
+    const detail = pullDetail();
+    detail.merge_request.ReviewDecision = "approved";
+
+    renderPullDetail(detail);
+
+    const trigger = screen.getByRole("button", { name: "APPROVED (2)" });
+    await fireEvent.click(trigger);
+
+    const popup = document.querySelector(".approval-popup");
+    expect(popup?.textContent).toContain("alice");
+    expect(popup?.textContent).toContain("bob");
+  });
 });

--- a/packages/ui/src/components/detail/ReviewDecisionChip.svelte
+++ b/packages/ui/src/components/detail/ReviewDecisionChip.svelte
@@ -155,7 +155,7 @@
     padding: 4px 6px;
     border-radius: 4px;
     color: var(--text-primary);
-    font-size: 12px;
+    font-size: var(--font-size-sm);
     line-height: 1.3;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/ui/src/components/detail/ReviewDecisionChip.svelte
+++ b/packages/ui/src/components/detail/ReviewDecisionChip.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+  import type { PREvent } from "../../api/types.js";
+  import Chip from "../shared/Chip.svelte";
+
+  interface Props {
+    decision: string;
+    events?: PREvent[] | null;
+  }
+
+  let { decision, events = [] }: Props = $props();
+
+  let popupOpen = $state(false);
+  let wrapEl = $state<HTMLDivElement>();
+
+  const approvers = $derived.by(() =>
+    approversFromReviewEvents(events ?? []),
+  );
+  const label = $derived(reviewLabel(decision, approvers.length));
+  const chipClass = $derived(reviewColor(decision));
+  const canExpand = $derived(
+    decision === "APPROVED" && approvers.length > 0,
+  );
+
+  function reviewColor(reviewDecision: string): string {
+    if (reviewDecision === "APPROVED") return "chip--green";
+    if (reviewDecision === "CHANGES_REQUESTED") return "chip--red";
+    return "chip--muted";
+  }
+
+  function reviewLabel(reviewDecision: string, approverCount: number): string {
+    const baseLabel = reviewDecision.replace(/_/g, " ");
+    if (reviewDecision === "APPROVED" && approverCount > 1) {
+      return `${baseLabel} (${approverCount})`;
+    }
+    return baseLabel;
+  }
+
+  function approversFromReviewEvents(reviewEvents: PREvent[]): string[] {
+    const latestByAuthor = new Map<
+      string,
+      { state: string; createdMs: number }
+    >();
+    for (const event of reviewEvents) {
+      if (event.EventType !== "review" || !event.Author) continue;
+      const state = event.Summary.toUpperCase();
+      if (
+        state !== "APPROVED" &&
+        state !== "CHANGES_REQUESTED" &&
+        state !== "DISMISSED"
+      ) {
+        continue;
+      }
+      const createdMs = Date.parse(event.CreatedAt);
+      const previous = latestByAuthor.get(event.Author);
+      if (!previous || createdMs >= previous.createdMs) {
+        latestByAuthor.set(event.Author, { state, createdMs });
+      }
+    }
+    return Array.from(latestByAuthor.entries())
+      .filter(([, review]) => review.state === "APPROVED")
+      .map(([author]) => author)
+      .sort((left, right) => left.localeCompare(right));
+  }
+
+  function closePopup(): void {
+    popupOpen = false;
+  }
+
+  function togglePopup(): void {
+    if (!canExpand) return;
+    popupOpen = !popupOpen;
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (popupOpen && e.key === "Escape") {
+      closePopup();
+    }
+  }
+
+  function onDocumentMousedown(e: MouseEvent): void {
+    if (!popupOpen) return;
+    const target = e.target as Node;
+    if (!wrapEl?.contains(target)) closePopup();
+  }
+
+  function onFocusout(): void {
+    queueMicrotask(() => {
+      if (!popupOpen) return;
+      const active = document.activeElement;
+      if (active && wrapEl?.contains(active)) return;
+      closePopup();
+    });
+  }
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+<svelte:document onmousedown={onDocumentMousedown} />
+
+{#if canExpand}
+  <div
+    class="approval-chip-wrap"
+    bind:this={wrapEl}
+    onfocusout={onFocusout}
+  >
+    <Chip
+      class={chipClass}
+      interactive
+      expanded={popupOpen}
+      title="Show approving reviewers"
+      onclick={togglePopup}
+    >
+      {label}
+    </Chip>
+    {#if popupOpen}
+      <div class="approval-popup" role="list">
+        {#each approvers as approver (approver)}
+          <div class="approval-popup-item" role="listitem">
+            {approver}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{:else}
+  <Chip class={chipClass}>{label}</Chip>
+{/if}
+
+<style>
+  .approval-chip-wrap {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .approval-popup {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 6px);
+    left: 0;
+    min-width: 120px;
+    max-width: min(220px, 70vw);
+    padding: 6px;
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    background: var(--bg-surface);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .approval-popup-item {
+    overflow: hidden;
+    padding: 4px 6px;
+    border-radius: 4px;
+    color: var(--text-primary);
+    font-size: 12px;
+    line-height: 1.3;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .approval-popup-item + .approval-popup-item {
+    margin-top: 2px;
+  }
+</style>

--- a/packages/ui/src/components/detail/ReviewDecisionChip.svelte
+++ b/packages/ui/src/components/detail/ReviewDecisionChip.svelte
@@ -15,11 +15,16 @@
   const approvers = $derived.by(() =>
     approversFromReviewEvents(events ?? []),
   );
-  const label = $derived(reviewLabel(decision, approvers.length));
-  const chipClass = $derived(reviewColor(decision));
+  const normalizedDecision = $derived(normalizeReviewDecision(decision));
+  const label = $derived(reviewLabel(normalizedDecision, approvers.length));
+  const chipClass = $derived(reviewColor(normalizedDecision));
   const canExpand = $derived(
-    decision === "APPROVED" && approvers.length > 0,
+    normalizedDecision === "APPROVED" && approvers.length > 0,
   );
+
+  function normalizeReviewDecision(reviewDecision: string): string {
+    return reviewDecision.trim().toUpperCase();
+  }
 
   function reviewColor(reviewDecision: string): string {
     if (reviewDecision === "APPROVED") return "chip--green";

--- a/packages/ui/src/components/detail/ReviewDecisionChip.test.ts
+++ b/packages/ui/src/components/detail/ReviewDecisionChip.test.ts
@@ -1,0 +1,53 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PREvent } from "../../api/types.js";
+import ReviewDecisionChip from "./ReviewDecisionChip.svelte";
+
+function reviewEvent(
+  author: string,
+  summary = "APPROVED",
+  createdAt = "2026-05-01T12:00:00Z",
+): PREvent {
+  return {
+    ID: Math.floor(Math.random() * 1_000_000),
+    MergeRequestID: 1,
+    PlatformID: 1,
+    PlatformExternalID: "",
+    EventType: "review",
+    Author: author,
+    Summary: summary,
+    Body: "",
+    MetadataJSON: "",
+    CreatedAt: createdAt,
+    DedupeKey: `review-${author}-${summary}-${createdAt}`,
+  };
+}
+
+describe("ReviewDecisionChip", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows approval count and expands approver names", async () => {
+    render(ReviewDecisionChip, {
+      props: {
+        decision: "APPROVED",
+        events: [
+          reviewEvent("alice", "APPROVED", "2026-05-01T12:00:00Z"),
+          reviewEvent("bob", "APPROVED", "2026-05-01T11:59:00Z"),
+        ],
+      },
+    });
+
+    const trigger = screen.getByRole("button", { name: "APPROVED (2)" });
+    await fireEvent.click(trigger);
+
+    const popup = document.querySelector(".approval-popup");
+    expect(popup?.textContent).toContain("alice");
+    expect(popup?.textContent).toContain("bob");
+
+    await fireEvent.mouseDown(document.body);
+
+    expect(document.querySelector(".approval-popup")).toBeNull();
+  });
+});


### PR DESCRIPTION
- Show multi-approval pull requests as `APPROVED (n)` in the PR detail chip row.
- Let maintainers click the approval chip to see the current approving reviewers.
- Close the approver popup on outside click, Escape, or focus leaving the control.