### PR TITLE
Refresh pending CI details while expanded

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -29,16 +29,10 @@ lacks browser testing infrastructure. middleman already has Playwright
 e2e coverage, and many required e2e tests here are API plus SQLite
 full-stack tests rather than purely browser concerns.
 
-Do not require endpoint-specific e2e tests for both default-host and
-`/host/{platform_host}` route forms when the host route is only a thin
-generic wrapper that copies path fields into the same handler and there
-is already coverage for that generic host-route mechanism. In those cases,
-use targeted unit/store tests for generated route selection plus one
-full-stack test for the behavior under the shared handler. Require a
-host-scoped full-stack e2e test only when the change adds custom host
-logic, changes route parsing/encoding, changes provider identity lookup,
-or exposes a regression that existing generic host-route tests would not
-catch.
+Do not require duplicate e2e coverage for default-host and
+`/host/{platform_host}` routes when the host route is only a generic
+wrapper. Require host-specific e2e only for custom host logic, route
+parsing, or provider identity changes.
 
 middleman targets Go 1.26, where the built-in new accepts expression
 operands such as new(expr). Do not flag new(expr) usage as invalid,

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -29,6 +29,17 @@ lacks browser testing infrastructure. middleman already has Playwright
 e2e coverage, and many required e2e tests here are API plus SQLite
 full-stack tests rather than purely browser concerns.
 
