### PR TITLE
Focus label filter from desktop buttons

### DIFF
--- a/frontend/tests/e2e-full/labels.spec.ts
+++ b/frontend/tests/e2e-full/labels.spec.ts
@@ -22,8 +22,12 @@ test.describe("label editing", () => {
 
       await page.getByRole("button", { name: "Labels" }).click();
       await expect(page.getByRole("dialog", { name: "Edit labels" })).toBeVisible();
+      await expect(page.getByLabel("Filter labels")).toBeFocused();
       await expect(page.getByRole("menuitemcheckbox", { name: /bug/i })).toHaveAttribute("aria-checked", "true");
       await expect(page.getByRole("menuitemcheckbox", { name: /triage/i })).toHaveAttribute("aria-checked", "false");
+      await page.keyboard.type("tri");
+      await expect(page.getByRole("menuitemcheckbox", { name: /bug/i })).toHaveCount(0);
+      await expect(page.getByRole("menuitemcheckbox", { name: /triage/i })).toBeVisible();
 
       const updateResponse = page.waitForResponse((response) =>
         response.request().method() === "PUT"
@@ -80,6 +84,7 @@ test.describe("label editing", () => {
 
       await page.getByRole("button", { name: "Labels" }).click();
       await expect(page.getByRole("dialog", { name: "Edit labels" })).toBeVisible();
+      await expect(page.getByLabel("Filter labels")).toBeFocused();
 
       const updateResponse = page.waitForResponse((response) =>
         response.request().method() === "PUT"

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -196,12 +196,14 @@
   let pendingLabel = $state<string | null>(null);
   let labelPickerAnchor = $state<HTMLDivElement>();
   let labelPickerPopover = $state<HTMLDivElement>();
+  let labelPickerAutofocusFilter = $state(false);
   let labelPickerStyle = $state("");
 
   function closeLabelPicker(): void {
     labelPickerOpen = false;
     labelPickerError = null;
     pendingLabel = null;
+    labelPickerAutofocusFilter = false;
   }
 
   function positionLabelPicker(): void {
@@ -226,7 +228,8 @@
     }
   }
 
-  async function openLabelPicker(): Promise<void> {
+  async function openLabelPicker(event?: MouseEvent): Promise<void> {
+    labelPickerAutofocusFilter = event !== undefined && !window.matchMedia("(pointer: coarse)").matches;
     labelPickerOpen = true;
     labelPickerError = null;
     labelCatalogSyncing = true;
@@ -874,6 +877,7 @@
                     syncing={labelCatalogSyncing}
                     {pendingLabel}
                     error={labelPickerError}
+                    autofocusFilter={labelPickerAutofocusFilter}
                     ontoggle={toggleLabel}
                     onclear={clearLabels}
                     onclose={closeLabelPicker}

--- a/packages/ui/src/components/detail/LabelPicker.svelte
+++ b/packages/ui/src/components/detail/LabelPicker.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import CheckIcon from "@lucide/svelte/icons/check";
   import EraserIcon from "@lucide/svelte/icons/eraser";
   import XIcon from "@lucide/svelte/icons/x";
@@ -10,6 +11,7 @@
     syncing?: boolean;
     pendingLabel?: string | null;
     error?: string | null;
+    autofocusFilter?: boolean;
     ontoggle: (name: string) => void | Promise<void>;
     onclear?: () => void | Promise<void>;
     onclose: () => void;
@@ -21,12 +23,18 @@
     syncing = false,
     pendingLabel = null,
     error = null,
+    autofocusFilter = false,
     ontoggle,
     onclear = undefined,
     onclose,
   }: Props = $props();
 
   let query = $state("");
+  let filterInput: HTMLInputElement | undefined = $state();
+
+  onMount(() => {
+    if (autofocusFilter) filterInput?.focus();
+  });
 
   const selectedNames = $derived(new Set(selectedLabels.map((label) => label.name)));
   const filteredLabels = $derived.by(() => {
@@ -80,7 +88,13 @@
 
   <label class="label-picker__filter">
     <span class="label-picker__sr-only">Filter labels</span>
-    <input bind:value={query} type="search" placeholder="Filter labels" aria-label="Filter labels" />
+    <input
+      bind:this={filterInput}
+      bind:value={query}
+      type="search"
+      placeholder="Filter labels"
+      aria-label="Filter labels"
+    />
   </label>
 
   {#if error}

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -615,6 +615,7 @@
   let labelPickerAnchor = $state<HTMLDivElement>();
   let labelPickerPopover = $state<HTMLDivElement>();
   let labelPickerLaunchedFromActionMenu = $state(false);
+  let labelPickerAutofocusFilter = $state(false);
   let labelPickerStyle = $state("");
 
   const workspace = $derived(detailStore.getDetail()?.workspace);
@@ -632,6 +633,7 @@
     labelPickerError = null;
     pendingLabel = null;
     labelPickerLaunchedFromActionMenu = false;
+    labelPickerAutofocusFilter = false;
   }
 
   function positionLabelPicker(): void {
@@ -680,6 +682,7 @@
     labelPickerAnchor = (event?.currentTarget as HTMLElement | null)?.closest<HTMLDivElement>(".label-editor-anchor")
       ?? visibleLabelPickerAnchor();
     labelPickerLaunchedFromActionMenu = Boolean(labelPickerAnchor?.closest(".actions-menu-popover"));
+    labelPickerAutofocusFilter = event !== undefined && !window.matchMedia("(pointer: coarse)").matches;
     if (labelPickerLaunchedFromActionMenu) {
       closeActionMenu();
     }
@@ -1308,6 +1311,7 @@
               syncing={labelCatalogSyncing}
               {pendingLabel}
               error={labelPickerError}
+              autofocusFilter={labelPickerAutofocusFilter}
               ontoggle={toggleLabel}
               onclear={clearLabels}
               onclose={closeLabelPicker}


### PR DESCRIPTION
- Focuses the label picker filter when desktop Labels buttons open the editor.
- Keeps non-button/touch openings from stealing focus while preserving command-palette label editing.