### PR TITLE
fix(workspace): serialize worktree mutations per repo

### DIFF
--- a/cmd/middleman/startup_token_e2e_test.go
+++ b/cmd/middleman/startup_token_e2e_test.go
@@ -22,6 +22,7 @@ import (
 // would run it on startup.
 func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 
 	// Fake gh on PATH. Records argv (one invocation per line) and
 	// emits a host-scoped token on stdout.
@@ -32,7 +33,7 @@ func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n" +
 		"printf '%s\\n' '" + fakeToken + "'\n"
-	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	require.NoError(os.WriteFile(ghPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir)
 	t.Setenv("FAKE_GH_ARGV", argvPath)
 
@@ -42,7 +43,7 @@ func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	// Config with a GHE repo. Loading via the public API exercises
 	// the same parsing path the daemon takes.
 	configPath := filepath.Join(t.TempDir(), "config.toml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	require.NoError(os.WriteFile(configPath, []byte(`
 host = "127.0.0.1"
 port = 0
 
@@ -53,17 +54,17 @@ owner = "acme"
 name = "widget"
 `), 0o644))
 	cfg, err := config.Load(configPath)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	tokens, err := collectProviderTokens(cfg)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	key := providerHostKey("github", "ghe.example.com")
 	assert.Equal(fakeToken, tokens[key],
 		"GHE provider key should resolve to the gh-supplied host token")
 
 	data, err := os.ReadFile(argvPath)
-	require.NoError(t, err)
+	require.NoError(err)
 	invocations := strings.Split(
 		strings.TrimRight(string(data), "\n"), "\n",
 	)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty/v2 v2.0.1
 	github.com/danielgtaylor/huma/v2 v2.37.3
+	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-github/v84 v84.0.0
 	github.com/oapi-codegen/runtime v1.3.1
@@ -94,7 +95,6 @@ require (
 	github.com/go-openapi/swag/typeutils v0.25.5 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -255,7 +255,6 @@ func TestClientEnsurePreservesStateOnContextCancellation(t *testing.T) {
 
 func TestClientEnsureSerializesConcurrentStarts(t *testing.T) {
 	require := require.New(t)
-	assert := Assert.New(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("in-process PTY owner test requires a host PTY")
 	}
@@ -301,9 +300,10 @@ func TestClientEnsureSerializesConcurrentStarts(t *testing.T) {
 		require.NoError(err)
 	}
 
-	data, err := os.ReadFile(record)
-	require.NoError(err)
-	assert.Equal("start", string(data))
+	require.Eventually(func() bool {
+		data, err := os.ReadFile(record)
+		return err == nil && string(data) == "start"
+	}, 2*time.Second, 20*time.Millisecond)
 }
 
 func TestClientStopPreservesStateOnContextCancellation(t *testing.T) {

--- a/internal/server/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspace_concurrent_e2e_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wesm/middleman/internal/apiclient/generated"
+)
+
+// TestWorkspaceConcurrentSameRepoOperationsE2E exercises the per-repo
+// worktree lock through the public API and SQLite. Two PRs in the same
+// repo are created concurrently, then one is retried while the other is
+// deleted at the same time. The lock must serialize the underlying
+// `git worktree add/remove/prune` calls so the bare clone ends in a
+// consistent state — no wedged worktree, no half-created branch, no
+// corrupt `worktrees/` metadata.
+func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := context.Background()
+	client := fixture.client
+
+	// Fixture already seeded PR #1; add PR #2 in the same repo so both
+	// concurrent creates target the same bare clone but different
+	// worktree paths.
+	seedPROnHost(t, fixture.database, "github.com", "acme", "widget", 2)
+
+	type createResult struct {
+		num int
+		ws  *generated.WorkspaceResponse
+		err error
+	}
+	created := make(chan createResult, 2)
+	var wg sync.WaitGroup
+	for _, num := range []int{1, 2} {
+		wg.Go(func() {
+			resp, err := client.HTTP.CreateWorkspaceWithResponse(
+				ctx,
+				generated.CreateWorkspaceInputBody{
+					PlatformHost: "github.com",
+					Owner:        "acme",
+					Name:         "widget",
+					MrNumber:     int64(num),
+				},
+			)
+			if err != nil {
+				created <- createResult{num: num, err: err}
+				return
+			}
+			if resp.StatusCode() != http.StatusAccepted || resp.JSON202 == nil {
+				created <- createResult{
+					num: num,
+					err: assertableStatusErr(resp.StatusCode()),
+				}
+				return
+			}
+			ready := waitForWorkspaceReady(t, ctx, client, resp.JSON202.Id)
+			created <- createResult{num: num, ws: ready}
+		})
+	}
+	wg.Wait()
+	close(created)
+
+	wsByNumber := map[int]*generated.WorkspaceResponse{}
+	for r := range created {
+		require.NoError(r.err, "create PR #%d", r.num)
+		require.NotNil(r.ws, "create PR #%d", r.num)
+		assert.Equal("ready", r.ws.Status)
+		wsByNumber[r.num] = r.ws
+	}
+	require.Len(wsByNumber, 2)
+
+	// Sanity check: the bare clone should now report two managed worktrees
+	// in addition to itself. If the lock failed to serialize the two
+	// concurrent `worktree add` calls, this list would be missing entries
+	// or have duplicate paths.
+	worktreeListed := listBareWorktrees(t, fixture.bare)
+	require.Equal(3, worktreeListed,
+		"expected bare clone + two workspace worktrees")
+
+	// Phase 2: drive a retry and a delete against the same bare clone at
+	// the same time. The lock must keep their worktree-mutation paths
+	// from clobbering each other.
+	retryTarget := wsByNumber[1]
+	deleteTarget := wsByNumber[2]
+	msg := "forced error for retry overlap"
+	require.NoError(fixture.database.UpdateWorkspaceStatus(
+		ctx, retryTarget.Id, "error", &msg,
+	))
+
+	force := true
+	type opResult struct {
+		op  string
+		err error
+	}
+	opOut := make(chan opResult, 2)
+
+	var phase2 sync.WaitGroup
+	phase2.Go(func() {
+		resp, err := client.HTTP.DeleteWorkspaceWithResponse(
+			ctx, deleteTarget.Id,
+			&generated.DeleteWorkspaceParams{Force: &force},
+		)
+		switch {
+		case err != nil:
+			opOut <- opResult{op: "delete", err: err}
+		case resp.StatusCode() != http.StatusNoContent:
+			opOut <- opResult{op: "delete", err: assertableStatusErr(resp.StatusCode())}
+		default:
+			opOut <- opResult{op: "delete"}
+		}
+	})
+	phase2.Go(func() {
+		resp, err := client.HTTP.RetryWorkspaceWithResponse(ctx, retryTarget.Id)
+		switch {
+		case err != nil:
+			opOut <- opResult{op: "retry", err: err}
+		case resp.StatusCode() != http.StatusAccepted || resp.JSON202 == nil:
+			opOut <- opResult{op: "retry", err: assertableStatusErr(resp.StatusCode())}
+		default:
+			waitForWorkspaceReady(t, ctx, client, retryTarget.Id)
+			opOut <- opResult{op: "retry"}
+		}
+	})
+	phase2.Wait()
+	close(opOut)
+	for r := range opOut {
+		require.NoError(r.err, "phase2 op %s", r.op)
+	}
+
+	// Verify final state. Deleted workspace is gone from the DB;
+	// retried workspace is ready again.
+	deletedRow, err := fixture.database.GetWorkspace(ctx, deleteTarget.Id)
+	require.NoError(err)
+	assert.Nil(deletedRow, "deleted workspace must be absent from DB")
+
+	retriedRow, err := fixture.database.GetWorkspace(ctx, retryTarget.Id)
+	require.NoError(err)
+	require.NotNil(retriedRow)
+	assert.Equal("ready", retriedRow.Status)
+	assert.Nil(retriedRow.ErrorMessage)
+
+	// The bare clone should now report itself + the surviving worktree
+	// (the retried one). Anything else points at a corrupt metadata
+	// state — exactly the failure mode the lock is supposed to prevent.
+	worktreeListed = listBareWorktrees(t, fixture.bare)
+	assert.Equal(2, worktreeListed,
+		"bare clone left with corrupt worktree list after concurrent ops")
+}
+
+// assertableStatusErr lets the goroutines surface unexpected status
+// codes without calling t.Fatal off the test goroutine.
+func assertableStatusErr(status int) error {
+	return &unexpectedStatusError{status: status}
+}
+
+type unexpectedStatusError struct {
+	status int
+}
+
+func (e *unexpectedStatusError) Error() string {
+	return "unexpected HTTP status: " + strings.TrimSpace(http.StatusText(e.status))
+}
+
+// listBareWorktrees counts entries in `git worktree list --porcelain`
+// for the given bare clone. The bare clone itself counts as one entry;
+// each managed worktree adds one more.
+func listBareWorktrees(t *testing.T, bare string) int {
+	t.Helper()
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = bare
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git worktree list: %s", out)
+	count := 0
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if strings.HasPrefix(line, "worktree ") {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -35,6 +35,7 @@ type Manager struct {
 	db                     *db.DB
 	worktreeDir            string
 	clones                 *gitclone.Manager
+	locks                  *FileLockManager
 	tmuxCmd                []string
 	ptyOwner               PtyOwnerClient
 	preferPtyOwner         bool
@@ -102,6 +103,7 @@ func NewManager(
 	return &Manager{
 		db:                     database,
 		worktreeDir:            worktreeDir,
+		locks:                  NewFileLockManager(),
 		retryQueued:            make(map[string]bool),
 		issueBranchSlugEnabled: true,
 	}
@@ -130,6 +132,22 @@ func (m *Manager) defaultIssueBranch(issueNumber int, title string) string {
 // operations. Called after the clone manager is initialized.
 func (m *Manager) SetClones(clones *gitclone.Manager) {
 	m.clones = clones
+}
+
+// withRepoLock acquires a lock for the clone directory, executes the function,
+// and releases the lock. The lock is released even if the function panics.
+func (m *Manager) withRepoLock(ctx context.Context, cloneDir string, fn func() error) error {
+	lock, err := m.locks.Acquire(ctx, cloneDir)
+	if err != nil {
+		return fmt.Errorf("acquire worktree lock for %q: %w", cloneDir, err)
+	}
+	defer func() {
+		if err := lock.Unlock(); err != nil {
+			slog.Warn("failed to release worktree lock",
+				"path", cloneDir, "err", err)
+		}
+	}()
+	return fn()
 }
 
 // SetTmuxCommand sets the command + argv prefix for every tmux
@@ -408,30 +426,32 @@ func (m *Manager) Setup(
 		)
 	}
 
-	branch, err := m.addWorktree(ctx, cloneDir, ws)
-	if err != nil {
-		return m.failSetup(
-			ctx,
-			ws.ID, workspaceSetupStageWorktree, err,
-		)
-	}
-	ws.WorkspaceBranch = branch
-	if err := m.updateWorkspaceBranch(
-		ctx, ws.ID, branch,
-	); err != nil {
-		m.rollbackWorktree(ctx, cloneDir, ws, branch)
-		return m.failSetup(
-			ctx,
-			ws.ID, workspaceSetupStageWorktree, err,
-		)
-	}
+	var branch string
+	err = m.withRepoLock(ctx, cloneDir, func() error {
+		var addErr error
+		branch, addErr = m.addWorktree(ctx, cloneDir, ws)
+		if addErr != nil {
+			return addErr
+		}
+		ws.WorkspaceBranch = branch
+		if err := m.updateWorkspaceBranch(
+			ctx, ws.ID, branch,
+		); err != nil {
+			m.rollbackWorktree(ctx, cloneDir, ws, branch)
+			return fmt.Errorf("update workspace branch: %w", err)
+		}
 
-	err = m.newTerminalSession(ctx, ws)
+		sessionErr := m.newTerminalSession(ctx, ws)
+		if sessionErr != nil {
+			m.rollbackWorktree(ctx, cloneDir, ws, branch)
+			return fmt.Errorf("new terminal session: %w", sessionErr)
+		}
+		return nil
+	})
 	if err != nil {
-		m.rollbackWorktree(ctx, cloneDir, ws, branch)
 		return m.failSetup(
 			ctx,
-			ws.ID, workspaceSetupStageTmuxSession, err,
+			ws.ID, workspaceSetupStageWorktree, err,
 		)
 	}
 	m.recordSetupEvent(
@@ -925,13 +945,15 @@ func (m *Manager) cleanupWorkspaceArtifactsForDelete(
 		return err
 	}
 
-	_ = runGit(
-		ctx, cloneDir,
-		"worktree", "remove", "--force", ws.WorktreePath,
-	)
-	m.deleteWorkspaceBranches(ctx, cloneDir, ws, ws.WorkspaceBranch)
-	_ = runGit(ctx, cloneDir, "worktree", "prune")
-	return nil
+	return m.withRepoLock(ctx, cloneDir, func() error {
+		_ = runGit(
+			ctx, cloneDir,
+			"worktree", "remove", "--force", ws.WorktreePath,
+		)
+		m.deleteWorkspaceBranches(ctx, cloneDir, ws, ws.WorkspaceBranch)
+		_ = runGit(ctx, cloneDir, "worktree", "prune")
+		return nil
+	})
 }
 
 func (m *Manager) cleanupTmuxSession(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -426,32 +426,30 @@ func (m *Manager) Setup(
 		)
 	}
 
-	var branch string
-	err = m.withRepoLock(ctx, cloneDir, func() error {
-		var addErr error
-		branch, addErr = m.addWorktree(ctx, cloneDir, ws)
-		if addErr != nil {
-			return addErr
-		}
-		ws.WorkspaceBranch = branch
-		if err := m.updateWorkspaceBranch(
-			ctx, ws.ID, branch,
-		); err != nil {
-			m.rollbackWorktree(ctx, cloneDir, ws, branch)
-			return fmt.Errorf("update workspace branch: %w", err)
-		}
-
-		sessionErr := m.newTerminalSession(ctx, ws)
-		if sessionErr != nil {
-			m.rollbackWorktree(ctx, cloneDir, ws, branch)
-			return fmt.Errorf("new terminal session: %w", sessionErr)
-		}
-		return nil
-	})
+	branch, err := m.addWorktree(ctx, cloneDir, ws)
 	if err != nil {
 		return m.failSetup(
 			ctx,
 			ws.ID, workspaceSetupStageWorktree, err,
+		)
+	}
+	ws.WorkspaceBranch = branch
+	if err := m.updateWorkspaceBranch(
+		ctx, ws.ID, branch,
+	); err != nil {
+		m.rollbackWorktree(ctx, cloneDir, ws, branch)
+		return m.failSetup(
+			ctx,
+			ws.ID, workspaceSetupStageWorktree, err,
+		)
+	}
+
+	err = m.newTerminalSession(ctx, ws)
+	if err != nil {
+		m.rollbackWorktree(ctx, cloneDir, ws, branch)
+		return m.failSetup(
+			ctx,
+			ws.ID, workspaceSetupStageTmuxSession, err,
 		)
 	}
 	m.recordSetupEvent(
@@ -477,7 +475,24 @@ func (m *Manager) Setup(
 	return nil
 }
 
+// addWorktree creates the workspace's worktree and branch under the
+// per-repo lock. The lock prevents concurrent worktree mutations on
+// the same bare clone from clobbering each other; see FileLockManager.
 func (m *Manager) addWorktree(
+	ctx context.Context, cloneDir string, ws *Workspace,
+) (string, error) {
+	var branch string
+	err := m.withRepoLock(ctx, cloneDir, func() error {
+		var addErr error
+		branch, addErr = m.addWorktreeLocked(ctx, cloneDir, ws)
+		return addErr
+	})
+	return branch, err
+}
+
+// addWorktreeLocked runs the worktree-add decision tree. Callers must
+// hold the per-repo lock for cloneDir before invoking this function.
+func (m *Manager) addWorktreeLocked(
 	ctx context.Context, cloneDir string, ws *Workspace,
 ) (string, error) {
 	if ws.ItemType == db.WorkspaceItemTypeIssue {
@@ -910,21 +925,23 @@ func (m *Manager) cleanupWorkspaceArtifactsForRetry(
 		return nil
 	}
 
-	if err := runGit(
-		ctx, cloneDir,
-		"worktree", "remove", "--force", ws.WorktreePath,
-	); err != nil && !isGitWorktreeAbsent(err) {
-		return fmt.Errorf("remove git worktree: %w", err)
-	}
-	if err := m.deleteWorkspaceBranchesStrict(
-		ctx, cloneDir, ws, ws.WorkspaceBranch,
-	); err != nil {
-		return err
-	}
-	if err := runGit(ctx, cloneDir, "worktree", "prune"); err != nil {
-		return fmt.Errorf("prune git worktrees: %w", err)
-	}
-	return nil
+	return m.withRepoLock(ctx, cloneDir, func() error {
+		if err := runGit(
+			ctx, cloneDir,
+			"worktree", "remove", "--force", ws.WorktreePath,
+		); err != nil && !isGitWorktreeAbsent(err) {
+			return fmt.Errorf("remove git worktree: %w", err)
+		}
+		if err := m.deleteWorkspaceBranchesStrict(
+			ctx, cloneDir, ws, ws.WorkspaceBranch,
+		); err != nil {
+			return err
+		}
+		if err := runGit(ctx, cloneDir, "worktree", "prune"); err != nil {
+			return fmt.Errorf("prune git worktrees: %w", err)
+		}
+		return nil
+	})
 }
 
 func (m *Manager) cleanupWorkspaceArtifactsForDelete(
@@ -943,6 +960,18 @@ func (m *Manager) cleanupWorkspaceArtifactsForDelete(
 	)
 	if err != nil {
 		return err
+	}
+	// If the clone is missing — manually removed, or never created
+	// because Setup failed before EnsureClone returned — there is
+	// nothing to clean up under the lock, and trying to acquire it
+	// would fail at file open. Match the retry-path's behavior and
+	// fall through to a successful no-op delete.
+	ready, err := gitCloneDirReady(cloneDir)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return nil
 	}
 
 	return m.withRepoLock(ctx, cloneDir, func() error {
@@ -1910,21 +1939,28 @@ func wrapWorkspaceSetupError(stage string, err error) error {
 }
 
 // rollbackWorktree removes a partially created worktree and its
-// branch.
+// branch under the per-repo lock.
 func (m *Manager) rollbackWorktree(
 	ctx context.Context, cloneDir string, ws *Workspace,
 	branch string,
 ) {
 	cleanupCtx, cancel := cleanupContext(ctx)
 	defer cancel()
-	if err := runGit(
-		cleanupCtx, cloneDir,
-		"worktree", "remove", "--force", ws.WorktreePath,
-	); err != nil {
-		slog.Warn("rollback: worktree remove failed",
-			"path", ws.WorktreePath, "err", err)
+	err := m.withRepoLock(cleanupCtx, cloneDir, func() error {
+		if err := runGit(
+			cleanupCtx, cloneDir,
+			"worktree", "remove", "--force", ws.WorktreePath,
+		); err != nil {
+			slog.Warn("rollback: worktree remove failed",
+				"path", ws.WorktreePath, "err", err)
+		}
+		m.deleteWorkspaceBranches(cleanupCtx, cloneDir, ws, branch)
+		return nil
+	})
+	if err != nil {
+		slog.Warn("rollback: acquire worktree lock failed",
+			"path", cloneDir, "err", err)
 	}
-	m.deleteWorkspaceBranches(cleanupCtx, cloneDir, ws, branch)
 }
 
 func (m *Manager) deleteWorkspaceBranches(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2442,108 +2444,209 @@ func TestWorkspaceBranchCandidatesUsesBareFallbackOnlyForLegacyWorkspace(t *test
 	assert.Equal([]string{"middleman/issue-10"}, got)
 }
 
-func TestFileLockManager_Acquire_And_Release(t *testing.T) {
+func TestFileLockManagerAcquireRelease(t *testing.T) {
 	require := require.New(t)
 	mgr := NewFileLockManager()
 	ctx := t.Context()
-	lockPath := t.TempDir()
+	repo := t.TempDir()
 
-	// Acquire lock
-	lock1, err := mgr.Acquire(ctx, lockPath)
+	first, err := mgr.Acquire(ctx, repo)
 	require.NoError(err)
-	require.NotNil(lock1)
+	require.NoError(first.Unlock())
 
-	// Release lock
-	err = lock1.Unlock()
+	second, err := mgr.Acquire(ctx, repo)
 	require.NoError(err)
-
-	// Should be able to acquire again
-	lock2, err := mgr.Acquire(ctx, lockPath)
-	require.NoError(err)
-	require.NotNil(lock2)
-
-	err = lock2.Unlock()
-	require.NoError(err)
+	require.NoError(second.Unlock())
 }
 
-func TestFileLockManager_Blocks_Concurrent_Acquires(t *testing.T) {
+func TestFileLockManagerSerializesGoroutines(t *testing.T) {
 	require := require.New(t)
 	mgr := NewFileLockManager()
 	ctx := t.Context()
-	lockPath := t.TempDir()
+	repo := t.TempDir()
 
-	// Acquire first lock
-	lock1, err := mgr.Acquire(ctx, lockPath)
+	const goroutines = 6
+	var inCritical atomic.Int32
+	var maxObserved atomic.Int32
+	var overlap atomic.Int32
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			lock, err := mgr.Acquire(ctx, repo)
+			if err != nil {
+				return
+			}
+			defer func() { _ = lock.Unlock() }()
+			current := inCritical.Add(1)
+			defer inCritical.Add(-1)
+			if current > 1 {
+				overlap.Add(1)
+			}
+			for {
+				prev := maxObserved.Load()
+				if current <= prev || maxObserved.CompareAndSwap(prev, current) {
+					break
+				}
+			}
+			time.Sleep(15 * time.Millisecond)
+		})
+	}
+	wg.Wait()
+
+	require.Equal(int32(1), maxObserved.Load(),
+		"only one goroutine should hold the lock at a time")
+	require.Equal(int32(0), overlap.Load(),
+		"no goroutine should observe another holder in its critical section")
+	require.Equal(int32(0), inCritical.Load())
+}
+
+func TestFileLockManagerCtxCancelWhileWaiting(t *testing.T) {
+	require := require.New(t)
+	mgr := NewFileLockManager()
+	repo := t.TempDir()
+
+	held, err := mgr.Acquire(t.Context(), repo)
+	require.NoError(err)
+	defer func() { _ = held.Unlock() }()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	gotErr := make(chan error, 1)
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		_, err := mgr.Acquire(ctx, repo)
+		gotErr <- err
+	}()
+	<-started
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-gotErr:
+		require.ErrorIs(err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		require.FailNow("Acquire did not return after ctx cancel")
+	}
+}
+
+func TestFileLockManagerDoubleUnlock(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	mgr := NewFileLockManager()
+	lock, err := mgr.Acquire(t.Context(), t.TempDir())
+	require.NoError(err)
+	require.NoError(lock.Unlock())
+	assert.Error(lock.Unlock())
+}
+
+func TestManagerWithRepoLockReleaseOnSuccess(t *testing.T) {
+	require := require.New(t)
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	repo := t.TempDir()
+
+	calls := 0
+	require.NoError(mgr.withRepoLock(t.Context(), repo, func() error {
+		calls++
+		return nil
+	}))
+	require.Equal(1, calls)
+
+	again, err := mgr.locks.Acquire(t.Context(), repo)
+	require.NoError(err)
+	require.NoError(again.Unlock())
+}
+
+func TestManagerWithRepoLockReleaseOnError(t *testing.T) {
+	require := require.New(t)
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	repo := t.TempDir()
+
+	sentinel := errors.New("inner failed")
+	err := mgr.withRepoLock(t.Context(), repo, func() error {
+		return sentinel
+	})
+	require.ErrorIs(err, sentinel)
+
+	again, err := mgr.locks.Acquire(t.Context(), repo)
+	require.NoError(err)
+	require.NoError(again.Unlock())
+}
+
+func TestManagerAddWorktreeAcquiresRepoLock(t *testing.T) {
+	require := require.New(t)
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	configureSameRepoPRRefs(t, cloneDir, "feature/lock-probe", 7)
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	// Hold the per-repo lock from outside addWorktree; it must wait.
+	held, err := mgr.locks.Acquire(t.Context(), cloneDir)
 	require.NoError(err)
 
-	// Try to acquire second lock concurrently
-	done := make(chan error)
+	ws := &Workspace{
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   7,
+		GitHeadRef:   "feature/lock-probe",
+		WorktreePath: filepath.Join(t.TempDir(), "wt"),
+	}
+	done := make(chan error, 1)
 	go func() {
-		lock2, err := mgr.Acquire(ctx, lockPath)
-		if err == nil {
-			defer lock2.Unlock()
-		}
+		_, err := mgr.addWorktree(t.Context(), cloneDir, ws)
 		done <- err
 	}()
 
-	// Give the goroutine time to try acquiring
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+		require.FailNow("addWorktree completed while the per-repo lock was held")
+	case <-time.After(80 * time.Millisecond):
+	}
 
-	// Release the first lock
-	err = lock1.Unlock()
-	require.NoError(err)
-
-	// Now the second acquire should succeed
-	err = <-done
-	require.NoError(err)
+	require.NoError(held.Unlock())
+	select {
+	case err := <-done:
+		require.NoError(err)
+	case <-time.After(5 * time.Second):
+		require.FailNow("addWorktree did not finish after lock release")
+	}
 }
 
-func TestManagerWithRepoLock_ReleaseOnSuccess(t *testing.T) {
+func TestManagerCleanupForDeleteAcquiresRepoLock(t *testing.T) {
 	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	wtDir := t.TempDir()
 
-	mgr := NewManager(d, wtDir)
+	host, owner, name := "github.com", "acme", "widget"
+	baseDir := t.TempDir()
+	cloneDir := filepath.Join(baseDir, host, owner, name+".git")
+	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
+	runWorkspaceTestGit(
+		t, baseDir, "init", "--bare", "--initial-branch=main", cloneDir,
+	)
 
-	lockPath := t.TempDir()
-	callCount := 0
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	mgr.SetClones(gitclone.New(baseDir, nil))
 
-	err := mgr.withRepoLock(ctx, lockPath, func() error {
-		callCount++
-		return nil
-	})
+	ws := &Workspace{
+		ID:           "ws-cleanup-lock",
+		PlatformHost: host,
+		RepoOwner:    owner,
+		RepoName:     name,
+		WorktreePath: filepath.Join(t.TempDir(), "missing-wt"),
+	}
 
+	held, err := mgr.locks.Acquire(t.Context(), cloneDir)
 	require.NoError(err)
-	require.Equal(1, callCount)
+	done := make(chan error, 1)
+	go func() { done <- mgr.cleanupWorkspaceArtifactsForDelete(t.Context(), ws) }()
 
-	// Lock should be released, so we should be able to acquire it
-	lock, err := mgr.locks.Acquire(ctx, lockPath)
-	require.NoError(err)
-	require.NotNil(lock)
-	lock.Unlock()
-}
-
-func TestManagerWithRepoLock_ReleaseOnError(t *testing.T) {
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	wtDir := t.TempDir()
-
-	mgr := NewManager(d, wtDir)
-
-	lockPath := t.TempDir()
-	testErr := errors.New("test error")
-
-	err := mgr.withRepoLock(ctx, lockPath, func() error {
-		return testErr
-	})
-
-	require.ErrorIs(err, testErr)
-
-	// Lock should still be released even after error
-	lock, err := mgr.locks.Acquire(ctx, lockPath)
-	require.NoError(err)
-	require.NotNil(lock)
-	lock.Unlock()
+	select {
+	case <-done:
+		require.FailNow("cleanupWorkspaceArtifactsForDelete proceeded under held lock")
+	case <-time.After(80 * time.Millisecond):
+	}
+	require.NoError(held.Unlock())
+	select {
+	case err := <-done:
+		require.NoError(err)
+	case <-time.After(5 * time.Second):
+		require.FailNow("cleanupWorkspaceArtifactsForDelete did not finish after release")
+	}
 }

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2441,3 +2441,109 @@ func TestWorkspaceBranchCandidatesUsesBareFallbackOnlyForLegacyWorkspace(t *test
 	got := workspaceBranchCandidates(ws, workspaceBranchUnknown)
 	assert.Equal([]string{"middleman/issue-10"}, got)
 }
+
+func TestFileLockManager_Acquire_And_Release(t *testing.T) {
+	require := require.New(t)
+	mgr := NewFileLockManager()
+	ctx := t.Context()
+	lockPath := t.TempDir()
+
+	// Acquire lock
+	lock1, err := mgr.Acquire(ctx, lockPath)
+	require.NoError(err)
+	require.NotNil(lock1)
+
+	// Release lock
+	err = lock1.Unlock()
+	require.NoError(err)
+
+	// Should be able to acquire again
+	lock2, err := mgr.Acquire(ctx, lockPath)
+	require.NoError(err)
+	require.NotNil(lock2)
+
+	err = lock2.Unlock()
+	require.NoError(err)
+}
+
+func TestFileLockManager_Blocks_Concurrent_Acquires(t *testing.T) {
+	require := require.New(t)
+	mgr := NewFileLockManager()
+	ctx := t.Context()
+	lockPath := t.TempDir()
+
+	// Acquire first lock
+	lock1, err := mgr.Acquire(ctx, lockPath)
+	require.NoError(err)
+
+	// Try to acquire second lock concurrently
+	done := make(chan error)
+	go func() {
+		lock2, err := mgr.Acquire(ctx, lockPath)
+		if err == nil {
+			defer lock2.Unlock()
+		}
+		done <- err
+	}()
+
+	// Give the goroutine time to try acquiring
+	time.Sleep(100 * time.Millisecond)
+
+	// Release the first lock
+	err = lock1.Unlock()
+	require.NoError(err)
+
+	// Now the second acquire should succeed
+	err = <-done
+	require.NoError(err)
+}
+
+func TestManagerWithRepoLock_ReleaseOnSuccess(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	wtDir := t.TempDir()
+
+	mgr := NewManager(d, wtDir)
+
+	lockPath := t.TempDir()
+	callCount := 0
+
+	err := mgr.withRepoLock(ctx, lockPath, func() error {
+		callCount++
+		return nil
+	})
+
+	require.NoError(err)
+	require.Equal(1, callCount)
+
+	// Lock should be released, so we should be able to acquire it
+	lock, err := mgr.locks.Acquire(ctx, lockPath)
+	require.NoError(err)
+	require.NotNil(lock)
+	lock.Unlock()
+}
+
+func TestManagerWithRepoLock_ReleaseOnError(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	wtDir := t.TempDir()
+
+	mgr := NewManager(d, wtDir)
+
+	lockPath := t.TempDir()
+	testErr := errors.New("test error")
+
+	err := mgr.withRepoLock(ctx, lockPath, func() error {
+		return testErr
+	})
+
+	require.ErrorIs(err, testErr)
+
+	// Lock should still be released even after error
+	lock, err := mgr.locks.Acquire(ctx, lockPath)
+	require.NoError(err)
+	require.NotNil(lock)
+	lock.Unlock()
+}

--- a/internal/workspace/repolock.go
+++ b/internal/workspace/repolock.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"golang.org/x/sync/semaphore"
 )
 
 // Locker is a held repository lock returned by FileLockManager.Acquire.
@@ -34,19 +35,19 @@ type FileLockManager struct {
 
 // repoLockState holds the per-repo serialization primitives.
 //
-// The channel semaphore is the in-process mutex: it enforces exclusion
-// between goroutines while still allowing Acquire(ctx, ...) to return
-// promptly when ctx is canceled while waiting. The Flock enforces
-// exclusion between this process and any other middleman process holding
-// the same on-disk lock file. Both are required: gofrs/flock returns
-// success immediately when the same *Flock instance is already locked
-// (see flock_unix.go:48), so a shared Flock alone does not serialize
+// The semaphore is the in-process mutex: it enforces exclusion between
+// goroutines while still allowing Acquire(ctx, ...) to return promptly
+// when ctx is canceled while waiting. The Flock enforces exclusion
+// between this process and any other middleman process holding the same
+// on-disk lock file. Both are required: gofrs/flock returns success
+// immediately when the same *Flock instance is already locked (see
+// flock_unix.go:48), so a shared Flock alone does not serialize
 // concurrent goroutines, and flock(2) on Linux locks the open file
 // description, so two fresh Flock instances in one process also fail to
 // serialize.
 type repoLockState struct {
-	sem  chan struct{}
-	file *flock.Flock
+	local *semaphore.Weighted
+	file  *flock.Flock
 }
 
 // fileLockRetryDelay is the poll interval inside TryLockContext when the
@@ -68,8 +69,8 @@ func (m *FileLockManager) stateFor(lockPath string) *repoLockState {
 		return s
 	}
 	s := &repoLockState{
-		sem:  make(chan struct{}, 1),
-		file: flock.New(lockPath),
+		local: semaphore.NewWeighted(1),
+		file:  flock.New(lockPath),
 	}
 	m.states[lockPath] = s
 	return s
@@ -87,19 +88,17 @@ func (m *FileLockManager) Acquire(
 	lockPath := filepath.Join(repoRoot, ".middleman-worktree.lock")
 	state := m.stateFor(lockPath)
 
-	select {
-	case state.sem <- struct{}{}:
-	case <-ctx.Done():
-		return nil, fmt.Errorf("acquire worktree lock %q: %w", repoRoot, ctx.Err())
+	if err := state.local.Acquire(ctx, 1); err != nil {
+		return nil, fmt.Errorf("acquire worktree lock %q: %w", repoRoot, err)
 	}
 
 	locked, err := state.file.TryLockContext(ctx, fileLockRetryDelay)
 	if err != nil {
-		<-state.sem
+		state.local.Release(1)
 		return nil, fmt.Errorf("acquire worktree lock %q: %w", repoRoot, err)
 	}
 	if !locked {
-		<-state.sem
+		state.local.Release(1)
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("acquire worktree lock %q: %w", repoRoot, err)
 		}
@@ -124,7 +123,7 @@ func (h *fileLockHandle) Unlock() error {
 	}
 	h.released = true
 	err := h.state.file.Unlock()
-	<-h.state.sem
+	h.state.local.Release(1)
 	if err != nil {
 		return fmt.Errorf("release worktree lock: %w", err)
 	}

--- a/internal/workspace/repolock.go
+++ b/internal/workspace/repolock.go
@@ -1,0 +1,69 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// Locker represents a file-based lock for a repository.
+type Locker interface {
+	// Unlock releases the lock, or errors if already released.
+	Unlock() error
+}
+
+// FileLockManager manages per-repository file locks keyed by clone path.
+type FileLockManager struct {
+	mu    sync.Mutex
+	locks map[string]*flock.Flock
+}
+
+// NewFileLockManager creates a new FileLockManager.
+func NewFileLockManager() *FileLockManager {
+	return &FileLockManager{
+		locks: make(map[string]*flock.Flock),
+	}
+}
+
+// Acquire acquires a lock for the given repository path, blocking until
+// the lock is available or the context is cancelled/times out.
+// The returned Locker must be unlocked via Unlock().
+func (m *FileLockManager) Acquire(ctx context.Context, repoPath string) (Locker, error) {
+	lockPath := filepath.Join(repoPath, ".middleman-worktree.lock")
+
+	m.mu.Lock()
+	fileLock := m.locks[lockPath]
+	if fileLock == nil {
+		fileLock = flock.New(lockPath)
+		m.locks[lockPath] = fileLock
+	}
+	m.mu.Unlock()
+
+	// Use TryLockContext which respects the context deadline and retries.
+	// TryLockContext returns (false, nil) when the context deadline is exceeded.
+	locked, err := fileLock.TryLockContext(ctx, 100*time.Millisecond)
+	if err != nil {
+		return nil, fmt.Errorf("lock error: %w", err)
+	}
+	if !locked {
+		// Determine the error reason: either context cancelled/deadline or general failure.
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("lock acquisition failed: %w", err)
+		}
+		return nil, errors.New("lock acquisition failed: unable to acquire lock")
+	}
+	return &fileLockHandle{lock: fileLock}, nil
+}
+
+type fileLockHandle struct {
+	lock *flock.Flock
+}
+
+func (h *fileLockHandle) Unlock() error {
+	return h.lock.Unlock()
+}

--- a/internal/workspace/repolock.go
+++ b/internal/workspace/repolock.go
@@ -11,59 +11,120 @@ import (
 	"github.com/gofrs/flock"
 )
 
-// Locker represents a file-based lock for a repository.
+// Locker is a held repository lock returned by FileLockManager.Acquire.
+// Unlock releases the lock and must be called exactly once.
 type Locker interface {
-	// Unlock releases the lock, or errors if already released.
 	Unlock() error
 }
 
-// FileLockManager manages per-repository file locks keyed by clone path.
+// FileLockManager serializes worktree mutations on a single bare clone.
+//
+// git worktree add/remove/prune all update the bare clone's worktrees
+// metadata, HEAD references, and the local branch namespace. Concurrent
+// operations against the same clone — two creates against the same branch,
+// or a retry cleanup overlapping a fresh setup — can wedge the worktree
+// or leave dangling branches. FileLockManager funnels every such
+// mutation through Acquire so the bare clone sees one mutation at a
+// time, both within one middleman process and across processes that
+// share the on-disk state.
 type FileLockManager struct {
-	mu    sync.Mutex
-	locks map[string]*flock.Flock
+	mu     sync.Mutex
+	states map[string]*repoLockState
 }
 
-// NewFileLockManager creates a new FileLockManager.
+// repoLockState holds the per-repo serialization primitives.
+//
+// The semaphore enforces exclusion between goroutines in this process.
+// The Flock enforces exclusion between this process and any other
+// middleman process holding the same on-disk lock file. Both are
+// required: gofrs/flock returns success immediately when the same
+// *Flock instance is already locked (see flock_unix.go:48), so a
+// shared Flock alone does not serialize concurrent goroutines, and
+// flock(2) on Linux locks the open file description, so two fresh
+// Flock instances in one process also fail to serialize.
+type repoLockState struct {
+	sem  chan struct{}
+	file *flock.Flock
+}
+
+// fileLockRetryDelay is the poll interval inside TryLockContext when the
+// file lock is held by another process. Short enough to feel responsive,
+// long enough to avoid burning CPU in the wait loop.
+const fileLockRetryDelay = 25 * time.Millisecond
+
+// NewFileLockManager constructs an empty FileLockManager.
 func NewFileLockManager() *FileLockManager {
 	return &FileLockManager{
-		locks: make(map[string]*flock.Flock),
+		states: make(map[string]*repoLockState),
 	}
 }
 
-// Acquire acquires a lock for the given repository path, blocking until
-// the lock is available or the context is cancelled/times out.
-// The returned Locker must be unlocked via Unlock().
-func (m *FileLockManager) Acquire(ctx context.Context, repoPath string) (Locker, error) {
-	lockPath := filepath.Join(repoPath, ".middleman-worktree.lock")
-
+func (m *FileLockManager) stateFor(lockPath string) *repoLockState {
 	m.mu.Lock()
-	fileLock := m.locks[lockPath]
-	if fileLock == nil {
-		fileLock = flock.New(lockPath)
-		m.locks[lockPath] = fileLock
+	defer m.mu.Unlock()
+	if s, ok := m.states[lockPath]; ok {
+		return s
 	}
-	m.mu.Unlock()
+	s := &repoLockState{
+		sem:  make(chan struct{}, 1),
+		file: flock.New(lockPath),
+	}
+	m.states[lockPath] = s
+	return s
+}
 
-	// Use TryLockContext which respects the context deadline and retries.
-	// TryLockContext returns (false, nil) when the context deadline is exceeded.
-	locked, err := fileLock.TryLockContext(ctx, 100*time.Millisecond)
+// Acquire blocks until both the in-process semaphore and the on-disk
+// file lock are held, or ctx is done. On success the returned Locker
+// holds the lock; Unlock must be called exactly once to release it.
+//
+// repoRoot is the bare clone directory; the lock file lives inside it
+// so the lock travels with the clone and disappears with it.
+func (m *FileLockManager) Acquire(
+	ctx context.Context, repoRoot string,
+) (Locker, error) {
+	lockPath := filepath.Join(repoRoot, ".middleman-worktree.lock")
+	state := m.stateFor(lockPath)
+
+	select {
+	case state.sem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("acquire worktree lock %q: %w", repoRoot, ctx.Err())
+	}
+
+	locked, err := state.file.TryLockContext(ctx, fileLockRetryDelay)
 	if err != nil {
-		return nil, fmt.Errorf("lock error: %w", err)
+		<-state.sem
+		return nil, fmt.Errorf("acquire worktree lock %q: %w", repoRoot, err)
 	}
 	if !locked {
-		// Determine the error reason: either context cancelled/deadline or general failure.
+		<-state.sem
 		if err := ctx.Err(); err != nil {
-			return nil, fmt.Errorf("lock acquisition failed: %w", err)
+			return nil, fmt.Errorf("acquire worktree lock %q: %w", repoRoot, err)
 		}
-		return nil, errors.New("lock acquisition failed: unable to acquire lock")
+		return nil, fmt.Errorf("acquire worktree lock %q: lock not acquired", repoRoot)
 	}
-	return &fileLockHandle{lock: fileLock}, nil
+	return &fileLockHandle{state: state}, nil
 }
 
 type fileLockHandle struct {
-	lock *flock.Flock
+	state    *repoLockState
+	released bool
+	mu       sync.Mutex
 }
 
+// Unlock releases both the file lock and the in-process semaphore.
+// Calling Unlock more than once returns an error.
 func (h *fileLockHandle) Unlock() error {
-	return h.lock.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.released {
+		return errors.New("worktree lock already released")
+	}
+	h.released = true
+	err := h.state.file.Unlock()
+	<-h.state.sem
+	if err != nil {
+		return fmt.Errorf("release worktree lock: %w", err)
+	}
+	return nil
 }

--- a/internal/workspace/repolock.go
+++ b/internal/workspace/repolock.go
@@ -34,14 +34,16 @@ type FileLockManager struct {
 
 // repoLockState holds the per-repo serialization primitives.
 //
-// The semaphore enforces exclusion between goroutines in this process.
-// The Flock enforces exclusion between this process and any other
-// middleman process holding the same on-disk lock file. Both are
-// required: gofrs/flock returns success immediately when the same
-// *Flock instance is already locked (see flock_unix.go:48), so a
-// shared Flock alone does not serialize concurrent goroutines, and
-// flock(2) on Linux locks the open file description, so two fresh
-// Flock instances in one process also fail to serialize.
+// The channel semaphore is the in-process mutex: it enforces exclusion
+// between goroutines while still allowing Acquire(ctx, ...) to return
+// promptly when ctx is canceled while waiting. The Flock enforces
+// exclusion between this process and any other middleman process holding
+// the same on-disk lock file. Both are required: gofrs/flock returns
+// success immediately when the same *Flock instance is already locked
+// (see flock_unix.go:48), so a shared Flock alone does not serialize
+// concurrent goroutines, and flock(2) on Linux locks the open file
+// description, so two fresh Flock instances in one process also fail to
+// serialize.
 type repoLockState struct {
 	sem  chan struct{}
 	file *flock.Flock


### PR DESCRIPTION
## Summary

- Serialize per-repository worktree mutations (`git worktree add/remove/prune`, `branch -D`) behind a per-clone lock so concurrent workspace create, retry, and delete against the same repo no longer race
- Cross-process via `gofrs/flock`; in-process via a per-path channel semaphore (file lock alone doesn't serialize same-process goroutines because `flock(2)` is per open-file-description)
- `Manager.Setup`, retry cleanup, delete cleanup, and rollback paths all acquire the lock