### PR TITLE
Expose per-repo operation availability on the wire

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2066,6 +2066,44 @@ components:
         - syncing
         - sync_error
       type: object
+    RepoOperations:
+      additionalProperties: false
+      properties:
+        add_comment:
+          $ref: "#/components/schemas/OperationAvailability"
+        add_label:
+          $ref: "#/components/schemas/OperationAvailability"
+        approve_workflow:
+          $ref: "#/components/schemas/OperationAvailability"
+        close_issue:
+          $ref: "#/components/schemas/OperationAvailability"
+        close_pr:
+          $ref: "#/components/schemas/OperationAvailability"
+        mark_ready_for_review:
+          $ref: "#/components/schemas/OperationAvailability"
+        merge_pr:
+          $ref: "#/components/schemas/OperationAvailability"
+        remove_label:
+          $ref: "#/components/schemas/OperationAvailability"
+        reopen_issue:
+          $ref: "#/components/schemas/OperationAvailability"
+        reopen_pr:
+          $ref: "#/components/schemas/OperationAvailability"
+        submit_review:
+          $ref: "#/components/schemas/OperationAvailability"
+      required:
+        - merge_pr
+        - close_pr
+        - reopen_pr
+        - mark_ready_for_review
+        - submit_review
+        - add_comment
+        - add_label
+        - remove_label
+        - close_issue
+        - reopen_issue
+        - approve_workflow
+      type: object
     RepoPreviewRequest:
       additionalProperties: false
       properties:
@@ -2251,9 +2289,7 @@ components:
         capabilities:
           $ref: "#/components/schemas/ProviderCapabilitiesResponse"
         operations:
-          additionalProperties:
-            $ref: "#/components/schemas/OperationAvailability"
-          type: object
+          $ref: "#/components/schemas/RepoOperations"
       required:
         - ID
         - Platform
@@ -2397,9 +2433,7 @@ components:
           format: int64
           type: integer
         operations:
-          additionalProperties:
-            $ref: "#/components/schemas/OperationAvailability"
-          type: object
+          $ref: "#/components/schemas/RepoOperations"
         owner:
           type: string
         platform_host:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1733,6 +1733,22 @@ components:
         - is_draft
         - title
       type: object
+    OperationAvailability:
+      additionalProperties: false
+      properties:
+        available:
+          type: boolean
+        code:
+          type: string
+        required_capability:
+          type: string
+        retry_at:
+          type: string
+        unavailable_reason:
+          type: string
+      required:
+        - available
+      type: object
     PlatformIdentityPayload:
       additionalProperties: false
       properties:
@@ -2234,6 +2250,10 @@ components:
           type: boolean
         capabilities:
           $ref: "#/components/schemas/ProviderCapabilitiesResponse"
+        operations:
+          additionalProperties:
+            $ref: "#/components/schemas/OperationAvailability"
+          type: object
       required:
         - ID
         - Platform
@@ -2255,6 +2275,7 @@ components:
         - BackfillIssueCompletedAt
         - CreatedAt
         - capabilities
+        - operations
       type: object
     RepoSummaryAuthorResponse:
       additionalProperties: false
@@ -2375,6 +2396,10 @@ components:
         open_pr_count:
           format: int64
           type: integer
+        operations:
+          additionalProperties:
+            $ref: "#/components/schemas/OperationAvailability"
+          type: object
         owner:
           type: string
         platform_host:
@@ -2410,6 +2435,7 @@ components:
         - commit_timeline
         - active_authors
         - recent_issues
