### PR TITLE
Modernize workspace force-delete prompt

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1688,21 +1688,21 @@
 
   .force-delete-header h2 {
     margin: 0;
-    font-size: 15px;
+    font-size: var(--font-size-lg);
     font-weight: 600;
     color: var(--text-primary);
   }
 
   .force-delete-message {
     margin: 0;
-    font-size: 13px;
+    font-size: var(--font-size-md);
     color: var(--text-secondary);
     line-height: 1.5;
   }
 
   .force-delete-hint {
     margin: 0;
-    font-size: 12.5px;
+    font-size: var(--font-size-sm);
     color: var(--text-muted);
     line-height: 1.5;
   }
@@ -1718,7 +1718,7 @@
   .force-delete-confirm {
     height: 30px;
     padding: 0 14px;
-    font-size: 12.5px;
+    font-size: var(--font-size-sm);
     font-weight: 500;
     border-radius: var(--radius-sm);
     cursor: pointer;

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -779,17 +779,32 @@
     if (actionsBlocked) return;
     actionError = null;
     const targetId = workspaceId;
+    // Capture the trigger synchronously: the click handler runs
+    // before `inert` is applied to .terminal-view, so this is the
+    // last point we can read the originating focused element. By
+    // the time the post-await effect runs, the browser has cleared
+    // focus to document.body.
+    const triggerEl =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
     const { error, response } = await client.DELETE(
       "/workspaces/{id}",
       {
         params: { path: { id: targetId } },
       },
     );
+    // The user can navigate away while the request is in flight;
+    // settling state for a workspace they're no longer viewing
+    // would open a stale prompt or yank them out of their new
+    // context.
+    if (targetId !== workspaceId) return;
     if (response.status === 409) {
+      previouslyFocusedEl = triggerEl;
+      forcePromptForId = targetId;
       forcePromptMessage =
         error?.detail ??
         "Workspace has uncommitted changes.";
-      forcePromptForId = targetId;
       return;
     }
     if (!response.ok && response.status !== 204) {
@@ -818,6 +833,11 @@
           },
         },
       );
