### PR TITLE
feat: scope gh auth token fallback by hostname

### DIFF
--- a/cmd/middleman/startup_token_e2e_test.go
+++ b/cmd/middleman/startup_token_e2e_test.go
@@ -9,8 +9,6 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/config"
-	"github.com/wesm/middleman/internal/db"
-	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
 
 // TestCollectProviderTokensInvokesGHWithHostnameForEnterprise wires the
@@ -24,11 +22,6 @@ import (
 // would run it on startup.
 func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	assert := Assert.New(t)
-
-	// Real SQLite-backed DB exists in the startup path; opening one
-	// here keeps the test honest about the dependency even though
-	// token resolution itself doesn't touch the database.
-	var _ *db.DB = dbtest.Open(t)
 
 	// Fake gh on PATH. Records argv (one invocation per line) and
 	// emits a host-scoped token on stdout.

--- a/cmd/middleman/startup_token_e2e_test.go
+++ b/cmd/middleman/startup_token_e2e_test.go
@@ -51,7 +51,7 @@ func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(configPath, []byte(`
 host = "127.0.0.1"
-port = 8091
+port = 0
 
 [[repos]]
 platform = "github"

--- a/cmd/middleman/startup_token_e2e_test.go
+++ b/cmd/middleman/startup_token_e2e_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/testutil/dbtest"
+)
+
+// TestCollectProviderTokensInvokesGHWithHostnameForEnterprise wires the
+// host-scoped fallback together with the production startup token
+// collector. A fake `gh` placed on PATH records its argv; loading a TOML
+// config that points at a GitHub Enterprise host and calling the same
+// collector main() uses verifies (a) the resolved token map carries the
+// host-scoped value, (b) `gh auth token --hostname <host>` was actually
+// invoked. Unit tests pin the helper in isolation; this test pins the
+// wiring from TOML parsing through subprocess invocation as the daemon
+// would run it on startup.
+func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
+	assert := Assert.New(t)
+
+	// Real SQLite-backed DB exists in the startup path; opening one
+	// here keeps the test honest about the dependency even though
+	// token resolution itself doesn't touch the database.
+	var _ *db.DB = dbtest.Open(t)
+
+	// Fake gh on PATH. Records argv (one invocation per line) and
+	// emits a host-scoped token on stdout.
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
+	ghPath := filepath.Join(dir, "gh")
+	const fakeToken = "ghe-token-from-gh"
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n" +
+		"printf '%s\\n' '" + fakeToken + "'\n"
+	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+
+	// Clear the env var that would short-circuit the gh fallback.
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+
+	// Config with a GHE repo. Loading via the public API exercises
+	// the same parsing path the daemon takes.
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+platform = "github"
+platform_host = "ghe.example.com"
+owner = "acme"
+name = "widget"
+`), 0o644))
+	cfg, err := config.Load(configPath)
+	require.NoError(t, err)
+
+	tokens, err := collectProviderTokens(cfg)
+	require.NoError(t, err)
+
+	key := providerHostKey("github", "ghe.example.com")
+	assert.Equal(fakeToken, tokens[key],
+		"GHE provider key should resolve to the gh-supplied host token")
+
+	data, err := os.ReadFile(argvPath)
+	require.NoError(t, err)
+	invocations := strings.Split(
+		strings.TrimRight(string(data), "\n"), "\n",
+	)
+	assert.Contains(invocations, "auth token --hostname ghe.example.com",
+		"expected gh auth token --hostname ghe.example.com invocation; got: %v",
+		invocations,
+	)
+}

