### PR TITLE
Collapse label editing palette action

### DIFF
--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -42,8 +42,7 @@ describe("defaultActions", () => {
     const ids = defaultActions.map((a) => a.id);
     expect(ids).toEqual(
       expect.arrayContaining([
-        "labels.edit.pr",
-        "labels.edit.issue",
+        "labels.edit",
         "go.next",
         "go.prev",
         "tab.toggle",
@@ -85,7 +84,7 @@ describe("defaultActions", () => {
   });
 
   it("dispatches Edit labels from PR detail context", () => {
-    const action = defaultActions.find((a) => a.id === "labels.edit.pr");
+    const action = defaultActions.find((a) => a.id === "labels.edit");
     expect(action).toBeDefined();
     setStoreInstances(() => ({
       detail: {
@@ -107,7 +106,7 @@ describe("defaultActions", () => {
   });
 
   it("dispatches Edit labels from issue detail context", () => {
-    const action = defaultActions.find((a) => a.id === "labels.edit.issue");
+    const action = defaultActions.find((a) => a.id === "labels.edit");
     expect(action).toBeDefined();
     setStoreInstances(() => ({
       issues: {

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -117,6 +117,12 @@ function issueLabelPickerDetail(ctx: Context): OpenLabelPickerDetail | null {
   );
 }
 
+function labelPickerDetail(ctx: Context): OpenLabelPickerDetail | null {
+  if (ctx.page === "pulls") return prLabelPickerDetail(ctx);
+  if (ctx.page === "issues") return issueLabelPickerDetail(ctx);
+  return null;
+}
+
 // Mirrors App.svelte's pre-migration page exclusions for `1`/`2`/`f`/etc.:
 // settings, design-system, repos, reviews, workspaces, activity all returned
 // early before the global shortcut switch ran.
@@ -290,26 +296,14 @@ export const defaultActions: Action[] = [
     handler: () => toggleCheatsheet(),
   },
   {
-    id: "labels.edit.pr",
+    id: "labels.edit",
     label: "Edit labels",
-    scope: "detail-pr",
+    scope: "detail",
     binding: null,
     priority: 0,
-    when: (ctx) => prLabelPickerDetail(ctx) !== null,
+    when: (ctx) => labelPickerDetail(ctx) !== null,
     handler: (ctx) => {
-      const detail = prLabelPickerDetail(ctx);
-      if (detail !== null) openLabelPickerFor(detail);
-    },
-  },
-  {
-    id: "labels.edit.issue",
-    label: "Edit labels",
-    scope: "detail-issue",
-    binding: null,
-    priority: 0,
-    when: (ctx) => issueLabelPickerDetail(ctx) !== null,
-    handler: (ctx) => {
-      const detail = issueLabelPickerDetail(ctx);
+      const detail = labelPickerDetail(ctx);
       if (detail !== null) openLabelPickerFor(detail);
     },
   },

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
@@ -12,6 +12,7 @@ const RESERVED_WHILE_MODAL_OPEN: KeySpec[] = [
 const SCOPE_SPECIFICITY: Record<Action["scope"], number> = {
   "detail-pr": 30,
   "detail-issue": 30,
+  detail: 30,
   "view-pulls": 20,
   "view-issues": 20,
   global: 10,

--- a/frontend/src/lib/stores/keyboard/types.ts
+++ b/frontend/src/lib/stores/keyboard/types.ts
@@ -11,6 +11,7 @@ export type ScopeTag =
   | "global"
   | "view-pulls"
   | "view-issues"
+  | "detail"
   | "detail-pr"
   | "detail-issue";
 

--- a/frontend/tests/e2e-full/labels.spec.ts
+++ b/frontend/tests/e2e-full/labels.spec.ts
@@ -6,6 +6,7 @@ test.describe("label editing", () => {
     await page.keyboard.press(process.platform === "darwin" ? "Meta+K" : "Control+K");
     await expect(page.getByRole("dialog", { name: "Command palette" })).toBeVisible();
     await page.locator(".palette-input").fill("Edit labels");
+    await expect(page.getByRole("button", { name: /Edit labels/ })).toHaveCount(1);
     await page.getByRole("button", { name: /Edit labels/ }).click();
     await expect(page.getByRole("dialog", { name: "Edit labels" })).toBeVisible();
   }


### PR DESCRIPTION
- Show one Edit labels command in the palette for PR and issue details
- Route that command through the current detail context so it opens the right label picker