+Do not require endpoint-specific e2e tests for both default-host and
+`/host/{platform_host}` route forms when the host route is only a thin
+generic wrapper that copies path fields into the same handler and there
+is already coverage for that generic host-route mechanism. In those cases,
+use targeted unit/store tests for generated route selection plus one
+full-stack test for the behavior under the shared handler. Require a
+host-scoped full-stack e2e test only when the change adds custom host
+logic, changes route parsing/encoding, changes provider identity lookup,
+or exposes a regression that existing generic host-route tests would not
+catch.
+
 middleman targets Go 1.26, where the built-in new accepts expression
 operands such as new(expr). Do not flag new(expr) usage as invalid,
 suspicious, or something that must be rewritten through a temporary

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -866,7 +866,7 @@ func run(
 				return
 			}
 			if err := database.UpdateMRDetailFetchedByRepoID(
-				r.Context(), repo.ID, 1, true,
+				r.Context(), repo.ID, 1, false,
 			); err != nil {
 				http.Error(w, "mark pending CI fetched", http.StatusInternalServerError)
 				return

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -776,6 +776,61 @@ func run(
 	)
 	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/pr-ci-state/pending" {
+			repo, err := database.GetRepoByOwnerName(
+				r.Context(), "acme", "widgets",
+			)
+			if err != nil || repo == nil {
+				http.Error(w, "repo not found", http.StatusNotFound)
+				return
+			}
+			pendingChecks, err := json.Marshal([]db.CICheck{{
+				Name:       "build",
+				Status:     "in_progress",
+				Conclusion: "",
+				URL:        "https://github.com/acme/widgets/actions/runs/1/job/1",
+				App:        "GitHub Actions",
+			}})
+			if err != nil {
+				http.Error(w, "marshal pending checks", http.StatusInternalServerError)
+				return
+			}
+			if err := database.UpdateMRCIStatus(
+				r.Context(), repo.ID, 1, "pending", string(pendingChecks),
+			); err != nil {
+				http.Error(w, "update pending CI", http.StatusInternalServerError)
+				return
+			}
+			if err := database.UpdateMRDetailFetchedByRepoID(
+				r.Context(), repo.ID, 1, true,
+			); err != nil {
+				http.Error(w, "mark pending CI fetched", http.StatusInternalServerError)
+				return
+			}
+
+			for _, pr := range fc.PRs["acme/widgets"] {
+				if pr.GetNumber() != 1 || pr.GetHead() == nil {
+					continue
+				}
+				key := fmt.Sprintf("acme/widgets@%s", pr.GetHead().GetSHA())
+				for _, run := range fc.CheckRuns[key] {
+					status := "completed"
+					conclusion := "success"
+					run.Status = &status
+					run.Conclusion = &conclusion
+				}
+				break
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"status": "pending",
+			}); err != nil {
+				slog.Warn("write e2e response", "err", err)
+			}
+			return
+		}
+		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-diff-summary/advance-head" {
 			repo, err := database.GetRepoByOwnerName(
 				r.Context(), "acme", "widgets",

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -808,14 +808,7 @@ func run(
 				return
 			}
 
-			var headSHA string
-			for _, pr := range fc.PRs["acme/widgets"] {
-				if pr.GetNumber() != 1 || pr.GetHead() == nil {
-					continue
-				}
-				headSHA = pr.GetHead().GetSHA()
-				break
-			}
+			headSHA := fc.PullRequestHeadSHA("acme", "widgets", 1)
 			if headSHA == "" {
 				http.Error(w, "PR head SHA not found", http.StatusNotFound)
 				return
@@ -872,23 +865,33 @@ func run(
 				return
 			}
 
-			for _, pr := range fc.PRs["acme/widgets"] {
-				if pr.GetNumber() != 1 || pr.GetHead() == nil {
-					continue
-				}
-				key := fmt.Sprintf("acme/widgets@%s", pr.GetHead().GetSHA())
-				for _, run := range fc.CheckRuns[key] {
-					status := "completed"
-					conclusion := "success"
-					run.Status = &status
-					run.Conclusion = &conclusion
-				}
-				break
+			if !fc.SetPullRequestCheckRunStatus(
+				"acme", "widgets", 1, "in_progress", "",
+			) {
+				http.Error(w, "update fixture check runs", http.StatusNotFound)
+				return
 			}
 
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(map[string]string{
 				"status": "pending",
+			}); err != nil {
+				slog.Warn("write e2e response", "err", err)
+			}
+			return
+		}
+		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/pr-ci-state/success" {
+			if !fc.SetPullRequestCheckRunStatus(
+				"acme", "widgets", 1, "completed", "success",
+			) {
+				http.Error(w, "update fixture check runs", http.StatusNotFound)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"status": "success",
 			}); err != nil {
 				slog.Warn("write e2e response", "err", err)
 			}
@@ -1063,40 +1066,5 @@ func patchFixturePRSHAs(fc *testutil.FixtureClient, owner, repo string, number i
 	if fc == nil {
 		return
 	}
-
-	repoKey := fmt.Sprintf("%s/%s", owner, repo)
-	oldHeadSHA := ""
-	patch := func(prs []*gh.PullRequest) {
-		for _, pr := range prs {
-			if pr.GetNumber() != number {
-				continue
-			}
-			if pr.Head == nil {
-				pr.Head = &gh.PullRequestBranch{}
-			}
-			if pr.Base == nil {
-				pr.Base = &gh.PullRequestBranch{}
-			}
-			if oldHeadSHA == "" {
-				oldHeadSHA = pr.Head.GetSHA()
-			}
-			pr.Head.SHA = &headSHA
-			pr.Base.SHA = &baseSHA
-		}
-	}
-
-	patch(fc.OpenPRs[repoKey])
-	patch(fc.PRs[repoKey])
-
-	if oldHeadSHA == "" || oldHeadSHA == headSHA {
-		return
-	}
-	oldRefKey := fmt.Sprintf("%s/%s@%s", owner, repo, oldHeadSHA)
-	newRefKey := fmt.Sprintf("%s/%s@%s", owner, repo, headSHA)
-	if combined, ok := fc.CombinedStatuses[oldRefKey]; ok {
-		fc.CombinedStatuses[newRefKey] = combined
-	}
-	if runs, ok := fc.CheckRuns[oldRefKey]; ok {
-		fc.CheckRuns[newRefKey] = runs
-	}
+	fc.UpdatePullRequestSHAs(owner, repo, number, headSHA, baseSHA)
 }

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -776,6 +776,70 @@ func run(
 	)
 	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/pr-workflow-approval/required" {
+			repo, err := database.GetRepoByOwnerName(
+				r.Context(), "acme", "widgets",
+			)
+			if err != nil || repo == nil {
+				http.Error(w, "repo not found", http.StatusNotFound)
+				return
+			}
+			pendingChecks, err := json.Marshal([]db.CICheck{{
+				Name:       "build",
+				Status:     "in_progress",
+				Conclusion: "",
+				URL:        "https://github.com/acme/widgets/actions/runs/1/job/1",
+				App:        "GitHub Actions",
+			}})
+			if err != nil {
+				http.Error(w, "marshal pending checks", http.StatusInternalServerError)
+				return
+			}
+			if err := database.UpdateMRCIStatus(
+				r.Context(), repo.ID, 1, "pending", string(pendingChecks),
+			); err != nil {
+				http.Error(w, "update pending CI", http.StatusInternalServerError)
+				return
+			}
+			if err := database.UpdateMRDetailFetchedByRepoID(
+				r.Context(), repo.ID, 1, true,
+			); err != nil {
+				http.Error(w, "mark pending CI fetched", http.StatusInternalServerError)
+				return
+			}
+
+			var headSHA string
+			for _, pr := range fc.PRs["acme/widgets"] {
+				if pr.GetNumber() != 1 || pr.GetHead() == nil {
+					continue
+				}
+				headSHA = pr.GetHead().GetSHA()
+				break
+			}
+			if headSHA == "" {
+				http.Error(w, "PR head SHA not found", http.StatusNotFound)
+				return
+			}
+			runID := int64(9001)
+			event := "pull_request"
+			number := 1
+			fc.WorkflowRuns[fmt.Sprintf("acme/widgets@%s", headSHA)] = []*gh.WorkflowRun{{
+				ID:           &runID,
+				HeadSHA:      &headSHA,
+				Event:        &event,
+				PullRequests: []*gh.PullRequest{{Number: &number}},
+			}}
+
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"status": "required",
+				"run_id": runID,
+			}); err != nil {
+				slog.Warn("write e2e response", "err", err)
+			}
+			return
+		}
+		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-ci-state/pending" {
 			repo, err := database.GetRepoByOwnerName(
 				r.Context(), "acme", "widgets",

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -823,12 +823,12 @@ func run(
 			runID := int64(9001)
 			event := "pull_request"
 			number := 1
-			fc.WorkflowRuns[fmt.Sprintf("acme/widgets@%s", headSHA)] = []*gh.WorkflowRun{{
+			fc.SetWorkflowRuns("acme", "widgets", headSHA, []*gh.WorkflowRun{{
 				ID:           &runID,
 				HeadSHA:      &headSHA,
 				Event:        &event,
 				PullRequests: []*gh.PullRequest{{Number: &number}},
-			}}
+			}})
 
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(map[string]any{

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -881,6 +881,23 @@ func run(
 			return
 		}
 		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/pr-ci-state/fail-refresh" {
+			if !fc.SetPullRequestCheckRunError(
+				"acme", "widgets", 1, errors.New("fixture CI refresh failed"),
+			) {
+				http.Error(w, "set fixture check error", http.StatusNotFound)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"status": "fail-refresh",
+			}); err != nil {
+				slog.Warn("write e2e response", "err", err)
+			}
+			return
+		}
+		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-ci-state/success" {
 			if !fc.SetPullRequestCheckRunStatus(
 				"acme", "widgets", 1, "completed", "success",

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -64,8 +64,10 @@ func TestPatchFixturePRSHAsUpdatesOpenPRs(t *testing.T) {
 	patchFixturePRSHAs(fc, "acme", "widgets", 1, "head-sha", "base-sha")
 
 	assert := Assert.New(t)
-	assert.Equal("head-sha", openPR.GetHead().GetSHA())
-	assert.Equal("base-sha", openPR.GetBase().GetSHA())
+	updated := fc.OpenPRs["acme/widgets"][0]
+	assert.Equal("head-sha", updated.GetHead().GetSHA())
+	assert.Equal("base-sha", updated.GetBase().GetSHA())
+	assert.Empty(openPR.GetHead().GetSHA(), "update should replace fixture PR instead of mutating shared pointer")
 }
 
 func TestPatchFixturePRSHAsUpdatesLookupPRs(t *testing.T) {
@@ -83,8 +85,10 @@ func TestPatchFixturePRSHAsUpdatesLookupPRs(t *testing.T) {
 	patchFixturePRSHAs(fc, "acme", "widgets", 1, "head-sha", "base-sha")
 
 	assert := Assert.New(t)
-	assert.Equal("head-sha", lookupPR.GetHead().GetSHA())
-	assert.Equal("base-sha", lookupPR.GetBase().GetSHA())
+	updated := fc.PRs["acme/widgets"][0]
+	assert.Equal("head-sha", updated.GetHead().GetSHA())
+	assert.Equal("base-sha", updated.GetBase().GetSHA())
+	assert.Empty(lookupPR.GetHead().GetSHA(), "update should replace fixture PR instead of mutating shared pointer")
 }
 
 // TestDefaultRoborevEndpointIsUnbindable pins the e2e server's

--- a/context/testing.md
+++ b/context/testing.md
@@ -32,20 +32,10 @@ notice the regression:
 Regenerate OpenAPI and generated clients with `make api-generate` after Huma
 route or API type changes.
 
-When a handler has both default-host and `/host/{platform_host}` routes, do not
-add duplicate full-stack e2e tests solely to exercise both path forms if the
-host route is a generic wrapper that forwards the same fields to the same
-handler. Prefer:
-
-- one full-stack API/SQLite test for the behavior through the shared handler;
-- route helper or generated-client tests that prove callers select the host path
-  when a non-default `platform_host` is present;
-- existing generic host-route e2e coverage for path parsing, host lookup, nested
-  owners, and provider identity.
-
-Add a host-specific full-stack e2e test when a change touches custom host logic,
-route parsing/encoding, provider identity lookup, or a bug that generic host
-coverage would not catch.
+Do not duplicate full-stack e2e tests across default-host and
+`/host/{platform_host}` route forms when the host route is only a generic
+wrapper. Add host-specific e2e coverage only for custom host logic, route
+parsing, or provider identity changes.
 
 ## Race test runtime
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -32,6 +32,21 @@ notice the regression:
 Regenerate OpenAPI and generated clients with `make api-generate` after Huma
 route or API type changes.
 
+When a handler has both default-host and `/host/{platform_host}` routes, do not
+add duplicate full-stack e2e tests solely to exercise both path forms if the
+host route is a generic wrapper that forwards the same fields to the same
+handler. Prefer:
+
+- one full-stack API/SQLite test for the behavior through the shared handler;
+- route helper or generated-client tests that prove callers select the host path
+  when a non-default `platform_host` is present;
+- existing generic host-route e2e coverage for path parsing, host lookup, nested
+  owners, and provider identity.
+
+Add a host-specific full-stack e2e test when a change touches custom host logic,
+route parsing/encoding, provider identity lookup, or a bug that generic host
+coverage would not catch.
+
 ## Race test runtime
 
 Treat `go test -race` runtime as a test architecture concern, not a CI-only

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3661,6 +3661,50 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Post host by platform host pulls by provider by owner by name by number approve workflows
+  /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/ci-refresh:
+    post:
+      operationId: post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ci-refresh
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MergeRequestDetailResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Post host by platform host pulls by provider by owner by name by number ci refresh
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-pr-comment-on-host
@@ -5473,6 +5517,45 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Post pulls by provider by owner by name by number approve workflows
+  /pulls/{provider}/{owner}/{name}/{number}/ci-refresh:
+    post:
+      operationId: post-pulls-by-provider-by-owner-by-name-by-number-ci-refresh
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MergeRequestDetailResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Post pulls by provider by owner by name by number ci refresh
   /pulls/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-pr-comment

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -93,6 +93,59 @@ describe("provider-aware detail API routes", () => {
     });
   });
 
+  it("serializes overlapping pending PR CI refreshes", async () => {
+    const detail = {
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+      },
+      merge_request: { Number: 1 },
+      events: [],
+    };
+    let resolvePost!: () => void;
+    const postDone = new Promise<void>((resolve) => {
+      resolvePost = resolve;
+    });
+    const client = {
+      GET: vi.fn(async () => ({ data: detail })),
+      POST: vi.fn(async () => {
+        await postDone;
+        return { data: detail };
+      }),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("acme", "widgets", 1, {
+      sync: false,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    } as never);
+
+    const first = store.refreshPendingCI("acme", "widgets", 1, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    });
+    const second = store.refreshPendingCI("acme", "widgets", 1, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    });
+    await Promise.resolve();
+
+    expect(client.POST).toHaveBeenCalledTimes(1);
+    resolvePost();
+    await Promise.all([first, second]);
+  });
+
   it("promotes pending workflow approval checks to foreground PR sync", async () => {
     const pendingDetail = {
       repo_owner: "acme",

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -41,6 +41,58 @@ describe("provider-aware detail API routes", () => {
     });
   });
 
+  it("refreshes pending PR CI through the provider sync endpoint", async () => {
+    const detail = {
+      repo_owner: "Group/SubGroup",
+      repo_name: "Project",
+      repo: {
+        provider: "gitlab",
+        platform_host: "gitlab.example.com:8443",
+        owner: "Group/SubGroup",
+        name: "Project",
+        repo_path: "Group/SubGroup/Project",
+      },
+      merge_request: { Number: 12 },
+      events: [],
+    };
+    const client = {
+      GET: vi.fn(async () => ({
+        data: detail,
+      })),
+      POST: vi.fn(async () => ({
+        data: detail,
+      })),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("Group/SubGroup", "Project", 12, {
+      sync: false,
+      provider: "gitlab",
+      platformHost: "gitlab.example.com:8443",
+      repoPath: "Group/SubGroup/Project",
+    } as never);
+
+    await store.refreshPendingCI("Group/SubGroup", "Project", 12, {
+      provider: "gitlab",
+      platformHost: "gitlab.example.com:8443",
+      repoPath: "Group/SubGroup/Project",
+    });
+
+    expect(client.POST).toHaveBeenCalledWith("/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/sync", {
+      params: {
+        path: {
+          provider: "gitlab",
+          platform_host: "gitlab.example.com:8443",
+          owner: "Group/SubGroup",
+          name: "Project",
+          number: 12,
+        },
+      },
+    });
+  });
+
   it("loads issue detail through the provider item endpoint", async () => {
     const client = {
       GET: vi.fn(async () => ({

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -146,6 +146,61 @@ describe("provider-aware detail API routes", () => {
     await Promise.all([first, second]);
   });
 
+  it("keeps CI refreshes in CI-only mode when workflow approval sync is disabled", async () => {
+    const pendingDetail = {
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        capabilities: { workflow_approval: true },
+      },
+      merge_request: {
+        Number: 1,
+        State: "open",
+        CIStatus: "pending",
+        CIChecksJSON: JSON.stringify([
+          { name: "build", status: "in_progress", conclusion: "" },
+        ]),
+        CIHadPending: true,
+      },
+      workflow_approval: { checked: false, required: false, count: 0 },
+      events: [],
+    };
+    const postPaths: string[] = [];
+    const client = {
+      GET: vi.fn(async () => ({ data: pendingDetail })),
+      POST: vi.fn(async (path: string) => {
+        postPaths.push(path);
+        return { data: pendingDetail };
+      }),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("acme", "widgets", 1, {
+      sync: false,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    } as never);
+
+    await store.refreshPendingCI("acme", "widgets", 1, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+      workflowApprovalSync: false,
+    });
+
+    expect(postPaths).toEqual([
+      "/pulls/{provider}/{owner}/{name}/{number}/ci-refresh",
+    ]);
+  });
+
   it("promotes CI refresh results that may need workflow approval to foreground PR sync", async () => {
     const pendingDetail = {
       repo_owner: "acme",

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -146,6 +146,70 @@ describe("provider-aware detail API routes", () => {
     await Promise.all([first, second]);
   });
 
+  it("promotes CI refresh results that may need workflow approval to foreground PR sync", async () => {
+    const pendingDetail = {
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        capabilities: { workflow_approval: true },
+      },
+      merge_request: {
+        Number: 1,
+        State: "open",
+        CIStatus: "pending",
+        CIChecksJSON: JSON.stringify([
+          { name: "build", status: "in_progress", conclusion: "" },
+        ]),
+        CIHadPending: true,
+      },
+      workflow_approval: { checked: false, required: false, count: 0 },
+      events: [],
+    };
+    const syncedDetail = {
+      ...pendingDetail,
+      workflow_approval: { checked: true, required: true, count: 1 },
+    };
+    const postPaths: string[] = [];
+    const client = {
+      GET: vi.fn(async () => ({ data: pendingDetail })),
+      POST: vi.fn(async (path: string) => {
+        postPaths.push(path);
+        return { data: path.endsWith("/sync") ? syncedDetail : pendingDetail };
+      }),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("acme", "widgets", 1, {
+      sync: false,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    } as never);
+
+    await store.refreshPendingCI("acme", "widgets", 1, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    });
+
+    expect(postPaths).toEqual([
+      "/pulls/{provider}/{owner}/{name}/{number}/ci-refresh",
+      "/pulls/{provider}/{owner}/{name}/{number}/sync",
+    ]);
+    expect(store.getDetail()?.workflow_approval).toEqual({
+      checked: true,
+      required: true,
+      count: 1,
+    });
+  });
+
   it("promotes pending workflow approval checks to foreground PR sync", async () => {
     const pendingDetail = {
       repo_owner: "acme",

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -41,7 +41,7 @@ describe("provider-aware detail API routes", () => {
     });
   });
 
-  it("refreshes pending PR CI through the provider sync endpoint", async () => {
+  it("refreshes pending PR CI through the provider CI endpoint", async () => {
     const detail = {
       repo_owner: "Group/SubGroup",
       repo_name: "Project",
@@ -80,7 +80,7 @@ describe("provider-aware detail API routes", () => {
       repoPath: "Group/SubGroup/Project",
     });
 
-    expect(client.POST).toHaveBeenCalledWith("/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/sync", {
+    expect(client.POST).toHaveBeenCalledWith("/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/ci-refresh", {
       params: {
         path: {
           provider: "gitlab",

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createDetailStore } from "@middleman/ui/stores/detail";
 import { createIssuesStore } from "@middleman/ui/stores/issues";
+import * as flash from "@middleman/ui/stores/flash";
 import type { MiddlemanClient } from "@middleman/ui";
 
 describe("provider-aware detail API routes", () => {
@@ -91,6 +92,91 @@ describe("provider-aware detail API routes", () => {
         },
       },
     });
+  });
+
+  it("flashes CI refresh warnings returned with preserved detail", async () => {
+    const detail = {
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+      },
+      merge_request: { Number: 1, CIStatus: "pending" },
+      warnings: ["Could not refresh CI checks; showing last known status."],
+      events: [],
+    };
+    const client = {
+      GET: vi.fn(async () => ({ data: detail })),
+      POST: vi.fn(async () => ({ data: detail })),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const showFlash = vi.spyOn(flash, "showFlash").mockImplementation(() => {});
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("acme", "widgets", 1, {
+      sync: false,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    } as never);
+
+    await store.refreshPendingCI("acme", "widgets", 1, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    });
+
+    expect(showFlash).toHaveBeenCalledWith(
+      "Could not refresh CI checks; showing last known status.",
+    );
+    showFlash.mockRestore();
+  });
+
+  it("flashes hard CI refresh request failures", async () => {
+    const detail = {
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+      },
+      merge_request: { Number: 1, CIStatus: "pending" },
+      events: [],
+    };
+    const client = {
+      GET: vi.fn(async () => ({ data: detail })),
+      POST: vi.fn(async () => ({
+        error: { detail: "refresh PR CI: upstream unavailable" },
+      })),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const showFlash = vi.spyOn(flash, "showFlash").mockImplementation(() => {});
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("acme", "widgets", 1, {
+      sync: false,
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    } as never);
+
+    await store.refreshPendingCI("acme", "widgets", 1, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    });
+
+    expect(showFlash).toHaveBeenCalledWith("refresh PR CI: upstream unavailable");
+    showFlash.mockRestore();
   });
 
   it("serializes overlapping pending PR CI refreshes", async () => {

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -112,6 +112,7 @@ describe("provider-aware detail API routes", () => {
         CIChecksJSON: JSON.stringify([
           { name: "build", status: "in_progress", conclusion: "" },
         ]),
+        CIHadPending: true,
       },
       workflow_approval: { checked: false, required: false, count: 0 },
       events: [],
@@ -149,6 +150,56 @@ describe("provider-aware detail API routes", () => {
       required: true,
       count: 1,
     });
+  });
+
+  it("keeps ordinary pending CI refreshes on the async PR sync endpoint", async () => {
+    const detail = {
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        capabilities: { workflow_approval: true },
+      },
+      merge_request: {
+        Number: 1,
+        State: "open",
+        CIStatus: "pending",
+        CIChecksJSON: JSON.stringify([
+          { name: "build", status: "in_progress", conclusion: "" },
+        ]),
+        CIHadPending: false,
+      },
+      workflow_approval: { checked: false, required: false, count: 0 },
+      events: [],
+    };
+    const postPaths: string[] = [];
+    const client = {
+      GET: vi.fn(async () => ({ data: detail })),
+      POST: vi.fn(async (path: string) => {
+        postPaths.push(path);
+        return { data: undefined };
+      }),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("acme", "widgets", 1, {
+      sync: "background",
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    } as never);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(postPaths).toEqual([
+      "/pulls/{provider}/{owner}/{name}/{number}/sync/async",
+    ]);
   });
 
   it("loads issue detail through the provider item endpoint", async () => {

--- a/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
+++ b/frontend/src/lib/stores/provider-detail-routes.svelte.test.ts
@@ -93,6 +93,64 @@ describe("provider-aware detail API routes", () => {
     });
   });
 
+  it("promotes pending workflow approval checks to foreground PR sync", async () => {
+    const pendingDetail = {
+      repo_owner: "acme",
+      repo_name: "widgets",
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        capabilities: { workflow_approval: true },
+      },
+      merge_request: {
+        Number: 1,
+        State: "open",
+        CIStatus: "pending",
+        CIChecksJSON: JSON.stringify([
+          { name: "build", status: "in_progress", conclusion: "" },
+        ]),
+      },
+      workflow_approval: { checked: false, required: false, count: 0 },
+      events: [],
+    };
+    const syncedDetail = {
+      ...pendingDetail,
+      workflow_approval: { checked: true, required: true, count: 1 },
+    };
+    const postPaths: string[] = [];
+    const client = {
+      GET: vi.fn(async () => ({ data: pendingDetail })),
+      POST: vi.fn(async (path: string) => {
+        postPaths.push(path);
+        return { data: syncedDetail };
+      }),
+      PUT: vi.fn(),
+      DELETE: vi.fn(),
+    } as unknown as MiddlemanClient;
+    const store = createDetailStore({ client });
+
+    await store.loadDetail("acme", "widgets", 1, {
+      sync: "background",
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+    } as never);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(postPaths).toEqual([
+      "/pulls/{provider}/{owner}/{name}/{number}/sync",
+    ]);
+    expect(store.getDetail()?.workflow_approval).toEqual({
+      checked: true,
+      required: true,
+      count: 1,
+    });
+  });
+
   it("loads issue detail through the provider item endpoint", async () => {
     const client = {
       GET: vi.fn(async () => ({

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -70,20 +70,20 @@ test.describe("CI dropdown", () => {
       await expect(pendingChip).toBeVisible();
       await backgroundSync;
 
+      const firstRefresh = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return response.request().method() === "POST" &&
+          url.pathname === "/api/v1/pulls/github/acme/widgets/1/ci-refresh";
+      });
+      await pendingChip.click();
+      await firstRefresh;
+
       const successResponse = await page.request.post(
         `${server.info.base_url}/__e2e/pr-ci-state/success`,
       );
       expect(successResponse.ok()).toBe(true);
       await expect(successResponse.json()).resolves.toEqual({ status: "success" });
 
-      const syncRequest = page.waitForRequest((request) => {
-        const url = new URL(request.url());
-        return request.method() === "POST" &&
-          url.pathname === "/api/v1/pulls/github/acme/widgets/1/ci-refresh";
-      });
-      await pendingChip.click();
-
-      await syncRequest;
       await expect(
         page
           .locator(".pull-detail")

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -41,7 +41,7 @@ test.describe("CI dropdown", () => {
       const syncRequest = page.waitForRequest((request) => {
         const url = new URL(request.url());
         return request.method() === "POST" &&
-          url.pathname === "/api/v1/pulls/github/acme/widgets/1/sync";
+          url.pathname === "/api/v1/pulls/github/acme/widgets/1/ci-refresh";
       });
       await pendingChip.click();
 

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -1,64 +1,58 @@
 import { expect, test } from "@playwright/test";
 
-type PRDetailResponseForTest = {
-  merge_request: {
-    CIStatus: string;
-    CIChecksJSON: string;
-    [key: string]: unknown;
-  };
-  [key: string]: unknown;
-};
+import { startIsolatedE2EServer } from "./support/e2eServer";
 
 test.describe("CI dropdown", () => {
   test("expanded pending CI checks trigger a detail sync refresh", async ({ page }) => {
-    let pendingDetail: PRDetailResponseForTest | null = null;
-    const pendingChecks = [
-      {
-        name: "build",
-        status: "in_progress",
-        conclusion: "",
-        url: "https://ci.example.com/build",
-        app: "GitHub Actions",
-      },
-    ];
-    await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
-      const response = await route.fetch();
-      pendingDetail = await response.json() as PRDetailResponseForTest;
-      pendingDetail!.merge_request.CIStatus = "pending";
-      pendingDetail!.merge_request.CIChecksJSON = JSON.stringify(pendingChecks);
-      await route.fulfill({ response, json: pendingDetail });
-    });
+    const server = await startIsolatedE2EServer();
+    try {
+      await page.addInitScript(() => {
+        const realSetInterval = window.setInterval;
+        window.setInterval = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+          realSetInterval(handler, timeout === 15_000 ? 100 : timeout, ...args)) as typeof window.setInterval;
+      });
 
-    const syncRequests: string[] = [];
-    await page.route("**/api/v1/pulls/github/acme/widgets/1/sync", async (route) => {
-      syncRequests.push(route.request().method());
-      const syncedDetail = {
-        ...pendingDetail,
-        merge_request: {
-          ...pendingDetail!.merge_request,
-          CIStatus: "success",
-          CIChecksJSON: JSON.stringify([
-            {
-              ...pendingChecks[0],
-              status: "completed",
-              conclusion: "success",
-            },
-          ]),
-        },
+      const seedResponse = await page.request.post(
+        `${server.info.base_url}/__e2e/pr-ci-state/pending`,
+      );
+      expect(seedResponse.ok()).toBe(true);
+      await expect(seedResponse.json()).resolves.toEqual({ status: "pending" });
+
+      const syncRequests: string[] = [];
+      page.on("request", (request) => {
+        if (
+          request.method() === "POST" &&
+          request.url().includes("/api/v1/pulls/github/acme/widgets/1/sync")
+        ) {
+          syncRequests.push(request.url());
+        }
+      });
+
+      await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
+
+      await page
+        .locator(".pull-detail")
+        .getByRole("button", { name: /CI:\s*pending \(1\)/i })
+        .click();
+
+      await expect.poll(() => syncRequests.length).toBeGreaterThan(0);
+      await expect(
+        page
+          .locator(".pull-detail")
+          .getByRole("button", { name: /CI:\s*success \(4\)/i }),
+      ).toBeVisible();
+
+      const detailResponse = await page.request.get(
+        `${server.info.base_url}/api/v1/pulls/github/acme/widgets/1`,
+      );
+      expect(detailResponse.ok()).toBe(true);
+      const storedDetail = await detailResponse.json() as {
+        merge_request: { CIStatus: string; CIChecksJSON: string };
       };
-      await route.fulfill({ status: 200, json: syncedDetail });
-    });
-
-    await page.goto("/pulls/github/acme/widgets/1");
-
-    await page
-      .locator(".pull-detail")
-      .getByRole("button", { name: /CI:\s*pending \(1\)/i })
-      .click();
-
-    await expect.poll(() => syncRequests.length, {
-      timeout: 17_000,
-    }).toBeGreaterThan(0);
+      expect(storedDetail.merge_request.CIStatus).toBe("success");
+    } finally {
+      await server.stop();
+    }
   });
 
   test("detail chips use the shared centered chip layout", async ({ page }) => {

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -3,6 +3,44 @@ import { expect, test } from "@playwright/test";
 import { startIsolatedE2EServer } from "./support/e2eServer";
 
 test.describe("CI dropdown", () => {
+  test("failed CI refresh preserves stored pending status", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const seedResponse = await page.request.post(
+        `${server.info.base_url}/__e2e/pr-ci-state/pending`,
+      );
+      expect(seedResponse.ok()).toBe(true);
+
+      const failResponse = await page.request.post(
+        `${server.info.base_url}/__e2e/pr-ci-state/fail-refresh`,
+      );
+      expect(failResponse.ok()).toBe(true);
+
+      const refreshResponse = await page.request.post(
+        `${server.info.base_url}/api/v1/pulls/github/acme/widgets/1/ci-refresh`,
+        { data: {} },
+      );
+      expect(refreshResponse.ok()).toBe(true);
+      const refreshedDetail = await refreshResponse.json() as {
+        merge_request: { CIStatus: string; CIChecksJSON: string };
+      };
+      expect(refreshedDetail.merge_request.CIStatus).toBe("pending");
+      expect(refreshedDetail.merge_request.CIChecksJSON).toContain("in_progress");
+
+      const storedResponse = await page.request.get(
+        `${server.info.base_url}/api/v1/pulls/github/acme/widgets/1`,
+      );
+      expect(storedResponse.ok()).toBe(true);
+      const storedDetail = await storedResponse.json() as {
+        merge_request: { CIStatus: string; CIChecksJSON: string };
+      };
+      expect(storedDetail.merge_request.CIStatus).toBe("pending");
+      expect(storedDetail.merge_request.CIChecksJSON).toContain("in_progress");
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("expanded pending CI checks trigger a detail sync refresh", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -18,24 +18,34 @@ test.describe("CI dropdown", () => {
       expect(seedResponse.ok()).toBe(true);
       await expect(seedResponse.json()).resolves.toEqual({ status: "pending" });
 
-      const syncRequests: string[] = [];
-      page.on("request", (request) => {
-        if (
-          request.method() === "POST" &&
-          request.url().includes("/api/v1/pulls/github/acme/widgets/1/sync")
-        ) {
-          syncRequests.push(request.url());
-        }
+      const backgroundSync = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return response.request().method() === "POST" &&
+          url.pathname === "/api/v1/pulls/github/acme/widgets/1/sync/async";
       });
 
       await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
 
-      await page
+      const pendingChip = page
         .locator(".pull-detail")
-        .getByRole("button", { name: /CI:\s*pending \(1\)/i })
-        .click();
+        .getByRole("button", { name: /CI:\s*pending \(1\)/i });
+      await expect(pendingChip).toBeVisible();
+      await backgroundSync;
 
-      await expect.poll(() => syncRequests.length).toBeGreaterThan(0);
+      const successResponse = await page.request.post(
+        `${server.info.base_url}/__e2e/pr-ci-state/success`,
+      );
+      expect(successResponse.ok()).toBe(true);
+      await expect(successResponse.json()).resolves.toEqual({ status: "success" });
+
+      const syncRequest = page.waitForRequest((request) => {
+        const url = new URL(request.url());
+        return request.method() === "POST" &&
+          url.pathname === "/api/v1/pulls/github/acme/widgets/1/sync";
+      });
+      await pendingChip.click();
+
+      await syncRequest;
       await expect(
         page
           .locator(".pull-detail")

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -1,6 +1,66 @@
 import { expect, test } from "@playwright/test";
 
+type PRDetailResponseForTest = {
+  merge_request: {
+    CIStatus: string;
+    CIChecksJSON: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
 test.describe("CI dropdown", () => {
+  test("expanded pending CI checks trigger a detail sync refresh", async ({ page }) => {
+    let pendingDetail: PRDetailResponseForTest | null = null;
+    const pendingChecks = [
+      {
+        name: "build",
+        status: "in_progress",
+        conclusion: "",
+        url: "https://ci.example.com/build",
+        app: "GitHub Actions",
+      },
+    ];
+    await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
+      const response = await route.fetch();
+      pendingDetail = await response.json() as PRDetailResponseForTest;
+      pendingDetail!.merge_request.CIStatus = "pending";
+      pendingDetail!.merge_request.CIChecksJSON = JSON.stringify(pendingChecks);
+      await route.fulfill({ response, json: pendingDetail });
+    });
+
+    const syncRequests: string[] = [];
+    await page.route("**/api/v1/pulls/github/acme/widgets/1/sync", async (route) => {
+      syncRequests.push(route.request().method());
+      const syncedDetail = {
+        ...pendingDetail,
+        merge_request: {
+          ...pendingDetail!.merge_request,
+          CIStatus: "success",
+          CIChecksJSON: JSON.stringify([
+            {
+              ...pendingChecks[0],
+              status: "completed",
+              conclusion: "success",
+            },
+          ]),
+        },
+      };
+      await route.fulfill({ status: 200, json: syncedDetail });
+    });
+
+    await page.goto("/pulls/github/acme/widgets/1");
+
+    await page
+      .locator(".pull-detail")
+      .getByRole("button", { name: /CI:\s*pending \(1\)/i })
+      .click();
+
+    await expect.poll(() => syncRequests.length, {
+      timeout: 17_000,
+    }).toBeGreaterThan(0);
+  });
+
   test("detail chips use the shared centered chip layout", async ({ page }) => {
     await page.goto("/pulls/github/acme/widgets/1");
 

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -119,6 +119,24 @@ test.describe("detail action buttons", () => {
     }
   });
 
+  test("PR detail shows approve workflows after real pending workflow sync", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const seedResponse = await page.request.post(
+        `${server.info.base_url}/__e2e/pr-workflow-approval/required`,
+      );
+      expect(seedResponse.ok()).toBe(true);
+
+      await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
+
+      await expect(
+        page.getByRole("button", { name: "Approve workflows" }),
+      ).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("issue workspace button still creates a middleman workspace after detail sync refresh", async ({ page }) => {
     const createdWorkspace = {
       id: "ws-issue-10",

--- a/frontend/tests/e2e-full/provider-capabilities.spec.ts
+++ b/frontend/tests/e2e-full/provider-capabilities.spec.ts
@@ -2,13 +2,6 @@ import { expect, test } from "@playwright/test";
 
 test.describe("provider capabilities", () => {
   test("PR detail shows locked state only for providers that support it", async ({ page }) => {
-    await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
-      const response = await route.fetch();
-      const body = await response.json();
-      body.merge_request.IsLocked = true;
-      await route.fulfill({ response, json: body });
-    });
-
     await page.goto(
       "/pulls/github/acme/widgets/1",
     );

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1551,6 +1551,9 @@ type ClientInterface interface {
 	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows request
 	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh request
+	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostPrCommentOnHostWithBody request with any body
 	PostPrCommentOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1713,6 +1716,9 @@ type ClientInterface interface {
 
 	// PostPullsByProviderByOwnerByNameByNumberApproveWorkflows request
 	PostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostPullsByProviderByOwnerByNameByNumberCiRefresh request
+	PostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostPrCommentWithBody request with any body
 	PostPrCommentWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2174,6 +2180,18 @@ func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberAppro
 
 func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(c.Server, platformHost, provider, owner, name, number)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2894,6 +2912,18 @@ func (c *Client) PostPullsByProviderByOwnerByNameByNumberApprove(ctx context.Con
 
 func (c *Client) PostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(c.Server, provider, owner, name, number)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -4744,6 +4774,68 @@ func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflo
 	}
 
 	operationPath := fmt.Sprintf("/host/%s/pulls/%s/%s/%s/%s/approve-workflows", pathParam0, pathParam1, pathParam2, pathParam3, pathParam4)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshRequest generates requests for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh
+func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam4 string
+
+	pathParam4, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/pulls/%s/%s/%s/%s/ci-refresh", pathParam0, pathParam1, pathParam2, pathParam3, pathParam4)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -7684,6 +7776,61 @@ func NewPostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(server s
 	return req, nil
 }
 
+// NewPostPullsByProviderByOwnerByNameByNumberCiRefreshRequest generates requests for PostPullsByProviderByOwnerByNameByNumberCiRefresh
+func NewPostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/pulls/%s/%s/%s/%s/ci-refresh", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewPostPrCommentRequest calls the generic PostPrComment builder with application/json body
 func NewPostPrCommentRequest(server string, provider string, owner string, name string, number int64, body PostPrCommentJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -10201,6 +10348,9 @@ type ClientWithResponsesInterface interface {
 	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse request
 	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error)
 
+	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request
+	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error)
+
 	// PostPrCommentOnHostWithBodyWithResponse request with any body
 	PostPrCommentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentOnHostResponse, error)
 
@@ -10363,6 +10513,9 @@ type ClientWithResponsesInterface interface {
 
 	// PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse request
 	PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error)
+
+	// PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request
+	PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error)
 
 	// PostPrCommentWithBodyWithResponse request with any body
 	PostPrCommentWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
@@ -10872,6 +11025,29 @@ func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflo
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *MergeRequestDetailResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11857,6 +12033,29 @@ func (r PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) Status
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *MergeRequestDetailResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13143,6 +13342,15 @@ func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByName
 	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp)
 }
 
+// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request returning *PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse
+func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
+	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx, platformHost, provider, owner, name, number, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp)
+}
+
 // PostPrCommentOnHostWithBodyWithResponse request with arbitrary body returning *PostPrCommentOnHostResponse
 func (c *ClientWithResponses) PostPrCommentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentOnHostResponse, error) {
 	rsp, err := c.PostPrCommentOnHostWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
@@ -13664,6 +13872,15 @@ func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberApproveWor
 		return nil, err
 	}
 	return ParsePostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp)
+}
+
+// PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request returning *PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse
+func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
+	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx, provider, owner, name, number, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp)
 }
 
 // PostPrCommentWithBodyWithResponse request with arbitrary body returning *PostPrCommentResponse
@@ -14672,6 +14889,39 @@ func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkf
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ActionStatusBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse parses an HTTP response from a PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse call
+func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp *http.Response) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest MergeRequestDetailResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16063,6 +16313,39 @@ func ParsePostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp *
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ActionStatusBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostPullsByProviderByOwnerByNameByNumberCiRefreshResponse parses an HTTP response from a PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse call
+func ParsePostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp *http.Response) (*PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest MergeRequestDetailResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2684,12 +2684,13 @@ func (d *DB) UpdateMRCIStatusForHead(
 	headSHA string,
 	ciStatus string,
 	ciChecksJSON string,
+	ciHadPending bool,
 ) error {
 	_, err := d.rw.ExecContext(ctx, `
 		UPDATE middleman_merge_requests
-		SET ci_status = ?, ci_checks_json = ?
+		SET ci_status = ?, ci_checks_json = ?, ci_had_pending = ?
 		WHERE repo_id = ? AND number = ? AND platform_head_sha = ?`,
-		ciStatus, ciChecksJSON,
+		ciStatus, ciChecksJSON, ciHadPending,
 		repoID, number, headSHA,
 	)
 	if err != nil {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2675,6 +2675,29 @@ func (d *DB) UpdateMRCIStatus(
 	return nil
 }
 
+// UpdateMRCIStatusForHead writes CI status and check runs JSON only when the
+// merge request still points at the head SHA that was refreshed.
+func (d *DB) UpdateMRCIStatusForHead(
+	ctx context.Context,
+	repoID int64,
+	number int,
+	headSHA string,
+	ciStatus string,
+	ciChecksJSON string,
+) error {
+	_, err := d.rw.ExecContext(ctx, `
+		UPDATE middleman_merge_requests
+		SET ci_status = ?, ci_checks_json = ?
+		WHERE repo_id = ? AND number = ? AND platform_head_sha = ?`,
+		ciStatus, ciChecksJSON,
+		repoID, number, headSHA,
+	)
+	if err != nil {
+		return fmt.Errorf("update mr ci status for head: %w", err)
+	}
+	return nil
+}
+
 // ClearMRCI resets ci_status, ci_checks_json, and ci_had_pending for a
 // merge request. UpsertMergeRequest preserves ci_had_pending across
 // upserts, so callers that observe a head SHA change need this to drop

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2688,7 +2688,7 @@ func (d *DB) UpdateMRCIStatusForHead(
 ) error {
 	_, err := d.rw.ExecContext(ctx, `
 		UPDATE middleman_merge_requests
-		SET ci_status = ?, ci_checks_json = ?, ci_had_pending = ?
+		SET ci_status = ?, ci_checks_json = ?, ci_had_pending = ci_had_pending OR ?
 		WHERE repo_id = ? AND number = ? AND platform_head_sha = ?`,
 		ciStatus, ciChecksJSON, ciHadPending,
 		repoID, number, headSHA,

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2773,6 +2773,41 @@ func TestGetDiffSHAsByRepoIDScopesDuplicateProviderRepos(t *testing.T) {
 	assert.Equal("github-diff-head", githubSHAs.DiffHeadSHA)
 }
 
+func TestUpdateMRCIStatusForHeadSkipsStaleHead(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "o", "r")
+	now := baseTime()
+	_, err := d.UpsertMergeRequest(ctx, &MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1001,
+		Number:          7,
+		Title:           "ci guarded",
+		State:           "open",
+		PlatformHeadSHA: "new-head",
+		CIStatus:        "pending",
+		CIChecksJSON:    `[{"name":"old","status":"in_progress"}]`,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	require.NoError(d.UpdateMRCIStatusForHead(ctx, repoID, 7, "old-head", "success", `[]`))
+	stale, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(stale)
+	assert.Equal("pending", stale.CIStatus)
+
+	require.NoError(d.UpdateMRCIStatusForHead(ctx, repoID, 7, "new-head", "success", `[]`))
+	fresh, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(fresh)
+	assert.Equal("success", fresh.CIStatus)
+}
+
 func TestGetPreviouslyOpenPRNumbers(t *testing.T) {
 	d := openTestDB(t)
 

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2795,17 +2795,18 @@ func TestUpdateMRCIStatusForHeadSkipsStaleHead(t *testing.T) {
 	})
 	require.NoError(err)
 
-	require.NoError(d.UpdateMRCIStatusForHead(ctx, repoID, 7, "old-head", "success", `[]`))
+	require.NoError(d.UpdateMRCIStatusForHead(ctx, repoID, 7, "old-head", "success", `[]`, false))
 	stale, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
 	require.NotNil(stale)
 	assert.Equal("pending", stale.CIStatus)
 
-	require.NoError(d.UpdateMRCIStatusForHead(ctx, repoID, 7, "new-head", "success", `[]`))
+	require.NoError(d.UpdateMRCIStatusForHead(ctx, repoID, 7, "new-head", "pending", `[{"name":"build","status":"in_progress"}]`, true))
 	fresh, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
 	require.NotNil(fresh)
-	assert.Equal("success", fresh.CIStatus)
+	assert.Equal("pending", fresh.CIStatus)
+	assert.True(fresh.CIHadPending)
 }
 
 func TestGetPreviouslyOpenPRNumbers(t *testing.T) {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2807,6 +2807,13 @@ func TestUpdateMRCIStatusForHeadSkipsStaleHead(t *testing.T) {
 	require.NotNil(fresh)
 	assert.Equal("pending", fresh.CIStatus)
 	assert.True(fresh.CIHadPending)
+
+	require.NoError(d.UpdateMRCIStatusForHead(ctx, repoID, 7, "new-head", "success", `[]`, false))
+	done, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(done)
+	assert.Equal("success", done.CIStatus)
+	assert.True(done.CIHadPending)
 }
 
 func TestGetPreviouslyOpenPRNumbers(t *testing.T) {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4190,37 +4190,45 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 	repoID int64,
 	number int,
 	headSHA string,
-) error {
+) ([]string, error) {
 	if headSHA == "" {
-		return nil
+		return nil, nil
 	}
 	if repoPlatform(repo) == platform.KindGitHub {
-		ciStatus, ciChecksJSON, ok, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
+		result, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		if !ok {
-			return nil
+		if result.Warning != "" {
+			return []string{result.Warning}, nil
 		}
-		return s.db.UpdateMRCIStatusForHead(
+		if !result.Updated {
+			return nil, nil
+		}
+		return nil, s.db.UpdateMRCIStatusForHead(
 			ctx, repoID, number, headSHA,
-			ciStatus, ciChecksJSON, ciHasPending(ciChecksJSON),
+			result.Status, result.ChecksJSON, ciHasPending(result.ChecksJSON),
 		)
 	}
 
 	ciReader, err := s.ciReaderFor(repo)
 	if err != nil {
 		if errors.Is(err, platform.ErrUnsupportedCapability) {
-			return nil
+			return nil, nil
 		}
-		return fmt.Errorf("resolve CI reader for %s/%s: %w", repo.Owner, repo.Name, err)
+		return nil, fmt.Errorf("resolve CI reader for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 	checks, err := ciReader.ListCIChecks(ctx, platformRepoRef(repo), headSHA)
 	if err != nil {
 		if errors.Is(err, platform.ErrUnsupportedCapability) {
-			return nil
+			return nil, nil
 		}
-		return fmt.Errorf("list CI checks for MR #%d: %w", number, err)
+		slog.Warn("list CI checks failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"number", number,
+			"err", err,
+		)
+		return []string{ciRefreshWarning}, nil
 	}
 	dbChecks := platform.DBCIChecks(checks)
 	if dbChecks == nil {
@@ -4232,9 +4240,9 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 		ctx, repoID, number, headSHA,
 		ciStatus, string(ciJSON), ciHasPending(string(ciJSON)),
 	); err != nil {
-		return fmt.Errorf("update CI status for MR #%d: %w", number, err)
+		return nil, fmt.Errorf("update CI status for MR #%d: %w", number, err)
 	}
-	return nil
+	return nil, nil
 }
 
 // refreshCIStatus fetches combined status and check runs for a PR's head SHA.
@@ -4249,14 +4257,23 @@ func (s *Syncer) refreshCIStatus(
 	number int,
 	headSHA string,
 ) error {
-	ciStatus, ciChecksJSON, ok, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
+	result, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
 	if err != nil {
 		return err
 	}
-	if !ok {
+	if !result.Updated {
 		return nil
 	}
-	return s.db.UpdateMRCIStatus(ctx, repoID, number, ciStatus, ciChecksJSON)
+	return s.db.UpdateMRCIStatus(ctx, repoID, number, result.Status, result.ChecksJSON)
+}
+
+const ciRefreshWarning = "Could not refresh CI checks; showing last known status."
+
+type ciStatusFetchResult struct {
+	Status     string
+	ChecksJSON string
+	Updated    bool
+	Warning    string
 }
 
 func (s *Syncer) fetchGitHubCIStatus(
@@ -4264,16 +4281,16 @@ func (s *Syncer) fetchGitHubCIStatus(
 	repo RepoRef,
 	number int,
 	headSHA string,
-) (string, string, bool, error) {
+) (ciStatusFetchResult, error) {
 	if headSHA == "" {
-		return "", "", false, nil
+		return ciStatusFetchResult{}, nil
 	}
 
 	// Fetch both sources. On failure, skip the DB write to preserve
 	// existing data rather than wiping it with empty values.
 	client, err := s.clientFor(repo)
 	if err != nil {
-		return "", "", false, fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
+		return ciStatusFetchResult{}, fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 	checkRuns, err := client.ListCheckRunsForRef(ctx, repo.Owner, repo.Name, headSHA)
 	if err != nil {
@@ -4282,7 +4299,7 @@ func (s *Syncer) fetchGitHubCIStatus(
 			"number", number,
 			"err", err,
 		)
-		return "", "", false, nil
+		return ciStatusFetchResult{Warning: ciRefreshWarning}, nil
 	}
 
 	combined, err := client.GetCombinedStatus(ctx, repo.Owner, repo.Name, headSHA)
@@ -4292,10 +4309,14 @@ func (s *Syncer) fetchGitHubCIStatus(
 			"number", number,
 			"err", err,
 		)
-		return "", "", false, nil
+		return ciStatusFetchResult{Warning: ciRefreshWarning}, nil
 	}
 
-	return DeriveOverallCIStatus(checkRuns, combined), NormalizeCIChecks(checkRuns, combined), true, nil
+	return ciStatusFetchResult{
+		Status:     DeriveOverallCIStatus(checkRuns, combined),
+		ChecksJSON: NormalizeCIChecks(checkRuns, combined),
+		Updated:    true,
+	}, nil
 }
 
 // ciHasPending parses the CI checks JSON and returns true if any

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4202,7 +4202,10 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 		if !ok {
 			return nil
 		}
-		return s.db.UpdateMRCIStatusForHead(ctx, repoID, number, headSHA, ciStatus, ciChecksJSON)
+		return s.db.UpdateMRCIStatusForHead(
+			ctx, repoID, number, headSHA,
+			ciStatus, ciChecksJSON, ciHasPending(ciChecksJSON),
+		)
 	}
 
 	ciReader, err := s.ciReaderFor(repo)
@@ -4225,7 +4228,10 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 	}
 	ciJSON, _ := json.Marshal(dbChecks)
 	ciStatus := deriveCIStatusFromChecks(dbChecks)
-	if err := s.db.UpdateMRCIStatusForHead(ctx, repoID, number, headSHA, ciStatus, string(ciJSON)); err != nil {
+	if err := s.db.UpdateMRCIStatusForHead(
+		ctx, repoID, number, headSHA,
+		ciStatus, string(ciJSON), ciHasPending(string(ciJSON)),
+	); err != nil {
 		return fmt.Errorf("update CI status for MR #%d: %w", number, err)
 	}
 	return nil

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4195,9 +4195,12 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 		return nil
 	}
 	if repoPlatform(repo) == platform.KindGitHub {
-		ciStatus, ciChecksJSON, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
+		ciStatus, ciChecksJSON, ok, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
 		if err != nil {
 			return err
+		}
+		if !ok {
+			return nil
 		}
 		return s.db.UpdateMRCIStatusForHead(ctx, repoID, number, headSHA, ciStatus, ciChecksJSON)
 	}
@@ -4240,9 +4243,12 @@ func (s *Syncer) refreshCIStatus(
 	number int,
 	headSHA string,
 ) error {
-	ciStatus, ciChecksJSON, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
+	ciStatus, ciChecksJSON, ok, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
 	if err != nil {
 		return err
+	}
+	if !ok {
+		return nil
 	}
 	return s.db.UpdateMRCIStatus(ctx, repoID, number, ciStatus, ciChecksJSON)
 }
@@ -4252,16 +4258,16 @@ func (s *Syncer) fetchGitHubCIStatus(
 	repo RepoRef,
 	number int,
 	headSHA string,
-) (string, string, error) {
+) (string, string, bool, error) {
 	if headSHA == "" {
-		return "", "", nil
+		return "", "", false, nil
 	}
 
 	// Fetch both sources. On failure, skip the DB write to preserve
 	// existing data rather than wiping it with empty values.
 	client, err := s.clientFor(repo)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
+		return "", "", false, fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 	checkRuns, err := client.ListCheckRunsForRef(ctx, repo.Owner, repo.Name, headSHA)
 	if err != nil {
@@ -4270,7 +4276,7 @@ func (s *Syncer) fetchGitHubCIStatus(
 			"number", number,
 			"err", err,
 		)
-		return "", "", nil
+		return "", "", false, nil
 	}
 
 	combined, err := client.GetCombinedStatus(ctx, repo.Owner, repo.Name, headSHA)
@@ -4280,10 +4286,10 @@ func (s *Syncer) fetchGitHubCIStatus(
 			"number", number,
 			"err", err,
 		)
-		return "", "", nil
+		return "", "", false, nil
 	}
 
-	return DeriveOverallCIStatus(checkRuns, combined), NormalizeCIChecks(checkRuns, combined), nil
+	return DeriveOverallCIStatus(checkRuns, combined), NormalizeCIChecks(checkRuns, combined), true, nil
 }
 
 // ciHasPending parses the CI checks JSON and returns true if any

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4195,7 +4195,11 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 		return nil
 	}
 	if repoPlatform(repo) == platform.KindGitHub {
-		return s.refreshCIStatus(ctx, repo, repoID, number, headSHA)
+		ciStatus, ciChecksJSON, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
+		if err != nil {
+			return err
+		}
+		return s.db.UpdateMRCIStatusForHead(ctx, repoID, number, headSHA, ciStatus, ciChecksJSON)
 	}
 
 	ciReader, err := s.ciReaderFor(repo)
@@ -4218,7 +4222,7 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 	}
 	ciJSON, _ := json.Marshal(dbChecks)
 	ciStatus := deriveCIStatusFromChecks(dbChecks)
-	if err := s.db.UpdateMRCIStatus(ctx, repoID, number, ciStatus, string(ciJSON)); err != nil {
+	if err := s.db.UpdateMRCIStatusForHead(ctx, repoID, number, headSHA, ciStatus, string(ciJSON)); err != nil {
 		return fmt.Errorf("update CI status for MR #%d: %w", number, err)
 	}
 	return nil
@@ -4236,15 +4240,28 @@ func (s *Syncer) refreshCIStatus(
 	number int,
 	headSHA string,
 ) error {
+	ciStatus, ciChecksJSON, err := s.fetchGitHubCIStatus(ctx, repo, number, headSHA)
+	if err != nil {
+		return err
+	}
+	return s.db.UpdateMRCIStatus(ctx, repoID, number, ciStatus, ciChecksJSON)
+}
+
+func (s *Syncer) fetchGitHubCIStatus(
+	ctx context.Context,
+	repo RepoRef,
+	number int,
+	headSHA string,
+) (string, string, error) {
 	if headSHA == "" {
-		return nil
+		return "", "", nil
 	}
 
 	// Fetch both sources. On failure, skip the DB write to preserve
 	// existing data rather than wiping it with empty values.
 	client, err := s.clientFor(repo)
 	if err != nil {
-		return fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
+		return "", "", fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 	checkRuns, err := client.ListCheckRunsForRef(ctx, repo.Owner, repo.Name, headSHA)
 	if err != nil {
@@ -4253,7 +4270,7 @@ func (s *Syncer) refreshCIStatus(
 			"number", number,
 			"err", err,
 		)
-		return nil
+		return "", "", nil
 	}
 
 	combined, err := client.GetCombinedStatus(ctx, repo.Owner, repo.Name, headSHA)
@@ -4263,13 +4280,10 @@ func (s *Syncer) refreshCIStatus(
 			"number", number,
 			"err", err,
 		)
-		return nil
+		return "", "", nil
 	}
 
-	ciStatus := DeriveOverallCIStatus(checkRuns, combined)
-	ciChecksJSON := NormalizeCIChecks(checkRuns, combined)
-
-	return s.db.UpdateMRCIStatus(ctx, repoID, number, ciStatus, ciChecksJSON)
+	return DeriveOverallCIStatus(checkRuns, combined), NormalizeCIChecks(checkRuns, combined), nil
 }
 
 // ciHasPending parses the CI checks JSON and returns true if any

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4181,6 +4181,49 @@ func (s *Syncer) refreshTimeline(
 	})
 }
 
+// RefreshMRCIStatusOnProvider fetches only CI checks for a PR's head SHA and
+// persists the derived CI fields. It intentionally skips the heavier PR detail
+// sync path (timeline, diff, review, and body refreshes).
+func (s *Syncer) RefreshMRCIStatusOnProvider(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	number int,
+	headSHA string,
+) error {
+	if headSHA == "" {
+		return nil
+	}
+	if repoPlatform(repo) == platform.KindGitHub {
+		return s.refreshCIStatus(ctx, repo, repoID, number, headSHA)
+	}
+
+	ciReader, err := s.ciReaderFor(repo)
+	if err != nil {
+		if errors.Is(err, platform.ErrUnsupportedCapability) {
+			return nil
+		}
+		return fmt.Errorf("resolve CI reader for %s/%s: %w", repo.Owner, repo.Name, err)
+	}
+	checks, err := ciReader.ListCIChecks(ctx, platformRepoRef(repo), headSHA)
+	if err != nil {
+		if errors.Is(err, platform.ErrUnsupportedCapability) {
+			return nil
+		}
+		return fmt.Errorf("list CI checks for MR #%d: %w", number, err)
+	}
+	dbChecks := platform.DBCIChecks(checks)
+	if dbChecks == nil {
+		dbChecks = []db.CICheck{}
+	}
+	ciJSON, _ := json.Marshal(dbChecks)
+	ciStatus := deriveCIStatusFromChecks(dbChecks)
+	if err := s.db.UpdateMRCIStatus(ctx, repoID, number, ciStatus, string(ciJSON)); err != nil {
+		return fmt.Errorf("update CI status for MR #%d: %w", number, err)
+	}
+	return nil
+}
+
 // refreshCIStatus fetches combined status and check runs for a PR's head SHA.
 // Called on every sync cycle for open PRs, since check runs change independently
 // of the PR's updated_at field. Takes headSHA and number directly so it can be

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -88,7 +88,9 @@ type mockClient struct {
 	forcePushEvents                 []ForcePushEvent
 	forcePushEventsErr              error
 	ciStatus                        *gh.CombinedStatus
+	ciStatusErr                     error
 	checkRuns                       []*gh.CheckRun
+	checkRunsErr                    error
 	workflowRuns                    []*gh.WorkflowRun
 	approveWorkflowRunFn            func(context.Context, string, string, int64) error
 	listOpenPRsCalled               bool
@@ -459,11 +461,17 @@ func (m *mockClient) ListForcePushEvents(_ context.Context, _, _ string, _ int) 
 func (m *mockClient) GetCombinedStatus(_ context.Context, _, _, _ string) (*gh.CombinedStatus, error) {
 	m.trackCall()
 	m.getCombinedCalls.Add(1)
+	if m.ciStatusErr != nil {
+		return nil, m.ciStatusErr
+	}
 	return m.ciStatus, nil
 }
 
 func (m *mockClient) ListCheckRunsForRef(_ context.Context, _, _, _ string) ([]*gh.CheckRun, error) {
 	m.trackCall()
+	if m.checkRunsErr != nil {
+		return nil, m.checkRunsErr
+	}
 	return m.checkRuns, nil
 }
 
@@ -4437,6 +4445,54 @@ func TestRefreshCIStatusAlwaysFetchesCombined(t *testing.T) {
 	// (legacy commit statuses exist alongside check runs).
 	assert.Equal(int32(1), mock.getCombinedCalls.Load(),
 		"GetCombinedStatus should always be called")
+}
+
+func TestRefreshCIStatusPreservesExistingStatusWhenChecksFail(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	now := time.Now().UTC()
+	_, err = d.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1001,
+		Number:          1,
+		Title:           "pending",
+		State:           "open",
+		PlatformHeadSHA: "abc123",
+		CIStatus:        "pending",
+		CIChecksJSON:    `[{"name":"build","status":"in_progress"}]`,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	mock := &mockClient{checkRunsErr: errors.New("temporary provider failure")}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock},
+		d, nil,
+		[]RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	err = syncer.refreshCIStatus(
+		t.Context(),
+		RepoRef{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+		repoID,
+		1,
+		"abc123",
+	)
+	require.NoError(err)
+
+	mr, err := d.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 1)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal("pending", mr.CIStatus)
+	assert.Contains(mr.CIChecksJSON, "in_progress")
 }
 
 func TestRefreshCIStatusFallsBackToCombinedWhenNoCheckRuns(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -439,6 +439,7 @@ type apiTestGitLabProvider struct {
 	releases           []platform.Release
 	tags               []platform.Tag
 	ciChecks           map[string][]platform.CICheck
+	ciErr              error
 }
 
 func (p *apiTestGitLabProvider) Platform() platform.Kind {
@@ -561,6 +562,9 @@ func (p *apiTestGitLabProvider) ListCIChecks(
 	_ platform.RepoRef,
 	sha string,
 ) ([]platform.CICheck, error) {
+	if p.ciErr != nil {
+		return nil, p.ciErr
+	}
 	return p.ciChecks[sha], nil
 }
 
@@ -2679,6 +2683,94 @@ func TestGitLabSyncCoversRepositoryItemsEventsOverviewAndCI(t *testing.T) {
 	assert.Equal(
 		"https://gitlab.example.com:8443/Group/SubGroup/Project.Special/-/releases/v1.2.0",
 		summary.LatestRelease.Url,
+	)
+}
+
+func TestAPICIRefreshWarnsAndPreservesCIWhenProviderFails(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	database := dbtest.Open(t)
+
+	ref := platform.RepoRef{
+		Platform:      platform.KindGitLab,
+		Host:          "gitlab.example.com",
+		Owner:         "group",
+		Name:          "project",
+		RepoPath:      "group/project",
+		DefaultBranch: "main",
+	}
+	provider := &apiTestGitLabProvider{
+		ref:   ref,
+		ciErr: errors.New("gitlab pipeline API unavailable"),
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	repoID, err := database.UpsertRepo(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Keep stale CI visible",
+		Author:          "ada",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		CIStatus:        "pending",
+		CIChecksJSON:    `[{"name":"pipeline","status":"in_progress","conclusion":""}]`,
+		CIHadPending:    true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindGitLab,
+			PlatformHost: ref.Host,
+			Owner:        ref.Owner,
+			Name:         ref.Name,
+			RepoPath:     ref.RepoPath,
+		}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON200)
+	assert.Equal("pending", resp.JSON200.MergeRequest.CIStatus)
+	assert.JSONEq(
+		`[{"name":"pipeline","status":"in_progress","conclusion":""}]`,
+		resp.JSON200.MergeRequest.CIChecksJSON,
+	)
+	require.NotNil(resp.JSON200.Warnings)
+	require.Len(*resp.JSON200.Warnings, 1)
+	assert.Contains((*resp.JSON200.Warnings)[0], "Could not refresh CI checks")
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("pending", stored.CIStatus)
+	assert.JSONEq(
+		`[{"name":"pipeline","status":"in_progress","conclusion":""}]`,
+		stored.CIChecksJSON,
 	)
 }
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -281,6 +281,8 @@ type acceptedOutput = acceptedStatusOutput
 
 type syncPROutput = bodyOutput[mergeRequestDetailResponse]
 
+type syncPRCIOutput = bodyOutput[mergeRequestDetailResponse]
+
 type syncIssueOutput = bodyOutput[issueDetailResponse]
 
 type resolveItemOutput = bodyOutput[resolveItemResponse]
@@ -617,6 +619,8 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 	huma.Post(api, hostPullPath+"/merge", s.mergePROnHost)
 	huma.Post(api, pullPath+"/sync", s.syncPR)
 	huma.Post(api, hostPullPath+"/sync", s.syncPROnHost)
+	huma.Post(api, pullPath+"/ci-refresh", s.syncPRCI)
+	huma.Post(api, hostPullPath+"/ci-refresh", s.syncPRCIOnHost)
 	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync", Method: http.MethodPost, Path: pullPath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueuePRSync)
 	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync-on-host", Method: http.MethodPost, Path: hostPullPath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueuePRSyncOnHost)
 	huma.Post(api, issuePath+"/sync", s.syncIssue)
@@ -2248,6 +2252,55 @@ func (s *Server) getRateLimits(
 	return &rateLimitsOutput{
 		Body: rateLimitsResponse{Hosts: hosts},
 	}, nil
+}
+
+func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRCIOutput, error) {
+	repo, err := s.lookupRepoByProviderRoute(
+		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
+	)
+	if err != nil {
+		return nil, providerRouteLookupError(err)
+	}
+
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("get pull request: " + err.Error())
+	}
+	if mr == nil {
+		return nil, huma.Error404NotFound("pull request not found")
+	}
+	if err := s.syncer.RefreshMRCIStatusOnProvider(
+		ctx,
+		ghclient.RepoRef{
+			Platform:           repoProviderKind(*repo),
+			Owner:              repo.Owner,
+			Name:               repo.Name,
+			PlatformHost:       repoProviderHost(*repo),
+			RepoPath:           repo.RepoPath,
+			PlatformExternalID: repo.PlatformRepoID,
+			WebURL:             repo.WebURL,
+			CloneURL:           repo.CloneURL,
+			DefaultBranch:      repo.DefaultBranch,
+		},
+		repo.ID,
+		input.Number,
+		mr.PlatformHeadSHA,
+	); err != nil {
+		return nil, huma.Error502BadGateway("refresh PR CI: " + err.Error())
+	}
+
+	mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("get pull request: " + err.Error())
+	}
+	if mr == nil {
+		return nil, huma.Error404NotFound("pull request not found after CI refresh")
+	}
+	body, err := s.buildPullDetailResponse(ctx, mr, workflowDBOnly)
+	if err != nil {
+		return nil, err
+	}
+	return &syncPRCIOutput{Body: body}, nil
 }
 
 func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROutput, error) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2269,7 +2269,7 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 	if mr == nil {
 		return nil, huma.Error404NotFound("pull request not found")
 	}
-	if err := s.syncer.RefreshMRCIStatusOnProvider(
+	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
 		ghclient.RepoRef{
 			Platform:           repoProviderKind(*repo),
@@ -2285,7 +2285,8 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 		repo.ID,
 		input.Number,
 		mr.PlatformHeadSHA,
-	); err != nil {
+	)
+	if err != nil {
 		return nil, huma.Error502BadGateway("refresh PR CI: " + err.Error())
 	}
 
@@ -2300,6 +2301,7 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 	if err != nil {
 		return nil, err
 	}
+	body.Warnings = append(body.Warnings, warnings...)
 	return &syncPRCIOutput{Body: body}, nil
 }
 

--- a/internal/server/provider_route_wrappers.go
+++ b/internal/server/provider_route_wrappers.go
@@ -433,6 +433,11 @@ func (s *Server) syncPROnHost(ctx context.Context, input *repoNumberHostInput) (
 	return s.syncPR(ctx, &next)
 }
 
+func (s *Server) syncPRCIOnHost(ctx context.Context, input *repoNumberHostInput) (*syncPRCIOutput, error) {
+	next := repoNumberFromHost(input)
+	return s.syncPRCI(ctx, &next)
+}
+
 func (s *Server) enqueuePRSyncOnHost(ctx context.Context, input *repoNumberHostInput) (*acceptedOutput, error) {
 	next := repoNumberFromHost(input)
 	return s.enqueuePRSync(ctx, &next)

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -85,7 +86,7 @@ func (c *FixtureClient) ListOpenPullRequests(
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return slices.Clone(c.OpenPRs[repoKey(owner, repo)]), nil
+	return clonePullRequests(c.OpenPRs[repoKey(owner, repo)]), nil
 }
 
 // ListOpenIssues returns the seeded open issues for the given repo.
@@ -179,7 +180,7 @@ func (c *FixtureClient) GetPullRequest(
 
 	for _, pr := range c.PRs[repoKey(owner, repo)] {
 		if pr.GetNumber() == number {
-			return pr, nil
+			return clonePullRequest(pr), nil
 		}
 	}
 	return nil, nil
@@ -474,27 +475,35 @@ func (c *FixtureClient) UpdatePullRequestSHAs(
 
 	repoKey := repoKey(owner, repo)
 	oldHeadSHA := ""
-	patch := func(prs []*gh.PullRequest) {
-		for _, pr := range prs {
+	patch := func(prs []*gh.PullRequest) []*gh.PullRequest {
+		patched := slices.Clone(prs)
+		for i, pr := range patched {
 			if pr.GetNumber() != number {
 				continue
 			}
-			if pr.Head == nil {
-				pr.Head = &gh.PullRequestBranch{}
+			copyPR := clonePullRequest(pr)
+			if copyPR.Head == nil {
+				copyPR.Head = &gh.PullRequestBranch{}
 			}
-			if pr.Base == nil {
-				pr.Base = &gh.PullRequestBranch{}
+			if copyPR.Base == nil {
+				copyPR.Base = &gh.PullRequestBranch{}
 			}
 			if oldHeadSHA == "" {
-				oldHeadSHA = pr.Head.GetSHA()
+				oldHeadSHA = copyPR.Head.GetSHA()
 			}
-			pr.Head.SHA = &headSHA
-			pr.Base.SHA = &baseSHA
+			copyPR.Head.SHA = &headSHA
+			copyPR.Base.SHA = &baseSHA
+			patched[i] = copyPR
 		}
+		return patched
 	}
 
-	patch(c.OpenPRs[repoKey])
-	patch(c.PRs[repoKey])
+	if c.OpenPRs != nil {
+		c.OpenPRs[repoKey] = patch(c.OpenPRs[repoKey])
+	}
+	if c.PRs != nil {
+		c.PRs[repoKey] = patch(c.PRs[repoKey])
+	}
 
 	if oldHeadSHA == "" || oldHeadSHA == headSHA {
 		return
@@ -509,17 +518,47 @@ func (c *FixtureClient) UpdatePullRequestSHAs(
 	}
 }
 
+func clonePullRequests(prs []*gh.PullRequest) []*gh.PullRequest {
+	cloned := make([]*gh.PullRequest, 0, len(prs))
+	for _, pr := range prs {
+		cloned = append(cloned, clonePullRequest(pr))
+	}
+	return cloned
+}
+
+func clonePullRequest(pr *gh.PullRequest) *gh.PullRequest {
+	return cloneFixtureValue(pr)
+}
+
 func cloneCheckRuns(runs []*gh.CheckRun) []*gh.CheckRun {
 	cloned := make([]*gh.CheckRun, 0, len(runs))
 	for _, run := range runs {
-		if run == nil {
-			cloned = append(cloned, nil)
-			continue
-		}
-		copyRun := *run
-		cloned = append(cloned, &copyRun)
+		cloned = append(cloned, cloneFixtureValue(run))
 	}
 	return cloned
+}
+
+func cloneWorkflowRuns(runs []*gh.WorkflowRun) []*gh.WorkflowRun {
+	cloned := make([]*gh.WorkflowRun, 0, len(runs))
+	for _, run := range runs {
+		cloned = append(cloned, cloneFixtureValue(run))
+	}
+	return cloned
+}
+
+func cloneFixtureValue[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	content, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	var cloned T
+	if err := json.Unmarshal(content, &cloned); err != nil {
+		return nil
+	}
+	return &cloned
 }
 
 // ListWorkflowRunsForHeadSHA returns seeded action-required workflow runs.
@@ -533,7 +572,7 @@ func (c *FixtureClient) ListWorkflowRunsForHeadSHA(
 	if len(runs) == 0 {
 		return nil, nil
 	}
-	return slices.Clone(runs), nil
+	return cloneWorkflowRuns(runs), nil
 }
 
 // SetWorkflowRuns seeds action-required workflow runs for a repo/head SHA.
@@ -544,7 +583,7 @@ func (c *FixtureClient) SetWorkflowRuns(owner, repo, headSHA string, runs []*gh.
 	if c.WorkflowRuns == nil {
 		c.WorkflowRuns = make(map[string][]*gh.WorkflowRun)
 	}
-	c.WorkflowRuns[refKey(owner, repo, headSHA)] = slices.Clone(runs)
+	c.WorkflowRuns[refKey(owner, repo, headSHA)] = cloneWorkflowRuns(runs)
 }
 
 // ApproveWorkflowRun returns an error (mutations not supported).
@@ -624,7 +663,7 @@ func (c *FixtureClient) MarkPullRequestReadyForReview(
 			),
 		}
 	}
-	return pr, nil
+	return clonePullRequest(pr), nil
 }
 
 // MergePullRequest returns an error (mutations not supported).
@@ -690,7 +729,7 @@ func (c *FixtureClient) EditPullRequest(
 			}
 		}
 	}
-	return updated, nil
+	return clonePullRequest(updated), nil
 }
 
 // EditIssue updates the seeded issue state for E2E mutations.

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -40,6 +40,7 @@ type FixtureClient struct {
 	CombinedStatuses          map[string]*gh.CombinedStatus
 	CheckRuns                 map[string][]*gh.CheckRun
 	Labels                    map[string][]*gh.Label
+	WorkflowRuns              map[string][]*gh.WorkflowRun
 	ListRepositoriesByOwnerFn func(context.Context, string) ([]*gh.Repository, error)
 	mu                        sync.Mutex
 	nextID                    int64
@@ -60,6 +61,7 @@ func NewFixtureClient() ghclient.Client {
 		CombinedStatuses: make(map[string]*gh.CombinedStatus),
 		CheckRuns:        make(map[string][]*gh.CheckRun),
 		Labels:           make(map[string][]*gh.Label),
+		WorkflowRuns:     make(map[string][]*gh.WorkflowRun),
 		nextID:           10_000,
 	}
 }
@@ -379,11 +381,15 @@ func (c *FixtureClient) ListCheckRunsForRef(
 	return slices.Clone(runs), nil
 }
 
-// ListWorkflowRunsForHeadSHA returns nil (read-only stub).
+// ListWorkflowRunsForHeadSHA returns seeded action-required workflow runs.
 func (c *FixtureClient) ListWorkflowRunsForHeadSHA(
-	_ context.Context, _, _, _ string,
+	_ context.Context, owner, repo, headSHA string,
 ) ([]*gh.WorkflowRun, error) {
-	return nil, nil
+	runs := c.WorkflowRuns[refKey(owner, repo, headSHA)]
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	return slices.Clone(runs), nil
 }
 
 // ApproveWorkflowRun returns an error (mutations not supported).

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -42,7 +42,7 @@ type FixtureClient struct {
 	Labels                    map[string][]*gh.Label
 	WorkflowRuns              map[string][]*gh.WorkflowRun
 	ListRepositoriesByOwnerFn func(context.Context, string) ([]*gh.Repository, error)
-	mu                        sync.Mutex
+	mu                        sync.RWMutex
 	nextID                    int64
 }
 
@@ -82,14 +82,20 @@ func refKey(owner, repo, ref string) string {
 func (c *FixtureClient) ListOpenPullRequests(
 	_ context.Context, owner, repo string,
 ) ([]*gh.PullRequest, error) {
-	return c.OpenPRs[repoKey(owner, repo)], nil
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return slices.Clone(c.OpenPRs[repoKey(owner, repo)]), nil
 }
 
 // ListOpenIssues returns the seeded open issues for the given repo.
 func (c *FixtureClient) ListOpenIssues(
 	_ context.Context, owner, repo string,
 ) ([]*gh.Issue, error) {
-	return c.OpenIssues[repoKey(owner, repo)], nil
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return slices.Clone(c.OpenIssues[repoKey(owner, repo)]), nil
 }
 
 // GetUser returns a stub user with the given login.
@@ -103,6 +109,9 @@ func (c *FixtureClient) ListRepositoriesByOwner(
 	if c.ListRepositoriesByOwnerFn != nil {
 		return c.ListRepositoriesByOwnerFn(ctx, owner)
 	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	repos := c.ReposByOwner[owner]
 	if len(repos) == 0 {
 		return nil, nil
@@ -113,6 +122,9 @@ func (c *FixtureClient) ListRepositoriesByOwner(
 func (c *FixtureClient) ListReleases(
 	_ context.Context, owner, repo string, perPage int,
 ) ([]*gh.RepositoryRelease, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	releases := c.Releases[repoKey(owner, repo)]
 	if len(releases) == 0 {
 		return nil, nil
@@ -126,6 +138,9 @@ func (c *FixtureClient) ListReleases(
 func (c *FixtureClient) ListTags(
 	_ context.Context, owner, repo string, perPage int,
 ) ([]*gh.RepositoryTag, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	tags := c.Tags[repoKey(owner, repo)]
 	if len(tags) == 0 {
 		return nil, nil
@@ -159,6 +174,9 @@ func (c *FixtureClient) GetRepository(
 func (c *FixtureClient) GetPullRequest(
 	_ context.Context, owner, repo string, number int,
 ) (*gh.PullRequest, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	for _, pr := range c.PRs[repoKey(owner, repo)] {
 		if pr.GetNumber() == number {
 			return pr, nil
@@ -199,6 +217,9 @@ func (c *FixtureClient) updatePullRequestDraft(owner, repo string, number int, d
 func (c *FixtureClient) GetIssue(
 	_ context.Context, owner, repo string, number int,
 ) (*gh.Issue, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	for _, iss := range c.Issues[repoKey(owner, repo)] {
 		if iss.GetNumber() == number {
 			return iss, nil
@@ -310,8 +331,8 @@ func (c *FixtureClient) CreateIssue(
 func (c *FixtureClient) ListIssueComments(
 	_ context.Context, owner, repo string, number int,
 ) ([]*gh.IssueComment, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	comments := c.Comments[issueKey(owner, repo, number)]
 	if len(comments) == 0 {
 		return nil, nil
@@ -322,7 +343,10 @@ func (c *FixtureClient) ListIssueComments(
 func (c *FixtureClient) ListIssueCommentsIfChanged(
 	ctx context.Context, owner, repo string, number int,
 ) ([]*gh.IssueComment, error) {
-	if len(c.Comments[issueKey(owner, repo, number)]) == 0 {
+	c.mu.RLock()
+	empty := len(c.Comments[issueKey(owner, repo, number)]) == 0
+	c.mu.RUnlock()
+	if empty {
 		return nil, &gh.ErrorResponse{
 			Response: &http.Response{StatusCode: http.StatusNotModified},
 		}
@@ -333,8 +357,8 @@ func (c *FixtureClient) ListIssueCommentsIfChanged(
 func (c *FixtureClient) ListReviews(
 	_ context.Context, owner, repo string, number int,
 ) ([]*gh.PullRequestReview, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	reviews := c.Reviews[issueKey(owner, repo, number)]
 	if len(reviews) == 0 {
 		return nil, nil
@@ -367,6 +391,9 @@ func (c *FixtureClient) ListPullRequestTimelineEvents(
 func (c *FixtureClient) GetCombinedStatus(
 	_ context.Context, owner, repo, ref string,
 ) (*gh.CombinedStatus, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.CombinedStatuses[refKey(owner, repo, ref)], nil
 }
 
@@ -374,19 +401,133 @@ func (c *FixtureClient) GetCombinedStatus(
 func (c *FixtureClient) ListCheckRunsForRef(
 	_ context.Context, owner, repo, ref string,
 ) ([]*gh.CheckRun, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	runs := c.CheckRuns[refKey(owner, repo, ref)]
 	if len(runs) == 0 {
 		return nil, nil
 	}
-	return slices.Clone(runs), nil
+	return cloneCheckRuns(runs), nil
+}
+
+// SetPullRequestCheckRunStatus updates all seeded check runs for a PR head.
+func (c *FixtureClient) SetPullRequestCheckRunStatus(
+	owner, repo string,
+	number int,
+	status, conclusion string,
+) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	headSHA := c.pullRequestHeadSHA(owner, repo, number)
+	if headSHA == "" {
+		return false
+	}
+	key := refKey(owner, repo, headSHA)
+	runs := c.CheckRuns[key]
+	if len(runs) == 0 {
+		return false
+	}
+	updated := make([]*gh.CheckRun, 0, len(runs))
+	for _, run := range runs {
+		if run == nil {
+			updated = append(updated, nil)
+			continue
+		}
+		copyRun := *run
+		copyRun.Status = &status
+		copyRun.Conclusion = &conclusion
+		updated = append(updated, &copyRun)
+	}
+	c.CheckRuns[key] = updated
+	return true
+}
+
+// PullRequestHeadSHA returns the seeded PR head SHA.
+func (c *FixtureClient) PullRequestHeadSHA(owner, repo string, number int) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.pullRequestHeadSHA(owner, repo, number)
+}
+
+func (c *FixtureClient) pullRequestHeadSHA(owner, repo string, number int) string {
+	for _, prs := range []map[string][]*gh.PullRequest{c.PRs, c.OpenPRs} {
+		for _, pr := range prs[repoKey(owner, repo)] {
+			if pr.GetNumber() == number && pr.GetHead() != nil {
+				return pr.GetHead().GetSHA()
+			}
+		}
+	}
+	return ""
+}
+
+// UpdatePullRequestSHAs updates seeded PR head/base SHAs and moves ref-based fixtures.
+func (c *FixtureClient) UpdatePullRequestSHAs(
+	owner, repo string,
+	number int,
+	headSHA, baseSHA string,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	repoKey := repoKey(owner, repo)
+	oldHeadSHA := ""
+	patch := func(prs []*gh.PullRequest) {
+		for _, pr := range prs {
+			if pr.GetNumber() != number {
+				continue
+			}
+			if pr.Head == nil {
+				pr.Head = &gh.PullRequestBranch{}
+			}
+			if pr.Base == nil {
+				pr.Base = &gh.PullRequestBranch{}
+			}
+			if oldHeadSHA == "" {
+				oldHeadSHA = pr.Head.GetSHA()
+			}
+			pr.Head.SHA = &headSHA
+			pr.Base.SHA = &baseSHA
+		}
+	}
+
+	patch(c.OpenPRs[repoKey])
+	patch(c.PRs[repoKey])
+
+	if oldHeadSHA == "" || oldHeadSHA == headSHA {
+		return
+	}
+	oldRefKey := refKey(owner, repo, oldHeadSHA)
+	newRefKey := refKey(owner, repo, headSHA)
+	if combined, ok := c.CombinedStatuses[oldRefKey]; ok {
+		c.CombinedStatuses[newRefKey] = combined
+	}
+	if runs, ok := c.CheckRuns[oldRefKey]; ok {
+		c.CheckRuns[newRefKey] = cloneCheckRuns(runs)
+	}
+}
+
+func cloneCheckRuns(runs []*gh.CheckRun) []*gh.CheckRun {
+	cloned := make([]*gh.CheckRun, 0, len(runs))
+	for _, run := range runs {
+		if run == nil {
+			cloned = append(cloned, nil)
+			continue
+		}
+		copyRun := *run
+		cloned = append(cloned, &copyRun)
+	}
+	return cloned
 }
 
 // ListWorkflowRunsForHeadSHA returns seeded action-required workflow runs.
 func (c *FixtureClient) ListWorkflowRunsForHeadSHA(
 	_ context.Context, owner, repo, headSHA string,
 ) ([]*gh.WorkflowRun, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	runs := c.WorkflowRuns[refKey(owner, repo, headSHA)]
 	if len(runs) == 0 {
@@ -490,6 +631,9 @@ func (c *FixtureClient) MarkPullRequestReadyForReview(
 func (c *FixtureClient) MergePullRequest(
 	_ context.Context, owner, repo string, number int, _, _, _ string,
 ) (*gh.PullRequestMergeResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	pr := c.findPullRequest(owner, repo, number)
 	if pr == nil {
 		return nil, nil
@@ -513,6 +657,9 @@ func (c *FixtureClient) MergePullRequest(
 func (c *FixtureClient) EditPullRequest(
 	_ context.Context, owner, repo string, number int, opts ghclient.EditPullRequestOpts,
 ) (*gh.PullRequest, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	now := gh.Timestamp{Time: time.Now().UTC()}
 	var updated *gh.PullRequest
 	for _, prs := range []map[string][]*gh.PullRequest{c.OpenPRs, c.PRs} {
@@ -553,6 +700,9 @@ func (c *FixtureClient) EditPullRequest(
 func (c *FixtureClient) EditIssue(
 	_ context.Context, owner, repo string, number int, state string,
 ) (*gh.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	now := gh.Timestamp{Time: time.Now().UTC()}
 	var updated *gh.Issue
 	for _, issues := range []map[string][]*gh.Issue{c.OpenIssues, c.Issues} {
@@ -581,6 +731,9 @@ func (c *FixtureClient) EditIssue(
 func (c *FixtureClient) EditIssueContent(
 	_ context.Context, owner, repo string, number int, title *string, body *string,
 ) (*gh.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	now := gh.Timestamp{Time: time.Now().UTC()}
 	var updated *gh.Issue
 	for _, issues := range []map[string][]*gh.Issue{c.OpenIssues, c.Issues} {

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -41,6 +41,7 @@ type FixtureClient struct {
 	CombinedStatuses          map[string]*gh.CombinedStatus
 	CheckRuns                 map[string][]*gh.CheckRun
 	Labels                    map[string][]*gh.Label
+	CheckRunErrors            map[string]error
 	WorkflowRuns              map[string][]*gh.WorkflowRun
 	ListRepositoriesByOwnerFn func(context.Context, string) ([]*gh.Repository, error)
 	mu                        sync.RWMutex
@@ -62,6 +63,7 @@ func NewFixtureClient() ghclient.Client {
 		CombinedStatuses: make(map[string]*gh.CombinedStatus),
 		CheckRuns:        make(map[string][]*gh.CheckRun),
 		Labels:           make(map[string][]*gh.Label),
+		CheckRunErrors:   make(map[string]error),
 		WorkflowRuns:     make(map[string][]*gh.WorkflowRun),
 		nextID:           10_000,
 	}
@@ -405,11 +407,35 @@ func (c *FixtureClient) ListCheckRunsForRef(
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	runs := c.CheckRuns[refKey(owner, repo, ref)]
+	key := refKey(owner, repo, ref)
+	if err := c.CheckRunErrors[key]; err != nil {
+		return nil, err
+	}
+	runs := c.CheckRuns[key]
 	if len(runs) == 0 {
 		return nil, nil
 	}
 	return cloneCheckRuns(runs), nil
+}
+
+// SetPullRequestCheckRunError makes CI check refreshes fail for a PR head.
+func (c *FixtureClient) SetPullRequestCheckRunError(
+	owner, repo string,
+	number int,
+	err error,
+) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	headSHA := c.pullRequestHeadSHA(owner, repo, number)
+	if headSHA == "" {
+		return false
+	}
+	if c.CheckRunErrors == nil {
+		c.CheckRunErrors = make(map[string]error)
+	}
+	c.CheckRunErrors[refKey(owner, repo, headSHA)] = err
+	return true
 }
 
 // SetPullRequestCheckRunStatus updates all seeded check runs for a PR head.

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -385,11 +385,25 @@ func (c *FixtureClient) ListCheckRunsForRef(
 func (c *FixtureClient) ListWorkflowRunsForHeadSHA(
 	_ context.Context, owner, repo, headSHA string,
 ) ([]*gh.WorkflowRun, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	runs := c.WorkflowRuns[refKey(owner, repo, headSHA)]
 	if len(runs) == 0 {
 		return nil, nil
 	}
 	return slices.Clone(runs), nil
+}
+
+// SetWorkflowRuns seeds action-required workflow runs for a repo/head SHA.
+func (c *FixtureClient) SetWorkflowRuns(owner, repo, headSHA string, runs []*gh.WorkflowRun) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.WorkflowRuns == nil {
+		c.WorkflowRuns = make(map[string][]*gh.WorkflowRun)
+	}
+	c.WorkflowRuns[refKey(owner, repo, headSHA)] = slices.Clone(runs)
 }
 
 // ApproveWorkflowRun returns an error (mutations not supported).

--- a/internal/testutil/fixture_client_workflow_test.go
+++ b/internal/testutil/fixture_client_workflow_test.go
@@ -10,6 +10,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFixtureClientPullRequestsAreReturnedAsCopies(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	client := NewFixtureClient()
+	fc, ok := client.(*FixtureClient)
+	require.True(ok)
+
+	originalHead := "old-head"
+	originalBase := "old-base"
+	fc.OpenPRs["acme/widgets"] = []*gh.PullRequest{{
+		Number: new(1),
+		Head:   &gh.PullRequestBranch{SHA: &originalHead},
+		Base:   &gh.PullRequestBranch{SHA: &originalBase},
+	}}
+	fc.PRs["acme/widgets"] = []*gh.PullRequest{{
+		Number: new(1),
+		Head:   &gh.PullRequestBranch{SHA: &originalHead},
+		Base:   &gh.PullRequestBranch{SHA: &originalBase},
+	}}
+
+	listed, err := fc.ListOpenPullRequests(t.Context(), "acme", "widgets")
+	require.NoError(err)
+	require.Len(listed, 1)
+	got, err := fc.GetPullRequest(t.Context(), "acme", "widgets", 1)
+	require.NoError(err)
+	require.NotNil(got)
+
+	mutatedHead := "caller-mutated"
+	listed[0].Head.SHA = &mutatedHead
+	got.Base.SHA = &mutatedHead
+	fc.UpdatePullRequestSHAs("acme", "widgets", 1, "new-head", "new-base")
+
+	assert.Equal("caller-mutated", listed[0].GetHead().GetSHA())
+	assert.Equal("caller-mutated", got.GetBase().GetSHA())
+	fresh, err := fc.GetPullRequest(t.Context(), "acme", "widgets", 1)
+	require.NoError(err)
+	require.NotNil(fresh)
+	assert.Equal("new-head", fresh.GetHead().GetSHA())
+	assert.Equal("new-base", fresh.GetBase().GetSHA())
+}
+
 func TestFixtureClientCheckRunsConcurrentStatusUpdates(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/testutil/fixture_client_workflow_test.go
+++ b/internal/testutil/fixture_client_workflow_test.go
@@ -1,0 +1,54 @@
+package testutil
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	gh "github.com/google/go-github/v84/github"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixtureClientWorkflowRunsConcurrentAccess(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	client := NewFixtureClient()
+	fc, ok := client.(*FixtureClient)
+	require.True(ok)
+
+	const goroutines = 8
+	const iterations = 100
+	var errors atomic.Int64
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := range iterations {
+				runID := int64(j)
+				fc.SetWorkflowRuns(
+					"acme", "widgets", "head-sha",
+					[]*gh.WorkflowRun{{ID: &runID}},
+				)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_, err := fc.ListWorkflowRunsForHeadSHA(
+					t.Context(), "acme", "widgets", "head-sha",
+				)
+				if err != nil {
+					errors.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	runs, err := fc.ListWorkflowRunsForHeadSHA(t.Context(), "acme", "widgets", "head-sha")
+	require.NoError(err)
+	assert.Zero(errors.Load())
+	assert.Len(runs, 1)
+}

--- a/internal/testutil/fixture_client_workflow_test.go
+++ b/internal/testutil/fixture_client_workflow_test.go
@@ -10,6 +10,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFixtureClientCheckRunsConcurrentStatusUpdates(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	client := NewFixtureClient()
+	fc, ok := client.(*FixtureClient)
+	require.True(ok)
+
+	headSHA := "head-sha"
+	status := "queued"
+	conclusion := ""
+	fc.PRs["acme/widgets"] = []*gh.PullRequest{{
+		Number: new(1),
+		Head:   &gh.PullRequestBranch{SHA: &headSHA},
+	}}
+	fc.CheckRuns["acme/widgets@head-sha"] = []*gh.CheckRun{{
+		Name:       new("test"),
+		Status:     &status,
+		Conclusion: &conclusion,
+	}}
+
+	const goroutines = 8
+	const iterations = 100
+	var errors atomic.Int64
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if !fc.SetPullRequestCheckRunStatus(
+					"acme", "widgets", 1, "completed", "success",
+				) {
+					errors.Add(1)
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				runs, err := fc.ListCheckRunsForRef(t.Context(), "acme", "widgets", headSHA)
+				if err != nil || len(runs) != 1 {
+					errors.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	runs, err := fc.ListCheckRunsForRef(t.Context(), "acme", "widgets", headSHA)
+	require.NoError(err)
+	require.Len(runs, 1)
+	assert.Zero(errors.Load())
+	assert.Equal("completed", runs[0].GetStatus())
+	assert.Equal("success", runs[0].GetConclusion())
+}
+
 func TestFixtureClientWorkflowRunsConcurrentAccess(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -108,6 +108,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Deletions:         30,
 		CommentCount:      3,
 		ReviewDecision:    "approved",
+		IsLocked:          true,
 		CIStatus:          "success",
 		CIChecksJSON:      string(ciChecksJSON),
 		CreatedAt:         w1Created,
@@ -731,7 +732,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	openPRs := map[string][]*gh.PullRequest{
 		"acme/widgets": {
-			setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body),
+			setPRLocked(setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body)),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1006, 6, "WIP: new dashboard layout", "carol", "open", true, "", w6Created, now.Add(-12*time.Hour)), 150, 40),
 			setPRStats(buildGHPR("acme", "widgets", 1007, 7, "Bump lodash from 4.17.20 to 4.17.21", "dependabot[bot]", "open", false, "", w7Created, now.Add(-6*time.Hour)), 1, 1),
@@ -746,7 +747,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	allPRs := map[string][]*gh.PullRequest{
 		"acme/widgets": {
-			setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body),
+			setPRLocked(setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body)),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1003, 3, "Upgrade dependency versions", "carol", "merged", false, "", now.Add(-10*24*time.Hour), w3Merged), 80, 80),
 			setPRStats(buildGHPR("acme", "widgets", 1004, 4, "Refactor storage backend", "alice", "merged", false, "", now.Add(-30*24*time.Hour), w4Merged), 420, 310),
@@ -903,6 +904,12 @@ func buildGHPR(
 // task-list checkboxes).
 func setPRBody(pr *gh.PullRequest, body string) *gh.PullRequest {
 	pr.Body = &body
+	return pr
+}
+
+func setPRLocked(pr *gh.PullRequest) *gh.PullRequest {
+	locked := true
+	pr.Locked = &locked
 	return pr
 }
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -853,7 +853,8 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 						},
 					},
 				},
-				nextID: 10_000,
+				WorkflowRuns: make(map[string][]*gh.WorkflowRun),
+				nextID:       10_000,
 			}
 		},
 	}

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -234,6 +234,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/ci-refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Post host by platform host pulls by provider by owner by name by number ci refresh */
+        post: operations["post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ci-refresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/comments": {
         parameters: {
             query?: never;
@@ -855,6 +872,23 @@ export interface paths {
         put?: never;
         /** Post pulls by provider by owner by name by number approve workflows */
         post: operations["post-pulls-by-provider-by-owner-by-name-by-number-approve-workflows"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pulls/{provider}/{owner}/{name}/{number}/ci-refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Post pulls by provider by owner by name by number ci refresh */
+        post: operations["post-pulls-by-provider-by-owner-by-name-by-number-ci-refresh"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3486,6 +3520,41 @@ export interface operations {
             };
         };
     };
+    "post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ci-refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MergeRequestDetailResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "post-pr-comment-on-host": {
         parameters: {
             query?: never;
@@ -5016,6 +5085,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ActionStatusBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "post-pulls-by-provider-by-owner-by-name-by-number-ci-refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MergeRequestDetailResponse"];
                 };
             };
             /** @description Error */

--- a/packages/ui/src/api/provider-routes.ts
+++ b/packages/ui/src/api/provider-routes.ts
@@ -54,6 +54,7 @@ type PullSuffix =
   | "/files"
   | "/file-preview"
   | "/github-state"
+  | "/ci-refresh"
   | "/import-metadata"
   | "/labels"
   | "/merge"

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -57,6 +57,10 @@
     return "var(--text-muted)";
   }
 
+  function isRefreshingCheck(check: CICheck): boolean {
+    return detailSyncing && check.status !== "completed";
+  }
+
   function chipColor(chipStatus: string): string {
     if (chipStatus === "success") return "chip--green";
     if (chipStatus === "failure" || chipStatus === "error") return "chip--red";
@@ -92,7 +96,15 @@
       target="_blank"
       rel="noopener noreferrer"
     >
-      <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+      <span class="ci-icon" style="color: {checkColor(check)}">
+        {#if isRefreshingCheck(check)}
+          <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
+          </svg>
+        {:else}
+          {checkIcon(check)}
+        {/if}
+      </span>
       <span class="ci-name">{check.name}</span>
       {#if duration}
         <span class="ci-duration">{duration}</span>
@@ -104,7 +116,15 @@
     </a>
   {:else}
     <div class="ci-check ci-check--static">
-      <span class="ci-icon" style="color: {checkColor(check)}">{checkIcon(check)}</span>
+      <span class="ci-icon" style="color: {checkColor(check)}">
+        {#if isRefreshingCheck(check)}
+          <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
+          </svg>
+        {:else}
+          {checkIcon(check)}
+        {/if}
+      </span>
       <span class="ci-name">{check.name}</span>
       {#if duration}
         <span class="ci-duration">{duration}</span>
@@ -239,6 +259,9 @@
   }
 
   .ci-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     font-weight: 700;
     font-size: var(--font-size-root);
     flex-shrink: 0;

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import LoaderCircleIcon from "@lucide/svelte/icons/loader-circle";
   import type { CICheck } from "../../api/types.js";
   import Chip from "../shared/Chip.svelte";
 
@@ -98,9 +99,9 @@
     >
       <span class="ci-icon" style="color: {checkColor(check)}">
         {#if isRefreshingCheck(check)}
-          <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
-          </svg>
+          <span class="sync-spinner" aria-hidden="true">
+            <LoaderCircleIcon size={14} strokeWidth={2} />
+          </span>
         {:else}
           {checkIcon(check)}
         {/if}
@@ -118,9 +119,9 @@
     <div class="ci-check ci-check--static">
       <span class="ci-icon" style="color: {checkColor(check)}">
         {#if isRefreshingCheck(check)}
-          <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
-          </svg>
+          <span class="sync-spinner" aria-hidden="true">
+            <LoaderCircleIcon size={14} strokeWidth={2} />
+          </span>
         {:else}
           {checkIcon(check)}
         {/if}
@@ -159,9 +160,9 @@
         {#if !detailLoaded}
           {#if detailSyncing}
             <div class="loading-placeholder">
-              <svg class="sync-spinner" width="14" height="14" viewBox="0 0 16 16" fill="none">
-                <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="8" stroke-linecap="round"/>
-              </svg>
+              <span class="sync-spinner" aria-hidden="true">
+                <LoaderCircleIcon size={14} strokeWidth={2} />
+              </span>
               Loading checks...
             </div>
           {:else}
@@ -310,6 +311,7 @@
   }
 
   .sync-spinner {
+    display: inline-flex;
     animation: spin 0.9s linear infinite;
   }
 

--- a/packages/ui/src/components/detail/CIStatus.test.ts
+++ b/packages/ui/src/components/detail/CIStatus.test.ts
@@ -7,6 +7,37 @@ describe("CIStatus", () => {
     cleanup();
   });
 
+  it("shows spinners for pending checks during refresh", () => {
+    render(CIStatus, {
+      props: {
+        status: "pending",
+        checksJSON: JSON.stringify([
+          {
+            name: "build",
+            status: "in_progress",
+            conclusion: "",
+            url: "",
+            app: "GitHub Actions",
+          },
+          {
+            name: "lint",
+            status: "completed",
+            conclusion: "success",
+            url: "",
+            app: "GitHub Actions",
+          },
+        ]),
+        detailLoaded: true,
+        detailSyncing: true,
+        expanded: true,
+      },
+    });
+
+    expect(document.querySelectorAll(".ci-check .sync-spinner")).toHaveLength(1);
+    expect(screen.queryByText("◦")).toBeNull();
+    expect(screen.getByText("✓")).toBeTruthy();
+  });
+
   it("renders expanded CI checks when chip is clicked", async () => {
     render(CIStatus, {
       props: {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -107,6 +107,7 @@
     hideWorkspaceAction?: boolean;
     hideStaleWhileLoading?: boolean;
     autoSync?: DetailSyncMode;
+    workflowApprovalSync?: boolean;
   }
 
   const {
@@ -121,6 +122,7 @@
     hideWorkspaceAction = false,
     hideStaleWhileLoading = false,
     autoSync = "background",
+    workflowApprovalSync = true,
   }: Props = $props();
 
   const routeRef = $derived({
@@ -226,6 +228,7 @@
     const requestPlatformHost = platformHost;
     const requestRepoPath = repoPath;
     const requestAutoSync = autoSync;
+    const requestWorkflowApprovalSync = workflowApprovalSync;
     untrack(() => {
       void detailStore.loadDetail(
         requestOwner,
@@ -233,6 +236,7 @@
         requestNumber,
         {
           sync: requestAutoSync,
+          workflowApprovalSync: requestWorkflowApprovalSync,
           provider: requestProvider,
           platformHost: requestPlatformHost,
           repoPath: requestRepoPath,

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -214,6 +214,7 @@
         provider,
         platformHost,
         repoPath,
+        workflowApprovalSync,
       });
     };
     refresh();

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -151,6 +151,16 @@
   const hasActiveTimelineFilters = $derived(
     activePRTimelineFilterCount(timelineFilter) > 0,
   );
+
+  function ciChecksHavePending(checksJSON: string): boolean {
+    if (!checksJSON) return false;
+    try {
+      const checks = JSON.parse(checksJSON) as Array<{ status?: string }>;
+      return checks.some((check) => check.status !== "completed");
+    } catch {
+      return false;
+    }
+  }
   async function editTimelineComment(
     event: { PlatformID: number | null },
     body: string,
@@ -183,6 +193,29 @@
       d.repo?.platform_host !== platformHost ||
       d.repo?.repo_path !== repoPath
     );
+  });
+
+  const shouldAutoRefreshCI = $derived.by(() => {
+    const pr = currentPR();
+    return Boolean(
+      ciExpanded &&
+      !stalePR &&
+      pr?.State === "open" &&
+      ciChecksHavePending(pr.CIChecksJSON),
+    );
+  });
+
+  $effect(() => {
+    if (!shouldAutoRefreshCI) return;
+    const refresh = () => {
+      void detailStore.refreshPendingCI(owner, name, number, {
+        provider,
+        platformHost,
+        repoPath,
+      });
+    };
+    const interval = setInterval(refresh, 15_000);
+    return () => clearInterval(interval);
   });
 
   $effect(() => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -216,6 +216,7 @@
         repoPath,
       });
     };
+    refresh();
     const interval = setInterval(refresh, 15_000);
     return () => clearInterval(interval);
   });

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -250,6 +250,7 @@ describe("PullDetail approvals", () => {
         provider: "github",
         platformHost: "github.com",
         repoPath: "acme/widget",
+        workflowApprovalSync: true,
       },
     );
   });

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -137,10 +137,11 @@ function renderPullDetail(detail: PullDetail) {
     updateKanbanState: vi.fn(),
     toggleDetailPRStar: vi.fn(),
     updatePRContent: vi.fn(),
+    refreshPendingCI: vi.fn(async () => undefined),
     editComment: vi.fn(),
   };
 
-  return render(PullDetailComponent, {
+  const rendered = render(PullDetailComponent, {
     props: {
       owner: "acme",
       name: "widget",
@@ -176,11 +177,13 @@ function renderPullDetail(detail: PullDetail) {
       [NAVIGATE_KEY, vi.fn()],
     ]),
   });
+  return { ...rendered, detailStore };
 }
 
 describe("PullDetail approvals", () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it("shows approval count and expands approver names", async () => {
@@ -210,5 +213,42 @@ describe("PullDetail approvals", () => {
     const popup = document.querySelector(".approval-popup");
     expect(popup?.textContent).toContain("alice");
     expect(popup?.textContent).toContain("bob");
+  });
+
+  it("auto-refreshes pending CI checks while the CI panel is expanded", async () => {
+    vi.useFakeTimers();
+    const detail = pullDetail();
+    detail.merge_request.CIStatus = "pending";
+    detail.merge_request.CIChecksJSON = JSON.stringify([
+      {
+        name: "build",
+        status: "in_progress",
+        conclusion: "",
+        url: "https://example.com/build",
+        app: "GitHub Actions",
+      },
+    ]);
+
+    const { detailStore } = renderPullDetail(detail);
+
+    expect(detailStore.refreshPendingCI).not.toHaveBeenCalled();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /CI:\s*pending \(1\)/i }),
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(detailStore.refreshPendingCI).toHaveBeenCalledTimes(1);
+    expect(detailStore.refreshPendingCI).toHaveBeenCalledWith(
+      "acme",
+      "widget",
+      1,
+      {
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/widget",
+      },
+    );
   });
 });

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -237,9 +237,11 @@ describe("PullDetail approvals", () => {
       screen.getByRole("button", { name: /CI:\s*pending \(1\)/i }),
     );
 
+    expect(detailStore.refreshPendingCI).toHaveBeenCalledTimes(1);
+
     await vi.advanceTimersByTimeAsync(15_000);
 
-    expect(detailStore.refreshPendingCI).toHaveBeenCalledTimes(1);
+    expect(detailStore.refreshPendingCI).toHaveBeenCalledTimes(2);
     expect(detailStore.refreshPendingCI).toHaveBeenCalledWith(
       "acme",
       "widget",

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -13,6 +13,7 @@ export type DetailSyncMode = boolean | "background";
 
 export interface DetailRequestOptions {
   sync?: DetailSyncMode;
+  workflowApprovalSync?: boolean;
   provider: string;
   platformHost?: string | undefined;
   repoPath: string;
@@ -76,8 +77,11 @@ function strongerSyncMode(
   return syncIntentRank(b) > syncIntentRank(a) ? b : a;
 }
 
-function needsWorkflowApprovalSync(detail: PullDetail | null): boolean {
-  if (!detail) return false;
+function needsWorkflowApprovalSync(
+  detail: PullDetail | null,
+  enabled: boolean,
+): boolean {
+  if (!enabled || !detail) return false;
   const pr = detail.merge_request;
   return Boolean(
     detail.repo?.capabilities?.workflow_approval &&
@@ -120,6 +124,7 @@ export function createDetailStore(
     key: string;
     promise: Promise<void> | null;
     syncMode: DetailSyncMode;
+    workflowApprovalSync: boolean;
   } | null = null;
 
   // Per-PR monotonic counters for kanban updates.
@@ -387,6 +392,7 @@ export function createDetailStore(
         activeLoad.syncMode,
         syncMode,
       );
+      activeLoad.workflowApprovalSync ||= options.workflowApprovalSync ?? true;
       return activeLoad.promise;
     }
 
@@ -395,7 +401,13 @@ export function createDetailStore(
       key: string;
       promise: Promise<void> | null;
       syncMode: DetailSyncMode;
-    } = { key, promise: null, syncMode };
+      workflowApprovalSync: boolean;
+    } = {
+      key,
+      promise: null,
+      syncMode,
+      workflowApprovalSync: options.workflowApprovalSync ?? true,
+    };
     activeLoad = currentLoad;
 
     // Keep the previously loaded detail visible while the new one
@@ -453,7 +465,7 @@ export function createDetailStore(
       if (gen === syncGeneration && finalSyncMode === true) {
         void syncDetail(owner, name, number, gen, requestRef);
       } else if (gen === syncGeneration && finalSyncMode === "background") {
-        if (needsWorkflowApprovalSync(detail)) {
+        if (needsWorkflowApprovalSync(detail, currentLoad.workflowApprovalSync)) {
           void syncDetail(owner, name, number, gen, requestRef);
           return;
         }

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -76,16 +76,6 @@ function strongerSyncMode(
   return syncIntentRank(b) > syncIntentRank(a) ? b : a;
 }
 
-function ciChecksHavePending(checksJSON: string | undefined): boolean {
-  if (!checksJSON) return false;
-  try {
-    const checks = JSON.parse(checksJSON) as Array<{ status?: string }>;
-    return checks.some((check) => check.status !== "completed");
-  } catch {
-    return false;
-  }
-}
-
 function needsWorkflowApprovalSync(detail: PullDetail | null): boolean {
   if (!detail) return false;
   const pr = detail.merge_request;
@@ -93,11 +83,7 @@ function needsWorkflowApprovalSync(detail: PullDetail | null): boolean {
     detail.repo?.capabilities?.workflow_approval &&
       pr?.State === "open" &&
       detail.workflow_approval?.checked === false &&
-      (
-        pr.CIStatus === "pending" ||
-        pr.CIHadPending ||
-        ciChecksHavePending(pr.CIChecksJSON)
-      ),
+      pr.CIHadPending,
   );
 }
 

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -584,6 +584,9 @@ export function createDetailStore(
             events: data.events ?? [],
           } as PullDetail);
           detailLoaded = data.detail_loaded ?? detailLoaded;
+          if (needsWorkflowApprovalSync(detail, true)) {
+            await syncDetail(owner, name, number, gen, ref);
+          }
         }
       } finally {
         if (gen === syncGeneration) syncing = false;

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -76,6 +76,31 @@ function strongerSyncMode(
   return syncIntentRank(b) > syncIntentRank(a) ? b : a;
 }
 
+function ciChecksHavePending(checksJSON: string | undefined): boolean {
+  if (!checksJSON) return false;
+  try {
+    const checks = JSON.parse(checksJSON) as Array<{ status?: string }>;
+    return checks.some((check) => check.status !== "completed");
+  } catch {
+    return false;
+  }
+}
+
+function needsWorkflowApprovalSync(detail: PullDetail | null): boolean {
+  if (!detail) return false;
+  const pr = detail.merge_request;
+  return Boolean(
+    detail.repo?.capabilities?.workflow_approval &&
+      pr?.State === "open" &&
+      detail.workflow_approval?.checked === false &&
+      (
+        pr.CIStatus === "pending" ||
+        pr.CIHadPending ||
+        ciChecksHavePending(pr.CIChecksJSON)
+      ),
+  );
+}
+
 export function createDetailStore(
   opts: DetailStoreOptions,
 ) {
@@ -442,6 +467,10 @@ export function createDetailStore(
       if (gen === syncGeneration && finalSyncMode === true) {
         void syncDetail(owner, name, number, gen, requestRef);
       } else if (gen === syncGeneration && finalSyncMode === "background") {
+        if (needsWorkflowApprovalSync(detail)) {
+          void syncDetail(owner, name, number, gen, requestRef);
+          return;
+        }
         void enqueueBackgroundDetailSync(
           owner,
           name,

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -554,7 +554,6 @@ export function createDetailStore(
     identity: DetailRequestOptions,
   ): Promise<void> {
     if (!isDetailShowing(owner, name, number)) return;
-    if (syncing) return;
     const ref = detailRequestRef(owner, name, number, identity);
     await syncDetail(owner, name, number, syncGeneration, ref);
   }

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -126,6 +126,10 @@ export function createDetailStore(
     syncMode: DetailSyncMode;
     workflowApprovalSync: boolean;
   } | null = null;
+  let activeCIRefresh: {
+    key: string;
+    promise: Promise<void>;
+  } | null = null;
 
   // Per-PR monotonic counters for kanban updates.
   const kanbanSeqByPR = new Map<string, number>();
@@ -555,34 +559,45 @@ export function createDetailStore(
   ): Promise<void> {
     if (!isDetailShowing(owner, name, number)) return;
     const ref = detailRequestRef(owner, name, number, identity);
+    const key = prKey(ref);
+    if (activeCIRefresh?.key === key) {
+      return activeCIRefresh.promise;
+    }
     const gen = syncGeneration;
-    syncing = true;
-    try {
-      const { data, error: requestError } = await apiClient.POST(
-        providerItemPath("pulls", ref, "/ci-refresh"),
-        {
-          params: {
-            path: { ...providerRouteParams(ref), number: ref.number },
+    const promise = (async () => {
+      syncing = true;
+      try {
+        const { data, error: requestError } = await apiClient.POST(
+          providerItemPath("pulls", ref, "/ci-refresh"),
+          {
+            params: {
+              path: { ...providerRouteParams(ref), number: ref.number },
+            },
           },
-        },
-      );
-      if (gen !== syncGeneration) return;
-      if (requestError) return;
-      if (data) {
-        storeError = null;
-        detail = withPreservedLocalBody({
-          ...data,
-          events: data.events ?? [],
-        } as PullDetail);
-        detailLoaded = data.detail_loaded ?? detailLoaded;
+        );
+        if (gen !== syncGeneration) return;
+        if (requestError) return;
+        if (data) {
+          storeError = null;
+          detail = withPreservedLocalBody({
+            ...data,
+            events: data.events ?? [],
+          } as PullDetail);
+          detailLoaded = data.detail_loaded ?? detailLoaded;
+        }
+      } finally {
+        if (gen === syncGeneration) syncing = false;
+        void syncDep?.refreshSyncStatus?.();
       }
-    } finally {
-      if (gen === syncGeneration) syncing = false;
-      void syncDep?.refreshSyncStatus?.();
-    }
-    if (gen === syncGeneration) {
-      await refreshPullsIfActive();
-    }
+      if (gen === syncGeneration) {
+        await refreshPullsIfActive();
+      }
+    })();
+    activeCIRefresh = { key, promise };
+    promise.finally(() => {
+      if (activeCIRefresh?.promise === promise) activeCIRefresh = null;
+    });
+    return promise;
   }
 
   async function updateKanbanState(

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -584,7 +584,7 @@ export function createDetailStore(
             events: data.events ?? [],
           } as PullDetail);
           detailLoaded = data.detail_loaded ?? detailLoaded;
-          if (needsWorkflowApprovalSync(detail, true)) {
+          if (needsWorkflowApprovalSync(detail, identity.workflowApprovalSync ?? true)) {
             await syncDetail(owner, name, number, gen, ref);
           }
         }

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -555,7 +555,34 @@ export function createDetailStore(
   ): Promise<void> {
     if (!isDetailShowing(owner, name, number)) return;
     const ref = detailRequestRef(owner, name, number, identity);
-    await syncDetail(owner, name, number, syncGeneration, ref);
+    const gen = syncGeneration;
+    syncing = true;
+    try {
+      const { data, error: requestError } = await apiClient.POST(
+        providerItemPath("pulls", ref, "/ci-refresh"),
+        {
+          params: {
+            path: { ...providerRouteParams(ref), number: ref.number },
+          },
+        },
+      );
+      if (gen !== syncGeneration) return;
+      if (requestError) return;
+      if (data) {
+        storeError = null;
+        detail = withPreservedLocalBody({
+          ...data,
+          events: data.events ?? [],
+        } as PullDetail);
+        detailLoaded = data.detail_loaded ?? detailLoaded;
+      }
+    } finally {
+      if (gen === syncGeneration) syncing = false;
+      void syncDep?.refreshSyncStatus?.();
+    }
+    if (gen === syncGeneration) {
+      await refreshPullsIfActive();
+    }
   }
 
   async function updateKanbanState(

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -520,6 +520,18 @@ export function createDetailStore(
     await refreshDetail(owner, name, number, syncGeneration, ref);
   }
 
+  async function refreshPendingCI(
+    owner: string,
+    name: string,
+    number: number,
+    identity: DetailRequestOptions,
+  ): Promise<void> {
+    if (!isDetailShowing(owner, name, number)) return;
+    if (syncing) return;
+    const ref = detailRequestRef(owner, name, number, identity);
+    await syncDetail(owner, name, number, syncGeneration, ref);
+  }
+
   async function updateKanbanState(
     owner: string,
     name: string,
@@ -1118,6 +1130,7 @@ export function createDetailStore(
     clearDetail,
     loadDetail,
     refreshDetailOnly,
+    refreshPendingCI,
     updateKanbanState,
     setPullLabels,
     updatePRContent,

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -8,6 +8,7 @@ import {
   providerRouteParams,
 } from "../api/provider-routes.js";
 import type { MiddlemanClient } from "../types.js";
+import { showFlash } from "./flash.svelte.js";
 
 export type DetailSyncMode = boolean | "background";
 
@@ -576,7 +577,10 @@ export function createDetailStore(
           },
         );
         if (gen !== syncGeneration) return;
-        if (requestError) return;
+        if (requestError) {
+          showFlash(apiErrorMessage(requestError, "Failed to refresh CI checks"));
+          return;
+        }
         if (data) {
           storeError = null;
           detail = withPreservedLocalBody({
@@ -584,6 +588,10 @@ export function createDetailStore(
             events: data.events ?? [],
           } as PullDetail);
           detailLoaded = data.detail_loaded ?? detailLoaded;
+          const warning = data.warnings?.[0];
+          if (warning) {
+            showFlash(warning);
+          }
           if (needsWorkflowApprovalSync(detail, identity.workflowApprovalSync ?? true)) {
             await syncDetail(owner, name, number, gen, ref);
           }

--- a/packages/ui/src/views/ActivityFeedView.svelte
+++ b/packages/ui/src/views/ActivityFeedView.svelte
@@ -226,6 +226,7 @@
           showStackSidebar={false}
           autoSyncDetail="background"
           hideStaleDetailWhileLoading={true}
+          workflowApprovalSync={false}
           onDetailTabChange={handleDetailTabChange}
         />
       {:else}

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -28,6 +28,7 @@
     showStackSidebar?: boolean;
     autoSyncDetail?: DetailSyncMode;
     hideStaleDetailWhileLoading?: boolean;
+    workflowApprovalSync?: boolean;
     onSidebarResize?: (width: number) => void;
     onDetailTabChange?: (tab: "conversation" | "files") => void;
   }
@@ -41,6 +42,7 @@
     showStackSidebar = true,
     autoSyncDetail = "background",
     hideStaleDetailWhileLoading = false,
+    workflowApprovalSync = true,
     onSidebarResize,
     onDetailTabChange,
   }: Props = $props();
@@ -113,6 +115,7 @@
         platformHost={selectedPR.platformHost}
         repoPath={selectedPR.repoPath}
         autoSync={autoSyncDetail}
+        {workflowApprovalSync}
         hideTabs={true}
         hideStaleWhileLoading={hideStaleDetailWhileLoading}
       />


### PR DESCRIPTION
- Closes #321
- Refreshes expanded pending CI checks without running full PR detail syncs for ordinary polling
- Preserves CI state during transient provider refresh failures and stale-head races
- Restores workflow-approval discovery so eligible PRs show the Approve workflows action
- Shows pending-check refresh activity while CI data is updating