--- a/docs/superpowers/plans/2026-05-19-gh-auth-hostname-fallback.md
+++ b/docs/superpowers/plans/2026-05-19-gh-auth-hostname-fallback.md
@@ -1,0 +1,634 @@
+# GH Auth Hostname Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scope `gh auth token` resolution by hostname so a GHE-only user with `gh auth login --hostname ghe.example` resolves the right token without setting `MIDDLEMAN_GITHUB_TOKEN`.
+
+**Architecture:** Replace `ghAuthToken()` in `internal/config/config.go` with `ghAuthTokenForHost(host)` that calls `gh auth token --hostname <host>` under a 5-second context timeout. Add a method `(*Config).gitHubTokenForHost(host)` that preserves the env-var-then-`gh` contract and thread it through `cfg.GitHubToken()` and `cfg.TokenForPlatformHost`. Retry bare `gh auth token` only when `--hostname github.com` is rejected by an older `gh` (detected from stderr).
+
+**Tech Stack:** Go 1.x, `os/exec` with `context.WithTimeout`, testify, table-driven tests, PATH-based fake-`gh` shell script seam already established in `config_test.go`.
+
+---
+
+## File Structure
+
+- `internal/config/config.go` — package-private `execCommand` variable, `ghAuthTokenForHost`, `(*Config).gitHubTokenForHost`, `isUnsupportedHostnameFlag`; updates to `(*Config).GitHubToken` and `(*Config).TokenForPlatformHost`.
+- `internal/config/config_test.go` — extend the fake-`gh` helper to capture argv and emit controlled exit-code/stderr; add new tests for host-scoped resolution, older-`gh` retry, and timeout.
+
+No new files. No new packages. No changes outside `internal/config/`.
+
+---
+
+## Task 1: Wire the test seam to a context-aware exec
+
+**Files:**
+- Modify: `internal/config/config.go` (the `var execCommand = exec.Command` line at ~1090 and `ghAuthToken` at ~1092)
+
+The current `var execCommand = exec.Command` cannot pass a context through. Switch it to `exec.CommandContext` and update the (still-host-agnostic) `ghAuthToken` to thread `context.Background()` so existing tests keep passing while the seam is ready for Task 2. This is the smallest behavior-preserving change.
+
+- [ ] **Step 1: Run existing config tests to capture the green baseline**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestGitHubToken' -shuffle=on`
+Expected: PASS for `TestGitHubToken`, `TestGitHubTokenFallsBackToGHCli`, `TestGitHubTokenPrefersEnvVarOverGHCli`, `TestGitHubTokenReturnsEmptyWhenGHCliUnavailable`.
+
+- [ ] **Step 2: Change `execCommand` to `exec.CommandContext` and update `ghAuthToken`**
+
+In `internal/config/config.go`, find:
+
+```go
+var execCommand = exec.Command
+
+func ghAuthToken() string {
+	out, err := execCommand("gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+```
+
+Replace with:
+
+```go
+var execCommand = exec.CommandContext
+
+func ghAuthToken() string {
+	out, err := execCommand(context.Background(), "gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+```
+
+Add `"context"` to the import block at the top of the file (alphabetical with the other stdlib imports between `"bytes"` and `"errors"`).
+
+- [ ] **Step 3: Run the same tests, still green**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestGitHubToken' -shuffle=on`
+Expected: PASS. The fake `gh` script under `PATH` still gets invoked the same way; only the function variable's signature changed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/config/config.go
+git commit -m "refactor(config): switch gh exec seam to CommandContext"
+```
+
+---
+
+## Task 2: Introduce `ghAuthTokenForHost` with `--hostname` and timeout
+
+**Files:**
+- Modify: `internal/config/config.go` (replace `ghAuthToken`, add helpers, leave `(*Config).GitHubToken` and `(*Config).TokenForPlatformHost` alone for now)
+- Test: `internal/config/config_test.go` (extend `setFakeGHCLI`, add new tests)
+
+This task introduces the new helper and tests it directly. `GitHubToken`/`TokenForPlatformHost` keep calling the old name in this task so existing behavior is unchanged; Task 3 wires them in.
+
+- [ ] **Step 1: Extend the fake-`gh` helper with argv capture, exit code, stderr, and sleep**
+
+In `internal/config/config_test.go`, replace the existing `setFakeGHCLI`:
+
+```go
+func setFakeGHCLI(t *testing.T, stdout string) {
+	t.Helper()
+	setFakeGHCLIScript(t, fakeGHCLIOptions{Stdout: stdout})
+}
+
+type fakeGHCLIOptions struct {
+	// Stdout is echoed verbatim on success (default exit 0).
+	Stdout string
+	// Stderr is echoed to stderr regardless of exit code.
+	Stderr string
+	// ExitCode is the exit status of the fake gh.
+	ExitCode int
+	// SleepSeconds, if >0, makes the fake sleep before exiting.
+	SleepSeconds int
+}
+
+// setFakeGHCLIScript writes a fake `gh` to a temp dir and points PATH
+// at it. The fake records its argv to <tempdir>/argv (newline-separated
+// across invocations), then emits stdout/stderr/exit per opts. The
+// path of the argv file is returned via env var FAKE_GH_ARGV so the
+// caller can read it.
+func setFakeGHCLIScript(t *testing.T, opts fakeGHCLIOptions) string {
+	t.Helper()
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
+	ghPath := filepath.Join(dir, "gh")
+	script := "#!/bin/sh\n"
+	script += "printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n"
+	if opts.SleepSeconds > 0 {
+		script += fmt.Sprintf("sleep %d\n", opts.SleepSeconds)
+	}
+	if opts.Stderr != "" {
+		script += "printf '%s\\n' " + shellSingleQuote(opts.Stderr) + " 1>&2\n"
+	}
+	if opts.Stdout != "" {
+		script += "printf '%s\\n' " + shellSingleQuote(opts.Stdout) + "\n"
+	}
+	script += fmt.Sprintf("exit %d\n", opts.ExitCode)
+	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+	return argvPath
+}
+
+// shellSingleQuote escapes s for safe inclusion inside single quotes
+// in a /bin/sh script.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// readFakeGHArgv returns the recorded argv strings (one entry per
+// invocation, in call order). Returns nil if no calls were made.
+func readFakeGHArgv(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	require.NoError(t, err)
+	raw := strings.TrimRight(string(data), "\n")
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\n")
+}
+```
+
+Add `"errors"`, `"fmt"`, and `"strings"` to the test file's import block if missing (`fmt` and `strings` are already imported elsewhere — check the existing import block at the top of `config_test.go` and add what's not there).
+
+- [ ] **Step 2: Write the first failing test — `ghAuthTokenForHost` passes `--hostname github.com`**
+
+Append to `config_test.go`:
+
+```go
+func TestGhAuthTokenForHostPassesHostnameFlag(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "gh-secret-github",
+	})
+
+	got := ghAuthTokenForHost("github.com")
+	Assert.Equal(t, "gh-secret-github", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1)
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestGhAuthTokenForHostPassesHostnameFlag' -shuffle=on`
+Expected: FAIL with `undefined: ghAuthTokenForHost`.
+
+- [ ] **Step 4: Implement `ghAuthTokenForHost` and the older-`gh` detection helper**
+
+In `internal/config/config.go`, replace the existing `ghAuthToken` function with:
+
+```go
+// ghAuthExecTimeout bounds each gh subprocess invocation. gh auth token
+// is local (no network) and returns in milliseconds; 5s is generous.
+const ghAuthExecTimeout = 5 * time.Second
+
+// ghAuthTokenForHost returns the token gh has stored for host, or "".
+// On older gh that does not recognize --hostname, this falls back to
+// bare `gh auth token` only when host is github.com — any other host
+// returns empty without retry so the caller surfaces a missing-token
+// error rather than the wrong host's token.
+func ghAuthTokenForHost(host string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), ghAuthExecTimeout)
+	defer cancel()
+
+	out, stderr, err := runGHAuthToken(ctx, "--hostname", host)
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	if host == platformpkg.DefaultGitHubHost && isUnsupportedHostnameFlag(err, stderr) {
+		out, _, err = runGHAuthToken(ctx)
+		if err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	}
+	return ""
+}
+
+// runGHAuthToken invokes `gh auth token` with the given extra args
+// under ctx, returning stdout, stderr, and any exec error.
+func runGHAuthToken(ctx context.Context, extraArgs ...string) ([]byte, []byte, error) {
+	args := append([]string{"auth", "token"}, extraArgs...)
+	cmd := execCommand(ctx, "gh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	return out, stderr.Bytes(), err
+}
+
+// isUnsupportedHostnameFlag reports whether the gh invocation failed
+// specifically because the installed gh does not recognize the
+// --hostname flag (cobra/pflag rejection text). Missing-binary,
+// context-deadline, auth-failure, and other nonzero exits all return
+// false so the caller does not retry bare.
+func isUnsupportedHostnameFlag(err error, stderr []byte) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	text := string(stderr)
+	return strings.Contains(text, "unknown flag: --hostname") ||
+		strings.Contains(text, "unknown shorthand flag")
+}
+```
+
+Delete the old `ghAuthToken` function entirely. `GitHubToken` still references `ghAuthToken` though — update it temporarily so the file compiles:
+
+```go
+func (c *Config) GitHubToken() string {
+	if token := os.Getenv(c.GitHubTokenEnv); token != "" {
+		return token
+	}
+	return ghAuthTokenForHost(platformpkg.DefaultGitHubHost)
+}
+```
+
+(Task 3 will replace this with `c.gitHubTokenForHost(...)`.)
+
+- [ ] **Step 5: Run the new test — passes**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestGhAuthTokenForHostPassesHostnameFlag' -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 6: Run the existing tests — still pass**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestGitHubToken' -shuffle=on`
+Expected: PASS. `TestGitHubTokenFallsBackToGHCli` (which used the old `setFakeGHCLI` shape) now exercises the new helper via `GitHubToken`, and the fake's stdout still resolves the token.
+
+- [ ] **Step 7: Add the older-`gh` retry tests**
+
+Append to `config_test.go`:
+
+```go
+func TestGhAuthTokenForHostRetriesBareWhenOldGHRejectsHostnameFlag(t *testing.T) {
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
+	ghPath := filepath.Join(dir, "gh")
+	// Older gh rejects --hostname; bare succeeds.
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
+case "$*" in
+*--hostname*)
+	printf 'unknown flag: --hostname\n' 1>&2
+	exit 2
+	;;
+*)
+	printf 'gh-secret-bare\n'
+	exit 0
+	;;
+esac
+`
+	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+
+	got := ghAuthTokenForHost("github.com")
+	Assert.Equal(t, "gh-secret-bare", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 2)
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+	Assert.Equal(t, "auth token", argv[1])
+}
+
+func TestGhAuthTokenForHostDoesNotRetryBareOnAuthFailure(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stderr:   "no oauth token",
+		ExitCode: 1,
+	})
+
+	got := ghAuthTokenForHost("github.com")
+	Assert.Empty(t, got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1, "should not retry bare on non-flag-rejection failure")
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+}
+
+func TestGhAuthTokenForHostDoesNotRetryBareOnGHEFlagRejection(t *testing.T) {
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
+	ghPath := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
+printf 'unknown flag: --hostname\n' 1>&2
+exit 2
+`
+	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+
+	got := ghAuthTokenForHost("ghe.example.com")
+	Assert.Empty(t, got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1, "non-github.com host must not retry bare")
+	Assert.Equal(t, "auth token --hostname ghe.example.com", argv[0])
+}
+
+func TestGhAuthTokenForHostReturnsEmptyWhenBinaryMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	Assert.Empty(t, ghAuthTokenForHost("github.com"))
+}
+```
+
+- [ ] **Step 8: Run all the new ghAuthTokenForHost tests — pass**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestGhAuthTokenForHost' -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 9: Add the timeout test**
+
+Append to `config_test.go`:
+
+```go
+func TestGhAuthTokenForHostTimesOut(t *testing.T) {
+	// Fake gh sleeps longer than the timeout, so the helper must
+	// return "" once the context expires.
+	setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout:       "never-reached",
+		SleepSeconds: 10,
+	})
+
+	start := time.Now()
+	got := ghAuthTokenForHost("github.com")
+	elapsed := time.Since(start)
+
+	Assert.Empty(t, got)
+	Assert.Less(
+		t, elapsed, ghAuthExecTimeout+2*time.Second,
+		"helper should return shortly after timeout, took %s", elapsed,
+	)
+}
+```
+
+Add `"time"` to the test file's import block if it isn't already there (it should already be present).
+
+- [ ] **Step 10: Run the timeout test**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestGhAuthTokenForHostTimesOut' -shuffle=on`
+Expected: PASS. The whole test should complete within roughly the timeout (5s + small slack).
+
+- [ ] **Step 11: Run the entire config package**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -shuffle=on`
+Expected: PASS for the whole package, including the original `TestGitHubToken*` tests.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): add host-scoped gh auth token helper"
+```
+
+---
+
+## Task 3: Thread the host through `TokenForPlatformHost` and `GitHubToken`
+
+**Files:**
+- Modify: `internal/config/config.go` (`(*Config).GitHubToken` and `(*Config).TokenForPlatformHost`; add `(*Config).gitHubTokenForHost`)
+- Test: `internal/config/config_test.go` (new tests for GHE-host resolution and ordering)
+
+The helper from Task 2 is in place. Now teach `TokenForPlatformHost` to call it with the right host for GitHub-platform repos, and fold the env-var-then-`gh` contract into a single method so both `GitHubToken()` and `TokenForPlatformHost` go through it.
+
+- [ ] **Step 1: Write the failing GHE-host test**
+
+Append to `config_test.go`:
+
+```go
+func TestTokenForPlatformHostUsesGHWithHostnameForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-secret",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "")
+	Assert.Equal(t, "ghe-secret", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1)
+	Assert.Equal(t, "auth token --hostname ghe.example.com", argv[0])
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestTokenForPlatformHostUsesGHWithHostnameForGHE' -shuffle=on`
+Expected: FAIL. Today `TokenForPlatformHost` calls `c.GitHubToken()` which, after Task 2, invokes `ghAuthTokenForHost(platformpkg.DefaultGitHubHost)` — so the argv will be `auth token --hostname github.com`, not the GHE host.
+
+- [ ] **Step 3: Add `(*Config).gitHubTokenForHost` and thread the host through**
+
+In `internal/config/config.go`, change `(*Config).GitHubToken` and `(*Config).TokenForPlatformHost`, and add the new method.
+
+Locate:
+
+```go
+func (c *Config) GitHubToken() string {
+	if token := os.Getenv(c.GitHubTokenEnv); token != "" {
+		return token
+	}
+	return ghAuthTokenForHost(platformpkg.DefaultGitHubHost)
+}
+```
+
+Replace with:
+
+```go
+func (c *Config) GitHubToken() string {
+	return c.gitHubTokenForHost(platformpkg.DefaultGitHubHost)
+}
+
+// gitHubTokenForHost resolves a github token for host. It checks the
+// configured env var first, then falls back to `gh auth token
+// --hostname <host>`. Internal helper; callers go through GitHubToken
+// or TokenForPlatformHost.
+func (c *Config) gitHubTokenForHost(host string) string {
+	if token := os.Getenv(c.GitHubTokenEnv); token != "" {
+		return token
+	}
+	return ghAuthTokenForHost(host)
+}
+```
+
+Locate the github-fallback branch in `TokenForPlatformHost`:
+
+```go
+	if p == defaultPlatform {
+		return c.GitHubToken()
+	}
+```
+
+Replace with:
+
+```go
+	if p == defaultPlatform {
+		return c.gitHubTokenForHost(h)
+	}
+```
+
+(`h` is already in scope from the earlier `normalizePlatformHost(p, host)` call.)
+
+- [ ] **Step 4: Run the new test — passes**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestTokenForPlatformHostUsesGHWithHostnameForGHE' -shuffle=on`
+Expected: PASS.
+
+- [ ] **Step 5: Add ordering tests for the GHE host**
+
+Append to `config_test.go`:
+
+```go
+func TestTokenForPlatformHostPrefersEnvOverGHForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-from-gh",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "ghe-from-env")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "")
+	Assert.Equal(t, "ghe-from-env", got)
+
+	Assert.Empty(t, readFakeGHArgv(t, argvPath), "env var should short-circuit gh")
+}
+
+func TestTokenForPlatformHostPrefersPlatformsEntryOverGHForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-from-gh",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+	t.Setenv("PLATFORMS_GHE_TOKEN", "ghe-from-platforms")
+
+	cfg := &Config{
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Platforms: []PlatformConfig{
+			{Type: "github", Host: "ghe.example.com", TokenEnv: "PLATFORMS_GHE_TOKEN"},
+		},
+	}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "")
+	Assert.Equal(t, "ghe-from-platforms", got)
+
+	Assert.Empty(t, readFakeGHArgv(t, argvPath), "[[platforms]] should short-circuit gh")
+}
+
+func TestTokenForPlatformHostPrefersRepoTokenEnvOverGHForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-from-gh",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+	t.Setenv("REPO_GHE_TOKEN", "ghe-from-repo")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "REPO_GHE_TOKEN")
+	Assert.Equal(t, "ghe-from-repo", got)
+
+	Assert.Empty(t, readFakeGHArgv(t, argvPath), "repo token_env should short-circuit gh")
+}
+
+func TestGitHubTokenInvokesGHWithGithubComHostname(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "default-host-secret",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.GitHubToken()
+	Assert.Equal(t, "default-host-secret", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1)
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+}
+```
+
+- [ ] **Step 6: Run the ordering tests**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -run 'TestTokenForPlatformHostPrefers|TestGitHubTokenInvokesGHWithGithubComHostname' -shuffle=on`
+Expected: PASS for all four.
+
+- [ ] **Step 7: Run the full config package**
+
+Run: `nix run nixpkgs#go -- test ./internal/config -shuffle=on`
+Expected: PASS for the whole package.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): scope gh auth token fallback by hostname"
+```
+
+---
+
+## Task 4: Final verification across the repo
+
+**Files:** none modified; this task is verification only.
+
+Make sure nothing outside `internal/config/` regressed (no caller depends on the old host-agnostic `ghAuthToken` shape), lint is clean, and full tests pass.
+
+- [ ] **Step 1: Confirm no other package references the removed symbol**
+
+Run: `nix run nixpkgs#ripgrep -- -n '\bghAuthToken\b' internal cmd`
+Expected: no matches (the helper was renamed to `ghAuthTokenForHost`). If any match shows up, fix it before continuing.
+
+- [ ] **Step 2: Run `go vet`**
+
+Run: `make vet`
+Expected: clean.
+
+- [ ] **Step 3: Run lint**
+
+Run: `make lint`
+Expected: clean. If golangci-lint flags anything in the touched files, fix it.
+
+- [ ] **Step 4: Run the full Go test suite**
+
+Run: `make test`
+Expected: PASS. The `-shuffle=on` flag is already on the make target.
+
+- [ ] **Step 5: Commit any lint fixes**
+
+If Steps 2-3 required edits, commit them:
+
+```bash
+git add -p internal/config
+git commit -m "chore(config): satisfy lint on host-scoped gh helper"
+```
+
+Otherwise nothing to commit; skip.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:**
+  - D1 (host-scoped helper) — Task 2 Step 4 (`ghAuthTokenForHost` replaces `ghAuthToken`).
+  - D2 (thread host through `TokenForPlatformHost`) — Task 3 Steps 3 and 4 (`gitHubTokenForHost`, updated `TokenForPlatformHost` branch).
+  - D3 (older-`gh` retry only for `github.com`) — Task 2 Steps 4 (implementation) and 7 (`TestGhAuthTokenForHostDoesNotRetryBareOnGHEFlagRejection`).
+  - D4 (5-second timeout) — Task 2 Step 4 (`ghAuthExecTimeout`) and Step 9 (`TestGhAuthTokenForHostTimesOut`).
+  - D5 (narrow detection of older-`gh` case, capture stderr explicitly) — Task 2 Step 4 (`isUnsupportedHostnameFlag` checks for `*exec.ExitError` and the two cobra/pflag substrings; `runGHAuthToken` sets `cmd.Stderr = &stderr` so the rejection text is visible).
+  - D6 (test seam) — Task 1 Steps 2 (the `var execCommand` change) and Task 2 Step 1 (`setFakeGHCLIScript` extends the PATH-based fake with argv capture, exit code, and stderr; no function-replacement seam introduced).
+  - Architecture: `TokenForPlatformHost -> gitHubTokenForHost -> ghAuthTokenForHost` — Task 3 Step 3.
+  - Risks (legacy `gh` on `github.com`) — Task 2 Step 7 explicitly tests `TestGhAuthTokenForHostRetriesBareWhenOldGHRejectsHostnameFlag`.
+  - Spec test list: every named test in the spec ("Testing" section) maps to a step above.
+- **Placeholder scan:** no TBDs, no "appropriate error handling", every code step has the actual code.
+- **Type consistency:** `ghAuthTokenForHost(host string) string`, `(*Config).gitHubTokenForHost(host string) string`, `runGHAuthToken(ctx context.Context, extraArgs ...string) ([]byte, []byte, error)`, `isUnsupportedHostnameFlag(err error, stderr []byte) bool`, `setFakeGHCLIScript(t *testing.T, opts fakeGHCLIOptions) string`, `readFakeGHArgv(t *testing.T, path string) []string`. All names match across tasks.
+
+---
+
+## Out of Scope (Surfaced as Follow-Ups, Not Pulled In)
+
+- Renaming or restructuring the rest of the token resolution chain.
+- New config knobs to control the fallback.
+- Equivalent CLI-fallback behavior for Forgejo / Gitea / GitLab (those providers don't ship a `gh`-style CLI today).
+- Context-aware token resolution end-to-end (the helper can later accept a caller-supplied `ctx` without breaking the exported API).
+- UI/API surface changes (none needed).

--- a/docs/superpowers/specs/2026-05-19-gh-auth-hostname-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-19-gh-auth-hostname-fallback-design.md
@@ -2,15 +2,18 @@
 
 ## Motivation
 
-middleman supports multi-provider authentication. For GitHub-family hosts the
-resolution chain is:
+middleman supports multi-provider authentication. For GitHub-family hosts
+the current resolution chain (`internal/config/config.go`
+`TokenForPlatformHost`) tries each step in order:
 
-1. Repo-level `token_env` (if set on the `[[repos]]` entry).
-2. `[[platforms]]` entry whose `(type, host)` matches the repo's
-   `(platform, platform_host)` and has `token_env` set.
-3. Provider default env var, e.g. `MIDDLEMAN_GITHUB_TOKEN`.
-4. **`gh auth token`** — only reached today when the repo's host is
-   `github.com` (and only via `cfg.GitHubToken()`).
+- Repo-level `token_env` (if set on the `[[repos]]` entry).
+- `[[platforms]]` entry whose `(type, host)` matches the repo's
+  `(platform, platform_host)` and has `token_env` set.
+- `MIDDLEMAN_GITHUB_TOKEN` via `cfg.GitHubToken()`.
+- **`gh auth token`** — bare, no `--hostname` argument. Reached today for
+  any github host (`github.com` or a GHE host) once the env-var step
+  comes up empty, via the path `TokenForPlatformHost -> GitHubToken ->
+  ghAuthToken`.
 
 The `gh auth token` invocation in `internal/config/config.go` is unscoped:
 
@@ -45,8 +48,9 @@ In scope:
 - Bound the subprocess at 5 seconds.
 - Keep the older-`gh` (no `--hostname` flag) compatibility for `github.com`
   only.
-- Test seam: make the subprocess injectable so unit tests stub `gh` without
-  relying on `PATH` shenanigans.
+- Tests stub the subprocess via the existing `PATH`-based fake-`gh`
+  pattern, with the fake extended to inspect argv and emit controlled
+  stdout/stderr/exit-code.
 
 Out of scope:
 
@@ -58,17 +62,33 @@ Out of scope:
 
 ## Decisions
 
-D1. **Host-scoped helper everywhere.** Replace `ghAuthToken()` with
-`ghAuthTokenForHost(ctx, host)`. The exported wrapper `cfg.GitHubToken()`
-becomes a thin call to `ghAuthTokenForHost(ctx, platform.DefaultGitHubHost)`.
-Every call into `gh auth token` knows which host it is resolving.
+D1. **Host-scoped helper everywhere.** Replace `ghAuthToken()` with an
+internal helper `ghAuthTokenForHost(host string)`. Every call into
+`gh auth token` knows which host it is resolving. (`cfg.GitHubToken()`'s
+env-var-then-gh contract is preserved via a new internal
+`gitHubTokenForHost(host)` — see D2.)
 
 D2. **Thread host through `TokenForPlatformHost`.** When the resolution
-chain reaches the `gh` step for `(platform == github, host)`, call
-`ghAuthTokenForHost(ctx, host)` rather than the previous host-agnostic
-`cfg.GitHubToken()`. The behavior for a `github.com` repo is unchanged;
-the behavior for a GHE host now reaches `gh auth token --hostname <ghe>`
-instead of bare `gh auth token`.
+chain reaches the github-fallback step for `(platform == github, host)`,
+call a host-aware internal helper that preserves the existing env-var
+contract:
+
+```go
+func (c *Config) gitHubTokenForHost(host string) string {
+    if token := os.Getenv(c.GitHubTokenEnv); token != "" {
+        return token
+    }
+    return ghAuthTokenForHost(host)
+}
+```
+
+`TokenForPlatformHost` for `(github, host)` calls
+`c.gitHubTokenForHost(host)` rather than the previous host-agnostic
+`c.GitHubToken()`. `cfg.GitHubToken()` becomes
+`c.gitHubTokenForHost(platformpkg.DefaultGitHubHost)`. The
+`MIDDLEMAN_GITHUB_TOKEN` fallback continues to work for any github
+host that lacks a more specific match; the only behavior change is that
+the `gh` step is now host-scoped.
 
 D3. **Older-`gh` compatibility for `github.com` only.** If
 `gh auth token --hostname github.com` fails specifically because the
@@ -92,11 +112,25 @@ D5. **Narrow detection of the older-`gh` case.**
 Missing binary (`exec.LookPath` failure / `*exec.Error`), context deadline,
 auth failure, or any other nonzero exit do not trigger the bare retry.
 
-D6. **Injectable test seam.** Keep the `var execCommand = exec.CommandContext`
-pattern. Tests stub it by replacing the variable with a fake that returns
-controlled stdout/stderr/exit-code; no test depends on `PATH` for stubbing
-`gh`, although we keep the existing PATH-based fakes for regression
-coverage where they are clearer.
+For detection to see the rejection text, the implementation must capture
+stderr explicitly — `Output()` populates `*exec.ExitError.Stderr` only
+when `cmd.Stderr` is unset, so the helper should assign
+`cmd.Stderr = &buf` and use `cmd.Output()`, or use `cmd.CombinedOutput()`
+and parse from the combined buffer. Either is fine; the spec does not
+mandate one.
+
+D6. **Test seam.** Keep the existing PATH-based fake-`gh` pattern that
+`setFakeGHCLI` already uses. The package-level `var execCommand =
+exec.CommandContext` exists so tests can swap to a function-replacement
+seam if a particular case needs it, but the default approach for new
+tests is the same as the old ones: write a small shell script to a temp
+dir and set `PATH=$dir`. New tests extend the fake's behavior (argv
+capture, controlled exit code, controlled stderr) inside the script
+rather than introducing a function-replacement seam.
+
+The variable changes from `exec.Command` to `exec.CommandContext` so the
+helper can pass its 5-second timeout context through; tests do not need
+to do anything different to keep working with the new signature.
 
 ## Architecture
 
