### PR TITLE
Keep responsive PR and issue routes stable

### DIFF
--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -37,12 +37,30 @@ Think about mobile work in this order:
 - Give focused PR/issue detail pages their own phone shell treatment even when they reuse desktop detail components internally.
 - Mobile escape hatches to desktop views are allowed, but they must be intentional and not the default path.
 
+## Responsive route and presentation model
+
+Viewport size chooses presentation, not route identity.
+
+- Canonical PR and issue routes such as `/pulls/...`, `/pulls/.../files`, and `/issues/...` must not be rewritten just because the viewport becomes narrow. A user who resizes a desktop detail page down and back up should stay on the same URL and naturally return to the desktop presentation when there is room again.
+- Narrow canonical PR/issue routes may reuse the same focus presentation used by `/focus`, but they must keep canonical route builders for list selection, detail-tab changes, and back/forward behavior.
+- `/focus` remains a valid explicit route family, but it should be a route over shared focus presentation components, not a separate implementation that canonical routes cannot enter or leave responsively.
+- `/m` remains a phone-first route family. Use it for workflows that need a mobile shell, not as an automatic replacement for every narrow canonical route.
+- Keep host-prefixed identity stable too. `/host/{platform_host}/pulls/...` and `/host/{platform_host}/issues/...` should not normalize back to default-host or `/focus` URLs during responsive presentation changes.
+
+Do not collapse these concepts:
+
+- **Compact/narrow presentation**: a desktop window, split pane, or embedded surface that is too narrow for sidebars or dense desktop chrome. It can use focus presentation, but it should retain desktop-scale typography and desktop action geometry.
+- **Phone-like presentation**: a touch/mobile-user-agent context where larger mobile tokens, hit targets, and phone-specific action layouts are appropriate.
+
+In code and tests, name predicates so this distinction is visible. Avoid generic helpers such as `isPhoneViewport()` when the real question is either "should this route use the compact focus presentation?" or "should this surface use phone-only sizing?"
+
 ## Typography and sizing
 
 - `frontend/src/app.css` owns the shared design tokens, including `--font-size-mobile-*`.
 - Mobile typography, spacing, radii, and hit targets should be mostly `rem`-based and expressed through scoped tokens.
 - The app intentionally keeps the global root font size small for desktop/terminal stability. Do not change the global `html` root just to make mobile readable.
 - Compensate inside mobile shells with mobile-scoped tokens such as `--mobile-type-*`, pointing back to the app-level mobile font-size tokens where possible.
+- Do not apply mobile-scoped tokens to every narrow desktop viewport. A desktop-narrow focus presentation should remain compact and desktop-scaled unless the environment is phone-like.
 - Avoid raw `px` as the sizing model for mobile typography, spacing, or touch targets. Hairline borders and tiny decorative strokes are the main exceptions.
 - Avoid device-DPI-specific scaling unless there is a proven, user-requested reason; it fights browser/user text scaling and makes the UI less predictable.
 
@@ -68,9 +86,10 @@ Avoid by default:
 
 ## Routing expectations
 
-- Phone list/start routes should route to phone-appropriate focused detail routes.
-- Focused detail tabs, such as PR files, must stay on focused/mobile route builders rather than falling back to desktop `/pulls/...` or `/issues/...` URLs.
-- Automatic mobile redirects should preserve user intent for deep links and should not bounce focused/detail routes back to the mobile landing page.
+- Phone list/start routes should route to phone-appropriate focused detail routes when the user is already in a phone route family.
+- Canonical list/detail routes should stay canonical when they are only changing presentation for a narrow viewport. Do not route desktop-narrow list clicks into `/focus` unless the current route family is already `/focus`.
+- Focused detail tabs, such as PR files, must use route builders for the active route family: focus builders for `/focus/...`, canonical builders for `/pulls/...` and `/issues/...`.
+- Automatic responsive redirects should be rare. Prefer presentation selection over URL replacement for canonical routes; when redirects are truly needed, preserve user intent for deep links and do not bounce focused/detail routes back to a landing page.
 - Desktop opt-out links are acceptable, but they should be explicit and test-covered.
 
 ## Verification expectations
@@ -80,6 +99,7 @@ For mobile-visible changes, verify behavior with a real phone profile, not only 
 Minimum expectations for meaningful mobile UI changes:
 
 - Use a Playwright phone profile or explicit phone-like viewport/user-agent setup appropriate for the repo's browser matrix.
+- Add a separate desktop-narrow regression when canonical PR/issue routes change responsive presentation. This should prove the URL stays canonical, the focus presentation appears when narrow, the phone-only class/tokens do not apply in desktop-narrow contexts, and the desktop shell returns after widening.
 - Assert the phone route renders a phone shell/component and not the desktop layout.
 - Assert no document-level horizontal overflow.
 - Check key element bounds for cards, filters, tabs, branch names, and action buttons; element clipping can happen even when document width is fine.
@@ -94,10 +114,11 @@ Before shipping mobile UX work, ask:
 - Is this a phone-first workflow, or did we just resize desktop?
 - Is the primary task obvious without scanning desktop chrome?
 - Are type, spacing, and hit targets driven by mobile tokens?
+- Are mobile tokens limited to phone-like contexts rather than every narrow desktop viewport?
 - Did we keep the global root font size stable?
 - Are provider/repo identity and item numbers still clear?
 - Do taps navigate to visible phone outcomes rather than desktop-only state?
