### PR TITLE
Share workspace diff range controls

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -6801,6 +6801,29 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Get workspaces by ID
+  /workspaces/{id}/commits:
+    get:
+      operationId: get-workspaces-by-id-commits
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommitsResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Get workspaces by ID commits
   /workspaces/{id}/diff:
     get:
       operationId: get-workspaces-by-id-diff
@@ -6830,6 +6853,27 @@ paths:
           name: path
           schema:
             description: Optional file path to limit the returned patch
+            type: string
+        - description: Scope to a single commit SHA
+          explode: false
+          in: query
+          name: commit
+          schema:
+            description: Scope to a single commit SHA
+            type: string
+        - description: Start SHA for range diff (inclusive)
+          explode: false
+          in: query
+          name: from
+          schema:
+            description: Start SHA for range diff (inclusive)
+            type: string
+        - description: End SHA for range diff (inclusive)
+          explode: false
+          in: query
+          name: to
+          schema:
+            description: End SHA for range diff (inclusive)
             type: string
       responses:
         "200":
@@ -6867,6 +6911,27 @@ paths:
           name: whitespace
           schema:
             description: Set to hide to ignore whitespace-only changes
+            type: string
+        - description: Scope to a single commit SHA
+          explode: false
+          in: query
+          name: commit
+          schema:
+            description: Scope to a single commit SHA
+            type: string
+        - description: Start SHA for range diff (inclusive)
+          explode: false
+          in: query
+          name: from
+          schema:
+            description: Start SHA for range diff (inclusive)
+            type: string
+        - description: End SHA for range diff (inclusive)
+          explode: false
+          in: query
+          name: to
+          schema:
+            description: End SHA for range diff (inclusive)
             type: string
       responses:
         "200":

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -366,6 +366,72 @@ describe("createDiffStore loadDiff", () => {
     });
   });
 
