### PR TITLE
Filter lists by labels

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -12,15 +12,43 @@ import (
 // listSearchCondition returns a SQL condition and args for a free-text search.
 // The title is searched as "#{number} {title}" so substring queries can match
 // the number, the title, or both at once (e.g. "278" hits "#278 fix bug").
-// Author is matched separately. The alias is the table alias used in the
+// Author is matched separately. Labels are matched by name for list aliases
+// with item-label join tables. The alias is the table alias used in the
 // surrounding query (e.g. "p" for merge requests, "i" for issues).
 func listSearchCondition(alias, search string) (string, []any) {
 	like := "%" + search + "%"
+	labelCondition := ""
+	switch alias {
+	case "p":
+		labelCondition = fmt.Sprintf(
+			` OR EXISTS (
+				SELECT 1
+				FROM middleman_merge_request_labels mrl
+				JOIN middleman_labels l ON l.id = mrl.label_id
+				WHERE mrl.merge_request_id = %s.id AND l.name LIKE ?
+			)`,
+			alias,
+		)
+	case "i":
+		labelCondition = fmt.Sprintf(
+			` OR EXISTS (
+				SELECT 1
+				FROM middleman_issue_labels il
+				JOIN middleman_labels l ON l.id = il.label_id
+				WHERE il.issue_id = %s.id AND l.name LIKE ?
+			)`,
+			alias,
+		)
+	}
 	cond := fmt.Sprintf(
-		"(('#' || %s.number || ' ' || %s.title) LIKE ? OR %s.author LIKE ?)",
-		alias, alias, alias,
+		"(('#' || %s.number || ' ' || %s.title) LIKE ? OR %s.author LIKE ?%s)",
+		alias, alias, alias, labelCondition,
 	)
-	return cond, []any{like, like}
+	args := []any{like, like}
+	if labelCondition != "" {
+		args = append(args, like)
+	}
+	return cond, args
 }
 
 func sqlPlaceholders(count int) string {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2143,6 +2143,30 @@ func TestListPullRequestsFilterBySearchNumber(t *testing.T) {
 	require.Len(prs, 3)
 }
 
+func TestListPullRequestsFilterBySearchLabel(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+
+	insertTestMR(t, d, repoID, 1, "add feature", base)
+	prID := insertTestMR(t, d, repoID, 2, "fix bug", base.Add(time.Hour))
+	require.NoError(d.ReplaceMergeRequestLabels(ctx, repoID, prID, []Label{{
+		PlatformID: 200,
+		Name:       "needs-review",
+		Color:      "fbca04",
+		UpdatedAt:  base,
+	}}))
+
+	prs, err := d.ListMergeRequests(ctx, ListMergeRequestsOpts{Search: "needs-review"})
+	require.NoError(err)
+	require.Len(prs, 1)
+	assert.Equal(2, prs[0].Number)
+}
+
 func TestListPullRequestsFilterByKanban(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -3129,6 +3153,30 @@ func TestListIssuesFilterBySearch(t *testing.T) {
 	issues, err = d.ListIssues(t.Context(), ListIssuesOpts{Search: "2"})
 	require.NoError(err)
 	require.Len(issues, 3)
+}
+
+func TestListIssuesFilterBySearchLabel(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+
+	insertTestIssue(t, d, repoID, 12, "report a bug", base)
+	issueID := insertTestIssue(t, d, repoID, 278, "filter broken", base.Add(time.Hour))
+	require.NoError(d.ReplaceIssueLabels(ctx, repoID, issueID, []Label{{
+		PlatformID: 300,
+		Name:       "needs-triage",
+		Color:      "d73a4a",
+		UpdatedAt:  base,
+	}}))
+
+	issues, err := d.ListIssues(ctx, ListIssuesOpts{Search: "needs-triage"})
+	require.NoError(err)
+	require.Len(issues, 1)
+	assert.Equal(278, issues[0].Number)
 }
 
 func TestReplaceIssueLabels_RejectsWrongRepoID(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5551,8 +5551,16 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	ctx := t.Context()
 
 	seedPR(t, database, "acme", "widget", 12, withSeedPRTitle("add feature"))
-	seedPR(t, database, "acme", "widget", 278, withSeedPRTitle("fix bug"))
+	prID := seedPR(t, database, "acme", "widget", 278, withSeedPRTitle("fix bug"))
 	seedPR(t, database, "acme", "widget", 290, withSeedPRTitle("another change"))
+	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	require.NoError(err)
+	require.NoError(database.ReplaceMergeRequestLabels(ctx, repo.ID, prID, []db.Label{{
+		PlatformID: 200,
+		Name:       "needs-review",
+		Color:      "fbca04",
+		UpdatedAt:  time.Now().UTC(),
+	}}))
 
 	client := setupTestClient(t, srv)
 
@@ -5579,6 +5587,9 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	q = "fix"
 	assert.ElementsMatch([]int{278}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 
+	q = "needs-review"
+	assert.ElementsMatch([]int{278}, pullNumbers(&generated.ListPullsParams{Q: &q}))
+
 	// Substring of number matches multiple.
 	q = "2"
 	assert.ElementsMatch([]int{12, 278, 290}, pullNumbers(&generated.ListPullsParams{Q: &q}))
@@ -5591,8 +5602,16 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 	ctx := t.Context()
 
 	seedIssueOnHost(t, database, "github.com", "acme", "widget", 12, "open", "report a bug")
-	seedIssueOnHost(t, database, "github.com", "acme", "widget", 278, "open", "filter broken")
+	issueID := seedIssueOnHost(t, database, "github.com", "acme", "widget", 278, "open", "filter broken")
 	seedIssueOnHost(t, database, "github.com", "acme", "widget", 290, "open", "another change")
+	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	require.NoError(err)
+	require.NoError(database.ReplaceIssueLabels(ctx, repo.ID, issueID, []db.Label{{
+		PlatformID: 300,
+		Name:       "needs-triage",
+		Color:      "d73a4a",
+		UpdatedAt:  time.Now().UTC(),
+	}}))
 
 	client := setupTestClient(t, srv)
 
@@ -5617,6 +5636,9 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 
 	// Title still matches.
 	q = "broken"
+	assert.ElementsMatch([]int{278}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
+
+	q = "needs-triage"
 	assert.ElementsMatch([]int{278}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
 
 	// Substring of number matches multiple.


### PR DESCRIPTION
- Include PR and issue labels in the existing list search text
- Keep number, title, and author matching on the same filter path
- Cover label-backed PR and issue searches through DB and API tests