### PR TITLE
Hide workflow status for closed PRs

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1393,6 +1393,11 @@ components:
         IsLocked:
           type: boolean
         KanbanStatus:
+          enum:
+            - new
+            - reviewing
+            - waiting
+            - awaiting_merge
           type: string
         LastActivityAt:
           format: date-time
@@ -1420,6 +1425,10 @@ components:
         Starred:
           type: boolean
         State:
+          enum:
+            - open
+            - closed
+            - merged
           type: string
         Title:
           type: string
@@ -1583,6 +1592,11 @@ components:
         IsLocked:
           type: boolean
         KanbanStatus:
+          enum:
+            - new
+            - reviewing
+            - waiting
+            - awaiting_merge
           type: string
         LastActivityAt:
           format: date-time
@@ -1610,6 +1624,10 @@ components:
         Starred:
           type: boolean
         State:
+          enum:
+            - open
+            - closed
+            - merged
           type: string
         Title:
           type: string

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -144,6 +144,17 @@ test.describe("PR list view", () => {
 
     const countBadge = page.locator(".filter-bar .list-count-chip");
     await expect(countBadge).toHaveText(/^4 PRs$/, { timeout: 5_000 });
+
+    await selectPullGrouping(page, "Status");
+
+    const headers = page.locator(".repo-header");
+    await expect(headers).toHaveCount(1);
+    await expect(headers.first().locator(".repo-header__name")).toHaveText(
+      "Closed",
+    );
+    await expect(headers.first().locator(".repo-header__count")).toHaveText(
+      "4",
+    );
   });
 
   test("search filters PRs by title", async ({ page }) => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -17,6 +17,96 @@ import (
 	"github.com/oapi-codegen/runtime"
 )
 
+// Defines values for MergeRequestKanbanStatus.
+const (
+	MergeRequestKanbanStatusAwaitingMerge MergeRequestKanbanStatus = "awaiting_merge"
+	MergeRequestKanbanStatusNew           MergeRequestKanbanStatus = "new"
+	MergeRequestKanbanStatusReviewing     MergeRequestKanbanStatus = "reviewing"
+	MergeRequestKanbanStatusWaiting       MergeRequestKanbanStatus = "waiting"
+)
+
+// Valid indicates whether the value is a known member of the MergeRequestKanbanStatus enum.
+func (e MergeRequestKanbanStatus) Valid() bool {
+	switch e {
+	case MergeRequestKanbanStatusAwaitingMerge:
+		return true
+	case MergeRequestKanbanStatusNew:
+		return true
+	case MergeRequestKanbanStatusReviewing:
+		return true
+	case MergeRequestKanbanStatusWaiting:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for MergeRequestState.
+const (
+	MergeRequestStateClosed MergeRequestState = "closed"
+	MergeRequestStateMerged MergeRequestState = "merged"
+	MergeRequestStateOpen   MergeRequestState = "open"
+)
+
+// Valid indicates whether the value is a known member of the MergeRequestState enum.
+func (e MergeRequestState) Valid() bool {
+	switch e {
+	case MergeRequestStateClosed:
+		return true
+	case MergeRequestStateMerged:
+		return true
+	case MergeRequestStateOpen:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for MergeRequestResponseKanbanStatus.
+const (
+	MergeRequestResponseKanbanStatusAwaitingMerge MergeRequestResponseKanbanStatus = "awaiting_merge"
+	MergeRequestResponseKanbanStatusNew           MergeRequestResponseKanbanStatus = "new"
+	MergeRequestResponseKanbanStatusReviewing     MergeRequestResponseKanbanStatus = "reviewing"
+	MergeRequestResponseKanbanStatusWaiting       MergeRequestResponseKanbanStatus = "waiting"
+)
+
+// Valid indicates whether the value is a known member of the MergeRequestResponseKanbanStatus enum.
+func (e MergeRequestResponseKanbanStatus) Valid() bool {
+	switch e {
+	case MergeRequestResponseKanbanStatusAwaitingMerge:
+		return true
+	case MergeRequestResponseKanbanStatusNew:
+		return true
+	case MergeRequestResponseKanbanStatusReviewing:
+		return true
+	case MergeRequestResponseKanbanStatusWaiting:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for MergeRequestResponseState.
+const (
+	MergeRequestResponseStateClosed MergeRequestResponseState = "closed"
+	MergeRequestResponseStateMerged MergeRequestResponseState = "merged"
+	MergeRequestResponseStateOpen   MergeRequestResponseState = "open"
+)
+
+// Valid indicates whether the value is a known member of the MergeRequestResponseState enum.
+func (e MergeRequestResponseState) Valid() bool {
+	switch e {
+	case MergeRequestResponseStateClosed:
+		return true
+	case MergeRequestResponseStateMerged:
+		return true
+	case MergeRequestResponseStateOpen:
+		return true
+	default:
+		return false
+	}
+}
+
 // ActionStatusBody defines model for ActionStatusBody.
 type ActionStatusBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -571,40 +661,46 @@ type MergePRInputBody struct {
 
 // MergeRequest defines model for MergeRequest.
 type MergeRequest struct {
-	Additions          int64      `json:"Additions"`
-	Author             string     `json:"Author"`
-	AuthorDisplayName  string     `json:"AuthorDisplayName"`
-	BaseBranch         string     `json:"BaseBranch"`
-	Body               string     `json:"Body"`
-	CIChecksJSON       string     `json:"CIChecksJSON"`
-	CIHadPending       bool       `json:"CIHadPending"`
-	CIStatus           string     `json:"CIStatus"`
-	ClosedAt           *time.Time `json:"ClosedAt"`
-	CommentCount       int64      `json:"CommentCount"`
-	CreatedAt          time.Time  `json:"CreatedAt"`
-	Deletions          int64      `json:"Deletions"`
-	DetailFetchedAt    *time.Time `json:"DetailFetchedAt"`
-	HeadBranch         string     `json:"HeadBranch"`
-	HeadRepoCloneURL   string     `json:"HeadRepoCloneURL"`
-	ID                 int64      `json:"ID"`
-	IsDraft            bool       `json:"IsDraft"`
-	IsLocked           bool       `json:"IsLocked"`
-	KanbanStatus       string     `json:"KanbanStatus"`
-	LastActivityAt     time.Time  `json:"LastActivityAt"`
-	MergeableState     string     `json:"MergeableState"`
-	MergedAt           *time.Time `json:"MergedAt"`
-	Number             int64      `json:"Number"`
-	PlatformExternalID string     `json:"PlatformExternalID"`
-	PlatformID         int64      `json:"PlatformID"`
-	RepoID             int64      `json:"RepoID"`
-	ReviewDecision     string     `json:"ReviewDecision"`
-	Starred            bool       `json:"Starred"`
-	State              string     `json:"State"`
-	Title              string     `json:"Title"`
-	URL                string     `json:"URL"`
-	UpdatedAt          time.Time  `json:"UpdatedAt"`
-	Labels             *[]Label   `json:"labels,omitempty"`
+	Additions          int64                    `json:"Additions"`
+	Author             string                   `json:"Author"`
+	AuthorDisplayName  string                   `json:"AuthorDisplayName"`
+	BaseBranch         string                   `json:"BaseBranch"`
+	Body               string                   `json:"Body"`
+	CIChecksJSON       string                   `json:"CIChecksJSON"`
+	CIHadPending       bool                     `json:"CIHadPending"`
+	CIStatus           string                   `json:"CIStatus"`
+	ClosedAt           *time.Time               `json:"ClosedAt"`
+	CommentCount       int64                    `json:"CommentCount"`
+	CreatedAt          time.Time                `json:"CreatedAt"`
+	Deletions          int64                    `json:"Deletions"`
+	DetailFetchedAt    *time.Time               `json:"DetailFetchedAt"`
+	HeadBranch         string                   `json:"HeadBranch"`
+	HeadRepoCloneURL   string                   `json:"HeadRepoCloneURL"`
+	ID                 int64                    `json:"ID"`
+	IsDraft            bool                     `json:"IsDraft"`
+	IsLocked           bool                     `json:"IsLocked"`
+	KanbanStatus       MergeRequestKanbanStatus `json:"KanbanStatus"`
+	LastActivityAt     time.Time                `json:"LastActivityAt"`
+	MergeableState     string                   `json:"MergeableState"`
+	MergedAt           *time.Time               `json:"MergedAt"`
+	Number             int64                    `json:"Number"`
+	PlatformExternalID string                   `json:"PlatformExternalID"`
+	PlatformID         int64                    `json:"PlatformID"`
+	RepoID             int64                    `json:"RepoID"`
+	ReviewDecision     string                   `json:"ReviewDecision"`
+	Starred            bool                     `json:"Starred"`
+	State              MergeRequestState        `json:"State"`
+	Title              string                   `json:"Title"`
+	URL                string                   `json:"URL"`
+	UpdatedAt          time.Time                `json:"UpdatedAt"`
+	Labels             *[]Label                 `json:"labels,omitempty"`
 }
+
+// MergeRequestKanbanStatus defines model for MergeRequest.KanbanStatus.
+type MergeRequestKanbanStatus string
+
+// MergeRequestState defines model for MergeRequest.State.
+type MergeRequestState string
 
 // MergeRequestDetailResponse defines model for MergeRequestDetailResponse.
 type MergeRequestDetailResponse struct {
@@ -630,46 +726,52 @@ type MergeRequestDetailResponse struct {
 
 // MergeRequestResponse defines model for MergeRequestResponse.
 type MergeRequestResponse struct {
-	Additions          int64                   `json:"Additions"`
-	Author             string                  `json:"Author"`
-	AuthorDisplayName  string                  `json:"AuthorDisplayName"`
-	BaseBranch         string                  `json:"BaseBranch"`
-	Body               string                  `json:"Body"`
-	CIChecksJSON       string                  `json:"CIChecksJSON"`
-	CIHadPending       bool                    `json:"CIHadPending"`
-	CIStatus           string                  `json:"CIStatus"`
-	ClosedAt           *time.Time              `json:"ClosedAt"`
-	CommentCount       int64                   `json:"CommentCount"`
-	CreatedAt          time.Time               `json:"CreatedAt"`
-	Deletions          int64                   `json:"Deletions"`
-	HeadBranch         string                  `json:"HeadBranch"`
-	HeadRepoCloneURL   string                  `json:"HeadRepoCloneURL"`
-	ID                 int64                   `json:"ID"`
-	IsDraft            bool                    `json:"IsDraft"`
-	IsLocked           bool                    `json:"IsLocked"`
-	KanbanStatus       string                  `json:"KanbanStatus"`
-	LastActivityAt     time.Time               `json:"LastActivityAt"`
-	MergeableState     string                  `json:"MergeableState"`
-	MergedAt           *time.Time              `json:"MergedAt"`
-	Number             int64                   `json:"Number"`
-	PlatformExternalID string                  `json:"PlatformExternalID"`
-	PlatformID         int64                   `json:"PlatformID"`
-	RepoID             int64                   `json:"RepoID"`
-	ReviewDecision     string                  `json:"ReviewDecision"`
-	Starred            bool                    `json:"Starred"`
-	State              string                  `json:"State"`
-	Title              string                  `json:"Title"`
-	URL                string                  `json:"URL"`
-	UpdatedAt          time.Time               `json:"UpdatedAt"`
-	DetailFetchedAt    *string                 `json:"detail_fetched_at,omitempty"`
-	DetailLoaded       bool                    `json:"detail_loaded"`
-	Labels             *[]Label                `json:"labels,omitempty"`
-	PlatformHost       string                  `json:"platform_host"`
-	Repo               RepoRefResponse         `json:"repo"`
-	RepoName           string                  `json:"repo_name"`
-	RepoOwner          string                  `json:"repo_owner"`
-	WorktreeLinks      *[]WorktreeLinkResponse `json:"worktree_links"`
+	Additions          int64                            `json:"Additions"`
+	Author             string                           `json:"Author"`
+	AuthorDisplayName  string                           `json:"AuthorDisplayName"`
+	BaseBranch         string                           `json:"BaseBranch"`
+	Body               string                           `json:"Body"`
+	CIChecksJSON       string                           `json:"CIChecksJSON"`
+	CIHadPending       bool                             `json:"CIHadPending"`
+	CIStatus           string                           `json:"CIStatus"`
+	ClosedAt           *time.Time                       `json:"ClosedAt"`
+	CommentCount       int64                            `json:"CommentCount"`
+	CreatedAt          time.Time                        `json:"CreatedAt"`
+	Deletions          int64                            `json:"Deletions"`
+	HeadBranch         string                           `json:"HeadBranch"`
+	HeadRepoCloneURL   string                           `json:"HeadRepoCloneURL"`
+	ID                 int64                            `json:"ID"`
+	IsDraft            bool                             `json:"IsDraft"`
+	IsLocked           bool                             `json:"IsLocked"`
+	KanbanStatus       MergeRequestResponseKanbanStatus `json:"KanbanStatus"`
+	LastActivityAt     time.Time                        `json:"LastActivityAt"`
+	MergeableState     string                           `json:"MergeableState"`
+	MergedAt           *time.Time                       `json:"MergedAt"`
+	Number             int64                            `json:"Number"`
+	PlatformExternalID string                           `json:"PlatformExternalID"`
+	PlatformID         int64                            `json:"PlatformID"`
+	RepoID             int64                            `json:"RepoID"`
+	ReviewDecision     string                           `json:"ReviewDecision"`
+	Starred            bool                             `json:"Starred"`
+	State              MergeRequestResponseState        `json:"State"`
+	Title              string                           `json:"Title"`
+	URL                string                           `json:"URL"`
+	UpdatedAt          time.Time                        `json:"UpdatedAt"`
+	DetailFetchedAt    *string                          `json:"detail_fetched_at,omitempty"`
+	DetailLoaded       bool                             `json:"detail_loaded"`
+	Labels             *[]Label                         `json:"labels,omitempty"`
+	PlatformHost       string                           `json:"platform_host"`
+	Repo               RepoRefResponse                  `json:"repo"`
+	RepoName           string                           `json:"repo_name"`
+	RepoOwner          string                           `json:"repo_owner"`
+	WorktreeLinks      *[]WorktreeLinkResponse          `json:"worktree_links"`
 }
+
+// MergeRequestResponseKanbanStatus defines model for MergeRequestResponse.KanbanStatus.
+type MergeRequestResponseKanbanStatus string
+
+// MergeRequestResponseState defines model for MergeRequestResponse.State.
+type MergeRequestResponseState string
 
 // MrImportMetadataResponse defines model for MrImportMetadataResponse.
 type MrImportMetadataResponse struct {

--- a/internal/db/fixtures_test.go
+++ b/internal/db/fixtures_test.go
@@ -55,7 +55,7 @@ func withMRBranches(head, base string) testMROpt {
 	}
 }
 
-func withMRState(state string) testMROpt {
+func withMRState(state MergeRequestState) testMROpt {
 	return func(mr *MergeRequest) { mr.State = state }
 }
 

--- a/internal/db/queries_stacks_test.go
+++ b/internal/db/queries_stacks_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func insertTestMRWithBranches(t *testing.T, d *DB, repoID int64, number int, head, base, state string) int64 {
+func insertTestMRWithBranches(t *testing.T, d *DB, repoID int64, number int, head, base string, state MergeRequestState) int64 {
 	t.Helper()
 	return insertTestMRWithOptions(t, d, testMR(repoID, number, withMRTitle("PR "+head), withMRBranches(head, base), withMRState(state)))
 }
@@ -18,11 +18,11 @@ func TestListPRsForStackDetection(t *testing.T) {
 	repoID := insertTestRepo(t, d, "org", "repo")
 
 	// open PR — included
-	insertTestMRWithBranches(t, d, repoID, 1, "feature/a", "main", "open")
+	insertTestMRWithBranches(t, d, repoID, 1, "feature/a", "main", MergeRequestStateOpen)
 	// merged PR — included
-	insertTestMRWithBranches(t, d, repoID, 2, "feature/b", "feature/a", "merged")
+	insertTestMRWithBranches(t, d, repoID, 2, "feature/b", "feature/a", MergeRequestStateMerged)
 	// closed PR — excluded
-	insertTestMRWithBranches(t, d, repoID, 3, "feature/c", "main", "closed")
+	insertTestMRWithBranches(t, d, repoID, 3, "feature/c", "main", MergeRequestStateClosed)
 
 	prs, err := d.ListPRsForStackDetection(t.Context(), repoID)
 	require.NoError(t, err)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2166,7 +2166,7 @@ func TestListPullRequestsFilterByKanban(t *testing.T) {
 	require.NoError(err)
 	require.Len(prs, 1)
 	assert.Equal(2, prs[0].Number)
-	assert.Equal("reviewing", prs[0].KanbanStatus)
+	assert.Equal(KanbanStatusReviewing, prs[0].KanbanStatus)
 }
 
 func TestListMergeRequests_AttachesLabels(t *testing.T) {
@@ -2984,7 +2984,7 @@ func TestUpdatePRState(t *testing.T) {
 	pr, err := d.GetMergeRequest(ctx, "o", "r", 1)
 	require.NoError(err)
 	require.NotNil(pr)
-	assert.Equal("merged", pr.State)
+	assert.Equal(MergeRequestStateMerged, pr.State)
 	require.NotNil(pr.MergedAt)
 	assert.True(pr.MergedAt.Equal(mergedAt))
 }

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -143,7 +143,7 @@ type MergeRequest struct {
 	Title              string
 	Author             string
 	AuthorDisplayName  string
-	State              string
+	State              MergeRequestState `enum:"open,closed,merged"`
 	IsDraft            bool
 	IsLocked           bool
 	Body               string
@@ -175,14 +175,31 @@ type MergeRequest struct {
 	// only when WorkflowApprovalHeadSHA matches PlatformHeadSHA. Only
 	// providers that surface a workflow-approval concept populate
 	// these columns; others leave them zero.
-	WorkflowApprovalCheckedAt *time.Time `json:"-"`
-	WorkflowApprovalHeadSHA   string     `json:"-"`
-	WorkflowApprovalRequired  bool       `json:"-"`
-	WorkflowApprovalCount     int        `json:"-"`
-	KanbanStatus              string
+	WorkflowApprovalCheckedAt *time.Time   `json:"-"`
+	WorkflowApprovalHeadSHA   string       `json:"-"`
+	WorkflowApprovalRequired  bool         `json:"-"`
+	WorkflowApprovalCount     int          `json:"-"`
+	KanbanStatus              KanbanStatus `enum:"new,reviewing,waiting,awaiting_merge"`
 	Starred                   bool
 	Labels                    []Label `json:"labels,omitempty"`
 }
+
+type MergeRequestState string
+
+const (
+	MergeRequestStateOpen   MergeRequestState = "open"
+	MergeRequestStateClosed MergeRequestState = "closed"
+	MergeRequestStateMerged MergeRequestState = "merged"
+)
+
+type KanbanStatus string
+
+const (
+	KanbanStatusNew           KanbanStatus = "new"
+	KanbanStatusReviewing     KanbanStatus = "reviewing"
+	KanbanStatusWaiting       KanbanStatus = "waiting"
+	KanbanStatusAwaitingMerge KanbanStatus = "awaiting_merge"
+)
 
 func (mr MergeRequest) Compare(other MergeRequest) int {
 	return cmp.Compare(mr.Number, other.Number)

--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -347,7 +347,7 @@ func TestSyncOpenToMergedTransition(t *testing.T) {
 	pr, err := d.GetMergeRequest(ctx, "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(pr)
-	assert.Equal("open", pr.State)
+	assert.Equal(db.MergeRequestStateOpen, pr.State)
 
 	// Verify diff SHAs were computed during open-state sync.
 	shasBeforeMerge, err := d.GetDiffSHAs(ctx, "owner", "repo", number)
@@ -608,7 +608,7 @@ func TestSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	mr, err := d.GetMergeRequest(ctx, "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(mr)
-	assert.Equal("merged", mr.State, "PR state should be persisted")
+	assert.Equal(db.MergeRequestStateMerged, mr.State, "PR state should be persisted")
 
 	// Diff SHAs are absent because rev-parse never found the merge commit.
 	shas, err := d.GetDiffSHAs(ctx, "owner", "repo", number)
@@ -706,5 +706,5 @@ func TestSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
 	mr, err := d.GetMergeRequest(ctx, "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(mr)
-	assert.Equal("merged", mr.State)
+	assert.Equal(db.MergeRequestStateMerged, mr.State)
 }

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -53,7 +53,7 @@ func NormalizePR(repoID int64, ghPR *gh.PullRequest) (*db.MergeRequest, error) {
 		Title:              platformMR.Title,
 		Author:             platformMR.Author,
 		AuthorDisplayName:  platformMR.AuthorDisplayName,
-		State:              platformMR.State,
+		State:              db.MergeRequestState(platformMR.State),
 		IsDraft:            platformMR.IsDraft,
 		IsLocked:           platformMR.IsLocked,
 		Body:               platformMR.Body,

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -74,7 +74,7 @@ func TestNormalizePR_OpenPR(t *testing.T) {
 	assert.Equal("https://github.com/owner/repo/pull/42", pr.URL)
 	assert.Equal("My PR", pr.Title)
 	assert.Equal("alice", pr.Author)
-	assert.Equal("open", pr.State)
+	assert.Equal(db.MergeRequestStateOpen, pr.State)
 	assert.False(pr.IsDraft)
 	assert.True(pr.IsLocked)
 	assert.Equal("description", pr.Body)
@@ -104,7 +104,7 @@ func TestNormalizePR_MergedPR(t *testing.T) {
 	pr, err := NormalizePR(3, ghPR)
 	require.NoError(t, err)
 
-	assert.Equal("merged", pr.State)
+	assert.Equal(db.MergeRequestStateMerged, pr.State)
 	require.NotNil(t, pr.MergedAt)
 	assert.True(pr.MergedAt.Equal(mergedAt))
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4456,7 +4456,7 @@ func (s *Syncer) refreshWorkflowApproval(
 	case ghPR != nil:
 		state = ghPR.GetState()
 	case normalized != nil:
-		state = normalized.State
+		state = string(normalized.State)
 	}
 	if state != "open" {
 		return

--- a/internal/platform/persist.go
+++ b/internal/platform/persist.go
@@ -35,7 +35,7 @@ func DBMergeRequest(repoID int64, mr MergeRequest) *db.MergeRequest {
 		Title:              mr.Title,
 		Author:             mr.Author,
 		AuthorDisplayName:  mr.AuthorDisplayName,
-		State:              mr.State,
+		State:              db.MergeRequestState(mr.State),
 		IsDraft:            mr.IsDraft,
 		IsLocked:           mr.IsLocked,
 		Body:               mr.Body,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1022,7 +1022,7 @@ func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
 
 	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
 	require.NoError(err)
-	require.Equal("merged", pr.State)
+	require.Equal(db.MergeRequestStateMerged, pr.State)
 	assertTimePtrEqualsUTC(t, pr.MergedAt, handlerNow)
 	assertTimePtrEqualsUTC(t, pr.ClosedAt, handlerNow)
 }
@@ -2465,7 +2465,7 @@ func TestAPISetKanbanState(t *testing.T) {
 	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
-	require.Equal("reviewing", pr.KanbanStatus)
+	require.Equal(db.KanbanStatusReviewing, pr.KanbanStatus)
 }
 
 func TestAPISetKanbanStateRejectsInvalidStatus(t *testing.T) {
@@ -3980,7 +3980,7 @@ func TestAPIMergePRRejectsNilProviderPayload(t *testing.T) {
 	mr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(mr)
-	assert.Equal("open", mr.State)
+	assert.Equal(db.MergeRequestStateOpen, mr.State)
 	assert.Nil(mr.MergedAt)
 }
 
@@ -4760,7 +4760,7 @@ func TestAPIClosePR(t *testing.T) {
 
 	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
 	require.NoError(err)
-	require.Equal("closed", pr.State)
+	require.Equal(db.MergeRequestStateClosed, pr.State)
 	assertTimePtrEqualsUTC(t, pr.ClosedAt, handlerNow)
 }
 
@@ -4786,7 +4786,7 @@ func TestAPIReopenPR(t *testing.T) {
 
 	pr, err := database.GetMergeRequest(ctx, "acme", "widget", 1)
 	require.NoError(err)
-	require.Equal("open", pr.State)
+	require.Equal(db.MergeRequestStateOpen, pr.State)
 	require.Nil(pr.ClosedAt, "closed_at should be cleared on reopen")
 }
 
@@ -4930,7 +4930,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 
 	closedPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
 	require.NoError(err)
-	require.Equal("closed", closedPR.State)
+	require.Equal(db.MergeRequestStateClosed, closedPR.State)
 	require.NotNil(closedPR.ClosedAt)
 
 	close(releaseSync)
@@ -4949,7 +4949,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 
 	finalPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
 	require.NoError(err)
-	assert.Equal("closed", finalPR.State)
+	assert.Equal(db.MergeRequestStateClosed, finalPR.State)
 	assert.NotNil(finalPR.ClosedAt)
 	assert.Equal("Test PR #1", finalPR.Title)
 	assert.True(finalPR.UpdatedAt.After(staleUpdatedAt))
@@ -5698,7 +5698,7 @@ func TestAPIListPullsReportsBackfilledMergedPRFromMergedAt(t *testing.T) {
 	apiPR := (*resp.JSON200)[0]
 	assert.Equal(int64(number), apiPR.Number)
 	assert.Equal(title, apiPR.Title)
-	assert.Equal("merged", apiPR.State)
+	assert.Equal(generated.MergeRequestResponseStateMerged, apiPR.State)
 	require.NotNil(apiPR.MergedAt)
 	assert.True(apiPR.MergedAt.Equal(mergedAt))
 }
@@ -8123,7 +8123,7 @@ func TestAPIClosePR422AlreadyClosed(t *testing.T) {
 	require.Equal(http.StatusOK, resp.StatusCode())
 
 	pr, _ := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
-	require.Equal("closed", pr.State)
+	require.Equal(db.MergeRequestStateClosed, pr.State)
 }
 
 // When MarkPullRequestReadyForReview returns (nil, nil) the handler
@@ -9310,7 +9310,7 @@ func TestAPIGitealikeMutationsPersistThroughServer(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, mergeResp.StatusCode())
 	mrSeven = requireMR(t, database, repo.ID, 7)
-	assert.Equal("merged", mrSeven.State)
+	assert.Equal(db.MergeRequestStateMerged, mrSeven.State)
 	require.NotNil(mrSeven.MergedAt)
 
 	stateResp, err := client.HTTP.SetPrGithubStateOnHostWithResponse(
@@ -9320,7 +9320,7 @@ func TestAPIGitealikeMutationsPersistThroughServer(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, stateResp.StatusCode())
 	mrNine := requireMR(t, database, repo.ID, 9)
-	assert.Equal("closed", mrNine.State)
+	assert.Equal(db.MergeRequestStateClosed, mrNine.State)
 	require.NotNil(mrNine.ClosedAt)
 
 	createIssueResp, err := client.HTTP.CreateIssueOnHostWithResponse(
@@ -11857,7 +11857,7 @@ func TestAPIListActivityFiltersConfiguredReposByHost(t *testing.T) {
 func seedStackedPR(
 	t *testing.T, database *db.DB,
 	owner, name string, number int,
-	head, base, state, ci, review string,
+	head, base string, state db.MergeRequestState, ci, review string,
 ) int64 {
 	return seedStackedPRDraft(t, database, owner, name, number, head, base, state, ci, review, false)
 }
@@ -11865,7 +11865,7 @@ func seedStackedPR(
 func seedStackedPRDraft(
 	t *testing.T, database *db.DB,
 	owner, name string, number int,
-	head, base, state, ci, review string,
+	head, base string, state db.MergeRequestState, ci, review string,
 	isDraft bool,
 ) int64 {
 	t.Helper()
@@ -11910,9 +11910,9 @@ func TestAPIListStacks(t *testing.T) {
 	srv, database := setupTestServer(t)
 	client := setupTestClient(t, srv)
 
-	seedStackedPR(t, database, "acme", "widget", 10, "feat/auth", "main", "open", "success", "APPROVED")
-	seedStackedPR(t, database, "acme", "widget", 11, "feat/auth-retry", "feat/auth", "open", "success", "APPROVED")
-	seedStackedPR(t, database, "acme", "widget", 12, "feat/auth-ui", "feat/auth-retry", "open", "pending", "")
+	seedStackedPR(t, database, "acme", "widget", 10, "feat/auth", "main", db.MergeRequestStateOpen, "success", "APPROVED")
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/auth-retry", "feat/auth", db.MergeRequestStateOpen, "success", "APPROVED")
+	seedStackedPR(t, database, "acme", "widget", 12, "feat/auth-ui", "feat/auth-retry", db.MergeRequestStateOpen, "pending", "")
 	runStackDetection(t, database, "acme", "widget")
 
 	resp, err := client.HTTP.ListStacksWithResponse(t.Context(), &generated.ListStacksParams{})
@@ -11939,12 +11939,12 @@ func TestAPIListStacks_RepoFilter(t *testing.T) {
 	client := setupTestClient(t, srv)
 	ctx := t.Context()
 
-	seedStackedPR(t, database, "acme", "widget", 10, "feat/a", "main", "open", "", "")
-	seedStackedPR(t, database, "acme", "widget", 11, "feat/b", "feat/a", "open", "", "")
+	seedStackedPR(t, database, "acme", "widget", 10, "feat/a", "main", db.MergeRequestStateOpen, "", "")
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/b", "feat/a", db.MergeRequestStateOpen, "", "")
 	runStackDetection(t, database, "acme", "widget")
 
-	seedStackedPR(t, database, "acme", "tools", 20, "feat/c", "main", "open", "", "")
-	seedStackedPR(t, database, "acme", "tools", 21, "feat/d", "feat/c", "open", "", "")
+	seedStackedPR(t, database, "acme", "tools", 20, "feat/c", "main", db.MergeRequestStateOpen, "", "")
+	seedStackedPR(t, database, "acme", "tools", 21, "feat/d", "feat/c", db.MergeRequestStateOpen, "", "")
 	runStackDetection(t, database, "acme", "tools")
 
 	respAll, err := client.HTTP.ListStacksWithResponse(ctx, &generated.ListStacksParams{})
@@ -11977,8 +11977,8 @@ func TestAPIGetStackForPR(t *testing.T) {
 	ctx := t.Context()
 
 	// Failing base with an open descendant is blocked.
-	seedStackedPR(t, database, "acme", "widget", 10, "feat/api-base", "main", "open", "failure", "")
-	seedStackedPR(t, database, "acme", "widget", 11, "feat/api-retry", "feat/api-base", "open", "success", "APPROVED")
+	seedStackedPR(t, database, "acme", "widget", 10, "feat/api-base", "main", db.MergeRequestStateOpen, "failure", "")
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/api-retry", "feat/api-base", db.MergeRequestStateOpen, "success", "APPROVED")
 	runStackDetection(t, database, "acme", "widget")
 
 	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx, "gh", "acme", "widget", 10)
@@ -12001,8 +12001,8 @@ func TestAPIGetStackForPR_DraftNotBaseReady(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	// Draft base with green CI + approval; non-draft tip pending.
-	seedStackedPRDraft(t, database, "acme", "widget", 10, "feat/x", "main", "open", "success", "APPROVED", true)
-	seedStackedPR(t, database, "acme", "widget", 11, "feat/y", "feat/x", "open", "pending", "")
+	seedStackedPRDraft(t, database, "acme", "widget", 10, "feat/x", "main", db.MergeRequestStateOpen, "success", "APPROVED", true)
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/y", "feat/x", db.MergeRequestStateOpen, "pending", "")
 	runStackDetection(t, database, "acme", "widget")
 
 	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(t.Context(), "gh", "acme", "widget", 10)
@@ -12020,8 +12020,8 @@ func TestAPIListStacks_DraftNotAllGreen(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	// Both draft, green CI + approved — must not be all_green.
-	seedStackedPRDraft(t, database, "acme", "widget", 10, "feat/a", "main", "open", "success", "APPROVED", true)
-	seedStackedPRDraft(t, database, "acme", "widget", 11, "feat/b", "feat/a", "open", "success", "APPROVED", true)
+	seedStackedPRDraft(t, database, "acme", "widget", 10, "feat/a", "main", db.MergeRequestStateOpen, "success", "APPROVED", true)
+	seedStackedPRDraft(t, database, "acme", "widget", 11, "feat/b", "feat/a", db.MergeRequestStateOpen, "success", "APPROVED", true)
 	runStackDetection(t, database, "acme", "widget")
 
 	resp, err := client.HTTP.ListStacksWithResponse(t.Context(), &generated.ListStacksParams{})
@@ -12106,8 +12106,8 @@ func TestAPIGetStackForPR_SingleFailingIsInProgress(t *testing.T) {
 
 	// 2-PR chain where tip is failing but has no descendants.
 	// Per blocked semantics, this is partial_merge when base is merged.
-	seedStackedPR(t, database, "acme", "widget", 10, "feat/base", "main", "merged", "success", "APPROVED")
-	seedStackedPR(t, database, "acme", "widget", 11, "feat/tip", "feat/base", "open", "failure", "")
+	seedStackedPR(t, database, "acme", "widget", 10, "feat/base", "main", db.MergeRequestStateMerged, "success", "APPROVED")
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/tip", "feat/base", db.MergeRequestStateOpen, "failure", "")
 	runStackDetection(t, database, "acme", "widget")
 
 	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(t.Context(), "gh", "acme", "widget", 11)
@@ -12125,8 +12125,8 @@ func TestAPIGetStackForPR_BaseBranchNotMain(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	// Base PR targets "master" not "main" — API must return real base_branch.
-	seedStackedPR(t, database, "acme", "widget", 10, "feat/base", "master", "open", "success", "APPROVED")
-	seedStackedPR(t, database, "acme", "widget", 11, "feat/tip", "feat/base", "open", "pending", "")
+	seedStackedPR(t, database, "acme", "widget", 10, "feat/base", "master", db.MergeRequestStateOpen, "success", "APPROVED")
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/tip", "feat/base", db.MergeRequestStateOpen, "pending", "")
 	runStackDetection(t, database, "acme", "widget")
 
 	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(t.Context(), "gh", "acme", "widget", 10)
@@ -17608,7 +17608,7 @@ func TestAPIEditPRPreservesDerivedFields(t *testing.T) {
 	require.Equal(7, after.CommentCount)
 	require.Equal("success", after.CIStatus)
 	require.Equal("APPROVED", after.ReviewDecision)
-	require.Equal("open", after.State)
+	require.Equal(db.MergeRequestStateOpen, after.State)
 }
 
 // --- edit-issue-content (PATCH) tests ---

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -851,7 +851,7 @@ func (s *Server) diffWarnings(mr *db.MergeRequest) []string {
 		PlatformBaseSHA: mr.PlatformBaseSHA,
 		DiffHeadSHA:     mr.DiffHeadSHA,
 		DiffBaseSHA:     mr.DiffBaseSHA,
-		State:           mr.State,
+		State:           string(mr.State),
 	}
 	if shas.Stale() {
 		return []string{"Diff data is out of date for this pull request."}
@@ -917,7 +917,7 @@ func (s *Server) getMRImportMetadata(
 			HeadBranch:       mr.HeadBranch,
 			PlatformHeadSHA:  mr.PlatformHeadSHA,
 			HeadRepoCloneURL: mr.HeadRepoCloneURL,
-			State:            mr.State,
+			State:            string(mr.State),
 			IsDraft:          mr.IsDraft,
 			Title:            mr.Title,
 		},

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
 
-func makePR(id int64, number int, head, base, state string) realdb.MergeRequest {
+const (
+	prOpen   = realdb.MergeRequestStateOpen
+	prMerged = realdb.MergeRequestStateMerged
+)
+
+func makePR(id int64, number int, head, base string, state realdb.MergeRequestState) realdb.MergeRequest {
 	return realdb.MergeRequest{
 		ID:         id,
 		Number:     number,
@@ -24,9 +29,9 @@ func makePR(id int64, number int, head, base, state string) realdb.MergeRequest 
 func TestDetectChains_LinearStack(t *testing.T) {
 	assert := Assert.New(t)
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "feature/auth-token", "main", "open"),
-		makePR(2, 101, "feature/auth-retry", "feature/auth-token", "open"),
-		makePR(3, 102, "feature/auth-ui", "feature/auth-retry", "open"),
+		makePR(1, 100, "feature/auth-token", "main", prOpen),
+		makePR(2, 101, "feature/auth-retry", "feature/auth-token", prOpen),
+		makePR(3, 102, "feature/auth-ui", "feature/auth-retry", prOpen),
 	}
 
 	chains := DetectChains(prs)
@@ -40,7 +45,7 @@ func TestDetectChains_LinearStack(t *testing.T) {
 func TestDetectChains_SinglePRNotAStack(t *testing.T) {
 	assert := Assert.New(t)
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "feature/solo", "main", "open"),
+		makePR(1, 100, "feature/solo", "main", prOpen),
 	}
 	chains := DetectChains(prs)
 	assert.Empty(chains)
@@ -49,9 +54,9 @@ func TestDetectChains_SinglePRNotAStack(t *testing.T) {
 func TestDetectChains_ForkPicksLowestNumber(t *testing.T) {
 	assert := Assert.New(t)
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "feature/base", "main", "open"),
-		makePR(2, 102, "feature/child-b", "feature/base", "open"),
-		makePR(3, 101, "feature/child-a", "feature/base", "open"),
+		makePR(1, 100, "feature/base", "main", prOpen),
+		makePR(2, 102, "feature/child-b", "feature/base", prOpen),
+		makePR(3, 101, "feature/child-a", "feature/base", prOpen),
 	}
 
 	chains := DetectChains(prs)
@@ -64,8 +69,8 @@ func TestDetectChains_ForkPicksLowestNumber(t *testing.T) {
 func TestDetectChains_CycleSkipped(t *testing.T) {
 	assert := Assert.New(t)
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "branch-a", "branch-b", "open"),
-		makePR(2, 101, "branch-b", "branch-a", "open"),
+		makePR(1, 100, "branch-a", "branch-b", prOpen),
+		makePR(2, 101, "branch-b", "branch-a", prOpen),
 	}
 	chains := DetectChains(prs)
 	assert.Empty(chains)
@@ -74,8 +79,8 @@ func TestDetectChains_CycleSkipped(t *testing.T) {
 func TestDetectChains_PartialMerge(t *testing.T) {
 	assert := Assert.New(t)
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "feature/a", "main", "merged"),
-		makePR(2, 101, "feature/b", "feature/a", "open"),
+		makePR(1, 100, "feature/a", "main", prMerged),
+		makePR(2, 101, "feature/b", "feature/a", prOpen),
 	}
 	chains := DetectChains(prs)
 	assert.Len(chains, 1)
@@ -87,9 +92,9 @@ func TestDetectChains_DuplicateHeadPrefersOpen(t *testing.T) {
 	// Merged PR and open PR share same head branch.
 	// Open PR should be preferred for chain building.
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "feature/auth", "main", "merged"),
-		makePR(2, 101, "feature/auth-ui", "feature/auth", "open"),
-		makePR(3, 200, "feature/auth", "main", "open"),
+		makePR(1, 100, "feature/auth", "main", prMerged),
+		makePR(2, 101, "feature/auth-ui", "feature/auth", prOpen),
+		makePR(3, 200, "feature/auth", "main", prOpen),
 	}
 
 	chains := DetectChains(prs)
@@ -105,9 +110,9 @@ func TestDetectChains_ForkPrefersOpenOverMerged(t *testing.T) {
 	// A -> B (merged, lower number) and A -> C (open, higher number).
 	// Should follow A -> C since C is open.
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "feature/base", "main", "open"),
-		makePR(2, 101, "feature/child-merged", "feature/base", "merged"),
-		makePR(3, 102, "feature/child-open", "feature/base", "open"),
+		makePR(1, 100, "feature/base", "main", prOpen),
+		makePR(2, 101, "feature/child-merged", "feature/base", prMerged),
+		makePR(3, 102, "feature/child-open", "feature/base", prOpen),
 	}
 
 	chains := DetectChains(prs)
@@ -121,8 +126,8 @@ func TestDetectChains_FullyMergedNotAStack(t *testing.T) {
 	assert := Assert.New(t)
 	// All PRs merged — should still detect the chain structure.
 	prs := []realdb.MergeRequest{
-		makePR(1, 100, "feature/a", "main", "merged"),
-		makePR(2, 101, "feature/b", "feature/a", "merged"),
+		makePR(1, 100, "feature/a", "main", prMerged),
+		makePR(2, 101, "feature/b", "feature/a", prMerged),
 	}
 	chains := DetectChains(prs)
 	// Chain exists but all merged — RunDetection filters these out.
@@ -134,20 +139,20 @@ func TestDeriveStackName(t *testing.T) {
 
 	// Common prefix on token boundary
 	assert.Equal("auth", DeriveStackName([]realdb.MergeRequest{
-		makePR(1, 1, "feature/auth-fix", "main", "open"),
-		makePR(2, 2, "feature/auth-retry", "feature/auth-fix", "open"),
+		makePR(1, 1, "feature/auth-fix", "main", prOpen),
+		makePR(2, 2, "feature/auth-retry", "feature/auth-fix", prOpen),
 	}))
 
 	// No common prefix -- falls back to base PR title
 	assert.Equal("PR branch-x", DeriveStackName([]realdb.MergeRequest{
-		makePR(1, 1, "branch-x", "main", "open"),
-		makePR(2, 2, "other-y", "branch-x", "open"),
+		makePR(1, 1, "branch-x", "main", prOpen),
+		makePR(2, 2, "other-y", "branch-x", prOpen),
 	}))
 
 	// Partial word boundary rejected
 	assert.Equal("PR feature/authorization", DeriveStackName([]realdb.MergeRequest{
-		makePR(1, 1, "feature/authorization", "main", "open"),
-		makePR(2, 2, "feature/authorizer", "feature/authorization", "open"),
+		makePR(1, 1, "feature/authorization", "main", prOpen),
+		makePR(2, 2, "feature/authorizer", "feature/authorization", prOpen),
 	}))
 }
 

--- a/middleman.go
+++ b/middleman.go
@@ -29,6 +29,14 @@ type (
 	RepoRef      = server.RepoRef
 	WorktreeLink = db.WorktreeLink
 	WatchedMR    = ghclient.WatchedMR
+
+	MergeRequestState = db.MergeRequestState
+)
+
+const (
+	MergeRequestStateOpen   = db.MergeRequestStateOpen
+	MergeRequestStateClosed = db.MergeRequestStateClosed
+	MergeRequestStateMerged = db.MergeRequestStateMerged
 )
 
 // Repo identifies a GitHub repository to monitor.
@@ -121,7 +129,7 @@ type MergeRequestSummary struct {
 	RepoOwner      string
 	RepoName       string
 	Number         int
-	State          string
+	State          MergeRequestState
 	Title          string
 	IsDraft        bool
 	CIStatus       string
@@ -368,7 +376,7 @@ func NewWithContext(
 						RepoOwner:      owner,
 						RepoName:       name,
 						Number:         mr.Number,
-						State:          string(mr.State),
+						State:          mr.State,
 						Title:          mr.Title,
 						IsDraft:        mr.IsDraft,
 						CIStatus:       mr.CIStatus,

--- a/middleman.go
+++ b/middleman.go
@@ -368,7 +368,7 @@ func NewWithContext(
 						RepoOwner:      owner,
 						RepoName:       name,
 						Number:         mr.Number,
-						State:          mr.State,
+						State:          string(mr.State),
 						Title:          mr.Title,
 						IsDraft:        mr.IsDraft,
 						CIStatus:       mr.CIStatus,

--- a/middleman_test.go
+++ b/middleman_test.go
@@ -41,6 +41,16 @@ func TestNewReturnsWorkingHandler(t *testing.T) {
 	Assert.Contains(t, rr.Body.String(), `window.__BASE_PATH__="/middleman/"`)
 }
 
+func TestMergeRequestSummaryUsesTypedState(t *testing.T) {
+	summary := MergeRequestSummary{State: MergeRequestStateOpen}
+
+	Assert.Equal(t, MergeRequestStateOpen, requireMergeRequestState(summary.State))
+}
+
+func requireMergeRequestState(state MergeRequestState) MergeRequestState {
+	return state
+}
+
 func TestNewEmbeddedBootstrapGlobals(t *testing.T) {
 	frontend := fstest.MapFS{
 		"index.html": &fstest.MapFile{

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2277,7 +2277,8 @@ export interface components {
             ID: number;
             IsDraft: boolean;
             IsLocked: boolean;
-            KanbanStatus: string;
+            /** @enum {string} */
+            KanbanStatus: "new" | "reviewing" | "waiting" | "awaiting_merge";
             /** Format: date-time */
             LastActivityAt: string;
             MergeableState: string;
@@ -2292,7 +2293,8 @@ export interface components {
             RepoID: number;
             ReviewDecision: string;
             Starred: boolean;
-            State: string;
+            /** @enum {string} */
+            State: "open" | "closed" | "merged";
             Title: string;
             URL: string;
             /** Format: date-time */
@@ -2347,7 +2349,8 @@ export interface components {
             ID: number;
             IsDraft: boolean;
             IsLocked: boolean;
-            KanbanStatus: string;
+            /** @enum {string} */
+            KanbanStatus: "new" | "reviewing" | "waiting" | "awaiting_merge";
             /** Format: date-time */
             LastActivityAt: string;
             MergeableState: string;
@@ -2362,7 +2365,8 @@ export interface components {
             RepoID: number;
             ReviewDecision: string;
             Starred: boolean;
-            State: string;
+            /** @enum {string} */
+            State: "open" | "closed" | "merged";
             Title: string;
             URL: string;
             /** Format: date-time */

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -49,7 +49,8 @@ export type IssueLabel = Label;
 export type RepoLabelsResponse = components["schemas"]["RepoLabelsResponse"];
 export type ItemLabelsResponse = components["schemas"]["ItemLabelsResponse"];
 
-export type KanbanStatus = "new" | "reviewing" | "waiting" | "awaiting_merge";
+export type KanbanStatus = PullRequest["KanbanStatus"];
+export type MergeRequestState = PullRequest["State"];
 
 export interface CICheck {
   name: string;

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -5,6 +5,7 @@
     KanbanStatus,
     Label,
     ProviderCapabilities,
+    PullRequest,
   } from "../../api/types.js";
   import type { DetailSyncMode } from "../../stores/detail.svelte.js";
   import {
@@ -593,13 +594,13 @@
   }
 
   function hasMergeConflicts(
-    pr: { State: string; MergeableState: string },
+    pr: Pick<PullRequest, "State" | "MergeableState">,
   ): boolean {
     return pr.State === "open" && pr.MergeableState === "dirty";
   }
 
   function buildOpenMergeInput(
-    pr: { State: string; IsDraft: boolean; MergeableState: string },
+    pr: Pick<PullRequest, "State" | "IsDraft" | "MergeableState">,
     capabilities: ProviderCapabilities,
   ): PRDetailActionInput {
     return {

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -57,6 +57,7 @@
 
   const statusLabel = $derived(kanbanLabels[pr.KanbanStatus] ?? pr.KanbanStatus);
   const statusClass = $derived(`status-chip--${pr.KanbanStatus.replace("_", "-")}`);
+  const showStatus = $derived(pr.State !== "closed" && pr.State !== "merged");
   const ago = $derived(timeAgo(pr.LastActivityAt));
   const hasWorktree = $derived(
     (pr.worktree_links?.length ?? 0) > 0,
@@ -209,7 +210,7 @@
           </svg>
         {/if}
       </span>
-      {#if statusLabel}
+      {#if showStatus && statusLabel}
         <Chip size="sm" class={`status-chip ${statusClass}`}>{statusLabel}</Chip>
       {/if}
       <span class="time">{ago}</span>

--- a/packages/ui/src/components/sidebar/PullItem.test.ts
+++ b/packages/ui/src/components/sidebar/PullItem.test.ts
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { PullRequest } from "../../api/types.js";
+import PullItem from "./PullItem.svelte";
+
+vi.mock("../../context.js", () => ({
+  getStores: () => ({
+    pulls: {
+      togglePRStar: vi.fn(),
+    },
+  }),
+  getHostState: () => ({}),
+}));
+
+function pr(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    ID: 1,
+    Number: 1,
+    Title: "Cache widget details",
+    Author: "alice",
+    State: "open",
+    IsDraft: false,
+    KanbanStatus: "reviewing",
+    LastActivityAt: "2026-05-01T12:00:00Z",
+    CIStatus: "",
+    MergeableState: "",
+    Starred: false,
+    labels: [],
+    repo_owner: "acme",
+    repo_name: "widgets",
+    repo: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repo_path: "acme/widgets",
+    },
+    worktree_links: [],
+    ...overrides,
+  } as PullRequest;
+}
+
+describe("PullItem", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the kanban status for open PRs", () => {
+    render(PullItem, {
+      props: {
+        pr: pr(),
+        selected: false,
+        showRepo: false,
+        onclick: vi.fn(),
+      },
+    });
+
+    expect(screen.getByText("Reviewing")).toBeTruthy();
+  });
+
+  it("hides the kanban status for closed and merged PRs", () => {
+    const { rerender } = render(PullItem, {
+      props: {
+        pr: pr({ State: "closed" }),
+        selected: false,
+        showRepo: false,
+        onclick: vi.fn(),
+      },
+    });
+
+    expect(screen.queryByText("Reviewing")).toBeNull();
+
+    rerender({
+      pr: pr({ State: "merged", KanbanStatus: "awaiting_merge" }),
+      selected: false,
+      showRepo: false,
+      onclick: vi.fn(),
+    });
+
+    expect(screen.queryByText("Ready")).toBeNull();
+  });
+});

--- a/packages/ui/src/stores/workflow.svelte.test.ts
+++ b/packages/ui/src/stores/workflow.svelte.test.ts
@@ -11,11 +11,12 @@ function pr(
   kanbanStatus: string,
   lastActivityAt: string,
   worktreeLinks: PullRequest["worktree_links"] = [],
+  state: PullRequest["State"] = "open",
 ): PullRequest {
   return {
     ID: id,
     Number: id,
-    State: "open",
+    State: state,
     KanbanStatus: kanbanStatus,
     LastActivityAt: lastActivityAt,
     worktree_links: worktreeLinks,
@@ -54,5 +55,21 @@ describe("PR status grouping", () => {
       ["awaiting_merge", "Awaiting Merge"],
     ]);
     expect(groups[0]?.items.map((item) => item.ID)).toEqual([3]);
+  });
+
+  it("groups closed and merged PRs under Closed after open workflow groups", () => {
+    const groups = groupByWorkflow([
+      pr(1, "reviewing", "2026-01-01T00:00:00Z"),
+      pr(2, "awaiting_merge", "2026-01-03T00:00:00Z", [], "closed"),
+      pr(3, "waiting", "2026-01-04T00:00:00Z", [], "merged"),
+      pr(4, "waiting", "2026-01-02T00:00:00Z"),
+    ]);
+
+    expect(groups.map((group) => [group.group, group.label])).toEqual([
+      ["reviewing", "Reviewing"],
+      ["waiting", "Waiting"],
+      ["closed", "Closed"],
+    ]);
+    expect(groups.at(-1)?.items.map((item) => item.ID)).toEqual([3, 2]);
   });
 });

--- a/packages/ui/src/stores/workflow.svelte.ts
+++ b/packages/ui/src/stores/workflow.svelte.ts
@@ -1,12 +1,13 @@
 import type { KanbanStatus, PullRequest } from "../api/types.js";
 
-export type WorkflowGroup = KanbanStatus;
+export type WorkflowGroup = KanbanStatus | "closed";
 
 export const workflowGroupOrder: WorkflowGroup[] = [
   "new",
   "reviewing",
   "waiting",
   "awaiting_merge",
+  "closed",
 ];
 
 export const workflowGroupLabels: Record<
@@ -17,6 +18,7 @@ export const workflowGroupLabels: Record<
   reviewing: "Reviewing",
   waiting: "Waiting",
   awaiting_merge: "Awaiting Merge",
+  closed: "Closed",
 };
 
 export interface WorkflowGroupEntry {
@@ -46,6 +48,9 @@ function normalizeKanbanStatus(
  * metadata/actions and does not override the user's review status.
  */
 export function classifyPR(pr: PullRequest): WorkflowGroup {
+  if (pr.State === "closed" || pr.State === "merged") {
+    return "closed";
+  }
   return normalizeKanbanStatus(pr.KanbanStatus);
 }
 


### PR DESCRIPTION
- Hide kanban workflow chips for closed and merged PRs in the sidebar
- Group closed and merged PRs under Closed when Status grouping is selected
- Type merge request state and kanban status through generated API clients