@@ -104,54 +138,65 @@ coverage where they are clearer.
 TokenForPlatformHost(platform, host, repoTokenEnv)
   -> repo token_env? -> return os.Getenv(repoTokenEnv)
   -> [[platforms]] match? -> return os.Getenv(pc.TokenEnv)
-  -> provider default env? -> return os.Getenv(defaultEnv)
-  -> platform == "github"? -> ghAuthTokenForHost(ctx, host)
-                              -> exec.CommandContext(ctx, "gh", "auth",
-                                                     "token",
-                                                     "--hostname", host)
-                              -> if host == "github.com" AND
-                                    isUnsupportedHostnameFlag(err, stderr):
-                                     retry bare exec.CommandContext(ctx, "gh",
-                                                                    "auth",
-                                                                    "token")
-                              -> return strings.TrimSpace(stdout) or ""
+  -> defaultTokenEnvForPlatformHost match? -> return os.Getenv(defaultEnv)
+                                              (forgejo/codeberg.org,
+                                               gitea/gitea.com)
+  -> platform == "github"? -> c.gitHubTokenForHost(host)
+                              -> os.Getenv(c.GitHubTokenEnv) if non-empty
+                              -> else ghAuthTokenForHost(host)
+                                       -> ctx, cancel := WithTimeout(
+                                                Background, 5s)
+                                       -> execCommand(ctx, "gh", "auth",
+                                                      "token",
+                                                      "--hostname", host)
+                                       -> if host == "github.com" AND
+                                             isUnsupportedHostnameFlag(
+                                                 err, stderr):
+                                            retry execCommand(ctx, "gh",
+                                                              "auth",
+                                                              "token")
+                                       -> return strings.TrimSpace(stdout)
+                                          or ""
   -> default: return ""
 