-- Did focused detail and tab routes remain mobile/focused routes?
-- Did Playwright cover a phone profile and the important interaction path?
+- Did focused detail and tab routes use builders for their active route family?
+- Did Playwright cover both a phone profile and any desktop-narrow canonical route behavior?
 
 If the answer to any of these is no, fix the interaction model before tuning individual CSS values.

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -150,6 +150,13 @@ When editing Svelte components, use the Svelte skills `skills/svelte-core-bestpr
 
 For TypeScript/Svelte state and routing contracts, avoid anonymous object type literals when the shape represents a domain concept that is reused or exposed across modules. Name shared item identity shapes, route payloads, embed callbacks, and API view models near the module that owns the concept, then import those types at call sites. PR/issue/file/focus route identity and URL construction belongs in the shared route item module at `packages/ui/src/routes.ts`; the frontend router remains the browser-location adapter over those builders. New routed item callers should use those named refs and builders instead of repeating `{ owner; name; number; platformHost }` shapes or hand-building `/pulls`, `/issues`, or `/focus` URLs.
 
+Responsive layout work should separate presentation mode from sizing mode.
+
+- Use compact/focus presentation to remove sidebars, split panes, or dense chrome when the available width is too small.
+- Use phone/mobile sizing only for phone-like contexts, such as coarse pointer, mobile user agent, or explicit force-mobile test paths.
+- Do not use one broad "phone viewport" predicate for both decisions. That makes desktop-narrow windows inherit oversized mobile typography, action grids, and touch-only geometry.
+- When a compact canonical route reuses focus presentation, keep desktop-scale tokens unless the environment is phone-like.
+
 Before adding UI styling:
 
 1. Check whether an existing shared primitive already expresses the pattern.

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -26,6 +26,23 @@ Interactive surfaces must agree on which item is selected.
 - When a view changes from item A to item B, reset transient action state that
   could otherwise submit or render against the wrong item.
 
+Responsive layout changes must not change route identity.
+
+- Resizing a canonical PR or issue route must not rewrite `/pulls/...`,
+  `/pulls/.../files`, `/issues/...`, or `/host/{platform_host}/...` into
+  `/focus/...` or `/m/...`.
+- Responsive presentation decisions belong in the shell/rendering layer. Route
+  builders still follow the active route family: canonical builders for
+  canonical routes, focus builders for explicit `/focus` routes, and mobile
+  builders for explicit `/m` flows.
+- If a canonical list route renders with the focus presentation because the
+  viewport is compact, selecting an item should still navigate to a canonical
+  detail route.
+- Distinguish compact desktop presentation from phone-like presentation in
+  state names and tests. Compact desktop may hide sidebars or use the focus
+  presentation; phone-like contexts may additionally use mobile typography,
+  touch hit targets, and phone-specific action layouts.
+
 Examples of transient state that should usually reset on identity change:
 
 - inline edit drafts

--- a/docs/superpowers/plans/2026-05-16-route-stable-responsive-details.md
+++ b/docs/superpowers/plans/2026-05-16-route-stable-responsive-details.md
@@ -1,0 +1,247 @@
+# Route-Stable Responsive Details Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep canonical PR and issue URLs stable while narrow viewports render the same focus presentation used by `/focus`.
+
+**Architecture:** Remove viewport-driven navigation from `App.svelte` and replace it with derived presentation selection. Reuse `PRListView`, `IssueListView`, and `FocusListView` for both explicit `/focus` routes and narrow canonical routes, with route-family-aware builders so canonical routes stay canonical.
+
+**Tech Stack:** Svelte 5, TypeScript, Bun, Playwright e2e, shared `@middleman/ui` route helpers.
+
+---
+
+### Task 1: Write Failing E2E Coverage
+
+**Files:**
+- Modify: `frontend/tests/e2e-full/mobile-routes.spec.ts`
+- Modify: `frontend/tests/e2e-full/routed-items.spec.ts`
+
+- [ ] **Step 1: Replace redirect assertions for canonical phone detail routes**
+
+In `frontend/tests/e2e-full/mobile-routes.spec.ts`, change the existing canonical desktop deep-link tests to assert stable URLs:
+
+```ts
+test("phone canonical PR files deep link renders focus presentation without changing URL", async ({ page }) => {
+  await page.goto("/pulls/github/acme/widgets/1/files");
+
+  await expect(page).toHaveURL(/\/pulls\/github\/acme\/widgets\/1\/files$/);
+  await expect(page.locator(".focus-layout .files-layout")).toBeVisible();
+  await expect(page.locator(".focus-layout .diff-view")).toBeVisible();
+  await expect(page.locator(".mobile-shell")).toHaveCount(0);
+});
+
+test("phone canonical issue deep link renders focus presentation without changing URL", async ({ page }) => {
+  await page.goto("/issues/github/acme/widgets/10");
+
+  await expect(page).toHaveURL(/\/issues\/github\/acme\/widgets\/10$/);
+  await expect(page.locator(".focus-layout .issue-detail .detail-title")).toBeVisible();
+  await expect(page.locator(".mobile-shell")).toHaveCount(0);
+});
+```
+
+- [ ] **Step 2: Add canonical narrow list route-family coverage**
+
+In `frontend/tests/e2e-full/routed-items.spec.ts`, add tests that phone-sized canonical lists use focus presentation but click to canonical URLs:
+
+```ts
+test("narrow canonical PR list routes selected rows to canonical detail", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/pulls");
+  await page.locator(".focus-list .pull-item").first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+
+  await page.locator(".focus-list .pull-item").filter({ hasText: prTitle }).first().click();
+
+  await expect(page).toHaveURL(/\/pulls\/github\/acme\/widgets\/1$/);
+  await expect(page.locator(".focus-layout .pull-detail .detail-title"))
+    .toContainText(prTitle);
+});
+
+test("narrow canonical issue list routes selected rows to canonical detail", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/issues");
+  await page.locator(".focus-list .issue-item").first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+
+  await page.locator(".focus-list .issue-item").filter({ hasText: issueTitle }).first().click();
+
+  await expect(page).toHaveURL(/\/issues\/github\/acme\/widgets\/10$/);
+  await expect(page.locator(".focus-layout .issue-detail .detail-title"))
+    .toContainText(issueTitle);
+});
+```
+
+- [ ] **Step 3: Run tests to verify RED**
+
+Run:
+
+```bash
+bun run --cwd frontend test:e2e:mock tests/e2e-full/mobile-routes.spec.ts -g "canonical .* without changing URL"
+bun run --cwd frontend test:e2e:mock tests/e2e-full/routed-items.spec.ts -g "narrow canonical"
+```
+
+Expected: tests fail because canonical routes still redirect or list clicks still use focus route builders.
+
+### Task 2: Make FocusListView Route-Family Aware
+
+**Files:**
+- Modify: `packages/ui/src/views/FocusListView.svelte`
+
+- [ ] **Step 1: Add route-family prop and canonical builders**
+
+Add imports and prop:
+
+```ts
+import {
+  buildFocusIssueRoute,
+  buildFocusPullRequestRoute,
+  buildIssueRoute,
+  buildPullRequestRoute,
+  type IssueRouteRef,
+  type PullRequestRouteRef,
+} from "../routes.js";
+
+type RouteFamily = "focus" | "canonical";
+
+interface Props {
+  listType: "mrs" | "issues";
+  repo?: string;
+  routeFamily?: RouteFamily;
+}
+
+const { listType, repo, routeFamily = "focus" }: Props = $props();
+```
+
+Update selection:
+
+```ts
+function handlePRSelect(ref: PullRequestRouteRef): void {
+  navigate(routeFamily === "canonical"
+    ? buildPullRequestRoute(ref)
+    : buildFocusPullRequestRoute(ref));
+}
+
+function handleIssueSelect(ref: IssueRouteRef): void {
+  navigate(routeFamily === "canonical"
+    ? buildIssueRoute(ref)
+    : buildFocusIssueRoute(ref));
+}
+```
+
+- [ ] **Step 2: Run Svelte autofixer**
+
+Run:
+
+```bash
+npx @sveltejs/mcp@0.1.22 svelte-autofixer packages/ui/src/views/FocusListView.svelte --svelte-version 5
+```
+
+Expected: no blocking Svelte issues.
+
+### Task 3: Select Focus Presentation Without URL Rewrites
+
+**Files:**
+- Modify: `frontend/src/App.svelte`
+
+- [ ] **Step 1: Remove automatic responsive redirect**
+
+Remove the `redirectPhoneToMobileRoute()` mount/effect path and any helper used only by that path. Keep explicit mobile tab navigation and the explicit desktop opt-out button.
+
+- [ ] **Step 2: Add focus presentation helpers**
+
+Add helpers in `App.svelte`:
+
+```ts
+function shouldUseResponsiveFocusPresentation(): boolean {
+  const route = getRoute();
+  if (!isPhoneViewport() && !shouldForceMobileRoutes()) return false;
+  if (route.page === "pulls") return route.view === "list";
+  return route.page === "issues";
+}
+
+function useFocusLayoutClass(): boolean {
+  return isPhoneViewport() || shouldForceMobileRoutes();
+}
+```
+
+- [ ] **Step 3: Reuse focus layout for canonical pulls/issues**
+
+Change the top route branch so it renders `.focus-layout` when either `route.page === "focus"` or `shouldUseResponsiveFocusPresentation()` is true. For canonical `/pulls`:
+
+```svelte
+{:else if r.page === "pulls"}
+  {#if r.selected}
+    <PRListView
+      selectedPR={r.selected}
+      detailTab={r.tab === "files" ? "files" : "conversation"}
+      isSidebarCollapsed={true}
+      hideSidebar={true}
+      showStackSidebar={false}
+    />
+  {:else}
+    <FocusListView listType="mrs" routeFamily="canonical" />
+  {/if}
+```
+
+For canonical `/issues`:
+
+```svelte
+{:else if r.page === "issues"}
+  {#if r.selected}
+    <IssueListView
+      selectedIssue={r.selected}
+      isSidebarCollapsed={true}
+      hideSidebar={true}
+    />
+  {:else}
+    <FocusListView listType="issues" routeFamily="canonical" />
+  {/if}
+```
+
+- [ ] **Step 4: Run Svelte autofixer**
+
+Run:
+
+```bash
+npx @sveltejs/mcp@0.1.22 svelte-autofixer frontend/src/App.svelte --svelte-version 5
+```
+
+Expected: no blocking Svelte issues.
+
+### Task 4: Verify and Commit
+
+**Files:**
+- Modify: test and Svelte files from prior tasks.
+
+- [ ] **Step 1: Run focused e2e tests**
+
+Run:
+
+```bash
+bun run --cwd frontend test:e2e:mock tests/e2e-full/mobile-routes.spec.ts -g "phone canonical|focused PR files"
+bun run --cwd frontend test:e2e:mock tests/e2e-full/routed-items.spec.ts -g "narrow canonical|focus .* routes selected"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run type and Svelte checks**
+
+Run:
+
+```bash
+bun run --cwd frontend check
+bunx --cwd frontend tsc --noEmit -p ./tsconfig.json
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add frontend/src/App.svelte frontend/tests/e2e-full/mobile-routes.spec.ts frontend/tests/e2e-full/routed-items.spec.ts packages/ui/src/views/FocusListView.svelte docs/superpowers/plans/2026-05-16-route-stable-responsive-details.md
+git commit -m "fix: keep responsive detail routes stable"
+```
+
+Expected: commit hooks pass and the commit records the route-stable responsive behavior.

--- a/docs/superpowers/specs/2026-05-16-route-stable-responsive-details-design.md
+++ b/docs/superpowers/specs/2026-05-16-route-stable-responsive-details-design.md
@@ -46,6 +46,9 @@ Routes keep their semantic meaning:
 - `/pulls/{ref}/files`: PR files route.
 - `/issues`: issue list route.
 - `/issues/{ref}`: issue detail route.
+- `/host/{platform_host}/pulls/{ref}`: self-hosted PR detail route.
+- `/host/{platform_host}/pulls/{ref}/files`: self-hosted PR files route.
+- `/host/{platform_host}/issues/{ref}`: self-hosted issue detail route.
 - `/m/...`: explicit mobile shell routes.
 - `/focus/...`: explicit focused routes.
 
@@ -58,8 +61,13 @@ Viewport width chooses presentation, not route identity:
 | `/pulls/{ref}/files` | Desktop PR files detail | Focus PR files presentation |
 | `/issues` | Desktop issue list with sidebar/detail placeholder | Focus issue list presentation |
 | `/issues/{ref}` | Desktop issue list + detail pane | Focus issue detail presentation |
+| `/host/{platform_host}/pulls/{ref}` | Desktop PR list + detail pane | Focus PR detail presentation |
+| `/host/{platform_host}/pulls/{ref}/files` | Desktop PR files detail | Focus PR files presentation |
+| `/host/{platform_host}/issues/{ref}` | Desktop issue list + detail pane | Focus issue detail presentation |
 
-The browser location must remain byte-for-byte stable during viewport-only transitions, including query parameters.
+The browser location must remain byte-for-byte stable during viewport-only transitions, including query parameters and hash fragments.
+
+The `{ref}` placeholder means the existing provider-aware identity tuple: `(provider, platform_host, owner, name, number)`, with `repoPath` preserving nested owner/group paths. Self-hosted routes must follow the existing `/host/{platform_host}/...` shape and must not be normalized back to default-host URLs during responsive presentation changes.
 
 ## Presentation Model
 
@@ -77,6 +85,7 @@ The implementation should derive booleans along these lines:
 - `isResponsivePhoneLayout`: true for phone-like width or the existing force-mobile testing flag.
 - `isCanonicalPullDetailRoute`: true for `/pulls/{ref}` and `/pulls/{ref}/files`.
 - `isCanonicalIssueDetailRoute`: true for `/issues/{ref}`.
+- Host-prefixed canonical detail routes are canonical detail routes too.
 - `useFocusDetailPresentation`: true when a canonical detail route is active and the layout is phone-like.
 - `useFocusListPresentation`: true when a canonical list route is active and the layout is phone-like.
 
@@ -89,6 +98,17 @@ These derived values decide props and wrapper classes:
 - Keep issue selection on canonical route builders while the current route is canonical.
 
 No presentation decision calls `navigate()` or `replaceUrl()`.
+
+Resize handling should only update presentation state. It must not trigger pull, issue, detail, or activity store reloads beyond the loads that already happen because the active route or filters changed.
+
+## Route Construction Boundary
+
+All route construction must go through the existing shared helpers:
+
+- `packages/ui/src/routes.ts` for UI route builders such as `buildPullRequestRoute`, `buildPullRequestFilesRoute`, `buildIssueRoute`, and their focus counterparts.
+- `packages/ui/src/api/provider-routes.ts` for provider-aware host/default-host decisions under those builders.
+
+Components must not hand-build canonical, focus, mobile, or host-prefixed PR/issue URLs. This keeps GitHub, GitLab, Gitea, Forgejo, and self-hosted provider routes on the same identity rules.
 
 ## Component Boundaries
 
@@ -122,6 +142,8 @@ Shared detail components:
 - Reuse the existing mobile/focus sizing tokens where possible.
 - Avoid duplicating detail markup solely because one route is canonical and another is `/focus`.
 - Prefer extracting shared presentation wrappers or props over maintaining parallel canonical and focus component trees.
+
+If a selected PR or issue is missing or still loading while a canonical route is rendered in focus presentation, the view should use the same loading, stale-detail, or missing-selection behavior as the corresponding `/focus` presentation. It should not bounce the user to a list route or rewrite the URL to recover.
 
 ## Mobile and Focus Routes
 
@@ -161,6 +183,30 @@ This means a user can:
 4. Resize wide.
 5. Return to the desktop files presentation at the same URL.
 
+Back and forward navigation after a resize should replay explicit user navigations only. A viewport transition must not create an extra history stop and must not replace the current stop.
+
+## Edge Cases
+
+- Query strings and hash fragments are preserved exactly during viewport transitions.
+- Browser back/forward after resizing follows the user's explicit navigation history, not any responsive presentation changes.
+- Direct `/focus/...` visits remain `/focus/...` at wide widths. They may render with wider spacing or shell affordances if desired, but widening the viewport does not convert them to `/pulls/...` or `/issues/...`.
+- PR tab changes use the current route family. On `/pulls/...` in narrow focus presentation, "Files changed" navigates to `/pulls/.../files`. On `/focus/pulls/...`, it navigates to `/focus/pulls/.../files`.
+- Host-prefixed route tab changes preserve the host prefix and platform host.
+- Missing or loading detail state keeps the active route stable and shows the shared focus/detail loading or empty state.
+
+## Acceptance Criteria
+
+- Resizing from desktop width to narrow width does not call `pushState`, `replaceState`, `navigate()`, or `replaceUrl()`.
+- Resizing from narrow width back to desktop width restores the desktop presentation for the same path.
+- Path, query string, and hash remain stable across resize-only transitions.
+- Canonical PR details, PR files, and issue details render the same focus presentation as `/focus` when narrow.
+- Canonical PR and issue list routes render the same focus list presentation as `/focus/mrs` and `/focus/issues` when narrow.
+- PR tab navigation preserves the current route family and provider-aware host prefix.
+- Explicit `/focus` routes still work when visited directly on narrow and wide viewports.
+- Self-hosted routes such as `/host/git.example.com/pulls/gitea/org/repo/1` and `/host/git.example.com/issues/gitea/org/repo/10` keep their host prefix across resize and tab changes.
+- Resize-only presentation changes do not trigger extra store reloads or duplicate detail fetches.
+- Browser back/forward history contains only explicit user navigations.
+
 ## Testing
 
 Update e2e coverage around the route-stability contract:
@@ -178,6 +224,9 @@ Repeat for:
 
 - `/pulls/github/acme/widgets/1/files`.
 - `/issues/github/acme/widgets/10`.
+- `/host/git.example.com/pulls/gitea/org/widgets/1`.
+- `/host/git.example.com/pulls/gitea/org/widgets/1/files`.
+- `/host/git.example.com/issues/gitea/org/widgets/10`.
 
 Keep explicit mobile route tests, but change tests that currently expect automatic redirects from canonical detail routes. They should instead assert stable URLs plus focus presentation.
 
@@ -187,6 +236,17 @@ For list routes, use the same principle:
 - `/issues` can render the focus issue list at narrow width without becoming `/m/issues`.
 
 If the implementation deliberately stages detail routes first, list route redirect tests should be marked for follow-up in the plan rather than left contradictory.
+
+## Implementation Stages
+
+1. Characterize the existing route parsing and route builders with focused unit tests, including default-host and `/host/{platform_host}` PR/issue detail paths.
+2. Extract or expose a shared focus presentation mode for `PRListView`, `IssueListView`, and the focus shell without changing behavior.
+3. Route canonical PR detail and files pages through the focus presentation at narrow widths while keeping canonical URLs and route builders.
+4. Add PR e2e coverage for resize stability, files-tab navigation, query/hash preservation, and host-prefixed routes.
+5. Repeat the canonical narrow focus presentation for issue detail routes.
+6. Add issue e2e coverage for resize stability, query/hash preservation, and host-prefixed routes.
+7. Apply the same route-stable focus-list presentation to canonical `/pulls` and `/issues` list routes at narrow widths.
+8. Update or remove tests that assert automatic canonical-to-mobile redirects, keeping explicit `/m` and `/focus` direct-visit coverage.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-05-16-route-stable-responsive-details-design.md
+++ b/docs/superpowers/specs/2026-05-16-route-stable-responsive-details-design.md
@@ -1,0 +1,205 @@
+# Route-Stable Responsive Details Design
+
+## Goal
+
+Make PR and issue detail pages responsive without changing the user's current URL when the viewport changes.
+
+The current behavior surprises desktop users who open a canonical detail URL such as `/pulls/github/acme/widgets/1/files`, resize the app narrow enough to trigger the phone layout, and then resize it wide again. The app rewrites the URL to a mobile/focus route, so the original desktop route cannot naturally return when the viewport becomes wide again.
+
+The desired behavior is simpler:
+
+- The route expresses what the user is looking at.
+- The viewport controls how that route is presented.
+- Narrow canonical PR and issue routes render the same focus presentation used by `/focus`.
+- Resizing the window never changes the route by itself.
+
+## Current Behavior
+
+`frontend/src/App.svelte` computes a phone-like layout from `window.innerWidth`, the app container size, and coarse pointer detection. When the app is on `activity`, `pulls`, or `issues`, `redirectPhoneToMobileRoute()` calls `replaceUrl()` if the viewport is phone-like.
+
+That means:
+
+- `/pulls` becomes `/m/pulls`.
+- `/issues` becomes `/m/issues`.
+- `/pulls/{provider}/{owner}/{name}/{number}` becomes `/focus/pulls/{provider}/{owner}/{name}/{number}`.
+- `/pulls/{provider}/{owner}/{name}/{number}/files` becomes `/focus/pulls/{provider}/{owner}/{name}/{number}/files`.
+- `/issues/{provider}/{owner}/{name}/{number}` becomes `/focus/issues/{provider}/{owner}/{name}/{number}`.
+
+This loses source-route information. Once the URL changes to `/focus/...`, resizing wider cannot know whether the user originally came from a desktop route, a phone activity card, a copied focused link, or an embed-like focused flow.
+
+## Design Decision
+
+Remove automatic responsive route rewriting.
+
+Canonical routes such as `/pulls`, `/pulls/...`, `/pulls/.../files`, `/issues`, and `/issues/...` remain the active location across all viewport widths. The app renders a desktop presentation at wide widths and the focus presentation at narrow widths, but the path does not change unless the user explicitly navigates.
+
+Existing explicit mobile/focus routes can continue to exist as routable product surfaces, but they are no longer the mechanism for responsive adaptation from canonical desktop routes. They are entered only through explicit links, direct visits, or phone-first flows that intentionally target them.
+
+`/focus` is acceptable only if it is a route over the same reusable focus presentation used by canonical PR and issue routes at narrow widths. It should not own a separate detail implementation that canonical routes cannot enter or leave as the viewport changes.
+
+## Route Model
+
+Routes keep their semantic meaning:
+
+- `/pulls`: PR list route.
+- `/pulls/{ref}`: PR detail route.
+- `/pulls/{ref}/files`: PR files route.
+- `/issues`: issue list route.
+- `/issues/{ref}`: issue detail route.
+- `/m/...`: explicit mobile shell routes.
+- `/focus/...`: explicit focused routes.
+
+Viewport width chooses presentation, not route identity:
+
+| Route | Wide presentation | Narrow presentation |
+| --- | --- | --- |
+| `/pulls` | Desktop PR list with sidebar/detail placeholder | Focus PR list presentation |
+| `/pulls/{ref}` | Desktop PR list + detail pane | Focus PR detail presentation |
+| `/pulls/{ref}/files` | Desktop PR files detail | Focus PR files presentation |
+| `/issues` | Desktop issue list with sidebar/detail placeholder | Focus issue list presentation |
+| `/issues/{ref}` | Desktop issue list + detail pane | Focus issue detail presentation |
+
+The browser location must remain byte-for-byte stable during viewport-only transitions, including query parameters.
+
+## Presentation Model
+
+Introduce a small presentation decision in the app shell rather than using navigation as the responsive mechanism.
+
+The app shell already has enough information to decide:
+
+- Current route from `getRoute()`.
+- Current page from `getPage()`.
+- Phone-like layout from the existing viewport/container checks.
+- Selected PR or issue from the route and stores.
+
+The implementation should derive booleans along these lines:
+
+- `isResponsivePhoneLayout`: true for phone-like width or the existing force-mobile testing flag.
+- `isCanonicalPullDetailRoute`: true for `/pulls/{ref}` and `/pulls/{ref}/files`.
+- `isCanonicalIssueDetailRoute`: true for `/issues/{ref}`.
+- `useFocusDetailPresentation`: true when a canonical detail route is active and the layout is phone-like.
+- `useFocusListPresentation`: true when a canonical list route is active and the layout is phone-like.
+
+These derived values decide props and wrapper classes:
+
+- Hide sidebars for focus detail presentations.
+- Hide trailing stack sidebars for focus PR detail.
+- Apply the existing mobile/focus detail sizing tokens to canonical detail routes when they are rendered in focus presentation.
+- Keep PR detail tab navigation on canonical route builders while the current route is canonical.
+- Keep issue selection on canonical route builders while the current route is canonical.
+
+No presentation decision calls `navigate()` or `replaceUrl()`.
+
+## Component Boundaries
+
+The key implementation boundary is reusable focus presentation, not route family. Canonical routes at narrow widths and `/focus` routes should select from the same list/detail presentation components with different route builders and optional shell chrome.
+
+Keep the change mostly in the frontend app shell and shared list/detail view props.
+
+`frontend/src/App.svelte`:
+
+- Remove the resize-driven call that rewrites canonical `activity`, `pulls`, and `issues` routes.
+- Replace it with derived presentation choices.
+- Continue to recognize explicit `/m/...` and `/focus/...` routes when those routes are actually active.
+- Route canonical PR/issue list and detail pages at narrow widths through the same focus presentation path as explicit `/focus` routes.
+- Pass focus presentation props/classes into `PRListView` and `IssueListView` for canonical routes at narrow widths and for explicit `/focus` routes.
+
+`packages/ui/src/views/PRListView.svelte`:
+
+- Continue accepting `selectedPR` and `detailTab`.
+- Add or reuse props for hiding sidebars and trailing stack UI.
+- Ensure `selectDetailTab()` uses route builders for the current route family: canonical PR builders for `/pulls/...`, focus PR builders for `/focus/pulls/...`.
+- Allow a focus presentation class or mode so the same component tree can render narrow canonical routes and explicit `/focus` routes.
+
+`packages/ui/src/views/IssueListView.svelte`:
+
+- Continue accepting `selectedIssue`.
+- Add or reuse props for hiding sidebars.
+- Allow the same focus presentation class or mode for canonical issue routes and explicit `/focus` issue routes.
+
+Shared detail components:
+
+- Reuse the existing mobile/focus sizing tokens where possible.
+- Avoid duplicating detail markup solely because one route is canonical and another is `/focus`.
+- Prefer extracting shared presentation wrappers or props over maintaining parallel canonical and focus component trees.
+
+## Mobile and Focus Routes
+
+The design does not need to delete `/m` or `/focus` to fix the bug.
+
+However, those routes should be treated as explicit destinations rather than automatic responsive rewrites. This keeps the current phone-first surfaces available while removing the irreversible resize behavior.
+
+`/focus` should remain only if it reuses the same PR and issue focus presentation that canonical routes use when narrow. Its value is route semantics and shell choice, not a separate copy of phone-detail behavior.
+
+For example:
+
+- Opening `/m/pulls` directly still shows the mobile PR list.
+- A phone activity card may still navigate to `/focus/pulls/...` if that is the intended phone-first flow.
+- A desktop user on `/pulls/...` who resizes narrow stays on `/pulls/...` while seeing the focus PR detail presentation.
+- Both `/pulls/...` at narrow width and `/focus/pulls/...` use the same PR focus presentation code.
+- Both `/issues/...` at narrow width and `/focus/issues/...` use the same issue focus presentation code.
+
+This avoids preserving complexity for the resize case while keeping compatibility with existing links and tests until a later cleanup decides whether `/focus` should be folded into canonical routes entirely.
+
+## Browser History
+
+Viewport changes must not add or replace history entries.
+
+Only explicit user navigation should change the location:
+
+- Clicking nav links.
+- Selecting a PR or issue from a list.
+- Changing PR detail tabs.
+- Opening an explicit desktop or mobile route link.
+- Browser back/forward.
+
+This means a user can:
+
+1. Open `/pulls/github/acme/widgets/1/files`.
+2. Resize narrow.
+3. Inspect the focus files presentation.
+4. Resize wide.
+5. Return to the desktop files presentation at the same URL.
+
+## Testing
+
+Update e2e coverage around the route-stability contract:
+
+- Start wide on `/pulls/github/acme/widgets/1`.
+- Assert desktop detail presentation.
+- Resize to phone width.
+- Assert the URL is still `/pulls/github/acme/widgets/1`.
+- Assert the focus detail presentation is visible and the desktop list/sidebar chrome is hidden.
+- Resize wide.
+- Assert the URL is still `/pulls/github/acme/widgets/1`.
+- Assert desktop detail presentation returns.
+
+Repeat for:
+
+- `/pulls/github/acme/widgets/1/files`.
+- `/issues/github/acme/widgets/10`.
+
+Keep explicit mobile route tests, but change tests that currently expect automatic redirects from canonical detail routes. They should instead assert stable URLs plus focus presentation.
+
+For list routes, use the same principle:
+
+- `/pulls` can render the focus PR list at narrow width without becoming `/m/pulls`.
+- `/issues` can render the focus issue list at narrow width without becoming `/m/issues`.
+
+If the implementation deliberately stages detail routes first, list route redirect tests should be marked for follow-up in the plan rather than left contradictory.
+
+## Risks
+
+The main risk is keeping two route families and accidentally letting them drift into two implementations. The mitigation is to make presentation mode a clear input to shared view components, and to keep route builders tied to the current route family.
+
+Another risk is regressing phone-first activity flows. Those flows should keep their explicit routes in this change. The only behavior being removed is automatic URL mutation caused by viewport size.
+
+## Out of Scope
+
+- Removing `/m` routes.
+- Removing `/focus` routes.
+- Redesigning mobile activity.
+- Changing provider-aware route shapes.
+- Changing API behavior or stored data.
+
+Those may be good future cleanups, but they are not required for reversible responsive detail behavior.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -103,7 +103,6 @@
   let appReady = $state(false);
   let viewportWidth = $state(window.innerWidth);
   let hasCoarsePointer = $state(window.matchMedia("(pointer: coarse)").matches);
-  let minScreenDimension = $state(readMinScreenDimension());
   let cleanupFullAppShell: (() => void) | undefined;
   let fullShellStores: StoreInstances | undefined;
   const appIconSrc = `${getBasePath().replace(/\/$/, "")}/favicon.svg`;
@@ -171,23 +170,23 @@
     return text ? `?${text}` : "?desktop=1";
   }
 
-  function readMinScreenDimension(): number {
-    const screen = (window as Window & { screen?: Screen }).screen;
-    if (!screen) return Number.POSITIVE_INFINITY;
-    return Math.min(screen.width, screen.height);
-  }
-
   function updateViewportState(): void {
     viewportWidth = window.innerWidth;
     hasCoarsePointer = window.matchMedia("(pointer: coarse)").matches;
-    minScreenDimension = readMinScreenDimension();
   }
 
-  function isPhoneViewport(): boolean {
+  function hasMobileUserAgent(): boolean {
+    return /\b(Android|iPhone|iPod|IEMobile|Mobile)\b/i.test(navigator.userAgent);
+  }
+
+  function isPhoneLikeViewport(): boolean {
+    return viewportWidth <= 640
+      && (hasCoarsePointer || hasMobileUserAgent());
+  }
+
+  function isCompactViewport(): boolean {
     const hasNarrowContainer = isNarrow();
-    const hasPhoneLikeTouchViewport = hasCoarsePointer
-      && minScreenDimension <= 640;
-    return viewportWidth <= 640 || hasNarrowContainer || hasPhoneLikeTouchViewport;
+    return viewportWidth <= 640 || hasNarrowContainer || isPhoneLikeViewport();
   }
 
   function shouldUseDesktopOnPhone(): boolean {
@@ -205,7 +204,7 @@
   function shouldUseResponsiveFocusPresentation(): boolean {
     const route = getRoute();
     if (shouldUseDesktopOnPhone()) return false;
-    if (!isPhoneViewport() && !shouldForceMobileRoutes()) return false;
+    if (!isCompactViewport() && !shouldForceMobileRoutes()) return false;
     if (route.page === "pulls") return route.view === "list";
     return route.page === "issues";
   }
@@ -215,13 +214,13 @@
   }
 
   function useFocusLayoutClass(): boolean {
-    return isPhoneViewport() || shouldForceMobileRoutes();
+    return isPhoneLikeViewport() || shouldForceMobileRoutes();
   }
 
   function shouldUseResponsiveMobileActivityPresentation(): boolean {
     if (shouldUseDesktopOnPhone()) return false;
     if (getPage() !== "activity") return false;
-    return isPhoneViewport() || shouldForceMobileRoutes();
+    return isCompactViewport() || shouldForceMobileRoutes();
   }
 
   function navigateFocusPRDetailTab(
@@ -763,7 +762,7 @@
             {detailTab}
             isSidebarCollapsed={isSidebarCollapsed()}
             sidebarWidth={getSidebarWidth()}
-            showStackSidebar={!isPhoneViewport() && !shouldForceMobileRoutes()}
+            showStackSidebar={!isPhoneLikeViewport() && !shouldForceMobileRoutes()}
             onSidebarResize={handleSidebarResize}
           />
         {/if}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -101,6 +101,9 @@
 
   let stores = $state<StoreInstances | undefined>();
   let appReady = $state(false);
+  let viewportWidth = $state(window.innerWidth);
+  let hasCoarsePointer = $state(window.matchMedia("(pointer: coarse)").matches);
+  let minScreenDimension = $state(readMinScreenDimension());
   let cleanupFullAppShell: (() => void) | undefined;
   let fullShellStores: StoreInstances | undefined;
   const appIconSrc = `${getBasePath().replace(/\/$/, "")}/favicon.svg`;
@@ -168,10 +171,23 @@
     return text ? `?${text}` : "?desktop=1";
   }
 
+  function readMinScreenDimension(): number {
+    const screen = (window as Window & { screen?: Screen }).screen;
+    if (!screen) return Number.POSITIVE_INFINITY;
+    return Math.min(screen.width, screen.height);
+  }
+
+  function updateViewportState(): void {
+    viewportWidth = window.innerWidth;
+    hasCoarsePointer = window.matchMedia("(pointer: coarse)").matches;
+    minScreenDimension = readMinScreenDimension();
+  }
+
   function isPhoneViewport(): boolean {
-    const hasPhoneLikeTouchViewport = window.matchMedia("(pointer: coarse)").matches
-      && Math.min(window.screen.width, window.screen.height) <= 640;
-    return window.innerWidth <= 640 || isNarrow() || hasPhoneLikeTouchViewport;
+    const hasNarrowContainer = isNarrow();
+    const hasPhoneLikeTouchViewport = hasCoarsePointer
+      && minScreenDimension <= 640;
+    return viewportWidth <= 640 || hasNarrowContainer || hasPhoneLikeTouchViewport;
   }
 
   function shouldUseDesktopOnPhone(): boolean {
@@ -504,6 +520,8 @@
     return registerPRDetailActions(buildPRDetailInput);
   });
 </script>
+
+<svelte:window onresize={updateViewportState} />
 
 {#if !shouldUseFullAppShell(getPage())}
   <WorkspaceEmbedShell />

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -387,7 +387,7 @@
       number: item.item_number,
     } satisfies RoutedItemRef;
 
-    if (isMobilePage(getPage())) {
+    if (isMobilePage(getPage()) || shouldUseResponsiveMobileActivityPresentation()) {
       navigate(buildRoutedItemRoute(selectedItem, { focus: true }));
       return;
     }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from "svelte";
+  import { onDestroy } from "svelte";
   import {
     Provider,
     PRListView,
@@ -168,14 +168,14 @@
     return text ? `?${text}` : "?desktop=1";
   }
 
-  function shouldUseDesktopOnPhone(): boolean {
-    return new URLSearchParams(window.location.search).get("desktop") === "1";
-  }
-
   function isPhoneViewport(): boolean {
     const hasPhoneLikeTouchViewport = window.matchMedia("(pointer: coarse)").matches
       && Math.min(window.screen.width, window.screen.height) <= 640;
     return window.innerWidth <= 640 || isNarrow() || hasPhoneLikeTouchViewport;
+  }
+
+  function shouldUseDesktopOnPhone(): boolean {
+    return new URLSearchParams(window.location.search).get("desktop") === "1";
   }
 
   function shouldForceMobileRoutes(): boolean {
@@ -184,6 +184,28 @@
       import.meta.env.VITE_MIDDLEMAN_FORCE_MOBILE_ROUTES === "1" ||
       import.meta.env.VITE_MIDDLEMAN_FORCE_MOBILE_ROUTES === "true"
     );
+  }
+
+  function shouldUseResponsiveFocusPresentation(): boolean {
+    const route = getRoute();
+    if (shouldUseDesktopOnPhone()) return false;
+    if (!isPhoneViewport() && !shouldForceMobileRoutes()) return false;
+    if (route.page === "pulls") return route.view === "list";
+    return route.page === "issues";
+  }
+
+  function shouldUseFocusPresentation(): boolean {
+    return getPage() === "focus" || shouldUseResponsiveFocusPresentation();
+  }
+
+  function useFocusLayoutClass(): boolean {
+    return isPhoneViewport() || shouldForceMobileRoutes();
+  }
+
+  function shouldUseResponsiveMobileActivityPresentation(): boolean {
+    if (shouldUseDesktopOnPhone()) return false;
+    if (getPage() !== "activity") return false;
+    return isPhoneViewport() || shouldForceMobileRoutes();
   }
 
   function navigateFocusPRDetailTab(
@@ -195,28 +217,6 @@
         ? buildFocusPullRequestFilesRoute(ref)
         : buildFocusPullRequestRoute(ref),
     );
-  }
-
-  function mobilePathForRoute(): string {
-    const route = getRoute();
-    if (route.page === "pulls") {
-      if (route.selected) {
-        return route.tab === "files"
-          ? buildFocusPullRequestFilesRoute(route.selected)
-          : buildFocusPullRequestRoute(route.selected);
-      }
-      return "/m/pulls";
-    }
-    if (route.page === "issues") {
-      if (route.selected) {
-        return buildRoutedItemRoute(
-          { ...route.selected, itemType: "issue" },
-          { focus: true },
-        );
-      }
-      return "/m/issues";
-    }
-    return "/m";
   }
 
   function desktopPathForMobileRoute(): string {
@@ -233,24 +233,6 @@
   function useDesktopView(): void {
     replaceUrl(`${desktopPathForMobileRoute()}${searchWithDesktopOptOut()}`);
   }
-
-  function redirectPhoneToMobileRoute(): void {
-    const page = getPage();
-    if (!shouldUseFullAppShell(page)) return;
-    if (isMobilePage(page)) return;
-    if (page !== "activity" && page !== "pulls" && page !== "issues") return;
-    if (!isPhoneViewport() && !shouldForceMobileRoutes()) return;
-    if (shouldUseDesktopOnPhone()) return;
-    replaceUrl(`${mobilePathForRoute()}${window.location.search}`);
-  }
-
-  onMount(() => {
-    redirectPhoneToMobileRoute();
-  });
-
-  $effect(() => {
-    redirectPhoneToMobileRoute();
-  });
 
   onDestroy(() => {
     stopFullAppShell();
@@ -575,25 +557,42 @@
     }}
     bind:stores
   >
-  {#if getPage() === "focus"}
+  {#if shouldUseFocusPresentation()}
     {@const r = getRoute()}
-    {#if r.page === "focus"}
-      <main
-        class="focus-layout"
-        class:focus-layout--phone={isPhoneViewport() || shouldForceMobileRoutes()}
-      >
-        {#if r.itemType === "mrs"}
-          <FocusListView
-            listType="mrs"
-            {...r.repo ? { repo: r.repo } : {}}
-          />
-        {:else if r.itemType === "issues"}
-          <FocusListView
-            listType="issues"
-            {...r.repo ? { repo: r.repo } : {}}
-          />
-        {:else if r.itemType === "pr"}
-          {@const selectedPR = {
+    <main
+      class="focus-layout"
+      class:focus-layout--phone={useFocusLayoutClass()}
+    >
+      {#if r.page === "focus" && r.itemType === "mrs"}
+        <FocusListView
+          listType="mrs"
+          {...r.repo ? { repo: r.repo } : {}}
+        />
+      {:else if r.page === "focus" && r.itemType === "issues"}
+        <FocusListView
+          listType="issues"
+          {...r.repo ? { repo: r.repo } : {}}
+        />
+      {:else if r.page === "focus" && r.itemType === "pr"}
+        {@const selectedPR = {
+          owner: r.owner,
+          name: r.name,
+          number: r.number,
+          provider: r.provider,
+          platformHost: r.platformHost,
+          repoPath: r.repoPath,
+        }}
+        <PRListView
+          {selectedPR}
+          detailTab={r.tab === "files" ? "files" : "conversation"}
+          onDetailTabChange={(tab) => navigateFocusPRDetailTab(selectedPR, tab)}
+          isSidebarCollapsed={true}
+          hideSidebar={true}
+          showStackSidebar={false}
+        />
+      {:else if r.page === "focus"}
+        <IssueListView
+          selectedIssue={{
             owner: r.owner,
             name: r.name,
             number: r.number,
@@ -601,31 +600,36 @@
             platformHost: r.platformHost,
             repoPath: r.repoPath,
           }}
-          <PRListView
-            {selectedPR}
-            detailTab={r.tab === "files" ? "files" : "conversation"}
-            onDetailTabChange={(tab) => navigateFocusPRDetailTab(selectedPR, tab)}
-            isSidebarCollapsed={true}
-            hideSidebar={true}
-            showStackSidebar={false}
-          />
-        {:else}
-          <IssueListView
-            selectedIssue={{
-              owner: r.owner,
-              name: r.name,
-              number: r.number,
-              provider: r.provider,
-              platformHost: r.platformHost,
-              repoPath: r.repoPath,
-            }}
-            isSidebarCollapsed={true}
-            hideSidebar={true}
-          />
-        {/if}
-      </main>
-    {/if}
-  {:else if isMobilePage(getPage())}
+          isSidebarCollapsed={true}
+          hideSidebar={true}
+        />
+      {:else if r.page === "pulls" && r.selected}
+        <PRListView
+          selectedPR={r.selected}
+          detailTab={r.tab === "files" ? "files" : "conversation"}
+          isSidebarCollapsed={true}
+          hideSidebar={true}
+          showStackSidebar={false}
+        />
+      {:else if r.page === "pulls"}
+        <FocusListView
+          listType="mrs"
+          routeFamily="canonical"
+        />
+      {:else if r.page === "issues" && r.selected}
+        <IssueListView
+          selectedIssue={r.selected}
+          isSidebarCollapsed={true}
+          hideSidebar={true}
+        />
+      {:else if r.page === "issues"}
+        <FocusListView
+          listType="issues"
+          routeFamily="canonical"
+        />
+      {/if}
+    </main>
+  {:else if isMobilePage(getPage()) || shouldUseResponsiveMobileActivityPresentation()}
     <section class="mobile-shell" aria-label="Phone view">
       <header class="mobile-topbar">
         <span class="mobile-brand">
@@ -635,7 +639,7 @@
 
         <nav class="mobile-tabs" aria-label="Phone navigation">
           <a
-            class:mobile-tab--active={getPage() === "mobile-activity"}
+            class:mobile-tab--active={getPage() === "mobile-activity" || getPage() === "activity"}
             href="/m"
             onclick={(e) => {
               e.preventDefault();

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -16,11 +16,16 @@
     MoonIcon,
     SettingsIcon,
     SidebarToggleIcon,
+    SpinnerIcon,
     SunIcon,
+    SyncIcon,
   } from "../../icons.ts";
   import { getGlobalRepo, setGlobalRepo } from "../../stores/filter.svelte.js";
   import { isEmbedded, getUIConfig } from "../../stores/embed-config.svelte.js";
-  import { isNarrow } from "../../stores/container.svelte.js";
+  import {
+    getContainerSize,
+    isNarrow,
+  } from "../../stores/container.svelte.js";
   import {
     isDark, toggleTheme, isThemeToggleVisible,
   } from "../../stores/theme.svelte.js";
@@ -48,6 +53,7 @@
   }
 
   const syncing = $derived(sync.getSyncState()?.running ?? false);
+  const compactHeader = $derived(getContainerSize() !== "wide");
 
   function routeForTab(
     destination: "pulls" | "issues",
@@ -111,7 +117,7 @@
   </div>
 
   <nav class="header-center">
-    {#if isNarrow()}
+    {#if compactHeader}
       <select
         class="nav-select"
         value={getPage() === "pulls" && getView() === "board" ? "board" : getPage()}
@@ -181,8 +187,29 @@
 
   <div class="header-right">
     {#if !getUIConfig().hideSync}
-      <button class="action-btn" onclick={handleSync} disabled={syncing}>
-        {syncing ? "Syncing..." : "Sync"}
+      <button
+        class="action-btn sync-btn"
+        aria-label={syncing ? "Syncing" : "Sync"}
+        title={syncing ? "Syncing" : "Sync"}
+        onclick={handleSync}
+        disabled={syncing}
+      >
+        {#if syncing}
+          <span class="sync-icon sync-icon--spinning" aria-hidden="true">
+            <SpinnerIcon
+              size="14"
+              strokeWidth="2"
+            />
+          </span>
+        {:else}
+          <span class="sync-icon" aria-hidden="true">
+            <SyncIcon
+              size="14"
+              strokeWidth="1.75"
+            />
+          </span>
+        {/if}
+        <span class="sync-label">{syncing ? "Syncing..." : "Sync"}</span>
       </button>
     {/if}
     {#if isThemeToggleVisible()}
@@ -253,6 +280,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
   }
 
   .tab-group {
@@ -303,6 +331,28 @@
     transition: background 0.15s, color 0.15s, border-color 0.15s;
   }
 
+  .sync-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    min-width: 34px;
+    min-height: 28px;
+  }
+
+  .sync-icon {
+    flex-shrink: 0;
+  }
+
+  .sync-icon--spinning {
+    animation: header-spin 0.9s linear infinite;
+  }
+
+  @keyframes header-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
   .action-btn:hover:not(:disabled) {
     background: var(--bg-surface-hover);
     color: var(--text-primary);
@@ -337,6 +387,43 @@
   [data-filled-icon="moon"] :global(svg path) {
     fill: currentColor;
     stroke: none;
+  }
+
+  :global(#app.container-medium) .app-header {
+    gap: 8px;
+    padding-inline: 10px;
+  }
+
+  :global(#app.container-medium) .header-left {
+    flex: 1 1 auto;
+    gap: 8px;
+  }
+
+  :global(#app.container-medium) .header-left :global(.typeahead) {
+    flex: 1 1 150px;
+    min-width: 128px;
+    max-width: 220px;
+  }
+
+  :global(#app.container-medium) .header-center {
+    flex: 0 0 132px;
+  }
+
+  :global(#app.container-medium) .nav-select {
+    width: 100%;
+  }
+
+  :global(#app.container-medium) .header-right {
+    flex: 0 0 auto;
+    gap: 6px;
+  }
+
+  :global(#app.container-medium) .sync-btn {
+    padding-inline: 9px;
+  }
+
+  :global(#app.container-medium) .sync-label {
+    display: none;
   }
 
   :global(#app.container-narrow) .app-header {
@@ -399,5 +486,9 @@
   :global(#app.container-narrow) .action-btn {
     min-height: 32px;
     padding-inline: 10px;
+  }
+
+  :global(#app.container-narrow) .sync-label {
+    display: none;
   }
 </style>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getStores, KbdBadge } from "@middleman/ui";
+  import { getStores, KbdBadge, SelectDropdown } from "@middleman/ui";
   import {
     getBasePath,
     getPage,
@@ -54,6 +54,34 @@
 
   const syncing = $derived(sync.getSyncState()?.running ?? false);
   const compactHeader = $derived(getContainerSize() !== "wide");
+  const compactNavOptions = $derived.by(() => {
+    const options = [
+      { value: "activity", label: "Activity" },
+      { value: "repos", label: "Repos" },
+      { value: "pulls", label: "PRs" },
+      { value: "issues", label: "Issues" },
+      { value: "board", label: "Board" },
+      { value: "reviews", label: "Reviews" },
+      { value: "workspaces", label: "Workspaces" },
+    ];
+
+    if (getPage() === "design-system") {
+      options.push({ value: "design-system", label: "Design system" });
+    }
+    if (getPage() === "terminal") {
+      options.push({ value: "terminal", label: "Workspaces" });
+    }
+    if (!isEmbedded() && getPage() === "settings") {
+      options.push({ value: "settings", label: "Settings" });
+    }
+
+    return options;
+  });
+  const compactNavValue = $derived(
+    getPage() === "pulls" && getView() === "board"
+      ? "board"
+      : getPage(),
+  );
 
   function routeForTab(
     destination: "pulls" | "issues",
@@ -87,6 +115,19 @@
     else if (destination === "settings") navigate("/settings");
     else if (destination === "design-system") navigate("/design-system");
   }
+
+  function navigateCompactNav(value: string): void {
+    if (value === "activity") navigate("/");
+    else if (value === "repos") navigateTab("repos");
+    else if (value === "pulls") navigateTab("pulls");
+    else if (value === "issues") navigateTab("issues");
+    else if (value === "board") navigateTab("board");
+    else if (value === "reviews") navigateTab("reviews");
+    else if (value === "workspaces" || value === "terminal") {
+      navigateTab("workspaces");
+    } else if (value === "settings") navigateTab("settings");
+    else if (value === "design-system") navigateTab("design-system");
+  }
 </script>
 
 <header class="app-header">
@@ -118,39 +159,13 @@
 
   <nav class="header-center">
     {#if compactHeader}
-      <select
+      <SelectDropdown
         class="nav-select"
-        value={getPage() === "pulls" && getView() === "board" ? "board" : getPage()}
-        onchange={(e) => {
-          const v = (e.target as HTMLSelectElement).value;
-          if (v === "activity") navigate("/");
-          else if (v === "repos") navigateTab("repos");
-          else if (v === "pulls") navigateTab("pulls");
-          else if (v === "issues") navigateTab("issues");
-          else if (v === "board") navigateTab("board");
-          else if (v === "reviews") navigateTab("reviews");
-          else if (v === "workspaces" || v === "terminal") navigateTab("workspaces");
-          else if (v === "settings") navigateTab("settings");
-          else if (v === "design-system") navigateTab("design-system");
-        }}
-      >
-        <option value="activity">Activity</option>
-        <option value="repos">Repos</option>
-        <option value="pulls">PRs</option>
-        <option value="issues">Issues</option>
-        <option value="board">Board</option>
-        <option value="reviews">Reviews</option>
-        <option value="workspaces">Workspaces</option>
-        {#if getPage() === "design-system"}
-          <option value="design-system">Design system</option>
-        {/if}
-        {#if getPage() === "terminal"}
-          <option value="terminal">Workspaces</option>
-        {/if}
-        {#if !isEmbedded() && getPage() === "settings"}
-          <option value="settings">Settings</option>
-        {/if}
-      </select>
+        value={compactNavValue}
+        options={compactNavOptions}
+        onchange={navigateCompactNav}
+        title="Page"
+      />
     {:else}
       <div class="tab-group">
         <button class="view-tab" class:active={getPage() === "activity"} onclick={() => { if (getPage() !== "activity") navigateTab("activity"); }}>
@@ -321,6 +336,8 @@
   }
 
   .action-btn {
+    box-sizing: border-box;
+    height: 28px;
     padding: 5px 12px;
     border-radius: var(--radius-sm);
     font-size: var(--font-size-md);
@@ -338,14 +355,20 @@
     gap: 7px;
     min-width: 34px;
     min-height: 28px;
+    line-height: 0;
   }
 
   .sync-icon {
+    display: inline-flex;
     flex-shrink: 0;
   }
 
   .sync-icon--spinning {
     animation: header-spin 0.9s linear infinite;
+  }
+
+  .sync-label {
+    line-height: 1;
   }
 
   @keyframes header-spin {
@@ -362,15 +385,6 @@
   .action-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
-  }
-
-  .nav-select {
-    font-size: var(--font-size-sm);
-    padding: 4px 8px;
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-sm);
-    background: var(--bg-surface);
-    color: var(--text-primary);
   }
 
   .daemon-indicator {
@@ -409,8 +423,14 @@
     flex: 0 0 132px;
   }
 
-  :global(#app.container-medium) .nav-select {
+  :global(#app.container-medium .nav-select) {
     width: 100%;
+    min-width: 0;
+  }
+
+  :global(#app.container-medium .nav-select .select-dropdown-trigger) {
+    border-color: var(--border-muted);
+    background: var(--bg-inset);
   }
 
   :global(#app.container-medium) .header-right {
@@ -419,7 +439,8 @@
   }
 
   :global(#app.container-medium) .sync-btn {
-    padding-inline: 9px;
+    min-height: 28px;
+    padding: 5px 10px;
   }
 
   :global(#app.container-medium) .sync-label {
@@ -471,8 +492,12 @@
     order: 2;
   }
 
-  :global(#app.container-narrow) .nav-select {
+  :global(#app.container-narrow .nav-select) {
     width: 100%;
+    min-width: 0;
+  }
+
+  :global(#app.container-narrow .nav-select .select-dropdown-trigger) {
     min-height: 32px;
     font-size: var(--font-size-md);
   }
@@ -484,7 +509,7 @@
   }
 
   :global(#app.container-narrow) .action-btn {
-    min-height: 32px;
+    height: 32px;
     padding-inline: 10px;
   }
 

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -155,10 +155,7 @@
         onchange={setGlobalRepo}
       />
     {/if}
-  </div>
-
-  <nav class="header-center">
-    {#if compactHeader}
+    {#if compactHeader && !isNarrow()}
       <SelectDropdown
         class="nav-select"
         value={compactNavValue}
@@ -166,6 +163,20 @@
         onchange={navigateCompactNav}
         title="Page"
       />
+    {/if}
+  </div>
+
+  <nav class="header-center">
+    {#if compactHeader}
+      {#if isNarrow()}
+        <SelectDropdown
+          class="nav-select"
+          value={compactNavValue}
+          options={compactNavOptions}
+          onchange={navigateCompactNav}
+          title="Page"
+        />
+      {/if}
     {:else}
       <div class="tab-group">
         <button class="view-tab" class:active={getPage() === "activity"} onclick={() => { if (getPage() !== "activity") navigateTab("activity"); }}>
@@ -420,7 +431,12 @@
   }
 
   :global(#app.container-medium) .header-center {
-    flex: 0 0 132px;
+    display: none;
+  }
+
+  :global(#app.container-medium) .header-left :global(.nav-select) {
+    flex: 0 0 164px;
+    min-width: 132px;
   }
 
   :global(#app.container-medium .nav-select) {

--- a/frontend/src/lib/stores/container.svelte.ts
+++ b/frontend/src/lib/stores/container.svelte.ts
@@ -6,7 +6,7 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 function classify(width: number): ContainerSize {
   if (width < 500) return "narrow";
-  if (width < 900) return "medium";
+  if (width < 1100) return "medium";
   return "wide";
 }
 

--- a/frontend/tests/e2e-full/container-layout.spec.ts
+++ b/frontend/tests/e2e-full/container-layout.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+test.setTimeout(60_000);
+
 test.describe("container-aware layout", () => {
   test("narrow viewport shows dropdown and collapses sidebar", async ({ page }) => {
     await page.setViewportSize({ width: 400, height: 600 });
@@ -38,6 +40,40 @@ test.describe("container-aware layout", () => {
     });
 
     expect(metrics.headerHeight).toBeGreaterThanOrEqual(76);
+    expect(Math.max(metrics.documentWidth, metrics.bodyWidth)).toBeLessThanOrEqual(
+      metrics.viewportWidth,
+    );
+  });
+
+  test("medium viewport collapses page tabs and sync label", async ({ page }) => {
+    await page.setViewportSize({ width: 785, height: 900 });
+    await page.goto("/pulls/github/acme/widgets/1?desktop=1");
+    const header = page.locator(".app-header");
+    await header.waitFor({ state: "visible", timeout: 10_000 });
+
+    await expect(page.locator(".nav-select")).toBeVisible({ timeout: 20_000 });
+    await expect(page.locator(".tab-group")).not.toBeAttached();
+    await expect(page.getByRole("button", { name: "Sync" })).toBeVisible();
+    await expect(page.locator(".sync-btn .sync-label")).not.toBeVisible();
+
+    const metrics = await page.evaluate(() => {
+      const headerRect = document.querySelector(".app-header")
+        ?.getBoundingClientRect();
+      const syncRect = document.querySelector(".sync-btn")
+        ?.getBoundingClientRect();
+      return {
+        headerRight: headerRect?.right ?? 0,
+        headerHeight: headerRect?.height ?? 0,
+        syncWidth: syncRect?.width ?? 0,
+        viewportWidth: window.innerWidth,
+        documentWidth: document.documentElement.scrollWidth,
+        bodyWidth: document.body.scrollWidth,
+      };
+    });
+
+    expect(metrics.headerRight).toBeLessThanOrEqual(metrics.viewportWidth);
+    expect(metrics.headerHeight).toBeLessThanOrEqual(52);
+    expect(metrics.syncWidth).toBeLessThanOrEqual(42);
     expect(Math.max(metrics.documentWidth, metrics.bodyWidth)).toBeLessThanOrEqual(
       metrics.viewportWidth,
     );

--- a/frontend/tests/e2e-full/container-layout.spec.ts
+++ b/frontend/tests/e2e-full/container-layout.spec.ts
@@ -46,7 +46,7 @@ test.describe("container-aware layout", () => {
   });
 
   test("medium viewport collapses page tabs and sync label", async ({ page }) => {
-    await page.setViewportSize({ width: 785, height: 900 });
+    await page.setViewportSize({ width: 1024, height: 768 });
     await page.goto("/pulls/github/acme/widgets/1?desktop=1");
     const header = page.locator(".app-header");
     await header.waitFor({ state: "visible", timeout: 10_000 });
@@ -56,15 +56,47 @@ test.describe("container-aware layout", () => {
     await expect(page.getByRole("button", { name: "Sync" })).toBeVisible();
     await expect(page.locator(".sync-btn .sync-label")).not.toBeVisible();
 
+    await page.getByRole("button", { name: "All repos" }).click();
+    await expect(page.locator(".typeahead-list")).toBeVisible();
+    const repoMenuStyle = await page.evaluate(() => {
+      const list = document.querySelector(".typeahead-list");
+      const style = list ? getComputedStyle(list) : null;
+      return {
+        background: style?.backgroundColor ?? "",
+        borderColor: style?.borderColor ?? "",
+        borderRadius: style?.borderRadius ?? "",
+      };
+    });
+
+    await page.locator(".nav-select .select-dropdown-trigger").click();
+    const navList = page.locator(".nav-select .select-dropdown-list");
+    await expect(navList).toBeVisible();
+    await expect(navList.getByRole("option", { name: "PRs" })).toBeVisible();
+    const navMenuStyle = await page.evaluate(() => {
+      const list = document.querySelector(".nav-select .select-dropdown-list");
+      const style = list ? getComputedStyle(list) : null;
+      return {
+        background: style?.backgroundColor ?? "",
+        borderColor: style?.borderColor ?? "",
+        borderRadius: style?.borderRadius ?? "",
+      };
+    });
+
+    expect(navMenuStyle).toEqual(repoMenuStyle);
+
     const metrics = await page.evaluate(() => {
       const headerRect = document.querySelector(".app-header")
         ?.getBoundingClientRect();
       const syncRect = document.querySelector(".sync-btn")
         ?.getBoundingClientRect();
+      const themeRect = document.querySelector("button[title='Toggle theme']")
+        ?.getBoundingClientRect();
       return {
         headerRight: headerRect?.right ?? 0,
         headerHeight: headerRect?.height ?? 0,
+        syncHeight: syncRect?.height ?? 0,
         syncWidth: syncRect?.width ?? 0,
+        themeHeight: themeRect?.height ?? 0,
         viewportWidth: window.innerWidth,
         documentWidth: document.documentElement.scrollWidth,
         bodyWidth: document.body.scrollWidth,
@@ -73,6 +105,7 @@ test.describe("container-aware layout", () => {
 
     expect(metrics.headerRight).toBeLessThanOrEqual(metrics.viewportWidth);
     expect(metrics.headerHeight).toBeLessThanOrEqual(52);
+    expect(Math.abs(metrics.syncHeight - metrics.themeHeight)).toBeLessThanOrEqual(1);
     expect(metrics.syncWidth).toBeLessThanOrEqual(42);
     expect(Math.max(metrics.documentWidth, metrics.bodyWidth)).toBeLessThanOrEqual(
       metrics.viewportWidth,
@@ -124,5 +157,18 @@ test.describe("container-aware layout", () => {
     // Wait for the resize observer debounce (100ms) to settle.
     await expect(page.locator(".tab-group")).toBeVisible({ timeout: 5_000 });
     await expect(page.locator(".nav-select")).not.toBeAttached();
+
+    const metrics = await page.evaluate(() => {
+      const syncRect = document.querySelector(".sync-btn")
+        ?.getBoundingClientRect();
+      const themeRect = document.querySelector("button[title='Toggle theme']")
+        ?.getBoundingClientRect();
+      return {
+        syncHeight: syncRect?.height ?? 0,
+        themeHeight: themeRect?.height ?? 0,
+      };
+    });
+
+    expect(Math.abs(metrics.syncHeight - metrics.themeHeight)).toBeLessThanOrEqual(1);
   });
 });

--- a/frontend/tests/e2e-full/container-layout.spec.ts
+++ b/frontend/tests/e2e-full/container-layout.spec.ts
@@ -91,9 +91,16 @@ test.describe("container-aware layout", () => {
         ?.getBoundingClientRect();
       const themeRect = document.querySelector("button[title='Toggle theme']")
         ?.getBoundingClientRect();
+      const repoRect = document.querySelector(".header-left .typeahead")
+        ?.getBoundingClientRect();
+      const navRect = document.querySelector(".header-left .nav-select")
+        ?.getBoundingClientRect();
       return {
         headerRight: headerRect?.right ?? 0,
         headerHeight: headerRect?.height ?? 0,
+        navInLeftHeader: Boolean(document.querySelector(".header-left .nav-select")),
+        navLeft: navRect?.left ?? 0,
+        repoRight: repoRect?.right ?? 0,
         syncHeight: syncRect?.height ?? 0,
         syncWidth: syncRect?.width ?? 0,
         themeHeight: themeRect?.height ?? 0,
@@ -105,6 +112,8 @@ test.describe("container-aware layout", () => {
 
     expect(metrics.headerRight).toBeLessThanOrEqual(metrics.viewportWidth);
     expect(metrics.headerHeight).toBeLessThanOrEqual(52);
+    expect(metrics.navInLeftHeader).toBe(true);
+    expect(metrics.navLeft - metrics.repoRight).toBeLessThanOrEqual(10);
     expect(Math.abs(metrics.syncHeight - metrics.themeHeight)).toBeLessThanOrEqual(1);
     expect(metrics.syncWidth).toBeLessThanOrEqual(42);
     expect(Math.max(metrics.documentWidth, metrics.bodyWidth)).toBeLessThanOrEqual(

--- a/frontend/tests/e2e-full/force-mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/force-mobile-routes.spec.ts
@@ -1,6 +1,10 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-test("force-mobile flag sends desktop viewport issue route to phone route", async ({ page }) => {
+async function expectPathname(page: Page, pathname: string): Promise<void> {
+  await expect.poll(() => new URL(page.url()).pathname).toBe(pathname);
+}
+
+test("force-mobile flag renders canonical issue route with focus presentation", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
   await page.addInitScript(() => {
     (window as unknown as { __MIDDLEMAN_FORCE_MOBILE_ROUTES__?: boolean }).__MIDDLEMAN_FORCE_MOBILE_ROUTES__ = true;
@@ -8,8 +12,8 @@ test("force-mobile flag sends desktop viewport issue route to phone route", asyn
 
   await page.goto("/issues");
 
-  await expect(page).toHaveURL(/\/m\/issues(?:\?|$)/);
-  await expect(page.locator(".mobile-shell")).toBeVisible();
-  await expect(page.locator(".mobile-tab--active")).toHaveText("Issues");
+  await expectPathname(page, "/issues");
+  await expect(page.locator(".focus-layout .focus-list")).toBeVisible();
+  await expect(page.locator(".mobile-shell")).toHaveCount(0);
   await expect(page.locator(".app-header")).toHaveCount(0);
 });

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -293,6 +293,24 @@ test.describe("phone routes", () => {
     await expect(page.locator(".mobile-shell")).toHaveCount(0);
   });
 
+  test("canonical activity phone presentation opens thread detail", async ({ page }) => {
+    await page.goto("/");
+    await expectPathname(page, "/");
+    await expect(page.locator(".mobile-shell")).toBeVisible();
+    await expect(page.locator(".mobile-activity-open").first()).toBeVisible();
+
+    await page.locator(".mobile-activity-open").first().click();
+
+    await expect(page).toHaveURL(/\/focus\/(?:host\/[^/]+\/)?(?:pulls|issues)\//);
+    await expect(page.locator(".focus-layout")).toBeVisible();
+    await expect(
+      page.locator(
+        ".focus-layout .pull-detail .detail-title, .focus-layout .issue-detail .detail-title",
+      ),
+    ).toBeVisible();
+    await expect(page.locator(".mobile-shell")).toHaveCount(0);
+  });
+
   test("focused PR files tab stays on the phone detail route", async ({ page }) => {
     await page.goto("/focus/pulls/github/acme/widgets/1");
     await expect(page.locator(".focus-layout .pull-detail .detail-title")).toBeVisible();

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -7,6 +7,10 @@ test.use({
   userAgent: iPhone13.userAgent,
 });
 
+async function expectPathname(page: Page, pathname: string): Promise<void> {
+  await expect.poll(() => new URL(page.url()).pathname).toBe(pathname);
+}
+
 async function expectReadableFocusList(
   page: Page,
   itemSelector: string,
@@ -122,10 +126,10 @@ async function expectReadableDetail(page: Page): Promise<void> {
 }
 
 test.describe("phone routes", () => {
-  test("phone viewport visiting desktop root redirects to the mobile activity route", async ({ page }) => {
+  test("phone viewport visiting desktop root renders mobile activity without changing URL", async ({ page }) => {
     await page.goto("/");
 
-    await expect(page).toHaveURL(/\/m(?:\?|$)/);
+    await expectPathname(page, "/");
     await expect(page.locator(".mobile-shell")).toBeVisible();
     await expect(page.locator(".mobile-tab--active")).toHaveText("Activity");
     await expect(page.locator(".mobile-topbar .mobile-app-icon")).toBeVisible();
@@ -301,19 +305,19 @@ test.describe("phone routes", () => {
     await expect(page.locator(".mobile-shell")).toHaveCount(0);
   });
 
-  test("phone desktop PR files deep link redirects to the focused files route", async ({ page }) => {
+  test("phone canonical PR files deep link renders focus presentation without changing URL", async ({ page }) => {
     await page.goto("/pulls/github/acme/widgets/1/files");
 
-    await expect(page).toHaveURL(/\/focus\/pulls\/github\/acme\/widgets\/1\/files$/);
+    await expectPathname(page, "/pulls/github/acme/widgets/1/files");
     await expect(page.locator(".focus-layout .files-layout")).toBeVisible();
     await expect(page.locator(".focus-layout .diff-view")).toBeVisible();
     await expect(page.locator(".mobile-shell")).toHaveCount(0);
   });
 
-  test("phone desktop issue deep link redirects to the focused issue route", async ({ page }) => {
+  test("phone canonical issue deep link renders focus presentation without changing URL", async ({ page }) => {
     await page.goto("/issues/github/acme/widgets/10");
 
-    await expect(page).toHaveURL(/\/focus\/issues\/github\/acme\/widgets\/10$/);
+    await expectPathname(page, "/issues/github/acme/widgets/10");
     await expect(page.locator(".focus-layout .issue-detail .detail-title")).toBeVisible();
     await expect(page.locator(".mobile-shell")).toHaveCount(0);
   });

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -178,13 +178,48 @@ test.describe("phone routes", () => {
       const desktopButton = document.querySelector(".mobile-desktop-link");
       const desktopIcon = document.querySelector(".mobile-desktop-link svg");
       const appIcon = document.querySelector(".mobile-app-icon");
-      const typeSelect = document.querySelector("select[aria-label='Activity type']");
-      const rangeSelect = document.querySelector("select[aria-label='Time range']");
-      const repoSelect = document.querySelector("select[aria-label='Repository']");
+      const typeSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Activity type']");
+      const rangeSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Time range']");
+      const repoSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Repository']");
       const search = document.querySelector(".search-input");
       const cardRect = firstCard?.getBoundingClientRect();
       const buttonRect = firstButton?.getBoundingClientRect();
       const searchRect = search?.getBoundingClientRect();
+      const styleFor = (node: Element | null) => node
+        ? getComputedStyle(node)
+        : null;
+      const themeSample = document.createElement("div");
+      themeSample.style.cssText = [
+        "position:absolute",
+        "left:-9999px",
+        "top:0",
+        "width:1px",
+        "height:1px",
+        "background:var(--bg-primary)",
+        "border-color:var(--border-default)",
+      ].join(";");
+      document.body.append(themeSample);
+      const surfaceSample = document.createElement("div");
+      surfaceSample.style.cssText = [
+        "position:absolute",
+        "left:-9999px",
+        "top:0",
+        "width:1px",
+        "height:1px",
+        "background:var(--bg-surface)",
+        "border-radius:var(--radius-lg)",
+      ].join(";");
+      document.body.append(surfaceSample);
+      const insetSample = document.createElement("div");
+      insetSample.style.cssText = [
+        "position:absolute",
+        "left:-9999px",
+        "top:0",
+        "width:1px",
+        "height:1px",
+        "background:var(--bg-inset)",
+      ].join(";");
+      document.body.append(insetSample);
       const compactRect = (node: Element | null) => {
         const r = node?.getBoundingClientRect();
         return r ? { left: r.left, right: r.right, height: r.height } : null;
@@ -211,6 +246,16 @@ test.describe("phone routes", () => {
         desktopButtonRect: compactRect(desktopButton),
         desktopIconPresent: Boolean(desktopIcon),
         appIconPresent: Boolean(appIcon),
+        inboxBackground: styleFor(document.querySelector(".mobile-activity-inbox"))?.backgroundColor ?? "",
+        cardBackground: styleFor(firstCard)?.backgroundColor ?? "",
+        cardBorderColor: styleFor(firstCard)?.borderColor ?? "",
+        cardRadius: styleFor(firstCard)?.borderRadius ?? "",
+        searchBackground: styleFor(document.querySelector(".mobile-activity-search"))?.backgroundColor ?? "",
+        themeBgPrimary: getComputedStyle(themeSample).backgroundColor,
+        themeBgSurface: getComputedStyle(surfaceSample).backgroundColor,
+        themeBgInset: getComputedStyle(insetSample).backgroundColor,
+        themeBorder: getComputedStyle(themeSample).borderColor,
+        themeRadiusLg: getComputedStyle(surfaceSample).borderRadius,
         typeSelectFontSize: fontSize(typeSelect),
         rangeSelectFontSize: fontSize(rangeSelect),
         repoSelectFontSize: fontSize(repoSelect),
@@ -241,6 +286,11 @@ test.describe("phone routes", () => {
     expect(metrics.desktopButtonRect?.height ?? 0).toBeGreaterThanOrEqual(44);
     expect(metrics.desktopIconPresent).toBe(true);
     expect(metrics.appIconPresent).toBe(true);
+    expect(metrics.inboxBackground).toBe(metrics.themeBgPrimary);
+    expect(metrics.cardBackground).toBe(metrics.themeBgSurface);
+    expect(metrics.cardBorderColor).toBe(metrics.themeBorder);
+    expect(metrics.cardRadius).toBe(metrics.themeRadiusLg);
+    expect(metrics.searchBackground).toBe(metrics.themeBgInset);
     expect(metrics.typeSelectFontSize).toBeGreaterThanOrEqual(15);
     expect(metrics.rangeSelectFontSize).toBeGreaterThanOrEqual(15);
     expect(metrics.repoSelectFontSize).toBeGreaterThanOrEqual(15);
@@ -258,12 +308,16 @@ test.describe("phone routes", () => {
     await page.goto("/m?range=30d&view=threaded");
     await expect(page.locator(".mobile-activity-inbox")).toBeVisible();
 
-    await page.getByLabel("Activity type").selectOption("prs");
-    await expect(page.getByLabel("Activity type")).toHaveValue("prs");
+    await page.getByRole("combobox", { name: /Activity type/ }).click();
+    await page.getByRole("option", { name: "PRs" }).click();
+    await expect(page.getByRole("combobox", { name: "Activity type: PRs" }))
+      .toBeVisible();
     await expect(page).toHaveURL(/types=new_pr/);
 
-    await page.getByLabel("Time range").selectOption("24h");
-    await expect(page.getByLabel("Time range")).toHaveValue("24h");
+    await page.getByRole("combobox", { name: /Time range/ }).click();
+    await page.getByRole("option", { name: "24h" }).click();
+    await expect(page.getByRole("combobox", { name: "Time range: 24h" }))
+      .toBeVisible();
     await expect(page).toHaveURL(/range=24h/);
 
     const activityForRepo = page.waitForResponse((response) => {
@@ -271,8 +325,10 @@ test.describe("phone routes", () => {
       return url.includes("/api/v1/activity")
         && url.includes("repo=github.com%2Facme%2Fwidgets");
     });
-    await page.getByLabel("Repository").selectOption("github.com/acme/widgets");
-    await expect(page.getByLabel("Repository")).toHaveValue("github.com/acme/widgets");
+    await page.getByRole("combobox", { name: /Repository/ }).click();
+    await page.getByRole("option", { name: "github.com/acme/widgets" }).click();
+    await expect(page.getByRole("combobox", { name: "Repository: github.com/acme/widgets" }))
+      .toBeVisible();
     await activityForRepo;
   });
 
@@ -376,6 +432,8 @@ test.describe("high-density phone routes", () => {
 
     await expect(page.locator(".mobile-shell")).toBeVisible();
     await expect(page.locator(".mobile-activity-inbox")).toBeVisible();
+    await page.getByRole("combobox", { name: /Activity type/ }).click();
+    await expect(page.getByRole("option", { name: "All" })).toBeVisible();
 
     const metrics = await page.evaluate(() => {
       const fontSize = (selector: string): number => {
@@ -388,11 +446,13 @@ test.describe("high-density phone routes", () => {
         ? getComputedStyle(node).getPropertyValue(name).trim()
         : "";
       const filterControls = [
-        ...document.querySelectorAll(".mobile-activity-filter-grid select, .mobile-filter-toggle"),
+        ...document.querySelectorAll(".mobile-activity-filter-grid .select-dropdown-trigger, .mobile-filter-toggle"),
       ]
         .map((control) => control.getBoundingClientRect())
         .map((rect) => ({ left: rect.left, right: rect.right }));
       const search = document.querySelector(".search-input")?.getBoundingClientRect();
+      const firstOption = document.querySelector(".mobile-filter-dropdown .select-dropdown-option")
+        ?.getBoundingClientRect();
       return {
         dpr: window.devicePixelRatio,
         viewportWidth: window.innerWidth,
@@ -401,7 +461,9 @@ test.describe("high-density phone routes", () => {
         activityTypeToken: tokenValue(inbox, "--mobile-type-body"),
         densityScale: tokenValue(inbox, "--mobile-device-density-scale"),
         bodyFontSize: fontSize(".mobile-activity-inbox"),
-        filterFontSize: fontSize(".mobile-activity-filter-grid select"),
+        filterFontSize: fontSize(".mobile-activity-filter-grid .select-dropdown-trigger"),
+        filterOptionFontSize: fontSize(".mobile-filter-dropdown .select-dropdown-option"),
+        filterOptionHeight: firstOption?.height ?? 0,
         tabFontSize: fontSize(".mobile-tabs a"),
         searchHeight: search?.height ?? 0,
         searchLeft: search?.left ?? 0,
@@ -417,6 +479,8 @@ test.describe("high-density phone routes", () => {
     expect(metrics.documentWidth).toBeLessThanOrEqual(metrics.viewportWidth);
     expect(metrics.bodyFontSize).toBeGreaterThanOrEqual(16);
     expect(metrics.filterFontSize).toBeGreaterThanOrEqual(15);
+    expect(metrics.filterOptionFontSize).toBeGreaterThanOrEqual(15);
+    expect(metrics.filterOptionHeight).toBeGreaterThanOrEqual(44);
     expect(metrics.tabFontSize).toBeGreaterThanOrEqual(16);
     expect(metrics.searchHeight).toBeGreaterThanOrEqual(44);
     expect(metrics.searchLeft).toBeGreaterThanOrEqual(0);

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -389,6 +389,19 @@ test.describe("phone routes", () => {
     await expect(page.locator(".mobile-shell")).toHaveCount(0);
   });
 
+  test("phone canonical PR files tab stays on the canonical detail route", async ({ page }) => {
+    await page.goto("/pulls/github/acme/widgets/1");
+    await expectPathname(page, "/pulls/github/acme/widgets/1");
+    await expect(page.locator(".focus-layout .pull-detail .detail-title")).toBeVisible();
+
+    await page.locator(".focus-layout .detail-tab", { hasText: "Files changed" }).click();
+
+    await expectPathname(page, "/pulls/github/acme/widgets/1/files");
+    await expect(page.locator(".focus-layout .files-layout")).toBeVisible();
+    await expect(page.locator(".focus-layout .diff-view")).toBeVisible();
+    await expect(page.locator(".mobile-shell")).toHaveCount(0);
+  });
+
   test("phone canonical PR files deep link renders focus presentation without changing URL", async ({ page }) => {
     await page.goto("/pulls/github/acme/widgets/1/files");
 

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -170,6 +170,9 @@ test.describe("phone routes", () => {
       const firstButton = document.querySelector(".mobile-activity-card button");
       const title = document.querySelector(".mobile-activity-card__title");
       const meta = document.querySelector(".mobile-activity-card__meta");
+      const metaItems = meta?.querySelectorAll("span") ?? [];
+      const metaRect = meta?.getBoundingClientRect();
+      const metaCountRect = metaItems[1]?.getBoundingClientRect();
       const eventLabel = document.querySelector(".mobile-activity-event__body strong");
       const eventAuthor = document.querySelector(".mobile-activity-event__body span");
       const eventTime = document.querySelector(".mobile-activity-event time");
@@ -237,6 +240,9 @@ test.describe("phone routes", () => {
         touchTargetHeight: buttonRect?.height ?? 0,
         titleFontSize: fontSize(title),
         metaFontSize: fontSize(meta),
+        metaItemCount: metaItems.length,
+        metaRight: metaRect?.right ?? 0,
+        metaCountRight: metaCountRect?.right ?? 0,
         eventLabelFontSize: fontSize(eventLabel),
         eventAuthorFontSize: fontSize(eventAuthor),
         eventTimeFontSize: fontSize(eventTime),
@@ -277,6 +283,8 @@ test.describe("phone routes", () => {
     expect(metrics.touchTargetHeight).toBeGreaterThanOrEqual(44);
     expect(metrics.titleFontSize).toBeGreaterThanOrEqual(19);
     expect(metrics.metaFontSize).toBeGreaterThanOrEqual(15);
+    expect(metrics.metaItemCount).toBe(2);
+    expect(Math.abs(metrics.metaRight - metrics.metaCountRight)).toBeLessThanOrEqual(1);
     expect(metrics.eventLabelFontSize).toBeGreaterThanOrEqual(15);
     expect(metrics.eventAuthorFontSize).toBeGreaterThanOrEqual(14);
     expect(metrics.eventTimeFontSize).toBeGreaterThanOrEqual(14);
@@ -327,16 +335,17 @@ test.describe("phone routes", () => {
     });
     await page.getByRole("combobox", { name: /Repository/ }).click();
     await page.getByRole("option", { name: "github.com/acme/widgets" }).click();
-    await expect(page.getByRole("combobox", { name: "Repository: github.com/acme/widgets" }))
+    await expect(page.getByRole("combobox", { name: "Repository: acme/widgets" }))
       .toBeVisible();
     await activityForRepo;
   });
 
-  test("mobile activity Open thread routes to a focused thread detail", async ({ page }) => {
+  test("mobile activity card routes to a focused thread detail", async ({ page }) => {
     await page.goto("/m?range=30d&view=threaded");
-    await expect(page.locator(".mobile-activity-open").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open thread" })).toHaveCount(0);
+    await expect(page.locator(".mobile-activity-card__button").first()).toBeVisible();
 
-    await page.locator(".mobile-activity-open").first().click();
+    await page.locator(".mobile-activity-card__button").first().click();
 
     await expect(page).toHaveURL(/\/focus\/(?:host\/[^/]+\/)?(?:pulls|issues)\//);
     await expect(page.locator(".focus-layout")).toBeVisible();
@@ -353,9 +362,10 @@ test.describe("phone routes", () => {
     await page.goto("/");
     await expectPathname(page, "/");
     await expect(page.locator(".mobile-shell")).toBeVisible();
-    await expect(page.locator(".mobile-activity-open").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open thread" })).toHaveCount(0);
+    await expect(page.locator(".mobile-activity-card__button").first()).toBeVisible();
 
-    await page.locator(".mobile-activity-open").first().click();
+    await page.locator(".mobile-activity-card__button").first().click();
 
     await expect(page).toHaveURL(/\/focus\/(?:host\/[^/]+\/)?(?:pulls|issues)\//);
     await expect(page.locator(".focus-layout")).toBeVisible();

--- a/frontend/tests/e2e-full/routed-items.spec.ts
+++ b/frontend/tests/e2e-full/routed-items.spec.ts
@@ -137,4 +137,21 @@ test.describe("routed item builders through the UI", () => {
       .toContainText(issueTitle);
     await expect((await detailLoaded).ok()).toBe(true);
   });
+
+  test("canonical PR detail swaps focus and desktop presentation as viewport resizes", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/pulls/github/acme/widgets/1");
+
+    await expectPathname(page, "/pulls/github/acme/widgets/1");
+    await expect(page.locator(".focus-layout.focus-layout--phone .pull-detail .detail-title"))
+      .toContainText(prTitle);
+    await expect(page.locator(".app-header")).toHaveCount(0);
+
+    await page.setViewportSize({ width: 1200, height: 844 });
+
+    await expectPathname(page, "/pulls/github/acme/widgets/1");
+    await expect(page.locator(".focus-layout")).toHaveCount(0);
+    await expect(page.locator(".app-header")).toBeVisible();
+    await expect(page.locator(".pull-detail .detail-title")).toContainText(prTitle);
+  });
 });

--- a/frontend/tests/e2e-full/routed-items.spec.ts
+++ b/frontend/tests/e2e-full/routed-items.spec.ts
@@ -143,7 +143,7 @@ test.describe("routed item builders through the UI", () => {
     await page.goto("/pulls/github/acme/widgets/1");
 
     await expectPathname(page, "/pulls/github/acme/widgets/1");
-    await expect(page.locator(".focus-layout.focus-layout--phone .pull-detail .detail-title"))
+    await expect(page.locator(".focus-layout:not(.focus-layout--phone) .pull-detail .detail-title"))
       .toContainText(prTitle);
     await expect(page.locator(".app-header")).toHaveCount(0);
 

--- a/frontend/tests/e2e-full/routed-items.spec.ts
+++ b/frontend/tests/e2e-full/routed-items.spec.ts
@@ -25,6 +25,10 @@ function issueDetailResponse(
   });
 }
 
+async function expectPathname(page: Page, pathname: string): Promise<void> {
+  await expect.poll(() => new URL(page.url()).pathname).toBe(pathname);
+}
+
 test.describe("routed item builders through the UI", () => {
   test("selecting a PR row routes to its API-backed detail", async ({ page }) => {
     await page.goto("/pulls");
@@ -37,9 +41,7 @@ test.describe("routed item builders through the UI", () => {
     );
     await page.locator(".pull-item").filter({ hasText: prTitle }).first().click();
 
-    await expect(page).toHaveURL(
-      /\/pulls\/github\/acme\/widgets\/1$/,
-    );
+    await expectPathname(page, "/pulls/github/acme/widgets/1");
     await expect(page.locator(".pull-detail .detail-title")).toContainText(prTitle);
     await expect((await detailLoaded).ok()).toBe(true);
   });
@@ -55,9 +57,7 @@ test.describe("routed item builders through the UI", () => {
     );
     await page.locator(".issue-item").filter({ hasText: issueTitle }).first().click();
 
-    await expect(page).toHaveURL(
-      /\/issues\/github\/acme\/widgets\/10$/,
-    );
+    await expectPathname(page, "/issues/github/acme/widgets/10");
     await expect(page.locator(".issue-detail .detail-title")).toContainText(issueTitle);
     await expect((await detailLoaded).ok()).toBe(true);
   });
@@ -99,6 +99,42 @@ test.describe("routed item builders through the UI", () => {
     await expect(page.locator(".focus-layout .issue-detail .detail-title"))
       .toContainText(issueTitle);
     await expect(page.locator(".app-header")).not.toBeAttached();
+    await expect((await detailLoaded).ok()).toBe(true);
+  });
+
+  test("narrow canonical PR list routes selected rows to canonical detail", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/pulls");
+    await page.locator(".focus-list .pull-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const detailLoaded = detailResponse(
+      page,
+      "/api/v1/pulls/github/acme/widgets/1",
+    );
+    await page.locator(".focus-list .pull-item").filter({ hasText: prTitle }).first().click();
+
+    await expectPathname(page, "/pulls/github/acme/widgets/1");
+    await expect(page.locator(".focus-layout .pull-detail .detail-title"))
+      .toContainText(prTitle);
+    await expect((await detailLoaded).ok()).toBe(true);
+  });
+
+  test("narrow canonical issue list routes selected rows to canonical detail", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/issues");
+    await page.locator(".focus-list .issue-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const detailLoaded = issueDetailResponse(
+      page,
+      "/api/v1/issues/github/acme/widgets/10",
+    );
+    await page.locator(".focus-list .issue-item").filter({ hasText: issueTitle }).first().click();
+
+    await expectPathname(page, "/issues/github/acme/widgets/10");
+    await expect(page.locator(".focus-layout .issue-detail .detail-title"))
+      .toContainText(issueTitle);
     await expect((await detailLoaded).ok()).toBe(true);
   });
 });

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -72,19 +72,21 @@ test.describe("mobile activity repository selector", () => {
     const activityRepos = await mockMobileRepoSettings(page);
 
     await page.goto("/m?range=30d&view=threaded");
-    const repoSelect = page.getByLabel("Repository");
+    const repoSelect = page.getByRole("combobox", { name: /Repository/ });
     await expect(repoSelect).toBeVisible();
 
-    await expect(repoSelect.locator("option")).toHaveText([
-      "All repos",
-      "github.com/acme/widgets",
-      "ghe.example.com/acme/widgets",
-    ]);
-    await expect(repoSelect.locator("option", { hasText: "acme/*" }))
+    await repoSelect.click();
+    await expect(page.getByRole("option", { name: "All repos" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "github.com/acme/widgets" }))
+      .toBeVisible();
+    await expect(page.getByRole("option", { name: "ghe.example.com/acme/widgets" }))
+      .toBeVisible();
+    await expect(page.getByRole("option", { name: "acme/*" }))
       .toHaveCount(0);
 
-    await repoSelect.selectOption("ghe.example.com/acme/widgets");
-    await expect(repoSelect).toHaveValue("ghe.example.com/acme/widgets");
+    await page.getByRole("option", { name: "ghe.example.com/acme/widgets" }).click();
+    await expect(page.getByRole("combobox", { name: "Repository: acme/widgets" }))
+      .toHaveText("acme/widgets");
     await expect.poll(() => activityRepos)
       .toContain("ghe.example.com/acme/widgets");
   });

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -159,3 +159,20 @@ test.describe("mobile activity repository selector", () => {
       .toHaveCount(0);
   });
 });
+
+test.describe("mobile PR status grouping", () => {
+  test("uses kanban status instead of worktree buckets", async ({ page }) => {
+    await mockApi(page);
+
+    await page.goto("/m/pulls");
+    await expect(page.locator(".focus-list")).toBeVisible();
+
+    await page.getByRole("button", { name: "Status" }).click();
+
+    await expect(page.locator(".workflow-group .group-header")).toHaveText([
+      "New",
+      "Reviewing",
+    ]);
+    await expect(page.getByText("Needs Worktree")).toHaveCount(0);
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,8 +37,8 @@
     "./api/csrf": { "default": "./src/api/csrf.ts" }
   },
   "scripts": {
-    "lint": "node ./node_modules/eslint/bin/eslint.js .",
-    "typecheck": "node ./node_modules/svelte-check/bin/svelte-check --tsconfig ./tsconfig.json --fail-on-warnings && node ./node_modules/typescript/bin/tsc --noEmit -p ./tsconfig.json"
+    "lint": "eslint .",
+    "typecheck": "node -e \"require(require.resolve('svelte-check/bin/svelte-check'))\" -- --tsconfig ./tsconfig.json --fail-on-warnings && tsc --noEmit -p ./tsconfig.json"
   },
   "dependencies": {
     "@lucide/svelte": "1.3.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "typecheck": "node -e \"require(require.resolve('svelte-check/bin/svelte-check'))\" -- --tsconfig ./tsconfig.json --fail-on-warnings && tsc --noEmit -p ./tsconfig.json"
+    "typecheck": "node -e \"process.argv.splice(1, 0, 'svelte-check'); require(require.resolve('svelte-check/bin/svelte-check'))\" -- --tsconfig ./tsconfig.json --fail-on-warnings && tsc --noEmit -p ./tsconfig.json"
   },
   "dependencies": {
     "@lucide/svelte": "1.3.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,8 +37,8 @@
     "./api/csrf": { "default": "./src/api/csrf.ts" }
   },
   "scripts": {
-    "lint": "eslint .",
-    "typecheck": "node -e \"process.argv.splice(1, 0, 'svelte-check'); require(require.resolve('svelte-check/bin/svelte-check'))\" -- --tsconfig ./tsconfig.json --fail-on-warnings && tsc --noEmit -p ./tsconfig.json"
+    "lint": "node ./node_modules/eslint/bin/eslint.js .",
+    "typecheck": "node -e \"process.argv.splice(1, 0, 'svelte-check'); require(require.resolve('svelte-check/bin/svelte-check'))\" -- --tsconfig ./tsconfig.json --fail-on-warnings && node ./node_modules/typescript/bin/tsc --noEmit -p ./tsconfig.json"
   },
   "dependencies": {
     "@lucide/svelte": "1.3.0",

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -1171,21 +1171,19 @@
             class="pull-detail-content"
             class:pull-detail-content--has-compact-actions={pr.State !== "merged" && !stalePR}
           >
-            {#snippet labelActionButton()}
-              <div class="label-editor-anchor">
-                <ActionButton
-                  class="btn--labels"
-                  label="Labels"
-                  shortLabel="Labels"
-                  size="sm"
-                  surface="soft"
-                  tone="neutral"
-                  disabled={stalePR}
-                  onclick={openLabelPicker}
-                >
-                  <TagsIcon size="16" aria-hidden="true" />
-                </ActionButton>
-              </div>
+            {#snippet labelActionButton(iconSize = 16)}
+              <ActionButton
+                class="btn--labels"
+                label="Labels"
+                shortLabel="Labels"
+                size="sm"
+                surface="soft"
+                tone="neutral"
+                disabled={stalePR}
+                onclick={openLabelPicker}
+              >
+                <TagsIcon size={iconSize} aria-hidden="true" />
+              </ActionButton>
             {/snippet}
 
       {#if detailStore.isStaleRefreshing()}
@@ -1359,7 +1357,7 @@
           <GitHubLabels {labels} mode="full" />
         {/if}
         {#if capabilities.read_labels && capabilities.label_mutation}
-          <div class="label-editor-anchor--inline">
+          <div class="label-editor-anchor label-editor-anchor--inline">
             {@render labelActionButton()}
           </div>
         {/if}
@@ -1607,8 +1605,8 @@
               <div class="actions-menu-popover">
                 {@render primaryActionButtons()}
                 {#if capabilities.read_labels && capabilities.label_mutation}
-                  <div class="actions-menu-popover__item actions-menu-popover__item--labels">
-                    {@render labelActionButton()}
+                  <div class="actions-menu-popover__item actions-menu-popover__item--labels label-editor-anchor">
+                    {@render labelActionButton(14)}
                   </div>
                 {/if}
                 {#if !hideWorkspaceAction}
@@ -2335,7 +2333,7 @@
     position: relative;
   }
 
-  .actions-menu-popover__item .label-editor-anchor {
+  .actions-menu-popover__item--labels.label-editor-anchor {
     width: 100%;
   }
 

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -318,6 +318,29 @@ describe("PullDetail approvals", () => {
     expect(document.querySelector(".actions-menu-popover")).toBeNull();
   });
 
+  it("keeps the actions menu Labels button on the compact action geometry", async () => {
+    const detail = pullDetail();
+    detail.repo.capabilities = {
+      ...capabilities,
+      read_labels: true,
+      label_mutation: true,
+    };
+
+    renderPullDetail(detail);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Actions" }));
+
+    const labelsAction = getActionMenuLabelsButton();
+    const labelsIcon = labelsAction.querySelector("svg");
+    const labelsItem = labelsAction.closest(".actions-menu-popover__item--labels");
+
+    expect(labelsAction.classList.contains("action-button--sm")).toBe(true);
+    expect(labelsAction.parentElement).toBe(labelsItem);
+    expect(labelsItem?.classList.contains("label-editor-anchor")).toBe(true);
+    expect(labelsIcon?.getAttribute("width")).toBe("14");
+    expect(labelsIcon?.getAttribute("height")).toBe("14");
+  });
+
   const warningCases = [
     {
       name: "does not describe GitHub unstable mergeability as required checks",

--- a/packages/ui/src/components/shared/SelectDropdown.svelte
+++ b/packages/ui/src/components/shared/SelectDropdown.svelte
@@ -14,6 +14,7 @@
   export interface SelectDropdownOption {
     value: string;
     label: string;
+    triggerLabel?: string;
     disabled?: boolean;
   }
 
@@ -48,8 +49,8 @@
   );
   const triggerLabel = $derived(
     title
-      ? `${title}: ${selectedOption?.label ?? value}`
-      : (selectedOption?.label ?? value),
+      ? `${title}: ${selectedOption?.triggerLabel ?? selectedOption?.label ?? value}`
+      : (selectedOption?.triggerLabel ?? selectedOption?.label ?? value),
   );
 
   $effect(() => {
@@ -161,7 +162,7 @@
     {title}
     {disabled}
   >
-    <span class="select-dropdown-value">{selectedOption?.label ?? value}</span>
+    <span class="select-dropdown-value">{selectedOption?.triggerLabel ?? selectedOption?.label ?? value}</span>
     <ChevronDownIcon
       class="select-dropdown-chevron"
       size="12"

--- a/packages/ui/src/components/shared/SelectDropdown.test.ts
+++ b/packages/ui/src/components/shared/SelectDropdown.test.ts
@@ -75,6 +75,25 @@ describe("SelectDropdown", () => {
     }
   });
 
+  it("can use a shorter label for the selected trigger", () => {
+    renderDropdown({
+      value: "github.com/acme/very-long-service",
+      options: [
+        {
+          value: "github.com/acme/very-long-service",
+          label: "github.com/acme/very-long-service",
+          triggerLabel: "acme/very-long-service",
+        },
+      ],
+      title: "Repository",
+    });
+
+    expect(
+      screen.getByRole("combobox", { name: "Repository: acme/very-long-service" })
+        .textContent?.trim(),
+    ).toBe("acme/very-long-service");
+  });
+
   it("closes when focus moves outside the dropdown", async () => {
     const { container } = renderDropdown();
     const outside = document.createElement("button");

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -32,7 +32,7 @@
     grouping.getGroupingMode(),
   );
   const workflowGroups = $derived(
-    groupByWorkflow(pulls.getPulls(), activeWorktreeKey),
+    groupByWorkflow(pulls.getPulls()),
   );
   const pullStateOptions = ["open", "closed", "all"] as const;
   const groupingOptions: {

--- a/packages/ui/src/stores/workflow.svelte.test.ts
+++ b/packages/ui/src/stores/workflow.svelte.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { PullRequest } from "../api/types.js";
+import {
+  classifyPR,
+  groupByWorkflow,
+} from "./workflow.svelte.js";
+
+function pr(
+  id: number,
+  kanbanStatus: string,
+  lastActivityAt: string,
+  worktreeLinks: PullRequest["worktree_links"] = [],
+): PullRequest {
+  return {
+    ID: id,
+    Number: id,
+    State: "open",
+    KanbanStatus: kanbanStatus,
+    LastActivityAt: lastActivityAt,
+    worktree_links: worktreeLinks,
+  } as PullRequest;
+}
+
+describe("PR status grouping", () => {
+  it("classifies by kanban status instead of worktree presence", () => {
+    expect(classifyPR(pr(1, "reviewing", "2026-01-01T00:00:00Z"))).toBe(
+      "reviewing",
+    );
+    expect(
+      classifyPR(
+        pr(2, "waiting", "2026-01-01T00:00:00Z", [
+          {
+            worktree_key: "projects/example",
+            worktree_branch: "example",
+          },
+        ]),
+      ),
+    ).toBe("waiting");
+  });
+
+  it("groups PRs in kanban order and falls back missing statuses to New", () => {
+    const groups = groupByWorkflow([
+      pr(1, "reviewing", "2026-01-01T00:00:00Z"),
+      pr(2, "awaiting_merge", "2026-01-03T00:00:00Z"),
+      pr(3, "", "2026-01-04T00:00:00Z"),
+      pr(4, "waiting", "2026-01-02T00:00:00Z"),
+    ]);
+
+    expect(groups.map((group) => [group.group, group.label])).toEqual([
+      ["new", "New"],
+      ["reviewing", "Reviewing"],
+      ["waiting", "Waiting"],
+      ["awaiting_merge", "Awaiting Merge"],
+    ]);
+    expect(groups[0]?.items.map((item) => item.ID)).toEqual([3]);
+  });
+});

--- a/packages/ui/src/stores/workflow.svelte.ts
+++ b/packages/ui/src/stores/workflow.svelte.ts
@@ -1,29 +1,22 @@
-import type { PullRequest } from "../api/types.js";
+import type { KanbanStatus, PullRequest } from "../api/types.js";
 
-export type WorkflowGroup =
-  | "needsWorktree"
-  | "blocked"
-  | "readyToMerge"
-  | "inProgress"
-  | "needsReview";
+export type WorkflowGroup = KanbanStatus;
 
 export const workflowGroupOrder: WorkflowGroup[] = [
-  "needsWorktree",
-  "blocked",
-  "readyToMerge",
-  "inProgress",
-  "needsReview",
+  "new",
+  "reviewing",
+  "waiting",
+  "awaiting_merge",
 ];
 
 export const workflowGroupLabels: Record<
   WorkflowGroup,
   string
 > = {
-  needsWorktree: "Needs Worktree",
-  blocked: "Blocked",
-  readyToMerge: "Ready to Merge",
-  inProgress: "In Progress",
-  needsReview: "Needs Review",
+  new: "New",
+  reviewing: "Reviewing",
+  waiting: "Waiting",
+  awaiting_merge: "Awaiting Merge",
 };
 
 export interface WorkflowGroupEntry {
@@ -32,81 +25,32 @@ export interface WorkflowGroupEntry {
   items: PullRequest[];
 }
 
-/**
- * Classify a PR into a workflow group.
- *
- * Precedence:
- * 1. Closed/merged -> fallback "needsReview"
- * 2. No worktree + open -> "needsWorktree"
- * 3. Linked to active worktree -> "inProgress"
- * 4. Failing CI -> "blocked"
- * 5. Changes requested -> "blocked"
- * 6. Merge conflicts or blocked merge state -> "blocked"
- * 7. Approved + not draft + CI not failing -> "readyToMerge"
- * 8. Review required -> "needsReview"
- * 9. Draft -> "needsReview"
- * 10. Fallback -> "needsReview"
- */
-export function classifyPR(
-  pr: PullRequest,
-  activeWorktreeKey?: string,
+function normalizeKanbanStatus(
+  status: string | undefined,
 ): WorkflowGroup {
-  if (pr.State === "merged" || pr.State === "closed") {
-    return "needsReview";
-  }
-
-  const hasWorktree =
-    (pr.worktree_links?.length ?? 0) > 0;
-
-  if (!hasWorktree && pr.State === "open") {
-    return "needsWorktree";
-  }
-
   if (
-    activeWorktreeKey &&
-    pr.worktree_links?.some(
-      (l) => l.worktree_key === activeWorktreeKey,
-    )
+    status === "new" ||
+    status === "reviewing" ||
+    status === "waiting" ||
+    status === "awaiting_merge"
   ) {
-    return "inProgress";
+    return status;
   }
-
-  if (pr.CIStatus === "failure") {
-    return "blocked";
-  }
-
-  if (pr.ReviewDecision === "CHANGES_REQUESTED") {
-    return "blocked";
-  }
-
-  if (
-    pr.MergeableState === "dirty" ||
-    pr.MergeableState === "blocked"
-  ) {
-    return "blocked";
-  }
-
-  if (
-    pr.ReviewDecision === "APPROVED" &&
-    !pr.IsDraft &&
-    pr.CIStatus !== "failure"
-  ) {
-    return "readyToMerge";
-  }
-
-  if (pr.ReviewDecision === "REVIEW_REQUIRED") {
-    return "needsReview";
-  }
-
-  if (pr.IsDraft) {
-    return "needsReview";
-  }
-
-  return "needsReview";
+  return "new";
 }
 
 /**
- * Group PRs by workflow classification.
+ * Classify a PR into the Status grouping used by PR lists.
+ *
+ * Status grouping mirrors the kanban board, so worktree linkage stays item
+ * metadata/actions and does not override the user's review status.
+ */
+export function classifyPR(pr: PullRequest): WorkflowGroup {
+  return normalizeKanbanStatus(pr.KanbanStatus);
+}
+
+/**
+ * Group PRs by kanban status.
  *
  * Returns groups in display order, omitting empty groups.
  * Items within each group are sorted by LastActivityAt
@@ -114,7 +58,6 @@ export function classifyPR(
  */
 export function groupByWorkflow(
   prs: PullRequest[],
-  activeWorktreeKey?: string,
 ): WorkflowGroupEntry[] {
   const buckets = new Map<WorkflowGroup, PullRequest[]>();
   for (const g of workflowGroupOrder) {
@@ -122,7 +65,7 @@ export function groupByWorkflow(
   }
 
   for (const pr of prs) {
-    const group = classifyPR(pr, activeWorktreeKey);
+    const group = classifyPR(pr);
     buckets.get(group)!.push(pr);
   }
 

--- a/packages/ui/src/views/FocusListView.svelte
+++ b/packages/ui/src/views/FocusListView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getStores, getNavigate, getActions, getHostState } from "../context.js";
+  import { getStores, getNavigate, getActions } from "../context.js";
   import { groupByWorkflow } from "../stores/workflow.svelte.js";
   import PullItem from "../components/sidebar/PullItem.svelte";
   import IssueItem from "../components/sidebar/IssueItem.svelte";
@@ -16,21 +16,17 @@
   const { pulls, issues, sync, settings, grouping } = getStores();
   const navigate = getNavigate();
   const actions = getActions();
-  const hostState = getHostState();
 
   const importAction = $derived(
     (actions.pull ?? []).find(
       (a) => a.id === "import-worktree",
     ),
   );
-  const activeWorktreeKey = $derived(
-    hostState.getActiveWorktreeKey?.(),
-  );
   const groupingMode = $derived(
     grouping.getGroupingMode(),
   );
   const workflowGroups = $derived(
-    groupByWorkflow(pulls.getPulls(), activeWorktreeKey),
+    groupByWorkflow(pulls.getPulls()),
   );
 
   interface Props {

--- a/packages/ui/src/views/FocusListView.svelte
+++ b/packages/ui/src/views/FocusListView.svelte
@@ -7,6 +7,8 @@
   import {
     buildFocusIssueRoute,
     buildFocusPullRequestRoute,
+    buildIssueRoute,
+    buildPullRequestRoute,
     type IssueRouteRef,
     type PullRequestRouteRef,
   } from "../routes.js";
@@ -34,9 +36,10 @@
   interface Props {
     listType: "mrs" | "issues";
     repo?: string;
+    routeFamily?: "focus" | "canonical";
   }
 
-  const { listType, repo }: Props = $props();
+  const { listType, repo, routeFamily = "focus" }: Props = $props();
 
   let searchInput = $state("");
   let debounceHandle: ReturnType<typeof setTimeout> | null =
@@ -121,11 +124,19 @@
   }
 
   function handlePRSelect(ref: PullRequestRouteRef): void {
-    navigate(buildFocusPullRequestRoute(ref));
+    navigate(
+      routeFamily === "canonical"
+        ? buildPullRequestRoute(ref)
+        : buildFocusPullRequestRoute(ref),
+    );
   }
 
   function handleIssueSelect(ref: IssueRouteRef): void {
-    navigate(buildFocusIssueRoute(ref));
+    navigate(
+      routeFamily === "canonical"
+        ? buildIssueRoute(ref)
+        : buildFocusIssueRoute(ref),
+    );
   }
 
   // Filter state accessors for PRs.

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -4,7 +4,6 @@
   import { getStores } from "../context.js";
   import type { ItemFilter, TimeRange } from "../stores/activity.svelte.js";
   import { parseAPITimestamp } from "../utils/time.js";
-  import ActionButton from "../components/shared/ActionButton.svelte";
   import ItemKindChip from "../components/shared/ItemKindChip.svelte";
   import ItemStateChip from "../components/shared/ItemStateChip.svelte";
   import SelectDropdown from "../components/shared/SelectDropdown.svelte";
@@ -343,7 +342,6 @@
               <span class="mobile-activity-card__meta">
                 <span>{repoLabel(item)}</span>
                 <span>{group.eventCount} {group.eventCount === 1 ? "event" : "events"}</span>
-                <span>{item.author}</span>
               </span>
             </button>
 
@@ -367,14 +365,6 @@
                 </button>
               {/each}
             </div>
-
-            <ActionButton
-              class="mobile-activity-open"
-              tone="info"
-              surface="soft"
-              label="Open thread"
-              onclick={() => handleCardClick(group)}
-            />
           </article>
         {/each}
       </div>
@@ -576,7 +566,7 @@
     flex-direction: column;
     gap: var(--mobile-space-sm);
     width: 100%;
-    min-height: calc(var(--mobile-hit-target) * 3);
+    min-height: var(--mobile-hit-target);
     padding: var(--mobile-space-md);
     border: 0;
     color: inherit;
@@ -632,16 +622,29 @@
   }
 
   .mobile-activity-card__meta {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: baseline;
     gap: var(--mobile-space-xs) var(--mobile-space-sm);
     color: var(--text-muted);
     font-size: var(--font-size-mobile-sm);
     line-height: 1.25;
   }
 
-  .mobile-activity-card__meta span:not(:last-child)::after {
-    content: "";
+  .mobile-activity-card__meta span {
+    min-width: 0;
+  }
+
+  .mobile-activity-card__meta span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobile-activity-card__meta span:last-child {
+    justify-self: end;
+    text-align: right;
+    white-space: nowrap;
   }
 
   .mobile-activity-events {
@@ -707,14 +710,6 @@
   .mobile-activity-event time {
     color: var(--text-muted);
     font-size: var(--font-size-mobile-xs);
-    font-weight: 750;
-  }
-
-  :global(.mobile-activity-open) {
-    width: calc(100% - (var(--mobile-space-sm) * 2));
-    margin: 0 var(--mobile-space-sm) var(--mobile-space-sm);
-    min-height: var(--mobile-hit-target);
-    font-size: var(--font-size-mobile-sm);
     font-weight: 750;
   }
 

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -4,8 +4,10 @@
   import { getStores } from "../context.js";
   import type { ItemFilter, TimeRange } from "../stores/activity.svelte.js";
   import { parseAPITimestamp } from "../utils/time.js";
+  import ActionButton from "../components/shared/ActionButton.svelte";
   import ItemKindChip from "../components/shared/ItemKindChip.svelte";
   import ItemStateChip from "../components/shared/ItemStateChip.svelte";
+  import SelectDropdown from "../components/shared/SelectDropdown.svelte";
   import {
     buildMobileActivityRepoOptions,
   } from "./mobileActivityRepoOptions.js";
@@ -35,12 +37,19 @@
     { value: "prs", label: "PRs" },
     { value: "issues", label: "Issues" },
   ];
+  const timeRangeOptions = timeRanges.map((range) => ({
+    value: range,
+    label: range,
+  }));
   let searchInput = $state("");
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let unsubSync: (() => void) | undefined;
 
   const repoOptions = $derived.by(() =>
-    buildMobileActivityRepoOptions(settings.getConfiguredRepos()),
+    [
+      { value: "", label: "All repos" },
+      ...buildMobileActivityRepoOptions(settings.getConfiguredRepos()),
+    ],
   );
 
   onMount(() => {
@@ -146,8 +155,8 @@
     applyFilters();
   }
 
-  function handleItemFilterChange(event: Event): void {
-    setItemFilter((event.target as HTMLSelectElement).value as ItemFilter);
+  function handleItemFilterChange(value: string): void {
+    setItemFilter(value as ItemFilter);
   }
 
   function setTimeRange(range: TimeRange): void {
@@ -156,12 +165,11 @@
     void activity.loadActivity();
   }
 
-  function handleTimeRangeChange(event: Event): void {
-    setTimeRange((event.target as HTMLSelectElement).value as TimeRange);
+  function handleTimeRangeChange(value: string): void {
+    setTimeRange(value as TimeRange);
   }
 
-  function handleRepoChange(event: Event): void {
-    const value = (event.target as HTMLSelectElement).value;
+  function handleRepoChange(value: string): void {
     onRepoChange?.(value || undefined);
     void activity.loadActivity();
   }
@@ -257,45 +265,38 @@
     </label>
 
     <div class="mobile-activity-filter-grid" aria-label="Activity filters">
-      <label class="mobile-filter-select">
+      <div class="mobile-filter-select">
         <span>Type</span>
-        <select
-          aria-label="Activity type"
+        <SelectDropdown
+          class="mobile-filter-dropdown"
+          title="Activity type"
           value={activity.getItemFilter()}
+          options={itemFilters}
           onchange={handleItemFilterChange}
-        >
-          {#each itemFilters as option}
-            <option value={option.value}>{option.label}</option>
-          {/each}
-        </select>
-      </label>
+        />
+      </div>
 
-      <label class="mobile-filter-select">
+      <div class="mobile-filter-select">
         <span>Range</span>
-        <select
-          aria-label="Time range"
+        <SelectDropdown
+          class="mobile-filter-dropdown"
+          title="Time range"
           value={activity.getTimeRange()}
+          options={timeRangeOptions}
           onchange={handleTimeRangeChange}
-        >
-          {#each timeRanges as range}
-            <option value={range}>{range}</option>
-          {/each}
-        </select>
-      </label>
+        />
+      </div>
 
-      <label class="mobile-filter-select mobile-filter-select--repo">
+      <div class="mobile-filter-select mobile-filter-select--repo">
         <span>Repo</span>
-        <select
-          aria-label="Repository"
+        <SelectDropdown
+          class="mobile-filter-dropdown"
+          title="Repository"
           value={selectedRepo ?? ""}
+          options={repoOptions}
           onchange={handleRepoChange}
-        >
-          <option value="">All repos</option>
-          {#each repoOptions as repo (repo.value)}
-            <option value={repo.value}>{repo.label}</option>
-          {/each}
-        </select>
-      </label>
+        />
+      </div>
 
       <button
         type="button"
@@ -367,11 +368,13 @@
               {/each}
             </div>
 
-            <button
-              type="button"
+            <ActionButton
               class="mobile-activity-open"
+              tone="info"
+              surface="soft"
+              label="Open thread"
               onclick={() => handleCardClick(group)}
-            >Open thread</button>
+            />
           </article>
         {/each}
       </div>
@@ -398,17 +401,15 @@
     --mobile-space-sm: 0.75rem;
     --mobile-space-md: 1rem;
     --mobile-space-lg: 1.35rem;
-    --mobile-radius-sm: 1rem;
-    --mobile-radius-md: 1.25rem;
+    --mobile-radius-sm: var(--radius-md);
+    --mobile-radius-md: var(--radius-lg);
     --mobile-hit-target: 3.5rem;
     container-type: inline-size;
     font-size: var(--font-size-mobile-body);
     flex: 1;
     min-height: 0;
     overflow: hidden;
-    background:
-      radial-gradient(circle at 50% -20%, color-mix(in srgb, var(--accent-blue) 22%, transparent), transparent 34%),
-      var(--bg-primary);
+    background: var(--bg-primary);
   }
 
   .mobile-activity-scroll {
@@ -422,12 +423,12 @@
   }
 
   .mobile-activity-hero {
-    margin: var(--mobile-space-2xs) var(--mobile-space-2xs) var(--mobile-space-md);
+    margin: var(--mobile-space-2xs) var(--mobile-space-2xs) var(--mobile-space-sm);
   }
 
   .mobile-activity-eyebrow {
     margin: 0 0 var(--mobile-space-2xs);
-    color: var(--text-muted);
+    color: var(--text-secondary);
     font-size: var(--font-size-mobile-sm);
     font-weight: 700;
     letter-spacing: 0.02em;
@@ -436,9 +437,9 @@
   .mobile-activity-hero h1 {
     margin: 0;
     color: var(--text-primary);
-    font-size: var(--font-size-mobile-display);
-    line-height: 1;
-    letter-spacing: -0.045em;
+    font-size: var(--font-size-mobile-title);
+    line-height: 1.16;
+    letter-spacing: 0;
   }
 
   .mobile-activity-search {
@@ -448,8 +449,8 @@
     gap: var(--mobile-space-sm);
     padding: 0 var(--mobile-space-md);
     border: thin solid var(--border-default);
-    border-radius: var(--mobile-radius-sm);
-    background: color-mix(in srgb, var(--bg-surface) 82%, transparent);
+    border-radius: var(--radius-lg);
+    background: var(--bg-inset);
     color: var(--text-muted);
     margin-bottom: var(--mobile-space-sm);
   }
@@ -485,9 +486,9 @@
     gap: var(--mobile-space-xs);
     padding: 0 var(--mobile-space-sm);
     border: thin solid var(--border-default);
-    border-radius: var(--mobile-radius-sm);
+    border-radius: var(--radius-md);
     color: var(--text-secondary);
-    background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+    background: var(--bg-inset);
   }
 
   .mobile-filter-select--repo {
@@ -501,35 +502,59 @@
     letter-spacing: 0.01em;
   }
 
-  .mobile-filter-select select {
-    min-width: 0;
+  .mobile-filter-select :global(.mobile-filter-dropdown) {
     width: 100%;
+    min-width: 0;
+  }
+
+  .mobile-filter-select :global(.mobile-filter-dropdown .select-dropdown-trigger) {
+    height: auto;
+    min-height: calc(var(--mobile-hit-target) - var(--mobile-space-sm));
+    padding: 0;
     border: 0;
-    outline: 0;
-    color: var(--text-primary);
     background: transparent;
-    font: inherit;
+    color: var(--text-primary);
     font-size: var(--font-size-mobile-sm);
     font-weight: 750;
   }
 
-  .mobile-filter-toggle,
-  .mobile-activity-open {
+  .mobile-filter-select :global(.mobile-filter-dropdown .select-dropdown-list) {
+    left: 0;
+    right: auto;
+    width: min(20rem, calc(100vw - (var(--mobile-space-sm) * 2)));
+    max-width: calc(100vw - (var(--mobile-space-sm) * 2));
+    padding: var(--mobile-space-2xs);
+    border-radius: var(--radius-md);
+  }
+
+  .mobile-filter-select :global(.mobile-filter-dropdown .select-dropdown-option) {
+    min-height: var(--mobile-hit-target);
+    padding: var(--mobile-space-xs) var(--mobile-space-sm);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-mobile-sm);
+    line-height: 1.2;
+  }
+
+  .mobile-filter-select :global(.mobile-filter-dropdown .select-dropdown-check) {
+    width: 1rem;
+  }
+
+  .mobile-filter-toggle {
     min-height: var(--mobile-hit-target);
     flex: 0 0 auto;
     padding: var(--mobile-space-sm) var(--mobile-space-md);
     border: thin solid var(--border-default);
-    border-radius: 999rem;
+    border-radius: var(--radius-md);
     color: var(--text-secondary);
-    background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+    background: var(--bg-inset);
     font-size: var(--font-size-mobile-sm);
     font-weight: 750;
   }
 
   .mobile-filter-toggle.active {
-    color: var(--bg-primary);
-    background: var(--text-primary);
-    border-color: transparent;
+    color: var(--accent-blue);
+    background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
+    border-color: color-mix(in srgb, var(--accent-blue) 34%, transparent);
   }
 
 
@@ -541,13 +566,9 @@
   .mobile-activity-card {
     overflow: hidden;
     border: thin solid var(--border-default);
-    border-radius: var(--mobile-radius-md);
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--bg-surface) 96%, white 4%),
-      color-mix(in srgb, var(--bg-surface) 88%, black 12%)
-    );
-    box-shadow: 0 0.65rem 2rem color-mix(in srgb, black 28%, transparent);
+    border-radius: var(--radius-lg);
+    background: var(--bg-surface);
+    box-shadow: var(--shadow-sm);
   }
 
   .mobile-activity-card__button {
@@ -580,7 +601,6 @@
   .mobile-activity-card__chips :global(.chip--md) {
     min-height: calc(var(--mobile-hit-target) * 0.55);
     padding: 0 var(--mobile-space-xs);
-    border-radius: 999rem;
     font-size: var(--font-size-mobile-xs);
   }
 
@@ -637,35 +657,31 @@
     align-items: center;
     gap: var(--mobile-space-sm);
     padding: var(--mobile-space-sm);
-    border: thin solid transparent;
-    border-radius: var(--mobile-radius-sm);
+    border: thin solid var(--border-muted);
+    border-radius: var(--radius-md);
     color: inherit;
-    background: color-mix(in srgb, var(--bg-inset) 72%, transparent);
+    background: var(--bg-inset);
     text-align: left;
   }
 
   .mobile-activity-event__dot {
     width: 0.62rem;
     height: 0.62rem;
-    border-radius: 999rem;
+    border-radius: 50%;
     background: var(--accent-blue);
-    box-shadow: 0 0 0 0.32rem color-mix(in srgb, var(--accent-blue) 12%, transparent);
   }
 
   .mobile-activity-event.event-comment .mobile-activity-event__dot {
     background: var(--accent-amber);
-    box-shadow: 0 0 0 0.32rem color-mix(in srgb, var(--accent-amber) 12%, transparent);
   }
 
   .mobile-activity-event.event-review .mobile-activity-event__dot,
   .mobile-activity-event.event-commit .mobile-activity-event__dot {
     background: var(--accent-green);
-    box-shadow: 0 0 0 0.32rem color-mix(in srgb, var(--accent-green) 12%, transparent);
   }
 
   .mobile-activity-event.event-force-push .mobile-activity-event__dot {
     background: var(--accent-red);
-    box-shadow: 0 0 0 0.32rem color-mix(in srgb, var(--accent-red) 12%, transparent);
   }
 
   .mobile-activity-event__body {
@@ -694,13 +710,12 @@
     font-weight: 750;
   }
 
-  .mobile-activity-open {
-    display: block;
+  :global(.mobile-activity-open) {
     width: calc(100% - (var(--mobile-space-sm) * 2));
     margin: 0 var(--mobile-space-sm) var(--mobile-space-sm);
-    color: var(--text-primary);
-    text-align: center;
-    background: color-mix(in srgb, var(--accent-blue) 13%, transparent);
+    min-height: var(--mobile-hit-target);
+    font-size: var(--font-size-mobile-sm);
+    font-weight: 750;
   }
 
   .mobile-activity-empty,
@@ -708,9 +723,9 @@
   .mobile-activity-capped {
     padding: var(--mobile-space-lg);
     border: thin solid var(--border-default);
-    border-radius: var(--mobile-radius-md);
+    border-radius: var(--radius-lg);
     color: var(--text-muted);
-    background: color-mix(in srgb, var(--bg-surface) 84%, transparent);
+    background: var(--bg-surface);
     font-size: var(--font-size-mobile-sm);
     text-align: center;
   }

--- a/packages/ui/src/views/mobileActivityRepoOptions.test.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.test.ts
@@ -21,8 +21,16 @@ describe("buildMobileActivityRepoOptions", () => {
     ]);
 
     expect(options).toEqual([
-      { value: "ghe.example.com/acme/widgets", label: "ghe.example.com/acme/widgets" },
-      { value: "github.com/acme/widgets", label: "github.com/acme/widgets" },
+      {
+        value: "ghe.example.com/acme/widgets",
+        label: "ghe.example.com/acme/widgets",
+        triggerLabel: "acme/widgets",
+      },
+      {
+        value: "github.com/acme/widgets",
+        label: "github.com/acme/widgets",
+        triggerLabel: "acme/widgets",
+      },
     ]);
   });
 
@@ -47,7 +55,11 @@ describe("buildMobileActivityRepoOptions", () => {
     ]);
 
     expect(options).toEqual([
-      { value: "ghe.example.com/acme/widgets", label: "ghe.example.com/acme/widgets" },
+      {
+        value: "ghe.example.com/acme/widgets",
+        label: "ghe.example.com/acme/widgets",
+        triggerLabel: "acme/widgets",
+      },
     ]);
   });
 });

--- a/packages/ui/src/views/mobileActivityRepoOptions.test.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.test.ts
@@ -14,7 +14,7 @@ const baseRepo = {
 };
 
 describe("buildMobileActivityRepoOptions", () => {
-  it("uses host-qualified values and labels when duplicate repo paths exist", () => {
+  it("uses host-qualified trigger labels when duplicate repo paths exist", () => {
     const options = buildMobileActivityRepoOptions([
       { ...baseRepo, platform_host: "github.com" },
       { ...baseRepo, platform_host: "ghe.example.com" },
@@ -24,7 +24,27 @@ describe("buildMobileActivityRepoOptions", () => {
       {
         value: "ghe.example.com/acme/widgets",
         label: "ghe.example.com/acme/widgets",
-        triggerLabel: "acme/widgets",
+        triggerLabel: "ghe.example.com/acme/widgets",
+      },
+      {
+        value: "github.com/acme/widgets",
+        label: "github.com/acme/widgets",
+        triggerLabel: "github.com/acme/widgets",
+      },
+    ]);
+  });
+
+  it("shortens trigger labels when repo paths are unique", () => {
+    const options = buildMobileActivityRepoOptions([
+      { ...baseRepo, platform_host: "github.com", repo_path: "acme/widgets" },
+      { ...baseRepo, platform_host: "ghe.example.com", repo_path: "acme/api" },
+    ]);
+
+    expect(options).toEqual([
+      {
+        value: "ghe.example.com/acme/api",
+        label: "ghe.example.com/acme/api",
+        triggerLabel: "acme/api",
       },
       {
         value: "github.com/acme/widgets",

--- a/packages/ui/src/views/mobileActivityRepoOptions.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.ts
@@ -16,13 +16,30 @@ function concreteRepoSelectorValue(repo: ConfigRepo): string | null {
 export function buildMobileActivityRepoOptions(
   repos: ConfigRepo[],
 ): MobileActivityRepoOption[] {
+  const valuesByRepoPath = new Map<string, Set<string>>();
+  for (const repo of repos) {
+    const value = concreteRepoSelectorValue(repo);
+    if (!value) continue;
+    const repoPath = repo.repo_path.trim();
+    let values = valuesByRepoPath.get(repoPath);
+    if (!values) {
+      values = new Set<string>();
+      valuesByRepoPath.set(repoPath, values);
+    }
+    values.add(value);
+  }
+
   const seen = new Set<string>();
   const options: MobileActivityRepoOption[] = [];
   for (const repo of repos) {
     const value = concreteRepoSelectorValue(repo);
     if (!value || seen.has(value)) continue;
     seen.add(value);
-    options.push({ value, label: value, triggerLabel: repo.repo_path.trim() });
+    const repoPath = repo.repo_path.trim();
+    const triggerLabel = (valuesByRepoPath.get(repoPath)?.size ?? 0) > 1
+      ? value
+      : repoPath;
+    options.push({ value, label: value, triggerLabel });
   }
   return options.sort((left, right) =>
     left.label.localeCompare(right.label, undefined, {

--- a/packages/ui/src/views/mobileActivityRepoOptions.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.ts
@@ -3,6 +3,7 @@ import type { ConfigRepo } from "../api/types.js";
 export interface MobileActivityRepoOption {
   value: string;
   label: string;
+  triggerLabel?: string;
 }
 
 function concreteRepoSelectorValue(repo: ConfigRepo): string | null {
@@ -21,7 +22,7 @@ export function buildMobileActivityRepoOptions(
     const value = concreteRepoSelectorValue(repo);
     if (!value || seen.has(value)) continue;
     seen.add(value);
-    options.push({ value, label: value });
+    options.push({ value, label: value, triggerLabel: repo.repo_path.trim() });
   }
   return options.sort((left, right) =>
     left.label.localeCompare(right.label, undefined, {

--- a/prek.toml
+++ b/prek.toml
@@ -73,7 +73,7 @@ hooks = [
     entry = "make api-generate",
     files = "^(go\\.mod|go\\.sum|cmd/middleman-openapi/.*\\.go|internal/server/.*\\.go|internal/db/.*\\.go|internal/apiclient/.*|frontend/package\\.json|frontend/bun\\.lock)$",
     pass_filenames = false,
-    priority = 0,
+    priority = 25,
   },
   {
     id = "gofmt",

--- a/prek.toml
+++ b/prek.toml
@@ -146,7 +146,7 @@ hooks = [
     files = "^(package\\.json|bun\\.lock|frontend/((src|tests)/.*\\.(svelte|ts)|package\\.json|tsconfig\\.json|vite\\.config\\.ts|playwright(-e2e)?\\.config\\.ts|eslint\\.config\\.(js|mjs|cjs))|packages/ui/(src/.*\\.(svelte|ts)|package\\.json|tsconfig\\.json|eslint\\.config\\.(js|mjs|cjs)))$",
     pass_filenames = false,
     require_serial = true,
-    priority = 5,
+    priority = 30,
   },
 ]
 


### PR DESCRIPTION
- Keep canonical PR and issue URLs stable while narrow layouts render the focus presentation
- Reuse focus list/detail components across canonical and explicit /focus routes
- Separate compact desktop presentation from phone-only sizing and document the responsive layout contract