### PR TITLE
Fix required-check warning wording for PR merge status

### DIFF
--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -382,6 +382,108 @@ test.describe("PR detail merge modal route reset", () => {
     ).toHaveCount(0);
   });
 
+  test("non-required failed checks do not show required-check warnings", async ({ page }) => {
+    await mockApi(page);
+    await mockSettings(page);
+
+    const nonRequiredFailurePR = {
+      ...prA,
+      Number: 101,
+      URL: "https://github.com/acme/widgets/pull/101",
+      Title: "Non-required failing check",
+      MergeableState: "unstable",
+      CIStatus: "failure",
+      CIChecksJSON: JSON.stringify([
+        {
+          name: "e2e",
+          status: "completed",
+          conclusion: "failure",
+          url: "https://example.com/e2e",
+          app: "GitHub Actions",
+        },
+      ]),
+    };
+
+    await page.route(
+      pullDetailApiPath(nonRequiredFailurePR),
+      async (route) => {
+        if (route.request().method() === "GET") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(detailEnvelopePR(nonRequiredFailurePR)),
+          });
+          return;
+        }
+        await route.fallback();
+      },
+    );
+
+    await page.goto(
+      `/pulls/github/${nonRequiredFailurePR.repo_owner}/${nonRequiredFailurePR.repo_name}/${nonRequiredFailurePR.Number}`,
+    );
+
+    await expect(page.locator(".detail-title")).toContainText(
+      nonRequiredFailurePR.Title,
+    );
+    await expect(
+      page.getByText("Required status checks have not passed."),
+    ).toHaveCount(0);
+  });
+
+  test("warning lines show required checks and branch freshness independently", async ({ page }) => {
+    await mockApi(page);
+    await mockSettings(page);
+
+    const requiredBehindPR = {
+      ...prA,
+      Number: 102,
+      URL: "https://github.com/acme/widgets/pull/102",
+      Title: "Required check and behind branch",
+      MergeableState: "behind",
+      CIStatus: "failure",
+      CIChecksJSON: JSON.stringify([
+        {
+          name: "build",
+          status: "completed",
+          conclusion: "failure",
+          url: "https://example.com/build",
+          app: "GitHub Actions",
+          required: true,
+        },
+      ]),
+    };
+
+    await page.route(
+      pullDetailApiPath(requiredBehindPR),
+      async (route) => {
+        if (route.request().method() === "GET") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(detailEnvelopePR(requiredBehindPR)),
+          });
+          return;
+        }
+        await route.fallback();
+      },
+    );
+
+    await page.goto(
+      `/pulls/github/${requiredBehindPR.repo_owner}/${requiredBehindPR.repo_name}/${requiredBehindPR.Number}`,
+    );
+
+    await expect(page.locator(".detail-title")).toContainText(
+      requiredBehindPR.Title,
+    );
+    await expect(
+      page.getByText("Required status checks have not passed."),
+    ).toBeVisible();
+    await expect(
+      page.getByText("This branch is behind the base branch and may need to be updated."),
+    ).toBeVisible();
+  });
+
   test("merge modal closes when the route changes and does not reopen for the new PR", async ({ page }) => {
     await mockApi(page);
     await mockSettings(page);

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -340,6 +340,29 @@ async function setupHeldIssue(
   return { release };
 }
 
+async function mockPullDetail(page: Page, pr: typeof prA): Promise<void> {
+  await page.route(
+    pullDetailApiPath(pr),
+    async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(detailEnvelopePR(pr)),
+        });
+        return;
+      }
+      await route.fallback();
+    },
+  );
+}
+
+async function gotoPullDetail(page: Page, pr: typeof prA): Promise<void> {
+  await page.goto(
+    `/pulls/github/${pr.repo_owner}/${pr.repo_name}/${pr.Number}`,
+  );
+}
+
 test.describe("PR detail merge modal route reset", () => {
   test("merge button is disabled when the PR has merge conflicts", async ({ page }) => {
     await mockApi(page);
@@ -350,24 +373,9 @@ test.describe("PR detail merge modal route reset", () => {
       MergeableState: "dirty",
     };
 
-    await page.route(
-      pullDetailApiPath(conflictedPR),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify(detailEnvelopePR(conflictedPR)),
-          });
-          return;
-        }
-        await route.fallback();
-      },
-    );
+    await mockPullDetail(page, conflictedPR);
 
-    await page.goto(
-      `/pulls/github/${conflictedPR.repo_owner}/${conflictedPR.repo_name}/${conflictedPR.Number}`,
-    );
+    await gotoPullDetail(page, conflictedPR);
 
     await expect(page.locator(".detail-title")).toContainText(
       conflictedPR.Title,
@@ -382,107 +390,82 @@ test.describe("PR detail merge modal route reset", () => {
     ).toHaveCount(0);
   });
 
-  test("non-required failed checks do not show required-check warnings", async ({ page }) => {
-    await mockApi(page);
-    await mockSettings(page);
-
-    const nonRequiredFailurePR = {
-      ...prA,
-      Number: 101,
-      URL: "https://github.com/acme/widgets/pull/101",
-      Title: "Non-required failing check",
-      MergeableState: "unstable",
-      CIStatus: "failure",
-      CIChecksJSON: JSON.stringify([
-        {
-          name: "e2e",
-          status: "completed",
-          conclusion: "failure",
-          url: "https://example.com/e2e",
-          app: "GitHub Actions",
-        },
-      ]),
-    };
-
-    await page.route(
-      pullDetailApiPath(nonRequiredFailurePR),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify(detailEnvelopePR(nonRequiredFailurePR)),
-          });
-          return;
-        }
-        await route.fallback();
+  const warningLineCases = [
+    {
+      name: "non-required failed checks do not show required-check warnings",
+      pr: {
+        ...prA,
+        Number: 101,
+        URL: "https://github.com/acme/widgets/pull/101",
+        Title: "Non-required failing check",
+        MergeableState: "unstable",
+        CIStatus: "failure",
+        CIChecksJSON: JSON.stringify([
+          {
+            name: "e2e",
+            status: "completed",
+            conclusion: "failure",
+            url: "https://example.com/e2e",
+            app: "GitHub Actions",
+          },
+        ]),
       },
-    );
-
-    await page.goto(
-      `/pulls/github/${nonRequiredFailurePR.repo_owner}/${nonRequiredFailurePR.repo_name}/${nonRequiredFailurePR.Number}`,
-    );
-
-    await expect(page.locator(".detail-title")).toContainText(
-      nonRequiredFailurePR.Title,
-    );
-    await expect(
-      page.getByText("Required status checks have not passed."),
-    ).toHaveCount(0);
-  });
-
-  test("warning lines show required checks and branch freshness independently", async ({ page }) => {
-    await mockApi(page);
-    await mockSettings(page);
-
-    const requiredBehindPR = {
-      ...prA,
-      Number: 102,
-      URL: "https://github.com/acme/widgets/pull/102",
-      Title: "Required check and behind branch",
-      MergeableState: "behind",
-      CIStatus: "failure",
-      CIChecksJSON: JSON.stringify([
-        {
-          name: "build",
-          status: "completed",
-          conclusion: "failure",
-          url: "https://example.com/build",
-          app: "GitHub Actions",
-          required: true,
-        },
-      ]),
-    };
-
-    await page.route(
-      pullDetailApiPath(requiredBehindPR),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify(detailEnvelopePR(requiredBehindPR)),
-          });
-          return;
-        }
-        await route.fallback();
+      requiredWarning: false,
+      behindWarning: false,
+    },
+    {
+      name: "warning lines show required checks and branch freshness independently",
+      pr: {
+        ...prA,
+        Number: 102,
+        URL: "https://github.com/acme/widgets/pull/102",
+        Title: "Required check and behind branch",
+        MergeableState: "behind",
+        CIStatus: "failure",
+        CIChecksJSON: JSON.stringify([
+          {
+            name: "build",
+            status: "completed",
+            conclusion: "failure",
+            url: "https://example.com/build",
+            app: "GitHub Actions",
+            required: true,
+          },
+        ]),
       },
-    );
+      requiredWarning: true,
+      behindWarning: true,
+    },
+  ];
 
