### PR TITLE
feat(server): RFC 9457 problem+json error envelope with stable codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ guardrail-check: frontend-api-client-check font-size-token-check huma-route-chec
 api-generate:
 	GOCACHE="$${GOCACHE:-/tmp/middleman-gocache}" go run ./cmd/middleman-openapi -out frontend/openapi/openapi.yaml
 	GOCACHE="$${GOCACHE:-/tmp/middleman-gocache}" go run ./cmd/middleman-openapi -out internal/apiclient/spec/openapi.json -version 3.0
-	cd packages/ui && bunx openapi-typescript ../../frontend/openapi/openapi.yaml -o src/api/generated/schema.ts
+	cd packages/ui && bunx openapi-typescript ../../frontend/openapi/openapi.yaml --enum-values -o src/api/generated/schema.ts
 	printf '%s\n' \
 		'/**' \
 		' * This file was auto-generated from frontend/openapi/openapi.yaml.' \

--- a/docs/superpowers/plans/2026-05-19-rfc9457-error-envelope.md
+++ b/docs/superpowers/plans/2026-05-19-rfc9457-error-envelope.md
@@ -1,0 +1,397 @@
+# RFC 9457 Error Envelope Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every `internal/server/` failure path returns a top-level RFC 9457 envelope with `code` (camelCase) and `details`, and the frontend has a typed worked example.
+
+**Architecture:** Replace `huma.NewError` with a custom `ProblemError` builder that adds `code` + `details` to the existing wire schema. Add a `problems.go` helper module owning the code taxonomy. Migrate every `huma.Error4xx`/`Error5xx` call site through the new helpers. Surface the enum to TS via OpenAPI `enum` tag.
+
+**Tech Stack:** Go 1.24, huma v2, openapi-typescript, Svelte 5, testify.
+
+---
+
+### Task 1: Define the code taxonomy and ProblemError type
+
+**Files:**
+- Create: `internal/server/problems.go`
+- Create: `internal/server/problems_test.go`
+
+- [ ] **Step 1: Author `ProblemError` type**
+
+In `internal/server/problems.go`, define `ProblemError` mirroring `huma.ErrorModel`'s wire fields and adding `Code` (string, enum-tagged) and `Details` (`map[string]any`). Implement `Error() string`, `GetStatus() int`, `ContentType(string) string` returning `application/problem+json` for `application/json`. Mark with json tags that match RFC 9457.
+
+The struct must register as schema `ErrorModel` so the generated client symbols stay stable. Use a `_ struct{ Name string }` field with the huma `name:` tag pattern, or override via `huma.SchemaRef`. Verify by inspecting the generated YAML after `make api-generate`.
+
+- [ ] **Step 2: Master code constants**
+
+Define a `ProblemCode` string type and a const block for every wire code in the taxonomy (`badRequest`, `notFound`, `unsupportedCapability`, `rateLimited`, …, alphabetical for stable OpenAPI). Add `allProblemCodes()` returning the slice for the `enum` tag value at init.
+
+The `Code` field uses `enum:"badRequest,...,..."` built from `allProblemCodes()` joined with commas. To do that at compile time, hard-code the enum tag with the same alphabetical order; add a unit test that asserts the constant slice matches the tag.
+
+- [ ] **Step 3: Helper constructors**
+
+Add helpers:
+- `problemError(status int, code ProblemCode, detail string, details map[string]any) huma.StatusError`
+- `problemBadRequest(code ProblemCode, detail string, details ...detailKV) huma.StatusError`
+- `problemNotFound(code ProblemCode, detail string, details ...detailKV) huma.StatusError`
+- `problemConflict(code ProblemCode, detail string, details ...detailKV) huma.StatusError`
+- `problemForbidden(detail string, details ...detailKV) huma.StatusError`
+- `problemInternal(detail string) huma.StatusError`
+- `problemUpstream(detail string, details ...detailKV) huma.StatusError`
+- `problemUnsupportedCapability(repo db.Repo, capability string) huma.StatusError`
+- `problemRateLimited(provider, host string, resetAt *time.Time) huma.StatusError`
+- `problemValidation(field string, detail string, allowed ...string) huma.StatusError`
+- `problemBranchConflict(branch, suggested string) huma.StatusError`
+- `problemPayloadTooLarge(maxBytes int64) huma.StatusError`
+- `problemServiceUnavailable(detail string) huma.StatusError`
+
+`detailKV` is a small helper struct used as variadic to make call sites readable: `detailKV{Key: "field", Value: "status"}`. Or pass `map[string]any{...}` directly — pick whichever is less verbose at the call sites; document the choice in the helper file.
+
+- [ ] **Step 4: Replace `huma.NewError`**
+
+In `init()` of `internal/server/problems.go`, set `huma.NewError = ...` to a function that returns a `*ProblemError` with `Code = codeForStatus(status)`. `codeForStatus` maps 400→badRequest, 401→unauthorized, 403→forbidden, 404→notFound, 409→conflict, 413→payloadTooLarge, 422→validationError, 429→rateLimited, 500→internalError, 502→upstreamError, 503→serviceUnavailable, default→internalError.
+
+Existing `huma.Error4xx("msg")` callers continue to compile and produce an envelope; they just get a code derived from status. Migration in later tasks overrides the code where richer semantics matter.
+
+- [ ] **Step 5: Unit tests for problems.go**
+
+Add table-driven tests in `internal/server/problems_test.go`:
+- Each helper sets the right status, code, and details keys.
+- `codeForStatus` returns the right code for every status in the taxonomy.
+- The enum tag string includes every constant declared.
+- `ContentType("application/json")` returns `application/problem+json`.
+- A round-trip JSON encode/decode of a `ProblemError` preserves `code` and `details`.
+
+```bash
+go test ./internal/server -run TestProblems -shuffle=on
+git commit -m "feat(server): add typed ProblemError envelope and helpers"
+```
+
+---
+
+### Task 2: Map platform-layer errors to wire codes
+
+**Files:**
+- Modify: `internal/server/problems.go` (add `mapPlatformError`)
+- Modify: `internal/server/problems_test.go`
+
+- [ ] **Step 1: `mapPlatformError(err error) huma.StatusError`**
+
+Use `errors.As(err, &platformErr *platform.Error)` to read `Code`, `Provider`, `PlatformHost`, `Capability`, `ResetAt`. Return:
+- `ErrCodeUnsupportedCapability` → `problemUnsupportedCapability` with provider context
+- `ErrCodeRateLimited` → `problemRateLimited` (`details.retryAfter` from `ResetAt.UTC().Format(time.RFC3339)` if non-nil)
+- `ErrCodePermissionDenied` → `problemForbidden`
+- `ErrCodeNotFound` → `problemNotFound("notFound", ...)`
+- `ErrCodeProviderNotConfigured`, `ErrCodeMissingToken`, `ErrCodeInvalidRepoRef` → `problemBadRequest`
+- default → `problemUpstream(err.Error(), ...)`
+
+Return `nil` for `nil` input and for `context.Canceled`/`DeadlineExceeded`.
+
+- [ ] **Step 2: Tests**
+
+Table-driven test in `problems_test.go`: each platform code maps to the expected wire code and status; `nil` input returns `nil`; context errors pass through.
+
+```bash
+go test ./internal/server -run TestMapPlatformError -shuffle=on
+git commit -m "feat(server): map platform.Error codes to wire problems"
+```
+
+---
+
+### Task 3: Migrate `internal/server/capabilities.go`
+
+**Files:**
+- Modify: `internal/server/capabilities.go`
+
+- [ ] **Step 1: Replace `unsupportedCapabilityProblem` body**
+
+Use `problemUnsupportedCapability(repo, capability)` directly. Delete the `unsupportedCapabilityDetail` struct and its `ErrorDetail()` method — the new helper carries everything in top-level `details`.
+
+- [ ] **Step 2: Verify `requireRepoRouteCapability` still wraps lookup errors**
+
+`providerRouteLookupError(err)` is the other escape. Leave it pointing at the new helpers (we'll migrate it in Task 4).
+
+```bash
+go test ./internal/server -shuffle=on -run TestAPIGitlab|TestAPI.*Capability
+git commit -m "refactor(server): migrate capability gate to typed problem"
+```
+
+---
+
+### Task 4: Migrate `internal/server/huma_routes.go`
+
+**Files:**
+- Modify: `internal/server/huma_routes.go`
+
+This is the bulk of the work (245 call sites). The approach:
+
+- [ ] **Step 1: Rewrite `providerRouteLookupError`**
+
+`errRepoPathRequired` → `problemBadRequest("badRequest", err.Error())`.
+`errRepoNotFound` → `problemNotFound("repoNotFound", "repo not found", detailKV{Key: "owner", Value: ...}, ...)`. The function has the parsed owner/name in scope via the call site; refactor signature if needed to thread that context. Simpler alternative: keep the function thin and have callers compose richer `details` outside it.
+
+`platform_host is required`/`unsupported platform` → `problemBadRequest("badRequest", err.Error())`.
+
+Default → `problemInternal("get repo failed")`.
+
+- [ ] **Step 2: Sweep huma_routes.go for `huma.Error400BadRequest`**
+
+For each occurrence:
+- Input-validation case (string-set check, blank check, must-be-non-empty) → `problemValidation(field, detail, allowed...)` with the right `field` and `allowed` list.
+- Bad request that wraps an `err.Error()` → `problemBadRequest("badRequest", err.Error())`.
+- Anything else → `problemBadRequest("badRequest", detail)`.
+
+The `validationError` cases include: status enum, kanban state enum, merge method enum, commit-range constraints, comment-body empty, title-blank.
+
+- [ ] **Step 3: Sweep for `huma.Error404NotFound`**
+
+- "repo not found" → `problemNotFound("repoNotFound", ...)`.
+- "pull request not found" / "pull request" lookup miss → `problemNotFound("pullNotFound", ...)`.
+- "merge request not found" → `problemNotFound("pullNotFound", ...)` (it's the same concept on the wire).
+- "issue not found" → `problemNotFound("issueNotFound", ...)`.
+- "comment not found" / "comment not found for pull request" → `problemNotFound("commentNotFound", ...)`.
+- "project not found" → `problemNotFound("projectNotFound", ...)`.
+- "workspace summary missing" → `problemNotFound("workspaceNotFound", ...)`.
+- "settings not available" → `problemNotFound("settingsUnavailable", ...)`.
+- Generic fallthrough → `problemNotFound("notFound", err.Error())`.
+
+- [ ] **Step 4: Sweep for `huma.Error409Conflict`**
+
+- `IssueWorkspaceBranchConflictError` path → `problemBranchConflict(branch, suggested)`. The existing inline `&huma.ErrorModel{Type:..., Title:..., Errors:...}` constructor is rewritten to the helper; the `Type` URI carrier (`issueWorkspaceBranchConflictType`) becomes `details.type` if still needed for callers.
+- All other 409 → `problemConflict("conflict", detail, ...)`.
+
+- [ ] **Step 5: Sweep for `huma.Error500InternalServerError`, `huma.Error502BadGateway`, `huma.Error503ServiceUnavailable`, `huma.Error413RequestEntityTooLarge`, `huma.Error403Forbidden`**
+
+- 500 → `problemInternal(detail)`.
+- 502 with provider error message → `problemUpstream(detail, ...details...)`. Pass through provider+host when known.
+- 503 → `problemServiceUnavailable(detail)`.
+- 413 → `problemPayloadTooLarge(maxBytes)`.
+- 403 → `problemForbidden(detail)`.
+
+- [ ] **Step 6: Verify the grep**
+
+```bash
+rg -n "huma\.Error[0-9]" internal/server/huma_routes.go
+```
+
+Returns nothing.
+
+- [ ] **Step 7: Run server tests**
+
+```bash
+go test ./internal/server -shuffle=on -short
+git commit -m "refactor(server): migrate huma_routes.go to typed problem helpers"
+```
+
+---
+
+### Task 5: Migrate remaining handler files
+
+**Files:**
+- Modify: `internal/server/settings_handlers.go`
+- Modify: `internal/server/repo_import_handlers.go`
+- Modify: `internal/server/projects_handlers.go`
+- Modify: `internal/server/label_handlers.go`
+- Modify: `internal/server/health_routes.go`
+
+- [ ] **Step 1: Apply the same patterns from Task 4 to each file**
+
+The same heuristic: validation → `problemValidation`, lookup miss → `problemNotFound(<specific>)`, provider failure → `problemUpstream`, 500 → `problemInternal`.
+
+Specific gotchas:
+- `label_handlers.go` has duplicate-label, missing-from-catalog, must-be-array errors. Each gets `problemValidation` with a meaningful `field` and (for missing-from-catalog) `details.label`.
+- `repo_import_handlers.go` has "GitHub API error" and "Provider API error" branches. Both become `problemUpstream`; pass provider+host in `details` when in scope.
+- `projects_handlers.go` has filesystem checks ("local_path does not exist", "is not a directory"). These get `problemValidation` with `field: "local_path"`.
+- `health_routes.go` 503s become `problemServiceUnavailable` with whatever shape the existing detail carried.
+
+- [ ] **Step 2: Verify the grep**
+
+```bash
+rg -n "huma\.Error[0-9]" internal/server/
+```
+
+Returns at most matches inside `problems.go` and inside test files (no production handler should have any).
+
+- [ ] **Step 3: Run server tests**
+
+```bash
+go test ./internal/server -shuffle=on -short
+git commit -m "refactor(server): migrate remaining handlers to typed problems"
+```
+
+---
+
+### Task 6: Translate platform errors at provider call sites
+
+**Files:**
+- Modify: `internal/server/huma_routes.go` (and any other handler that catches `*platform.Error`)
+
+- [ ] **Step 1: Find provider call sites**
+
+```bash
+rg -n "platform\.Error|platform\.Err[A-Z]" internal/server/
+```
+
+For every handler that today returns a generic 502 after a provider failure but receives a `*platform.Error`, replace the literal handler-side string match with `mapPlatformError(err)`. Handlers that intercept a specific platform code first (e.g. for a custom message) still can; they just call the new helpers instead of `huma.Error...`.
+
+- [ ] **Step 2: Wire rate-limit response**
+
+In `internal/server/huma_routes.go`, the rate-limit tracker exposes `rt.ResetAt()`. When a provider call returns a 429-flavored error and we have the tracker in scope, `problemRateLimited(provider, host, rt.ResetAt())` populates `details.retryAfter`. When the tracker isn't in scope, fall through to `mapPlatformError` which uses `platform.Error.ResetAt`.
+
+- [ ] **Step 3: Tests**
+
+Will be added in Task 9; no test gate at this commit.
+
+```bash
+go test ./internal/server -shuffle=on -short
+git commit -m "feat(server): translate platform error codes to wire problems"
+```
+
+---
+
+### Task 7: Update the existing capability-test helper and any tests asserting on `errors[].value.code`
+
+**Files:**
+- Modify: `internal/server/api_test.go` (`assertUnsupportedCapabilityProblem`)
+- Modify: any test that asserts on `errors[0].value.code` or `errors[0].message == "unsupported_capability"`
+
+- [ ] **Step 1: Rewrite `assertUnsupportedCapabilityProblem`**
+
+Decode into a struct exposing `Code string`, `Details map[string]any`. Assert:
+- `Code == "unsupportedCapability"`
+- `Details["capability"] == capability`
+- `Details["provider"] == provider`
+- `Details["platformHost"] == host`
+- Legacy `errors[]` either gone or no longer asserted on.
+
+- [ ] **Step 2: rg for any other test asserting on errors[].value**
+
+```bash
+rg -n "Errors\[0\]\.Value|errors\[0\]\.value" internal/server/ frontend/ packages/
+```
+
+Migrate each to the top-level fields. The `branch_conflict` path (`IssueWorkspaceBranchConflictError`) currently asserts on Errors[]; update to assert `details.branch` and `details.suggestedBranch`.
+
+- [ ] **Step 3: Run server tests**
+
+```bash
+go test ./internal/server -shuffle=on -short
+git commit -m "test(server): assert on typed problem fields instead of errors[].value"
+```
+
+---
+
+### Task 8: Regenerate API artifacts and TS schema
+
+**Files:**
+- Modify: `frontend/openapi/openapi.yaml` (generated)
+- Modify: `internal/apiclient/spec/openapi.json` (generated)
+- Modify: `internal/apiclient/generated/client.gen.go` (generated)
+- Modify: `packages/ui/src/api/generated/schema.ts` (generated)
+- Modify: `packages/ui/src/api/generated/client.ts` (generated)
+
+- [ ] **Step 1: Run `make api-generate`**
+
+```bash
+make api-generate
+```
+
+- [ ] **Step 2: Verify outputs**
+
+- `frontend/openapi/openapi.yaml`: search for `code:` and confirm the enum is present with the full taxonomy.
+- `packages/ui/src/api/generated/schema.ts`: confirm `ErrorModel.code` is a string-literal union covering every code.
+- `internal/apiclient/generated/client.gen.go`: confirm `ErrorModel.Code` is a `*string` (or whatever shape oapi-codegen picks) on the Go side.
+
+If the wire schema name changed from `ErrorModel`, restore via the registry hint in `problems.go` (Task 1 Step 1).
+
+- [ ] **Step 3: Commit generated artifacts**
+
+```bash
+make lint vet
+git commit -m "chore: regenerate API artifacts with problem code enum"
+```
+
+---
+
+### Task 9: Wire-level integration tests
+
+**Files:**
+- Modify: `internal/server/api_test.go`
+
+- [ ] **Step 1: `TestAPIUnsupportedCapabilityEnvelope`**
+
+Reuse `setupGitlabCapabilityTestServer`. Trigger any capability-gated mutation route (e.g. workflow approval) and decode the body into a struct with `Code`, `Details`. Assert `Code == "unsupportedCapability"` and `Details["capability"] == "workflow_approval"`.
+
+- [ ] **Step 2: `TestAPIRateLimitedEnvelope`**
+
+Use a mock provider client that returns `platform.ErrRateLimited` with a non-nil `ResetAt`. Make a request that hits that provider. Assert `Code == "rateLimited"` and `Details["retryAfter"]` parses as RFC 3339.
+
+- [ ] **Step 3: `TestAPIValidationErrorEnvelope`**
+
+Send an invalid `setKanbanState` body (e.g. `status: "frobnicated"`). Assert `Code == "validationError"`, `Details["field"] == "status"`, `Details["allowed"]` is the expected slice.
+
+- [ ] **Step 4: Run**
+
+```bash
+go test ./internal/server -shuffle=on -run TestAPI.*Envelope
+git commit -m "test(server): wire-level RFC 9457 envelope coverage"
+```
+
+---
+
+### Task 10: Frontend TypeScript helper and Svelte worked example
+
+**Files:**
+- Create: `packages/ui/src/api/problems.ts`
+- Create: `packages/ui/src/api/problems.test.ts`
+- Modify: one existing Svelte component that already branches on capability (find via `rg "capability" packages/ui/src/components/`).
+
+- [ ] **Step 1: `problems.ts`**
+
+Export:
+- `type ProblemBody` mirroring the generated schema fields (or import the schema directly).
+- `type ProblemCode` from the generated union: `type ProblemCode = NonNullable<components["schemas"]["ErrorModel"]["code"]>` (or whatever it ends up named).
+- A `const ProblemCodes` value object with each code so other modules can branch via `case ProblemCodes.unsupportedCapability:`.
+- `isProblem(value: unknown): value is ProblemBody` type guard.
+- `async function readProblem(response: Response): Promise<ProblemBody | null>` that returns null if `response.ok` or the body isn't problem+json.
+
+- [ ] **Step 2: Unit tests for `problems.ts`**
+
+`packages/ui/src/api/problems.test.ts`: mock fetch responses for problem+json bodies; assert the type guard and reader behave correctly.
+
+- [ ] **Step 3: Svelte branch on `unsupportedCapability`**
+
+In the existing capability-driven UI (find via `provider-capabilities` consumers), when an API call rejects, read the problem with `readProblem`, and if `code === ProblemCodes.unsupportedCapability`, show the capability-disabled affordance with `body.details.capability` in the tooltip. Otherwise fall back to the current generic failure UI.
+
+The exact component is whatever today already hides/disables based on `provider-capabilities.ts`. If no live error path exists, add the example to the existing comment-submit flow or the merge-button flow — those already call providers.
+
+- [ ] **Step 4: Run frontend tests**
+
+```bash
+cd packages/ui && bun run test
+git commit -m "feat(ui): branch on RFC 9457 problem code for capability gate"
+```
+
+---
+
+### Task 11: Final verification
+
+- [ ] **Step 1: Verify the grep**
+
+```bash
+rg -n "huma\.Error[0-9]" internal/server/
+```
+
+Only matches inside `problems.go` and the seed file are acceptable.
+
+- [ ] **Step 2: Lint, vet, full test**
+
+```bash
+make lint && make vet && make test-short
+```
+
+- [ ] **Step 3: Generated-artifact diff sanity**
+
+`git diff main -- frontend/openapi/openapi.yaml | head -200` should show the new `code` enum on `ErrorModel`. `git diff main -- packages/ui/src/api/generated/schema.ts | head -100` should show the same union on the TS schema.
+
+No commit; this task is purely the verification step before stopping.

--- a/docs/superpowers/specs/2026-05-19-rfc9457-error-envelope-design.md
+++ b/docs/superpowers/specs/2026-05-19-rfc9457-error-envelope-design.md
@@ -1,0 +1,246 @@
+# Typed RFC 9457 Error Envelope — Design Spec
+
+**Status:** Drafted 2026-05-19 (worktree: agent-a8b603b4d8d1dd2ee).
+
+## Problem
+
+Every failure path in `internal/server/` returns an `application/problem+json`
+body whose only machine-readable signal is the HTTP status code. The
+human-readable `detail` is the only field the Svelte UI can branch on.
+The UI substring-matches that prose to decide which recovery affordance to
+show (re-auth, retry countdown, capability missing). This couples UI
+behavior to backend prose, breaks when the prose is reworded, and prevents
+typed handling on the frontend.
+
+`internal/server/capabilities.go` already has a partial typed
+implementation: it returns `huma.NewError(...)` with a side-channel
+`ErrorDetail.Value` map carrying `{code, provider, platform_host,
+capability}`. The `code` value lives inside `errors[0].value.code` rather
+than on the envelope itself, and only the capability-gate path uses it.
+
+## Goal
+
+Every failure path in `internal/server/` returns an RFC 9457 error envelope
+with a top-level, machine-readable `code` (camelCase) and a top-level
+`details` object. Two codes are required by spec:
+
+- `unsupportedCapability`, with `details.capability` carrying the missing
+  capability name.
+- `rateLimited`, with `details.retryAfter` carrying the reset time
+  (RFC 3339 string).
+
+Plus enough additional codes to cover every existing handler call site
+without losing semantic precision.
+
+A grep for `huma.Error4` or `huma.Error5` in `internal/server/` returns
+nothing outside test fixtures and the new helper module itself.
+
+The generated TypeScript client surfaces `code` as a typed string union
+(via OpenAPI `enum`). A Svelte error boundary branches on `code` as a
+worked example.
+
+Wire-level integration tests assert on `code` and `details` for at least
+three failure paths: `unsupportedCapability`, `rateLimited`, and one
+additional path (chosen: input validation, code `validationError`).
+
+## Non-goals
+
+- Migrating tests or generated OpenAPI docs to a new format.
+- Adding new HTTP statuses or new error semantics. Same statuses, same
+  triggers, richer body.
+- Translating any backend prose to a different locale. `detail` and
+  `title` stay English.
+- Restructuring `internal/platform/errors.go`. Its `PlatformErrorCode`
+  snake_case constants stay as-is; they're mapped to camelCase wire codes
+  at the `internal/server/` boundary.
+- Wiring every Svelte component to branch on `code`. One worked example
+  on the capability gate is the deliverable; broader rollout is a
+  follow-up.
+
+## Decisions
+
+### D1: Code naming convention is camelCase on the wire
+
+The task spec hard-codes `unsupportedCapability` and `rateLimited` as
+wire literals. Every other code uses the same convention. Internal Go
+`PlatformErrorCode` (`unsupported_capability`, `rate_limited`, etc.) stay
+snake_case; the boundary at `internal/server/` translates them.
+
+### D2: Replace `huma.NewError` with a custom builder
+
+Huma exposes `var NewError` as the central error constructor. Every
+`huma.Error4xx`/`Error5xx` helper calls through it. We replace the global
+with a builder that returns our own `ProblemError` type implementing
+`huma.StatusError` and `huma.ContentTypeFilter`. Existing call sites still
+work; new wire fields appear automatically.
+
+`ProblemError` shape:
+
+```go
+type ProblemError struct {
+    // RFC 9457 core
+    Type     string `json:"type,omitempty" format:"uri" default:"about:blank"`
+    Title    string `json:"title,omitempty"`
+    Status   int    `json:"status,omitempty"`
+    Detail   string `json:"detail,omitempty"`
+    Instance string `json:"instance,omitempty"`
+
+    // huma compat (kept for parity; populated when callers pass details)
+    Errors []*huma.ErrorDetail `json:"errors,omitempty"`
+
+    // RFC 9457 extension members
+    Code    ErrorCode      `json:"code" enum:"badRequest,notFound,..." doc:"Machine-readable error code"`
+    Details map[string]any `json:"details,omitempty" doc:"Machine-readable error context"`
+}
+```
+
+`enum` is generated from the master code list.
+
+### D3: A new helper module `internal/server/problems.go`
+
+All construction goes through `problemError(status, code, detail,
+details...)` and convenience wrappers `problemBadRequest`,
+`problemNotFound`, `problemConflict`, `problemUpstream`,
+`problemInternal`, `problemUnsupportedCapability`, `problemRateLimited`,
+etc. Wrappers fill in the right status + code automatically.
+
+`huma.Error4xx`/`Error5xx` callers are migrated en masse to the
+appropriate wrapper. After migration, a grep for the huma helpers under
+`internal/server/` is empty.
+
+### D4: Code taxonomy (initial)
+
+| Wire code               | Status | When                                                     | `details` shape                                           |
+|-------------------------|-------:|----------------------------------------------------------|-----------------------------------------------------------|
+| `badRequest`            |    400 | Generic 400 fallback                                     | none                                                      |
+| `validationError`       |    400 | Input validation (allowed-values, blank, must-be-format) | `{field?: string, allowed?: []string}`                    |
+| `notFound`              |    404 | Generic 404 fallback                                     | none                                                      |
+| `repoNotFound`          |    404 | Repo by (provider, host, owner, name) lookup miss        | `{provider, host, owner, name}` (when known)              |
+| `pullNotFound`          |    404 | Pull by (repo, number) miss                              | `{number?: int}`                                          |
+| `issueNotFound`         |    404 | Issue by (repo, number) miss                             | `{number?: int}`                                          |
+| `commentNotFound`       |    404 | Comment by (mr/issue, id) miss                           | `{commentId?: int}`                                       |
+| `workspaceNotFound`     |    404 | Workspace lookup miss                                    | none                                                      |
+| `projectNotFound`       |    404 | Local-project record miss                                | none                                                      |
+| `settingsUnavailable`   |    404 | Settings store nil (read-only middleman)                 | none                                                      |
+| `forbidden`             |    403 | Generic 403 fallback                                     | none                                                      |
+| `unsupportedCapability` |    409 | Provider lacks a capability the request needs            | `{capability, provider, platformHost}`                    |
+| `conflict`              |    409 | Generic 409 fallback                                     | none                                                      |
+| `branchConflict`        |    409 | Existing local branch blocks workspace creation          | `{branch, suggestedBranch}`                               |
+| `payloadTooLarge`       |    413 | Body exceeds limit                                       | `{maxBytes?: int}`                                        |
+| `rateLimited`           |    429 | Upstream provider 429                                    | `{retryAfter?: string, provider?, platformHost?}`         |
+| `internalError`         |    500 | Generic 5xx fallback                                     | none                                                      |
+| `upstreamError`         |    502 | Provider API failure (auth, 5xx, network)                | `{provider?, platformHost?}`                              |
+| `serviceUnavailable`    |    503 | Stack health 503                                         | none                                                      |
+
+Codes are added to the master enum in `internal/server/problems.go`. The
+enum order is alphabetical for stable OpenAPI diffs.
+
+### D5: Translation from platform layer
+
+`internal/server/` wraps each platform call with `mapPlatformError(err)`
+that switches on `errors.As(err, &platform.Error{})` and returns the
+appropriate `ProblemError`:
+
+- `ErrCodeUnsupportedCapability` → `problemUnsupportedCapability(...)`
+- `ErrCodeRateLimited` → `problemRateLimited(...)` (uses platform's
+  `ResetAt` for `details.retryAfter`)
+- `ErrCodePermissionDenied` → `problemForbidden(...)` with platform context
+- `ErrCodeNotFound` → `problemNotFound(...)` (caller may override with a
+  more specific code like `repoNotFound`)
+- `ErrCodeProviderNotConfigured`, `ErrCodeMissingToken`,
+  `ErrCodeInvalidRepoRef` → `problemBadRequest(...)` (these are
+  config-time issues exposed at request time)
+
+### D6: OpenAPI surfaces the enum
+
+The `enum:"..."` tag on `ProblemError.Code` causes huma to emit an OpenAPI
+schema enum. `openapi-typescript` turns that into a TS string-literal
+union: `code: "badRequest" | "notFound" | "unsupportedCapability" | ...`.
+The frontend imports `components["schemas"]["ErrorModel"]` (same name —
+huma uses the type name; we name the Go type `ErrorModel` for backward
+compatibility, with `ProblemError` as an alias).
+
+Actually: keeping the Go type name `ErrorModel` would shadow huma's
+own. Instead we name the type `ProblemError` and rename the OpenAPI
+schema via huma's `huma.SchemaRef` machinery to keep the on-wire schema
+name stable. If that proves harder than expected, allow the OpenAPI
+schema name to become `ProblemError` and update generated TS imports —
+the change is tracked by `make api-generate`.
+
+### D7: Frontend worked example
+
+`packages/ui/src/api/problems.ts` exports:
+
+```ts
+export const ProblemCode = {
+  unsupportedCapability: "unsupportedCapability",
+  rateLimited: "rateLimited",
+  ...
+} as const;
+export type ProblemCode = (typeof ProblemCode)[keyof typeof ProblemCode];
+```
+
+Plus an `isProblem(value): value is ProblemBody` type guard.
+
+The capability-disabled UI surface (today a grey-out + tooltip) becomes a
+branch on `ProblemCode.unsupportedCapability` in the existing component
+that consumes `provider-capabilities.ts`. A test in
+`packages/ui/src/api/problem-handlers.test.ts` mocks a `fetch` response
+with a problem+json body and asserts the branch fires.
+
+### D8: Tests
+
+Wire-level integration tests in `internal/server/api_test.go`:
+
+1. `TestAPIUnsupportedCapabilityEnvelope`: Trigger a capability-gated
+   route against the gitlab fake; assert top-level `code ==
+   "unsupportedCapability"` and `details.capability == "<expected>"`.
+2. `TestAPIRateLimitedEnvelope`: Inject a `platform.Error` with
+   `ErrCodeRateLimited` through a mock provider; assert `code ==
+   "rateLimited"` and `details.retryAfter` is a parseable RFC 3339 string.
+3. `TestAPIValidationErrorEnvelope`: Send an invalid `setKanbanState`
+   body; assert `code == "validationError"` and `details.field ==
+   "status"`, `details.allowed == ["new","reviewing",...]`.
+
+The existing `assertUnsupportedCapabilityProblem` helper is rewritten to
+check the top-level `code` and `details` instead of `errors[0].value`.
+
+## Migration plan
+
+1. Land `internal/server/problems.go` + replace `huma.NewError`. Tests
+   still pass because the legacy `Error4xx("msg")` paths flow through
+   the new builder with `code = <statusToCode>`.
+2. Rewrite the seven offender files (`huma_routes.go`,
+   `settings_handlers.go`, `repo_import_handlers.go`,
+   `projects_handlers.go`, `label_handlers.go`, `health_routes.go`,
+   `capabilities.go`) call site by call site, picking the best code from
+   the taxonomy. Each migrated site loses the `huma.Error4xx`/`Error5xx`
+   token. Run `make test` after each file.
+3. Update `assertUnsupportedCapabilityProblem` and tests it underpins.
+4. Regenerate API artifacts: `make api-generate`. Verify the TS schema
+   contains the enum.
+5. Add the TS `ProblemCode` helper + a Svelte branch on
+   `unsupportedCapability` in the existing capability gate UI.
+6. Add the three wire-level integration tests.
+7. `make lint`, `make vet`, `make test-short`, full frontend test as
+   needed.
+
+## Risks
+
+- Replacing `huma.NewError` is global to the binary, not scoped per huma
+  instance. Acceptable because we own the only huma instance (the server),
+  and the helpers exist in the same package.
+- A few error sites today carry `errors[].value` payloads (e.g.
+  branch-conflict). Those move into top-level `details`. The legacy
+  `errors[]` field stays populated for huma-internal validation messages
+  so we don't break introspection.
+- OpenAPI schema rename (`ErrorModel` → `ProblemError`): callers of the
+  generated `ErrorModel` symbol (Go: `generated.ErrorModel`, TS:
+  `components["schemas"]["ErrorModel"]`) need updating. Plan: keep the
+  Go-side `ErrorModel` name on the wire schema via the registry hint, so
+  generated artifacts keep the existing symbol. We add `Code` and
+  `Details` fields to the existing wire schema rather than renaming.
+- Pre-existing snake_case `code` value at
+  `errors[0].value.code = "unsupported_capability"` is removed because
+  it's superseded by the top-level camelCase `code`. The legacy ad-hoc
+  field is unused outside the test helper.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -617,53 +617,6 @@ components:
         value:
           description: The value at the given location
       type: object
-    ErrorModel:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/schemas/ErrorModel.json
-          format: uri
-          readOnly: true
-          type: string
-        detail:
-          description: A human-readable explanation specific to this occurrence of the problem.
-          examples:
-            - Property foo is required but is missing.
-          type: string
-        errors:
-          description: Optional list of individual error details
-          items:
-            $ref: "#/components/schemas/ErrorDetail"
-          type:
-            - array
-            - "null"
-        instance:
-          description: A URI reference that identifies the specific occurrence of the problem.
-          examples:
-            - https://example.com/error-log/abc123
-          format: uri
-          type: string
-        status:
-          description: HTTP status code
-          examples:
-            - 400
-          format: int64
-          type: integer
-        title:
-          description: A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
-          examples:
-            - Bad Request
-          type: string
-        type:
-          default: about:blank
-          description: A URI reference to human-readable documentation for the error.
-          examples:
-            - https://example.com/errors/example
-          format: uri
-          type: string
-      type: object
     FilePreviewResponse:
       additionalProperties: false
       properties:
@@ -1825,6 +1778,85 @@ components:
           type: string
       required:
         - body
+      type: object
+    ProblemError:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/ProblemError.json
+          format: uri
+          readOnly: true
+          type: string
+        code:
+          description: Machine-readable error code. Stable across occurrences.
+          enum:
+            - badRequest
+            - branchConflict
+            - commentNotFound
+            - conflict
+            - forbidden
+            - internalError
+            - issueNotFound
+            - notFound
+            - payloadTooLarge
+            - projectNotFound
+            - pullNotFound
+            - rateLimited
+            - repoNotFound
+            - serviceUnavailable
+            - settingsUnavailable
+            - unauthorized
+            - unsupportedCapability
+            - upstreamError
+            - validationError
+            - workspaceNotFound
+          examples:
+            - badRequest
+          type: string
+        detail:
+          description: A human-readable explanation specific to this occurrence of the problem.
+          examples:
+            - Property foo is required but is missing.
+          type: string
+        details:
+          additionalProperties: {}
+          description: Machine-readable error context, keyed by code-specific conventions.
+          type: object
+        errors:
+          description: Optional list of individual error details
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+          type:
+            - array
+            - "null"
+        instance:
+          description: A URI reference that identifies the specific occurrence of the problem.
+          examples:
+            - https://example.com/error-log/abc123
+          format: uri
+          type: string
+        status:
+          description: HTTP status code
+          examples:
+            - 400
+          format: int64
+          type: integer
+        title:
+          description: A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
+          examples:
+            - Bad Request
+          type: string
+        type:
+          default: about:blank
+          description: A URI reference to human-readable documentation for the error.
+          examples:
+            - https://example.com/errors/example
+          format: uri
+          type: string
+      required:
+        - code
       type: object
     ProjectResponse:
       additionalProperties: false
@@ -3070,7 +3102,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List activity
       tags:
@@ -3087,7 +3119,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Stream server events
       tags:
@@ -3133,7 +3165,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Create issue
       tags:
@@ -3179,7 +3211,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get issue
       tags:
@@ -3230,7 +3262,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit issue content
       tags:
@@ -3282,7 +3314,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Post issue comment
       tags:
@@ -3340,7 +3372,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit issue comment
       tags:
@@ -3392,7 +3424,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set issue GitHub state
       tags:
@@ -3444,7 +3476,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set issue labels
       tags:
@@ -3490,7 +3522,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Sync issue
       tags:
@@ -3532,7 +3564,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Enqueue issue sync
       tags:
@@ -3584,7 +3616,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Create issue workspace
       tags:
@@ -3630,7 +3662,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request
       tags:
@@ -3681,7 +3713,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit pull request content
       tags:
@@ -3733,7 +3765,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Approve pull request
       tags:
@@ -3779,7 +3811,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Approve pull request workflows
       tags:
@@ -3825,7 +3857,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Refresh pull request CI
       tags:
@@ -3877,7 +3909,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Post pull request comment
       tags:
@@ -3935,7 +3967,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit pull request comment
       tags:
@@ -3981,7 +4013,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request commits
       tags:
@@ -4053,7 +4085,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request diff
       tags:
@@ -4127,7 +4159,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request file preview
       tags:
@@ -4173,7 +4205,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request files
       tags:
@@ -4225,7 +4257,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set pull request GitHub state
       tags:
@@ -4271,7 +4303,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request import metadata
       tags:
@@ -4323,7 +4355,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set pull request labels
       tags:
@@ -4375,7 +4407,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Merge pull request
       tags:
@@ -4421,7 +4453,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Mark pull request ready for review
       tags:
@@ -4467,7 +4499,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request stack
       tags:
@@ -4515,7 +4547,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set pull request kanban state
       tags:
@@ -4561,7 +4593,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Sync pull request
       tags:
@@ -4603,7 +4635,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Enqueue pull request sync
       tags:
@@ -4639,7 +4671,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Delete repository
       tags:
@@ -4678,7 +4710,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get repository
       tags:
@@ -4734,7 +4766,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get comment autocomplete
       tags:
@@ -4774,7 +4806,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List repository labels
       tags:
@@ -4814,7 +4846,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Refresh repository
       tags:
@@ -4860,7 +4892,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Resolve repository item
       tags:
@@ -4916,7 +4948,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List issues
       tags:
@@ -4957,7 +4989,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Create issue
       tags:
@@ -4998,7 +5030,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get issue
       tags:
@@ -5044,7 +5076,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit issue content
       tags:
@@ -5091,7 +5123,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Post issue comment
       tags:
@@ -5144,7 +5176,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit issue comment
       tags:
@@ -5191,7 +5223,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set issue GitHub state
       tags:
@@ -5238,7 +5270,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set issue labels
       tags:
@@ -5279,7 +5311,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Sync issue
       tags:
@@ -5316,7 +5348,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Enqueue issue sync
       tags:
@@ -5363,7 +5395,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Create issue workspace
       tags:
@@ -5382,7 +5414,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List projects
       tags:
@@ -5406,7 +5438,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Register project
       tags:
@@ -5431,7 +5463,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get project
       tags:
@@ -5456,7 +5488,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List launch targets
       tags:
@@ -5481,7 +5513,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List worktrees
       tags:
@@ -5511,7 +5543,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Register worktree
       tags:
@@ -5572,7 +5604,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List pull requests
       tags:
@@ -5613,7 +5645,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request
       tags:
@@ -5659,7 +5691,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit pull request content
       tags:
@@ -5706,7 +5738,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Approve pull request
       tags:
@@ -5747,7 +5779,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Approve pull request workflows
       tags:
@@ -5788,7 +5820,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Refresh pull request CI
       tags:
@@ -5835,7 +5867,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Post pull request comment
       tags:
@@ -5888,7 +5920,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Edit pull request comment
       tags:
@@ -5929,7 +5961,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request commits
       tags:
@@ -5996,7 +6028,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request diff
       tags:
@@ -6065,7 +6097,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request file preview
       tags:
@@ -6106,7 +6138,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request files
       tags:
@@ -6153,7 +6185,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set pull request GitHub state
       tags:
@@ -6194,7 +6226,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request import metadata
       tags:
@@ -6241,7 +6273,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set pull request labels
       tags:
@@ -6288,7 +6320,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Merge pull request
       tags:
@@ -6329,7 +6361,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Mark pull request ready for review
       tags:
@@ -6370,7 +6402,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get pull request stack
       tags:
@@ -6413,7 +6445,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Set pull request kanban state
       tags:
@@ -6454,7 +6486,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Sync pull request
       tags:
@@ -6491,7 +6523,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Enqueue pull request sync
       tags:
@@ -6510,7 +6542,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get rate limits
       tags:
@@ -6541,7 +6573,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Delete repository
       tags:
@@ -6575,7 +6607,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get repository
       tags:
@@ -6626,7 +6658,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get comment autocomplete
       tags:
@@ -6661,7 +6693,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List repository labels
       tags:
@@ -6696,7 +6728,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Refresh repository
       tags:
@@ -6737,7 +6769,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Resolve repository item
       tags:
@@ -6760,7 +6792,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List repositories
       tags:
@@ -6784,7 +6816,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Add repository
       tags:
@@ -6809,7 +6841,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Bulk add repositories
       tags:
@@ -6834,7 +6866,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Preview repositories
       tags:
@@ -6857,7 +6889,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List repository summaries
       tags:
@@ -6876,7 +6908,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get roborev status
       tags:
@@ -6895,7 +6927,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get settings
       tags:
@@ -6919,7 +6951,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Update settings
       tags:
@@ -6948,7 +6980,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List stacks
       tags:
@@ -6969,7 +7001,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Unstar repository
       tags:
@@ -6989,7 +7021,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Star repository
       tags:
@@ -7004,7 +7036,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Trigger sync
       tags:
@@ -7023,7 +7055,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get sync status
       tags:
@@ -7042,7 +7074,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get server version
       tags:
@@ -7061,7 +7093,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List workspaces
       tags:
@@ -7085,7 +7117,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Create workspace
       tags:
@@ -7111,7 +7143,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Delete workspace
       tags:
@@ -7135,7 +7167,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get workspace
       tags:
@@ -7160,7 +7192,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get workspace commits
       tags:
@@ -7227,7 +7259,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get workspace diff
       tags:
@@ -7287,7 +7319,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get workspace files
       tags:
@@ -7312,7 +7344,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Retry workspace
       tags:
@@ -7337,7 +7369,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get workspace runtime
       tags:
@@ -7368,7 +7400,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Launch workspace runtime session
       tags:
@@ -7394,7 +7426,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Stop workspace runtime session
       tags:
@@ -7419,7 +7451,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorModel"
+                $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Ensure workspace runtime shell
       tags:

--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -40,7 +40,7 @@ export const client = createRuntimeClient();
 export function apiErrorMessage(
   error:
     | Pick<
-        Partial<components["schemas"]["ErrorModel"]>,
+        Partial<components["schemas"]["ProblemError"]>,
         "detail" | "title"
       >
     | undefined,

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -107,6 +107,78 @@ func (e MergeRequestResponseState) Valid() bool {
 	}
 }
 
+// Defines values for ProblemErrorCode.
+const (
+	BadRequest            ProblemErrorCode = "badRequest"
+	BranchConflict        ProblemErrorCode = "branchConflict"
+	CommentNotFound       ProblemErrorCode = "commentNotFound"
+	Conflict              ProblemErrorCode = "conflict"
+	Forbidden             ProblemErrorCode = "forbidden"
+	InternalError         ProblemErrorCode = "internalError"
+	IssueNotFound         ProblemErrorCode = "issueNotFound"
+	NotFound              ProblemErrorCode = "notFound"
+	PayloadTooLarge       ProblemErrorCode = "payloadTooLarge"
+	ProjectNotFound       ProblemErrorCode = "projectNotFound"
+	PullNotFound          ProblemErrorCode = "pullNotFound"
+	RateLimited           ProblemErrorCode = "rateLimited"
+	RepoNotFound          ProblemErrorCode = "repoNotFound"
+	ServiceUnavailable    ProblemErrorCode = "serviceUnavailable"
+	SettingsUnavailable   ProblemErrorCode = "settingsUnavailable"
+	Unauthorized          ProblemErrorCode = "unauthorized"
+	UnsupportedCapability ProblemErrorCode = "unsupportedCapability"
+	UpstreamError         ProblemErrorCode = "upstreamError"
+	ValidationError       ProblemErrorCode = "validationError"
+	WorkspaceNotFound     ProblemErrorCode = "workspaceNotFound"
+)
+
+// Valid indicates whether the value is a known member of the ProblemErrorCode enum.
+func (e ProblemErrorCode) Valid() bool {
+	switch e {
+	case BadRequest:
+		return true
+	case BranchConflict:
+		return true
+	case CommentNotFound:
+		return true
+	case Conflict:
+		return true
+	case Forbidden:
+		return true
+	case InternalError:
+		return true
+	case IssueNotFound:
+		return true
+	case NotFound:
+		return true
+	case PayloadTooLarge:
+		return true
+	case ProjectNotFound:
+		return true
+	case PullNotFound:
+		return true
+	case RateLimited:
+		return true
+	case RepoNotFound:
+		return true
+	case ServiceUnavailable:
+		return true
+	case SettingsUnavailable:
+		return true
+	case Unauthorized:
+		return true
+	case UnsupportedCapability:
+		return true
+	case UpstreamError:
+		return true
+	case ValidationError:
+		return true
+	case WorkspaceNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
 // ActionStatusBody defines model for ActionStatusBody.
 type ActionStatusBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -385,30 +457,6 @@ type ErrorDetail struct {
 
 	// Value The value at the given location
 	Value interface{} `json:"value,omitempty"`
-}
-
-// ErrorModel defines model for ErrorModel.
-type ErrorModel struct {
-	// Schema A URL to the JSON Schema for this object.
-	Schema *string `json:"$schema,omitempty"`
-
-	// Detail A human-readable explanation specific to this occurrence of the problem.
-	Detail *string `json:"detail,omitempty"`
-
-	// Errors Optional list of individual error details
-	Errors *[]ErrorDetail `json:"errors,omitempty"`
-
-	// Instance A URI reference that identifies the specific occurrence of the problem.
-	Instance *string `json:"instance,omitempty"`
-
-	// Status HTTP status code
-	Status *int64 `json:"status,omitempty"`
-
-	// Title A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
-	Title *string `json:"title,omitempty"`
-
-	// Type A URI reference to human-readable documentation for the error.
-	Type *string `json:"type,omitempty"`
 }
 
 // FilePreviewResponse defines model for FilePreviewResponse.
@@ -830,6 +878,39 @@ type PostIssueCommentInputBody struct {
 	Schema *string `json:"$schema,omitempty"`
 	Body   string  `json:"body"`
 }
+
+// ProblemError defines model for ProblemError.
+type ProblemError struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+
+	// Code Machine-readable error code. Stable across occurrences.
+	Code ProblemErrorCode `json:"code"`
+
+	// Detail A human-readable explanation specific to this occurrence of the problem.
+	Detail *string `json:"detail,omitempty"`
+
+	// Details Machine-readable error context, keyed by code-specific conventions.
+	Details *map[string]interface{} `json:"details,omitempty"`
+
+	// Errors Optional list of individual error details
+	Errors *[]ErrorDetail `json:"errors,omitempty"`
+
+	// Instance A URI reference that identifies the specific occurrence of the problem.
+	Instance *string `json:"instance,omitempty"`
+
+	// Status HTTP status code
+	Status *int64 `json:"status,omitempty"`
+
+	// Title A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
+	Title *string `json:"title,omitempty"`
+
+	// Type A URI reference to human-readable documentation for the error.
+	Type *string `json:"type,omitempty"`
+}
+
+// ProblemErrorCode Machine-readable error code. Stable across occurrences.
+type ProblemErrorCode string
 
 // ProjectResponse defines model for ProjectResponse.
 type ProjectResponse struct {
@@ -10986,7 +11067,7 @@ type ListActivityResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActivityResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11009,7 +11090,7 @@ type CreateIssueOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *IssueResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11032,7 +11113,7 @@ type GetIssueOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11055,7 +11136,7 @@ type EditIssueContentOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11078,7 +11159,7 @@ type PostIssueCommentOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *IssueEvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11101,7 +11182,7 @@ type EditIssueCommentOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueEvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11124,7 +11205,7 @@ type SetIssueGithubStateOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *GithubStateOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11147,7 +11228,7 @@ type SetIssueLabelsOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ItemLabelsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11170,7 +11251,7 @@ type SyncIssueOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11192,7 +11273,7 @@ func (r SyncIssueOnHostResponse) StatusCode() int {
 type EnqueueIssueSyncOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11215,7 +11296,7 @@ type CreateIssueWorkspaceOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON202                       *WorkspaceResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11238,7 +11319,7 @@ type GetPullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11261,7 +11342,7 @@ type EditPrContentOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11284,7 +11365,7 @@ type ApprovePullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11307,7 +11388,7 @@ type ApprovePullWorkflowsOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11330,7 +11411,7 @@ type RefreshPullCiOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11353,7 +11434,7 @@ type PostPrCommentOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *MREvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11376,7 +11457,7 @@ type EditPrCommentOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MREvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11399,7 +11480,7 @@ type GetPullCommitsOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommitsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11422,7 +11503,7 @@ type GetPullDiffOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *DiffResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11445,7 +11526,7 @@ type GetPullFilePreviewOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilePreviewResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11468,7 +11549,7 @@ type GetPullFilesOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilesResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11491,7 +11572,7 @@ type SetPrGithubStateOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *GithubStateOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11514,7 +11595,7 @@ type GetPullImportMetadataOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MrImportMetadataResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11537,7 +11618,7 @@ type SetPrLabelsOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ItemLabelsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11560,7 +11641,7 @@ type MergePullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergePRBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11583,7 +11664,7 @@ type MarkPullReadyForReviewOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11606,7 +11687,7 @@ type GetPullStackOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *StackContextResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11628,7 +11709,7 @@ func (r GetPullStackOnHostResponse) StatusCode() int {
 type SetKanbanStateOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11651,7 +11732,7 @@ type SyncPullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11673,7 +11754,7 @@ func (r SyncPullOnHostResponse) StatusCode() int {
 type EnqueuePrSyncOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11695,7 +11776,7 @@ func (r EnqueuePrSyncOnHostResponse) StatusCode() int {
 type DeleteRepoOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11718,7 +11799,7 @@ type GetRepoOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RepoResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11741,7 +11822,7 @@ type GetCommentAutocompleteOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommentAutocompleteResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11764,7 +11845,7 @@ type ListRepoLabelsOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RepoLabelsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11787,7 +11868,7 @@ type RefreshRepoOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *SettingsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11810,7 +11891,7 @@ type ResolveRepoItemOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ResolveItemResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11833,7 +11914,7 @@ type ListIssuesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *[]IssueResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11856,7 +11937,7 @@ type CreateIssueResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *IssueResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11879,7 +11960,7 @@ type GetIssueResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11902,7 +11983,7 @@ type EditIssueContentResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11925,7 +12006,7 @@ type PostIssueCommentResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *IssueEvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11948,7 +12029,7 @@ type EditIssueCommentResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueEvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11971,7 +12052,7 @@ type SetIssueGithubStateResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *GithubStateOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -11994,7 +12075,7 @@ type SetIssueLabelsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ItemLabelsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12017,7 +12098,7 @@ type SyncIssueResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12039,7 +12120,7 @@ func (r SyncIssueResponse) StatusCode() int {
 type EnqueueIssueSyncResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12062,7 +12143,7 @@ type CreateIssueWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON202                       *WorkspaceResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12085,7 +12166,7 @@ type ListProjectsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ListProjectsOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12108,7 +12189,7 @@ type RegisterProjectResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *ProjectResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12131,7 +12212,7 @@ type GetProjectResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ProjectResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12154,7 +12235,7 @@ type ListLaunchTargetsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ListLaunchTargetsOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12177,7 +12258,7 @@ type ListWorktreesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ListWorktreesOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12200,7 +12281,7 @@ type RegisterWorktreeResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *WorktreeResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12223,7 +12304,7 @@ type ListPullsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *[]MergeRequestResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12246,7 +12327,7 @@ type GetPullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12269,7 +12350,7 @@ type EditPrContentResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12292,7 +12373,7 @@ type ApprovePullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12315,7 +12396,7 @@ type ApprovePullWorkflowsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12338,7 +12419,7 @@ type RefreshPullCiResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12361,7 +12442,7 @@ type PostPrCommentResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *MREvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12384,7 +12465,7 @@ type EditPrCommentResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MREvent
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12407,7 +12488,7 @@ type GetPullCommitsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommitsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12430,7 +12511,7 @@ type GetPullDiffResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *DiffResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12453,7 +12534,7 @@ type GetPullFilePreviewResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilePreviewResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12476,7 +12557,7 @@ type GetPullFilesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilesResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12499,7 +12580,7 @@ type SetPrGithubStateResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *GithubStateOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12522,7 +12603,7 @@ type GetPullImportMetadataResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MrImportMetadataResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12545,7 +12626,7 @@ type SetPrLabelsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ItemLabelsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12568,7 +12649,7 @@ type MergePullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergePRBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12591,7 +12672,7 @@ type MarkPullReadyForReviewResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12614,7 +12695,7 @@ type GetPullStackResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *StackContextResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12636,7 +12717,7 @@ func (r GetPullStackResponse) StatusCode() int {
 type SetKanbanStateResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12659,7 +12740,7 @@ type SyncPullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12681,7 +12762,7 @@ func (r SyncPullResponse) StatusCode() int {
 type EnqueuePrSyncResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12704,7 +12785,7 @@ type GetRateLimitsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RateLimitsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12726,7 +12807,7 @@ func (r GetRateLimitsResponse) StatusCode() int {
 type DeleteRepoResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12749,7 +12830,7 @@ type GetRepoResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RepoResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12772,7 +12853,7 @@ type GetCommentAutocompleteResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommentAutocompleteResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12795,7 +12876,7 @@ type ListRepoLabelsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RepoLabelsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12818,7 +12899,7 @@ type RefreshRepoResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *SettingsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12841,7 +12922,7 @@ type ResolveRepoItemResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ResolveItemResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12864,7 +12945,7 @@ type ListReposResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *[]RepoResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12887,7 +12968,7 @@ type AddRepoResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *SettingsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12910,7 +12991,7 @@ type BulkAddReposResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON201                       *SettingsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12933,7 +13014,7 @@ type PreviewReposResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RepoPreviewResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12956,7 +13037,7 @@ type ListRepoSummariesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *[]RepoSummaryResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -12979,7 +13060,7 @@ type GetRoborevStatusResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RoborevStatusResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13002,7 +13083,7 @@ type GetSettingsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *SettingsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13025,7 +13106,7 @@ type UpdateSettingsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *SettingsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13048,7 +13129,7 @@ type ListStacksResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *[]StackResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13070,7 +13151,7 @@ func (r ListStacksResponse) StatusCode() int {
 type UnsetStarredResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13092,7 +13173,7 @@ func (r UnsetStarredResponse) StatusCode() int {
 type SetStarredResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13114,7 +13195,7 @@ func (r SetStarredResponse) StatusCode() int {
 type TriggerSyncResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13137,7 +13218,7 @@ type GetSyncStatusResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *SyncStatus
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13160,7 +13241,7 @@ type GetVersionResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *VersionOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13183,7 +13264,7 @@ type ListWorkspacesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ListWorkspacesOutputBody
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13206,7 +13287,7 @@ type CreateWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON202                       *WorkspaceResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13228,7 +13309,7 @@ func (r CreateWorkspaceResponse) StatusCode() int {
 type DeleteWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13251,7 +13332,7 @@ type GetWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *WorkspaceResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13274,7 +13355,7 @@ type GetWorkspaceCommitsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommitsResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13297,7 +13378,7 @@ type GetWorkspaceDiffResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *DiffResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13320,7 +13401,7 @@ type GetWorkspaceFilesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilesResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13343,7 +13424,7 @@ type RetryWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON202                       *WorkspaceResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13366,7 +13447,7 @@ type GetWorkspaceRuntimeResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *WorkspaceRuntimeResponse
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13389,7 +13470,7 @@ type LaunchWorkspaceRuntimeSessionResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *SessionInfo
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13411,7 +13492,7 @@ func (r LaunchWorkspaceRuntimeSessionResponse) StatusCode() int {
 type StopWorkspaceRuntimeSessionResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -13434,7 +13515,7 @@ type EnsureWorkspaceRuntimeShellResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *SessionInfo
-	ApplicationproblemJSONDefault *ErrorModel
+	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
@@ -14767,7 +14848,7 @@ func ParseListActivityResponse(rsp *http.Response) (*ListActivityResponse, error
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14800,7 +14881,7 @@ func ParseCreateIssueOnHostResponse(rsp *http.Response) (*CreateIssueOnHostRespo
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14833,7 +14914,7 @@ func ParseGetIssueOnHostResponse(rsp *http.Response) (*GetIssueOnHostResponse, e
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14866,7 +14947,7 @@ func ParseEditIssueContentOnHostResponse(rsp *http.Response) (*EditIssueContentO
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14899,7 +14980,7 @@ func ParsePostIssueCommentOnHostResponse(rsp *http.Response) (*PostIssueCommentO
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14932,7 +15013,7 @@ func ParseEditIssueCommentOnHostResponse(rsp *http.Response) (*EditIssueCommentO
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14965,7 +15046,7 @@ func ParseSetIssueGithubStateOnHostResponse(rsp *http.Response) (*SetIssueGithub
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14998,7 +15079,7 @@ func ParseSetIssueLabelsOnHostResponse(rsp *http.Response) (*SetIssueLabelsOnHos
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15031,7 +15112,7 @@ func ParseSyncIssueOnHostResponse(rsp *http.Response) (*SyncIssueOnHostResponse,
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15057,7 +15138,7 @@ func ParseEnqueueIssueSyncOnHostResponse(rsp *http.Response) (*EnqueueIssueSyncO
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15090,7 +15171,7 @@ func ParseCreateIssueWorkspaceOnHostResponse(rsp *http.Response) (*CreateIssueWo
 		response.JSON202 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15123,7 +15204,7 @@ func ParseGetPullOnHostResponse(rsp *http.Response) (*GetPullOnHostResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15156,7 +15237,7 @@ func ParseEditPrContentOnHostResponse(rsp *http.Response) (*EditPrContentOnHostR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15189,7 +15270,7 @@ func ParseApprovePullOnHostResponse(rsp *http.Response) (*ApprovePullOnHostRespo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15222,7 +15303,7 @@ func ParseApprovePullWorkflowsOnHostResponse(rsp *http.Response) (*ApprovePullWo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15255,7 +15336,7 @@ func ParseRefreshPullCiOnHostResponse(rsp *http.Response) (*RefreshPullCiOnHostR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15288,7 +15369,7 @@ func ParsePostPrCommentOnHostResponse(rsp *http.Response) (*PostPrCommentOnHostR
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15321,7 +15402,7 @@ func ParseEditPrCommentOnHostResponse(rsp *http.Response) (*EditPrCommentOnHostR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15354,7 +15435,7 @@ func ParseGetPullCommitsOnHostResponse(rsp *http.Response) (*GetPullCommitsOnHos
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15387,7 +15468,7 @@ func ParseGetPullDiffOnHostResponse(rsp *http.Response) (*GetPullDiffOnHostRespo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15420,7 +15501,7 @@ func ParseGetPullFilePreviewOnHostResponse(rsp *http.Response) (*GetPullFilePrev
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15453,7 +15534,7 @@ func ParseGetPullFilesOnHostResponse(rsp *http.Response) (*GetPullFilesOnHostRes
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15486,7 +15567,7 @@ func ParseSetPrGithubStateOnHostResponse(rsp *http.Response) (*SetPrGithubStateO
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15519,7 +15600,7 @@ func ParseGetPullImportMetadataOnHostResponse(rsp *http.Response) (*GetPullImpor
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15552,7 +15633,7 @@ func ParseSetPrLabelsOnHostResponse(rsp *http.Response) (*SetPrLabelsOnHostRespo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15585,7 +15666,7 @@ func ParseMergePullOnHostResponse(rsp *http.Response) (*MergePullOnHostResponse,
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15618,7 +15699,7 @@ func ParseMarkPullReadyForReviewOnHostResponse(rsp *http.Response) (*MarkPullRea
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15651,7 +15732,7 @@ func ParseGetPullStackOnHostResponse(rsp *http.Response) (*GetPullStackOnHostRes
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15677,7 +15758,7 @@ func ParseSetKanbanStateOnHostResponse(rsp *http.Response) (*SetKanbanStateOnHos
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15710,7 +15791,7 @@ func ParseSyncPullOnHostResponse(rsp *http.Response) (*SyncPullOnHostResponse, e
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15736,7 +15817,7 @@ func ParseEnqueuePrSyncOnHostResponse(rsp *http.Response) (*EnqueuePrSyncOnHostR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15762,7 +15843,7 @@ func ParseDeleteRepoOnHostResponse(rsp *http.Response) (*DeleteRepoOnHostRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15795,7 +15876,7 @@ func ParseGetRepoOnHostResponse(rsp *http.Response) (*GetRepoOnHostResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15828,7 +15909,7 @@ func ParseGetCommentAutocompleteOnHostResponse(rsp *http.Response) (*GetCommentA
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15861,7 +15942,7 @@ func ParseListRepoLabelsOnHostResponse(rsp *http.Response) (*ListRepoLabelsOnHos
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15894,7 +15975,7 @@ func ParseRefreshRepoOnHostResponse(rsp *http.Response) (*RefreshRepoOnHostRespo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15927,7 +16008,7 @@ func ParseResolveRepoItemOnHostResponse(rsp *http.Response) (*ResolveRepoItemOnH
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15960,7 +16041,7 @@ func ParseListIssuesResponse(rsp *http.Response) (*ListIssuesResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -15993,7 +16074,7 @@ func ParseCreateIssueResponse(rsp *http.Response) (*CreateIssueResponse, error) 
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16026,7 +16107,7 @@ func ParseGetIssueResponse(rsp *http.Response) (*GetIssueResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16059,7 +16140,7 @@ func ParseEditIssueContentResponse(rsp *http.Response) (*EditIssueContentRespons
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16092,7 +16173,7 @@ func ParsePostIssueCommentResponse(rsp *http.Response) (*PostIssueCommentRespons
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16125,7 +16206,7 @@ func ParseEditIssueCommentResponse(rsp *http.Response) (*EditIssueCommentRespons
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16158,7 +16239,7 @@ func ParseSetIssueGithubStateResponse(rsp *http.Response) (*SetIssueGithubStateR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16191,7 +16272,7 @@ func ParseSetIssueLabelsResponse(rsp *http.Response) (*SetIssueLabelsResponse, e
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16224,7 +16305,7 @@ func ParseSyncIssueResponse(rsp *http.Response) (*SyncIssueResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16250,7 +16331,7 @@ func ParseEnqueueIssueSyncResponse(rsp *http.Response) (*EnqueueIssueSyncRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16283,7 +16364,7 @@ func ParseCreateIssueWorkspaceResponse(rsp *http.Response) (*CreateIssueWorkspac
 		response.JSON202 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16316,7 +16397,7 @@ func ParseListProjectsResponse(rsp *http.Response) (*ListProjectsResponse, error
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16349,7 +16430,7 @@ func ParseRegisterProjectResponse(rsp *http.Response) (*RegisterProjectResponse,
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16382,7 +16463,7 @@ func ParseGetProjectResponse(rsp *http.Response) (*GetProjectResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16415,7 +16496,7 @@ func ParseListLaunchTargetsResponse(rsp *http.Response) (*ListLaunchTargetsRespo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16448,7 +16529,7 @@ func ParseListWorktreesResponse(rsp *http.Response) (*ListWorktreesResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16481,7 +16562,7 @@ func ParseRegisterWorktreeResponse(rsp *http.Response) (*RegisterWorktreeRespons
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16514,7 +16595,7 @@ func ParseListPullsResponse(rsp *http.Response) (*ListPullsResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16547,7 +16628,7 @@ func ParseGetPullResponse(rsp *http.Response) (*GetPullResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16580,7 +16661,7 @@ func ParseEditPrContentResponse(rsp *http.Response) (*EditPrContentResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16613,7 +16694,7 @@ func ParseApprovePullResponse(rsp *http.Response) (*ApprovePullResponse, error) 
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16646,7 +16727,7 @@ func ParseApprovePullWorkflowsResponse(rsp *http.Response) (*ApprovePullWorkflow
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16679,7 +16760,7 @@ func ParseRefreshPullCiResponse(rsp *http.Response) (*RefreshPullCiResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16712,7 +16793,7 @@ func ParsePostPrCommentResponse(rsp *http.Response) (*PostPrCommentResponse, err
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16745,7 +16826,7 @@ func ParseEditPrCommentResponse(rsp *http.Response) (*EditPrCommentResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16778,7 +16859,7 @@ func ParseGetPullCommitsResponse(rsp *http.Response) (*GetPullCommitsResponse, e
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16811,7 +16892,7 @@ func ParseGetPullDiffResponse(rsp *http.Response) (*GetPullDiffResponse, error) 
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16844,7 +16925,7 @@ func ParseGetPullFilePreviewResponse(rsp *http.Response) (*GetPullFilePreviewRes
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16877,7 +16958,7 @@ func ParseGetPullFilesResponse(rsp *http.Response) (*GetPullFilesResponse, error
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16910,7 +16991,7 @@ func ParseSetPrGithubStateResponse(rsp *http.Response) (*SetPrGithubStateRespons
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16943,7 +17024,7 @@ func ParseGetPullImportMetadataResponse(rsp *http.Response) (*GetPullImportMetad
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16976,7 +17057,7 @@ func ParseSetPrLabelsResponse(rsp *http.Response) (*SetPrLabelsResponse, error) 
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17009,7 +17090,7 @@ func ParseMergePullResponse(rsp *http.Response) (*MergePullResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17042,7 +17123,7 @@ func ParseMarkPullReadyForReviewResponse(rsp *http.Response) (*MarkPullReadyForR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17075,7 +17156,7 @@ func ParseGetPullStackResponse(rsp *http.Response) (*GetPullStackResponse, error
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17101,7 +17182,7 @@ func ParseSetKanbanStateResponse(rsp *http.Response) (*SetKanbanStateResponse, e
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17134,7 +17215,7 @@ func ParseSyncPullResponse(rsp *http.Response) (*SyncPullResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17160,7 +17241,7 @@ func ParseEnqueuePrSyncResponse(rsp *http.Response) (*EnqueuePrSyncResponse, err
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17193,7 +17274,7 @@ func ParseGetRateLimitsResponse(rsp *http.Response) (*GetRateLimitsResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17219,7 +17300,7 @@ func ParseDeleteRepoResponse(rsp *http.Response) (*DeleteRepoResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17252,7 +17333,7 @@ func ParseGetRepoResponse(rsp *http.Response) (*GetRepoResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17285,7 +17366,7 @@ func ParseGetCommentAutocompleteResponse(rsp *http.Response) (*GetCommentAutocom
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17318,7 +17399,7 @@ func ParseListRepoLabelsResponse(rsp *http.Response) (*ListRepoLabelsResponse, e
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17351,7 +17432,7 @@ func ParseRefreshRepoResponse(rsp *http.Response) (*RefreshRepoResponse, error) 
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17384,7 +17465,7 @@ func ParseResolveRepoItemResponse(rsp *http.Response) (*ResolveRepoItemResponse,
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17417,7 +17498,7 @@ func ParseListReposResponse(rsp *http.Response) (*ListReposResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17450,7 +17531,7 @@ func ParseAddRepoResponse(rsp *http.Response) (*AddRepoResponse, error) {
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17483,7 +17564,7 @@ func ParseBulkAddReposResponse(rsp *http.Response) (*BulkAddReposResponse, error
 		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17516,7 +17597,7 @@ func ParsePreviewReposResponse(rsp *http.Response) (*PreviewReposResponse, error
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17549,7 +17630,7 @@ func ParseListRepoSummariesResponse(rsp *http.Response) (*ListRepoSummariesRespo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17582,7 +17663,7 @@ func ParseGetRoborevStatusResponse(rsp *http.Response) (*GetRoborevStatusRespons
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17615,7 +17696,7 @@ func ParseGetSettingsResponse(rsp *http.Response) (*GetSettingsResponse, error) 
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17648,7 +17729,7 @@ func ParseUpdateSettingsResponse(rsp *http.Response) (*UpdateSettingsResponse, e
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17681,7 +17762,7 @@ func ParseListStacksResponse(rsp *http.Response) (*ListStacksResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17707,7 +17788,7 @@ func ParseUnsetStarredResponse(rsp *http.Response) (*UnsetStarredResponse, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17733,7 +17814,7 @@ func ParseSetStarredResponse(rsp *http.Response) (*SetStarredResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17759,7 +17840,7 @@ func ParseTriggerSyncResponse(rsp *http.Response) (*TriggerSyncResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17792,7 +17873,7 @@ func ParseGetSyncStatusResponse(rsp *http.Response) (*GetSyncStatusResponse, err
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17825,7 +17906,7 @@ func ParseGetVersionResponse(rsp *http.Response) (*GetVersionResponse, error) {
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17858,7 +17939,7 @@ func ParseListWorkspacesResponse(rsp *http.Response) (*ListWorkspacesResponse, e
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17891,7 +17972,7 @@ func ParseCreateWorkspaceResponse(rsp *http.Response) (*CreateWorkspaceResponse,
 		response.JSON202 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17917,7 +17998,7 @@ func ParseDeleteWorkspaceResponse(rsp *http.Response) (*DeleteWorkspaceResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17950,7 +18031,7 @@ func ParseGetWorkspaceResponse(rsp *http.Response) (*GetWorkspaceResponse, error
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17983,7 +18064,7 @@ func ParseGetWorkspaceCommitsResponse(rsp *http.Response) (*GetWorkspaceCommitsR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18016,7 +18097,7 @@ func ParseGetWorkspaceDiffResponse(rsp *http.Response) (*GetWorkspaceDiffRespons
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18049,7 +18130,7 @@ func ParseGetWorkspaceFilesResponse(rsp *http.Response) (*GetWorkspaceFilesRespo
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18082,7 +18163,7 @@ func ParseRetryWorkspaceResponse(rsp *http.Response) (*RetryWorkspaceResponse, e
 		response.JSON202 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18115,7 +18196,7 @@ func ParseGetWorkspaceRuntimeResponse(rsp *http.Response) (*GetWorkspaceRuntimeR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18148,7 +18229,7 @@ func ParseLaunchWorkspaceRuntimeSessionResponse(rsp *http.Response) (*LaunchWork
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18174,7 +18255,7 @@ func ParseStopWorkspaceRuntimeSessionResponse(rsp *http.Response) (*StopWorkspac
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18207,7 +18288,7 @@ func ParseEnsureWorkspaceRuntimeShellResponse(rsp *http.Response) (*EnsureWorksp
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest ErrorModel
+		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/configwatch/watcher_test.go
+++ b/internal/configwatch/watcher_test.go
@@ -189,9 +189,11 @@ func TestWatcher_StopsOnContextCancel(t *testing.T) {
 }
 
 func TestWatcher_DoneWaitsForInFlightCallback(t *testing.T) {
+	require := require.New(t)
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
-	require.NoError(t, os.WriteFile(path, []byte("a = 1"), 0o600))
+	require.NoError(os.WriteFile(path, []byte("a = 1"), 0o600))
 
 	callbackStarted := make(chan struct{})
 	callbackRelease := make(chan struct{})
@@ -203,23 +205,23 @@ func TestWatcher_DoneWaitsForInFlightCallback(t *testing.T) {
 			<-callbackRelease
 		},
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	w.Start(ctx)
-	require.NoError(t, w.WaitReady(ctx))
+	require.NoError(w.WaitReady(ctx))
 
-	require.NoError(t, os.WriteFile(path, []byte("a = 2"), 0o600))
+	require.NoError(os.WriteFile(path, []byte("a = 2"), 0o600))
 	select {
 	case <-callbackStarted:
 	case <-time.After(time.Second):
-		require.FailNow(t, "callback did not start")
+		require.FailNow("callback did not start")
 	}
 
 	cancel()
 	select {
 	case <-w.Done():
-		require.FailNow(t, "watcher stopped before callback returned")
+		require.FailNow("watcher stopped before callback returned")
 	case <-time.After(50 * time.Millisecond):
 	}
 
@@ -227,6 +229,6 @@ func TestWatcher_DoneWaitsForInFlightCallback(t *testing.T) {
 	select {
 	case <-w.Done():
 	case <-time.After(time.Second):
-		require.FailNow(t, "watcher did not stop after callback returned")
+		require.FailNow("watcher did not stop after callback returned")
 	}
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9310,6 +9310,215 @@ func TestAPIGitLabUnsupportedMutationsReturnCodedCapabilityErrors(t *testing.T) 
 	}
 }
 
+// TestAPIUnsupportedCapabilityEnvelope is the wire-level guarantee that
+// the gitlab capability gate emits an RFC 9457 envelope with a top-level
+// `code = "unsupportedCapability"` and `details.capability` carrying the
+// capability the route required. Frontend callers branch on `code`.
+func TestAPIUnsupportedCapabilityEnvelope(t *testing.T) {
+	srv, _ := setupGitLabCapabilityServer(t)
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/approve-workflows",
+		nil,
+	)
+	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal("unsupportedCapability", problem.Code)
+	require.NotNil(problem.Details)
+	assert.Equal("workflow_approval", problem.Details["capability"])
+	assert.Equal("gitlab", problem.Details["provider"])
+	assert.Equal("gitlab.example.com", problem.Details["platformHost"])
+}
+
+// TestAPIRateLimitedEnvelope drives a provider mutation through a fake
+// gitlab provider that returns a platform.Error with ErrCodeRateLimited
+// and a known ResetAt. The handler routes the failure through
+// providerCallProblem / mapPlatformError, which builds the rateLimited
+// problem with details.retryAfter populated as an RFC 3339 string.
+func TestAPIRateLimitedEnvelope(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	reset := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	srv := setupGitLabIssueMutatorServer(t, &platform.Error{
+		Code:         platform.ErrCodeRateLimited,
+		Provider:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		ResetAt:      &reset,
+	})
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/host/gitlab.example.com/issues/gl/group/project",
+		map[string]string{"title": "Rate limited", "body": "test"},
+	)
+	require.Equal(http.StatusTooManyRequests, rr.Code, rr.Body.String())
+
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal("rateLimited", problem.Code)
+	require.NotNil(problem.Details)
+	assert.Equal("gitlab", problem.Details["provider"])
+	assert.Equal("gitlab.example.com", problem.Details["platformHost"])
+	retryAfter, ok := problem.Details["retryAfter"].(string)
+	require.True(ok, "details.retryAfter must be a string, got %T", problem.Details["retryAfter"])
+	parsed, parseErr := time.Parse(time.RFC3339, retryAfter)
+	require.NoError(parseErr)
+	assert.Equal(reset.UTC(), parsed.UTC())
+}
+
+// TestAPIValidationErrorEnvelope sends an invalid kanban status and
+// expects the typed validationError envelope with details.field and
+// details.allowed.
+func TestAPIValidationErrorEnvelope(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     7777,
+		Number:         42,
+		URL:            "https://github.com/acme/widget/pull/42",
+		Title:          "Validation test",
+		Author:         "alice",
+		State:          "open",
+		HeadBranch:     "feature",
+		BaseBranch:     "main",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(err)
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPut,
+		"/api/v1/pulls/gh/acme/widget/42/state",
+		map[string]string{"status": "frobnicated"},
+	)
+	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal("validationError", problem.Code)
+	require.NotNil(problem.Details)
+	assert.Equal("body.status", problem.Details["field"])
+	allowed, ok := problem.Details["allowed"].([]any)
+	require.True(ok, "details.allowed must be an array, got %T", problem.Details["allowed"])
+	expected := []any{"new", "reviewing", "waiting", "awaiting_merge"}
+	assert.Equal(expected, allowed)
+}
+
+// setupGitLabIssueMutatorServer returns a server backed by a gitlab
+// provider whose IssueMutator.CreateIssue returns the supplied error.
+// The other capabilities are unchanged from setupGitLabCapabilityServer.
+func setupGitLabIssueMutatorServer(t *testing.T, createIssueErr error) *Server {
+	t.Helper()
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	database := dbtest.Open(t)
+
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	provider := &issueMutatorGitLabProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref:           ref,
+			mergeRequests: nil,
+			issues: []platform.Issue{{
+				Repo:           ref,
+				PlatformID:     8001,
+				Number:         11,
+				URL:            "https://gitlab.example.com/group/project/-/issues/11",
+				Title:          "Existing",
+				Author:         "alice",
+				State:          "open",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+		},
+		createIssueErr: createIssueErr,
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	repo := ghclient.RepoRef{
+		Platform:           platform.KindGitLab,
+		Owner:              "group",
+		Name:               "project",
+		PlatformHost:       "gitlab.example.com",
+		RepoPath:           "group/project",
+		PlatformRepoID:     4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	syncer.RunOnce(ctx)
+	return srv
+}
+
+// issueMutatorGitLabProvider embeds apiTestGitLabProvider but advertises
+// issue_mutation capability and returns the supplied error from
+// CreateIssue. Used by TestAPIRateLimitedEnvelope.
+type issueMutatorGitLabProvider struct {
+	apiTestGitLabProvider
+	createIssueErr error
+}
+
+func (p *issueMutatorGitLabProvider) Capabilities() platform.Capabilities {
+	caps := p.apiTestGitLabProvider.Capabilities()
+	caps.IssueMutation = true
+	return caps
+}
+
+func (p *issueMutatorGitLabProvider) CreateIssue(
+	_ context.Context,
+	_ platform.RepoRef,
+	_, _ string,
+) (platform.Issue, error) {
+	return platform.Issue{}, p.createIssueErr
+}
+
 func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -16573,11 +16782,13 @@ type rawIssueDetailResponse struct {
 }
 
 type rawProblemDetail struct {
-	Type   string `json:"type"`
-	Title  string `json:"title"`
-	Status int    `json:"status"`
-	Detail string `json:"detail"`
-	Errors []struct {
+	Type    string         `json:"type"`
+	Title   string         `json:"title"`
+	Status  int            `json:"status"`
+	Detail  string         `json:"detail"`
+	Code    string         `json:"code"`
+	Details map[string]any `json:"details"`
+	Errors  []struct {
 		Message  string `json:"message"`
 		Location string `json:"location"`
 		Value    any    `json:"value"`
@@ -17181,7 +17392,16 @@ func TestWorkspaceCreateIssueBranchConflictReturnsTyped409(t *testing.T) {
 	)
 	assert.Equal(http.StatusConflict, problem.Status)
 	assert.NotEmpty(problem.Detail)
+	// Wire-typed envelope: code branchConflict, details carry the
+	// conflicting branch and a suggested alternative so the UI can
+	// branch on code rather than message text.
+	assert.Equal("branchConflict", problem.Code)
+	require.NotNil(problem.Details)
+	assert.Equal("middleman/issue-7", problem.Details["branch"])
+	assert.Equal("middleman/issue-7-2", problem.Details["suggestedBranch"])
 
+	// The legacy Errors[] entries stay populated for clients that still
+	// introspect per-field huma details.
 	locations := map[string]any{}
 	for _, errDetail := range problem.Errors {
 		locations[errDetail.Location] = errDetail.Value

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10538,26 +10538,22 @@ func assertUnsupportedCapabilityProblem(
 	assert := Assert.New(t)
 
 	var problem struct {
-		Title  string `json:"title"`
-		Status int    `json:"status"`
-		Detail string `json:"detail"`
-		Errors []struct {
-			Message  string         `json:"message"`
-			Location string         `json:"location"`
-			Value    map[string]any `json:"value"`
-		} `json:"errors"`
+		Title   string         `json:"title"`
+		Status  int            `json:"status"`
+		Detail  string         `json:"detail"`
+		Code    string         `json:"code"`
+		Details map[string]any `json:"details"`
 	}
 	require.NoError(json.NewDecoder(body).Decode(&problem))
 	assert.Equal(http.StatusText(http.StatusConflict), problem.Title)
 	assert.Equal(http.StatusConflict, problem.Status)
 	assert.Contains(problem.Detail, "Unsupported provider capability")
-	require.Len(problem.Errors, 1)
-	assert.Equal("unsupported_capability", problem.Errors[0].Message)
-	assert.Equal("provider.capabilities", problem.Errors[0].Location)
-	assert.Equal("unsupported_capability", problem.Errors[0].Value["code"])
-	assert.Equal(provider, problem.Errors[0].Value["provider"])
-	assert.Equal(host, problem.Errors[0].Value["platform_host"])
-	assert.Equal(capability, problem.Errors[0].Value["capability"])
+	assert.Equal("unsupportedCapability", problem.Code,
+		"top-level RFC 9457 code must be the camelCase wire literal")
+	require.NotNil(problem.Details, "details must be present on unsupportedCapability problem")
+	assert.Equal(capability, problem.Details["capability"])
+	assert.Equal(provider, problem.Details["provider"])
+	assert.Equal(host, problem.Details["platformHost"])
 }
 
 func TestAPIGitealikeLockedPRPersistsThroughServer(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9381,6 +9381,116 @@ func TestAPICapabilityGatedRouteReturnsLookupProblemBeforeCapabilityProblem(t *t
 	}
 }
 
+func TestAPICapabilityGatedMutationsHandleMissingSyncer(t *testing.T) {
+	database := dbtest.Open(t)
+	srv := New(database, nil, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	seedPR(t, database, "acme", "widget", 7)
+	seedIssue(t, database, "acme", "widget", 11, "open")
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       any
+		capability string
+	}{
+		{
+			name:       "PR content",
+			method:     http.MethodPatch,
+			path:       "/api/v1/pulls/gh/acme/widget/7",
+			body:       map[string]string{"title": "Updated title"},
+			capability: "state_mutation",
+		},
+		{
+			name:       "issue content",
+			method:     http.MethodPatch,
+			path:       "/api/v1/issues/gh/acme/widget/11",
+			body:       map[string]string{"title": "Updated title"},
+			capability: "state_mutation",
+		},
+		{
+			name:       "PR comment",
+			method:     http.MethodPost,
+			path:       "/api/v1/pulls/gh/acme/widget/7/comments",
+			body:       map[string]string{"body": "hello"},
+			capability: "comment_mutation",
+		},
+		{
+			name:       "issue comment",
+			method:     http.MethodPost,
+			path:       "/api/v1/issues/gh/acme/widget/11/comments",
+			body:       map[string]string{"body": "hello"},
+			capability: "comment_mutation",
+		},
+		{
+			name:       "issue creation",
+			method:     http.MethodPost,
+			path:       "/api/v1/issues/gh/acme/widget",
+			body:       map[string]string{"title": "New issue", "body": "Issue body"},
+			capability: "issue_mutation",
+		},
+		{
+			name:       "review approval",
+			method:     http.MethodPost,
+			path:       "/api/v1/pulls/gh/acme/widget/7/approve",
+			body:       map[string]string{"body": "looks good"},
+			capability: "review_mutation",
+		},
+		{
+			name:       "workflow approval",
+			method:     http.MethodPost,
+			path:       "/api/v1/pulls/gh/acme/widget/7/approve-workflows",
+			body:       nil,
+			capability: "workflow_approval",
+		},
+		{
+			name:       "ready for review",
+			method:     http.MethodPost,
+			path:       "/api/v1/pulls/gh/acme/widget/7/ready-for-review",
+			body:       nil,
+			capability: "ready_for_review",
+		},
+		{
+			name:   "merge",
+			method: http.MethodPost,
+			path:   "/api/v1/pulls/gh/acme/widget/7/merge",
+			body: map[string]string{
+				"method":         "squash",
+				"commit_title":   "Merge PR",
+				"commit_message": "Merge PR",
+			},
+			capability: "merge_mutation",
+		},
+		{
+			name:       "PR state",
+			method:     http.MethodPost,
+			path:       "/api/v1/pulls/gh/acme/widget/7/github-state",
+			body:       map[string]string{"state": "closed"},
+			capability: "state_mutation",
+		},
+		{
+			name:       "issue state",
+			method:     http.MethodPost,
+			path:       "/api/v1/issues/gh/acme/widget/11/github-state",
+			body:       map[string]string{"state": "closed"},
+			capability: "state_mutation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			rr := doJSON(t, srv, tt.method, tt.path, tt.body)
+			require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+			assertUnsupportedCapabilityProblem(
+				t, rr.Body, "github", "github.com", tt.capability,
+			)
+		})
+	}
+}
+
 // TestAPIRateLimitedEnvelope drives a provider mutation through a fake
 // gitlab provider that returns a platform.Error with ErrCodeRateLimited
 // and a known ResetAt. The handler routes the failure through

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9343,9 +9343,6 @@ func TestAPIUnsupportedCapabilityEnvelope(t *testing.T) {
 // providerCallProblem / mapPlatformError, which builds the rateLimited
 // problem with details.retryAfter populated as an RFC 3339 string.
 func TestAPIRateLimitedEnvelope(t *testing.T) {
-	require := require.New(t)
-	assert := Assert.New(t)
-
 	reset := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
 	srv := setupGitLabIssueMutatorServer(t, &platform.Error{
 		Code:         platform.ErrCodeRateLimited,
@@ -9354,26 +9351,51 @@ func TestAPIRateLimitedEnvelope(t *testing.T) {
 		ResetAt:      &reset,
 	})
 
-	rr := doJSON(
-		t,
-		srv,
-		http.MethodPost,
-		"/api/v1/host/gitlab.example.com/issues/gl/group/project",
-		map[string]string{"title": "Rate limited", "body": "test"},
-	)
-	require.Equal(http.StatusTooManyRequests, rr.Code, rr.Body.String())
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{
+			name:   "issue create",
+			method: http.MethodPost,
+			path:   "/api/v1/host/gitlab.example.com/issues/gl/group/project",
+			body:   map[string]string{"title": "Rate limited", "body": "test"},
+		},
+		{
+			name:   "pull content edit",
+			method: http.MethodPatch,
+			path:   "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7",
+			body:   map[string]string{"title": "Rate limited"},
+		},
+	}
 
-	var problem rawProblemDetail
-	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
-	assert.Equal("rateLimited", problem.Code)
-	require.NotNil(problem.Details)
-	assert.Equal("gitlab", problem.Details["provider"])
-	assert.Equal("gitlab.example.com", problem.Details["platformHost"])
-	retryAfter, ok := problem.Details["retryAfter"].(string)
-	require.True(ok, "details.retryAfter must be a string, got %T", problem.Details["retryAfter"])
-	parsed, parseErr := time.Parse(time.RFC3339, retryAfter)
-	require.NoError(parseErr)
-	assert.Equal(reset.UTC(), parsed.UTC())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := Assert.New(t)
+
+			rr := doJSON(t, srv, tt.method, tt.path, tt.body)
+			require.Equal(http.StatusTooManyRequests, rr.Code, rr.Body.String())
+
+			var problem rawProblemDetail
+			require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+			assert.Equal("rateLimited", problem.Code)
+			require.NotNil(problem.Details)
+			assert.Equal("gitlab", problem.Details["provider"])
+			assert.Equal("gitlab.example.com", problem.Details["platformHost"])
+			retryAfter, ok := problem.Details["retryAfter"].(string)
+			require.True(
+				ok,
+				"details.retryAfter must be a string, got %T",
+				problem.Details["retryAfter"],
+			)
+			parsed, parseErr := time.Parse(time.RFC3339, retryAfter)
+			require.NoError(parseErr)
+			assert.Equal(reset.UTC(), parsed.UTC())
+		})
+	}
 }
 
 // TestAPIValidationErrorEnvelope sends an invalid kanban status and
@@ -9454,8 +9476,21 @@ func setupGitLabIssueMutatorServer(t *testing.T, createIssueErr error) *Server {
 	}
 	provider := &issueMutatorGitLabProvider{
 		apiTestGitLabProvider: apiTestGitLabProvider{
-			ref:           ref,
-			mergeRequests: nil,
+			ref: ref,
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           ref,
+				PlatformID:     7001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "Existing MR",
+				Author:         "alice",
+				State:          "open",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
 			issues: []platform.Issue{{
 				Repo:           ref,
 				PlatformID:     8001,
@@ -9469,7 +9504,7 @@ func setupGitLabIssueMutatorServer(t *testing.T, createIssueErr error) *Server {
 				LastActivityAt: now,
 			}},
 		},
-		createIssueErr: createIssueErr,
+		providerErr: createIssueErr,
 	}
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
@@ -9502,12 +9537,13 @@ func setupGitLabIssueMutatorServer(t *testing.T, createIssueErr error) *Server {
 // CreateIssue. Used by TestAPIRateLimitedEnvelope.
 type issueMutatorGitLabProvider struct {
 	apiTestGitLabProvider
-	createIssueErr error
+	providerErr error
 }
 
 func (p *issueMutatorGitLabProvider) Capabilities() platform.Capabilities {
 	caps := p.apiTestGitLabProvider.Capabilities()
 	caps.IssueMutation = true
+	caps.StateMutation = true
 	return caps
 }
 
@@ -9516,7 +9552,16 @@ func (p *issueMutatorGitLabProvider) CreateIssue(
 	_ platform.RepoRef,
 	_, _ string,
 ) (platform.Issue, error) {
-	return platform.Issue{}, p.createIssueErr
+	return platform.Issue{}, p.providerErr
+}
+
+func (p *issueMutatorGitLabProvider) EditMergeRequestContent(
+	_ context.Context,
+	_ platform.RepoRef,
+	_ int,
+	_, _ *string,
+) (platform.MergeRequest, error) {
+	return platform.MergeRequest{}, p.providerErr
 }
 
 func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9337,6 +9337,50 @@ func TestAPIUnsupportedCapabilityEnvelope(t *testing.T) {
 	assert.Equal("gitlab.example.com", problem.Details["platformHost"])
 }
 
+func TestAPICapabilityGatedRouteReturnsLookupProblemBeforeCapabilityProblem(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	tests := []struct {
+		name     string
+		path     string
+		wantCode int
+		wantWire string
+	}{
+		{
+			name:     "unknown repo",
+			path:     "/api/v1/pulls/gh/acme/unknown/7",
+			wantCode: http.StatusNotFound,
+			wantWire: "repoNotFound",
+		},
+		{
+			name:     "invalid provider",
+			path:     "/api/v1/pulls/not-a-provider/acme/widget/7",
+			wantCode: http.StatusBadRequest,
+			wantWire: "badRequest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := Assert.New(t)
+
+			rr := doJSON(
+				t,
+				srv,
+				http.MethodPatch,
+				tt.path,
+				map[string]string{"title": "Updated title"},
+			)
+			require.Equal(tt.wantCode, rr.Code, rr.Body.String())
+
+			var problem rawProblemDetail
+			require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+			assert.Equal(tt.wantWire, problem.Code)
+		})
+	}
+}
+
 // TestAPIRateLimitedEnvelope drives a provider mutation through a fake
 // gitlab provider that returns a platform.Error with ErrCodeRateLimited
 // and a known ResetAt. The handler routes the failure through

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -17397,8 +17397,8 @@ func TestWorkspaceCreateIssueBranchConflictReturnsTyped409(t *testing.T) {
 	// branch on code rather than message text.
 	assert.Equal("branchConflict", problem.Code)
 	require.NotNil(problem.Details)
-	assert.Equal("middleman/issue-7", problem.Details["branch"])
-	assert.Equal("middleman/issue-7-2", problem.Details["suggestedBranch"])
+	assert.Equal(slugBranch, problem.Details["branch"])
+	assert.Equal(slugBranch+"-2", problem.Details["suggestedBranch"])
 
 	// The legacy Errors[] entries stay populated for clients that still
 	// introspect per-field huma details.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1017,7 +1017,7 @@ func TestAPIMergePRForwardsGitHubErrorDetailsAndLogsError(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
 
-	var body generated.ErrorModel
+	var body generated.ProblemError
 	require.NoError(json.Unmarshal(resp.Body, &body))
 	require.NotNil(body.Detail)
 	assert.Contains(*body.Detail, "Required status check \"build\" is failing")

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -56,6 +56,13 @@ func unsupportedCapabilityProblem(repo db.Repo, capability string) huma.StatusEr
 	return problemUnsupportedCapability(repo, capability)
 }
 
+func (s *Server) requireSyncerCapability(repo db.Repo, capability string) error {
+	if s.syncer == nil {
+		return unsupportedCapabilityProblem(repo, capability)
+	}
+	return nil
+}
+
 func (s *Server) requireRepoRouteCapability(
 	ctx context.Context,
 	provider, platformHost, owner, name, capability string,

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/wesm/middleman/internal/db"
@@ -19,46 +18,6 @@ const (
 	capabilityReadLabels       = "read_labels"
 	capabilityLabelMutation    = "label_mutation"
 )
-
-type unsupportedCapabilityDetail struct {
-	code         string
-	provider     string
-	platformHost string
-	capability   string
-}
-
-func (d unsupportedCapabilityDetail) Error() string {
-	return d.code
-}
-
-func (d unsupportedCapabilityDetail) ErrorDetail() *huma.ErrorDetail {
-	return &huma.ErrorDetail{
-		Message:  d.code,
-		Location: "provider.capabilities",
-		Value: map[string]string{
-			"code":          d.code,
-			"provider":      d.provider,
-			"platform_host": d.platformHost,
-			"capability":    d.capability,
-		},
-	}
-}
-
-func unsupportedCapabilityProblem(
-	repo db.Repo,
-	capability string,
-) huma.StatusError {
-	return huma.NewError(
-		http.StatusConflict,
-		"Unsupported provider capability",
-		unsupportedCapabilityDetail{
-			code:         "unsupported_capability",
-			provider:     string(repoProviderKind(repo)),
-			platformHost: repoProviderHost(repo),
-			capability:   capability,
-		},
-	)
-}
 
 func capabilityEnabled(
 	caps providerCapabilitiesResponse,
@@ -88,6 +47,15 @@ func capabilityEnabled(
 	}
 }
 
+// unsupportedCapabilityProblem is a thin alias for
+// problemUnsupportedCapability so that handler files which already use
+// this name from outside requireRepoRouteCapability don't need to import
+// problems.go's helper by its new name. Both spellings are kept for
+// readability at the call sites.
+func unsupportedCapabilityProblem(repo db.Repo, capability string) huma.StatusError {
+	return problemUnsupportedCapability(repo, capability)
+}
+
 func (s *Server) requireRepoRouteCapability(
 	ctx context.Context,
 	provider, platformHost, owner, name, capability string,
@@ -99,7 +67,12 @@ func (s *Server) requireRepoRouteCapability(
 		return nil, providerRouteLookupError(err)
 	}
 	if !capabilityEnabled(s.capabilitiesForRepo(*repo), capability) {
-		return nil, unsupportedCapabilityProblem(*repo, capability)
+		return nil, problemUnsupportedCapability(*repo, capability)
 	}
 	return repo, nil
 }
+
+// Compile-time guard that huma is imported even after the migration
+// removed the direct ErrorDetail/StatusError usage from this file. The
+// huma_routes.go file still imports huma so this is belt-and-suspenders.
+var _ huma.StatusError = (*ProblemError)(nil)

--- a/internal/server/health_routes.go
+++ b/internal/server/health_routes.go
@@ -34,12 +34,12 @@ func (s *Server) livez(_ context.Context, _ *struct{}) (*healthOutput, error) {
 
 func (s *Server) healthz(ctx context.Context, _ *struct{}) (*healthOutput, error) {
 	if s.db == nil {
-		return nil, huma.Error503ServiceUnavailable("database unavailable")
+		return nil, problemServiceUnavailable("database unavailable")
 	}
 
 	var probe int
 	if err := s.db.ReadDB().QueryRowContext(ctx, "SELECT 1").Scan(&probe); err != nil {
-		return nil, huma.Error503ServiceUnavailable("database unavailable")
+		return nil, problemServiceUnavailable("database unavailable")
 	}
 
 	return &healthOutput{

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1425,9 +1425,8 @@ func (s *Server) createIssue(
 		ctx, platformRepoRefFromDB(*repo), title, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"provider API error: "+err.Error(),
-			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		return nil, providerCallProblem(
+			err, string(repoProviderKind(*repo)), repoProviderHost(*repo),
 		)
 	}
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -49,16 +49,16 @@ type getPullOutput = bodyOutput[mergeRequestDetailResponse]
 
 func providerRouteLookupError(err error) error {
 	if errors.Is(err, errRepoPathRequired) {
-		return huma.Error400BadRequest(err.Error())
+		return problemBadRequest(CodeBadRequest, err.Error(), nil)
 	}
 	if errors.Is(err, errRepoNotFound) {
-		return huma.Error404NotFound("repo not found")
+		return problemNotFound(CodeRepoNotFound, "repo not found", nil)
 	}
 	if strings.Contains(err.Error(), "platform_host is required") ||
 		strings.Contains(err.Error(), "unsupported platform") {
-		return huma.Error400BadRequest(err.Error())
+		return problemBadRequest(CodeBadRequest, err.Error(), nil)
 	}
-	return huma.Error500InternalServerError("get repo failed")
+	return problemInternal("get repo failed")
 }
 
 type getMRImportMetadataOutput = bodyOutput[mrImportMetadataResponse]
@@ -781,8 +781,10 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 			"open": true, "closed": true, "all": true,
 		}
 		if !valid[input.State] {
-			return nil, huma.Error400BadRequest(
+			return nil, problemValidation(
+				"query.state",
 				"state must be one of: open, closed, all",
+				"open", "closed", "all",
 			)
 		}
 	}
@@ -806,12 +808,12 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 
 	mrs, err := s.db.ListMergeRequests(ctx, opts)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("list pulls failed")
+		return nil, problemInternal("list pulls failed")
 	}
 
 	repoByID, err := s.lookupRepoMap(ctx)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("repo lookup failed")
+		return nil, problemInternal("repo lookup failed")
 	}
 
 	mrIDs := make([]int64, len(mrs))
@@ -820,7 +822,7 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 	}
 	links, err := s.db.GetWorktreeLinksForMRs(ctx, mrIDs)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("load worktree links failed")
+		return nil, problemInternal("load worktree links failed")
 	}
 	linksByMR := indexWorktreeLinksByMR(links)
 
@@ -861,10 +863,10 @@ func (s *Server) getPull(ctx context.Context, input *repoNumberInput) (*getPullO
 	}
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get pull request failed")
+		return nil, problemInternal("get pull request failed")
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 
 	body, err := s.buildPullDetailResponse(ctx, mr)
@@ -881,7 +883,7 @@ func (s *Server) buildPullDetailResponse(
 ) (mergeRequestDetailResponse, error) {
 	events, err := s.db.ListMREvents(ctx, mr.ID)
 	if err != nil {
-		return mergeRequestDetailResponse{}, huma.Error500InternalServerError("list mr events failed")
+		return mergeRequestDetailResponse{}, problemInternal("list mr events failed")
 	}
 	if events == nil {
 		events = []db.MREvent{}
@@ -889,16 +891,12 @@ func (s *Server) buildPullDetailResponse(
 
 	dbLinks, err := s.db.GetWorktreeLinksForMR(ctx, mr.ID)
 	if err != nil {
-		return mergeRequestDetailResponse{}, huma.Error500InternalServerError(
-			"load worktree links failed",
-		)
+		return mergeRequestDetailResponse{}, problemInternal("load worktree links failed")
 	}
 
 	repo, err := s.db.GetRepoByID(ctx, mr.RepoID)
 	if err != nil || repo == nil {
-		return mergeRequestDetailResponse{}, huma.Error500InternalServerError(
-			"load repo failed",
-		)
+		return mergeRequestDetailResponse{}, problemInternal("load repo failed")
 	}
 	resp := mergeRequestDetailResponse{
 		MergeRequest:     mr,
@@ -1014,12 +1012,10 @@ func (s *Server) getMRImportMetadata(
 	}
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"failed to query merge request",
-		)
+		return nil, problemInternal("failed to query merge request")
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("merge request not found")
+		return nil, problemNotFound(CodePullNotFound, "merge request not found", nil)
 	}
 	return &getMRImportMetadataOutput{
 		Body: mrImportMetadataResponse{
@@ -1036,7 +1032,11 @@ func (s *Server) getMRImportMetadata(
 
 func (s *Server) setKanbanState(ctx context.Context, input *setKanbanStateInput) (*statusOnlyOutput, error) {
 	if !validKanbanStates[input.Body.Status] {
-		return nil, huma.Error400BadRequest("status must be one of: new, reviewing, waiting, awaiting_merge")
+		return nil, problemValidation(
+			"body.status",
+			"status must be one of: new, reviewing, waiting, awaiting_merge",
+			"new", "reviewing", "waiting", "awaiting_merge",
+		)
 	}
 
 	repo, err := s.lookupRepoByProviderRoute(
@@ -1053,10 +1053,10 @@ func (s *Server) setKanbanState(ctx context.Context, input *setKanbanStateInput)
 	}
 	mrID, err := s.lookupMRID(ctx, ref)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, problemNotFound(CodePullNotFound, err.Error(), nil)
 	}
 	if err := s.db.SetKanbanState(ctx, mrID, input.Body.Status); err != nil {
-		return nil, huma.Error500InternalServerError("set kanban state failed")
+		return nil, problemInternal("set kanban state failed")
 	}
 
 	return &statusOnlyOutput{Status: http.StatusOK}, nil
@@ -1066,12 +1066,12 @@ func (s *Server) editPRContent(
 	ctx context.Context, input *editPRContentInput,
 ) (*editPRContentOutput, error) {
 	if input.Body.Title == nil && input.Body.Body == nil {
-		return nil, huma.Error400BadRequest(
+		return nil, problemValidation("body",
 			"at least one of title or body must be provided",
 		)
 	}
 	if input.Body.Title != nil && strings.TrimSpace(*input.Body.Title) == "" {
-		return nil, huma.Error400BadRequest("title must not be blank")
+		return nil, problemValidation("body.title", "title must not be blank")
 	}
 
 	repo, err := s.requireRepoRouteCapability(
@@ -1087,25 +1087,24 @@ func (s *Server) editPRContent(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityStateMutation)
 	}
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get pull request failed",
-		)
+		return nil, problemInternal("get pull request failed")
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 
 	updatedMR, err := mutator.EditMergeRequestContent(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Title, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway(
-			"provider API error: " + err.Error(),
+		return nil, problemUpstream(
+			"provider API error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
 		)
 	}
 
@@ -1128,16 +1127,12 @@ func (s *Server) editPRContent(
 	if err := s.db.UpdateMRTitleBody(
 		ctx, mr.ID, newTitle, newBody, updatedAt,
 	); err != nil {
-		return nil, huma.Error500InternalServerError(
-			"update title/body failed",
-		)
+		return nil, problemInternal("update title/body failed")
 	}
 
 	mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil || mr == nil {
-		return nil, huma.Error500InternalServerError(
-			"re-read pull request failed",
-		)
+		return nil, problemInternal("re-read pull request failed")
 	}
 
 	body, err := s.buildPullDetailResponse(ctx, mr)
@@ -1152,12 +1147,12 @@ func (s *Server) editIssueContent(
 	ctx context.Context, input *editIssueContentInput,
 ) (*editIssueContentOutput, error) {
 	if input.Body.Title == nil && input.Body.Body == nil {
-		return nil, huma.Error400BadRequest(
+		return nil, problemValidation("body",
 			"at least one of title or body must be provided",
 		)
 	}
 	if input.Body.Title != nil && strings.TrimSpace(*input.Body.Title) == "" {
-		return nil, huma.Error400BadRequest("title must not be blank")
+		return nil, problemValidation("body.title", "title must not be blank")
 	}
 
 	repo, err := s.requireRepoRouteCapability(
@@ -1173,23 +1168,24 @@ func (s *Server) editIssueContent(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityStateMutation)
 	}
 
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get issue failed")
+		return nil, problemInternal("get issue failed")
 	}
 	if issue == nil {
-		return nil, huma.Error404NotFound("issue not found")
+		return nil, problemNotFound(CodeIssueNotFound, "issue not found", nil)
 	}
 
 	updatedIssue, err := mutator.EditIssueContent(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Title, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway(
-			"provider API error: " + err.Error(),
+		return nil, problemUpstream(
+			"provider API error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
 		)
 	}
 
@@ -1212,16 +1208,12 @@ func (s *Server) editIssueContent(
 	if err := s.db.UpdateIssueTitleBody(
 		ctx, issue.ID, newTitle, newBody, updatedAt,
 	); err != nil {
-		return nil, huma.Error500InternalServerError(
-			"update title/body failed",
-		)
+		return nil, problemInternal("update title/body failed")
 	}
 
 	issue, err = s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil || issue == nil {
-		return nil, huma.Error500InternalServerError(
-			"re-read issue failed",
-		)
+		return nil, problemInternal("re-read issue failed")
 	}
 
 	body, err := s.buildIssueDetailResponse(ctx, repo, issue)
@@ -1234,7 +1226,7 @@ func (s *Server) editIssueContent(
 
 func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*postCommentOutput, error) {
 	if strings.TrimSpace(input.Body.Body) == "" {
-		return nil, huma.Error400BadRequest("comment body must not be empty")
+		return nil, problemValidation("body.body", "comment body must not be empty")
 	}
 
 	repo, err := s.requireRepoRouteCapability(
@@ -1250,14 +1242,17 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityCommentMutation)
 	}
 
 	platformEvent, err := mutator.CreateMergeRequestComment(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("create comment on provider failed")
+		return nil, problemUpstream(
+			"create comment on provider failed",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	ref := repoNumberPathRef{
@@ -1268,7 +1263,7 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 	}
 	mrID, err := s.lookupMRID(ctx, ref)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, problemNotFound(CodePullNotFound, err.Error(), nil)
 	}
 
 	event := platform.DBMREvent(mrID, platformEvent)
@@ -1281,7 +1276,7 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 
 func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*editCommentOutput, error) {
 	if strings.TrimSpace(input.Body.Body) == "" {
-		return nil, huma.Error400BadRequest("comment body must not be empty")
+		return nil, problemValidation("body.body", "comment body must not be empty")
 	}
 
 	repo, err := s.requireRepoRouteCapability(
@@ -1297,7 +1292,7 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityCommentMutation)
 	}
 
 	ref := repoNumberPathRef{
@@ -1308,28 +1303,31 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 	}
 	mrID, err := s.lookupMRID(ctx, ref)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, problemNotFound(CodePullNotFound, err.Error(), nil)
 	}
 
 	exists, err := s.db.MRCommentEventExists(ctx, mrID, input.CommentID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("validate comment target failed")
+		return nil, problemInternal("validate comment target failed")
 	}
 	if !exists {
-		return nil, huma.Error404NotFound("comment not found for pull request")
+		return nil, problemNotFound(CodeCommentNotFound, "comment not found for pull request", nil)
 	}
 
 	platformEvent, err := mutator.EditMergeRequestComment(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.CommentID, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("edit comment on provider failed")
+		return nil, problemUpstream(
+			"edit comment on provider failed",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 	platformEvent.MergeRequestNumber = input.Number
 
 	event := platform.DBMREvent(mrID, platformEvent)
 	if err := s.db.UpsertMREvents(ctx, []db.MREvent{event}); err != nil {
-		return nil, huma.Error500InternalServerError("persist edited comment failed")
+		return nil, problemInternal("persist edited comment failed")
 	}
 
 	return &editCommentOutput{Body: event}, nil
@@ -1341,8 +1339,10 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 			"open": true, "closed": true, "all": true,
 		}
 		if !valid[input.State] {
-			return nil, huma.Error400BadRequest(
+			return nil, problemValidation(
+				"query.state",
 				"state must be one of: open, closed, all",
+				"open", "closed", "all",
 			)
 		}
 	}
@@ -1365,12 +1365,12 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 
 	issues, err := s.db.ListIssues(ctx, opts)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("list issues failed")
+		return nil, problemInternal("list issues failed")
 	}
 
 	repoByID, err := s.lookupRepoMap(ctx)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("repo lookup failed")
+		return nil, problemInternal("repo lookup failed")
 	}
 
 	out := make([]issueResponse, 0, len(issues))
@@ -1401,7 +1401,7 @@ func (s *Server) createIssue(
 ) (*createIssueOutput, error) {
 	title := strings.TrimSpace(input.Body.Title)
 	if title == "" {
-		return nil, huma.Error400BadRequest("issue title must not be empty")
+		return nil, problemValidation("body.title", "issue title must not be empty")
 	}
 
 	repo, err := s.lookupRepoByProviderRoute(
@@ -1418,38 +1418,33 @@ func (s *Server) createIssue(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityIssueMutation)
 	}
 
 	platformIssue, err := mutator.CreateIssue(
 		ctx, platformRepoRefFromDB(*repo), title, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway(
-			"provider API error: " + err.Error(),
+		return nil, problemUpstream(
+			"provider API error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
 		)
 	}
 
 	issue := platform.DBIssue(repo.ID, platformIssue)
 	issueID, err := s.db.UpsertIssue(ctx, issue)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"save issue failed",
-		)
+		return nil, problemInternal("save issue failed")
 	}
 	if err := s.db.ReplaceIssueLabels(ctx, repo.ID, issueID, issue.Labels); err != nil {
-		return nil, huma.Error500InternalServerError(
-			"save issue labels failed",
-		)
+		return nil, problemInternal("save issue labels failed")
 	}
 
 	savedIssue, err := s.db.GetIssueByRepoIDAndNumber(
 		ctx, repo.ID, issue.Number,
 	)
 	if err != nil || savedIssue == nil {
-		return nil, huma.Error500InternalServerError(
-			"re-read issue failed",
-		)
+		return nil, problemInternal("re-read issue failed")
 	}
 	savedIssue.ID = issueID
 
@@ -1480,10 +1475,10 @@ func (s *Server) getIssue(ctx context.Context, input *issueRepoNumberInput) (*ge
 	}
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get issue failed")
+		return nil, problemInternal("get issue failed")
 	}
 	if issue == nil {
-		return nil, huma.Error404NotFound("issue not found")
+		return nil, problemNotFound(CodeIssueNotFound, "issue not found", nil)
 	}
 
 	issueResp, err := s.buildIssueDetailResponse(ctx, repo, issue)
@@ -1500,7 +1495,7 @@ func (s *Server) buildIssueDetailResponse(
 ) (issueDetailResponse, error) {
 	events, err := s.db.ListIssueEvents(ctx, issue.ID)
 	if err != nil {
-		return issueDetailResponse{}, huma.Error500InternalServerError("list issue events failed")
+		return issueDetailResponse{}, problemInternal("list issue events failed")
 	}
 	if events == nil {
 		events = []db.IssueEvent{}
@@ -1534,7 +1529,7 @@ func (s *Server) buildIssueDetailResponse(
 
 func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentInput) (*postIssueCommentOutput, error) {
 	if strings.TrimSpace(input.Body.Body) == "" {
-		return nil, huma.Error400BadRequest("comment body must not be empty")
+		return nil, problemValidation("body.body", "comment body must not be empty")
 	}
 
 	repo, err := s.lookupRepoByProviderRoute(
@@ -1551,14 +1546,17 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityCommentMutation)
 	}
 
 	platformEvent, err := mutator.CreateIssueComment(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("create comment on provider failed")
+		return nil, problemUpstream(
+			"create comment on provider failed",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	ref := repoNumberPathRef{
@@ -1569,7 +1567,7 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 	}
 	issueID, err := s.lookupIssueID(ctx, ref)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, problemNotFound(CodeIssueNotFound, err.Error(), nil)
 	}
 
 	event := platform.DBIssueEvent(issueID, platformEvent)
@@ -1582,7 +1580,7 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 
 func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentInput) (*editIssueCommentOutput, error) {
 	if strings.TrimSpace(input.Body.Body) == "" {
-		return nil, huma.Error400BadRequest("comment body must not be empty")
+		return nil, problemValidation("body.body", "comment body must not be empty")
 	}
 
 	repo, err := s.lookupRepoByProviderRoute(
@@ -1599,7 +1597,7 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityCommentMutation)
 	}
 
 	ref := repoNumberPathRef{
@@ -1610,28 +1608,31 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 	}
 	issueID, err := s.lookupIssueID(ctx, ref)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, problemNotFound(CodeIssueNotFound, err.Error(), nil)
 	}
 
 	exists, err := s.db.IssueCommentEventExists(ctx, issueID, input.CommentID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("validate comment target failed")
+		return nil, problemInternal("validate comment target failed")
 	}
 	if !exists {
-		return nil, huma.Error404NotFound("comment not found for issue")
+		return nil, problemNotFound(CodeCommentNotFound, "comment not found for issue", nil)
 	}
 
 	platformEvent, err := mutator.EditIssueComment(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.CommentID, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("edit comment on provider failed")
+		return nil, problemUpstream(
+			"edit comment on provider failed",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 	platformEvent.IssueNumber = input.Number
 
 	event := platform.DBIssueEvent(issueID, platformEvent)
 	if err := s.db.UpsertIssueEvents(ctx, []db.IssueEvent{event}); err != nil {
-		return nil, huma.Error500InternalServerError("persist edited comment failed")
+		return nil, problemInternal("persist edited comment failed")
 	}
 
 	return &editIssueCommentOutput{Body: event}, nil
@@ -1643,7 +1644,7 @@ func (s *Server) setStarred(ctx context.Context, input *starredInput) (*statusOn
 		return nil, err
 	}
 	if err := s.db.SetStarred(ctx, input.Body.ItemType, repoID, input.Body.Number); err != nil {
-		return nil, huma.Error500InternalServerError("set starred failed")
+		return nil, problemInternal("set starred failed")
 	}
 	return &statusOnlyOutput{Status: http.StatusOK}, nil
 }
@@ -1654,7 +1655,7 @@ func (s *Server) unsetStarred(ctx context.Context, input *starredInput) (*status
 		return nil, err
 	}
 	if err := s.db.UnsetStarred(ctx, input.Body.ItemType, repoID, input.Body.Number); err != nil {
-		return nil, huma.Error500InternalServerError("unset starred failed")
+		return nil, problemInternal("unset starred failed")
 	}
 	return &statusOnlyOutput{Status: http.StatusOK}, nil
 }
@@ -1699,7 +1700,7 @@ func (s *Server) getCommentAutocomplete(
 			limit,
 		)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("list comment autocomplete users failed")
+			return nil, problemInternal("list comment autocomplete users failed")
 		}
 		return &commentAutocompleteOutput{Body: commentAutocompleteResponse{Users: users}}, nil
 	case "#":
@@ -1712,11 +1713,11 @@ func (s *Server) getCommentAutocomplete(
 			limit,
 		)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("list comment autocomplete references failed")
+			return nil, problemInternal("list comment autocomplete references failed")
 		}
 		return &commentAutocompleteOutput{Body: commentAutocompleteResponse{References: references}}, nil
 	default:
-		return nil, huma.Error400BadRequest("trigger must be @ or #")
+		return nil, problemValidation("query.trigger", "trigger must be @ or #", "@", "#")
 	}
 }
 
@@ -1734,14 +1735,17 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityReviewMutation)
 	}
 
 	platformEvent, err := mutator.ApproveMergeRequest(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Body,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("provider API error")
+		return nil, problemUpstream(
+			"provider API error",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	ref := repoNumberPathRef{
@@ -1771,29 +1775,32 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get pull request failed")
+		return nil, problemInternal("get pull request failed")
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 
 	client, err := s.syncer.ClientForHost(repo.PlatformHost)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityWorkflowApproval)
 	}
 	mutator, err := s.syncer.WorkflowApprovalMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityWorkflowApproval)
 	}
 
 	pr, err := client.GetPullRequest(ctx, input.Owner, input.Name, input.Number)
 	if err != nil {
-		return nil, huma.Error502BadGateway("GitHub API error")
+		return nil, problemUpstream(
+			"GitHub API error",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 	if pr == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 
 	headSHA := pr.GetHead().GetSHA()
@@ -1803,7 +1810,10 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 
 	runs, err := client.ListWorkflowRunsForHeadSHA(ctx, input.Owner, input.Name, headSHA)
 	if err != nil {
-		return nil, huma.Error502BadGateway("GitHub API error")
+		return nil, problemUpstream(
+			"GitHub API error",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, ghclient.PRSource{
 		Number:           input.Number,
@@ -1826,7 +1836,10 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 					slog.Warn("sync after workflow approval failure", "err", syncErr)
 				}
 			}
-			return nil, huma.Error502BadGateway(err.Error())
+			return nil, problemUpstream(
+				err.Error(),
+				string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			)
 		}
 		approvedCount++
 	}
@@ -1868,7 +1881,7 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityReadyForReview)
 	}
 
 	pr, err := mutator.MarkReadyForReview(ctx, platformRepoRefFromDB(*repo), input.Number)
@@ -1908,10 +1921,16 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 			"number", input.Number,
 			"err", err,
 		)
-		return nil, huma.Error502BadGateway(err.Error())
+		return nil, problemUpstream(
+			err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 	if pr.Number == 0 {
-		return nil, huma.Error502BadGateway("provider API returned no pull request")
+		return nil, problemUpstream(
+			"provider API returned no pull request",
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	if repo != nil {
@@ -1927,7 +1946,11 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutput, error) {
 	validMethods := map[string]bool{"merge": true, "squash": true, "rebase": true}
 	if !validMethods[input.Body.Method] {
-		return nil, huma.Error400BadRequest("invalid merge method: must be merge, squash, or rebase")
+		return nil, problemValidation(
+			"body.method",
+			"invalid merge method: must be merge, squash, or rebase",
+			"merge", "squash", "rebase",
+		)
 	}
 
 	repo, err := s.requireRepoRouteCapability(
@@ -1943,7 +1966,7 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityMergeMutation)
 	}
 
 	result, err := mutator.MergeMergeRequest(
@@ -1973,21 +1996,27 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 						slog.Warn("background sync after merge failure", "err", syncErr)
 					}
 				})
-				return nil, huma.Error409Conflict(message)
+				return nil, problemConflict(CodeConflict, message, nil)
 			}
 
 			// Forward 4xx provider errors as-is so the user sees the real cause
 			// (e.g. 422 validation, 403 forbidden). 5xx becomes 502.
 			if status >= 400 && status < 500 {
-				return nil, huma.NewError(status, message)
+				return nil, newProblem(status, codeForStatus(status), message, nil)
 			}
-			return nil, huma.Error502BadGateway("provider merge error: " + message)
+			return nil, problemUpstream(
+				"provider merge error: "+message,
+				string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			)
 		}
 		slog.Error("provider merge transport error",
 			"owner", input.Owner, "repo", input.Name,
 			"number", input.Number, "method", input.Body.Method,
 			"err", err)
-		return nil, huma.Error502BadGateway("provider merge error: " + err.Error())
+		return nil, problemUpstream(
+			"provider merge error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	now := s.now().UTC()
@@ -2060,8 +2089,10 @@ func (s *Server) setPRGitHubState(
 	ctx context.Context, input *githubStateInput,
 ) (*githubStateOutput, error) {
 	if input.Body.State != "open" && input.Body.State != "closed" {
-		return nil, huma.Error400BadRequest(
+		return nil, problemValidation(
+			"body.state",
 			"state must be 'open' or 'closed'",
+			"open", "closed",
 		)
 	}
 
@@ -2078,21 +2109,21 @@ func (s *Server) setPRGitHubState(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityStateMutation)
 	}
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get pull request: " + err.Error(),
-		)
+		return nil, problemInternal("get pull request: " + err.Error())
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 	if mr.State == "merged" {
-		return nil, huma.Error409Conflict(
+		return nil, problemConflict(
+			CodeConflict,
 			"cannot change state of a merged pull request",
+			nil,
 		)
 	}
 
@@ -2107,23 +2138,31 @@ func (s *Server) setPRGitHubState(
 			{
 				client, clientErr := s.syncer.ClientForHost(repo.PlatformHost)
 				if clientErr != nil {
-					return nil, huma.Error404NotFound(clientErr.Error())
+					return nil, unsupportedCapabilityProblem(*repo, capabilityStateMutation)
 				}
 				ghPR, fetchErr := client.GetPullRequest(
 					ctx, input.Owner, input.Name, input.Number,
 				)
 				if fetchErr == nil {
 					if ghPR == nil {
-						return nil, huma.Error502BadGateway("GitHub API returned no pull request")
+						return nil, problemUpstream(
+							"GitHub API returned no pull request",
+							string(repoProviderKind(*repo)), repoProviderHost(*repo),
+						)
 					}
 					normalized, normalizeErr := ghclient.NormalizePR(repoID, ghPR)
 					if normalizeErr != nil {
-						return nil, huma.Error502BadGateway("GitHub API error: " + normalizeErr.Error())
+						return nil, problemUpstream(
+							"GitHub API error: "+normalizeErr.Error(),
+							string(repoProviderKind(*repo)), repoProviderHost(*repo),
+						)
 					}
 					_, _ = s.db.UpsertMergeRequest(ctx, normalized)
 					if ghPR.GetMerged() {
-						return nil, huma.Error409Conflict(
+						return nil, problemConflict(
+							CodeConflict,
 							"cannot change state of a merged pull request",
+							nil,
 						)
 					}
 					// Already in requested state (concurrent edit).
@@ -2135,8 +2174,9 @@ func (s *Server) setPRGitHubState(
 				}
 			}
 		}
-		return nil, huma.Error502BadGateway(
-			"GitHub API error: " + err.Error(),
+		return nil, problemUpstream(
+			"GitHub API error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
 		)
 	}
 
@@ -2151,9 +2191,7 @@ func (s *Server) setPRGitHubState(
 		ctx, repoID, input.Number,
 		input.Body.State, nil, closedAt,
 	); err != nil {
-		return nil, huma.Error500InternalServerError(
-			"update mr state: " + err.Error(),
-		)
+		return nil, problemInternal("update mr state: " + err.Error())
 	}
 
 	out := &githubStateOutput{}
@@ -2165,8 +2203,10 @@ func (s *Server) setIssueGitHubState(
 	ctx context.Context, input *githubStateInput,
 ) (*githubStateOutput, error) {
 	if input.Body.State != "open" && input.Body.State != "closed" {
-		return nil, huma.Error400BadRequest(
+		return nil, problemValidation(
+			"body.state",
 			"state must be 'open' or 'closed'",
+			"open", "closed",
 		)
 	}
 
@@ -2180,17 +2220,17 @@ func (s *Server) setIssueGitHubState(
 	}
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get issue: " + err.Error())
+		return nil, problemInternal("get issue: " + err.Error())
 	}
 	if issue == nil {
-		return nil, huma.Error404NotFound("issue not found")
+		return nil, problemNotFound(CodeIssueNotFound, "issue not found", nil)
 	}
 
 	mutator, err := s.syncer.StateMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, huma.Error404NotFound(err.Error())
+		return nil, unsupportedCapabilityProblem(*repo, capabilityStateMutation)
 	}
 
 	if _, err := mutator.SetIssueState(
@@ -2203,20 +2243,26 @@ func (s *Server) setIssueGitHubState(
 			// requested state (concurrent edit), treat as success.
 			client, clientErr := s.syncer.ClientForHost(repo.PlatformHost)
 			if clientErr != nil {
-				return nil, huma.Error404NotFound(clientErr.Error())
+				return nil, unsupportedCapabilityProblem(*repo, capabilityStateMutation)
 			}
 			ghIssue, fetchErr := client.GetIssue(
 				ctx, input.Owner, input.Name, input.Number,
 			)
 			if fetchErr == nil {
 				if ghIssue == nil {
-					return nil, huma.Error502BadGateway("GitHub API returned no issue")
+					return nil, problemUpstream(
+						"GitHub API returned no issue",
+						string(repoProviderKind(*repo)), repoProviderHost(*repo),
+					)
 				}
 				normalized, normalizeErr := ghclient.NormalizeIssue(
 					repo.ID, ghIssue,
 				)
 				if normalizeErr != nil {
-					return nil, huma.Error502BadGateway("GitHub API error: " + normalizeErr.Error())
+					return nil, problemUpstream(
+						"GitHub API error: "+normalizeErr.Error(),
+						string(repoProviderKind(*repo)), repoProviderHost(*repo),
+					)
 				}
 				_, _ = s.db.UpsertIssue(ctx, normalized)
 				if ghIssue.GetState() == input.Body.State {
@@ -2226,8 +2272,9 @@ func (s *Server) setIssueGitHubState(
 				}
 			}
 		}
-		return nil, huma.Error502BadGateway(
-			"GitHub API error: " + err.Error(),
+		return nil, problemUpstream(
+			"GitHub API error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
 		)
 	}
 
@@ -2240,9 +2287,7 @@ func (s *Server) setIssueGitHubState(
 		ctx, repo.ID, issue.Number,
 		input.Body.State, closedAt,
 	); err != nil {
-		return nil, huma.Error500InternalServerError(
-			"update issue state: " + err.Error(),
-		)
+		return nil, problemInternal("update issue state: " + err.Error())
 	}
 
 	out := &githubStateOutput{}
@@ -2253,7 +2298,7 @@ func (s *Server) setIssueGitHubState(
 func (s *Server) listRepos(ctx context.Context, _ *struct{}) (*listReposOutput, error) {
 	repos, err := s.db.ListRepos(ctx)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("list repos failed")
+		return nil, problemInternal("list repos failed")
 	}
 	if repos == nil {
 		repos = []db.Repo{}
@@ -2275,9 +2320,7 @@ func (s *Server) listRepoSummaries(
 ) (*listRepoSummariesOutput, error) {
 	summaries, err := s.db.ListRepoSummaries(ctx)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"list repo summaries failed",
-		)
+		return nil, problemInternal("list repo summaries failed")
 	}
 	if s.cfg != nil {
 		summaries = s.filterConfiguredRepoSummaries(summaries)
@@ -2360,10 +2403,10 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get pull request: " + err.Error())
+		return nil, problemInternal("get pull request: " + err.Error())
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
@@ -2383,15 +2426,18 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 		mr.PlatformHeadSHA,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("refresh PR CI: " + err.Error())
+		return nil, problemUpstream(
+			"refresh PR CI: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get pull request: " + err.Error())
+		return nil, problemInternal("get pull request: " + err.Error())
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found after CI refresh")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found after CI refresh", nil)
 	}
 	body, err := s.buildPullDetailResponse(ctx, mr)
 	if err != nil {
@@ -2420,17 +2466,20 @@ func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROut
 	)
 	if syncErr != nil && !errors.As(syncErr, &diffErr) {
 		if strings.Contains(syncErr.Error(), "is not tracked") {
-			return nil, huma.Error403Forbidden(syncErr.Error())
+			return nil, problemForbidden(syncErr.Error(), nil)
 		}
-		return nil, huma.Error502BadGateway("sync PR: " + syncErr.Error())
+		return nil, problemUpstream(
+			"sync PR: "+syncErr.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get pull request: " + err.Error())
+		return nil, problemInternal("get pull request: " + err.Error())
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull request not found after sync")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found after sync", nil)
 	}
 
 	body, err := s.buildPullDetailResponse(ctx, mr)
@@ -2498,22 +2547,25 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "is not tracked") {
-			return nil, huma.Error403Forbidden(err.Error())
+			return nil, problemForbidden(err.Error(), nil)
 		}
-		return nil, huma.Error502BadGateway("sync issue: " + err.Error())
+		return nil, problemUpstream(
+			"sync issue: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get issue: " + err.Error())
+		return nil, problemInternal("get issue: " + err.Error())
 	}
 	if issue == nil {
-		return nil, huma.Error404NotFound("issue not found after sync")
+		return nil, problemNotFound(CodeIssueNotFound, "issue not found after sync", nil)
 	}
 
 	events, err := s.db.ListIssueEvents(ctx, issue.ID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("list issue events: " + err.Error())
+		return nil, problemInternal("list issue events: " + err.Error())
 	}
 	if events == nil {
 		events = []db.IssueEvent{}
@@ -2588,7 +2640,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 	if input.Since != "" {
 		t, err := time.Parse(time.RFC3339, input.Since)
 		if err != nil {
-			return nil, huma.Error400BadRequest("invalid since: " + err.Error())
+			return nil, problemValidation("query.since", "invalid since: "+err.Error())
 		}
 		opts.Since = &t
 	} else {
@@ -2599,7 +2651,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 	if input.After != "" {
 		t, source, sourceID, err := db.DecodeCursor(input.After)
 		if err != nil {
-			return nil, huma.Error400BadRequest("invalid after cursor: " + err.Error())
+			return nil, problemValidation("query.after", "invalid after cursor: "+err.Error())
 		}
 		opts.AfterTime = &t
 		opts.AfterSource = source
@@ -2609,7 +2661,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 	items, err := s.db.ListActivity(ctx, opts)
 	if err != nil {
 		slog.Error("list activity failed", "err", err)
-		return nil, huma.Error500InternalServerError("list activity failed")
+		return nil, problemInternal("list activity failed")
 	}
 
 	if s.cfg != nil {
@@ -2693,9 +2745,7 @@ func (s *Server) resolveItem(
 	}
 	itemType, found, err := s.db.ResolveItemNumber(ctx, repo.ID, number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"resolve item: " + err.Error(),
-		)
+		return nil, problemInternal("resolve item: " + err.Error())
 	}
 	if found {
 		return &resolveItemOutput{
@@ -2708,7 +2758,7 @@ func (s *Server) resolveItem(
 	}
 
 	if repoProviderKind(*repo) != platform.KindGitHub {
-		return nil, huma.Error404NotFound("item not found")
+		return nil, problemNotFound(CodeNotFound, "item not found", nil)
 	}
 
 	itemType, err = s.syncer.SyncItemByNumber(
@@ -2726,17 +2776,15 @@ func (s *Server) resolveItem(
 		if errors.As(err, &ghErr) {
 			if ghErr.Response != nil &&
 				ghErr.Response.StatusCode == 404 {
-				return nil, huma.Error404NotFound(
-					"item not found: " + err.Error(),
-				)
+				return nil, problemNotFound(CodeNotFound,
+					"item not found: "+err.Error(), nil)
 			}
-			return nil, huma.Error502BadGateway(
-				"GitHub API error: " + err.Error(),
+			return nil, problemUpstream(
+				"GitHub API error: "+err.Error(),
+				string(repoProviderKind(*repo)), repoProviderHost(*repo),
 			)
 		}
-		return nil, huma.Error500InternalServerError(
-			"resolve item: " + err.Error(),
-		)
+		return nil, problemInternal("resolve item: " + err.Error())
 	}
 	if diffErr != nil {
 		slog.Warn("resolve item: diff sync failed but PR row was synced",
@@ -2758,7 +2806,8 @@ func (s *Server) resolveItem(
 
 func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (int64, error) {
 	if !validateStarredRequest(body) {
-		return 0, huma.Error400BadRequest("item_type must be 'pr' or 'issue'")
+		return 0, problemValidation("body.item_type",
+			"item_type must be 'pr' or 'issue'", "pr", "issue")
 	}
 
 	var (
@@ -2774,9 +2823,9 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 	}
 	if err != nil {
 		if errors.Is(err, errRepoNotFound) {
-			return 0, huma.Error404NotFound(err.Error())
+			return 0, problemNotFound(CodeRepoNotFound, err.Error(), nil)
 		}
-		return 0, huma.Error500InternalServerError("repo lookup failed")
+		return 0, problemInternal("repo lookup failed")
 	}
 
 	return repoID, nil
@@ -2788,7 +2837,7 @@ type getCommitsOutput = bodyOutput[commitsResponse]
 
 func (s *Server) getCommits(ctx context.Context, input *repoNumberInput) (*getCommitsOutput, error) {
 	if s.clones == nil {
-		return nil, huma.Error503ServiceUnavailable("commits not available: clone manager not configured")
+		return nil, problemServiceUnavailable("commits not available: clone manager not configured")
 	}
 
 	repo, err := s.lookupRepoByProviderRoute(
@@ -2799,22 +2848,25 @@ func (s *Server) getCommits(ctx context.Context, input *repoNumberInput) (*getCo
 	}
 	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to look up PR")
+		return nil, problemInternal("failed to look up PR")
 	}
 	if shas == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 	if shas.DiffHeadSHA == "" || shas.MergeBaseSHA == "" {
-		return nil, huma.Error404NotFound("commits not available for this pull request")
+		return nil, problemNotFound(CodeNotFound, "commits not available for this pull request", nil)
 	}
 
 	host := repoProviderHost(*repo)
 	commits, err := s.clones.ListCommits(ctx, host, repo.Owner, repo.Name, shas.MergeBaseSHA, shas.DiffHeadSHA)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
-			return nil, huma.Error404NotFound("commits not available: referenced commit not found")
+			return nil, problemNotFound(CodeNotFound, "commits not available: referenced commit not found", nil)
 		}
-		return nil, huma.Error502BadGateway("failed to list commits: " + err.Error())
+		return nil, problemUpstream(
+			"failed to list commits: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 
 	resp := commitsResponse{Commits: make([]commitResponse, len(commits))}
@@ -2866,13 +2918,13 @@ func (s *Server) resolveDiffRange(
 	}
 	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to look up PR")
+		return nil, problemInternal("failed to look up PR")
 	}
 	if shas == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 	if shas.DiffHeadSHA == "" || shas.MergeBaseSHA == "" {
-		return nil, huma.Error404NotFound("diff not available for this pull request")
+		return nil, problemNotFound(CodeNotFound, "diff not available for this pull request", nil)
 	}
 
 	host := repoProviderHost(*repo)
@@ -2893,7 +2945,7 @@ func (s *Server) resolveDiffRange(
 		}
 		parent, err := s.clones.ParentOf(ctx, host, repo.Owner, repo.Name, input.Commit)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("failed to resolve parent: " + err.Error())
+			return nil, problemInternal("failed to resolve parent: " + err.Error())
 		}
 		diffFrom = parent
 		diffTo = input.Commit
@@ -2905,17 +2957,17 @@ func (s *Server) resolveDiffRange(
 		}
 		// In newest-first order, "from" (older) must have a higher index than "to" (newer).
 		if indexMap[input.From] <= indexMap[input.To] {
-			return nil, huma.Error400BadRequest("invalid range: 'from' must be older than 'to'")
+			return nil, problemValidation("query", "invalid range: 'from' must be older than 'to'")
 		}
 		parent, err := s.clones.ParentOf(ctx, host, repo.Owner, repo.Name, input.From)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("failed to resolve parent: " + err.Error())
+			return nil, problemInternal("failed to resolve parent: " + err.Error())
 		}
 		diffFrom = parent
 		diffTo = input.To
 
 	default:
-		return nil, huma.Error400BadRequest("invalid scope: use 'commit' alone or 'from'+'to' together")
+		return nil, problemValidation("query", "invalid scope: use 'commit' alone or 'from'+'to' together")
 	}
 
 	return &resolvedDiffRange{
@@ -2930,7 +2982,7 @@ func (s *Server) resolveDiffRange(
 
 func (s *Server) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOutput, error) {
 	if s.clones == nil {
-		return nil, huma.Error503ServiceUnavailable("diff view not available: clone manager not configured")
+		return nil, problemServiceUnavailable("diff view not available: clone manager not configured")
 	}
 
 	resolved, err := s.resolveDiffRange(ctx, input)
@@ -2942,10 +2994,10 @@ func (s *Server) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOutp
 	result, err := s.clones.Diff(ctx, resolved.host, resolved.owner, resolved.name, resolved.fromSHA, resolved.toSHA, hideWhitespace)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
-			return nil, huma.Error404NotFound("diff not available: referenced commit not found")
+			return nil, problemNotFound(CodeNotFound, "diff not available: referenced commit not found", nil)
 		}
 		slog.Error("failed to compute diff", "owner", input.Owner, "name", input.Name, "number", input.Number, "err", err)
-		return nil, huma.Error502BadGateway("failed to compute diff")
+		return nil, problemUpstream("failed to compute diff", "", "")
 	}
 
 	result.Stale = resolved.diffSHAs.Stale()
@@ -2977,10 +3029,10 @@ type getFilePreviewOutput = bodyOutput[filePreviewResponse]
 
 func (s *Server) getFilePreview(ctx context.Context, input *getFilePreviewInput) (*getFilePreviewOutput, error) {
 	if s.clones == nil {
-		return nil, huma.Error503ServiceUnavailable("file preview not available: clone manager not configured")
+		return nil, problemServiceUnavailable("file preview not available: clone manager not configured")
 	}
 	if strings.TrimSpace(input.Path) == "" {
-		return nil, huma.Error400BadRequest("path is required")
+		return nil, problemValidation("query.path", "path is required")
 	}
 
 	resolved, err := s.resolveDiffRange(ctx, &getDiffInput{
@@ -3009,10 +3061,10 @@ func (s *Server) getFilePreview(ctx context.Context, input *getFilePreviewInput)
 	)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
-			return nil, huma.Error404NotFound("file preview not available: referenced commit not found")
+			return nil, problemNotFound(CodeNotFound, "file preview not available: referenced commit not found", nil)
 		}
 		slog.Error("failed to validate preview path", "owner", input.Owner, "name", input.Name, "number", input.Number, "path", input.Path, "err", err)
-		return nil, huma.Error502BadGateway("failed to validate file preview")
+		return nil, problemUpstream("failed to validate file preview", "", "")
 	}
 	found := false
 	for _, file := range files {
@@ -3030,7 +3082,7 @@ func (s *Server) getFilePreview(ctx context.Context, input *getFilePreviewInput)
 		break
 	}
 	if !found {
-		return nil, huma.Error404NotFound("file preview not available: file is not changed in this diff")
+		return nil, problemNotFound(CodeNotFound, "file preview not available: file is not changed in this diff", nil)
 	}
 
 	content, err := s.clones.FileContent(
@@ -3044,13 +3096,13 @@ func (s *Server) getFilePreview(ctx context.Context, input *getFilePreviewInput)
 	)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
-			return nil, huma.Error404NotFound("file preview not available: referenced file not found")
+			return nil, problemNotFound(CodeNotFound, "file preview not available: referenced file not found", nil)
 		}
 		if errors.Is(err, gitclone.ErrTooLarge) {
-			return nil, huma.Error413RequestEntityTooLarge("file preview is too large")
+			return nil, problemPayloadTooLarge("file preview is too large", maxFilePreviewBytes)
 		}
 		slog.Error("failed to read file preview", "owner", input.Owner, "name", input.Name, "number", input.Number, "path", input.Path, "err", err)
-		return nil, huma.Error502BadGateway("failed to read file preview")
+		return nil, problemUpstream("failed to read file preview", "", "")
 	}
 
 	return &getFilePreviewOutput{Body: filePreviewResponse{
@@ -3097,7 +3149,7 @@ type getFilesOutput = bodyOutput[filesResponse]
 
 func (s *Server) getFiles(ctx context.Context, input *getFilesInput) (*getFilesOutput, error) {
 	if s.clones == nil {
-		return nil, huma.Error503ServiceUnavailable("files view not available: clone manager not configured")
+		return nil, problemServiceUnavailable("files view not available: clone manager not configured")
 	}
 
 	repo, err := s.lookupRepoByProviderRoute(
@@ -3108,23 +3160,23 @@ func (s *Server) getFiles(ctx context.Context, input *getFilesInput) (*getFilesO
 	}
 	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to look up PR")
+		return nil, problemInternal("failed to look up PR")
 	}
 	if shas == nil {
-		return nil, huma.Error404NotFound("pull request not found")
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 	if shas.DiffHeadSHA == "" || shas.MergeBaseSHA == "" {
-		return nil, huma.Error404NotFound("file list not available for this pull request")
+		return nil, problemNotFound(CodeNotFound, "file list not available for this pull request", nil)
 	}
 
 	host := repoProviderHost(*repo)
 	files, err := s.clones.DiffFiles(ctx, host, repo.Owner, repo.Name, shas.MergeBaseSHA, shas.DiffHeadSHA)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
-			return nil, huma.Error404NotFound("file list not available: referenced commit not found")
+			return nil, problemNotFound(CodeNotFound, "file list not available: referenced commit not found", nil)
 		}
 		slog.Error("failed to list files", "owner", input.Owner, "name", input.Name, "number", input.Number, "err", err)
-		return nil, huma.Error502BadGateway("failed to list files")
+		return nil, problemUpstream("failed to list files", "", "")
 	}
 
 	return &getFilesOutput{Body: filesResponse{
@@ -3144,7 +3196,7 @@ func (s *Server) validateSHAs(
 ) (map[string]int, error) {
 	commits, err := s.clones.ListCommits(ctx, host, input.Owner, input.Name, shas.MergeBaseSHA, shas.DiffHeadSHA)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to list commits for validation: " + err.Error())
+		return nil, problemInternal("failed to list commits for validation: " + err.Error())
 	}
 	indexMap := make(map[string]int, len(commits))
 	for i, c := range commits {
@@ -3152,7 +3204,7 @@ func (s *Server) validateSHAs(
 	}
 	for _, sha := range userSHAs {
 		if _, ok := indexMap[sha]; !ok {
-			return nil, huma.Error400BadRequest("sha not in pull request: " + sha)
+			return nil, problemValidation("query", "sha not in pull request: "+sha)
 		}
 	}
 	return indexMap, nil
@@ -3163,16 +3215,16 @@ func (s *Server) validateSHAs(
 func (s *Server) listStacks(ctx context.Context, input *listStacksInput) (*listStacksOutput, error) {
 	if input.Repo != "" {
 		if strings.Count(input.Repo, "/") != 1 {
-			return nil, huma.Error400BadRequest("invalid repo filter: expected owner/name")
+			return nil, problemValidation("query.repo", "invalid repo filter: expected owner/name")
 		}
 		owner, name, _ := strings.Cut(input.Repo, "/")
 		if owner == "" || name == "" {
-			return nil, huma.Error400BadRequest("invalid repo filter: expected owner/name")
+			return nil, problemValidation("query.repo", "invalid repo filter: expected owner/name")
 		}
 	}
 	stackList, memberMap, err := s.db.ListStacksWithMembers(ctx, input.Repo)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("list stacks failed")
+		return nil, problemInternal("list stacks failed")
 	}
 
 	out := make([]stackResponse, 0, len(stackList))
@@ -3200,10 +3252,10 @@ func (s *Server) getStackForPR(ctx context.Context, input *repoNumberInput) (*ge
 	}
 	stack, members, err := s.db.GetStackForPRByRepoID(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get stack for pr failed")
+		return nil, problemInternal("get stack for pr failed")
 	}
 	if stack == nil {
-		return nil, huma.Error404NotFound("PR is not part of a stack")
+		return nil, problemNotFound(CodeNotFound, "PR is not part of a stack", nil)
 	}
 
 	var position int
@@ -3237,9 +3289,7 @@ func (s *Server) createWorkspace(
 	ctx context.Context, input *createWorkspaceInput,
 ) (*createWorkspaceOutput, error) {
 	if s.workspaces == nil {
-		return nil, huma.Error503ServiceUnavailable(
-			"workspace manager not configured",
-		)
+		return nil, problemServiceUnavailable("workspace manager not configured")
 	}
 
 	ws, err := s.workspaces.Create(
@@ -3251,32 +3301,26 @@ func (s *Server) createWorkspace(
 	)
 	if err != nil {
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
+			return nil, problemNotFound(CodeWorkspaceNotFound, err.Error(), nil)
 		}
 		if errors.Is(err, workspace.ErrWorkspaceNotSynced) {
-			return nil, huma.Error404NotFound(err.Error())
+			return nil, problemNotFound(CodeWorkspaceNotFound, err.Error(), nil)
 		}
 		if errors.Is(err, workspace.ErrWorkspaceDuplicate) {
-			return nil, huma.Error409Conflict(
-				"workspace already exists for this MR")
+			return nil, problemConflict(CodeConflict,
+				"workspace already exists for this MR", nil)
 		}
-		return nil, huma.Error500InternalServerError(
-			"create workspace: " + err.Error(),
-		)
+		return nil, problemInternal("create workspace: " + err.Error())
 	}
 
 	s.runWorkspaceSetup(ws)
 
 	summary, err := s.workspaces.GetSummary(ctx, ws.ID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get workspace summary: " + err.Error(),
-		)
+		return nil, problemInternal("get workspace summary: " + err.Error())
 	}
 	if summary == nil {
-		return nil, huma.Error500InternalServerError(
-			"workspace summary missing after create",
-		)
+		return nil, problemInternal("workspace summary missing after create")
 	}
 	return &createWorkspaceOutput{
 		Status: http.StatusAccepted,
@@ -3368,9 +3412,7 @@ func (s *Server) createIssueWorkspace(
 	ctx context.Context, input *createIssueWorkspaceInput,
 ) (*createWorkspaceOutput, error) {
 	if s.workspaces == nil {
-		return nil, huma.Error503ServiceUnavailable(
-			"workspace manager not configured",
-		)
+		return nil, problemServiceUnavailable("workspace manager not configured")
 	}
 	repo, err := s.lookupRepoByProviderRoute(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
@@ -3387,21 +3429,15 @@ func (s *Server) createIssueWorkspace(
 		input.Number,
 	)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"lookup existing issue workspace: " + err.Error(),
-		)
+		return nil, problemInternal("lookup existing issue workspace: " + err.Error())
 	}
 	if existing != nil {
 		summary, getErr := s.workspaces.GetSummary(ctx, existing.ID)
 		if getErr != nil {
-			return nil, huma.Error500InternalServerError(
-				"get workspace summary: " + getErr.Error(),
-			)
+			return nil, problemInternal("get workspace summary: " + getErr.Error())
 		}
 		if summary == nil {
-			return nil, huma.Error500InternalServerError(
-				"workspace summary missing for existing workspace",
-			)
+			return nil, problemInternal("workspace summary missing for existing workspace")
 		}
 		return &createWorkspaceOutput{
 			Status: http.StatusAccepted,
@@ -3424,34 +3460,44 @@ func (s *Server) createIssueWorkspace(
 		msg := err.Error()
 		var branchConflict *workspace.IssueWorkspaceBranchConflictError
 		if errors.As(err, &branchConflict) {
-			conflict := &huma.ErrorModel{
-				Type:   issueWorkspaceBranchConflictType,
-				Title:  "Issue workspace branch conflict",
-				Status: http.StatusConflict,
-				Detail: "A local branch with the requested name already exists.",
-				Errors: []*huma.ErrorDetail{
-					{
-						Message:  "Requested branch already exists",
-						Location: "body.git_head_ref",
-						Value:    branchConflict.Branch,
-					},
-					{
-						Message:  "Suggested alternative branch name",
-						Location: "body.suggested_git_head_ref",
-						Value:    branchConflict.SuggestedBranch,
-					},
+			// Branch-conflict gets the typed problem envelope with
+			// Type carrying the URN and Details carrying the conflicting
+			// branch + suggested alternative. The legacy Errors[]
+			// entries are populated for callers still introspecting
+			// per-field huma error details.
+			conflict := newProblem(
+				http.StatusConflict,
+				CodeBranchConflict,
+				"A local branch with the requested name already exists.",
+				map[string]any{
+					"branch":          branchConflict.Branch,
+					"suggestedBranch": branchConflict.SuggestedBranch,
+				},
+			)
+			conflict.Type = issueWorkspaceBranchConflictType
+			conflict.Title = "Issue workspace branch conflict"
+			conflict.Errors = []*huma.ErrorDetail{
+				{
+					Message:  "Requested branch already exists",
+					Location: "body.git_head_ref",
+					Value:    branchConflict.Branch,
+				},
+				{
+					Message:  "Suggested alternative branch name",
+					Location: "body.suggested_git_head_ref",
+					Value:    branchConflict.SuggestedBranch,
 				},
 			}
 			return nil, conflict
 		}
 		if strings.Contains(msg, "not tracked") {
-			return nil, huma.Error404NotFound(msg)
+			return nil, problemNotFound(CodeNotFound, msg, nil)
 		}
 		if strings.Contains(msg, "not synced") {
-			return nil, huma.Error404NotFound(msg)
+			return nil, problemNotFound(CodeNotFound, msg, nil)
 		}
 		if strings.Contains(msg, "invalid branch name") {
-			return nil, huma.Error400BadRequest(msg)
+			return nil, problemValidation("body.git_head_ref", msg)
 		}
 		if strings.Contains(msg, "UNIQUE constraint") {
 			existing, getErr := s.workspaces.GetByIssue(
@@ -3471,23 +3517,17 @@ func (s *Server) createIssueWorkspace(
 				}
 			}
 		}
-		return nil, huma.Error500InternalServerError(
-			"create issue workspace: " + msg,
-		)
+		return nil, problemInternal("create issue workspace: " + msg)
 	}
 
 	s.runWorkspaceSetup(ws)
 
 	summary, err := s.workspaces.GetSummary(ctx, ws.ID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get workspace summary: " + err.Error(),
-		)
+		return nil, problemInternal("get workspace summary: " + err.Error())
 	}
 	if summary == nil {
-		return nil, huma.Error500InternalServerError(
-			"workspace summary missing after create",
-		)
+		return nil, problemInternal("workspace summary missing after create")
 	}
 
 	return &createWorkspaceOutput{
@@ -3516,9 +3556,7 @@ func (s *Server) listWorkspaces(
 
 	summaries, err := s.workspaces.ListSummaries(ctx)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"list workspaces failed",
-		)
+		return nil, problemInternal("list workspaces failed")
 	}
 
 	list := make([]workspaceResponse, len(summaries))
@@ -3564,19 +3602,15 @@ func (s *Server) getWorkspace(
 	ctx context.Context, input *getWorkspaceInput,
 ) (*getWorkspaceOutput, error) {
 	if s.workspaces == nil {
-		return nil, huma.Error503ServiceUnavailable(
-			"workspace manager not configured",
-		)
+		return nil, problemServiceUnavailable("workspace manager not configured")
 	}
 
 	summary, err := s.workspaces.GetSummary(ctx, input.ID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get workspace failed",
-		)
+		return nil, problemInternal("get workspace failed")
 	}
 	if summary == nil {
-		return nil, huma.Error404NotFound("workspace not found")
+		return nil, problemNotFound(CodeWorkspaceNotFound, "workspace not found", nil)
 	}
 
 	return &getWorkspaceOutput{
@@ -3599,12 +3633,11 @@ func (s *Server) getWorkspaceCommits(
 			"workspace_id", input.ID,
 			"err", err,
 		)
-		return nil, huma.Error502BadGateway("failed to list workspace commits")
+		return nil, problemUpstream("failed to list workspace commits", "", "")
 	}
 	if !ok {
-		return nil, huma.Error404NotFound(
-			"commits not available for this workspace",
-		)
+		return nil, problemNotFound(CodeNotFound,
+			"commits not available for this workspace", nil)
 	}
 
 	resp := commitsResponse{Commits: make([]commitResponse, len(commits))}
@@ -3643,9 +3676,7 @@ func (s *Server) getWorkspaceFiles(
 			"base", req.Base,
 			"err", diffErr,
 		)
-		return nil, huma.Error502BadGateway(
-			"failed to list workspace files",
-		)
+		return nil, problemUpstream("failed to list workspace files", "", "")
 	}
 	if !ok {
 		return nil, workspaceDiffBaseUnavailable(req.Base)
@@ -3695,9 +3726,7 @@ func (s *Server) getWorkspaceDiff(
 			"base", req.Base,
 			"err", diffErr,
 		)
-		return nil, huma.Error502BadGateway(
-			"failed to compute workspace diff",
-		)
+		return nil, problemUpstream("failed to compute workspace diff", "", "")
 	}
 	if !ok {
 		return nil, workspaceDiffBaseUnavailable(req.Base)
@@ -3715,23 +3744,23 @@ func (s *Server) workspaceDiffRequest(
 	baseInput string,
 ) (workspaceDiffRequest, error) {
 	if s.workspaces == nil {
-		return workspaceDiffRequest{}, huma.Error503ServiceUnavailable(
+		return workspaceDiffRequest{}, problemServiceUnavailable(
 			"workspace manager not configured",
 		)
 	}
 
 	summary, err := s.workspaces.GetSummary(ctx, id)
 	if err != nil {
-		return workspaceDiffRequest{}, huma.Error500InternalServerError(
-			"get workspace failed",
-		)
+		return workspaceDiffRequest{}, problemInternal("get workspace failed")
 	}
 	if summary == nil {
-		return workspaceDiffRequest{}, huma.Error404NotFound("workspace not found")
+		return workspaceDiffRequest{}, problemNotFound(
+			CodeWorkspaceNotFound, "workspace not found", nil,
+		)
 	}
 	if summary.Status != "ready" {
-		return workspaceDiffRequest{}, huma.Error409Conflict(
-			"workspace is not ready",
+		return workspaceDiffRequest{}, problemConflict(
+			CodeConflict, "workspace is not ready", nil,
 		)
 	}
 
@@ -3756,8 +3785,10 @@ func (s *Server) workspaceDiffRequest(
 			MergeTargetBranch: targetBranch,
 		}, nil
 	default:
-		return workspaceDiffRequest{}, huma.Error400BadRequest(
+		return workspaceDiffRequest{}, problemValidation(
+			"query.base",
 			"base must be head, pushed, or merge-target",
+			"head", "pushed", "merge-target",
 		)
 	}
 }
@@ -3800,9 +3831,7 @@ func (s *Server) applyWorkspaceDiffScope(
 			ctx, req.Summary.WorktreePath, commit,
 		)
 		if err != nil {
-			return huma.Error500InternalServerError(
-				"failed to resolve parent: " + err.Error(),
-			)
+			return problemInternal("failed to resolve parent: " + err.Error())
 		}
 		req.FromSHA = parent
 		req.ToSHA = commit
@@ -3814,7 +3843,7 @@ func (s *Server) applyWorkspaceDiffScope(
 			return err
 		}
 		if indexMap[from] < indexMap[to] {
-			return huma.Error400BadRequest(
+			return problemValidation("query",
 				"invalid range: 'from' must be older than or equal to 'to'",
 			)
 		}
@@ -3822,16 +3851,14 @@ func (s *Server) applyWorkspaceDiffScope(
 			ctx, req.Summary.WorktreePath, from,
 		)
 		if err != nil {
-			return huma.Error500InternalServerError(
-				"failed to resolve parent: " + err.Error(),
-			)
+			return problemInternal("failed to resolve parent: " + err.Error())
 		}
 		req.FromSHA = parent
 		req.ToSHA = to
 		return nil
 
 	default:
-		return huma.Error400BadRequest(
+		return problemValidation("query",
 			"invalid scope: use 'commit' alone or 'from'+'to' together",
 		)
 	}
@@ -3844,14 +3871,13 @@ func (s *Server) validateWorkspaceSHAs(
 ) (map[string]int, error) {
 	commits, ok, err := s.workspaceCommits(ctx, req)
 	if err != nil {
-		return nil, huma.Error502BadGateway(
-			"failed to list workspace commits: " + err.Error(),
+		return nil, problemUpstream(
+			"failed to list workspace commits: "+err.Error(), "", "",
 		)
 	}
 	if !ok {
-		return nil, huma.Error404NotFound(
-			"commits not available for this workspace",
-		)
+		return nil, problemNotFound(CodeNotFound,
+			"commits not available for this workspace", nil)
 	}
 	indexMap := make(map[string]int, len(commits))
 	for i, c := range commits {
@@ -3859,7 +3885,7 @@ func (s *Server) validateWorkspaceSHAs(
 	}
 	for _, sha := range shas {
 		if _, ok := indexMap[sha]; !ok {
-			return nil, huma.Error400BadRequest(
+			return nil, problemValidation("query",
 				"invalid scope: commit is not in this workspace branch",
 			)
 		}
@@ -3989,9 +4015,7 @@ func (s *Server) workspaceMergeTargetBranch(
 		summary.RepoName,
 	)
 	if err != nil {
-		return "", false, huma.Error500InternalServerError(
-			"get workspace repo failed",
-		)
+		return "", false, problemInternal("get workspace repo failed")
 	}
 	if repo == nil {
 		return "", false, nil
@@ -4001,9 +4025,7 @@ func (s *Server) workspaceMergeTargetBranch(
 		ctx, repo.ID, prNumber,
 	)
 	if err != nil {
-		return "", false, huma.Error500InternalServerError(
-			"get workspace pull request failed",
-		)
+		return "", false, problemInternal("get workspace pull request failed")
 	}
 	if mr == nil || strings.TrimSpace(mr.BaseBranch) == "" {
 		return "", false, nil
@@ -4015,35 +4037,29 @@ func workspaceDiffBaseUnavailable(
 	base workspace.WorktreeDiffBase,
 ) error {
 	if base == workspace.WorktreeDiffBaseMergeTarget {
-		return huma.Error404NotFound(
-			"workspace merge target branch not available",
-		)
+		return problemNotFound(CodeNotFound,
+			"workspace merge target branch not available", nil)
 	}
-	return huma.Error404NotFound(
-		"workspace pushed branch not available",
-	)
+	return problemNotFound(CodeNotFound,
+		"workspace pushed branch not available", nil)
 }
 
 func (s *Server) retryWorkspace(
 	ctx context.Context, input *retryWorkspaceInput,
 ) (*createWorkspaceOutput, error) {
 	if s.workspaces == nil {
-		return nil, huma.Error503ServiceUnavailable(
-			"workspace manager not configured",
-		)
+		return nil, problemServiceUnavailable("workspace manager not configured")
 	}
 
 	ws, startNow, err := s.workspaces.RequestRetry(ctx, input.ID)
 	if err != nil {
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
+			return nil, problemNotFound(CodeWorkspaceNotFound, err.Error(), nil)
 		}
 		if errors.Is(err, workspace.ErrWorkspaceInvalidState) {
-			return nil, huma.Error409Conflict(err.Error())
+			return nil, problemConflict(CodeConflict, err.Error(), nil)
 		}
-		return nil, huma.Error500InternalServerError(
-			"retry workspace: " + err.Error(),
-		)
+		return nil, problemInternal("retry workspace: " + err.Error())
 	}
 
 	if startNow {
@@ -4052,14 +4068,10 @@ func (s *Server) retryWorkspace(
 
 	summary, err := s.workspaces.GetSummary(ctx, ws.ID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get workspace summary: " + err.Error(),
-		)
+		return nil, problemInternal("get workspace summary: " + err.Error())
 	}
 	if summary == nil {
-		return nil, huma.Error500InternalServerError(
-			"workspace summary missing after retry",
-		)
+		return nil, problemInternal("workspace summary missing after retry")
 	}
 	resp := s.toWorkspaceResponse(ctx, summary)
 	s.hub.Broadcast(Event{
@@ -4307,7 +4319,7 @@ func (s *Server) launchWorkspaceRuntimeSession(
 	}
 	targetKey := strings.TrimSpace(input.Body.TargetKey)
 	if targetKey == "" {
-		return nil, huma.Error400BadRequest("target_key is required")
+		return nil, problemValidation("body.target_key", "target_key is required")
 	}
 
 	if targetKey == string(localruntime.LaunchTargetPlainShell) {
@@ -4315,9 +4327,7 @@ func (s *Server) launchWorkspaceRuntimeSession(
 			ctx, summary.ID, summary.WorktreePath,
 		)
 		if err != nil {
-			return nil, huma.Error500InternalServerError(
-				"ensure shell: " + err.Error(),
-			)
+			return nil, problemInternal("ensure shell: " + err.Error())
 		}
 		return &workspaceRuntimeSessionOutput{Body: session}, nil
 	}
@@ -4334,9 +4344,7 @@ func (s *Server) launchWorkspaceRuntimeSession(
 			session.CreatedAt,
 		); err != nil {
 			_ = s.runtime.Stop(ctx, summary.ID, session.Key)
-			return nil, huma.Error500InternalServerError(
-				"record runtime tmux session: " + err.Error(),
-			)
+			return nil, problemInternal("record runtime tmux session: " + err.Error())
 		}
 		if runtimeSessionTmuxSession(
 			s.runtime.ListSessions(summary.ID), session.Key,
@@ -4345,7 +4353,7 @@ func (s *Server) launchWorkspaceRuntimeSession(
 				ctx, summary.ID, session.TmuxSession,
 				session.CreatedAt,
 			); err != nil {
-				return nil, huma.Error500InternalServerError(
+				return nil, problemInternal(
 					"forget missing runtime tmux session: " + err.Error(),
 				)
 			}
@@ -4376,9 +4384,8 @@ func (s *Server) stopWorkspaceRuntimeSession(
 					ctx, summary.ID, targetKey,
 				)
 				if stopErr != nil {
-					return nil, huma.Error500InternalServerError(
-						"stop stored runtime tmux session: " +
-							stopErr.Error(),
+					return nil, problemInternal(
+						"stop stored runtime tmux session: " + stopErr.Error(),
 					)
 				}
 				if stopped {
@@ -4389,26 +4396,22 @@ func (s *Server) stopWorkspaceRuntimeSession(
 				ctx, summary.ID, input.SessionKey,
 			)
 			if stopErr != nil {
-				return nil, huma.Error500InternalServerError(
+				return nil, problemInternal(
 					"stop stored runtime tmux session: " + stopErr.Error(),
 				)
 			}
 			if stopped {
 				return nil, nil
 			}
-			return nil, huma.Error404NotFound(err.Error())
+			return nil, problemNotFound(CodeNotFound, err.Error(), nil)
 		}
-		return nil, huma.Error500InternalServerError(
-			"stop runtime session: " + err.Error(),
-		)
+		return nil, problemInternal("stop runtime session: " + err.Error())
 	}
 	if tmuxSession != "" {
 		if err := s.workspaces.ForgetRuntimeTmuxSession(
 			ctx, summary.ID, tmuxSession,
 		); err != nil {
-			return nil, huma.Error500InternalServerError(
-				"forget runtime tmux session: " + err.Error(),
-			)
+			return nil, problemInternal("forget runtime tmux session: " + err.Error())
 		}
 	}
 	return nil, nil
@@ -4447,9 +4450,7 @@ func (s *Server) ensureWorkspaceRuntimeShell(
 		ctx, summary.ID, summary.WorktreePath,
 	)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"ensure shell: " + err.Error(),
-		)
+		return nil, problemInternal("ensure shell: " + err.Error())
 	}
 	return &workspaceRuntimeSessionOutput{Body: session}, nil
 }
@@ -4459,24 +4460,19 @@ func (s *Server) getReadyRuntimeWorkspace(
 	id string,
 ) (*db.WorkspaceSummary, error) {
 	if s.workspaces == nil || s.runtime == nil {
-		return nil, huma.Error503ServiceUnavailable(
-			"workspace runtime not configured",
-		)
+		return nil, problemServiceUnavailable("workspace runtime not configured")
 	}
 
 	summary, err := s.workspaces.GetSummary(ctx, id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
-			"get workspace failed",
-		)
+		return nil, problemInternal("get workspace failed")
 	}
 	if summary == nil {
-		return nil, huma.Error404NotFound("workspace not found")
+		return nil, problemNotFound(CodeWorkspaceNotFound, "workspace not found", nil)
 	}
 	if summary.Status != "ready" {
-		return nil, huma.Error409Conflict(
-			"workspace not ready (status: " + summary.Status + ")",
-		)
+		return nil, problemConflict(CodeConflict,
+			"workspace not ready (status: "+summary.Status+")", nil)
 	}
 	return summary, nil
 }
@@ -4484,13 +4480,13 @@ func (s *Server) getReadyRuntimeWorkspace(
 func workspaceRuntimeLaunchError(err error) error {
 	msg := err.Error()
 	if strings.Contains(msg, "target not found") {
-		return huma.Error404NotFound(msg)
+		return problemNotFound(CodeNotFound, msg, nil)
 	}
 	if strings.Contains(msg, "not available") ||
 		strings.Contains(msg, "no command") {
-		return huma.Error400BadRequest(msg)
+		return problemBadRequest(CodeBadRequest, msg, nil)
 	}
-	return huma.Error500InternalServerError("launch session: " + msg)
+	return problemInternal("launch session: " + msg)
 }
 
 // deleteWorkspace tears down a middleman-managed workspace.
@@ -4501,9 +4497,7 @@ func (s *Server) deleteWorkspace(
 	ctx context.Context, input *deleteWorkspaceInput,
 ) (*struct{}, error) {
 	if s.workspaces == nil {
-		return nil, huma.Error503ServiceUnavailable(
-			"workspace manager not configured",
-		)
+		return nil, problemServiceUnavailable("workspace manager not configured")
 	}
 
 	if s.runtime != nil {
@@ -4526,17 +4520,13 @@ func (s *Server) deleteWorkspace(
 	)
 	if err != nil {
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {
-			return nil, huma.Error404NotFound(err.Error())
+			return nil, problemNotFound(CodeWorkspaceNotFound, err.Error(), nil)
 		}
-		return nil, huma.Error500InternalServerError(
-			"delete workspace: " + err.Error(),
-		)
+		return nil, problemInternal("delete workspace: " + err.Error())
 	}
 	if len(dirty) > 0 {
-		return nil, huma.Error409Conflict(
-			"workspace has uncommitted changes: " +
-				strings.Join(dirty, ", "),
-		)
+		return nil, problemConflict(CodeConflict,
+			"workspace has uncommitted changes: "+strings.Join(dirty, ", "), nil)
 	}
 
 	return nil, nil

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1102,9 +1102,10 @@ func (s *Server) editPRContent(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Title, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"provider API error: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"provider API error: "+err.Error(),
 		)
 	}
 
@@ -1183,9 +1184,10 @@ func (s *Server) editIssueContent(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Title, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"provider API error: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"provider API error: "+err.Error(),
 		)
 	}
 
@@ -1249,9 +1251,10 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"create comment on provider failed",
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"create comment on provider failed",
 		)
 	}
 
@@ -1318,9 +1321,10 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.CommentID, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"edit comment on provider failed",
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"edit comment on provider failed",
 		)
 	}
 	platformEvent.MergeRequestNumber = input.Number
@@ -1552,9 +1556,10 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"create comment on provider failed",
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"create comment on provider failed",
 		)
 	}
 
@@ -1622,9 +1627,10 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.CommentID, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"edit comment on provider failed",
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"edit comment on provider failed",
 		)
 	}
 	platformEvent.IssueNumber = input.Number
@@ -1741,9 +1747,10 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Body,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"provider API error",
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"provider API error",
 		)
 	}
 
@@ -1793,9 +1800,10 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 
 	pr, err := client.GetPullRequest(ctx, input.Owner, input.Name, input.Number)
 	if err != nil {
-		return nil, problemUpstream(
-			"GitHub API error",
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"GitHub API error",
 		)
 	}
 	if pr == nil {
@@ -1809,9 +1817,10 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 
 	runs, err := client.ListWorkflowRunsForHeadSHA(ctx, input.Owner, input.Name, headSHA)
 	if err != nil {
-		return nil, problemUpstream(
-			"GitHub API error",
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"GitHub API error",
 		)
 	}
 	pending := ghclient.FilterWorkflowRunsAwaitingApproval(runs, ghclient.PRSource{
@@ -1835,9 +1844,10 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 					slog.Warn("sync after workflow approval failure", "err", syncErr)
 				}
 			}
-			return nil, problemUpstream(
-				err.Error(),
+			return nil, providerCallProblemWithDetail(
+				err,
 				string(repoProviderKind(*repo)), repoProviderHost(*repo),
+				err.Error(),
 			)
 		}
 		approvedCount++
@@ -1920,9 +1930,10 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 			"number", input.Number,
 			"err", err,
 		)
-		return nil, problemUpstream(
-			err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			err.Error(),
 		)
 	}
 	if pr.Number == 0 {
@@ -2012,9 +2023,10 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 			"owner", input.Owner, "repo", input.Name,
 			"number", input.Number, "method", input.Body.Method,
 			"err", err)
-		return nil, problemUpstream(
-			"provider merge error: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"provider merge error: "+err.Error(),
 		)
 	}
 
@@ -2173,9 +2185,10 @@ func (s *Server) setPRGitHubState(
 				}
 			}
 		}
-		return nil, problemUpstream(
-			"GitHub API error: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"GitHub API error: "+err.Error(),
 		)
 	}
 
@@ -2271,9 +2284,10 @@ func (s *Server) setIssueGitHubState(
 				}
 			}
 		}
-		return nil, problemUpstream(
-			"GitHub API error: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"GitHub API error: "+err.Error(),
 		)
 	}
 
@@ -2425,9 +2439,10 @@ func (s *Server) syncPRCI(ctx context.Context, input *repoNumberInput) (*syncPRC
 		mr.PlatformHeadSHA,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"refresh PR CI: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"refresh PR CI: "+err.Error(),
 		)
 	}
 
@@ -2467,9 +2482,10 @@ func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROut
 		if strings.Contains(syncErr.Error(), "is not tracked") {
 			return nil, problemForbidden(syncErr.Error(), nil)
 		}
-		return nil, problemUpstream(
-			"sync PR: "+syncErr.Error(),
+		return nil, providerCallProblemWithDetail(
+			syncErr,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"sync PR: "+syncErr.Error(),
 		)
 	}
 
@@ -2548,9 +2564,10 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 		if strings.Contains(err.Error(), "is not tracked") {
 			return nil, problemForbidden(err.Error(), nil)
 		}
-		return nil, problemUpstream(
-			"sync issue: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"sync issue: "+err.Error(),
 		)
 	}
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1082,6 +1082,9 @@ func (s *Server) editPRContent(
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.MergeRequestContentMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1164,6 +1167,9 @@ func (s *Server) editIssueContent(
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.IssueContentMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1239,6 +1245,9 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.CommentMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1288,6 +1297,9 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 		capabilityCommentMutation,
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
 
@@ -1417,6 +1429,9 @@ func (s *Server) createIssue(
 	if !capabilityEnabled(s.capabilitiesForRepo(*repo), capabilityIssueMutation) {
 		return nil, unsupportedCapabilityProblem(*repo, capabilityIssueMutation)
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityIssueMutation); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.IssueMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1544,6 +1559,9 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 	if !capabilityEnabled(s.capabilitiesForRepo(*repo), capabilityCommentMutation) {
 		return nil, unsupportedCapabilityProblem(*repo, capabilityCommentMutation)
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.CommentMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1595,6 +1613,9 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 	}
 	if !capabilityEnabled(s.capabilitiesForRepo(*repo), capabilityCommentMutation) {
 		return nil, unsupportedCapabilityProblem(*repo, capabilityCommentMutation)
+	}
+	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
+		return nil, err
 	}
 
 	mutator, err := s.syncer.CommentMutator(
@@ -1735,6 +1756,9 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityReviewMutation); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.ReviewMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1776,6 +1800,9 @@ func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (
 		capabilityWorkflowApproval,
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSyncerCapability(*repo, capabilityWorkflowApproval); err != nil {
 		return nil, err
 	}
 
@@ -1885,6 +1912,9 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityReadyForReview); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.ReadyForReviewMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1969,6 +1999,9 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 		capabilityMergeMutation,
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireSyncerCapability(*repo, capabilityMergeMutation); err != nil {
 		return nil, err
 	}
 
@@ -2115,6 +2148,9 @@ func (s *Server) setPRGitHubState(
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
+		return nil, err
+	}
 
 	mutator, err := s.syncer.StateMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -2236,6 +2272,9 @@ func (s *Server) setIssueGitHubState(
 	}
 	if issue == nil {
 		return nil, problemNotFound(CodeIssueNotFound, "issue not found", nil)
+	}
+	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
+		return nil, err
 	}
 
 	mutator, err := s.syncer.StateMutator(

--- a/internal/server/label_handlers.go
+++ b/internal/server/label_handlers.go
@@ -153,9 +153,10 @@ func (s *Server) setPullLabels(
 		ctx, platformRepoRefFromDB(*repo), input.Number, names,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"provider API error: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"provider API error: "+err.Error(),
 		)
 	}
 	labels := platform.DBLabels(providerLabels, time.Now().UTC())
@@ -200,9 +201,10 @@ func (s *Server) setIssueLabels(
 		ctx, platformRepoRefFromDB(*repo), input.Number, names,
 	)
 	if err != nil {
-		return nil, problemUpstream(
-			"provider API error: "+err.Error(),
+		return nil, providerCallProblemWithDetail(
+			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"provider API error: "+err.Error(),
 		)
 	}
 	labels := platform.DBLabels(providerLabels, time.Now().UTC())

--- a/internal/server/label_handlers.go
+++ b/internal/server/label_handlers.go
@@ -3,10 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
-	"github.com/danielgtaylor/huma/v2"
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/platform"
 )
@@ -101,7 +101,7 @@ func (s *Server) listRepoLabels(
 
 	labels, freshness, err := s.db.ListRepoLabelCatalog(ctx, repo.ID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("list repo labels failed")
+		return nil, problemInternal("list repo labels failed")
 	}
 	syncing := false
 	if labelCatalogStale(freshness, time.Now().UTC()) {
@@ -136,10 +136,10 @@ func (s *Server) setPullLabels(
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get pull failed")
+		return nil, problemInternal("get pull failed")
 	}
 	if mr == nil {
-		return nil, huma.Error404NotFound("pull not found")
+		return nil, problemNotFound(CodePullNotFound, "pull not found", nil)
 	}
 
 	if s.syncer == nil {
@@ -153,11 +153,14 @@ func (s *Server) setPullLabels(
 		ctx, platformRepoRefFromDB(*repo), input.Number, names,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("provider API error: " + err.Error())
+		return nil, problemUpstream(
+			"provider API error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 	labels := platform.DBLabels(providerLabels, time.Now().UTC())
 	if err := s.db.ReplaceMergeRequestLabels(ctx, repo.ID, mr.ID, labels); err != nil {
-		return nil, huma.Error500InternalServerError("save pull labels failed")
+		return nil, problemInternal("save pull labels failed")
 	}
 	return &setLabelsOutput{Body: itemLabelsResponse{Labels: labels}}, nil
 }
@@ -180,10 +183,10 @@ func (s *Server) setIssueLabels(
 
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("get issue failed")
+		return nil, problemInternal("get issue failed")
 	}
 	if issue == nil {
-		return nil, huma.Error404NotFound("issue not found")
+		return nil, problemNotFound(CodeIssueNotFound, "issue not found", nil)
 	}
 
 	if s.syncer == nil {
@@ -197,11 +200,14 @@ func (s *Server) setIssueLabels(
 		ctx, platformRepoRefFromDB(*repo), input.Number, names,
 	)
 	if err != nil {
-		return nil, huma.Error502BadGateway("provider API error: " + err.Error())
+		return nil, problemUpstream(
+			"provider API error: "+err.Error(),
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+		)
 	}
 	labels := platform.DBLabels(providerLabels, time.Now().UTC())
 	if err := s.db.ReplaceIssueLabels(ctx, repo.ID, issue.ID, labels); err != nil {
-		return nil, huma.Error500InternalServerError("save issue labels failed")
+		return nil, problemInternal("save issue labels failed")
 	}
 	return &setLabelsOutput{Body: itemLabelsResponse{Labels: labels}}, nil
 }
@@ -226,18 +232,18 @@ func (s *Server) resolveRequestedLabelNames(
 		return nil, nil, unsupportedCapabilityProblem(*repo, capabilityLabelMutation)
 	}
 	if names == nil {
-		return nil, nil, huma.Error400BadRequest("labels must be an array")
+		return nil, nil, problemValidation("body.labels", "labels must be an array")
 	}
 
 	catalog, freshness, err := s.db.ListRepoLabelCatalog(ctx, repo.ID)
 	if err != nil {
-		return nil, nil, huma.Error500InternalServerError("list repo labels failed")
+		return nil, nil, problemInternal("list repo labels failed")
 	}
 	if labelCatalogStale(freshness, time.Now().UTC()) && s.syncer != nil {
 		_ = s.syncer.RefreshRepoLabelCatalog(ctx, *repo)
 		catalog, _, err = s.db.ListRepoLabelCatalog(ctx, repo.ID)
 		if err != nil {
-			return nil, nil, huma.Error500InternalServerError("list repo labels failed")
+			return nil, nil, problemInternal("list repo labels failed")
 		}
 	}
 	catalogByName := make(map[string]struct{}, len(catalog))
@@ -250,13 +256,20 @@ func (s *Server) resolveRequestedLabelNames(
 	for _, raw := range names {
 		labelName := strings.TrimSpace(raw)
 		if labelName == "" {
-			return nil, nil, huma.Error400BadRequest("label names must not be empty")
+			return nil, nil, problemValidation("body.labels", "label names must not be empty")
 		}
 		if _, ok := seen[labelName]; ok {
-			return nil, nil, huma.Error400BadRequest(fmt.Sprintf("duplicate label %q", labelName))
+			return nil, nil, problemValidation(
+				"body.labels", fmt.Sprintf("duplicate label %q", labelName),
+			)
 		}
 		if _, ok := catalogByName[labelName]; !ok {
-			return nil, nil, huma.Error400BadRequest(fmt.Sprintf("label %q is not in the repository label catalog", labelName))
+			return nil, nil, newProblem(
+				http.StatusBadRequest,
+				CodeValidationError,
+				fmt.Sprintf("label %q is not in the repository label catalog", labelName),
+				map[string]any{"field": "body.labels", "label": labelName},
+			)
 		}
 		seen[labelName] = struct{}{}
 		resolved = append(resolved, labelName)

--- a/internal/server/problems.go
+++ b/internal/server/problems.go
@@ -1,0 +1,452 @@
+// Package server's problems.go defines the RFC 9457 (application/problem+json)
+// error envelope that every internal/server/ failure path returns. The
+// envelope adds two top-level fields beyond the huma defaults so frontend
+// code can branch on stable, machine-readable signals instead of substring-
+// matching English prose:
+//
+//   - `code`: a camelCase string from the closed enum below.
+//   - `details`: a free-form map carrying machine-readable context.
+//
+// Construction goes through the problem* helpers; package init replaces
+// huma.NewError so legacy huma.Error4xx/Error5xx callers (which we migrate
+// away from in the same change set) still produce a valid envelope with
+// a status-derived code while migration is in flight.
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/wesm/middleman/internal/db"
+	"github.com/wesm/middleman/internal/platform"
+)
+
+// ProblemCode is the machine-readable error code carried on the wire.
+type ProblemCode string
+
+// The closed set of wire codes. Order matters: the enum struct tag on
+// ProblemError.Code must list these in the same order, and the
+// allProblemCodes test asserts the two stay in sync.
+const (
+	CodeBadRequest            ProblemCode = "badRequest"
+	CodeBranchConflict        ProblemCode = "branchConflict"
+	CodeCommentNotFound       ProblemCode = "commentNotFound"
+	CodeConflict              ProblemCode = "conflict"
+	CodeForbidden             ProblemCode = "forbidden"
+	CodeInternalError         ProblemCode = "internalError"
+	CodeIssueNotFound         ProblemCode = "issueNotFound"
+	CodeNotFound              ProblemCode = "notFound"
+	CodePayloadTooLarge       ProblemCode = "payloadTooLarge"
+	CodeProjectNotFound       ProblemCode = "projectNotFound"
+	CodePullNotFound          ProblemCode = "pullNotFound"
+	CodeRateLimited           ProblemCode = "rateLimited"
+	CodeRepoNotFound          ProblemCode = "repoNotFound"
+	CodeServiceUnavailable    ProblemCode = "serviceUnavailable"
+	CodeSettingsUnavailable   ProblemCode = "settingsUnavailable"
+	CodeUnauthorized          ProblemCode = "unauthorized"
+	CodeUnsupportedCapability ProblemCode = "unsupportedCapability"
+	CodeUpstreamError         ProblemCode = "upstreamError"
+	CodeValidationError       ProblemCode = "validationError"
+	CodeWorkspaceNotFound     ProblemCode = "workspaceNotFound"
+)
+
+// allProblemCodes returns every declared ProblemCode in alphabetical order.
+// The enum tag on ProblemError.Code must list the same set in the same
+// order; problems_test.go asserts the two are consistent.
+func allProblemCodes() []ProblemCode {
+	return []ProblemCode{
+		CodeBadRequest,
+		CodeBranchConflict,
+		CodeCommentNotFound,
+		CodeConflict,
+		CodeForbidden,
+		CodeInternalError,
+		CodeIssueNotFound,
+		CodeNotFound,
+		CodePayloadTooLarge,
+		CodeProjectNotFound,
+		CodePullNotFound,
+		CodeRateLimited,
+		CodeRepoNotFound,
+		CodeServiceUnavailable,
+		CodeSettingsUnavailable,
+		CodeUnauthorized,
+		CodeUnsupportedCapability,
+		CodeUpstreamError,
+		CodeValidationError,
+		CodeWorkspaceNotFound,
+	}
+}
+
+// ProblemError is the RFC 9457 problem-details envelope returned for every
+// failure path. The huma.ErrorModel-compatible fields (Type/Title/Status/
+// Detail/Instance/Errors) keep behavior parity with huma's defaults so
+// existing clients keep working; the Code and Details extension members
+// are new.
+//
+// The Go type name "ProblemError" intentionally differs from huma's
+// "ErrorModel" to avoid shadowing the upstream type, but the wire schema
+// is named "ErrorModel" (via the huma.RegisterTypeAlias call below) so
+// the generated OpenAPI document and downstream clients keep the
+// existing symbol name.
+type ProblemError struct {
+	// Type is a URI reference identifying the problem type. Defaults to
+	// "about:blank" per RFC 9457 when not set.
+	Type string `json:"type,omitempty" format:"uri" default:"about:blank" example:"https://example.com/errors/example" doc:"A URI reference to human-readable documentation for the error."`
+
+	// Title is a short, human-readable summary. Stable across occurrences
+	// of the same problem type.
+	Title string `json:"title,omitempty" example:"Bad Request" doc:"A short, human-readable summary of the problem type. This value should not change between occurrences of the error."`
+
+	// Status is the HTTP status code. Always set by the helpers.
+	Status int `json:"status,omitempty" example:"400" doc:"HTTP status code"`
+
+	// Detail is a human-readable explanation of this occurrence.
+	Detail string `json:"detail,omitempty" example:"Property foo is required but is missing." doc:"A human-readable explanation specific to this occurrence of the problem."`
+
+	// Instance is a URI reference identifying this specific occurrence.
+	Instance string `json:"instance,omitempty" format:"uri" example:"https://example.com/error-log/abc123" doc:"A URI reference that identifies the specific occurrence of the problem."`
+
+	// Errors keeps parity with huma.ErrorModel for the validation-failure
+	// path where huma emits per-field details. New code paths should
+	// populate Details instead and leave Errors empty.
+	Errors []*huma.ErrorDetail `json:"errors,omitempty" doc:"Optional list of individual error details"`
+
+	// Code is the machine-readable error code drawn from the closed enum
+	// in allProblemCodes(). Frontend logic branches on this value.
+	Code ProblemCode `json:"code" enum:"badRequest,branchConflict,commentNotFound,conflict,forbidden,internalError,issueNotFound,notFound,payloadTooLarge,projectNotFound,pullNotFound,rateLimited,repoNotFound,serviceUnavailable,settingsUnavailable,unauthorized,unsupportedCapability,upstreamError,validationError,workspaceNotFound" example:"badRequest" doc:"Machine-readable error code. Stable across occurrences."`
+
+	// Details is a free-form map of machine-readable context for this
+	// occurrence (e.g. {capability: "merge_mutation"} or
+	// {retryAfter: "2026-05-19T12:00:00Z"}).
+	Details map[string]any `json:"details,omitempty" doc:"Machine-readable error context, keyed by code-specific conventions."`
+}
+
+// Schema name override: keep the generated wire schema named "ErrorModel"
+// even though the Go type is "ProblemError". This means generated TS
+// `components["schemas"]["ErrorModel"]` and generated Go
+// `apiclient.ErrorModel` keep their existing symbol names.
+func (ProblemError) SchemaName() string { return "ErrorModel" }
+
+// Error returns Detail (or the code if Detail is empty) so ProblemError
+// satisfies the error interface.
+func (p *ProblemError) Error() string {
+	if p == nil {
+		return "<nil problem>"
+	}
+	if p.Detail != "" {
+		return p.Detail
+	}
+	return string(p.Code)
+}
+
+// GetStatus satisfies huma.StatusError.
+func (p *ProblemError) GetStatus() int { return p.Status }
+
+// ContentType rewrites application/json to application/problem+json per
+// RFC 9457, mirroring huma's ErrorModel behavior.
+func (p *ProblemError) ContentType(ct string) string {
+	switch ct {
+	case "application/json":
+		return "application/problem+json"
+	case "application/cbor":
+		return "application/problem+cbor"
+	default:
+		return ct
+	}
+}
+
+// codeForStatus maps an HTTP status to the default wire code. Used when
+// callers reach for huma.Error4xx without specifying a code (e.g. during
+// migration) or when our own helpers don't pick a richer code.
+func codeForStatus(status int) ProblemCode {
+	switch status {
+	case http.StatusBadRequest:
+		return CodeBadRequest
+	case http.StatusUnauthorized:
+		return CodeUnauthorized
+	case http.StatusForbidden:
+		return CodeForbidden
+	case http.StatusNotFound:
+		return CodeNotFound
+	case http.StatusConflict:
+		return CodeConflict
+	case http.StatusRequestEntityTooLarge:
+		return CodePayloadTooLarge
+	case http.StatusUnprocessableEntity:
+		return CodeValidationError
+	case http.StatusTooManyRequests:
+		return CodeRateLimited
+	case http.StatusServiceUnavailable:
+		return CodeServiceUnavailable
+	case http.StatusBadGateway:
+		return CodeUpstreamError
+	default:
+		if status >= 500 {
+			return CodeInternalError
+		}
+		return CodeBadRequest
+	}
+}
+
+// titleForStatus returns the standard HTTP status text for a status code,
+// matching the huma.ErrorModel default behavior.
+func titleForStatus(status int) string {
+	if t := http.StatusText(status); t != "" {
+		return t
+	}
+	return "Error"
+}
+
+// newProblem is the canonical constructor. Status drives both the wire
+// status and (when code is empty) the default code; detail is the
+// human-readable message; details is the machine-readable context. The
+// returned value satisfies huma.StatusError.
+func newProblem(status int, code ProblemCode, detail string, details map[string]any) *ProblemError {
+	if code == "" {
+		code = codeForStatus(status)
+	}
+	return &ProblemError{
+		Status:  status,
+		Title:   titleForStatus(status),
+		Detail:  detail,
+		Code:    code,
+		Details: details,
+	}
+}
+
+// problemBadRequest returns a 400 with the supplied code (defaults to
+// CodeBadRequest when "").
+func problemBadRequest(code ProblemCode, detail string, details map[string]any) huma.StatusError {
+	if code == "" {
+		code = CodeBadRequest
+	}
+	return newProblem(http.StatusBadRequest, code, detail, details)
+}
+
+// problemValidation returns a 400 with code CodeValidationError, embedding
+// the offending field and (optionally) the allowed values. Field is the
+// JSON path of the value at fault ("body.status", "query.repo", etc.).
+func problemValidation(field, detail string, allowed ...string) huma.StatusError {
+	d := map[string]any{}
+	if field != "" {
+		d["field"] = field
+	}
+	if len(allowed) > 0 {
+		d["allowed"] = allowed
+	}
+	if len(d) == 0 {
+		d = nil
+	}
+	return newProblem(http.StatusBadRequest, CodeValidationError, detail, d)
+}
+
+// problemNotFound returns a 404 with the supplied code. Pass CodeNotFound
+// for the generic case or one of CodeRepoNotFound, CodePullNotFound, etc.
+// for richer semantics.
+func problemNotFound(code ProblemCode, detail string, details map[string]any) huma.StatusError {
+	if code == "" {
+		code = CodeNotFound
+	}
+	return newProblem(http.StatusNotFound, code, detail, details)
+}
+
+// problemConflict returns a 409 with the supplied code.
+func problemConflict(code ProblemCode, detail string, details map[string]any) huma.StatusError {
+	if code == "" {
+		code = CodeConflict
+	}
+	return newProblem(http.StatusConflict, code, detail, details)
+}
+
+// problemForbidden returns a 403.
+func problemForbidden(detail string, details map[string]any) huma.StatusError {
+	return newProblem(http.StatusForbidden, CodeForbidden, detail, details)
+}
+
+// problemInternal returns a 500.
+func problemInternal(detail string) huma.StatusError {
+	return newProblem(http.StatusInternalServerError, CodeInternalError, detail, nil)
+}
+
+// problemUpstream returns a 502 (provider API failure). The optional
+// provider/host are surfaced in details when non-empty.
+func problemUpstream(detail, provider, host string) huma.StatusError {
+	d := map[string]any{}
+	if provider != "" {
+		d["provider"] = provider
+	}
+	if host != "" {
+		d["platformHost"] = host
+	}
+	if len(d) == 0 {
+		d = nil
+	}
+	return newProblem(http.StatusBadGateway, CodeUpstreamError, detail, d)
+}
+
+// problemServiceUnavailable returns a 503.
+func problemServiceUnavailable(detail string) huma.StatusError {
+	return newProblem(http.StatusServiceUnavailable, CodeServiceUnavailable, detail, nil)
+}
+
+// problemPayloadTooLarge returns a 413 with maxBytes in details when known.
+func problemPayloadTooLarge(detail string, maxBytes int64) huma.StatusError {
+	var d map[string]any
+	if maxBytes > 0 {
+		d = map[string]any{"maxBytes": maxBytes}
+	}
+	return newProblem(http.StatusRequestEntityTooLarge, CodePayloadTooLarge, detail, d)
+}
+
+// problemUnsupportedCapability returns a 409 with code
+// CodeUnsupportedCapability and details {capability, provider,
+// platformHost}.
+func problemUnsupportedCapability(repo db.Repo, capability string) huma.StatusError {
+	details := map[string]any{
+		"capability":   capability,
+		"provider":     string(repoProviderKind(repo)),
+		"platformHost": repoProviderHost(repo),
+	}
+	return newProblem(
+		http.StatusConflict,
+		CodeUnsupportedCapability,
+		"Unsupported provider capability",
+		details,
+	)
+}
+
+// problemRateLimited returns a 429 with code CodeRateLimited. retryAfter
+// is rendered as an RFC 3339 string when non-nil; provider/host go into
+// details when non-empty.
+func problemRateLimited(provider, host string, retryAfter *time.Time) huma.StatusError {
+	d := map[string]any{}
+	if retryAfter != nil {
+		d["retryAfter"] = retryAfter.UTC().Format(time.RFC3339)
+	}
+	if provider != "" {
+		d["provider"] = provider
+	}
+	if host != "" {
+		d["platformHost"] = host
+	}
+	if len(d) == 0 {
+		d = nil
+	}
+	return newProblem(
+		http.StatusTooManyRequests,
+		CodeRateLimited,
+		"Upstream rate limit exceeded",
+		d,
+	)
+}
+
+// problemBranchConflict returns the 409 used when a local branch already
+// exists with the workspace's requested name. The branch and suggested
+// alternative go into details.
+func problemBranchConflict(branch, suggested string) huma.StatusError {
+	d := map[string]any{}
+	if branch != "" {
+		d["branch"] = branch
+	}
+	if suggested != "" {
+		d["suggestedBranch"] = suggested
+	}
+	if len(d) == 0 {
+		d = nil
+	}
+	return newProblem(
+		http.StatusConflict,
+		CodeBranchConflict,
+		"A local branch with the requested name already exists.",
+		d,
+	)
+}
+
+// mapPlatformError translates an error from internal/platform into a wire
+// problem. Returns nil for nil input or context cancellation so callers
+// can propagate those without altering control flow. Returns a generic
+// upstream problem with the error's text when no platform.Error is in
+// the chain.
+func mapPlatformError(err error) huma.StatusError {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	var pe *platform.Error
+	if !errors.As(err, &pe) {
+		return problemUpstream(err.Error(), "", "")
+	}
+	provider := string(pe.Provider)
+	host := pe.PlatformHost
+	switch pe.Code {
+	case platform.ErrCodeUnsupportedCapability:
+		// We don't have a db.Repo here, so synthesize the details directly
+		// rather than going through problemUnsupportedCapability.
+		details := map[string]any{
+			"capability":   pe.Capability,
+			"provider":     provider,
+			"platformHost": host,
+		}
+		return newProblem(
+			http.StatusConflict,
+			CodeUnsupportedCapability,
+			"Unsupported provider capability",
+			details,
+		)
+	case platform.ErrCodeRateLimited:
+		return problemRateLimited(provider, host, pe.ResetAt)
+	case platform.ErrCodePermissionDenied:
+		d := map[string]any{}
+		if provider != "" {
+			d["provider"] = provider
+		}
+		if host != "" {
+			d["platformHost"] = host
+		}
+		if len(d) == 0 {
+			d = nil
+		}
+		return problemForbidden(err.Error(), d)
+	case platform.ErrCodeNotFound:
+		return problemNotFound(CodeNotFound, err.Error(), nil)
+	case platform.ErrCodeProviderNotConfigured,
+		platform.ErrCodeMissingToken,
+		platform.ErrCodeInvalidRepoRef:
+		return problemBadRequest(CodeBadRequest, err.Error(), nil)
+	default:
+		return problemUpstream(err.Error(), provider, host)
+	}
+}
+
+// init replaces huma.NewError so any remaining huma.ErrorNxx callers
+// (or huma's own internal validators) emit a ProblemError envelope.
+// Without this hook, migration would be all-or-nothing: any missed call
+// site would emit a body with no code field. With it, every code path
+// already produces a code (status-derived) and migration becomes
+// incremental.
+func init() {
+	huma.NewError = func(status int, msg string, errs ...error) huma.StatusError {
+		details := make([]*huma.ErrorDetail, 0, len(errs))
+		for _, e := range errs {
+			if e == nil {
+				continue
+			}
+			if d, ok := e.(huma.ErrorDetailer); ok {
+				details = append(details, d.ErrorDetail())
+				continue
+			}
+			details = append(details, &huma.ErrorDetail{Message: e.Error()})
+		}
+		p := newProblem(status, codeForStatus(status), msg, nil)
+		if len(details) > 0 {
+			p.Errors = details
+		}
+		return p
+	}
+}

--- a/internal/server/problems.go
+++ b/internal/server/problems.go
@@ -365,14 +365,26 @@ func problemBranchConflict(branch, suggested string) huma.StatusError {
 // is in the chain; when one is, mapPlatformError handles the translation
 // (and ignores the provider/host arguments).
 func providerCallProblem(err error, provider, host string) huma.StatusError {
+	return providerCallProblemWithDetail(err, provider, host, "")
+}
+
+func providerCallProblemWithDetail(
+	err error,
+	provider, host, detail string,
+) huma.StatusError {
 	if err == nil {
 		return nil
 	}
 	var pe *platform.Error
 	if errors.As(err, &pe) {
-		return mapPlatformError(err)
+		if mapped := mapPlatformError(err); mapped != nil {
+			return mapped
+		}
 	}
-	return problemUpstream(err.Error(), provider, host)
+	if detail == "" {
+		detail = err.Error()
+	}
+	return problemUpstream(detail, provider, host)
 }
 
 // mapPlatformError translates an error from internal/platform into a wire

--- a/internal/server/problems.go
+++ b/internal/server/problems.go
@@ -88,10 +88,10 @@ func allProblemCodes() []ProblemCode {
 // are new.
 //
 // The Go type name "ProblemError" intentionally differs from huma's
-// "ErrorModel" to avoid shadowing the upstream type, but the wire schema
-// is named "ErrorModel" (via the huma.RegisterTypeAlias call below) so
-// the generated OpenAPI document and downstream clients keep the
-// existing symbol name.
+// "ErrorModel" to avoid shadowing the upstream type. The OpenAPI schema
+// name therefore becomes ProblemError too, and generated clients pick
+// up that symbol (components["schemas"]["ProblemError"] in TS,
+// apiclient.ProblemError in Go).
 type ProblemError struct {
 	// Type is a URI reference identifying the problem type. Defaults to
 	// "about:blank" per RFC 9457 when not set.
@@ -124,12 +124,6 @@ type ProblemError struct {
 	// {retryAfter: "2026-05-19T12:00:00Z"}).
 	Details map[string]any `json:"details,omitempty" doc:"Machine-readable error context, keyed by code-specific conventions."`
 }
-
-// Schema name override: keep the generated wire schema named "ErrorModel"
-// even though the Go type is "ProblemError". This means generated TS
-// `components["schemas"]["ErrorModel"]` and generated Go
-// `apiclient.ErrorModel` keep their existing symbol names.
-func (ProblemError) SchemaName() string { return "ErrorModel" }
 
 // Error returns Detail (or the code if Detail is empty) so ProblemError
 // satisfies the error interface.

--- a/internal/server/problems.go
+++ b/internal/server/problems.go
@@ -366,6 +366,21 @@ func problemBranchConflict(branch, suggested string) huma.StatusError {
 	)
 }
 
+// providerCallProblem translates a provider-call error into a wire
+// problem. Provider/host narrow the upstream problem when no platform.Error
+// is in the chain; when one is, mapPlatformError handles the translation
+// (and ignores the provider/host arguments).
+func providerCallProblem(err error, provider, host string) huma.StatusError {
+	if err == nil {
+		return nil
+	}
+	var pe *platform.Error
+	if errors.As(err, &pe) {
+		return mapPlatformError(err)
+	}
+	return problemUpstream(err.Error(), provider, host)
+}
+
 // mapPlatformError translates an error from internal/platform into a wire
 // problem. Returns nil for nil input or context cancellation so callers
 // can propagate those without altering control flow. Returns a generic

--- a/internal/server/problems_test.go
+++ b/internal/server/problems_test.go
@@ -1,0 +1,413 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/platform"
+)
+
+// structField is a tiny reflection helper for inspecting struct tags
+// from tests. Returns the named field on the supplied pointer's element
+// type. The bool is false when the field doesn't exist.
+func structField(p any, name string) (reflect.StructField, bool) {
+	t := reflect.TypeOf(p)
+	if t == nil {
+		return reflect.StructField{}, false
+	}
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return reflect.StructField{}, false
+	}
+	return t.FieldByName(name)
+}
+
+// TestProblemErrorEnumTagMatchesConstants asserts that the `enum:` struct
+// tag on ProblemError.Code lists exactly the same wire values that
+// allProblemCodes() returns, in the same order. If a new code is added
+// to one list and the other is forgotten, this test catches the drift.
+func TestProblemErrorEnumTagMatchesConstants(t *testing.T) {
+	require := require.New(t)
+
+	// Pull the enum tag off ProblemError.Code via reflection.
+	codeField, ok := structField((*ProblemError)(nil), "Code")
+	require.True(ok, "Code field not found on ProblemError")
+
+	enumTag, ok := codeField.Tag.Lookup("enum")
+	require.True(ok, "enum tag missing on Code field")
+	tagValues := strings.Split(enumTag, ",")
+
+	declared := allProblemCodes()
+	require.Len(tagValues, len(declared), "enum tag and allProblemCodes() length differ")
+
+	for i, c := range declared {
+		require.Equal(string(c), tagValues[i], "enum tag entry %d differs from declared code", i)
+	}
+
+	// And the slice should be sorted alphabetically to keep OpenAPI diffs
+	// stable as new codes are added.
+	sorted := make([]string, len(declared))
+	for i, c := range declared {
+		sorted[i] = string(c)
+	}
+	require.True(sort.StringsAreSorted(sorted), "allProblemCodes() must be alphabetical")
+}
+
+func TestProblemErrorContentTypeRewritesJSON(t *testing.T) {
+	assert := Assert.New(t)
+	p := &ProblemError{Status: http.StatusBadRequest, Code: CodeBadRequest}
+
+	assert.Equal("application/problem+json", p.ContentType("application/json"))
+	assert.Equal("application/problem+cbor", p.ContentType("application/cbor"))
+	assert.Equal("text/plain", p.ContentType("text/plain"))
+}
+
+func TestProblemErrorRoundTripJSONPreservesCodeAndDetails(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	original := newProblem(
+		http.StatusConflict,
+		CodeUnsupportedCapability,
+		"Unsupported provider capability",
+		map[string]any{
+			"capability":   "merge_mutation",
+			"provider":     "gitlab",
+			"platformHost": "gitlab.example.com",
+		},
+	)
+
+	encoded, err := json.Marshal(original)
+	require.NoError(err)
+
+	// Top-level code and details survive the round trip.
+	require.Contains(string(encoded), `"code":"unsupportedCapability"`)
+	require.Contains(string(encoded), `"details":{`)
+
+	var decoded ProblemError
+	require.NoError(json.Unmarshal(encoded, &decoded))
+	assert.Equal(CodeUnsupportedCapability, decoded.Code)
+	assert.Equal("merge_mutation", decoded.Details["capability"])
+	assert.Equal("gitlab", decoded.Details["provider"])
+	assert.Equal("gitlab.example.com", decoded.Details["platformHost"])
+}
+
+func TestCodeForStatus(t *testing.T) {
+	cases := []struct {
+		status int
+		want   ProblemCode
+	}{
+		{http.StatusBadRequest, CodeBadRequest},
+		{http.StatusUnauthorized, CodeUnauthorized},
+		{http.StatusForbidden, CodeForbidden},
+		{http.StatusNotFound, CodeNotFound},
+		{http.StatusConflict, CodeConflict},
+		{http.StatusRequestEntityTooLarge, CodePayloadTooLarge},
+		{http.StatusUnprocessableEntity, CodeValidationError},
+		{http.StatusTooManyRequests, CodeRateLimited},
+		{http.StatusServiceUnavailable, CodeServiceUnavailable},
+		{http.StatusBadGateway, CodeUpstreamError},
+		{http.StatusInternalServerError, CodeInternalError},
+		{http.StatusNotImplemented, CodeInternalError},
+		{http.StatusTeapot, CodeBadRequest},
+	}
+
+	assert := Assert.New(t)
+	for _, tc := range cases {
+		assert.Equal(tc.want, codeForStatus(tc.status), "status %d", tc.status)
+	}
+}
+
+func TestProblemHelpersSetStatusCodeAndDetails(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cases := []struct {
+		name        string
+		make        func() huma.StatusError
+		wantStatus  int
+		wantCode    ProblemCode
+		wantDetails map[string]any
+	}{
+		{
+			name:       "BadRequestDefault",
+			make:       func() huma.StatusError { return problemBadRequest("", "go away", nil) },
+			wantStatus: http.StatusBadRequest,
+			wantCode:   CodeBadRequest,
+		},
+		{
+			name: "BadRequestCustomCode",
+			make: func() huma.StatusError {
+				return problemBadRequest(CodeRepoNotFound, "x", map[string]any{"owner": "acme"})
+			},
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    CodeRepoNotFound,
+			wantDetails: map[string]any{"owner": "acme"},
+		},
+		{
+			name:        "Validation",
+			make:        func() huma.StatusError { return problemValidation("body.status", "bad", "a", "b") },
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    CodeValidationError,
+			wantDetails: map[string]any{"field": "body.status", "allowed": []string{"a", "b"}},
+		},
+		{
+			name:       "NotFoundDefault",
+			make:       func() huma.StatusError { return problemNotFound("", "nope", nil) },
+			wantStatus: http.StatusNotFound,
+			wantCode:   CodeNotFound,
+		},
+		{
+			name:       "NotFoundCustom",
+			make:       func() huma.StatusError { return problemNotFound(CodePullNotFound, "nope", nil) },
+			wantStatus: http.StatusNotFound,
+			wantCode:   CodePullNotFound,
+		},
+		{
+			name:       "ConflictDefault",
+			make:       func() huma.StatusError { return problemConflict("", "boom", nil) },
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeConflict,
+		},
+		{
+			name:       "Forbidden",
+			make:       func() huma.StatusError { return problemForbidden("nope", nil) },
+			wantStatus: http.StatusForbidden,
+			wantCode:   CodeForbidden,
+		},
+		{
+			name:       "Internal",
+			make:       func() huma.StatusError { return problemInternal("boom") },
+			wantStatus: http.StatusInternalServerError,
+			wantCode:   CodeInternalError,
+		},
+		{
+			name:        "UpstreamWithProviderHost",
+			make:        func() huma.StatusError { return problemUpstream("boom", "gitlab", "gitlab.com") },
+			wantStatus:  http.StatusBadGateway,
+			wantCode:    CodeUpstreamError,
+			wantDetails: map[string]any{"provider": "gitlab", "platformHost": "gitlab.com"},
+		},
+		{
+			name:       "UpstreamWithoutContext",
+			make:       func() huma.StatusError { return problemUpstream("boom", "", "") },
+			wantStatus: http.StatusBadGateway,
+			wantCode:   CodeUpstreamError,
+		},
+		{
+			name:        "PayloadTooLarge",
+			make:        func() huma.StatusError { return problemPayloadTooLarge("too big", 1024) },
+			wantStatus:  http.StatusRequestEntityTooLarge,
+			wantCode:    CodePayloadTooLarge,
+			wantDetails: map[string]any{"maxBytes": int64(1024)},
+		},
+		{
+			name:       "ServiceUnavailable",
+			make:       func() huma.StatusError { return problemServiceUnavailable("down") },
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   CodeServiceUnavailable,
+		},
+		{
+			name:        "BranchConflict",
+			make:        func() huma.StatusError { return problemBranchConflict("main", "main-fix") },
+			wantStatus:  http.StatusConflict,
+			wantCode:    CodeBranchConflict,
+			wantDetails: map[string]any{"branch": "main", "suggestedBranch": "main-fix"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.make()
+			require.NotNil(err)
+			pe, ok := err.(*ProblemError)
+			require.True(ok, "want *ProblemError, got %T", err)
+
+			assert.Equal(tc.wantStatus, pe.Status)
+			assert.Equal(tc.wantStatus, pe.GetStatus())
+			assert.Equal(tc.wantCode, pe.Code)
+			if tc.wantDetails != nil {
+				assert.Equal(tc.wantDetails, pe.Details)
+			}
+			// Helpers must always populate Title from status.
+			assert.NotEmpty(pe.Title)
+		})
+	}
+}
+
+func TestProblemRateLimitedFormatsResetAt(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	reset := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	err := problemRateLimited("github", "github.com", &reset)
+	pe, ok := err.(*ProblemError)
+	require.True(ok)
+
+	assert.Equal(http.StatusTooManyRequests, pe.Status)
+	assert.Equal(CodeRateLimited, pe.Code)
+	assert.Equal("github", pe.Details["provider"])
+	assert.Equal("github.com", pe.Details["platformHost"])
+	assert.Equal("2026-05-19T12:00:00Z", pe.Details["retryAfter"])
+
+	// nil reset → no retryAfter key.
+	err = problemRateLimited("github", "github.com", nil)
+	pe = err.(*ProblemError)
+	_, has := pe.Details["retryAfter"]
+	assert.False(has, "details should not contain retryAfter when reset is nil")
+}
+
+func TestMapPlatformError(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	reset := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		input       error
+		wantNil     bool
+		wantStatus  int
+		wantCode    ProblemCode
+		wantDetails map[string]any
+	}{
+		{name: "Nil", input: nil, wantNil: true},
+		{name: "ContextCanceled", input: context.Canceled, wantNil: true},
+		{name: "ContextDeadlineExceeded", input: context.DeadlineExceeded, wantNil: true},
+		{
+			name: "UnsupportedCapability",
+			input: &platform.Error{
+				Code:         platform.ErrCodeUnsupportedCapability,
+				Provider:     "gitlab",
+				PlatformHost: "gitlab.com",
+				Capability:   "merge_mutation",
+			},
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeUnsupportedCapability,
+			wantDetails: map[string]any{
+				"capability":   "merge_mutation",
+				"provider":     "gitlab",
+				"platformHost": "gitlab.com",
+			},
+		},
+		{
+			name: "RateLimited",
+			input: &platform.Error{
+				Code:         platform.ErrCodeRateLimited,
+				Provider:     "github",
+				PlatformHost: "github.com",
+				ResetAt:      &reset,
+			},
+			wantStatus: http.StatusTooManyRequests,
+			wantCode:   CodeRateLimited,
+			wantDetails: map[string]any{
+				"provider":     "github",
+				"platformHost": "github.com",
+				"retryAfter":   "2026-05-19T12:00:00Z",
+			},
+		},
+		{
+			name: "PermissionDenied",
+			input: &platform.Error{
+				Code:         platform.ErrCodePermissionDenied,
+				Provider:     "github",
+				PlatformHost: "github.com",
+				Err:          errors.New("token lacks scope"),
+			},
+			wantStatus: http.StatusForbidden,
+			wantCode:   CodeForbidden,
+			wantDetails: map[string]any{
+				"provider":     "github",
+				"platformHost": "github.com",
+			},
+		},
+		{
+			name:       "NotFound",
+			input:      &platform.Error{Code: platform.ErrCodeNotFound},
+			wantStatus: http.StatusNotFound,
+			wantCode:   CodeNotFound,
+		},
+		{
+			name:       "ProviderNotConfigured",
+			input:      &platform.Error{Code: platform.ErrCodeProviderNotConfigured},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   CodeBadRequest,
+		},
+		{
+			name:       "MissingToken",
+			input:      &platform.Error{Code: platform.ErrCodeMissingToken},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   CodeBadRequest,
+		},
+		{
+			name:       "InvalidRepoRef",
+			input:      &platform.Error{Code: platform.ErrCodeInvalidRepoRef},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   CodeBadRequest,
+		},
+		{
+			name:       "PlainError",
+			input:      errors.New("boom"),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   CodeUpstreamError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mapPlatformError(tc.input)
+			if tc.wantNil {
+				assert.Nil(got)
+				return
+			}
+			require.NotNil(got, "expected mapPlatformError to return a problem for %v", tc.input)
+			pe, ok := got.(*ProblemError)
+			require.True(ok, "want *ProblemError, got %T", got)
+			assert.Equal(tc.wantStatus, pe.Status)
+			assert.Equal(tc.wantCode, pe.Code)
+			if tc.wantDetails != nil {
+				assert.Equal(tc.wantDetails, pe.Details)
+			}
+		})
+	}
+}
+
+// TestHumaNewErrorIsReplaced confirms that legacy huma.Error4xx callers
+// still flow through to a ProblemError envelope so the migration is
+// incremental. As call sites move to typed helpers this test guards
+// against regressing the fallback behavior.
+func TestHumaNewErrorIsReplaced(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	got := huma.Error400BadRequest("oops")
+	pe, ok := got.(*ProblemError)
+	require.True(ok, "huma.Error400BadRequest should now return *ProblemError, got %T", got)
+	assert.Equal(http.StatusBadRequest, pe.Status)
+	assert.Equal(CodeBadRequest, pe.Code)
+	assert.Equal("oops", pe.Detail)
+
+	// huma.NewError with non-nil errs[i] populates Errors[] for parity.
+	got = huma.Error400BadRequest("oops", fmt.Errorf("inner"))
+	pe = got.(*ProblemError)
+	require.Len(pe.Errors, 1)
+	assert.Equal("inner", pe.Errors[0].Message)
+
+	// A 502 returns the upstreamError default code.
+	got = huma.Error502BadGateway("boom")
+	pe = got.(*ProblemError)
+	assert.Equal(CodeUpstreamError, pe.Code)
+}

--- a/internal/server/problems_test.go
+++ b/internal/server/problems_test.go
@@ -385,6 +385,28 @@ func TestMapPlatformError(t *testing.T) {
 	}
 }
 
+func TestProviderCallProblemDoesNotReturnNilForContextWrappedPlatformError(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	got := providerCallProblem(
+		&platform.Error{
+			Code: platform.ErrCodeRateLimited,
+			Err:  context.Canceled,
+		},
+		"github",
+		"github.com",
+	)
+	require.NotNil(got)
+	pe, ok := got.(*ProblemError)
+	require.True(ok, "want *ProblemError, got %T", got)
+	assert.Equal(http.StatusBadGateway, pe.Status)
+	assert.Equal(CodeUpstreamError, pe.Code)
+	require.NotNil(pe.Details)
+	assert.Equal("github", pe.Details["provider"])
+	assert.Equal("github.com", pe.Details["platformHost"])
+}
+
 // TestHumaNewErrorIsReplaced confirms that legacy huma.Error4xx callers
 // still flow through to a ProblemError envelope so the migration is
 // incremental. As call sites move to typed helpers this test guards

--- a/internal/server/projects_handlers.go
+++ b/internal/server/projects_handlers.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/danielgtaylor/huma/v2"
 	"github.com/wesm/middleman/internal/config"
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/projects"
@@ -113,21 +112,21 @@ func (s *Server) registerProject(
 ) (*registerProjectOutput, error) {
 	rawPath := strings.TrimSpace(input.Body.LocalPath)
 	if rawPath == "" {
-		return nil, huma.Error400BadRequest("local_path is required")
+		return nil, problemValidation("body.local_path", "local_path is required")
 	}
 	abs, err := filepath.Abs(rawPath)
 	if err != nil {
-		return nil, huma.Error400BadRequest("resolve local_path: " + err.Error())
+		return nil, problemValidation("body.local_path", "resolve local_path: "+err.Error())
 	}
 	stat, err := os.Stat(abs)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, huma.Error400BadRequest("local_path does not exist: " + abs)
+			return nil, problemValidation("body.local_path", "local_path does not exist: "+abs)
 		}
-		return nil, huma.Error500InternalServerError("stat local_path: " + err.Error())
+		return nil, problemInternal("stat local_path: " + err.Error())
 	}
 	if !stat.IsDir() {
-		return nil, huma.Error400BadRequest("local_path is not a directory: " + abs)
+		return nil, problemValidation("body.local_path", "local_path is not a directory: "+abs)
 	}
 
 	displayName := strings.TrimSpace(input.Body.DisplayName)
@@ -149,7 +148,7 @@ func (s *Server) registerProject(
 			Name:         identity.Name,
 		})
 		if upsertErr != nil {
-			return nil, huma.Error500InternalServerError(
+			return nil, problemInternal(
 				"upsert repo identity: " + upsertErr.Error(),
 			)
 		}
@@ -164,11 +163,13 @@ func (s *Server) registerProject(
 	})
 	if err != nil {
 		if errors.Is(err, db.ErrProjectPathTaken) {
-			return nil, huma.Error409Conflict(
-				"a project is already registered at " + abs,
+			return nil, problemConflict(
+				CodeConflict,
+				"a project is already registered at "+abs,
+				nil,
 			)
 		}
-		return nil, huma.Error500InternalServerError("register project: " + err.Error())
+		return nil, problemInternal("register project: " + err.Error())
 	}
 
 	return &registerProjectOutput{Body: projectResponseFromDB(created)}, nil
@@ -189,7 +190,8 @@ func (s *Server) resolveProjectIdentity(
 		owner := strings.TrimSpace(caller.Owner)
 		name := strings.TrimSpace(caller.Name)
 		if platform == "" || host == "" || owner == "" || name == "" {
-			return nil, huma.Error400BadRequest(
+			return nil, problemValidation(
+				"body.platform_identity",
 				"platform_identity requires platform, platform_host, owner, and name",
 			)
 		}
@@ -199,7 +201,7 @@ func (s *Server) resolveProjectIdentity(
 		ctx, abs, s.knownProjectPlatformHosts(),
 	)
 	if err != nil {
-		return nil, huma.Error500InternalServerError(
+		return nil, problemInternal(
 			"resolve platform identity: " + err.Error(),
 		)
 	}
@@ -235,7 +237,7 @@ func (s *Server) listProjects(
 ) (*listProjectsOutput, error) {
 	rows, err := s.db.ListProjects(ctx)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("list projects: " + err.Error())
+		return nil, problemInternal("list projects: " + err.Error())
 	}
 	out := &listProjectsOutput{}
 	out.Body.Projects = projectResponsesFromDB(rows)
@@ -248,9 +250,9 @@ func (s *Server) getProject(
 	project, err := s.db.GetProjectByID(ctx, input.ProjectID)
 	if err != nil {
 		if errors.Is(err, db.ErrProjectNotFound) {
-			return nil, huma.Error404NotFound("project not found")
+			return nil, problemNotFound(CodeProjectNotFound, "project not found", nil)
 		}
-		return nil, huma.Error500InternalServerError("get project: " + err.Error())
+		return nil, problemInternal("get project: " + err.Error())
 	}
 	return &getProjectOutput{Body: projectResponseFromDB(project)}, nil
 }
@@ -260,15 +262,15 @@ func (s *Server) registerWorktree(
 ) (*registerWorktreeOutput, error) {
 	branch := strings.TrimSpace(input.Body.Branch)
 	if branch == "" {
-		return nil, huma.Error400BadRequest("branch is required")
+		return nil, problemValidation("body.branch", "branch is required")
 	}
 	path := strings.TrimSpace(input.Body.Path)
 	if path == "" {
-		return nil, huma.Error400BadRequest("path is required")
+		return nil, problemValidation("body.path", "path is required")
 	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return nil, huma.Error400BadRequest("resolve path: " + err.Error())
+		return nil, problemValidation("body.path", "resolve path: "+err.Error())
 	}
 
 	created, err := s.db.CreateProjectWorktree(ctx, db.CreateProjectWorktreeInput{
@@ -279,13 +281,15 @@ func (s *Server) registerWorktree(
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrProjectNotFound):
-			return nil, huma.Error404NotFound("project not found")
+			return nil, problemNotFound(CodeProjectNotFound, "project not found", nil)
 		case errors.Is(err, db.ErrWorktreePathTaken):
-			return nil, huma.Error409Conflict(
-				"a worktree is already registered at " + abs,
+			return nil, problemConflict(
+				CodeConflict,
+				"a worktree is already registered at "+abs,
+				nil,
 			)
 		}
-		return nil, huma.Error500InternalServerError("register worktree: " + err.Error())
+		return nil, problemInternal("register worktree: " + err.Error())
 	}
 	return &registerWorktreeOutput{Body: worktreeResponseFromDB(created)}, nil
 }
@@ -296,9 +300,9 @@ func (s *Server) listWorktrees(
 	rows, err := s.db.ListProjectWorktrees(ctx, input.ProjectID)
 	if err != nil {
 		if errors.Is(err, db.ErrProjectNotFound) {
-			return nil, huma.Error404NotFound("project not found")
+			return nil, problemNotFound(CodeProjectNotFound, "project not found", nil)
 		}
-		return nil, huma.Error500InternalServerError("list worktrees: " + err.Error())
+		return nil, problemInternal("list worktrees: " + err.Error())
 	}
 	out := &listWorktreesOutput{}
 	out.Body.Worktrees = worktreeResponsesFromDB(rows)
@@ -310,9 +314,9 @@ func (s *Server) listLaunchTargets(
 ) (*listLaunchTargetsOutput, error) {
 	if _, err := s.db.GetProjectByID(ctx, input.ProjectID); err != nil {
 		if errors.Is(err, db.ErrProjectNotFound) {
-			return nil, huma.Error404NotFound("project not found")
+			return nil, problemNotFound(CodeProjectNotFound, "project not found", nil)
 		}
-		return nil, huma.Error500InternalServerError("get project: " + err.Error())
+		return nil, problemInternal("get project: " + err.Error())
 	}
 	// Resolve fresh on every call so PATH changes (a newly installed
 	// agent, a deleted binary) take effect without restarting the

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path"
@@ -415,7 +416,7 @@ func (s *Server) previewRepos(
 	input *repoPreviewInput,
 ) (*repoPreviewOutput, error) {
 	if s.cfgPath == "" {
-		return nil, huma.Error404NotFound("settings not available")
+		return nil, problemNotFound(CodeSettingsUnavailable, "settings not available", nil)
 	}
 
 	provider, host, err := normalizeImportPlatform(
@@ -423,13 +424,13 @@ func (s *Server) previewRepos(
 		importRequestHost(input.Body.Host, input.Body.PlatformHost),
 	)
 	if err != nil {
-		return nil, huma.Error400BadRequest(err.Error())
+		return nil, problemValidation("body.provider", err.Error())
 	}
 	owner, pattern, err := normalizeImportOwnerPattern(
 		provider, input.Body.Owner, input.Body.Pattern,
 	)
 	if err != nil {
-		return nil, huma.Error400BadRequest(err.Error())
+		return nil, problemValidation("body", err.Error())
 	}
 
 	s.cfgMu.Lock()
@@ -440,24 +441,28 @@ func (s *Server) previewRepos(
 	if provider == platform.KindGitHub {
 		client, err := s.syncer.ClientForHost(host)
 		if err != nil {
-			return nil, huma.Error502BadGateway("GitHub API error: " + err.Error())
+			return nil, problemUpstream("GitHub API error: "+err.Error(), "github", host)
 		}
 		rows, err = buildRepoPreviewRows(
 			ctx, client, exactConfiguredRepoSet(repos), owner, pattern, host,
 		)
 		if err != nil {
-			return nil, huma.Error502BadGateway("GitHub API error: " + err.Error())
+			return nil, problemUpstream("GitHub API error: "+err.Error(), "github", host)
 		}
 	} else {
 		reader, err := s.syncer.RepositoryReader(provider, host)
 		if err != nil {
-			return nil, huma.Error502BadGateway("Provider API error: " + err.Error())
+			return nil, problemUpstream(
+				"Provider API error: "+err.Error(), string(provider), host,
+			)
 		}
 		rows, err = buildPlatformRepoPreviewRows(
 			ctx, reader, provider, host, exactConfiguredRepoSet(repos), owner, pattern,
 		)
 		if err != nil {
-			return nil, huma.Error502BadGateway("Provider API error: " + err.Error())
+			return nil, problemUpstream(
+				"Provider API error: "+err.Error(), string(provider), host,
+			)
 		}
 	}
 	return &repoPreviewOutput{
@@ -529,10 +534,19 @@ func configFromResolvedRepo(candidate config.Repo, ref ghclient.RepoRef) config.
 	return repo
 }
 
+// bulkApplyError is a sentinel carrying the wire problem produced by
+// applyBulkExactRepos so the handler can return it directly without
+// re-classifying status codes.
+type bulkApplyError struct {
+	problem huma.StatusError
+}
+
+func (e *bulkApplyError) Error() string { return e.problem.Error() }
+
 func (s *Server) applyBulkExactRepos(
 	ctx context.Context,
 	resolved []resolvedBulkRepo,
-) (settingsResponse, int, error) {
+) (settingsResponse, error) {
 	s.cfgMu.Lock()
 	existing := exactConfiguredRepoSet(s.cfg.Repos)
 	addConfigs := make([]config.Repo, 0, len(resolved))
@@ -548,8 +562,11 @@ func (s *Server) applyBulkExactRepos(
 	}
 	if len(addConfigs) == 0 {
 		s.cfgMu.Unlock()
-		return settingsResponse{}, http.StatusBadRequest,
-			fmt.Errorf("all selected repositories are already configured")
+		return settingsResponse{}, &bulkApplyError{problem: problemBadRequest(
+			CodeBadRequest,
+			"all selected repositories are already configured",
+			nil,
+		)}
 	}
 
 	prev := slices.Clone(s.cfg.Repos)
@@ -557,23 +574,26 @@ func (s *Server) applyBulkExactRepos(
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Repos = prev
 		s.cfgMu.Unlock()
-		return settingsResponse{}, http.StatusBadRequest, err
+		return settingsResponse{}, &bulkApplyError{problem: problemBadRequest(
+			CodeBadRequest, err.Error(), nil,
+		)}
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Repos = prev
 		s.cfgMu.Unlock()
-		return settingsResponse{}, http.StatusInternalServerError,
-			fmt.Errorf("save config: %w", err)
+		return settingsResponse{}, &bulkApplyError{problem: problemInternal(
+			"save config: " + err.Error(),
+		)}
 	}
 	if err := s.persistResolvedRepos(ctx, addRefs); err != nil {
 		s.cfg.Repos = prev
 		s.cfgMu.Unlock()
-		return settingsResponse{}, http.StatusInternalServerError, err
+		return settingsResponse{}, &bulkApplyError{problem: problemInternal(err.Error())}
 	}
 	s.mergeTrackedRepos(addRefs)
 	s.cfgMu.Unlock()
 
-	return s.buildLocalSettingsResponse(), http.StatusCreated, nil
+	return s.buildLocalSettingsResponse(), nil
 }
 
 func (s *Server) bulkAddRepos(
@@ -581,11 +601,11 @@ func (s *Server) bulkAddRepos(
 	input *bulkAddReposInput,
 ) (*bulkAddReposOutput, error) {
 	if s.cfgPath == "" {
-		return nil, huma.Error404NotFound("settings not available")
+		return nil, problemNotFound(CodeSettingsUnavailable, "settings not available", nil)
 	}
 
 	if len(input.Body.Repos) == 0 {
-		return nil, huma.Error400BadRequest("repos are required")
+		return nil, problemValidation("body.repos", "repos are required")
 	}
 
 	candidates := make([]config.Repo, 0, len(input.Body.Repos))
@@ -595,7 +615,7 @@ func (s *Server) bulkAddRepos(
 	for _, raw := range input.Body.Repos {
 		repo, err := normalizeExactRepoInput(raw)
 		if err != nil {
-			return nil, huma.Error400BadRequest(err.Error())
+			return nil, problemValidation("body.repos", err.Error())
 		}
 		key := configuredRepoImportKey(repo)
 		if _, ok := existing[key]; ok {
@@ -604,19 +624,24 @@ func (s *Server) bulkAddRepos(
 		candidates = append(candidates, repo)
 	}
 	if len(candidates) == 0 {
-		return nil, huma.Error400BadRequest(
+		return nil, problemBadRequest(
+			CodeBadRequest,
 			"all selected repositories are already configured",
+			nil,
 		)
 	}
 
 	resolved, err := validateBulkExactRepos(ctx, s.syncer, candidates)
 	if err != nil {
-		status, msg := classifyResolveError(err)
-		return nil, huma.NewError(status, msg)
+		return nil, classifyResolveProblem(err)
 	}
-	resp, status, err := s.applyBulkExactRepos(ctx, resolved)
+	resp, err := s.applyBulkExactRepos(ctx, resolved)
 	if err != nil {
-		return nil, huma.NewError(status, err.Error())
+		var bae *bulkApplyError
+		if errors.As(err, &bae) {
+			return nil, bae.problem
+		}
+		return nil, problemInternal(err.Error())
 	}
 
 	s.syncer.TriggerRun(context.WithoutCancel(ctx))

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"path"
 	"slices"
 	"strings"
@@ -306,20 +305,21 @@ func (s *Server) defaultPlatformHost() string {
 	return strings.ToLower(strings.TrimSpace(host))
 }
 
-func classifyResolveError(err error) (int, string) {
-	switch {
-	case errors.Is(err, ghclient.ErrConfiguredRepoArchived):
-		return http.StatusBadRequest, err.Error()
-	default:
-		return http.StatusBadGateway, "GitHub API error: " + err.Error()
+// classifyResolveProblem maps a configured-repo resolve error to its wire
+// problem. Archived repos are caller-side validation; everything else is
+// an upstream provider failure.
+func classifyResolveProblem(err error) huma.StatusError {
+	if errors.Is(err, ghclient.ErrConfiguredRepoArchived) {
+		return problemBadRequest(CodeBadRequest, err.Error(), nil)
 	}
+	return problemUpstream("GitHub API error: "+err.Error(), "github", "")
 }
 
 func (s *Server) getSettings(
 	_ context.Context, _ *struct{},
 ) (*getSettingsOutput, error) {
 	if s.cfg == nil {
-		return nil, huma.Error404NotFound("settings not available")
+		return nil, problemNotFound(CodeSettingsUnavailable, "settings not available", nil)
 	}
 
 	return &getSettingsOutput{Body: s.buildLocalSettingsResponse()}, nil
@@ -329,7 +329,7 @@ func (s *Server) updateSettings(
 	_ context.Context, input *updateSettingsInput,
 ) (*settingsOutput, error) {
 	if s.cfgPath == "" {
-		return nil, huma.Error404NotFound("settings not available")
+		return nil, problemNotFound(CodeSettingsUnavailable, "settings not available", nil)
 	}
 
 	s.cfgMu.Lock()
@@ -357,15 +357,14 @@ func (s *Server) updateSettings(
 		s.cfg.Terminal = prevTerminal
 		s.cfg.Agents = prevAgents
 		s.cfgMu.Unlock()
-		return nil, huma.Error400BadRequest(err.Error())
+		return nil, problemBadRequest(CodeBadRequest, err.Error(), nil)
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Activity = prevActivity
 		s.cfg.Terminal = prevTerminal
 		s.cfg.Agents = prevAgents
 		s.cfgMu.Unlock()
-		return nil, huma.Error500InternalServerError(
-			"save config: " + err.Error())
+		return nil, problemInternal("save config: " + err.Error())
 	}
 	s.refreshRuntimeTargetsLocked()
 	s.cfgMu.Unlock()
@@ -399,15 +398,15 @@ func (s *Server) addConfiguredRepo(
 	ctx context.Context, input *addRepoInput,
 ) (*settingsOutput, error) {
 	if s.cfgPath == "" {
-		return nil, huma.Error404NotFound("settings not available")
+		return nil, problemNotFound(CodeSettingsUnavailable, "settings not available", nil)
 	}
 	if input.Body.Owner == "" || input.Body.Name == "" {
-		return nil, huma.Error400BadRequest("owner and name are required")
+		return nil, problemValidation("body", "owner and name are required")
 	}
 
 	provider, err := normalizeRouteProvider(input.Body.Provider)
 	if err != nil {
-		return nil, huma.Error400BadRequest(err.Error())
+		return nil, problemValidation("body.provider", err.Error())
 	}
 	newRepo := config.Repo{
 		Platform:     provider,
@@ -421,9 +420,9 @@ func (s *Server) addConfiguredRepo(
 	for _, rp := range s.cfg.Repos {
 		if sameConfiguredRepo(rp, newRepo) {
 			s.cfgMu.Unlock()
-			return nil, huma.Error400BadRequest(
-				input.Body.Owner + "/" + input.Body.Name +
-					" is already configured")
+			return nil, problemBadRequest(CodeBadRequest,
+				input.Body.Owner+"/"+input.Body.Name+
+					" is already configured", nil)
 		}
 	}
 	allRepos := append(slices.Clone(s.cfg.Repos), newRepo)
@@ -433,8 +432,7 @@ func (s *Server) addConfiguredRepo(
 		ctx, s.configuredClients(allRepos), newRepo,
 	)
 	if err != nil {
-		status, msg := classifyResolveError(err)
-		return nil, huma.NewError(status, msg)
+		return nil, classifyResolveProblem(err)
 	}
 
 	// Re-acquire lock and apply the addition to current state
@@ -443,22 +441,21 @@ func (s *Server) addConfiguredRepo(
 	for _, rp := range s.cfg.Repos {
 		if sameConfiguredRepo(rp, newRepo) {
 			s.cfgMu.Unlock()
-			return nil, huma.Error400BadRequest(
-				input.Body.Owner + "/" + input.Body.Name +
-					" is already configured")
+			return nil, problemBadRequest(CodeBadRequest,
+				input.Body.Owner+"/"+input.Body.Name+
+					" is already configured", nil)
 		}
 	}
 	s.cfg.Repos = append(s.cfg.Repos, newRepo)
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Repos = s.cfg.Repos[:len(s.cfg.Repos)-1]
 		s.cfgMu.Unlock()
-		return nil, huma.Error400BadRequest(err.Error())
+		return nil, problemBadRequest(CodeBadRequest, err.Error(), nil)
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Repos = s.cfg.Repos[:len(s.cfg.Repos)-1]
 		s.cfgMu.Unlock()
-		return nil, huma.Error500InternalServerError(
-			"save config: " + err.Error())
+		return nil, problemInternal("save config: " + err.Error())
 	}
 	s.mergeTrackedRepos(expanded)
 	s.cfgMu.Unlock()
@@ -471,14 +468,14 @@ func (s *Server) refreshConfiguredRepo(
 	ctx context.Context, input *repoConfigInput,
 ) (*settingsOutput, error) {
 	if s.cfgPath == "" {
-		return nil, huma.Error404NotFound("settings not available")
+		return nil, problemNotFound(CodeSettingsUnavailable, "settings not available", nil)
 	}
 
 	owner := input.Owner
 	name := input.Name
 	provider, err := normalizeRouteProvider(input.Provider)
 	if err != nil {
-		return nil, huma.Error400BadRequest(err.Error())
+		return nil, problemValidation("path.provider", err.Error())
 	}
 	targetRef := config.Repo{
 		Platform:     provider,
@@ -502,20 +499,19 @@ func (s *Server) refreshConfiguredRepo(
 		}
 	}
 	if target == nil {
-		return nil, huma.Error404NotFound(
-			owner + "/" + name + " is not configured")
+		return nil, problemNotFound(CodeRepoNotFound,
+			owner+"/"+name+" is not configured", nil)
 	}
 	if !target.HasNameGlob() {
-		return nil, huma.Error400BadRequest(
-			"refresh is only supported for glob patterns")
+		return nil, problemBadRequest(CodeBadRequest,
+			"refresh is only supported for glob patterns", nil)
 	}
 
 	_, expanded, err := ghclient.ResolveConfiguredRepo(
 		ctx, s.configuredClients(repos), *target,
 	)
 	if err != nil {
-		status, msg := classifyResolveError(err)
-		return nil, huma.NewError(status, msg)
+		return nil, classifyResolveProblem(err)
 	}
 
 	// Re-acquire cfgMu and verify the target glob still exists
@@ -537,13 +533,12 @@ func (s *Server) refreshConfiguredRepo(
 	}
 	if !stillExists {
 		s.cfgMu.Unlock()
-		return nil, huma.Error404NotFound(
-			owner + "/" + name + " is no longer configured")
+		return nil, problemNotFound(CodeRepoNotFound,
+			owner+"/"+name+" is no longer configured", nil)
 	}
 	if err := s.persistResolvedRepos(ctx, expanded); err != nil {
 		s.cfgMu.Unlock()
-		return nil, huma.Error500InternalServerError(
-			"persist resolved repos: " + err.Error())
+		return nil, problemInternal("persist resolved repos: " + err.Error())
 	}
 	s.replaceGlobRepos(*target, expanded, currentRepos)
 	s.cfgMu.Unlock()
@@ -567,14 +562,14 @@ func (s *Server) deleteConfiguredRepo(
 	_ context.Context, input *repoConfigInput,
 ) (*struct{}, error) {
 	if s.cfgPath == "" {
-		return nil, huma.Error404NotFound("settings not available")
+		return nil, problemNotFound(CodeSettingsUnavailable, "settings not available", nil)
 	}
 
 	owner := input.Owner
 	name := input.Name
 	provider, err := normalizeRouteProvider(input.Provider)
 	if err != nil {
-		return nil, huma.Error400BadRequest(err.Error())
+		return nil, problemValidation("path.provider", err.Error())
 	}
 	targetRef := config.Repo{
 		Platform:     provider,
@@ -596,8 +591,8 @@ func (s *Server) deleteConfiguredRepo(
 	}
 	if idx == -1 {
 		s.cfgMu.Unlock()
-		return nil, huma.Error404NotFound(
-			owner + "/" + name + " is not configured")
+		return nil, problemNotFound(CodeRepoNotFound,
+			owner+"/"+name+" is not configured", nil)
 	}
 
 	prev := slices.Clone(s.cfg.Repos)
@@ -607,8 +602,7 @@ func (s *Server) deleteConfiguredRepo(
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Repos = prev
 		s.cfgMu.Unlock()
-		return nil, huma.Error500InternalServerError(
-			"save config: " + err.Error())
+		return nil, problemInternal("save config: " + err.Error())
 	}
 	s.removeConfigRepos(s.cfg.Repos)
 	s.cfgMu.Unlock()

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
     "./api/types": { "default": "./src/api/types.ts" },
     "./api/client": { "default": "./src/api/generated/client.ts" },
     "./api/schema": { "default": "./src/api/generated/schema.ts" },
+    "./api/problems": { "default": "./src/api/problems.ts" },
     "./api/provider-capabilities": { "default": "./src/api/provider-capabilities.ts" },
     "./api/provider-routes": { "default": "./src/api/provider-routes.ts" },
     "./utils/time": { "default": "./src/utils/time.ts" },

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -6851,3 +6851,16 @@ export interface operations {
         };
     };
 }
+type FlattenedDeepRequired<T> = {
+    [K in keyof T]-?: FlattenedDeepRequired<T[K] extends unknown[] | undefined | null ? Extract<T[K], unknown[]>[number] : T[K]>;
+};
+type ReadonlyArray<T> = [
+    Exclude<T, undefined>
+] extends [
+    unknown[]
+] ? Readonly<Exclude<T, undefined>> : Readonly<Exclude<T, undefined>[]>;
+export const mergeRequestKanbanStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequest"]["KanbanStatus"]> = ["new", "reviewing", "waiting", "awaiting_merge"];
+export const mergeRequestStateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequest"]["State"]> = ["open", "closed", "merged"];
+export const mergeRequestResponseKanbanStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequestResponse"]["KanbanStatus"]> = ["new", "reviewing", "waiting", "awaiting_merge"];
+export const mergeRequestResponseStateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequestResponse"]["State"]> = ["open", "closed", "merged"];
+export const problemErrorCodeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ProblemError"]["code"]> = ["badRequest", "branchConflict", "commentNotFound", "conflict", "forbidden", "internalError", "issueNotFound", "notFound", "payloadTooLarge", "projectNotFound", "pullNotFound", "rateLimited", "repoNotFound", "serviceUnavailable", "settingsUnavailable", "unauthorized", "unsupportedCapability", "upstreamError", "validationError", "workspaceNotFound"];

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1964,45 +1964,6 @@ export interface components {
             /** @description The value at the given location */
             value?: unknown;
         };
-        ErrorModel: {
-            /**
-             * Format: uri
-             * @description A URL to the JSON Schema for this object.
-             * @example /api/v1/schemas/ErrorModel.json
-             */
-            readonly $schema?: string;
-            /**
-             * @description A human-readable explanation specific to this occurrence of the problem.
-             * @example Property foo is required but is missing.
-             */
-            detail?: string;
-            /** @description Optional list of individual error details */
-            errors?: components["schemas"]["ErrorDetail"][] | null;
-            /**
-             * Format: uri
-             * @description A URI reference that identifies the specific occurrence of the problem.
-             * @example https://example.com/error-log/abc123
-             */
-            instance?: string;
-            /**
-             * Format: int64
-             * @description HTTP status code
-             * @example 400
-             */
-            status?: number;
-            /**
-             * @description A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
-             * @example Bad Request
-             */
-            title?: string;
-            /**
-             * Format: uri
-             * @description A URI reference to human-readable documentation for the error.
-             * @default about:blank
-             * @example https://example.com/errors/example
-             */
-            type: string;
-        };
         FilePreviewResponse: {
             /**
              * Format: uri
@@ -2505,6 +2466,55 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
+        };
+        ProblemError: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/ProblemError.json
+             */
+            readonly $schema?: string;
+            /**
+             * @description Machine-readable error code. Stable across occurrences.
+             * @example badRequest
+             * @enum {string}
+             */
+            code: "badRequest" | "branchConflict" | "commentNotFound" | "conflict" | "forbidden" | "internalError" | "issueNotFound" | "notFound" | "payloadTooLarge" | "projectNotFound" | "pullNotFound" | "rateLimited" | "repoNotFound" | "serviceUnavailable" | "settingsUnavailable" | "unauthorized" | "unsupportedCapability" | "upstreamError" | "validationError" | "workspaceNotFound";
+            /**
+             * @description A human-readable explanation specific to this occurrence of the problem.
+             * @example Property foo is required but is missing.
+             */
+            detail?: string;
+            /** @description Machine-readable error context, keyed by code-specific conventions. */
+            details?: {
+                [key: string]: unknown;
+            };
+            /** @description Optional list of individual error details */
+            errors?: components["schemas"]["ErrorDetail"][] | null;
+            /**
+             * Format: uri
+             * @description A URI reference that identifies the specific occurrence of the problem.
+             * @example https://example.com/error-log/abc123
+             */
+            instance?: string;
+            /**
+             * Format: int64
+             * @description HTTP status code
+             * @example 400
+             */
+            status?: number;
+            /**
+             * @description A short, human-readable summary of the problem type. This value should not change between occurrences of the error.
+             * @example Bad Request
+             */
+            title?: string;
+            /**
+             * Format: uri
+             * @description A URI reference to human-readable documentation for the error.
+             * @default about:blank
+             * @example https://example.com/errors/example
+             */
+            type: string;
         };
         ProjectResponse: {
             /**
@@ -3067,7 +3077,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3096,7 +3106,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3134,7 +3144,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3169,7 +3179,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3208,7 +3218,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3247,7 +3257,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3287,7 +3297,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3326,7 +3336,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3365,7 +3375,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3400,7 +3410,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3433,7 +3443,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3472,7 +3482,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3507,7 +3517,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3546,7 +3556,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3585,7 +3595,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3620,7 +3630,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3655,7 +3665,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3694,7 +3704,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3734,7 +3744,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3769,7 +3779,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3812,7 +3822,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3856,7 +3866,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3891,7 +3901,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3930,7 +3940,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -3965,7 +3975,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4004,7 +4014,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4043,7 +4053,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4078,7 +4088,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4113,7 +4123,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4150,7 +4160,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4185,7 +4195,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4218,7 +4228,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4252,7 +4262,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4284,7 +4294,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4322,7 +4332,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4356,7 +4366,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4390,7 +4400,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4425,7 +4435,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4461,7 +4471,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4498,7 +4508,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4532,7 +4542,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4570,7 +4580,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4608,7 +4618,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4647,7 +4657,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4685,7 +4695,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4723,7 +4733,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4757,7 +4767,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4789,7 +4799,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4827,7 +4837,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4856,7 +4866,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4889,7 +4899,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4920,7 +4930,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4951,7 +4961,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -4982,7 +4992,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5017,7 +5027,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5054,7 +5064,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5088,7 +5098,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5126,7 +5136,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5164,7 +5174,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5198,7 +5208,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5232,7 +5242,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5270,7 +5280,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5309,7 +5319,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5343,7 +5353,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5385,7 +5395,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5428,7 +5438,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5462,7 +5472,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5500,7 +5510,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5534,7 +5544,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5572,7 +5582,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5610,7 +5620,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5644,7 +5654,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5678,7 +5688,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5714,7 +5724,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5748,7 +5758,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5780,7 +5790,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5809,7 +5819,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5842,7 +5852,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5873,7 +5883,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5910,7 +5920,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5943,7 +5953,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -5976,7 +5986,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6010,7 +6020,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6039,7 +6049,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6072,7 +6082,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6105,7 +6115,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6138,7 +6148,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6167,7 +6177,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6196,7 +6206,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6225,7 +6235,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6258,7 +6268,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6289,7 +6299,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6320,7 +6330,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6351,7 +6361,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6378,7 +6388,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6407,7 +6417,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6436,7 +6446,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6465,7 +6475,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6498,7 +6508,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6529,7 +6539,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6560,7 +6570,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6591,7 +6601,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6635,7 +6645,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6677,7 +6687,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6708,7 +6718,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6739,7 +6749,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6774,7 +6784,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6804,7 +6814,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };
@@ -6835,7 +6845,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
+                    "application/problem+json": components["schemas"]["ProblemError"];
                 };
             };
         };

--- a/packages/ui/src/api/problems.test.ts
+++ b/packages/ui/src/api/problems.test.ts
@@ -12,7 +12,7 @@ describe("isProblem", () => {
   it("accepts a body with a known code", () => {
     expect(
       isProblem({
-        code: "unsupportedCapability",
+        code: ProblemCodes.unsupportedCapability,
         type: "about:blank",
         details: { capability: "merge_mutation" },
       }),
@@ -68,7 +68,7 @@ describe("readProblem", () => {
       title: "Conflict",
       status: 409,
       detail: "Unsupported provider capability",
-      code: "unsupportedCapability",
+      code: ProblemCodes.unsupportedCapability,
       details: { capability: "merge_mutation", provider: "gitlab" },
     });
     const problem = await readProblem(response);
@@ -87,7 +87,7 @@ describe("problemCapability", () => {
   it("returns details.capability for an unsupportedCapability problem", () => {
     expect(
       problemCapability({
-        code: "unsupportedCapability",
+        code: ProblemCodes.unsupportedCapability,
         type: "about:blank",
         details: { capability: "merge_mutation" },
       }),
@@ -97,7 +97,7 @@ describe("problemCapability", () => {
   it("returns undefined for other codes", () => {
     expect(
       problemCapability({
-        code: "badRequest",
+        code: ProblemCodes.badRequest,
         type: "about:blank",
       }),
     ).toBeUndefined();
@@ -106,7 +106,7 @@ describe("problemCapability", () => {
   it("returns undefined when details.capability is missing", () => {
     expect(
       problemCapability({
-        code: "unsupportedCapability",
+        code: ProblemCodes.unsupportedCapability,
         type: "about:blank",
       }),
     ).toBeUndefined();
@@ -116,7 +116,7 @@ describe("problemCapability", () => {
 describe("problemRetryAfter", () => {
   it("parses an RFC 3339 retryAfter from a rateLimited problem", () => {
     const got = problemRetryAfter({
-      code: "rateLimited",
+      code: ProblemCodes.rateLimited,
       type: "about:blank",
       details: { retryAfter: "2026-05-19T12:00:00Z" },
     });
@@ -126,7 +126,7 @@ describe("problemRetryAfter", () => {
   it("returns undefined for other codes", () => {
     expect(
       problemRetryAfter({
-        code: "badRequest",
+        code: ProblemCodes.badRequest,
         type: "about:blank",
       }),
     ).toBeUndefined();
@@ -135,7 +135,7 @@ describe("problemRetryAfter", () => {
   it("returns undefined for malformed retryAfter", () => {
     expect(
       problemRetryAfter({
-        code: "rateLimited",
+        code: ProblemCodes.rateLimited,
         type: "about:blank",
         details: { retryAfter: "not-a-date" },
       }),

--- a/packages/ui/src/api/problems.test.ts
+++ b/packages/ui/src/api/problems.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isProblem,
+  problemCapability,
+  problemRetryAfter,
+  ProblemCodes,
+  readProblem,
+} from "./problems";
+
+describe("isProblem", () => {
+  it("accepts a body with a known code", () => {
+    expect(
+      isProblem({
+        code: "unsupportedCapability",
+        type: "about:blank",
+        details: { capability: "merge_mutation" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects null and non-objects", () => {
+    expect(isProblem(null)).toBe(false);
+    expect(isProblem(undefined)).toBe(false);
+    expect(isProblem("error")).toBe(false);
+    expect(isProblem(42)).toBe(false);
+  });
+
+  it("rejects objects without a code", () => {
+    expect(isProblem({ detail: "missing code" })).toBe(false);
+  });
+
+  it("rejects objects whose code is unknown", () => {
+    expect(isProblem({ code: "frobnicated" })).toBe(false);
+  });
+});
+
+describe("readProblem", () => {
+  function jsonResponse(
+    body: unknown,
+    init: ResponseInit & { contentType?: string } = {},
+  ): Response {
+    const headers = new Headers(init.headers);
+    headers.set("content-type", init.contentType ?? "application/problem+json");
+    return new Response(JSON.stringify(body), {
+      status: init.status ?? 409,
+      statusText: init.statusText,
+      headers,
+    });
+  }
+
+  it("returns null for ok responses", async () => {
+    const response = new Response("{}", { status: 200 });
+    expect(await readProblem(response)).toBeNull();
+  });
+
+  it("returns null for non-json bodies", async () => {
+    const response = new Response("oops", {
+      status: 500,
+      headers: { "content-type": "text/plain" },
+    });
+    expect(await readProblem(response)).toBeNull();
+  });
+
+  it("decodes a problem+json body", async () => {
+    const response = jsonResponse({
+      type: "about:blank",
+      title: "Conflict",
+      status: 409,
+      detail: "Unsupported provider capability",
+      code: "unsupportedCapability",
+      details: { capability: "merge_mutation", provider: "gitlab" },
+    });
+    const problem = await readProblem(response);
+    expect(problem).not.toBeNull();
+    expect(problem?.code).toBe(ProblemCodes.unsupportedCapability);
+    expect(problem?.details?.["capability"]).toBe("merge_mutation");
+  });
+
+  it("returns null when the body is a different shape", async () => {
+    const response = jsonResponse({ status: "ok" }, { status: 500 });
+    expect(await readProblem(response)).toBeNull();
+  });
+});
+
+describe("problemCapability", () => {
+  it("returns details.capability for an unsupportedCapability problem", () => {
+    expect(
+      problemCapability({
+        code: "unsupportedCapability",
+        type: "about:blank",
+        details: { capability: "merge_mutation" },
+      }),
+    ).toBe("merge_mutation");
+  });
+
+  it("returns undefined for other codes", () => {
+    expect(
+      problemCapability({
+        code: "badRequest",
+        type: "about:blank",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when details.capability is missing", () => {
+    expect(
+      problemCapability({
+        code: "unsupportedCapability",
+        type: "about:blank",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("problemRetryAfter", () => {
+  it("parses an RFC 3339 retryAfter from a rateLimited problem", () => {
+    const got = problemRetryAfter({
+      code: "rateLimited",
+      type: "about:blank",
+      details: { retryAfter: "2026-05-19T12:00:00Z" },
+    });
+    expect(got?.toISOString()).toBe("2026-05-19T12:00:00.000Z");
+  });
+
+  it("returns undefined for other codes", () => {
+    expect(
+      problemRetryAfter({
+        code: "badRequest",
+        type: "about:blank",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for malformed retryAfter", () => {
+    expect(
+      problemRetryAfter({
+        code: "rateLimited",
+        type: "about:blank",
+        details: { retryAfter: "not-a-date" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/ui/src/api/problems.ts
+++ b/packages/ui/src/api/problems.ts
@@ -3,6 +3,7 @@
 // and isProblem from this module rather than substring-matching the
 // human-readable detail text — code is the stable contract.
 
+import { problemErrorCodeValues } from "./generated/schema";
 import type { components } from "./generated/schema";
 
 export type ProblemBody = components["schemas"]["ProblemError"];
@@ -12,32 +13,11 @@ export type ProblemBody = components["schemas"]["ProblemError"];
 // the union without manual sync.
 export type ProblemCode = ProblemBody["code"];
 
-// ProblemCodes is the runtime constant counterpart of ProblemCode for
-// `switch` / `case ProblemCodes.unsupportedCapability:` style branching.
-// Adding a code here is a typecheck failure if the wire enum drifts
-// because the keys are typed against the union literal.
-export const ProblemCodes = {
-  badRequest: "badRequest",
-  branchConflict: "branchConflict",
-  commentNotFound: "commentNotFound",
-  conflict: "conflict",
-  forbidden: "forbidden",
-  internalError: "internalError",
-  issueNotFound: "issueNotFound",
-  notFound: "notFound",
-  payloadTooLarge: "payloadTooLarge",
-  projectNotFound: "projectNotFound",
-  pullNotFound: "pullNotFound",
-  rateLimited: "rateLimited",
-  repoNotFound: "repoNotFound",
-  serviceUnavailable: "serviceUnavailable",
-  settingsUnavailable: "settingsUnavailable",
-  unauthorized: "unauthorized",
-  unsupportedCapability: "unsupportedCapability",
-  upstreamError: "upstreamError",
-  validationError: "validationError",
-  workspaceNotFound: "workspaceNotFound",
-} as const satisfies Record<ProblemCode, ProblemCode>;
+export const ProblemCodes = Object.fromEntries(
+  problemErrorCodeValues.map((code) => [code, code]),
+) as { readonly [K in ProblemCode]: K };
+
+const problemCodeValues = new Set<string>(problemErrorCodeValues);
 
 // isProblem narrows an unknown value (e.g. a parsed JSON response body)
 // to ProblemBody. It checks the top-level shape - object with a code
@@ -50,7 +30,7 @@ export function isProblem(value: unknown): value is ProblemBody {
   if (typeof code !== "string") {
     return false;
   }
-  return Object.prototype.hasOwnProperty.call(ProblemCodes, code);
+  return problemCodeValues.has(code);
 }
 
 // readProblem decodes a fetch Response body as a problem when the

--- a/packages/ui/src/api/problems.ts
+++ b/packages/ui/src/api/problems.ts
@@ -1,0 +1,102 @@
+// Typed helpers for the RFC 9457 problem+json envelope returned by every
+// internal/server failure path. Frontend code should import ProblemCodes
+// and isProblem from this module rather than substring-matching the
+// human-readable detail text — code is the stable contract.
+
+import type { components } from "./generated/schema";
+
+export type ProblemBody = components["schemas"]["ProblemError"];
+
+// ProblemCode is the closed union of wire codes emitted by the server.
+// Drawn from the generated OpenAPI enum so a new server code lights up
+// the union without manual sync.
+export type ProblemCode = ProblemBody["code"];
+
+// ProblemCodes is the runtime constant counterpart of ProblemCode for
+// `switch` / `case ProblemCodes.unsupportedCapability:` style branching.
+// Adding a code here is a typecheck failure if the wire enum drifts
+// because the keys are typed against the union literal.
+export const ProblemCodes = {
+  badRequest: "badRequest",
+  branchConflict: "branchConflict",
+  commentNotFound: "commentNotFound",
+  conflict: "conflict",
+  forbidden: "forbidden",
+  internalError: "internalError",
+  issueNotFound: "issueNotFound",
+  notFound: "notFound",
+  payloadTooLarge: "payloadTooLarge",
+  projectNotFound: "projectNotFound",
+  pullNotFound: "pullNotFound",
+  rateLimited: "rateLimited",
+  repoNotFound: "repoNotFound",
+  serviceUnavailable: "serviceUnavailable",
+  settingsUnavailable: "settingsUnavailable",
+  unauthorized: "unauthorized",
+  unsupportedCapability: "unsupportedCapability",
+  upstreamError: "upstreamError",
+  validationError: "validationError",
+  workspaceNotFound: "workspaceNotFound",
+} as const satisfies Record<ProblemCode, ProblemCode>;
+
+// isProblem narrows an unknown value (e.g. a parsed JSON response body)
+// to ProblemBody. It checks the top-level shape - object with a code
+// field that matches one of the known codes.
+export function isProblem(value: unknown): value is ProblemBody {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const code = (value as { code?: unknown }).code;
+  if (typeof code !== "string") {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(ProblemCodes, code);
+}
+
+// readProblem decodes a fetch Response body as a problem when the
+// response is not OK and the content-type is application/problem+json.
+// Returns null for ok responses, non-problem bodies, or parse failures.
+export async function readProblem(
+  response: Response,
+): Promise<ProblemBody | null> {
+  if (response.ok) {
+    return null;
+  }
+  const ct = response.headers.get("content-type") ?? "";
+  if (!ct.includes("application/problem+json") && !ct.includes("application/json")) {
+    return null;
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return null;
+  }
+  return isProblem(body) ? body : null;
+}
+
+// problemCapability reads details.capability from an unsupportedCapability
+// problem so call sites can render a typed tooltip without dipping into
+// the loose details record.
+export function problemCapability(problem: ProblemBody): string | undefined {
+  if (problem.code !== ProblemCodes.unsupportedCapability) {
+    return undefined;
+  }
+  const cap = problem.details?.["capability"];
+  return typeof cap === "string" ? cap : undefined;
+}
+
+// problemRetryAfter reads details.retryAfter from a rateLimited problem
+// and returns it parsed as a Date. Returns undefined when the field is
+// missing or not a valid RFC 3339 string.
+export function problemRetryAfter(problem: ProblemBody): Date | undefined {
+  if (problem.code !== ProblemCodes.rateLimited) {
+    return undefined;
+  }
+  const retry = problem.details?.["retryAfter"];
+  if (typeof retry !== "string") {
+    return undefined;
+  }
+  const parsed = new Date(retry);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}

--- a/scripts/dev-backend-build.sh
+++ b/scripts/dev-backend-build.sh
@@ -107,7 +107,7 @@ generate_api_artifacts() {
     tmp_schema="$(mktemp "$state_dir/frontend-schema.XXXXXX")"
     (
       cd frontend
-      "$BUN_BIN" x openapi-typescript openapi/openapi.yaml -o "../$tmp_schema"
+      "$BUN_BIN" x openapi-typescript openapi/openapi.yaml --enum-values -o "../$tmp_schema"
     )
     write_if_changed "$frontend_schema" "$tmp_schema" >/dev/null 2>&1 || true
     generate_frontend_client


### PR DESCRIPTION
## Summary

- Handlers in `internal/server/` now return `application/problem+json` (RFC 9457) on failure paths. Body carries `type`, `title`, `status`, `detail`, plus a machine-readable `code` and a typed `details` map.
- Stable codes for the cases the frontend already had to substring-match: `unsupportedCapability` (with `details.capability`), `rateLimited` (with `details.retryAfter`), validation errors (with `details.field` / `details.allowed`), distinct not-found codes for repo / pull / issue / comment / project / workspace / settings, and a branch-conflict envelope with `details.branch` / `details.suggestedBranch`.
- Generated TS client surfaces the closed `Code` enum; `packages/ui/src/api/problems.ts` exposes `isProblem`, `readProblem`, `problemCapability`, `problemRetryAfter`.
- Three wire-level integration tests pin the envelope shape end-to-end (unsupported capability, rate limited via a fake gitlab provider, validation error).