### PR TITLE
feat(api): document every Huma route and lock metadata coverage with a contract test

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -103,6 +103,12 @@ for diff, files, commits, file preview, or future repo-scoped provider work.
 The generated clients and `packages/ui/src/api/provider-routes.ts` should be the
 single frontend path builder for these routes.
 
+When adding or renaming provider-aware Huma routes, treat `OperationID` as a
+generated-client contract. Keep default-host and host-prefixed variants paired,
+use the same `Summary` and tag for both, and reserve the `-on-host` suffix for
+the host-prefixed operation ID. Run `make api-generate` and update generated
+client call sites in the same change.
+
 ## Frontend Threading
 
 Frontend state should keep a reusable provider ref:
@@ -130,4 +136,4 @@ Choose the smallest boundary that catches the regression:
 - optional container/live tests when fakes cannot validate provider API drift.
 
 Run Go tests with `-shuffle=on`. Regenerate OpenAPI and generated clients with
-`make api-generate` after Huma route or API type changes.
+`make api-generate` after Huma route, route metadata, or API type changes.

--- a/context/testing.md
+++ b/context/testing.md
@@ -32,6 +32,38 @@ notice the regression:
 Regenerate OpenAPI and generated clients with `make api-generate` after Huma
 route or API type changes.
 
+## Huma API Contract
+
+Every public operation in `/api/v1/openapi.json` must have explicit OpenAPI
+metadata at the route registration site:
+
+- stable kebab-case `OperationID`;
+- short imperative `Summary`;
+- exactly one tag from the API tag taxonomy enforced in
+  `internal/server/route_metadata_test.go`.
+
+Use `documentOperation(...)` for Huma convenience helpers such as `huma.Get`
+and `huma.Post`. Use inline `Summary`, `Tags`, and `OperationID` fields for
+`huma.Register` blocks. Do not rely on Huma's generated summary or operation
+ID; those names feed checked-in generated clients, so changing an
+`OperationID` is a generated-client API change even when the HTTP path is
+unchanged.
+
+Health routes on the separate health Huma API intentionally disable OpenAPI and
+docs output. Terminal and proxy routes registered through `Adapter().Handle`
+must stay hidden or on a docs-disabled API unless they are promoted to public
+REST operations with the same metadata and generation workflow.
+
+For route metadata changes, run:
+
+```sh
+go test ./internal/server -run 'TestHumaContractMetadata|TestHumaConvenienceRoutesUseDocumentOperation|TestRouteMetadataWalker' -shuffle=on
+make api-generate
+```
+
+Then review generated Go and TypeScript client diffs for operation-name
+renames and update checked-in callers that use generated method/type names.
+
 Do not duplicate full-stack e2e tests across default-host and
 `/host/{platform_host}` route forms when the host route is only a generic
 wrapper. Add host-specific e2e coverage only for custom host logic, route

--- a/docs/superpowers/plans/2026-05-19-huma-openapi-metadata.md
+++ b/docs/superpowers/plans/2026-05-19-huma-openapi-metadata.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make every non-Hidden operation in middleman's Huma-served OpenAPI document carry an explicit Summary, at least one Tag, and a stable, unique OperationID, and guard the invariant with a live-OpenAPI walker test.
+**Goal:** Make every non-Hidden operation in middleman's Huma-served OpenAPI document carry an explicit Summary, exactly one known Tag, and a stable, unique OperationID, and guard the invariant with live-OpenAPI and source-level tests.
 
 **Architecture:** Add a contract test in `internal/server/route_metadata_test.go` that walks the live `*huma.OpenAPI` document produced by `server.NewOpenAPI()`. Introduce a small `documentOperation` registration helper and use it (or inline `huma.Operation` fields) to attach Summary, Tags, and OperationID to every existing non-Hidden route. After the source backfill, regenerate the four checked-in API artifacts via `make api-generate` so the metadata flows into the Go client and TypeScript schema.
 
@@ -80,14 +80,8 @@ func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
 			if strings.TrimSpace(op.Summary) == "" {
 				failures = append(failures, label+": missing Summary")
 			}
-			if op.Metadata["_convenience_summary"] != nil {
-				failures = append(failures, label+": auto-generated Summary")
-			}
 			if strings.TrimSpace(op.OperationID) == "" {
 				failures = append(failures, label+": missing OperationID")
-			}
-			if op.Metadata["_convenience_id"] != nil {
-				failures = append(failures, label+": auto-generated OperationID")
 			}
 			if len(op.Tags) < 1 {
 				failures = append(failures, label+": missing Tags")
@@ -97,6 +91,10 @@ func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
 						failures = append(failures, label+": empty Tag")
 					}
 				}
+			}
+			if !usesKnownSingleTag(op.Tags) {
+				failures = append(failures,
+					label+": expected exactly one tag from the API tag taxonomy")
 			}
 			if op.OperationID != "" {
 				if prior, ok := seen[op.OperationID]; ok {
@@ -112,8 +110,8 @@ func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
 }
 
 // TestHumaContractMetadata asserts that every non-Hidden operation in the
-// live OpenAPI document carries an explicit Summary, at least one Tag, and a
-// unique OperationID that is not the huma convenience-helper default.
+// live OpenAPI document carries an explicit Summary, exactly one known Tag,
+// and a unique OperationID.
 func TestHumaContractMetadata(t *testing.T) {
 	require := require.New(t)
 	openAPI := NewOpenAPI()
@@ -157,7 +155,7 @@ Run:
 nix run 'nixpkgs#go' -- test ./internal/server -run TestHumaContractMetadata -shuffle=on
 ```
 
-Expected: FAIL. Output contains entries like `GET /pulls: missing Summary`, `POST /pulls/{provider}/{owner}/{name}/{number}/approve: auto-generated OperationID`, `GET /version: missing Tags`.
+Expected: FAIL. Output contains entries like `GET /pulls: missing Summary`, `POST /pulls/{provider}/{owner}/{name}/{number}/approve: missing Tags`, `GET /version: missing Tags`.
 
 - [ ] **Step 3: Run the teeth-test in isolation and verify it passes**
 
@@ -1034,12 +1032,11 @@ get-settings, update-settings, add-repo, refresh-repo (and -on-host),
 delete-repo (and -on-host). All carry the Settings tag.
 
 With this commit every non-Hidden operation in /api/v1/openapi.json
-carries an explicit Summary, at least one Tag, and a unique
+carries an explicit Summary, exactly one known Tag, and a unique
 OperationID. The new TestHumaContractMetadata walks the live OpenAPI
 document and fails the build if a future change drops any of those
-three. A small teeth-test guards against the assertion becoming a
-no-op if Huma's _convenience_id/_convenience_summary marker keys ever
-move.
+three. Teeth-tests guard against the assertion becoming a no-op, and
+a source-level check keeps Huma convenience routes on documentOperation.
 EOF
 )"
 ```
@@ -1125,7 +1122,7 @@ For each match, rewrite the call site to the new OperationID-derived method name
 | `GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse` | `GetIssueOnHostWithResponse` |
 | `PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse` | `SyncIssueWithResponse` |
 | `PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse` | `SyncIssueOnHostWithResponse` |
-| `PostRepoByProviderByOwnerByNameResolveByNumberWithResponse` | `ResolveItemWithResponse` |
+| `PostRepoByProviderByOwnerByNameResolveByNumberWithResponse` | `ResolveRepoItemWithResponse` |
 | `GetActivityWithResponse` | `ListActivityWithResponse` |
 
 If the same line carries a `JSONRequestBody` type that was also renamed (for example `PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody` → `MergePullJSONRequestBody`), rename that too.

--- a/docs/superpowers/plans/2026-05-19-huma-openapi-metadata.md
+++ b/docs/superpowers/plans/2026-05-19-huma-openapi-metadata.md
@@ -1,0 +1,1259 @@
+# Huma OpenAPI Operation Metadata Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every non-Hidden operation in middleman's Huma-served OpenAPI document carry an explicit Summary, at least one Tag, and a stable, unique OperationID, and guard the invariant with a live-OpenAPI walker test.
+
+**Architecture:** Add a contract test in `internal/server/route_metadata_test.go` that walks the live `*huma.OpenAPI` document produced by `server.NewOpenAPI()`. Introduce a small `documentOperation` registration helper and use it (or inline `huma.Operation` fields) to attach Summary, Tags, and OperationID to every existing non-Hidden route. After the source backfill, regenerate the four checked-in API artifacts via `make api-generate` so the metadata flows into the Go client and TypeScript schema.
+
+**Tech Stack:** Go (huma/v2, testify), oapi-codegen, openapi-typescript, Bun.
+
+**Pre-commit hook caveat:** The repository's `prek.toml` configures a `make test-short` pre-commit hook that runs every Go test on commit. Across Tasks 2-3 the contract test file from Task 1 lives uncommitted on disk; `go test ./...` and any `make test-short` invocation will pick it up and fail until Task 4 lands. The pre-commit hook is not installed in this worktree, so commits in Tasks 2-3 succeed in practice. If the hook is later installed via `make install-hooks`, run the registerAPI/provider-repo backfills with the contract-test file temporarily stashed out of the worktree (move to `/tmp/route_metadata_test.go.draft`, then restore for Task 4). Do not pass `--no-verify`.
+
+---
+
+### Task 1: Sketch the Contract Test as a Working File
+
+This task drafts the contract test so subsequent backfill tasks have a concrete acceptance criterion to drive off. The test is not committed yet: a single commit at this point would either (a) break `go test ./...` and refuse to land in any environment with a `make test-short` pre-commit hook, or (b) require an awkward `t.Skip` that adds churn to a later removal commit. Instead, the working file lives uncommitted alongside the backfill tasks and lands in Task 4 once the live OpenAPI document already satisfies it.
+
+**Files:**
+- Create (uncommitted for now): `internal/server/route_metadata_test.go`
+
+- [ ] **Step 1: Write the contract test and negative-case smoke test**
+
+Create `internal/server/route_metadata_test.go`:
+
+```go
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// collectMetadataFailures walks an OpenAPI document and returns one entry per
+// missing-or-auto-generated metadata field on every non-nil operation. The
+// returned slice is sorted so failure output is stable across test runs.
+func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
+	var failures []string
+	seen := map[string]string{}
+
+	paths := make([]string, 0, len(openAPI.Paths))
+	for p := range openAPI.Paths {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		item := openAPI.Paths[path]
+		if item == nil {
+			continue
+		}
+		for _, opRef := range []struct {
+			method string
+			op     *huma.Operation
+		}{
+			{http.MethodGet, item.Get},
+			{http.MethodPut, item.Put},
+			{http.MethodPost, item.Post},
+			{http.MethodDelete, item.Delete},
+			{http.MethodOptions, item.Options},
+			{http.MethodHead, item.Head},
+			{http.MethodPatch, item.Patch},
+			{http.MethodTrace, item.Trace},
+		} {
+			op := opRef.op
+			if op == nil {
+				continue
+			}
+			label := fmt.Sprintf("%s %s", opRef.method, path)
+
+			if strings.TrimSpace(op.Summary) == "" {
+				failures = append(failures, label+": missing Summary")
+			}
+			if op.Metadata["_convenience_summary"] != nil {
+				failures = append(failures, label+": auto-generated Summary")
+			}
+			if strings.TrimSpace(op.OperationID) == "" {
+				failures = append(failures, label+": missing OperationID")
+			}
+			if op.Metadata["_convenience_id"] != nil {
+				failures = append(failures, label+": auto-generated OperationID")
+			}
+			if len(op.Tags) < 1 {
+				failures = append(failures, label+": missing Tags")
+			} else {
+				for _, tag := range op.Tags {
+					if strings.TrimSpace(tag) == "" {
+						failures = append(failures, label+": empty Tag")
+					}
+				}
+			}
+			if op.OperationID != "" {
+				if prior, ok := seen[op.OperationID]; ok {
+					failures = append(failures,
+						label+": duplicate OperationID with "+prior)
+				} else {
+					seen[op.OperationID] = label
+				}
+			}
+		}
+	}
+	return failures
+}
+
+// TestHumaContractMetadata asserts that every non-Hidden operation in the
+// live OpenAPI document carries an explicit Summary, at least one Tag, and a
+// unique OperationID that is not the huma convenience-helper default.
+func TestHumaContractMetadata(t *testing.T) {
+	require := require.New(t)
+	openAPI := NewOpenAPI()
+	require.NotNil(openAPI)
+	require.NotEmpty(openAPI.Paths, "OpenAPI document should expose paths")
+
+	failures := collectMetadataFailures(openAPI)
+	assert.Empty(t, failures, strings.Join(failures, "\n"))
+}
+
+// TestRouteMetadataWalkerCatchesUnannotatedRoute is a teeth-test: it builds
+// a tiny in-process huma.API with one convenience-helper route that has no
+// metadata, runs collectMetadataFailures, and asserts the walker reports at
+// least one failure. Guards against the contract test becoming a no-op if
+// Huma changes how it marks auto-generated values.
+func TestRouteMetadataWalkerCatchesUnannotatedRoute(t *testing.T) {
+	require := require.New(t)
+
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("test", "0.0.0"))
+
+	type emptyInput struct{}
+	type emptyOutput struct{}
+	huma.Get(api, "/unannotated", func(
+		_ context.Context, _ *emptyInput,
+	) (*emptyOutput, error) {
+		return &emptyOutput{}, nil
+	})
+
+	failures := collectMetadataFailures(api.OpenAPI())
+	require.NotEmpty(failures,
+		"walker must flag unannotated routes; got no failures")
+}
+```
+
+- [ ] **Step 2: Run the contract test to confirm it currently fails (sanity check)**
+
+Run:
+
+```bash
+nix run 'nixpkgs#go' -- test ./internal/server -run TestHumaContractMetadata -shuffle=on
+```
+
+Expected: FAIL. Output contains entries like `GET /pulls: missing Summary`, `POST /pulls/{provider}/{owner}/{name}/{number}/approve: auto-generated OperationID`, `GET /version: missing Tags`.
+
+- [ ] **Step 3: Run the teeth-test in isolation and verify it passes**
+
+```bash
+nix run 'nixpkgs#go' -- test ./internal/server -run TestRouteMetadataWalkerCatchesUnannotatedRoute -shuffle=on
+```
+
+Expected: PASS. The teeth test does not depend on the production registrations.
+
+- [ ] **Step 4: Do not commit yet**
+
+Leave the test file uncommitted. It will be committed in Task 6 once the backfill makes it pass. This step has no shell command; it's a reminder to not stage the file.
+
+---
+
+### Task 2: Backfill Top-Level Routes In registerAPI
+
+This task adds the `documentOperation` helper and uses it on every route in `registerAPI` (excluding `registerProviderRepoAPI` and `registerSettingsAPI`, which are separate tasks). The helper and its first use go in the same commit so `golangci-lint`'s `unused` check does not reject a stand-alone helper definition.
+
+**Files:**
+- Modify: `internal/server/huma_routes.go` (lines 413-575 approximately)
+
+- [ ] **Step 1: Add the documentOperation helper next to apiConfig**
+
+In `internal/server/huma_routes.go`, immediately after the `apiConfig` function (around line 422), add:
+
+```go
+// documentOperation returns an operationHandler that sets Summary, Tags, and
+// OperationID on the resulting *huma.Operation. Use it with the huma.Get/
+// Post/Put/Patch/Delete convenience helpers so routes registered through
+// shorthand still carry the metadata that the OpenAPI contract test enforces.
+func documentOperation(
+	operationID, summary string, tags ...string,
+) func(*huma.Operation) {
+	return func(o *huma.Operation) {
+		o.OperationID = operationID
+		o.Summary = summary
+		o.Tags = tags
+	}
+}
+```
+
+- [ ] **Step 2: Backfill the version, activity, pulls, issues, and starred routes**
+
+Replace the existing registrations in `registerAPI` with their metadata-bearing equivalents. For the `get-version` block, change:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID: "get-version",
+		Method:      http.MethodGet,
+		Path:        "/version",
+	}, s.getVersion)
+
+	huma.Get(api, "/activity", s.listActivity)
+	huma.Get(api, "/pulls", s.listPulls)
+	huma.Get(api, "/issues", s.listIssues)
+```
+
+to:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID: "get-version",
+		Method:      http.MethodGet,
+		Path:        "/version",
+		Summary:     "Get server version",
+		Tags:        []string{"System"},
+	}, s.getVersion)
+
+	huma.Get(api, "/activity", s.listActivity,
+		documentOperation("list-activity", "List activity", "Activity"))
+	huma.Get(api, "/pulls", s.listPulls,
+		documentOperation("list-pulls", "List pull requests", "Pull Requests"))
+	huma.Get(api, "/issues", s.listIssues,
+		documentOperation("list-issues", "List issues", "Issues"))
+```
+
+- [ ] **Step 3: Backfill repo summaries and starred routes**
+
+Replace:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "list-repo-summaries",
+		Method:        http.MethodGet,
+		Path:          "/repos/summary",
+		DefaultStatus: http.StatusOK,
+	}, s.listRepoSummaries)
+	huma.Register(api, huma.Operation{
+		OperationID:   "set-starred",
+		Method:        http.MethodPut,
+		Path:          "/starred",
+		DefaultStatus: http.StatusOK,
+	}, s.setStarred)
+	huma.Register(api, huma.Operation{
+		OperationID:   "unset-starred",
+		Method:        http.MethodDelete,
+		Path:          "/starred",
+		DefaultStatus: http.StatusOK,
+	}, s.unsetStarred)
+```
+
+with:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "list-repo-summaries",
+		Method:        http.MethodGet,
+		Path:          "/repos/summary",
+		DefaultStatus: http.StatusOK,
+		Summary:       "List repository summaries",
+		Tags:          []string{"Repositories"},
+	}, s.listRepoSummaries)
+	huma.Register(api, huma.Operation{
+		OperationID:   "set-starred",
+		Method:        http.MethodPut,
+		Path:          "/starred",
+		DefaultStatus: http.StatusOK,
+		Summary:       "Star repository",
+		Tags:          []string{"Settings"},
+	}, s.setStarred)
+	huma.Register(api, huma.Operation{
+		OperationID:   "unset-starred",
+		Method:        http.MethodDelete,
+		Path:          "/starred",
+		DefaultStatus: http.StatusOK,
+		Summary:       "Unstar repository",
+		Tags:          []string{"Settings"},
+	}, s.unsetStarred)
+```
+
+- [ ] **Step 4: Backfill repos, preview-repos, bulk-add-repos**
+
+Replace:
+
+```go
+	huma.Get(api, "/repos", s.listRepos)
+	huma.Register(api, huma.Operation{
+		OperationID:   "preview-repos",
+		Method:        http.MethodPost,
+		Path:          "/repos/preview",
+		DefaultStatus: http.StatusOK,
+	}, s.previewRepos)
+	huma.Register(api, huma.Operation{
+		OperationID:   "bulk-add-repos",
+		Method:        http.MethodPost,
+		Path:          "/repos/bulk",
+		DefaultStatus: http.StatusCreated,
+	}, s.bulkAddRepos)
+```
+
+with:
+
+```go
+	huma.Get(api, "/repos", s.listRepos,
+		documentOperation("list-repos", "List repositories", "Repositories"))
+	huma.Register(api, huma.Operation{
+		OperationID:   "preview-repos",
+		Method:        http.MethodPost,
+		Path:          "/repos/preview",
+		DefaultStatus: http.StatusOK,
+		Summary:       "Preview repositories",
+		Tags:          []string{"Repositories"},
+	}, s.previewRepos)
+	huma.Register(api, huma.Operation{
+		OperationID:   "bulk-add-repos",
+		Method:        http.MethodPost,
+		Path:          "/repos/bulk",
+		DefaultStatus: http.StatusCreated,
+		Summary:       "Bulk add repositories",
+		Tags:          []string{"Repositories"},
+	}, s.bulkAddRepos)
+```
+
+- [ ] **Step 5: Backfill sync/event/status routes**
+
+Replace:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "trigger-sync",
+		Method:        http.MethodPost,
+		Path:          "/sync",
+		DefaultStatus: http.StatusAccepted,
+	}, s.triggerSync)
+	huma.Register(api, huma.Operation{
+		OperationID: "stream-events",
+		Method:      http.MethodGet,
+		Path:        "/events",
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "Server-sent event stream",
+				Content: map[string]*huma.MediaType{
+					"text/event-stream": {},
+				},
+			},
+		},
+	}, s.streamEvents)
+	huma.Get(api, "/sync/status", s.syncStatus)
+	huma.Get(api, "/rate-limits", s.getRateLimits)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-roborev-status",
+		Method:      http.MethodGet,
+		Path:        "/roborev/status",
+	}, s.getRoborevStatus)
+
+	huma.Get(api, "/stacks", s.listStacks)
+```
+
+with:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "trigger-sync",
+		Method:        http.MethodPost,
+		Path:          "/sync",
+		DefaultStatus: http.StatusAccepted,
+		Summary:       "Trigger sync",
+		Tags:          []string{"Sync"},
+	}, s.triggerSync)
+	huma.Register(api, huma.Operation{
+		OperationID: "stream-events",
+		Method:      http.MethodGet,
+		Path:        "/events",
+		Summary:     "Stream server events",
+		Tags:        []string{"System"},
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "Server-sent event stream",
+				Content: map[string]*huma.MediaType{
+					"text/event-stream": {},
+				},
+			},
+		},
+	}, s.streamEvents)
+	huma.Get(api, "/sync/status", s.syncStatus,
+		documentOperation("get-sync-status", "Get sync status", "Sync"))
+	huma.Get(api, "/rate-limits", s.getRateLimits,
+		documentOperation("get-rate-limits", "Get rate limits", "Sync"))
+	huma.Register(api, huma.Operation{
+		OperationID: "get-roborev-status",
+		Method:      http.MethodGet,
+		Path:        "/roborev/status",
+		Summary:     "Get roborev status",
+		Tags:        []string{"Roborev"},
+	}, s.getRoborevStatus)
+
+	huma.Get(api, "/stacks", s.listStacks,
+		documentOperation("list-stacks", "List stacks", "Stacks"))
+```
+
+- [ ] **Step 6: Backfill workspace routes**
+
+Replace the entire workspace block (from `create-workspace` through `delete-workspace`):
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "create-workspace",
+		Method:        http.MethodPost,
+		Path:          "/workspaces",
+		DefaultStatus: http.StatusAccepted,
+	}, s.createWorkspace)
+	huma.Get(api, "/workspaces", s.listWorkspaces)
+	huma.Get(api, "/workspaces/{id}", s.getWorkspace)
+	huma.Get(api, "/workspaces/{id}/commits", s.getWorkspaceCommits)
+	huma.Get(api, "/workspaces/{id}/diff", s.getWorkspaceDiff)
+	huma.Get(api, "/workspaces/{id}/files", s.getWorkspaceFiles)
+	huma.Register(api, huma.Operation{
+		OperationID:   "retry-workspace",
+		Method:        http.MethodPost,
+		Path:          "/workspaces/{id}/retry",
+		DefaultStatus: http.StatusAccepted,
+	}, s.retryWorkspace)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-workspace-runtime",
+		Method:      http.MethodGet,
+		Path:        "/workspaces/{id}/runtime",
+	}, s.getWorkspaceRuntime)
+	huma.Register(api, huma.Operation{
+		OperationID: "launch-workspace-runtime-session",
+		Method:      http.MethodPost,
+		Path:        "/workspaces/{id}/runtime/sessions",
+	}, s.launchWorkspaceRuntimeSession)
+	huma.Register(api, huma.Operation{
+		OperationID:   "stop-workspace-runtime-session",
+		Method:        http.MethodDelete,
+		Path:          "/workspaces/{id}/runtime/sessions/{session_key}",
+		DefaultStatus: http.StatusNoContent,
+	}, s.stopWorkspaceRuntimeSession)
+	huma.Register(api, huma.Operation{
+		OperationID: "ensure-workspace-runtime-shell",
+		Method:      http.MethodPost,
+		Path:        "/workspaces/{id}/runtime/shell",
+	}, s.ensureWorkspaceRuntimeShell)
+	huma.Register(api, huma.Operation{
+		OperationID:   "delete-workspace",
+		Method:        http.MethodDelete,
+		Path:          "/workspaces/{id}",
+		DefaultStatus: http.StatusNoContent,
+	}, s.deleteWorkspace)
+```
+
+with:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "create-workspace",
+		Method:        http.MethodPost,
+		Path:          "/workspaces",
+		DefaultStatus: http.StatusAccepted,
+		Summary:       "Create workspace",
+		Tags:          []string{"Workspaces"},
+	}, s.createWorkspace)
+	huma.Get(api, "/workspaces", s.listWorkspaces,
+		documentOperation("list-workspaces", "List workspaces", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}", s.getWorkspace,
+		documentOperation("get-workspace", "Get workspace", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/commits", s.getWorkspaceCommits,
+		documentOperation("get-workspace-commits", "Get workspace commits", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/diff", s.getWorkspaceDiff,
+		documentOperation("get-workspace-diff", "Get workspace diff", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/files", s.getWorkspaceFiles,
+		documentOperation("get-workspace-files", "Get workspace files", "Workspaces"))
+	huma.Register(api, huma.Operation{
+		OperationID:   "retry-workspace",
+		Method:        http.MethodPost,
+		Path:          "/workspaces/{id}/retry",
+		DefaultStatus: http.StatusAccepted,
+		Summary:       "Retry workspace",
+		Tags:          []string{"Workspaces"},
+	}, s.retryWorkspace)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-workspace-runtime",
+		Method:      http.MethodGet,
+		Path:        "/workspaces/{id}/runtime",
+		Summary:     "Get workspace runtime",
+		Tags:        []string{"Workspaces"},
+	}, s.getWorkspaceRuntime)
+	huma.Register(api, huma.Operation{
+		OperationID: "launch-workspace-runtime-session",
+		Method:      http.MethodPost,
+		Path:        "/workspaces/{id}/runtime/sessions",
+		Summary:     "Launch workspace runtime session",
+		Tags:        []string{"Workspaces"},
+	}, s.launchWorkspaceRuntimeSession)
+	huma.Register(api, huma.Operation{
+		OperationID:   "stop-workspace-runtime-session",
+		Method:        http.MethodDelete,
+		Path:          "/workspaces/{id}/runtime/sessions/{session_key}",
+		DefaultStatus: http.StatusNoContent,
+		Summary:       "Stop workspace runtime session",
+		Tags:          []string{"Workspaces"},
+	}, s.stopWorkspaceRuntimeSession)
+	huma.Register(api, huma.Operation{
+		OperationID: "ensure-workspace-runtime-shell",
+		Method:      http.MethodPost,
+		Path:        "/workspaces/{id}/runtime/shell",
+		Summary:     "Ensure workspace runtime shell",
+		Tags:        []string{"Workspaces"},
+	}, s.ensureWorkspaceRuntimeShell)
+	huma.Register(api, huma.Operation{
+		OperationID:   "delete-workspace",
+		Method:        http.MethodDelete,
+		Path:          "/workspaces/{id}",
+		DefaultStatus: http.StatusNoContent,
+		Summary:       "Delete workspace",
+		Tags:          []string{"Workspaces"},
+	}, s.deleteWorkspace)
+```
+
+- [ ] **Step 7: Backfill projects, worktrees, and launch targets**
+
+Replace:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "register-project",
+		Method:        http.MethodPost,
+		Path:          "/projects",
+		DefaultStatus: http.StatusCreated,
+	}, s.registerProject)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-projects",
+		Method:      http.MethodGet,
+		Path:        "/projects",
+	}, s.listProjects)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-project",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}",
+	}, s.getProject)
+	huma.Register(api, huma.Operation{
+		OperationID:   "register-worktree",
+		Method:        http.MethodPost,
+		Path:          "/projects/{project_id}/worktrees",
+		DefaultStatus: http.StatusCreated,
+	}, s.registerWorktree)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-worktrees",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}/worktrees",
+	}, s.listWorktrees)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-launch-targets",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}/launch-targets",
+	}, s.listLaunchTargets)
+```
+
+with:
+
+```go
+	huma.Register(api, huma.Operation{
+		OperationID:   "register-project",
+		Method:        http.MethodPost,
+		Path:          "/projects",
+		DefaultStatus: http.StatusCreated,
+		Summary:       "Register project",
+		Tags:          []string{"Projects"},
+	}, s.registerProject)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-projects",
+		Method:      http.MethodGet,
+		Path:        "/projects",
+		Summary:     "List projects",
+		Tags:        []string{"Projects"},
+	}, s.listProjects)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-project",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}",
+		Summary:     "Get project",
+		Tags:        []string{"Projects"},
+	}, s.getProject)
+	huma.Register(api, huma.Operation{
+		OperationID:   "register-worktree",
+		Method:        http.MethodPost,
+		Path:          "/projects/{project_id}/worktrees",
+		DefaultStatus: http.StatusCreated,
+		Summary:       "Register worktree",
+		Tags:          []string{"Projects"},
+	}, s.registerWorktree)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-worktrees",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}/worktrees",
+		Summary:     "List worktrees",
+		Tags:        []string{"Projects"},
+	}, s.listWorktrees)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-launch-targets",
+		Method:      http.MethodGet,
+		Path:        "/projects/{project_id}/launch-targets",
+		Summary:     "List launch targets",
+		Tags:        []string{"Projects"},
+	}, s.listLaunchTargets)
+```
+
+- [ ] **Step 8: Run contract test and verify remaining failures are confined to provider-repo routes and settings routes**
+
+Run:
+
+```bash
+nix run 'nixpkgs#go' -- test ./internal/server -run TestHumaContractMetadata -shuffle=on
+```
+
+Expected: FAIL, but every remaining failure line should reference a path matching `^/(host/|repo/|repos$|pulls/|issues/|settings)`. No failures should reference `/pulls`, `/issues`, `/activity`, `/version`, `/repos`, `/workspaces`, `/projects`, `/sync`, `/stacks`, `/events`, `/rate-limits`, `/roborev/status`, or `/starred`.
+
+- [ ] **Step 9: Commit the registerAPI backfill (helper + every change in Task 2)**
+
+```bash
+git add internal/server/huma_routes.go
+git commit -m "$(cat <<'EOF'
+feat(server): document top-level Huma routes in registerAPI
+
+Backfills Summary, Tags, and (where missing) OperationID on every
+non-provider-repo route registered through registerAPI: list/get
+operations for version, activity, pulls, issues, repos, workspaces,
+projects, stacks, plus trigger-sync, sync status, rate limits, the
+SSE /events stream, and starred/unstarred mutations.
+
+Picks one tag per route from the taxonomy in the spec so the docs UI
+groups related operations together: Pull Requests, Issues,
+Repositories, Settings, Sync, Activity, Stacks, Workspaces, Projects,
+Roborev, System.
+
+Adds a documentOperation(operationID, summary string, tags ...string)
+helper next to apiConfig so callers can fill the three required pieces
+of OpenAPI metadata in one expression alongside huma.Get/Post/Put/
+Patch/Delete shorthand calls.
+EOF
+)"
+```
+
+---
+
+### Task 3: Backfill Provider-Repo Routes In registerProviderRepoAPI
+
+This task covers everything registered inside `registerProviderRepoAPI` (roughly lines 577-661 in `huma_routes.go`). The inline `huma.Register(api, huma.Operation{...})` calls keep their structure; they just gain `Summary` and `Tags` fields. The convenience-helper calls (`huma.Get`/`huma.Post`) gain a `documentOperation(...)` argument. Several existing OperationIDs already conform to the kebab-case `verb-resource[-qualifier]` convention and stay as-is; the rest follow the conventions in the spec.
+
+**Files:**
+- Modify: `internal/server/huma_routes.go` (lines 577-661 approximately)
+
+- [ ] **Step 1: Backfill PR detail, kanban-state, content, comments, and labels**
+
+Replace:
+
+```go
+	huma.Get(api, pullPath, s.getPull)
+	huma.Get(api, hostPullPath, s.getPullOnHost)
+	huma.Get(api, pullPath+"/import-metadata", s.getMRImportMetadata)
+	huma.Get(api, hostPullPath+"/import-metadata", s.getMRImportMetadataOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-kanban-state", Method: http.MethodPut, Path: pullPath + "/state", DefaultStatus: http.StatusOK}, s.setKanbanState)
+	huma.Register(api, huma.Operation{OperationID: "set-kanban-state-on-host", Method: http.MethodPut, Path: hostPullPath + "/state", DefaultStatus: http.StatusOK}, s.setKanbanStateOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-content", Method: http.MethodPatch, Path: pullPath, DefaultStatus: http.StatusOK}, s.editPRContent)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-content-on-host", Method: http.MethodPatch, Path: hostPullPath, DefaultStatus: http.StatusOK}, s.editPRContentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "post-pr-comment", Method: http.MethodPost, Path: pullPath + "/comments", DefaultStatus: http.StatusCreated}, s.postComment)
+	huma.Register(api, huma.Operation{OperationID: "post-pr-comment-on-host", Method: http.MethodPost, Path: hostPullPath + "/comments", DefaultStatus: http.StatusCreated}, s.postCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment", Method: http.MethodPatch, Path: pullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editComment)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment-on-host", Method: http.MethodPatch, Path: hostPullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-labels", Method: http.MethodPut, Path: pullPath + "/labels", DefaultStatus: http.StatusOK}, s.setPullLabels)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-labels-on-host", Method: http.MethodPut, Path: hostPullPath + "/labels", DefaultStatus: http.StatusOK}, s.setPullLabelsOnHost)
+```
+
+with:
+
+```go
+	huma.Get(api, pullPath, s.getPull,
+		documentOperation("get-pull", "Get pull request", "Pull Requests"))
+	huma.Get(api, hostPullPath, s.getPullOnHost,
+		documentOperation("get-pull-on-host", "Get pull request", "Pull Requests"))
+	huma.Get(api, pullPath+"/import-metadata", s.getMRImportMetadata,
+		documentOperation("get-pull-import-metadata", "Get pull request import metadata", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/import-metadata", s.getMRImportMetadataOnHost,
+		documentOperation("get-pull-import-metadata-on-host", "Get pull request import metadata", "Pull Requests"))
+	huma.Register(api, huma.Operation{OperationID: "set-kanban-state", Method: http.MethodPut, Path: pullPath + "/state", DefaultStatus: http.StatusOK, Summary: "Set pull request kanban state", Tags: []string{"Pull Requests"}}, s.setKanbanState)
+	huma.Register(api, huma.Operation{OperationID: "set-kanban-state-on-host", Method: http.MethodPut, Path: hostPullPath + "/state", DefaultStatus: http.StatusOK, Summary: "Set pull request kanban state", Tags: []string{"Pull Requests"}}, s.setKanbanStateOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-content", Method: http.MethodPatch, Path: pullPath, DefaultStatus: http.StatusOK, Summary: "Edit pull request content", Tags: []string{"Pull Requests"}}, s.editPRContent)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-content-on-host", Method: http.MethodPatch, Path: hostPullPath, DefaultStatus: http.StatusOK, Summary: "Edit pull request content", Tags: []string{"Pull Requests"}}, s.editPRContentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "post-pr-comment", Method: http.MethodPost, Path: pullPath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post pull request comment", Tags: []string{"Pull Requests"}}, s.postComment)
+	huma.Register(api, huma.Operation{OperationID: "post-pr-comment-on-host", Method: http.MethodPost, Path: hostPullPath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post pull request comment", Tags: []string{"Pull Requests"}}, s.postCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment", Method: http.MethodPatch, Path: pullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit pull request comment", Tags: []string{"Pull Requests"}}, s.editComment)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment-on-host", Method: http.MethodPatch, Path: hostPullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit pull request comment", Tags: []string{"Pull Requests"}}, s.editCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-labels", Method: http.MethodPut, Path: pullPath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set pull request labels", Tags: []string{"Pull Requests"}}, s.setPullLabels)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-labels-on-host", Method: http.MethodPut, Path: hostPullPath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set pull request labels", Tags: []string{"Pull Requests"}}, s.setPullLabelsOnHost)
+```
+
+- [ ] **Step 2: Backfill issue creation, detail, content, comments, and labels**
+
+Replace:
+
+```go
+	huma.Register(api, huma.Operation{OperationID: "create-issue", Method: http.MethodPost, Path: issueRepoPath, DefaultStatus: http.StatusCreated}, s.createIssue)
+	huma.Register(api, huma.Operation{OperationID: "create-issue-on-host", Method: http.MethodPost, Path: hostIssueRepoPath, DefaultStatus: http.StatusCreated}, s.createIssueOnHost)
+	huma.Get(api, issuePath, s.getIssue)
+	huma.Get(api, hostIssuePath, s.getIssueOnHost)
+	huma.Register(api, huma.Operation{OperationID: "post-issue-comment", Method: http.MethodPost, Path: issuePath + "/comments", DefaultStatus: http.StatusCreated}, s.postIssueComment)
+	huma.Register(api, huma.Operation{OperationID: "post-issue-comment-on-host", Method: http.MethodPost, Path: hostIssuePath + "/comments", DefaultStatus: http.StatusCreated}, s.postIssueCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content", Method: http.MethodPatch, Path: issuePath, DefaultStatus: http.StatusOK}, s.editIssueContent)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content-on-host", Method: http.MethodPatch, Path: hostIssuePath, DefaultStatus: http.StatusOK}, s.editIssueContentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment", Method: http.MethodPatch, Path: issuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editIssueComment)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment-on-host", Method: http.MethodPatch, Path: hostIssuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editIssueCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-labels", Method: http.MethodPut, Path: issuePath + "/labels", DefaultStatus: http.StatusOK}, s.setIssueLabels)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-labels-on-host", Method: http.MethodPut, Path: hostIssuePath + "/labels", DefaultStatus: http.StatusOK}, s.setIssueLabelsOnHost)
+```
+
+with:
+
+```go
+	huma.Register(api, huma.Operation{OperationID: "create-issue", Method: http.MethodPost, Path: issueRepoPath, DefaultStatus: http.StatusCreated, Summary: "Create issue", Tags: []string{"Issues"}}, s.createIssue)
+	huma.Register(api, huma.Operation{OperationID: "create-issue-on-host", Method: http.MethodPost, Path: hostIssueRepoPath, DefaultStatus: http.StatusCreated, Summary: "Create issue", Tags: []string{"Issues"}}, s.createIssueOnHost)
+	huma.Get(api, issuePath, s.getIssue,
+		documentOperation("get-issue", "Get issue", "Issues"))
+	huma.Get(api, hostIssuePath, s.getIssueOnHost,
+		documentOperation("get-issue-on-host", "Get issue", "Issues"))
+	huma.Register(api, huma.Operation{OperationID: "post-issue-comment", Method: http.MethodPost, Path: issuePath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post issue comment", Tags: []string{"Issues"}}, s.postIssueComment)
+	huma.Register(api, huma.Operation{OperationID: "post-issue-comment-on-host", Method: http.MethodPost, Path: hostIssuePath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post issue comment", Tags: []string{"Issues"}}, s.postIssueCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content", Method: http.MethodPatch, Path: issuePath, DefaultStatus: http.StatusOK, Summary: "Edit issue content", Tags: []string{"Issues"}}, s.editIssueContent)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content-on-host", Method: http.MethodPatch, Path: hostIssuePath, DefaultStatus: http.StatusOK, Summary: "Edit issue content", Tags: []string{"Issues"}}, s.editIssueContentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment", Method: http.MethodPatch, Path: issuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit issue comment", Tags: []string{"Issues"}}, s.editIssueComment)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment-on-host", Method: http.MethodPatch, Path: hostIssuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit issue comment", Tags: []string{"Issues"}}, s.editIssueCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-labels", Method: http.MethodPut, Path: issuePath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set issue labels", Tags: []string{"Issues"}}, s.setIssueLabels)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-labels-on-host", Method: http.MethodPut, Path: hostIssuePath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set issue labels", Tags: []string{"Issues"}}, s.setIssueLabelsOnHost)
+```
+
+- [ ] **Step 3: Backfill repo resolve, repo detail, repo labels, comment autocomplete**
+
+Replace:
+
+```go
+	huma.Post(api, repoPath+"/resolve/{number}", s.resolveItem)
+	huma.Post(api, hostRepoPath+"/resolve/{number}", s.resolveItemOnHost)
+	huma.Get(api, repoPath, s.getRepo)
+	huma.Get(api, hostRepoPath, s.getRepoOnHost)
+	huma.Register(api, huma.Operation{OperationID: "list-repo-labels", Method: http.MethodGet, Path: repoPath + "/labels", DefaultStatus: http.StatusOK}, s.listRepoLabels)
+	huma.Register(api, huma.Operation{OperationID: "list-repo-labels-on-host", Method: http.MethodGet, Path: hostRepoPath + "/labels", DefaultStatus: http.StatusOK}, s.listRepoLabelsOnHost)
+	huma.Get(api, repoPath+"/comment-autocomplete", s.getCommentAutocomplete)
+	huma.Get(api, hostRepoPath+"/comment-autocomplete", s.getCommentAutocompleteOnHost)
+```
+
+with:
+
+```go
+	huma.Post(api, repoPath+"/resolve/{number}", s.resolveItem,
+		documentOperation("resolve-item", "Resolve repository item", "Repositories"))
+	huma.Post(api, hostRepoPath+"/resolve/{number}", s.resolveItemOnHost,
+		documentOperation("resolve-item-on-host", "Resolve repository item", "Repositories"))
+	huma.Get(api, repoPath, s.getRepo,
+		documentOperation("get-repo", "Get repository", "Repositories"))
+	huma.Get(api, hostRepoPath, s.getRepoOnHost,
+		documentOperation("get-repo-on-host", "Get repository", "Repositories"))
+	huma.Register(api, huma.Operation{OperationID: "list-repo-labels", Method: http.MethodGet, Path: repoPath + "/labels", DefaultStatus: http.StatusOK, Summary: "List repository labels", Tags: []string{"Repositories"}}, s.listRepoLabels)
+	huma.Register(api, huma.Operation{OperationID: "list-repo-labels-on-host", Method: http.MethodGet, Path: hostRepoPath + "/labels", DefaultStatus: http.StatusOK, Summary: "List repository labels", Tags: []string{"Repositories"}}, s.listRepoLabelsOnHost)
+	huma.Get(api, repoPath+"/comment-autocomplete", s.getCommentAutocomplete,
+		documentOperation("get-comment-autocomplete", "Get comment autocomplete", "Repositories"))
+	huma.Get(api, hostRepoPath+"/comment-autocomplete", s.getCommentAutocompleteOnHost,
+		documentOperation("get-comment-autocomplete-on-host", "Get comment autocomplete", "Repositories"))
+```
+
+- [ ] **Step 4: Backfill PR mutations (approve, ready-for-review, merge, sync, ci-refresh, github-state)**
+
+Replace:
+
+```go
+	huma.Post(api, pullPath+"/approve", s.approvePR)
+	huma.Post(api, hostPullPath+"/approve", s.approvePROnHost)
+	huma.Post(api, pullPath+"/approve-workflows", s.approveWorkflows)
+	huma.Post(api, hostPullPath+"/approve-workflows", s.approveWorkflowsOnHost)
+	huma.Post(api, pullPath+"/ready-for-review", s.readyForReview)
+	huma.Post(api, hostPullPath+"/ready-for-review", s.readyForReviewOnHost)
+	huma.Post(api, pullPath+"/merge", s.mergePR)
+	huma.Post(api, hostPullPath+"/merge", s.mergePROnHost)
+	huma.Post(api, pullPath+"/sync", s.syncPR)
+	huma.Post(api, hostPullPath+"/sync", s.syncPROnHost)
+	huma.Post(api, pullPath+"/ci-refresh", s.syncPRCI)
+	huma.Post(api, hostPullPath+"/ci-refresh", s.syncPRCIOnHost)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync", Method: http.MethodPost, Path: pullPath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueuePRSync)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync-on-host", Method: http.MethodPost, Path: hostPullPath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueuePRSyncOnHost)
+	huma.Post(api, issuePath+"/sync", s.syncIssue)
+	huma.Post(api, hostIssuePath+"/sync", s.syncIssueOnHost)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync", Method: http.MethodPost, Path: issuePath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueueIssueSync)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync-on-host", Method: http.MethodPost, Path: hostIssuePath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueueIssueSyncOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state", Method: http.MethodPost, Path: pullPath + "/github-state", DefaultStatus: http.StatusOK}, s.setPRGitHubState)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state-on-host", Method: http.MethodPost, Path: hostPullPath + "/github-state", DefaultStatus: http.StatusOK}, s.setPRGitHubStateOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state", Method: http.MethodPost, Path: issuePath + "/github-state", DefaultStatus: http.StatusOK}, s.setIssueGitHubState)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state-on-host", Method: http.MethodPost, Path: hostIssuePath + "/github-state", DefaultStatus: http.StatusOK}, s.setIssueGitHubStateOnHost)
+```
+
+with:
+
+```go
+	huma.Post(api, pullPath+"/approve", s.approvePR,
+		documentOperation("approve-pull", "Approve pull request", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/approve", s.approvePROnHost,
+		documentOperation("approve-pull-on-host", "Approve pull request", "Pull Requests"))
+	huma.Post(api, pullPath+"/approve-workflows", s.approveWorkflows,
+		documentOperation("approve-pull-workflows", "Approve pull request workflows", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/approve-workflows", s.approveWorkflowsOnHost,
+		documentOperation("approve-pull-workflows-on-host", "Approve pull request workflows", "Pull Requests"))
+	huma.Post(api, pullPath+"/ready-for-review", s.readyForReview,
+		documentOperation("mark-pull-ready-for-review", "Mark pull request ready for review", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/ready-for-review", s.readyForReviewOnHost,
+		documentOperation("mark-pull-ready-for-review-on-host", "Mark pull request ready for review", "Pull Requests"))
+	huma.Post(api, pullPath+"/merge", s.mergePR,
+		documentOperation("merge-pull", "Merge pull request", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/merge", s.mergePROnHost,
+		documentOperation("merge-pull-on-host", "Merge pull request", "Pull Requests"))
+	huma.Post(api, pullPath+"/sync", s.syncPR,
+		documentOperation("sync-pull", "Sync pull request", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/sync", s.syncPROnHost,
+		documentOperation("sync-pull-on-host", "Sync pull request", "Pull Requests"))
+	huma.Post(api, pullPath+"/ci-refresh", s.syncPRCI,
+		documentOperation("refresh-pull-ci", "Refresh pull request CI", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/ci-refresh", s.syncPRCIOnHost,
+		documentOperation("refresh-pull-ci-on-host", "Refresh pull request CI", "Pull Requests"))
+	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync", Method: http.MethodPost, Path: pullPath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue pull request sync", Tags: []string{"Pull Requests"}}, s.enqueuePRSync)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync-on-host", Method: http.MethodPost, Path: hostPullPath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue pull request sync", Tags: []string{"Pull Requests"}}, s.enqueuePRSyncOnHost)
+	huma.Post(api, issuePath+"/sync", s.syncIssue,
+		documentOperation("sync-issue", "Sync issue", "Issues"))
+	huma.Post(api, hostIssuePath+"/sync", s.syncIssueOnHost,
+		documentOperation("sync-issue-on-host", "Sync issue", "Issues"))
+	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync", Method: http.MethodPost, Path: issuePath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue issue sync", Tags: []string{"Issues"}}, s.enqueueIssueSync)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync-on-host", Method: http.MethodPost, Path: hostIssuePath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue issue sync", Tags: []string{"Issues"}}, s.enqueueIssueSyncOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state", Method: http.MethodPost, Path: pullPath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set pull request GitHub state", Tags: []string{"Pull Requests"}}, s.setPRGitHubState)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state-on-host", Method: http.MethodPost, Path: hostPullPath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set pull request GitHub state", Tags: []string{"Pull Requests"}}, s.setPRGitHubStateOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state", Method: http.MethodPost, Path: issuePath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set issue GitHub state", Tags: []string{"Issues"}}, s.setIssueGitHubState)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state-on-host", Method: http.MethodPost, Path: hostIssuePath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set issue GitHub state", Tags: []string{"Issues"}}, s.setIssueGitHubStateOnHost)
+```
+
+- [ ] **Step 5: Backfill PR commits/diff/files/file-preview/stack and create-issue-workspace**
+
+Replace:
+
+```go
+	huma.Get(api, pullPath+"/commits", s.getCommits)
+	huma.Get(api, hostPullPath+"/commits", s.getCommitsOnHost)
+	huma.Get(api, pullPath+"/diff", s.getDiff)
+	huma.Get(api, hostPullPath+"/diff", s.getDiffOnHost)
+	huma.Get(api, pullPath+"/files", s.getFiles)
+	huma.Get(api, hostPullPath+"/files", s.getFilesOnHost)
+	huma.Get(api, pullPath+"/file-preview", s.getFilePreview)
+	huma.Get(api, hostPullPath+"/file-preview", s.getFilePreviewOnHost)
+	huma.Get(api, pullPath+"/stack", s.getStackForPR)
+	huma.Get(api, hostPullPath+"/stack", s.getStackForPROnHost)
+	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace", Method: http.MethodPost, Path: issuePath + "/workspace", DefaultStatus: http.StatusAccepted}, s.createIssueWorkspace)
+	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace-on-host", Method: http.MethodPost, Path: hostIssuePath + "/workspace", DefaultStatus: http.StatusAccepted}, s.createIssueWorkspaceOnHost)
+```
+
+with:
+
+```go
+	huma.Get(api, pullPath+"/commits", s.getCommits,
+		documentOperation("get-pull-commits", "Get pull request commits", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/commits", s.getCommitsOnHost,
+		documentOperation("get-pull-commits-on-host", "Get pull request commits", "Pull Requests"))
+	huma.Get(api, pullPath+"/diff", s.getDiff,
+		documentOperation("get-pull-diff", "Get pull request diff", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/diff", s.getDiffOnHost,
+		documentOperation("get-pull-diff-on-host", "Get pull request diff", "Pull Requests"))
+	huma.Get(api, pullPath+"/files", s.getFiles,
+		documentOperation("get-pull-files", "Get pull request files", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/files", s.getFilesOnHost,
+		documentOperation("get-pull-files-on-host", "Get pull request files", "Pull Requests"))
+	huma.Get(api, pullPath+"/file-preview", s.getFilePreview,
+		documentOperation("get-pull-file-preview", "Get pull request file preview", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/file-preview", s.getFilePreviewOnHost,
+		documentOperation("get-pull-file-preview-on-host", "Get pull request file preview", "Pull Requests"))
+	huma.Get(api, pullPath+"/stack", s.getStackForPR,
+		documentOperation("get-pull-stack", "Get pull request stack", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/stack", s.getStackForPROnHost,
+		documentOperation("get-pull-stack-on-host", "Get pull request stack", "Pull Requests"))
+	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace", Method: http.MethodPost, Path: issuePath + "/workspace", DefaultStatus: http.StatusAccepted, Summary: "Create issue workspace", Tags: []string{"Issues"}}, s.createIssueWorkspace)
+	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace-on-host", Method: http.MethodPost, Path: hostIssuePath + "/workspace", DefaultStatus: http.StatusAccepted, Summary: "Create issue workspace", Tags: []string{"Issues"}}, s.createIssueWorkspaceOnHost)
+```
+
+- [ ] **Step 6: Run the contract test and verify only settings routes are left**
+
+Run:
+
+```bash
+nix run 'nixpkgs#go' -- test ./internal/server -run TestHumaContractMetadata -shuffle=on
+```
+
+Expected: FAIL, with the remaining failures referring only to settings paths: `/settings`, `/repos`, `/repo/{provider}/{owner}/{name}`, `/repo/{provider}/{owner}/{name}/refresh`, `/host/{platform_host}/repo/{provider}/{owner}/{name}`, `/host/{platform_host}/repo/{provider}/{owner}/{name}/refresh`.
+
+- [ ] **Step 7: Commit the provider-repo backfill**
+
+```bash
+git add internal/server/huma_routes.go
+git commit -m "$(cat <<'EOF'
+feat(server): document provider-repo Huma routes
+
+Backfills Summary, Tags, and OperationID on every route inside
+registerProviderRepoAPI. Tags follow the spec taxonomy: PR detail,
+content, comments, labels, kanban state, mutations (approve / merge /
+ready-for-review / sync / ci-refresh), commits/diff/files/file-preview/
+stack, and create-issue-workspace all carry the Pull Requests or
+Issues tag. Repo-level reads (resolve, get, list labels, comment
+autocomplete) carry the Repositories tag.
+
+Convenience-helper calls gain a documentOperation() argument; existing
+huma.Register blocks gain Summary and Tags fields without moving the
+OperationID. Host-prefixed variants share the same Summary and Tag and
+get a unique -on-host OperationID suffix so the contract test's
+uniqueness check passes.
+
+Per-PR sync and per-issue sync remain under their primary tag
+(Pull Requests / Issues) rather than the global Sync tag, matching the
+taxonomy in the spec.
+EOF
+)"
+```
+
+---
+
+### Task 4: Backfill Settings Routes And Commit The Contract Test
+
+After this task the contract test passes; the final settings backfill plus the previously-uncommitted `route_metadata_test.go` from Task 1 land in one atomic commit that flips the OpenAPI document from un-tagged to fully tagged and locks the new invariant in.
+
+**Files:**
+- Modify: `internal/server/settings_routes.go`
+- Add (from Task 1): `internal/server/route_metadata_test.go`
+
+- [ ] **Step 1: Backfill every block in registerSettingsAPI**
+
+Replace the entire body of `registerSettingsAPI` (lines 41-80) with:
+
+```go
+func (s *Server) registerSettingsAPI(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-settings",
+		Method:      http.MethodGet,
+		Path:        "/settings",
+		Summary:     "Get settings",
+		Tags:        []string{"Settings"},
+	}, s.getSettings)
+	huma.Register(api, huma.Operation{
+		OperationID: "update-settings",
+		Method:      http.MethodPut,
+		Path:        "/settings",
+		Summary:     "Update settings",
+		Tags:        []string{"Settings"},
+	}, s.updateSettings)
+	huma.Register(api, huma.Operation{
+		OperationID:   "add-repo",
+		Method:        http.MethodPost,
+		Path:          "/repos",
+		DefaultStatus: http.StatusCreated,
+		Summary:       "Add repository",
+		Tags:          []string{"Settings"},
+	}, s.addConfiguredRepo)
+	huma.Register(api, huma.Operation{
+		OperationID: "refresh-repo",
+		Method:      http.MethodPost,
+		Path:        "/repo/{provider}/{owner}/{name}/refresh",
+		Summary:     "Refresh repository",
+		Tags:        []string{"Settings"},
+	}, s.refreshConfiguredRepo)
+	huma.Register(api, huma.Operation{
+		OperationID: "refresh-repo-on-host",
+		Method:      http.MethodPost,
+		Path:        "/host/{platform_host}/repo/{provider}/{owner}/{name}/refresh",
+		Summary:     "Refresh repository",
+		Tags:        []string{"Settings"},
+	}, s.refreshConfiguredRepoOnHost)
+	huma.Register(api, huma.Operation{
+		OperationID:   "delete-repo",
+		Method:        http.MethodDelete,
+		Path:          "/repo/{provider}/{owner}/{name}",
+		DefaultStatus: http.StatusNoContent,
+		Summary:       "Delete repository",
+		Tags:          []string{"Settings"},
+	}, s.deleteConfiguredRepo)
+	huma.Register(api, huma.Operation{
+		OperationID:   "delete-repo-on-host",
+		Method:        http.MethodDelete,
+		Path:          "/host/{platform_host}/repo/{provider}/{owner}/{name}",
+		DefaultStatus: http.StatusNoContent,
+		Summary:       "Delete repository",
+		Tags:          []string{"Settings"},
+	}, s.deleteConfiguredRepoOnHost)
+}
+```
+
+- [ ] **Step 2: Run the contract test and verify it passes**
+
+Run:
+
+```bash
+nix run 'nixpkgs#go' -- test ./internal/server -run TestHumaContractMetadata -shuffle=on
+```
+
+Expected: PASS. The walker should find no missing-or-auto-generated metadata anywhere in the OpenAPI document.
+
+- [ ] **Step 3: Run the full server package tests to confirm no regressions**
+
+Run:
+
+```bash
+nix run 'nixpkgs#go' -- test ./internal/server -shuffle=on
+```
+
+Expected: PASS. No test in `internal/server` should depend on the auto-generated OperationID or Summary text; if any do, the failure surface is small and obvious.
+
+- [ ] **Step 4: Commit the settings backfill together with the contract test**
+
+```bash
+git add internal/server/settings_routes.go internal/server/route_metadata_test.go
+git commit -m "$(cat <<'EOF'
+feat(server): document settings routes and land OpenAPI metadata contract test
+
+Backfills Summary and Tags on every block in registerSettingsAPI:
+get-settings, update-settings, add-repo, refresh-repo (and -on-host),
+delete-repo (and -on-host). All carry the Settings tag.
+
+With this commit every non-Hidden operation in /api/v1/openapi.json
+carries an explicit Summary, at least one Tag, and a unique
+OperationID. The new TestHumaContractMetadata walks the live OpenAPI
+document and fails the build if a future change drops any of those
+three. A small teeth-test guards against the assertion becoming a
+no-op if Huma's _convenience_id/_convenience_summary marker keys ever
+move.
+EOF
+)"
+```
+
+---
+
+### Task 5: Regenerate Checked-In API Artifacts
+
+**Files:**
+- Modify: `frontend/openapi/openapi.yaml`
+- Modify: `internal/apiclient/generated/client.gen.go`
+- Modify: `packages/ui/src/api/generated/schema.ts`
+- May modify: `packages/ui/src/api/generated/client.ts`
+- May modify: `internal/server/api_test.go`, `internal/server/tmux_wrapper_test.go`, `internal/server/apitest/api_test.go`, `internal/server/workspacetest/*.go` (rename references to auto-generated client methods)
+- May modify: `packages/ui/src/api/types.ts` (rename `operations["get-activity"]` to `operations["list-activity"]`)
+
+- [ ] **Step 1: Regenerate via make api-generate**
+
+Run:
+
+```bash
+nix shell 'nixpkgs#go' 'nixpkgs#bun' --command make api-generate
+```
+
+Expected: writes `frontend/openapi/openapi.yaml`, `internal/apiclient/spec/openapi.json` (gitignored), `packages/ui/src/api/generated/schema.ts`, `packages/ui/src/api/generated/client.ts`, and `internal/apiclient/generated/client.gen.go`. The Go client diff will be large but mechanical — every operation's method/type names change to match the new OperationIDs.
+
+- [ ] **Step 2: Verify the regenerated OpenAPI document carries the new metadata**
+
+Spot-check one operation:
+
+```bash
+nix run 'nixpkgs#jq' -- '.paths["/pulls/{provider}/{owner}/{name}/{number}/approve"].post | {operationId, summary, tags}' internal/apiclient/spec/openapi.json
+```
+
+Expected: `{ "operationId": "approve-pull", "summary": "Approve pull request", "tags": ["Pull Requests"] }`.
+
+If `internal/apiclient/spec/openapi.json` is gitignored and not present after generation, use the YAML form instead:
+
+```bash
+nix run 'nixpkgs#yq-go' -- '.paths["/pulls/{provider}/{owner}/{name}/{number}/approve"].post | pick(["operationId","summary","tags"])' frontend/openapi/openapi.yaml
+```
+
+Expected: same content rendered as YAML.
+
+- [ ] **Step 3: Try to build the server tests and surface any consumer of the old method names**
+
+Run:
+
+```bash
+nix run 'nixpkgs#go' -- vet ./internal/server/... ./internal/apiclient/...
+```
+
+Expected: many `undefined: <OldMethodName>` errors in `internal/server/api_test.go`, `internal/server/tmux_wrapper_test.go`, `internal/server/apitest/api_test.go`, and `internal/server/workspacetest/*_test.go`. The Go test files reference the previously auto-generated client method names (for example `client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWithResponse`), which the regeneration renamed (to `client.HTTP.ApprovePullWithResponse`, etc.).
+
+Locate the old method-name references:
+
+```bash
+nix run 'nixpkgs#ripgrep' -- "client\.HTTP\.(Get|Post|Put|Patch|Delete)(Pulls|Issues|Repo|HostByPlatformHost)ByProviderByOwnerByName|client\.HTTP\.(Get|Post)HostByPlatformHost(Pulls|Issues|Repo|RepoByProvider)" --type go --glob '!internal/apiclient/generated/**'
+```
+
+For each match, rewrite the call site to the new OperationID-derived method name. The mapping is mechanical: a route with OperationID `approve-pull` produces `ApprovePullWithResponse`. Lookups in the regenerated `internal/apiclient/generated/client.gen.go` resolve any uncertainty. Concrete renames most likely to appear:
+
+| Old method (post-regen: gone) | New method |
+|---|---|
+| `PostPullsByProviderByOwnerByNameByNumberApproveWithResponse` | `ApprovePullWithResponse` |
+| `PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithResponse` | `ApprovePullOnHostWithResponse` |
+| `PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse` | `ApprovePullWorkflowsWithResponse` |
+| `PostPullsByProviderByOwnerByNameByNumberMergeWithResponse` | `MergePullWithResponse` |
+| `PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithResponse` | `MergePullOnHostWithResponse` |
+| `PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse` | `MarkPullReadyForReviewWithResponse` |
+| `PostPullsByProviderByOwnerByNameByNumberSyncWithResponse` | `SyncPullWithResponse` |
+| `PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncWithResponse` | `SyncPullOnHostWithResponse` |
+| `PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse` | `RefreshPullCiWithResponse` |
+| `PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse` | `RefreshPullCiOnHostWithResponse` |
+| `GetPullsByProviderByOwnerByNameByNumberWithResponse` | `GetPullWithResponse` |
+| `GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse` | `GetPullOnHostWithResponse` |
+| `GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse` | `GetPullCommitsWithResponse` |
+| `GetPullsByProviderByOwnerByNameByNumberDiffWithResponse` | `GetPullDiffWithResponse` |
+| `GetPullsByProviderByOwnerByNameByNumberFilesWithResponse` | `GetPullFilesWithResponse` |
+| `GetPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse` | `GetPullFilePreviewWithResponse` |
+| `GetPullsByProviderByOwnerByNameByNumberStackWithResponse` | `GetPullStackWithResponse` |
+| `GetIssuesByProviderByOwnerByNameByNumberWithResponse` | `GetIssueWithResponse` |
+| `GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse` | `GetIssueOnHostWithResponse` |
+| `PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse` | `SyncIssueWithResponse` |
+| `PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse` | `SyncIssueOnHostWithResponse` |
+| `PostRepoByProviderByOwnerByNameResolveByNumberWithResponse` | `ResolveItemWithResponse` |
+| `GetActivityWithResponse` | `ListActivityWithResponse` |
+
+If the same line carries a `JSONRequestBody` type that was also renamed (for example `PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody` → `MergePullJSONRequestBody`), rename that too.
+
+Some `client.HTTP.*` method names in the test files (`CreateIssueWithResponse`, `CreateWorkspaceWithResponse`, `ListPullsWithResponse`, `SetKanbanStateWithResponse`, `TriggerSyncWithResponse`, etc.) already derive from existing explicit OperationIDs that the spec keeps as-is. Those don't change. Confirm by checking the new `internal/apiclient/generated/client.gen.go` after regeneration.
+
+- [ ] **Step 4: Rename the TS consumer**
+
+The pre-existing OperationID `get-activity` (Huma's auto-generated kebab-case from `GET /activity`) becomes `list-activity` after the backfill. Update the TypeScript consumer:
+
+In `packages/ui/src/api/types.ts`, change:
+
+```ts
+export type ActivityParams = NonNullable<operations["get-activity"]["parameters"]["query"]>;
+```
+
+to:
+
+```ts
+export type ActivityParams = NonNullable<operations["list-activity"]["parameters"]["query"]>;
+```
+
+Verify no other TS callsite references `operations["get-activity"]`:
+
+```bash
+nix run 'nixpkgs#ripgrep' -- 'operations\["get-activity"\]' packages/ frontend/
+```
+
+Expected: only `packages/ui/src/api/types.ts` (which was just updated) and `packages/ui/src/api/generated/schema.ts` (which is the generated definition site and now reads `"list-activity"`). If anything else surfaces, rename it too.
+
+- [ ] **Step 5: Run the full Go test suite to confirm renames compile and pass**
+
+Run:
+
+```bash
+nix run 'nixpkgs#go' -- test ./... -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run frontend type checks to confirm TS consumers compile**
+
+Run:
+
+```bash
+nix shell 'nixpkgs#bun' --command bash -c 'cd packages/ui && bun run typecheck'
+```
+
+Expected: PASS. The `ActivityParams` rename resolves the `get-activity` → `list-activity` shift; no other TS site refers to a renamed operation by ID.
+
+- [ ] **Step 7: Commit the regenerated artifacts together with the consumer renames**
+
+The regeneration and the consumer renames must commit together because individually they leave the tree in a non-compiling state: the regenerated client lacks the old method names, the unrenamed tests reference the old method names, and the unrenamed `ActivityParams` references a no-longer-existing operation key. Stage everything together:
+
+```bash
+git add frontend/openapi/openapi.yaml internal/apiclient/generated/client.gen.go packages/ui/src/api/generated/schema.ts packages/ui/src/api/generated/client.ts packages/ui/src/api/types.ts
+git add internal/server/api_test.go internal/server/tmux_wrapper_test.go internal/server/apitest/ internal/server/workspacetest/
+git commit -m "$(cat <<'EOF'
+chore(api): regenerate clients with explicit OperationID, Summary, Tags
+
+Regenerates frontend/openapi/openapi.yaml, internal/apiclient/
+generated/client.gen.go, and packages/ui/src/api/generated/schema.ts
+from the now-fully-documented Huma routes. Method and type names in
+the Go client and TS schema track the new OperationIDs, so paths like
+PostPullsByProviderByOwnerByNameByNumberApprove become ApprovePull.
+
+Also renames every consumer of the auto-generated method names in
+internal/server/api_test.go and the apitest / workspacetest /
+tmux_wrapper_test files, plus the one TS consumer that referenced
+the auto-generated operations["get-activity"] type (now
+operations["list-activity"]).
+
+Diff in the generated files is large but mechanical: every operation's
+name and the surrounding response/request types shift in lockstep
+with the upstream OperationID.
+EOF
+)"
+```
+
+If `git add` of an `internal/server/apitest/` or `workspacetest/` path fails because nothing in those directories changed, drop the missing path and re-run the add+commit pair.
+
+---
+
+### Task 6: Final Lint And Vet Pass
+
+**Files:**
+- None (verification only).
+
+- [ ] **Step 1: Run go vet across the workspace**
+
+```bash
+nix run 'nixpkgs#go' -- vet ./...
+```
+
+Expected: PASS. No vet diagnostics.
+
+- [ ] **Step 2: Run golangci-lint via nix**
+
+The Makefile lint target requires the globally-banned `mise`. Use golangci-lint directly:
+
+```bash
+nix shell 'nixpkgs#golangci-lint' 'nixpkgs#go' --command golangci-lint run ./...
+```
+
+Expected: PASS. No new warnings.
+
+- [ ] **Step 3: Run testify helper check (replicates Makefile lint's second half)**
+
+```bash
+nix run 'nixpkgs#go' -- run ./cmd/testify-helper-check ./...
+```
+
+Expected: PASS. The contract test uses a local `assert := require.New(t)` for the document-build precondition and falls back to package-level `assert.Empty(t, ...)` for the failures slice; both are explicit `t`-receiver calls within testify's idioms and the assertion-counter helper should not flag them.
+
+- [ ] **Step 4: Run the full Go test suite one last time**
+
+```bash
+nix run 'nixpkgs#go' -- test ./... -shuffle=on
+```
+
+Expected: PASS. No regressions.
+
+- [ ] **Step 5: Verify the working tree is clean**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean`.
+
+No commit in this task — verification only.

--- a/docs/superpowers/specs/2026-05-19-huma-openapi-metadata-design.md
+++ b/docs/superpowers/specs/2026-05-19-huma-openapi-metadata-design.md
@@ -10,7 +10,7 @@ The middleman backend registers most routes through Huma's shorthand convenience
 
 - Verbose, path-derived `OperationID` values (e.g., `GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommits`) that surface in the generated Go API client as method names. These can shift when paths change and are unpleasant to type and read.
 - Auto-generated `Summary` strings that read like sentences scraped from the route pattern ("Get pulls by provider by owner by name by number"), not what the operation actually does.
-- No `Tags`, so Swagger UI renders the entire API as one flat alphabetical pile with no grouping.
+- No `Tags`, so middleman's API docs UI (Huma serves Stoplight Elements at `/docs` by default) renders the entire API as one flat alphabetical pile with no grouping.
 
 middleman already has an AST-level guardrail at `internal/server/route_registration_test.go:16` that blocks raw `http.ServeMux.Handle` registrations on `/api/...` paths. The metadata equivalent is missing: nothing prevents a maintainer from adding a new `huma.Get` shorthand without metadata. This design adds that guardrail at the live-OpenAPI level and backfills the existing routes to satisfy it.
 
@@ -26,9 +26,9 @@ In scope:
 Out of scope:
 
 - Health endpoints (`/healthz`, `/livez`) — registered on a separate Huma API with OpenAPI/docs output disabled. They never appear in `/api/v1/openapi.json` and need no taxonomy decisions.
-- Hidden operations — terminal WebSocket upgrades and the roborev proxy. Hidden ops never enter the OpenAPI document (`internal/server/huma_routes.go` and the Huma runtime both honor `Hidden=true`), so the test naturally excludes them.
+- Hidden operations — terminal WebSocket upgrades and the roborev proxy. They are registered through `api.Adapter().Handle` rather than `huma.Register`, so they never call `oapi.AddOperation` and never enter `api.OpenAPI().Paths` regardless of the `Hidden=true` flag. The test walks `Paths` and naturally excludes them.
 - A route-inventory-from-markdown pattern. middleman has high route churn and the maintenance burden of a separate inventory exceeds its value.
-- Renaming the existing already-explicit `OperationID` values that already match the convention. Where an existing ID conflicts with the new convention or duplicates another, this design renames it; otherwise it stays.
+- Bulk renaming of already-conforming explicit `OperationID` values. Where an existing ID conflicts with the new convention or duplicates another after backfill, this design renames it; otherwise it stays.
 - Frontend changes. The TypeScript schema regenerates, but no frontend code is touched in this design.
 
 ## Design
@@ -46,7 +46,7 @@ Each non-Hidden operation is tagged with exactly one tag from this set:
 - `Stacks` — `list-stacks`.
 - `Workspaces` — workspace lifecycle and runtime operations.
 - `Projects` — project + worktree registration and listing, plus `list-launch-targets`.
-- `Roborev` — `get-roborev-status` only. The proxy operations are Hidden.
+- `Roborev` — `get-roborev-status` only. The roborev proxy operations live on a different `huma.API` instance entirely and never reach the `/api/v1/openapi.json` document.
 - `System` — `/version` and `/events` (SSE). Catch-all for cross-domain server-info endpoints.
 
 Each route gets exactly one tag. Host-prefixed variants get the same tag as their non-host counterpart, because the `host/{platform_host}/` prefix is a URL routing concern, not a semantic one.
@@ -68,9 +68,9 @@ Examples:
 - `Get sync status`
 - `Connect workspace terminal` — only if a Hidden route is later un-hidden; Hidden ops do not need a Summary today.
 
-This matches the OpenAPI convention used by Stripe, GitHub, and Linear, and matches Huma's own `GenerateSummary` shape so the diff against the auto-generated values is small. The same resource verbiage is used in both the Summary and the OperationID, varying only by separator and capitalization.
+Imperative-mood summaries are the OpenAPI convention used by Stripe, GitHub, and Linear. The same resource verbiage is used in both the Summary and the OperationID, varying only by separator and capitalization, so a maintainer who writes one almost has the other.
 
-Host-prefixed and non-host variants share the same Summary. They're the same operation; the path difference is a routing concern. Differentiating them in the Summary would read like duplication noise in Swagger UI.
+Host-prefixed and non-host variants share the same Summary. They're the same operation; the path difference is a routing concern. Differentiating them in the Summary would read like duplication noise in the docs UI.
 
 ### OperationID convention
 
@@ -101,21 +101,22 @@ This avoids `comment`-only or `label`-only IDs that could collide once new resou
 
 ### Test design
 
-The test lives in `internal/server/` (suggested filename `route_metadata_test.go`, suggested function name `TestHumaContractMetadata`). It does not need a database, mock GitHub client, or a running server: it constructs the OpenAPI document with `server.NewOpenAPI()`, which is already used by `cmd/middleman-openapi/main.go`.
+The test lives in `internal/server/` (suggested filename `route_metadata_test.go`, suggested function name `TestHumaContractMetadata`). It constructs the OpenAPI document with `server.NewOpenAPI()` — the same call `cmd/middleman-openapi/main.go` uses to write the checked-in `frontend/openapi/openapi.yaml` — so the test asserts against the exact same document the generated clients are built from. It needs no database, mock GitHub client, or running server because `NewOpenAPI` builds against a fresh `*Server{}`.
 
 Procedure:
 
-1. Build the document: `openAPI := server.NewOpenAPI()`. This calls `s.registerAPI(api)` on a fresh `*Server{}` and returns `api.OpenAPI()`.
-2. Walk `openAPI.Paths`. For each `(path, *huma.PathItem)`, walk each non-nil HTTP-method operation pointer (`Get`, `Put`, `Post`, `Delete`, `Options`, `Head`, `Patch`, `Trace`).
-3. For each `*huma.Operation` found:
-   - Assert `strings.TrimSpace(op.Summary) != ""`.
-   - Assert `op.Metadata["_convenience_summary"] == nil`. This is what catches auto-generated values that happen to be non-empty.
-   - Assert `strings.TrimSpace(op.OperationID) != ""` and `op.Metadata["_convenience_id"] == nil`.
-   - Assert `len(op.Tags) >= 1` and each entry is a non-empty trimmed string.
-   - Record `op.OperationID -> "METHOD PATH"` in a `map[string]string`. If the key already exists, record the collision.
-4. After the walk, collect failures into a slice and call `assert.Empty` on it. The failure message lists every failing route as `METHOD PATH: <issue>` so a maintainer who breaks the test sees exactly which route to fix and why (`missing Summary`, `auto-generated OperationID`, `missing Tags`, `duplicate OperationID with METHOD PATH`).
+- Build the document. `openAPI := server.NewOpenAPI()` calls `s.registerAPI(api)` on a fresh `*Server{}` and returns `api.OpenAPI()`.
+- Walk `openAPI.Paths`. For each `(path, *huma.PathItem)`, walk each non-nil HTTP-method operation pointer (`Get`, `Put`, `Post`, `Delete`, `Options`, `Head`, `Patch`, `Trace`).
+- For each `*huma.Operation` found, append one entry to a `failures []string` slice for every check that does not pass:
+  - `strings.TrimSpace(op.Summary) == ""` → `METHOD PATH: missing Summary`.
+  - `op.Metadata["_convenience_summary"] != nil` → `METHOD PATH: auto-generated Summary`. This is what catches auto-generated values that happen to be non-empty.
+  - `strings.TrimSpace(op.OperationID) == ""` → `METHOD PATH: missing OperationID`.
+  - `op.Metadata["_convenience_id"] != nil` → `METHOD PATH: auto-generated OperationID`.
+  - `len(op.Tags) < 1` or any entry is an empty trimmed string → `METHOD PATH: missing Tags`.
+  - The OperationID already appears in a `seen map[string]string` populated by prior iterations → `METHOD PATH: duplicate OperationID with METHOD PATH` (the prior entry).
+- After the walk, call `assert.Empty(t, failures, strings.Join(failures, "\n"))` once. This surfaces every offending route in one failed assertion so a maintainer who breaks the test sees exactly which routes to fix and why.
 
-The test uses testify (`require` for the document build; `assert` plus a local `assert := assert.New(t)` helper for per-route checks so multiple failures surface in one run).
+The test uses testify (`require` for the document build; `assert.Empty` on the final `failures` slice). It does not run per-route assertions — collecting into the slice lets one test invocation report every offender at once rather than aborting on the first.
 
 A negative-case smoke test in the same file verifies the assertion has teeth: it constructs a tiny in-process `huma.API` with one route registered via `huma.Get` and no metadata, walks it with the same helper used by the production test, and asserts the helper returns at least one failure. This guards against the test becoming a no-op if Huma changes how it marks auto-generated values.
 
@@ -169,13 +170,13 @@ The plan runs `make api-generate` once after the source backfill is complete and
 - `internal/apiclient/generated/client.gen.go` — regenerated, checked in.
 - `packages/ui/src/api/generated/schema.ts` — regenerated, checked in.
 
-Roughly 130 routes in total are backfilled (~100 reachable through `registerAPI`/`registerProviderRepoAPI` plus ~10 under `registerSettingsAPI`, with host-variant doubling on most repo-scoped routes).
+On the order of a hundred routes are backfilled, split between `registerAPI`/`registerProviderRepoAPI` in `huma_routes.go` and `registerSettingsAPI` in `settings_routes.go`. Most repo-scoped routes are duplicated as host-prefixed variants and contribute two entries each.
 
 ## Risks
 
 - **Diff size.** The regenerated `client.gen.go` and `schema.ts` will be large because every operation's generated method/type name changes. Reviewer load is mitigated by committing the source changes in one logical commit and the regeneration in a second commit so the human-edited and machine-emitted changes can be reviewed separately.
 - **OperationID collisions.** Renaming an existing explicit OperationID can collide with another route in the same document. The test catches this, but it surfaces only after the change. Mitigation: the plan introduces the helper + the new OperationID in small batches per file (`huma_routes.go` first, then `settings_routes.go`) and runs the test after each batch.
-- **Hidden marker false negatives.** If a future maintainer adds a route via `api.Adapter().Handle` without setting `Hidden=true` and without going through `huma.Register`, the operation might bypass the OpenAPI document entirely (`api.OpenAPI().Paths` won't see it) and the test won't notice. This is the same gap the existing AST-level guardrail addresses (it blocks raw mux registrations); the AST test continues to cover it. No new mitigation needed.
+- **Adapter().Handle bypass.** Routes registered through `api.Adapter().Handle(op, handler)` never reach `huma.Register`, which means they never call `oapi.AddOperation` and never enter `api.OpenAPI().Paths` regardless of whether `Hidden=true` is set. The test will not see them. middleman uses this path today for the terminal upgrades and the roborev proxy, all of which are intentional. The risk is a future maintainer adding a public route via Adapter().Handle and expecting the test to police it. Mitigation: the existing AST-level guardrail (`route_registration_test.go`) already blocks raw mux registrations; the metadata test does not extend to Adapter().Handle, and that's an explicit limitation. Adding an AST check for Adapter().Handle public routes is a separate follow-up if it becomes a real problem.
 - **Huma internals shift.** If Huma changes the `Metadata["_convenience_*"]` marker key or removes it entirely, the test loses its primary signal for distinguishing auto-generated values. The negative-case smoke test catches this on the next Huma upgrade. If the marker disappears, the test falls back to checking `op.Summary != huma.GenerateSummary(method, path, response)`, but that path is not implemented in v1 because the marker is the cleaner signal.
 
 ## Open questions

--- a/docs/superpowers/specs/2026-05-19-huma-openapi-metadata-design.md
+++ b/docs/superpowers/specs/2026-05-19-huma-openapi-metadata-design.md
@@ -1,0 +1,183 @@
+# Huma OpenAPI Operation Metadata Coverage Design
+
+## Goal
+
+Make every non-Hidden operation in middleman's Huma-served OpenAPI document carry an explicit, useful `Summary`, at least one `Tag`, and a stable, unique `OperationID`, and guard that invariant with a live-OpenAPI walker test so it cannot regress.
+
+## Why
+
+The middleman backend registers most routes through Huma's shorthand convenience helpers (`huma.Get(api, "/pulls", s.listPulls)`). Those calls auto-generate a `Summary` and `OperationID` from the method and path and stash a marker (`_convenience_summary`, `_convenience_id`) in `Operation.Metadata` so callers can detect that the value is a default. Today nothing forces the registrations to override those defaults, so the live OpenAPI document carries:
+
+- Verbose, path-derived `OperationID` values (e.g., `GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommits`) that surface in the generated Go API client as method names. These can shift when paths change and are unpleasant to type and read.
+- Auto-generated `Summary` strings that read like sentences scraped from the route pattern ("Get pulls by provider by owner by name by number"), not what the operation actually does.
+- No `Tags`, so Swagger UI renders the entire API as one flat alphabetical pile with no grouping.
+
+middleman already has an AST-level guardrail at `internal/server/route_registration_test.go:16` that blocks raw `http.ServeMux.Handle` registrations on `/api/...` paths. The metadata equivalent is missing: nothing prevents a maintainer from adding a new `huma.Get` shorthand without metadata. This design adds that guardrail at the live-OpenAPI level and backfills the existing routes to satisfy it.
+
+## Scope
+
+In scope:
+
+- A Go test (suggested name `TestHumaContractMetadata`) in `internal/server/` that builds the live OpenAPI document with `server.NewOpenAPI()`, walks `Paths`, and asserts metadata coverage on every non-Hidden operation.
+- A small registration-site helper that attaches `Summary`, `Tags`, and `OperationID` in one expression and is the canonical way to fill metadata on Huma convenience helpers.
+- A mechanical backfill of `Summary`, `Tags`, and `OperationID` on every existing non-Hidden route reachable through `/api/v1/openapi.json`. That covers handlers registered in `huma_routes.go`, `settings_routes.go`, and (where applicable) any other file registering routes on the same `huma.API`.
+- A `make api-generate` regeneration of `frontend/openapi/openapi.yaml`, `internal/apiclient/spec/openapi.json`, the Go API client, and the TypeScript schema so the new metadata flows into the checked-in artifacts.
+
+Out of scope:
+
+- Health endpoints (`/healthz`, `/livez`) — registered on a separate Huma API with OpenAPI/docs output disabled. They never appear in `/api/v1/openapi.json` and need no taxonomy decisions.
+- Hidden operations — terminal WebSocket upgrades and the roborev proxy. Hidden ops never enter the OpenAPI document (`internal/server/huma_routes.go` and the Huma runtime both honor `Hidden=true`), so the test naturally excludes them.
+- A route-inventory-from-markdown pattern. middleman has high route churn and the maintenance burden of a separate inventory exceeds its value.
+- Renaming the existing already-explicit `OperationID` values that already match the convention. Where an existing ID conflicts with the new convention or duplicates another, this design renames it; otherwise it stays.
+- Frontend changes. The TypeScript schema regenerates, but no frontend code is touched in this design.
+
+## Design
+
+### Tag taxonomy
+
+Each non-Hidden operation is tagged with exactly one tag from this set:
+
+- `Pull Requests` — every operation whose primary resource is a pull/merge request. Includes per-PR sync, CI refresh, comments, labels, approval, merge, ready-for-review, GitHub-state mutation, commits/diff/files/stack listings, and the `import-metadata` and `file-preview` reads. Host-prefixed variants get the same tag.
+- `Issues` — every operation whose primary resource is an issue. Same coverage shape as Pull Requests, plus `create-issue-workspace`.
+- `Repositories` — repo-level reads and mutations not handled by Settings: `list-repos`, `list-repo-summaries`, `list-repo-labels`, `comment-autocomplete`, `get-repo`, `resolve-item`, `preview-repos`, `bulk-add-repos`.
+- `Settings` — configuration mutations: `get-settings`, `update-settings`, `add-repo`, `refresh-repo`, `delete-repo`, plus their host variants. Also `set-starred` and `unset-starred` because they configure the user's pinned set.
+- `Sync` — global sync orchestration: `trigger-sync`, `sync-status`, `rate-limits`. Per-PR / per-issue sync remains under Pull Requests / Issues.
+- `Activity` — `list-activity`.
+- `Stacks` — `list-stacks`.
+- `Workspaces` — workspace lifecycle and runtime operations.
+- `Projects` — project + worktree registration and listing, plus `list-launch-targets`.
+- `Roborev` — `get-roborev-status` only. The proxy operations are Hidden.
+- `System` — `/version` and `/events` (SSE). Catch-all for cross-domain server-info endpoints.
+
+Each route gets exactly one tag. Host-prefixed variants get the same tag as their non-host counterpart, because the `host/{platform_host}/` prefix is a URL routing concern, not a semantic one.
+
+### Summary phrasing
+
+Imperative-mood, present tense, first word capitalized, no trailing period.
+
+Form: `Verb resource [qualifier]`.
+
+Examples:
+
+- `List pull requests`
+- `Get pull request`
+- `Approve pull request`
+- `Set pull request kanban state`
+- `Post pull request comment`
+- `Trigger sync`
+- `Get sync status`
+- `Connect workspace terminal` — only if a Hidden route is later un-hidden; Hidden ops do not need a Summary today.
+
+This matches the OpenAPI convention used by Stripe, GitHub, and Linear, and matches Huma's own `GenerateSummary` shape so the diff against the auto-generated values is small. The same resource verbiage is used in both the Summary and the OperationID, varying only by separator and capitalization.
+
+Host-prefixed and non-host variants share the same Summary. They're the same operation; the path difference is a routing concern. Differentiating them in the Summary would read like duplication noise in Swagger UI.
+
+### OperationID convention
+
+`verb-resource[-qualifier]`, kebab-case.
+
+Examples:
+
+- `list-pulls`
+- `get-pull`
+- `approve-pull`
+- `set-pull-kanban-state`
+- `post-pull-comment`
+- `trigger-sync`
+- `get-sync-status`
+
+Conventions:
+
+- Plural for collection reads (`list-pulls`, `list-issues`), singular for item reads/mutations (`get-pull`, `approve-pull`).
+- Host-prefixed variants append `-on-host` so each route still has a unique OperationID. Many existing routes already follow this pattern (`approve-pull`/`approve-pull-on-host`). This is the only place where the host-vs-non-host distinction surfaces in metadata.
+- Where an existing `OperationID` already conforms, keep it (e.g., `edit-pr-content`, `set-kanban-state`). Where renaming is cheaper than working around an inconsistency, rename. The test catches uniqueness violations.
+
+Comments and labels are nested under their parent resource:
+
+- `post-pull-comment` / `edit-pull-comment` / `set-pull-labels`
+- `post-issue-comment` / `edit-issue-comment` / `set-issue-labels`
+
+This avoids `comment`-only or `label`-only IDs that could collide once new resources gain comments.
+
+### Test design
+
+The test lives in `internal/server/` (suggested filename `route_metadata_test.go`, suggested function name `TestHumaContractMetadata`). It does not need a database, mock GitHub client, or a running server: it constructs the OpenAPI document with `server.NewOpenAPI()`, which is already used by `cmd/middleman-openapi/main.go`.
+
+Procedure:
+
+1. Build the document: `openAPI := server.NewOpenAPI()`. This calls `s.registerAPI(api)` on a fresh `*Server{}` and returns `api.OpenAPI()`.
+2. Walk `openAPI.Paths`. For each `(path, *huma.PathItem)`, walk each non-nil HTTP-method operation pointer (`Get`, `Put`, `Post`, `Delete`, `Options`, `Head`, `Patch`, `Trace`).
+3. For each `*huma.Operation` found:
+   - Assert `strings.TrimSpace(op.Summary) != ""`.
+   - Assert `op.Metadata["_convenience_summary"] == nil`. This is what catches auto-generated values that happen to be non-empty.
+   - Assert `strings.TrimSpace(op.OperationID) != ""` and `op.Metadata["_convenience_id"] == nil`.
+   - Assert `len(op.Tags) >= 1` and each entry is a non-empty trimmed string.
+   - Record `op.OperationID -> "METHOD PATH"` in a `map[string]string`. If the key already exists, record the collision.
+4. After the walk, collect failures into a slice and call `assert.Empty` on it. The failure message lists every failing route as `METHOD PATH: <issue>` so a maintainer who breaks the test sees exactly which route to fix and why (`missing Summary`, `auto-generated OperationID`, `missing Tags`, `duplicate OperationID with METHOD PATH`).
+
+The test uses testify (`require` for the document build; `assert` plus a local `assert := assert.New(t)` helper for per-route checks so multiple failures surface in one run).
+
+A negative-case smoke test in the same file verifies the assertion has teeth: it constructs a tiny in-process `huma.API` with one route registered via `huma.Get` and no metadata, walks it with the same helper used by the production test, and asserts the helper returns at least one failure. This guards against the test becoming a no-op if Huma changes how it marks auto-generated values.
+
+### Source-level backfill style
+
+A small helper attaches the metadata at the registration site:
+
+```go
+// documentOperation returns an operationHandler that sets Summary, Tags, and
+// OperationID on the resulting *huma.Operation. Use it with the huma.Get/Post/
+// Put/Patch/Delete convenience helpers.
+func documentOperation(operationID, summary string, tags ...string) func(*huma.Operation) {
+    return func(o *huma.Operation) {
+        o.OperationID = operationID
+        o.Summary = summary
+        o.Tags = tags
+    }
+}
+```
+
+It lives in `internal/server/huma_routes.go` next to the other registration helpers. Callers look like:
+
+```go
+huma.Get(api, "/pulls", s.listPulls,
+    documentOperation("list-pulls", "List pull requests", "Pull Requests"))
+huma.Post(api, pullPath+"/approve", s.approvePR,
+    documentOperation("approve-pull", "Approve pull request", "Pull Requests"))
+```
+
+Existing `huma.Register(api, huma.Operation{OperationID: "...", Method: ..., Path: ...}, h)` blocks keep their structure; they gain `Summary` and `Tags` fields inline. Where an existing block lacks `OperationID`, it gains that too. The helper is intentionally not used for `huma.Register` call sites: they already have a verbose form, and forcing the helper through them would lose the `Method`/`Path`/`DefaultStatus` clarity.
+
+The helper's signature does not allow mistakes. `Summary` and `OperationID` are required positional parameters; `Tags` is variadic with the existing taxonomy supplied as string literals. Passing an empty tag list is possible at the type level but fails the test, which is the desired feedback loop.
+
+### Generated-artifact regeneration
+
+`make api-generate` updates four artifacts that the metadata flows into:
+
+- `frontend/openapi/openapi.yaml` — checked in. Used by the TypeScript schema generator.
+- `internal/apiclient/spec/openapi.json` — generated, fed into `go tool oapi-codegen` for the Go client. Not checked in.
+- `internal/apiclient/generated/client.gen.go` — generated Go client. Checked in. Method names derive from `OperationID`, so the diff here will be large but mechanical.
+- `packages/ui/src/api/generated/schema.ts` — generated TypeScript schema. Checked in. Tag groupings appear here as TS namespaces if the generator supports them.
+
+The plan runs `make api-generate` once after the source backfill is complete and commits all four artifacts together so the regeneration diff is bounded and reviewable.
+
+## Files affected
+
+- `internal/server/route_metadata_test.go` (new) — `TestHumaContractMetadata` and the negative-case smoke test.
+- `internal/server/huma_routes.go` — `documentOperation` helper; backfill on every convenience call and every existing `huma.Register` block inside `registerAPI` and `registerProviderRepoAPI`.
+- `internal/server/settings_routes.go` — backfill on every block inside `registerSettingsAPI`.
+- `frontend/openapi/openapi.yaml` — regenerated, checked in.
+- `internal/apiclient/generated/client.gen.go` — regenerated, checked in.
+- `packages/ui/src/api/generated/schema.ts` — regenerated, checked in.
+
+Roughly 130 routes in total are backfilled (~100 reachable through `registerAPI`/`registerProviderRepoAPI` plus ~10 under `registerSettingsAPI`, with host-variant doubling on most repo-scoped routes).
+
+## Risks
+
+- **Diff size.** The regenerated `client.gen.go` and `schema.ts` will be large because every operation's generated method/type name changes. Reviewer load is mitigated by committing the source changes in one logical commit and the regeneration in a second commit so the human-edited and machine-emitted changes can be reviewed separately.
+- **OperationID collisions.** Renaming an existing explicit OperationID can collide with another route in the same document. The test catches this, but it surfaces only after the change. Mitigation: the plan introduces the helper + the new OperationID in small batches per file (`huma_routes.go` first, then `settings_routes.go`) and runs the test after each batch.
+- **Hidden marker false negatives.** If a future maintainer adds a route via `api.Adapter().Handle` without setting `Hidden=true` and without going through `huma.Register`, the operation might bypass the OpenAPI document entirely (`api.OpenAPI().Paths` won't see it) and the test won't notice. This is the same gap the existing AST-level guardrail addresses (it blocks raw mux registrations); the AST test continues to cover it. No new mitigation needed.
+- **Huma internals shift.** If Huma changes the `Metadata["_convenience_*"]` marker key or removes it entirely, the test loses its primary signal for distinguishing auto-generated values. The negative-case smoke test catches this on the next Huma upgrade. If the marker disappears, the test falls back to checking `op.Summary != huma.GenerateSummary(method, path, response)`, but that path is not implemented in v1 because the marker is the cleaner signal.
+
+## Open questions
+
+None. All three design choices (taxonomy, value style, helper shape) have been settled in brainstorming with the codex consult agreeing on each.

--- a/docs/superpowers/specs/2026-05-19-huma-openapi-metadata-design.md
+++ b/docs/superpowers/specs/2026-05-19-huma-openapi-metadata-design.md
@@ -109,16 +109,16 @@ Procedure:
 - Walk `openAPI.Paths`. For each `(path, *huma.PathItem)`, walk each non-nil HTTP-method operation pointer (`Get`, `Put`, `Post`, `Delete`, `Options`, `Head`, `Patch`, `Trace`).
 - For each `*huma.Operation` found, append one entry to a `failures []string` slice for every check that does not pass:
   - `strings.TrimSpace(op.Summary) == ""` → `METHOD PATH: missing Summary`.
-  - `op.Metadata["_convenience_summary"] != nil` → `METHOD PATH: auto-generated Summary`. This is what catches auto-generated values that happen to be non-empty.
   - `strings.TrimSpace(op.OperationID) == ""` → `METHOD PATH: missing OperationID`.
-  - `op.Metadata["_convenience_id"] != nil` → `METHOD PATH: auto-generated OperationID`.
-  - `len(op.Tags) < 1` or any entry is an empty trimmed string → `METHOD PATH: missing Tags`.
+  - `len(op.Tags) < 1` → `METHOD PATH: missing Tags`.
+  - Any tag entry is an empty trimmed string → `METHOD PATH: empty Tag`.
+  - `op.Tags` is not exactly one tag from the taxonomy above → `METHOD PATH: expected exactly one tag from the API tag taxonomy`.
   - The OperationID already appears in a `seen map[string]string` populated by prior iterations → `METHOD PATH: duplicate OperationID with METHOD PATH` (the prior entry).
 - After the walk, call `assert.Empty(t, failures, strings.Join(failures, "\n"))` once. This surfaces every offending route in one failed assertion so a maintainer who breaks the test sees exactly which routes to fix and why.
 
 The test uses testify (`require` for the document build; `assert.Empty` on the final `failures` slice). It does not run per-route assertions — collecting into the slice lets one test invocation report every offender at once rather than aborting on the first.
 
-A negative-case smoke test in the same file verifies the assertion has teeth: it constructs a tiny in-process `huma.API` with one route registered via `huma.Get` and no metadata, walks it with the same helper used by the production test, and asserts the helper returns at least one failure. This guards against the test becoming a no-op if Huma changes how it marks auto-generated values.
+A negative-case smoke test in the same file verifies the assertion has teeth: it constructs a tiny in-process `huma.API` with one route registered via `huma.Get` and no metadata, walks it with the same helper used by the production test, and asserts the helper returns at least one failure. Another smoke test rejects unknown or multiple tags. A source-level AST test rejects production Huma convenience registrations (`Get`, `Post`, `Put`, `Patch`, `Delete`, `Head`, `Options`) that do not use `documentOperation`, because the live OpenAPI document cannot always distinguish an intentionally supplied summary or operation ID from Huma's generated default when the strings match.
 
 ### Source-level backfill style
 
@@ -177,7 +177,7 @@ On the order of a hundred routes are backfilled, split between `registerAPI`/`re
 - **Diff size.** The regenerated `client.gen.go` and `schema.ts` will be large because every operation's generated method/type name changes. Reviewer load is mitigated by committing the source changes in one logical commit and the regeneration in a second commit so the human-edited and machine-emitted changes can be reviewed separately.
 - **OperationID collisions.** Renaming an existing explicit OperationID can collide with another route in the same document. The test catches this, but it surfaces only after the change. Mitigation: the plan introduces the helper + the new OperationID in small batches per file (`huma_routes.go` first, then `settings_routes.go`) and runs the test after each batch.
 - **Adapter().Handle bypass.** Routes registered through `api.Adapter().Handle(op, handler)` never reach `huma.Register`, which means they never call `oapi.AddOperation` and never enter `api.OpenAPI().Paths` regardless of whether `Hidden=true` is set. The test will not see them. middleman uses this path today for the terminal upgrades and the roborev proxy, all of which are intentional. The risk is a future maintainer adding a public route via Adapter().Handle and expecting the test to police it. Mitigation: the existing AST-level guardrail (`route_registration_test.go`) already blocks raw mux registrations; the metadata test does not extend to Adapter().Handle, and that's an explicit limitation. Adding an AST check for Adapter().Handle public routes is a separate follow-up if it becomes a real problem.
-- **Huma internals shift.** If Huma changes the `Metadata["_convenience_*"]` marker key or removes it entirely, the test loses its primary signal for distinguishing auto-generated values. The negative-case smoke test catches this on the next Huma upgrade. If the marker disappears, the test falls back to checking `op.Summary != huma.GenerateSummary(method, path, response)`, but that path is not implemented in v1 because the marker is the cleaner signal.
+- **Huma internals shift.** The implementation intentionally avoids Huma's internal `Metadata["_convenience_*"]` markers because they are not a stable signal of maintainer intent when an explicit value matches Huma's default. The live OpenAPI walker enforces the public document shape, and the AST guardrail enforces use of `documentOperation` for convenience helpers.
 
 ## Open questions
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2968,7 +2968,7 @@ openapi: 3.1.0
 paths:
   /activity:
     get:
-      operationId: get-activity
+      operationId: list-activity
       parameters:
         - explode: false
           in: query
@@ -3012,7 +3012,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get activity
+      summary: List activity
+      tags:
+        - Activity
   /events:
     get:
       operationId: stream-events
@@ -3027,6 +3029,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Stream server events
+      tags:
+        - System
   /host/{platform_host}/issues/{provider}/{owner}/{name}:
     post:
       operationId: create-issue-on-host
@@ -3070,9 +3075,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Create issue
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}:
     get:
-      operationId: get-host-by-platform-host-issues-by-provider-by-owner-by-name-by-number
+      operationId: get-issue-on-host
       parameters:
         - in: path
           name: provider
@@ -3113,7 +3121,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host issues by provider by owner by name by number
+      summary: Get issue
+      tags:
+        - Issues
     patch:
       operationId: edit-issue-content-on-host
       parameters:
@@ -3162,6 +3172,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit issue content
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-issue-comment-on-host
@@ -3211,6 +3224,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Post issue comment
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/comments/{comment_id}:
     patch:
       operationId: edit-issue-comment-on-host
@@ -3266,6 +3282,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit issue comment
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/github-state:
     post:
       operationId: set-issue-github-state-on-host
@@ -3315,6 +3334,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set issue GitHub state
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/labels:
     put:
       operationId: set-issue-labels-on-host
@@ -3364,9 +3386,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set issue labels
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/sync:
     post:
-      operationId: post-host-by-platform-host-issues-by-provider-by-owner-by-name-by-number-sync
+      operationId: sync-issue-on-host
       parameters:
         - in: path
           name: provider
@@ -3407,7 +3432,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host issues by provider by owner by name by number sync
+      summary: Sync issue
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/sync/async:
     post:
       operationId: enqueue-issue-sync-on-host
@@ -3447,6 +3474,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Enqueue issue sync
+      tags:
+        - Issues
   /host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/workspace:
     post:
       operationId: create-issue-workspace-on-host
@@ -3496,9 +3526,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Create issue workspace
+      tags:
+        - Issues
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}:
     get:
-      operationId: get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number
+      operationId: get-pull-on-host
       parameters:
         - in: path
           name: provider
@@ -3539,7 +3572,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host pulls by provider by owner by name by number
+      summary: Get pull request
+      tags:
+        - Pull Requests
     patch:
       operationId: edit-pr-content-on-host
       parameters:
@@ -3588,9 +3623,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit pull request content
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/approve:
     post:
-      operationId: post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-approve
+      operationId: approve-pull-on-host
       parameters:
         - in: path
           name: provider
@@ -3637,10 +3675,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host pulls by provider by owner by name by number approve
+      summary: Approve pull request
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/approve-workflows:
     post:
-      operationId: post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-approve-workflows
+      operationId: approve-pull-workflows-on-host
       parameters:
         - in: path
           name: provider
@@ -3681,10 +3721,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host pulls by provider by owner by name by number approve workflows
+      summary: Approve pull request workflows
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/ci-refresh:
     post:
-      operationId: post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ci-refresh
+      operationId: refresh-pull-ci-on-host
       parameters:
         - in: path
           name: provider
@@ -3725,7 +3767,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host pulls by provider by owner by name by number ci refresh
+      summary: Refresh pull request CI
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-pr-comment-on-host
@@ -3775,6 +3819,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Post pull request comment
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/comments/{comment_id}:
     patch:
       operationId: edit-pr-comment-on-host
@@ -3830,9 +3877,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit pull request comment
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/commits:
     get:
-      operationId: get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-commits
+      operationId: get-pull-commits-on-host
       parameters:
         - in: path
           name: provider
@@ -3873,10 +3923,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host pulls by provider by owner by name by number commits
+      summary: Get pull request commits
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/diff:
     get:
-      operationId: get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-diff
+      operationId: get-pull-diff-on-host
       parameters:
         - in: path
           name: provider
@@ -3943,10 +3995,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host pulls by provider by owner by name by number diff
+      summary: Get pull request diff
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/file-preview:
     get:
-      operationId: get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-file-preview
+      operationId: get-pull-file-preview-on-host
       parameters:
         - in: path
           name: provider
@@ -4015,10 +4069,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host pulls by provider by owner by name by number file preview
+      summary: Get pull request file preview
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/files:
     get:
-      operationId: get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-files
+      operationId: get-pull-files-on-host
       parameters:
         - in: path
           name: provider
@@ -4059,7 +4115,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host pulls by provider by owner by name by number files
+      summary: Get pull request files
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/github-state:
     post:
       operationId: set-pr-github-state-on-host
@@ -4109,9 +4167,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set pull request GitHub state
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/import-metadata:
     get:
-      operationId: get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-import-metadata
+      operationId: get-pull-import-metadata-on-host
       parameters:
         - in: path
           name: provider
@@ -4152,7 +4213,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host pulls by provider by owner by name by number import metadata
+      summary: Get pull request import metadata
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/labels:
     put:
       operationId: set-pr-labels-on-host
@@ -4202,9 +4265,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set pull request labels
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/merge:
     post:
-      operationId: post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-merge
+      operationId: merge-pull-on-host
       parameters:
         - in: path
           name: provider
@@ -4251,10 +4317,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host pulls by provider by owner by name by number merge
+      summary: Merge pull request
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/ready-for-review:
     post:
-      operationId: post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ready-for-review
+      operationId: mark-pull-ready-for-review-on-host
       parameters:
         - in: path
           name: provider
@@ -4295,10 +4363,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host pulls by provider by owner by name by number ready for review
+      summary: Mark pull request ready for review
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/stack:
     get:
-      operationId: get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-stack
+      operationId: get-pull-stack-on-host
       parameters:
         - in: path
           name: provider
@@ -4339,7 +4409,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host pulls by provider by owner by name by number stack
+      summary: Get pull request stack
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/state:
     put:
       operationId: set-kanban-state-on-host
@@ -4385,9 +4457,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set pull request kanban state
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/sync:
     post:
-      operationId: post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-sync
+      operationId: sync-pull-on-host
       parameters:
         - in: path
           name: provider
@@ -4428,7 +4503,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host pulls by provider by owner by name by number sync
+      summary: Sync pull request
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/sync/async:
     post:
       operationId: enqueue-pr-sync-on-host
@@ -4468,6 +4545,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Enqueue pull request sync
+      tags:
+        - Pull Requests
   /host/{platform_host}/repo/{provider}/{owner}/{name}:
     delete:
       operationId: delete-repo-on-host
@@ -4501,8 +4581,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Delete repository
+      tags:
+        - Settings
     get:
-      operationId: get-host-by-platform-host-repo-by-provider-by-owner-by-name
+      operationId: get-repo-on-host
       parameters:
         - in: path
           name: provider
@@ -4537,10 +4620,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host repo by provider by owner by name
+      summary: Get repository
+      tags:
+        - Repositories
   /host/{platform_host}/repo/{provider}/{owner}/{name}/comment-autocomplete:
     get:
-      operationId: get-host-by-platform-host-repo-by-provider-by-owner-by-name-comment-autocomplete
+      operationId: get-comment-autocomplete-on-host
       parameters:
         - in: path
           name: provider
@@ -4591,7 +4676,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get host by platform host repo by provider by owner by name comment autocomplete
+      summary: Get comment autocomplete
+      tags:
+        - Repositories
   /host/{platform_host}/repo/{provider}/{owner}/{name}/labels:
     get:
       operationId: list-repo-labels-on-host
@@ -4629,6 +4716,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: List repository labels
+      tags:
+        - Repositories
   /host/{platform_host}/repo/{provider}/{owner}/{name}/refresh:
     post:
       operationId: refresh-repo-on-host
@@ -4666,9 +4756,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Refresh repository
+      tags:
+        - Settings
   /host/{platform_host}/repo/{provider}/{owner}/{name}/resolve/{number}:
     post:
-      operationId: post-host-by-platform-host-repo-by-provider-by-owner-by-name-resolve-by-number
+      operationId: resolve-repo-item-on-host
       parameters:
         - in: path
           name: provider
@@ -4709,7 +4802,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post host by platform host repo by provider by owner by name resolve by number
+      summary: Resolve repository item
+      tags:
+        - Repositories
   /issues:
     get:
       operationId: list-issues
@@ -4764,6 +4859,8 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: List issues
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}:
     post:
       operationId: create-issue
@@ -4802,9 +4899,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Create issue
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}:
     get:
-      operationId: get-issues-by-provider-by-owner-by-name-by-number
+      operationId: get-issue
       parameters:
         - in: path
           name: provider
@@ -4840,7 +4940,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get issues by provider by owner by name by number
+      summary: Get issue
+      tags:
+        - Issues
     patch:
       operationId: edit-issue-content
       parameters:
@@ -4884,6 +4986,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit issue content
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-issue-comment
@@ -4928,6 +5033,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Post issue comment
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}/comments/{comment_id}:
     patch:
       operationId: edit-issue-comment
@@ -4978,6 +5086,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit issue comment
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}/github-state:
     post:
       operationId: set-issue-github-state
@@ -5022,6 +5133,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set issue GitHub state
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}/labels:
     put:
       operationId: set-issue-labels
@@ -5066,9 +5180,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set issue labels
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}/sync:
     post:
-      operationId: post-issues-by-provider-by-owner-by-name-by-number-sync
+      operationId: sync-issue
       parameters:
         - in: path
           name: provider
@@ -5104,7 +5221,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post issues by provider by owner by name by number sync
+      summary: Sync issue
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}/sync/async:
     post:
       operationId: enqueue-issue-sync
@@ -5139,6 +5258,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Enqueue issue sync
+      tags:
+        - Issues
   /issues/{provider}/{owner}/{name}/{number}/workspace:
     post:
       operationId: create-issue-workspace
@@ -5183,6 +5305,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Create issue workspace
+      tags:
+        - Issues
   /projects:
     get:
       operationId: list-projects
@@ -5199,6 +5324,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: List projects
+      tags:
+        - Projects
     post:
       operationId: register-project
       requestBody:
@@ -5220,6 +5348,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Register project
+      tags:
+        - Projects
   /projects/{project_id}:
     get:
       operationId: get-project
@@ -5242,6 +5373,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Get project
+      tags:
+        - Projects
   /projects/{project_id}/launch-targets:
     get:
       operationId: list-launch-targets
@@ -5264,6 +5398,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: List launch targets
+      tags:
+        - Projects
   /projects/{project_id}/worktrees:
     get:
       operationId: list-worktrees
@@ -5286,6 +5423,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: List worktrees
+      tags:
+        - Projects
     post:
       operationId: register-worktree
       parameters:
@@ -5313,6 +5453,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Register worktree
+      tags:
+        - Projects
   /pulls:
     get:
       operationId: list-pulls
@@ -5371,10 +5514,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: List pulls
+      summary: List pull requests
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}:
     get:
-      operationId: get-pulls-by-provider-by-owner-by-name-by-number
+      operationId: get-pull
       parameters:
         - in: path
           name: provider
@@ -5410,7 +5555,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get pulls by provider by owner by name by number
+      summary: Get pull request
+      tags:
+        - Pull Requests
     patch:
       operationId: edit-pr-content
       parameters:
@@ -5454,9 +5601,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit pull request content
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/approve:
     post:
-      operationId: post-pulls-by-provider-by-owner-by-name-by-number-approve
+      operationId: approve-pull
       parameters:
         - in: path
           name: provider
@@ -5498,10 +5648,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post pulls by provider by owner by name by number approve
+      summary: Approve pull request
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/approve-workflows:
     post:
-      operationId: post-pulls-by-provider-by-owner-by-name-by-number-approve-workflows
+      operationId: approve-pull-workflows
       parameters:
         - in: path
           name: provider
@@ -5537,10 +5689,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post pulls by provider by owner by name by number approve workflows
+      summary: Approve pull request workflows
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/ci-refresh:
     post:
-      operationId: post-pulls-by-provider-by-owner-by-name-by-number-ci-refresh
+      operationId: refresh-pull-ci
       parameters:
         - in: path
           name: provider
@@ -5576,7 +5730,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post pulls by provider by owner by name by number ci refresh
+      summary: Refresh pull request CI
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/comments:
     post:
       operationId: post-pr-comment
@@ -5621,6 +5777,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Post pull request comment
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/comments/{comment_id}:
     patch:
       operationId: edit-pr-comment
@@ -5671,9 +5830,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Edit pull request comment
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/commits:
     get:
-      operationId: get-pulls-by-provider-by-owner-by-name-by-number-commits
+      operationId: get-pull-commits
       parameters:
         - in: path
           name: provider
@@ -5709,10 +5871,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get pulls by provider by owner by name by number commits
+      summary: Get pull request commits
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/diff:
     get:
-      operationId: get-pulls-by-provider-by-owner-by-name-by-number-diff
+      operationId: get-pull-diff
       parameters:
         - in: path
           name: provider
@@ -5774,10 +5938,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get pulls by provider by owner by name by number diff
+      summary: Get pull request diff
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/file-preview:
     get:
-      operationId: get-pulls-by-provider-by-owner-by-name-by-number-file-preview
+      operationId: get-pull-file-preview
       parameters:
         - in: path
           name: provider
@@ -5841,10 +6007,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get pulls by provider by owner by name by number file preview
+      summary: Get pull request file preview
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/files:
     get:
-      operationId: get-pulls-by-provider-by-owner-by-name-by-number-files
+      operationId: get-pull-files
       parameters:
         - in: path
           name: provider
@@ -5880,7 +6048,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get pulls by provider by owner by name by number files
+      summary: Get pull request files
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/github-state:
     post:
       operationId: set-pr-github-state
@@ -5925,9 +6095,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set pull request GitHub state
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/import-metadata:
     get:
-      operationId: get-pulls-by-provider-by-owner-by-name-by-number-import-metadata
+      operationId: get-pull-import-metadata
       parameters:
         - in: path
           name: provider
@@ -5963,7 +6136,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get pulls by provider by owner by name by number import metadata
+      summary: Get pull request import metadata
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/labels:
     put:
       operationId: set-pr-labels
@@ -6008,9 +6183,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set pull request labels
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/merge:
     post:
-      operationId: post-pulls-by-provider-by-owner-by-name-by-number-merge
+      operationId: merge-pull
       parameters:
         - in: path
           name: provider
@@ -6052,10 +6230,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post pulls by provider by owner by name by number merge
+      summary: Merge pull request
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/ready-for-review:
     post:
-      operationId: post-pulls-by-provider-by-owner-by-name-by-number-ready-for-review
+      operationId: mark-pull-ready-for-review
       parameters:
         - in: path
           name: provider
@@ -6091,10 +6271,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post pulls by provider by owner by name by number ready for review
+      summary: Mark pull request ready for review
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/stack:
     get:
-      operationId: get-pulls-by-provider-by-owner-by-name-by-number-stack
+      operationId: get-pull-stack
       parameters:
         - in: path
           name: provider
@@ -6130,7 +6312,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get pulls by provider by owner by name by number stack
+      summary: Get pull request stack
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/state:
     put:
       operationId: set-kanban-state
@@ -6171,9 +6355,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Set pull request kanban state
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/sync:
     post:
-      operationId: post-pulls-by-provider-by-owner-by-name-by-number-sync
+      operationId: sync-pull
       parameters:
         - in: path
           name: provider
@@ -6209,7 +6396,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post pulls by provider by owner by name by number sync
+      summary: Sync pull request
+      tags:
+        - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/sync/async:
     post:
       operationId: enqueue-pr-sync
@@ -6244,6 +6433,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Enqueue pull request sync
+      tags:
+        - Pull Requests
   /rate-limits:
     get:
       operationId: get-rate-limits
@@ -6261,6 +6453,8 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Get rate limits
+      tags:
+        - Sync
   /repo/{provider}/{owner}/{name}:
     delete:
       operationId: delete-repo
@@ -6289,8 +6483,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Delete repository
+      tags:
+        - Settings
     get:
-      operationId: get-repo-by-provider-by-owner-by-name
+      operationId: get-repo
       parameters:
         - in: path
           name: provider
@@ -6320,10 +6517,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get repo by provider by owner by name
+      summary: Get repository
+      tags:
+        - Repositories
   /repo/{provider}/{owner}/{name}/comment-autocomplete:
     get:
-      operationId: get-repo-by-provider-by-owner-by-name-comment-autocomplete
+      operationId: get-comment-autocomplete
       parameters:
         - in: path
           name: provider
@@ -6369,7 +6568,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get repo by provider by owner by name comment autocomplete
+      summary: Get comment autocomplete
+      tags:
+        - Repositories
   /repo/{provider}/{owner}/{name}/labels:
     get:
       operationId: list-repo-labels
@@ -6402,6 +6603,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: List repository labels
+      tags:
+        - Repositories
   /repo/{provider}/{owner}/{name}/refresh:
     post:
       operationId: refresh-repo
@@ -6434,9 +6638,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Refresh repository
+      tags:
+        - Settings
   /repo/{provider}/{owner}/{name}/resolve/{number}:
     post:
-      operationId: post-repo-by-provider-by-owner-by-name-resolve-by-number
+      operationId: resolve-repo-item
       parameters:
         - in: path
           name: provider
@@ -6472,7 +6679,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Post repo by provider by owner by name resolve by number
+      summary: Resolve repository item
+      tags:
+        - Repositories
   /repos:
     get:
       operationId: list-repos
@@ -6493,7 +6702,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: List repos
+      summary: List repositories
+      tags:
+        - Repositories
     post:
       operationId: add-repo
       requestBody:
@@ -6515,6 +6726,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Add repository
+      tags:
+        - Settings
   /repos/bulk:
     post:
       operationId: bulk-add-repos
@@ -6537,6 +6751,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Bulk add repositories
+      tags:
+        - Repositories
   /repos/preview:
     post:
       operationId: preview-repos
@@ -6559,6 +6776,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Preview repositories
+      tags:
+        - Repositories
   /repos/summary:
     get:
       operationId: list-repo-summaries
@@ -6579,6 +6799,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: List repository summaries
+      tags:
+        - Repositories
   /roborev/status:
     get:
       operationId: get-roborev-status
@@ -6595,6 +6818,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Get roborev status
+      tags:
+        - Roborev
   /settings:
     get:
       operationId: get-settings
@@ -6611,6 +6837,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Get settings
+      tags:
+        - Settings
     put:
       operationId: update-settings
       requestBody:
@@ -6632,6 +6861,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Update settings
+      tags:
+        - Settings
   /stacks:
     get:
       operationId: list-stacks
@@ -6659,6 +6891,8 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: List stacks
+      tags:
+        - Stacks
   /starred:
     delete:
       operationId: unset-starred
@@ -6677,6 +6911,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Unstar repository
+      tags:
+        - Settings
     put:
       operationId: set-starred
       requestBody:
@@ -6694,6 +6931,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Star repository
+      tags:
+        - Settings
   /sync:
     post:
       operationId: trigger-sync
@@ -6706,6 +6946,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Trigger sync
+      tags:
+        - Sync
   /sync/status:
     get:
       operationId: get-sync-status
@@ -6723,6 +6966,8 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Get sync status
+      tags:
+        - Sync
   /version:
     get:
       operationId: get-version
@@ -6739,9 +6984,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Get server version
+      tags:
+        - System
   /workspaces:
     get:
-      operationId: get-workspaces
+      operationId: list-workspaces
       responses:
         "200":
           content:
@@ -6755,7 +7003,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get workspaces
+      summary: List workspaces
+      tags:
+        - Workspaces
     post:
       operationId: create-workspace
       requestBody:
@@ -6777,6 +7027,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Create workspace
+      tags:
+        - Workspaces
   /workspaces/{id}:
     delete:
       operationId: delete-workspace
@@ -6800,8 +7053,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Delete workspace
+      tags:
+        - Workspaces
     get:
-      operationId: get-workspaces-by-id
+      operationId: get-workspace
       parameters:
         - in: path
           name: id
@@ -6821,10 +7077,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get workspaces by ID
+      summary: Get workspace
+      tags:
+        - Workspaces
   /workspaces/{id}/commits:
     get:
-      operationId: get-workspaces-by-id-commits
+      operationId: get-workspace-commits
       parameters:
         - in: path
           name: id
@@ -6844,10 +7102,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get workspaces by ID commits
+      summary: Get workspace commits
+      tags:
+        - Workspaces
   /workspaces/{id}/diff:
     get:
-      operationId: get-workspaces-by-id-diff
+      operationId: get-workspace-diff
       parameters:
         - in: path
           name: id
@@ -6909,10 +7169,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get workspaces by ID diff
+      summary: Get workspace diff
+      tags:
+        - Workspaces
   /workspaces/{id}/files:
     get:
-      operationId: get-workspaces-by-id-files
+      operationId: get-workspace-files
       parameters:
         - in: path
           name: id
@@ -6967,7 +7229,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
-      summary: Get workspaces by ID files
+      summary: Get workspace files
+      tags:
+        - Workspaces
   /workspaces/{id}/retry:
     post:
       operationId: retry-workspace
@@ -6990,6 +7254,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Retry workspace
+      tags:
+        - Workspaces
   /workspaces/{id}/runtime:
     get:
       operationId: get-workspace-runtime
@@ -7012,6 +7279,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Get workspace runtime
+      tags:
+        - Workspaces
   /workspaces/{id}/runtime/sessions:
     post:
       operationId: launch-workspace-runtime-session
@@ -7040,6 +7310,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Launch workspace runtime session
+      tags:
+        - Workspaces
   /workspaces/{id}/runtime/sessions/{session_key}:
     delete:
       operationId: stop-workspace-runtime-session
@@ -7063,6 +7336,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Stop workspace runtime session
+      tags:
+        - Workspaces
   /workspaces/{id}/runtime/shell:
     post:
       operationId: ensure-workspace-runtime-shell
@@ -7085,5 +7361,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
+      summary: Ensure workspace runtime shell
+      tags:
+        - Workspaces
 servers:
   - url: /api/v1

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1262,8 +1262,8 @@ type WorktreeResponse struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// GetActivityParams defines parameters for GetActivity.
-type GetActivityParams struct {
+// ListActivityParams defines parameters for ListActivity.
+type ListActivityParams struct {
 	Repo   *string   `form:"repo,omitempty" json:"repo,omitempty"`
 	Types  *[]string `form:"types,omitempty" json:"types,omitempty"`
 	Search *string   `form:"search,omitempty" json:"search,omitempty"`
@@ -1271,8 +1271,8 @@ type GetActivityParams struct {
 	Since  *string   `form:"since,omitempty" json:"since,omitempty"`
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams defines parameters for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiff.
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams struct {
+// GetPullDiffOnHostParams defines parameters for GetPullDiffOnHost.
+type GetPullDiffOnHostParams struct {
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
 
 	// Commit Scope to a single commit SHA
@@ -1285,8 +1285,8 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams struct 
 	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams defines parameters for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreview.
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams struct {
+// GetPullFilePreviewOnHostParams defines parameters for GetPullFilePreviewOnHost.
+type GetPullFilePreviewOnHostParams struct {
 	// Path Changed file path to preview
 	Path *string `form:"path,omitempty" json:"path,omitempty"`
 
@@ -1300,8 +1300,8 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams 
 	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
-// GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteParams defines parameters for GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocomplete.
-type GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteParams struct {
+// GetCommentAutocompleteOnHostParams defines parameters for GetCommentAutocompleteOnHost.
+type GetCommentAutocompleteOnHostParams struct {
 	Trigger *string `form:"trigger,omitempty" json:"trigger,omitempty"`
 	Q       *string `form:"q,omitempty" json:"q,omitempty"`
 	Limit   *int64  `form:"limit,omitempty" json:"limit,omitempty"`
@@ -1328,8 +1328,8 @@ type ListPullsParams struct {
 	Offset  *int64  `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
-// GetPullsByProviderByOwnerByNameByNumberDiffParams defines parameters for GetPullsByProviderByOwnerByNameByNumberDiff.
-type GetPullsByProviderByOwnerByNameByNumberDiffParams struct {
+// GetPullDiffParams defines parameters for GetPullDiff.
+type GetPullDiffParams struct {
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
 
 	// Commit Scope to a single commit SHA
@@ -1342,8 +1342,8 @@ type GetPullsByProviderByOwnerByNameByNumberDiffParams struct {
 	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
-// GetPullsByProviderByOwnerByNameByNumberFilePreviewParams defines parameters for GetPullsByProviderByOwnerByNameByNumberFilePreview.
-type GetPullsByProviderByOwnerByNameByNumberFilePreviewParams struct {
+// GetPullFilePreviewParams defines parameters for GetPullFilePreview.
+type GetPullFilePreviewParams struct {
 	// Path Changed file path to preview
 	Path *string `form:"path,omitempty" json:"path,omitempty"`
 
@@ -1357,8 +1357,8 @@ type GetPullsByProviderByOwnerByNameByNumberFilePreviewParams struct {
 	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
-// GetRepoByProviderByOwnerByNameCommentAutocompleteParams defines parameters for GetRepoByProviderByOwnerByNameCommentAutocomplete.
-type GetRepoByProviderByOwnerByNameCommentAutocompleteParams struct {
+// GetCommentAutocompleteParams defines parameters for GetCommentAutocomplete.
+type GetCommentAutocompleteParams struct {
 	Trigger *string `form:"trigger,omitempty" json:"trigger,omitempty"`
 	Q       *string `form:"q,omitempty" json:"q,omitempty"`
 	Limit   *int64  `form:"limit,omitempty" json:"limit,omitempty"`
@@ -1374,8 +1374,8 @@ type DeleteWorkspaceParams struct {
 	Force *bool `form:"force,omitempty" json:"force,omitempty"`
 }
 
-// GetWorkspacesByIdDiffParams defines parameters for GetWorkspacesByIdDiff.
-type GetWorkspacesByIdDiffParams struct {
+// GetWorkspaceDiffParams defines parameters for GetWorkspaceDiff.
+type GetWorkspaceDiffParams struct {
 	// Base Diff base: head, pushed, or merge-target
 	Base *string `form:"base,omitempty" json:"base,omitempty"`
 
@@ -1395,8 +1395,8 @@ type GetWorkspacesByIdDiffParams struct {
 	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
-// GetWorkspacesByIdFilesParams defines parameters for GetWorkspacesByIdFiles.
-type GetWorkspacesByIdFilesParams struct {
+// GetWorkspaceFilesParams defines parameters for GetWorkspaceFiles.
+type GetWorkspaceFilesParams struct {
 	// Base Diff base: head, pushed, or merge-target
 	Base *string `form:"base,omitempty" json:"base,omitempty"`
 
@@ -1437,8 +1437,8 @@ type CreateIssueWorkspaceOnHostJSONRequestBody = CreateIssueWorkspaceHostInputBo
 // EditPrContentOnHostJSONRequestBody defines body for EditPrContentOnHost for application/json ContentType.
 type EditPrContentOnHostJSONRequestBody = EditPRContentHostInputBody
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody defines body for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApprove for application/json ContentType.
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody = ApprovePRHostInputBody
+// ApprovePullOnHostJSONRequestBody defines body for ApprovePullOnHost for application/json ContentType.
+type ApprovePullOnHostJSONRequestBody = ApprovePRHostInputBody
 
 // PostPrCommentOnHostJSONRequestBody defines body for PostPrCommentOnHost for application/json ContentType.
 type PostPrCommentOnHostJSONRequestBody = PostCommentHostInputBody
@@ -1452,8 +1452,8 @@ type SetPrGithubStateOnHostJSONRequestBody = GithubStateHostInputBody
 // SetPrLabelsOnHostJSONRequestBody defines body for SetPrLabelsOnHost for application/json ContentType.
 type SetPrLabelsOnHostJSONRequestBody = SetLabelsRequest
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody defines body for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge for application/json ContentType.
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody = MergePRHostInputBody
+// MergePullOnHostJSONRequestBody defines body for MergePullOnHost for application/json ContentType.
+type MergePullOnHostJSONRequestBody = MergePRHostInputBody
 
 // SetKanbanStateOnHostJSONRequestBody defines body for SetKanbanStateOnHost for application/json ContentType.
 type SetKanbanStateOnHostJSONRequestBody = SetKanbanStateHostInputBody
@@ -1488,8 +1488,8 @@ type RegisterWorktreeJSONRequestBody = RegisterWorktreeInputBody
 // EditPrContentJSONRequestBody defines body for EditPrContent for application/json ContentType.
 type EditPrContentJSONRequestBody = EditPRContentInputBody
 
-// PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody defines body for PostPullsByProviderByOwnerByNameByNumberApprove for application/json ContentType.
-type PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody = ApprovePRInputBody
+// ApprovePullJSONRequestBody defines body for ApprovePull for application/json ContentType.
+type ApprovePullJSONRequestBody = ApprovePRInputBody
 
 // PostPrCommentJSONRequestBody defines body for PostPrComment for application/json ContentType.
 type PostPrCommentJSONRequestBody = PostCommentInputBody
@@ -1503,8 +1503,8 @@ type SetPrGithubStateJSONRequestBody = GithubStateInputBody
 // SetPrLabelsJSONRequestBody defines body for SetPrLabels for application/json ContentType.
 type SetPrLabelsJSONRequestBody = SetLabelsRequest
 
-// PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody defines body for PostPullsByProviderByOwnerByNameByNumberMerge for application/json ContentType.
-type PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody = MergePRInputBody
+// MergePullJSONRequestBody defines body for MergePull for application/json ContentType.
+type MergePullJSONRequestBody = MergePRInputBody
 
 // SetKanbanStateJSONRequestBody defines body for SetKanbanState for application/json ContentType.
 type SetKanbanStateJSONRequestBody = SetKanbanStateInputBody
@@ -1606,8 +1606,8 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
-	// GetActivity request
-	GetActivity(ctx context.Context, params *GetActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListActivity request
+	ListActivity(ctx context.Context, params *ListActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StreamEvents request
 	StreamEvents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1617,8 +1617,8 @@ type ClientInterface interface {
 
 	CreateIssueOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, body CreateIssueOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber request
-	GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetIssueOnHost request
+	GetIssueOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditIssueContentOnHostWithBody request with any body
 	EditIssueContentOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1645,8 +1645,8 @@ type ClientInterface interface {
 
 	SetIssueLabelsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetIssueLabelsOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSync request
-	PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSync(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// SyncIssueOnHost request
+	SyncIssueOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EnqueueIssueSyncOnHost request
 	EnqueueIssueSyncOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1656,24 +1656,24 @@ type ClientInterface interface {
 
 	CreateIssueWorkspaceOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body CreateIssueWorkspaceOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumber request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullOnHost request
+	GetPullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditPrContentOnHostWithBody request with any body
 	EditPrContentOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	EditPrContentOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body EditPrContentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBody request with any body
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ApprovePullOnHostWithBody request with any body
+	ApprovePullOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApprove(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ApprovePullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body ApprovePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ApprovePullWorkflowsOnHost request
+	ApprovePullWorkflowsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// RefreshPullCiOnHost request
+	RefreshPullCiOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostPrCommentOnHostWithBody request with any body
 	PostPrCommentOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1685,49 +1685,49 @@ type ClientInterface interface {
 
 	EditPrCommentOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, commentId int64, body EditPrCommentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommits request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommits(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullCommitsOnHost request
+	GetPullCommitsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiff request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiff(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullDiffOnHost request
+	GetPullDiffOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullDiffOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreview request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreview(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullFilePreviewOnHost request
+	GetPullFilePreviewOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullFilePreviewOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFiles request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFiles(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullFilesOnHost request
+	GetPullFilesOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetPrGithubStateOnHostWithBody request with any body
 	SetPrGithubStateOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SetPrGithubStateOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetPrGithubStateOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadata request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadata(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullImportMetadataOnHost request
+	GetPullImportMetadataOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetPrLabelsOnHostWithBody request with any body
 	SetPrLabelsOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SetPrLabelsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetPrLabelsOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBody request with any body
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// MergePullOnHostWithBody request with any body
+	MergePullOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	MergePullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body MergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReview request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReview(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// MarkPullReadyForReviewOnHost request
+	MarkPullReadyForReviewOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStack request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStack(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullStackOnHost request
+	GetPullStackOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetKanbanStateOnHostWithBody request with any body
 	SetKanbanStateOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SetKanbanStateOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetKanbanStateOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSync request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSync(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// SyncPullOnHost request
+	SyncPullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EnqueuePrSyncOnHost request
 	EnqueuePrSyncOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1735,11 +1735,11 @@ type ClientInterface interface {
 	// DeleteRepoOnHost request
 	DeleteRepoOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostRepoByProviderByOwnerByName request
-	GetHostByPlatformHostRepoByProviderByOwnerByName(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetRepoOnHost request
+	GetRepoOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocomplete request
-	GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocomplete(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetCommentAutocompleteOnHost request
+	GetCommentAutocompleteOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListRepoLabelsOnHost request
 	ListRepoLabelsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1747,8 +1747,8 @@ type ClientInterface interface {
 	// RefreshRepoOnHost request
 	RefreshRepoOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumber request
-	PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ResolveRepoItemOnHost request
+	ResolveRepoItemOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListIssues request
 	ListIssues(ctx context.Context, params *ListIssuesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1758,8 +1758,8 @@ type ClientInterface interface {
 
 	CreateIssue(ctx context.Context, provider string, owner string, name string, body CreateIssueJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetIssuesByProviderByOwnerByNameByNumber request
-	GetIssuesByProviderByOwnerByNameByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetIssue request
+	GetIssue(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditIssueContentWithBody request with any body
 	EditIssueContentWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1786,8 +1786,8 @@ type ClientInterface interface {
 
 	SetIssueLabels(ctx context.Context, provider string, owner string, name string, number int64, body SetIssueLabelsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostIssuesByProviderByOwnerByNameByNumberSync request
-	PostIssuesByProviderByOwnerByNameByNumberSync(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// SyncIssue request
+	SyncIssue(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EnqueueIssueSync request
 	EnqueueIssueSync(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1822,24 +1822,24 @@ type ClientInterface interface {
 	// ListPulls request
 	ListPulls(ctx context.Context, params *ListPullsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetPullsByProviderByOwnerByNameByNumber request
-	GetPullsByProviderByOwnerByNameByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPull request
+	GetPull(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EditPrContentWithBody request with any body
 	EditPrContentWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	EditPrContent(ctx context.Context, provider string, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberApproveWithBody request with any body
-	PostPullsByProviderByOwnerByNameByNumberApproveWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ApprovePullWithBody request with any body
+	ApprovePullWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostPullsByProviderByOwnerByNameByNumberApprove(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ApprovePull(ctx context.Context, provider string, owner string, name string, number int64, body ApprovePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberApproveWorkflows request
-	PostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ApprovePullWorkflows request
+	ApprovePullWorkflows(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberCiRefresh request
-	PostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// RefreshPullCi request
+	RefreshPullCi(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostPrCommentWithBody request with any body
 	PostPrCommentWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1851,49 +1851,49 @@ type ClientInterface interface {
 
 	EditPrComment(ctx context.Context, provider string, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberCommits request
-	GetPullsByProviderByOwnerByNameByNumberCommits(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullCommits request
+	GetPullCommits(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberDiff request
-	GetPullsByProviderByOwnerByNameByNumberDiff(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullDiff request
+	GetPullDiff(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberFilePreview request
-	GetPullsByProviderByOwnerByNameByNumberFilePreview(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullFilePreview request
+	GetPullFilePreview(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberFiles request
-	GetPullsByProviderByOwnerByNameByNumberFiles(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullFiles request
+	GetPullFiles(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetPrGithubStateWithBody request with any body
 	SetPrGithubStateWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SetPrGithubState(ctx context.Context, provider string, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberImportMetadata request
-	GetPullsByProviderByOwnerByNameByNumberImportMetadata(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullImportMetadata request
+	GetPullImportMetadata(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetPrLabelsWithBody request with any body
 	SetPrLabelsWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SetPrLabels(ctx context.Context, provider string, owner string, name string, number int64, body SetPrLabelsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberMergeWithBody request with any body
-	PostPullsByProviderByOwnerByNameByNumberMergeWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// MergePullWithBody request with any body
+	MergePullWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PostPullsByProviderByOwnerByNameByNumberMerge(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	MergePull(ctx context.Context, provider string, owner string, name string, number int64, body MergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberReadyForReview request
-	PostPullsByProviderByOwnerByNameByNumberReadyForReview(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// MarkPullReadyForReview request
+	MarkPullReadyForReview(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberStack request
-	GetPullsByProviderByOwnerByNameByNumberStack(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetPullStack request
+	GetPullStack(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetKanbanStateWithBody request with any body
 	SetKanbanStateWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SetKanbanState(ctx context.Context, provider string, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberSync request
-	PostPullsByProviderByOwnerByNameByNumberSync(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// SyncPull request
+	SyncPull(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EnqueuePrSync request
 	EnqueuePrSync(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1904,11 +1904,11 @@ type ClientInterface interface {
 	// DeleteRepo request
 	DeleteRepo(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetRepoByProviderByOwnerByName request
-	GetRepoByProviderByOwnerByName(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetRepo request
+	GetRepo(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetRepoByProviderByOwnerByNameCommentAutocomplete request
-	GetRepoByProviderByOwnerByNameCommentAutocomplete(ctx context.Context, provider string, owner string, name string, params *GetRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetCommentAutocomplete request
+	GetCommentAutocomplete(ctx context.Context, provider string, owner string, name string, params *GetCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListRepoLabels request
 	ListRepoLabels(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1916,8 +1916,8 @@ type ClientInterface interface {
 	// RefreshRepo request
 	RefreshRepo(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// PostRepoByProviderByOwnerByNameResolveByNumber request
-	PostRepoByProviderByOwnerByNameResolveByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ResolveRepoItem request
+	ResolveRepoItem(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListRepos request
 	ListRepos(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1973,8 +1973,8 @@ type ClientInterface interface {
 	// GetVersion request
 	GetVersion(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetWorkspaces request
-	GetWorkspaces(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// ListWorkspaces request
+	ListWorkspaces(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateWorkspaceWithBody request with any body
 	CreateWorkspaceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1984,17 +1984,17 @@ type ClientInterface interface {
 	// DeleteWorkspace request
 	DeleteWorkspace(ctx context.Context, id string, params *DeleteWorkspaceParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetWorkspacesById request
-	GetWorkspacesById(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetWorkspace request
+	GetWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetWorkspacesByIdCommits request
-	GetWorkspacesByIdCommits(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetWorkspaceCommits request
+	GetWorkspaceCommits(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetWorkspacesByIdDiff request
-	GetWorkspacesByIdDiff(ctx context.Context, id string, params *GetWorkspacesByIdDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetWorkspaceDiff request
+	GetWorkspaceDiff(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetWorkspacesByIdFiles request
-	GetWorkspacesByIdFiles(ctx context.Context, id string, params *GetWorkspacesByIdFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetWorkspaceFiles request
+	GetWorkspaceFiles(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RetryWorkspace request
 	RetryWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2014,8 +2014,8 @@ type ClientInterface interface {
 	EnsureWorkspaceRuntimeShell(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) GetActivity(ctx context.Context, params *GetActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetActivityRequest(c.Server, params)
+func (c *Client) ListActivity(ctx context.Context, params *ListActivityParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListActivityRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2062,8 +2062,8 @@ func (c *Client) CreateIssueOnHost(ctx context.Context, platformHost string, pro
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) GetIssueOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetIssueOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2194,8 +2194,8 @@ func (c *Client) SetIssueLabelsOnHost(ctx context.Context, platformHost string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSync(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) SyncIssueOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSyncIssueOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2242,8 +2242,8 @@ func (c *Client) CreateIssueWorkspaceOnHost(ctx context.Context, platformHost st
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) GetPullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2278,8 +2278,8 @@ func (c *Client) EditPrContentOnHost(ctx context.Context, platformHost string, p
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody(c.Server, platformHost, provider, owner, name, number, contentType, body)
+func (c *Client) ApprovePullOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApprovePullOnHostRequestWithBody(c.Server, platformHost, provider, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2290,8 +2290,8 @@ func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberAppro
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApprove(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequest(c.Server, platformHost, provider, owner, name, number, body)
+func (c *Client) ApprovePullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body ApprovePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApprovePullOnHostRequest(c.Server, platformHost, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2302,8 +2302,8 @@ func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberAppro
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) ApprovePullWorkflowsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApprovePullWorkflowsOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2314,8 +2314,8 @@ func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberAppro
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) RefreshPullCiOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRefreshPullCiOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2374,8 +2374,8 @@ func (c *Client) EditPrCommentOnHost(ctx context.Context, platformHost string, p
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommits(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) GetPullCommitsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullCommitsOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2386,8 +2386,8 @@ func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommit
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiff(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffRequest(c.Server, platformHost, provider, owner, name, number, params)
+func (c *Client) GetPullDiffOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullDiffOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullDiffOnHostRequest(c.Server, platformHost, provider, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2398,8 +2398,8 @@ func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiff(c
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreview(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewRequest(c.Server, platformHost, provider, owner, name, number, params)
+func (c *Client) GetPullFilePreviewOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullFilePreviewOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullFilePreviewOnHostRequest(c.Server, platformHost, provider, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2410,8 +2410,8 @@ func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePr
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFiles(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) GetPullFilesOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullFilesOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2446,8 +2446,8 @@ func (c *Client) SetPrGithubStateOnHost(ctx context.Context, platformHost string
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadata(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) GetPullImportMetadataOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullImportMetadataOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2482,8 +2482,8 @@ func (c *Client) SetPrLabelsOnHost(ctx context.Context, platformHost string, pro
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody(c.Server, platformHost, provider, owner, name, number, contentType, body)
+func (c *Client) MergePullOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMergePullOnHostRequestWithBody(c.Server, platformHost, provider, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2494,8 +2494,8 @@ func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequest(c.Server, platformHost, provider, owner, name, number, body)
+func (c *Client) MergePullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body MergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMergePullOnHostRequest(c.Server, platformHost, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2506,8 +2506,8 @@ func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReview(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) MarkPullReadyForReviewOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMarkPullReadyForReviewOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2518,8 +2518,8 @@ func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReady
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStack(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) GetPullStackOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullStackOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2554,8 +2554,8 @@ func (c *Client) SetKanbanStateOnHost(ctx context.Context, platformHost string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSync(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) SyncPullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSyncPullOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2590,8 +2590,8 @@ func (c *Client) DeleteRepoOnHost(ctx context.Context, platformHost string, prov
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostRepoByProviderByOwnerByName(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostRepoByProviderByOwnerByNameRequest(c.Server, platformHost, provider, owner, name)
+func (c *Client) GetRepoOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoOnHostRequest(c.Server, platformHost, provider, owner, name)
 	if err != nil {
 		return nil, err
 	}
@@ -2602,8 +2602,8 @@ func (c *Client) GetHostByPlatformHostRepoByProviderByOwnerByName(ctx context.Co
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocomplete(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteRequest(c.Server, platformHost, provider, owner, name, params)
+func (c *Client) GetCommentAutocompleteOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCommentAutocompleteOnHostRequest(c.Server, platformHost, provider, owner, name, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2638,8 +2638,8 @@ func (c *Client) RefreshRepoOnHost(ctx context.Context, platformHost string, pro
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumber(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberRequest(c.Server, platformHost, provider, owner, name, number)
+func (c *Client) ResolveRepoItemOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewResolveRepoItemOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2686,8 +2686,8 @@ func (c *Client) CreateIssue(ctx context.Context, provider string, owner string,
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetIssuesByProviderByOwnerByNameByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetIssuesByProviderByOwnerByNameByNumberRequest(c.Server, provider, owner, name, number)
+func (c *Client) GetIssue(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetIssueRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2818,8 +2818,8 @@ func (c *Client) SetIssueLabels(ctx context.Context, provider string, owner stri
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostIssuesByProviderByOwnerByNameByNumberSync(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostIssuesByProviderByOwnerByNameByNumberSyncRequest(c.Server, provider, owner, name, number)
+func (c *Client) SyncIssue(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSyncIssueRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -2974,8 +2974,8 @@ func (c *Client) ListPulls(ctx context.Context, params *ListPullsParams, reqEdit
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetPullsByProviderByOwnerByNameByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPullsByProviderByOwnerByNameByNumberRequest(c.Server, provider, owner, name, number)
+func (c *Client) GetPull(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3010,8 +3010,8 @@ func (c *Client) EditPrContent(ctx context.Context, provider string, owner strin
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberApproveWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody(c.Server, provider, owner, name, number, contentType, body)
+func (c *Client) ApprovePullWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApprovePullRequestWithBody(c.Server, provider, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3022,8 +3022,8 @@ func (c *Client) PostPullsByProviderByOwnerByNameByNumberApproveWithBody(ctx con
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberApprove(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberApproveRequest(c.Server, provider, owner, name, number, body)
+func (c *Client) ApprovePull(ctx context.Context, provider string, owner string, name string, number int64, body ApprovePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApprovePullRequest(c.Server, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3034,8 +3034,8 @@ func (c *Client) PostPullsByProviderByOwnerByNameByNumberApprove(ctx context.Con
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(c.Server, provider, owner, name, number)
+func (c *Client) ApprovePullWorkflows(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewApprovePullWorkflowsRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3046,8 +3046,8 @@ func (c *Client) PostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx co
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(c.Server, provider, owner, name, number)
+func (c *Client) RefreshPullCi(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRefreshPullCiRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3106,8 +3106,8 @@ func (c *Client) EditPrComment(ctx context.Context, provider string, owner strin
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetPullsByProviderByOwnerByNameByNumberCommits(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPullsByProviderByOwnerByNameByNumberCommitsRequest(c.Server, provider, owner, name, number)
+func (c *Client) GetPullCommits(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullCommitsRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3118,8 +3118,8 @@ func (c *Client) GetPullsByProviderByOwnerByNameByNumberCommits(ctx context.Cont
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetPullsByProviderByOwnerByNameByNumberDiff(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPullsByProviderByOwnerByNameByNumberDiffRequest(c.Server, provider, owner, name, number, params)
+func (c *Client) GetPullDiff(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullDiffRequest(c.Server, provider, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3130,8 +3130,8 @@ func (c *Client) GetPullsByProviderByOwnerByNameByNumberDiff(ctx context.Context
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetPullsByProviderByOwnerByNameByNumberFilePreview(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPullsByProviderByOwnerByNameByNumberFilePreviewRequest(c.Server, provider, owner, name, number, params)
+func (c *Client) GetPullFilePreview(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullFilePreviewRequest(c.Server, provider, owner, name, number, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3142,8 +3142,8 @@ func (c *Client) GetPullsByProviderByOwnerByNameByNumberFilePreview(ctx context.
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetPullsByProviderByOwnerByNameByNumberFiles(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPullsByProviderByOwnerByNameByNumberFilesRequest(c.Server, provider, owner, name, number)
+func (c *Client) GetPullFiles(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullFilesRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3178,8 +3178,8 @@ func (c *Client) SetPrGithubState(ctx context.Context, provider string, owner st
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetPullsByProviderByOwnerByNameByNumberImportMetadata(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPullsByProviderByOwnerByNameByNumberImportMetadataRequest(c.Server, provider, owner, name, number)
+func (c *Client) GetPullImportMetadata(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullImportMetadataRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3214,8 +3214,8 @@ func (c *Client) SetPrLabels(ctx context.Context, provider string, owner string,
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberMergeWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody(c.Server, provider, owner, name, number, contentType, body)
+func (c *Client) MergePullWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMergePullRequestWithBody(c.Server, provider, owner, name, number, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3226,8 +3226,8 @@ func (c *Client) PostPullsByProviderByOwnerByNameByNumberMergeWithBody(ctx conte
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberMerge(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberMergeRequest(c.Server, provider, owner, name, number, body)
+func (c *Client) MergePull(ctx context.Context, provider string, owner string, name string, number int64, body MergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMergePullRequest(c.Server, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3238,8 +3238,8 @@ func (c *Client) PostPullsByProviderByOwnerByNameByNumberMerge(ctx context.Conte
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberReadyForReview(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberReadyForReviewRequest(c.Server, provider, owner, name, number)
+func (c *Client) MarkPullReadyForReview(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMarkPullReadyForReviewRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3250,8 +3250,8 @@ func (c *Client) PostPullsByProviderByOwnerByNameByNumberReadyForReview(ctx cont
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetPullsByProviderByOwnerByNameByNumberStack(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPullsByProviderByOwnerByNameByNumberStackRequest(c.Server, provider, owner, name, number)
+func (c *Client) GetPullStack(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPullStackRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3286,8 +3286,8 @@ func (c *Client) SetKanbanState(ctx context.Context, provider string, owner stri
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostPullsByProviderByOwnerByNameByNumberSync(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostPullsByProviderByOwnerByNameByNumberSyncRequest(c.Server, provider, owner, name, number)
+func (c *Client) SyncPull(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSyncPullRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3334,8 +3334,8 @@ func (c *Client) DeleteRepo(ctx context.Context, provider string, owner string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetRepoByProviderByOwnerByName(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetRepoByProviderByOwnerByNameRequest(c.Server, provider, owner, name)
+func (c *Client) GetRepo(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoRequest(c.Server, provider, owner, name)
 	if err != nil {
 		return nil, err
 	}
@@ -3346,8 +3346,8 @@ func (c *Client) GetRepoByProviderByOwnerByName(ctx context.Context, provider st
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetRepoByProviderByOwnerByNameCommentAutocomplete(ctx context.Context, provider string, owner string, name string, params *GetRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetRepoByProviderByOwnerByNameCommentAutocompleteRequest(c.Server, provider, owner, name, params)
+func (c *Client) GetCommentAutocomplete(ctx context.Context, provider string, owner string, name string, params *GetCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCommentAutocompleteRequest(c.Server, provider, owner, name, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3382,8 +3382,8 @@ func (c *Client) RefreshRepo(ctx context.Context, provider string, owner string,
 	return c.Client.Do(req)
 }
 
-func (c *Client) PostRepoByProviderByOwnerByNameResolveByNumber(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPostRepoByProviderByOwnerByNameResolveByNumberRequest(c.Server, provider, owner, name, number)
+func (c *Client) ResolveRepoItem(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewResolveRepoItemRequest(c.Server, provider, owner, name, number)
 	if err != nil {
 		return nil, err
 	}
@@ -3634,8 +3634,8 @@ func (c *Client) GetVersion(ctx context.Context, reqEditors ...RequestEditorFn) 
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetWorkspaces(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetWorkspacesRequest(c.Server)
+func (c *Client) ListWorkspaces(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListWorkspacesRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -3682,8 +3682,8 @@ func (c *Client) DeleteWorkspace(ctx context.Context, id string, params *DeleteW
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetWorkspacesById(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetWorkspacesByIdRequest(c.Server, id)
+func (c *Client) GetWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkspaceRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -3694,8 +3694,8 @@ func (c *Client) GetWorkspacesById(ctx context.Context, id string, reqEditors ..
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetWorkspacesByIdCommits(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetWorkspacesByIdCommitsRequest(c.Server, id)
+func (c *Client) GetWorkspaceCommits(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkspaceCommitsRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -3706,8 +3706,8 @@ func (c *Client) GetWorkspacesByIdCommits(ctx context.Context, id string, reqEdi
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetWorkspacesByIdDiff(ctx context.Context, id string, params *GetWorkspacesByIdDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetWorkspacesByIdDiffRequest(c.Server, id, params)
+func (c *Client) GetWorkspaceDiff(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkspaceDiffRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3718,8 +3718,8 @@ func (c *Client) GetWorkspacesByIdDiff(ctx context.Context, id string, params *G
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetWorkspacesByIdFiles(ctx context.Context, id string, params *GetWorkspacesByIdFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetWorkspacesByIdFilesRequest(c.Server, id, params)
+func (c *Client) GetWorkspaceFiles(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkspaceFilesRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3802,8 +3802,8 @@ func (c *Client) EnsureWorkspaceRuntimeShell(ctx context.Context, id string, req
 	return c.Client.Do(req)
 }
 
-// NewGetActivityRequest generates requests for GetActivity
-func NewGetActivityRequest(server string, params *GetActivityParams) (*http.Request, error) {
+// NewListActivityRequest generates requests for ListActivity
+func NewListActivityRequest(server string, params *ListActivityParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -4010,8 +4010,8 @@ func NewCreateIssueOnHostRequestWithBody(server string, platformHost string, pro
 	return req, nil
 }
 
-// NewGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberRequest generates requests for GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber
-func NewGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetIssueOnHostRequest generates requests for GetIssueOnHost
+func NewGetIssueOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4454,8 +4454,8 @@ func NewSetIssueLabelsOnHostRequestWithBody(server string, platformHost string, 
 	return req, nil
 }
 
-// NewPostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncRequest generates requests for PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSync
-func NewPostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewSyncIssueOnHostRequest generates requests for SyncIssueOnHost
+func NewSyncIssueOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4653,8 +4653,8 @@ func NewCreateIssueWorkspaceOnHostRequestWithBody(server string, platformHost st
 	return req, nil
 }
 
-// NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberRequest generates requests for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumber
-func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullOnHostRequest generates requests for GetPullOnHost
+func NewGetPullOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4790,19 +4790,19 @@ func NewEditPrContentOnHostRequestWithBody(server string, platformHost string, p
 	return req, nil
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequest calls the generic PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApprove builder with application/json body
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequest(server string, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody) (*http.Request, error) {
+// NewApprovePullOnHostRequest calls the generic ApprovePullOnHost builder with application/json body
+func NewApprovePullOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64, body ApprovePullOnHostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody(server, platformHost, provider, owner, name, number, "application/json", bodyReader)
+	return NewApprovePullOnHostRequestWithBody(server, platformHost, provider, owner, name, number, "application/json", bodyReader)
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody generates requests for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApprove with any type of body
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody(server string, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+// NewApprovePullOnHostRequestWithBody generates requests for ApprovePullOnHost with any type of body
+func NewApprovePullOnHostRequestWithBody(server string, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4865,8 +4865,8 @@ func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRequest
 	return req, nil
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest generates requests for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewApprovePullWorkflowsOnHostRequest generates requests for ApprovePullWorkflowsOnHost
+func NewApprovePullWorkflowsOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -4927,8 +4927,8 @@ func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflo
 	return req, nil
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshRequest generates requests for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewRefreshPullCiOnHostRequest generates requests for RefreshPullCiOnHost
+func NewRefreshPullCiOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5146,8 +5146,8 @@ func NewEditPrCommentOnHostRequestWithBody(server string, platformHost string, p
 	return req, nil
 }
 
-// NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsRequest generates requests for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommits
-func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullCommitsOnHostRequest generates requests for GetPullCommitsOnHost
+func NewGetPullCommitsOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5208,8 +5208,8 @@ func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsRequest(
 	return req, nil
 }
 
-// NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffRequest generates requests for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiff
-func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffRequest(server string, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams) (*http.Request, error) {
+// NewGetPullDiffOnHostRequest generates requests for GetPullDiffOnHost
+func NewGetPullDiffOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64, params *GetPullDiffOnHostParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5340,8 +5340,8 @@ func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffRequest(ser
 	return req, nil
 }
 
-// NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewRequest generates requests for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreview
-func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewRequest(server string, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams) (*http.Request, error) {
+// NewGetPullFilePreviewOnHostRequest generates requests for GetPullFilePreviewOnHost
+func NewGetPullFilePreviewOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64, params *GetPullFilePreviewOnHostParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5472,8 +5472,8 @@ func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewRequ
 	return req, nil
 }
 
-// NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesRequest generates requests for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFiles
-func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullFilesOnHostRequest generates requests for GetPullFilesOnHost
+func NewGetPullFilesOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5609,8 +5609,8 @@ func NewSetPrGithubStateOnHostRequestWithBody(server string, platformHost string
 	return req, nil
 }
 
-// NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataRequest generates requests for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadata
-func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullImportMetadataOnHostRequest generates requests for GetPullImportMetadataOnHost
+func NewGetPullImportMetadataOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5746,19 +5746,19 @@ func NewSetPrLabelsOnHostRequestWithBody(server string, platformHost string, pro
 	return req, nil
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequest calls the generic PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge builder with application/json body
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequest(server string, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody) (*http.Request, error) {
+// NewMergePullOnHostRequest calls the generic MergePullOnHost builder with application/json body
+func NewMergePullOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64, body MergePullOnHostJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody(server, platformHost, provider, owner, name, number, "application/json", bodyReader)
+	return NewMergePullOnHostRequestWithBody(server, platformHost, provider, owner, name, number, "application/json", bodyReader)
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody generates requests for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge with any type of body
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody(server string, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+// NewMergePullOnHostRequestWithBody generates requests for MergePullOnHost with any type of body
+func NewMergePullOnHostRequestWithBody(server string, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5821,8 +5821,8 @@ func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRequestWi
 	return req, nil
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewRequest generates requests for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReview
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewMarkPullReadyForReviewOnHostRequest generates requests for MarkPullReadyForReviewOnHost
+func NewMarkPullReadyForReviewOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -5883,8 +5883,8 @@ func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReview
 	return req, nil
 }
 
-// NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackRequest generates requests for GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStack
-func NewGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullStackOnHostRequest generates requests for GetPullStackOnHost
+func NewGetPullStackOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6020,8 +6020,8 @@ func NewSetKanbanStateOnHostRequestWithBody(server string, platformHost string, 
 	return req, nil
 }
 
-// NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncRequest generates requests for PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSync
-func NewPostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewSyncPullOnHostRequest generates requests for SyncPullOnHost
+func NewSyncPullOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6199,8 +6199,8 @@ func NewDeleteRepoOnHostRequest(server string, platformHost string, provider str
 	return req, nil
 }
 
-// NewGetHostByPlatformHostRepoByProviderByOwnerByNameRequest generates requests for GetHostByPlatformHostRepoByProviderByOwnerByName
-func NewGetHostByPlatformHostRepoByProviderByOwnerByNameRequest(server string, platformHost string, provider string, owner string, name string) (*http.Request, error) {
+// NewGetRepoOnHostRequest generates requests for GetRepoOnHost
+func NewGetRepoOnHostRequest(server string, platformHost string, provider string, owner string, name string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6254,8 +6254,8 @@ func NewGetHostByPlatformHostRepoByProviderByOwnerByNameRequest(server string, p
 	return req, nil
 }
 
-// NewGetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteRequest generates requests for GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocomplete
-func NewGetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteRequest(server string, platformHost string, provider string, owner string, name string, params *GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteParams) (*http.Request, error) {
+// NewGetCommentAutocompleteOnHostRequest generates requests for GetCommentAutocompleteOnHost
+func NewGetCommentAutocompleteOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6473,8 +6473,8 @@ func NewRefreshRepoOnHostRequest(server string, platformHost string, provider st
 	return req, nil
 }
 
-// NewPostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberRequest generates requests for PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumber
-func NewPostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewResolveRepoItemOnHostRequest generates requests for ResolveRepoItemOnHost
+func NewResolveRepoItemOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -6725,8 +6725,8 @@ func NewCreateIssueRequestWithBody(server string, provider string, owner string,
 	return req, nil
 }
 
-// NewGetIssuesByProviderByOwnerByNameByNumberRequest generates requests for GetIssuesByProviderByOwnerByNameByNumber
-func NewGetIssuesByProviderByOwnerByNameByNumberRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetIssueRequest generates requests for GetIssue
+func NewGetIssueRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -7127,8 +7127,8 @@ func NewSetIssueLabelsRequestWithBody(server string, provider string, owner stri
 	return req, nil
 }
 
-// NewPostIssuesByProviderByOwnerByNameByNumberSyncRequest generates requests for PostIssuesByProviderByOwnerByNameByNumberSync
-func NewPostIssuesByProviderByOwnerByNameByNumberSyncRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewSyncIssueRequest generates requests for SyncIssue
+func NewSyncIssueRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -7666,8 +7666,8 @@ func NewListPullsRequest(server string, params *ListPullsParams) (*http.Request,
 	return req, nil
 }
 
-// NewGetPullsByProviderByOwnerByNameByNumberRequest generates requests for GetPullsByProviderByOwnerByNameByNumber
-func NewGetPullsByProviderByOwnerByNameByNumberRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullRequest generates requests for GetPull
+func NewGetPullRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -7789,19 +7789,19 @@ func NewEditPrContentRequestWithBody(server string, provider string, owner strin
 	return req, nil
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberApproveRequest calls the generic PostPullsByProviderByOwnerByNameByNumberApprove builder with application/json body
-func NewPostPullsByProviderByOwnerByNameByNumberApproveRequest(server string, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody) (*http.Request, error) {
+// NewApprovePullRequest calls the generic ApprovePull builder with application/json body
+func NewApprovePullRequest(server string, provider string, owner string, name string, number int64, body ApprovePullJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody(server, provider, owner, name, number, "application/json", bodyReader)
+	return NewApprovePullRequestWithBody(server, provider, owner, name, number, "application/json", bodyReader)
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody generates requests for PostPullsByProviderByOwnerByNameByNumberApprove with any type of body
-func NewPostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody(server string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+// NewApprovePullRequestWithBody generates requests for ApprovePull with any type of body
+func NewApprovePullRequestWithBody(server string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -7857,8 +7857,8 @@ func NewPostPullsByProviderByOwnerByNameByNumberApproveRequestWithBody(server st
 	return req, nil
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest generates requests for PostPullsByProviderByOwnerByNameByNumberApproveWorkflows
-func NewPostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewApprovePullWorkflowsRequest generates requests for ApprovePullWorkflows
+func NewApprovePullWorkflowsRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -7912,8 +7912,8 @@ func NewPostPullsByProviderByOwnerByNameByNumberApproveWorkflowsRequest(server s
 	return req, nil
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberCiRefreshRequest generates requests for PostPullsByProviderByOwnerByNameByNumberCiRefresh
-func NewPostPullsByProviderByOwnerByNameByNumberCiRefreshRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewRefreshPullCiRequest generates requests for RefreshPullCi
+func NewRefreshPullCiRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8110,8 +8110,8 @@ func NewEditPrCommentRequestWithBody(server string, provider string, owner strin
 	return req, nil
 }
 
-// NewGetPullsByProviderByOwnerByNameByNumberCommitsRequest generates requests for GetPullsByProviderByOwnerByNameByNumberCommits
-func NewGetPullsByProviderByOwnerByNameByNumberCommitsRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullCommitsRequest generates requests for GetPullCommits
+func NewGetPullCommitsRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8165,8 +8165,8 @@ func NewGetPullsByProviderByOwnerByNameByNumberCommitsRequest(server string, pro
 	return req, nil
 }
 
-// NewGetPullsByProviderByOwnerByNameByNumberDiffRequest generates requests for GetPullsByProviderByOwnerByNameByNumberDiff
-func NewGetPullsByProviderByOwnerByNameByNumberDiffRequest(server string, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberDiffParams) (*http.Request, error) {
+// NewGetPullDiffRequest generates requests for GetPullDiff
+func NewGetPullDiffRequest(server string, provider string, owner string, name string, number int64, params *GetPullDiffParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8290,8 +8290,8 @@ func NewGetPullsByProviderByOwnerByNameByNumberDiffRequest(server string, provid
 	return req, nil
 }
 
-// NewGetPullsByProviderByOwnerByNameByNumberFilePreviewRequest generates requests for GetPullsByProviderByOwnerByNameByNumberFilePreview
-func NewGetPullsByProviderByOwnerByNameByNumberFilePreviewRequest(server string, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberFilePreviewParams) (*http.Request, error) {
+// NewGetPullFilePreviewRequest generates requests for GetPullFilePreview
+func NewGetPullFilePreviewRequest(server string, provider string, owner string, name string, number int64, params *GetPullFilePreviewParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8415,8 +8415,8 @@ func NewGetPullsByProviderByOwnerByNameByNumberFilePreviewRequest(server string,
 	return req, nil
 }
 
-// NewGetPullsByProviderByOwnerByNameByNumberFilesRequest generates requests for GetPullsByProviderByOwnerByNameByNumberFiles
-func NewGetPullsByProviderByOwnerByNameByNumberFilesRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullFilesRequest generates requests for GetPullFiles
+func NewGetPullFilesRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8538,8 +8538,8 @@ func NewSetPrGithubStateRequestWithBody(server string, provider string, owner st
 	return req, nil
 }
 
-// NewGetPullsByProviderByOwnerByNameByNumberImportMetadataRequest generates requests for GetPullsByProviderByOwnerByNameByNumberImportMetadata
-func NewGetPullsByProviderByOwnerByNameByNumberImportMetadataRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullImportMetadataRequest generates requests for GetPullImportMetadata
+func NewGetPullImportMetadataRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8661,19 +8661,19 @@ func NewSetPrLabelsRequestWithBody(server string, provider string, owner string,
 	return req, nil
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberMergeRequest calls the generic PostPullsByProviderByOwnerByNameByNumberMerge builder with application/json body
-func NewPostPullsByProviderByOwnerByNameByNumberMergeRequest(server string, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody) (*http.Request, error) {
+// NewMergePullRequest calls the generic MergePull builder with application/json body
+func NewMergePullRequest(server string, provider string, owner string, name string, number int64, body MergePullJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody(server, provider, owner, name, number, "application/json", bodyReader)
+	return NewMergePullRequestWithBody(server, provider, owner, name, number, "application/json", bodyReader)
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody generates requests for PostPullsByProviderByOwnerByNameByNumberMerge with any type of body
-func NewPostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody(server string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+// NewMergePullRequestWithBody generates requests for MergePull with any type of body
+func NewMergePullRequestWithBody(server string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8729,8 +8729,8 @@ func NewPostPullsByProviderByOwnerByNameByNumberMergeRequestWithBody(server stri
 	return req, nil
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberReadyForReviewRequest generates requests for PostPullsByProviderByOwnerByNameByNumberReadyForReview
-func NewPostPullsByProviderByOwnerByNameByNumberReadyForReviewRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewMarkPullReadyForReviewRequest generates requests for MarkPullReadyForReview
+func NewMarkPullReadyForReviewRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8784,8 +8784,8 @@ func NewPostPullsByProviderByOwnerByNameByNumberReadyForReviewRequest(server str
 	return req, nil
 }
 
-// NewGetPullsByProviderByOwnerByNameByNumberStackRequest generates requests for GetPullsByProviderByOwnerByNameByNumberStack
-func NewGetPullsByProviderByOwnerByNameByNumberStackRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewGetPullStackRequest generates requests for GetPullStack
+func NewGetPullStackRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8907,8 +8907,8 @@ func NewSetKanbanStateRequestWithBody(server string, provider string, owner stri
 	return req, nil
 }
 
-// NewPostPullsByProviderByOwnerByNameByNumberSyncRequest generates requests for PostPullsByProviderByOwnerByNameByNumberSync
-func NewPostPullsByProviderByOwnerByNameByNumberSyncRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewSyncPullRequest generates requests for SyncPull
+func NewSyncPullRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9092,8 +9092,8 @@ func NewDeleteRepoRequest(server string, provider string, owner string, name str
 	return req, nil
 }
 
-// NewGetRepoByProviderByOwnerByNameRequest generates requests for GetRepoByProviderByOwnerByName
-func NewGetRepoByProviderByOwnerByNameRequest(server string, provider string, owner string, name string) (*http.Request, error) {
+// NewGetRepoRequest generates requests for GetRepo
+func NewGetRepoRequest(server string, provider string, owner string, name string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9140,8 +9140,8 @@ func NewGetRepoByProviderByOwnerByNameRequest(server string, provider string, ow
 	return req, nil
 }
 
-// NewGetRepoByProviderByOwnerByNameCommentAutocompleteRequest generates requests for GetRepoByProviderByOwnerByNameCommentAutocomplete
-func NewGetRepoByProviderByOwnerByNameCommentAutocompleteRequest(server string, provider string, owner string, name string, params *GetRepoByProviderByOwnerByNameCommentAutocompleteParams) (*http.Request, error) {
+// NewGetCommentAutocompleteRequest generates requests for GetCommentAutocomplete
+func NewGetCommentAutocompleteRequest(server string, provider string, owner string, name string, params *GetCommentAutocompleteParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9338,8 +9338,8 @@ func NewRefreshRepoRequest(server string, provider string, owner string, name st
 	return req, nil
 }
 
-// NewPostRepoByProviderByOwnerByNameResolveByNumberRequest generates requests for PostRepoByProviderByOwnerByNameResolveByNumber
-func NewPostRepoByProviderByOwnerByNameResolveByNumberRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
+// NewResolveRepoItemRequest generates requests for ResolveRepoItem
+func NewResolveRepoItemRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9871,8 +9871,8 @@ func NewGetVersionRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewGetWorkspacesRequest generates requests for GetWorkspaces
-func NewGetWorkspacesRequest(server string) (*http.Request, error) {
+// NewListWorkspacesRequest generates requests for ListWorkspaces
+func NewListWorkspacesRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -9994,8 +9994,8 @@ func NewDeleteWorkspaceRequest(server string, id string, params *DeleteWorkspace
 	return req, nil
 }
 
-// NewGetWorkspacesByIdRequest generates requests for GetWorkspacesById
-func NewGetWorkspacesByIdRequest(server string, id string) (*http.Request, error) {
+// NewGetWorkspaceRequest generates requests for GetWorkspace
+func NewGetWorkspaceRequest(server string, id string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10028,8 +10028,8 @@ func NewGetWorkspacesByIdRequest(server string, id string) (*http.Request, error
 	return req, nil
 }
 
-// NewGetWorkspacesByIdCommitsRequest generates requests for GetWorkspacesByIdCommits
-func NewGetWorkspacesByIdCommitsRequest(server string, id string) (*http.Request, error) {
+// NewGetWorkspaceCommitsRequest generates requests for GetWorkspaceCommits
+func NewGetWorkspaceCommitsRequest(server string, id string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10062,8 +10062,8 @@ func NewGetWorkspacesByIdCommitsRequest(server string, id string) (*http.Request
 	return req, nil
 }
 
-// NewGetWorkspacesByIdDiffRequest generates requests for GetWorkspacesByIdDiff
-func NewGetWorkspacesByIdDiffRequest(server string, id string, params *GetWorkspacesByIdDiffParams) (*http.Request, error) {
+// NewGetWorkspaceDiffRequest generates requests for GetWorkspaceDiff
+func NewGetWorkspaceDiffRequest(server string, id string, params *GetWorkspaceDiffParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10198,8 +10198,8 @@ func NewGetWorkspacesByIdDiffRequest(server string, id string, params *GetWorksp
 	return req, nil
 }
 
-// NewGetWorkspacesByIdFilesRequest generates requests for GetWorkspacesByIdFiles
-func NewGetWorkspacesByIdFilesRequest(server string, id string, params *GetWorkspacesByIdFilesParams) (*http.Request, error) {
+// NewGetWorkspaceFilesRequest generates requests for GetWorkspaceFiles
+func NewGetWorkspaceFilesRequest(server string, id string, params *GetWorkspaceFilesParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10551,16 +10551,16 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
-	// GetActivityWithResponse request
-	GetActivityWithResponse(ctx context.Context, params *GetActivityParams, reqEditors ...RequestEditorFn) (*GetActivityResponse, error)
+	// ListActivityWithResponse request
+	ListActivityWithResponse(ctx context.Context, params *ListActivityParams, reqEditors ...RequestEditorFn) (*ListActivityResponse, error)
 
 	// CreateIssueOnHostWithBodyWithResponse request with any body
 	CreateIssueOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateIssueOnHostResponse, error)
 
 	CreateIssueOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, body CreateIssueOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIssueOnHostResponse, error)
 
-	// GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse request
-	GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse, error)
+	// GetIssueOnHostWithResponse request
+	GetIssueOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetIssueOnHostResponse, error)
 
 	// EditIssueContentOnHostWithBodyWithResponse request with any body
 	EditIssueContentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueContentOnHostResponse, error)
@@ -10587,8 +10587,8 @@ type ClientWithResponsesInterface interface {
 
 	SetIssueLabelsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetIssueLabelsOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueLabelsOnHostResponse, error)
 
-	// PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse request
-	PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse, error)
+	// SyncIssueOnHostWithResponse request
+	SyncIssueOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncIssueOnHostResponse, error)
 
 	// EnqueueIssueSyncOnHostWithResponse request
 	EnqueueIssueSyncOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*EnqueueIssueSyncOnHostResponse, error)
@@ -10598,24 +10598,24 @@ type ClientWithResponsesInterface interface {
 
 	CreateIssueWorkspaceOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body CreateIssueWorkspaceOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIssueWorkspaceOnHostResponse, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse, error)
+	// GetPullOnHostWithResponse request
+	GetPullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullOnHostResponse, error)
 
 	// EditPrContentOnHostWithBodyWithResponse request with any body
 	EditPrContentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentOnHostResponse, error)
 
 	EditPrContentOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body EditPrContentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentOnHostResponse, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse request with any body
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse, error)
+	// ApprovePullOnHostWithBodyWithResponse request with any body
+	ApprovePullOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ApprovePullOnHostResponse, error)
 
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse, error)
+	ApprovePullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body ApprovePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*ApprovePullOnHostResponse, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error)
+	// ApprovePullWorkflowsOnHostWithResponse request
+	ApprovePullWorkflowsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ApprovePullWorkflowsOnHostResponse, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error)
+	// RefreshPullCiOnHostWithResponse request
+	RefreshPullCiOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*RefreshPullCiOnHostResponse, error)
 
 	// PostPrCommentOnHostWithBodyWithResponse request with any body
 	PostPrCommentOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentOnHostResponse, error)
@@ -10627,49 +10627,49 @@ type ClientWithResponsesInterface interface {
 
 	EditPrCommentOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, commentId int64, body EditPrCommentOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentOnHostResponse, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsWithResponse request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse, error)
+	// GetPullCommitsOnHostWithResponse request
+	GetPullCommitsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullCommitsOnHostResponse, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffWithResponse request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse, error)
+	// GetPullDiffOnHostWithResponse request
+	GetPullDiffOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullDiffOnHostParams, reqEditors ...RequestEditorFn) (*GetPullDiffOnHostResponse, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse, error)
+	// GetPullFilePreviewOnHostWithResponse request
+	GetPullFilePreviewOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullFilePreviewOnHostParams, reqEditors ...RequestEditorFn) (*GetPullFilePreviewOnHostResponse, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesWithResponse request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse, error)
+	// GetPullFilesOnHostWithResponse request
+	GetPullFilesOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullFilesOnHostResponse, error)
 
 	// SetPrGithubStateOnHostWithBodyWithResponse request with any body
 	SetPrGithubStateOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateOnHostResponse, error)
 
 	SetPrGithubStateOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetPrGithubStateOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateOnHostResponse, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse, error)
+	// GetPullImportMetadataOnHostWithResponse request
+	GetPullImportMetadataOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullImportMetadataOnHostResponse, error)
 
 	// SetPrLabelsOnHostWithBodyWithResponse request with any body
 	SetPrLabelsOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrLabelsOnHostResponse, error)
 
 	SetPrLabelsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetPrLabelsOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrLabelsOnHostResponse, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse request with any body
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse, error)
+	// MergePullOnHostWithBodyWithResponse request with any body
+	MergePullOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MergePullOnHostResponse, error)
 
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse, error)
+	MergePullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body MergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*MergePullOnHostResponse, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse, error)
+	// MarkPullReadyForReviewOnHostWithResponse request
+	MarkPullReadyForReviewOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewOnHostResponse, error)
 
-	// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackWithResponse request
-	GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse, error)
+	// GetPullStackOnHostWithResponse request
+	GetPullStackOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullStackOnHostResponse, error)
 
 	// SetKanbanStateOnHostWithBodyWithResponse request with any body
 	SetKanbanStateOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateOnHostResponse, error)
 
 	SetKanbanStateOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body SetKanbanStateOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateOnHostResponse, error)
 
-	// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncWithResponse request
-	PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse, error)
+	// SyncPullOnHostWithResponse request
+	SyncPullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncPullOnHostResponse, error)
 
 	// EnqueuePrSyncOnHostWithResponse request
 	EnqueuePrSyncOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*EnqueuePrSyncOnHostResponse, error)
@@ -10677,11 +10677,11 @@ type ClientWithResponsesInterface interface {
 	// DeleteRepoOnHostWithResponse request
 	DeleteRepoOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*DeleteRepoOnHostResponse, error)
 
-	// GetHostByPlatformHostRepoByProviderByOwnerByNameWithResponse request
-	GetHostByPlatformHostRepoByProviderByOwnerByNameWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostRepoByProviderByOwnerByNameResponse, error)
+	// GetRepoOnHostWithResponse request
+	GetRepoOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoOnHostResponse, error)
 
-	// GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteWithResponse request
-	GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse, error)
+	// GetCommentAutocompleteOnHostWithResponse request
+	GetCommentAutocompleteOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*GetCommentAutocompleteOnHostResponse, error)
 
 	// ListRepoLabelsOnHostWithResponse request
 	ListRepoLabelsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*ListRepoLabelsOnHostResponse, error)
@@ -10689,8 +10689,8 @@ type ClientWithResponsesInterface interface {
 	// RefreshRepoOnHostWithResponse request
 	RefreshRepoOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*RefreshRepoOnHostResponse, error)
 
-	// PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberWithResponse request
-	PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse, error)
+	// ResolveRepoItemOnHostWithResponse request
+	ResolveRepoItemOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ResolveRepoItemOnHostResponse, error)
 
 	// ListIssuesWithResponse request
 	ListIssuesWithResponse(ctx context.Context, params *ListIssuesParams, reqEditors ...RequestEditorFn) (*ListIssuesResponse, error)
@@ -10700,8 +10700,8 @@ type ClientWithResponsesInterface interface {
 
 	CreateIssueWithResponse(ctx context.Context, provider string, owner string, name string, body CreateIssueJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIssueResponse, error)
 
-	// GetIssuesByProviderByOwnerByNameByNumberWithResponse request
-	GetIssuesByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetIssuesByProviderByOwnerByNameByNumberResponse, error)
+	// GetIssueWithResponse request
+	GetIssueWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetIssueResponse, error)
 
 	// EditIssueContentWithBodyWithResponse request with any body
 	EditIssueContentWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditIssueContentResponse, error)
@@ -10728,8 +10728,8 @@ type ClientWithResponsesInterface interface {
 
 	SetIssueLabelsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body SetIssueLabelsJSONRequestBody, reqEditors ...RequestEditorFn) (*SetIssueLabelsResponse, error)
 
-	// PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse request
-	PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostIssuesByProviderByOwnerByNameByNumberSyncResponse, error)
+	// SyncIssueWithResponse request
+	SyncIssueWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncIssueResponse, error)
 
 	// EnqueueIssueSyncWithResponse request
 	EnqueueIssueSyncWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*EnqueueIssueSyncResponse, error)
@@ -10764,24 +10764,24 @@ type ClientWithResponsesInterface interface {
 	// ListPullsWithResponse request
 	ListPullsWithResponse(ctx context.Context, params *ListPullsParams, reqEditors ...RequestEditorFn) (*ListPullsResponse, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberWithResponse request
-	GetPullsByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberResponse, error)
+	// GetPullWithResponse request
+	GetPullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullResponse, error)
 
 	// EditPrContentWithBodyWithResponse request with any body
 	EditPrContentWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
 
 	EditPrContentWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body EditPrContentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrContentResponse, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse request with any body
-	PostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberApproveResponse, error)
+	// ApprovePullWithBodyWithResponse request with any body
+	ApprovePullWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ApprovePullResponse, error)
 
-	PostPullsByProviderByOwnerByNameByNumberApproveWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberApproveResponse, error)
+	ApprovePullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body ApprovePullJSONRequestBody, reqEditors ...RequestEditorFn) (*ApprovePullResponse, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse request
-	PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error)
+	// ApprovePullWorkflowsWithResponse request
+	ApprovePullWorkflowsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ApprovePullWorkflowsResponse, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request
-	PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error)
+	// RefreshPullCiWithResponse request
+	RefreshPullCiWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*RefreshPullCiResponse, error)
 
 	// PostPrCommentWithBodyWithResponse request with any body
 	PostPrCommentWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPrCommentResponse, error)
@@ -10793,49 +10793,49 @@ type ClientWithResponsesInterface interface {
 
 	EditPrCommentWithResponse(ctx context.Context, provider string, owner string, name string, number int64, commentId int64, body EditPrCommentJSONRequestBody, reqEditors ...RequestEditorFn) (*EditPrCommentResponse, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse request
-	GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberCommitsResponse, error)
+	// GetPullCommitsWithResponse request
+	GetPullCommitsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullCommitsResponse, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberDiffWithResponse request
-	GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberDiffResponse, error)
+	// GetPullDiffWithResponse request
+	GetPullDiffWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullDiffParams, reqEditors ...RequestEditorFn) (*GetPullDiffResponse, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse request
-	GetPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse, error)
+	// GetPullFilePreviewWithResponse request
+	GetPullFilePreviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullFilePreviewParams, reqEditors ...RequestEditorFn) (*GetPullFilePreviewResponse, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberFilesWithResponse request
-	GetPullsByProviderByOwnerByNameByNumberFilesWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberFilesResponse, error)
+	// GetPullFilesWithResponse request
+	GetPullFilesWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullFilesResponse, error)
 
 	// SetPrGithubStateWithBodyWithResponse request with any body
 	SetPrGithubStateWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
 
 	SetPrGithubStateWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body SetPrGithubStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrGithubStateResponse, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse request
-	GetPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse, error)
+	// GetPullImportMetadataWithResponse request
+	GetPullImportMetadataWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullImportMetadataResponse, error)
 
 	// SetPrLabelsWithBodyWithResponse request with any body
 	SetPrLabelsWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetPrLabelsResponse, error)
 
 	SetPrLabelsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body SetPrLabelsJSONRequestBody, reqEditors ...RequestEditorFn) (*SetPrLabelsResponse, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse request with any body
-	PostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberMergeResponse, error)
+	// MergePullWithBodyWithResponse request with any body
+	MergePullWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MergePullResponse, error)
 
-	PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberMergeResponse, error)
+	MergePullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body MergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*MergePullResponse, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse request
-	PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse, error)
+	// MarkPullReadyForReviewWithResponse request
+	MarkPullReadyForReviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewResponse, error)
 
-	// GetPullsByProviderByOwnerByNameByNumberStackWithResponse request
-	GetPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberStackResponse, error)
+	// GetPullStackWithResponse request
+	GetPullStackWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullStackResponse, error)
 
 	// SetKanbanStateWithBodyWithResponse request with any body
 	SetKanbanStateWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
 
 	SetKanbanStateWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body SetKanbanStateJSONRequestBody, reqEditors ...RequestEditorFn) (*SetKanbanStateResponse, error)
 
-	// PostPullsByProviderByOwnerByNameByNumberSyncWithResponse request
-	PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberSyncResponse, error)
+	// SyncPullWithResponse request
+	SyncPullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncPullResponse, error)
 
 	// EnqueuePrSyncWithResponse request
 	EnqueuePrSyncWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*EnqueuePrSyncResponse, error)
@@ -10846,11 +10846,11 @@ type ClientWithResponsesInterface interface {
 	// DeleteRepoWithResponse request
 	DeleteRepoWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*DeleteRepoResponse, error)
 
-	// GetRepoByProviderByOwnerByNameWithResponse request
-	GetRepoByProviderByOwnerByNameWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoByProviderByOwnerByNameResponse, error)
+	// GetRepoWithResponse request
+	GetRepoWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoResponse, error)
 
-	// GetRepoByProviderByOwnerByNameCommentAutocompleteWithResponse request
-	GetRepoByProviderByOwnerByNameCommentAutocompleteWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*GetRepoByProviderByOwnerByNameCommentAutocompleteResponse, error)
+	// GetCommentAutocompleteWithResponse request
+	GetCommentAutocompleteWithResponse(ctx context.Context, provider string, owner string, name string, params *GetCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*GetCommentAutocompleteResponse, error)
 
 	// ListRepoLabelsWithResponse request
 	ListRepoLabelsWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*ListRepoLabelsResponse, error)
@@ -10858,8 +10858,8 @@ type ClientWithResponsesInterface interface {
 	// RefreshRepoWithResponse request
 	RefreshRepoWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*RefreshRepoResponse, error)
 
-	// PostRepoByProviderByOwnerByNameResolveByNumberWithResponse request
-	PostRepoByProviderByOwnerByNameResolveByNumberWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostRepoByProviderByOwnerByNameResolveByNumberResponse, error)
+	// ResolveRepoItemWithResponse request
+	ResolveRepoItemWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ResolveRepoItemResponse, error)
 
 	// ListReposWithResponse request
 	ListReposWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListReposResponse, error)
@@ -10915,8 +10915,8 @@ type ClientWithResponsesInterface interface {
 	// GetVersionWithResponse request
 	GetVersionWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetVersionResponse, error)
 
-	// GetWorkspacesWithResponse request
-	GetWorkspacesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetWorkspacesResponse, error)
+	// ListWorkspacesWithResponse request
+	ListWorkspacesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListWorkspacesResponse, error)
 
 	// CreateWorkspaceWithBodyWithResponse request with any body
 	CreateWorkspaceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateWorkspaceResponse, error)
@@ -10926,17 +10926,17 @@ type ClientWithResponsesInterface interface {
 	// DeleteWorkspaceWithResponse request
 	DeleteWorkspaceWithResponse(ctx context.Context, id string, params *DeleteWorkspaceParams, reqEditors ...RequestEditorFn) (*DeleteWorkspaceResponse, error)
 
-	// GetWorkspacesByIdWithResponse request
-	GetWorkspacesByIdWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdResponse, error)
+	// GetWorkspaceWithResponse request
+	GetWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspaceResponse, error)
 
-	// GetWorkspacesByIdCommitsWithResponse request
-	GetWorkspacesByIdCommitsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdCommitsResponse, error)
+	// GetWorkspaceCommitsWithResponse request
+	GetWorkspaceCommitsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspaceCommitsResponse, error)
 
-	// GetWorkspacesByIdDiffWithResponse request
-	GetWorkspacesByIdDiffWithResponse(ctx context.Context, id string, params *GetWorkspacesByIdDiffParams, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdDiffResponse, error)
+	// GetWorkspaceDiffWithResponse request
+	GetWorkspaceDiffWithResponse(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*GetWorkspaceDiffResponse, error)
 
-	// GetWorkspacesByIdFilesWithResponse request
-	GetWorkspacesByIdFilesWithResponse(ctx context.Context, id string, params *GetWorkspacesByIdFilesParams, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdFilesResponse, error)
+	// GetWorkspaceFilesWithResponse request
+	GetWorkspaceFilesWithResponse(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilesResponse, error)
 
 	// RetryWorkspaceWithResponse request
 	RetryWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RetryWorkspaceResponse, error)
@@ -10956,7 +10956,7 @@ type ClientWithResponsesInterface interface {
 	EnsureWorkspaceRuntimeShellWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EnsureWorkspaceRuntimeShellResponse, error)
 }
 
-type GetActivityResponse struct {
+type ListActivityResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActivityResponse
@@ -10964,7 +10964,7 @@ type GetActivityResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetActivityResponse) Status() string {
+func (r ListActivityResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -10972,7 +10972,7 @@ func (r GetActivityResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetActivityResponse) StatusCode() int {
+func (r ListActivityResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11002,7 +11002,7 @@ func (r CreateIssueOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse struct {
+type GetIssueOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
@@ -11010,7 +11010,7 @@ type GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse) Status() string {
+func (r GetIssueOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11018,7 +11018,7 @@ func (r GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse) Stat
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse) StatusCode() int {
+func (r GetIssueOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11140,7 +11140,7 @@ func (r SetIssueLabelsOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse struct {
+type SyncIssueOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
@@ -11148,7 +11148,7 @@ type PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse str
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse) Status() string {
+func (r SyncIssueOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11156,7 +11156,7 @@ func (r PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse)
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse) StatusCode() int {
+func (r SyncIssueOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11208,7 +11208,7 @@ func (r CreateIssueWorkspaceOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse struct {
+type GetPullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
@@ -11216,7 +11216,7 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse) Status() string {
+func (r GetPullOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11224,7 +11224,7 @@ func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse) Statu
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse) StatusCode() int {
+func (r GetPullOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11254,7 +11254,7 @@ func (r EditPrContentOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse struct {
+type ApprovePullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
@@ -11262,7 +11262,7 @@ type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse s
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse) Status() string {
+func (r ApprovePullOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11270,14 +11270,14 @@ func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRespons
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse) StatusCode() int {
+func (r ApprovePullOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse struct {
+type ApprovePullWorkflowsOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
@@ -11285,7 +11285,7 @@ type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsR
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) Status() string {
+func (r ApprovePullWorkflowsOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11293,14 +11293,14 @@ func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflo
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) StatusCode() int {
+func (r ApprovePullWorkflowsOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse struct {
+type RefreshPullCiOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
@@ -11308,7 +11308,7 @@ type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) Status() string {
+func (r RefreshPullCiOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11316,7 +11316,7 @@ func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshRespo
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) StatusCode() int {
+func (r RefreshPullCiOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11369,7 +11369,7 @@ func (r EditPrCommentOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse struct {
+type GetPullCommitsOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommitsResponse
@@ -11377,7 +11377,7 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse st
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse) Status() string {
+func (r GetPullCommitsOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11385,14 +11385,14 @@ func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse) StatusCode() int {
+func (r GetPullCommitsOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse struct {
+type GetPullDiffOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *DiffResponse
@@ -11400,7 +11400,7 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse struc
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse) Status() string {
+func (r GetPullDiffOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11408,14 +11408,14 @@ func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse) S
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse) StatusCode() int {
+func (r GetPullDiffOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse struct {
+type GetPullFilePreviewOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilePreviewResponse
@@ -11423,7 +11423,7 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewRespons
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse) Status() string {
+func (r GetPullFilePreviewOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11431,14 +11431,14 @@ func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResp
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse) StatusCode() int {
+func (r GetPullFilePreviewOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse struct {
+type GetPullFilesOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilesResponse
@@ -11446,7 +11446,7 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse stru
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse) Status() string {
+func (r GetPullFilesOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11454,7 +11454,7 @@ func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse) 
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse) StatusCode() int {
+func (r GetPullFilesOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11484,7 +11484,7 @@ func (r SetPrGithubStateOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse struct {
+type GetPullImportMetadataOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MrImportMetadataResponse
@@ -11492,7 +11492,7 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResp
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse) Status() string {
+func (r GetPullImportMetadataOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11500,7 +11500,7 @@ func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataR
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse) StatusCode() int {
+func (r GetPullImportMetadataOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11530,7 +11530,7 @@ func (r SetPrLabelsOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse struct {
+type MergePullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergePRBody
@@ -11538,7 +11538,7 @@ type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse str
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse) Status() string {
+func (r MergePullOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11546,14 +11546,14 @@ func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse)
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse) StatusCode() int {
+func (r MergePullOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse struct {
+type MarkPullReadyForReviewOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
@@ -11561,7 +11561,7 @@ type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewRes
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse) Status() string {
+func (r MarkPullReadyForReviewOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11569,14 +11569,14 @@ func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReview
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse) StatusCode() int {
+func (r MarkPullReadyForReviewOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse struct {
+type GetPullStackOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *StackContextResponse
@@ -11584,7 +11584,7 @@ type GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse stru
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse) Status() string {
+func (r GetPullStackOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11592,7 +11592,7 @@ func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse) 
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse) StatusCode() int {
+func (r GetPullStackOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11621,7 +11621,7 @@ func (r SetKanbanStateOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse struct {
+type SyncPullOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
@@ -11629,7 +11629,7 @@ type PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse stru
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse) Status() string {
+func (r SyncPullOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11637,7 +11637,7 @@ func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse) 
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse) StatusCode() int {
+func (r SyncPullOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11688,7 +11688,7 @@ func (r DeleteRepoOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type GetHostByPlatformHostRepoByProviderByOwnerByNameResponse struct {
+type GetRepoOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RepoResponse
@@ -11696,7 +11696,7 @@ type GetHostByPlatformHostRepoByProviderByOwnerByNameResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostRepoByProviderByOwnerByNameResponse) Status() string {
+func (r GetRepoOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11704,14 +11704,14 @@ func (r GetHostByPlatformHostRepoByProviderByOwnerByNameResponse) Status() strin
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostRepoByProviderByOwnerByNameResponse) StatusCode() int {
+func (r GetRepoOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse struct {
+type GetCommentAutocompleteOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommentAutocompleteResponse
@@ -11719,7 +11719,7 @@ type GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse) Status() string {
+func (r GetCommentAutocompleteOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11727,7 +11727,7 @@ func (r GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteRespo
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse) StatusCode() int {
+func (r GetCommentAutocompleteOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11780,7 +11780,7 @@ func (r RefreshRepoOnHostResponse) StatusCode() int {
 	return 0
 }
 
-type PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse struct {
+type ResolveRepoItemOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ResolveItemResponse
@@ -11788,7 +11788,7 @@ type PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse st
 }
 
 // Status returns HTTPResponse.Status
-func (r PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse) Status() string {
+func (r ResolveRepoItemOnHostResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11796,7 +11796,7 @@ func (r PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse) StatusCode() int {
+func (r ResolveRepoItemOnHostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11849,7 +11849,7 @@ func (r CreateIssueResponse) StatusCode() int {
 	return 0
 }
 
-type GetIssuesByProviderByOwnerByNameByNumberResponse struct {
+type GetIssueResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
@@ -11857,7 +11857,7 @@ type GetIssuesByProviderByOwnerByNameByNumberResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetIssuesByProviderByOwnerByNameByNumberResponse) Status() string {
+func (r GetIssueResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -11865,7 +11865,7 @@ func (r GetIssuesByProviderByOwnerByNameByNumberResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetIssuesByProviderByOwnerByNameByNumberResponse) StatusCode() int {
+func (r GetIssueResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -11987,7 +11987,7 @@ func (r SetIssueLabelsResponse) StatusCode() int {
 	return 0
 }
 
-type PostIssuesByProviderByOwnerByNameByNumberSyncResponse struct {
+type SyncIssueResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *IssueDetailResponse
@@ -11995,7 +11995,7 @@ type PostIssuesByProviderByOwnerByNameByNumberSyncResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostIssuesByProviderByOwnerByNameByNumberSyncResponse) Status() string {
+func (r SyncIssueResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12003,7 +12003,7 @@ func (r PostIssuesByProviderByOwnerByNameByNumberSyncResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostIssuesByProviderByOwnerByNameByNumberSyncResponse) StatusCode() int {
+func (r SyncIssueResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12216,7 +12216,7 @@ func (r ListPullsResponse) StatusCode() int {
 	return 0
 }
 
-type GetPullsByProviderByOwnerByNameByNumberResponse struct {
+type GetPullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
@@ -12224,7 +12224,7 @@ type GetPullsByProviderByOwnerByNameByNumberResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetPullsByProviderByOwnerByNameByNumberResponse) Status() string {
+func (r GetPullResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12232,7 +12232,7 @@ func (r GetPullsByProviderByOwnerByNameByNumberResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetPullsByProviderByOwnerByNameByNumberResponse) StatusCode() int {
+func (r GetPullResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12262,7 +12262,7 @@ func (r EditPrContentResponse) StatusCode() int {
 	return 0
 }
 
-type PostPullsByProviderByOwnerByNameByNumberApproveResponse struct {
+type ApprovePullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
@@ -12270,7 +12270,7 @@ type PostPullsByProviderByOwnerByNameByNumberApproveResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostPullsByProviderByOwnerByNameByNumberApproveResponse) Status() string {
+func (r ApprovePullResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12278,14 +12278,14 @@ func (r PostPullsByProviderByOwnerByNameByNumberApproveResponse) Status() string
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostPullsByProviderByOwnerByNameByNumberApproveResponse) StatusCode() int {
+func (r ApprovePullResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse struct {
+type ApprovePullWorkflowsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
@@ -12293,7 +12293,7 @@ type PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) Status() string {
+func (r ApprovePullWorkflowsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12301,14 +12301,14 @@ func (r PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) Status
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse) StatusCode() int {
+func (r ApprovePullWorkflowsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse struct {
+type RefreshPullCiResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
@@ -12316,7 +12316,7 @@ type PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) Status() string {
+func (r RefreshPullCiResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12324,7 +12324,7 @@ func (r PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) Status() stri
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse) StatusCode() int {
+func (r RefreshPullCiResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12377,7 +12377,7 @@ func (r EditPrCommentResponse) StatusCode() int {
 	return 0
 }
 
-type GetPullsByProviderByOwnerByNameByNumberCommitsResponse struct {
+type GetPullCommitsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommitsResponse
@@ -12385,7 +12385,7 @@ type GetPullsByProviderByOwnerByNameByNumberCommitsResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetPullsByProviderByOwnerByNameByNumberCommitsResponse) Status() string {
+func (r GetPullCommitsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12393,14 +12393,14 @@ func (r GetPullsByProviderByOwnerByNameByNumberCommitsResponse) Status() string 
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetPullsByProviderByOwnerByNameByNumberCommitsResponse) StatusCode() int {
+func (r GetPullCommitsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetPullsByProviderByOwnerByNameByNumberDiffResponse struct {
+type GetPullDiffResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *DiffResponse
@@ -12408,7 +12408,7 @@ type GetPullsByProviderByOwnerByNameByNumberDiffResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetPullsByProviderByOwnerByNameByNumberDiffResponse) Status() string {
+func (r GetPullDiffResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12416,14 +12416,14 @@ func (r GetPullsByProviderByOwnerByNameByNumberDiffResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetPullsByProviderByOwnerByNameByNumberDiffResponse) StatusCode() int {
+func (r GetPullDiffResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse struct {
+type GetPullFilePreviewResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilePreviewResponse
@@ -12431,7 +12431,7 @@ type GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse) Status() string {
+func (r GetPullFilePreviewResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12439,14 +12439,14 @@ func (r GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse) Status() str
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse) StatusCode() int {
+func (r GetPullFilePreviewResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetPullsByProviderByOwnerByNameByNumberFilesResponse struct {
+type GetPullFilesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilesResponse
@@ -12454,7 +12454,7 @@ type GetPullsByProviderByOwnerByNameByNumberFilesResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetPullsByProviderByOwnerByNameByNumberFilesResponse) Status() string {
+func (r GetPullFilesResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12462,7 +12462,7 @@ func (r GetPullsByProviderByOwnerByNameByNumberFilesResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetPullsByProviderByOwnerByNameByNumberFilesResponse) StatusCode() int {
+func (r GetPullFilesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12492,7 +12492,7 @@ func (r SetPrGithubStateResponse) StatusCode() int {
 	return 0
 }
 
-type GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse struct {
+type GetPullImportMetadataResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MrImportMetadataResponse
@@ -12500,7 +12500,7 @@ type GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse) Status() string {
+func (r GetPullImportMetadataResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12508,7 +12508,7 @@ func (r GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse) Status() 
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse) StatusCode() int {
+func (r GetPullImportMetadataResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12538,7 +12538,7 @@ func (r SetPrLabelsResponse) StatusCode() int {
 	return 0
 }
 
-type PostPullsByProviderByOwnerByNameByNumberMergeResponse struct {
+type MergePullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergePRBody
@@ -12546,7 +12546,7 @@ type PostPullsByProviderByOwnerByNameByNumberMergeResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostPullsByProviderByOwnerByNameByNumberMergeResponse) Status() string {
+func (r MergePullResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12554,14 +12554,14 @@ func (r PostPullsByProviderByOwnerByNameByNumberMergeResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostPullsByProviderByOwnerByNameByNumberMergeResponse) StatusCode() int {
+func (r MergePullResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse struct {
+type MarkPullReadyForReviewResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ActionStatusBody
@@ -12569,7 +12569,7 @@ type PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse) Status() string {
+func (r MarkPullReadyForReviewResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12577,14 +12577,14 @@ func (r PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse) Status()
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse) StatusCode() int {
+func (r MarkPullReadyForReviewResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetPullsByProviderByOwnerByNameByNumberStackResponse struct {
+type GetPullStackResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *StackContextResponse
@@ -12592,7 +12592,7 @@ type GetPullsByProviderByOwnerByNameByNumberStackResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetPullsByProviderByOwnerByNameByNumberStackResponse) Status() string {
+func (r GetPullStackResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12600,7 +12600,7 @@ func (r GetPullsByProviderByOwnerByNameByNumberStackResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetPullsByProviderByOwnerByNameByNumberStackResponse) StatusCode() int {
+func (r GetPullStackResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12629,7 +12629,7 @@ func (r SetKanbanStateResponse) StatusCode() int {
 	return 0
 }
 
-type PostPullsByProviderByOwnerByNameByNumberSyncResponse struct {
+type SyncPullResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *MergeRequestDetailResponse
@@ -12637,7 +12637,7 @@ type PostPullsByProviderByOwnerByNameByNumberSyncResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostPullsByProviderByOwnerByNameByNumberSyncResponse) Status() string {
+func (r SyncPullResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12645,7 +12645,7 @@ func (r PostPullsByProviderByOwnerByNameByNumberSyncResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostPullsByProviderByOwnerByNameByNumberSyncResponse) StatusCode() int {
+func (r SyncPullResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12719,7 +12719,7 @@ func (r DeleteRepoResponse) StatusCode() int {
 	return 0
 }
 
-type GetRepoByProviderByOwnerByNameResponse struct {
+type GetRepoResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *RepoResponse
@@ -12727,7 +12727,7 @@ type GetRepoByProviderByOwnerByNameResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetRepoByProviderByOwnerByNameResponse) Status() string {
+func (r GetRepoResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12735,14 +12735,14 @@ func (r GetRepoByProviderByOwnerByNameResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetRepoByProviderByOwnerByNameResponse) StatusCode() int {
+func (r GetRepoResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetRepoByProviderByOwnerByNameCommentAutocompleteResponse struct {
+type GetCommentAutocompleteResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommentAutocompleteResponse
@@ -12750,7 +12750,7 @@ type GetRepoByProviderByOwnerByNameCommentAutocompleteResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetRepoByProviderByOwnerByNameCommentAutocompleteResponse) Status() string {
+func (r GetCommentAutocompleteResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12758,7 +12758,7 @@ func (r GetRepoByProviderByOwnerByNameCommentAutocompleteResponse) Status() stri
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetRepoByProviderByOwnerByNameCommentAutocompleteResponse) StatusCode() int {
+func (r GetCommentAutocompleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12811,7 +12811,7 @@ func (r RefreshRepoResponse) StatusCode() int {
 	return 0
 }
 
-type PostRepoByProviderByOwnerByNameResolveByNumberResponse struct {
+type ResolveRepoItemResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ResolveItemResponse
@@ -12819,7 +12819,7 @@ type PostRepoByProviderByOwnerByNameResolveByNumberResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r PostRepoByProviderByOwnerByNameResolveByNumberResponse) Status() string {
+func (r ResolveRepoItemResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -12827,7 +12827,7 @@ func (r PostRepoByProviderByOwnerByNameResolveByNumberResponse) Status() string 
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r PostRepoByProviderByOwnerByNameResolveByNumberResponse) StatusCode() int {
+func (r ResolveRepoItemResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13153,7 +13153,7 @@ func (r GetVersionResponse) StatusCode() int {
 	return 0
 }
 
-type GetWorkspacesResponse struct {
+type ListWorkspacesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *ListWorkspacesOutputBody
@@ -13161,7 +13161,7 @@ type GetWorkspacesResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetWorkspacesResponse) Status() string {
+func (r ListWorkspacesResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -13169,7 +13169,7 @@ func (r GetWorkspacesResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetWorkspacesResponse) StatusCode() int {
+func (r ListWorkspacesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13221,7 +13221,7 @@ func (r DeleteWorkspaceResponse) StatusCode() int {
 	return 0
 }
 
-type GetWorkspacesByIdResponse struct {
+type GetWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *WorkspaceResponse
@@ -13229,7 +13229,7 @@ type GetWorkspacesByIdResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetWorkspacesByIdResponse) Status() string {
+func (r GetWorkspaceResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -13237,14 +13237,14 @@ func (r GetWorkspacesByIdResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetWorkspacesByIdResponse) StatusCode() int {
+func (r GetWorkspaceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetWorkspacesByIdCommitsResponse struct {
+type GetWorkspaceCommitsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *CommitsResponse
@@ -13252,7 +13252,7 @@ type GetWorkspacesByIdCommitsResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetWorkspacesByIdCommitsResponse) Status() string {
+func (r GetWorkspaceCommitsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -13260,14 +13260,14 @@ func (r GetWorkspacesByIdCommitsResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetWorkspacesByIdCommitsResponse) StatusCode() int {
+func (r GetWorkspaceCommitsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetWorkspacesByIdDiffResponse struct {
+type GetWorkspaceDiffResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *DiffResponse
@@ -13275,7 +13275,7 @@ type GetWorkspacesByIdDiffResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetWorkspacesByIdDiffResponse) Status() string {
+func (r GetWorkspaceDiffResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -13283,14 +13283,14 @@ func (r GetWorkspacesByIdDiffResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetWorkspacesByIdDiffResponse) StatusCode() int {
+func (r GetWorkspaceDiffResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetWorkspacesByIdFilesResponse struct {
+type GetWorkspaceFilesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
 	JSON200                       *FilesResponse
@@ -13298,7 +13298,7 @@ type GetWorkspacesByIdFilesResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetWorkspacesByIdFilesResponse) Status() string {
+func (r GetWorkspaceFilesResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -13306,7 +13306,7 @@ func (r GetWorkspacesByIdFilesResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetWorkspacesByIdFilesResponse) StatusCode() int {
+func (r GetWorkspaceFilesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -13427,13 +13427,13 @@ func (r EnsureWorkspaceRuntimeShellResponse) StatusCode() int {
 	return 0
 }
 
-// GetActivityWithResponse request returning *GetActivityResponse
-func (c *ClientWithResponses) GetActivityWithResponse(ctx context.Context, params *GetActivityParams, reqEditors ...RequestEditorFn) (*GetActivityResponse, error) {
-	rsp, err := c.GetActivity(ctx, params, reqEditors...)
+// ListActivityWithResponse request returning *ListActivityResponse
+func (c *ClientWithResponses) ListActivityWithResponse(ctx context.Context, params *ListActivityParams, reqEditors ...RequestEditorFn) (*ListActivityResponse, error) {
+	rsp, err := c.ListActivity(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetActivityResponse(rsp)
+	return ParseListActivityResponse(rsp)
 }
 
 // CreateIssueOnHostWithBodyWithResponse request with arbitrary body returning *CreateIssueOnHostResponse
@@ -13453,13 +13453,13 @@ func (c *ClientWithResponses) CreateIssueOnHostWithResponse(ctx context.Context,
 	return ParseCreateIssueOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse request returning *GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse
-func (c *ClientWithResponses) GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse, error) {
-	rsp, err := c.GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumber(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// GetIssueOnHostWithResponse request returning *GetIssueOnHostResponse
+func (c *ClientWithResponses) GetIssueOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetIssueOnHostResponse, error) {
+	rsp, err := c.GetIssueOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse(rsp)
+	return ParseGetIssueOnHostResponse(rsp)
 }
 
 // EditIssueContentOnHostWithBodyWithResponse request with arbitrary body returning *EditIssueContentOnHostResponse
@@ -13547,13 +13547,13 @@ func (c *ClientWithResponses) SetIssueLabelsOnHostWithResponse(ctx context.Conte
 	return ParseSetIssueLabelsOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse request returning *PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse
-func (c *ClientWithResponses) PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse, error) {
-	rsp, err := c.PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSync(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// SyncIssueOnHostWithResponse request returning *SyncIssueOnHostResponse
+func (c *ClientWithResponses) SyncIssueOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncIssueOnHostResponse, error) {
+	rsp, err := c.SyncIssueOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse(rsp)
+	return ParseSyncIssueOnHostResponse(rsp)
 }
 
 // EnqueueIssueSyncOnHostWithResponse request returning *EnqueueIssueSyncOnHostResponse
@@ -13582,13 +13582,13 @@ func (c *ClientWithResponses) CreateIssueWorkspaceOnHostWithResponse(ctx context
 	return ParseCreateIssueWorkspaceOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse request returning *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse
-func (c *ClientWithResponses) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse, error) {
-	rsp, err := c.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumber(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// GetPullOnHostWithResponse request returning *GetPullOnHostResponse
+func (c *ClientWithResponses) GetPullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullOnHostResponse, error) {
+	rsp, err := c.GetPullOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse(rsp)
+	return ParseGetPullOnHostResponse(rsp)
 }
 
 // EditPrContentOnHostWithBodyWithResponse request with arbitrary body returning *EditPrContentOnHostResponse
@@ -13608,39 +13608,39 @@ func (c *ClientWithResponses) EditPrContentOnHostWithResponse(ctx context.Contex
 	return ParseEditPrContentOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse request with arbitrary body returning *PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
+// ApprovePullOnHostWithBodyWithResponse request with arbitrary body returning *ApprovePullOnHostResponse
+func (c *ClientWithResponses) ApprovePullOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ApprovePullOnHostResponse, error) {
+	rsp, err := c.ApprovePullOnHostWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse(rsp)
+	return ParseApprovePullOnHostResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApprove(ctx, platformHost, provider, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) ApprovePullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body ApprovePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*ApprovePullOnHostResponse, error) {
+	rsp, err := c.ApprovePullOnHost(ctx, platformHost, provider, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse(rsp)
+	return ParseApprovePullOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse request returning *PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// ApprovePullWorkflowsOnHostWithResponse request returning *ApprovePullWorkflowsOnHostResponse
+func (c *ClientWithResponses) ApprovePullWorkflowsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ApprovePullWorkflowsOnHostResponse, error) {
+	rsp, err := c.ApprovePullWorkflowsOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp)
+	return ParseApprovePullWorkflowsOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request returning *PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// RefreshPullCiOnHostWithResponse request returning *RefreshPullCiOnHostResponse
+func (c *ClientWithResponses) RefreshPullCiOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*RefreshPullCiOnHostResponse, error) {
+	rsp, err := c.RefreshPullCiOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp)
+	return ParseRefreshPullCiOnHostResponse(rsp)
 }
 
 // PostPrCommentOnHostWithBodyWithResponse request with arbitrary body returning *PostPrCommentOnHostResponse
@@ -13677,40 +13677,40 @@ func (c *ClientWithResponses) EditPrCommentOnHostWithResponse(ctx context.Contex
 	return ParseEditPrCommentOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsWithResponse request returning *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse
-func (c *ClientWithResponses) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse, error) {
-	rsp, err := c.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommits(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// GetPullCommitsOnHostWithResponse request returning *GetPullCommitsOnHostResponse
+func (c *ClientWithResponses) GetPullCommitsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullCommitsOnHostResponse, error) {
+	rsp, err := c.GetPullCommitsOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse(rsp)
+	return ParseGetPullCommitsOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffWithResponse request returning *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse
-func (c *ClientWithResponses) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse, error) {
-	rsp, err := c.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiff(ctx, platformHost, provider, owner, name, number, params, reqEditors...)
+// GetPullDiffOnHostWithResponse request returning *GetPullDiffOnHostResponse
+func (c *ClientWithResponses) GetPullDiffOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullDiffOnHostParams, reqEditors ...RequestEditorFn) (*GetPullDiffOnHostResponse, error) {
+	rsp, err := c.GetPullDiffOnHost(ctx, platformHost, provider, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse(rsp)
+	return ParseGetPullDiffOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse request returning *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse
-func (c *ClientWithResponses) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse, error) {
-	rsp, err := c.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreview(ctx, platformHost, provider, owner, name, number, params, reqEditors...)
+// GetPullFilePreviewOnHostWithResponse request returning *GetPullFilePreviewOnHostResponse
+func (c *ClientWithResponses) GetPullFilePreviewOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, params *GetPullFilePreviewOnHostParams, reqEditors ...RequestEditorFn) (*GetPullFilePreviewOnHostResponse, error) {
+	rsp, err := c.GetPullFilePreviewOnHost(ctx, platformHost, provider, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse(rsp)
+	return ParseGetPullFilePreviewOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesWithResponse request returning *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse
-func (c *ClientWithResponses) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse, error) {
-	rsp, err := c.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFiles(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// GetPullFilesOnHostWithResponse request returning *GetPullFilesOnHostResponse
+func (c *ClientWithResponses) GetPullFilesOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullFilesOnHostResponse, error) {
+	rsp, err := c.GetPullFilesOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse(rsp)
+	return ParseGetPullFilesOnHostResponse(rsp)
 }
 
 // SetPrGithubStateOnHostWithBodyWithResponse request with arbitrary body returning *SetPrGithubStateOnHostResponse
@@ -13730,13 +13730,13 @@ func (c *ClientWithResponses) SetPrGithubStateOnHostWithResponse(ctx context.Con
 	return ParseSetPrGithubStateOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse request returning *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse
-func (c *ClientWithResponses) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse, error) {
-	rsp, err := c.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadata(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// GetPullImportMetadataOnHostWithResponse request returning *GetPullImportMetadataOnHostResponse
+func (c *ClientWithResponses) GetPullImportMetadataOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullImportMetadataOnHostResponse, error) {
+	rsp, err := c.GetPullImportMetadataOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse(rsp)
+	return ParseGetPullImportMetadataOnHostResponse(rsp)
 }
 
 // SetPrLabelsOnHostWithBodyWithResponse request with arbitrary body returning *SetPrLabelsOnHostResponse
@@ -13756,39 +13756,39 @@ func (c *ClientWithResponses) SetPrLabelsOnHostWithResponse(ctx context.Context,
 	return ParseSetPrLabelsOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse request with arbitrary body returning *PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
+// MergePullOnHostWithBodyWithResponse request with arbitrary body returning *MergePullOnHostResponse
+func (c *ClientWithResponses) MergePullOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MergePullOnHostResponse, error) {
+	rsp, err := c.MergePullOnHostWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse(rsp)
+	return ParseMergePullOnHostResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMerge(ctx, platformHost, provider, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) MergePullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body MergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*MergePullOnHostResponse, error) {
+	rsp, err := c.MergePullOnHost(ctx, platformHost, provider, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse(rsp)
+	return ParseMergePullOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse request returning *PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReview(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// MarkPullReadyForReviewOnHostWithResponse request returning *MarkPullReadyForReviewOnHostResponse
+func (c *ClientWithResponses) MarkPullReadyForReviewOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewOnHostResponse, error) {
+	rsp, err := c.MarkPullReadyForReviewOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse(rsp)
+	return ParseMarkPullReadyForReviewOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackWithResponse request returning *GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse
-func (c *ClientWithResponses) GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse, error) {
-	rsp, err := c.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStack(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// GetPullStackOnHostWithResponse request returning *GetPullStackOnHostResponse
+func (c *ClientWithResponses) GetPullStackOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullStackOnHostResponse, error) {
+	rsp, err := c.GetPullStackOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse(rsp)
+	return ParseGetPullStackOnHostResponse(rsp)
 }
 
 // SetKanbanStateOnHostWithBodyWithResponse request with arbitrary body returning *SetKanbanStateOnHostResponse
@@ -13808,13 +13808,13 @@ func (c *ClientWithResponses) SetKanbanStateOnHostWithResponse(ctx context.Conte
 	return ParseSetKanbanStateOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncWithResponse request returning *PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse
-func (c *ClientWithResponses) PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse, error) {
-	rsp, err := c.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSync(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// SyncPullOnHostWithResponse request returning *SyncPullOnHostResponse
+func (c *ClientWithResponses) SyncPullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncPullOnHostResponse, error) {
+	rsp, err := c.SyncPullOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse(rsp)
+	return ParseSyncPullOnHostResponse(rsp)
 }
 
 // EnqueuePrSyncOnHostWithResponse request returning *EnqueuePrSyncOnHostResponse
@@ -13835,22 +13835,22 @@ func (c *ClientWithResponses) DeleteRepoOnHostWithResponse(ctx context.Context, 
 	return ParseDeleteRepoOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostRepoByProviderByOwnerByNameWithResponse request returning *GetHostByPlatformHostRepoByProviderByOwnerByNameResponse
-func (c *ClientWithResponses) GetHostByPlatformHostRepoByProviderByOwnerByNameWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostRepoByProviderByOwnerByNameResponse, error) {
-	rsp, err := c.GetHostByPlatformHostRepoByProviderByOwnerByName(ctx, platformHost, provider, owner, name, reqEditors...)
+// GetRepoOnHostWithResponse request returning *GetRepoOnHostResponse
+func (c *ClientWithResponses) GetRepoOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoOnHostResponse, error) {
+	rsp, err := c.GetRepoOnHost(ctx, platformHost, provider, owner, name, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostRepoByProviderByOwnerByNameResponse(rsp)
+	return ParseGetRepoOnHostResponse(rsp)
 }
 
-// GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteWithResponse request returning *GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse
-func (c *ClientWithResponses) GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse, error) {
-	rsp, err := c.GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocomplete(ctx, platformHost, provider, owner, name, params, reqEditors...)
+// GetCommentAutocompleteOnHostWithResponse request returning *GetCommentAutocompleteOnHostResponse
+func (c *ClientWithResponses) GetCommentAutocompleteOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*GetCommentAutocompleteOnHostResponse, error) {
+	rsp, err := c.GetCommentAutocompleteOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse(rsp)
+	return ParseGetCommentAutocompleteOnHostResponse(rsp)
 }
 
 // ListRepoLabelsOnHostWithResponse request returning *ListRepoLabelsOnHostResponse
@@ -13871,13 +13871,13 @@ func (c *ClientWithResponses) RefreshRepoOnHostWithResponse(ctx context.Context,
 	return ParseRefreshRepoOnHostResponse(rsp)
 }
 
-// PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberWithResponse request returning *PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse
-func (c *ClientWithResponses) PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse, error) {
-	rsp, err := c.PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumber(ctx, platformHost, provider, owner, name, number, reqEditors...)
+// ResolveRepoItemOnHostWithResponse request returning *ResolveRepoItemOnHostResponse
+func (c *ClientWithResponses) ResolveRepoItemOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ResolveRepoItemOnHostResponse, error) {
+	rsp, err := c.ResolveRepoItemOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse(rsp)
+	return ParseResolveRepoItemOnHostResponse(rsp)
 }
 
 // ListIssuesWithResponse request returning *ListIssuesResponse
@@ -13906,13 +13906,13 @@ func (c *ClientWithResponses) CreateIssueWithResponse(ctx context.Context, provi
 	return ParseCreateIssueResponse(rsp)
 }
 
-// GetIssuesByProviderByOwnerByNameByNumberWithResponse request returning *GetIssuesByProviderByOwnerByNameByNumberResponse
-func (c *ClientWithResponses) GetIssuesByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetIssuesByProviderByOwnerByNameByNumberResponse, error) {
-	rsp, err := c.GetIssuesByProviderByOwnerByNameByNumber(ctx, provider, owner, name, number, reqEditors...)
+// GetIssueWithResponse request returning *GetIssueResponse
+func (c *ClientWithResponses) GetIssueWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetIssueResponse, error) {
+	rsp, err := c.GetIssue(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetIssuesByProviderByOwnerByNameByNumberResponse(rsp)
+	return ParseGetIssueResponse(rsp)
 }
 
 // EditIssueContentWithBodyWithResponse request with arbitrary body returning *EditIssueContentResponse
@@ -14000,13 +14000,13 @@ func (c *ClientWithResponses) SetIssueLabelsWithResponse(ctx context.Context, pr
 	return ParseSetIssueLabelsResponse(rsp)
 }
 
-// PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse request returning *PostIssuesByProviderByOwnerByNameByNumberSyncResponse
-func (c *ClientWithResponses) PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostIssuesByProviderByOwnerByNameByNumberSyncResponse, error) {
-	rsp, err := c.PostIssuesByProviderByOwnerByNameByNumberSync(ctx, provider, owner, name, number, reqEditors...)
+// SyncIssueWithResponse request returning *SyncIssueResponse
+func (c *ClientWithResponses) SyncIssueWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncIssueResponse, error) {
+	rsp, err := c.SyncIssue(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostIssuesByProviderByOwnerByNameByNumberSyncResponse(rsp)
+	return ParseSyncIssueResponse(rsp)
 }
 
 // EnqueueIssueSyncWithResponse request returning *EnqueueIssueSyncResponse
@@ -14114,13 +14114,13 @@ func (c *ClientWithResponses) ListPullsWithResponse(ctx context.Context, params 
 	return ParseListPullsResponse(rsp)
 }
 
-// GetPullsByProviderByOwnerByNameByNumberWithResponse request returning *GetPullsByProviderByOwnerByNameByNumberResponse
-func (c *ClientWithResponses) GetPullsByProviderByOwnerByNameByNumberWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberResponse, error) {
-	rsp, err := c.GetPullsByProviderByOwnerByNameByNumber(ctx, provider, owner, name, number, reqEditors...)
+// GetPullWithResponse request returning *GetPullResponse
+func (c *ClientWithResponses) GetPullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullResponse, error) {
+	rsp, err := c.GetPull(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPullsByProviderByOwnerByNameByNumberResponse(rsp)
+	return ParseGetPullResponse(rsp)
 }
 
 // EditPrContentWithBodyWithResponse request with arbitrary body returning *EditPrContentResponse
@@ -14140,39 +14140,39 @@ func (c *ClientWithResponses) EditPrContentWithResponse(ctx context.Context, pro
 	return ParseEditPrContentResponse(rsp)
 }
 
-// PostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse request with arbitrary body returning *PostPullsByProviderByOwnerByNameByNumberApproveResponse
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberApproveWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberApproveResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberApproveWithBody(ctx, provider, owner, name, number, contentType, body, reqEditors...)
+// ApprovePullWithBodyWithResponse request with arbitrary body returning *ApprovePullResponse
+func (c *ClientWithResponses) ApprovePullWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ApprovePullResponse, error) {
+	rsp, err := c.ApprovePullWithBody(ctx, provider, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberApproveResponse(rsp)
+	return ParseApprovePullResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberApproveWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberApproveResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberApprove(ctx, provider, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) ApprovePullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body ApprovePullJSONRequestBody, reqEditors ...RequestEditorFn) (*ApprovePullResponse, error) {
+	rsp, err := c.ApprovePull(ctx, provider, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberApproveResponse(rsp)
+	return ParseApprovePullResponse(rsp)
 }
 
-// PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse request returning *PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberApproveWorkflows(ctx, provider, owner, name, number, reqEditors...)
+// ApprovePullWorkflowsWithResponse request returning *ApprovePullWorkflowsResponse
+func (c *ClientWithResponses) ApprovePullWorkflowsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ApprovePullWorkflowsResponse, error) {
+	rsp, err := c.ApprovePullWorkflows(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp)
+	return ParseApprovePullWorkflowsResponse(rsp)
 }
 
-// PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse request returning *PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberCiRefresh(ctx, provider, owner, name, number, reqEditors...)
+// RefreshPullCiWithResponse request returning *RefreshPullCiResponse
+func (c *ClientWithResponses) RefreshPullCiWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*RefreshPullCiResponse, error) {
+	rsp, err := c.RefreshPullCi(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp)
+	return ParseRefreshPullCiResponse(rsp)
 }
 
 // PostPrCommentWithBodyWithResponse request with arbitrary body returning *PostPrCommentResponse
@@ -14209,40 +14209,40 @@ func (c *ClientWithResponses) EditPrCommentWithResponse(ctx context.Context, pro
 	return ParseEditPrCommentResponse(rsp)
 }
 
-// GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse request returning *GetPullsByProviderByOwnerByNameByNumberCommitsResponse
-func (c *ClientWithResponses) GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberCommitsResponse, error) {
-	rsp, err := c.GetPullsByProviderByOwnerByNameByNumberCommits(ctx, provider, owner, name, number, reqEditors...)
+// GetPullCommitsWithResponse request returning *GetPullCommitsResponse
+func (c *ClientWithResponses) GetPullCommitsWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullCommitsResponse, error) {
+	rsp, err := c.GetPullCommits(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPullsByProviderByOwnerByNameByNumberCommitsResponse(rsp)
+	return ParseGetPullCommitsResponse(rsp)
 }
 
-// GetPullsByProviderByOwnerByNameByNumberDiffWithResponse request returning *GetPullsByProviderByOwnerByNameByNumberDiffResponse
-func (c *ClientWithResponses) GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberDiffParams, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberDiffResponse, error) {
-	rsp, err := c.GetPullsByProviderByOwnerByNameByNumberDiff(ctx, provider, owner, name, number, params, reqEditors...)
+// GetPullDiffWithResponse request returning *GetPullDiffResponse
+func (c *ClientWithResponses) GetPullDiffWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullDiffParams, reqEditors ...RequestEditorFn) (*GetPullDiffResponse, error) {
+	rsp, err := c.GetPullDiff(ctx, provider, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPullsByProviderByOwnerByNameByNumberDiffResponse(rsp)
+	return ParseGetPullDiffResponse(rsp)
 }
 
-// GetPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse request returning *GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse
-func (c *ClientWithResponses) GetPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullsByProviderByOwnerByNameByNumberFilePreviewParams, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse, error) {
-	rsp, err := c.GetPullsByProviderByOwnerByNameByNumberFilePreview(ctx, provider, owner, name, number, params, reqEditors...)
+// GetPullFilePreviewWithResponse request returning *GetPullFilePreviewResponse
+func (c *ClientWithResponses) GetPullFilePreviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, params *GetPullFilePreviewParams, reqEditors ...RequestEditorFn) (*GetPullFilePreviewResponse, error) {
+	rsp, err := c.GetPullFilePreview(ctx, provider, owner, name, number, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPullsByProviderByOwnerByNameByNumberFilePreviewResponse(rsp)
+	return ParseGetPullFilePreviewResponse(rsp)
 }
 
-// GetPullsByProviderByOwnerByNameByNumberFilesWithResponse request returning *GetPullsByProviderByOwnerByNameByNumberFilesResponse
-func (c *ClientWithResponses) GetPullsByProviderByOwnerByNameByNumberFilesWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberFilesResponse, error) {
-	rsp, err := c.GetPullsByProviderByOwnerByNameByNumberFiles(ctx, provider, owner, name, number, reqEditors...)
+// GetPullFilesWithResponse request returning *GetPullFilesResponse
+func (c *ClientWithResponses) GetPullFilesWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullFilesResponse, error) {
+	rsp, err := c.GetPullFiles(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPullsByProviderByOwnerByNameByNumberFilesResponse(rsp)
+	return ParseGetPullFilesResponse(rsp)
 }
 
 // SetPrGithubStateWithBodyWithResponse request with arbitrary body returning *SetPrGithubStateResponse
@@ -14262,13 +14262,13 @@ func (c *ClientWithResponses) SetPrGithubStateWithResponse(ctx context.Context, 
 	return ParseSetPrGithubStateResponse(rsp)
 }
 
-// GetPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse request returning *GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse
-func (c *ClientWithResponses) GetPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse, error) {
-	rsp, err := c.GetPullsByProviderByOwnerByNameByNumberImportMetadata(ctx, provider, owner, name, number, reqEditors...)
+// GetPullImportMetadataWithResponse request returning *GetPullImportMetadataResponse
+func (c *ClientWithResponses) GetPullImportMetadataWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullImportMetadataResponse, error) {
+	rsp, err := c.GetPullImportMetadata(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPullsByProviderByOwnerByNameByNumberImportMetadataResponse(rsp)
+	return ParseGetPullImportMetadataResponse(rsp)
 }
 
 // SetPrLabelsWithBodyWithResponse request with arbitrary body returning *SetPrLabelsResponse
@@ -14288,39 +14288,39 @@ func (c *ClientWithResponses) SetPrLabelsWithResponse(ctx context.Context, provi
 	return ParseSetPrLabelsResponse(rsp)
 }
 
-// PostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse request with arbitrary body returning *PostPullsByProviderByOwnerByNameByNumberMergeResponse
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberMergeWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberMergeResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberMergeWithBody(ctx, provider, owner, name, number, contentType, body, reqEditors...)
+// MergePullWithBodyWithResponse request with arbitrary body returning *MergePullResponse
+func (c *ClientWithResponses) MergePullWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MergePullResponse, error) {
+	rsp, err := c.MergePullWithBody(ctx, provider, owner, name, number, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberMergeResponse(rsp)
+	return ParseMergePullResponse(rsp)
 }
 
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberMergeResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberMerge(ctx, provider, owner, name, number, body, reqEditors...)
+func (c *ClientWithResponses) MergePullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body MergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*MergePullResponse, error) {
+	rsp, err := c.MergePull(ctx, provider, owner, name, number, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberMergeResponse(rsp)
+	return ParseMergePullResponse(rsp)
 }
 
-// PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse request returning *PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberReadyForReview(ctx, provider, owner, name, number, reqEditors...)
+// MarkPullReadyForReviewWithResponse request returning *MarkPullReadyForReviewResponse
+func (c *ClientWithResponses) MarkPullReadyForReviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewResponse, error) {
+	rsp, err := c.MarkPullReadyForReview(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse(rsp)
+	return ParseMarkPullReadyForReviewResponse(rsp)
 }
 
-// GetPullsByProviderByOwnerByNameByNumberStackWithResponse request returning *GetPullsByProviderByOwnerByNameByNumberStackResponse
-func (c *ClientWithResponses) GetPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullsByProviderByOwnerByNameByNumberStackResponse, error) {
-	rsp, err := c.GetPullsByProviderByOwnerByNameByNumberStack(ctx, provider, owner, name, number, reqEditors...)
+// GetPullStackWithResponse request returning *GetPullStackResponse
+func (c *ClientWithResponses) GetPullStackWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*GetPullStackResponse, error) {
+	rsp, err := c.GetPullStack(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPullsByProviderByOwnerByNameByNumberStackResponse(rsp)
+	return ParseGetPullStackResponse(rsp)
 }
 
 // SetKanbanStateWithBodyWithResponse request with arbitrary body returning *SetKanbanStateResponse
@@ -14340,13 +14340,13 @@ func (c *ClientWithResponses) SetKanbanStateWithResponse(ctx context.Context, pr
 	return ParseSetKanbanStateResponse(rsp)
 }
 
-// PostPullsByProviderByOwnerByNameByNumberSyncWithResponse request returning *PostPullsByProviderByOwnerByNameByNumberSyncResponse
-func (c *ClientWithResponses) PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostPullsByProviderByOwnerByNameByNumberSyncResponse, error) {
-	rsp, err := c.PostPullsByProviderByOwnerByNameByNumberSync(ctx, provider, owner, name, number, reqEditors...)
+// SyncPullWithResponse request returning *SyncPullResponse
+func (c *ClientWithResponses) SyncPullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*SyncPullResponse, error) {
+	rsp, err := c.SyncPull(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostPullsByProviderByOwnerByNameByNumberSyncResponse(rsp)
+	return ParseSyncPullResponse(rsp)
 }
 
 // EnqueuePrSyncWithResponse request returning *EnqueuePrSyncResponse
@@ -14376,22 +14376,22 @@ func (c *ClientWithResponses) DeleteRepoWithResponse(ctx context.Context, provid
 	return ParseDeleteRepoResponse(rsp)
 }
 
-// GetRepoByProviderByOwnerByNameWithResponse request returning *GetRepoByProviderByOwnerByNameResponse
-func (c *ClientWithResponses) GetRepoByProviderByOwnerByNameWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoByProviderByOwnerByNameResponse, error) {
-	rsp, err := c.GetRepoByProviderByOwnerByName(ctx, provider, owner, name, reqEditors...)
+// GetRepoWithResponse request returning *GetRepoResponse
+func (c *ClientWithResponses) GetRepoWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoResponse, error) {
+	rsp, err := c.GetRepo(ctx, provider, owner, name, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetRepoByProviderByOwnerByNameResponse(rsp)
+	return ParseGetRepoResponse(rsp)
 }
 
-// GetRepoByProviderByOwnerByNameCommentAutocompleteWithResponse request returning *GetRepoByProviderByOwnerByNameCommentAutocompleteResponse
-func (c *ClientWithResponses) GetRepoByProviderByOwnerByNameCommentAutocompleteWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoByProviderByOwnerByNameCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*GetRepoByProviderByOwnerByNameCommentAutocompleteResponse, error) {
-	rsp, err := c.GetRepoByProviderByOwnerByNameCommentAutocomplete(ctx, provider, owner, name, params, reqEditors...)
+// GetCommentAutocompleteWithResponse request returning *GetCommentAutocompleteResponse
+func (c *ClientWithResponses) GetCommentAutocompleteWithResponse(ctx context.Context, provider string, owner string, name string, params *GetCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*GetCommentAutocompleteResponse, error) {
+	rsp, err := c.GetCommentAutocomplete(ctx, provider, owner, name, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetRepoByProviderByOwnerByNameCommentAutocompleteResponse(rsp)
+	return ParseGetCommentAutocompleteResponse(rsp)
 }
 
 // ListRepoLabelsWithResponse request returning *ListRepoLabelsResponse
@@ -14412,13 +14412,13 @@ func (c *ClientWithResponses) RefreshRepoWithResponse(ctx context.Context, provi
 	return ParseRefreshRepoResponse(rsp)
 }
 
-// PostRepoByProviderByOwnerByNameResolveByNumberWithResponse request returning *PostRepoByProviderByOwnerByNameResolveByNumberResponse
-func (c *ClientWithResponses) PostRepoByProviderByOwnerByNameResolveByNumberWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*PostRepoByProviderByOwnerByNameResolveByNumberResponse, error) {
-	rsp, err := c.PostRepoByProviderByOwnerByNameResolveByNumber(ctx, provider, owner, name, number, reqEditors...)
+// ResolveRepoItemWithResponse request returning *ResolveRepoItemResponse
+func (c *ClientWithResponses) ResolveRepoItemWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*ResolveRepoItemResponse, error) {
+	rsp, err := c.ResolveRepoItem(ctx, provider, owner, name, number, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParsePostRepoByProviderByOwnerByNameResolveByNumberResponse(rsp)
+	return ParseResolveRepoItemResponse(rsp)
 }
 
 // ListReposWithResponse request returning *ListReposResponse
@@ -14595,13 +14595,13 @@ func (c *ClientWithResponses) GetVersionWithResponse(ctx context.Context, reqEdi
 	return ParseGetVersionResponse(rsp)
 }
 
-// GetWorkspacesWithResponse request returning *GetWorkspacesResponse
-func (c *ClientWithResponses) GetWorkspacesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetWorkspacesResponse, error) {
-	rsp, err := c.GetWorkspaces(ctx, reqEditors...)
+// ListWorkspacesWithResponse request returning *ListWorkspacesResponse
+func (c *ClientWithResponses) ListWorkspacesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListWorkspacesResponse, error) {
+	rsp, err := c.ListWorkspaces(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetWorkspacesResponse(rsp)
+	return ParseListWorkspacesResponse(rsp)
 }
 
 // CreateWorkspaceWithBodyWithResponse request with arbitrary body returning *CreateWorkspaceResponse
@@ -14630,40 +14630,40 @@ func (c *ClientWithResponses) DeleteWorkspaceWithResponse(ctx context.Context, i
 	return ParseDeleteWorkspaceResponse(rsp)
 }
 
-// GetWorkspacesByIdWithResponse request returning *GetWorkspacesByIdResponse
-func (c *ClientWithResponses) GetWorkspacesByIdWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdResponse, error) {
-	rsp, err := c.GetWorkspacesById(ctx, id, reqEditors...)
+// GetWorkspaceWithResponse request returning *GetWorkspaceResponse
+func (c *ClientWithResponses) GetWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspaceResponse, error) {
+	rsp, err := c.GetWorkspace(ctx, id, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetWorkspacesByIdResponse(rsp)
+	return ParseGetWorkspaceResponse(rsp)
 }
 
-// GetWorkspacesByIdCommitsWithResponse request returning *GetWorkspacesByIdCommitsResponse
-func (c *ClientWithResponses) GetWorkspacesByIdCommitsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdCommitsResponse, error) {
-	rsp, err := c.GetWorkspacesByIdCommits(ctx, id, reqEditors...)
+// GetWorkspaceCommitsWithResponse request returning *GetWorkspaceCommitsResponse
+func (c *ClientWithResponses) GetWorkspaceCommitsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspaceCommitsResponse, error) {
+	rsp, err := c.GetWorkspaceCommits(ctx, id, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetWorkspacesByIdCommitsResponse(rsp)
+	return ParseGetWorkspaceCommitsResponse(rsp)
 }
 
-// GetWorkspacesByIdDiffWithResponse request returning *GetWorkspacesByIdDiffResponse
-func (c *ClientWithResponses) GetWorkspacesByIdDiffWithResponse(ctx context.Context, id string, params *GetWorkspacesByIdDiffParams, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdDiffResponse, error) {
-	rsp, err := c.GetWorkspacesByIdDiff(ctx, id, params, reqEditors...)
+// GetWorkspaceDiffWithResponse request returning *GetWorkspaceDiffResponse
+func (c *ClientWithResponses) GetWorkspaceDiffWithResponse(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*GetWorkspaceDiffResponse, error) {
+	rsp, err := c.GetWorkspaceDiff(ctx, id, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetWorkspacesByIdDiffResponse(rsp)
+	return ParseGetWorkspaceDiffResponse(rsp)
 }
 
-// GetWorkspacesByIdFilesWithResponse request returning *GetWorkspacesByIdFilesResponse
-func (c *ClientWithResponses) GetWorkspacesByIdFilesWithResponse(ctx context.Context, id string, params *GetWorkspacesByIdFilesParams, reqEditors ...RequestEditorFn) (*GetWorkspacesByIdFilesResponse, error) {
-	rsp, err := c.GetWorkspacesByIdFiles(ctx, id, params, reqEditors...)
+// GetWorkspaceFilesWithResponse request returning *GetWorkspaceFilesResponse
+func (c *ClientWithResponses) GetWorkspaceFilesWithResponse(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilesResponse, error) {
+	rsp, err := c.GetWorkspaceFiles(ctx, id, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetWorkspacesByIdFilesResponse(rsp)
+	return ParseGetWorkspaceFilesResponse(rsp)
 }
 
 // RetryWorkspaceWithResponse request returning *RetryWorkspaceResponse
@@ -14719,15 +14719,15 @@ func (c *ClientWithResponses) EnsureWorkspaceRuntimeShellWithResponse(ctx contex
 	return ParseEnsureWorkspaceRuntimeShellResponse(rsp)
 }
 
-// ParseGetActivityResponse parses an HTTP response from a GetActivityWithResponse call
-func ParseGetActivityResponse(rsp *http.Response) (*GetActivityResponse, error) {
+// ParseListActivityResponse parses an HTTP response from a ListActivityWithResponse call
+func ParseListActivityResponse(rsp *http.Response) (*ListActivityResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetActivityResponse{
+	response := &ListActivityResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -14785,15 +14785,15 @@ func ParseCreateIssueOnHostResponse(rsp *http.Response) (*CreateIssueOnHostRespo
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse parses an HTTP response from a GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse call
-func ParseGetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse(rsp *http.Response) (*GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse, error) {
+// ParseGetIssueOnHostResponse parses an HTTP response from a GetIssueOnHostWithResponse call
+func ParseGetIssueOnHostResponse(rsp *http.Response) (*GetIssueOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberResponse{
+	response := &GetIssueOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -14983,15 +14983,15 @@ func ParseSetIssueLabelsOnHostResponse(rsp *http.Response) (*SetIssueLabelsOnHos
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse parses an HTTP response from a PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse call
-func ParsePostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse(rsp *http.Response) (*PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse, error) {
+// ParseSyncIssueOnHostResponse parses an HTTP response from a SyncIssueOnHostWithResponse call
+func ParseSyncIssueOnHostResponse(rsp *http.Response) (*SyncIssueOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncResponse{
+	response := &SyncIssueOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15075,15 +15075,15 @@ func ParseCreateIssueWorkspaceOnHostResponse(rsp *http.Response) (*CreateIssueWo
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse parses an HTTP response from a GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse call
-func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse(rsp *http.Response) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse, error) {
+// ParseGetPullOnHostResponse parses an HTTP response from a GetPullOnHostWithResponse call
+func ParseGetPullOnHostResponse(rsp *http.Response) (*GetPullOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberResponse{
+	response := &GetPullOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15141,15 +15141,15 @@ func ParseEditPrContentOnHostResponse(rsp *http.Response) (*EditPrContentOnHostR
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse parses an HTTP response from a PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithResponse call
-func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse(rsp *http.Response) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse, error) {
+// ParseApprovePullOnHostResponse parses an HTTP response from a ApprovePullOnHostWithResponse call
+func ParseApprovePullOnHostResponse(rsp *http.Response) (*ApprovePullOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveResponse{
+	response := &ApprovePullOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15174,15 +15174,15 @@ func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveRespo
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse parses an HTTP response from a PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse call
-func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp *http.Response) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error) {
+// ParseApprovePullWorkflowsOnHostResponse parses an HTTP response from a ApprovePullWorkflowsOnHostWithResponse call
+func ParseApprovePullWorkflowsOnHostResponse(rsp *http.Response) (*ApprovePullWorkflowsOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse{
+	response := &ApprovePullWorkflowsOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15207,15 +15207,15 @@ func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWorkf
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse parses an HTTP response from a PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse call
-func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp *http.Response) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
+// ParseRefreshPullCiOnHostResponse parses an HTTP response from a RefreshPullCiOnHostWithResponse call
+func ParseRefreshPullCiOnHostResponse(rsp *http.Response) (*RefreshPullCiOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshResponse{
+	response := &RefreshPullCiOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15306,15 +15306,15 @@ func ParseEditPrCommentOnHostResponse(rsp *http.Response) (*EditPrCommentOnHostR
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse parses an HTTP response from a GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsWithResponse call
-func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse(rsp *http.Response) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse, error) {
+// ParseGetPullCommitsOnHostResponse parses an HTTP response from a GetPullCommitsOnHostWithResponse call
+func ParseGetPullCommitsOnHostResponse(rsp *http.Response) (*GetPullCommitsOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsResponse{
+	response := &GetPullCommitsOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15339,15 +15339,15 @@ func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberCommitsRespon
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse parses an HTTP response from a GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffWithResponse call
-func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse(rsp *http.Response) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse, error) {
+// ParseGetPullDiffOnHostResponse parses an HTTP response from a GetPullDiffOnHostWithResponse call
+func ParseGetPullDiffOnHostResponse(rsp *http.Response) (*GetPullDiffOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse{
+	response := &GetPullDiffOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15372,15 +15372,15 @@ func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberDiffResponse(
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse parses an HTTP response from a GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse call
-func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse(rsp *http.Response) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse, error) {
+// ParseGetPullFilePreviewOnHostResponse parses an HTTP response from a GetPullFilePreviewOnHostWithResponse call
+func ParseGetPullFilePreviewOnHostResponse(rsp *http.Response) (*GetPullFilePreviewOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewResponse{
+	response := &GetPullFilePreviewOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15405,15 +15405,15 @@ func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilePreviewRe
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse parses an HTTP response from a GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesWithResponse call
-func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse(rsp *http.Response) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse, error) {
+// ParseGetPullFilesOnHostResponse parses an HTTP response from a GetPullFilesOnHostWithResponse call
+func ParseGetPullFilesOnHostResponse(rsp *http.Response) (*GetPullFilesOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberFilesResponse{
+	response := &GetPullFilesOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15471,15 +15471,15 @@ func ParseSetPrGithubStateOnHostResponse(rsp *http.Response) (*SetPrGithubStateO
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse parses an HTTP response from a GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse call
-func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse(rsp *http.Response) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse, error) {
+// ParseGetPullImportMetadataOnHostResponse parses an HTTP response from a GetPullImportMetadataOnHostWithResponse call
+func ParseGetPullImportMetadataOnHostResponse(rsp *http.Response) (*GetPullImportMetadataOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberImportMetadataResponse{
+	response := &GetPullImportMetadataOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15537,15 +15537,15 @@ func ParseSetPrLabelsOnHostResponse(rsp *http.Response) (*SetPrLabelsOnHostRespo
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse parses an HTTP response from a PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithResponse call
-func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse(rsp *http.Response) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse, error) {
+// ParseMergePullOnHostResponse parses an HTTP response from a MergePullOnHostWithResponse call
+func ParseMergePullOnHostResponse(rsp *http.Response) (*MergePullOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeResponse{
+	response := &MergePullOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15570,15 +15570,15 @@ func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeRespons
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse parses an HTTP response from a PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse call
-func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse(rsp *http.Response) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse, error) {
+// ParseMarkPullReadyForReviewOnHostResponse parses an HTTP response from a MarkPullReadyForReviewOnHostWithResponse call
+func ParseMarkPullReadyForReviewOnHostResponse(rsp *http.Response) (*MarkPullReadyForReviewOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse{
+	response := &MarkPullReadyForReviewOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15603,15 +15603,15 @@ func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberReadyForRevi
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse parses an HTTP response from a GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackWithResponse call
-func ParseGetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse(rsp *http.Response) (*GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse, error) {
+// ParseGetPullStackOnHostResponse parses an HTTP response from a GetPullStackOnHostWithResponse call
+func ParseGetPullStackOnHostResponse(rsp *http.Response) (*GetPullStackOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberStackResponse{
+	response := &GetPullStackOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15662,15 +15662,15 @@ func ParseSetKanbanStateOnHostResponse(rsp *http.Response) (*SetKanbanStateOnHos
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse parses an HTTP response from a PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncWithResponse call
-func ParsePostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse(rsp *http.Response) (*PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse, error) {
+// ParseSyncPullOnHostResponse parses an HTTP response from a SyncPullOnHostWithResponse call
+func ParseSyncPullOnHostResponse(rsp *http.Response) (*SyncPullOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncResponse{
+	response := &SyncPullOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15747,15 +15747,15 @@ func ParseDeleteRepoOnHostResponse(rsp *http.Response) (*DeleteRepoOnHostRespons
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostRepoByProviderByOwnerByNameResponse parses an HTTP response from a GetHostByPlatformHostRepoByProviderByOwnerByNameWithResponse call
-func ParseGetHostByPlatformHostRepoByProviderByOwnerByNameResponse(rsp *http.Response) (*GetHostByPlatformHostRepoByProviderByOwnerByNameResponse, error) {
+// ParseGetRepoOnHostResponse parses an HTTP response from a GetRepoOnHostWithResponse call
+func ParseGetRepoOnHostResponse(rsp *http.Response) (*GetRepoOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostRepoByProviderByOwnerByNameResponse{
+	response := &GetRepoOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15780,15 +15780,15 @@ func ParseGetHostByPlatformHostRepoByProviderByOwnerByNameResponse(rsp *http.Res
 	return response, nil
 }
 
-// ParseGetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse parses an HTTP response from a GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteWithResponse call
-func ParseGetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse(rsp *http.Response) (*GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse, error) {
+// ParseGetCommentAutocompleteOnHostResponse parses an HTTP response from a GetCommentAutocompleteOnHostWithResponse call
+func ParseGetCommentAutocompleteOnHostResponse(rsp *http.Response) (*GetCommentAutocompleteOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHostByPlatformHostRepoByProviderByOwnerByNameCommentAutocompleteResponse{
+	response := &GetCommentAutocompleteOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15879,15 +15879,15 @@ func ParseRefreshRepoOnHostResponse(rsp *http.Response) (*RefreshRepoOnHostRespo
 	return response, nil
 }
 
-// ParsePostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse parses an HTTP response from a PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberWithResponse call
-func ParsePostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse(rsp *http.Response) (*PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse, error) {
+// ParseResolveRepoItemOnHostResponse parses an HTTP response from a ResolveRepoItemOnHostWithResponse call
+func ParseResolveRepoItemOnHostResponse(rsp *http.Response) (*ResolveRepoItemOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostHostByPlatformHostRepoByProviderByOwnerByNameResolveByNumberResponse{
+	response := &ResolveRepoItemOnHostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -15978,15 +15978,15 @@ func ParseCreateIssueResponse(rsp *http.Response) (*CreateIssueResponse, error) 
 	return response, nil
 }
 
-// ParseGetIssuesByProviderByOwnerByNameByNumberResponse parses an HTTP response from a GetIssuesByProviderByOwnerByNameByNumberWithResponse call
-func ParseGetIssuesByProviderByOwnerByNameByNumberResponse(rsp *http.Response) (*GetIssuesByProviderByOwnerByNameByNumberResponse, error) {
+// ParseGetIssueResponse parses an HTTP response from a GetIssueWithResponse call
+func ParseGetIssueResponse(rsp *http.Response) (*GetIssueResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetIssuesByProviderByOwnerByNameByNumberResponse{
+	response := &GetIssueResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16176,15 +16176,15 @@ func ParseSetIssueLabelsResponse(rsp *http.Response) (*SetIssueLabelsResponse, e
 	return response, nil
 }
 
-// ParsePostIssuesByProviderByOwnerByNameByNumberSyncResponse parses an HTTP response from a PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse call
-func ParsePostIssuesByProviderByOwnerByNameByNumberSyncResponse(rsp *http.Response) (*PostIssuesByProviderByOwnerByNameByNumberSyncResponse, error) {
+// ParseSyncIssueResponse parses an HTTP response from a SyncIssueWithResponse call
+func ParseSyncIssueResponse(rsp *http.Response) (*SyncIssueResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostIssuesByProviderByOwnerByNameByNumberSyncResponse{
+	response := &SyncIssueResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16499,15 +16499,15 @@ func ParseListPullsResponse(rsp *http.Response) (*ListPullsResponse, error) {
 	return response, nil
 }
 
-// ParseGetPullsByProviderByOwnerByNameByNumberResponse parses an HTTP response from a GetPullsByProviderByOwnerByNameByNumberWithResponse call
-func ParseGetPullsByProviderByOwnerByNameByNumberResponse(rsp *http.Response) (*GetPullsByProviderByOwnerByNameByNumberResponse, error) {
+// ParseGetPullResponse parses an HTTP response from a GetPullWithResponse call
+func ParseGetPullResponse(rsp *http.Response) (*GetPullResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPullsByProviderByOwnerByNameByNumberResponse{
+	response := &GetPullResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16565,15 +16565,15 @@ func ParseEditPrContentResponse(rsp *http.Response) (*EditPrContentResponse, err
 	return response, nil
 }
 
-// ParsePostPullsByProviderByOwnerByNameByNumberApproveResponse parses an HTTP response from a PostPullsByProviderByOwnerByNameByNumberApproveWithResponse call
-func ParsePostPullsByProviderByOwnerByNameByNumberApproveResponse(rsp *http.Response) (*PostPullsByProviderByOwnerByNameByNumberApproveResponse, error) {
+// ParseApprovePullResponse parses an HTTP response from a ApprovePullWithResponse call
+func ParseApprovePullResponse(rsp *http.Response) (*ApprovePullResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostPullsByProviderByOwnerByNameByNumberApproveResponse{
+	response := &ApprovePullResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16598,15 +16598,15 @@ func ParsePostPullsByProviderByOwnerByNameByNumberApproveResponse(rsp *http.Resp
 	return response, nil
 }
 
-// ParsePostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse parses an HTTP response from a PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse call
-func ParsePostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp *http.Response) (*PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse, error) {
+// ParseApprovePullWorkflowsResponse parses an HTTP response from a ApprovePullWorkflowsWithResponse call
+func ParseApprovePullWorkflowsResponse(rsp *http.Response) (*ApprovePullWorkflowsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse{
+	response := &ApprovePullWorkflowsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16631,15 +16631,15 @@ func ParsePostPullsByProviderByOwnerByNameByNumberApproveWorkflowsResponse(rsp *
 	return response, nil
 }
 
-// ParsePostPullsByProviderByOwnerByNameByNumberCiRefreshResponse parses an HTTP response from a PostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse call
-func ParsePostPullsByProviderByOwnerByNameByNumberCiRefreshResponse(rsp *http.Response) (*PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse, error) {
+// ParseRefreshPullCiResponse parses an HTTP response from a RefreshPullCiWithResponse call
+func ParseRefreshPullCiResponse(rsp *http.Response) (*RefreshPullCiResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostPullsByProviderByOwnerByNameByNumberCiRefreshResponse{
+	response := &RefreshPullCiResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16730,15 +16730,15 @@ func ParseEditPrCommentResponse(rsp *http.Response) (*EditPrCommentResponse, err
 	return response, nil
 }
 
-// ParseGetPullsByProviderByOwnerByNameByNumberCommitsResponse parses an HTTP response from a GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse call
-func ParseGetPullsByProviderByOwnerByNameByNumberCommitsResponse(rsp *http.Response) (*GetPullsByProviderByOwnerByNameByNumberCommitsResponse, error) {
+// ParseGetPullCommitsResponse parses an HTTP response from a GetPullCommitsWithResponse call
+func ParseGetPullCommitsResponse(rsp *http.Response) (*GetPullCommitsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPullsByProviderByOwnerByNameByNumberCommitsResponse{
+	response := &GetPullCommitsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16763,15 +16763,15 @@ func ParseGetPullsByProviderByOwnerByNameByNumberCommitsResponse(rsp *http.Respo
 	return response, nil
 }
 
-// ParseGetPullsByProviderByOwnerByNameByNumberDiffResponse parses an HTTP response from a GetPullsByProviderByOwnerByNameByNumberDiffWithResponse call
-func ParseGetPullsByProviderByOwnerByNameByNumberDiffResponse(rsp *http.Response) (*GetPullsByProviderByOwnerByNameByNumberDiffResponse, error) {
+// ParseGetPullDiffResponse parses an HTTP response from a GetPullDiffWithResponse call
+func ParseGetPullDiffResponse(rsp *http.Response) (*GetPullDiffResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPullsByProviderByOwnerByNameByNumberDiffResponse{
+	response := &GetPullDiffResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16796,15 +16796,15 @@ func ParseGetPullsByProviderByOwnerByNameByNumberDiffResponse(rsp *http.Response
 	return response, nil
 }
 
-// ParseGetPullsByProviderByOwnerByNameByNumberFilePreviewResponse parses an HTTP response from a GetPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse call
-func ParseGetPullsByProviderByOwnerByNameByNumberFilePreviewResponse(rsp *http.Response) (*GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse, error) {
+// ParseGetPullFilePreviewResponse parses an HTTP response from a GetPullFilePreviewWithResponse call
+func ParseGetPullFilePreviewResponse(rsp *http.Response) (*GetPullFilePreviewResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPullsByProviderByOwnerByNameByNumberFilePreviewResponse{
+	response := &GetPullFilePreviewResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16829,15 +16829,15 @@ func ParseGetPullsByProviderByOwnerByNameByNumberFilePreviewResponse(rsp *http.R
 	return response, nil
 }
 
-// ParseGetPullsByProviderByOwnerByNameByNumberFilesResponse parses an HTTP response from a GetPullsByProviderByOwnerByNameByNumberFilesWithResponse call
-func ParseGetPullsByProviderByOwnerByNameByNumberFilesResponse(rsp *http.Response) (*GetPullsByProviderByOwnerByNameByNumberFilesResponse, error) {
+// ParseGetPullFilesResponse parses an HTTP response from a GetPullFilesWithResponse call
+func ParseGetPullFilesResponse(rsp *http.Response) (*GetPullFilesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPullsByProviderByOwnerByNameByNumberFilesResponse{
+	response := &GetPullFilesResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16895,15 +16895,15 @@ func ParseSetPrGithubStateResponse(rsp *http.Response) (*SetPrGithubStateRespons
 	return response, nil
 }
 
-// ParseGetPullsByProviderByOwnerByNameByNumberImportMetadataResponse parses an HTTP response from a GetPullsByProviderByOwnerByNameByNumberImportMetadataWithResponse call
-func ParseGetPullsByProviderByOwnerByNameByNumberImportMetadataResponse(rsp *http.Response) (*GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse, error) {
+// ParseGetPullImportMetadataResponse parses an HTTP response from a GetPullImportMetadataWithResponse call
+func ParseGetPullImportMetadataResponse(rsp *http.Response) (*GetPullImportMetadataResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPullsByProviderByOwnerByNameByNumberImportMetadataResponse{
+	response := &GetPullImportMetadataResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16961,15 +16961,15 @@ func ParseSetPrLabelsResponse(rsp *http.Response) (*SetPrLabelsResponse, error) 
 	return response, nil
 }
 
-// ParsePostPullsByProviderByOwnerByNameByNumberMergeResponse parses an HTTP response from a PostPullsByProviderByOwnerByNameByNumberMergeWithResponse call
-func ParsePostPullsByProviderByOwnerByNameByNumberMergeResponse(rsp *http.Response) (*PostPullsByProviderByOwnerByNameByNumberMergeResponse, error) {
+// ParseMergePullResponse parses an HTTP response from a MergePullWithResponse call
+func ParseMergePullResponse(rsp *http.Response) (*MergePullResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostPullsByProviderByOwnerByNameByNumberMergeResponse{
+	response := &MergePullResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -16994,15 +16994,15 @@ func ParsePostPullsByProviderByOwnerByNameByNumberMergeResponse(rsp *http.Respon
 	return response, nil
 }
 
-// ParsePostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse parses an HTTP response from a PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse call
-func ParsePostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse(rsp *http.Response) (*PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse, error) {
+// ParseMarkPullReadyForReviewResponse parses an HTTP response from a MarkPullReadyForReviewWithResponse call
+func ParseMarkPullReadyForReviewResponse(rsp *http.Response) (*MarkPullReadyForReviewResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse{
+	response := &MarkPullReadyForReviewResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17027,15 +17027,15 @@ func ParsePostPullsByProviderByOwnerByNameByNumberReadyForReviewResponse(rsp *ht
 	return response, nil
 }
 
-// ParseGetPullsByProviderByOwnerByNameByNumberStackResponse parses an HTTP response from a GetPullsByProviderByOwnerByNameByNumberStackWithResponse call
-func ParseGetPullsByProviderByOwnerByNameByNumberStackResponse(rsp *http.Response) (*GetPullsByProviderByOwnerByNameByNumberStackResponse, error) {
+// ParseGetPullStackResponse parses an HTTP response from a GetPullStackWithResponse call
+func ParseGetPullStackResponse(rsp *http.Response) (*GetPullStackResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPullsByProviderByOwnerByNameByNumberStackResponse{
+	response := &GetPullStackResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17086,15 +17086,15 @@ func ParseSetKanbanStateResponse(rsp *http.Response) (*SetKanbanStateResponse, e
 	return response, nil
 }
 
-// ParsePostPullsByProviderByOwnerByNameByNumberSyncResponse parses an HTTP response from a PostPullsByProviderByOwnerByNameByNumberSyncWithResponse call
-func ParsePostPullsByProviderByOwnerByNameByNumberSyncResponse(rsp *http.Response) (*PostPullsByProviderByOwnerByNameByNumberSyncResponse, error) {
+// ParseSyncPullResponse parses an HTTP response from a SyncPullWithResponse call
+func ParseSyncPullResponse(rsp *http.Response) (*SyncPullResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostPullsByProviderByOwnerByNameByNumberSyncResponse{
+	response := &SyncPullResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17204,15 +17204,15 @@ func ParseDeleteRepoResponse(rsp *http.Response) (*DeleteRepoResponse, error) {
 	return response, nil
 }
 
-// ParseGetRepoByProviderByOwnerByNameResponse parses an HTTP response from a GetRepoByProviderByOwnerByNameWithResponse call
-func ParseGetRepoByProviderByOwnerByNameResponse(rsp *http.Response) (*GetRepoByProviderByOwnerByNameResponse, error) {
+// ParseGetRepoResponse parses an HTTP response from a GetRepoWithResponse call
+func ParseGetRepoResponse(rsp *http.Response) (*GetRepoResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetRepoByProviderByOwnerByNameResponse{
+	response := &GetRepoResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17237,15 +17237,15 @@ func ParseGetRepoByProviderByOwnerByNameResponse(rsp *http.Response) (*GetRepoBy
 	return response, nil
 }
 
-// ParseGetRepoByProviderByOwnerByNameCommentAutocompleteResponse parses an HTTP response from a GetRepoByProviderByOwnerByNameCommentAutocompleteWithResponse call
-func ParseGetRepoByProviderByOwnerByNameCommentAutocompleteResponse(rsp *http.Response) (*GetRepoByProviderByOwnerByNameCommentAutocompleteResponse, error) {
+// ParseGetCommentAutocompleteResponse parses an HTTP response from a GetCommentAutocompleteWithResponse call
+func ParseGetCommentAutocompleteResponse(rsp *http.Response) (*GetCommentAutocompleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetRepoByProviderByOwnerByNameCommentAutocompleteResponse{
+	response := &GetCommentAutocompleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17336,15 +17336,15 @@ func ParseRefreshRepoResponse(rsp *http.Response) (*RefreshRepoResponse, error) 
 	return response, nil
 }
 
-// ParsePostRepoByProviderByOwnerByNameResolveByNumberResponse parses an HTTP response from a PostRepoByProviderByOwnerByNameResolveByNumberWithResponse call
-func ParsePostRepoByProviderByOwnerByNameResolveByNumberResponse(rsp *http.Response) (*PostRepoByProviderByOwnerByNameResolveByNumberResponse, error) {
+// ParseResolveRepoItemResponse parses an HTTP response from a ResolveRepoItemWithResponse call
+func ParseResolveRepoItemResponse(rsp *http.Response) (*ResolveRepoItemResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &PostRepoByProviderByOwnerByNameResolveByNumberResponse{
+	response := &ResolveRepoItemResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17810,15 +17810,15 @@ func ParseGetVersionResponse(rsp *http.Response) (*GetVersionResponse, error) {
 	return response, nil
 }
 
-// ParseGetWorkspacesResponse parses an HTTP response from a GetWorkspacesWithResponse call
-func ParseGetWorkspacesResponse(rsp *http.Response) (*GetWorkspacesResponse, error) {
+// ParseListWorkspacesResponse parses an HTTP response from a ListWorkspacesWithResponse call
+func ParseListWorkspacesResponse(rsp *http.Response) (*ListWorkspacesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetWorkspacesResponse{
+	response := &ListWorkspacesResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17902,15 +17902,15 @@ func ParseDeleteWorkspaceResponse(rsp *http.Response) (*DeleteWorkspaceResponse,
 	return response, nil
 }
 
-// ParseGetWorkspacesByIdResponse parses an HTTP response from a GetWorkspacesByIdWithResponse call
-func ParseGetWorkspacesByIdResponse(rsp *http.Response) (*GetWorkspacesByIdResponse, error) {
+// ParseGetWorkspaceResponse parses an HTTP response from a GetWorkspaceWithResponse call
+func ParseGetWorkspaceResponse(rsp *http.Response) (*GetWorkspaceResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetWorkspacesByIdResponse{
+	response := &GetWorkspaceResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17935,15 +17935,15 @@ func ParseGetWorkspacesByIdResponse(rsp *http.Response) (*GetWorkspacesByIdRespo
 	return response, nil
 }
 
-// ParseGetWorkspacesByIdCommitsResponse parses an HTTP response from a GetWorkspacesByIdCommitsWithResponse call
-func ParseGetWorkspacesByIdCommitsResponse(rsp *http.Response) (*GetWorkspacesByIdCommitsResponse, error) {
+// ParseGetWorkspaceCommitsResponse parses an HTTP response from a GetWorkspaceCommitsWithResponse call
+func ParseGetWorkspaceCommitsResponse(rsp *http.Response) (*GetWorkspaceCommitsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetWorkspacesByIdCommitsResponse{
+	response := &GetWorkspaceCommitsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -17968,15 +17968,15 @@ func ParseGetWorkspacesByIdCommitsResponse(rsp *http.Response) (*GetWorkspacesBy
 	return response, nil
 }
 
-// ParseGetWorkspacesByIdDiffResponse parses an HTTP response from a GetWorkspacesByIdDiffWithResponse call
-func ParseGetWorkspacesByIdDiffResponse(rsp *http.Response) (*GetWorkspacesByIdDiffResponse, error) {
+// ParseGetWorkspaceDiffResponse parses an HTTP response from a GetWorkspaceDiffWithResponse call
+func ParseGetWorkspaceDiffResponse(rsp *http.Response) (*GetWorkspaceDiffResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetWorkspacesByIdDiffResponse{
+	response := &GetWorkspaceDiffResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -18001,15 +18001,15 @@ func ParseGetWorkspacesByIdDiffResponse(rsp *http.Response) (*GetWorkspacesByIdD
 	return response, nil
 }
 
-// ParseGetWorkspacesByIdFilesResponse parses an HTTP response from a GetWorkspacesByIdFilesWithResponse call
-func ParseGetWorkspacesByIdFilesResponse(rsp *http.Response) (*GetWorkspacesByIdFilesResponse, error) {
+// ParseGetWorkspaceFilesResponse parses an HTTP response from a GetWorkspaceFilesWithResponse call
+func ParseGetWorkspaceFilesResponse(rsp *http.Response) (*GetWorkspaceFilesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetWorkspacesByIdFilesResponse{
+	response := &GetWorkspaceFilesResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -792,7 +792,7 @@ func TestAPIMergePR405ReturnsGitHubMessage(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -821,7 +821,7 @@ func TestAPIMergePR409ReturnsGitHubMessage(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -847,7 +847,7 @@ func TestAPIMergePRNetworkErrorReturns502(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -876,7 +876,7 @@ func TestAPIMergePR422ForwardsGitHubMessage(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -905,7 +905,7 @@ func TestAPIMergePR403ForwardsGitHubMessage(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -934,7 +934,7 @@ func TestAPIMergePR5xxReturns502WithGitHubMessage(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -977,7 +977,7 @@ func TestAPIMergePRForwardsGitHubErrorDetailsAndLogsError(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -1009,7 +1009,7 @@ func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 		generated.MergePRInputBody{
 			CommitTitle:   "title",
@@ -1080,7 +1080,7 @@ func TestAPIGetPullIsDBOnly(t *testing.T) {
 	seedPRWithHeadSHA(t, database, "acme", "widget", 1, "deadbeef")
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1139,7 +1139,7 @@ func TestAPISyncPRIncludesWorkflowApproval(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	resp, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1189,7 +1189,7 @@ func TestAPISyncPRPersistsMergeableState(t *testing.T) {
 	})
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	resp, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1248,7 +1248,7 @@ func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {
 			}, withSeedPRHeadSHA("abc123"), withSeedPRBaseSHA("def456"))
 			client := setupTestClient(t, srv)
 
-			resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+			resp, err := client.HTTP.SyncPullWithResponse(
 				t.Context(), "gh", "acme", "widget", 1,
 			)
 			require.NoError(err)
@@ -1317,7 +1317,7 @@ func TestAPIEnqueuePRSyncPersistsWorkflowApproval(t *testing.T) {
 	require.Equal(http.StatusAccepted, resp.StatusCode())
 
 	require.Eventually(func() bool {
-		detail, dErr := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+		detail, dErr := client.HTTP.GetPullWithResponse(
 			t.Context(), "gh", "acme", "widget", 1,
 		)
 		if dErr != nil || detail.JSON200 == nil {
@@ -1328,7 +1328,7 @@ func TestAPIEnqueuePRSyncPersistsWorkflowApproval(t *testing.T) {
 	}, 3*time.Second, 25*time.Millisecond,
 		"GET should return persisted workflow_approval after async sync")
 
-	detail, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	detail, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1390,7 +1390,7 @@ func TestAPIGetPullClearsWorkflowApprovalWhenHeadMoves(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	// First sync: persists required=true for abc123.
-	syncResp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	syncResp, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1399,13 +1399,13 @@ func TestAPIGetPullClearsWorkflowApprovalWhenHeadMoves(t *testing.T) {
 
 	// Head moves forward (force-push); new SHA has no action_required runs.
 	headSHA.Store("def456")
-	syncResp2, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	syncResp2, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, syncResp2.StatusCode())
 
-	detail, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	detail, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1482,7 +1482,7 @@ func TestAPIApproveWorkflows(t *testing.T) {
 	))
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(
+	resp, err := client.HTTP.ApprovePullWorkflowsWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1537,7 +1537,7 @@ func TestAPIApproveWorkflowsZeroMatchesStillSyncsPR(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(
+	resp, err := client.HTTP.ApprovePullWorkflowsWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1606,7 +1606,7 @@ func TestAPIApproveWorkflowsReturnsUnderlyingApprovalErrorAfterPartialFailure(t 
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(
+	resp, err := client.HTTP.ApprovePullWorkflowsWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1674,7 +1674,7 @@ func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	resp, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1741,7 +1741,7 @@ func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(
+	resp, err := client.HTTP.ApprovePullWorkflowsWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1798,7 +1798,7 @@ func TestAPISyncPRIgnoresWorkflowRunsForOtherPRAtSameSHA(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	resp, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1865,7 +1865,7 @@ func TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(
+	resp, err := client.HTTP.ApprovePullWorkflowsWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1932,7 +1932,7 @@ func TestAPIApproveWorkflowsRejectsRunFromDifferentForkAtSameSHA(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWorkflowsWithResponse(
+	resp, err := client.HTTP.ApprovePullWorkflowsWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -1945,7 +1945,7 @@ func TestAPIGetPullNotFound(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 999,
 	)
 	require.NoError(t, err)
@@ -1980,7 +1980,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissing(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -2034,7 +2034,7 @@ func TestAPIGetPullNoDiffWarningWhenSHAsPresent(t *testing.T) {
 	))
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 2,
 	)
 	require.NoError(err)
@@ -2085,7 +2085,7 @@ func TestAPIGetPullEmitsStaleDiffWarning(t *testing.T) {
 	))
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 3,
 	)
 	require.NoError(err)
@@ -2138,7 +2138,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnBaseDrift(t *testing.T) {
 	))
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 4,
 	)
 	require.NoError(err)
@@ -2192,7 +2192,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnMergedPR(t *testing.T) {
 	))
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 5,
 	)
 	require.NoError(err)
@@ -2239,7 +2239,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissingClosed(t *testing.T) {
 	// diff sync errored out.
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 6,
 	)
 	require.NoError(err)
@@ -2290,7 +2290,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnClosedPR(t *testing.T) {
 	))
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 7,
 	)
 	require.NoError(err)
@@ -2342,7 +2342,7 @@ func TestAPIGetPullNoDiffWarningOnMergedPRWithBaseDrift(t *testing.T) {
 	))
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 8,
 	)
 	require.NoError(err)
@@ -2422,7 +2422,7 @@ func TestAPISyncPRSanitizesDiffFailureWarning(t *testing.T) {
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	resp, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -2809,7 +2809,7 @@ func TestGitLabSyncCoversRepositoryItemsEventsOverviewAndCI(t *testing.T) {
 	providerName := "gitlab"
 	providerHost := "gitlab.example.com:8443"
 	mrNumber := int64(7)
-	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+	pullResp, err := client.HTTP.GetPullOnHostWithResponse(
 		ctx, providerHost, providerName, "Group/SubGroup", "Project.Special", mrNumber,
 	)
 	require.NoError(err)
@@ -2822,7 +2822,7 @@ func TestGitLabSyncCoversRepositoryItemsEventsOverviewAndCI(t *testing.T) {
 	assert.Len(*pullResp.JSON200.Events, 1)
 
 	issueNumber := int64(11)
-	issueResp, err := client.HTTP.GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(
+	issueResp, err := client.HTTP.GetIssueOnHostWithResponse(
 		ctx, providerHost, providerName, "Group/SubGroup", "Project.Special", issueNumber,
 	)
 	require.NoError(err)
@@ -2911,7 +2911,7 @@ func TestAPICIRefreshWarnsAndPreservesCIWhenProviderFails(t *testing.T) {
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberCiRefreshWithResponse(
+	resp, err := client.HTTP.RefreshPullCiOnHostWithResponse(
 		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
 	)
 	require.NoError(err)
@@ -3108,7 +3108,7 @@ func TestProviderRefSyncEndpointsUseGitLabNestedRepoPath(t *testing.T) {
 	issueDirect := int64(11)
 	issueAsync := int64(12)
 
-	prResp, err := client.HTTP.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	prResp, err := client.HTTP.SyncPullOnHostWithResponse(
 		ctx, providerHost, providerName, "Group/SubGroup", "Project.Special", mrDirect,
 	)
 	require.NoError(err)
@@ -3119,7 +3119,7 @@ func TestProviderRefSyncEndpointsUseGitLabNestedRepoPath(t *testing.T) {
 	assert.Equal("Sync direct provider MR", prResp.JSON200.MergeRequest.Title)
 	assert.Len(*prResp.JSON200.Events, 1)
 
-	issueResp, err := client.HTTP.PostHostByPlatformHostIssuesByProviderByOwnerByNameByNumberSyncWithResponse(
+	issueResp, err := client.HTTP.SyncIssueOnHostWithResponse(
 		ctx, providerHost, providerName, "Group/SubGroup", "Project.Special", issueDirect,
 	)
 	require.NoError(err)
@@ -3929,12 +3929,12 @@ func TestAPIApprovePRRejectsNilProviderPayload(t *testing.T) {
 	mrID := seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberApproveWithResponse(
+	resp, err := client.HTTP.ApprovePullWithResponse(
 		t.Context(), "gh",
 		"acme",
 		"widget",
 		1,
-		generated.PostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody{},
+		generated.ApprovePullJSONRequestBody{},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
@@ -3965,12 +3965,12 @@ func TestAPIMergePRRejectsNilProviderPayload(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullWithResponse(
 		t.Context(), "gh",
 		"acme",
 		"widget",
 		1,
-		generated.PostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody{
+		generated.MergePullJSONRequestBody{
 			Method: "squash",
 		},
 	)
@@ -4587,7 +4587,7 @@ func TestAPIReadyForReview(t *testing.T) {
 	require.NoError(err)
 	require.NoError(database.EnsureKanbanState(t.Context(), prID))
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(
+	resp, err := client.HTTP.MarkPullReadyForReviewWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -4906,10 +4906,10 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	syncDone := make(chan *generated.PostPullsByProviderByOwnerByNameByNumberSyncResponse, 1)
+	syncDone := make(chan *generated.SyncPullResponse, 1)
 	syncErr := make(chan error, 1)
 	go func() {
-		resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+		resp, err := client.HTTP.SyncPullWithResponse(
 			t.Context(), "gh", "acme", "widget", 1,
 		)
 		if err != nil {
@@ -5017,10 +5017,10 @@ func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
 	))
 	client := setupTestClient(t, srv)
 
-	syncDone := make(chan *generated.PostPullsByProviderByOwnerByNameByNumberSyncResponse, 1)
+	syncDone := make(chan *generated.SyncPullResponse, 1)
 	syncErr := make(chan error, 1)
 	go func() {
-		resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+		resp, err := client.HTTP.SyncPullWithResponse(
 			t.Context(), "gh", "acme", "widget", 1,
 		)
 		if err != nil {
@@ -5036,7 +5036,7 @@ func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
 		require.Fail("CI refresh did not start")
 	}
 
-	detailResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	detailResp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -5114,13 +5114,13 @@ func TestAPISyncPRClearsCIWhenHeadSHAChanges(t *testing.T) {
 	))
 	client := setupTestClient(t, srv)
 
-	syncResp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	syncResp, err := client.HTTP.SyncPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, syncResp.StatusCode())
 
-	detailResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	detailResp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -5350,10 +5350,10 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 	require.NoError(err)
 	require.NoError(database.EnsureKanbanState(t.Context(), prID))
 
-	syncDone := make(chan *generated.PostPullsByProviderByOwnerByNameByNumberSyncResponse, 1)
+	syncDone := make(chan *generated.SyncPullResponse, 1)
 	syncErr := make(chan error, 1)
 	go func() {
-		resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+		resp, err := client.HTTP.SyncPullWithResponse(
 			t.Context(), "gh", "acme", "widget", 1,
 		)
 		if err != nil {
@@ -5365,7 +5365,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 
 	<-syncStarted
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(
+	resp, err := client.HTTP.MarkPullReadyForReviewWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -5433,10 +5433,10 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 	seedIssue(t, database, "acme", "widget", 5, "open")
 	client := setupTestClient(t, srv)
 
-	syncDone := make(chan *generated.PostIssuesByProviderByOwnerByNameByNumberSyncResponse, 1)
+	syncDone := make(chan *generated.SyncIssueResponse, 1)
 	syncErr := make(chan error, 1)
 	go func() {
-		resp, err := client.HTTP.PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse(
+		resp, err := client.HTTP.SyncIssueWithResponse(
 			t.Context(), "gh", "acme", "widget", 5,
 		)
 		if err != nil {
@@ -5521,7 +5521,7 @@ func TestAPISyncIssueNilUpdatedAtFallsBackToCreatedAt(t *testing.T) {
 
 	// Before the nil guard, refreshIssueTimeline panicked on
 	// ghIssue.UpdatedAt.Time and the handler returned 502.
-	syncResp, err := client.HTTP.PostIssuesByProviderByOwnerByNameByNumberSyncWithResponse(
+	syncResp, err := client.HTTP.SyncIssueWithResponse(
 		ctx, "gh", "acme", "widget", 9,
 	)
 	require.NoError(err)
@@ -5535,7 +5535,7 @@ func TestAPISyncIssueNilUpdatedAtFallsBackToCreatedAt(t *testing.T) {
 
 	// Verify the persisted value round-trips through the read
 	// endpoint so the storage -> serializer path is covered.
-	getResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	getResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", 9,
 	)
 	require.NoError(err)
@@ -5752,7 +5752,7 @@ func TestAPIGetIssueAcceptsMixedCaseRepoPath(t *testing.T) {
 	seedIssue(t, database, "acme", "widget", 5, "open")
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetIssueWithResponse(
 		t.Context(), "gh", "Acme", "Widget", 5,
 	)
 	require.NoError(err)
@@ -6177,7 +6177,7 @@ func TestAPIIssueDataFromGraphQLSync(t *testing.T) {
 	assert.Equal("bug", (*apiIssue.Labels)[0].Name)
 
 	// Verify via GetIssue API
-	detailResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	detailResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", 60,
 	)
 	require.NoError(err)
@@ -6283,7 +6283,7 @@ func TestE2EGraphQLIssueSyncThroughAPI(t *testing.T) {
 	require.Len(*apiIssue.Labels, 1)
 	assert.Equal("bug", (*apiIssue.Labels)[0].Name)
 
-	detailResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	detailResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", 80,
 	)
 	require.NoError(err)
@@ -6404,7 +6404,7 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 	// API must expose GraphQL TotalCount (42), not stale DB (5).
 	// With the preservation bug, count would remain 5.
 	client := setupTestClient(t, srv)
-	detailResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	detailResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", 90,
 	)
 	require.NoError(err)
@@ -6511,7 +6511,7 @@ func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -6532,7 +6532,7 @@ func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -6641,7 +6641,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -6657,7 +6657,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -6792,7 +6792,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenAnotherPRChanges(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(targetNumber),
 	)
 	require.NoError(err)
@@ -6807,7 +6807,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenAnotherPRChanges(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(targetNumber),
 	)
 	require.NoError(err)
@@ -6901,7 +6901,7 @@ func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -6922,7 +6922,7 @@ func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -7016,7 +7016,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -7032,7 +7032,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -7158,7 +7158,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenAnotherIssueChanges(t *testing.T
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(targetNumber),
 	)
 	require.NoError(err)
@@ -7173,7 +7173,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenAnotherIssueChanges(t *testing.T
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(targetNumber),
 	)
 	require.NoError(err)
@@ -7259,7 +7259,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 
 	require.NoError(srv.syncer.SyncMR(ctx, "acme", "widget", prNumber))
 
-	firstResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -7276,7 +7276,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 
 	require.NoError(srv.syncer.SyncMR(ctx, "acme", "widget", prNumber))
 
-	secondResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -7355,7 +7355,7 @@ func TestE2EIssueDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 
 	require.NoError(srv.syncer.SyncIssue(ctx, "acme", "widget", issueNumber))
 
-	firstResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -7372,7 +7372,7 @@ func TestE2EIssueDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 
 	require.NoError(srv.syncer.SyncIssue(ctx, "acme", "widget", issueNumber))
 
-	secondResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -7472,7 +7472,7 @@ func TestE2EIssueDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -7489,7 +7489,7 @@ func TestE2EIssueDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetIssueWithResponse(
 		ctx, "gh", "acme", "widget", int64(issueNumber),
 	)
 	require.NoError(err)
@@ -7596,7 +7596,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	firstResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	firstResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -7613,7 +7613,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	secondResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	secondResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -7724,7 +7724,7 @@ func TestE2EGraphQLBulkSyncPersistsWorkflowApproval(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -7850,7 +7850,7 @@ func TestE2EGraphQLBulkSyncPersistsWorkflowApprovalForForkPR(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -7961,7 +7961,7 @@ func TestE2EGraphQLBulkSyncKeepsNewestCICheckBySuiteCreatedAt(t *testing.T) {
 
 	srv.syncer.RunOnce(ctx)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -8139,7 +8139,7 @@ func TestAPIReadyForReview502OnNilPR(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(
+	resp, err := client.HTTP.MarkPullReadyForReviewWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -8157,7 +8157,7 @@ func TestAPIReadyForReviewReturnsUnderlyingErrorDetail(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(
+	resp, err := client.HTTP.MarkPullReadyForReviewWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -8221,7 +8221,7 @@ func TestAPIReadyForReviewStaleStateRefreshesAndReturnsSuccess(t *testing.T) {
 
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(
+	resp, err := client.HTTP.MarkPullReadyForReviewWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -8274,7 +8274,7 @@ func TestAPIReadyForReview404RefreshesStaleDraftState(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberReadyForReviewWithResponse(
+	resp, err := client.HTTP.MarkPullReadyForReviewWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -8327,7 +8327,7 @@ func TestResolveItem_PR(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 42)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostRepoByProviderByOwnerByNameResolveByNumberWithResponse(
+	resp, err := client.HTTP.ResolveRepoItemWithResponse(
 		t.Context(), "gh", "acme", "widget", 42,
 	)
 	require.NoError(err)
@@ -8345,7 +8345,7 @@ func TestResolveItem_Issue(t *testing.T) {
 	seedIssue(t, database, "acme", "widget", 7, "open")
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostRepoByProviderByOwnerByNameResolveByNumberWithResponse(
+	resp, err := client.HTTP.ResolveRepoItemWithResponse(
 		t.Context(), "gh", "acme", "widget", 7,
 	)
 	require.NoError(err)
@@ -8361,7 +8361,7 @@ func TestResolveItem_UntrackedRepo(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostRepoByProviderByOwnerByNameResolveByNumberWithResponse(
+	resp, err := client.HTTP.ResolveRepoItemWithResponse(
 		t.Context(), "gh", "unknown", "repo", 1,
 	)
 	require.NoError(err)
@@ -8388,7 +8388,7 @@ func TestResolveItem_NotFoundOnGitHub(t *testing.T) {
 	require.NoError(err)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostRepoByProviderByOwnerByNameResolveByNumberWithResponse(
+	resp, err := client.HTTP.ResolveRepoItemWithResponse(
 		t.Context(), "gh", "acme", "widget", 999,
 	)
 	require.NoError(err)
@@ -8411,7 +8411,7 @@ func TestResolveItem_GitHubServerError(t *testing.T) {
 	require.NoError(err)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.PostRepoByProviderByOwnerByNameResolveByNumberWithResponse(
+	resp, err := client.HTTP.ResolveRepoItemWithResponse(
 		t.Context(), "gh", "acme", "widget", 999,
 	)
 	require.NoError(err)
@@ -8983,7 +8983,7 @@ func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
 	assert.True(mr.IsLocked)
 	assert.Equal("success", mr.CIStatus)
 
-	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+	pullResp, err := client.HTTP.GetPullOnHostWithResponse(
 		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 7,
 	)
 	require.NoError(err)
@@ -8997,7 +8997,7 @@ func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
 	require.Len(*pullResp.JSON200.Events, 1)
 	assert.Equal("looks good", (*pullResp.JSON200.Events)[0].Body)
 
-	issueResp, err := client.HTTP.GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(
+	issueResp, err := client.HTTP.GetIssueOnHostWithResponse(
 		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 8,
 	)
 	require.NoError(err)
@@ -9138,7 +9138,7 @@ func TestAPIGitealikeHTTPMergeabilityPersistsThroughServer(t *testing.T) {
 			assert.Empty(requireMR(t, database, repo.ID, 8).MergeableState)
 			assert.Empty(requireMR(t, database, repo.ID, 9).MergeableState)
 
-			detailResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+			detailResp, err := client.HTTP.GetPullOnHostWithResponse(
 				ctx, tt.host, string(tt.kind), "tea", "kettle", 7,
 			)
 			require.NoError(err)
@@ -9289,9 +9289,9 @@ func TestAPIGitealikeMutationsPersistThroughServer(t *testing.T) {
 	require.Len(mrEvents, 1)
 	assert.Equal("Still good", mrEvents[0].Body)
 
-	approveResp, err := client.HTTP.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveWithResponse(
+	approveResp, err := client.HTTP.ApprovePullOnHostWithResponse(
 		ctx, "gitea.test", "gitea", "tea", "kettle", 7,
-		generated.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberApproveJSONRequestBody{Body: "approved"},
+		generated.ApprovePullOnHostJSONRequestBody{Body: "approved"},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, approveResp.StatusCode())
@@ -9299,9 +9299,9 @@ func TestAPIGitealikeMutationsPersistThroughServer(t *testing.T) {
 	require.NoError(err)
 	assert.Len(mrEvents, 2)
 
-	mergeResp, err := client.HTTP.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	mergeResp, err := client.HTTP.MergePullOnHostWithResponse(
 		ctx, "gitea.test", "gitea", "tea", "kettle", 7,
-		generated.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody{
+		generated.MergePullOnHostJSONRequestBody{
 			Method:        "squash",
 			CommitTitle:   "Merge kettle",
 			CommitMessage: "Merge Gitea MR",
@@ -9524,7 +9524,7 @@ func TestAPIGiteaActionsSyncPersistsThroughServer(t *testing.T) {
 	mr := requireMR(t, database, repo.ID, 5)
 	require.Equal("failure", mr.CIStatus)
 
-	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+	pullResp, err := client.HTTP.GetPullOnHostWithResponse(
 		ctx, "gitea.test", "gitea", "tea", "actions", 5,
 	)
 	require.NoError(err)
@@ -9639,9 +9639,9 @@ func TestAPIGitealikeMergeConflictReturnsConflict(t *testing.T) {
 	assert.Equal("dirty", requireMR(t, database, repo.ID, 7).MergeableState)
 	transport.pulls[0].Title = "Refreshed kettle after conflict"
 
-	resp, err := client.HTTP.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeWithResponse(
+	resp, err := client.HTTP.MergePullOnHostWithResponse(
 		ctx, "gitea.test", "gitea", "tea", "kettle", 7,
-		generated.PostHostByPlatformHostPullsByProviderByOwnerByNameByNumberMergeJSONRequestBody{
+		generated.MergePullOnHostJSONRequestBody{
 			Method:        "squash",
 			CommitTitle:   "Merge kettle",
 			CommitMessage: "Merge Gitea MR",
@@ -10197,7 +10197,7 @@ func TestAPIGitealikeLockedPRPersistsThroughServer(t *testing.T) {
 	assert.False(mr.IsDraft)
 	assert.True(mr.IsLocked)
 
-	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+	pullResp, err := client.HTTP.GetPullOnHostWithResponse(
 		ctx, "codeberg.test", "forgejo", "forgejo", "tea", 7,
 	)
 	require.NoError(err)
@@ -10308,7 +10308,7 @@ func TestAPIGitealikeDraftPRFieldsPersistThroughServer(t *testing.T) {
 	require.Len(mr.Labels, 1)
 	assert.Equal("bug", mr.Labels[0].Name)
 
-	pullResp, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+	pullResp, err := client.HTTP.GetPullOnHostWithResponse(
 		ctx, "gitea.test", "gitea", "gitea", "tea", 8,
 	)
 	require.NoError(err)
@@ -10484,7 +10484,7 @@ func TestProviderIssueRouteGeneratedClientEscapesGitLabRepoPath(t *testing.T) {
 	})
 	require.NoError(err)
 
-	resp, err := client.HTTP.GetHostByPlatformHostIssuesByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetIssueOnHostWithResponse(
 		ctx, host, provider, "Team One/Sub Team", "project+#1", number,
 	)
 	require.NoError(err)
@@ -10582,7 +10582,7 @@ func TestAPIGetFiles503WhenCloneManagerNil(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberFilesWithResponse(
+	resp, err := client.HTTP.GetPullFilesWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -10659,7 +10659,7 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	require.NoError(err)
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, mergeBase, mergeBase))
 
-	filesResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberFilesWithResponse(
+	filesResp, err := client.HTTP.GetPullFilesWithResponse(
 		ctx, "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -10670,7 +10670,7 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	assert.False(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "bun.lock").IsGenerated)
 	assert.False(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "src.ts").IsGenerated)
 
-	diffResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	diffResp, err := client.HTTP.GetPullDiffWithResponse(
 		ctx, "gh", "acme", "widget", 1,
 		nil,
 	)
@@ -11125,7 +11125,7 @@ func TestAPIGetPullDetailLoaded(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	// Before detail fetch: detail_loaded=false.
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -11156,7 +11156,7 @@ func TestAPIGetPullDetailLoaded(t *testing.T) {
 	})
 	require.NoError(err)
 
-	resp2, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp2, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 2,
 	)
 	require.NoError(err)
@@ -11230,8 +11230,8 @@ func TestAPIActivityReturnsUTCCreatedAt(t *testing.T) {
 	}}))
 
 	since := createdAtUTC.Add(-time.Hour).Format(time.RFC3339)
-	resp, err := client.HTTP.GetActivityWithResponse(
-		ctx, &generated.GetActivityParams{Since: &since},
+	resp, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11432,8 +11432,8 @@ func TestAPIActivityStartupRepairsLegacyTimestampStorage(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	since := "2026-04-11T11:30:00Z"
-	resp, err := client.HTTP.GetActivityWithResponse(
-		ctx, &generated.GetActivityParams{Since: &since},
+	resp, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11452,8 +11452,8 @@ func TestAPIActivityStartupRepairsLegacyTimestampStorage(t *testing.T) {
 	assertRFC3339UTC(t, commentItems[1].CreatedAt, time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC))
 
 	since = "2026-04-11T12:30:00Z"
-	resp, err = client.HTTP.GetActivityWithResponse(
-		ctx, &generated.GetActivityParams{Since: &since},
+	resp, err = client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11564,7 +11564,7 @@ func TestAPIGetCommits(t *testing.T) {
 	assert := Assert.New(t)
 
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse(
+	resp, err := client.HTTP.GetPullCommitsWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -11579,7 +11579,7 @@ func TestAPIGetCommits(t *testing.T) {
 func TestAPIGetCommits_NotFound(t *testing.T) {
 	client, _, _, _, _ := setupTestServerWithClones(t)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberCommitsWithResponse(
+	resp, err := client.HTTP.GetPullCommitsWithResponse(
 		t.Context(), "gh", "acme", "widget", 999,
 	)
 	require.NoError(t, err)
@@ -11590,9 +11590,9 @@ func TestAPIGetDiff_SingleCommit(t *testing.T) {
 	require := require.New(t)
 
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	resp, err := client.HTTP.GetPullDiffWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberDiffParams{Commit: &commitSHAs[2]},
+		&generated.GetPullDiffParams{Commit: &commitSHAs[2]},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11648,9 +11648,9 @@ func TestAPIGetFilePreview_ReturnsDeletedFileContent(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	path := "config.yaml"
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberFilePreviewWithResponse(
+	resp, err := client.HTTP.GetPullFilePreviewWithResponse(
 		ctx, "gh", "acme", "widgets", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberFilePreviewParams{Path: &path},
+		&generated.GetPullFilePreviewParams{Path: &path},
 	)
 
 	require.NoError(err)
@@ -11668,9 +11668,9 @@ func TestAPIGetDiff_Range(t *testing.T) {
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	from := commitSHAs[4] // commit 1 (oldest)
 	to := commitSHAs[2]   // commit 3
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	resp, err := client.HTTP.GetPullDiffWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberDiffParams{From: &from, To: &to},
+		&generated.GetPullDiffParams{From: &from, To: &to},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11681,9 +11681,9 @@ func TestAPIGetDiff_Range(t *testing.T) {
 func TestAPIGetDiff_InvalidScope(t *testing.T) {
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	from := commitSHAs[0]
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	resp, err := client.HTTP.GetPullDiffWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberDiffParams{Commit: &commitSHAs[0], From: &from},
+		&generated.GetPullDiffParams{Commit: &commitSHAs[0], From: &from},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -11692,9 +11692,9 @@ func TestAPIGetDiff_InvalidScope(t *testing.T) {
 func TestAPIGetDiff_UnknownSHA(t *testing.T) {
 	client, _, _, _, _ := setupTestServerWithClones(t)
 	bogus := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	resp, err := client.HTTP.GetPullDiffWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberDiffParams{Commit: &bogus},
+		&generated.GetPullDiffParams{Commit: &bogus},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -11704,9 +11704,9 @@ func TestAPIGetDiff_ReversedRange(t *testing.T) {
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	from := commitSHAs[0] // newest
 	to := commitSHAs[4]   // oldest
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	resp, err := client.HTTP.GetPullDiffWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberDiffParams{From: &from, To: &to},
+		&generated.GetPullDiffParams{From: &from, To: &to},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -11715,9 +11715,9 @@ func TestAPIGetDiff_ReversedRange(t *testing.T) {
 func TestAPIGetDiff_FromWithoutTo(t *testing.T) {
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	from := commitSHAs[0]
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	resp, err := client.HTTP.GetPullDiffWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberDiffParams{From: &from},
+		&generated.GetPullDiffParams{From: &from},
 	)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -11763,9 +11763,9 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"))
 
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberDiffWithResponse(
+	resp, err := client.HTTP.GetPullDiffWithResponse(
 		t.Context(), "gh", "acme", "rootrepo", 1,
-		&generated.GetPullsByProviderByOwnerByNameByNumberDiffParams{Commit: &rootSHA},
+		&generated.GetPullDiffParams{Commit: &rootSHA},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11793,8 +11793,8 @@ func TestAPIListActivity(t *testing.T) {
 	}))
 
 	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
-	resp, err := client.HTTP.GetActivityWithResponse(
-		ctx, &generated.GetActivityParams{Since: &since},
+	resp, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11816,8 +11816,8 @@ func TestAPIListActivityAcceptsHostQualifiedRepoFilter(t *testing.T) {
 
 	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
 	repo := "ghe.example.com/acme/widget"
-	resp, err := client.HTTP.GetActivityWithResponse(
-		t.Context(), &generated.GetActivityParams{Since: &since, Repo: &repo},
+	resp, err := client.HTTP.ListActivityWithResponse(
+		t.Context(), &generated.ListActivityParams{Since: &since, Repo: &repo},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -11981,7 +11981,7 @@ func TestAPIGetStackForPR(t *testing.T) {
 	seedStackedPR(t, database, "acme", "widget", 11, "feat/api-retry", "feat/api-base", db.MergeRequestStateOpen, "success", "APPROVED")
 	runStackDetection(t, database, "acme", "widget")
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx, "gh", "acme", "widget", 10)
+	resp, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "widget", 10)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 	require.NotNil(resp.JSON200)
@@ -11990,7 +11990,7 @@ func TestAPIGetStackForPR(t *testing.T) {
 	assert.Equal("blocked", resp.JSON200.Health)
 
 	seedPR(t, database, "acme", "widget", 99)
-	resp2, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx, "gh", "acme", "widget", 99)
+	resp2, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "widget", 99)
 	require.NoError(err)
 	assert.Equal(http.StatusNotFound, resp2.StatusCode())
 }
@@ -12005,7 +12005,7 @@ func TestAPIGetStackForPR_DraftNotBaseReady(t *testing.T) {
 	seedStackedPR(t, database, "acme", "widget", 11, "feat/y", "feat/x", db.MergeRequestStateOpen, "pending", "")
 	runStackDetection(t, database, "acme", "widget")
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(t.Context(), "gh", "acme", "widget", 10)
+	resp, err := client.HTTP.GetPullStackWithResponse(t.Context(), "gh", "acme", "widget", 10)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode())
 	require.NotNil(t, resp.JSON200)
@@ -12091,7 +12091,7 @@ func TestAPIStacks_DetectionViaSyncHook(t *testing.T) {
 	require.Len(stks, 1, "sync-hook detection should produce one stack")
 	assert.Equal("hook", stks[0].Name)
 
-	ctxResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(ctx, "gh", "acme", "widget", 10)
+	ctxResp, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "widget", 10)
 	require.NoError(err)
 	require.Equal(http.StatusOK, ctxResp.StatusCode())
 	require.NotNil(ctxResp.JSON200)
@@ -12110,7 +12110,7 @@ func TestAPIGetStackForPR_SingleFailingIsInProgress(t *testing.T) {
 	seedStackedPR(t, database, "acme", "widget", 11, "feat/tip", "feat/base", db.MergeRequestStateOpen, "failure", "")
 	runStackDetection(t, database, "acme", "widget")
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(t.Context(), "gh", "acme", "widget", 11)
+	resp, err := client.HTTP.GetPullStackWithResponse(t.Context(), "gh", "acme", "widget", 11)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode())
 	require.NotNil(t, resp.JSON200)
@@ -12129,7 +12129,7 @@ func TestAPIGetStackForPR_BaseBranchNotMain(t *testing.T) {
 	seedStackedPR(t, database, "acme", "widget", 11, "feat/tip", "feat/base", db.MergeRequestStateOpen, "pending", "")
 	runStackDetection(t, database, "acme", "widget")
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberStackWithResponse(t.Context(), "gh", "acme", "widget", 10)
+	resp, err := client.HTTP.GetPullStackWithResponse(t.Context(), "gh", "acme", "widget", 10)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 	require.NotNil(resp.JSON200)
@@ -12316,7 +12316,7 @@ func TestCICheckDedupLatestRunWinsE2E(t *testing.T) {
 	client := setupTestClient(t, srv)
 	seedPR(t, database, "acme", "widget", prNumber)
 
-	resp, err := client.HTTP.PostPullsByProviderByOwnerByNameByNumberSyncWithResponse(
+	resp, err := client.HTTP.SyncPullWithResponse(
 		context.Background(), "gh", "acme", "widget", int64(prNumber),
 	)
 	require.NoError(err)
@@ -12575,7 +12575,7 @@ func waitForWorkspaceStatus(
 	defer ticker.Stop()
 
 	for {
-		getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(
+		getResp, err := client.HTTP.GetWorkspaceWithResponse(
 			ctx, wsID,
 		)
 		require.NoError(t, err)
@@ -12895,7 +12895,7 @@ func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 
 	var got *generated.WorkspaceResponse
 	require.Eventually(func() bool {
-		resp, err := fixture.client.HTTP.GetWorkspacesByIdWithResponse(ctx, ws.Id)
+		resp, err := fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
 		if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
 			return false
 		}
@@ -13708,7 +13708,7 @@ exit 0
 	assert.Contains(newSession, "@middleman_owner")
 	assert.Contains(newSession, srv.workspaces.TmuxOwnerMarker())
 
-	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
 	require.NoError(err)
 	require.Equal(http.StatusOK, listResp.StatusCode())
 	require.NotNil(listResp.JSON200)
@@ -13794,7 +13794,7 @@ exit 0
 	})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetWorkspacesByIdWithResponse(t.Context(), ws.ID)
+	resp, err := client.HTTP.GetWorkspaceWithResponse(t.Context(), ws.ID)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
@@ -13886,7 +13886,7 @@ exit 0
 	})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	client := setupTestClient(t, srv)
-	resp, err := client.HTTP.GetWorkspacesByIdWithResponse(t.Context(), ws.ID)
+	resp, err := client.HTTP.GetWorkspaceWithResponse(t.Context(), ws.ID)
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 	require.NotNil(resp.JSON200)
@@ -14331,7 +14331,7 @@ exit 0
 		},
 	))
 
-	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
 	require.NoError(err)
 	require.Equal(http.StatusOK, listResp.StatusCode())
 	require.NotNil(listResp.JSON200)
@@ -14498,7 +14498,7 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 	runGit(t, ws.WorktreePath, "add", ".")
 	runGit(t, ws.WorktreePath, "commit", "-m", "ahead 2")
 
-	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
 	require.NoError(err)
 	require.Equal(http.StatusOK, listResp.StatusCode())
 	require.NotNil(listResp.JSON200)
@@ -15123,7 +15123,7 @@ func TestWorkspaceListPrunesMissingTmuxSessionsE2E(t *testing.T) {
 		},
 	))
 
-	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
 	require.NoError(err)
 	require.Equal(http.StatusOK, listResp.StatusCode())
 	require.NotNil(listResp.JSON200)
@@ -16149,7 +16149,7 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	ctx := t.Context()
 
 	// 1. List workspaces -- initially empty.
-	listResp, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
 	require.NoError(err)
 	require.Equal(http.StatusOK, listResp.StatusCode())
 	require.NotNil(listResp.JSON200)
@@ -16184,7 +16184,7 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	waitForWorkspaceReady(t, ctx, client, wsID)
 
 	// 3. Get workspace by ID.
-	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(
+	getResp, err := client.HTTP.GetWorkspaceWithResponse(
 		ctx, wsID,
 	)
 	require.NoError(err)
@@ -16193,7 +16193,7 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	assert.Equal(wsID, getResp.JSON200.Id)
 
 	// 4. List workspaces -- now has one.
-	listResp2, err := client.HTTP.GetWorkspacesWithResponse(ctx)
+	listResp2, err := client.HTTP.ListWorkspacesWithResponse(ctx)
 	require.NoError(err)
 	require.Equal(http.StatusOK, listResp2.StatusCode())
 	require.NotNil(listResp2.JSON200)
@@ -16209,7 +16209,7 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	require.Equal(http.StatusNoContent, delResp.StatusCode())
 
 	// 6. Verify deleted -- GET returns 404.
-	getResp2, err := client.HTTP.GetWorkspacesByIdWithResponse(
+	getResp2, err := client.HTTP.GetWorkspaceWithResponse(
 		ctx, wsID,
 	)
 	require.NoError(err)
@@ -16360,7 +16360,7 @@ func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 	wsID := createResp.JSON202.Id
 
 	// MR detail should include the workspace reference.
-	mrResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	mrResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -16621,7 +16621,7 @@ func TestWorkspaceCreatePRAndIssueCanCoexistForSameRepoNumber(t *testing.T) {
 	assert.Equal(int64(1), issueResp.JSON202.ItemNumber)
 	assert.NotEqual(prResp.JSON202.Id, issueResp.JSON202.Id)
 
-	listResp, err := fixture.client.HTTP.GetWorkspacesWithResponse(ctx)
+	listResp, err := fixture.client.HTTP.ListWorkspacesWithResponse(ctx)
 	require.NoError(err)
 	require.Equal(http.StatusOK, listResp.StatusCode())
 	require.NotNil(listResp.JSON200)
@@ -17322,7 +17322,7 @@ func TestWorkspacePRDetailPlatformHost(t *testing.T) {
 	ctx := t.Context()
 
 	// PR on github.com
-	r1, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	r1, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", 10,
 	)
 	require.NoError(err)
@@ -17331,7 +17331,7 @@ func TestWorkspacePRDetailPlatformHost(t *testing.T) {
 	assert.Equal("github.com", r1.JSON200.PlatformHost)
 
 	// PR on ghe.example.com (same owner/name, different number)
-	r2, err := client.HTTP.GetHostByPlatformHostPullsByProviderByOwnerByNameByNumberWithResponse(
+	r2, err := client.HTTP.GetPullOnHostWithResponse(
 		ctx, "ghe.example.com", "gh", "acme", "widget", 20,
 	)
 	require.NoError(err)
@@ -17434,7 +17434,7 @@ func TestWorkspaceDeleteDirty(t *testing.T) {
 	assert.Equal(http.StatusNoContent, delResp2.StatusCode())
 
 	// Verify deleted.
-	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(
+	getResp, err := client.HTTP.GetWorkspaceWithResponse(
 		ctx, wsID,
 	)
 	require.NoError(err)
@@ -17478,7 +17478,7 @@ func TestWorkspaceDeleteDirty(t *testing.T) {
 	assert.Equal(http.StatusNoContent, del4.StatusCode())
 
 	// Verify deleted.
-	get2, err := client.HTTP.GetWorkspacesByIdWithResponse(ctx, ws2ID)
+	get2, err := client.HTTP.GetWorkspaceWithResponse(ctx, ws2ID)
 	require.NoError(err)
 	assert.Equal(http.StatusNotFound, get2.StatusCode())
 }

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -43,7 +43,7 @@ func TestAPIGetPull(t *testing.T) {
 	seedPRWithHeadSHA(t, database, "acme", "widget", 1, "abc123def456")
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -62,7 +62,7 @@ func TestAPIGetPullAcceptsMixedCaseRepoPath(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "Acme", "Widget", 1,
 	)
 	require.NoError(err)
@@ -119,7 +119,7 @@ func TestAPIGetPullIncludesBranches(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -141,7 +141,7 @@ func TestAPIGetPullIncludesLabels(t *testing.T) {
 	}})
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetPullWithResponse(
 		t.Context(), "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
@@ -229,7 +229,7 @@ func TestAPIGetIssueIncludesLabels(t *testing.T) {
 	}})
 	client := setupTestClient(t, srv)
 
-	resp, err := client.HTTP.GetIssuesByProviderByOwnerByNameByNumberWithResponse(
+	resp, err := client.HTTP.GetIssueWithResponse(
 		t.Context(), "gh", "acme", "widget", 5,
 	)
 	require.NoError(err)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -421,16 +421,36 @@ func apiConfig(basePath string) huma.Config {
 	return config
 }
 
+// documentOperation returns an operation-builder callback that sets Summary,
+// Tags, and OperationID on the resulting *huma.Operation. Use it with the
+// huma.Get/Post/Put/Patch/Delete convenience helpers so routes registered
+// through shorthand still carry the metadata that the OpenAPI contract test
+// enforces.
+func documentOperation(
+	operationID, summary string, tags ...string,
+) func(*huma.Operation) {
+	return func(o *huma.Operation) {
+		o.OperationID = operationID
+		o.Summary = summary
+		o.Tags = tags
+	}
+}
+
 func (s *Server) registerAPI(api huma.API) {
 	huma.Register(api, huma.Operation{
 		OperationID: "get-version",
 		Method:      http.MethodGet,
 		Path:        "/version",
+		Summary:     "Get server version",
+		Tags:        []string{"System"},
 	}, s.getVersion)
 
-	huma.Get(api, "/activity", s.listActivity)
-	huma.Get(api, "/pulls", s.listPulls)
-	huma.Get(api, "/issues", s.listIssues)
+	huma.Get(api, "/activity", s.listActivity,
+		documentOperation("list-activity", "List activity", "Activity"))
+	huma.Get(api, "/pulls", s.listPulls,
+		documentOperation("list-pulls", "List pull requests", "Pull Requests"))
+	huma.Get(api, "/issues", s.listIssues,
+		documentOperation("list-issues", "List issues", "Issues"))
 	s.registerProviderRepoAPI(api)
 
 	huma.Register(api, huma.Operation{
@@ -438,32 +458,43 @@ func (s *Server) registerAPI(api huma.API) {
 		Method:        http.MethodGet,
 		Path:          "/repos/summary",
 		DefaultStatus: http.StatusOK,
+		Summary:       "List repository summaries",
+		Tags:          []string{"Repositories"},
 	}, s.listRepoSummaries)
 	huma.Register(api, huma.Operation{
 		OperationID:   "set-starred",
 		Method:        http.MethodPut,
 		Path:          "/starred",
 		DefaultStatus: http.StatusOK,
+		Summary:       "Star repository",
+		Tags:          []string{"Settings"},
 	}, s.setStarred)
 	huma.Register(api, huma.Operation{
 		OperationID:   "unset-starred",
 		Method:        http.MethodDelete,
 		Path:          "/starred",
 		DefaultStatus: http.StatusOK,
+		Summary:       "Unstar repository",
+		Tags:          []string{"Settings"},
 	}, s.unsetStarred)
 
-	huma.Get(api, "/repos", s.listRepos)
+	huma.Get(api, "/repos", s.listRepos,
+		documentOperation("list-repos", "List repositories", "Repositories"))
 	huma.Register(api, huma.Operation{
 		OperationID:   "preview-repos",
 		Method:        http.MethodPost,
 		Path:          "/repos/preview",
 		DefaultStatus: http.StatusOK,
+		Summary:       "Preview repositories",
+		Tags:          []string{"Repositories"},
 	}, s.previewRepos)
 	huma.Register(api, huma.Operation{
 		OperationID:   "bulk-add-repos",
 		Method:        http.MethodPost,
 		Path:          "/repos/bulk",
 		DefaultStatus: http.StatusCreated,
+		Summary:       "Bulk add repositories",
+		Tags:          []string{"Repositories"},
 	}, s.bulkAddRepos)
 	s.registerSettingsAPI(api)
 	huma.Register(api, huma.Operation{
@@ -471,11 +502,15 @@ func (s *Server) registerAPI(api huma.API) {
 		Method:        http.MethodPost,
 		Path:          "/sync",
 		DefaultStatus: http.StatusAccepted,
+		Summary:       "Trigger sync",
+		Tags:          []string{"Sync"},
 	}, s.triggerSync)
 	huma.Register(api, huma.Operation{
 		OperationID: "stream-events",
 		Method:      http.MethodGet,
 		Path:        "/events",
+		Summary:     "Stream server events",
+		Tags:        []string{"System"},
 		Responses: map[string]*huma.Response{
 			"200": {
 				Description: "Server-sent event stream",
@@ -485,59 +520,83 @@ func (s *Server) registerAPI(api huma.API) {
 			},
 		},
 	}, s.streamEvents)
-	huma.Get(api, "/sync/status", s.syncStatus)
-	huma.Get(api, "/rate-limits", s.getRateLimits)
+	huma.Get(api, "/sync/status", s.syncStatus,
+		documentOperation("get-sync-status", "Get sync status", "Sync"))
+	huma.Get(api, "/rate-limits", s.getRateLimits,
+		documentOperation("get-rate-limits", "Get rate limits", "Sync"))
 	huma.Register(api, huma.Operation{
 		OperationID: "get-roborev-status",
 		Method:      http.MethodGet,
 		Path:        "/roborev/status",
+		Summary:     "Get roborev status",
+		Tags:        []string{"Roborev"},
 	}, s.getRoborevStatus)
 
-	huma.Get(api, "/stacks", s.listStacks)
+	huma.Get(api, "/stacks", s.listStacks,
+		documentOperation("list-stacks", "List stacks", "Stacks"))
 
 	huma.Register(api, huma.Operation{
 		OperationID:   "create-workspace",
 		Method:        http.MethodPost,
 		Path:          "/workspaces",
 		DefaultStatus: http.StatusAccepted,
+		Summary:       "Create workspace",
+		Tags:          []string{"Workspaces"},
 	}, s.createWorkspace)
-	huma.Get(api, "/workspaces", s.listWorkspaces)
-	huma.Get(api, "/workspaces/{id}", s.getWorkspace)
-	huma.Get(api, "/workspaces/{id}/commits", s.getWorkspaceCommits)
-	huma.Get(api, "/workspaces/{id}/diff", s.getWorkspaceDiff)
-	huma.Get(api, "/workspaces/{id}/files", s.getWorkspaceFiles)
+	huma.Get(api, "/workspaces", s.listWorkspaces,
+		documentOperation("list-workspaces", "List workspaces", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}", s.getWorkspace,
+		documentOperation("get-workspace", "Get workspace", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/commits", s.getWorkspaceCommits,
+		documentOperation("get-workspace-commits", "Get workspace commits", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/diff", s.getWorkspaceDiff,
+		documentOperation("get-workspace-diff", "Get workspace diff", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/files", s.getWorkspaceFiles,
+		documentOperation("get-workspace-files", "Get workspace files", "Workspaces"))
 	huma.Register(api, huma.Operation{
 		OperationID:   "retry-workspace",
 		Method:        http.MethodPost,
 		Path:          "/workspaces/{id}/retry",
 		DefaultStatus: http.StatusAccepted,
+		Summary:       "Retry workspace",
+		Tags:          []string{"Workspaces"},
 	}, s.retryWorkspace)
 	huma.Register(api, huma.Operation{
 		OperationID: "get-workspace-runtime",
 		Method:      http.MethodGet,
 		Path:        "/workspaces/{id}/runtime",
+		Summary:     "Get workspace runtime",
+		Tags:        []string{"Workspaces"},
 	}, s.getWorkspaceRuntime)
 	huma.Register(api, huma.Operation{
 		OperationID: "launch-workspace-runtime-session",
 		Method:      http.MethodPost,
 		Path:        "/workspaces/{id}/runtime/sessions",
+		Summary:     "Launch workspace runtime session",
+		Tags:        []string{"Workspaces"},
 	}, s.launchWorkspaceRuntimeSession)
 	huma.Register(api, huma.Operation{
 		OperationID:   "stop-workspace-runtime-session",
 		Method:        http.MethodDelete,
 		Path:          "/workspaces/{id}/runtime/sessions/{session_key}",
 		DefaultStatus: http.StatusNoContent,
+		Summary:       "Stop workspace runtime session",
+		Tags:          []string{"Workspaces"},
 	}, s.stopWorkspaceRuntimeSession)
 	huma.Register(api, huma.Operation{
 		OperationID: "ensure-workspace-runtime-shell",
 		Method:      http.MethodPost,
 		Path:        "/workspaces/{id}/runtime/shell",
+		Summary:     "Ensure workspace runtime shell",
+		Tags:        []string{"Workspaces"},
 	}, s.ensureWorkspaceRuntimeShell)
 	huma.Register(api, huma.Operation{
 		OperationID:   "delete-workspace",
 		Method:        http.MethodDelete,
 		Path:          "/workspaces/{id}",
 		DefaultStatus: http.StatusNoContent,
+		Summary:       "Delete workspace",
+		Tags:          []string{"Workspaces"},
 	}, s.deleteWorkspace)
 
 	huma.Register(api, huma.Operation{
@@ -545,32 +604,44 @@ func (s *Server) registerAPI(api huma.API) {
 		Method:        http.MethodPost,
 		Path:          "/projects",
 		DefaultStatus: http.StatusCreated,
+		Summary:       "Register project",
+		Tags:          []string{"Projects"},
 	}, s.registerProject)
 	huma.Register(api, huma.Operation{
 		OperationID: "list-projects",
 		Method:      http.MethodGet,
 		Path:        "/projects",
+		Summary:     "List projects",
+		Tags:        []string{"Projects"},
 	}, s.listProjects)
 	huma.Register(api, huma.Operation{
 		OperationID: "get-project",
 		Method:      http.MethodGet,
 		Path:        "/projects/{project_id}",
+		Summary:     "Get project",
+		Tags:        []string{"Projects"},
 	}, s.getProject)
 	huma.Register(api, huma.Operation{
 		OperationID:   "register-worktree",
 		Method:        http.MethodPost,
 		Path:          "/projects/{project_id}/worktrees",
 		DefaultStatus: http.StatusCreated,
+		Summary:       "Register worktree",
+		Tags:          []string{"Projects"},
 	}, s.registerWorktree)
 	huma.Register(api, huma.Operation{
 		OperationID: "list-worktrees",
 		Method:      http.MethodGet,
 		Path:        "/projects/{project_id}/worktrees",
+		Summary:     "List worktrees",
+		Tags:        []string{"Projects"},
 	}, s.listWorktrees)
 	huma.Register(api, huma.Operation{
 		OperationID: "list-launch-targets",
 		Method:      http.MethodGet,
 		Path:        "/projects/{project_id}/launch-targets",
+		Summary:     "List launch targets",
+		Tags:        []string{"Projects"},
 	}, s.listLaunchTargets)
 }
 
@@ -586,78 +657,114 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 	issuePath := issueRepoPath + "/{number}"
 	hostIssuePath := hostIssueRepoPath + "/{number}"
 
-	huma.Get(api, pullPath, s.getPull)
-	huma.Get(api, hostPullPath, s.getPullOnHost)
-	huma.Get(api, pullPath+"/import-metadata", s.getMRImportMetadata)
-	huma.Get(api, hostPullPath+"/import-metadata", s.getMRImportMetadataOnHost)
-	huma.Register(api, huma.Operation{OperationID: "set-kanban-state", Method: http.MethodPut, Path: pullPath + "/state", DefaultStatus: http.StatusOK}, s.setKanbanState)
-	huma.Register(api, huma.Operation{OperationID: "set-kanban-state-on-host", Method: http.MethodPut, Path: hostPullPath + "/state", DefaultStatus: http.StatusOK}, s.setKanbanStateOnHost)
-	huma.Register(api, huma.Operation{OperationID: "edit-pr-content", Method: http.MethodPatch, Path: pullPath, DefaultStatus: http.StatusOK}, s.editPRContent)
-	huma.Register(api, huma.Operation{OperationID: "edit-pr-content-on-host", Method: http.MethodPatch, Path: hostPullPath, DefaultStatus: http.StatusOK}, s.editPRContentOnHost)
-	huma.Register(api, huma.Operation{OperationID: "post-pr-comment", Method: http.MethodPost, Path: pullPath + "/comments", DefaultStatus: http.StatusCreated}, s.postComment)
-	huma.Register(api, huma.Operation{OperationID: "post-pr-comment-on-host", Method: http.MethodPost, Path: hostPullPath + "/comments", DefaultStatus: http.StatusCreated}, s.postCommentOnHost)
-	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment", Method: http.MethodPatch, Path: pullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editComment)
-	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment-on-host", Method: http.MethodPatch, Path: hostPullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editCommentOnHost)
-	huma.Register(api, huma.Operation{OperationID: "set-pr-labels", Method: http.MethodPut, Path: pullPath + "/labels", DefaultStatus: http.StatusOK}, s.setPullLabels)
-	huma.Register(api, huma.Operation{OperationID: "set-pr-labels-on-host", Method: http.MethodPut, Path: hostPullPath + "/labels", DefaultStatus: http.StatusOK}, s.setPullLabelsOnHost)
+	huma.Get(api, pullPath, s.getPull,
+		documentOperation("get-pull", "Get pull request", "Pull Requests"))
+	huma.Get(api, hostPullPath, s.getPullOnHost,
+		documentOperation("get-pull-on-host", "Get pull request", "Pull Requests"))
+	huma.Get(api, pullPath+"/import-metadata", s.getMRImportMetadata,
+		documentOperation("get-pull-import-metadata", "Get pull request import metadata", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/import-metadata", s.getMRImportMetadataOnHost,
+		documentOperation("get-pull-import-metadata-on-host", "Get pull request import metadata", "Pull Requests"))
+	huma.Register(api, huma.Operation{OperationID: "set-kanban-state", Method: http.MethodPut, Path: pullPath + "/state", DefaultStatus: http.StatusOK, Summary: "Set pull request kanban state", Tags: []string{"Pull Requests"}}, s.setKanbanState)
+	huma.Register(api, huma.Operation{OperationID: "set-kanban-state-on-host", Method: http.MethodPut, Path: hostPullPath + "/state", DefaultStatus: http.StatusOK, Summary: "Set pull request kanban state", Tags: []string{"Pull Requests"}}, s.setKanbanStateOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-content", Method: http.MethodPatch, Path: pullPath, DefaultStatus: http.StatusOK, Summary: "Edit pull request content", Tags: []string{"Pull Requests"}}, s.editPRContent)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-content-on-host", Method: http.MethodPatch, Path: hostPullPath, DefaultStatus: http.StatusOK, Summary: "Edit pull request content", Tags: []string{"Pull Requests"}}, s.editPRContentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "post-pr-comment", Method: http.MethodPost, Path: pullPath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post pull request comment", Tags: []string{"Pull Requests"}}, s.postComment)
+	huma.Register(api, huma.Operation{OperationID: "post-pr-comment-on-host", Method: http.MethodPost, Path: hostPullPath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post pull request comment", Tags: []string{"Pull Requests"}}, s.postCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment", Method: http.MethodPatch, Path: pullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit pull request comment", Tags: []string{"Pull Requests"}}, s.editComment)
+	huma.Register(api, huma.Operation{OperationID: "edit-pr-comment-on-host", Method: http.MethodPatch, Path: hostPullPath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit pull request comment", Tags: []string{"Pull Requests"}}, s.editCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-labels", Method: http.MethodPut, Path: pullPath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set pull request labels", Tags: []string{"Pull Requests"}}, s.setPullLabels)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-labels-on-host", Method: http.MethodPut, Path: hostPullPath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set pull request labels", Tags: []string{"Pull Requests"}}, s.setPullLabelsOnHost)
 
-	huma.Register(api, huma.Operation{OperationID: "create-issue", Method: http.MethodPost, Path: issueRepoPath, DefaultStatus: http.StatusCreated}, s.createIssue)
-	huma.Register(api, huma.Operation{OperationID: "create-issue-on-host", Method: http.MethodPost, Path: hostIssueRepoPath, DefaultStatus: http.StatusCreated}, s.createIssueOnHost)
-	huma.Get(api, issuePath, s.getIssue)
-	huma.Get(api, hostIssuePath, s.getIssueOnHost)
-	huma.Register(api, huma.Operation{OperationID: "post-issue-comment", Method: http.MethodPost, Path: issuePath + "/comments", DefaultStatus: http.StatusCreated}, s.postIssueComment)
-	huma.Register(api, huma.Operation{OperationID: "post-issue-comment-on-host", Method: http.MethodPost, Path: hostIssuePath + "/comments", DefaultStatus: http.StatusCreated}, s.postIssueCommentOnHost)
-	huma.Register(api, huma.Operation{OperationID: "edit-issue-content", Method: http.MethodPatch, Path: issuePath, DefaultStatus: http.StatusOK}, s.editIssueContent)
-	huma.Register(api, huma.Operation{OperationID: "edit-issue-content-on-host", Method: http.MethodPatch, Path: hostIssuePath, DefaultStatus: http.StatusOK}, s.editIssueContentOnHost)
-	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment", Method: http.MethodPatch, Path: issuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editIssueComment)
-	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment-on-host", Method: http.MethodPatch, Path: hostIssuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK}, s.editIssueCommentOnHost)
-	huma.Register(api, huma.Operation{OperationID: "set-issue-labels", Method: http.MethodPut, Path: issuePath + "/labels", DefaultStatus: http.StatusOK}, s.setIssueLabels)
-	huma.Register(api, huma.Operation{OperationID: "set-issue-labels-on-host", Method: http.MethodPut, Path: hostIssuePath + "/labels", DefaultStatus: http.StatusOK}, s.setIssueLabelsOnHost)
+	huma.Register(api, huma.Operation{OperationID: "create-issue", Method: http.MethodPost, Path: issueRepoPath, DefaultStatus: http.StatusCreated, Summary: "Create issue", Tags: []string{"Issues"}}, s.createIssue)
+	huma.Register(api, huma.Operation{OperationID: "create-issue-on-host", Method: http.MethodPost, Path: hostIssueRepoPath, DefaultStatus: http.StatusCreated, Summary: "Create issue", Tags: []string{"Issues"}}, s.createIssueOnHost)
+	huma.Get(api, issuePath, s.getIssue,
+		documentOperation("get-issue", "Get issue", "Issues"))
+	huma.Get(api, hostIssuePath, s.getIssueOnHost,
+		documentOperation("get-issue-on-host", "Get issue", "Issues"))
+	huma.Register(api, huma.Operation{OperationID: "post-issue-comment", Method: http.MethodPost, Path: issuePath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post issue comment", Tags: []string{"Issues"}}, s.postIssueComment)
+	huma.Register(api, huma.Operation{OperationID: "post-issue-comment-on-host", Method: http.MethodPost, Path: hostIssuePath + "/comments", DefaultStatus: http.StatusCreated, Summary: "Post issue comment", Tags: []string{"Issues"}}, s.postIssueCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content", Method: http.MethodPatch, Path: issuePath, DefaultStatus: http.StatusOK, Summary: "Edit issue content", Tags: []string{"Issues"}}, s.editIssueContent)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-content-on-host", Method: http.MethodPatch, Path: hostIssuePath, DefaultStatus: http.StatusOK, Summary: "Edit issue content", Tags: []string{"Issues"}}, s.editIssueContentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment", Method: http.MethodPatch, Path: issuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit issue comment", Tags: []string{"Issues"}}, s.editIssueComment)
+	huma.Register(api, huma.Operation{OperationID: "edit-issue-comment-on-host", Method: http.MethodPatch, Path: hostIssuePath + "/comments/{comment_id}", DefaultStatus: http.StatusOK, Summary: "Edit issue comment", Tags: []string{"Issues"}}, s.editIssueCommentOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-labels", Method: http.MethodPut, Path: issuePath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set issue labels", Tags: []string{"Issues"}}, s.setIssueLabels)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-labels-on-host", Method: http.MethodPut, Path: hostIssuePath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set issue labels", Tags: []string{"Issues"}}, s.setIssueLabelsOnHost)
 
-	huma.Post(api, repoPath+"/resolve/{number}", s.resolveItem)
-	huma.Post(api, hostRepoPath+"/resolve/{number}", s.resolveItemOnHost)
-	huma.Get(api, repoPath, s.getRepo)
-	huma.Get(api, hostRepoPath, s.getRepoOnHost)
-	huma.Register(api, huma.Operation{OperationID: "list-repo-labels", Method: http.MethodGet, Path: repoPath + "/labels", DefaultStatus: http.StatusOK}, s.listRepoLabels)
-	huma.Register(api, huma.Operation{OperationID: "list-repo-labels-on-host", Method: http.MethodGet, Path: hostRepoPath + "/labels", DefaultStatus: http.StatusOK}, s.listRepoLabelsOnHost)
-	huma.Get(api, repoPath+"/comment-autocomplete", s.getCommentAutocomplete)
-	huma.Get(api, hostRepoPath+"/comment-autocomplete", s.getCommentAutocompleteOnHost)
+	huma.Post(api, repoPath+"/resolve/{number}", s.resolveItem,
+		documentOperation("resolve-item", "Resolve repository item", "Repositories"))
+	huma.Post(api, hostRepoPath+"/resolve/{number}", s.resolveItemOnHost,
+		documentOperation("resolve-item-on-host", "Resolve repository item", "Repositories"))
+	huma.Get(api, repoPath, s.getRepo,
+		documentOperation("get-repo", "Get repository", "Repositories"))
+	huma.Get(api, hostRepoPath, s.getRepoOnHost,
+		documentOperation("get-repo-on-host", "Get repository", "Repositories"))
+	huma.Register(api, huma.Operation{OperationID: "list-repo-labels", Method: http.MethodGet, Path: repoPath + "/labels", DefaultStatus: http.StatusOK, Summary: "List repository labels", Tags: []string{"Repositories"}}, s.listRepoLabels)
+	huma.Register(api, huma.Operation{OperationID: "list-repo-labels-on-host", Method: http.MethodGet, Path: hostRepoPath + "/labels", DefaultStatus: http.StatusOK, Summary: "List repository labels", Tags: []string{"Repositories"}}, s.listRepoLabelsOnHost)
+	huma.Get(api, repoPath+"/comment-autocomplete", s.getCommentAutocomplete,
+		documentOperation("get-comment-autocomplete", "Get comment autocomplete", "Repositories"))
+	huma.Get(api, hostRepoPath+"/comment-autocomplete", s.getCommentAutocompleteOnHost,
+		documentOperation("get-comment-autocomplete-on-host", "Get comment autocomplete", "Repositories"))
 
-	huma.Post(api, pullPath+"/approve", s.approvePR)
-	huma.Post(api, hostPullPath+"/approve", s.approvePROnHost)
-	huma.Post(api, pullPath+"/approve-workflows", s.approveWorkflows)
-	huma.Post(api, hostPullPath+"/approve-workflows", s.approveWorkflowsOnHost)
-	huma.Post(api, pullPath+"/ready-for-review", s.readyForReview)
-	huma.Post(api, hostPullPath+"/ready-for-review", s.readyForReviewOnHost)
-	huma.Post(api, pullPath+"/merge", s.mergePR)
-	huma.Post(api, hostPullPath+"/merge", s.mergePROnHost)
-	huma.Post(api, pullPath+"/sync", s.syncPR)
-	huma.Post(api, hostPullPath+"/sync", s.syncPROnHost)
-	huma.Post(api, pullPath+"/ci-refresh", s.syncPRCI)
-	huma.Post(api, hostPullPath+"/ci-refresh", s.syncPRCIOnHost)
-	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync", Method: http.MethodPost, Path: pullPath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueuePRSync)
-	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync-on-host", Method: http.MethodPost, Path: hostPullPath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueuePRSyncOnHost)
-	huma.Post(api, issuePath+"/sync", s.syncIssue)
-	huma.Post(api, hostIssuePath+"/sync", s.syncIssueOnHost)
-	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync", Method: http.MethodPost, Path: issuePath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueueIssueSync)
-	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync-on-host", Method: http.MethodPost, Path: hostIssuePath + "/sync/async", DefaultStatus: http.StatusAccepted}, s.enqueueIssueSyncOnHost)
-	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state", Method: http.MethodPost, Path: pullPath + "/github-state", DefaultStatus: http.StatusOK}, s.setPRGitHubState)
-	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state-on-host", Method: http.MethodPost, Path: hostPullPath + "/github-state", DefaultStatus: http.StatusOK}, s.setPRGitHubStateOnHost)
-	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state", Method: http.MethodPost, Path: issuePath + "/github-state", DefaultStatus: http.StatusOK}, s.setIssueGitHubState)
-	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state-on-host", Method: http.MethodPost, Path: hostIssuePath + "/github-state", DefaultStatus: http.StatusOK}, s.setIssueGitHubStateOnHost)
+	huma.Post(api, pullPath+"/approve", s.approvePR,
+		documentOperation("approve-pull", "Approve pull request", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/approve", s.approvePROnHost,
+		documentOperation("approve-pull-on-host", "Approve pull request", "Pull Requests"))
+	huma.Post(api, pullPath+"/approve-workflows", s.approveWorkflows,
+		documentOperation("approve-pull-workflows", "Approve pull request workflows", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/approve-workflows", s.approveWorkflowsOnHost,
+		documentOperation("approve-pull-workflows-on-host", "Approve pull request workflows", "Pull Requests"))
+	huma.Post(api, pullPath+"/ready-for-review", s.readyForReview,
+		documentOperation("mark-pull-ready-for-review", "Mark pull request ready for review", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/ready-for-review", s.readyForReviewOnHost,
+		documentOperation("mark-pull-ready-for-review-on-host", "Mark pull request ready for review", "Pull Requests"))
+	huma.Post(api, pullPath+"/merge", s.mergePR,
+		documentOperation("merge-pull", "Merge pull request", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/merge", s.mergePROnHost,
+		documentOperation("merge-pull-on-host", "Merge pull request", "Pull Requests"))
+	huma.Post(api, pullPath+"/sync", s.syncPR,
+		documentOperation("sync-pull", "Sync pull request", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/sync", s.syncPROnHost,
+		documentOperation("sync-pull-on-host", "Sync pull request", "Pull Requests"))
+	huma.Post(api, pullPath+"/ci-refresh", s.syncPRCI,
+		documentOperation("refresh-pull-ci", "Refresh pull request CI", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/ci-refresh", s.syncPRCIOnHost,
+		documentOperation("refresh-pull-ci-on-host", "Refresh pull request CI", "Pull Requests"))
+	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync", Method: http.MethodPost, Path: pullPath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue pull request sync", Tags: []string{"Pull Requests"}}, s.enqueuePRSync)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-pr-sync-on-host", Method: http.MethodPost, Path: hostPullPath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue pull request sync", Tags: []string{"Pull Requests"}}, s.enqueuePRSyncOnHost)
+	huma.Post(api, issuePath+"/sync", s.syncIssue,
+		documentOperation("sync-issue", "Sync issue", "Issues"))
+	huma.Post(api, hostIssuePath+"/sync", s.syncIssueOnHost,
+		documentOperation("sync-issue-on-host", "Sync issue", "Issues"))
+	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync", Method: http.MethodPost, Path: issuePath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue issue sync", Tags: []string{"Issues"}}, s.enqueueIssueSync)
+	huma.Register(api, huma.Operation{OperationID: "enqueue-issue-sync-on-host", Method: http.MethodPost, Path: hostIssuePath + "/sync/async", DefaultStatus: http.StatusAccepted, Summary: "Enqueue issue sync", Tags: []string{"Issues"}}, s.enqueueIssueSyncOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state", Method: http.MethodPost, Path: pullPath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set pull request GitHub state", Tags: []string{"Pull Requests"}}, s.setPRGitHubState)
+	huma.Register(api, huma.Operation{OperationID: "set-pr-github-state-on-host", Method: http.MethodPost, Path: hostPullPath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set pull request GitHub state", Tags: []string{"Pull Requests"}}, s.setPRGitHubStateOnHost)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state", Method: http.MethodPost, Path: issuePath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set issue GitHub state", Tags: []string{"Issues"}}, s.setIssueGitHubState)
+	huma.Register(api, huma.Operation{OperationID: "set-issue-github-state-on-host", Method: http.MethodPost, Path: hostIssuePath + "/github-state", DefaultStatus: http.StatusOK, Summary: "Set issue GitHub state", Tags: []string{"Issues"}}, s.setIssueGitHubStateOnHost)
 
-	huma.Get(api, pullPath+"/commits", s.getCommits)
-	huma.Get(api, hostPullPath+"/commits", s.getCommitsOnHost)
-	huma.Get(api, pullPath+"/diff", s.getDiff)
-	huma.Get(api, hostPullPath+"/diff", s.getDiffOnHost)
-	huma.Get(api, pullPath+"/files", s.getFiles)
-	huma.Get(api, hostPullPath+"/files", s.getFilesOnHost)
-	huma.Get(api, pullPath+"/file-preview", s.getFilePreview)
-	huma.Get(api, hostPullPath+"/file-preview", s.getFilePreviewOnHost)
-	huma.Get(api, pullPath+"/stack", s.getStackForPR)
-	huma.Get(api, hostPullPath+"/stack", s.getStackForPROnHost)
-	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace", Method: http.MethodPost, Path: issuePath + "/workspace", DefaultStatus: http.StatusAccepted}, s.createIssueWorkspace)
-	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace-on-host", Method: http.MethodPost, Path: hostIssuePath + "/workspace", DefaultStatus: http.StatusAccepted}, s.createIssueWorkspaceOnHost)
+	huma.Get(api, pullPath+"/commits", s.getCommits,
+		documentOperation("get-pull-commits", "Get pull request commits", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/commits", s.getCommitsOnHost,
+		documentOperation("get-pull-commits-on-host", "Get pull request commits", "Pull Requests"))
+	huma.Get(api, pullPath+"/diff", s.getDiff,
+		documentOperation("get-pull-diff", "Get pull request diff", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/diff", s.getDiffOnHost,
+		documentOperation("get-pull-diff-on-host", "Get pull request diff", "Pull Requests"))
+	huma.Get(api, pullPath+"/files", s.getFiles,
+		documentOperation("get-pull-files", "Get pull request files", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/files", s.getFilesOnHost,
+		documentOperation("get-pull-files-on-host", "Get pull request files", "Pull Requests"))
+	huma.Get(api, pullPath+"/file-preview", s.getFilePreview,
+		documentOperation("get-pull-file-preview", "Get pull request file preview", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/file-preview", s.getFilePreviewOnHost,
+		documentOperation("get-pull-file-preview-on-host", "Get pull request file preview", "Pull Requests"))
+	huma.Get(api, pullPath+"/stack", s.getStackForPR,
+		documentOperation("get-pull-stack", "Get pull request stack", "Pull Requests"))
+	huma.Get(api, hostPullPath+"/stack", s.getStackForPROnHost,
+		documentOperation("get-pull-stack-on-host", "Get pull request stack", "Pull Requests"))
+	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace", Method: http.MethodPost, Path: issuePath + "/workspace", DefaultStatus: http.StatusAccepted, Summary: "Create issue workspace", Tags: []string{"Issues"}}, s.createIssueWorkspace)
+	huma.Register(api, huma.Operation{OperationID: "create-issue-workspace-on-host", Method: http.MethodPost, Path: hostIssuePath + "/workspace", DefaultStatus: http.StatusAccepted, Summary: "Create issue workspace", Tags: []string{"Issues"}}, s.createIssueWorkspaceOnHost)
 }
 
 func NewOpenAPI() *huma.OpenAPI {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -692,9 +692,9 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 	huma.Register(api, huma.Operation{OperationID: "set-issue-labels-on-host", Method: http.MethodPut, Path: hostIssuePath + "/labels", DefaultStatus: http.StatusOK, Summary: "Set issue labels", Tags: []string{"Issues"}}, s.setIssueLabelsOnHost)
 
 	huma.Post(api, repoPath+"/resolve/{number}", s.resolveItem,
-		documentOperation("resolve-item", "Resolve repository item", "Repositories"))
+		documentOperation("resolve-repo-item", "Resolve repository item", "Repositories"))
 	huma.Post(api, hostRepoPath+"/resolve/{number}", s.resolveItemOnHost,
-		documentOperation("resolve-item-on-host", "Resolve repository item", "Repositories"))
+		documentOperation("resolve-repo-item-on-host", "Resolve repository item", "Repositories"))
 	huma.Get(api, repoPath, s.getRepo,
 		documentOperation("get-repo", "Get repository", "Repositories"))
 	huma.Get(api, hostRepoPath, s.getRepoOnHost,

--- a/internal/server/route_metadata_test.go
+++ b/internal/server/route_metadata_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// collectMetadataFailures walks an OpenAPI document and returns one entry per
+// missing metadata field on every non-nil operation. The returned slice is
+// sorted so failure output is stable across test runs.
+//
+// The walker checks each operation for a non-empty Summary, a non-empty
+// OperationID, at least one non-empty Tag, and a globally-unique OperationID.
+// It deliberately does not consult huma's internal _convenience_summary and
+// _convenience_id markers: those markers fire when an explicit value happens
+// to match what huma would auto-generate ("List issues" for GET /issues), so
+// they are not a reliable signal of "this was never set on purpose". The
+// non-empty Tag check carries that load instead, because huma never sets a
+// default tag list.
+func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
+	var failures []string
+	seen := map[string]string{}
+
+	paths := make([]string, 0, len(openAPI.Paths))
+	for p := range openAPI.Paths {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		item := openAPI.Paths[path]
+		if item == nil {
+			continue
+		}
+		for _, opRef := range []struct {
+			method string
+			op     *huma.Operation
+		}{
+			{http.MethodGet, item.Get},
+			{http.MethodPut, item.Put},
+			{http.MethodPost, item.Post},
+			{http.MethodDelete, item.Delete},
+			{http.MethodOptions, item.Options},
+			{http.MethodHead, item.Head},
+			{http.MethodPatch, item.Patch},
+			{http.MethodTrace, item.Trace},
+		} {
+			op := opRef.op
+			if op == nil {
+				continue
+			}
+			label := fmt.Sprintf("%s %s", opRef.method, path)
+
+			if strings.TrimSpace(op.Summary) == "" {
+				failures = append(failures, label+": missing Summary")
+			}
+			if strings.TrimSpace(op.OperationID) == "" {
+				failures = append(failures, label+": missing OperationID")
+			}
+			if len(op.Tags) < 1 {
+				failures = append(failures, label+": missing Tags")
+			} else {
+				for _, tag := range op.Tags {
+					if strings.TrimSpace(tag) == "" {
+						failures = append(failures, label+": empty Tag")
+					}
+				}
+			}
+			if op.OperationID != "" {
+				if prior, ok := seen[op.OperationID]; ok {
+					failures = append(failures,
+						label+": duplicate OperationID with "+prior)
+				} else {
+					seen[op.OperationID] = label
+				}
+			}
+		}
+	}
+	return failures
+}
+
+// TestHumaContractMetadata asserts that every non-Hidden operation in the
+// live OpenAPI document carries an explicit Summary, at least one Tag, and a
+// unique non-empty OperationID.
+func TestHumaContractMetadata(t *testing.T) {
+	require := require.New(t)
+	openAPI := NewOpenAPI()
+	require.NotNil(openAPI)
+	require.NotEmpty(openAPI.Paths, "OpenAPI document should expose paths")
+
+	failures := collectMetadataFailures(openAPI)
+	assert.Empty(t, failures, strings.Join(failures, "\n"))
+}
+
+// TestRouteMetadataWalkerCatchesUnannotatedRoute is a teeth-test: it builds
+// a tiny in-process huma.API with one convenience-helper route that has no
+// metadata callback, runs collectMetadataFailures, and asserts the walker
+// reports at least one failure. Catches the case where collectMetadataFailures
+// regresses into a no-op (for example by losing the Tags check) and keeps the
+// contract test honest if huma changes how its convenience helpers fill in
+// default Summary and OperationID values.
+func TestRouteMetadataWalkerCatchesUnannotatedRoute(t *testing.T) {
+	require := require.New(t)
+
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("test", "0.0.0"))
+
+	type emptyInput struct{}
+	type emptyOutput struct{}
+	huma.Get(api, "/unannotated", func(
+		_ context.Context, _ *emptyInput,
+	) (*emptyOutput, error) {
+		return &emptyOutput{}, nil
+	})
+
+	failures := collectMetadataFailures(api.OpenAPI())
+	require.NotEmpty(failures,
+		"walker must flag unannotated routes; got no failures")
+}

--- a/internal/server/route_metadata_test.go
+++ b/internal/server/route_metadata_test.go
@@ -3,7 +3,12 @@ package server
 import (
 	"context"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -14,18 +19,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var allowedAPITags = map[string]struct{}{
+	"Activity":      {},
+	"Issues":        {},
+	"Projects":      {},
+	"Pull Requests": {},
+	"Repositories":  {},
+	"Roborev":       {},
+	"Settings":      {},
+	"Stacks":        {},
+	"Sync":          {},
+	"System":        {},
+	"Workspaces":    {},
+}
+
 // collectMetadataFailures walks an OpenAPI document and returns one entry per
 // missing metadata field on every non-nil operation. The returned slice is
 // sorted so failure output is stable across test runs.
 //
 // The walker checks each operation for a non-empty Summary, a non-empty
-// OperationID, at least one non-empty Tag, and a globally-unique OperationID.
+// OperationID, exactly one non-empty Tag from the API tag taxonomy, and a
+// globally-unique OperationID.
 // It deliberately does not consult huma's internal _convenience_summary and
 // _convenience_id markers: those markers fire when an explicit value happens
 // to match what huma would auto-generate ("List issues" for GET /issues), so
 // they are not a reliable signal of "this was never set on purpose". The
-// non-empty Tag check carries that load instead, because huma never sets a
-// default tag list.
+// source-level convenience-route test enforces the registration pattern that
+// the live OpenAPI document cannot distinguish by value alone.
 func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
 	var failures []string
 	seen := map[string]string{}
@@ -75,6 +95,10 @@ func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
 					}
 				}
 			}
+			if len(op.Tags) > 0 && !usesKnownSingleTag(op.Tags) {
+				failures = append(failures,
+					label+": expected exactly one tag from the API tag taxonomy")
+			}
 			if op.OperationID != "" {
 				if prior, ok := seen[op.OperationID]; ok {
 					failures = append(failures,
@@ -88,9 +112,68 @@ func collectMetadataFailures(openAPI *huma.OpenAPI) []string {
 	return failures
 }
 
+func usesKnownSingleTag(tags []string) bool {
+	if len(tags) != 1 {
+		return false
+	}
+	_, ok := allowedAPITags[strings.TrimSpace(tags[0])]
+	return ok
+}
+
+func collectConvenienceRouteMetadataFailures(path string, source []byte) []string {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, 0)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: parse: %v", path, err)}
+	}
+
+	var failures []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !isHumaConvenienceMethod(selector.Sel.Name) {
+			return true
+		}
+		pkg, ok := selector.X.(*ast.Ident)
+		if !ok || pkg.Name != "huma" {
+			return true
+		}
+		for _, arg := range call.Args {
+			argCall, ok := arg.(*ast.CallExpr)
+			if !ok {
+				continue
+			}
+			ident, ok := argCall.Fun.(*ast.Ident)
+			if ok && ident.Name == "documentOperation" {
+				return true
+			}
+		}
+		pos := fset.Position(call.Pos())
+		failures = append(failures, fmt.Sprintf(
+			"%s:%d: huma.%s must use documentOperation for OpenAPI metadata",
+			path, pos.Line, selector.Sel.Name,
+		))
+		return true
+	})
+	sort.Strings(failures)
+	return failures
+}
+
+func isHumaConvenienceMethod(name string) bool {
+	switch name {
+	case "Get", "Post", "Put", "Patch", "Delete", "Head", "Options":
+		return true
+	default:
+		return false
+	}
+}
+
 // TestHumaContractMetadata asserts that every non-Hidden operation in the
-// live OpenAPI document carries an explicit Summary, at least one Tag, and a
-// unique non-empty OperationID.
+// live OpenAPI document carries an explicit Summary, exactly one known Tag,
+// and a unique non-empty OperationID.
 func TestHumaContractMetadata(t *testing.T) {
 	require := require.New(t)
 	openAPI := NewOpenAPI()
@@ -98,6 +181,25 @@ func TestHumaContractMetadata(t *testing.T) {
 	require.NotEmpty(openAPI.Paths, "OpenAPI document should expose paths")
 
 	failures := collectMetadataFailures(openAPI)
+	assert.Empty(t, failures, strings.Join(failures, "\n"))
+}
+
+func TestHumaConvenienceRoutesUseDocumentOperation(t *testing.T) {
+	require := require.New(t)
+
+	paths, err := filepath.Glob("*.go")
+	require.NoError(err)
+
+	var failures []string
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") || path == "health_routes.go" {
+			continue
+		}
+		source, err := os.ReadFile(path)
+		require.NoError(err)
+		failures = append(failures,
+			collectConvenienceRouteMetadataFailures(path, source)...)
+	}
 	assert.Empty(t, failures, strings.Join(failures, "\n"))
 }
 
@@ -125,4 +227,42 @@ func TestRouteMetadataWalkerCatchesUnannotatedRoute(t *testing.T) {
 	failures := collectMetadataFailures(api.OpenAPI())
 	require.NotEmpty(failures,
 		"walker must flag unannotated routes; got no failures")
+}
+
+func TestRouteMetadataWalkerRejectsUnknownOrMultipleTags(t *testing.T) {
+	require := require.New(t)
+
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("test", "0.0.0"))
+
+	type emptyInput struct{}
+	type emptyOutput struct{}
+	huma.Get(api, "/bad-tag", func(
+		_ context.Context, _ *emptyInput,
+	) (*emptyOutput, error) {
+		return &emptyOutput{}, nil
+	}, func(op *huma.Operation) {
+		op.OperationID = "bad-tag"
+		op.Summary = "Get bad tag"
+		op.Tags = []string{"Pull Requests", "Not A Tag"}
+	})
+
+	failures := collectMetadataFailures(api.OpenAPI())
+	require.Contains(failures,
+		"GET /bad-tag: expected exactly one tag from the API tag taxonomy")
+}
+
+func TestConvenienceRouteMetadataWalkerRejectsTagOnlyCallback(t *testing.T) {
+	require := require.New(t)
+
+	source := []byte(`package server
+func (s *Server) register(api huma.API) {
+	huma.Get(api, "/tag-only", s.handler, func(op *huma.Operation) {
+		op.Tags = []string{"Issues"}
+	})
+}`)
+
+	failures := collectConvenienceRouteMetadataFailures("sample.go", source)
+	require.Contains(failures,
+		"sample.go:3: huma.Get must use documentOperation for OpenAPI metadata")
 }

--- a/internal/server/settings_routes.go
+++ b/internal/server/settings_routes.go
@@ -43,38 +43,52 @@ func (s *Server) registerSettingsAPI(api huma.API) {
 		OperationID: "get-settings",
 		Method:      http.MethodGet,
 		Path:        "/settings",
+		Summary:     "Get settings",
+		Tags:        []string{"Settings"},
 	}, s.getSettings)
 	huma.Register(api, huma.Operation{
 		OperationID: "update-settings",
 		Method:      http.MethodPut,
 		Path:        "/settings",
+		Summary:     "Update settings",
+		Tags:        []string{"Settings"},
 	}, s.updateSettings)
 	huma.Register(api, huma.Operation{
 		OperationID:   "add-repo",
 		Method:        http.MethodPost,
 		Path:          "/repos",
 		DefaultStatus: http.StatusCreated,
+		Summary:       "Add repository",
+		Tags:          []string{"Settings"},
 	}, s.addConfiguredRepo)
 	huma.Register(api, huma.Operation{
 		OperationID: "refresh-repo",
 		Method:      http.MethodPost,
 		Path:        "/repo/{provider}/{owner}/{name}/refresh",
+		Summary:     "Refresh repository",
+		Tags:        []string{"Settings"},
 	}, s.refreshConfiguredRepo)
 	huma.Register(api, huma.Operation{
 		OperationID: "refresh-repo-on-host",
 		Method:      http.MethodPost,
 		Path:        "/host/{platform_host}/repo/{provider}/{owner}/{name}/refresh",
+		Summary:     "Refresh repository",
+		Tags:        []string{"Settings"},
 	}, s.refreshConfiguredRepoOnHost)
 	huma.Register(api, huma.Operation{
 		OperationID:   "delete-repo",
 		Method:        http.MethodDelete,
 		Path:          "/repo/{provider}/{owner}/{name}",
 		DefaultStatus: http.StatusNoContent,
+		Summary:       "Delete repository",
+		Tags:          []string{"Settings"},
 	}, s.deleteConfiguredRepo)
 	huma.Register(api, huma.Operation{
 		OperationID:   "delete-repo-on-host",
 		Method:        http.MethodDelete,
 		Path:          "/host/{platform_host}/repo/{provider}/{owner}/{name}",
 		DefaultStatus: http.StatusNoContent,
+		Summary:       "Delete repository",
+		Tags:          []string{"Settings"},
 	}, s.deleteConfiguredRepoOnHost)
 }

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -376,7 +376,7 @@ func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 
 	waitForWorkspaceReady(t, ctx, client, wsID)
 
-	getResp, err := client.HTTP.GetWorkspacesById(ctx, wsID)
+	getResp, err := client.HTTP.GetWorkspace(ctx, wsID)
 	require.NoError(err)
 	defer getResp.Body.Close()
 	require.Equal(http.StatusOK, getResp.StatusCode)
@@ -390,7 +390,7 @@ func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 	assert.Equal("⠴ t3code-b5014b03", *got.TmuxPaneTitle)
 	assert.True(got.TmuxWorking)
 
-	listResp, err := client.HTTP.GetWorkspaces(ctx)
+	listResp, err := client.HTTP.ListWorkspaces(ctx)
 	require.NoError(err)
 	defer listResp.Body.Close()
 	require.Equal(http.StatusOK, listResp.StatusCode)
@@ -613,7 +613,7 @@ func TestListWorkspacesFetchesTmuxActivityConcurrently(t *testing.T) {
 		require.NoError(err)
 	}
 
-	resp, err := client.HTTP.GetWorkspaces(ctx)
+	resp, err := client.HTTP.ListWorkspaces(ctx)
 	require.NoError(err)
 	defer resp.Body.Close()
 	require.Equal(http.StatusOK, resp.StatusCode)
@@ -668,7 +668,7 @@ func TestWorkspaceListReturnsUnknownWhenTmuxActivityProbeTimesOut(t *testing.T) 
 
 	requestCtx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	resp, err := client.HTTP.GetWorkspaces(requestCtx)
+	resp, err := client.HTTP.ListWorkspaces(requestCtx)
 	require.NoError(err)
 	defer resp.Body.Close()
 	require.Equal(http.StatusOK, resp.StatusCode)
@@ -754,7 +754,7 @@ func TestConcurrentWorkspaceListsCoalesceTmuxActivityProbe(t *testing.T) {
 	for range 2 {
 		go func() {
 			defer wg.Done()
-			resp, getErr := client.HTTP.GetWorkspaces(ctx)
+			resp, getErr := client.HTTP.ListWorkspaces(ctx)
 			errs <- getErr
 			if resp != nil {
 				resp.Body.Close()
@@ -853,7 +853,7 @@ func TestWorkspaceListTmuxActivityRefreshesEveryReadyWorkspace(t *testing.T) {
 		return time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
 	})
 
-	resp, err := client.HTTP.GetWorkspaces(ctx)
+	resp, err := client.HTTP.ListWorkspaces(ctx)
 	require.NoError(err)
 	defer resp.Body.Close()
 	require.Equal(http.StatusOK, resp.StatusCode)
@@ -942,7 +942,7 @@ func TestWorkspaceListTmuxActivityStressDoesNotLeakProcesses(t *testing.T) {
 	for range 48 {
 		go func() {
 			defer wg.Done()
-			resp, getErr := client.HTTP.GetWorkspaces(ctx)
+			resp, getErr := client.HTTP.ListWorkspaces(ctx)
 			errs <- getErr
 			if resp != nil {
 				resp.Body.Close()
@@ -984,7 +984,7 @@ func getRawWorkspaceActivity(
 	TmuxLastOutputAt   *string `json:"tmux_last_output_at"`
 } {
 	t.Helper()
-	resp, err := client.HTTP.GetWorkspacesById(ctx, wsID)
+	resp, err := client.HTTP.GetWorkspace(ctx, wsID)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -1202,7 +1202,7 @@ func TestWorkspaceShutdownCancellationPersistsFailureViaAPI(t *testing.T) {
 	t.Cleanup(func() { gracefulShutdown(t, restarted) })
 	restartedClient := setupTestClient(t, restarted)
 
-	getResp, err := restartedClient.HTTP.GetWorkspacesByIdWithResponse(
+	getResp, err := restartedClient.HTTP.GetWorkspaceWithResponse(
 		ctx, wsID,
 	)
 	require.NoError(err)
@@ -1287,7 +1287,7 @@ func TestWorkspaceSetupFailureRollbackCleansWorktreeViaAPI(t *testing.T) {
 	var failed *generated.WorkspaceResponse
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			require.NoError(getErr)
@@ -1400,7 +1400,7 @@ func TestWorkspaceRetryWhileCreatingQueuesAndRunsAfterFailureViaAPI(t *testing.T
 	var ready *generated.WorkspaceResponse
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			require.NoError(getErr)
@@ -1587,7 +1587,7 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 	// Poll for status == "ready".
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			if getErr != nil || getResp.JSON200 == nil {
@@ -1709,7 +1709,7 @@ func TestWorkspaceSetupResourceExhaustionGetsHelpfulErrorViaAPI(t *testing.T) {
 	var failed *generated.WorkspaceResponse
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			require.NoError(getErr)
@@ -1778,7 +1778,7 @@ func TestTmuxWrapperKillSession(t *testing.T) {
 	// session is known to exist from the manager's perspective.
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			if getErr != nil || getResp.JSON200 == nil {
@@ -1852,7 +1852,7 @@ func TestDeleteWorkspacePreservesRowWhenTmuxKillFails(t *testing.T) {
 
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			if getErr != nil || getResp.JSON200 == nil {
@@ -1880,7 +1880,7 @@ func TestDeleteWorkspacePreservesRowWhenTmuxKillFails(t *testing.T) {
 		"permission denied",
 	)
 
-	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(ctx, wsID)
+	getResp, err := client.HTTP.GetWorkspaceWithResponse(ctx, wsID)
 	require.NoError(err)
 	require.Equal(http.StatusOK, getResp.StatusCode())
 	require.NotNil(getResp.JSON200)
@@ -1925,7 +1925,7 @@ func TestDeleteWorkspaceTreatsTmuxServerExitAsGoneE2E(t *testing.T) {
 
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				t.Context(), wsID,
 			)
 			if getErr != nil || getResp.JSON200 == nil {
@@ -1943,7 +1943,7 @@ func TestDeleteWorkspaceTreatsTmuxServerExitAsGoneE2E(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, delResp.StatusCode())
 
-	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(t.Context(), wsID)
+	getResp, err := client.HTTP.GetWorkspaceWithResponse(t.Context(), wsID)
 	require.NoError(err)
 	require.Equal(http.StatusNotFound, getResp.StatusCode())
 
@@ -1995,7 +1995,7 @@ func TestDeleteErroredWorkspaceAllowsUnavailableTmux(t *testing.T) {
 
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			if getErr != nil || getResp.JSON200 == nil {
@@ -2013,7 +2013,7 @@ func TestDeleteErroredWorkspaceAllowsUnavailableTmux(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, delResp.StatusCode())
 
-	getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(ctx, wsID)
+	getResp, err := client.HTTP.GetWorkspaceWithResponse(ctx, wsID)
 	require.NoError(err)
 	assert.Equal(http.StatusNotFound, getResp.StatusCode())
 }
@@ -2074,7 +2074,7 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 
 	require.Eventually(
 		func() bool {
-			getResp, getErr := client.HTTP.GetWorkspacesByIdWithResponse(
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
 				ctx, wsID,
 			)
 			if getErr != nil || getResp.JSON200 == nil {

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -244,7 +244,7 @@ func waitForWorkspaceReady(
 	defer ticker.Stop()
 
 	for {
-		getResp, err := client.HTTP.GetWorkspacesByIdWithResponse(waitCtx, wsID)
+		getResp, err := client.HTTP.GetWorkspaceWithResponse(waitCtx, wsID)
 		require.NoError(t, err, "polling workspace readiness: %s", wsID)
 		if getResp.StatusCode() == http.StatusOK &&
 			getResp.JSON200 != nil &&

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -11,8 +11,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get activity */
-        get: operations["get-activity"];
+        /** List activity */
+        get: operations["list-activity"];
         put?: never;
         post?: never;
         delete?: never;
@@ -28,6 +28,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Stream server events */
         get: operations["stream-events"];
         put?: never;
         post?: never;
@@ -46,6 +47,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Create issue */
         post: operations["create-issue-on-host"];
         delete?: never;
         options?: never;
@@ -60,13 +62,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host issues by provider by owner by name by number */
-        get: operations["get-host-by-platform-host-issues-by-provider-by-owner-by-name-by-number"];
+        /** Get issue */
+        get: operations["get-issue-on-host"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit issue content */
         patch: operations["edit-issue-content-on-host"];
         trace?: never;
     };
@@ -79,6 +82,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Post issue comment */
         post: operations["post-issue-comment-on-host"];
         delete?: never;
         options?: never;
@@ -99,6 +103,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit issue comment */
         patch: operations["edit-issue-comment-on-host"];
         trace?: never;
     };
@@ -111,6 +116,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Set issue GitHub state */
         post: operations["set-issue-github-state-on-host"];
         delete?: never;
         options?: never;
@@ -126,6 +132,7 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        /** Set issue labels */
         put: operations["set-issue-labels-on-host"];
         post?: never;
         delete?: never;
@@ -143,8 +150,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host issues by provider by owner by name by number sync */
-        post: operations["post-host-by-platform-host-issues-by-provider-by-owner-by-name-by-number-sync"];
+        /** Sync issue */
+        post: operations["sync-issue-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -160,6 +167,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Enqueue issue sync */
         post: operations["enqueue-issue-sync-on-host"];
         delete?: never;
         options?: never;
@@ -176,6 +184,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Create issue workspace */
         post: operations["create-issue-workspace-on-host"];
         delete?: never;
         options?: never;
@@ -190,13 +199,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host pulls by provider by owner by name by number */
-        get: operations["get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number"];
+        /** Get pull request */
+        get: operations["get-pull-on-host"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit pull request content */
         patch: operations["edit-pr-content-on-host"];
         trace?: never;
     };
@@ -209,8 +219,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host pulls by provider by owner by name by number approve */
-        post: operations["post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-approve"];
+        /** Approve pull request */
+        post: operations["approve-pull-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -226,8 +236,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host pulls by provider by owner by name by number approve workflows */
-        post: operations["post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-approve-workflows"];
+        /** Approve pull request workflows */
+        post: operations["approve-pull-workflows-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -243,8 +253,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host pulls by provider by owner by name by number ci refresh */
-        post: operations["post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ci-refresh"];
+        /** Refresh pull request CI */
+        post: operations["refresh-pull-ci-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -260,6 +270,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Post pull request comment */
         post: operations["post-pr-comment-on-host"];
         delete?: never;
         options?: never;
@@ -280,6 +291,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit pull request comment */
         patch: operations["edit-pr-comment-on-host"];
         trace?: never;
     };
@@ -290,8 +302,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host pulls by provider by owner by name by number commits */
-        get: operations["get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-commits"];
+        /** Get pull request commits */
+        get: operations["get-pull-commits-on-host"];
         put?: never;
         post?: never;
         delete?: never;
@@ -307,8 +319,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host pulls by provider by owner by name by number diff */
-        get: operations["get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-diff"];
+        /** Get pull request diff */
+        get: operations["get-pull-diff-on-host"];
         put?: never;
         post?: never;
         delete?: never;
@@ -324,8 +336,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host pulls by provider by owner by name by number file preview */
-        get: operations["get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-file-preview"];
+        /** Get pull request file preview */
+        get: operations["get-pull-file-preview-on-host"];
         put?: never;
         post?: never;
         delete?: never;
@@ -341,8 +353,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host pulls by provider by owner by name by number files */
-        get: operations["get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-files"];
+        /** Get pull request files */
+        get: operations["get-pull-files-on-host"];
         put?: never;
         post?: never;
         delete?: never;
@@ -360,6 +372,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Set pull request GitHub state */
         post: operations["set-pr-github-state-on-host"];
         delete?: never;
         options?: never;
@@ -374,8 +387,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host pulls by provider by owner by name by number import metadata */
-        get: operations["get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-import-metadata"];
+        /** Get pull request import metadata */
+        get: operations["get-pull-import-metadata-on-host"];
         put?: never;
         post?: never;
         delete?: never;
@@ -392,6 +405,7 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        /** Set pull request labels */
         put: operations["set-pr-labels-on-host"];
         post?: never;
         delete?: never;
@@ -409,8 +423,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host pulls by provider by owner by name by number merge */
-        post: operations["post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-merge"];
+        /** Merge pull request */
+        post: operations["merge-pull-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -426,8 +440,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host pulls by provider by owner by name by number ready for review */
-        post: operations["post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ready-for-review"];
+        /** Mark pull request ready for review */
+        post: operations["mark-pull-ready-for-review-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -441,8 +455,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host pulls by provider by owner by name by number stack */
-        get: operations["get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-stack"];
+        /** Get pull request stack */
+        get: operations["get-pull-stack-on-host"];
         put?: never;
         post?: never;
         delete?: never;
@@ -459,6 +473,7 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        /** Set pull request kanban state */
         put: operations["set-kanban-state-on-host"];
         post?: never;
         delete?: never;
@@ -476,8 +491,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host pulls by provider by owner by name by number sync */
-        post: operations["post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-sync"];
+        /** Sync pull request */
+        post: operations["sync-pull-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -493,6 +508,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Enqueue pull request sync */
         post: operations["enqueue-pr-sync-on-host"];
         delete?: never;
         options?: never;
@@ -507,10 +523,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host repo by provider by owner by name */
-        get: operations["get-host-by-platform-host-repo-by-provider-by-owner-by-name"];
+        /** Get repository */
+        get: operations["get-repo-on-host"];
         put?: never;
         post?: never;
+        /** Delete repository */
         delete: operations["delete-repo-on-host"];
         options?: never;
         head?: never;
@@ -524,8 +541,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get host by platform host repo by provider by owner by name comment autocomplete */
-        get: operations["get-host-by-platform-host-repo-by-provider-by-owner-by-name-comment-autocomplete"];
+        /** Get comment autocomplete */
+        get: operations["get-comment-autocomplete-on-host"];
         put?: never;
         post?: never;
         delete?: never;
@@ -541,6 +558,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** List repository labels */
         get: operations["list-repo-labels-on-host"];
         put?: never;
         post?: never;
@@ -559,6 +577,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Refresh repository */
         post: operations["refresh-repo-on-host"];
         delete?: never;
         options?: never;
@@ -575,8 +594,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post host by platform host repo by provider by owner by name resolve by number */
-        post: operations["post-host-by-platform-host-repo-by-provider-by-owner-by-name-resolve-by-number"];
+        /** Resolve repository item */
+        post: operations["resolve-repo-item-on-host"];
         delete?: never;
         options?: never;
         head?: never;
@@ -609,6 +628,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Create issue */
         post: operations["create-issue"];
         delete?: never;
         options?: never;
@@ -623,13 +643,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get issues by provider by owner by name by number */
-        get: operations["get-issues-by-provider-by-owner-by-name-by-number"];
+        /** Get issue */
+        get: operations["get-issue"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit issue content */
         patch: operations["edit-issue-content"];
         trace?: never;
     };
@@ -642,6 +663,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Post issue comment */
         post: operations["post-issue-comment"];
         delete?: never;
         options?: never;
@@ -662,6 +684,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit issue comment */
         patch: operations["edit-issue-comment"];
         trace?: never;
     };
@@ -674,6 +697,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Set issue GitHub state */
         post: operations["set-issue-github-state"];
         delete?: never;
         options?: never;
@@ -689,6 +713,7 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        /** Set issue labels */
         put: operations["set-issue-labels"];
         post?: never;
         delete?: never;
@@ -706,8 +731,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post issues by provider by owner by name by number sync */
-        post: operations["post-issues-by-provider-by-owner-by-name-by-number-sync"];
+        /** Sync issue */
+        post: operations["sync-issue"];
         delete?: never;
         options?: never;
         head?: never;
@@ -723,6 +748,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Enqueue issue sync */
         post: operations["enqueue-issue-sync"];
         delete?: never;
         options?: never;
@@ -739,6 +765,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Create issue workspace */
         post: operations["create-issue-workspace"];
         delete?: never;
         options?: never;
@@ -753,8 +780,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** List projects */
         get: operations["list-projects"];
         put?: never;
+        /** Register project */
         post: operations["register-project"];
         delete?: never;
         options?: never;
@@ -769,6 +798,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get project */
         get: operations["get-project"];
         put?: never;
         post?: never;
@@ -785,6 +815,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** List launch targets */
         get: operations["list-launch-targets"];
         put?: never;
         post?: never;
@@ -801,8 +832,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** List worktrees */
         get: operations["list-worktrees"];
         put?: never;
+        /** Register worktree */
         post: operations["register-worktree"];
         delete?: never;
         options?: never;
@@ -817,7 +850,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List pulls */
+        /** List pull requests */
         get: operations["list-pulls"];
         put?: never;
         post?: never;
@@ -834,13 +867,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get pulls by provider by owner by name by number */
-        get: operations["get-pulls-by-provider-by-owner-by-name-by-number"];
+        /** Get pull request */
+        get: operations["get-pull"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit pull request content */
         patch: operations["edit-pr-content"];
         trace?: never;
     };
@@ -853,8 +887,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post pulls by provider by owner by name by number approve */
-        post: operations["post-pulls-by-provider-by-owner-by-name-by-number-approve"];
+        /** Approve pull request */
+        post: operations["approve-pull"];
         delete?: never;
         options?: never;
         head?: never;
@@ -870,8 +904,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post pulls by provider by owner by name by number approve workflows */
-        post: operations["post-pulls-by-provider-by-owner-by-name-by-number-approve-workflows"];
+        /** Approve pull request workflows */
+        post: operations["approve-pull-workflows"];
         delete?: never;
         options?: never;
         head?: never;
@@ -887,8 +921,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post pulls by provider by owner by name by number ci refresh */
-        post: operations["post-pulls-by-provider-by-owner-by-name-by-number-ci-refresh"];
+        /** Refresh pull request CI */
+        post: operations["refresh-pull-ci"];
         delete?: never;
         options?: never;
         head?: never;
@@ -904,6 +938,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Post pull request comment */
         post: operations["post-pr-comment"];
         delete?: never;
         options?: never;
@@ -924,6 +959,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
+        /** Edit pull request comment */
         patch: operations["edit-pr-comment"];
         trace?: never;
     };
@@ -934,8 +970,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get pulls by provider by owner by name by number commits */
-        get: operations["get-pulls-by-provider-by-owner-by-name-by-number-commits"];
+        /** Get pull request commits */
+        get: operations["get-pull-commits"];
         put?: never;
         post?: never;
         delete?: never;
@@ -951,8 +987,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get pulls by provider by owner by name by number diff */
-        get: operations["get-pulls-by-provider-by-owner-by-name-by-number-diff"];
+        /** Get pull request diff */
+        get: operations["get-pull-diff"];
         put?: never;
         post?: never;
         delete?: never;
@@ -968,8 +1004,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get pulls by provider by owner by name by number file preview */
-        get: operations["get-pulls-by-provider-by-owner-by-name-by-number-file-preview"];
+        /** Get pull request file preview */
+        get: operations["get-pull-file-preview"];
         put?: never;
         post?: never;
         delete?: never;
@@ -985,8 +1021,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get pulls by provider by owner by name by number files */
-        get: operations["get-pulls-by-provider-by-owner-by-name-by-number-files"];
+        /** Get pull request files */
+        get: operations["get-pull-files"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1004,6 +1040,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Set pull request GitHub state */
         post: operations["set-pr-github-state"];
         delete?: never;
         options?: never;
@@ -1018,8 +1055,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get pulls by provider by owner by name by number import metadata */
-        get: operations["get-pulls-by-provider-by-owner-by-name-by-number-import-metadata"];
+        /** Get pull request import metadata */
+        get: operations["get-pull-import-metadata"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1036,6 +1073,7 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        /** Set pull request labels */
         put: operations["set-pr-labels"];
         post?: never;
         delete?: never;
@@ -1053,8 +1091,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post pulls by provider by owner by name by number merge */
-        post: operations["post-pulls-by-provider-by-owner-by-name-by-number-merge"];
+        /** Merge pull request */
+        post: operations["merge-pull"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1070,8 +1108,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post pulls by provider by owner by name by number ready for review */
-        post: operations["post-pulls-by-provider-by-owner-by-name-by-number-ready-for-review"];
+        /** Mark pull request ready for review */
+        post: operations["mark-pull-ready-for-review"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1085,8 +1123,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get pulls by provider by owner by name by number stack */
-        get: operations["get-pulls-by-provider-by-owner-by-name-by-number-stack"];
+        /** Get pull request stack */
+        get: operations["get-pull-stack"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1103,6 +1141,7 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        /** Set pull request kanban state */
         put: operations["set-kanban-state"];
         post?: never;
         delete?: never;
@@ -1120,8 +1159,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post pulls by provider by owner by name by number sync */
-        post: operations["post-pulls-by-provider-by-owner-by-name-by-number-sync"];
+        /** Sync pull request */
+        post: operations["sync-pull"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1137,6 +1176,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Enqueue pull request sync */
         post: operations["enqueue-pr-sync"];
         delete?: never;
         options?: never;
@@ -1168,10 +1208,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get repo by provider by owner by name */
-        get: operations["get-repo-by-provider-by-owner-by-name"];
+        /** Get repository */
+        get: operations["get-repo"];
         put?: never;
         post?: never;
+        /** Delete repository */
         delete: operations["delete-repo"];
         options?: never;
         head?: never;
@@ -1185,8 +1226,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get repo by provider by owner by name comment autocomplete */
-        get: operations["get-repo-by-provider-by-owner-by-name-comment-autocomplete"];
+        /** Get comment autocomplete */
+        get: operations["get-comment-autocomplete"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1202,6 +1243,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** List repository labels */
         get: operations["list-repo-labels"];
         put?: never;
         post?: never;
@@ -1220,6 +1262,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Refresh repository */
         post: operations["refresh-repo"];
         delete?: never;
         options?: never;
@@ -1236,8 +1279,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Post repo by provider by owner by name resolve by number */
-        post: operations["post-repo-by-provider-by-owner-by-name-resolve-by-number"];
+        /** Resolve repository item */
+        post: operations["resolve-repo-item"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1251,9 +1294,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List repos */
+        /** List repositories */
         get: operations["list-repos"];
         put?: never;
+        /** Add repository */
         post: operations["add-repo"];
         delete?: never;
         options?: never;
@@ -1270,6 +1314,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Bulk add repositories */
         post: operations["bulk-add-repos"];
         delete?: never;
         options?: never;
@@ -1286,6 +1331,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Preview repositories */
         post: operations["preview-repos"];
         delete?: never;
         options?: never;
@@ -1300,6 +1346,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** List repository summaries */
         get: operations["list-repo-summaries"];
         put?: never;
         post?: never;
@@ -1316,6 +1363,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get roborev status */
         get: operations["get-roborev-status"];
         put?: never;
         post?: never;
@@ -1332,7 +1380,9 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get settings */
         get: operations["get-settings"];
+        /** Update settings */
         put: operations["update-settings"];
         post?: never;
         delete?: never;
@@ -1366,8 +1416,10 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
+        /** Star repository */
         put: operations["set-starred"];
         post?: never;
+        /** Unstar repository */
         delete: operations["unset-starred"];
         options?: never;
         head?: never;
@@ -1383,6 +1435,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Trigger sync */
         post: operations["trigger-sync"];
         delete?: never;
         options?: never;
@@ -1414,6 +1467,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get server version */
         get: operations["get-version"];
         put?: never;
         post?: never;
@@ -1430,9 +1484,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get workspaces */
-        get: operations["get-workspaces"];
+        /** List workspaces */
+        get: operations["list-workspaces"];
         put?: never;
+        /** Create workspace */
         post: operations["create-workspace"];
         delete?: never;
         options?: never;
@@ -1447,10 +1502,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get workspaces by ID */
-        get: operations["get-workspaces-by-id"];
+        /** Get workspace */
+        get: operations["get-workspace"];
         put?: never;
         post?: never;
+        /** Delete workspace */
         delete: operations["delete-workspace"];
         options?: never;
         head?: never;
@@ -1464,8 +1520,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get workspaces by ID commits */
-        get: operations["get-workspaces-by-id-commits"];
+        /** Get workspace commits */
+        get: operations["get-workspace-commits"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1481,8 +1537,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get workspaces by ID diff */
-        get: operations["get-workspaces-by-id-diff"];
+        /** Get workspace diff */
+        get: operations["get-workspace-diff"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1498,8 +1554,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get workspaces by ID files */
-        get: operations["get-workspaces-by-id-files"];
+        /** Get workspace files */
+        get: operations["get-workspace-files"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1517,6 +1573,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Retry workspace */
         post: operations["retry-workspace"];
         delete?: never;
         options?: never;
@@ -1531,6 +1588,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** Get workspace runtime */
         get: operations["get-workspace-runtime"];
         put?: never;
         post?: never;
@@ -1549,6 +1607,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Launch workspace runtime session */
         post: operations["launch-workspace-runtime-session"];
         delete?: never;
         options?: never;
@@ -1566,6 +1625,7 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
+        /** Stop workspace runtime session */
         delete: operations["stop-workspace-runtime-session"];
         options?: never;
         head?: never;
@@ -1581,6 +1641,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** Ensure workspace runtime shell */
         post: operations["ensure-workspace-runtime-shell"];
         delete?: never;
         options?: never;
@@ -2954,7 +3015,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    "get-activity": {
+    "list-activity": {
         parameters: {
             query?: {
                 repo?: string;
@@ -3056,7 +3117,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-issues-by-provider-by-owner-by-name-by-number": {
+    "get-issue-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3287,7 +3348,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-issues-by-provider-by-owner-by-name-by-number-sync": {
+    "sync-issue-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3394,7 +3455,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number": {
+    "get-pull-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3468,7 +3529,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-approve": {
+    "approve-pull-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3507,7 +3568,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-approve-workflows": {
+    "approve-pull-workflows-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3542,7 +3603,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ci-refresh": {
+    "refresh-pull-ci-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3656,7 +3717,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-commits": {
+    "get-pull-commits-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3691,7 +3752,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-diff": {
+    "get-pull-diff-on-host": {
         parameters: {
             query?: {
                 whitespace?: string;
@@ -3734,7 +3795,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-file-preview": {
+    "get-pull-file-preview-on-host": {
         parameters: {
             query?: {
                 /** @description Changed file path to preview */
@@ -3778,7 +3839,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-files": {
+    "get-pull-files-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3852,7 +3913,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-import-metadata": {
+    "get-pull-import-metadata-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3926,7 +3987,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-merge": {
+    "merge-pull-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -3965,7 +4026,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-ready-for-review": {
+    "mark-pull-ready-for-review-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -4000,7 +4061,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-stack": {
+    "get-pull-stack-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -4072,7 +4133,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-pulls-by-provider-by-owner-by-name-by-number-sync": {
+    "sync-pull-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -4140,7 +4201,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-repo-by-provider-by-owner-by-name": {
+    "get-repo-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -4206,7 +4267,7 @@ export interface operations {
             };
         };
     };
-    "get-host-by-platform-host-repo-by-provider-by-owner-by-name-comment-autocomplete": {
+    "get-comment-autocomplete-on-host": {
         parameters: {
             query?: {
                 trigger?: string;
@@ -4312,7 +4373,7 @@ export interface operations {
             };
         };
     };
-    "post-host-by-platform-host-repo-by-provider-by-owner-by-name-resolve-by-number": {
+    "resolve-repo-item-on-host": {
         parameters: {
             query?: never;
             header?: never;
@@ -4420,7 +4481,7 @@ export interface operations {
             };
         };
     };
-    "get-issues-by-provider-by-owner-by-name-by-number": {
+    "get-issue": {
         parameters: {
             query?: never;
             header?: never;
@@ -4645,7 +4706,7 @@ export interface operations {
             };
         };
     };
-    "post-issues-by-provider-by-owner-by-name-by-number-sync": {
+    "sync-issue": {
         parameters: {
             query?: never;
             header?: never;
@@ -4976,7 +5037,7 @@ export interface operations {
             };
         };
     };
-    "get-pulls-by-provider-by-owner-by-name-by-number": {
+    "get-pull": {
         parameters: {
             query?: never;
             header?: never;
@@ -5048,7 +5109,7 @@ export interface operations {
             };
         };
     };
-    "post-pulls-by-provider-by-owner-by-name-by-number-approve": {
+    "approve-pull": {
         parameters: {
             query?: never;
             header?: never;
@@ -5086,7 +5147,7 @@ export interface operations {
             };
         };
     };
-    "post-pulls-by-provider-by-owner-by-name-by-number-approve-workflows": {
+    "approve-pull-workflows": {
         parameters: {
             query?: never;
             header?: never;
@@ -5120,7 +5181,7 @@ export interface operations {
             };
         };
     };
-    "post-pulls-by-provider-by-owner-by-name-by-number-ci-refresh": {
+    "refresh-pull-ci": {
         parameters: {
             query?: never;
             header?: never;
@@ -5231,7 +5292,7 @@ export interface operations {
             };
         };
     };
-    "get-pulls-by-provider-by-owner-by-name-by-number-commits": {
+    "get-pull-commits": {
         parameters: {
             query?: never;
             header?: never;
@@ -5265,7 +5326,7 @@ export interface operations {
             };
         };
     };
-    "get-pulls-by-provider-by-owner-by-name-by-number-diff": {
+    "get-pull-diff": {
         parameters: {
             query?: {
                 whitespace?: string;
@@ -5307,7 +5368,7 @@ export interface operations {
             };
         };
     };
-    "get-pulls-by-provider-by-owner-by-name-by-number-file-preview": {
+    "get-pull-file-preview": {
         parameters: {
             query?: {
                 /** @description Changed file path to preview */
@@ -5350,7 +5411,7 @@ export interface operations {
             };
         };
     };
-    "get-pulls-by-provider-by-owner-by-name-by-number-files": {
+    "get-pull-files": {
         parameters: {
             query?: never;
             header?: never;
@@ -5422,7 +5483,7 @@ export interface operations {
             };
         };
     };
-    "get-pulls-by-provider-by-owner-by-name-by-number-import-metadata": {
+    "get-pull-import-metadata": {
         parameters: {
             query?: never;
             header?: never;
@@ -5494,7 +5555,7 @@ export interface operations {
             };
         };
     };
-    "post-pulls-by-provider-by-owner-by-name-by-number-merge": {
+    "merge-pull": {
         parameters: {
             query?: never;
             header?: never;
@@ -5532,7 +5593,7 @@ export interface operations {
             };
         };
     };
-    "post-pulls-by-provider-by-owner-by-name-by-number-ready-for-review": {
+    "mark-pull-ready-for-review": {
         parameters: {
             query?: never;
             header?: never;
@@ -5566,7 +5627,7 @@ export interface operations {
             };
         };
     };
-    "get-pulls-by-provider-by-owner-by-name-by-number-stack": {
+    "get-pull-stack": {
         parameters: {
             query?: never;
             header?: never;
@@ -5636,7 +5697,7 @@ export interface operations {
             };
         };
     };
-    "post-pulls-by-provider-by-owner-by-name-by-number-sync": {
+    "sync-pull": {
         parameters: {
             query?: never;
             header?: never;
@@ -5731,7 +5792,7 @@ export interface operations {
             };
         };
     };
-    "get-repo-by-provider-by-owner-by-name": {
+    "get-repo": {
         parameters: {
             query?: never;
             header?: never;
@@ -5795,7 +5856,7 @@ export interface operations {
             };
         };
     };
-    "get-repo-by-provider-by-owner-by-name-comment-autocomplete": {
+    "get-comment-autocomplete": {
         parameters: {
             query?: {
                 trigger?: string;
@@ -5898,7 +5959,7 @@ export interface operations {
             };
         };
     };
-    "post-repo-by-provider-by-owner-by-name-resolve-by-number": {
+    "resolve-repo-item": {
         parameters: {
             query?: never;
             header?: never;
@@ -6358,7 +6419,7 @@ export interface operations {
             };
         };
     };
-    "get-workspaces": {
+    "list-workspaces": {
         parameters: {
             query?: never;
             header?: never;
@@ -6420,7 +6481,7 @@ export interface operations {
             };
         };
     };
-    "get-workspaces-by-id": {
+    "get-workspace": {
         parameters: {
             query?: never;
             header?: never;
@@ -6482,7 +6543,7 @@ export interface operations {
             };
         };
     };
-    "get-workspaces-by-id-commits": {
+    "get-workspace-commits": {
         parameters: {
             query?: never;
             header?: never;
@@ -6513,7 +6574,7 @@ export interface operations {
             };
         };
     };
-    "get-workspaces-by-id-diff": {
+    "get-workspace-diff": {
         parameters: {
             query?: {
                 /** @description Diff base: head, pushed, or merge-target */
@@ -6557,7 +6618,7 @@ export interface operations {
             };
         };
     };
-    "get-workspaces-by-id-files": {
+    "get-workspace-files": {
         parameters: {
             query?: {
                 /** @description Diff base: head, pushed, or merge-target */

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -32,7 +32,7 @@ export type CommentAutocompleteResponse =
   components["schemas"]["CommentAutocompleteResponse"];
 export type CommentAutocompleteReference =
   components["schemas"]["CommentAutocompleteReference"];
-export type ActivityParams = NonNullable<operations["get-activity"]["parameters"]["query"]>;
+export type ActivityParams = NonNullable<operations["list-activity"]["parameters"]["query"]>;
 export type PullsParams = operations["list-pulls"]["parameters"]["query"];
 export type IssuesParams = operations["list-issues"]["parameters"]["query"];
 export type MergeParams = components["schemas"]["MergePRInputBody"];


### PR DESCRIPTION
## Summary

- Every Huma route now carries an explicit `Summary`, `Tags`, and `OperationID`. Tag taxonomy: Pull Requests, Issues, Repositories, Settings, Sync, Activity, Stacks, Workspaces, Projects, Roborev, System. Host-prefixed variants share their non-host counterpart's tag + Summary and only differ in an `-on-host` `OperationID` suffix.
- New contract test in `internal/server/route_metadata_test.go` walks `NewOpenAPI()` and fails on any operation with empty Summary, OperationID, or Tags; also enforces OperationID uniqueness. A teeth-test pins regression detection by registering an unannotated route on a throwaway `huma.API`.
- TS client and Go client regenerated against the new metadata so downstream type names are stable.
- The `resolve-item` OperationID is now `resolve-repo-item` (and the `-on-host` variant) to avoid colliding with the existing `ResolveItemResponse` schema component.