-    await page.goto(
-      `/pulls/github/${requiredBehindPR.repo_owner}/${requiredBehindPR.repo_name}/${requiredBehindPR.Number}`,
-    );
+  for (const { name, pr, requiredWarning, behindWarning } of warningLineCases) {
+    test(name, async ({ page }) => {
+      await mockApi(page);
+      await mockSettings(page);
+      await mockPullDetail(page, pr);
 
-    await expect(page.locator(".detail-title")).toContainText(
-      requiredBehindPR.Title,
-    );
-    await expect(
-      page.getByText("Required status checks have not passed."),
-    ).toBeVisible();
-    await expect(
-      page.getByText("This branch is behind the base branch and may need to be updated."),
-    ).toBeVisible();
-  });
+      await gotoPullDetail(page, pr);
+
+      await expect(page.locator(".detail-title")).toContainText(pr.Title);
+
+      const requiredStatusWarning = page.getByText(
+        "Required status checks have not passed.",
+      );
+      const behindBranchWarning = page.getByText(
+        "This branch is behind the base branch and may need to be updated.",
+      );
+      if (requiredWarning) {
+        await expect(requiredStatusWarning).toBeVisible();
+      } else {
+        await expect(requiredStatusWarning).toHaveCount(0);
+      }
+      if (behindWarning) {
+        await expect(behindBranchWarning).toBeVisible();
+      } else {
+        await expect(behindBranchWarning).toHaveCount(0);
+      }
+    });
+  }
 
   test("merge modal closes when the route changes and does not reopen for the new PR", async ({ page }) => {
     await mockApi(page);

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -57,6 +57,7 @@ export interface CICheck {
   conclusion: string;
   url: string;
   app: string;
+  required?: boolean;
   duration_seconds?: number;
 }
 

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -166,6 +166,46 @@
       return false;
     }
   }
