### PR TITLE
feat: include issue title in issue-workspace branch names

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -7,6 +7,12 @@ default_platform_host = "github.com"
 host = "127.0.0.1"
 port = 8091
 
+# Style of branch name created for new issue workspaces. "slug" (default)
+# appends a sanitized slug derived from the issue title onto the bare
+# middleman/issue-<n> form, e.g. middleman/issue-1234-add-foo-to-bar.
+# Set to "bare" to keep the legacy middleman/issue-<n> form.
+# issue_workspace_branch_style = "slug"
+
 [terminal]
 # Terminal renderer: "xterm" (default) or "ghostty-web"
 renderer = "xterm"

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -123,7 +123,7 @@ test.describe("detail action buttons", () => {
       await access(readyWorkspace.worktree_path);
       expect(
         gitOutput(readyWorkspace.worktree_path, ["branch", "--show-current"]),
-      ).toBe("middleman/issue-10");
+      ).toBe("middleman/issue-10-widget-rendering-broken-on-safari");
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -108,7 +108,9 @@ test.describe("detail action buttons", () => {
       expect(createdWorkspace.platform_host).toBe("github.com");
       expect(createdWorkspace.item_type).toBe("issue");
       expect(createdWorkspace.item_number).toBe(10);
-      expect(createdWorkspace.git_head_ref).toBe("middleman/issue-10");
+      expect(createdWorkspace.git_head_ref).toBe(
+        "middleman/issue-10-widget-rendering-broken-on-safari",
+      );
 
       await expect(page).toHaveURL(
         new RegExp(`/terminal/${createdWorkspace.id}$`),

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.36.0
 	golang.org/x/tools v0.43.0
 	modernc.org/sqlite v1.48.0
 )
@@ -201,7 +202,6 @@ require (
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,18 @@ const (
 	defaultPlatformHost      = platformpkg.DefaultGitHubHost
 )
 
+const (
+	// IssueWorkspaceBranchStyleSlug appends a slug derived from the
+	// issue title onto middleman/issue-<n>, producing recognizable
+	// branch names that match common GitHub workflow conventions.
+	IssueWorkspaceBranchStyleSlug = "slug"
+	// IssueWorkspaceBranchStyleBare keeps the original
+	// middleman/issue-<n> form with no title slug appended.
+	IssueWorkspaceBranchStyleBare = "bare"
+
+	defaultIssueWorkspaceBranchStyle = IssueWorkspaceBranchStyleSlug
+)
+
 type Repo struct {
 	Owner        string `toml:"owner" json:"owner"`
 	Name         string `toml:"name" json:"name"`
@@ -505,22 +517,23 @@ type Shell struct {
 }
 
 type Config struct {
-	SyncInterval        string           `toml:"sync_interval"`
-	GitHubTokenEnv      string           `toml:"github_token_env"`
-	DefaultPlatformHost string           `toml:"default_platform_host"`
-	Host                string           `toml:"host"`
-	Port                int              `toml:"port"`
-	BasePath            string           `toml:"base_path"`
-	DataDir             string           `toml:"data_dir"`
-	SyncBudgetPerHour   int              `toml:"sync_budget_per_hour"`
-	Repos               []Repo           `toml:"repos"`
-	Platforms           []PlatformConfig `toml:"platforms"`
-	Activity            Activity         `toml:"activity"`
-	Terminal            Terminal         `toml:"terminal"`
-	Agents              []Agent          `toml:"agents"`
-	Roborev             Roborev          `toml:"roborev"`
-	Tmux                Tmux             `toml:"tmux"`
-	Shell               Shell            `toml:"shell"`
+	SyncInterval               string           `toml:"sync_interval"`
+	GitHubTokenEnv             string           `toml:"github_token_env"`
+	DefaultPlatformHost        string           `toml:"default_platform_host"`
+	Host                       string           `toml:"host"`
+	Port                       int              `toml:"port"`
+	BasePath                   string           `toml:"base_path"`
+	DataDir                    string           `toml:"data_dir"`
+	SyncBudgetPerHour          int              `toml:"sync_budget_per_hour"`
+	IssueWorkspaceBranchStyle  string           `toml:"issue_workspace_branch_style"`
+	Repos                      []Repo           `toml:"repos"`
+	Platforms                  []PlatformConfig `toml:"platforms"`
+	Activity                   Activity         `toml:"activity"`
+	Terminal                   Terminal         `toml:"terminal"`
+	Agents                     []Agent          `toml:"agents"`
+	Roborev                    Roborev          `toml:"roborev"`
+	Tmux                       Tmux             `toml:"tmux"`
+	Shell                      Shell            `toml:"shell"`
 }
 
 func DefaultConfigPath() string {
@@ -693,6 +706,10 @@ func Load(path string) (*Config, error) {
 		cfg.SyncBudgetPerHour = defaultSyncBudgetPerHour
 	}
 
+	if strings.TrimSpace(cfg.IssueWorkspaceBranchStyle) == "" {
+		cfg.IssueWorkspaceBranchStyle = defaultIssueWorkspaceBranchStyle
+	}
+
 	if cfg.BasePath == "" {
 		cfg.BasePath = defaultBasePath
 	} else {
@@ -825,6 +842,21 @@ func (c *Config) Validate() error {
 		return fmt.Errorf(
 			"config: invalid activity time_range %q",
 			c.Activity.TimeRange,
+		)
+	}
+
+	c.IssueWorkspaceBranchStyle = strings.TrimSpace(c.IssueWorkspaceBranchStyle)
+	if c.IssueWorkspaceBranchStyle == "" {
+		c.IssueWorkspaceBranchStyle = defaultIssueWorkspaceBranchStyle
+	}
+	switch c.IssueWorkspaceBranchStyle {
+	case IssueWorkspaceBranchStyleSlug, IssueWorkspaceBranchStyleBare:
+	default:
+		return fmt.Errorf(
+			"config: invalid issue_workspace_branch_style %q: must be %q or %q",
+			c.IssueWorkspaceBranchStyle,
+			IssueWorkspaceBranchStyleSlug,
+			IssueWorkspaceBranchStyleBare,
 		)
 	}
 
@@ -1148,6 +1180,23 @@ func (c *Config) TmuxAgentSessionsEnabled() bool {
 		*c.Tmux.AgentSessions
 }
 
+// IssueWorkspaceBranchSlugEnabled reports whether new issue
+// workspaces should derive a title slug onto their branch name.
+// Defaults to true (the "slug" style); returns false for "bare".
+func (c *Config) IssueWorkspaceBranchSlugEnabled() bool {
+	if c == nil {
+		return true
+	}
+	switch strings.TrimSpace(c.IssueWorkspaceBranchStyle) {
+	case "", IssueWorkspaceBranchStyleSlug:
+		return true
+	case IssueWorkspaceBranchStyleBare:
+		return false
+	default:
+		return true
+	}
+}
+
 func reposForSave(repos []Repo) []Repo {
 	if repos == nil {
 		return nil
@@ -1168,22 +1217,23 @@ func reposForSave(repos []Repo) []Repo {
 
 // configFile is the subset of Config written to disk.
 type configFile struct {
-	SyncInterval        string           `toml:"sync_interval"`
-	GitHubTokenEnv      string           `toml:"github_token_env"`
-	DefaultPlatformHost string           `toml:"default_platform_host,omitempty"`
-	Host                string           `toml:"host"`
-	Port                int              `toml:"port"`
-	SyncBudgetPerHour   int              `toml:"sync_budget_per_hour,omitempty"`
-	BasePath            string           `toml:"base_path,omitempty"`
-	DataDir             string           `toml:"data_dir,omitempty"`
-	Repos               []Repo           `toml:"repos"`
-	Platforms           []PlatformConfig `toml:"platforms,omitempty"`
-	Activity            Activity         `toml:"activity"`
-	Terminal            Terminal         `toml:"terminal,omitempty"`
-	Agents              []Agent          `toml:"agents,omitempty"`
-	Roborev             Roborev          `toml:"roborev,omitempty"`
-	Tmux                Tmux             `toml:"tmux,omitempty"`
-	Shell               Shell            `toml:"shell,omitempty"`
+	SyncInterval              string           `toml:"sync_interval"`
+	GitHubTokenEnv            string           `toml:"github_token_env"`
+	DefaultPlatformHost       string           `toml:"default_platform_host,omitempty"`
+	Host                      string           `toml:"host"`
+	Port                      int              `toml:"port"`
+	SyncBudgetPerHour         int              `toml:"sync_budget_per_hour,omitempty"`
+	BasePath                  string           `toml:"base_path,omitempty"`
+	DataDir                   string           `toml:"data_dir,omitempty"`
+	IssueWorkspaceBranchStyle string           `toml:"issue_workspace_branch_style,omitempty"`
+	Repos                     []Repo           `toml:"repos"`
+	Platforms                 []PlatformConfig `toml:"platforms,omitempty"`
+	Activity                  Activity         `toml:"activity"`
+	Terminal                  Terminal         `toml:"terminal,omitempty"`
+	Agents                    []Agent          `toml:"agents,omitempty"`
+	Roborev                   Roborev          `toml:"roborev,omitempty"`
+	Tmux                      Tmux             `toml:"tmux,omitempty"`
+	Shell                     Shell            `toml:"shell,omitempty"`
 }
 
 // Save writes the current config to the given path.
@@ -1214,6 +1264,9 @@ func (c *Config) Save(path string) error {
 	}
 	if c.DataDir != DefaultDataDir() {
 		f.DataDir = c.DataDir
+	}
+	if c.IssueWorkspaceBranchStyle != defaultIssueWorkspaceBranchStyle {
+		f.IssueWorkspaceBranchStyle = c.IssueWorkspaceBranchStyle
 	}
 
 	var buf bytes.Buffer

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1554,6 +1554,92 @@ name = "b"
 	Assert.Equal(t, "xterm", cfg.Terminal.Renderer)
 }
 
+func TestIssueWorkspaceBranchStyleDefaultsToSlug(t *testing.T) {
+	path := writeConfig(t, `
+[[repos]]
+owner = "a"
+name = "b"
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	Assert.Equal(t, IssueWorkspaceBranchStyleSlug, cfg.IssueWorkspaceBranchStyle)
+	Assert.True(t, cfg.IssueWorkspaceBranchSlugEnabled())
+}
+
+func TestIssueWorkspaceBranchStyleAcceptsBare(t *testing.T) {
+	path := writeConfig(t, `
+issue_workspace_branch_style = "bare"
+
+[[repos]]
+owner = "a"
+name = "b"
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	Assert.Equal(t, IssueWorkspaceBranchStyleBare, cfg.IssueWorkspaceBranchStyle)
+	Assert.False(t, cfg.IssueWorkspaceBranchSlugEnabled())
+}
+
+func TestIssueWorkspaceBranchStyleRejectsInvalidValue(t *testing.T) {
+	path := writeConfig(t, `
+issue_workspace_branch_style = "fancy"
+
+[[repos]]
+owner = "a"
+name = "b"
+`)
+	_, err := Load(path)
+	require.Error(t, err)
+	Assert.Contains(t, err.Error(), "invalid issue_workspace_branch_style")
+}
+
+func TestIssueWorkspaceBranchStyleRoundTrip(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+issue_workspace_branch_style = "bare"
+
+[[repos]]
+owner = "a"
+name = "b"
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(IssueWorkspaceBranchStyleBare, cfg.IssueWorkspaceBranchStyle)
+
+	savePath := filepath.Join(t.TempDir(), "saved.toml")
+	require.NoError(t, cfg.Save(savePath))
+
+	cfg2, err := Load(savePath)
+	require.NoError(t, err)
+	assert.Equal(IssueWorkspaceBranchStyleBare, cfg2.IssueWorkspaceBranchStyle)
+	assert.False(cfg2.IssueWorkspaceBranchSlugEnabled())
+}
+
+func TestIssueWorkspaceBranchStyleSlugIsOmittedFromSavedConfig(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+issue_workspace_branch_style = "slug"
+
+[[repos]]
+owner = "a"
+name = "b"
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(IssueWorkspaceBranchStyleSlug, cfg.IssueWorkspaceBranchStyle)
+
+	savePath := filepath.Join(t.TempDir(), "saved.toml")
+	require.NoError(t, cfg.Save(savePath))
+
+	data, err := os.ReadFile(savePath)
+	require.NoError(t, err)
+	// The default style should not be written back to disk; the
+	// field is treated as opt-out only.
+	assert.NotContains(string(data), "issue_workspace_branch_style")
+}
+
 func TestTerminalRendererRejectsInvalidValue(t *testing.T) {
 	path := writeConfig(t, `
 [[repos]]

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -16468,11 +16468,12 @@ func TestWorkspaceCreateIssueE2E(t *testing.T) {
 	require.NotEmpty(created.ID)
 	assert.Equal("issue", created.ItemType)
 	assert.Equal(7, created.ItemNumber)
-	assert.Equal("middleman/issue-7", created.GitHeadRef)
+	// seedIssue uses title "Test Issue" → slug style appends "-test-issue".
+	assert.Equal("middleman/issue-7-test-issue", created.GitHeadRef)
 
 	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
 	assert.Equal(
-		"middleman/issue-7",
+		"middleman/issue-7-test-issue",
 		gitOutput(t, ready.WorktreePath, "branch", "--show-current"),
 	)
 	assert.Equal(
@@ -16494,6 +16495,75 @@ func TestWorkspaceCreateIssueE2E(t *testing.T) {
 	require.NotNil(issueDetail.Workspace)
 	assert.Equal(created.ID, issueDetail.Workspace.ID)
 	assert.NotEmpty(issueDetail.Workspace.Status)
+}
+
+func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := context.Background()
+
+	// Replace the seed title with a multi-word issue title to make
+	// sure the slug appears in the issue-workspace branch name.
+	seedIssueOnHost(
+		t, fixture.database, "github.com", "acme", "widget", 8,
+		"open", "Add foo to bar",
+	)
+
+	createRR := doJSON(
+		t,
+		fixture.server,
+		http.MethodPost,
+		"/api/v1/issues/gh/acme/widget/8/workspace",
+		map[string]string{},
+	)
+	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
+
+	var created rawWorkspaceStatusResponse
+	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
+	assert.Equal("middleman/issue-8-add-foo-to-bar", created.GitHeadRef)
+
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	assert.Equal(
+		"middleman/issue-8-add-foo-to-bar",
+		gitOutput(t, ready.WorktreePath, "branch", "--show-current"),
+	)
+}
+
+func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cfg := &config.Config{
+		IssueWorkspaceBranchStyle: config.IssueWorkspaceBranchStyleBare,
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := context.Background()
+
+	seedIssueOnHost(
+		t, fixture.database, "github.com", "acme", "widget", 9,
+		"open", "Add foo to bar",
+	)
+
+	createRR := doJSON(
+		t,
+		fixture.server,
+		http.MethodPost,
+		"/api/v1/issues/gh/acme/widget/9/workspace",
+		map[string]string{},
+	)
+	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
+
+	var created rawWorkspaceStatusResponse
+	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
+	assert.Equal("middleman/issue-9", created.GitHeadRef)
+
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	assert.Equal(
+		"middleman/issue-9",
+		gitOutput(t, ready.WorktreePath, "branch", "--show-current"),
+	)
 }
 
 func TestWorkspaceCreateIssueIsIdempotent(t *testing.T) {
@@ -16551,7 +16621,7 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
 	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
 	assert.Equal(
-		"middleman/issue-7",
+		"middleman/issue-7-test-issue",
 		gitOutput(t, ready.WorktreePath, "branch", "--show-current"),
 	)
 
@@ -16577,7 +16647,7 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 	require.NoError(json.NewDecoder(recreateRR.Body).Decode(&recreated))
 	recreatedReady := waitForWorkspaceReady(t, ctx, fixture.client, recreated.ID)
 	assert.Equal(
-		"middleman/issue-7",
+		"middleman/issue-7-test-issue",
 		gitOutput(t, recreatedReady.WorktreePath, "branch", "--show-current"),
 	)
 }
@@ -16638,12 +16708,16 @@ func TestWorkspaceCreateIssueBranchConflictReturnsTyped409(t *testing.T) {
 
 	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
 
+	// seedIssue uses the title "Test Issue", which the slug style
+	// turns into "middleman/issue-7-test-issue". Pre-create that
+	// branch so CreateIssue surfaces a branch conflict.
+	const slugBranch = "middleman/issue-7-test-issue"
 	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
 	runGit(
 		t,
 		fixture.bare,
 		"update-ref",
-		"refs/heads/middleman/issue-7",
+		"refs/heads/"+slugBranch,
 		mainSHA,
 	)
 
@@ -16669,9 +16743,9 @@ func TestWorkspaceCreateIssueBranchConflictReturnsTyped409(t *testing.T) {
 	for _, errDetail := range problem.Errors {
 		locations[errDetail.Location] = errDetail.Value
 	}
-	assert.Equal("middleman/issue-7", locations["body.git_head_ref"])
+	assert.Equal(slugBranch, locations["body.git_head_ref"])
 	assert.Equal(
-		"middleman/issue-7-2",
+		slugBranch+"-2",
 		locations["body.suggested_git_head_ref"],
 	)
 
@@ -16681,7 +16755,7 @@ func TestWorkspaceCreateIssueBranchConflictReturnsTyped409(t *testing.T) {
 		http.MethodPost,
 		"/api/v1/issues/gh/acme/widget/7/workspace",
 		map[string]any{
-			"git_head_ref":          "middleman/issue-7",
+			"git_head_ref":          slugBranch,
 			"reuse_existing_branch": true,
 		},
 	)
@@ -16691,14 +16765,14 @@ func TestWorkspaceCreateIssueBranchConflictReturnsTyped409(t *testing.T) {
 	require.NoError(json.NewDecoder(reuseRR.Body).Decode(&reused))
 	reusedReady := waitForWorkspaceReady(t, ctx, fixture.client, reused.ID)
 	assert.Equal(
-		"middleman/issue-7",
+		slugBranch,
 		gitOutput(t, reusedReady.WorktreePath, "branch", "--show-current"),
 	)
 
 	stored, err := fixture.database.GetWorkspace(ctx, reused.ID)
 	require.NoError(err)
 	require.NotNil(stored)
-	assert.Equal("middleman/issue-7", stored.WorkspaceBranch)
+	assert.Equal(slugBranch, stored.WorkspaceBranch)
 }
 
 func prepareIssueWorkspaceAssociationFixture(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -430,6 +430,9 @@ func newServer(
 		s.workspaces = workspace.NewManager(database, options.WorktreeDir)
 		s.workspacePRMonitor = workspace.NewPRMonitor(database)
 		s.workspaces.SetTmuxCommand(tmuxCmd)
+		s.workspaces.SetIssueBranchSlugEnabled(
+			cfg.IssueWorkspaceBranchSlugEnabled(),
+		)
 		ptyOwnerDir := options.PtyOwnerDir
 		if ptyOwnerDir == "" {
 			ptyOwnerDir = filepath.Join(

--- a/internal/workspace/issue_branch.go
+++ b/internal/workspace/issue_branch.go
@@ -1,0 +1,117 @@
+package workspace
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// issueBranchMaxLen caps the full middleman/issue-<n>-<slug> branch
+// name. The ceiling is well below git's 255-byte ref limit and leaves
+// a small headroom for nextAvailableBranchName to append a "-N"
+// disambiguator on collision.
+const issueBranchMaxLen = 100
+
+// issueBranchSlugBudget is the upper bound the disambiguator helper
+// can append onto issueBranchMaxLen-derived names. Five chars is
+// enough for `-NNNN` collision suffixes up to 9999.
+const issueBranchSlugBudget = 5
+
+// issueWorkspaceBranch returns middleman's conventional issue-only
+// branch name without a title slug. Use this for the "bare" branch
+// style and as a fallback when a title cannot be slugified.
+func issueWorkspaceBranch(issueNumber int) string {
+	return fmt.Sprintf("middleman/issue-%d", issueNumber)
+}
+
+// issueWorkspaceBranchWithTitle returns a slugified branch name for an
+// issue workspace. It appends a lowercase ASCII slug derived from the
+// issue title to the bare form, capped at issueBranchMaxLen and
+// truncated at a separator boundary when possible. Titles that
+// slugify to an empty string fall back to issueWorkspaceBranch.
+func issueWorkspaceBranchWithTitle(issueNumber int, title string) string {
+	bare := issueWorkspaceBranch(issueNumber)
+	slug := slugifyIssueTitle(title)
+	if slug == "" {
+		return bare
+	}
+	budget := issueBranchMaxLen - issueBranchSlugBudget - len(bare) - len("-")
+	if budget <= 0 {
+		return bare
+	}
+	if len(slug) > budget {
+		slug = truncateSlug(slug, budget)
+		if slug == "" {
+			return bare
+		}
+	}
+	return bare + "-" + slug
+}
+
+// slugifyIssueTitle turns an arbitrary issue title into a safe slug:
+// lowercase ASCII letters, digits, and dashes. Non-ASCII letters with
+// canonical ASCII decompositions (Latin accented chars) are folded
+// down; unconvertible runes (CJK, emoji, other symbols) are dropped.
+// Consecutive separators collapse into a single dash, leading and
+// trailing separators are trimmed.
+func slugifyIssueTitle(title string) string {
+	folded := foldToASCII(title)
+	var b strings.Builder
+	b.Grow(len(folded))
+	prevDash := true
+	for _, r := range folded {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(unicode.ToLower(r))
+			prevDash = false
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// foldToASCII normalizes the input via NFKD and drops combining marks
+// so that "café" becomes "cafe" and "naïve" becomes "naive". Runes
+// that have no ASCII decomposition (CJK, emoji) survive the
+// transform but are dropped by the slugifier's allow-list.
+func foldToASCII(s string) string {
+	t := transform.Chain(
+		norm.NFKD,
+		runes.Remove(runes.In(unicode.Mn)),
+		norm.NFC,
+	)
+	out, _, err := transform.String(t, s)
+	if err != nil {
+		return s
+	}
+	return out
+}
+
+// truncateSlug shortens an ASCII slug to at most maxLen bytes,
+// preferring to cut at the last dash so a partial word is not left at
+// the end. Returns "" if no separator-aligned cut is possible and
+// the head chunk would itself be empty after dash trimming.
+func truncateSlug(slug string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	if len(slug) <= maxLen {
+		return slug
+	}
+	cut := slug[:maxLen]
+	if i := strings.LastIndexByte(cut, '-'); i > 0 {
+		cut = cut[:i]
+	}
+	return strings.Trim(cut, "-")
+}

--- a/internal/workspace/issue_branch_test.go
+++ b/internal/workspace/issue_branch_test.go
@@ -1,0 +1,216 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+)
+
+func TestIssueWorkspaceBranchSlug(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		number      int
+		title       string
+		want        string
+		mustContain string
+	}{
+		{
+			name:   "typical title",
+			number: 1234,
+			title:  "Add foo to bar",
+			want:   "middleman/issue-1234-add-foo-to-bar",
+		},
+		{
+			name:   "empty title falls back to bare",
+			number: 7,
+			title:  "",
+			want:   "middleman/issue-7",
+		},
+		{
+			name:   "whitespace title falls back to bare",
+			number: 8,
+			title:  "   \t\n",
+			want:   "middleman/issue-8",
+		},
+		{
+			name:   "all-punctuation title falls back to bare",
+			number: 9,
+			title:  "!@#$%^&*()",
+			want:   "middleman/issue-9",
+		},
+		{
+			name:   "slashes are sanitized",
+			number: 10,
+			title:  "feat/api: add /v2 endpoint",
+			want:   "middleman/issue-10-feat-api-add-v2-endpoint",
+		},
+		{
+			name:   "leading and trailing dots removed",
+			number: 11,
+			title:  "...refactor things...",
+			want:   "middleman/issue-11-refactor-things",
+		},
+		{
+			name:   "leading slash and dot are stripped from slug",
+			number: 12,
+			title:  "./.config bug",
+			want:   "middleman/issue-12-config-bug",
+		},
+		{
+			name:   "accented letters are reduced to ascii",
+			number: 13,
+			title:  "naïve café façade",
+			want:   "middleman/issue-13-naive-cafe-facade",
+		},
+		{
+			name:   "cjk characters are stripped",
+			number: 14,
+			title:  "添加 features please",
+			want:   "middleman/issue-14-features-please",
+		},
+		{
+			name:   "cjk-only title falls back to bare",
+			number: 15,
+			title:  "添加新功能",
+			want:   "middleman/issue-15",
+		},
+		{
+			name:   "emoji are stripped",
+			number: 16,
+			title:  "Fix: bug 🐛 hits everyone 🚀",
+			want:   "middleman/issue-16-fix-bug-hits-everyone",
+		},
+		{
+			name:   "emoji-only title falls back to bare",
+			number: 17,
+			title:  "🐛🚀🐢",
+			want:   "middleman/issue-17",
+		},
+		{
+			name:   "uppercase is lowercased",
+			number: 18,
+			title:  "FOO BAR BAZ",
+			want:   "middleman/issue-18-foo-bar-baz",
+		},
+		{
+			name:   "internal dots collapsed",
+			number: 19,
+			title:  "v1.2.3 release",
+			want:   "middleman/issue-19-v1-2-3-release",
+		},
+		{
+			name:   "consecutive separators collapsed",
+			number: 20,
+			title:  "a   --  b---c",
+			want:   "middleman/issue-20-a-b-c",
+		},
+		{
+			name:   "numbers preserved",
+			number: 21,
+			title:  "Bug 9000 in module 42",
+			want:   "middleman/issue-21-bug-9000-in-module-42",
+		},
+		{
+			name:   "ascii control characters dropped",
+			number: 22,
+			title:  "tab\tand\nnewline",
+			want:   "middleman/issue-22-tab-and-newline",
+		},
+		{
+			name:   "underscore mapped to dash",
+			number: 23,
+			title:  "fix snake_case parser",
+			want:   "middleman/issue-23-fix-snake-case-parser",
+		},
+		{
+			name:        "very long title truncated under cap",
+			number:      999,
+			title:       strings.Repeat("word ", 200),
+			mustContain: "middleman/issue-999-word",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := issueWorkspaceBranchWithTitle(tc.number, tc.title)
+
+			assert := Assert.New(t)
+			if tc.want != "" {
+				assert.Equal(tc.want, got)
+			}
+			if tc.mustContain != "" {
+				assert.Contains(got, tc.mustContain)
+			}
+			assert.LessOrEqual(
+				len(got), issueBranchMaxLen,
+				"branch %q exceeds %d-char cap",
+				got, issueBranchMaxLen,
+			)
+			assert.False(strings.HasSuffix(got, "-"),
+				"branch %q should not end with -", got)
+			assert.False(strings.HasSuffix(got, "."),
+				"branch %q should not end with .", got)
+			assert.NotContains(got, "..",
+				"branch %q must not contain ..", got)
+			assert.NotContains(got, "//",
+				"branch %q must not contain //", got)
+			assert.False(strings.HasPrefix(got, "/"),
+				"branch %q must not start with /", got)
+		})
+	}
+}
+
+func TestIssueWorkspaceBranchSlugTruncatesAtWordBoundary(t *testing.T) {
+	t.Parallel()
+	assert := Assert.New(t)
+
+	long := strings.Repeat("alpha-beta-gamma-delta ", 20)
+	got := issueWorkspaceBranchWithTitle(42, long)
+
+	assert.LessOrEqual(len(got), issueBranchMaxLen)
+	// Truncation should land cleanly on a separator, not mid-word.
+	assert.False(strings.HasSuffix(got, "-"),
+		"trailing dash on %q signals raw truncation", got)
+	// Should still carry the slug prefix, not just fall back to bare.
+	assert.True(strings.HasPrefix(got, "middleman/issue-42-alpha"),
+		"unexpected prefix in %q", got)
+}
+
+func TestIssueWorkspaceBranchSlugProducesValidGitRef(t *testing.T) {
+	t.Parallel()
+	assert := Assert.New(t)
+
+	cases := []struct {
+		number int
+		title  string
+	}{
+		{1, "Add foo to bar"},
+		{2, ""},
+		{3, strings.Repeat("very long ", 50)},
+		{4, "./.dotfile -- weird-- name"},
+		{5, "naïve café résumé"},
+		{6, "🚀 launch the rocket 🛰️"},
+		{7, "中文 标题 with mixed text"},
+	}
+
+	for _, tc := range cases {
+		branch := issueWorkspaceBranchWithTitle(tc.number, tc.title)
+		err := validateLocalBranchName(t.Context(), "", branch)
+		assert.NoError(err, "branch %q for title %q should be valid",
+			branch, tc.title)
+	}
+}
+
+func TestIssueWorkspaceBranchBareIgnoresTitle(t *testing.T) {
+	t.Parallel()
+	assert := Assert.New(t)
+
+	assert.Equal(
+		"middleman/issue-42",
+		issueWorkspaceBranch(42),
+	)
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1993,15 +1993,16 @@ func workspaceBranchCandidates(
 ) []string {
 	if managedBranch == workspaceBranchUnknown {
 		if ws.ItemType == db.WorkspaceItemTypeIssue {
-			// Prefer the persisted branch (which honors any title
-			// slug) but fall back to the bare middleman/issue-<n>
-			// form so cleanup still finds pre-slug branches if the
-			// workspace pre-dates this feature.
-			bare := issueWorkspaceBranch(ws.ItemNumber)
-			if ws.GitHeadRef != "" && ws.GitHeadRef != bare {
-				return []string{ws.GitHeadRef, bare}
+			// Trust the persisted branch. The bare-form fallback
+			// only applies when GitHeadRef is empty (pre-feature
+			// workspaces); a slug-style workspace's bare-form
+			// branch may be a user-owned local branch that
+			// middleman never created, so cleanup must not delete
+			// it as a candidate.
+			if ws.GitHeadRef != "" {
+				return []string{ws.GitHeadRef}
 			}
-			return []string{bare}
+			return []string{issueWorkspaceBranch(ws.ItemNumber)}
 		}
 		return []string{syntheticPRWorktreeBranch(ws.ItemNumber)}
 	}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -32,15 +32,16 @@ import (
 // intentionally not a generic host worktree browser or arbitrary Git
 // automation layer.
 type Manager struct {
-	db             *db.DB
-	worktreeDir    string
-	clones         *gitclone.Manager
-	tmuxCmd        []string
-	ptyOwner       PtyOwnerClient
-	preferPtyOwner bool
-	retryMu        sync.Mutex
-	retryQueued    map[string]bool
-	runtimeTmuxMu  sync.Mutex
+	db                     *db.DB
+	worktreeDir            string
+	clones                 *gitclone.Manager
+	tmuxCmd                []string
+	ptyOwner               PtyOwnerClient
+	preferPtyOwner         bool
+	retryMu                sync.Mutex
+	retryQueued            map[string]bool
+	runtimeTmuxMu          sync.Mutex
+	issueBranchSlugEnabled bool
 }
 
 // CreateIssueOptions controls how issue-backed workspaces choose their branch.
@@ -99,10 +100,30 @@ func NewManager(
 	database *db.DB, worktreeDir string,
 ) *Manager {
 	return &Manager{
-		db:          database,
-		worktreeDir: worktreeDir,
-		retryQueued: make(map[string]bool),
+		db:                     database,
+		worktreeDir:            worktreeDir,
+		retryQueued:            make(map[string]bool),
+		issueBranchSlugEnabled: true,
 	}
+}
+
+// SetIssueBranchSlugEnabled controls whether issue-workspace branch
+// names include a slug derived from the issue title. When false, the
+// manager keeps the legacy bare middleman/issue-<n> form. Default is
+// true, matching the configured default issue_workspace_branch_style.
+func (m *Manager) SetIssueBranchSlugEnabled(enabled bool) {
+	m.issueBranchSlugEnabled = enabled
+}
+
+// defaultIssueBranch returns the middleman issue-workspace branch
+// name to use when the caller did not pass an explicit GitHeadRef.
+// When the slug style is enabled and the issue has a usable title,
+// the bare middleman/issue-<n> is suffixed with a sanitized slug.
+func (m *Manager) defaultIssueBranch(issueNumber int, title string) string {
+	if m.issueBranchSlugEnabled {
+		return issueWorkspaceBranchWithTitle(issueNumber, title)
+	}
+	return issueWorkspaceBranch(issueNumber)
 }
 
 // SetClones sets the git clone manager used for bare clone
@@ -239,7 +260,7 @@ func (m *Manager) CreateIssue(
 
 	gitHeadRef := opts.GitHeadRef
 	if gitHeadRef == "" {
-		gitHeadRef = issueWorkspaceBranch(issueNumber)
+		gitHeadRef = m.defaultIssueBranch(issueNumber, issue.Title)
 	}
 	if err := validateLocalBranchName(ctx, "", gitHeadRef); err != nil {
 		return nil, err
@@ -588,10 +609,6 @@ func workspaceStartRef(ws *Workspace) string {
 
 func syntheticPRWorktreeBranch(mrNumber int) string {
 	return fmt.Sprintf("middleman/pr-%d", mrNumber)
-}
-
-func issueWorkspaceBranch(issueNumber int) string {
-	return fmt.Sprintf("middleman/issue-%d", issueNumber)
 }
 
 func setBranchUpstream(
@@ -1976,7 +1993,15 @@ func workspaceBranchCandidates(
 ) []string {
 	if managedBranch == workspaceBranchUnknown {
 		if ws.ItemType == db.WorkspaceItemTypeIssue {
-			return []string{issueWorkspaceBranch(ws.ItemNumber)}
+			// Prefer the persisted branch (which honors any title
+			// slug) but fall back to the bare middleman/issue-<n>
+			// form so cleanup still finds pre-slug branches if the
+			// workspace pre-dates this feature.
+			bare := issueWorkspaceBranch(ws.ItemNumber)
+			if ws.GitHeadRef != "" && ws.GitHeadRef != bare {
+				return []string{ws.GitHeadRef, bare}
+			}
+			return []string{bare}
 		}
 		return []string{syntheticPRWorktreeBranch(ws.ItemNumber)}
 	}

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -195,6 +195,85 @@ func TestCreatePRHeadRepoClassification(t *testing.T) {
 	}
 }
 
+func TestCreateIssueDefaultBranchSluggified(t *testing.T) {
+	tests := []struct {
+		name      string
+		title     string
+		slugStyle bool
+		want      string
+	}{
+		{
+			name:      "slug style with usable title",
+			title:     "Add foo to bar",
+			slugStyle: true,
+			want:      "middleman/issue-7-add-foo-to-bar",
+		},
+		{
+			name:      "slug style with empty title falls back to bare",
+			title:     "",
+			slugStyle: true,
+			want:      "middleman/issue-7",
+		},
+		{
+			name:      "slug style with all-punctuation falls back to bare",
+			title:     "?!@#",
+			slugStyle: true,
+			want:      "middleman/issue-7",
+		},
+		{
+			name:      "bare style ignores title",
+			title:     "Add foo to bar",
+			slugStyle: false,
+			want:      "middleman/issue-7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			require := require.New(t)
+
+			d := openTestDB(t)
+			ctx := t.Context()
+			repoID := seedRepo(t, d, "github.com", "acme", "widget")
+			seedIssue(t, d, repoID, 7, tt.title)
+
+			mgr := NewManager(d, t.TempDir())
+			mgr.SetIssueBranchSlugEnabled(tt.slugStyle)
+
+			ws, err := mgr.CreateIssue(
+				ctx, "github.com", "acme", "widget", 7,
+				CreateIssueOptions{},
+			)
+			require.NoError(err)
+			require.NotNil(ws)
+
+			assert.Equal(tt.want, ws.GitHeadRef)
+			assert.Equal(tt.want, ws.WorkspaceBranch)
+		})
+	}
+}
+
+func TestCreateIssueExplicitGitHeadRefBypassesSlug(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedIssue(t, d, repoID, 7, "Add foo to bar")
+
+	mgr := NewManager(d, t.TempDir())
+
+	ws, err := mgr.CreateIssue(
+		ctx, "github.com", "acme", "widget", 7,
+		CreateIssueOptions{GitHeadRef: "custom/branch"},
+	)
+	require.NoError(err)
+	require.NotNil(ws)
+	assert.Equal("custom/branch", ws.GitHeadRef)
+}
+
 func TestCreateRepoNotTracked(t *testing.T) {
 	d := openTestDB(t)
 	mgr := NewManager(d, t.TempDir())

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2412,3 +2412,32 @@ func (f *fakePtyOwnerClient) Snapshot(
 		Title:  f.SnapshotTitle,
 	}, nil
 }
+
+func TestWorkspaceBranchCandidatesDoesNotIncludeBareForSluggedWorkspace(t *testing.T) {
+	// Slug-style issue workspace whose bare-form branch name might
+	// be a user-owned local branch unrelated to middleman. Cleanup
+	// must return only the persisted GitHeadRef so the unrelated
+	// branch is not deleted.
+	assert := Assert.New(t)
+	ws := &Workspace{
+		ItemType:   db.WorkspaceItemTypeIssue,
+		ItemNumber: 10,
+		GitHeadRef: "middleman/issue-10-widget-rendering-broken",
+	}
+	got := workspaceBranchCandidates(ws, workspaceBranchUnknown)
+	assert.Equal([]string{"middleman/issue-10-widget-rendering-broken"}, got)
+}
+
+func TestWorkspaceBranchCandidatesUsesBareFallbackOnlyForLegacyWorkspace(t *testing.T) {
+	// Pre-feature issue workspaces have no recorded GitHeadRef.
+	// Cleanup must still find the bare middleman/issue-<n> branch
+	// those workspaces actually use.
+	assert := Assert.New(t)
+	ws := &Workspace{
+		ItemType:   db.WorkspaceItemTypeIssue,
+		ItemNumber: 10,
+		GitHeadRef: "",
+	}
+	got := workspaceBranchCandidates(ws, workspaceBranchUnknown)
+	assert.Equal([]string{"middleman/issue-10"}, got)
+}

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -107,7 +107,12 @@ func (m *PRMonitor) detectAssociatedPR(
 	if currentBranch == "" {
 		return 0, false, nil
 	}
-	if currentBranch == issueWorkspaceBranch(ws.ItemNumber) {
+	// Skip while the workspace is still on its managed issue branch:
+	// no associated PR can exist yet. Compare to the persisted branch
+	// (which honors the configured slug/bare style) rather than
+	// recomputing, so an issue rename never desyncs detection.
+	if currentBranch == ws.GitHeadRef ||
+		currentBranch == issueWorkspaceBranch(ws.ItemNumber) {
 		return 0, false, nil
 	}
 

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -108,11 +108,16 @@ func (m *PRMonitor) detectAssociatedPR(
 		return 0, false, nil
 	}
 	// Skip while the workspace is still on its managed issue branch:
-	// no associated PR can exist yet. Compare to the persisted branch
-	// (which honors the configured slug/bare style) rather than
-	// recomputing, so an issue rename never desyncs detection.
-	if currentBranch == ws.GitHeadRef ||
-		currentBranch == issueWorkspaceBranch(ws.ItemNumber) {
+	// no associated PR can exist yet. The bare-form fallback only
+	// applies when the workspace pre-dates the slug feature (empty
+	// GitHeadRef); otherwise a user who hand-checks-out the legacy
+	// bare branch name on a slug-style workspace would silently
+	// suppress PR detection for an unrelated branch.
+	managedBranch := ws.GitHeadRef
+	if managedBranch == "" {
+		managedBranch = issueWorkspaceBranch(ws.ItemNumber)
+	}
+	if currentBranch == managedBranch {
 		return 0, false, nil
 	}
 

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -235,6 +235,74 @@ func TestPRMonitorRunOnceSkipsSyntheticIssueBranch(t *testing.T) {
 	assert.Nil(ws.AssociatedPRNumber)
 }
 
+func TestPRMonitorRunOnceAssociatesPRWhenSlugWorkspaceCheckedOutToBareBranch(t *testing.T) {
+	// Regression: a slug-style workspace (GitHeadRef = the slugged
+	// branch) checked out to the legacy bare-form branch
+	// `middleman/issue-<n>` is NOT on its managed branch and should
+	// not suppress PR detection. The bare-form fallback only applies
+	// to pre-feature workspaces with an empty GitHeadRef.
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedIssue(t, d, repoID, 7, "Track workspace association")
+
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "middleman/issue-7")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "feature.txt"), []byte("feature\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, worktreePath, "add", ".")
+	runWorkspaceTestGit(t, worktreePath, "commit", "-m", "feature commit")
+	headSHA, err := gitHeadSHA(ctx, worktreePath)
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      repoID*10000 + 42,
+		Number:          42,
+		Title:           "Test PR",
+		Author:          "author",
+		State:           "open",
+		HeadBranch:      "middleman/issue-7",
+		PlatformHeadSHA: headSHA,
+		BaseBranch:      "main",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	require.NoError(d.InsertWorkspace(ctx, &db.Workspace{
+		ID:           "ws-issue-slug",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypeIssue,
+		ItemNumber:   7,
+		GitHeadRef:   "middleman/issue-7-track-workspace-association",
+		WorktreePath: worktreePath,
+		TmuxSession:  "middleman-ws-issue-slug",
+		Status:       "ready",
+	}))
+
+	monitor := NewPRMonitor(d)
+	updates, err := monitor.RunOnce(ctx)
+	require.NoError(err)
+	require.Len(updates, 1)
+	assert.Equal("ws-issue-slug", updates[0].WorkspaceID)
+	assert.Equal(42, updates[0].PRNumber)
+
+	ws, err := d.GetWorkspace(ctx, "ws-issue-slug")
+	require.NoError(err)
+	require.NotNil(ws)
+	require.NotNil(ws.AssociatedPRNumber)
+	assert.Equal(42, *ws.AssociatedPRNumber)
+}
+
 func TestPRMonitorRunOnceUsesUpstreamRemoteIdentity(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
## Summary

- Issue-workspace branches now include a slugified issue title (e.g. `middleman/issue-1234-add-foo-to-bar`) instead of bare `middleman/issue-1234`, so branches stay recognizable in `git log`, PR titles, and the GitHub UI.
- Opt out with `issue_workspace_branch_style = "bare"` in config. Default is `"slug"`.
- Existing workspaces are untouched; the change only affects newly created issue workspaces.

The slug folds Latin accents to ASCII, drops CJK/emoji, collapses non-alphanumerics into single dashes, and truncates at 100 chars preferring a word boundary. Titles that slugify to empty fall back to the bare form. The workspace monitor compares against the persisted `GitHeadRef` so renamed titles don't break detection.