### PR TITLE
fix: strip git hook env in test helpers

### DIFF
--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -17,26 +17,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitclone"
+	"github.com/wesm/middleman/internal/gitenv"
 )
 
 // gitRun runs a git command in the given dir and returns trimmed stdout.
-// It filters GIT_DIR, GIT_WORK_TREE, and GIT_INDEX_FILE from the
-// inherited environment so that pre-commit hooks (which set GIT_DIR to
-// the real repo) don't cause test git operations to mutate the host
-// repo's config.
+// It filters inherited GIT_* variables so that pre-commit hooks don't
+// cause test git operations to mutate the host repo's config.
 func gitRun(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "GIT_DIR=") ||
-			strings.HasPrefix(e, "GIT_WORK_TREE=") ||
-			strings.HasPrefix(e, "GIT_INDEX_FILE=") {
-			continue
-		}
-		cmd.Env = append(cmd.Env, e)
-	}
-	cmd.Env = append(cmd.Env,
+	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_AUTHOR_NAME=test",
 		"GIT_AUTHOR_EMAIL=test@test.com",
 		"GIT_COMMITTER_NAME=test",

--- a/internal/server/projects_handlers_test.go
+++ b/internal/server/projects_handlers_test.go
@@ -16,6 +16,7 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/gitenv"
 )
 
 // TestW1SliceAGate is the falsifiable capability gate from the convergence
@@ -751,11 +752,41 @@ func TestListProjects_ReturnsEmptyArrayNotNull(t *testing.T) {
 		"empty list must serialize as [] for embedder iteration safety")
 }
 
+func TestInitLocalOnlyGitRepoIgnoresInheritedGitEnv(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	host := t.TempDir()
+	initCmd := exec.Command("git", "init", "-q", "-b", "main", host)
+	initCmd.Env = gitenv.StripAll(os.Environ())
+	require.NoError(initCmd.Run(), "seed host repo")
+
+	hostConfig := filepath.Join(host, ".git", "config")
+	before, err := os.ReadFile(hostConfig)
+	require.NoError(err)
+
+	target := t.TempDir()
+	t.Setenv("GIT_DIR", filepath.Join(host, ".git"))
+	t.Setenv("GIT_WORK_TREE", target)
+
+	require.NoError(initLocalOnlyGitRepo(target))
+
+	after, err := os.ReadFile(hostConfig)
+	require.NoError(err)
+	assert.Equal(string(before), string(after),
+		"git init helper must not write core.worktree to inherited host config")
+	assert.FileExists(filepath.Join(target, ".git", "config"))
+}
+
 // initLocalOnlyGitRepo runs `git init` in dir without configuring any remote,
 // matching the no-`gh` Add Existing path.
 func initLocalOnlyGitRepo(dir string) error {
 	cmd := exec.Command("git", "init", "-q")
 	cmd.Dir = dir
+	cmd.Env = gitenv.StripAll(os.Environ())
 	if err := cmd.Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Strip inherited GIT_* variables from project registration test repo setup
- Add a regression test for host config contamination under hook-style Git env
- Normalize an older integration git helper to use shared Git env stripping

Validation:
- Simulated GIT_DIR/GIT_WORK_TREE hook env around TestInitLocalOnlyGitRepoIgnoresInheritedGitEnv
- Verified no core.worktree entry in simulated host or main repo config
- go test -tags integration ./internal/github -run TestComputeMergedPRDiffSHAs_MergeCommit -shuffle=on
- commit hooks, including go test (short)
