### PR TITLE
Fix stale conflict status line

### DIFF
--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -695,6 +695,10 @@ test.describe("PR detail stale-action gating", () => {
     // PR A is still on screen because B is held.
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
 
+    const starBtn = page.locator(".pull-detail button.star-btn");
+    await expect(starBtn).toBeDisabled();
+    await starBtn.click({ force: true }).catch(() => {});
+
     // Close button must be disabled — clicking it must not fire
     // POST /github-state for PR B.
     const closeBtn = page.locator(".btn--close").first();

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -137,7 +137,9 @@ const issueY = {
   Body: "Body Y",
 };
 
-function detailEnvelopePR(pr: typeof prA): unknown {
+function detailEnvelopePR(
+  pr: typeof prA & { workspace?: { id: string } },
+): unknown {
   return {
     merge_request: pr,
     repo: repoEnvelope(pr),
@@ -146,10 +148,13 @@ function detailEnvelopePR(pr: typeof prA): unknown {
     detail_loaded: true,
     detail_fetched_at: "2026-04-01T12:00:00Z",
     worktree_links: pr.worktree_links,
+    workspace: pr.workspace,
   };
 }
 
-function detailEnvelopeIssue(issue: typeof issueX): unknown {
+function detailEnvelopeIssue(
+  issue: typeof issueX & { workspace?: { id: string } },
+): unknown {
   return {
     issue,
     events: [],
@@ -159,6 +164,7 @@ function detailEnvelopeIssue(issue: typeof issueX): unknown {
     repo_name: issue.repo_name,
     detail_loaded: true,
     detail_fetched_at: "2026-04-01T12:00:00Z",
+    workspace: issue.workspace,
   };
 }
 
@@ -716,6 +722,42 @@ test.describe("PR detail stale-action gating", () => {
     // No user-mutation request was sent during the stale window.
     expect(userMutations).toEqual([]);
   });
+
+  test("existing workspace navigation is inert while the new PR is loading", async ({ page }) => {
+    const prWithWorkspace = {
+      ...prA,
+      workspace: { id: "ws-pr-a" },
+    };
+    const { release } = await setupHeldPR(page, prWithWorkspace, prB);
+
+    await page.goto(
+      `/pulls/github/${prWithWorkspace.repo_owner}/${prWithWorkspace.repo_name}/${prWithWorkspace.Number}`,
+    );
+    await expect(page.locator(".detail-title")).toContainText(
+      prWithWorkspace.Title,
+    );
+
+    await page.evaluate(([owner, name, number]) => {
+      window.history.pushState(
+        null,
+        "",
+        `/pulls/github/${owner}/${name}/${number}`,
+      );
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
+
+    await expect(page.locator(".detail-title")).toContainText(
+      prWithWorkspace.Title,
+    );
+
+    const openWs = page.locator("button.btn--workspace");
+    await expect(openWs).toBeDisabled();
+    await openWs.click({ force: true }).catch(() => {});
+    await expect(page).not.toHaveURL(/\/terminal\/ws-pr-a/);
+
+    release();
+    await expect(page.locator(".detail-title")).toContainText(prB.Title);
+  });
 });
 
 test.describe("issue detail stale-action gating", () => {
@@ -769,5 +811,43 @@ test.describe("issue detail stale-action gating", () => {
     await expect(closeBtn).toBeEnabled();
 
     expect(userMutations).toEqual([]);
+  });
+
+  test("existing workspace navigation is inert while the new issue is loading", async ({ page }) => {
+    const issueWithWorkspace = {
+      ...issueX,
+      workspace: { id: "ws-issue-x" },
+    };
+    const { release } = await setupHeldIssue(page, issueWithWorkspace, issueY);
+
+    await page.goto(
+      `/issues/github/${issueWithWorkspace.repo_owner}/${issueWithWorkspace.repo_name}/${issueWithWorkspace.Number}`,
+    );
+    await expect(page.locator(".issue-detail .detail-title")).toContainText(
+      issueWithWorkspace.Title,
+    );
+
+    await page.evaluate(([owner, name, number]) => {
+      window.history.pushState(
+        null,
+        "",
+        `/issues/github/${owner}/${name}/${number}`,
+      );
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }, [issueY.repo_owner, issueY.repo_name, issueY.Number] as const);
+
+    await expect(page.locator(".issue-detail .detail-title")).toContainText(
+      issueWithWorkspace.Title,
+    );
+
+    const openWs = page.locator(".issue-detail button.btn--workspace");
+    await expect(openWs).toBeDisabled();
+    await openWs.click({ force: true }).catch(() => {});
+    await expect(page).not.toHaveURL(/\/terminal\/ws-issue-x/);
+
+    release();
+    await expect(page.locator(".issue-detail .detail-title")).toContainText(
+      issueY.Title,
+    );
   });
 });

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -696,14 +696,12 @@ test.describe("PR detail stale-action gating", () => {
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
 
     const starBtn = page.locator(".pull-detail button.star-btn");
-    await expect(starBtn).toBeDisabled();
-    await starBtn.click({ force: true }).catch(() => {});
+    await expect(starBtn).toHaveCount(0);
 
-    // Close button must be disabled — clicking it must not fire
+    // Close button must be hidden — clicking stale controls must not fire
     // POST /github-state for PR B.
     const closeBtn = page.locator(".btn--close").first();
-    await expect(closeBtn).toBeDisabled();
-    await closeBtn.click({ force: true }).catch(() => {});
+    await expect(closeBtn).toHaveCount(0);
 
     // Create Workspace button must be disabled. A force-click must
     // not fire POST /workspaces.
@@ -721,7 +719,7 @@ test.describe("PR detail stale-action gating", () => {
     // re-enable.
     release();
     await expect(page.locator(".detail-title")).toContainText(prB.Title);
-    await expect(closeBtn).toBeEnabled();
+    await expect(page.locator(".btn--close").first()).toBeEnabled();
 
     // No user-mutation request was sent during the stale window.
     expect(userMutations).toEqual([]);
@@ -791,8 +789,7 @@ test.describe("issue detail stale-action gating", () => {
     );
 
     const starBtn = page.locator(".issue-detail .star-btn");
-    await expect(starBtn).toBeDisabled();
-    await starBtn.click({ force: true }).catch(() => {});
+    await expect(starBtn).toHaveCount(0);
 
     const closeBtn = page.locator(".issue-detail .btn--close");
     await expect(closeBtn).toBeDisabled();

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -58,6 +58,53 @@ const prSquashOnly = {
   repo_name: "squash-only",
 };
 
+const providerCapabilities = {
+  comment_mutation: true,
+  issue_mutation: true,
+  merge_mutation: true,
+  read_ci: true,
+  read_comments: true,
+  read_issues: true,
+  read_merge_requests: true,
+  read_releases: true,
+  read_repositories: true,
+  ready_for_review: true,
+  review_mutation: true,
+  state_mutation: true,
+  workflow_approval: true,
+};
+
+function repoEnvelope(item: {
+  repo_owner: string;
+  repo_name: string;
+  platform_host: string;
+}) {
+  return {
+    provider: "github",
+    platform_host: item.platform_host,
+    owner: item.repo_owner,
+    name: item.repo_name,
+    repo_path: `${item.repo_owner}/${item.repo_name}`,
+    capabilities: providerCapabilities,
+  };
+}
+
+function pullDetailApiPath(pr: typeof prA): string {
+  return `**/api/v1/pulls/github/${pr.repo_owner}/${pr.repo_name}/${pr.Number}`;
+}
+
+function issueDetailApiPath(issue: {
+  repo_owner: string;
+  repo_name: string;
+  Number: number;
+}): string {
+  return `**/api/v1/issues/github/${issue.repo_owner}/${issue.repo_name}/${issue.Number}`;
+}
+
+function repoSettingsApiPath(pr: typeof prA): string {
+  return `**/api/v1/repo/github/${pr.repo_owner}/${pr.repo_name}`;
+}
+
 const issueX = {
   ID: 31,
   RepoID: 1,
@@ -93,6 +140,7 @@ const issueY = {
 function detailEnvelopePR(pr: typeof prA): unknown {
   return {
     merge_request: pr,
+    repo: repoEnvelope(pr),
     repo_owner: pr.repo_owner,
     repo_name: pr.repo_name,
     detail_loaded: true,
@@ -105,6 +153,7 @@ function detailEnvelopeIssue(issue: typeof issueX): unknown {
   return {
     issue,
     events: [],
+    repo: repoEnvelope(issue),
     platform_host: issue.platform_host,
     repo_owner: issue.repo_owner,
     repo_name: issue.repo_name,
@@ -163,6 +212,32 @@ async function mockSettings(page: Page): Promise<void> {
       }),
     });
   });
+
+  await page.route("**/api/v1/repo/github/**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    const parts = new URL(route.request().url()).pathname.split("/");
+    const owner = parts.at(-2) ?? "acme";
+    const name = parts.at(-1) ?? "widgets";
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ID: name === "squash-only" ? prSquashOnly.RepoID : prA.RepoID,
+        Owner: owner,
+        Name: name,
+        AllowSquashMerge: true,
+        AllowMergeCommit: true,
+        AllowRebaseMerge: true,
+        LastSyncStartedAt: "2026-04-01T12:00:00Z",
+        LastSyncCompletedAt: "2026-04-01T12:00:30Z",
+        LastSyncError: "",
+        CreatedAt: "2026-03-01T00:00:00Z",
+      }),
+    });
+  });
 }
 
 async function setupHeldPR(
@@ -179,7 +254,7 @@ async function setupHeldPR(
 
   // Fast PR: instant detail GET.
   await page.route(
-    `**/api/v1/repos/${fast.repo_owner}/${fast.repo_name}/pulls/${fast.Number}`,
+    pullDetailApiPath(fast),
     async (route: Route) => {
       if (route.request().method() === "GET") {
         await route.fulfill({
@@ -195,7 +270,7 @@ async function setupHeldPR(
 
   // Slow PR: held until release().
   await page.route(
-    `**/api/v1/repos/${slow.repo_owner}/${slow.repo_name}/pulls/${slow.Number}`,
+    pullDetailApiPath(slow),
     async (route: Route) => {
       if (route.request().method() === "GET") {
         await slowDelay;
@@ -226,7 +301,7 @@ async function setupHeldIssue(
   });
 
   await page.route(
-    `**/api/v1/repos/${fast.repo_owner}/${fast.repo_name}/issues/${fast.Number}`,
+    issueDetailApiPath(fast),
     async (route: Route) => {
       if (route.request().method() === "GET") {
         await route.fulfill({
@@ -241,7 +316,7 @@ async function setupHeldIssue(
   );
 
   await page.route(
-    `**/api/v1/repos/${slow.repo_owner}/${slow.repo_name}/issues/${slow.Number}`,
+    issueDetailApiPath(slow),
     async (route: Route) => {
       if (route.request().method() === "GET") {
         await slowDelay;
@@ -270,7 +345,7 @@ test.describe("PR detail merge modal route reset", () => {
     };
 
     await page.route(
-      `**/api/v1/repos/${conflictedPR.repo_owner}/${conflictedPR.repo_name}/pulls/${conflictedPR.Number}`,
+      pullDetailApiPath(conflictedPR),
       async (route) => {
         if (route.request().method() === "GET") {
           await route.fulfill({
@@ -307,7 +382,7 @@ test.describe("PR detail merge modal route reset", () => {
 
     for (const pr of [prA, prB]) {
       await page.route(
-        `**/api/v1/repos/${pr.repo_owner}/${pr.repo_name}/pulls/${pr.Number}`,
+        pullDetailApiPath(pr),
         async (route) => {
           if (route.request().method() === "GET") {
             await route.fulfill({
@@ -356,7 +431,7 @@ test.describe("PR detail merge modal route reset", () => {
 
     for (const pr of [prA, prSquashOnly]) {
       await page.route(
-        `**/api/v1/repos/${pr.repo_owner}/${pr.repo_name}/pulls/${pr.Number}`,
+        pullDetailApiPath(pr),
         async (route) => {
           if (route.request().method() === "GET") {
             await route.fulfill({
@@ -377,7 +452,7 @@ test.describe("PR detail merge modal route reset", () => {
     });
 
     await page.route(
-      `**/api/v1/repos/${prSquashOnly.repo_owner}/${prSquashOnly.repo_name}`,
+      repoSettingsApiPath(prSquashOnly),
       async (route) => {
         if (route.request().method() === "GET") {
           await squashSettingsReady;
@@ -449,7 +524,7 @@ test.describe("detail load-error banner", () => {
     await mockSettings(page);
 
     await page.route(
-      `**/api/v1/repos/${prA.repo_owner}/${prA.repo_name}/pulls/${prA.Number}`,
+      pullDetailApiPath(prA),
       async (route) => {
         if (route.request().method() === "GET") {
           await route.fulfill({
@@ -463,7 +538,7 @@ test.describe("detail load-error banner", () => {
       },
     );
     await page.route(
-      `**/api/v1/repos/${prB.repo_owner}/${prB.repo_name}/pulls/${prB.Number}`,
+      pullDetailApiPath(prB),
       async (route) => {
         if (route.request().method() === "GET") {
           await route.fulfill({
@@ -502,7 +577,7 @@ test.describe("detail load-error banner", () => {
     await mockSettings(page);
 
     await page.route(
-      `**/api/v1/repos/${issueX.repo_owner}/${issueX.repo_name}/issues/${issueX.Number}`,
+      issueDetailApiPath(issueX),
       async (route) => {
         if (route.request().method() === "GET") {
           await route.fulfill({
@@ -516,7 +591,7 @@ test.describe("detail load-error banner", () => {
       },
     );
     await page.route(
-      `**/api/v1/repos/${issueY.repo_owner}/${issueY.repo_name}/issues/${issueY.Number}`,
+      issueDetailApiPath(issueY),
       async (route) => {
         if (route.request().method() === "GET") {
           await route.fulfill({
@@ -556,6 +631,44 @@ test.describe("detail load-error banner", () => {
 });
 
 test.describe("PR detail stale-action gating", () => {
+  test("conflict warning hides while a clean PR is loading", async ({ page }) => {
+    const conflictedPR = {
+      ...prA,
+      MergeableState: "dirty",
+    };
+    const cleanPR = {
+      ...prB,
+      MergeableState: "clean",
+    };
+    const { release } = await setupHeldPR(page, conflictedPR, cleanPR);
+
+    await page.goto(
+      `/pulls/github/${conflictedPR.repo_owner}/${conflictedPR.repo_name}/${conflictedPR.Number}`,
+    );
+    await expect(page.locator(".detail-title")).toContainText(
+      conflictedPR.Title,
+    );
+    await expect(page.getByText("This branch has conflicts")).toBeVisible();
+
+    await page.evaluate(([owner, name, number]) => {
+      window.history.pushState(
+        null,
+        "",
+        `/pulls/github/${owner}/${name}/${number}`,
+      );
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }, [cleanPR.repo_owner, cleanPR.repo_name, cleanPR.Number] as const);
+
+    await expect(page.locator(".detail-title")).toContainText(
+      conflictedPR.Title,
+    );
+    await expect(page.getByText("This branch has conflicts")).toHaveCount(0);
+
+    release();
+    await expect(page.locator(".detail-title")).toContainText(cleanPR.Title);
+    await expect(page.getByText("This branch has conflicts")).toHaveCount(0);
+  });
+
   test("close, comment, and create-workspace are inert while the new PR is loading", async ({ page }) => {
     const userMutations = recordUserMutations(page);
     const { release } = await setupHeldPR(page, prA, prB);

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -401,13 +401,13 @@
   }
 </script>
 
-{#if issues.isIssueDetailLoading() && (issues.getIssueDetail() === null || staleIssue)}
+{#if issues.isIssueDetailLoading() && issues.getIssueDetail() === null}
   <div class="state-center"><p class="state-msg">Loading...</p></div>
-{:else if issues.getIssueDetailError() !== null && (issues.getIssueDetail() === null || staleIssue)}
+{:else if issues.getIssueDetailError() !== null && issues.getIssueDetail() === null}
   <div class="state-center"><p class="state-msg state-msg--error">Error: {issues.getIssueDetailError()}</p></div>
 {:else}
   {@const detail = issues.getIssueDetail()}
-  {#if detail !== null && !staleIssue}
+  {#if detail !== null}
     {@const issue = detail.issue}
     {@const labels = issue.labels ?? []}
     {@const capabilities = detail.repo?.capabilities ?? defaultProviderCapabilities}

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -56,6 +56,7 @@
     provider: string;
     platformHost?: string | undefined;
     repoPath: string;
+    hideStaleWhileLoading?: boolean;
     autoSync?: IssueDetailSyncMode;
   }
 
@@ -66,6 +67,7 @@
     provider,
     platformHost,
     repoPath,
+    hideStaleWhileLoading = false,
     autoSync = "background",
   }: Props = $props();
 
@@ -101,6 +103,7 @@
     event: { PlatformID: number | null },
     body: string,
   ): Promise<boolean> {
+    if (staleIssue) return false;
     if (event.PlatformID === null) return false;
     return issues.editIssueComment(owner, name, number, event.PlatformID, body);
   }
@@ -401,9 +404,9 @@
   }
 </script>
 
-{#if issues.isIssueDetailLoading() && issues.getIssueDetail() === null}
+{#if issues.isIssueDetailLoading() && (issues.getIssueDetail() === null || (staleIssue && hideStaleWhileLoading))}
   <div class="state-center"><p class="state-msg">Loading...</p></div>
-{:else if issues.getIssueDetailError() !== null && issues.getIssueDetail() === null}
+{:else if issues.getIssueDetailError() !== null && (issues.getIssueDetail() === null || (staleIssue && hideStaleWhileLoading))}
   <div class="state-center"><p class="state-msg state-msg--error">Error: {issues.getIssueDetailError()}</p></div>
 {:else}
   {@const detail = issues.getIssueDetail()}
@@ -518,7 +521,11 @@
         {#if workspace}
           <ActionButton
             class="btn--workspace"
-            onclick={() => navigate(`/terminal/${workspace.id}`)}
+            disabled={staleIssue}
+            onclick={() => {
+              if (staleIssue) return;
+              navigate(`/terminal/${workspace.id}`);
+            }}
             tone="info"
             surface="soft"
             size="sm"
@@ -545,7 +552,10 @@
           <ActionButton
             class="btn--close"
             disabled={stateSubmitting || staleIssue}
-            onclick={() => handleStateChange("closed")}
+            onclick={() => {
+              if (staleIssue) return;
+              handleStateChange("closed");
+            }}
             tone="danger"
             surface="outline"
             size="sm"
@@ -558,7 +568,10 @@
           <ActionButton
             class="btn--reopen"
             disabled={stateSubmitting || staleIssue}
-            onclick={() => handleStateChange("open")}
+            onclick={() => {
+              if (staleIssue) return;
+              handleStateChange("open");
+            }}
             tone="success"
             surface="solid"
             size="sm"
@@ -617,7 +630,7 @@
             repoOwner={owner}
             repoName={name}
             {repoPath}
-            onEditComment={capabilities.comment_mutation
+            onEditComment={capabilities.comment_mutation && !staleIssue
               ? editTimelineComment
               : undefined}
           />

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -407,13 +407,14 @@
   <div class="state-center"><p class="state-msg state-msg--error">Error: {issues.getIssueDetailError()}</p></div>
 {:else}
   {@const detail = issues.getIssueDetail()}
+  {@const staleLoadError = staleIssue && issues.getIssueDetailError() !== null}
   {#if detail !== null}
     {@const issue = detail.issue}
     {@const labels = issue.labels ?? []}
     {@const capabilities = detail.repo?.capabilities ?? defaultProviderCapabilities}
     <div class="issue-detail">
       <div class="issue-detail-content">
-      {#if staleIssue && issues.getIssueDetailError() !== null}
+      {#if staleLoadError}
         <div class="detail-load-error" data-testid="detail-load-error">
           Couldn't load this issue: {issues.getIssueDetailError()}
         </div>

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -431,11 +431,10 @@
       <!-- Header -->
       <div class="detail-header">
         <h2 class="detail-title">{issue.Title}</h2>
-        {#if !uiConfig.hideStar}
+        {#if !uiConfig.hideStar && !staleIssue}
           <button
             class="star-btn"
             onclick={handleStarClick}
-            disabled={staleIssue}
             title={issue.Starred ? "Unstar" : "Star"}
           >
             {#if issue.Starred}

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -605,13 +605,13 @@
 <svelte:window onkeydown={onActionMenuKeydown} />
 <svelte:document onmousedown={onActionMenuDocumentMousedown} />
 
-{#if detailStore.isDetailLoading() && (detailStore.getDetail() === null || stalePR)}
+{#if detailStore.isDetailLoading() && detailStore.getDetail() === null}
   <div class="state-center"><p class="state-msg">Loading…</p></div>
-{:else if detailStore.getDetailError() !== null && (detailStore.getDetail() === null || stalePR)}
+{:else if detailStore.getDetailError() !== null && detailStore.getDetail() === null}
   <div class="state-center"><p class="state-msg state-msg--error">Error: {detailStore.getDetailError()}</p></div>
 {:else}
   {@const detail = detailStore.getDetail()}
-  {#if detail !== null && !stalePR}
+  {#if detail !== null}
     {@const pr = detail.merge_request}
     {@const capabilities = detail.repo?.capabilities ?? defaultProviderCapabilities}
     {@const lockedSupported = supportsLocked(
@@ -835,20 +835,20 @@
       {/if}
 
       <!-- Mergeable state warnings -->
-      {#if pr.State === "open" && pr.MergeableState === "dirty"}
+      {#if !stalePR && pr.State === "open" && pr.MergeableState === "dirty"}
         <div class="merge-warning merge-warning--conflict">
           <span>This branch has conflicts that must be resolved before merging.</span>
           <a href={pr.URL} target="_blank" rel="noopener noreferrer">View on GitHub</a>
         </div>
-      {:else if pr.State === "open" && pr.MergeableState === "blocked"}
+      {:else if !stalePR && pr.State === "open" && pr.MergeableState === "blocked"}
         <div class="merge-warning merge-warning--info">
           <span>Branch protection rules may prevent this merge.</span>
         </div>
-      {:else if pr.State === "open" && pr.MergeableState === "behind"}
+      {:else if !stalePR && pr.State === "open" && pr.MergeableState === "behind"}
         <div class="merge-warning merge-warning--info">
           <span>This branch is behind the base branch and may need to be updated.</span>
         </div>
-      {:else if pr.State === "open" && pr.MergeableState === "unstable"}
+      {:else if !stalePR && pr.State === "open" && pr.MergeableState === "unstable"}
         <div class="merge-warning merge-warning--info">
           <span>Required status checks have not passed.</span>
         </div>

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -277,6 +277,13 @@
     titleDraft = "";
   }
 
+  function handleStarClick(): void {
+    if (stalePR) return;
+    const mr = currentPR();
+    if (!mr) return;
+    void detailStore.toggleDetailPRStar(owner, name, number, mr.Starred);
+  }
+
   async function saveTitle(): Promise<void> {
     if (stalePR) return;
     if (!currentCapabilities().state_mutation) return;
@@ -709,10 +716,7 @@
               <button
                 class="star-btn"
                 disabled={stalePR}
-                onclick={() => {
-                  if (stalePR) return;
-                  void detailStore.toggleDetailPRStar(owner, name, number, pr.Starred);
-                }}
+                onclick={handleStarClick}
                 title={pr.Starred ? "Unstar" : "Star"}
               >
                 {#if pr.Starred}

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -611,6 +611,7 @@
   <div class="state-center"><p class="state-msg state-msg--error">Error: {detailStore.getDetailError()}</p></div>
 {:else}
   {@const detail = detailStore.getDetail()}
+  {@const staleLoadError = stalePR && detailStore.getDetailError() !== null}
   {#if detail !== null}
     {@const pr = detail.merge_request}
     {@const capabilities = detail.repo?.capabilities ?? defaultProviderCapabilities}
@@ -621,7 +622,7 @@
       detail.repo?.name ?? name,
     )}
     <div class="pull-detail-wrap">
-      {#if stalePR && detailStore.getDetailError() !== null}
+      {#if staleLoadError}
         <div class="detail-load-error" data-testid="detail-load-error">
           Couldn't load this pull request: {detailStore.getDetailError()}
         </div>

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -91,6 +91,7 @@
     onPullsRefresh?: () => Promise<void>;
     hideTabs?: boolean;
     hideWorkspaceAction?: boolean;
+    hideStaleWhileLoading?: boolean;
     autoSync?: DetailSyncMode;
   }
 
@@ -104,6 +105,7 @@
     onPullsRefresh,
     hideTabs = false,
     hideWorkspaceAction = false,
+    hideStaleWhileLoading = false,
     autoSync = "background",
   }: Props = $props();
 
@@ -131,6 +133,7 @@
     event: { PlatformID: number | null },
     body: string,
   ): Promise<boolean> {
+    if (stalePR) return false;
     if (event.PlatformID === null) return false;
     return detailStore.editComment(owner, name, number, event.PlatformID, body);
   }
@@ -261,6 +264,7 @@
   }
 
   function startEditTitle(): void {
+    if (stalePR) return;
     if (!currentCapabilities().state_mutation) return;
     const mr = currentPR();
     if (!mr) return;
@@ -311,6 +315,7 @@
   let savingBody = $state(false);
 
   function startEditBody(): void {
+    if (stalePR) return;
     if (!currentCapabilities().state_mutation) return;
     const mr = currentPR();
     if (!mr) return;
@@ -605,9 +610,9 @@
 <svelte:window onkeydown={onActionMenuKeydown} />
 <svelte:document onmousedown={onActionMenuDocumentMousedown} />
 
-{#if detailStore.isDetailLoading() && detailStore.getDetail() === null}
+{#if detailStore.isDetailLoading() && (detailStore.getDetail() === null || (stalePR && hideStaleWhileLoading))}
   <div class="state-center"><p class="state-msg">Loading…</p></div>
-{:else if detailStore.getDetailError() !== null && detailStore.getDetail() === null}
+{:else if detailStore.getDetailError() !== null && (detailStore.getDetail() === null || (stalePR && hideStaleWhileLoading))}
   <div class="state-center"><p class="state-msg state-msg--error">Error: {detailStore.getDetailError()}</p></div>
 {:else}
   {@const detail = detailStore.getDetail()}
@@ -695,7 +700,11 @@
         {:else if capabilities.state_mutation}
           <div class="title-line">
             <h2 class="detail-title">{pr.Title}</h2>
-            <button class="edit-title-btn" onclick={startEditTitle}>Edit</button>
+            <button
+              class="edit-title-btn"
+              onclick={startEditTitle}
+              disabled={stalePR}
+            >Edit</button>
             {#if !uiConfig.hideStar}
               <button
                 class="star-btn"
@@ -731,6 +740,7 @@
             options={kanbanOptions}
             onchange={onKanbanChange}
             title="Change workflow status"
+            disabled={stalePR}
           />
         {/if}
       </div>
@@ -829,6 +839,7 @@
         options={kanbanOptions}
         onchange={onKanbanChange}
         title="Change workflow status"
+        disabled={stalePR}
       />
 
       {#if labels.length > 0}
@@ -914,9 +925,10 @@
               title={mergeDisabledByConflicts
                 ? "Resolve merge conflicts before merging"
                 : ""}
-              onclick={() =>
-                runOpenMerge(buildOpenMergeInput(pr, capabilities))
-              }
+              onclick={() => {
+                if (stalePR) return;
+                runOpenMerge(buildOpenMergeInput(pr, capabilities));
+              }}
               tone="success"
               surface="solid"
               size="sm"
@@ -1006,7 +1018,11 @@
           {#if workspace}
             <ActionButton
               class="btn--workspace"
-              onclick={() => navigate(`/terminal/${workspace.id}`)}
+              disabled={stalePR}
+              onclick={() => {
+                if (stalePR) return;
+                navigate(`/terminal/${workspace.id}`);
+              }}
               tone="info"
               surface="soft"
               size="sm"
@@ -1137,6 +1153,7 @@
             <button
               class="edit-body-btn"
               onclick={startEditBody}
+              disabled={stalePR}
             >
               Edit
             </button>
@@ -1191,7 +1208,11 @@
             <div class="inset-box markdown-body">{@html renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath })}</div>
           </div>
         {:else if capabilities.state_mutation}
-          <button class="add-description-btn" onclick={startEditBody}>
+          <button
+            class="add-description-btn"
+            onclick={startEditBody}
+            disabled={stalePR}
+          >
             Add a description
           </button>
         {/if}
@@ -1229,7 +1250,7 @@
             {repoPath}
             filtered={hasActiveTimelineFilters}
             showCommitDetails={timelineFilter.showCommitDetails}
-            onEditComment={capabilities.comment_mutation
+            onEditComment={capabilities.comment_mutation && !stalePR
               ? editTimelineComment
               : undefined}
           />

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -707,15 +707,15 @@
         {:else if capabilities.state_mutation}
           <div class="title-line">
             <h2 class="detail-title">{pr.Title}</h2>
-            <button
-              class="edit-title-btn"
-              onclick={startEditTitle}
-              disabled={stalePR}
-            >Edit</button>
-            {#if !uiConfig.hideStar}
+            {#if !stalePR}
+              <button
+                class="edit-title-btn"
+                onclick={startEditTitle}
+              >Edit</button>
+            {/if}
+            {#if !uiConfig.hideStar && !stalePR}
               <button
                 class="star-btn"
-                disabled={stalePR}
                 onclick={handleStarClick}
                 title={pr.Starred ? "Unstar" : "Star"}
               >
@@ -738,14 +738,15 @@
               </svg>
             </a>
           </div>
-          <SelectDropdown
-            class="kanban-select kanban-select--header kanban-select--{pr.KanbanStatus.replace('_', '-')}"
-            value={pr.KanbanStatus}
-            options={kanbanOptions}
-            onchange={onKanbanChange}
-            title="Change workflow status"
-            disabled={stalePR}
-          />
+          {#if !stalePR}
+            <SelectDropdown
+              class="kanban-select kanban-select--header kanban-select--{pr.KanbanStatus.replace('_', '-')}"
+              value={pr.KanbanStatus}
+              options={kanbanOptions}
+              onchange={onKanbanChange}
+              title="Change workflow status"
+            />
+          {/if}
         {/if}
       </div>
 
@@ -837,14 +838,15 @@
         />
       </div>
 
-      <SelectDropdown
-        class="kanban-select kanban-select--below-chips kanban-select--{pr.KanbanStatus.replace('_', '-')}"
-        value={pr.KanbanStatus}
-        options={kanbanOptions}
-        onchange={onKanbanChange}
-        title="Change workflow status"
-        disabled={stalePR}
-      />
+      {#if !stalePR}
+        <SelectDropdown
+          class="kanban-select kanban-select--below-chips kanban-select--{pr.KanbanStatus.replace('_', '-')}"
+          value={pr.KanbanStatus}
+          options={kanbanOptions}
+          onchange={onKanbanChange}
+          title="Change workflow status"
+        />
+      {/if}
 
       {#if labels.length > 0}
         <GitHubLabels {labels} mode="full" />
@@ -988,7 +990,7 @@
       {/snippet}
 
       <!-- Approve / Merge / Close / Reopen actions -->
-      {#if pr.State !== "merged"}
+      {#if pr.State !== "merged" && !stalePR}
         <div class="primary-actions-wrap">
           <div class="actions-row actions-row--primary">
             {@render primaryActionButtons()}
@@ -1153,11 +1155,10 @@
       <div class="section body-section">
         <div class="section-header">
           <span class="section-title-inline">Description</span>
-          {#if !editingBody && capabilities.state_mutation}
+          {#if !editingBody && capabilities.state_mutation && !stalePR}
             <button
               class="edit-body-btn"
               onclick={startEditBody}
-              disabled={stalePR}
             >
               Edit
             </button>
@@ -1211,11 +1212,10 @@
             </button>
             <div class="inset-box markdown-body">{@html renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath })}</div>
           </div>
-        {:else if capabilities.state_mutation}
+        {:else if capabilities.state_mutation && !stalePR}
           <button
             class="add-description-btn"
             onclick={startEditBody}
-            disabled={stalePR}
           >
             Add a description
           </button>

--- a/packages/ui/src/views/ActivityFeedView.svelte
+++ b/packages/ui/src/views/ActivityFeedView.svelte
@@ -225,6 +225,7 @@
           hideSidebar={true}
           showStackSidebar={false}
           autoSyncDetail="background"
+          hideStaleDetailWhileLoading={true}
           onDetailTabChange={handleDetailTabChange}
         />
       {:else}
@@ -240,6 +241,7 @@
           isSidebarCollapsed={true}
           hideSidebar={true}
           autoSyncDetail="background"
+          hideStaleDetailWhileLoading={true}
         />
       {/if}
     </section>

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -16,6 +16,7 @@
     hideSidebar?: boolean;
     sidebarWidth?: number;
     autoSyncDetail?: IssueDetailSyncMode;
+    hideStaleDetailWhileLoading?: boolean;
     onSidebarResize?: (width: number) => void;
   }
 
@@ -25,6 +26,7 @@
     hideSidebar = false,
     sidebarWidth = 340,
     autoSyncDetail = "background",
+    hideStaleDetailWhileLoading = false,
     onSidebarResize,
   }: Props = $props();
 </script>
@@ -51,6 +53,7 @@
       platformHost={selectedIssue.platformHost}
       repoPath={selectedIssue.repoPath}
       autoSync={autoSyncDetail}
+      hideStaleWhileLoading={hideStaleDetailWhileLoading}
     />
   {:else}
     <div class="placeholder-content">

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -27,6 +27,7 @@
     sidebarWidth?: number;
     showStackSidebar?: boolean;
     autoSyncDetail?: DetailSyncMode;
+    hideStaleDetailWhileLoading?: boolean;
     onSidebarResize?: (width: number) => void;
     onDetailTabChange?: (tab: "conversation" | "files") => void;
   }
@@ -39,6 +40,7 @@
     sidebarWidth = 340,
     showStackSidebar = true,
     autoSyncDetail = "background",
+    hideStaleDetailWhileLoading = false,
     onSidebarResize,
     onDetailTabChange,
   }: Props = $props();
@@ -112,6 +114,7 @@
         repoPath={selectedPR.repoPath}
         autoSync={autoSyncDetail}
         hideTabs={true}
+        hideStaleWhileLoading={hideStaleDetailWhileLoading}
       />
     {/if}
   {:else}


### PR DESCRIPTION
- Hide mergeability warnings while a newly selected PR is still loading.
- Keep stale detail views visible with disabled actions instead of showing status for wrong item.

Closes #318