-GitHubToken() = ghAuthTokenForHost(ctx, DefaultGitHubHost)
-                — back-compat wrapper used by provider startup to seed the
-                default github.com slot. Behavior is identical to today
-                modulo the now-explicit --hostname github.com argument.
+GitHubToken() = c.gitHubTokenForHost(platformpkg.DefaultGitHubHost)
+
+  Direct caller: provider_startup.collectProviderTokens seeds the
+  default github.com slot through this method. Behavior is identical to
+  today for that caller modulo the now-explicit --hostname github.com
+  argument when the env var is empty.
 ```
 
-The 5-second timeout is created inside `ghAuthTokenForHost` so all callers
-inherit it without plumbing a context through every site:
+The 5-second timeout is created inside `ghAuthTokenForHost` so callers
+don't have to plumb a context through every site:
 
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 defer cancel()
+cmd := execCommand(ctx, "gh", "auth", "token", "--hostname", host)
 ```
 
-Callers do not need to thread a context themselves; we are not introducing
-context-aware token resolution to the rest of the codebase as part of this
-change. (If the surrounding code grows context plumbing later, the helper
-can accept an external context without a signature break — see "Future
-work".)
+This change does not introduce context-aware token resolution to the
+rest of the codebase.
 
 ## Components
 
 - `internal/config/config.go`
   - Replace `ghAuthToken()` with `ghAuthTokenForHost(host string)` (no
     exported signature change; it's an internal helper).
+  - Add `c.gitHubTokenForHost(host string)` (method on `*Config`):
+    checks `os.Getenv(c.GitHubTokenEnv)` then falls back to
+    `ghAuthTokenForHost(host)`.
   - Add `isUnsupportedHostnameFlag(err error, stderr []byte) bool`
     (file-local).
   - Change `var execCommand = exec.Command` to
     `var execCommand = exec.CommandContext`. The variable still serves as
     the test seam.
-  - Update `cfg.GitHubToken()` to delegate to
-    `ghAuthTokenForHost(platform.DefaultGitHubHost)`.
+  - Update `cfg.GitHubToken()` to return
+    `c.gitHubTokenForHost(platformpkg.DefaultGitHubHost)`.
   - Update `cfg.TokenForPlatformHost` so the final-fallback path for
-    `platform == "github"` calls `ghAuthTokenForHost(host)` instead of
-    `cfg.GitHubToken()`.
+    `platform == "github"` calls `c.gitHubTokenForHost(host)` instead of
+    `c.GitHubToken()`.
 
 - `internal/config/config_test.go`
   - Extend `setFakeGHCLI` (or add a sibling helper) so a fake `gh` can
@@ -190,9 +235,21 @@ work".)
 ## Data flow
 
 No persisted state changes. No DB migration. No API surface change. No
-new env var or TOML key. The only behavioral difference visible to a
-user is that `gh auth login --hostname ghe.example` now feeds the GHE
-host's token resolution without `MIDDLEMAN_GITHUB_TOKEN` being set.
+new env var or TOML key. User-visible behavior changes are limited to
+how the `gh` step resolves:
+
+- A user with `gh auth login --hostname ghe.example` and
+  `platform_host = "ghe.example"` configured now gets the GHE token
+  without setting `MIDDLEMAN_GITHUB_TOKEN`. (New.)
+- A user with multiple `gh` accounts (e.g. github.com plus a GHE host)
+  and `MIDDLEMAN_GITHUB_TOKEN` empty stops returning gh's default-host
+  token for non-default hosts and instead resolves each host's token
+  independently. (Implicit bug fix.)
+- A user on an older `gh` that does not support `--hostname` and
+  `platform_host = "ghe.example"` with `MIDDLEMAN_GITHUB_TOKEN` empty:
+  today returns the bare-`gh` token (wrong host); after this change
+  returns empty for that GHE host, surfacing the existing missing-token
+  error. github.com keeps working via the bare retry.
 
 ## Error handling
 
@@ -235,9 +292,9 @@ timeout, stubbed subprocess).
 ## Future work
 
 - If middleman grows context-aware token resolution end-to-end, the
-  helper's signature is ready: `ghAuthTokenForHost(ctx context.Context,
-  host string)`. The internal-only helper can accept an external context
-  without a signature break.
+  internal helper can grow a `ctx context.Context` parameter without
+  breaking the exported `cfg.GitHubToken()` and
+  `cfg.TokenForPlatformHost` APIs.
 - If a similar `gh`-style fallback ever shows up for another provider,
   we would generalize the helper and detection logic. Not part of this
   change.

--- a/docs/superpowers/specs/2026-05-19-gh-auth-hostname-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-19-gh-auth-hostname-fallback-design.md
@@ -1,0 +1,256 @@
+# Design: Scope `gh auth token` fallback by hostname
+
+## Motivation
+
+middleman supports multi-provider authentication. For GitHub-family hosts the
+resolution chain is:
+
+1. Repo-level `token_env` (if set on the `[[repos]]` entry).
+2. `[[platforms]]` entry whose `(type, host)` matches the repo's
+   `(platform, platform_host)` and has `token_env` set.
+3. Provider default env var, e.g. `MIDDLEMAN_GITHUB_TOKEN`.
+4. **`gh auth token`** — only reached today when the repo's host is
+   `github.com` (and only via `cfg.GitHubToken()`).
+
+The `gh auth token` invocation in `internal/config/config.go` is unscoped:
+
+```go
+func ghAuthToken() string {
+    out, err := execCommand("gh", "auth", "token").Output()
+    if err != nil {
+        return ""
+    }
+    return strings.TrimSpace(string(out))
+}
+```
+
+A user who has authenticated to GitHub Enterprise via
+`gh auth login --hostname ghe.example` and configured a repo with
+`platform_host = "ghe.example"` still has to set `MIDDLEMAN_GITHUB_TOKEN`
+manually. The same user with multiple `gh` accounts (one for `github.com`,
+one for `ghe.example`) silently gets whichever host `gh` happens to treat
+as the default — which is rarely the GHE host. This is a common
+onboarding paper-cut for GHE users.
+
+Fix: pass the resolved hostname into `gh auth token --hostname <host>` so
+each provider host resolves independently.
+
+## Scope
+
+In scope:
+
+- Replace `ghAuthToken()` with a host-aware helper.
+- Thread the resolved hostname through `cfg.TokenForPlatformHost` and
+  `cfg.GitHubToken()`.
+- Bound the subprocess at 5 seconds.
+- Keep the older-`gh` (no `--hostname` flag) compatibility for `github.com`
+  only.
+- Test seam: make the subprocess injectable so unit tests stub `gh` without
+  relying on `PATH` shenanigans.
+
+Out of scope:
+
+- Renaming or restructuring the rest of the token resolution chain.
+- Adding new config knobs to control the fallback.
+- Any platform other than GitHub. Forgejo, Gitea, and GitLab don't have a
+  `gh`-style CLI fallback today and don't grow one here.
+- UI surfaces. This is server-side resolution; no API or SPA change.
+
+## Decisions
+
+D1. **Host-scoped helper everywhere.** Replace `ghAuthToken()` with
+`ghAuthTokenForHost(ctx, host)`. The exported wrapper `cfg.GitHubToken()`
+becomes a thin call to `ghAuthTokenForHost(ctx, platform.DefaultGitHubHost)`.
+Every call into `gh auth token` knows which host it is resolving.
+
+D2. **Thread host through `TokenForPlatformHost`.** When the resolution
+chain reaches the `gh` step for `(platform == github, host)`, call
+`ghAuthTokenForHost(ctx, host)` rather than the previous host-agnostic
+`cfg.GitHubToken()`. The behavior for a `github.com` repo is unchanged;
+the behavior for a GHE host now reaches `gh auth token --hostname <ghe>`
+instead of bare `gh auth token`.
+
+D3. **Older-`gh` compatibility for `github.com` only.** If
+`gh auth token --hostname github.com` fails specifically because the
+installed `gh` does not recognize `--hostname`, retry bare `gh auth token`.
+For any other host, do not retry. Other failure modes (missing binary,
+context deadline, auth failure, invalid host, unrelated nonzero exit)
+return empty without a bare retry.
+
+D4. **Subprocess timeout of 5 seconds.** Wrap each subprocess in a
+`context.WithTimeout(ctx, 5*time.Second)` so a hung `gh` cannot stall
+startup or token refresh.
+
+D5. **Narrow detection of the older-`gh` case.**
+`isUnsupportedHostnameFlag(err, stderr)` requires both:
+
+- `err` is `*exec.ExitError` (the subprocess actually ran and exited
+  non-zero), AND
+- `stderr` matches one of `unknown flag: --hostname` or
+  `unknown shorthand flag` (the `cobra`/`pflag` rejection text).
+
+Missing binary (`exec.LookPath` failure / `*exec.Error`), context deadline,
+auth failure, or any other nonzero exit do not trigger the bare retry.
+
+D6. **Injectable test seam.** Keep the `var execCommand = exec.CommandContext`
+pattern. Tests stub it by replacing the variable with a fake that returns
+controlled stdout/stderr/exit-code; no test depends on `PATH` for stubbing
+`gh`, although we keep the existing PATH-based fakes for regression
+coverage where they are clearer.
+
+## Architecture
+
+```
+TokenForPlatformHost(platform, host, repoTokenEnv)
+  -> repo token_env? -> return os.Getenv(repoTokenEnv)
+  -> [[platforms]] match? -> return os.Getenv(pc.TokenEnv)
+  -> provider default env? -> return os.Getenv(defaultEnv)
+  -> platform == "github"? -> ghAuthTokenForHost(ctx, host)
+                              -> exec.CommandContext(ctx, "gh", "auth",
+                                                     "token",
+                                                     "--hostname", host)
+                              -> if host == "github.com" AND
+                                    isUnsupportedHostnameFlag(err, stderr):
+                                     retry bare exec.CommandContext(ctx, "gh",
+                                                                    "auth",
+                                                                    "token")
+                              -> return strings.TrimSpace(stdout) or ""
+  -> default: return ""
+
+GitHubToken() = ghAuthTokenForHost(ctx, DefaultGitHubHost)
+                — back-compat wrapper used by provider startup to seed the
+                default github.com slot. Behavior is identical to today
+                modulo the now-explicit --hostname github.com argument.
+```
+
+The 5-second timeout is created inside `ghAuthTokenForHost` so all callers
+inherit it without plumbing a context through every site:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+```
+
+Callers do not need to thread a context themselves; we are not introducing
+context-aware token resolution to the rest of the codebase as part of this
+change. (If the surrounding code grows context plumbing later, the helper
+can accept an external context without a signature break — see "Future
+work".)
+
+## Components
+
+- `internal/config/config.go`
+  - Replace `ghAuthToken()` with `ghAuthTokenForHost(host string)` (no
+    exported signature change; it's an internal helper).
+  - Add `isUnsupportedHostnameFlag(err error, stderr []byte) bool`
+    (file-local).
+  - Change `var execCommand = exec.Command` to
+    `var execCommand = exec.CommandContext`. The variable still serves as
+    the test seam.
+  - Update `cfg.GitHubToken()` to delegate to
+    `ghAuthTokenForHost(platform.DefaultGitHubHost)`.
+  - Update `cfg.TokenForPlatformHost` so the final-fallback path for
+    `platform == "github"` calls `ghAuthTokenForHost(host)` instead of
+    `cfg.GitHubToken()`.
+
+- `internal/config/config_test.go`
+  - Extend `setFakeGHCLI` (or add a sibling helper) so a fake `gh` can
+    inspect its own argv. Add a helper that writes a richer fake `gh`
+    script which emits a controlled exit code, stdout, and stderr based on
+    the flags it receives.
+  - New unit tests:
+    - `TestTokenForPlatformHostUsesGHWithHostnameForGHE` —
+      `gh --hostname ghe.example` returns the GHE token; no env var, no
+      `[[platforms]]` entry.
+    - `TestTokenForPlatformHostPrefersEnvOverGHForGHE` — env wins.
+    - `TestTokenForPlatformHostPrefersPlatformsEntryOverGHForGHE` —
+      `[[platforms]]` entry wins.
+    - `TestTokenForPlatformHostPrefersRepoTokenEnvOverGHForGHE` —
+      repo-level `token_env` wins.
+    - `TestGitHubTokenInvokesGHWithGithubComHostname` — verifies
+      `cfg.GitHubToken()` calls `gh auth token --hostname github.com`.
+    - `TestGitHubTokenRetriesBareWhenOldGHRejectsHostnameFlag` — fake `gh`
+      returns "unknown flag: --hostname" on `--hostname github.com`, then
+      succeeds bare; helper returns the token.
+    - `TestGitHubTokenDoesNotRetryBareOnAuthFailure` — fake `gh` returns
+      nonzero with non-flag-rejection stderr; helper returns empty;
+      assert the subprocess was called exactly once.
+    - `TestGHEHostDoesNotRetryBareOnFlagRejection` — fake `gh` returns
+      "unknown flag: --hostname" on `--hostname ghe.example`; helper
+      returns empty; subprocess called exactly once.
+    - `TestGHAuthTokenTimesOut` — fake `gh` sleeps longer than the
+      configured timeout; helper returns empty in less than the timeout +
+      slack.
+  - Keep existing tests
+    (`TestGitHubTokenFallsBackToGHCli`, `TestGitHubTokenReturnsEmptyWhenGHCliUnavailable`,
+    `TestGitHubTokenPrefersEnvVarOverGHCli`). Their existing fake-`gh`
+    scripts continue to work because the new helper still invokes `gh`
+    via `execCommand`.
+
+## Data flow
+
+No persisted state changes. No DB migration. No API surface change. No
+new env var or TOML key. The only behavioral difference visible to a
+user is that `gh auth login --hostname ghe.example` now feeds the GHE
+host's token resolution without `MIDDLEMAN_GITHUB_TOKEN` being set.
+
+## Error handling
+
+- Missing `gh` binary (`exec.LookPath` resolves to nothing, or the
+  subprocess fails to start): return empty. Today's behavior.
+- Subprocess exits non-zero with `unknown flag: --hostname` /
+  `unknown shorthand flag` stderr, and host is `github.com`: retry bare.
+  Today's behavior preserved.
+- Same stderr but host is not `github.com`: return empty. No retry. The
+  user sees the existing "no token for github host <ghe.example>" error
+  at provider startup, which is the right surface.
+- Subprocess context deadline exceeded (5s): return empty. Do not retry.
+- Subprocess nonzero with any other stderr (auth failure, network error,
+  malformed host): return empty. Do not retry.
+
+All "return empty" paths fall through to the same missing-token error
+already emitted by `collectProviderTokens`. We do not add new error
+variants; the existing error already tells the user which platform/host
+is unresolved and which env var would satisfy it.
+
+## Testing
+
+- All new tests use `t.TempDir()` for fake-`gh` scripts and `t.Setenv`
+  for env-var control.
+- Tests assert on subprocess invocation by writing the fake's argv to a
+  side-channel file (the fake `gh` script does
+  `echo "$@" > "$ARGV_FILE"`). The Go test reads that file to assert
+  the expected flags were passed.
+- Tests run with `-shuffle=on` (the make target already does this).
+- No e2e tests against a real `gh` binary or a real GHE host. Live `gh`
+  behavior is not the subject under test; the subject is middleman's
+  invocation contract.
+
+## Open questions
+
+None. The brief constrains every meaningful design fork (host-scoped,
+env-wins, repo-`token_env`-wins, github.com-only legacy fallback, 5s
+timeout, stubbed subprocess).
+
+## Future work
+
+- If middleman grows context-aware token resolution end-to-end, the
+  helper's signature is ready: `ghAuthTokenForHost(ctx context.Context,
+  host string)`. The internal-only helper can accept an external context
+  without a signature break.
+- If a similar `gh`-style fallback ever shows up for another provider,
+  we would generalize the helper and detection logic. Not part of this
+  change.
+
+## Risks
+
+- Older `gh` users on `github.com` who do not yet have
+  `MIDDLEMAN_GITHUB_TOKEN` set rely on the bare retry. The retry covers
+  them. We do not break that path.
+- A user with `gh auth login` only for the default host (call it
+  `github.com`) and a repo configured for `ghe.example` will see "no
+  token" at startup instead of getting the wrong-but-non-empty token.
+  This is the correct outcome.
+- The 5-second timeout could in theory cut off a slow `gh` call. In
+  practice `gh auth token` is local (no network) and returns in
+  milliseconds; 5s is generous. If users surface flakes we can grow it.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -790,7 +790,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("config: host %q is not loopback; only loopback addresses are supported", c.Host)
 	}
 
-	if c.Port < 1 || c.Port > 65535 {
+	if c.Port < 0 || c.Port > 65535 {
 		return fmt.Errorf("config: invalid port %d", c.Port)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -1087,10 +1088,10 @@ func appendTokenEnvName(names []string, name string) []string {
 	return append(names, name)
 }
 
-var execCommand = exec.Command
+var execCommand = exec.CommandContext
 
 func ghAuthToken() string {
-	out, err := execCommand("gh", "auth", "token").Output()
+	out, err := execCommand(context.Background(), "gh", "auth", "token").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -973,7 +973,7 @@ func (c *Config) GitHubToken() string {
 	if token := os.Getenv(c.GitHubTokenEnv); token != "" {
 		return token
 	}
-	return ghAuthToken()
+	return ghAuthTokenForHost(platformpkg.DefaultGitHubHost)
 }
 
 func (c *Config) TokenForPlatformHost(platform, host, repoTokenEnv string) string {
@@ -1090,12 +1090,60 @@ func appendTokenEnvName(names []string, name string) []string {
 
 var execCommand = exec.CommandContext
 
-func ghAuthToken() string {
-	out, err := execCommand(context.Background(), "gh", "auth", "token").Output()
-	if err != nil {
-		return ""
+// ghAuthExecTimeout bounds each gh subprocess invocation. gh auth
+// token is a local lookup and returns in milliseconds; 5s is generous
+// and prevents a hung gh from stalling startup.
+const ghAuthExecTimeout = 5 * time.Second
+
+// ghAuthTokenForHost returns the token gh has stored for host, or "".
+// Older gh versions that do not recognize --hostname trigger a fallback
+// to bare `gh auth token` only when host is the default github.com.
+// Any other host returns empty without retry so the caller surfaces a
+// missing-token error rather than the wrong host's token.
+func ghAuthTokenForHost(host string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), ghAuthExecTimeout)
+	defer cancel()
+
+	out, stderr, err := runGHAuthToken(ctx, "--hostname", host)
+	if err == nil {
+		return strings.TrimSpace(string(out))
 	}
-	return strings.TrimSpace(string(out))
+	if host == platformpkg.DefaultGitHubHost &&
+		isUnsupportedHostnameFlag(err, stderr) {
+		out, _, err = runGHAuthToken(ctx)
+		if err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	}
+	return ""
+}
+
+// runGHAuthToken invokes `gh auth token` with the given extra args
+// under ctx. stderr is captured explicitly so the caller can inspect
+// the rejection text from older gh versions (cmd.Output() only fills
+// *ExitError.Stderr when cmd.Stderr is unset).
+func runGHAuthToken(ctx context.Context, extraArgs ...string) ([]byte, []byte, error) {
+	args := append([]string{"auth", "token"}, extraArgs...)
+	cmd := execCommand(ctx, "gh", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	return out, stderr.Bytes(), err
+}
+
+// isUnsupportedHostnameFlag reports whether the gh invocation failed
+// specifically because the installed gh does not recognize the
+// --hostname flag (cobra/pflag rejection text). Missing-binary,
+// context-deadline, auth-failure, and unrelated nonzero exits all
+// return false so the caller does not retry bare.
+func isUnsupportedHostnameFlag(err error, stderr []byte) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	text := string(stderr)
+	return strings.Contains(text, "unknown flag: --hostname") ||
+		strings.Contains(text, "unknown shorthand flag")
 }
 
 func (c *Config) BudgetPerHour() int {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -970,10 +970,18 @@ func (c *Config) SyncDuration() time.Duration {
 }
 
 func (c *Config) GitHubToken() string {
+	return c.gitHubTokenForHost(platformpkg.DefaultGitHubHost)
+}
+
+// gitHubTokenForHost resolves a github token for a specific host. The
+// configured GitHubTokenEnv env var wins when non-empty, otherwise
+// the helper falls back to `gh auth token --hostname <host>`. Internal
+// callers go through GitHubToken() or TokenForPlatformHost.
+func (c *Config) gitHubTokenForHost(host string) string {
 	if token := os.Getenv(c.GitHubTokenEnv); token != "" {
 		return token
 	}
-	return ghAuthTokenForHost(platformpkg.DefaultGitHubHost)
+	return ghAuthTokenForHost(host)
 }
 
 func (c *Config) TokenForPlatformHost(platform, host, repoTokenEnv string) string {
@@ -1002,7 +1010,7 @@ func (c *Config) TokenForPlatformHost(platform, host, repoTokenEnv string) strin
 		return os.Getenv(defaultTokenEnv)
 	}
 	if p == defaultPlatform {
-		return c.GitHubToken()
+		return c.gitHubTokenForHost(h)
 	}
 	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2344,3 +2344,79 @@ func TestGhAuthTokenForHostTimesOut(t *testing.T) {
 		"helper should return shortly after timeout, took %s", elapsed,
 	)
 }
+
+func TestTokenForPlatformHostUsesGHWithHostnameForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-secret",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "")
+	Assert.Equal(t, "ghe-secret", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1)
+	Assert.Equal(t, "auth token --hostname ghe.example.com", argv[0])
+}
+
+func TestTokenForPlatformHostPrefersEnvOverGHForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-from-gh",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "ghe-from-env")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "")
+	Assert.Equal(t, "ghe-from-env", got)
+
+	Assert.Empty(t, readFakeGHArgv(t, argvPath), "env var should short-circuit gh")
+}
+
+func TestTokenForPlatformHostPrefersPlatformsEntryOverGHForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-from-gh",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+	t.Setenv("PLATFORMS_GHE_TOKEN", "ghe-from-platforms")
+
+	cfg := &Config{
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN",
+		Platforms: []PlatformConfig{
+			{Type: "github", Host: "ghe.example.com", TokenEnv: "PLATFORMS_GHE_TOKEN"},
+		},
+	}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "")
+	Assert.Equal(t, "ghe-from-platforms", got)
+
+	Assert.Empty(t, readFakeGHArgv(t, argvPath), "[[platforms]] should short-circuit gh")
+}
+
+func TestTokenForPlatformHostPrefersRepoTokenEnvOverGHForGHE(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "ghe-from-gh",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+	t.Setenv("REPO_GHE_TOKEN", "ghe-from-repo")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.TokenForPlatformHost("github", "ghe.example.com", "REPO_GHE_TOKEN")
+	Assert.Equal(t, "ghe-from-repo", got)
+
+	Assert.Empty(t, readFakeGHArgv(t, argvPath), "repo token_env should short-circuit gh")
+}
+
+func TestGitHubTokenInvokesGHWithGithubComHostname(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "default-host-secret",
+	})
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+
+	cfg := &Config{GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN"}
+	got := cfg.GitHubToken()
+	Assert.Equal(t, "default-host-secret", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1)
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,10 +34,102 @@ func roundTripConfigString(t *testing.T, content string) (*Config, *Config) {
 
 func setFakeGHCLI(t *testing.T, stdout string) {
 	t.Helper()
+	setFakeGHCLIScript(t, fakeGHCLIOptions{Stdout: stdout})
+}
+
+type fakeGHCLIOptions struct {
+	// Stdout is echoed verbatim on success.
+	Stdout string
+	// Stderr is echoed to stderr regardless of exit code.
+	Stderr string
+	// ExitCode is the exit status of the fake gh. Default 0.
+	ExitCode int
+	// SleepSeconds, if >0, makes the fake sleep before exiting.
+	SleepSeconds int
+}
+
+// setFakeGHCLIScript writes a fake `gh` to a temp dir and points PATH
+// at it. The fake records its argv to <tempdir>/argv (one entry per
+// invocation, newline-separated), then emits stdout/stderr/exit per
+// opts. The argv-file path is returned and also exported via
+// FAKE_GH_ARGV so the script can locate it.
+//
+// To keep PATH minimal (the fake gh should be the only resolvable
+// `gh`), the helper embeds absolute paths for any external tools the
+// script needs — currently just `sleep` when SleepSeconds > 0.
+func setFakeGHCLIScript(t *testing.T, opts fakeGHCLIOptions) string {
+	t.Helper()
 	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
 	ghPath := filepath.Join(dir, "gh")
-	require.NoError(t, os.WriteFile(ghPath, []byte("#!/bin/sh\necho "+stdout+"\n"), 0o755))
+	script := "#!/bin/sh\n"
+	script += "printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n"
+	if opts.SleepSeconds > 0 {
+		// exec replaces the shell so there's no orphaned child
+		// holding stdout open after the parent gets SIGKILL'd by
+		// CommandContext; without exec, cmd.Output() blocks for
+		// the full sleep duration even after the shell is dead.
+		// SleepSeconds is therefore terminal in the script: any
+		// stderr/stdout/exit configured below is unreachable when
+		// SleepSeconds > 0, by design (the test stops the helper
+		// via context timeout, not by letting the fake finish).
+		sleepBin := resolveSleepBinary(t)
+		script += fmt.Sprintf("exec %s %d\n", sleepBin, opts.SleepSeconds)
+	}
+	if opts.Stderr != "" {
+		script += "printf '%s\\n' " + shellSingleQuote(opts.Stderr) + " 1>&2\n"
+	}
+	if opts.Stdout != "" {
+		script += "printf '%s\\n' " + shellSingleQuote(opts.Stdout) + "\n"
+	}
+	script += fmt.Sprintf("exit %d\n", opts.ExitCode)
+	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+	return argvPath
+}
+
+// resolveSleepBinary returns an absolute path to a `sleep` binary,
+// looked up under the test's original PATH before we replaced it with
+// the fake-gh dir. Tests that need sleep inline it as an absolute path
+// so the fake-gh script does not depend on the runtime PATH.
+func resolveSleepBinary(t *testing.T) string {
+	t.Helper()
+	for _, dir := range filepath.SplitList(originalTestPATH) {
+		candidate := filepath.Join(dir, "sleep")
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	require.FailNow(t, fmt.Sprintf("sleep binary not found on PATH %q", originalTestPATH))
+	return ""
+}
+
+// originalTestPATH captures the test process's PATH at package init,
+// before any test mutates it via t.Setenv. Used to locate external
+// utilities the fake-gh script needs.
+var originalTestPATH = os.Getenv("PATH")
+
+// shellSingleQuote escapes s for safe inclusion inside single quotes
+// in a /bin/sh script.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// readFakeGHArgv returns the recorded argv strings, one per
+// invocation, in call order. Returns nil when no calls were made.
+func readFakeGHArgv(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	require.NoError(t, err)
+	raw := strings.TrimRight(string(data), "\n")
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\n")
 }
 
 func TestLoadValid(t *testing.T) {
@@ -2144,5 +2239,108 @@ func TestTokenEnvNamesIncludesFallbackProviderDefaultsForRepoTokenEnv(t *testing
 			"REPO_GITEA_TOKEN",
 		},
 		cfg.TokenEnvNames(),
+	)
+}
+
+func TestGhAuthTokenForHostPassesHostnameFlag(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout: "gh-secret-github",
+	})
+
+	got := ghAuthTokenForHost("github.com")
+	Assert.Equal(t, "gh-secret-github", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1)
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+}
+
+func TestGhAuthTokenForHostRetriesBareWhenOldGHRejectsHostnameFlag(t *testing.T) {
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
+	ghPath := filepath.Join(dir, "gh")
+	// Older gh rejects --hostname; bare succeeds.
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
+case "$*" in
+*--hostname*)
+	printf 'unknown flag: --hostname\n' 1>&2
+	exit 2
+	;;
+*)
+	printf 'gh-secret-bare\n'
+	exit 0
+	;;
+esac
+`
+	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+
+	got := ghAuthTokenForHost("github.com")
+	Assert.Equal(t, "gh-secret-bare", got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 2)
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+	Assert.Equal(t, "auth token", argv[1])
+}
+
+func TestGhAuthTokenForHostDoesNotRetryBareOnAuthFailure(t *testing.T) {
+	argvPath := setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stderr:   "no oauth token",
+		ExitCode: 1,
+	})
+
+	got := ghAuthTokenForHost("github.com")
+	Assert.Empty(t, got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1, "should not retry bare on non-flag-rejection failure")
+	Assert.Equal(t, "auth token --hostname github.com", argv[0])
+}
+
+func TestGhAuthTokenForHostDoesNotRetryBareOnGHEFlagRejection(t *testing.T) {
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
+	ghPath := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
+printf 'unknown flag: --hostname\n' 1>&2
+exit 2
+`
+	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+
+	got := ghAuthTokenForHost("ghe.example.com")
+	Assert.Empty(t, got)
+
+	argv := readFakeGHArgv(t, argvPath)
+	require.Len(t, argv, 1, "non-github.com host must not retry bare")
+	Assert.Equal(t, "auth token --hostname ghe.example.com", argv[0])
+}
+
+func TestGhAuthTokenForHostReturnsEmptyWhenBinaryMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	Assert.Empty(t, ghAuthTokenForHost("github.com"))
+}
+
+func TestGhAuthTokenForHostTimesOut(t *testing.T) {
+	// Fake gh sleeps longer than the timeout, so the helper must
+	// return "" once the context expires.
+	setFakeGHCLIScript(t, fakeGHCLIOptions{
+		Stdout:       "never-reached",
+		SleepSeconds: 10,
+	})
+
+	start := time.Now()
+	got := ghAuthTokenForHost("github.com")
+	elapsed := time.Since(start)
+
+	Assert.Empty(t, got)
+	Assert.Less(
+		t, elapsed, ghAuthExecTimeout+2*time.Second,
+		"helper should return shortly after timeout, took %s", elapsed,
 	)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2256,6 +2256,9 @@ func TestGhAuthTokenForHostPassesHostnameFlag(t *testing.T) {
 }
 
 func TestGhAuthTokenForHostRetriesBareWhenOldGHRejectsHostnameFlag(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
 	dir := t.TempDir()
 	argvPath := filepath.Join(dir, "argv")
 	ghPath := filepath.Join(dir, "gh")
@@ -2273,17 +2276,17 @@ case "$*" in
 	;;
 esac
 `
-	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	require.NoError(os.WriteFile(ghPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir)
 	t.Setenv("FAKE_GH_ARGV", argvPath)
 
 	got := ghAuthTokenForHost("github.com")
-	Assert.Equal(t, "gh-secret-bare", got)
+	assert.Equal("gh-secret-bare", got)
 
 	argv := readFakeGHArgv(t, argvPath)
-	require.Len(t, argv, 2)
-	Assert.Equal(t, "auth token --hostname github.com", argv[0])
-	Assert.Equal(t, "auth token", argv[1])
+	require.Len(argv, 2)
+	assert.Equal("auth token --hostname github.com", argv[0])
+	assert.Equal("auth token", argv[1])
 }
 
 func TestGhAuthTokenForHostDoesNotRetryBareOnAuthFailure(t *testing.T) {
@@ -2301,6 +2304,9 @@ func TestGhAuthTokenForHostDoesNotRetryBareOnAuthFailure(t *testing.T) {
 }
 
 func TestGhAuthTokenForHostDoesNotRetryBareOnGHEFlagRejection(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
 	dir := t.TempDir()
 	argvPath := filepath.Join(dir, "argv")
 	ghPath := filepath.Join(dir, "gh")
@@ -2309,16 +2315,16 @@ printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
 printf 'unknown flag: --hostname\n' 1>&2
 exit 2
 `
-	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	require.NoError(os.WriteFile(ghPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir)
 	t.Setenv("FAKE_GH_ARGV", argvPath)
 
 	got := ghAuthTokenForHost("ghe.example.com")
-	Assert.Empty(t, got)
+	assert.Empty(got)
 
 	argv := readFakeGHArgv(t, argvPath)
-	require.Len(t, argv, 1, "non-github.com host must not retry bare")
-	Assert.Equal(t, "auth token --hostname ghe.example.com", argv[0])
+	require.Len(argv, 1, "non-github.com host must not retry bare")
+	assert.Equal("auth token --hostname ghe.example.com", argv[0])
 }
 
 func TestGhAuthTokenForHostReturnsEmptyWhenBinaryMissing(t *testing.T) {


### PR DESCRIPTION
## Summary

- `gh auth token` fallback now runs as `gh auth token --hostname <host>` per provider host, so users already authenticated to a non-default GitHub instance via `gh auth login --hostname ghe.example` no longer need to set `MIDDLEMAN_GITHUB_TOKEN` manually.
- Env vars and repo-level `token_env` overrides still win over the `gh` fallback.
- Subprocess is bounded with a 5s context timeout.
- Older `gh` versions that don't recognize `--hostname` get a graceful retry without the flag — but only for `github.com`. Any other host returns empty rather than risk surfacing the wrong host's token.