### PR TITLE
Speed up exact repository previews

### DIFF
--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   testIgnore: /support\//,
   fullyParallel: true,
   timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
   expect: {
     timeout: 5_000,
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
   timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
   expect: {
     timeout: 5_000,
   },

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -267,6 +267,18 @@ func buildRepoPreviewRows(
 	owner, pattern string,
 	host string,
 ) ([]repoPreviewRow, error) {
+	if !repoImportPatternHasGlob(pattern) {
+		repo, err := client.GetRepository(ctx, owner, pattern)
+		if err == nil {
+			if repo.GetArchived() {
+				return []repoPreviewRow{}, nil
+			}
+			return []repoPreviewRow{
+				buildRepoPreviewRow(repo, owner, host, exactConfigured),
+			}, nil
+		}
+	}
+
 	repos, err := client.ListRepositoriesByOwner(ctx, owner)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -289,12 +301,6 @@ func buildRepoPreviewRows(
 		}
 		rows = append(rows, buildRepoPreviewRow(repo, owner, host, exactConfigured))
 	}
-	if len(rows) == 0 && !repoImportPatternHasGlob(pattern) {
-		repo, err := client.GetRepository(ctx, owner, pattern)
-		if err == nil && !repo.GetArchived() {
-			rows = append(rows, buildRepoPreviewRow(repo, owner, host, exactConfigured))
-		}
-	}
 	return rows, nil
 }
 
@@ -306,6 +312,26 @@ func buildPlatformRepoPreviewRows(
 	exactConfigured map[string]struct{},
 	owner, pattern string,
 ) ([]repoPreviewRow, error) {
+	if !repoImportPatternHasGlob(pattern) {
+		repo, err := reader.GetRepository(ctx, platform.RepoRef{
+			Platform: provider,
+			Host:     host,
+			Owner:    owner,
+			Name:     pattern,
+			RepoPath: owner + "/" + pattern,
+		})
+		if err == nil {
+			if repo.Archived {
+				return []repoPreviewRow{}, nil
+			}
+			return []repoPreviewRow{
+				buildPlatformRepoPreviewRow(
+					repo, provider, host, owner, exactConfigured,
+				),
+			}, nil
+		}
+	}
+
 	repos, err := reader.ListRepositories(ctx, owner, platform.RepositoryListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -332,20 +358,6 @@ func buildPlatformRepoPreviewRows(
 		rows = append(rows, buildPlatformRepoPreviewRow(
 			repo, provider, host, owner, exactConfigured,
 		))
-	}
-	if len(rows) == 0 && !repoImportPatternHasGlob(pattern) {
-		repo, err := reader.GetRepository(ctx, platform.RepoRef{
-			Platform: provider,
-			Host:     host,
-			Owner:    owner,
-			Name:     pattern,
-			RepoPath: owner + "/" + pattern,
-		})
-		if err == nil && !repo.Archived {
-			rows = append(rows, buildPlatformRepoPreviewRow(
-				repo, provider, host, owner, exactConfigured,
-			))
-		}
 	}
 	return rows, nil
 }

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -1419,7 +1419,7 @@ name = "widget-*"
 	assert.NotContains(rr.Body.String(), "other")
 }
 
-func TestHandlePreviewReposFallsBackToExactLookupWhenListOmitsRepo(t *testing.T) {
+func TestHandlePreviewReposFallsBackToListWhenExactLookupFails(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	privateRepo := true
@@ -1434,12 +1434,76 @@ func TestHandlePreviewReposFallsBackToExactLookupWhenListOmitsRepo(t *testing.T)
 		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
 			listCalls.Add(1)
 			assert.Equal("mariusvniekerk", owner)
-			return []*gh.Repository{}, nil
+			return []*gh.Repository{
+				{
+					Name:        &name,
+					Owner:       &gh.User{Login: &ownerLogin},
+					Description: &description,
+					Private:     &privateRepo,
+					Fork:        &forkRepo,
+					Archived:    new(false),
+					PushedAt:    &pushedAt,
+				},
+			}, nil
 		},
 		getRepositoryFn: func(_ context.Context, owner, repo string) (*gh.Repository, error) {
 			getCalls.Add(1)
 			assert.Equal("mariusvniekerk", owner)
 			assert.Equal("dotfiles2026", repo)
+			return nil, errors.New("not found")
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+`, mock)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+		"provider": "github",
+		"host":     "github.com",
+		"owner":    "mariusvniekerk",
+		"pattern":  "dotfiles2026",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp repoPreviewResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp.Repos, 1)
+	assert.Equal(int32(1), getCalls.Load())
+	assert.Equal(int32(1), listCalls.Load())
+	assert.Equal("mariusvniekerk", resp.Repos[0].Owner)
+	assert.Equal("dotfiles2026", resp.Repos[0].Name)
+	assert.Equal("personal dotfiles", *resp.Repos[0].Description)
+	assert.True(resp.Repos[0].Private)
+	assert.False(resp.Repos[0].Fork)
+	assert.False(resp.Repos[0].AlreadyConfigured)
+	require.NotNil(resp.Repos[0].PushedAt)
+	assert.Equal(pushedAt.Time.UTC().Format(time.RFC3339), *resp.Repos[0].PushedAt)
+}
+
+func TestHandlePreviewReposUsesExactLookupForConcreteRepo(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	privateRepo := true
+	forkRepo := false
+	pushedAt := gh.Timestamp{Time: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	name := "tesseract-feedstock"
+	ownerLogin := "anacondarecipes"
+	description := "A conda-smithy repository for tesseract"
+	var listCalls atomic.Int32
+	var getCalls atomic.Int32
+	mock := &mockGH{
+		listReposByOwnerFn: func(_ context.Context, owner string) ([]*gh.Repository, error) {
+			listCalls.Add(1)
+			assert.Fail("concrete repo preview should not list repositories", "owner: %s", owner)
+			return []*gh.Repository{}, nil
+		},
+		getRepositoryFn: func(_ context.Context, owner, repo string) (*gh.Repository, error) {
+			getCalls.Add(1)
+			assert.Equal("anacondarecipes", owner)
+			assert.Equal("tesseract-feedstock", repo)
 			return &gh.Repository{
 				Name:        &name,
 				Owner:       &gh.User{Login: &ownerLogin},
@@ -1461,19 +1525,19 @@ port = 8091
 	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
-		"owner":    "mariusvniekerk",
-		"pattern":  "dotfiles2026",
+		"owner":    "anacondarecipes",
+		"pattern":  "tesseract-feedstock",
 	})
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp repoPreviewResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(resp.Repos, 1)
-	assert.Equal(int32(1), listCalls.Load())
 	assert.Equal(int32(1), getCalls.Load())
-	assert.Equal("mariusvniekerk", resp.Repos[0].Owner)
-	assert.Equal("dotfiles2026", resp.Repos[0].Name)
-	assert.Equal("personal dotfiles", *resp.Repos[0].Description)
+	assert.Equal(int32(0), listCalls.Load())
+	assert.Equal("anacondarecipes", resp.Repos[0].Owner)
+	assert.Equal("tesseract-feedstock", resp.Repos[0].Name)
+	assert.Equal("A conda-smithy repository for tesseract", *resp.Repos[0].Description)
 	assert.True(resp.Repos[0].Private)
 	assert.False(resp.Repos[0].Fork)
 	assert.False(resp.Repos[0].AlreadyConfigured)


### PR DESCRIPTION
## Summary
- Preview exact repository imports with an exact repository lookup before listing all owner repositories
- Keep list-and-filter preview behavior for glob patterns and fallback cases
- Add separate coverage for exact lookup and fallback preview behavior
