### PR TITLE
Fix CI dropdown layout stability

### DIFF
--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -64,8 +64,8 @@ test.describe("CI dropdown", () => {
 
       await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
 
-      const pendingChip = page
-        .locator(".pull-detail")
+      const detail = page.locator(".pull-detail");
+      const pendingChip = detail
         .getByRole("button", { name: /CI:\s*pending \(1\)/i });
       await expect(pendingChip).toBeVisible();
       await backgroundSync;
@@ -77,6 +77,12 @@ test.describe("CI dropdown", () => {
       });
       await pendingChip.click();
       await firstRefresh;
+      expect(
+        await detail.locator(".ci-check .sync-spinner").count(),
+      ).toBeGreaterThan(0);
+      await expect(
+        detail.locator(".ci-check .sync-spinner svg").first(),
+      ).toHaveAttribute("width", "12");
 
       const successResponse = await page.request.post(
         `${server.info.base_url}/__e2e/pr-ci-state/success`,
@@ -138,6 +144,7 @@ test.describe("CI dropdown", () => {
     const diffStatsChip = detail.locator(".chip--muted", {
       hasText: /^\+\d+\/-\d+$/,
     });
+    const labelsButton = detail.getByRole("button", { name: /^Labels$/ });
     const actionRow = detail.locator(".primary-actions-wrap");
     await chip.waitFor({ state: "visible", timeout: 10_000 });
     const chipStylesBefore = await chip.evaluate((node) => {
@@ -150,6 +157,7 @@ test.describe("CI dropdown", () => {
     });
     const chipBox = await chip.boundingBox();
     const diffStatsBox = await diffStatsChip.boundingBox();
+    const labelsBox = await labelsButton.boundingBox();
     const actionRowBox = await actionRow.boundingBox();
     await chip.click();
 
@@ -159,13 +167,16 @@ test.describe("CI dropdown", () => {
 
     const checksBox = await checks.boundingBox();
     const expandedDiffStatsBox = await diffStatsChip.boundingBox();
+    const expandedLabelsBox = await labelsButton.boundingBox();
     const expandedActionRowBox = await actionRow.boundingBox();
 
     expect(chipBox).not.toBeNull();
     expect(diffStatsBox).not.toBeNull();
+    expect(labelsBox).not.toBeNull();
     expect(actionRowBox).not.toBeNull();
     expect(checksBox).not.toBeNull();
     expect(expandedDiffStatsBox).not.toBeNull();
+    expect(expandedLabelsBox).not.toBeNull();
     expect(expandedActionRowBox).not.toBeNull();
     expect(chipStylesBefore.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
     expect(chipStylesBefore.paddingRight).not.toBe("0px");
@@ -175,6 +186,7 @@ test.describe("CI dropdown", () => {
     expect(ciGap).toBeLessThan(11);
     expect(expandedDiffStatsBox!.height).toBeLessThan(40);
     expect(expandedDiffStatsBox!.y).toBe(diffStatsBox!.y);
+    expect(expandedLabelsBox!.y).toBe(labelsBox!.y);
     expect(expandedActionRowBox!.y).toBeGreaterThan(actionRowBox!.y);
 
     await expect(detail.locator(".ci-name")).toHaveText([

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -59,8 +59,8 @@
     return "var(--text-muted)";
   }
 
-  function isRefreshingCheck(check: CICheck): boolean {
-    return detailSyncing && check.status !== "completed";
+  function isPendingCheck(check: CICheck): boolean {
+    return check.status !== "completed";
   }
 
   function chipColor(chipStatus: string): string {
@@ -99,9 +99,9 @@
       rel="noopener noreferrer"
     >
       <span class="ci-icon" style="color: {checkColor(check)}">
-        {#if isRefreshingCheck(check)}
+        {#if isPendingCheck(check)}
           <span class="sync-spinner" aria-hidden="true">
-            <LoaderCircleIcon size={14} strokeWidth={2} />
+            <LoaderCircleIcon size={12} strokeWidth={2} />
           </span>
         {:else}
           {checkIcon(check)}
@@ -119,9 +119,9 @@
   {:else}
     <div class="ci-check ci-check--static">
       <span class="ci-icon" style="color: {checkColor(check)}">
-        {#if isRefreshingCheck(check)}
+        {#if isPendingCheck(check)}
           <span class="sync-spinner" aria-hidden="true">
-            <LoaderCircleIcon size={14} strokeWidth={2} />
+            <LoaderCircleIcon size={12} strokeWidth={2} />
           </span>
         {:else}
           {checkIcon(check)}
@@ -223,7 +223,7 @@
     border-radius: var(--radius-md);
     overflow: auto;
     flex-shrink: 0;
-    max-height: min(320px, 50vh);
+    max-height: min(340px, 50vh);
   }
 
   .ci-section-label {

--- a/packages/ui/src/components/detail/CIStatus.test.ts
+++ b/packages/ui/src/components/detail/CIStatus.test.ts
@@ -38,6 +38,34 @@ describe("CIStatus", () => {
     expect(screen.getByText("✓")).toBeTruthy();
   });
 
+  it("keeps spinners for pending checks after refresh settles", () => {
+    render(CIStatus, {
+      props: {
+        status: "pending",
+        checksJSON: JSON.stringify([
+          {
+            name: "build",
+            status: "in_progress",
+            conclusion: "",
+            url: "",
+            app: "GitHub Actions",
+          },
+        ]),
+        detailLoaded: true,
+        detailSyncing: false,
+        expanded: true,
+      },
+    });
+
+    expect(document.querySelectorAll(".ci-check .sync-spinner")).toHaveLength(1);
+    expect(
+      document
+        .querySelector(".ci-check .sync-spinner svg")
+        ?.getAttribute("width"),
+    ).toBe("12");
+    expect(screen.queryByText("◦")).toBeNull();
+  });
+
   it("renders expanded CI checks when chip is clicked", async () => {
     render(CIStatus, {
       props: {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -1347,14 +1347,6 @@
         {#if hasWorktreeLinks}
           <Chip class="chip--teal">Worktree</Chip>
         {/if}
-        <CIStatus
-          status={pr.CIStatus}
-          checksJSON={pr.CIChecksJSON}
-          detailLoaded={detailStore.getDetailLoaded()}
-          detailSyncing={detailStore.isDetailSyncing()}
-          bind:expanded={ciExpanded}
-          showButton={false}
-        />
         {#if labels.length > 0}
           <GitHubLabels {labels} mode="full" />
         {/if}
@@ -1381,6 +1373,14 @@
             />
           </div>
         {/if}
+        <CIStatus
+          status={pr.CIStatus}
+          checksJSON={pr.CIChecksJSON}
+          detailLoaded={detailStore.getDetailLoaded()}
+          detailSyncing={detailStore.isDetailSyncing()}
+          bind:expanded={ciExpanded}
+          showButton={false}
+        />
       </div>
 
       {#if !stalePR}


### PR DESCRIPTION
- Keep in-progress CI checks animated after refreshes settle, using a smaller spinner.
- Keep Labels in the top chip row when CI checks expand.
- Let the expanded CI list fit the common ten-check view cleanly.