### PR TITLE
feat: pick up config edits without restart via fsnotify

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -76,10 +76,11 @@ func main() {
 }
 
 type e2eServerInfo struct {
-	Host    string `json:"host"`
-	Port    int    `json:"port"`
-	BaseURL string `json:"base_url"`
-	PID     int    `json:"pid"`
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	BaseURL    string `json:"base_url"`
+	PID        int    `json:"pid"`
+	ConfigPath string `json:"config_path"`
 }
 
 type e2eStaticProvider struct {
@@ -998,10 +999,11 @@ func run(
 	}
 
 	info := e2eServerInfo{
-		Host:    "127.0.0.1",
-		Port:    tcpAddr.Port,
-		BaseURL: fmt.Sprintf("http://127.0.0.1:%d", tcpAddr.Port),
-		PID:     os.Getpid(),
+		Host:       "127.0.0.1",
+		Port:       tcpAddr.Port,
+		BaseURL:    fmt.Sprintf("http://127.0.0.1:%d", tcpAddr.Port),
+		PID:        os.Getpid(),
+		ConfigPath: cfgPath,
 	}
 	if err := writeServerInfoFile(serverInfoFile, info); err != nil {
 		return fmt.Errorf("write server info file: %w", err)

--- a/frontend/tests/e2e-full/config-hot-reload.spec.ts
+++ b/frontend/tests/e2e-full/config-hot-reload.spec.ts
@@ -1,0 +1,34 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+import { startIsolatedE2EServer } from "./support/e2eServer";
+
+test("config file changes update visible repo choices through SSE", async ({ page }) => {
+  const server = await startIsolatedE2EServer();
+  try {
+    await page.goto(`${server.info.base_url}/pulls`);
+    await page.locator(".pull-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    const selector = page.getByTitle("Select repository");
+    await selector.click();
+    await expect(
+      page.getByRole("option", { name: "github.com/hotreload/config-watch" }),
+    ).toHaveCount(0);
+
+    const initialConfig = await readFile(server.info.config_path, "utf8");
+    await writeFile(
+      server.info.config_path,
+      `${initialConfig}
+[[repos]]
+owner = "hotreload"
+name = "config-watch"
+`,
+    );
+
+    await expect(
+      page.getByRole("option", { name: "github.com/hotreload/config-watch" }),
+    ).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await server.stop();
+  }
+});

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -14,6 +14,7 @@ export type E2EServerInfo = {
   port: number;
   base_url: string;
   pid: number;
+  config_path: string;
 };
 
 export type IsolatedE2EServer = {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty/v2 v2.0.1
 	github.com/danielgtaylor/huma/v2 v2.37.3
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-github/v84 v84.0.0
@@ -72,7 +73,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsevents v0.2.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/getkin/kin-openapi v0.133.0 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect

--- a/internal/configwatch/watcher.go
+++ b/internal/configwatch/watcher.go
@@ -150,25 +150,32 @@ func (w *Watcher) run(ctx context.Context) {
 	w.markReady(nil)
 
 	// debounceTimer is created lazily so we don't pay for a stopped
-	// timer on watchers that never see an event.
+	// timer on watchers that never see an event. The callback runs in
+	// this goroutine, not via time.AfterFunc, so Done only closes after
+	// any in-flight callback has returned.
 	var debounceTimer *time.Timer
+	var debounceC <-chan time.Time
 	defer func() {
 		if debounceTimer != nil {
-			debounceTimer.Stop()
+			if !debounceTimer.Stop() {
+				select {
+				case <-debounceTimer.C:
+				default:
+				}
+			}
 		}
 	}()
-
-	fire := func() {
-		// Skip empty defensive guard: if OnChange panics, propagate.
-		// Callers should keep OnChange robust; this watcher must not
-		// silently swallow callback errors.
-		w.onChange()
-	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-debounceC:
+			debounceC = nil
+			// Skip empty defensive guard: if OnChange panics, propagate.
+			// Callers should keep OnChange robust; this watcher must not
+			// silently swallow callback errors.
+			w.onChange()
 		case ev, ok := <-fsw.Events:
 			if !ok {
 				return
@@ -186,10 +193,17 @@ func (w *Watcher) run(ctx context.Context) {
 			// editor save flows touch permissions and we'd rather
 			// be conservative.
 			if debounceTimer == nil {
-				debounceTimer = time.AfterFunc(w.debounce, fire)
+				debounceTimer = time.NewTimer(w.debounce)
 			} else {
+				if !debounceTimer.Stop() {
+					select {
+					case <-debounceTimer.C:
+					default:
+					}
+				}
 				debounceTimer.Reset(w.debounce)
 			}
+			debounceC = debounceTimer.C
 		case _, ok := <-fsw.Errors:
 			if !ok {
 				return

--- a/internal/configwatch/watcher.go
+++ b/internal/configwatch/watcher.go
@@ -1,0 +1,203 @@
+// Package configwatch watches a config file for in-place edits and invokes
+// a callback after debouncing fsnotify events. It registers the watch on
+// the parent directory so atomic-rename save patterns (e.g. vim ":w") and
+// editor-style write-to-temp-then-rename flows are caught on both Linux
+// inotify and macOS APFS FSEvents.
+package configwatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// DefaultDebounce is the default debounce window applied between the last
+// observed filesystem event and the callback invocation. Editors that save
+// via the temp-file + rename pattern (vim, sd -i, etc.) emit several events
+// in quick succession; the debounce coalesces those into one callback.
+const DefaultDebounce = 100 * time.Millisecond
+
+// Watcher observes a single configuration file and invokes OnChange once
+// per debounced burst of filesystem events. Zero value is not usable;
+// construct via New.
+type Watcher struct {
+	path     string
+	dir      string
+	base     string
+	debounce time.Duration
+	onChange func()
+	now      func() time.Time
+
+	// readyCh is closed once the underlying fsnotify watcher has either
+	// successfully registered the directory or recorded a startup error.
+	readyCh chan struct{}
+	readyMu sync.Mutex
+	readyOK bool
+	readyEr error
+
+	// done is closed when the run goroutine exits.
+	done chan struct{}
+}
+
+// Options configure a Watcher.
+type Options struct {
+	// Path is the absolute path to the config file. The parent directory
+	// is registered with fsnotify; events whose basename matches Path are
+	// forwarded through the debounce timer.
+	Path string
+
+	// OnChange is invoked once per debounced event burst. Required.
+	// Callers should make OnChange idempotent because the watcher will
+	// also fire for the daemon's own writes (e.g. UI Save).
+	OnChange func()
+
+	// Debounce overrides DefaultDebounce. Values <= 0 fall back to the
+	// default.
+	Debounce time.Duration
+
+	// Now overrides time.Now for tests. nil falls back to time.Now.
+	Now func() time.Time
+}
+
+// New constructs a Watcher. It validates the inputs but does not touch the
+// filesystem; call Start to begin watching.
+func New(opts Options) (*Watcher, error) {
+	if opts.Path == "" {
+		return nil, errors.New("configwatch: Path is required")
+	}
+	if opts.OnChange == nil {
+		return nil, errors.New("configwatch: OnChange is required")
+	}
+	path, err := filepath.Abs(opts.Path)
+	if err != nil {
+		return nil, fmt.Errorf("configwatch: resolve path: %w", err)
+	}
+	debounce := opts.Debounce
+	if debounce <= 0 {
+		debounce = DefaultDebounce
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Watcher{
+		path:     path,
+		dir:      filepath.Dir(path),
+		base:     filepath.Base(path),
+		debounce: debounce,
+		onChange: opts.OnChange,
+		now:      now,
+		readyCh:  make(chan struct{}),
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Start launches the watcher goroutine. It returns immediately; the
+// goroutine exits when ctx is canceled. Start may only be called once.
+func (w *Watcher) Start(ctx context.Context) {
+	go w.run(ctx)
+}
+
+// WaitReady blocks until the watcher has registered the directory with
+// fsnotify, the watcher's run loop exits, or ctx is canceled. It returns
+// any startup error recorded by the run goroutine. Tests use it to
+// synchronize on watcher registration before mutating the file.
+func (w *Watcher) WaitReady(ctx context.Context) error {
+	select {
+	case <-w.readyCh:
+		w.readyMu.Lock()
+		defer w.readyMu.Unlock()
+		return w.readyEr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Done returns a channel that is closed when the watcher goroutine has
+// exited. Useful for tests that want to observe shutdown.
+func (w *Watcher) Done() <-chan struct{} { return w.done }
+
+func (w *Watcher) markReady(err error) {
+	w.readyMu.Lock()
+	defer w.readyMu.Unlock()
+	if w.readyOK {
+		return
+	}
+	w.readyOK = true
+	w.readyEr = err
+	close(w.readyCh)
+}
+
+func (w *Watcher) run(ctx context.Context) {
+	defer close(w.done)
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.markReady(fmt.Errorf("configwatch: new watcher: %w", err))
+		return
+	}
+	defer fsw.Close()
+
+	if err := fsw.Add(w.dir); err != nil {
+		w.markReady(fmt.Errorf("configwatch: add %s: %w", w.dir, err))
+		return
+	}
+	w.markReady(nil)
+
+	// debounceTimer is created lazily so we don't pay for a stopped
+	// timer on watchers that never see an event.
+	var debounceTimer *time.Timer
+	defer func() {
+		if debounceTimer != nil {
+			debounceTimer.Stop()
+		}
+	}()
+
+	fire := func() {
+		// Skip empty defensive guard: if OnChange panics, propagate.
+		// Callers should keep OnChange robust; this watcher must not
+		// silently swallow callback errors.
+		w.onChange()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-fsw.Events:
+			if !ok {
+				return
+			}
+			if filepath.Base(ev.Name) != w.base {
+				continue
+			}
+			// Watch RENAME and REMOVE too: atomic-rename editors
+			// (vim's :w with backupcopy=no) may produce a RENAME
+			// where the original inode is moved aside before the
+			// new file is renamed into place. Some editors also
+			// recreate the file; on macOS APFS the kqueue-backed
+			// fsnotify implementation surfaces these as CREATE.
+			// CHMOD-only events are still forwarded because some
+			// editor save flows touch permissions and we'd rather
+			// be conservative.
+			if debounceTimer == nil {
+				debounceTimer = time.AfterFunc(w.debounce, fire)
+			} else {
+				debounceTimer.Reset(w.debounce)
+			}
+		case _, ok := <-fsw.Errors:
+			if !ok {
+				return
+			}
+			// fsnotify errors are surfaced via the Errors channel;
+			// log via the caller's debug stream is out of scope for
+			// this leaf package. We swallow them so a single read
+			// error doesn't tear down the watcher loop.
+		}
+	}
+}

--- a/internal/configwatch/watcher_test.go
+++ b/internal/configwatch/watcher_test.go
@@ -187,3 +187,46 @@ func TestWatcher_StopsOnContextCancel(t *testing.T) {
 		require.FailNow(t, "watcher did not stop after context cancel")
 	}
 }
+
+func TestWatcher_DoneWaitsForInFlightCallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("a = 1"), 0o600))
+
+	callbackStarted := make(chan struct{})
+	callbackRelease := make(chan struct{})
+	w, err := New(Options{
+		Path:     path,
+		Debounce: 10 * time.Millisecond,
+		OnChange: func() {
+			close(callbackStarted)
+			<-callbackRelease
+		},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	w.Start(ctx)
+	require.NoError(t, w.WaitReady(ctx))
+
+	require.NoError(t, os.WriteFile(path, []byte("a = 2"), 0o600))
+	select {
+	case <-callbackStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "callback did not start")
+	}
+
+	cancel()
+	select {
+	case <-w.Done():
+		require.FailNow(t, "watcher stopped before callback returned")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(callbackRelease)
+	select {
+	case <-w.Done():
+	case <-time.After(time.Second):
+		require.FailNow(t, "watcher did not stop after callback returned")
+	}
+}

--- a/internal/configwatch/watcher_test.go
+++ b/internal/configwatch/watcher_test.go
@@ -1,0 +1,189 @@
+package configwatch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestWatcher constructs a watcher with a 25 ms debounce so tests stay
+// fast while still verifying the coalescing behavior.
+func newTestWatcher(t *testing.T, path string, onChange func()) *Watcher {
+	t.Helper()
+	w, err := New(Options{
+		Path:     path,
+		OnChange: onChange,
+		Debounce: 25 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	return w
+}
+
+func waitForCount(t *testing.T, c *atomic.Int32, want int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if c.Load() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.Equalf(t, want, c.Load(), "callback count never reached %d", want)
+}
+
+func TestWatcher_NewValidatesInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+		err  string
+	}{
+		{name: "missing path", opts: Options{OnChange: func() {}}, err: "Path is required"},
+		{name: "missing callback", opts: Options{Path: "/tmp/x"}, err: "OnChange is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.opts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.err)
+		})
+	}
+}
+
+func TestWatcher_FiresAfterDebounce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("a = 1"), 0o600))
+
+	var count atomic.Int32
+	w := newTestWatcher(t, path, func() { count.Add(1) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	w.Start(ctx)
+	require.NoError(t, w.WaitReady(ctx))
+
+	require.NoError(t, os.WriteFile(path, []byte("a = 2"), 0o600))
+
+	waitForCount(t, &count, 1, time.Second)
+}
+
+func TestWatcher_DebouncesBurst(t *testing.T) {
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("a = 1"), 0o600))
+
+	var count atomic.Int32
+	w := newTestWatcher(t, path, func() { count.Add(1) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	w.Start(ctx)
+	require.NoError(t, w.WaitReady(ctx))
+
+	// Five rapid writes; debounce should coalesce into a single callback.
+	for i := range 5 {
+		content := []byte("a = " + string(rune('0'+i)))
+		require.NoError(t, os.WriteFile(path, content, 0o600))
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	waitForCount(t, &count, 1, time.Second)
+
+	// Give the debounce window a chance to lapse so any extra callback
+	// would have fired. The debounce is 25 ms; sleep well beyond that.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(int32(1), count.Load(),
+		"expected exactly one callback from coalesced burst")
+}
+
+func TestWatcher_IgnoresUnrelatedFiles(t *testing.T) {
+	req := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	req.NoError(os.WriteFile(path, []byte("a = 1"), 0o600))
+
+	var count atomic.Int32
+	w := newTestWatcher(t, path, func() { count.Add(1) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	w.Start(ctx)
+	req.NoError(w.WaitReady(ctx))
+
+	// Writes to a sibling file in the same directory must not fire.
+	sibling := filepath.Join(dir, "other.toml")
+	req.NoError(os.WriteFile(sibling, []byte("noise = true"), 0o600))
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(0), count.Load(),
+		"sibling file should not trigger the watcher")
+}
+
+func TestWatcher_FiresOnAtomicRename(t *testing.T) {
+	req := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	req.NoError(os.WriteFile(path, []byte("a = 1"), 0o600))
+
+	var count atomic.Int32
+	w := newTestWatcher(t, path, func() { count.Add(1) })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	w.Start(ctx)
+	req.NoError(w.WaitReady(ctx))
+
+	// Atomic-rename save pattern: write a sibling, then rename over.
+	// Vim's ":w" uses this when backupcopy=auto.
+	tmp := filepath.Join(dir, ".config.toml.tmp")
+	req.NoError(os.WriteFile(tmp, []byte("a = 2"), 0o600))
+	req.NoError(os.Rename(tmp, path))
+
+	waitForCount(t, &count, 1, time.Second)
+}
+
+func TestWatcher_StartFailureSurfacedThroughWaitReady(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-dir", "config.toml")
+	w, err := New(Options{
+		Path:     missing,
+		OnChange: func() {},
+		Debounce: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	w.Start(ctx)
+
+	err = w.WaitReady(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add")
+}
+
+func TestWatcher_StopsOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("a = 1"), 0o600))
+
+	w := newTestWatcher(t, path, func() {})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	w.Start(ctx)
+	require.NoError(t, w.WaitReady(ctx))
+
+	cancel()
+
+	select {
+	case <-w.Done():
+	case <-time.After(time.Second):
+		require.FailNow(t, "watcher did not stop after context cancel")
+	}
+}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1239,6 +1239,13 @@ func (s *Syncer) RepositoryReader(
 	return s.clients.RepositoryReader(kind, canonicalRepoHost(host))
 }
 
+// Registry returns the boot-time platform registry. Callers must not
+// mutate the returned registry; it is shared by every sync codepath and
+// rebuilt only on daemon restart.
+func (s *Syncer) Registry() *platform.Registry {
+	return s.clients
+}
+
 func (s *Syncer) LabelReader(
 	kind platform.Kind,
 	host string,

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -49,6 +49,7 @@ type startupConfigSnapshot struct {
 	Roborev             config.Roborev
 	Tmux                config.Tmux
 	Shell               config.Shell
+	TokenEnvNames       []string
 }
 
 func snapshotStartupConfig(cfg *config.Config) startupConfigSnapshot {
@@ -73,6 +74,8 @@ func snapshotStartupConfig(cfg *config.Config) startupConfigSnapshot {
 		snap.Tmux.AgentSessions = &v
 	}
 	snap.Shell.Command = slices.Clone(cfg.Shell.Command)
+	snap.TokenEnvNames = cfg.TokenEnvNames()
+	slices.Sort(snap.TokenEnvNames)
 	return snap
 }
 
@@ -124,6 +127,9 @@ func (s *Server) handleConfigFileChanged() {
 	if s.cfgPath == "" {
 		return
 	}
+	s.configReloadMu.Lock()
+	defer s.configReloadMu.Unlock()
+
 	event := s.applyConfigChange(s.bgCtx)
 	s.hub.Broadcast(Event{
 		Type: "config.changed",
@@ -171,7 +177,8 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 	// whose (platform, host) the registry never learned about cannot
 	// reach a client without a restart; skip those for SetRepos but
 	// keep them in s.cfg so the UI mirrors the file.
-	resolved, skipped := s.resolveReposForReload(ctx, newCfg.Repos)
+	previous := s.syncer.TrackedRepos()
+	resolved, skipped := s.resolveReposForReload(ctx, newCfg.Repos, previous)
 	if len(skipped) > 0 {
 		slog.Info(
 			"config reload: skipping repos for unknown platform hosts",
@@ -213,6 +220,7 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 func (s *Server) resolveReposForReload(
 	ctx context.Context,
 	repos []config.Repo,
+	previous []ghclient.RepoRef,
 ) ([]ghclient.RepoRef, []string) {
 	if s.syncer == nil {
 		return nil, nil
@@ -246,11 +254,7 @@ func (s *Server) resolveReposForReload(
 				"name", raw.Name,
 				"err", err,
 			)
-			if raw.HasNameGlob() {
-				expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
-			} else {
-				expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
-			}
+			expanded = ghclient.FallbackConfiguredRepoRefs(previous, raw)
 		}
 		for _, repo := range expanded {
 			key := strings.ToLower(string(repoPlatformOrDefault(repo))) + "\x00" +

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -1,0 +1,294 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/configwatch"
+	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/platform"
+)
+
+// configChangedEvent is the payload broadcast on the SSE "config.changed"
+// channel. A late subscriber receives the most recently broadcast event so
+// it can detect a stale-config state even if it connected after the parse
+// error landed.
+type configChangedEvent struct {
+	// Valid reports whether the reloaded file parsed and validated. The
+	// daemon keeps the previous in-memory config when Valid is false.
+	Valid bool `json:"valid"`
+	// Error is set when Valid is false; it contains a sanitized message
+	// derived from the config parser/validator.
+	Error string `json:"error,omitempty"`
+	// RestartRequired is true when one or more startup-bound fields
+	// (listener address, base path, sync interval, data dir, token env
+	// names, platform registry, tmux/shell command, etc.) differ from
+	// the boot-time snapshot. Hot-reloadable fields (repos, activity,
+	// terminal, agents) are applied regardless.
+	RestartRequired bool `json:"restart_required"`
+}
+
+// startupConfigSnapshot is a deep copy of the fields the server binds at
+// startup. It is taken once in newServer and compared in applyConfigChange
+// to detect drift that the watcher cannot fix without a restart.
+type startupConfigSnapshot struct {
+	SyncInterval        string
+	GitHubTokenEnv      string
+	DefaultPlatformHost string
+	Host                string
+	Port                int
+	BasePath            string
+	DataDir             string
+	SyncBudgetPerHour   int
+	Platforms           []config.PlatformConfig
+	Roborev             config.Roborev
+	Tmux                config.Tmux
+	Shell               config.Shell
+}
+
+func snapshotStartupConfig(cfg *config.Config) startupConfigSnapshot {
+	if cfg == nil {
+		return startupConfigSnapshot{}
+	}
+	snap := startupConfigSnapshot{
+		SyncInterval:        cfg.SyncInterval,
+		GitHubTokenEnv:      cfg.GitHubTokenEnv,
+		DefaultPlatformHost: cfg.DefaultPlatformHost,
+		Host:                cfg.Host,
+		Port:                cfg.Port,
+		BasePath:            cfg.BasePath,
+		DataDir:             cfg.DataDir,
+		SyncBudgetPerHour:   cfg.SyncBudgetPerHour,
+		Platforms:           slices.Clone(cfg.Platforms),
+		Roborev:             cfg.Roborev,
+	}
+	snap.Tmux.Command = slices.Clone(cfg.Tmux.Command)
+	if cfg.Tmux.AgentSessions != nil {
+		v := *cfg.Tmux.AgentSessions
+		snap.Tmux.AgentSessions = &v
+	}
+	snap.Shell.Command = slices.Clone(cfg.Shell.Command)
+	return snap
+}
+
+func (s startupConfigSnapshot) restartRequiredFor(cfg *config.Config) bool {
+	if cfg == nil {
+		return true
+	}
+	candidate := snapshotStartupConfig(cfg)
+	// Reflect-deep-equal handles slice and pointer comparison correctly
+	// here; the snapshot owns its own slices so external mutation cannot
+	// blur the comparison.
+	return !reflect.DeepEqual(s, candidate)
+}
+
+// startConfigWatcher initializes the fsnotify-based watcher. It is a noop
+// when cfgPath is empty (tests that build a Server without persistence) or
+// when the parent directory of cfgPath does not exist on disk. The
+// watcher goroutine is registered with runBackground so Shutdown waits
+// for it to drain.
+func (s *Server) startConfigWatcher() {
+	if s.cfgPath == "" {
+		return
+	}
+	w, err := configwatch.New(configwatch.Options{
+		Path:     s.cfgPath,
+		OnChange: s.handleConfigFileChanged,
+	})
+	if err != nil {
+		slog.Warn("config watcher init failed", "err", err)
+		return
+	}
+	s.configWatcher = w
+	if !s.runBackground(func(ctx context.Context) {
+		w.Start(ctx)
+		<-w.Done()
+	}) {
+		// Shutdown started before we could schedule the watcher; the
+		// daemon is on its way out, nothing more to do.
+		s.configWatcher = nil
+	}
+}
+
+// handleConfigFileChanged is invoked by the watcher after debouncing a
+// burst of fsnotify events on the config file. It reloads the file,
+// applies hot-reloadable fields, and broadcasts a config.changed SSE
+// event. The daemon stays running on the previous in-memory config when
+// the reload fails so an editor mid-save cannot crash the process.
+func (s *Server) handleConfigFileChanged() {
+	if s.cfgPath == "" {
+		return
+	}
+	event := s.applyConfigChange(s.bgCtx)
+	s.hub.Broadcast(Event{
+		Type: "config.changed",
+		Data: event,
+	})
+}
+
+// applyConfigChange reloads the config file, copies hot-reloadable fields
+// onto the in-memory config, refreshes the syncer's repo set and runtime
+// targets, and returns the payload to broadcast. The whole apply runs
+// under cfgMu so concurrent Settings-UI mutations and a second watcher
+// reload cannot interleave. The lock is held until everything reachable
+// from s.cfg is consistent; the SSE broadcast is intentionally moved out
+// of this function (to handleConfigFileChanged) so a slow subscriber
+// cannot stall the daemon.
+func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
+	newCfg, err := config.Load(s.cfgPath)
+	if err != nil {
+		slog.Warn(
+			"config reload failed; keeping last-known-good",
+			"path", s.cfgPath,
+			"err", err,
+		)
+		return configChangedEvent{
+			Valid: false,
+			Error: sanitizeConfigError(err, s.cfgPath),
+		}
+	}
+
+	s.cfgMu.Lock()
+	defer s.cfgMu.Unlock()
+
+	if s.cfg == nil {
+		// Defensive: a Server constructed without a cfg cannot be hot
+		// reloaded; treat the change as a parse error so subscribers
+		// learn nothing useful was applied.
+		return configChangedEvent{
+			Valid: false,
+			Error: "config reload disabled: server has no in-memory config",
+		}
+	}
+
+	// Apply hot-reloadable fields. Repos and Platforms are deep-copied
+	// so subsequent in-memory mutations from the Settings UI cannot
+	// surprise the file's last view.
+	s.cfg.Repos = slices.Clone(newCfg.Repos)
+	s.cfg.Platforms = slices.Clone(newCfg.Platforms)
+	s.cfg.Activity = newCfg.Activity
+	s.cfg.Terminal = newCfg.Terminal
+	s.cfg.Agents = cloneConfigAgents(newCfg.Agents)
+
+	restartRequired := s.bootCfgSnapshot.restartRequiredFor(newCfg)
+
+	// Resolve the new repo set against the boot-time registry. Repos
+	// whose (platform, host) the registry never learned about cannot
+	// reach a client without a restart; skip those for SetRepos but
+	// keep them in s.cfg so the UI mirrors the file.
+	resolved, skipped := s.resolveReposForReload(ctx, newCfg.Repos)
+	if len(skipped) > 0 {
+		slog.Info(
+			"config reload: skipping repos for unknown platform hosts",
+			"path", s.cfgPath,
+			"skipped", skipped,
+		)
+		restartRequired = true
+	}
+	s.syncer.SetRepos(resolved)
+
+	s.refreshRuntimeTargetsLocked()
+
+	slog.Info(
+		"config reload applied",
+		"path", s.cfgPath,
+		"repo_count", len(resolved),
+		"restart_required", restartRequired,
+	)
+	return configChangedEvent{Valid: true, RestartRequired: restartRequired}
+}
+
+// resolveReposForReload walks the reloaded repo list and asks the syncer
+// (via the boot-time platform registry) whether each (provider, host)
+// pair has a client. Known hosts are resolved into RepoRefs; unknown
+// hosts are returned in the skipped slice with a "owner/name@host"
+// display string for logging.
+func (s *Server) resolveReposForReload(
+	ctx context.Context,
+	repos []config.Repo,
+) ([]ghclient.RepoRef, []string) {
+	if s.syncer == nil {
+		return nil, nil
+	}
+	resolved := make([]ghclient.RepoRef, 0, len(repos))
+	seen := make(map[string]struct{}, len(repos))
+	skipped := make([]string, 0)
+
+	for _, raw := range repos {
+		host := raw.PlatformHostOrDefault()
+		kind := platform.Kind(raw.PlatformOrDefault())
+		if _, err := s.syncer.RepositoryReader(kind, host); err != nil {
+			skipped = append(skipped, fmt.Sprintf(
+				"%s/%s@%s/%s",
+				string(kind), host, raw.Owner, raw.Name,
+			))
+			continue
+		}
+		_, expanded, err := ghclient.ResolveConfiguredRepoWithRegistry(
+			ctx, s.syncer.Registry(), raw,
+		)
+		if err != nil {
+			// Network failure or transient API error: fall back to a
+			// synthetic RepoRef built from the configured fields so
+			// the syncer still has a target to retry on its next
+			// tick. This matches resolveStartupRepos's offline-
+			// resilience behavior.
+			slog.Warn(
+				"config reload resolve repo failed; using fallback",
+				"owner", raw.Owner,
+				"name", raw.Name,
+				"err", err,
+			)
+			if raw.HasNameGlob() {
+				expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
+			} else {
+				expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
+			}
+		}
+		for _, repo := range expanded {
+			key := strings.ToLower(string(repoPlatformOrDefault(repo))) + "\x00" +
+				strings.ToLower(canonicalReloadHost(repo)) + "\x00" +
+				strings.ToLower(repo.Owner) + "\x00" +
+				strings.ToLower(repo.Name)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			resolved = append(resolved, repo)
+		}
+	}
+	return resolved, skipped
+}
+
+func repoPlatformOrDefault(repo ghclient.RepoRef) platform.Kind {
+	if repo.Platform != "" {
+		return repo.Platform
+	}
+	return platform.KindGitHub
+}
+
+func canonicalReloadHost(repo ghclient.RepoRef) string {
+	if repo.PlatformHost != "" {
+		return repo.PlatformHost
+	}
+	if host, ok := platform.DefaultHost(repoPlatformOrDefault(repo)); ok {
+		return host
+	}
+	return platform.DefaultGitHubHost
+}
+
+// sanitizeConfigError trims internal path prefixes from the error so the
+// frontend payload does not leak the absolute config path on the user's
+// machine. The path is already known to the operator from logs.
+func sanitizeConfigError(err error, cfgPath string) string {
+	msg := err.Error()
+	if cfgPath != "" {
+		msg = strings.ReplaceAll(msg, cfgPath, "config.toml")
+	}
+	return msg
+}

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -133,12 +133,11 @@ func (s *Server) handleConfigFileChanged() {
 
 // applyConfigChange reloads the config file, copies hot-reloadable fields
 // onto the in-memory config, refreshes the syncer's repo set and runtime
-// targets, and returns the payload to broadcast. The whole apply runs
-// under cfgMu so concurrent Settings-UI mutations and a second watcher
-// reload cannot interleave. The lock is held until everything reachable
-// from s.cfg is consistent; the SSE broadcast is intentionally moved out
-// of this function (to handleConfigFileChanged) so a slow subscriber
-// cannot stall the daemon.
+// targets, and returns the payload to broadcast. Repository expansion can
+// touch provider clients, so it happens before taking cfgMu. The lock is
+// held only while applying the already-resolved result to in-memory state.
+// The SSE broadcast is intentionally moved out of this function (to
+// handleConfigFileChanged) so a slow subscriber cannot stall the daemon.
 func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 	newCfg, err := config.Load(s.cfgPath)
 	if err != nil {
@@ -154,9 +153,8 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 	}
 
 	s.cfgMu.Lock()
-	defer s.cfgMu.Unlock()
-
 	if s.cfg == nil {
+		s.cfgMu.Unlock()
 		// Defensive: a Server constructed without a cfg cannot be hot
 		// reloaded; treat the change as a parse error so subscribers
 		// learn nothing useful was applied.
@@ -165,15 +163,7 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 			Error: "config reload disabled: server has no in-memory config",
 		}
 	}
-
-	// Apply hot-reloadable fields. Repos and Platforms are deep-copied
-	// so subsequent in-memory mutations from the Settings UI cannot
-	// surprise the file's last view.
-	s.cfg.Repos = slices.Clone(newCfg.Repos)
-	s.cfg.Platforms = slices.Clone(newCfg.Platforms)
-	s.cfg.Activity = newCfg.Activity
-	s.cfg.Terminal = newCfg.Terminal
-	s.cfg.Agents = cloneConfigAgents(newCfg.Agents)
+	s.cfgMu.Unlock()
 
 	restartRequired := s.bootCfgSnapshot.restartRequiredFor(newCfg)
 
@@ -190,6 +180,18 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 		)
 		restartRequired = true
 	}
+
+	s.cfgMu.Lock()
+	defer s.cfgMu.Unlock()
+	// Apply hot-reloadable fields. Repos and Platforms are deep-copied
+	// so subsequent in-memory mutations from the Settings UI cannot
+	// surprise the file's last view.
+	s.cfg.Repos = slices.Clone(newCfg.Repos)
+	s.cfg.Platforms = slices.Clone(newCfg.Platforms)
+	s.cfg.Activity = newCfg.Activity
+	s.cfg.Terminal = newCfg.Terminal
+	s.cfg.Agents = cloneConfigAgents(newCfg.Agents)
+
 	s.syncer.SetRepos(resolved)
 
 	s.refreshRuntimeTargetsLocked()

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1,0 +1,405 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// waitForConfigWatcher blocks until the server's config watcher has
+// registered the directory with fsnotify, or the timeout elapses. Tests
+// that mutate the config file must call this first; otherwise an
+// fsnotify race can drop the event and the test will hang.
+func waitForConfigWatcher(t *testing.T, srv *Server, timeout time.Duration) {
+	t.Helper()
+	require.NotNil(t, srv.configWatcher, "server has no config watcher")
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+	require.NoError(t, srv.configWatcher.WaitReady(ctx))
+}
+
+func writeConfigToml(t *testing.T, path string, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func atomicRenameConfigToml(t *testing.T, path string, content string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	tmp := filepath.Join(dir, ".config-watcher.tmp")
+	require.NoError(t, os.WriteFile(tmp, []byte(content), 0o644))
+	require.NoError(t, os.Rename(tmp, path))
+}
+
+// configEventStream wraps a live SSE HTTP connection and yields
+// config.changed events on a channel. Callers must call Close to stop
+// the goroutine; the channel is closed when the stream ends.
+type configEventStream struct {
+	resp   *http.Response
+	cancel context.CancelFunc
+	events chan configChangedEvent
+}
+
+func (s *configEventStream) Close() {
+	s.cancel()
+	_ = s.resp.Body.Close()
+}
+
+// streamConfigEvents subscribes to /api/v1/events via a real httptest
+// server and forwards every config.changed event onto the returned
+// channel. The goroutine drains the SSE stream until the test context
+// (or the explicit cancel) fires.
+func streamConfigEvents(t *testing.T, srv *Server) *configEventStream {
+	t.Helper()
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, ts.URL+"/api/v1/events", http.NoBody,
+	)
+	require.NoError(t, err)
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+
+	stream := &configEventStream{
+		resp:   resp,
+		cancel: cancel,
+		events: make(chan configChangedEvent, 8),
+	}
+
+	// Wait for the handler to register before returning, so the test
+	// does not race the watcher's first event against subscriber setup.
+	require.Eventually(t, func() bool {
+		srv.hub.mu.Lock()
+		defer srv.hub.mu.Unlock()
+		return len(srv.hub.subscribers) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	go func() {
+		defer close(stream.events)
+		scanner := bufio.NewScanner(resp.Body)
+		// SSE frames can contain newlines inside the data: line in
+		// theory; in practice this server marshals JSON to a single
+		// line so a default bufio.Scanner is enough.
+		buf := make([]byte, 0, 1024)
+		scanner.Buffer(buf, 1024*1024)
+		var eventType, dataLine string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if rest, ok := strings.CutPrefix(line, "event: "); ok {
+				eventType = rest
+				continue
+			}
+			if rest, ok := strings.CutPrefix(line, "data: "); ok {
+				dataLine = rest
+				continue
+			}
+			if line != "" {
+				continue
+			}
+			if eventType == "config.changed" && dataLine != "" {
+				var ev configChangedEvent
+				if err := json.Unmarshal([]byte(dataLine), &ev); err == nil {
+					select {
+					case stream.events <- ev:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			eventType, dataLine = "", ""
+		}
+	}()
+
+	return stream
+}
+
+func waitForConfigEvent(
+	t *testing.T,
+	stream *configEventStream,
+	timeout time.Duration,
+) configChangedEvent {
+	t.Helper()
+	select {
+	case ev, ok := <-stream.events:
+		require.True(t, ok, "events channel closed before an event arrived")
+		return ev
+	case <-time.After(timeout):
+		require.FailNow(t, "timed out waiting for config.changed event")
+		return configChangedEvent{}
+	}
+}
+
+const validReloadConfig = `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`
+
+const validReloadConfigExtraRepo = `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[repos]]
+owner = "globex"
+name = "engine"
+`
+
+const validReloadConfigChangedActivity = `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[activity]
+view_mode = "flat"
+time_range = "30d"
+`
+
+const validReloadConfigRestartRequired = `
+sync_interval = "10m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`
+
+const invalidReloadConfig = `
+sync_interval = "5m"
+host = "not-an-ip"
+port = 8091
+`
+
+const malformedTomlConfig = `
+sync_interval = "5m
+host = "127.0.0.1"
+`
+
+func TestConfigReload_WatcherFiresOnInPlaceEdit(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	writeConfigToml(t, cfgPath, validReloadConfigChangedActivity)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	assert.True(ev.Valid, "expected valid reload")
+	assert.Empty(ev.Error)
+	assert.False(ev.RestartRequired)
+
+	srv.cfgMu.Lock()
+	gotActivity := srv.cfg.Activity
+	srv.cfgMu.Unlock()
+	assert.Equal("flat", gotActivity.ViewMode)
+	assert.Equal("30d", gotActivity.TimeRange)
+}
+
+func TestConfigReload_WatcherFiresOnAtomicRename(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	atomicRenameConfigToml(t, cfgPath, validReloadConfigChangedActivity)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	assert.True(ev.Valid)
+	assert.False(ev.RestartRequired)
+}
+
+func TestConfigReload_RestartRequiredOnStartupFieldChange(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	writeConfigToml(t, cfgPath, validReloadConfigRestartRequired)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	assert.True(ev.Valid)
+	assert.True(ev.RestartRequired, "sync_interval change should mark restart_required")
+}
+
+func TestConfigReload_InvalidConfigKeepsLastKnownGood(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	// Capture the original config so we can confirm it stays put.
+	srv.cfgMu.Lock()
+	prevHost := srv.cfg.Host
+	prevPort := srv.cfg.Port
+	prevSyncInterval := srv.cfg.SyncInterval
+	srv.cfgMu.Unlock()
+
+	writeConfigToml(t, cfgPath, invalidReloadConfig)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	assert.False(ev.Valid)
+	assert.NotEmpty(ev.Error)
+
+	// Daemon still holds the prior cfg snapshot.
+	srv.cfgMu.Lock()
+	defer srv.cfgMu.Unlock()
+	assert.Equal(prevHost, srv.cfg.Host)
+	assert.Equal(prevPort, srv.cfg.Port)
+	assert.Equal(prevSyncInterval, srv.cfg.SyncInterval)
+}
+
+func TestConfigReload_MalformedTomlDoesNotCrash(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	writeConfigToml(t, cfgPath, malformedTomlConfig)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	assert.False(ev.Valid)
+	assert.Contains(strings.ToLower(ev.Error), "config.toml",
+		"parse error should reference the sanitized config path")
+}
+
+func TestConfigReload_NewRepoEntersSyncerTrackedSet(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	writeConfigToml(t, cfgPath, validReloadConfigExtraRepo)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	require.True(ev.Valid)
+
+	tracked := srv.syncer.TrackedRepos()
+	owners := make(map[string]struct{}, len(tracked))
+	for _, r := range tracked {
+		owners[strings.ToLower(r.Owner)+"/"+strings.ToLower(r.Name)] = struct{}{}
+	}
+	assert.Contains(owners, "globex/engine",
+		"new repo from config edit should appear in syncer tracked set")
+}
+
+func TestConfigReload_DebouncesBurstedWrites(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	// Multiple rapid writes within the 100 ms debounce window should
+	// coalesce into one config.changed event.
+	for i := range 4 {
+		var content string
+		switch i % 2 {
+		case 0:
+			content = validReloadConfig
+		case 1:
+			content = validReloadConfigChangedActivity
+		}
+		writeConfigToml(t, cfgPath, content)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	assert.True(ev.Valid)
+
+	// Drain any extra events that arrive within a short window — the
+	// debounce should have prevented them, but we don't assert "no
+	// extras at all" since fsnotify ordering on some kernels can
+	// flush a second event after the rename burst.
+	select {
+	case extra, ok := <-stream.events:
+		if ok {
+			// A second event is acceptable but should be valid and quick.
+			assert.True(extra.Valid)
+		}
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestConfigReload_SubscriberAfterParseErrorGetsCachedEvent(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+
+	// Drive an invalid edit and let the daemon broadcast.
+	earlyStream := streamConfigEvents(t, srv)
+	writeConfigToml(t, cfgPath, invalidReloadConfig)
+	ev := waitForConfigEvent(t, earlyStream, 2*time.Second)
+	earlyStream.Close()
+	assert.False(ev.Valid)
+
+	// A new subscriber connecting now should still observe the parse
+	// error via the cached config_status slot, not silently miss it.
+	lateStream := streamConfigEvents(t, srv)
+	defer lateStream.Close()
+	cached := waitForConfigEvent(t, lateStream, 2*time.Second)
+	assert.False(cached.Valid)
+	assert.NotEmpty(cached.Error)
+}

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,8 +13,10 @@ import (
 	"testing"
 	"time"
 
+	gh "github.com/google/go-github/v84/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ghclient "github.com/wesm/middleman/internal/github"
 )
 
 // waitForConfigWatcher blocks until the server's config watcher has
@@ -170,6 +173,29 @@ owner = "globex"
 name = "engine"
 `
 
+const validReloadConfigRepoTokenEnv = `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+token_env = "MIDDLEMAN_REPO_TOKEN"
+`
+
+const validReloadConfigGlobRepo = `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget-*"
+`
+
 const validReloadConfigChangedActivity = `
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
@@ -265,6 +291,24 @@ func TestConfigReload_RestartRequiredOnStartupFieldChange(t *testing.T) {
 	assert.True(ev.RestartRequired, "sync_interval change should mark restart_required")
 }
 
+func TestConfigReload_RestartRequiredOnRepoTokenEnvChange(t *testing.T) {
+	assert := assert.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	writeConfigToml(t, cfgPath, validReloadConfigRepoTokenEnv)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	assert.True(ev.Valid)
+	assert.True(ev.RestartRequired,
+		"repo token_env change should mark restart_required")
+}
+
 func TestConfigReload_InvalidConfigKeepsLastKnownGood(t *testing.T) {
 	assert := assert.New(t)
 
@@ -337,6 +381,39 @@ func TestConfigReload_NewRepoEntersSyncerTrackedSet(t *testing.T) {
 	}
 	assert.Contains(owners, "globex/engine",
 		"new repo from config edit should appear in syncer tracked set")
+}
+
+func TestConfigReload_GlobFailureKeepsPreviouslyTrackedMatches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig, &mockGH{
+			listReposByOwnerFn: func(context.Context, string) ([]*gh.Repository, error) {
+				return nil, errors.New("temporary repo listing failure")
+			},
+		},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Owner:        "acme",
+		Name:         "widget-api",
+		PlatformHost: "github.com",
+		RepoPath:     "acme/widget-api",
+	}})
+
+	writeConfigToml(t, cfgPath, validReloadConfigGlobRepo)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	require.True(ev.Valid)
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Equal("acme", tracked[0].Owner)
+	assert.Equal("widget-api", tracked[0].Name)
 }
 
 func TestConfigReload_DebouncesBurstedWrites(t *testing.T) {

--- a/internal/server/event_hub.go
+++ b/internal/server/event_hub.go
@@ -30,17 +30,18 @@ type RecordedEvent struct {
 // EventHub manages SSE subscribers with fan-out broadcasting, monotonic
 // event ids, and a ring buffer of recent events for replay on reconnect.
 type EventHub struct {
-	mu             sync.Mutex
-	subscribers    map[uint64]chan RecordedEvent
-	nextSubID      uint64
-	nextEventID    uint64
-	lastSyncStatus *RecordedEvent
-	ring           []RecordedEvent
-	ringHead       int
-	ringCount      int
-	done           chan struct{}
-	closeOnce      sync.Once
-	closed         bool // guarded by mu
+	mu               sync.Mutex
+	subscribers      map[uint64]chan RecordedEvent
+	nextSubID        uint64
+	nextEventID      uint64
+	lastSyncStatus   *RecordedEvent
+	lastConfigStatus *RecordedEvent
+	ring             []RecordedEvent
+	ringHead         int
+	ringCount        int
+	done             chan struct{}
+	closeOnce        sync.Once
+	closed           bool // guarded by mu
 }
 
 // NewEventHub creates a ready-to-use hub with the default ring capacity.
@@ -67,8 +68,9 @@ func NewEventHubWithCapacity(capacity int) *EventHub {
 // cached sync_status exists, it is pre-loaded onto the subscriber's
 // channel so a fresh client with no cursor learns the latest sync state
 // without a round-trip. Callers that handle replay themselves (the
-// cursor-bearing SSE path) pass false to avoid duplicating the cached
-// status with a ring-replay copy.
+// cursor-bearing SSE path) pass false to avoid duplicating cached
+// events with ring-replay copies. The latest config.changed event is
+// also pre-loaded for fresh subscribers when injectCached is true.
 //
 // Returns the event channel and the hub's done channel. If the hub is
 // already closed, returns an immediately-closed channel and the closed
@@ -88,6 +90,11 @@ func (h *EventHub) Subscribe(
 	ch := make(chan RecordedEvent, 16)
 	if injectCached && h.lastSyncStatus != nil {
 		ch <- *h.lastSyncStatus
+	}
+	// Replay the latest config event so a client connecting after a
+	// parse error still learns the daemon is running on stale config.
+	if injectCached && h.lastConfigStatus != nil {
+		ch <- *h.lastConfigStatus
 	}
 	h.subscribers[id] = ch
 	h.mu.Unlock()
@@ -117,11 +124,11 @@ func (h *EventHub) unsubscribe(id uint64) {
 }
 
 // Broadcast sends an event to all subscribers, stamps it with the next
-// monotonic id, records it in the ring buffer, and (for sync_status
-// events) updates the cached latest-status pointer. Slow consumers
-// (full channel) are evicted. Returns the assigned id, which is useful
-// for tests and for callers that need to correlate the broadcast with
-// downstream state.
+// monotonic id, records it in the ring buffer, and updates cached
+// latest-status pointers for event types that fresh subscribers need.
+// Slow consumers (full channel) are evicted. Returns the assigned id,
+// which is useful for tests and for callers that need to correlate the
+// broadcast with downstream state.
 func (h *EventHub) Broadcast(event Event) uint64 {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -129,9 +136,13 @@ func (h *EventHub) Broadcast(event Event) uint64 {
 	h.nextEventID++
 	rec := RecordedEvent{ID: h.nextEventID, Event: event}
 
-	if event.Type == "sync_status" {
+	switch event.Type {
+	case "sync_status":
 		copyRec := rec
 		h.lastSyncStatus = &copyRec
+	case "config.changed":
+		copyRec := rec
+		h.lastConfigStatus = &copyRec
 	}
 
 	h.ringStoreLocked(rec)

--- a/internal/server/event_hub.go
+++ b/internal/server/event_hub.go
@@ -88,13 +88,8 @@ func (h *EventHub) Subscribe(
 	id := h.nextSubID
 	h.nextSubID++
 	ch := make(chan RecordedEvent, 16)
-	if injectCached && h.lastSyncStatus != nil {
-		ch <- *h.lastSyncStatus
-	}
-	// Replay the latest config event so a client connecting after a
-	// parse error still learns the daemon is running on stale config.
-	if injectCached && h.lastConfigStatus != nil {
-		ch <- *h.lastConfigStatus
+	if injectCached {
+		h.enqueueCachedLocked(ch)
 	}
 	h.subscribers[id] = ch
 	h.mu.Unlock()
@@ -105,6 +100,26 @@ func (h *EventHub) Subscribe(
 	}()
 
 	return ch, h.done
+}
+
+// enqueueCachedLocked preloads cached status events in monotonic ID order.
+// Caller must hold mu.
+func (h *EventHub) enqueueCachedLocked(ch chan<- RecordedEvent) {
+	var cached []RecordedEvent
+	if h.lastSyncStatus != nil {
+		cached = append(cached, *h.lastSyncStatus)
+	}
+	// Replay the latest config event so a client connecting after a
+	// parse error still learns the daemon is running on stale config.
+	if h.lastConfigStatus != nil {
+		cached = append(cached, *h.lastConfigStatus)
+	}
+	if len(cached) == 2 && cached[1].ID < cached[0].ID {
+		cached[0], cached[1] = cached[1], cached[0]
+	}
+	for _, rec := range cached {
+		ch <- rec
+	}
 }
 
 // unsubscribeLocked removes and closes the subscriber channel.

--- a/internal/server/event_hub_test.go
+++ b/internal/server/event_hub_test.go
@@ -189,6 +189,49 @@ func TestEventHub_CloseUnsubscribesAll(t *testing.T) {
 	assert.False(t, ok2)
 }
 
+func TestEventHub_ConfigChangedCachedForNewSubscribers(t *testing.T) {
+	hub := NewEventHub()
+	defer hub.Close()
+
+	hub.Broadcast(Event{
+		Type: "config.changed",
+		Data: map[string]any{"valid": true},
+	})
+
+	ch, _ := hub.Subscribe(t.Context(), true)
+
+	select {
+	case ev := <-ch:
+		assert.Equal(t, "config.changed", ev.Event.Type)
+	case <-time.After(time.Second):
+		require.FailNow(t, "expected cached config.changed event")
+	}
+}
+
+func TestEventHub_LatestConfigStatusReplayedToLateSubscriber(t *testing.T) {
+	assert := assert.New(t)
+
+	hub := NewEventHub()
+	defer hub.Close()
+
+	hub.Broadcast(Event{
+		Type: "config.changed",
+		Data: map[string]any{"valid": false, "error": "first"},
+	})
+	hub.Broadcast(Event{
+		Type: "config.changed",
+		Data: map[string]any{"valid": true},
+	})
+
+	ch, _ := hub.Subscribe(t.Context(), true)
+
+	ev := <-ch
+	assert.Equal("config.changed", ev.Event.Type)
+	data, ok := ev.Event.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(true, data["valid"], "subscriber should see the most recent config status")
+}
+
 func TestEventHub_BroadcastAfterSlowConsumerEviction(t *testing.T) {
 	hub := NewEventHub()
 	defer hub.Close()

--- a/internal/server/event_hub_test.go
+++ b/internal/server/event_hub_test.go
@@ -147,6 +147,28 @@ func TestEventHub_CacheUpdatedOnLatestSyncStatus(t *testing.T) {
 	assert.Equal(t, "t2", ev.Event.Data, "new subscriber should get the latest cached status")
 }
 
+func TestEventHub_CachedStatusesPreserveIDOrder(t *testing.T) {
+	assert := assert.New(t)
+
+	hub := NewEventHub()
+	defer hub.Close()
+
+	configID := hub.Broadcast(Event{
+		Type: "config.changed",
+		Data: map[string]any{"valid": true},
+	})
+	syncID := hub.Broadcast(Event{Type: "sync_status", Data: "running"})
+
+	ch, _ := hub.Subscribe(t.Context(), true)
+
+	first := <-ch
+	second := <-ch
+	assert.Equal(configID, first.ID)
+	assert.Equal("config.changed", first.Event.Type)
+	assert.Equal(syncID, second.ID)
+	assert.Equal("sync_status", second.Event.Type)
+}
+
 func TestEventHub_SubscribeOrderingWithBroadcast(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/configwatch"
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitclone"
 	ghclient "github.com/wesm/middleman/internal/github"
@@ -130,16 +131,22 @@ func (c shutdownAwareContext) Value(key any) any {
 
 // Server holds the HTTP mux and its dependencies.
 type Server struct {
-	db                     *db.DB
-	syncer                 *ghclient.Syncer
-	clones                 *gitclone.Manager
-	workspaces             *workspace.Manager
-	workspacePRMonitor     *workspace.PRMonitor
-	tmuxActivity           *tmuxActivityTracker
-	runtime                *localruntime.Manager
-	cfg                    *config.Config
-	cfgPath                string
-	cfgMu                  sync.Mutex
+	db                 *db.DB
+	syncer             *ghclient.Syncer
+	clones             *gitclone.Manager
+	workspaces         *workspace.Manager
+	workspacePRMonitor *workspace.PRMonitor
+	tmuxActivity       *tmuxActivityTracker
+	runtime            *localruntime.Manager
+	cfg                *config.Config
+	cfgPath            string
+	cfgMu              sync.Mutex
+	// bootCfgSnapshot freezes the subset of config fields that are
+	// bound at startup (registry, listeners, clone manager, etc.) so a
+	// config-file watcher reload can detect when those changed and
+	// surface restart_required to the UI without ever mutating them.
+	bootCfgSnapshot        startupConfigSnapshot
+	configWatcher          *configwatch.Watcher
 	basePath               string
 	options                ServerOptions
 	version                string
@@ -414,6 +421,7 @@ func newServer(
 		clones:                 clones,
 		cfg:                    cfg,
 		cfgPath:                cfgPath,
+		bootCfgSnapshot:        snapshotStartupConfig(cfg),
 		options:                options,
 		now:                    time.Now,
 		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
@@ -501,6 +509,11 @@ func newServer(
 	if s.workspaces != nil {
 		s.runBackground(s.runWorkspacePRMonitorLoop)
 	}
+
+	// Watch the config file so an external edit (vim, dotfiles deploy,
+	// sd -i, etc.) is picked up without a restart. Watcher init failures
+	// are logged inside startConfigWatcher; the server still serves.
+	s.startConfigWatcher()
 
 	healthAPI := humago.New(mux, healthAPIConfig())
 	s.registerHealthAPI(healthAPI)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,6 +141,7 @@ type Server struct {
 	cfg                *config.Config
 	cfgPath            string
 	cfgMu              sync.Mutex
+	configReloadMu     sync.Mutex
 	// bootCfgSnapshot freezes the subset of config fields that are
 	// bound at startup (registry, listeners, clone manager, etc.) so a
 	// config-file watcher reload can detect when those changed and

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -70,6 +70,7 @@
   import {
     createEventsStore,
   } from "./stores/events.svelte.js";
+  import type { ActivitySettings, ConfigRepo } from "./api/types.js";
 
   interface Props {
     client: MiddlemanClient;
@@ -194,6 +195,42 @@
     }
     const diffStore = createDiffStore(diffOpts);
 
+    function hydrateSettings(
+      repos: ConfigRepo[],
+      activity: ActivitySettings,
+      terminal: { font_family: string; renderer: string },
+    ): void {
+      settingsStore.setConfiguredRepos(repos);
+      settingsStore.setTerminalFontFamily(terminal.font_family);
+      settingsStore.setTerminalRenderer(
+        terminal.renderer === "ghostty-web" ? "ghostty-web" : "xterm",
+      );
+      activityStore.hydrateDefaults(activity);
+    }
+
+    async function reloadSettingsAfterConfigChange(): Promise<void> {
+      const { data } = await cl.GET("/settings");
+      if (!data) return;
+      hydrateSettings(
+        data.repos ?? [],
+        {
+          view_mode: data.activity.view_mode === "threaded"
+            ? "threaded"
+            : "flat",
+          time_range: (
+            data.activity.time_range === "24h" ||
+            data.activity.time_range === "30d" ||
+            data.activity.time_range === "90d"
+          )
+            ? data.activity.time_range
+            : "7d",
+          hide_closed: data.activity.hide_closed,
+          hide_bots: data.activity.hide_bots,
+        },
+        data.terminal,
+      );
+    }
+
     const eventsStore = createEventsStore({
       ...(cfg.basePath != null && {
         getBasePath: () => cfg.basePath as string,
@@ -205,6 +242,13 @@
       },
       onSyncStatus: (status) => {
         syncStore.setSyncStatus(status);
+      },
+      onConfigChanged: (event) => {
+        if (!event.valid) return;
+        void reloadSettingsAfterConfigChange();
+        void pullsStore.loadPulls();
+        void issuesStore.loadIssues();
+        void activityStore.loadActivity();
       },
       onReconnectStale: () => {
         // The replay ring rolled past the client's cursor while it

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -231,6 +231,18 @@
       );
     }
 
+    async function handleConfigChanged(
+      event: { valid: boolean },
+    ): Promise<void> {
+      if (!event.valid) return;
+      await reloadSettingsAfterConfigChange();
+      await Promise.all([
+        pullsStore.loadPulls(),
+        issuesStore.loadIssues(),
+        activityStore.loadActivity(),
+      ]);
+    }
+
     const eventsStore = createEventsStore({
       ...(cfg.basePath != null && {
         getBasePath: () => cfg.basePath as string,
@@ -244,11 +256,7 @@
         syncStore.setSyncStatus(status);
       },
       onConfigChanged: (event) => {
-        if (!event.valid) return;
-        void reloadSettingsAfterConfigChange();
-        void pullsStore.loadPulls();
-        void issuesStore.loadIssues();
-        void activityStore.loadActivity();
+        void handleConfigChanged(event);
       },
       onReconnectStale: () => {
         // The replay ring rolled past the client's cursor while it

--- a/packages/ui/src/stores/events.svelte.ts
+++ b/packages/ui/src/stores/events.svelte.ts
@@ -1,5 +1,11 @@
 import type { SyncStatus } from "../api/types.js";
 
+export interface ConfigChangedEvent {
+  valid: boolean;
+  error?: string;
+  restart_required: boolean;
+}
+
 export interface EventsStoreOptions {
   /**
    * Base URL path (typically from config.basePath). Trailing
@@ -10,6 +16,8 @@ export interface EventsStoreOptions {
   onDataChanged?: () => void;
   /** Called on each `sync_status` SSE frame. */
   onSyncStatus?: (status: SyncStatus) => void;
+  /** Called on each `config.changed` SSE frame. */
+  onConfigChanged?: (event: ConfigChangedEvent) => void;
   /**
    * Called on a `reconnect.stale` SSE frame. The server emits this
    * when the client's Last-Event-ID cursor predates its replay ring,
@@ -59,6 +67,16 @@ export function createEventsStore(opts: EventsStoreOptions = {}) {
           (ev as MessageEvent).data,
         ) as SyncStatus;
         opts.onSyncStatus?.(status);
+      } catch {
+        // ignore malformed frames
+      }
+    });
+    source.addEventListener("config.changed", (ev) => {
+      try {
+        const event = JSON.parse(
+          (ev as MessageEvent).data,
+        ) as ConfigChangedEvent;
+        opts.onConfigChanged?.(event);
       } catch {
         // ignore malformed frames
       }


### PR DESCRIPTION
## Summary

- Editing `~/.config/middleman/config.toml` directly (vim, scripts, dotfiles deploy) now picks up within ~200ms; no restart required.
- New `internal/configwatch` package wraps fsnotify with a debounce that handles atomic-rename editors.
- On a successful reload, hot-reloadable fields apply under the existing `cfgMu` and the syncer's repo set updates next tick. Invalid mid-edit TOML emits a `config.changed { valid: false, error }` event without crashing; last-known-good config stays active.
- A `config.changed` SSE event is broadcast (sanitized — no token values) so frontends can refetch on the fly. Late subscribers get the cached event.
- A `restart_required` flag surfaces when a boot-bound field (e.g. listen host/port, base path) drifts so the UI can prompt for a restart instead of silently ignoring the change.