+
+  function requiredStatusChecksHaveNotPassed(checksJSON: string): boolean {
+    if (!checksJSON) return false;
+    try {
+      const checks = JSON.parse(checksJSON) as Array<{
+        required?: boolean;
+        status?: string;
+        conclusion?: string;
+      }>;
+      return checks.some((check) =>
+        check.required === true &&
+        (
+          check.status !== "completed" ||
+          !["success", "neutral", "skipped"].includes(check.conclusion ?? "")
+        ),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  function hasWarningLines(
+    prState: string,
+    mergeableState: string,
+    checksJSON: string,
+    warnings: readonly string[] | null | undefined,
+  ): boolean {
+    return (
+      (
+        prState === "open" &&
+        (
+          mergeableState === "dirty" ||
+          mergeableState === "blocked" ||
+          mergeableState === "behind" ||
+          requiredStatusChecksHaveNotPassed(checksJSON)
+        )
+      ) ||
+      (warnings?.length ?? 0) > 0
+    );
+  }
   async function editTimelineComment(
     event: { PlatformID: number | null },
     body: string,
@@ -1327,33 +1367,46 @@
       {/if}
 
 
-      <!-- Mergeable state warnings -->
-      {#if !stalePR && pr.State === "open" && pr.MergeableState === "dirty"}
-        <div class="merge-warning merge-warning--conflict">
-          <span>This branch has conflicts that must be resolved before merging.</span>
-          <a href={pr.URL} target="_blank" rel="noopener noreferrer">View on GitHub</a>
+      <!-- Pull request warnings -->
+      {#if !stalePR && hasWarningLines(pr.State, pr.MergeableState, pr.CIChecksJSON, detail.warnings)}
+        <div class="merge-warnings" aria-label="Pull request warnings">
+          {#if pr.State === "open" && pr.MergeableState === "dirty"}
+            <div class="merge-warning-line merge-warning-line--conflict">
+              <span>This branch has conflicts that must be resolved before merging.</span>
+              <a href={pr.URL} target="_blank" rel="noopener noreferrer">View on GitHub</a>
+            </div>
+          {/if}
+          {#if pr.State === "open" && pr.MergeableState === "blocked"}
+            <div class="merge-warning-line">
+              <span>Branch protection rules may prevent this merge.</span>
+            </div>
+          {/if}
+          {#if pr.State === "open" && pr.MergeableState === "behind"}
+            <div class="merge-warning-line">
+              <span>This branch is behind the base branch and may need to be updated.</span>
+            </div>
+          {/if}
+          {#if pr.State === "open" && requiredStatusChecksHaveNotPassed(pr.CIChecksJSON)}
+            <div class="merge-warning-line">
+              <span>Required status checks have not passed.</span>
+            </div>
+          {/if}
+          {#if detail.warnings && detail.warnings.length > 0}
+            {#each detail.warnings as warning (warning)}
+              <div class="merge-warning-line">
+                <span>{warning}</span>
+              </div>
+            {/each}
+          {/if}
         </div>
-      {:else if !stalePR && pr.State === "open" && pr.MergeableState === "blocked"}
-        <div class="merge-warning merge-warning--info">
-          <span>Branch protection rules may prevent this merge.</span>
+      {:else if stalePR && detail.warnings && detail.warnings.length > 0}
+        <div class="merge-warnings" aria-label="Pull request warnings">
+          {#each detail.warnings as warning (warning)}
+            <div class="merge-warning-line">
+              <span>{warning}</span>
+            </div>
+          {/each}
         </div>
-      {:else if !stalePR && pr.State === "open" && pr.MergeableState === "behind"}
-        <div class="merge-warning merge-warning--info">
-          <span>This branch is behind the base branch and may need to be updated.</span>
-        </div>
-      {:else if !stalePR && pr.State === "open" && pr.MergeableState === "unstable"}
-        <div class="merge-warning merge-warning--info">
-          <span>Required status checks have not passed.</span>
-        </div>
-      {/if}
-
-      <!-- Diff sync warnings (stale or unavailable diff data) -->
-      {#if detail.warnings && detail.warnings.length > 0}
-        {#each detail.warnings as warning (warning)}
-          <div class="merge-warning merge-warning--info">
-            <span>{warning}</span>
-          </div>
-        {/each}
       {/if}
 
       {#snippet primaryActionButtons()}
@@ -2403,31 +2456,33 @@
     line-height: 1.6;
   }
 
-  .merge-warning {
+  .merge-warnings {
     font-size: var(--font-size-sm);
     padding: 8px 12px;
     border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+    color: var(--text-secondary);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .merge-warning-line {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 8px;
   }
 
-  .merge-warning a {
+  .merge-warning-line a {
     color: inherit;
     text-decoration: underline;
     white-space: nowrap;
     flex-shrink: 0;
   }
 
-  .merge-warning--conflict {
-    background: color-mix(in srgb, var(--accent-amber) 12%, transparent);
+  .merge-warning-line--conflict {
     color: var(--accent-amber);
-  }
-
-  .merge-warning--info {
-    background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
-    color: var(--text-secondary);
   }
 
   .files-stat {
@@ -2647,7 +2702,7 @@
     .section-title,
     .section-title-inline,
     .files-stat,
-    .merge-warning,
+    .merge-warnings,
     .action-error,
     .refresh-banner,
     .loading-placeholder,

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -255,45 +255,65 @@ describe("PullDetail approvals", () => {
     );
   });
 
-  it("does not describe GitHub unstable mergeability as required checks", () => {
-    const detail = pullDetail();
-    detail.merge_request.MergeableState = "unstable";
-    detail.merge_request.CIStatus = "failure";
-    detail.merge_request.CIChecksJSON = JSON.stringify([
-      {
-        name: "e2e",
-        status: "completed",
-        conclusion: "failure",
-        url: "https://example.com/e2e",
-        app: "GitHub Actions",
-      },
-    ]);
+  const warningCases = [
+    {
+      name: "does not describe GitHub unstable mergeability as required checks",
+      mergeableState: "unstable",
+      checks: [
+        {
+          name: "e2e",
+          status: "completed",
+          conclusion: "failure",
+          url: "https://example.com/e2e",
+          app: "GitHub Actions",
+        },
+      ],
+      requiredWarning: false,
+      behindWarning: false,
+    },
+    {
+      name: "shows required CI and branch freshness warnings independently",
+      mergeableState: "behind",
+      checks: [
+        {
+          name: "build",
+          status: "completed",
+          conclusion: "failure",
+          url: "https://example.com/build",
+          app: "GitHub Actions",
+          required: true,
+        },
+      ],
+      requiredWarning: true,
+      behindWarning: true,
+    },
+  ];
 
-    renderPullDetail(detail);
+  for (const { name, mergeableState, checks, requiredWarning, behindWarning } of warningCases) {
+    it(name, () => {
+      const detail = pullDetail();
+      detail.merge_request.MergeableState = mergeableState;
+      detail.merge_request.CIStatus = "failure";
+      detail.merge_request.CIChecksJSON = JSON.stringify(checks);
 
-    expect(screen.queryByText(/required status checks/i)).toBeNull();
-  });
+      renderPullDetail(detail);
 
-  it("shows required CI and branch freshness warnings independently", () => {
-    const detail = pullDetail();
-    detail.merge_request.MergeableState = "behind";
-    detail.merge_request.CIStatus = "failure";
-    detail.merge_request.CIChecksJSON = JSON.stringify([
-      {
-        name: "build",
-        status: "completed",
-        conclusion: "failure",
-        url: "https://example.com/build",
-        app: "GitHub Actions",
-        required: true,
-      },
-    ]);
-
-    renderPullDetail(detail);
-
-    expect(screen.getByText("Required status checks have not passed.")).not.toBeNull();
-    expect(
-      screen.getByText("This branch is behind the base branch and may need to be updated."),
-    ).not.toBeNull();
-  });
+      const requiredStatusWarning = screen.queryByText(
+        "Required status checks have not passed.",
+      );
+      const behindBranchWarning = screen.queryByText(
+        "This branch is behind the base branch and may need to be updated.",
+      );
+      if (requiredWarning) {
+        expect(requiredStatusWarning).not.toBeNull();
+      } else {
+        expect(requiredStatusWarning).toBeNull();
+      }
+      if (behindWarning) {
+        expect(behindBranchWarning).not.toBeNull();
+      } else {
+        expect(behindBranchWarning).toBeNull();
+      }
+    });
+  }
 });

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -254,4 +254,46 @@ describe("PullDetail approvals", () => {
       },
     );
   });
+
+  it("does not describe GitHub unstable mergeability as required checks", () => {
+    const detail = pullDetail();
+    detail.merge_request.MergeableState = "unstable";
+    detail.merge_request.CIStatus = "failure";
+    detail.merge_request.CIChecksJSON = JSON.stringify([
+      {
+        name: "e2e",
+        status: "completed",
+        conclusion: "failure",
+        url: "https://example.com/e2e",
+        app: "GitHub Actions",
+      },
+    ]);
+
+    renderPullDetail(detail);
+
+    expect(screen.queryByText(/required status checks/i)).toBeNull();
+  });
+
+  it("shows required CI and branch freshness warnings independently", () => {
+    const detail = pullDetail();
+    detail.merge_request.MergeableState = "behind";
+    detail.merge_request.CIStatus = "failure";
+    detail.merge_request.CIChecksJSON = JSON.stringify([
+      {
+        name: "build",
+        status: "completed",
+        conclusion: "failure",
+        url: "https://example.com/build",
+        app: "GitHub Actions",
+        required: true,
+      },
+    ]);
+
+    renderPullDetail(detail);
+
+    expect(screen.getByText("Required status checks have not passed.")).not.toBeNull();
+    expect(
+      screen.getByText("This branch is behind the base branch and may need to be updated."),
+    ).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Split the PR warning area into separate lines so conflict, behind-base, and CI-related notices can appear together.
- Only show the required-check warning when an individual CI check is explicitly marked `required` and is not passing.
- Keep ordinary failed CI visible through the CI UI without implying branch protection is configured.
- Consolidate the new regression coverage with table-driven component and Playwright tests.

## Testing
- `bun run --cwd frontend test ../packages/ui/src/components/detail/PullDetail.test.ts`
- `bun run --cwd frontend test:e2e:mock tests/e2e/detail-stale-actions.spec.ts -g 'required|warning lines'`
- `bun run --cwd frontend typecheck`
- `bun run --cwd packages/ui typecheck`