+  it("preserves workspace scope when switching between single-file and stacked diffs", async () => {
+    const calls: string[] = [];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        calls.push(url);
+        if (url.includes("/workspaces/ws-1/commits")) {
+          return Response.json({
+            commits: [
+              {
+                sha: "sha2",
+                message: "second",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+              {
+                sha: "sha1",
+                message: "first",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(files);
+        }
+        if (url.includes("/workspaces/ws-1/diff")) {
+          return Response.json(diff);
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "merge-target");
+    await store.loadCommits();
+
+    store.selectCommit("sha2");
+
+    await vi.waitFor(() => {
+      expect(calls).toContain(
+        "/api/v1/workspaces/ws-1/files?base=merge-target&commit=sha2",
+      );
+    });
+
+    calls.length = 0;
+    await store.loadWorkspaceDiff("ws-1", "merge-target", true);
+
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/files?base=merge-target&commit=sha2",
+    );
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2",
+    );
+    expect(store.getScope()).toEqual({ kind: "commit", sha: "sha2" });
+  });
+
   it("refetches workspace files when toggling whitespace hiding", async () => {
     const calls: string[] = [];
     const filesAll = makeFilesResult(["a.ts", "whitespace.ts"]);

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -302,6 +302,70 @@ describe("createDiffStore loadDiff", () => {
     });
   });
 
+  it("applies selected range scope to workspace files and patch requests", async () => {
+    const calls: string[] = [];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        calls.push(url);
+        if (url.includes("/workspaces/ws-1/commits")) {
+          return Response.json({
+            commits: [
+              {
+                sha: "sha3",
+                message: "third",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+              {
+                sha: "sha2",
+                message: "second",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+              {
+                sha: "sha1",
+                message: "first",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(files);
+        }
+        if (url.includes("/workspaces/ws-1/diff")) {
+          return Response.json(diff);
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "merge-target");
+    await store.loadCommits();
+
+    store.selectRange("sha3", "sha2");
+
+    await vi.waitFor(() => {
+      expect(calls).toContain(
+        "/api/v1/workspaces/ws-1/files?base=merge-target&from=sha2&to=sha3",
+      );
+      expect(calls).toContain(
+        "/api/v1/workspaces/ws-1/diff?base=merge-target&from=sha2&to=sha3&path=src%2Fapp.go",
+      );
+    });
+  });
+
   it("refetches workspace files when toggling whitespace hiding", async () => {
     const calls: string[] = [];
     const filesAll = makeFilesResult(["a.ts", "whitespace.ts"]);

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -191,6 +191,117 @@ describe("createDiffStore loadDiff", () => {
     );
   });
 
+  it("loads commits for the active workspace diff", async () => {
+    const calls: string[] = [];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        calls.push(url);
+        if (url.includes("/workspaces/ws-1/commits")) {
+          return Response.json({
+            commits: [
+              {
+                sha: "sha2",
+                message: "second",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+              {
+                sha: "sha1",
+                message: "first",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(files);
+        }
+        if (url.includes("/workspaces/ws-1/diff")) {
+          return Response.json(diff);
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+    await store.loadCommits();
+
+    expect(calls).toContain("/api/v1/workspaces/ws-1/commits");
+    expect(store.getCommits()?.map((commit) => commit.sha)).toEqual([
+      "sha2",
+      "sha1",
+    ]);
+  });
+
+  it("applies selected commit scope to workspace files and patch requests", async () => {
+    const calls: string[] = [];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        calls.push(url);
+        if (url.includes("/workspaces/ws-1/commits")) {
+          return Response.json({
+            commits: [
+              {
+                sha: "sha2",
+                message: "second",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+              {
+                sha: "sha1",
+                message: "first",
+                author_name: "Alice",
+                authored_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }
+        if (url.includes("/workspaces/ws-1/files")) {
+          return Response.json(files);
+        }
+        if (url.includes("/workspaces/ws-1/diff")) {
+          return Response.json(diff);
+        }
+        return Response.json({}, { status: 404 });
+      },
+    );
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "merge-target");
+    await store.loadCommits();
+
+    store.selectCommit("sha2");
+
+    await vi.waitFor(() => {
+      expect(calls).toContain(
+        "/api/v1/workspaces/ws-1/files?base=merge-target&commit=sha2",
+      );
+      expect(calls).toContain(
+        "/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2&path=src%2Fapp.go",
+      );
+    });
+  });
+
   it("refetches workspace files when toggling whitespace hiding", async () => {
     const calls: string[] = [];
     const filesAll = makeFilesResult(["a.ts", "whitespace.ts"]);

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -877,8 +877,7 @@ test.describe("activity split view and detail drawers", () => {
     await expect(detail.locator(".diff-file")).toHaveCount(1);
     const fileSidebar = detail.locator(".files-layout > .files-sidebar");
     await expect(fileSidebar).toBeVisible();
-    await expect(fileSidebar.locator(".commit-section .commit-section__label"))
-      .toHaveText("Commits");
+    await expect(detail.locator(".diff-scope-picker")).toBeVisible();
     await expect(fileSidebar.locator(".diff-file-row")).toHaveCount(1);
     await expect(fileSidebar.locator(".diff-file-row .diff-file-name"))
       .toHaveText("handler.go");
@@ -907,8 +906,7 @@ test.describe("activity split view and detail drawers", () => {
     await expect(sidebar).toBeVisible();
     await expect(drawer.locator(".files-layout > .files-main .diff-view")).toBeVisible();
 
-    await expect(sidebar.locator(".commit-section .commit-section__label"))
-      .toHaveText("Commits");
+    await expect(drawer.locator(".diff-scope-picker")).toBeVisible();
     await expect(sidebar.locator(".diff-file-row")).toHaveCount(1);
     await expect(sidebar.locator(".diff-file-row .diff-file-name"))
       .toHaveText("handler.go");

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1048,7 +1048,7 @@ test.describe("diff view", () => {
         },
       ],
     };
-    const scopedRequests: string[] = [];
+    const scopedDiffRequests: string[] = [];
     const fixtureFor = (url: URL): DiffResult => {
       if (url.searchParams.has("from") && url.searchParams.has("to")) {
         return rangedDiff;
@@ -1061,7 +1061,6 @@ test.describe("diff view", () => {
 
     await page.route("**/api/v1/pulls/github/acme/widgets/1/files**", async (route) => {
       const url = new URL(route.request().url());
-      scopedRequests.push(url.toString());
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1070,7 +1069,7 @@ test.describe("diff view", () => {
     });
     await page.route("**/api/v1/pulls/github/acme/widgets/1/diff*", async (route) => {
       const url = new URL(route.request().url());
-      scopedRequests.push(url.toString());
+      scopedDiffRequests.push(url.toString());
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1109,7 +1108,7 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-file")).toHaveCount(2);
     await expect(page.locator('[data-file-path="frontend/src/ranged.ts"]'))
       .toBeVisible();
-    expect(scopedRequests.some((requestURL) => {
+    expect(scopedDiffRequests.some((requestURL) => {
       const url = new URL(requestURL);
       return url.searchParams.get("from") === olderSHA &&
         url.searchParams.get("to") === commitSHA;

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -973,8 +973,8 @@ test.describe("diff view", () => {
     await expect(detailFiles.locator(".diff-file-row")).toHaveCount(4);
   });
 
-  test("commit list resets expand state when switching PRs", async ({ page }) => {
-    // Mock diff for PR 1 and PR 2 (same fixture is fine — we care about expand state).
+  test("commit scope resets when switching PRs", async ({ page }) => {
+    // Mock diff for PR 1 and PR 2 (same fixture is fine — we care about scope state).
     await mockDiffApi(page, smallDiff);
     await page.route("**/api/v1/pulls/github/acme/widgets/2/files", async (route) => {
       await route.fulfill({
@@ -1006,18 +1006,74 @@ test.describe("diff view", () => {
     await waitForDiffLoaded(page);
     await waitForSidebarFilesLoaded(page);
 
-    // Expand commit section under PR 1 and verify a commit row renders.
-    const toggle = page.locator(".commit-section__toggle").first();
-    await toggle.click();
-    await expect(page.locator(".commit-section__body").first()).toBeVisible();
+    // Open the shared commit picker under PR 1 and select a scoped commit.
+    await page.getByRole("button", { name: "Select commit range" }).click();
     await expect(page.locator(".commit-item").first()).toBeVisible();
+    await page.locator(".commit-item").first().click();
+    await expect(page.locator(".scope-pill__label")).toHaveText("abc1234");
 
     // Switch to PR 2.
     await page.goto("/pulls/github/acme/widgets/2/files");
     await waitForSidebarFilesLoaded(page);
 
-    // Commit section should be collapsed on new PR (body hidden).
-    await expect(page.locator(".commit-section__body")).toHaveCount(0);
+    // The selected commit scope should reset on the new PR.
+    await expect(page.locator(".scope-pill__label")).toHaveText("HEAD");
+  });
+
+  test("commit range picker scopes the visible diff", async ({ page }) => {
+    const scopedDiff: DiffResult = {
+      ...smallDiff,
+      files: [
+        {
+          ...smallDiff.files[1]!,
+          path: "frontend/src/scoped.ts",
+          old_path: "frontend/src/scoped.ts",
+        },
+      ],
+    };
+
+    await page.route("**/api/v1/pulls/github/acme/widgets/1/files**", async (route) => {
+      const url = new URL(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          filesFromDiff(url.searchParams.has("commit") ? scopedDiff : smallDiff),
+        ),
+      });
+    });
+    await page.route("**/api/v1/pulls/github/acme/widgets/1/diff*", async (route) => {
+      const url = new URL(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(url.searchParams.has("commit") ? scopedDiff : smallDiff),
+      });
+    });
+    await page.route("**/api/v1/pulls/github/acme/widgets/1/commits", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          commits: [
+            { sha: "abc1234567890123456789012345678901234567", message: "scoped commit", authored_at: "2026-04-01T00:00:00Z", author_name: "alice" },
+            { sha: "def1234567890123456789012345678901234567", message: "base commit", authored_at: "2026-03-31T00:00:00Z", author_name: "alice" },
+          ],
+        }),
+      });
+    });
+
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await expect(page.locator(".diff-file")).toHaveCount(4);
+
+    await page.getByRole("button", { name: "Select commit range" }).click();
+    await page.locator(".commit-item").first().click();
+
+    await expect(page.locator(".scope-pill__label")).toHaveText("abc1234");
+    await expect(page.locator(".diff-file")).toHaveCount(1);
+    await expect(page.locator(".diff-file").first())
+      .toHaveAttribute("data-file-path", "frontend/src/scoped.ts");
   });
 });
 
@@ -1384,7 +1440,7 @@ test.describe("diff view (git-backed)", () => {
     }, 20 * 24 * 60 * 60 * 1000);
 
     await page.goto("/pulls/github/acme/widgets/1/files");
-    await page.locator(".commit-section__toggle").click();
+    await page.getByRole("button", { name: "Select commit range" }).click();
     await page.locator(".commit-item").first()
       .waitFor({ state: "visible", timeout: 10_000 });
 

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1020,7 +1020,9 @@ test.describe("diff view", () => {
     await expect(page.locator(".scope-pill__label")).toHaveText("HEAD");
   });
 
-  test("commit range picker scopes the visible diff", async ({ page }) => {
+  test("commit range picker scopes single commits and ranges", async ({ page }) => {
+    const commitSHA = "abc1234567890123456789012345678901234567";
+    const olderSHA = "def1234567890123456789012345678901234567";
     const scopedDiff: DiffResult = {
       ...smallDiff,
       files: [
@@ -1031,23 +1033,48 @@ test.describe("diff view", () => {
         },
       ],
     };
+    const rangedDiff: DiffResult = {
+      ...smallDiff,
+      files: [
+        {
+          ...smallDiff.files[1]!,
+          path: "frontend/src/scoped.ts",
+          old_path: "frontend/src/scoped.ts",
+        },
+        {
+          ...smallDiff.files[2]!,
+          path: "frontend/src/ranged.ts",
+          old_path: "frontend/src/ranged.ts",
+        },
+      ],
+    };
+    const scopedRequests: string[] = [];
+    const fixtureFor = (url: URL): DiffResult => {
+      if (url.searchParams.has("from") && url.searchParams.has("to")) {
+        return rangedDiff;
+      }
+      if (url.searchParams.has("commit")) {
+        return scopedDiff;
+      }
+      return smallDiff;
+    };
 
     await page.route("**/api/v1/pulls/github/acme/widgets/1/files**", async (route) => {
       const url = new URL(route.request().url());
+      scopedRequests.push(url.toString());
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify(
-          filesFromDiff(url.searchParams.has("commit") ? scopedDiff : smallDiff),
-        ),
+        body: JSON.stringify(filesFromDiff(fixtureFor(url))),
       });
     });
     await page.route("**/api/v1/pulls/github/acme/widgets/1/diff*", async (route) => {
       const url = new URL(route.request().url());
+      scopedRequests.push(url.toString());
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify(url.searchParams.has("commit") ? scopedDiff : smallDiff),
+        body: JSON.stringify(fixtureFor(url)),
       });
     });
     await page.route("**/api/v1/pulls/github/acme/widgets/1/commits", async (route) => {
@@ -1056,8 +1083,8 @@ test.describe("diff view", () => {
         contentType: "application/json",
         body: JSON.stringify({
           commits: [
-            { sha: "abc1234567890123456789012345678901234567", message: "scoped commit", authored_at: "2026-04-01T00:00:00Z", author_name: "alice" },
-            { sha: "def1234567890123456789012345678901234567", message: "base commit", authored_at: "2026-03-31T00:00:00Z", author_name: "alice" },
+            { sha: commitSHA, message: "scoped commit", authored_at: "2026-04-01T00:00:00Z", author_name: "alice" },
+            { sha: olderSHA, message: "base commit", authored_at: "2026-03-31T00:00:00Z", author_name: "alice" },
           ],
         }),
       });
@@ -1068,12 +1095,25 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-file")).toHaveCount(4);
 
     await page.getByRole("button", { name: "Select commit range" }).click();
-    await page.locator(".commit-item").first().click();
+    const commitItems = page.locator(".commit-item");
+    await commitItems.first().click();
 
     await expect(page.locator(".scope-pill__label")).toHaveText("abc1234");
     await expect(page.locator(".diff-file")).toHaveCount(1);
     await expect(page.locator(".diff-file").first())
       .toHaveAttribute("data-file-path", "frontend/src/scoped.ts");
+
+    await commitItems.nth(1).click({ modifiers: ["Shift"] });
+
+    await expect(page.locator(".scope-pill__label")).toHaveText("def1234..abc1234");
+    await expect(page.locator(".diff-file")).toHaveCount(2);
+    await expect(page.locator('[data-file-path="frontend/src/ranged.ts"]'))
+      .toBeVisible();
+    expect(scopedRequests.some((requestURL) => {
+      const url = new URL(requestURL);
+      return url.searchParams.get("from") === olderSHA &&
+        url.searchParams.get("to") === commitSHA;
+    })).toBe(true);
   });
 });
 

--- a/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
@@ -272,6 +272,14 @@ test.describe("workspace tab persistence", () => {
       await expect(activeDiffFile).toHaveAttribute("title", "alpha.ts");
       await expect(page.locator('.right-sidebar .diff-file-row[title="beta_test.go"]'))
         .toHaveCount(0);
+      await page.locator(".right-sidebar .file-list-toggle").click();
+      await expect(page.locator(".right-sidebar .workspace-diff-sidebar"))
+        .toHaveCount(0);
+      await expect(page.locator(".right-sidebar .diff-file")).toHaveCount(1);
+      await page.locator(".right-sidebar .file-list-toggle").click();
+      await expect(page.locator(".right-sidebar .workspace-diff-sidebar"))
+        .toBeVisible();
+      await expect(activeDiffFile).toHaveAttribute("title", "alpha.ts");
       await expect(panes).toHaveCount(1);
       await expect(homeTab).toHaveAttribute("aria-selected", "true");
 

--- a/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
@@ -264,6 +264,29 @@ test.describe("workspace tab persistence", () => {
       expect(toolbarMetrics.scrollWidth).toBeLessThanOrEqual(
         toolbarMetrics.clientWidth,
       );
+      await page.setViewportSize({ width: 760, height: 720 });
+      const compactDiffMetrics = await page
+        .locator(".right-sidebar .workspace-diff-layout")
+        .evaluate((layout) => {
+          const sidebar = layout.querySelector<HTMLElement>(
+            ".workspace-diff-sidebar",
+          );
+          const handle = layout.querySelector<HTMLElement>(
+            ".workspace-diff-resize-handle",
+          );
+          return {
+            direction: getComputedStyle(layout).flexDirection,
+            handleDisplay: handle ? getComputedStyle(handle).display : "",
+            layoutWidth: layout.getBoundingClientRect().width,
+            sidebarWidth: sidebar?.getBoundingClientRect().width ?? 0,
+          };
+        });
+      expect(compactDiffMetrics.direction).toBe("column");
+      expect(compactDiffMetrics.handleDisplay).toBe("none");
+      expect(compactDiffMetrics.sidebarWidth).toBeGreaterThanOrEqual(
+        compactDiffMetrics.layoutWidth - 1,
+      );
+      await page.setViewportSize({ width: 1100, height: 720 });
       await diffToolbar.locator(".compact-more-btn").click();
       const compactMenu = page.locator(".right-sidebar .compact-menu");
       await expect(compactMenu).toBeVisible();

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1281,6 +1281,15 @@ type GetWorkspacesByIdDiffParams struct {
 
 	// Path Optional file path to limit the returned patch
 	Path *string `form:"path,omitempty" json:"path,omitempty"`
+
+	// Commit Scope to a single commit SHA
+	Commit *string `form:"commit,omitempty" json:"commit,omitempty"`
+
+	// From Start SHA for range diff (inclusive)
+	From *string `form:"from,omitempty" json:"from,omitempty"`
+
+	// To End SHA for range diff (inclusive)
+	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
 // GetWorkspacesByIdFilesParams defines parameters for GetWorkspacesByIdFiles.
@@ -1290,6 +1299,15 @@ type GetWorkspacesByIdFilesParams struct {
 
 	// Whitespace Set to hide to ignore whitespace-only changes
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
+
+	// Commit Scope to a single commit SHA
+	Commit *string `form:"commit,omitempty" json:"commit,omitempty"`
+
+	// From Start SHA for range diff (inclusive)
+	From *string `form:"from,omitempty" json:"from,omitempty"`
+
+	// To End SHA for range diff (inclusive)
+	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
 // CreateIssueOnHostJSONRequestBody defines body for CreateIssueOnHost for application/json ContentType.
@@ -1865,6 +1883,9 @@ type ClientInterface interface {
 
 	// GetWorkspacesById request
 	GetWorkspacesById(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetWorkspacesByIdCommits request
+	GetWorkspacesByIdCommits(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetWorkspacesByIdDiff request
 	GetWorkspacesByIdDiff(ctx context.Context, id string, params *GetWorkspacesByIdDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3560,6 +3581,18 @@ func (c *Client) DeleteWorkspace(ctx context.Context, id string, params *DeleteW
 
 func (c *Client) GetWorkspacesById(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetWorkspacesByIdRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetWorkspacesByIdCommits(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkspacesByIdCommitsRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -9892,6 +9925,40 @@ func NewGetWorkspacesByIdRequest(server string, id string) (*http.Request, error
 	return req, nil
 }
 
+// NewGetWorkspacesByIdCommitsRequest generates requests for GetWorkspacesByIdCommits
+func NewGetWorkspacesByIdCommitsRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workspaces/%s/commits", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetWorkspacesByIdDiffRequest generates requests for GetWorkspacesByIdDiff
 func NewGetWorkspacesByIdDiffRequest(server string, id string, params *GetWorkspacesByIdDiffParams) (*http.Request, error) {
 	var err error
@@ -9969,6 +10036,54 @@ func NewGetWorkspacesByIdDiffRequest(server string, id string, params *GetWorksp
 
 		}
 
+		if params.Commit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "commit", *params.Commit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "from", *params.From, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.To != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "to", *params.To, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -10028,6 +10143,54 @@ func NewGetWorkspacesByIdFilesRequest(server string, id string, params *GetWorks
 		if params.Whitespace != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "whitespace", *params.Whitespace, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Commit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "commit", *params.Commit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "from", *params.From, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.To != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "to", *params.To, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -10662,6 +10825,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetWorkspacesByIdWithResponse request
 	GetWorkspacesByIdWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdResponse, error)
+
+	// GetWorkspacesByIdCommitsWithResponse request
+	GetWorkspacesByIdCommitsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdCommitsResponse, error)
 
 	// GetWorkspacesByIdDiffWithResponse request
 	GetWorkspacesByIdDiffWithResponse(ctx context.Context, id string, params *GetWorkspacesByIdDiffParams, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdDiffResponse, error)
@@ -12975,6 +13141,29 @@ func (r GetWorkspacesByIdResponse) StatusCode() int {
 	return 0
 }
 
+type GetWorkspacesByIdCommitsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *CommitsResponse
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r GetWorkspacesByIdCommitsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetWorkspacesByIdCommitsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetWorkspacesByIdDiffResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -14345,6 +14534,15 @@ func (c *ClientWithResponses) GetWorkspacesByIdWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseGetWorkspacesByIdResponse(rsp)
+}
+
+// GetWorkspacesByIdCommitsWithResponse request returning *GetWorkspacesByIdCommitsResponse
+func (c *ClientWithResponses) GetWorkspacesByIdCommitsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdCommitsResponse, error) {
+	rsp, err := c.GetWorkspacesByIdCommits(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetWorkspacesByIdCommitsResponse(rsp)
 }
 
 // GetWorkspacesByIdDiffWithResponse request returning *GetWorkspacesByIdDiffResponse
@@ -17617,6 +17815,39 @@ func ParseGetWorkspacesByIdResponse(rsp *http.Response) (*GetWorkspacesByIdRespo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest WorkspaceResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetWorkspacesByIdCommitsResponse parses an HTTP response from a GetWorkspacesByIdCommitsWithResponse call
+func ParseGetWorkspacesByIdCommitsResponse(rsp *http.Response) (*GetWorkspacesByIdCommitsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetWorkspacesByIdCommitsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CommitsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14192,6 +14192,95 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assert.Equal(int64(1), pushedDiff.WhitespaceOnlyCount)
 }
 
+func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "local-one.go"),
+		[]byte("package one\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "local one")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "local-two.go"),
+		[]byte("package two\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "local two")
+
+	commits := requestWorkspaceCommits(t, srv, ws.Id)
+	require.Len(commits.Commits, 3)
+	assert.Equal("local two", commits.Commits[0].Message)
+	assert.Equal("local one", commits.Commits[1].Message)
+	assert.Equal("feature commit", commits.Commits[2].Message)
+}
+
+func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
+	require := require.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "local-one.go"),
+		[]byte("package one\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "local one")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "local-two.go"),
+		[]byte("package two\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "local two")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "dirty.go"),
+		[]byte("package dirty\n"), 0o644,
+	))
+
+	commits := requestWorkspaceCommits(t, srv, ws.Id)
+	require.Len(commits.Commits, 3)
+	newest := commits.Commits[0].SHA
+	older := commits.Commits[1].SHA
+
+	singleFiles := requestWorkspaceFilesQuery(
+		t, srv, ws.Id, "base=head&commit="+url.QueryEscape(newest),
+	)
+	require.NotNil(singleFiles.Files)
+	assertWorkspaceDiffPaths(t, *singleFiles.Files, []string{"local-two.go"})
+
+	singleDiff := requestWorkspaceDiffQuery(
+		t, srv, ws.Id, "base=head&commit="+url.QueryEscape(newest),
+	)
+	require.NotNil(singleDiff.Files)
+	assertWorkspaceDiffPaths(t, *singleDiff.Files, []string{"local-two.go"})
+
+	rangeDiff := requestWorkspaceDiffQuery(
+		t,
+		srv,
+		ws.Id,
+		"base=head&from="+url.QueryEscape(older)+"&to="+url.QueryEscape(newest),
+	)
+	require.NotNil(rangeDiff.Files)
+	assertWorkspaceDiffPaths(
+		t,
+		*rangeDiff.Files,
+		[]string{"local-one.go", "local-two.go"},
+	)
+}
+
 func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -14392,6 +14481,29 @@ func requestWorkspaceFiles(
 	if len(whitespace) > 0 {
 		query += "&whitespace=" + whitespace[0]
 	}
+	return requestWorkspaceFilesPath(t, srv, query)
+}
+
+func requestWorkspaceFilesQuery(
+	t *testing.T,
+	srv *Server,
+	workspaceID string,
+	query string,
+) generated.FilesResponse {
+	t.Helper()
+
+	return requestWorkspaceFilesPath(
+		t, srv, "/api/v1/workspaces/"+workspaceID+"/files?"+query,
+	)
+}
+
+func requestWorkspaceFilesPath(
+	t *testing.T,
+	srv *Server,
+	query string,
+) generated.FilesResponse {
+	t.Helper()
+
 	req := httptest.NewRequest(
 		http.MethodGet,
 		query,
@@ -14404,6 +14516,29 @@ func requestWorkspaceFiles(
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var body generated.FilesResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return body
+}
+
+func requestWorkspaceCommits(
+	t *testing.T,
+	srv *Server,
+	workspaceID string,
+) commitsResponse {
+	t.Helper()
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/workspaces/"+workspaceID+"/commits",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body commitsResponse
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 	return body
 }
@@ -14421,6 +14556,29 @@ func requestWorkspaceDiff(
 	if len(whitespace) > 0 {
 		query += "&whitespace=" + whitespace[0]
 	}
+	return requestWorkspaceDiffPath(t, srv, query)
+}
+
+func requestWorkspaceDiffQuery(
+	t *testing.T,
+	srv *Server,
+	workspaceID string,
+	query string,
+) generated.DiffResponse {
+	t.Helper()
+
+	return requestWorkspaceDiffPath(
+		t, srv, "/api/v1/workspaces/"+workspaceID+"/diff?"+query,
+	)
+}
+
+func requestWorkspaceDiffPath(
+	t *testing.T,
+	srv *Server,
+	query string,
+) generated.DiffResponse {
+	t.Helper()
+
 	req := httptest.NewRequest(
 		http.MethodGet,
 		query,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14267,6 +14267,19 @@ func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
 	require.NotNil(singleDiff.Files)
 	assertWorkspaceDiffPaths(t, *singleDiff.Files, []string{"local-two.go"})
 
+	rangeFiles := requestWorkspaceFilesQuery(
+		t,
+		srv,
+		ws.Id,
+		"base=head&from="+url.QueryEscape(older)+"&to="+url.QueryEscape(newest),
+	)
+	require.NotNil(rangeFiles.Files)
+	assertWorkspaceDiffPaths(
+		t,
+		*rangeFiles.Files,
+		[]string{"local-one.go", "local-two.go"},
+	)
+
 	rangeDiff := requestWorkspaceDiffQuery(
 		t,
 		srv,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -330,6 +330,9 @@ type getWorkspaceFilesInput struct {
 	ID         string `path:"id"`
 	Base       string `query:"base"      doc:"Diff base: head, pushed, or merge-target"`
 	Whitespace string `query:"whitespace" doc:"Set to hide to ignore whitespace-only changes"`
+	Commit     string `query:"commit" doc:"Scope to a single commit SHA"`
+	From       string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
+	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
 }
 
 type getWorkspaceDiffInput struct {
@@ -337,6 +340,13 @@ type getWorkspaceDiffInput struct {
 	Base       string `query:"base"      doc:"Diff base: head, pushed, or merge-target"`
 	Whitespace string `query:"whitespace" doc:"Set to hide to ignore whitespace-only changes"`
 	Path       string `query:"path"      doc:"Optional file path to limit the returned patch"`
+	Commit     string `query:"commit" doc:"Scope to a single commit SHA"`
+	From       string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
+	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
+}
+
+type getWorkspaceCommitsInput struct {
+	ID string `path:"id"`
 }
 
 type retryWorkspaceInput struct {
@@ -374,6 +384,7 @@ type getWorkspaceOutput = bodyOutput[workspaceResponse]
 
 type getWorkspaceDiffOutput = bodyOutput[diffResponse]
 type getWorkspaceFilesOutput = bodyOutput[filesResponse]
+type getWorkspaceCommitsOutput = bodyOutput[commitsResponse]
 
 type getWorkspaceRuntimeOutput = bodyOutput[workspaceRuntimeResponse]
 
@@ -385,6 +396,8 @@ type workspaceDiffRequest struct {
 	Summary           *db.WorkspaceSummary
 	Base              workspace.WorktreeDiffBase
 	MergeTargetBranch string
+	FromSHA           string
+	ToSHA             string
 }
 
 type listActivityInput struct {
@@ -490,6 +503,7 @@ func (s *Server) registerAPI(api huma.API) {
 	}, s.createWorkspace)
 	huma.Get(api, "/workspaces", s.listWorkspaces)
 	huma.Get(api, "/workspaces/{id}", s.getWorkspace)
+	huma.Get(api, "/workspaces/{id}/commits", s.getWorkspaceCommits)
 	huma.Get(api, "/workspaces/{id}/diff", s.getWorkspaceDiff)
 	huma.Get(api, "/workspaces/{id}/files", s.getWorkspaceFiles)
 	huma.Register(api, huma.Operation{
@@ -3488,11 +3502,51 @@ func (s *Server) getWorkspace(
 	}, nil
 }
 
+func (s *Server) getWorkspaceCommits(
+	ctx context.Context, input *getWorkspaceCommitsInput,
+) (*getWorkspaceCommitsOutput, error) {
+	req, err := s.workspaceDiffRequest(ctx, input.ID, "")
+	if err != nil {
+		return nil, err
+	}
+
+	commits, ok, err := s.workspaceCommits(ctx, req)
+	if err != nil {
+		slog.Error(
+			"failed to list workspace commits",
+			"workspace_id", input.ID,
+			"err", err,
+		)
+		return nil, huma.Error502BadGateway("failed to list workspace commits")
+	}
+	if !ok {
+		return nil, huma.Error404NotFound(
+			"commits not available for this workspace",
+		)
+	}
+
+	resp := commitsResponse{Commits: make([]commitResponse, len(commits))}
+	for i, c := range commits {
+		resp.Commits[i] = commitResponse{
+			SHA:        c.SHA,
+			Message:    c.Message,
+			AuthorName: c.AuthorName,
+			AuthoredAt: c.AuthoredAt.UTC(),
+		}
+	}
+	return &getWorkspaceCommitsOutput{Body: resp}, nil
+}
+
 func (s *Server) getWorkspaceFiles(
 	ctx context.Context, input *getWorkspaceFilesInput,
 ) (*getWorkspaceFilesOutput, error) {
 	req, err := s.workspaceDiffRequest(ctx, input.ID, input.Base)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.applyWorkspaceDiffScope(
+		ctx, &req, input.Commit, input.From, input.To,
+	); err != nil {
 		return nil, err
 	}
 
@@ -3540,6 +3594,11 @@ func (s *Server) getWorkspaceDiff(
 ) (*getWorkspaceDiffOutput, error) {
 	req, err := s.workspaceDiffRequest(ctx, input.ID, input.Base)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.applyWorkspaceDiffScope(
+		ctx, &req, input.Commit, input.From, input.To,
+	); err != nil {
 		return nil, err
 	}
 
@@ -3621,11 +3680,125 @@ func (s *Server) workspaceDiffRequest(
 	}
 }
 
+func (s *Server) workspaceCommits(
+	ctx context.Context,
+	req workspaceDiffRequest,
+) ([]gitclone.Commit, bool, error) {
+	targetBranch, ok, err := s.workspaceMergeTargetBranch(ctx, req.Summary)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return workspace.WorktreeCommitsAgainstMergeTarget(
+		ctx,
+		req.Summary.WorktreePath,
+		targetBranch,
+	)
+}
+
+func (s *Server) applyWorkspaceDiffScope(
+	ctx context.Context,
+	req *workspaceDiffRequest,
+	commit string,
+	from string,
+	to string,
+) error {
+	hasCommit := commit != ""
+	hasFrom := from != ""
+	hasTo := to != ""
+
+	switch {
+	case !hasCommit && !hasFrom && !hasTo:
+		return nil
+
+	case hasCommit && !hasFrom && !hasTo:
+		if _, err := s.validateWorkspaceSHAs(ctx, *req, commit); err != nil {
+			return err
+		}
+		parent, err := workspace.WorktreeParentOf(
+			ctx, req.Summary.WorktreePath, commit,
+		)
+		if err != nil {
+			return huma.Error500InternalServerError(
+				"failed to resolve parent: " + err.Error(),
+			)
+		}
+		req.FromSHA = parent
+		req.ToSHA = commit
+		return nil
+
+	case !hasCommit && hasFrom && hasTo:
+		indexMap, err := s.validateWorkspaceSHAs(ctx, *req, from, to)
+		if err != nil {
+			return err
+		}
+		if indexMap[from] < indexMap[to] {
+			return huma.Error400BadRequest(
+				"invalid range: 'from' must be older than or equal to 'to'",
+			)
+		}
+		parent, err := workspace.WorktreeParentOf(
+			ctx, req.Summary.WorktreePath, from,
+		)
+		if err != nil {
+			return huma.Error500InternalServerError(
+				"failed to resolve parent: " + err.Error(),
+			)
+		}
+		req.FromSHA = parent
+		req.ToSHA = to
+		return nil
+
+	default:
+		return huma.Error400BadRequest(
+			"invalid scope: use 'commit' alone or 'from'+'to' together",
+		)
+	}
+}
+
+func (s *Server) validateWorkspaceSHAs(
+	ctx context.Context,
+	req workspaceDiffRequest,
+	shas ...string,
+) (map[string]int, error) {
+	commits, ok, err := s.workspaceCommits(ctx, req)
+	if err != nil {
+		return nil, huma.Error502BadGateway(
+			"failed to list workspace commits: " + err.Error(),
+		)
+	}
+	if !ok {
+		return nil, huma.Error404NotFound(
+			"commits not available for this workspace",
+		)
+	}
+	indexMap := make(map[string]int, len(commits))
+	for i, c := range commits {
+		indexMap[c.SHA] = i
+	}
+	for _, sha := range shas {
+		if _, ok := indexMap[sha]; !ok {
+			return nil, huma.Error400BadRequest(
+				"invalid scope: commit is not in this workspace branch",
+			)
+		}
+	}
+	return indexMap, nil
+}
+
 func (s *Server) workspaceDiffFiles(
 	ctx context.Context,
 	req workspaceDiffRequest,
 	hideWhitespace bool,
 ) ([]gitclone.DiffFile, bool, error) {
+	if req.FromSHA != "" && req.ToSHA != "" {
+		return workspace.WorktreeDiffFilesBetween(
+			ctx,
+			req.Summary.WorktreePath,
+			req.FromSHA,
+			req.ToSHA,
+			hideWhitespace,
+		)
+	}
 	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
 		return workspace.WorktreeDiffFilesAgainstMergeTarget(
 			ctx,
@@ -3645,6 +3818,25 @@ func (s *Server) workspaceDiff(
 	hideWhitespace bool,
 	path string,
 ) (*gitclone.DiffResult, bool, error) {
+	if req.FromSHA != "" && req.ToSHA != "" {
+		if path != "" {
+			return workspace.WorktreeFileDiffBetween(
+				ctx,
+				req.Summary.WorktreePath,
+				req.FromSHA,
+				req.ToSHA,
+				hideWhitespace,
+				path,
+			)
+		}
+		return workspace.WorktreeDiffBetween(
+			ctx,
+			req.Summary.WorktreePath,
+			req.FromSHA,
+			req.ToSHA,
+			hideWhitespace,
+		)
+	}
 	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
 		if path != "" {
 			return workspace.WorktreeFileDiffAgainstMergeTarget(
@@ -3676,6 +3868,19 @@ func (s *Server) workspaceDiffWhitespaceOnlyCount(
 	ctx context.Context,
 	req workspaceDiffRequest,
 ) (int, bool, error) {
+	if req.FromSHA != "" && req.ToSHA != "" {
+		result, ok, err := workspace.WorktreeDiffBetween(
+			ctx,
+			req.Summary.WorktreePath,
+			req.FromSHA,
+			req.ToSHA,
+			false,
+		)
+		if result == nil {
+			return 0, ok, err
+		}
+		return result.WhitespaceOnlyCount, ok, err
+	}
 	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
 		return workspace.WorktreeDiffWhitespaceOnlyCountAgainstMergeTarget(
 			ctx,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3869,17 +3869,12 @@ func (s *Server) workspaceDiffWhitespaceOnlyCount(
 	req workspaceDiffRequest,
 ) (int, bool, error) {
 	if req.FromSHA != "" && req.ToSHA != "" {
-		result, ok, err := workspace.WorktreeDiffBetween(
+		return workspace.WorktreeDiffWhitespaceOnlyCountBetween(
 			ctx,
 			req.Summary.WorktreePath,
 			req.FromSHA,
 			req.ToSHA,
-			false,
 		)
-		if result == nil {
-			return 0, ok, err
-		}
-		return result.WhitespaceOnlyCount, ok, err
 	}
 	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
 		return workspace.WorktreeDiffWhitespaceOnlyCountAgainstMergeTarget(

--- a/internal/workspace/commits.go
+++ b/internal/workspace/commits.go
@@ -1,0 +1,93 @@
+package workspace
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wesm/middleman/internal/gitclone"
+)
+
+const emptyTreeSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+// WorktreeCommitsAgainstMergeTarget returns first-parent commits on the
+// checked-out workspace branch that are not reachable from the merge target.
+func WorktreeCommitsAgainstMergeTarget(
+	ctx context.Context,
+	dir string,
+	targetBranch string,
+) ([]gitclone.Commit, bool, error) {
+	baseRef, ok, err := worktreeMergeTargetBaseRef(ctx, dir, targetBranch)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	commits, err := worktreeCommits(ctx, dir, baseRef, "HEAD")
+	return commits, true, err
+}
+
+func worktreeCommits(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	headRef string,
+) ([]gitclone.Commit, error) {
+	args := []string{
+		"log",
+		"--first-parent",
+		"--format=%H%x00%an%x00%aI%x00%s",
+		baseRef + ".." + headRef,
+	}
+	out, err := worktreeGitOutput(ctx, dir, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list commits: %w", err)
+	}
+
+	var commits []gitclone.Commit
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\x00", 4)
+		if len(parts) != 4 {
+			return nil, fmt.Errorf("unexpected git log line: %q", line)
+		}
+		t, err := time.Parse(time.RFC3339, parts[2])
+		if err != nil {
+			return nil, fmt.Errorf("parse commit date %q: %w", parts[2], err)
+		}
+		commits = append(commits, gitclone.Commit{
+			SHA:        parts[0],
+			AuthorName: parts[1],
+			AuthoredAt: t,
+			Message:    parts[3],
+		})
+	}
+	return commits, scanner.Err()
+}
+
+func WorktreeParentOf(
+	ctx context.Context,
+	dir string,
+	sha string,
+) (string, error) {
+	out, err := worktreeGitOutput(ctx, dir,
+		"rev-list", "--parents", "-n", "1", sha,
+	)
+	if err != nil {
+		return "", fmt.Errorf("parent of %s: %w", sha, err)
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("parent of %s: empty rev-list output", sha)
+	}
+	if len(fields) == 1 {
+		return emptyTreeSHA, nil
+	}
+	return fields[1], nil
+}

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -83,6 +83,16 @@ func WorktreeDiffWhitespaceOnlyCountAgainstMergeTarget(
 	return count, true, err
 }
 
+func WorktreeDiffWhitespaceOnlyCountBetween(
+	ctx context.Context,
+	dir string,
+	fromRef string,
+	toRef string,
+) (int, bool, error) {
+	count, err := worktreeWhitespaceOnlyCount(ctx, dir, fromRef, toRef, "")
+	return count, err == nil, err
+}
+
 func worktreeDiffFilesFromRef(
 	ctx context.Context,
 	dir string,

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -51,7 +51,7 @@ func WorktreeDiffWhitespaceOnlyCount(
 		return 0, ok, err
 	}
 
-	count, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, "")
+	count, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, "", "")
 	return count, true, err
 }
 
@@ -79,7 +79,7 @@ func WorktreeDiffWhitespaceOnlyCountAgainstMergeTarget(
 		return 0, ok, err
 	}
 
-	count, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, "")
+	count, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, "", "")
 	return count, true, err
 }
 
@@ -89,42 +89,71 @@ func worktreeDiffFilesFromRef(
 	baseRef string,
 	hideWhitespace bool,
 ) ([]gitclone.DiffFile, bool, error) {
-	rawArgs := addWorktreeWhitespaceFlag([]string{
+	files, err := worktreeDiffFilesFromRefs(
+		ctx, dir, baseRef, "", hideWhitespace, true,
+	)
+	return files, err == nil, err
+}
+
+func WorktreeDiffFilesBetween(
+	ctx context.Context,
+	dir string,
+	fromRef string,
+	toRef string,
+	hideWhitespace bool,
+) ([]gitclone.DiffFile, bool, error) {
+	files, err := worktreeDiffFilesFromRefs(
+		ctx, dir, fromRef, toRef, hideWhitespace, false,
+	)
+	return files, err == nil, err
+}
+
+func worktreeDiffFilesFromRefs(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	headRef string,
+	hideWhitespace bool,
+	includeUntracked bool,
+) ([]gitclone.DiffFile, error) {
+	rawArgs := appendWorktreeHeadRef(addWorktreeWhitespaceFlag([]string{
 		"diff", "--raw", "-z", "-M", "-C", "--find-copies-harder",
 		baseRef,
-	}, hideWhitespace)
+	}, hideWhitespace), headRef)
 	rawOut, err := worktreeGitOutput(ctx, dir, rawArgs...)
 	if err != nil {
-		return nil, false, fmt.Errorf("git diff --raw: %w", err)
+		return nil, fmt.Errorf("git diff --raw: %w", err)
 	}
 	files := gitclone.ParseRawZ(rawOut)
 	if files == nil {
 		files = []gitclone.DiffFile{}
 	}
 	if hideWhitespace {
-		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, "")
+		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, headRef, "")
 		if err != nil {
-			return nil, false, fmt.Errorf("whitespace files: %w", err)
+			return nil, fmt.Errorf("whitespace files: %w", err)
 		}
 		files = filterWorktreeWhitespaceOnlyFiles(files, wsFiles)
 	}
 
-	numstatArgs := addWorktreeWhitespaceFlag([]string{
+	numstatArgs := appendWorktreeHeadRef(addWorktreeWhitespaceFlag([]string{
 		"diff", "--numstat", "-z", "-M", "-C", "--find-copies-harder",
 		baseRef,
-	}, hideWhitespace)
+	}, hideWhitespace), headRef)
 	numstatOut, err := worktreeGitOutput(ctx, dir, numstatArgs...)
 	if err != nil {
-		return nil, false, fmt.Errorf("git diff --numstat: %w", err)
+		return nil, fmt.Errorf("git diff --numstat: %w", err)
 	}
 	counts := parseWorktreeNumstatZ(numstatOut)
 	applyWorktreeNumstat(files, counts)
 	if hideWhitespace {
 		files = dropWhitespaceOnlyModifications(files, counts)
 	}
-	files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
+	if includeUntracked {
+		files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
+	}
 	markWorktreeGeneratedFiles(ctx, dir, files)
-	return files, true, nil
+	return files, nil
 }
 
 func WorktreeDiff(
@@ -194,6 +223,33 @@ func worktreeDiffFromRef(
 	return worktreeDiffFromRefPath(ctx, dir, baseRef, hideWhitespace, "")
 }
 
+func WorktreeDiffBetween(
+	ctx context.Context,
+	dir string,
+	fromRef string,
+	toRef string,
+	hideWhitespace bool,
+) (*gitclone.DiffResult, bool, error) {
+	result, err := worktreeDiffFromRefsPath(
+		ctx, dir, fromRef, toRef, hideWhitespace, "", false,
+	)
+	return result, err == nil, err
+}
+
+func WorktreeFileDiffBetween(
+	ctx context.Context,
+	dir string,
+	fromRef string,
+	toRef string,
+	hideWhitespace bool,
+	path string,
+) (*gitclone.DiffResult, bool, error) {
+	result, err := worktreeDiffFromRefsPath(
+		ctx, dir, fromRef, toRef, hideWhitespace, path, false,
+	)
+	return result, err == nil, err
+}
+
 func worktreeDiffFromRefPath(
 	ctx context.Context,
 	dir string,
@@ -201,44 +257,59 @@ func worktreeDiffFromRefPath(
 	hideWhitespace bool,
 	path string,
 ) (*gitclone.DiffResult, bool, error) {
+	result, err := worktreeDiffFromRefsPath(
+		ctx, dir, baseRef, "", hideWhitespace, path, true,
+	)
+	return result, err == nil, err
+}
+
+func worktreeDiffFromRefsPath(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	headRef string,
+	hideWhitespace bool,
+	path string,
+	includeUntracked bool,
+) (*gitclone.DiffResult, error) {
 	path, err := cleanWorktreeDiffPath(path)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
-	wsCount, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, path)
+	wsCount, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, headRef, path)
 	if err != nil {
-		return nil, false, fmt.Errorf("whitespace count: %w", err)
+		return nil, fmt.Errorf("whitespace count: %w", err)
 	}
 
-	rawArgs := addWorktreeWhitespaceFlag([]string{
+	rawArgs := appendWorktreeHeadRef(addWorktreeWhitespaceFlag([]string{
 		"diff", "--raw", "-z", "-M", "-C", "--find-copies-harder",
 		baseRef,
-	}, hideWhitespace)
+	}, hideWhitespace), headRef)
 	rawArgs = appendWorktreePathspec(rawArgs, path)
 	rawOut, err := worktreeGitOutput(ctx, dir, rawArgs...)
 	if err != nil {
-		return nil, false, fmt.Errorf("git diff --raw: %w", err)
+		return nil, fmt.Errorf("git diff --raw: %w", err)
 	}
 	files := gitclone.ParseRawZ(rawOut)
 
-	numstatArgs := addWorktreeWhitespaceFlag([]string{
+	numstatArgs := appendWorktreeHeadRef(addWorktreeWhitespaceFlag([]string{
 		"diff", "--numstat", "-z", "-M", "-C", "--find-copies-harder",
 		baseRef,
-	}, hideWhitespace)
+	}, hideWhitespace), headRef)
 	numstatArgs = appendWorktreePathspec(numstatArgs, path)
 	numstatOut, err := worktreeGitOutput(ctx, dir, numstatArgs...)
 	if err != nil {
-		return nil, false, fmt.Errorf("git diff --numstat: %w", err)
+		return nil, fmt.Errorf("git diff --numstat: %w", err)
 	}
 
-	patchArgs := addWorktreeWhitespaceFlag([]string{
+	patchArgs := appendWorktreeHeadRef(addWorktreeWhitespaceFlag([]string{
 		"diff", "-M", "-C", "--find-copies-harder", "-U3", baseRef,
-	}, hideWhitespace)
+	}, hideWhitespace), headRef)
 	patchArgs = appendWorktreePathspec(patchArgs, path)
 	patchOut, err := worktreeGitOutput(ctx, dir, patchArgs...)
 	if err != nil {
-		return nil, false, fmt.Errorf("git diff patch: %w", err)
+		return nil, fmt.Errorf("git diff patch: %w", err)
 	}
 	files = gitclone.ParsePatch(patchOut, files)
 	if files == nil {
@@ -251,26 +322,28 @@ func worktreeDiffFromRefPath(
 	}
 
 	if !hideWhitespace {
-		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, path)
+		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, headRef, path)
 		if err == nil {
 			for i := range files {
 				files[i].IsWhitespaceOnly = wsFiles[files[i].Path]
 			}
 		}
 	}
-	if path == "" {
+	if includeUntracked && path == "" {
 		files = append(files, worktreeUntrackedFiles(ctx, dir, true, hideWhitespace)...)
-	} else if file, ok := worktreeUntrackedFile(
-		ctx, dir, path, true, hideWhitespace,
-	); ok {
-		files = append(files, file)
+	} else if includeUntracked {
+		if file, ok := worktreeUntrackedFile(
+			ctx, dir, path, true, hideWhitespace,
+		); ok {
+			files = append(files, file)
+		}
 	}
 	markWorktreeGeneratedFiles(ctx, dir, files)
 
 	return &gitclone.DiffResult{
 		WhitespaceOnlyCount: wsCount,
 		Files:               files,
-	}, true, nil
+	}, nil
 }
 
 func markWorktreeGeneratedFiles(
@@ -368,6 +441,13 @@ func appendWorktreePathspec(args []string, path string) []string {
 		return args
 	}
 	return append(args, "--", path)
+}
+
+func appendWorktreeHeadRef(args []string, headRef string) []string {
+	if headRef == "" {
+		return args
+	}
+	return append(args, headRef)
 }
 
 func cleanWorktreeDiffPath(path string) (string, error) {
@@ -608,9 +688,9 @@ func parseWorktreeNumstatInt(value string) int {
 }
 
 func worktreeWhitespaceOnlyCount(
-	ctx context.Context, dir string, baseRef string, path string,
+	ctx context.Context, dir string, baseRef string, headRef string, path string,
 ) (int, error) {
-	files, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, path)
+	files, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, headRef, path)
 	if err != nil {
 		return 0, err
 	}
@@ -618,11 +698,11 @@ func worktreeWhitespaceOnlyCount(
 }
 
 func worktreeWhitespaceOnlyFiles(
-	ctx context.Context, dir string, baseRef string, path string,
+	ctx context.Context, dir string, baseRef string, headRef string, path string,
 ) (map[string]bool, error) {
-	allArgs := appendWorktreePathspec([]string{
+	allArgs := appendWorktreePathspec(appendWorktreeHeadRef([]string{
 		"diff", "--raw", "-z", "--no-renames", baseRef,
-	}, path)
+	}, headRef), path)
 	outAll, err := worktreeGitOutput(ctx, dir, allArgs...)
 	if err != nil {
 		return nil, err
@@ -631,8 +711,11 @@ func worktreeWhitespaceOnlyFiles(
 	allFiles := worktreeRawPaths(outAll)
 	result := make(map[string]bool)
 	for file := range allFiles {
-		outNoWhitespace, err := worktreeGitOutput(ctx, dir,
-			"diff", "--numstat", "-z", "--no-renames", "-w", baseRef, "--", file,
+		args := appendWorktreeHeadRef([]string{
+			"diff", "--numstat", "-z", "--no-renames", "-w", baseRef,
+		}, headRef)
+		outNoWhitespace, err := worktreeGitOutput(
+			ctx, dir, appendWorktreePathspec(args, file)...,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/workspace/diff_test.go
+++ b/internal/workspace/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	Assert "github.com/stretchr/testify/assert"
@@ -172,6 +173,35 @@ func TestWorktreeDiffAgainstPushedBranchIncludesLocalCommitsAndDirtyChanges(t *t
 	assert.Contains(paths, "committed.go")
 	assert.Contains(paths, "dirty.go")
 	assert.Equal(0, diff.WhitespaceOnlyCount)
+}
+
+func TestWorktreeDiffWhitespaceOnlyCountBetweenUsesRangeRefs(t *testing.T) {
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	baseSHA := strings.TrimSpace(
+		string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD")),
+	)
+
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "f.txt"), []byte("f1  \n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "whitespace change")
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "base.txt"), []byte("base changed\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "content change")
+	headSHA := strings.TrimSpace(
+		string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD")),
+	)
+
+	count, ok, err := WorktreeDiffWhitespaceOnlyCountBetween(
+		t.Context(), work, baseSHA, headSHA,
+	)
+	require.NoError(err)
+	require.True(ok)
+	Assert.New(t).Equal(1, count)
 }
 
 func TestWorktreeDiffAgainstMergeTargetUsesMergeBase(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -653,7 +653,7 @@ func configureForkPRRefs(
 	return originSHA, pullSHA
 }
 
-func runWorkspaceTestGit(t *testing.T, dir string, args ...string) {
+func runWorkspaceTestGit(t *testing.T, dir string, args ...string) []byte {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
@@ -664,6 +664,7 @@ func runWorkspaceTestGit(t *testing.T, dir string, args ...string) {
 	)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v failed: %s", args, out)
+	return out
 }
 
 func TestShellFromPasswdLine(t *testing.T) {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1457,6 +1457,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/workspaces/{id}/commits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get workspaces by ID commits */
+        get: operations["get-workspaces-by-id-commits"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/workspaces/{id}/diff": {
         parameters: {
             query?: never;
@@ -6460,6 +6477,37 @@ export interface operations {
             };
         };
     };
+    "get-workspaces-by-id-commits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommitsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "get-workspaces-by-id-diff": {
         parameters: {
             query?: {
@@ -6469,6 +6517,12 @@ export interface operations {
                 whitespace?: string;
                 /** @description Optional file path to limit the returned patch */
                 path?: string;
+                /** @description Scope to a single commit SHA */
+                commit?: string;
+                /** @description Start SHA for range diff (inclusive) */
+                from?: string;
+                /** @description End SHA for range diff (inclusive) */
+                to?: string;
             };
             header?: never;
             path: {
@@ -6505,6 +6559,12 @@ export interface operations {
                 base?: string;
                 /** @description Set to hide to ignore whitespace-only changes */
                 whitespace?: string;
+                /** @description Scope to a single commit SHA */
+                commit?: string;
+                /** @description Start SHA for range diff (inclusive) */
+                from?: string;
+                /** @description End SHA for range diff (inclusive) */
+                to?: string;
             };
             header?: never;
             path: {

--- a/packages/ui/src/components/diff/DiffFilesLayout.svelte
+++ b/packages/ui/src/components/diff/DiffFilesLayout.svelte
@@ -141,7 +141,7 @@
       aria-label="Changed files"
       style:--diff-file-tree-width={`${fileTreeWidth}px`}
     >
-      <DiffSidebar />
+      <DiffSidebar showCommits={false} />
     </aside>
     <SplitResizeHandle
       class="files-resize-handle"

--- a/packages/ui/src/components/diff/DiffScopePicker.svelte
+++ b/packages/ui/src/components/diff/DiffScopePicker.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+  import { getStores } from "../../context.js";
+  import CommitListItem from "./CommitListItem.svelte";
+  import ScopePill from "./ScopePill.svelte";
+
+  const { diff: diffStore } = getStores();
+
+  let open = $state(false);
+  let pickerRef = $state<HTMLDivElement>();
+
+  const commits = $derived(diffStore.getCommits());
+  const commitsLoading = $derived(diffStore.isCommitsLoading());
+  const commitsError = $derived(diffStore.getCommitsError());
+  const scope = $derived(diffStore.getScope());
+
+  function toggle(): void {
+    open = !open;
+    if (open) {
+      void diffStore.loadCommits();
+    }
+  }
+
+  function close(): void {
+    open = false;
+  }
+
+  function isActive(sha: string): boolean {
+    if (scope.kind === "commit") return scope.sha === sha;
+    if (scope.kind !== "range" || !commits) return false;
+    const fromIdx = commits.findIndex((c) => c.sha === scope.fromSha);
+    const toIdx = commits.findIndex((c) => c.sha === scope.toSha);
+    const idx = commits.findIndex((c) => c.sha === sha);
+    if (fromIdx === -1 || toIdx === -1 || idx === -1) return false;
+    return idx >= toIdx && idx <= fromIdx;
+  }
+
+  function handleCommitClick(sha: string, shiftKey: boolean): void {
+    if (shiftKey && scope.kind === "commit") {
+      diffStore.selectRange(scope.sha, sha);
+    } else {
+      diffStore.selectCommit(sha);
+    }
+  }
+
+  function handleDocumentClick(event: MouseEvent): void {
+    if (!open) return;
+    const target = event.target;
+    if (target instanceof Node && pickerRef?.contains(target)) return;
+    close();
+  }
+
+  function handleDocumentKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") close();
+  }
+</script>
+
+<svelte:document onclick={handleDocumentClick} onkeydown={handleDocumentKeydown} />
+
+<div class="diff-scope-picker" bind:this={pickerRef}>
+  <div class="diff-scope-picker__control">
+    <button
+      class="diff-scope-picker__trigger"
+      type="button"
+      aria-label="Select commit range"
+      aria-expanded={open}
+      onclick={toggle}
+    >
+      <span class="diff-scope-picker__label">Commits</span>
+    </button>
+    <ScopePill {scope} onreset={diffStore.resetToHead} />
+  </div>
+
+  {#if open}
+    <div class="diff-scope-picker__menu">
+      <div class="diff-scope-picker__menu-header">
+        <span>Commit range</span>
+        {#if scope.kind !== "head"}
+          <button
+            class="diff-scope-picker__reset"
+            type="button"
+            onclick={diffStore.resetToHead}
+          >
+            Clear
+          </button>
+        {/if}
+      </div>
+
+      {#if commitsLoading}
+        <div class="diff-scope-picker__state">Loading commits</div>
+      {:else if commitsError}
+        <div class="diff-scope-picker__state diff-scope-picker__state--error">
+          {commitsError}
+        </div>
+      {:else if commits && commits.length > 0}
+        <div class="diff-scope-picker__list">
+          {#each commits as commit (commit.sha)}
+            <CommitListItem
+              {commit}
+              active={isActive(commit.sha)}
+              onclick={handleCommitClick}
+            />
+          {/each}
+        </div>
+      {:else if commits}
+        <div class="diff-scope-picker__state">No commits</div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .diff-scope-picker {
+    position: relative;
+    min-width: 0;
+    flex-shrink: 0;
+  }
+
+  .diff-scope-picker__control {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 26px;
+    padding: 2px 6px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+  }
+
+  .diff-scope-picker__control:hover {
+    border-color: var(--accent-blue);
+    color: var(--text-primary);
+  }
+
+  .diff-scope-picker__trigger {
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+  }
+
+  .diff-scope-picker__label {
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .diff-scope-picker__menu {
+    position: absolute;
+    z-index: 55;
+    top: calc(100% + 4px);
+    right: 0;
+    width: min(420px, 72vw);
+    max-height: min(460px, 70vh);
+    overflow: hidden;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    box-shadow: var(--shadow-md);
+  }
+
+  .diff-scope-picker__menu-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 7px 10px;
+    border-bottom: 1px solid var(--border-muted);
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .diff-scope-picker__reset {
+    border: 0;
+    background: transparent;
+    color: var(--accent-blue);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+  }
+
+  .diff-scope-picker__list {
+    max-height: 390px;
+    overflow-y: auto;
+    padding: 3px 0;
+  }
+
+  .diff-scope-picker__state {
+    padding: 12px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .diff-scope-picker__state--error {
+    color: var(--accent-red);
+  }
+
+  @media (max-width: 720px) {
+    .diff-scope-picker__menu {
+      left: 0;
+      right: auto;
+      width: min(360px, 86vw);
+    }
+  }
+</style>

--- a/packages/ui/src/components/diff/DiffSidebar.svelte
+++ b/packages/ui/src/components/diff/DiffSidebar.svelte
@@ -81,9 +81,7 @@
   // does not silently hide files in the next PR.
   $effect(() => {
     const key = resetKey;
-    if (showCommits) {
-      pulls.getSelectedPR();
-    }
+    pulls.getSelectedPR();
     if (key === "\0") return;
     fileFilterText = "";
   });

--- a/packages/ui/src/components/diff/DiffSidebar.svelte
+++ b/packages/ui/src/components/diff/DiffSidebar.svelte
@@ -63,6 +63,18 @@
     }
   }
 
+  function handleFileRowClick(path: string): void {
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) return;
+    diff.requestScrollToFile(path);
+  }
+
+  function handleFileRowKeydown(event: KeyboardEvent, path: string): void {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    diff.requestScrollToFile(path);
+  }
+
   // Per-diff file filter input (shown when 10+ files in diff).
   let fileFilterText = $state("");
   // Reset filter whenever selected PR changes so stale filter text
@@ -113,16 +125,19 @@
         <div class="diff-dir-header">{group.dir}/</div>
       {/if}
       {#each group.files as f (f.path)}
-        <button
+        <div
           class="diff-file-row"
           class:diff-file-row--active={diff.getActiveFile() === f.path}
           class:diff-file-row--nested={!!group.dir}
-          onclick={() => diff.requestScrollToFile(f.path)}
+          role="button"
+          tabindex="0"
+          onclick={() => handleFileRowClick(f.path)}
+          onkeydown={(event) => handleFileRowKeydown(event, f.path)}
           title={f.path}
         >
           <span class="diff-file-status" style="color: {statusColor(f.status)}">{statusLetter(f.status)}</span>
           <span class="diff-file-name" class:diff-file-name--deleted={f.status === "deleted"}>{filename(f.path)}</span>
-        </button>
+        </div>
       {/each}
     {/each}
   {/if}
@@ -188,6 +203,7 @@
     text-align: left;
     color: var(--text-secondary);
     transition: background 0.15s ease;
+    cursor: pointer;
   }
 
   .diff-file-row--nested {
@@ -220,6 +236,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    user-select: text;
   }
 
   .diff-file-name--deleted {

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -5,13 +5,19 @@
     diffFileCategoryOptions,
     type DiffFileCategoryFilter,
   } from "../../utils/diff-categories.js";
+  import DiffScopePicker from "./DiffScopePicker.svelte";
 
   interface Props {
     compact?: boolean;
     showRichPreview?: boolean;
+    showScopePicker?: boolean;
   }
 
-  let { compact = false, showRichPreview = true }: Props = $props();
+  let {
+    compact = false,
+    showRichPreview = true,
+    showScopePicker = true,
+  }: Props = $props();
 
   const { diff } = getStores();
   const tabOptions = [1, 2, 4, 8] as const;
@@ -163,6 +169,9 @@
         {/each}
       </div>
     </div>
+  {/if}
+  {#if showScopePicker}
+    <DiffScopePicker />
   {/if}
   <div class="compact-menu-wrap" bind:this={compactMenuRef}>
     <button

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -347,7 +347,7 @@
                 />
                 {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
                   <div class="diff-files-wrap">
-                    <DiffSidebar />
+                    <DiffSidebar showCommits={false} />
                   </div>
                 {/if}
               {/each}
@@ -370,7 +370,7 @@
               />
               {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
                 <div class="diff-files-wrap">
-                  <DiffSidebar />
+                  <DiffSidebar showCommits={false} />
                 </div>
               {/if}
             {/each}
@@ -389,7 +389,7 @@
           />
           {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
             <div class="diff-files-wrap">
-              <DiffSidebar />
+              <DiffSidebar showCommits={false} />
             </div>
           {/if}
         {/each}
@@ -398,7 +398,7 @@
   </div>
   {#if needsFallbackFileList}
     <div class="diff-files-wrap">
-                  <DiffSidebar />
+                  <DiffSidebar showCommits={false} />
                 </div>
   {/if}
   <div class="sidebar-footer">

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -40,6 +40,7 @@
   const maxFileListWidth = 520;
   const minDiffPaneWidth = 320;
   const resizeHandleWidth = 4;
+  const compactLayoutWidth = 720;
   let fileListResizeStartWidth = 0;
 
   let base = $state<WorkspaceDiffBase>("head");
@@ -68,6 +69,7 @@
 
   function layoutMaxFileListWidth(): number {
     if (workspaceDiffLayoutWidth <= 0) return maxFileListWidth;
+    if (workspaceDiffLayoutWidth <= compactLayoutWidth) return maxFileListWidth;
     return Math.max(
       0,
       workspaceDiffLayoutWidth - minDiffPaneWidth - resizeHandleWidth,
@@ -102,7 +104,9 @@
   function updateWorkspaceDiffLayoutWidth(width: number): void {
     if (!Number.isFinite(width) || width <= 0) return;
     workspaceDiffLayoutWidth = Math.round(width);
-    fileListWidth = clampFileListWidth(fileListWidth);
+    if (workspaceDiffLayoutWidth > compactLayoutWidth) {
+      fileListWidth = clampFileListWidth(fileListWidth);
+    }
   }
 
   $effect(() => {
@@ -242,6 +246,7 @@
   .workspace-diff {
     display: flex;
     flex-direction: column;
+    container-type: inline-size;
     height: 100%;
     min-width: 0;
     overflow: hidden;
@@ -351,7 +356,7 @@
     overflow: hidden;
   }
 
-  @media (max-width: 720px) {
+  @container (max-width: 720px) {
     .workspace-diff-layout {
       flex-direction: column;
     }

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
+  import PanelLeftCloseIcon from "@lucide/svelte/icons/panel-left-close";
+  import PanelLeftOpenIcon from "@lucide/svelte/icons/panel-left-open";
   import DiffSidebar from "../diff/DiffSidebar.svelte";
+  import DiffScopePicker from "../diff/DiffScopePicker.svelte";
   import DiffToolbar from "../diff/DiffToolbar.svelte";
+  import SplitResizeHandle from "../shared/SplitResizeHandle.svelte";
+  import type { SplitResizeEvent } from "../shared/split-resize.js";
   import DiffView from "../diff/DiffView.svelte";
   import { getStores } from "../../context.js";
   import type { WorkspaceDiffBase } from "../../stores/diff.svelte.js";
@@ -28,20 +33,130 @@
   }: Props = $props();
   const { diff } = getStores();
 
+  const storageKey = "workspace-diff-file-list-width";
+  const hiddenStorageKey = "workspace-diff-file-list-hidden";
+  const defaultFileListWidth = 280;
+  const minFileListWidth = 200;
+  const maxFileListWidth = 520;
+  const minDiffPaneWidth = 320;
+  const resizeHandleWidth = 4;
+  let fileListResizeStartWidth = 0;
+
   let base = $state<WorkspaceDiffBase>("head");
   let loadedKey = "";
+  let workspaceDiffLayout = $state<HTMLDivElement>();
+  let workspaceDiffLayoutWidth = $state(0);
+  let fileListWidth = $state(loadFileListWidth());
+  let fileListHidden = $state(loadFileListHidden());
   const resetKey = $derived(`${workspaceID}:${base}`);
+
+  function safeGetItem(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  function safeSetItem(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function layoutMaxFileListWidth(): number {
+    if (workspaceDiffLayoutWidth <= 0) return maxFileListWidth;
+    return Math.max(
+      0,
+      workspaceDiffLayoutWidth - minDiffPaneWidth - resizeHandleWidth,
+    );
+  }
+
+  function minAllowedFileListWidth(): number {
+    return Math.min(minFileListWidth, layoutMaxFileListWidth());
+  }
+
+  function maxAllowedFileListWidth(): number {
+    return Math.min(maxFileListWidth, layoutMaxFileListWidth());
+  }
+
+  function clampFileListWidth(width: number): number {
+    return Math.max(
+      minAllowedFileListWidth(),
+      Math.min(maxAllowedFileListWidth(), Math.round(width)),
+    );
+  }
+
+  function loadFileListWidth(): number {
+    const raw = Number.parseInt(safeGetItem(storageKey) ?? "", 10);
+    if (!Number.isFinite(raw)) return defaultFileListWidth;
+    return clampFileListWidth(raw);
+  }
+
+  function loadFileListHidden(): boolean {
+    return safeGetItem(hiddenStorageKey) === "true";
+  }
+
+  function updateWorkspaceDiffLayoutWidth(width: number): void {
+    if (!Number.isFinite(width) || width <= 0) return;
+    workspaceDiffLayoutWidth = Math.round(width);
+    fileListWidth = clampFileListWidth(fileListWidth);
+  }
 
   $effect(() => {
     if (!active) return;
-    const key = `${workspaceID}:${base}`;
+    const key = `${workspaceID}:${base}:${fileListHidden ? "stacked" : "single"}`;
     if (loadedKey === key) return;
     loadedKey = key;
-    void diff.loadWorkspaceDiff(workspaceID, base);
+    void diff.loadWorkspaceDiff(workspaceID, base, fileListHidden);
+  });
+
+  $effect(() => {
+    const layout = workspaceDiffLayout;
+    if (!layout) return;
+
+    updateWorkspaceDiffLayoutWidth(layout.getBoundingClientRect().width);
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver((entries) => {
+      updateWorkspaceDiffLayoutWidth(
+        entries[0]?.contentRect.width ?? layout.getBoundingClientRect().width,
+      );
+    });
+    observer.observe(layout);
+
+    return () => {
+      observer.disconnect();
+    };
   });
 
   function selectBase(nextBase: WorkspaceDiffBase): void {
     base = nextBase;
+  }
+
+  function toggleFileList(): void {
+    fileListHidden = !fileListHidden;
+    safeSetItem(hiddenStorageKey, String(fileListHidden));
+  }
+
+  function handleFileListResizeStart(): void {
+    fileListResizeStartWidth = fileListWidth;
+  }
+
+  function widthFromResize(event: SplitResizeEvent): number {
+    return clampFileListWidth(fileListResizeStartWidth + event.deltaX);
+  }
+
+  function handleFileListResize(event: SplitResizeEvent): void {
+    fileListWidth = widthFromResize(event);
+  }
+
+  function handleFileListResizeEnd(event: SplitResizeEvent): void {
+    const finalWidth = widthFromResize(event);
+    fileListWidth = finalWidth;
+    safeSetItem(storageKey, String(finalWidth));
   }
 </script>
 
@@ -74,12 +189,39 @@
         Merge target
       </button>
     </div>
+    <DiffScopePicker />
+    <button
+      class="file-list-toggle"
+      type="button"
+      aria-label={fileListHidden ? "Show changed files" : "Hide changed files"}
+      title={fileListHidden ? "Show changed files" : "Hide changed files"}
+      onclick={toggleFileList}
+    >
+      {#if fileListHidden}
+        <PanelLeftOpenIcon size={16} strokeWidth={1.8} aria-hidden="true" />
+      {:else}
+        <PanelLeftCloseIcon size={16} strokeWidth={1.8} aria-hidden="true" />
+      {/if}
+    </button>
   </div>
-  <DiffToolbar compact showRichPreview={false} />
-  <div class="workspace-diff-layout">
-    <aside class="workspace-diff-sidebar">
-      <DiffSidebar showCommits={false} {resetKey} />
-    </aside>
+  <DiffToolbar compact showRichPreview={false} showScopePicker={false} />
+  <div class="workspace-diff-layout" bind:this={workspaceDiffLayout}>
+    {#if !fileListHidden}
+      <aside
+        class="workspace-diff-sidebar"
+        aria-label="Changed files"
+        style:--workspace-diff-file-list-width={`${fileListWidth}px`}
+      >
+        <DiffSidebar showCommits={false} {resetKey} />
+      </aside>
+      <SplitResizeHandle
+        class="workspace-diff-resize-handle"
+        ariaLabel="Resize workspace file list"
+        onResizeStart={handleFileListResizeStart}
+        onResize={handleFileListResize}
+        onResizeEnd={handleFileListResizeEnd}
+      />
+    {/if}
     <div class="workspace-diff-main">
       <DiffView
         {provider}
@@ -115,6 +257,10 @@
     border-bottom: 1px solid var(--diff-border);
     background: var(--bg-surface);
     flex-shrink: 0;
+  }
+
+  .workspace-diff-scope :global(.diff-scope-picker) {
+    margin-left: auto;
   }
 
   .scope-label {
@@ -164,6 +310,23 @@
     color: #fff;
   }
 
+  .file-list-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 24px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    color: var(--text-muted);
+  }
+
+  .file-list-toggle:hover {
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+  }
+
   .workspace-diff-layout {
     display: flex;
     flex: 1;
@@ -174,7 +337,7 @@
   .workspace-diff-sidebar {
     display: flex;
     flex-direction: column;
-    width: 280px;
+    width: var(--workspace-diff-file-list-width, 280px);
     flex-shrink: 0;
     overflow-y: auto;
     border-right: 1px solid var(--border-default);
@@ -198,6 +361,10 @@
       max-height: 35vh;
       border-right: none;
       border-bottom: 1px solid var(--border-default);
+    }
+
+    :global(.workspace-diff-resize-handle) {
+      display: none;
     }
   }
 </style>

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -169,6 +169,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let currentNumber = $state(0);
   let currentWorkspaceID = $state("");
   let currentWorkspaceBase = $state<WorkspaceDiffBase>("head");
+  let currentWorkspaceStacked = $state(false);
   let workspaceWhitespaceOnlyCount = $state(0);
   let currentProvider = $state("");
   let currentPlatformHost = $state<string | undefined>(undefined);
@@ -378,7 +379,11 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
 
   async function reloadWorkspaceDiffOnly(): Promise<void> {
-    await loadWorkspaceDiff(currentWorkspaceID, currentWorkspaceBase);
+    await loadWorkspaceDiff(
+      currentWorkspaceID,
+      currentWorkspaceBase,
+      currentWorkspaceStacked,
+    );
   }
 
   function toggleFileCollapsed(
@@ -476,16 +481,22 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   function workspaceDiffQuery(base: WorkspaceDiffBase): {
     base: WorkspaceDiffBase;
     whitespace?: string;
+    commit?: string;
+    from?: string;
+    to?: string;
   } {
     return {
       base,
-      ...(hideWhitespace && { whitespace: "hide" }),
+      ...diffQuery(),
     };
   }
 
   function workspaceFileDiffQuery(base: WorkspaceDiffBase, path: string): {
     base: WorkspaceDiffBase;
     whitespace?: string;
+    commit?: string;
+    from?: string;
+    to?: string;
     path: string;
   } {
     return {
@@ -668,12 +679,15 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   async function loadWorkspaceDiff(
     workspaceID: string,
     base: WorkspaceDiffBase,
+    stacked = false,
   ): Promise<void> {
     const workspaceChanged =
       workspaceID !== currentWorkspaceID ||
-      base !== currentWorkspaceBase;
+      base !== currentWorkspaceBase ||
+      stacked !== currentWorkspaceStacked;
     currentWorkspaceID = workspaceID;
     currentWorkspaceBase = base;
+    currentWorkspaceStacked = stacked;
     currentOwner = "";
     currentName = "";
     currentNumber = 0;
@@ -705,6 +719,31 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       return;
     } finally {
       finishFilesLoad(filesAc);
+    }
+
+    if (stacked) {
+      try {
+        const { data, error, response } = await apiClient.GET(
+          "/workspaces/{id}/diff",
+          {
+            params: {
+              path: { id: workspaceID },
+              query: workspaceDiffQuery(base),
+            },
+            signal: diffAc.signal,
+          },
+        );
+        if (!diffLoadIsCurrent(diffAc)) return;
+        if (!data) {
+          throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+        }
+        applyDiffResult(data);
+      } catch (_err) {
+        failDiffLoad(_err, diffAc, filesAc);
+      } finally {
+        finishDiffLoad(diffAc);
+      }
+      return;
     }
 
     const visibleFiles = getVisibleFileList()?.files ?? [];
@@ -798,6 +837,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentNumber = 0;
     currentWorkspaceID = "";
     currentWorkspaceBase = "head";
+    currentWorkspaceStacked = false;
     workspaceWhitespaceOnlyCount = 0;
     currentProvider = "";
     currentPlatformHost = undefined;
@@ -806,32 +846,62 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
   async function loadCommits(): Promise<void> {
     if (commits || commitsLoading) return;
-    if (!currentOwner || !currentName || !currentNumber) return;
+    if (!currentWorkspaceID && (!currentOwner || !currentName || !currentNumber)) {
+      return;
+    }
 
     commitsLoading = true;
     commitsError = null;
     const owner = currentOwner;
     const name = currentName;
     const number = currentNumber;
+    const workspaceID = currentWorkspaceID;
     const ref = currentRouteRef();
     try {
-      const { data, error, response } = await apiClient.GET(
-        providerItemPath("pulls", ref, "/commits"),
-        {
-          params: { path: { ...providerRouteParams(ref), number } },
-        },
-      );
-      if (currentOwner !== owner || currentName !== name || currentNumber !== number) return;
+      const { data, error, response } = workspaceID
+        ? await apiClient.GET(
+          "/workspaces/{id}/commits",
+          {
+            params: { path: { id: workspaceID } },
+          },
+        )
+        : await apiClient.GET(
+          providerItemPath("pulls", ref, "/commits"),
+          {
+            params: { path: { ...providerRouteParams(ref), number } },
+          },
+        );
+      if (
+        currentWorkspaceID !== workspaceID ||
+        currentOwner !== owner ||
+        currentName !== name ||
+        currentNumber !== number
+      ) return;
       if (!data) {
         throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
       }
-      if (currentOwner !== owner || currentName !== name || currentNumber !== number) return;
+      if (
+        currentWorkspaceID !== workspaceID ||
+        currentOwner !== owner ||
+        currentName !== name ||
+        currentNumber !== number
+      ) return;
       commits = data.commits ?? [];
     } catch (err) {
-      if (currentOwner !== owner || currentName !== name || currentNumber !== number) return;
+      if (
+        currentWorkspaceID !== workspaceID ||
+        currentOwner !== owner ||
+        currentName !== name ||
+        currentNumber !== number
+      ) return;
       commitsError = err instanceof Error ? err.message : String(err);
     } finally {
-      if (currentOwner === owner && currentName === name && currentNumber === number) {
+      if (
+        currentWorkspaceID === workspaceID &&
+        currentOwner === owner &&
+        currentName === name &&
+        currentNumber === number
+      ) {
         commitsLoading = false;
       }
     }
@@ -858,6 +928,12 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     clearFilePreviewCache();
     if (currentOwner && currentName && currentNumber) {
       void loadDiff(currentOwner, currentName, currentNumber, currentRouteRef());
+    } else if (currentWorkspaceID) {
+      void loadWorkspaceDiff(
+        currentWorkspaceID,
+        currentWorkspaceBase,
+        currentWorkspaceStacked,
+      );
     }
   }
 
@@ -871,6 +947,12 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     clearFilePreviewCache();
     if (currentOwner && currentName && currentNumber) {
       void loadDiff(currentOwner, currentName, currentNumber, currentRouteRef());
+    } else if (currentWorkspaceID) {
+      void loadWorkspaceDiff(
+        currentWorkspaceID,
+        currentWorkspaceBase,
+        currentWorkspaceStacked,
+      );
     }
   }
 
@@ -879,6 +961,12 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     clearFilePreviewCache();
     if (currentOwner && currentName && currentNumber) {
       void loadDiff(currentOwner, currentName, currentNumber, currentRouteRef());
+    } else if (currentWorkspaceID) {
+      void loadWorkspaceDiff(
+        currentWorkspaceID,
+        currentWorkspaceBase,
+        currentWorkspaceStacked,
+      );
     }
   }
 

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -681,17 +681,16 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     base: WorkspaceDiffBase,
     stacked = false,
   ): Promise<void> {
-    const workspaceChanged =
+    const workspaceScopeChanged =
       workspaceID !== currentWorkspaceID ||
-      base !== currentWorkspaceBase ||
-      stacked !== currentWorkspaceStacked;
+      base !== currentWorkspaceBase;
     currentWorkspaceID = workspaceID;
     currentWorkspaceBase = base;
     currentWorkspaceStacked = stacked;
     currentOwner = "";
     currentName = "";
     currentNumber = 0;
-    if (workspaceChanged) {
+    if (workspaceScopeChanged) {
       resetDiffScopeState();
     }
 


### PR DESCRIPTION
- Add a shared commit/range picker for PR and workspace diff views
- Add workspace commit listing plus commit/range-scoped diff APIs backed by the local worktree
- Make the workspace diff file list resizable, collapsible, and friendlier to filename text selection

Validation:
- go test ./internal/workspace -shuffle=on
- go test ./internal/server -shuffle=on
- bun run typecheck
- bun run test
- bun run build

Note: the mock Playwright e2e suite was attempted but stopped after unrelated existing failures/timeouts.