### PR TITLE
Fix approval form open state

### DIFF
--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../packages/ui/src/context.js", () => ({
@@ -11,15 +17,28 @@ vi.mock("../../packages/ui/src/context.js", () => ({
 
 import ApproveButton from "../../packages/ui/src/components/detail/ApproveButton.svelte";
 
+const defaultProps = {
+  provider: "github",
+  platformHost: "github.com",
+  owner: "acme",
+  name: "widget",
+  repoPath: "acme/widget",
+  number: 1,
+};
+
+function renderApproveButton(overrides: Partial<typeof defaultProps> = {}) {
+  return render(ApproveButton, {
+    props: { ...defaultProps, ...overrides },
+  });
+}
+
 describe("ApproveButton tooltips", () => {
   afterEach(() => {
     cleanup();
   });
 
   it("collapsed button title describes opening the form, not submitting", () => {
-    render(ApproveButton, {
-      props: { provider: "github", platformHost: "github.com", owner: "acme", name: "widget", repoPath: "acme/widget", number: 1 },
-    });
+    renderApproveButton();
 
     const trigger = screen.getByRole("button", { name: /approve/i });
     expect(trigger.getAttribute("title")).toBe(
@@ -28,22 +47,49 @@ describe("ApproveButton tooltips", () => {
   });
 
   it("expanded submit button carries the actual submit-review tooltip", async () => {
-    render(ApproveButton, {
-      props: { provider: "github", platformHost: "github.com", owner: "acme", name: "widget", repoPath: "acme/widget", number: 1 },
-    });
+    renderApproveButton();
 
     await fireEvent.click(screen.getByRole("button", { name: /approve/i }));
 
-    const submit = screen.getByRole("button", { name: /^approve$/i });
+    const submit = screen.getByTitle(
+      "Submit an approving code review on this pull request",
+    );
     expect(submit.getAttribute("title")).toBe(
       "Submit an approving code review on this pull request",
     );
   });
 
-  it("collapses and clears the draft when the PR identity changes", async () => {
-    const { rerender } = render(ApproveButton, {
-      props: { provider: "github", platformHost: "github.com", owner: "acme", name: "widget", repoPath: "acme/widget", number: 1 },
+  it("keeps the approval trigger stable while opening the approval popover", async () => {
+    renderApproveButton();
+
+    const trigger = screen.getByRole("button", { name: /^approve$/i });
+    await fireEvent.click(trigger);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      screen.getByRole("dialog", { name: "Approve pull request" }),
+    ).toBeTruthy();
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole("textbox"));
     });
+  });
+
+  it("collapses the approval popover from cancel without removing the trigger", async () => {
+    renderApproveButton();
+
+    const trigger = screen.getByRole("button", { name: /^approve$/i });
+    await fireEvent.click(trigger);
+    await fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      screen.queryByRole("dialog", { name: "Approve pull request" }),
+    ).toBeNull();
+  });
+
+  it("collapses and clears the draft when the PR identity changes", async () => {
+    const { rerender } = renderApproveButton();
 
     await fireEvent.click(screen.getByRole("button", { name: /approve/i }));
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;

--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -5,13 +5,17 @@ import {
   screen,
   waitFor,
 } from "@testing-library/svelte";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPost = vi.hoisted(() => vi.fn());
+const mockLoadDetail = vi.hoisted(() => vi.fn());
+const mockLoadPulls = vi.hoisted(() => vi.fn());
 
 vi.mock("../../packages/ui/src/context.js", () => ({
-  getClient: () => ({ POST: vi.fn() }),
+  getClient: () => ({ POST: mockPost }),
   getStores: () => ({
-    detail: { loadDetail: vi.fn() },
-    pulls: { loadPulls: vi.fn() },
+    detail: { loadDetail: mockLoadDetail },
+    pulls: { loadPulls: mockLoadPulls },
   }),
 }));
 
@@ -33,8 +37,17 @@ function renderApproveButton(overrides: Partial<typeof defaultProps> = {}) {
 }
 
 describe("ApproveButton tooltips", () => {
+  beforeEach(() => {
+    mockPost.mockResolvedValue({ data: { status: "approved" } });
+    mockLoadDetail.mockResolvedValue(undefined);
+    mockLoadPulls.mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     cleanup();
+    mockPost.mockReset();
+    mockLoadDetail.mockReset();
+    mockLoadPulls.mockReset();
   });
 
   it("collapsed button title describes opening the form, not submitting", () => {
@@ -97,6 +110,43 @@ describe("ApproveButton tooltips", () => {
     expect(
       screen.queryByRole("dialog", { name: "Approve pull request" }),
     ).toBeNull();
+  });
+
+  it("keeps the approval popover open and trigger disabled while submitting", async () => {
+    let resolvePost: (value: { data: { status: string } }) => void = () => {};
+    mockPost.mockReturnValue(new Promise((resolve) => {
+      resolvePost = resolve;
+    }));
+    renderApproveButton();
+
+    const trigger = screen.getByRole("button", { name: /^approve$/i });
+    await fireEvent.click(trigger);
+    await fireEvent.input(screen.getByRole("textbox"), {
+      target: { value: "lgtm" },
+    });
+    await fireEvent.click(screen.getByTitle(
+      "Submit an approving code review on this pull request",
+    ));
+
+    await waitFor(() => {
+      expect(trigger.hasAttribute("disabled")).toBe(true);
+    });
+    expect(
+      screen.getByRole("dialog", { name: "Approve pull request" }),
+    ).toBeTruthy();
+
+    await fireEvent.click(trigger);
+    expect(
+      screen.getByRole("dialog", { name: "Approve pull request" }),
+    ).toBeTruthy();
+
+    resolvePost({ data: { status: "approved" } });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Approve pull request" }),
+      ).toBeNull();
+    });
   });
 
   it("collapses and clears the draft when the PR identity changes", async () => {

--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -75,6 +75,17 @@ describe("ApproveButton tooltips", () => {
     });
   });
 
+  it("renders the optional comment placeholder as display text", async () => {
+    renderApproveButton();
+
+    await fireEvent.click(screen.getByRole("button", { name: /^approve$/i }));
+
+    expect(
+      screen.getByPlaceholderText("Leave an optional comment…"),
+    ).toBeTruthy();
+    expect(screen.queryByPlaceholderText(/\\u2026/)).toBeNull();
+  });
+
   it("collapses the approval popover from cancel without removing the trigger", async () => {
     renderApproveButton();
 

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -21,6 +21,15 @@ type WorkspaceStatusResponse = {
   error_message?: string | null;
 };
 
+type PullDetailResponse = {
+  events: Array<{
+    EventType: string;
+    Author: string;
+    Body: string;
+    Summary: string;
+  }>;
+};
+
 const lockedWorkspaceTestTimeoutMs = 120_000;
 
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
@@ -549,6 +558,69 @@ test.describe("detail action buttons", () => {
       .toBeVisible();
     await expect(page.locator(".actions-menu-popover .btn--green"))
       .toHaveText("Approve");
+  });
+
+  test("approve action submits through API, persists review, and refreshes detail and list data", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const baseURL = isolatedServer.info.base_url;
+      const approvalBody = "LGTM from approve e2e";
+      const detailURL = `${baseURL}/api/v1/pulls/github/acme/widgets/1`;
+
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+
+      await page.locator(".btn--approve").first().click();
+      await page.locator(".approve-comment").fill(approvalBody);
+
+      const approveResponsePromise = page.waitForResponse((response) =>
+        response.request().method() === "POST"
+        && response.url() === `${detailURL}/approve`
+      );
+      const detailRefreshPromise = page.waitForResponse((response) =>
+        response.request().method() === "GET"
+        && response.url() === detailURL
+      );
+      const listRefreshPromise = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return response.request().method() === "GET"
+          && url.origin === baseURL
+          && url.pathname === "/api/v1/pulls";
+      });
+
+      await page.locator(".approve-actions .btn--green").click();
+
+      const approveResponse = await approveResponsePromise;
+      expect(approveResponse.status()).toBe(200);
+      expect((await approveResponse.json()).status).toBe("approved");
+      expect((await detailRefreshPromise).ok()).toBe(true);
+      expect((await listRefreshPromise).ok()).toBe(true);
+
+      await expect(page.locator(".approve-popover")).toHaveCount(0);
+      await expect(page.locator(".event-card", { hasText: approvalBody }))
+        .toBeVisible();
+
+      await expect.poll(async () => {
+        const response = await api!.get("/api/v1/pulls/github/acme/widgets/1");
+        expect(response.ok()).toBe(true);
+        const detail = await response.json() as PullDetailResponse;
+        return detail.events.some((event) =>
+          event.EventType === "review"
+          && event.Author === "fixture-bot"
+          && event.Summary === "APPROVED"
+          && event.Body === approvalBody
+        );
+      }).toBe(true);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
   });
 
   test("self-contained actions close the narrow actions menu after success", async ({ page }) => {

--- a/internal/testutil/fixture_client.go
+++ b/internal/testutil/fixture_client.go
@@ -664,11 +664,41 @@ func (c *FixtureClient) EditIssueComment(
 	return nil, fmt.Errorf("%w: comment %d", errFixtureNotFound, commentID)
 }
 
-// CreateReview returns an error (mutations not supported).
+// CreateReview records an approving review so full-stack e2e tests can verify
+// review mutations through the HTTP API and persisted timeline state.
 func (c *FixtureClient) CreateReview(
-	_ context.Context, _, _ string, _ int, _, _ string,
+	_ context.Context, owner, repo string, number int, event, body string,
 ) (*gh.PullRequestReview, error) {
-	return nil, errFixtureReadOnly
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.findPullRequest(owner, repo, number) == nil {
+		return nil, fmt.Errorf("%w: pull request %s/%s#%d", errFixtureNotFound, owner, repo, number)
+	}
+
+	id := c.nextID
+	c.nextID++
+	now := gh.Timestamp{Time: time.Now().UTC()}
+	login := "fixture-bot"
+	state := strings.ToUpper(event)
+	if state == "APPROVE" {
+		state = "APPROVED"
+	}
+	nodeID := fmt.Sprintf("PRR_fixture_%d", id)
+	htmlURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d#pullrequestreview-%d", owner, repo, number, id)
+
+	review := &gh.PullRequestReview{
+		ID:          &id,
+		NodeID:      &nodeID,
+		User:        &gh.User{Login: &login},
+		Body:        &body,
+		State:       &state,
+		SubmittedAt: &now,
+		HTMLURL:     &htmlURL,
+	}
+	key := issueKey(owner, repo, number)
+	c.Reviews[key] = append(c.Reviews[key], review)
+	return review, nil
 }
 
 func (c *FixtureClient) MarkPullRequestReadyForReview(

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -111,7 +111,7 @@
       <textarea
         bind:this={commentInput}
         class="approve-comment"
-        placeholder="Leave an optional comment\u2026"
+        placeholder="Leave an optional comment…"
         bind:value={body}
         rows={3}
       ></textarea>

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CheckIcon from "@lucide/svelte/icons/check";
+  import { tick } from "svelte";
   import { getClient, getStores } from "../../context.js";
   import ActionButton from "../shared/ActionButton.svelte";
   import { runApprovePR, type PRDetailActionInput } from "./keyboard-actions.js";
@@ -33,6 +34,7 @@
   let body = $state("");
   let submitting = $state(false);
   let error = $state<string | null>(null);
+  let commentInput = $state<HTMLTextAreaElement | undefined>();
 
   // Reset draft state on PR identity change so an open form with
   // PR A's body cannot submit to PR B once the route transitions.
@@ -43,6 +45,14 @@
     expanded = false;
     body = "";
     error = null;
+  });
+
+  $effect(() => {
+    if (!expanded) return;
+
+    void tick().then(() => {
+      commentInput?.focus();
+    });
   });
 
   function buildInput(): PRDetailActionInput {
@@ -78,76 +88,108 @@
   }
 </script>
 
-<div class="approve-section">
+<div class={["approve-section", expanded && "approve-section--open"]}>
+  <ActionButton
+    class="btn btn--approve"
+    onclick={() => { if (!disabled) expanded = !expanded; }}
+    {disabled}
+    ariaExpanded={expanded}
+    tone="success"
+    surface="soft"
+    title={expanded
+      ? "Close the approval form"
+      : "Open the approval form to submit a code review on this pull request"}
+    label="Approve"
+    shortLabel="Approve"
+    {size}
+  >
+    <CheckIcon size="14" strokeWidth="2.4" aria-hidden="true" />
+  </ActionButton>
+
   {#if expanded}
-    <textarea
-      class="approve-comment"
-      placeholder="Leave an optional comment\u2026"
-      bind:value={body}
-      rows={3}
-    ></textarea>
-    {#if error}
-      <p class="approve-error">{error}</p>
-    {/if}
-    <div class="approve-actions">
-      <ActionButton
-        class="btn btn--secondary"
-        onclick={() => { expanded = false; }}
-        disabled={submitting}
-        tone="neutral"
-        surface="outline"
-      >
-        Cancel
-      </ActionButton>
-      <ActionButton
-        class="btn btn--primary btn--green"
-        onclick={() => void handleApprove()}
-        disabled={submitting || disabled}
-        tone="success"
-        surface="solid"
-        title="Submit an approving code review on this pull request"
-      >
-        {submitting ? "Approving\u2026" : "Approve"}
-      </ActionButton>
+    <div class="approve-popover" role="dialog" aria-label="Approve pull request">
+      <textarea
+        bind:this={commentInput}
+        class="approve-comment"
+        placeholder="Leave an optional comment\u2026"
+        bind:value={body}
+        rows={3}
+      ></textarea>
+      {#if error}
+        <p class="approve-error">{error}</p>
+      {/if}
+      <div class="approve-actions">
+        <ActionButton
+          class="btn btn--secondary"
+          onclick={() => { expanded = false; }}
+          disabled={submitting}
+          tone="neutral"
+          surface="outline"
+        >
+          Cancel
+        </ActionButton>
+        <ActionButton
+          class="btn btn--primary btn--green"
+          onclick={() => void handleApprove()}
+          disabled={submitting || disabled}
+          tone="success"
+          surface="solid"
+          title="Submit an approving code review on this pull request"
+        >
+          {submitting ? "Approving\u2026" : "Approve"}
+        </ActionButton>
+      </div>
     </div>
-  {:else}
-    <ActionButton
-      class="btn btn--approve"
-      onclick={() => { if (!disabled) expanded = true; }}
-      {disabled}
-      tone="success"
-      surface="soft"
-      title="Open the approval form to submit a code review on this pull request"
-      label="Approve"
-      shortLabel="Approve"
-      {size}
-    >
-      <CheckIcon size="14" strokeWidth="2.4" aria-hidden="true" />
-    </ActionButton>
   {/if}
 </div>
 
 <style>
   .approve-section {
+    position: relative;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    max-width: 100%;
+  }
+
+  .approve-section--open {
+    z-index: 30;
+  }
+
+  .approve-popover {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
     display: flex;
     flex-direction: column;
     gap: 8px;
+    width: min(360px, calc(100vw - 32px));
+    padding: 10px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.2);
   }
 
   .approve-comment {
+    width: 100%;
+    min-height: 74px;
     font-size: var(--font-size-root);
-    padding: 8px 10px;
+    padding: 9px 10px;
     background: var(--bg-inset);
-    border: 1px solid var(--border-default);
+    border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
     color: var(--text-primary);
     resize: vertical;
     max-height: 150px;
     line-height: 1.5;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
   }
+
   .approve-comment:focus {
     border-color: var(--accent-blue);
     outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 32%, transparent);
   }
 
   .approve-error {
@@ -159,5 +201,12 @@
     display: flex;
     gap: 8px;
     justify-content: flex-end;
+    width: 100%;
+  }
+
+  @media (max-width: 420px) {
+    .approve-popover {
+      width: min(320px, calc(100vw - 24px));
+    }
   }
 </style>

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -73,7 +73,7 @@
   }
 
   async function handleApprove(): Promise<void> {
-    if (disabled) return;
+    if (disabled || submitting) return;
     submitting = true;
     error = null;
     try {
@@ -91,8 +91,8 @@
 <div class={["approve-section", expanded && "approve-section--open"]}>
   <ActionButton
     class="btn btn--approve"
-    onclick={() => { if (!disabled) expanded = !expanded; }}
-    {disabled}
+    onclick={() => { if (!disabled && !submitting) expanded = !expanded; }}
+    disabled={disabled || submitting}
     ariaExpanded={expanded}
     tone="success"
     surface="soft"

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -2308,6 +2308,16 @@
     width: 100%;
   }
 
+  .actions-menu-popover :global(.approve-section--open) {
+    gap: 8px;
+  }
+
+  .actions-menu-popover :global(.approve-popover) {
+    position: static;
+    width: 100%;
+    box-shadow: none;
+  }
+
   .actions-menu-popover :global(.approve-actions) {
     flex-wrap: wrap;
   }

--- a/packages/ui/src/components/shared/ActionButton.svelte
+++ b/packages/ui/src/components/shared/ActionButton.svelte
@@ -14,6 +14,7 @@
     title?: string;
     label?: string;
     shortLabel?: string;
+    ariaExpanded?: boolean;
     class?: string;
     onclick?: (event: MouseEvent) => void;
     children?: Snippet;
@@ -29,6 +30,7 @@
     title = undefined,
     label = undefined,
     shortLabel = undefined,
+    ariaExpanded = undefined,
     class: className = "",
     onclick = undefined,
     children,
@@ -51,6 +53,7 @@
   class={classes}
   {disabled}
   {title}
+  aria-expanded={ariaExpanded}
   aria-label={label && shortLabel ? label : undefined}
   onclick={onclick}
 >
@@ -81,9 +84,24 @@
     padding: 6px 14px;
     border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: opacity 0.1s, background 0.1s;
+    transition:
+      background-color 0.12s ease,
+      border-color 0.12s ease,
+      color 0.12s ease,
+      box-shadow 0.12s ease,
+      transform 0.08s ease,
+      opacity 0.1s ease;
     white-space: nowrap;
     line-height: 1;
+  }
+
+  .action-button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 42%, transparent);
+  }
+
+  .action-button:active:not(:disabled) {
+    transform: translateY(1px);
   }
 
   .action-button:disabled {
@@ -139,6 +157,14 @@
     background: #176b2e;
     border-color: #176b2e;
   }
+  .action-button--solid.action-button--success:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-green) 48%, transparent);
+  }
+  .action-button--solid.action-button--success:active:not(:disabled),
+  .action-button--solid.action-button--success[aria-expanded="true"] {
+    background: #145c27;
+    border-color: #145c27;
+  }
 
   /* Success soft — approve */
   .action-button--soft.action-button--success {
@@ -148,6 +174,14 @@
   }
   .action-button--soft.action-button--success:hover:not(:disabled) {
     background: color-mix(in srgb, var(--accent-green) 20%, transparent);
+  }
+  .action-button--soft.action-button--success:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-green) 38%, transparent);
+  }
+  .action-button--soft.action-button--success:active:not(:disabled),
+  .action-button--soft.action-button--success[aria-expanded="true"] {
+    background: color-mix(in srgb, var(--accent-green) 26%, transparent);
+    border-color: color-mix(in srgb, var(--accent-green) 48%, transparent);
   }
 
   /* Info soft — ready for review */


### PR DESCRIPTION
- Keep the Approve action stable when opening the optional review comment form.
- Render the approval form as an anchored popover with cleaner active/focus states.
- Fix the optional comment placeholder so the ellipsis displays normally.