+      // The force-delete on the server is destructive and runs to
+      // completion either way; once the user has moved on we just
+      // drop the response on the floor so navigate() doesn't pull
+      // them away from their new workspace.
+      if (targetId !== workspaceId) return;
       if (!response.ok && response.status !== 204) {
         actionError = apiErrorMessage(
           error,
@@ -874,12 +894,6 @@
 
   $effect(() => {
     if (forcePromptMessage !== null) {
-      if (
-        previouslyFocusedEl === null &&
-        document.activeElement instanceof HTMLElement
-      ) {
-        previouslyFocusedEl = document.activeElement;
-      }
       void tick().then(() => cancelForceBtnEl?.focus());
     } else if (previouslyFocusedEl !== null) {
       previouslyFocusedEl.focus();

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -113,6 +113,12 @@
   let forcePromptForId = $state<string | null>(null);
   let forceDeleting = $state(false);
   let cancelForceBtnEl = $state<HTMLButtonElement | null>(null);
+  // Bumps on every workspace route change. Async delete callbacks
+  // capture this at request time and bail out if it has moved on,
+  // covering the case where the user leaves and returns to the same
+  // workspace before an in-flight response settles — an id check
+  // alone would let a stale 409 reopen the prompt.
+  let workspaceGen = 0;
   let runtimeError = $state<string | null>(null);
   let pollTimer = $state<ReturnType<
     typeof setInterval
@@ -779,6 +785,7 @@
     if (actionsBlocked) return;
     actionError = null;
     const targetId = workspaceId;
+    const targetGen = workspaceGen;
     // Capture the trigger synchronously: the click handler runs
     // before `inert` is applied to .terminal-view, so this is the
     // last point we can read the originating focused element. By
@@ -797,8 +804,13 @@
     // The user can navigate away while the request is in flight;
     // settling state for a workspace they're no longer viewing
     // would open a stale prompt or yank them out of their new
-    // context.
-    if (targetId !== workspaceId) return;
+    // context. The generation check also covers an A→B→A round
+    // trip where the id alone would compare equal.
+    if (
+      targetId !== workspaceId ||
+      targetGen !== workspaceGen
+    )
+      return;
     if (response.status === 409) {
       previouslyFocusedEl = triggerEl;
       forcePromptForId = targetId;
@@ -821,6 +833,7 @@
     if (forceDeleting) return;
     const targetId = forcePromptForId;
     if (targetId === null) return;
+    const targetGen = workspaceGen;
     forceDeleting = true;
     actionError = null;
     try {
@@ -837,7 +850,11 @@
       // completion either way; once the user has moved on we just
       // drop the response on the floor so navigate() doesn't pull
       // them away from their new workspace.
-      if (targetId !== workspaceId) return;
+      if (
+        targetId !== workspaceId ||
+        targetGen !== workspaceGen
+      )
+        return;
       if (!response.ok && response.status !== 204) {
         actionError = apiErrorMessage(
           error,
@@ -955,9 +972,12 @@
     // A 409 force-delete prompt is bound to the workspace that
     // produced it. Dismiss it on any route change so the user
     // can't confirm a destructive action targeting a workspace
-    // they're no longer looking at.
+    // they're no longer looking at. Bumping the generation token
+    // also invalidates any in-flight DELETE callback that captured
+    // the previous value.
     forcePromptMessage = null;
     forcePromptForId = null;
+    workspaceGen += 1;
     tmuxTerminalMounted = restoredTab === "tmux";
     mountedSessionKeys = restoredTab.startsWith("session:")
       ? [restoredTab.slice("session:".length)]

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { tick, untrack } from "svelte";
+  import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
   import { navigate } from "../../stores/router.svelte.ts";
   import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
   import TerminalPane from "./TerminalPane.svelte";
@@ -107,6 +109,9 @@
   let loadError = $state<string | null>(null);
   let actionError = $state<string | null>(null);
   let retryingSetup = $state(false);
+  let forcePromptMessage = $state<string | null>(null);
+  let forceDeleting = $state(false);
+  let cancelForceBtnEl = $state<HTMLButtonElement | null>(null);
   let runtimeError = $state<string | null>(null);
   let pollTimer = $state<ReturnType<
     typeof setInterval
@@ -779,24 +784,12 @@
       },
     );
     if (response.status === 409) {
-      const msg =
+      forcePromptMessage =
         error?.detail ??
         "Workspace has uncommitted changes.";
-      if (!confirm(`${msg}\n\nForce delete?`)) return;
-      const force = await client.DELETE("/workspaces/{id}", {
-        params: {
-          path: { id: workspaceId },
-          query: { force: true },
-        },
-      });
-      if (!force.response.ok && force.response.status !== 204) {
-        actionError = apiErrorMessage(
-          force.error,
-          `Delete failed (${force.response.status})`,
-        );
-        return;
-      }
-    } else if (!response.ok && response.status !== 204) {
+      return;
+    }
+    if (!response.ok && response.status !== 204) {
       actionError = apiErrorMessage(
         error,
         `Delete failed (${response.status})`,
@@ -805,6 +798,60 @@
     }
     navigate("/workspaces");
   }
+
+  async function confirmForceDelete(): Promise<void> {
+    if (forceDeleting) return;
+    forceDeleting = true;
+    actionError = null;
+    try {
+      const { error, response } = await client.DELETE(
+        "/workspaces/{id}",
+        {
+          params: {
+            path: { id: workspaceId },
+            query: { force: true },
+          },
+        },
+      );
+      if (!response.ok && response.status !== 204) {
+        actionError = apiErrorMessage(
+          error,
+          `Delete failed (${response.status})`,
+        );
+        forcePromptMessage = null;
+        return;
+      }
+      forcePromptMessage = null;
+      navigate("/workspaces");
+    } finally {
+      forceDeleting = false;
+    }
+  }
+
+  function cancelForceDelete(): void {
+    if (forceDeleting) return;
+    forcePromptMessage = null;
+  }
+
+  function handleForcePromptKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelForceDelete();
+    }
+  }
+
+  $effect(() => {
+    if (forcePromptMessage !== null) {
+      void tick().then(() => cancelForceBtnEl?.focus());
+    }
+  });
+
+  $effect(() => {
+    if (forcePromptMessage === null) return;
+    return untrack(() =>
+      pushModalFrame("workspace-force-delete", []),
+    );
+  });
 
   $effect(() => {
     if (!workspace) return;
@@ -1196,6 +1243,58 @@
   {/if}
 </div>
 
+{#if forcePromptMessage !== null}
+  <div
+    class="force-delete-backdrop"
+    role="presentation"
+    onkeydown={handleForcePromptKeydown}
+  >
+    <div
+      class="force-delete-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="force-delete-title"
+      aria-describedby="force-delete-message"
+    >
+      <div class="force-delete-header">
+        <AlertIcon
+          class="force-delete-icon"
+          size="20"
+          strokeWidth="2"
+          aria-hidden="true"
+        />
+        <h2 id="force-delete-title">Force delete workspace?</h2>
+      </div>
+      <p id="force-delete-message" class="force-delete-message">
+        {forcePromptMessage}
+      </p>
+      <p class="force-delete-hint">
+        Force-deleting discards any uncommitted changes in the
+        worktree. This cannot be undone.
+      </p>
+      <div class="force-delete-actions">
+        <button
+          type="button"
+          class="force-delete-cancel"
+          disabled={forceDeleting}
+          bind:this={cancelForceBtnEl}
+          onclick={cancelForceDelete}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="force-delete-confirm"
+          disabled={forceDeleting}
+          onclick={() => void confirmForceDelete()}
+        >
+          {forceDeleting ? "Deleting…" : "Force delete"}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
 <style>
   .terminal-view {
     display: flex;
@@ -1466,5 +1565,132 @@
   .right-sidebar {
     flex-shrink: 0;
     overflow: hidden;
+  }
+
+  .force-delete-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: color-mix(in srgb, black 50%, transparent);
+    backdrop-filter: blur(2px);
+    animation: force-delete-fade 120ms ease-out;
+  }
+
+  .force-delete-dialog {
+    width: min(420px, 100%);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 24px 80px rgb(0 0 0 / 35%);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    animation: force-delete-pop 160ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .force-delete-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  :global(.force-delete-icon) {
+    color: var(--accent-red);
+    flex-shrink: 0;
+  }
+
+  .force-delete-header h2 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .force-delete-message {
+    margin: 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .force-delete-hint {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .force-delete-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .force-delete-cancel,
+  .force-delete-confirm {
+    height: 30px;
+    padding: 0 14px;
+    font-size: 12.5px;
+    font-weight: 500;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color 80ms ease, color 80ms ease,
+      border-color 80ms ease;
+  }
+
+  .force-delete-cancel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    color: var(--text-secondary);
+  }
+
+  .force-delete-cancel:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .force-delete-confirm {
+    background: var(--accent-red);
+    border: 1px solid var(--accent-red);
+    color: #fff;
+    font-weight: 600;
+  }
+
+  .force-delete-confirm:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent-red) 88%, black);
+    border-color: color-mix(in srgb, var(--accent-red) 88%, black);
+  }
+
+  .force-delete-cancel:disabled,
+  .force-delete-confirm:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  @keyframes force-delete-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes force-delete-pop {
+    from {
+      opacity: 0;
+      transform: scale(0.96) translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
   }
 </style>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -110,6 +110,7 @@
   let actionError = $state<string | null>(null);
   let retryingSetup = $state(false);
   let forcePromptMessage = $state<string | null>(null);
+  let forcePromptForId = $state<string | null>(null);
   let forceDeleting = $state(false);
   let cancelForceBtnEl = $state<HTMLButtonElement | null>(null);
   let runtimeError = $state<string | null>(null);
@@ -777,16 +778,18 @@
   async function handleDelete(): Promise<void> {
     if (actionsBlocked) return;
     actionError = null;
+    const targetId = workspaceId;
     const { error, response } = await client.DELETE(
       "/workspaces/{id}",
       {
-        params: { path: { id: workspaceId } },
+        params: { path: { id: targetId } },
       },
     );
     if (response.status === 409) {
       forcePromptMessage =
         error?.detail ??
         "Workspace has uncommitted changes.";
+      forcePromptForId = targetId;
       return;
     }
     if (!response.ok && response.status !== 204) {
@@ -801,6 +804,8 @@
 
   async function confirmForceDelete(): Promise<void> {
     if (forceDeleting) return;
+    const targetId = forcePromptForId;
+    if (targetId === null) return;
     forceDeleting = true;
     actionError = null;
     try {
@@ -808,7 +813,7 @@
         "/workspaces/{id}",
         {
           params: {
-            path: { id: workspaceId },
+            path: { id: targetId },
             query: { force: true },
           },
         },
@@ -819,9 +824,11 @@
           `Delete failed (${response.status})`,
         );
         forcePromptMessage = null;
+        forcePromptForId = null;
         return;
       }
       forcePromptMessage = null;
+      forcePromptForId = null;
       navigate("/workspaces");
     } finally {
       forceDeleting = false;
@@ -831,6 +838,7 @@
   function cancelForceDelete(): void {
     if (forceDeleting) return;
     forcePromptMessage = null;
+    forcePromptForId = null;
   }
 
   let previouslyFocusedEl: HTMLElement | null = null;
@@ -930,6 +938,12 @@
     loadError = null;
     actionError = null;
     runtimeError = null;
+    // A 409 force-delete prompt is bound to the workspace that
+    // produced it. Dismiss it on any route change so the user
+    // can't confirm a destructive action targeting a workspace
+    // they're no longer looking at.
+    forcePromptMessage = null;
+    forcePromptForId = null;
     tmuxTerminalMounted = restoredTab === "tmux";
     mountedSessionKeys = restoredTab.startsWith("session:")
       ? [restoredTab.slice("session:".length)]

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -833,16 +833,49 @@
     forcePromptMessage = null;
   }
 
+  let previouslyFocusedEl: HTMLElement | null = null;
+
   function handleForcePromptKeydown(event: KeyboardEvent): void {
     if (event.key === "Escape") {
       event.preventDefault();
       cancelForceDelete();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const container = event.currentTarget;
+    if (!(container instanceof HTMLElement)) return;
+    const dialog = container.querySelector("[role='dialog']");
+    if (!(dialog instanceof HTMLElement)) return;
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        "button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex='-1'])",
+      ),
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!first || !last) return;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
     }
   }
 
   $effect(() => {
     if (forcePromptMessage !== null) {
+      if (
+        previouslyFocusedEl === null &&
+        document.activeElement instanceof HTMLElement
+      ) {
+        previouslyFocusedEl = document.activeElement;
+      }
       void tick().then(() => cancelForceBtnEl?.focus());
+    } else if (previouslyFocusedEl !== null) {
+      previouslyFocusedEl.focus();
+      previouslyFocusedEl = null;
     }
   });
 
@@ -948,7 +981,7 @@
   });
 </script>
 
-<div class="terminal-view">
+<div class="terminal-view" inert={forcePromptMessage !== null}>
   {#snippet terminalMainContent()}
     <div class="terminal-main">
       {#if !workspaceId}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -801,17 +801,15 @@
         params: { path: { id: targetId } },
       },
     );
-    // The user can navigate away while the request is in flight;
-    // settling state for a workspace they're no longer viewing
-    // would open a stale prompt or yank them out of their new
-    // context. The generation check also covers an A→B→A round
-    // trip where the id alone would compare equal.
-    if (
-      targetId !== workspaceId ||
-      targetGen !== workspaceGen
-    )
-      return;
+    // Different workspace now: the user has moved on and nothing
+    // about this response applies.
+    if (targetId !== workspaceId) return;
     if (response.status === 409) {
+      // A 409 that lands after the user briefly left and returned
+      // to the same workspace would feel like an unrequested
+      // prompt; suppress it on a generation mismatch and let the
+      // user retry if they want.
+      if (targetGen !== workspaceGen) return;
       previouslyFocusedEl = triggerEl;
       forcePromptForId = targetId;
       forcePromptMessage =
@@ -820,12 +818,17 @@
       return;
     }
     if (!response.ok && response.status !== 204) {
+      if (targetGen !== workspaceGen) return;
       actionError = apiErrorMessage(
         error,
         `Delete failed (${response.status})`,
       );
       return;
     }
+    // Successful delete: the server destroyed this workspace and
+    // the user is still looking at it. Navigate away even after
+    // an A→B→A round trip — otherwise they'd be staring at a
+    // workspace that no longer exists.
     navigate("/workspaces");
   }
 
@@ -847,15 +850,12 @@
         },
       );
       // The force-delete on the server is destructive and runs to
-      // completion either way; once the user has moved on we just
-      // drop the response on the floor so navigate() doesn't pull
-      // them away from their new workspace.
-      if (
-        targetId !== workspaceId ||
-        targetGen !== workspaceGen
-      )
-        return;
+      // completion either way; once the user has moved to a
+      // different workspace we just drop the response on the
+      // floor so navigate() doesn't pull them away.
+      if (targetId !== workspaceId) return;
       if (!response.ok && response.status !== 204) {
+        if (targetGen !== workspaceGen) return;
         actionError = apiErrorMessage(
           error,
           `Delete failed (${response.status})`,
@@ -864,6 +864,10 @@
         forcePromptForId = null;
         return;
       }
+      // Successful force-delete on the workspace the user is
+      // viewing — navigate away even after an A→B→A round trip
+      // so we don't leave them on a workspace the server just
+      // destroyed.
       forcePromptMessage = null;
       forcePromptForId = null;
       navigate("/workspaces");

--- a/frontend/tests/e2e-full/workspace-force-delete.spec.ts
+++ b/frontend/tests/e2e-full/workspace-force-delete.spec.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+} from "@playwright/test";
+import {
+  startIsolatedWorkspaceE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
+
+type WorkspaceStatusResponse = {
+  id: string;
+  status: string;
+  worktree_path?: string;
+};
+
+const lockedWorkspaceTestTimeoutMs = 120_000;
+
+function hasCommand(command: string, args: string[] = ["--version"]): boolean {
+  try {
+    execFileSync(command, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForWorkspaceReady(
+  api: APIRequestContext,
+  workspaceId: string,
+): Promise<WorkspaceStatusResponse> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const response = await api.get(`/api/v1/workspaces/${workspaceId}`);
+    expect(response.ok()).toBe(true);
+    const workspace = (await response.json()) as WorkspaceStatusResponse;
+    if (workspace.status === "ready") {
+      return workspace;
+    }
+    if (workspace.status === "error") {
+      throw new Error(`workspace ${workspaceId} failed to become ready`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`workspace ${workspaceId} did not become ready`);
+}
+
+test.describe("workspace force-delete", () => {
+  test.describe.configure({
+    mode: "serial",
+    timeout: lockedWorkspaceTestTimeoutMs,
+  });
+
+  test("dirty workspace triggers the 409 prompt and force delete cleans up via the real API", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      // Seeded issue 13 has no other coverage and gives us an isolated
+      // workspace with a fresh worktree we can dirty.
+      const createResponse = await api.post(
+        "/api/v1/issues/github/acme/widgets/13/workspace",
+        { data: {} },
+      );
+      expect(createResponse.status()).toBe(202);
+      const created =
+        (await createResponse.json()) as WorkspaceStatusResponse;
+      const ready = await waitForWorkspaceReady(api, created.id);
+      expect(ready.worktree_path).toBeTruthy();
+
+      // Drop an uncommitted file so the first DELETE hits the dirty
+      // preflight on the workspace manager and returns 409.
+      await writeFile(
+        join(ready.worktree_path!, "demo-dirty.txt"),
+        "uncommitted\n",
+      );
+
+      await page.goto(
+        `${isolatedServer.info.base_url}/terminal/${created.id}`,
+      );
+
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+
+      const dialog = page.getByRole("dialog", {
+        name: "Force delete workspace?",
+      });
+      await expect(dialog).toBeVisible();
+      // The server's 409 detail names the dirty file — verifying it
+      // reached the UI catches the whole detail-pass-through chain.
+      await expect(dialog).toContainText("demo-dirty.txt");
+
+      await dialog
+        .getByRole("button", { name: "Force delete" })
+        .click();
+
+      await expect(page).toHaveURL(/\/workspaces$/);
+
+      // The forced DELETE actually removed the workspace from the DB.
+      const after = await api.get(`/api/v1/workspaces/${created.id}`);
+      expect(after.status()).toBe(404);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+});

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -958,6 +958,47 @@ test.describe("terminal state icons", () => {
       ).toBeHidden();
     },
   );
+
+  test(
+    "in-flight successful DELETE does not yank the user off the route they chose",
+    async ({ page }) => {
+      await setupTerminalMocks(page);
+
+      await page.route(
+        (url) =>
+          url.pathname === "/api/v1/workspaces/ws-123",
+        async (route) => {
+          if (route.request().method() !== "DELETE") {
+            await route.fallback();
+            return;
+          }
+          // Delay long enough for the user to navigate away
+          // before the 204 lands.
+          await new Promise((resolve) => setTimeout(resolve, 400));
+          await route.fulfill({ status: 204 });
+        },
+      );
+
+      await page.goto("/terminal/ws-123");
+
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+
+      // Without the post-await guard in handleDelete, the stale
+      // 204 would call navigate("/workspaces") and the user would
+      // be yanked away from /pulls.
+      await page.evaluate(() => {
+        history.pushState(null, "", "/pulls");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+
+      await page.waitForTimeout(700);
+
+      await expect(page).toHaveURL(/\/pulls$/);
+    },
+  );
 });
 
 test.describe("workspace launch home", () => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -798,6 +798,55 @@ test.describe("terminal state icons", () => {
       await expect(headerDelete).toBeFocused();
     },
   );
+
+  test(
+    "force-delete prompt is dismissed when the workspace route changes",
+    async ({ page }) => {
+      const deleteRequests: string[] = [];
+      page.on("request", (req) => {
+        if (req.method() === "DELETE") {
+          deleteRequests.push(req.url());
+        }
+      });
+
+      await setupTerminalMocks(page, {
+        workspaceDeleteResponses: [
+          {
+            status: 409,
+            body: {
+              detail: "Worktree has uncommitted changes.",
+            },
+          },
+        ],
+      });
+
+      await page.goto("/terminal/ws-123");
+
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+
+      const dialog = page.getByRole("dialog", {
+        name: "Force delete workspace?",
+      });
+      await expect(dialog).toBeVisible();
+
+      // The component persists across workspaceId changes (no {#key} wrapper),
+      // so the prompt would otherwise stay open after navigation and leak a
+      // destructive confirmation onto the next workspace.
+      await page.evaluate(() => {
+        history.pushState(null, "", "/workspaces");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+
+      await expect(dialog).toBeHidden();
+      // Only the initial DELETE fired — no force-delete reached the server
+      // after the route change dismissed the prompt.
+      expect(deleteRequests).toHaveLength(1);
+      expect(deleteRequests[0]).not.toContain("force=true");
+    },
+  );
 });
 
 test.describe("workspace launch home", () => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -232,7 +232,7 @@ async function setupTerminalMocks(
   );
 
   await page.route(
-    `**/api/v1/workspaces/${ws.id}`,
+    (url) => url.pathname === `/api/v1/workspaces/${ws.id}`,
     async (route) => {
       if (route.request().method() === "GET") {
         const nextResponse = detailResponses.shift();
@@ -256,10 +256,14 @@ async function setupTerminalMocks(
       // DELETE
       const nextDelete = deleteResponses.shift();
       if (nextDelete) {
+        if (nextDelete.body === undefined) {
+          await route.fulfill({ status: nextDelete.status });
+          return;
+        }
         await route.fulfill({
           status: nextDelete.status,
           contentType: "application/json",
-          body: JSON.stringify(nextDelete.body ?? {}),
+          body: JSON.stringify(nextDelete.body),
         });
         return;
       }
@@ -733,6 +737,65 @@ test.describe("terminal state icons", () => {
       await expect(dialog).toBeHidden();
       await expect(page).not.toHaveURL(/\/workspaces$/);
       expect(deleteRequests).toHaveLength(1);
+    },
+  );
+
+  test(
+    "force-delete prompt traps focus, makes background inert, and restores focus on cancel",
+    async ({ page }) => {
+      await setupTerminalMocks(page, {
+        workspaceDeleteResponses: [
+          {
+            status: 409,
+            body: {
+              detail: "Worktree has uncommitted changes.",
+            },
+          },
+        ],
+      });
+
+      await page.goto("/terminal/ws-123");
+
+      const headerDelete = page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" });
+      await headerDelete.click();
+
+      const dialog = page.getByRole("dialog", {
+        name: "Force delete workspace?",
+      });
+      await expect(dialog).toBeVisible();
+
+      const cancel = dialog.getByRole("button", { name: "Cancel" });
+      const force = dialog.getByRole("button", {
+        name: "Force delete",
+      });
+
+      // Initial focus lands on Cancel — the safe default for a destructive action.
+      await expect(cancel).toBeFocused();
+
+      // The workspace shell beneath the modal is inert and unreachable.
+      await expect(page.locator(".terminal-view")).toHaveAttribute(
+        "inert",
+        "",
+      );
+
+      // Tab cycles within the dialog (Cancel -> Force delete -> Cancel).
+      await page.keyboard.press("Tab");
+      await expect(force).toBeFocused();
+      await page.keyboard.press("Tab");
+      await expect(cancel).toBeFocused();
+      await page.keyboard.press("Shift+Tab");
+      await expect(force).toBeFocused();
+
+      // Closing the dialog restores focus to the trigger.
+      await cancel.click();
+      await expect(dialog).toBeHidden();
+      await expect(page.locator(".terminal-view")).not.toHaveAttribute(
+        "inert",
+        "",
+      );
+      await expect(headerDelete).toBeFocused();
     },
   );
 });

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -847,6 +847,58 @@ test.describe("terminal state icons", () => {
       expect(deleteRequests[0]).not.toContain("force=true");
     },
   );
+
+  test(
+    "in-flight 409 response does not surface a prompt after the user has navigated away",
+    async ({ page }) => {
+      await setupTerminalMocks(page);
+
+      // Replace the default DELETE handler with one that holds the
+      // 409 response long enough for the test to navigate before
+      // it lands.
+      await page.route(
+        (url) =>
+          url.pathname === "/api/v1/workspaces/ws-123",
+        async (route) => {
+          if (route.request().method() !== "DELETE") {
+            await route.fallback();
+            return;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 400));
+          await route.fulfill({
+            status: 409,
+            contentType: "application/json",
+            body: JSON.stringify({
+              detail: "Worktree has uncommitted changes.",
+            }),
+          });
+        },
+      );
+
+      await page.goto("/terminal/ws-123");
+
+      // Kick off the DELETE, then immediately leave the workspace.
+      // The DELETE handler in handleDelete is async, so this is the
+      // exact race condition the post-await guard exists to handle.
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+      await page.evaluate(() => {
+        history.pushState(null, "", "/workspaces");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+
+      // Wait past the route delay so the response settles either way.
+      await page.waitForTimeout(700);
+
+      await expect(
+        page.getByRole("dialog", {
+          name: "Force delete workspace?",
+        }),
+      ).toBeHidden();
+    },
+  );
 });
 
 test.describe("workspace launch home", () => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -999,6 +999,51 @@ test.describe("terminal state icons", () => {
       await expect(page).toHaveURL(/\/pulls$/);
     },
   );
+
+  test(
+    "successful DELETE after A→B→A still navigates away from the deleted workspace",
+    async ({ page }) => {
+      await setupTerminalMocks(page);
+
+      await page.route(
+        (url) =>
+          url.pathname === "/api/v1/workspaces/ws-123",
+        async (route) => {
+          if (route.request().method() !== "DELETE") {
+            await route.fallback();
+            return;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          await route.fulfill({ status: 204 });
+        },
+      );
+
+      await page.goto("/terminal/ws-123");
+
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+
+      // Round-trip back to the same workspace before the 204 lands.
+      // The generation token has advanced, but the workspace the
+      // user is looking at has just been destroyed on the server —
+      // we must still navigate away rather than leave them staring
+      // at a dead workspace.
+      await page.evaluate(() => {
+        history.pushState(null, "", "/workspaces");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+      await page.evaluate(() => {
+        history.pushState(null, "", "/terminal/ws-123");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+
+      await expect(page).toHaveURL(/\/workspaces$/, {
+        timeout: 2000,
+      });
+    },
+  );
 });
 
 test.describe("workspace launch home", () => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -899,6 +899,65 @@ test.describe("terminal state icons", () => {
       ).toBeHidden();
     },
   );
+
+  test(
+    "stale 409 does not reopen the prompt after the user leaves and returns to the same workspace",
+    async ({ page }) => {
+      await setupTerminalMocks(page);
+
+      await page.route(
+        (url) =>
+          url.pathname === "/api/v1/workspaces/ws-123",
+        async (route) => {
+          if (route.request().method() !== "DELETE") {
+            await route.fallback();
+            return;
+          }
+          // Hold the response long enough for the test to navigate
+          // away and back before it lands.
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          await route.fulfill({
+            status: 409,
+            contentType: "application/json",
+            body: JSON.stringify({
+              detail: "Worktree has uncommitted changes.",
+            }),
+          });
+        },
+      );
+
+      await page.goto("/terminal/ws-123");
+
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+
+      // A round-trip back to the same workspace would defeat an
+      // id-only guard: the captured targetId matches the current
+      // workspaceId, but the prompt should still not reappear
+      // because the user has explicitly left and returned. Two
+      // separate evaluate calls mirror real user clicks — each
+      // pops an event-loop turn so Svelte's effects flush between
+      // them and the generation counter advances.
+      await page.evaluate(() => {
+        history.pushState(null, "", "/workspaces");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+      await page.evaluate(() => {
+        history.pushState(null, "", "/terminal/ws-123");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+
+      await page.waitForTimeout(800);
+
+      await expect(
+        page.getByRole("dialog", {
+          name: "Force delete workspace?",
+        }),
+      ).toBeHidden();
+    },
+  );
 });
 
 test.describe("workspace launch home", () => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -158,6 +158,10 @@ async function setupTerminalMocks(
       status: number;
       body?: unknown;
     }>;
+    workspaceDeleteResponses?: Array<{
+      status: number;
+      body?: unknown;
+    }>;
     workspaceRetryResponse?: {
       status: number;
       body?: unknown;
@@ -171,6 +175,9 @@ async function setupTerminalMocks(
   const rrStatus = opts?.roborevStatus ?? roborevStatus;
   const detailResponses = [
     ...(opts?.workspaceDetailResponses ?? []),
+  ];
+  const deleteResponses = [
+    ...(opts?.workspaceDeleteResponses ?? []),
   ];
   const runtime = JSON.parse(
     JSON.stringify(opts?.runtime ?? workspaceRuntime),
@@ -247,6 +254,15 @@ async function setupTerminalMocks(
         return;
       }
       // DELETE
+      const nextDelete = deleteResponses.shift();
+      if (nextDelete) {
+        await route.fulfill({
+          status: nextDelete.status,
+          contentType: "application/json",
+          body: JSON.stringify(nextDelete.body ?? {}),
+        });
+        return;
+      }
       await route.fulfill({ status: 204 });
     },
   );
@@ -621,6 +637,102 @@ test.describe("terminal state icons", () => {
         .click();
 
       await expect(page).toHaveURL(/\/workspaces$/);
+    },
+  );
+
+  test(
+    "force-delete prompt confirms and retries delete with force=true",
+    async ({ page }) => {
+      const deleteRequests: string[] = [];
+      page.on("request", (req) => {
+        if (
+          req.method() === "DELETE" &&
+          req.url().includes("/api/v1/workspaces/ws-123")
+        ) {
+          deleteRequests.push(req.url());
+        }
+      });
+
+      await setupTerminalMocks(page, {
+        workspaceDeleteResponses: [
+          {
+            status: 409,
+            body: {
+              detail: "Worktree has uncommitted changes.",
+            },
+          },
+          { status: 204 },
+        ],
+      });
+
+      await page.goto("/terminal/ws-123");
+
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+
+      const dialog = page.getByRole("dialog", {
+        name: "Force delete workspace?",
+      });
+      await expect(dialog).toBeVisible();
+      await expect(dialog).toContainText(
+        "Worktree has uncommitted changes.",
+      );
+
+      await dialog
+        .getByRole("button", { name: "Force delete" })
+        .click();
+
+      await expect(page).toHaveURL(/\/workspaces$/);
+      expect(deleteRequests).toHaveLength(2);
+      expect(deleteRequests[1]).toContain("force=true");
+    },
+  );
+
+  test(
+    "force-delete prompt cancel keeps the workspace and the modal closes",
+    async ({ page }) => {
+      const deleteRequests: string[] = [];
+      page.on("request", (req) => {
+        if (
+          req.method() === "DELETE" &&
+          req.url().includes("/api/v1/workspaces/ws-123")
+        ) {
+          deleteRequests.push(req.url());
+        }
+      });
+
+      await setupTerminalMocks(page, {
+        workspaceDeleteResponses: [
+          {
+            status: 409,
+            body: {
+              detail: "Worktree has uncommitted changes.",
+            },
+          },
+        ],
+      });
+
+      await page.goto("/terminal/ws-123");
+
+      await page
+        .locator(".header-bar")
+        .getByRole("button", { name: "Delete" })
+        .click();
+
+      const dialog = page.getByRole("dialog", {
+        name: "Force delete workspace?",
+      });
+      await expect(dialog).toBeVisible();
+
+      await dialog
+        .getByRole("button", { name: "Cancel" })
+        .click();
+
+      await expect(dialog).toBeHidden();
+      await expect(page).not.toHaveURL(/\/workspaces$/);
+      expect(deleteRequests).toHaveLength(1);
     },
   );
 });


### PR DESCRIPTION
The header **Delete** button on a workspace previously fell through to a native `confirm()` when the server returned 409 ("worktree has uncommitted changes"). Replaced with an in-page dialog that matches the app's modal language.

- Surface tokens (`--bg-surface`, `--accent-red`, `--radius-lg`), backdrop blur + pop-in animation
- Cancel focused by default, Escape cancels, `Force delete` is the danger action
- Registers a `workspace-force-delete` frame on the modal-stack (#310) so `j`/`k`/`?`/Cmd+K don't fire underneath
- 409 detail from the server is rendered verbatim, with a "This cannot be undone" hint
- Two new Playwright tests cover the confirm and cancel paths; `setupTerminalMocks` grows a `workspaceDeleteResponses` queue to script 409→204

![force-delete-modal.png](https://github.com/user-attachments/assets/af0edc26-3b5e-4c58-b09d-2712299d33c3)