+        - operations
       type: object
     ResolveItemResponse:
       additionalProperties: false

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -502,15 +502,13 @@ test.describe("detail action buttons", () => {
       expect(settingsResponse.ok()).toBe(true);
       const settings = await settingsResponse.json() as {
         ViewerCanMerge: boolean;
-        operations: Record<string, { available: boolean; code?: string }>;
+        operations: {
+          merge_pr: { available: boolean; code?: string };
+        };
       };
       expect(settings.ViewerCanMerge).toBe(false);
-      const mergeOp = settings.operations.merge_pr;
-      if (mergeOp === undefined) {
-        throw new Error("operations.merge_pr missing from repo response");
-      }
-      expect(mergeOp.available).toBe(false);
-      expect(mergeOp.code).toBe("viewer_cannot_merge");
+      expect(settings.operations.merge_pr.available).toBe(false);
+      expect(settings.operations.merge_pr.code).toBe("viewer_cannot_merge");
 
       await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
       await expect(page.locator(".pull-detail")).toBeVisible();

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -485,7 +485,7 @@ test.describe("detail action buttons", () => {
     }
   });
 
-  test("repo merge permission hides merge action end-to-end", async ({ page }) => {
+  test("repo merge permission disables merge action with reason end-to-end", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     try {
       isolatedServer = await startIsolatedE2EServer();
@@ -500,15 +500,28 @@ test.describe("detail action buttons", () => {
         `${baseURL}/api/v1/repo/github/acme/widgets`,
       );
       expect(settingsResponse.ok()).toBe(true);
-      const settings = await settingsResponse.json() as { ViewerCanMerge: boolean };
+      const settings = await settingsResponse.json() as {
+        ViewerCanMerge: boolean;
+        operations: Record<string, { available: boolean; code?: string }>;
+      };
       expect(settings.ViewerCanMerge).toBe(false);
+      expect(settings.operations.merge_pr.available).toBe(false);
+      expect(settings.operations.merge_pr.code).toBe("viewer_cannot_merge");
 
       await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
       await expect(page.locator(".pull-detail")).toBeVisible();
       await expect(page.locator(".detail-title")).toContainText(
         "Add widget caching layer",
       );
-      await expect(page.locator(".btn--merge")).toHaveCount(0);
+      const merge = page.locator(".btn--merge").first();
+      await expect(merge).toBeVisible();
+      await expect(merge).toBeDisabled();
+      await expect(merge).toHaveAttribute(
+        "title",
+        "You do not have permission to merge in this repository",
+      );
+      // Clicking a disabled merge button must not open the merge modal.
+      await merge.click({ force: true });
       await expect(
         page.locator(".modal-title", { hasText: "Merge Pull Request" }),
       ).toHaveCount(0);

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -505,8 +505,12 @@ test.describe("detail action buttons", () => {
         operations: Record<string, { available: boolean; code?: string }>;
       };
       expect(settings.ViewerCanMerge).toBe(false);
-      expect(settings.operations.merge_pr.available).toBe(false);
-      expect(settings.operations.merge_pr.code).toBe("viewer_cannot_merge");
+      const mergeOp = settings.operations.merge_pr;
+      if (mergeOp === undefined) {
+        throw new Error("operations.merge_pr missing from repo response");
+      }
+      expect(mergeOp.available).toBe(false);
+      expect(mergeOp.code).toBe("viewer_cannot_merge");
 
       await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
       await expect(page.locator(".pull-detail")).toBeVisible();

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -786,6 +786,15 @@ type MrImportMetadataResponse struct {
 	Title            string  `json:"title"`
 }
 
+// OperationAvailability defines model for OperationAvailability.
+type OperationAvailability struct {
+	Available          bool    `json:"available"`
+	Code               *string `json:"code,omitempty"`
+	RequiredCapability *string `json:"required_capability,omitempty"`
+	RetryAt            *string `json:"retry_at,omitempty"`
+	UnavailableReason  *string `json:"unavailable_reason,omitempty"`
+}
+
 // PlatformIdentityPayload defines model for PlatformIdentityPayload.
 type PlatformIdentityPayload struct {
 	Name         string `json:"name"`
@@ -962,27 +971,28 @@ type RepoRefResponse struct {
 // RepoResponse defines model for RepoResponse.
 type RepoResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema                   *string                      `json:"$schema,omitempty"`
-	AllowMergeCommit         bool                         `json:"AllowMergeCommit"`
-	AllowRebaseMerge         bool                         `json:"AllowRebaseMerge"`
-	AllowSquashMerge         bool                         `json:"AllowSquashMerge"`
-	BackfillIssueComplete    bool                         `json:"BackfillIssueComplete"`
-	BackfillIssueCompletedAt *time.Time                   `json:"BackfillIssueCompletedAt"`
-	BackfillIssuePage        int64                        `json:"BackfillIssuePage"`
-	BackfillPRComplete       bool                         `json:"BackfillPRComplete"`
-	BackfillPRCompletedAt    *time.Time                   `json:"BackfillPRCompletedAt"`
-	BackfillPRPage           int64                        `json:"BackfillPRPage"`
-	CreatedAt                time.Time                    `json:"CreatedAt"`
-	ID                       int64                        `json:"ID"`
-	LastSyncCompletedAt      *time.Time                   `json:"LastSyncCompletedAt"`
-	LastSyncError            string                       `json:"LastSyncError"`
-	LastSyncStartedAt        *time.Time                   `json:"LastSyncStartedAt"`
-	Name                     string                       `json:"Name"`
-	Owner                    string                       `json:"Owner"`
-	Platform                 string                       `json:"Platform"`
-	PlatformHost             string                       `json:"PlatformHost"`
-	ViewerCanMerge           bool                         `json:"ViewerCanMerge"`
-	Capabilities             ProviderCapabilitiesResponse `json:"capabilities"`
+	Schema                   *string                          `json:"$schema,omitempty"`
+	AllowMergeCommit         bool                             `json:"AllowMergeCommit"`
+	AllowRebaseMerge         bool                             `json:"AllowRebaseMerge"`
+	AllowSquashMerge         bool                             `json:"AllowSquashMerge"`
+	BackfillIssueComplete    bool                             `json:"BackfillIssueComplete"`
+	BackfillIssueCompletedAt *time.Time                       `json:"BackfillIssueCompletedAt"`
+	BackfillIssuePage        int64                            `json:"BackfillIssuePage"`
+	BackfillPRComplete       bool                             `json:"BackfillPRComplete"`
+	BackfillPRCompletedAt    *time.Time                       `json:"BackfillPRCompletedAt"`
+	BackfillPRPage           int64                            `json:"BackfillPRPage"`
+	CreatedAt                time.Time                        `json:"CreatedAt"`
+	ID                       int64                            `json:"ID"`
+	LastSyncCompletedAt      *time.Time                       `json:"LastSyncCompletedAt"`
+	LastSyncError            string                           `json:"LastSyncError"`
+	LastSyncStartedAt        *time.Time                       `json:"LastSyncStartedAt"`
+	Name                     string                           `json:"Name"`
+	Owner                    string                           `json:"Owner"`
+	Platform                 string                           `json:"Platform"`
+	PlatformHost             string                           `json:"PlatformHost"`
+	ViewerCanMerge           bool                             `json:"ViewerCanMerge"`
+	Capabilities             ProviderCapabilitiesResponse     `json:"capabilities"`
+	Operations               map[string]OperationAvailability `json:"operations"`
 }
 
 // RepoSummaryAuthorResponse defines model for RepoSummaryAuthorResponse.
@@ -1035,6 +1045,7 @@ type RepoSummaryResponse struct {
 	Name                 string                            `json:"name"`
 	OpenIssueCount       int64                             `json:"open_issue_count"`
 	OpenPrCount          int64                             `json:"open_pr_count"`
+	Operations           map[string]OperationAvailability  `json:"operations"`
 	Owner                string                            `json:"owner"`
 	PlatformHost         string                            `json:"platform_host"`
 	RecentIssues         *[]RepoSummaryIssueResponse       `json:"recent_issues"`

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -922,6 +922,21 @@ type RepoLabelsResponse struct {
 	Syncing   bool     `json:"syncing"`
 }
 
+// RepoOperations defines model for RepoOperations.
+type RepoOperations struct {
+	AddComment         OperationAvailability `json:"add_comment"`
+	AddLabel           OperationAvailability `json:"add_label"`
+	ApproveWorkflow    OperationAvailability `json:"approve_workflow"`
+	CloseIssue         OperationAvailability `json:"close_issue"`
+	ClosePr            OperationAvailability `json:"close_pr"`
+	MarkReadyForReview OperationAvailability `json:"mark_ready_for_review"`
+	MergePr            OperationAvailability `json:"merge_pr"`
+	RemoveLabel        OperationAvailability `json:"remove_label"`
+	ReopenIssue        OperationAvailability `json:"reopen_issue"`
+	ReopenPr           OperationAvailability `json:"reopen_pr"`
+	SubmitReview       OperationAvailability `json:"submit_review"`
+}
+
 // RepoPreviewRequest defines model for RepoPreviewRequest.
 type RepoPreviewRequest struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -971,28 +986,28 @@ type RepoRefResponse struct {
 // RepoResponse defines model for RepoResponse.
 type RepoResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema                   *string                          `json:"$schema,omitempty"`
-	AllowMergeCommit         bool                             `json:"AllowMergeCommit"`
-	AllowRebaseMerge         bool                             `json:"AllowRebaseMerge"`
-	AllowSquashMerge         bool                             `json:"AllowSquashMerge"`
-	BackfillIssueComplete    bool                             `json:"BackfillIssueComplete"`
-	BackfillIssueCompletedAt *time.Time                       `json:"BackfillIssueCompletedAt"`
-	BackfillIssuePage        int64                            `json:"BackfillIssuePage"`
-	BackfillPRComplete       bool                             `json:"BackfillPRComplete"`
-	BackfillPRCompletedAt    *time.Time                       `json:"BackfillPRCompletedAt"`
-	BackfillPRPage           int64                            `json:"BackfillPRPage"`
-	CreatedAt                time.Time                        `json:"CreatedAt"`
-	ID                       int64                            `json:"ID"`
-	LastSyncCompletedAt      *time.Time                       `json:"LastSyncCompletedAt"`
-	LastSyncError            string                           `json:"LastSyncError"`
-	LastSyncStartedAt        *time.Time                       `json:"LastSyncStartedAt"`
-	Name                     string                           `json:"Name"`
-	Owner                    string                           `json:"Owner"`
-	Platform                 string                           `json:"Platform"`
-	PlatformHost             string                           `json:"PlatformHost"`
-	ViewerCanMerge           bool                             `json:"ViewerCanMerge"`
-	Capabilities             ProviderCapabilitiesResponse     `json:"capabilities"`
-	Operations               map[string]OperationAvailability `json:"operations"`
+	Schema                   *string                      `json:"$schema,omitempty"`
+	AllowMergeCommit         bool                         `json:"AllowMergeCommit"`
+	AllowRebaseMerge         bool                         `json:"AllowRebaseMerge"`
+	AllowSquashMerge         bool                         `json:"AllowSquashMerge"`
+	BackfillIssueComplete    bool                         `json:"BackfillIssueComplete"`
+	BackfillIssueCompletedAt *time.Time                   `json:"BackfillIssueCompletedAt"`
+	BackfillIssuePage        int64                        `json:"BackfillIssuePage"`
+	BackfillPRComplete       bool                         `json:"BackfillPRComplete"`
+	BackfillPRCompletedAt    *time.Time                   `json:"BackfillPRCompletedAt"`
+	BackfillPRPage           int64                        `json:"BackfillPRPage"`
+	CreatedAt                time.Time                    `json:"CreatedAt"`
+	ID                       int64                        `json:"ID"`
+	LastSyncCompletedAt      *time.Time                   `json:"LastSyncCompletedAt"`
+	LastSyncError            string                       `json:"LastSyncError"`
+	LastSyncStartedAt        *time.Time                   `json:"LastSyncStartedAt"`
+	Name                     string                       `json:"Name"`
+	Owner                    string                       `json:"Owner"`
+	Platform                 string                       `json:"Platform"`
+	PlatformHost             string                       `json:"PlatformHost"`
+	ViewerCanMerge           bool                         `json:"ViewerCanMerge"`
+	Capabilities             ProviderCapabilitiesResponse `json:"capabilities"`
+	Operations               RepoOperations               `json:"operations"`
 }
 
 // RepoSummaryAuthorResponse defines model for RepoSummaryAuthorResponse.
@@ -1045,7 +1060,7 @@ type RepoSummaryResponse struct {
 	Name                 string                            `json:"name"`
 	OpenIssueCount       int64                             `json:"open_issue_count"`
 	OpenPrCount          int64                             `json:"open_pr_count"`
-	Operations           map[string]OperationAvailability  `json:"operations"`
+	Operations           RepoOperations                    `json:"operations"`
 	Owner                string                            `json:"owner"`
 	PlatformHost         string                            `json:"platform_host"`
 	RecentIssues         *[]RepoSummaryIssueResponse       `json:"recent_issues"`

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -52,7 +52,8 @@ type repoResponse struct {
 	BackfillIssueComplete    bool
 	BackfillIssueCompletedAt *time.Time
 	CreatedAt                time.Time
-	Capabilities             providerCapabilitiesResponse `json:"capabilities"`
+	Capabilities             providerCapabilitiesResponse     `json:"capabilities"`
+	Operations               map[string]OperationAvailability `json:"operations"`
 }
 
 // mergeRequestResponse extends db.MergeRequest with resolved repo owner/name fields.
@@ -172,6 +173,7 @@ type repoSummaryResponse struct {
 	TimelineUpdatedAt    string                           `json:"timeline_updated_at,omitempty"`
 	ActiveAuthors        []repoSummaryAuthorResponse      `json:"active_authors"`
 	RecentIssues         []repoSummaryIssueResponse       `json:"recent_issues"`
+	Operations           map[string]OperationAvailability `json:"operations"`
 }
 
 type commentAutocompleteResponse struct {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -52,8 +52,8 @@ type repoResponse struct {
 	BackfillIssueComplete    bool
 	BackfillIssueCompletedAt *time.Time
 	CreatedAt                time.Time
-	Capabilities             providerCapabilitiesResponse     `json:"capabilities"`
-	Operations               map[string]OperationAvailability `json:"operations"`
+	Capabilities             providerCapabilitiesResponse `json:"capabilities"`
+	Operations               RepoOperations               `json:"operations"`
 }
 
 // mergeRequestResponse extends db.MergeRequest with resolved repo owner/name fields.
@@ -173,7 +173,7 @@ type repoSummaryResponse struct {
 	TimelineUpdatedAt    string                           `json:"timeline_updated_at,omitempty"`
 	ActiveAuthors        []repoSummaryAuthorResponse      `json:"active_authors"`
 	RecentIssues         []repoSummaryIssueResponse       `json:"recent_issues"`
-	Operations           map[string]OperationAvailability `json:"operations"`
+	Operations           RepoOperations                   `json:"operations"`
 }
 
 type commentAutocompleteResponse struct {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -219,6 +219,7 @@ func (s *Server) toRepoSummaryResponse(
 		OpenIssueCount:      summary.OpenIssueCount,
 		ActiveAuthors:       make([]repoSummaryAuthorResponse, 0, len(summary.ActiveAuthors)),
 		RecentIssues:        make([]repoSummaryIssueResponse, 0, len(summary.RecentIssues)),
+		Operations:          s.repoOperations(summary.Repo),
 	}
 	if summary.Repo.LastSyncStartedAt != nil {
 		resp.LastSyncStartedAt = formatUTCRFC3339(*summary.Repo.LastSyncStartedAt)

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/ratelimit"
+)
+
+// Operation names used as keys in the operations map on the wire.
+// Adding or renaming a constant here is a breaking wire change; the
+// frontend depends on these literals to drive button enablement.
+const (
+	operationMergePR            = "merge_pr"
+	operationClosePR            = "close_pr"
+	operationReopenPR           = "reopen_pr"
+	operationMarkReadyForReview = "mark_ready_for_review"
+	operationSubmitReview       = "submit_review"
+	operationAddComment         = "add_comment"
+	operationAddLabel           = "add_label"
+	operationRemoveLabel        = "remove_label"
+	operationCloseIssue         = "close_issue"
+	operationReopenIssue        = "reopen_issue"
+	operationApproveWorkflow    = "approve_workflow"
+)
+
+// Availability codes returned to clients. Empty code means available.
+const (
+	availabilityCodeUnsupportedCapability = "unsupported_capability"
+	availabilityCodeViewerCannotMerge     = "viewer_cannot_merge"
+	availabilityCodeRateLimited           = "rate_limited"
+)
+
+// OperationAvailability is the wire-level shape describing whether
+// a write operation can be invoked against a repository right now.
+// It collapses the inputs the UI would otherwise have to mirror
+// piecemeal: provider capability flags, per-repo viewer permissions,
+// and host-wide rate-limit state.
+type OperationAvailability struct {
+	Available          bool   `json:"available"`
+	Code               string `json:"code,omitempty"`
+	UnavailableReason  string `json:"unavailable_reason,omitempty"`
+	RequiredCapability string `json:"required_capability,omitempty"`
+	RetryAt            string `json:"retry_at,omitempty"`
+}
+
+// operationDescriptor lists the capabilities an operation needs.
+// requiredCapabilities is checked in declaration order so the first
+// missing capability becomes RequiredCapability, giving deterministic
+// behavior when multiple are absent.
+type operationDescriptor struct {
+	name                 string
+	requiredCapabilities []string
+}
+
+func operationCatalog() []operationDescriptor {
+	return []operationDescriptor{
+		{name: operationMergePR, requiredCapabilities: []string{capabilityMergeMutation}},
+		{name: operationClosePR, requiredCapabilities: []string{capabilityStateMutation}},
+		{name: operationReopenPR, requiredCapabilities: []string{capabilityStateMutation}},
+		{name: operationMarkReadyForReview, requiredCapabilities: []string{capabilityReadyForReview}},
+		{name: operationSubmitReview, requiredCapabilities: []string{capabilityReviewMutation}},
+		{name: operationAddComment, requiredCapabilities: []string{capabilityCommentMutation}},
+		{name: operationAddLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}},
+		{name: operationRemoveLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}},
+		{name: operationCloseIssue, requiredCapabilities: []string{capabilityIssueMutation}},
+		{name: operationReopenIssue, requiredCapabilities: []string{capabilityIssueMutation}},
+		{name: operationApproveWorkflow, requiredCapabilities: []string{capabilityWorkflowApproval}},
+	}
+}
+
+// repoOperations derives the operation availability map for a repo
+// from current provider capabilities, the repo's per-viewer merge
+// permission, and the host's REST/GraphQL rate-limit state.
+//
+// The set of keys is fixed by operationCatalog() so the client can
+// rely on every operation appearing in every response.
+func (s *Server) repoOperations(repo db.Repo) map[string]OperationAvailability {
+	caps := s.capabilitiesForRepo(repo)
+	rate := s.rateLimitedReason(repo)
+	catalog := operationCatalog()
+
+	out := make(map[string]OperationAvailability, len(catalog))
+	for _, op := range catalog {
+		out[op.name] = deriveOperationAvailability(op, caps, repo, rate)
+	}
+	return out
+}
+
+func deriveOperationAvailability(
+	op operationDescriptor,
+	caps providerCapabilitiesResponse,
+	repo db.Repo,
+	rate rateLimitAvailability,
+) OperationAvailability {
+	for _, capability := range op.requiredCapabilities {
+		if !capabilityEnabled(caps, capability) {
+			return OperationAvailability{
+				Code:               availabilityCodeUnsupportedCapability,
+				UnavailableReason:  fmt.Sprintf("Provider does not support %s", capability),
+				RequiredCapability: capability,
+			}
+		}
+	}
+	if op.name == operationMergePR && !repo.ViewerCanMerge {
+		return OperationAvailability{
+			Code:              availabilityCodeViewerCannotMerge,
+			UnavailableReason: "You do not have permission to merge in this repository",
+		}
+	}
+	if rate.limited {
+		return OperationAvailability{
+			Code:              availabilityCodeRateLimited,
+			UnavailableReason: rate.reason,
+			RetryAt:           rate.retryAt,
+		}
+	}
+	return OperationAvailability{Available: true}
+}
+
+// rateLimitAvailability is the result of consulting the rate
+// trackers for a repo's host. limited is true when either the REST
+// or GraphQL tracker for the host is paused.
+type rateLimitAvailability struct {
+	limited bool
+	reason  string
+	retryAt string
+}
+
+func (s *Server) rateLimitedReason(repo db.Repo) rateLimitAvailability {
+	if s == nil || s.syncer == nil {
+		return rateLimitAvailability{}
+	}
+	host := repoProviderHost(repo)
+	providerName := string(repoProviderKind(repo))
+	key := ratelimit.RateBucketKey(providerName, host)
+
+	// Either tracker being paused blocks operations: REST handles
+	// the mutation calls themselves, but GraphQL shares the same
+	// API budget on GitHub, so its pause also signals that mutating
+	// the repo is likely to fail.
+	if rt, ok := s.syncer.RateTrackers()[key]; ok && rt != nil && rt.IsPaused() {
+		return formatRateLimit(host, rt.ResetAt())
+	}
+	if rt, ok := s.syncer.GQLRateTrackers()[key]; ok && rt != nil && rt.IsPaused() {
+		return formatRateLimit(host, rt.ResetAt())
+	}
+	return rateLimitAvailability{}
+}
+
+func formatRateLimit(host string, resetAt *time.Time) rateLimitAvailability {
+	res := rateLimitAvailability{limited: true}
+	if resetAt != nil {
+		res.retryAt = formatUTCRFC3339(*resetAt)
+		res.reason = fmt.Sprintf(
+			"%s rate-limited; retry at %s",
+			host, resetAt.UTC().Format("15:04"),
+		)
+		return res
+	}
+	res.reason = fmt.Sprintf("%s rate-limited", host)
+	return res
+}

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -32,6 +32,16 @@ const (
 	availabilityCodeRateLimited           = "rate_limited"
 )
 
+// apiBucket identifies which API quota an operation consumes. GitHub
+// exposes REST and GraphQL as independent budgets, so a pause on one
+// must not block operations served by the other.
+type apiBucket int
+
+const (
+	apiBucketREST apiBucket = iota
+	apiBucketGraphQL
+)
+
 // OperationAvailability is the wire-level shape describing whether
 // a write operation can be invoked against a repository right now.
 // It collapses the inputs the UI would otherwise have to mirror
@@ -65,37 +75,48 @@ type RepoOperations struct {
 	ApproveWorkflow    OperationAvailability `json:"approve_workflow"`
 }
 
-// operationDescriptor lists the capabilities an operation needs.
-// requiredCapabilities is checked in declaration order so the first
-// missing capability becomes RequiredCapability, giving deterministic
-// behavior when multiple are absent.
+// operationDescriptor lists the capabilities an operation needs and
+// the API bucket it consumes. requiredCapabilities is checked in
+// declaration order so the first missing capability becomes
+// RequiredCapability, giving deterministic behavior when multiple
+// are absent.
 type operationDescriptor struct {
 	name                 string
 	requiredCapabilities []string
+	bucket               apiBucket
 }
 
+// All currently-cataloged mutations are served by REST. The bucket
+// field exists so a future GraphQL-backed operation opts in
+// explicitly rather than inheriting REST's rate-limit state.
 var (
-	descMergePR            = operationDescriptor{name: operationMergePR, requiredCapabilities: []string{capabilityMergeMutation}}
-	descClosePR            = operationDescriptor{name: operationClosePR, requiredCapabilities: []string{capabilityStateMutation}}
-	descReopenPR           = operationDescriptor{name: operationReopenPR, requiredCapabilities: []string{capabilityStateMutation}}
-	descMarkReadyForReview = operationDescriptor{name: operationMarkReadyForReview, requiredCapabilities: []string{capabilityReadyForReview}}
-	descSubmitReview       = operationDescriptor{name: operationSubmitReview, requiredCapabilities: []string{capabilityReviewMutation}}
-	descAddComment         = operationDescriptor{name: operationAddComment, requiredCapabilities: []string{capabilityCommentMutation}}
-	descAddLabel           = operationDescriptor{name: operationAddLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}}
-	descRemoveLabel        = operationDescriptor{name: operationRemoveLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}}
-	descCloseIssue         = operationDescriptor{name: operationCloseIssue, requiredCapabilities: []string{capabilityIssueMutation}}
-	descReopenIssue        = operationDescriptor{name: operationReopenIssue, requiredCapabilities: []string{capabilityIssueMutation}}
-	descApproveWorkflow    = operationDescriptor{name: operationApproveWorkflow, requiredCapabilities: []string{capabilityWorkflowApproval}}
+	descMergePR            = operationDescriptor{name: operationMergePR, requiredCapabilities: []string{capabilityMergeMutation}, bucket: apiBucketREST}
+	descClosePR            = operationDescriptor{name: operationClosePR, requiredCapabilities: []string{capabilityStateMutation}, bucket: apiBucketREST}
+	descReopenPR           = operationDescriptor{name: operationReopenPR, requiredCapabilities: []string{capabilityStateMutation}, bucket: apiBucketREST}
+	descMarkReadyForReview = operationDescriptor{name: operationMarkReadyForReview, requiredCapabilities: []string{capabilityReadyForReview}, bucket: apiBucketREST}
+	descSubmitReview       = operationDescriptor{name: operationSubmitReview, requiredCapabilities: []string{capabilityReviewMutation}, bucket: apiBucketREST}
+	descAddComment         = operationDescriptor{name: operationAddComment, requiredCapabilities: []string{capabilityCommentMutation}, bucket: apiBucketREST}
+	descAddLabel           = operationDescriptor{name: operationAddLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}, bucket: apiBucketREST}
+	descRemoveLabel        = operationDescriptor{name: operationRemoveLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}, bucket: apiBucketREST}
+	descCloseIssue         = operationDescriptor{name: operationCloseIssue, requiredCapabilities: []string{capabilityIssueMutation}, bucket: apiBucketREST}
+	descReopenIssue        = operationDescriptor{name: operationReopenIssue, requiredCapabilities: []string{capabilityIssueMutation}, bucket: apiBucketREST}
+	descApproveWorkflow    = operationDescriptor{name: operationApproveWorkflow, requiredCapabilities: []string{capabilityWorkflowApproval}, bucket: apiBucketREST}
 )
 
 // repoOperations derives the availability of every operation for a
 // repo from current provider capabilities, the repo's per-viewer
-// merge permission, and the host's REST/GraphQL rate-limit state.
+// merge permission, and the rate-limit state of the host's API
+// buckets. Each operation consults only the bucket it consumes, so
+// a paused GraphQL tracker does not block REST-backed operations
+// and vice versa.
 func (s *Server) repoOperations(repo db.Repo) RepoOperations {
 	caps := s.capabilitiesForRepo(repo)
-	rate := s.rateLimitedReason(repo)
+	rates := map[apiBucket]rateLimitAvailability{
+		apiBucketREST:    s.rateLimitedReason(repo, apiBucketREST),
+		apiBucketGraphQL: s.rateLimitedReason(repo, apiBucketGraphQL),
+	}
 	derive := func(op operationDescriptor) OperationAvailability {
-		return deriveOperationAvailability(op, caps, repo, rate)
+		return deriveOperationAvailability(op, caps, repo, rates[op.bucket])
 	}
 	return RepoOperations{
 		MergePR:            derive(descMergePR),
@@ -143,16 +164,15 @@ func deriveOperationAvailability(
 	return OperationAvailability{Available: true}
 }
 
-// rateLimitAvailability is the result of consulting the rate
-// trackers for a repo's host. limited is true when either the REST
-// or GraphQL tracker for the host is paused.
+// rateLimitAvailability is the result of consulting a rate tracker
+// for a repo's host. limited is true when the tracker is paused.
 type rateLimitAvailability struct {
 	limited bool
 	reason  string
 	retryAt string
 }
 
-func (s *Server) rateLimitedReason(repo db.Repo) rateLimitAvailability {
+func (s *Server) rateLimitedReason(repo db.Repo, bucket apiBucket) rateLimitAvailability {
 	if s == nil || s.syncer == nil {
 		return rateLimitAvailability{}
 	}
@@ -160,14 +180,16 @@ func (s *Server) rateLimitedReason(repo db.Repo) rateLimitAvailability {
 	providerName := string(repoProviderKind(repo))
 	key := ratelimit.RateBucketKey(providerName, host)
 
-	// Either tracker being paused blocks operations: REST handles
-	// the mutation calls themselves, but GraphQL shares the same
-	// API budget on GitHub, so its pause also signals that mutating
-	// the repo is likely to fail.
-	if rt, ok := s.syncer.RateTrackers()[key]; ok && rt != nil && rt.IsPaused() {
-		return formatRateLimit(host, rt.ResetAt())
+	var trackers map[string]*ratelimit.RateTracker
+	switch bucket {
+	case apiBucketREST:
+		trackers = s.syncer.RateTrackers()
+	case apiBucketGraphQL:
+		trackers = s.syncer.GQLRateTrackers()
+	default:
+		return rateLimitAvailability{}
 	}
-	if rt, ok := s.syncer.GQLRateTrackers()[key]; ok && rt != nil && rt.IsPaused() {
+	if rt, ok := trackers[key]; ok && rt != nil && rt.IsPaused() {
 		return formatRateLimit(host, rt.ResetAt())
 	}
 	return rateLimitAvailability{}

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -8,9 +8,9 @@ import (
 	"github.com/wesm/middleman/internal/ratelimit"
 )
 
-// Operation names used as keys in the operations map on the wire.
-// Adding or renaming a constant here is a breaking wire change; the
-// frontend depends on these literals to drive button enablement.
+// Operation names. These string literals are the JSON field names
+// of RepoOperations and are part of the wire contract; renaming one
+// is a breaking change for clients pinned to an older schema.
 const (
 	operationMergePR            = "merge_pr"
 	operationClosePR            = "close_pr"
@@ -45,6 +45,26 @@ type OperationAvailability struct {
 	RetryAt            string `json:"retry_at,omitempty"`
 }
 
+// RepoOperations carries the availability of every supported write
+// operation for a repository. Naming each operation as a struct
+// field (rather than a free-form string-keyed map) makes the set of
+// operations part of the OpenAPI contract: clients get typed access
+// to each field and adding a new operation requires an explicit
+// server change.
+type RepoOperations struct {
+	MergePR            OperationAvailability `json:"merge_pr"`
+	ClosePR            OperationAvailability `json:"close_pr"`
+	ReopenPR           OperationAvailability `json:"reopen_pr"`
+	MarkReadyForReview OperationAvailability `json:"mark_ready_for_review"`
+	SubmitReview       OperationAvailability `json:"submit_review"`
+	AddComment         OperationAvailability `json:"add_comment"`
+	AddLabel           OperationAvailability `json:"add_label"`
+	RemoveLabel        OperationAvailability `json:"remove_label"`
+	CloseIssue         OperationAvailability `json:"close_issue"`
+	ReopenIssue        OperationAvailability `json:"reopen_issue"`
+	ApproveWorkflow    OperationAvailability `json:"approve_workflow"`
+}
+
 // operationDescriptor lists the capabilities an operation needs.
 // requiredCapabilities is checked in declaration order so the first
 // missing capability becomes RequiredCapability, giving deterministic
@@ -54,38 +74,42 @@ type operationDescriptor struct {
 	requiredCapabilities []string
 }
 
-func operationCatalog() []operationDescriptor {
-	return []operationDescriptor{
-		{name: operationMergePR, requiredCapabilities: []string{capabilityMergeMutation}},
-		{name: operationClosePR, requiredCapabilities: []string{capabilityStateMutation}},
-		{name: operationReopenPR, requiredCapabilities: []string{capabilityStateMutation}},
-		{name: operationMarkReadyForReview, requiredCapabilities: []string{capabilityReadyForReview}},
-		{name: operationSubmitReview, requiredCapabilities: []string{capabilityReviewMutation}},
-		{name: operationAddComment, requiredCapabilities: []string{capabilityCommentMutation}},
-		{name: operationAddLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}},
-		{name: operationRemoveLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}},
-		{name: operationCloseIssue, requiredCapabilities: []string{capabilityIssueMutation}},
-		{name: operationReopenIssue, requiredCapabilities: []string{capabilityIssueMutation}},
-		{name: operationApproveWorkflow, requiredCapabilities: []string{capabilityWorkflowApproval}},
-	}
-}
+var (
+	descMergePR            = operationDescriptor{name: operationMergePR, requiredCapabilities: []string{capabilityMergeMutation}}
+	descClosePR            = operationDescriptor{name: operationClosePR, requiredCapabilities: []string{capabilityStateMutation}}
+	descReopenPR           = operationDescriptor{name: operationReopenPR, requiredCapabilities: []string{capabilityStateMutation}}
+	descMarkReadyForReview = operationDescriptor{name: operationMarkReadyForReview, requiredCapabilities: []string{capabilityReadyForReview}}
+	descSubmitReview       = operationDescriptor{name: operationSubmitReview, requiredCapabilities: []string{capabilityReviewMutation}}
+	descAddComment         = operationDescriptor{name: operationAddComment, requiredCapabilities: []string{capabilityCommentMutation}}
+	descAddLabel           = operationDescriptor{name: operationAddLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}}
+	descRemoveLabel        = operationDescriptor{name: operationRemoveLabel, requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation}}
+	descCloseIssue         = operationDescriptor{name: operationCloseIssue, requiredCapabilities: []string{capabilityIssueMutation}}
+	descReopenIssue        = operationDescriptor{name: operationReopenIssue, requiredCapabilities: []string{capabilityIssueMutation}}
+	descApproveWorkflow    = operationDescriptor{name: operationApproveWorkflow, requiredCapabilities: []string{capabilityWorkflowApproval}}
+)
 
-// repoOperations derives the operation availability map for a repo
-// from current provider capabilities, the repo's per-viewer merge
-// permission, and the host's REST/GraphQL rate-limit state.
-//
-// The set of keys is fixed by operationCatalog() so the client can
-// rely on every operation appearing in every response.
-func (s *Server) repoOperations(repo db.Repo) map[string]OperationAvailability {
+// repoOperations derives the availability of every operation for a
+// repo from current provider capabilities, the repo's per-viewer
+// merge permission, and the host's REST/GraphQL rate-limit state.
+func (s *Server) repoOperations(repo db.Repo) RepoOperations {
 	caps := s.capabilitiesForRepo(repo)
 	rate := s.rateLimitedReason(repo)
-	catalog := operationCatalog()
-
-	out := make(map[string]OperationAvailability, len(catalog))
-	for _, op := range catalog {
-		out[op.name] = deriveOperationAvailability(op, caps, repo, rate)
+	derive := func(op operationDescriptor) OperationAvailability {
+		return deriveOperationAvailability(op, caps, repo, rate)
 	}
-	return out
+	return RepoOperations{
+		MergePR:            derive(descMergePR),
+		ClosePR:            derive(descClosePR),
+		ReopenPR:           derive(descReopenPR),
+		MarkReadyForReview: derive(descMarkReadyForReview),
+		SubmitReview:       derive(descSubmitReview),
+		AddComment:         derive(descAddComment),
+		AddLabel:           derive(descAddLabel),
+		RemoveLabel:        derive(descRemoveLabel),
+		CloseIssue:         derive(descCloseIssue),
+		ReopenIssue:        derive(descReopenIssue),
+		ApproveWorkflow:    derive(descApproveWorkflow),
+	}
 }
 
 func deriveOperationAvailability(

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -1,0 +1,297 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/db"
+	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/ratelimit"
+	"github.com/wesm/middleman/internal/testutil/dbtest"
+)
+
+func TestDeriveOperationAvailability(t *testing.T) {
+	allCaps := providerCapabilitiesResponse{
+		ReadRepositories:  true,
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+		ReadComments:      true,
+		ReadReleases:      true,
+		ReadCI:            true,
+		ReadLabels:        true,
+		CommentMutation:   true,
+		StateMutation:     true,
+		MergeMutation:     true,
+		ReviewMutation:    true,
+		WorkflowApproval:  true,
+		ReadyForReview:    true,
+		IssueMutation:     true,
+		LabelMutation:     true,
+	}
+	mergePR := operationDescriptor{
+		name:                 operationMergePR,
+		requiredCapabilities: []string{capabilityMergeMutation},
+	}
+	addLabel := operationDescriptor{
+		name:                 operationAddLabel,
+		requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation},
+	}
+	resetAt := time.Date(2026, 5, 19, 14, 35, 0, 0, time.UTC)
+	limitedRate := rateLimitAvailability{
+		limited: true,
+		reason:  "github.com rate-limited; retry at 14:35",
+		retryAt: resetAt.UTC().Format(time.RFC3339),
+	}
+	repoCanMerge := db.Repo{ViewerCanMerge: true}
+	repoCannotMerge := db.Repo{ViewerCanMerge: false}
+
+	tests := []struct {
+		name     string
+		op       operationDescriptor
+		caps     providerCapabilitiesResponse
+		repo     db.Repo
+		rate     rateLimitAvailability
+		expected OperationAvailability
+	}{
+		{
+			name:     "healthy merge_pr is available",
+			op:       mergePR,
+			caps:     allCaps,
+			repo:     repoCanMerge,
+			expected: OperationAvailability{Available: true},
+		},
+		{
+			name: "missing required capability surfaces unsupported_capability",
+			op:   mergePR,
+			caps: func() providerCapabilitiesResponse {
+				c := allCaps
+				c.MergeMutation = false
+				return c
+			}(),
+			repo: repoCanMerge,
+			expected: OperationAvailability{
+				Code:               availabilityCodeUnsupportedCapability,
+				UnavailableReason:  "Provider does not support merge_mutation",
+				RequiredCapability: capabilityMergeMutation,
+			},
+		},
+		{
+			name: "first missing capability wins for multi-cap operations",
+			op:   addLabel,
+			caps: func() providerCapabilitiesResponse {
+				c := allCaps
+				c.ReadLabels = false
+				c.LabelMutation = false
+				return c
+			}(),
+			repo: repoCanMerge,
+			expected: OperationAvailability{
+				Code:               availabilityCodeUnsupportedCapability,
+				UnavailableReason:  "Provider does not support read_labels",
+				RequiredCapability: capabilityReadLabels,
+			},
+		},
+		{
+			name: "viewer without merge permission cannot merge even when capability exists",
+			op:   mergePR,
+			caps: allCaps,
+			repo: repoCannotMerge,
+			expected: OperationAvailability{
+				Code:              availabilityCodeViewerCannotMerge,
+				UnavailableReason: "You do not have permission to merge in this repository",
+			},
+		},
+		{
+			name:     "viewer_can_merge gate is scoped to merge_pr only",
+			op:       operationDescriptor{name: operationClosePR, requiredCapabilities: []string{capabilityStateMutation}},
+			caps:     allCaps,
+			repo:     repoCannotMerge,
+			expected: OperationAvailability{Available: true},
+		},
+		{
+			name: "rate-limited host blocks even when capability and permission exist",
+			op:   mergePR,
+			caps: allCaps,
+			repo: repoCanMerge,
+			rate: limitedRate,
+			expected: OperationAvailability{
+				Code:              availabilityCodeRateLimited,
+				UnavailableReason: "github.com rate-limited; retry at 14:35",
+				RetryAt:           resetAt.UTC().Format(time.RFC3339),
+			},
+		},
+		{
+			name: "unsupported capability takes precedence over rate limit",
+			op:   mergePR,
+			caps: func() providerCapabilitiesResponse {
+				c := allCaps
+				c.MergeMutation = false
+				return c
+			}(),
+			repo: repoCanMerge,
+			rate: limitedRate,
+			expected: OperationAvailability{
+				Code:               availabilityCodeUnsupportedCapability,
+				UnavailableReason:  "Provider does not support merge_mutation",
+				RequiredCapability: capabilityMergeMutation,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveOperationAvailability(tc.op, tc.caps, tc.repo, tc.rate)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestFormatRateLimit(t *testing.T) {
+	assert := Assert.New(t)
+
+	resetAt := time.Date(2026, 5, 19, 14, 35, 0, 0, time.UTC)
+	got := formatRateLimit("github.com", &resetAt)
+	assert.True(got.limited)
+	assert.Equal("github.com rate-limited; retry at 14:35", got.reason)
+	assert.Equal(resetAt.UTC().Format(time.RFC3339), got.retryAt)
+
+	unknown := formatRateLimit("ghe.example.com", nil)
+	assert.True(unknown.limited)
+	assert.Equal("ghe.example.com rate-limited", unknown.reason)
+	assert.Empty(unknown.retryAt)
+}
+
+func TestRepoOperationsCatalogIsStable(t *testing.T) {
+	// The catalog of operation names is a wire contract. Renaming
+	// a key here breaks frontends already in flight, so the test
+	// asserts the full list as a guard against accidental renames.
+	got := make([]string, 0, len(operationCatalog()))
+	for _, op := range operationCatalog() {
+		got = append(got, op.name)
+	}
+	require.Equal(t, []string{
+		"merge_pr",
+		"close_pr",
+		"reopen_pr",
+		"mark_ready_for_review",
+		"submit_review",
+		"add_comment",
+		"add_label",
+		"remove_label",
+		"close_issue",
+		"reopen_issue",
+		"approve_workflow",
+	}, got)
+}
+
+// newServerWithRateTracker builds a Server whose syncer is wired
+// with a single REST rate tracker for github.com so tests can flip
+// the host into the paused state by calling UpdateFromRate.
+func newServerWithRateTracker(t *testing.T) (*Server, *db.DB, *ratelimit.RateTracker) {
+	t.Helper()
+	database := dbtest.Open(t)
+	rt := ghclient.NewRateTracker(database, "github.com", "rest")
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": &mockGH{}},
+		database, nil,
+		[]ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		map[string]*ghclient.RateTracker{ratelimit.RateBucketKey("github", "github.com"): rt},
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	return srv, database, rt
+}
+
+func TestAPIRepoResponseIncludesOperationsHealthy(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database, _ := newServerWithRateTracker(t)
+	_, err := database.UpsertRepo(
+		t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	// Schema default is viewer_can_merge=1, so no extra update is
+	// needed; the fresh row already satisfies the merge permission.
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var resp repoResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+
+	// Wire shape: every catalog operation is present.
+	require.NotEmpty(resp.Operations)
+	for _, op := range operationCatalog() {
+		require.Contains(resp.Operations, op.name, "missing operation: %s", op.name)
+	}
+	merge := resp.Operations[operationMergePR]
+	assert.True(merge.Available)
+	assert.Empty(merge.Code)
+	assert.Empty(merge.UnavailableReason)
+}
+
+func TestAPIRepoResponseIncludesOperationsRateLimited(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database, rt := newServerWithRateTracker(t)
+	_, err := database.UpsertRepo(
+		t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	// Schema default already grants viewer merge permission.
+
+	resetAt := time.Now().UTC().Add(30 * time.Minute)
+	rt.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var resp repoResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+
+	require.NotEmpty(resp.Operations)
+	merge := resp.Operations[operationMergePR]
+	assert.False(merge.Available)
+	assert.Equal(availabilityCodeRateLimited, merge.Code)
+	assert.Contains(merge.UnavailableReason, "rate-limited")
+	assert.NotEmpty(merge.RetryAt)
+}
+
+func TestAPIRepoResponseIncludesOperationsViewerCannotMerge(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database := setupTestServer(t)
+	repoID, err := database.UpsertRepo(
+		t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	// Schema defaults viewer_can_merge to 1; flip to false so the
+	// merge gate (not the capability gate) decides this case.
+	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, false))
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var resp repoResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+
+	merge := resp.Operations[operationMergePR]
+	assert.False(merge.Available)
+	assert.Equal(availabilityCodeViewerCannotMerge, merge.Code)
+	assert.Empty(merge.RequiredCapability)
+
+	// Other operations remain available because viewer_can_merge only
+	// gates merge_pr.
+	closePR := resp.Operations[operationClosePR]
+	assert.True(closePR.Available)
+}

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -165,15 +166,20 @@ func TestFormatRateLimit(t *testing.T) {
 	assert.Empty(unknown.retryAt)
 }
 
-func TestRepoOperationsCatalogIsStable(t *testing.T) {
-	// The catalog of operation names is a wire contract. Renaming
-	// a key here breaks frontends already in flight, so the test
-	// asserts the full list as a guard against accidental renames.
-	got := make([]string, 0, len(operationCatalog()))
-	for _, op := range operationCatalog() {
-		got = append(got, op.name)
+func TestRepoOperationsWireShape(t *testing.T) {
+	// The set of operation field names on RepoOperations is a wire
+	// contract. Renaming a json tag here breaks any frontend pinned
+	// to an older schema, so the test enumerates the full set as a
+	// guard against accidental renames.
+	require := require.New(t)
+	fields := reflect.VisibleFields(reflect.TypeFor[RepoOperations]())
+	tags := make([]string, 0, len(fields))
+	for _, f := range fields {
+		tag := f.Tag.Get("json")
+		require.NotEmpty(tag, "field %s missing json tag", f.Name)
+		tags = append(tags, tag)
 	}
-	require.Equal(t, []string{
+	require.Equal([]string{
 		"merge_pr",
 		"close_pr",
 		"reopen_pr",
@@ -185,7 +191,7 @@ func TestRepoOperationsCatalogIsStable(t *testing.T) {
 		"close_issue",
 		"reopen_issue",
 		"approve_workflow",
-	}, got)
+	}, tags)
 }
 
 // newServerWithRateTracker builds a Server whose syncer is wired
@@ -227,12 +233,7 @@ func TestAPIRepoResponseIncludesOperationsHealthy(t *testing.T) {
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 
-	// Wire shape: every catalog operation is present.
-	require.NotEmpty(resp.Operations)
-	for _, op := range operationCatalog() {
-		require.Contains(resp.Operations, op.name, "missing operation: %s", op.name)
-	}
-	merge := resp.Operations[operationMergePR]
+	merge := resp.Operations.MergePR
 	assert.True(merge.Available)
 	assert.Empty(merge.Code)
 	assert.Empty(merge.UnavailableReason)
@@ -258,8 +259,7 @@ func TestAPIRepoResponseIncludesOperationsRateLimited(t *testing.T) {
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 
-	require.NotEmpty(resp.Operations)
-	merge := resp.Operations[operationMergePR]
+	merge := resp.Operations.MergePR
 	assert.False(merge.Available)
 	assert.Equal(availabilityCodeRateLimited, merge.Code)
 	assert.Contains(merge.UnavailableReason, "rate-limited")
@@ -285,13 +285,12 @@ func TestAPIRepoResponseIncludesOperationsViewerCannotMerge(t *testing.T) {
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 
-	merge := resp.Operations[operationMergePR]
+	merge := resp.Operations.MergePR
 	assert.False(merge.Available)
 	assert.Equal(availabilityCodeViewerCannotMerge, merge.Code)
 	assert.Empty(merge.RequiredCapability)
 
 	// Other operations remain available because viewer_can_merge only
 	// gates merge_pr.
-	closePR := resp.Operations[operationClosePR]
-	assert.True(closePR.Available)
+	assert.True(resp.Operations.ClosePR.Available)
 }

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -266,6 +266,53 @@ func TestAPIRepoResponseIncludesOperationsRateLimited(t *testing.T) {
 	assert.NotEmpty(merge.RetryAt)
 }
 
+func TestAPIRepoResponseIncludesOperationsGraphQLPauseDoesNotBlockREST(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	// Mutations in middleman are REST-backed, so a paused GraphQL
+	// tracker must leave merge_pr available; this guards against
+	// the earlier behavior that treated either tracker's pause as
+	// blocking every operation.
+	database := dbtest.Open(t)
+	restRT := ghclient.NewRateTracker(database, "github.com", "rest")
+	gqlRT := ghclient.NewRateTracker(database, "github.com", "graphql")
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": &mockGH{}},
+		database, nil,
+		[]ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		map[string]*ghclient.RateTracker{ratelimit.RateBucketKey("github", "github.com"): restRT},
+		nil,
+	)
+	syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcher("fake-token", "github.com", gqlRT, nil),
+	})
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	_, err := database.UpsertRepo(
+		t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+
+	// Pause GraphQL by reporting zero remaining requests with a
+	// future reset; leave REST untouched.
+	resetAt := time.Now().UTC().Add(30 * time.Minute)
+	gqlRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var resp repoResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+
+	merge := resp.Operations.MergePR
+	assert.True(merge.Available, "merge_pr is REST-backed; GraphQL pause must not block it")
+	assert.Empty(merge.Code)
+}
+
 func TestAPIRepoResponseIncludesOperationsViewerCannotMerge(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/server/repo_ref.go
+++ b/internal/server/repo_ref.go
@@ -125,6 +125,7 @@ func (s *Server) repoResponse(repo db.Repo) repoResponse {
 		BackfillIssueCompletedAt: repo.BackfillIssueCompletedAt,
 		CreatedAt:                repo.CreatedAt,
 		Capabilities:             s.capabilitiesForRepo(repo),
+		Operations:               s.repoOperations(repo),
 	}
 }
 

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2556,6 +2556,19 @@ export interface components {
             synced_at?: string;
             syncing: boolean;
         };
+        RepoOperations: {
+            add_comment: components["schemas"]["OperationAvailability"];
+            add_label: components["schemas"]["OperationAvailability"];
+            approve_workflow: components["schemas"]["OperationAvailability"];
+            close_issue: components["schemas"]["OperationAvailability"];
+            close_pr: components["schemas"]["OperationAvailability"];
+            mark_ready_for_review: components["schemas"]["OperationAvailability"];
+            merge_pr: components["schemas"]["OperationAvailability"];
+            remove_label: components["schemas"]["OperationAvailability"];
+            reopen_issue: components["schemas"]["OperationAvailability"];
+            reopen_pr: components["schemas"]["OperationAvailability"];
+            submit_review: components["schemas"]["OperationAvailability"];
+        };
         RepoPreviewRequest: {
             /**
              * Format: uri
@@ -2637,9 +2650,7 @@ export interface components {
             PlatformHost: string;
             ViewerCanMerge: boolean;
             capabilities: components["schemas"]["ProviderCapabilitiesResponse"];
-            operations: {
-                [key: string]: components["schemas"]["OperationAvailability"];
-            };
+            operations: components["schemas"]["RepoOperations"];
         };
         RepoSummaryAuthorResponse: {
             /** Format: int64 */
@@ -2690,9 +2701,7 @@ export interface components {
             open_issue_count: number;
             /** Format: int64 */
             open_pr_count: number;
-            operations: {
-                [key: string]: components["schemas"]["OperationAvailability"];
-            };
+            operations: components["schemas"]["RepoOperations"];
             owner: string;
             platform_host: string;
             recent_issues: components["schemas"]["RepoSummaryIssueResponse"][] | null;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2396,6 +2396,13 @@ export interface components {
             state: string;
             title: string;
         };
+        OperationAvailability: {
+            available: boolean;
+            code?: string;
+            required_capability?: string;
+            retry_at?: string;
+            unavailable_reason?: string;
+        };
         PlatformIdentityPayload: {
             name: string;
             owner: string;
@@ -2630,6 +2637,9 @@ export interface components {
             PlatformHost: string;
             ViewerCanMerge: boolean;
             capabilities: components["schemas"]["ProviderCapabilitiesResponse"];
+            operations: {
+                [key: string]: components["schemas"]["OperationAvailability"];
+            };
         };
         RepoSummaryAuthorResponse: {
             /** Format: int64 */
@@ -2680,6 +2690,9 @@ export interface components {
             open_issue_count: number;
             /** Format: int64 */
             open_pr_count: number;
+            operations: {
+                [key: string]: components["schemas"]["OperationAvailability"];
+            };
             owner: string;
             platform_host: string;
             recent_issues: components["schemas"]["RepoSummaryIssueResponse"][] | null;

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -15,6 +15,8 @@ export type PullRequest =
   components["schemas"]["MergeRequestResponse"];
 export type ProviderCapabilities =
   components["schemas"]["ProviderCapabilitiesResponse"];
+export type OperationAvailability =
+  components["schemas"]["OperationAvailability"];
 export type Issue =
   components["schemas"]["IssueResponse"];
 export type IssueEvent = components["schemas"]["IssueEvent"];

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -17,6 +17,8 @@ export type ProviderCapabilities =
   components["schemas"]["ProviderCapabilitiesResponse"];
 export type OperationAvailability =
   components["schemas"]["OperationAvailability"];
+export type RepoOperations =
+  components["schemas"]["RepoOperations"];
 export type Issue =
   components["schemas"]["IssueResponse"];
 export type IssueEvent = components["schemas"]["IssueEvent"];

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -4,6 +4,7 @@
     DiffFile,
     KanbanStatus,
     Label,
+    OperationAvailability,
     ProviderCapabilities,
     PullRequest,
   } from "../../api/types.js";
@@ -522,6 +523,7 @@
     allowMerge: boolean;
     allowRebase: boolean;
     viewerCanMerge: boolean;
+    operations?: Record<string, OperationAvailability>;
   };
 
   let repoSettings = $state<RepoSettings | null>(null);
@@ -541,6 +543,7 @@
         allowMerge: data.AllowMergeCommit,
         allowRebase: data.AllowRebaseMerge,
         viewerCanMerge: data.ViewerCanMerge,
+        operations: data.operations,
       };
     }).catch(() => {
       if (requestID === repoSettingsRequestID) {
@@ -1476,17 +1479,23 @@
               oncompleted={closeActionMenu}
             />
           {/if}
-          {#if repoSettings && capabilities.merge_mutation && repoSettings.viewerCanMerge}
+          {@const mergeOp = repoSettings?.operations?.merge_pr}
+          {@const mergeOpUnavailable = mergeOp !== undefined && !mergeOp.available}
+          {#if repoSettings && (mergeOp !== undefined
+              || (capabilities.merge_mutation && repoSettings.viewerCanMerge))}
             {@const mergeSettings = repoSettings}
             {@const mergeDisabledByConflicts = hasMergeConflicts(pr)}
+            {@const mergeTitle = mergeDisabledByConflicts
+              ? "Resolve merge conflicts before merging"
+              : mergeOpUnavailable
+                ? mergeOp?.unavailable_reason ?? ""
+                : ""}
             <ActionButton
               class="btn--merge"
-              disabled={stalePR || mergeDisabledByConflicts}
-              title={mergeDisabledByConflicts
-                ? "Resolve merge conflicts before merging"
-                : ""}
+              disabled={stalePR || mergeDisabledByConflicts || mergeOpUnavailable}
+              title={mergeTitle}
               onclick={() => {
-                if (stalePR) return;
+                if (stalePR || mergeOpUnavailable) return;
                 runOpenMerge(buildOpenMergeInput(pr, capabilities));
               }}
               tone="success"

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -4,9 +4,9 @@
     DiffFile,
     KanbanStatus,
     Label,
-    OperationAvailability,
     ProviderCapabilities,
     PullRequest,
+    RepoOperations,
   } from "../../api/types.js";
   import type { DetailSyncMode } from "../../stores/detail.svelte.js";
   import {
@@ -523,7 +523,7 @@
     allowMerge: boolean;
     allowRebase: boolean;
     viewerCanMerge: boolean;
-    operations?: Record<string, OperationAvailability>;
+    operations?: RepoOperations;
   };
 
   let repoSettings = $state<RepoSettings | null>(null);

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -420,4 +420,32 @@ describe("PullDetail approvals", () => {
       ).toBeNull();
     });
   });
+
+  it("renders the merge button as disabled with reason when operations.merge_pr.available is false", async () => {
+    const detail = pullDetail();
+    detail.repo.capabilities.merge_mutation = true;
+
+    renderPullDetail(detail, {
+      AllowSquashMerge: true,
+      AllowMergeCommit: false,
+      AllowRebaseMerge: false,
+      ViewerCanMerge: true,
+      operations: {
+        merge_pr: {
+          available: false,
+          code: "rate_limited",
+          unavailable_reason: "github.com rate-limited; retry at 14:35",
+          retry_at: "2026-05-19T14:35:00Z",
+        },
+      },
+    });
+
+    const button = await vi.waitFor(() => {
+      const found = screen.queryByRole("button", { name: /merge/i });
+      expect(found).not.toBeNull();
+      return found as HTMLButtonElement;
+    });
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe("github.com rate-limited; retry at 14:35");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds an `operations` map on the repo summary and repo detail responses, keyed by operation name (`merge_pr`, `submit_review`, `add_comment`, …) with `available`, `code`, `unavailable_reason`, `required_capability`, and `retry_at`.
- Derivation collapses provider capability flags, the per-repo `viewer_can_merge` bit, and the REST/GraphQL rate-limit pause for the host. Codes are `unsupported_capability`, `viewer_cannot_merge`, and `rate_limited`.
- The merge button in `PullDetail.svelte` now reads `operations.merge_pr.available` from the repo detail fetch and renders disabled with the server-supplied reason in `title` when unavailable. The legacy capability+viewer gate stays as a fallback when an older server omits operations.

## Why

The merge button mirrored capability flags and viewer permissions in Svelte conditionals and had no signal at all for transient rate-limit pauses; users discovered unavailability by clicking and getting a 409. With operation availability on the wire, the UI can disable controls preemptively and explain why on hover.

## Tests

- Table-driven unit coverage of every derivation branch plus precedence between capability gaps, viewer permission, and rate-limit pauses.
- Catalog-stability test guarding the wire-contract operation names.
- Three wire-level tests over `/api/v1/repo/{provider}/{owner}/{name}` (healthy, rate-limited, viewer cannot merge).
- A Svelte test asserting the merge button renders disabled with the unavailable_reason as `title` when `operations.merge_pr.available` is false.