### PR TITLE
docs(testing): pin the wire-level testing discipline with paving examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ make vet        # go vet
 - When a test function has more than 3 assertions, create a local helper with `assert := Assert.New(t)` and use the helper methods for the rest of the checks
 - Do not use `t.Fatal`, `t.Fatalf`, `t.Error`, `t.Errorf`, `t.Fail`, or `t.FailNow` in tests; use testify assertions instead
 - Prefer the generated Go API client in `internal/apiclient` for integration-style API tests
-- For HTTP tests of user-visible behavior, follow the wire-level testing discipline in `context/testing.md` — exercise the request through `srv.ServeHTTP` and assert on the response a client would observe, not the handler's return value. The discipline names when to use `internal/server/apitest/`, `internal/server/e2etest/`, and the fault-injection exception.
+- For HTTP tests of user-visible behavior, follow the wire-level discipline in `context/testing.md`: route through `srv.ServeHTTP`, assert on what a client observes, and pick `internal/server/apitest/` or `internal/server/e2etest/` per the rules there.
 - Use `openTestDB(t)` helper for database tests
 - All tests use `t.TempDir()` for temp directories
 - Tests should be fast and isolated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ make vet        # go vet
 - When a test function has more than 3 assertions, create a local helper with `assert := Assert.New(t)` and use the helper methods for the rest of the checks
 - Do not use `t.Fatal`, `t.Fatalf`, `t.Error`, `t.Errorf`, `t.Fail`, or `t.FailNow` in tests; use testify assertions instead
 - Prefer the generated Go API client in `internal/apiclient` for integration-style API tests
+- For HTTP tests of user-visible behavior, follow the wire-level testing discipline in `context/testing.md` — exercise the request through `srv.ServeHTTP` and assert on the response a client would observe, not the handler's return value. The discipline names when to use `internal/server/apitest/`, `internal/server/e2etest/`, and the fault-injection exception.
 - Use `openTestDB(t)` helper for database tests
 - All tests use `t.TempDir()` for temp directories
 - Tests should be fast and isolated

--- a/context/testing.md
+++ b/context/testing.md
@@ -134,6 +134,97 @@ that call `t.Run`, `t.Parallel`, or `t.Deadline` inside the bubble.
 `synctest.Wait` is race-detector synchronization, so it is useful under
 `go test -race` when the test is structurally eligible.
 
+## HTTP testing discipline
+
+A test of user-visible HTTP behavior is **wire-level** when both of the
+following hold:
+
+1. The request flows through `srv.ServeHTTP`, so every middleware the
+   production server installs runs against the test request.
+2. Assertions read the response a client would actually observe: status
+   code, response headers, and response body bytes. The handler
+   function's return value is not consulted.
+
+Two transports satisfy this definition:
+
+- **In-process via `httptest.NewRecorder`** is the default for
+  request / response tests. Used by `internal/server/apitest/` and the
+  in-package `doJSON` helper. Fast, no port allocation, deterministic.
+  Fires every middleware. Does not faithfully simulate streaming I/O:
+  there is no `net.Conn` behind the recorder, the recorder buffers
+  writes until the handler returns, and `Flush` on the wrapped writer
+  does not push bytes toward an attached reader.
+- **Real socket via `httptest.NewServer`** is required for streaming,
+  hijack, long-lived, or `Flush`-sensitive endpoints. Used by
+  `internal/server/e2etest/` and the in-package `TestSSE_*` tests in
+  `internal/server/server_test.go`.
+
+Direct handler-function calls (for example, `s.handleSSE(w, r)`) are not
+wire-level. They bypass routing and every middleware. Allow them only
+when the test injects a fault into the `http.ResponseWriter` itself
+(deadline failures, hijack errors, write cancellation simulated by a
+wrapping writer) or otherwise probes control flow that cannot be
+expressed against a real or simulated wire. The two existing tests of
+this shape (`TestSSE_TerminatesOnInitialDeadlineFailure` and
+`TestSSE_TerminatesOnMidStreamDeadlineFailure`) are the legitimate
+exception, not a path to avoid.
+
+For new code that ships user-visible HTTP behavior:
+
+- Default to a wire-level test in `internal/server/apitest/` (recorder
+  transport, generated client). The OpenAPI contract is what consumers
+  see, and parsing through the generated types catches schema drift the
+  test author would not catch with an ad-hoc struct.
+- Use `internal/server/e2etest/` for any streaming, hijack, or
+  `Flush`-sensitive endpoint. SSE, the roborev proxy streams, and any
+  future WebSocket flow belong here. Real socket is non-negotiable
+  because the recorder collapses the `Flush` timing observable.
+- Use a raw `http.Request` over the recorder transport when the test
+  exercises a path the generated client cannot construct, such as a
+  deliberately wrong `Content-Type`, an intentionally malformed body,
+  or any preflight failure that only the runtime mutation guard can
+  produce. Add a comment naming the reason; this is the only signal a
+  reader has that the test is intentionally not using the generated
+  client.
+- Direct handler-function calls are allowed only for fault injection on
+  the `http.ResponseWriter`. Add a comment naming the fault being
+  injected.
+
+Handler-internal helper unit tests (URL parsing helpers, label diff
+functions, capability resolution) are fine as plain function unit tests
+in `package server` and are not in scope. The rule applies to tests of
+user-visible HTTP behavior, not to tests of internal helpers that
+compose into a handler.
+
+The bug classes wire-level tests catch:
+
+| Bug class | Assertion target |
+|-----------|------------------|
+| Time field serialization (`Z` vs `+00:00`) | Raw response body; handler-internal tests inspect `time.Time` values before marshaling. |
+| Error code missing from OpenAPI doc | `apitest/` generated client surfaces unknown status variants and schema mismatches against `generated.ErrorModel`. |
+| Header set in handler but stripped by middleware | `resp.Header`, not the handler's `w.Header()` before middleware ran. |
+| Status code overridden by middleware | `resp.StatusCode`, not the handler's return. |
+| Mutation guard short-circuits before handler dispatch | `srv.ServeHTTP` runs the full middleware chain; handler-internal tests calling the handler directly miss this entirely. |
+| SSE Content-Type / Cache-Control drift | Real-socket read; the recorder does not faithfully simulate what a real client sees on a buffered stream. |
+
+Three worked examples ship the discipline:
+
+- `internal/server/e2etest/sse_contract_test.go` pins the SSE response
+  headers and first cached `sync_status` frame on the wire.
+- `internal/server/apitest/mutation_guard_test.go` sends a raw `POST`
+  with `Content-Type: text/plain` and asserts the 415 response shape.
+- `internal/server/workspacetest/issue_workspace_conflict_test.go`
+  reproduces an in-package 409 test as a black-box example that decodes
+  through `generated.ErrorModel`. The original in-package test stays in
+  place.
+
+A `make lint-wire` target is intentionally out of scope. Either it
+would flag the legitimate fault-injection tests and require annotation
+comments to suppress (one-time churn for low ongoing value), or it
+would enforce a no-internal-imports rule already enforced informally by
+Go's package boundary. A future lint can be added if there is
+measurable churn around the rule.
+
 ## Related context
 
 - [`context/provider-architecture.md`](./provider-architecture.md) documents the

--- a/context/testing.md
+++ b/context/testing.md
@@ -136,94 +136,55 @@ that call `t.Run`, `t.Parallel`, or `t.Deadline` inside the bubble.
 
 ## HTTP testing discipline
 
-A test of user-visible HTTP behavior is **wire-level** when both of the
-following hold:
+A test of user-visible HTTP behavior is **wire-level** when the request flows
+through `srv.ServeHTTP` (every middleware runs) and assertions read what a
+client observes: status, response headers, and body bytes. The handler
+function's return value is not consulted.
 
-1. The request flows through `srv.ServeHTTP`, so every middleware the
-   production server installs runs against the test request.
-2. Assertions read the response a client would actually observe: status
-   code, response headers, and response body bytes. The handler
-   function's return value is not consulted.
+Two transports qualify:
 
-Two transports satisfy this definition:
+- **`httptest.NewRecorder`** is the default for request/response tests, used
+  by `internal/server/apitest/`. No `net.Conn`, so writes buffer until the
+  handler returns and `Flush` does not push toward a reader — the recorder
+  cannot honor streaming or hijack semantics.
+- **`httptest.NewServer`** is required for streaming, hijack, or
+  `Flush`-sensitive endpoints. Used by `internal/server/e2etest/` and the
+  in-package `TestSSE_*` tests.
 
-- **In-process via `httptest.NewRecorder`** is the default for
-  request / response tests. Used by `internal/server/apitest/` and the
-  in-package `doJSON` helper. Fast, no port allocation, deterministic.
-  Fires every middleware. Does not faithfully simulate streaming I/O:
-  there is no `net.Conn` behind the recorder, the recorder buffers
-  writes until the handler returns, and `Flush` on the wrapped writer
-  does not push bytes toward an attached reader.
-- **Real socket via `httptest.NewServer`** is required for streaming,
-  hijack, long-lived, or `Flush`-sensitive endpoints. Used by
-  `internal/server/e2etest/` and the in-package `TestSSE_*` tests in
-  `internal/server/server_test.go`.
+Defaults for new code:
 
-Direct handler-function calls (for example, `s.handleSSE(w, r)`) are not
-wire-level. They bypass routing and every middleware. Allow them only
-when the test injects a fault into the `http.ResponseWriter` itself
-(deadline failures, hijack errors, write cancellation simulated by a
-wrapping writer) or otherwise probes control flow that cannot be
-expressed against a real or simulated wire. The two existing tests of
-this shape (`TestSSE_TerminatesOnInitialDeadlineFailure` and
-`TestSSE_TerminatesOnMidStreamDeadlineFailure`) are the legitimate
-exception, not a path to avoid.
+- API request/response → `internal/server/apitest/` with the generated client;
+  decoding through `generated.ErrorModel` catches OpenAPI drift.
+- Streaming, hijack, `Flush`-sensitive → `internal/server/e2etest/`.
+- Inputs the generated client cannot produce (wrong `Content-Type`, malformed
+  body, preflight failure) → raw `http.Request` over the recorder; comment
+  the reason.
+- Direct handler-function calls (`s.handleSSE(w, r)`) skip routing and
+  middleware. Allowed only to inject a fault into the `http.ResponseWriter`;
+  comment the fault. The two `TestSSE_Terminates...` deadline tests are the
+  legitimate exception.
 
-For new code that ships user-visible HTTP behavior:
+Handler-internal helper unit tests (URL parsing, label diffs, capability
+resolution) stay as plain unit tests in `package server` and are out of
+scope.
 
-- Default to a wire-level test in `internal/server/apitest/` (recorder
-  transport, generated client). The OpenAPI contract is what consumers
-  see, and parsing through the generated types catches schema drift the
-  test author would not catch with an ad-hoc struct.
-- Use `internal/server/e2etest/` for any streaming, hijack, or
-  `Flush`-sensitive endpoint. SSE, the roborev proxy streams, and any
-  future WebSocket flow belong here. Real socket is non-negotiable
-  because the recorder collapses the `Flush` timing observable.
-- Use a raw `http.Request` over the recorder transport when the test
-  exercises a path the generated client cannot construct, such as a
-  deliberately wrong `Content-Type`, an intentionally malformed body,
-  or any preflight failure that only the runtime mutation guard can
-  produce. Add a comment naming the reason; this is the only signal a
-  reader has that the test is intentionally not using the generated
-  client.
-- Direct handler-function calls are allowed only for fault injection on
-  the `http.ResponseWriter`. Add a comment naming the fault being
-  injected.
+Bug classes wire-level catches:
 
-Handler-internal helper unit tests (URL parsing helpers, label diff
-functions, capability resolution) are fine as plain function unit tests
-in `package server` and are not in scope. The rule applies to tests of
-user-visible HTTP behavior, not to tests of internal helpers that
-compose into a handler.
+| Bug class | Why the wire matters |
+|-----------|----------------------|
+| Time serialization (`Z` vs `+00:00`) | Response bytes, not `time.Time` before marshaling. |
+| Error missing from OpenAPI doc | Generated client surfaces unknown status variants. |
+| Header rewritten or stripped by middleware | `resp.Header`, not `w.Header()` inside the handler. |
+| Status overridden by middleware | `resp.StatusCode`, not the handler return. |
+| Mutation guard short-circuits before dispatch | Only `srv.ServeHTTP` runs the full middleware chain. |
+| SSE `Content-Type` / `Cache-Control` drift | Real-socket read; the recorder is buffered. |
 
-The bug classes wire-level tests catch:
-
-| Bug class | Assertion target |
-|-----------|------------------|
-| Time field serialization (`Z` vs `+00:00`) | Raw response body; handler-internal tests inspect `time.Time` values before marshaling. |
-| Error code missing from OpenAPI doc | `apitest/` generated client surfaces unknown status variants and schema mismatches against `generated.ErrorModel`. |
-| Header set in handler but stripped by middleware | `resp.Header`, not the handler's `w.Header()` before middleware ran. |
-| Status code overridden by middleware | `resp.StatusCode`, not the handler's return. |
-| Mutation guard short-circuits before handler dispatch | `srv.ServeHTTP` runs the full middleware chain; handler-internal tests calling the handler directly miss this entirely. |
-| SSE Content-Type / Cache-Control drift | Real-socket read; the recorder does not faithfully simulate what a real client sees on a buffered stream. |
-
-Three worked examples ship the discipline:
-
-- `internal/server/e2etest/sse_contract_test.go` pins the SSE response
-  headers and first cached `sync_status` frame on the wire.
-- `internal/server/apitest/mutation_guard_test.go` sends a raw `POST`
-  with `Content-Type: text/plain` and asserts the 415 response shape.
-- `internal/server/workspacetest/issue_workspace_conflict_test.go`
-  reproduces an in-package 409 test as a black-box example that decodes
-  through `generated.ErrorModel`. The original in-package test stays in
-  place.
-
-A `make lint-wire` target is intentionally out of scope. Either it
-would flag the legitimate fault-injection tests and require annotation
-comments to suppress (one-time churn for low ongoing value), or it
-would enforce a no-internal-imports rule already enforced informally by
-Go's package boundary. A future lint can be added if there is
-measurable churn around the rule.
+Worked examples: `internal/server/e2etest/sse_contract_test.go` pins SSE
+headers and the first cached `sync_status` frame;
+`internal/server/apitest/mutation_guard_test.go` asserts the 415 response
+for `POST Content-Type: text/plain`;
+`internal/server/workspacetest/issue_workspace_conflict_test.go` reproduces
+a 409 through `generated.ErrorModel` alongside the in-package original.
 
 ## Related context
 

--- a/docs/superpowers/plans/2026-05-19-wire-level-testing-discipline.md
+++ b/docs/superpowers/plans/2026-05-19-wire-level-testing-discipline.md
@@ -1,0 +1,696 @@
+# Wire-Level HTTP Testing Discipline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document a forward-looking discipline for wire-level HTTP tests in middleman, with three worked examples (SSE contract pin, mutation-guard 415, branch-conflict 409 migration) that establish the shape new tests should take.
+
+**Architecture:** Three concrete tests in the existing black-box packages (`internal/server/e2etest/`, `internal/server/apitest/`, `internal/server/workspacetest/`), plus a new "HTTP testing discipline" section in `context/testing.md` and one cross-reference bullet in `CLAUDE.md`. No production code changes; no migration of existing tests beyond the one converted example.
+
+**Tech Stack:** Go 1.24, testify (require/assert), `net/http`, `net/http/httptest` (recorder + real socket), the generated Go API client in `internal/apiclient/generated/`, the existing `EventHub` in `internal/server/`.
+
+---
+
+### Task 1: SSE Contract Pin Paving Test in e2etest/
+
+**Spec reference:** Worked example 1.
+
+**Files:**
+- Create: `internal/server/e2etest/sse_contract_test.go`
+
+This test exercises the SSE endpoint over a real socket via `httptest.NewServer`. It pre-broadcasts a `sync_status` event before starting the server, then asserts that the first frame on the wire carries the cached payload, with the response headers (`Content-Type: text/event-stream`, `Cache-Control: no-cache`) intact. It does not assert `Connection` (hop-by-hop and absent under HTTP/2).
+
+- [ ] **Step 1: Write the test file**
+
+Create `internal/server/e2etest/sse_contract_test.go` with the following contents:
+
+```go
+package e2etest
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/server"
+)
+
+// TestSSEContractPinDeliversCachedSyncStatusFrame is a paving wire-level test:
+// it exercises the /api/v1/events endpoint through a real httptest.NewServer
+// socket, which is the only transport that faithfully simulates flushed
+// streaming I/O. The in-process recorder buffers writes until the handler
+// returns, so a recorder-based test would not catch middleware that strips
+// or rewrites streaming response headers, nor would it observe the SSE frame
+// boundary.
+//
+// The test pins the visible contract for a single cached sync_status event:
+// status 200, the streaming Content-Type, Cache-Control: no-cache, and the
+// first SSE frame's event/data lines. Pre-broadcasting through the hub
+// before the server starts removes the broadcast / read race a non-cached
+// first event would introduce.
+func TestSSEContractPinDeliversCachedSyncStatusFrame(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	srv.Hub().Broadcast(server.Event{
+		Type: "sync_status",
+		Data: map[string]bool{"running": false},
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/api/v1/events")
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal("text/event-stream", resp.Header.Get("Content-Type"))
+	assert.Equal("no-cache", resp.Header.Get("Cache-Control"))
+
+	eventType, dataLine := readFirstSSEFrame(t, resp.Body)
+	require.Equal("sync_status", eventType)
+
+	var payload map[string]bool
+	require.NoError(json.Unmarshal([]byte(dataLine), &payload))
+	assert.Equal(map[string]bool{"running": false}, payload)
+}
+
+// readFirstSSEFrame reads from r until it sees a blank-line terminator,
+// returning the event type and the bytes after "data: " on the data line.
+// The SSE wire format is one or more "field: value" lines terminated by a
+// blank line.
+func readFirstSSEFrame(t *testing.T, r io.Reader) (string, string) {
+	t.Helper()
+	scanner := bufio.NewScanner(r)
+	var eventType, data string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if rest, ok := strings.CutPrefix(line, "event: "); ok {
+			eventType = rest
+		}
+		if rest, ok := strings.CutPrefix(line, "data: "); ok {
+			data = rest
+		}
+		if line == "" && eventType != "" {
+			return eventType, data
+		}
+	}
+	require.FailNow(t, "did not read a complete SSE frame")
+	return "", ""
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./internal/server/e2etest -run TestSSEContractPinDeliversCachedSyncStatusFrame -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify the test fails when the contract regresses**
+
+Apply a temporary change in `internal/server/server.go` to break the contract — for example, change `w.Header().Set("Cache-Control", "no-cache")` to `w.Header().Set("Cache-Control", "max-age=300")` in `handleSSE`. Re-run the test:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./internal/server/e2etest -run TestSSEContractPinDeliversCachedSyncStatusFrame -shuffle=on
+```
+
+Expected: FAIL with a Cache-Control mismatch. Then revert the change in `server.go` and re-run; expected PASS.
+
+This is a verification step that confirms the test pins the contract on the wire. Do not commit the broken state. After reverting, confirm `git status` shows only the new test file.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add internal/server/e2etest/sse_contract_test.go
+git commit -m "test: pin SSE response contract over a real socket
+
+The recorder transport buffers writes until the handler returns and
+collapses SSE frame boundaries, so it cannot catch middleware that adds,
+drops, or rewrites streaming response headers like Cache-Control. Add a
+paving example in e2etest/ that exercises /api/v1/events through
+httptest.NewServer and pins the response status, streaming content type,
+and the first cached sync_status frame on the wire."
+```
+
+---
+
+### Task 2: Mutation Guard 415 Paving Test in apitest/
+
+**Spec reference:** Worked example 2.
+
+**Files:**
+- Create: `internal/server/apitest/mutation_guard_test.go`
+
+This test deliberately violates a precondition the generated client always satisfies (a `Content-Type` other than `application/json` on a mutating route). The generated client cannot construct this request, so the test uses a raw `http.Request` sent through `srv.ServeHTTP` via `httptest.NewRecorder`. The full middleware chain runs; a handler-internal test calling the handler directly would never trigger the mutation guard.
+
+- [ ] **Step 1: Write the test file**
+
+Create `internal/server/apitest/mutation_guard_test.go` with the following contents:
+
+```go
+package apitest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMutationGuardRejectsNonJSONContentTypeWithProblemBody is a paving
+// wire-level test: it covers the path where the test deliberately violates
+// a precondition the generated client always satisfies. The generated
+// client sets Content-Type: application/json automatically on mutation
+// requests, so the only way to exercise the CSRF/Content-Type guard from
+// a wire-level test is to construct a raw http.Request.
+//
+// The request still flows through srv.ServeHTTP, which means the full
+// middleware chain runs. A handler-internal test that called the handler
+// function directly would never trigger the guard at all, because the
+// guard short-circuits the request before handler dispatch.
+//
+// The asserted shape is the wire response: status 415, the JSON error
+// envelope writeError produces, and the response Content-Type header
+// writeJSON sets.
+func TestMutationGuardRejectsNonJSONContentTypeWithProblemBody(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sync",
+		bytes.NewReader(nil),
+	)
+	req.Header.Set("Content-Type", "text/plain")
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusUnsupportedMediaType, resp.StatusCode)
+	assert.Equal("application/json", resp.Header.Get("Content-Type"))
+
+	var body map[string]string
+	require.NoError(json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(body["error"], "Content-Type must be application/json")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./internal/server/apitest -run TestMutationGuardRejectsNonJSONContentTypeWithProblemBody -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run in short mode to confirm it stays in the fast tier**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./internal/server/apitest -run TestMutationGuardRejectsNonJSONContentTypeWithProblemBody -short -shuffle=on
+```
+
+Expected: PASS (apitest/ does not skip in short mode).
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add internal/server/apitest/mutation_guard_test.go
+git commit -m "test: pin mutation guard 415 response shape on the wire
+
+Handler-internal tests that call mutation handlers directly never reach
+the CSRF / Content-Type middleware, so a regression where the guard
+stops short-circuiting non-JSON bodies (or drops the JSON error envelope)
+would slip past. Add a paving example in apitest/ that sends a raw POST
+with text/plain through srv.ServeHTTP and pins status 415, the
+application/json response header, and the writeError body shape."
+```
+
+---
+
+### Task 3: Branch-Conflict 409 Migration in workspacetest/
+
+**Spec reference:** Worked example 3.
+
+**Files:**
+- Modify: `internal/server/workspacetest/fixtures_test.go`
+- Create: `internal/server/workspacetest/issue_workspace_conflict_test.go`
+
+This task migrates the shape (not the coverage) of `TestWorkspaceCreateIssueBranchConflictReturnsTyped409` from `package server` to `package workspacetest`, parsing the response through the generated `ErrorModel` type. The original in-package test stays in place — the goal is the side-by-side worked example, not coverage replacement.
+
+The migrated test reuses the existing `setupWorkspaceServerFixture` (which already provides a real git remote and clone). It needs a small additional helper to seed an issue, since today only PRs are seeded.
+
+- [ ] **Step 1: Add the seedIssue helper to workspacetest fixtures**
+
+In `internal/server/workspacetest/fixtures_test.go`, add the helper. Insert it after the existing `seedPROnHost` function so related seed helpers cluster together:
+
+```go
+func seedIssue(
+	t *testing.T, database *db.DB,
+	owner, name string, number int, state string,
+) int64 {
+	t.Helper()
+	ctx := t.Context()
+
+	repoID, err := database.UpsertRepo(
+		ctx, db.GitHubRepoIdentity("github.com", owner, name),
+	)
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	issue := &db.Issue{
+		RepoID:         repoID,
+		PlatformID:     int64(number) * 1000,
+		Number:         number,
+		URL:            fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, name, number),
+		Title:          fmt.Sprintf("Test Issue #%d", number),
+		Author:         "testuser",
+		State:          state,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	}
+	if state == "closed" {
+		issue.ClosedAt = &now
+	}
+	issueID, err := database.UpsertIssue(ctx, issue)
+	require.NoError(t, err)
+	return issueID
+}
+```
+
+The existing imports in `fixtures_test.go` already cover everything this helper needs (`fmt`, `testing`, `time`, `db`, `require`).
+
+- [ ] **Step 2: Add a testGitSHA helper to workspacetest fixtures**
+
+The migrated test reads the SHA of `refs/heads/main` from the remote to set up the conflicting `middleman/issue-7` ref. Add a helper alongside `runGit` in `fixtures_test.go`. Insert it after `runGit`:
+
+```go
+func testGitSHA(t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = dir
+	cmd.Env = append(
+		gitenv.StripAll(os.Environ()),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+```
+
+The existing imports already cover everything this helper needs (`os/exec`, `os`, `strings`, `gitenv`, `require`).
+
+- [ ] **Step 3: Write the migrated test file**
+
+Create `internal/server/workspacetest/issue_workspace_conflict_test.go` with the following contents:
+
+```go
+package workspacetest
+
+import (
+	"net/http"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/apiclient/generated"
+)
+
+// TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient is a
+// black-box migration of TestWorkspaceCreateIssueBranchConflictReturnsTyped409
+// (still in internal/server/api_test.go). The original asserts the same
+// behavior using a package-local rawProblemDetail struct; this version
+// decodes through generated.ErrorModel so a regression that drifts the
+// 409 response shape away from the published OpenAPI contract fails this
+// test.
+//
+// The migration is not a transport change — both shapes go through
+// srv.ServeHTTP via the recorder transport. It is a package-boundary
+// change: this file lives in package workspacetest, cannot reach into
+// package server's unexported helpers, and uses the generated apiclient
+// instead of the in-package doJSON helper. workspacetest/ is the natural
+// home because setupWorkspaceServerFixture already wires up a real git
+// remote, which apitest/ does not.
+func TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	fixture := setupWorkspaceServerFixture(t, nil)
+
+	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
+
+	// Pre-create the branch the handler would otherwise allocate, so
+	// the next workspace request hits the typed conflict path.
+	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
+	runGit(
+		t,
+		fixture.bare,
+		"update-ref",
+		"refs/heads/middleman/issue-7",
+		mainSHA,
+	)
+
+	resp, err := fixture.client.HTTP.CreateIssueWorkspaceWithResponse(
+		t.Context(), "gh", "acme", "widget", 7,
+		generated.CreateIssueWorkspaceInputBody{},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusConflict, resp.StatusCode(), string(resp.Body))
+
+	problem := resp.ApplicationproblemJSONDefault
+	require.NotNil(problem, "default error model must be populated for 409")
+
+	require.NotNil(problem.Type)
+	assert.Equal(
+		"urn:middleman:error:issue-workspace-branch-conflict",
+		*problem.Type,
+	)
+	require.NotNil(problem.Status)
+	assert.EqualValues(http.StatusConflict, *problem.Status)
+	require.NotNil(problem.Detail)
+	assert.NotEmpty(*problem.Detail)
+
+	require.NotNil(problem.Errors)
+	locations := map[string]any{}
+	for _, e := range *problem.Errors {
+		if e.Location == nil {
+			continue
+		}
+		locations[*e.Location] = e.Value
+	}
+	assert.Equal("middleman/issue-7", locations["body.git_head_ref"])
+	assert.Equal(
+		"middleman/issue-7-2",
+		locations["body.suggested_git_head_ref"],
+	)
+}
+```
+
+- [ ] **Step 4: Run the migrated test**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./internal/server/workspacetest -run TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Confirm the migrated test skips in short mode**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./internal/server/workspacetest -run TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient -short -shuffle=on
+```
+
+Expected: PASS with no test executed (workspacetest's `setupWorkspaceServerFixture` already calls `t.Skip("workspace e2e tests skipped in short mode")`). The new test inherits that skip; no additional skip directive is needed.
+
+- [ ] **Step 6: Confirm the original in-package test still passes**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./internal/server -run TestWorkspaceCreateIssueBranchConflictReturnsTyped409 -shuffle=on
+```
+
+Expected: PASS. The point of the migration is to ship a side-by-side example, not to replace coverage.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add internal/server/workspacetest/fixtures_test.go \
+        internal/server/workspacetest/issue_workspace_conflict_test.go
+git commit -m "test: migrate branch-conflict 409 example through generated client
+
+The existing in-package test decodes the 409 problem body into a
+package-local rawProblemDetail struct, which means a future change that
+drifts the response away from the published OpenAPI contract would still
+pass. Add a sibling test in workspacetest/ that parses the same response
+through generated.ErrorModel via the generated apiclient. The original
+test stays in place; this is a worked example of the package-boundary
+shape, not a coverage replacement."
+```
+
+---
+
+### Task 4: Document the Discipline
+
+**Spec reference:** "Where the doctrine lives" and acceptance criteria.
+
+**Files:**
+- Modify: `context/testing.md`
+- Modify: `CLAUDE.md`
+
+This task adds the doctrine itself: the operational definition of "wire-level," when to choose each shape, the fault-injection exception, and the bug-class table. It cross-references the discipline from `CLAUDE.md` so the Testing section there points readers to it.
+
+- [ ] **Step 1: Append the HTTP testing discipline section to context/testing.md**
+
+Open `context/testing.md`. Insert the following section between the existing `## Race test runtime` section and the existing `## Related context` section. The section sits as a peer of the existing topical sections (Live GraphQL validation, Provider work, Race test runtime) and the SQLite Fixtures / Sleep And Timer Tests subsections under Race test runtime.
+
+Add this new top-level section before `## Related context`:
+
+```markdown
+## HTTP testing discipline
+
+A test of user-visible HTTP behavior is **wire-level** when both of the
+following hold:
+
+1. The request flows through `srv.ServeHTTP`, so every middleware the
+   production server installs runs against the test request.
+2. Assertions read the response a client would actually observe: status
+   code, response headers, and response body bytes. The handler
+   function's return value is not consulted.
+
+Two transports satisfy this definition:
+
+- **In-process via `httptest.NewRecorder`** is the default for
+  request / response tests. Used by `internal/server/apitest/` and the
+  in-package `doJSON` helper. Fast, no port allocation, deterministic.
+  Fires every middleware. Does not faithfully simulate streaming I/O:
+  there is no `net.Conn` behind the recorder, the recorder buffers
+  writes until the handler returns, and `Flush` on the wrapped writer
+  does not push bytes toward an attached reader.
+- **Real socket via `httptest.NewServer`** is required for streaming,
+  hijack, long-lived, or `Flush`-sensitive endpoints. Used by
+  `internal/server/e2etest/` and the in-package `TestSSE_*` tests in
+  `internal/server/server_test.go`.
+
+Direct handler-function calls (for example, `s.handleSSE(w, r)`) are not
+wire-level. They bypass routing and every middleware. Allow them only
+when the test injects a fault into the `http.ResponseWriter` itself
+(deadline failures, hijack errors, write cancellation simulated by a
+wrapping writer) or otherwise probes control flow that cannot be
+expressed against a real or simulated wire. The two existing tests of
+this shape (`TestSSE_TerminatesOnInitialDeadlineFailure` and
+`TestSSE_TerminatesOnMidStreamDeadlineFailure`) are the legitimate
+exception, not a path to avoid.
+
+For new code that ships user-visible HTTP behavior:
+
+- Default to a wire-level test in `internal/server/apitest/` (recorder
+  transport, generated client). The OpenAPI contract is what consumers
+  see, and parsing through the generated types catches schema drift the
+  test author would not catch with an ad-hoc struct.
+- Use `internal/server/e2etest/` for any streaming, hijack, or
+  `Flush`-sensitive endpoint. SSE, the roborev proxy streams, and any
+  future WebSocket flow belong here. Real socket is non-negotiable
+  because the recorder collapses the `Flush` timing observable.
+- Use a raw `http.Request` over the recorder transport when the test
+  exercises a path the generated client cannot construct, such as a
+  deliberately wrong `Content-Type`, an intentionally malformed body,
+  or any preflight failure that only the runtime mutation guard can
+  produce. Add a comment naming the reason; this is the only signal a
+  reader has that the test is intentionally not using the generated
+  client.
+- Direct handler-function calls are allowed only for fault injection on
+  the `http.ResponseWriter`. Add a comment naming the fault being
+  injected.
+
+Handler-internal helper unit tests (URL parsing helpers, label diff
+functions, capability resolution) are fine as plain function unit tests
+in `package server` and are not in scope. The rule applies to tests of
+user-visible HTTP behavior, not to tests of internal helpers that
+compose into a handler.
+
+The bug classes wire-level tests catch:
+
+| Bug class | Assertion target |
+|-----------|------------------|
+| Time field serialization (`Z` vs `+00:00`) | Raw response body; handler-internal tests inspect `time.Time` values before marshaling. |
+| Error code missing from OpenAPI doc | `apitest/` generated client surfaces unknown status variants and schema mismatches against `generated.ErrorModel`. |
+| Header set in handler but stripped by middleware | `resp.Header`, not the handler's `w.Header()` before middleware ran. |
+| Status code overridden by middleware | `resp.StatusCode`, not the handler's return. |
+| Mutation guard short-circuits before handler dispatch | `srv.ServeHTTP` runs the full middleware chain; handler-internal tests calling the handler directly miss this entirely. |
+| SSE Content-Type / Cache-Control drift | Real-socket read; the recorder does not faithfully simulate what a real client sees on a buffered stream. |
+
+Three worked examples ship the discipline:
+
+- `internal/server/e2etest/sse_contract_test.go` pins the SSE response
+  headers and first cached `sync_status` frame on the wire.
+- `internal/server/apitest/mutation_guard_test.go` sends a raw `POST`
+  with `Content-Type: text/plain` and asserts the 415 response shape.
+- `internal/server/workspacetest/issue_workspace_conflict_test.go`
+  reproduces an in-package 409 test as a black-box example that decodes
+  through `generated.ErrorModel`. The original in-package test stays in
+  place.
+
+A `make lint-wire` target is intentionally out of scope. Either it
+would flag the legitimate fault-injection tests and require annotation
+comments to suppress (one-time churn for low ongoing value), or it
+would enforce a no-internal-imports rule already enforced informally by
+Go's package boundary. A future lint can be added if there is
+measurable churn around the rule.
+```
+
+- [ ] **Step 2: Add the cross-reference bullet to CLAUDE.md**
+
+In `CLAUDE.md`, in the `### Test Guidelines` subsection under `## Testing`, add a new bullet immediately after the existing bullet that begins `- Prefer the generated Go API client in \`internal/apiclient\` for integration-style API tests`. The new bullet:
+
+```markdown
+- For HTTP tests of user-visible behavior, follow the wire-level testing discipline in `context/testing.md` — exercise the request through `srv.ServeHTTP` and assert on the response a client would observe, not the handler's return value. The discipline names when to use `internal/server/apitest/`, `internal/server/e2etest/`, and the fault-injection exception.
+```
+
+The bullet sits naturally next to the existing apiclient bullet because both speak to integration-style API tests; together they tell a reader what shape to write and how to dispatch it.
+
+- [ ] **Step 3: Verify the docs render cleanly**
+
+Run:
+
+```sh
+git diff --check context/testing.md CLAUDE.md
+```
+
+Expected: no whitespace errors.
+
+Re-read both files to confirm:
+- `context/testing.md` has the new `## HTTP testing discipline` section between `## Race test runtime` and `## Related context`.
+- The bug-class table renders as a markdown table.
+- `CLAUDE.md` has exactly one new bullet, positioned after the apiclient bullet under `### Test Guidelines`.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add context/testing.md CLAUDE.md
+git commit -m "docs: spell out wire-level HTTP testing discipline
+
+The boundary between handler-internal tests and tests that exercise the
+full middleware chain through srv.ServeHTTP has been unwritten, so bug
+classes that only show up on the wire (header rewrites, status
+overrides, schema drift against the OpenAPI contract, mutation guard
+short-circuits) can slip through. Add an HTTP testing discipline
+section to context/testing.md that names the two wire-level transports,
+the fault-injection exception, when to choose each shape, and the bug
+classes wire-level catches. Cross-reference it from CLAUDE.md."
+```
+
+---
+
+### Task 5: Final Verification
+
+**Spec reference:** Acceptance criteria.
+
+- [ ] **Step 1: Run the full Go test suite**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./... -shuffle=on
+```
+
+Expected: all tests pass. The three new tests and the unchanged original branch-conflict test all show up in their respective packages.
+
+- [ ] **Step 2: Run the short-mode test suite**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go test ./... -short -shuffle=on
+```
+
+Expected: all tests pass; the mutation-guard test in `apitest/` runs; the SSE contract test in `e2etest/` runs (e2etest has no package-level short skip); the workspacetest migration is skipped by `setupWorkspaceServerFixture`'s existing `t.Skip`.
+
+- [ ] **Step 3: Run go vet**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#go' --command go vet ./...
+```
+
+Expected: clean (no findings).
+
+- [ ] **Step 4: Run the linter**
+
+Run:
+
+```sh
+nix shell 'nixpkgs#golangci-lint' --command golangci-lint run
+```
+
+Expected: clean. If any new finding appears in the new test files, fix it in a new commit.
+
+- [ ] **Step 5: Confirm `git status` is clean**
+
+Run:
+
+```sh
+git status
+```
+
+Expected: working tree clean. All four commits (Tasks 1-4) on the current branch.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Operational definition" — covered by the new `## HTTP testing discipline` section in `context/testing.md` (Task 4 Step 1).
+- "When to write what shape" — same section, the per-shape guidance bullet list.
+- "Bug classes" — same section, the bug-class table.
+- "Where the doctrine lives" — Tasks 4 Step 1 (testing.md) and Step 2 (CLAUDE.md).
+- Worked example 1, SSE contract pin — Task 1.
+- Worked example 2, mutation guard 415 — Task 2.
+- Worked example 3, branch-conflict 409 migration — Task 3.
+- "Lint target" — explicitly out of scope, noted in the testing.md section.
+- "File touchpoints" — every touchpoint in the spec is created or modified by an explicit step.
+- Acceptance criteria — Task 5 covers the full-suite, short-mode, vet, and lint gates.
+
+**Placeholder scan:** no "TBD", "TODO", "implement later", "similar to Task N", or hand-wave steps. Every code block is complete and self-contained.
+
+**Type consistency:**
+- `generated.CreateIssueWorkspaceInputBody{}` matches the type at `internal/apiclient/generated/client.gen.go:279`.
+- `generated.ErrorModel` matches `internal/apiclient/generated/client.gen.go:391`.
+- `ErrorModel.Errors` is `*[]ErrorDetail` (per the generated source), so the test dereferences with `*problem.Errors` and ranges over the slice — matches the code in Task 3 Step 3.
+- `ErrorDetail.Location` is `*string`, so the test guards with `if e.Location == nil { continue }` — matches the code.
+- `server.Event{Type: ..., Data: ...}` matches `internal/server/event_hub.go:9`.
+- `srv.Hub().Broadcast(...)` matches `internal/server/server.go:198` (`func (s *Server) Hub() *EventHub`).
+- `setupTestServer(t)` returns `(*server.Server, *db.DB)` in both `internal/server/apitest/fixtures_test.go:26` and `internal/server/e2etest/fixtures_test.go:23`. Both task tests use the same name and signature.
+- `setupWorkspaceServerFixture` in `internal/server/workspacetest/fixtures_test.go:36` returns `workspaceServerFixture`, which exposes `server`, `client`, `database`, `bare`, `remote` — all referenced consistently in Task 3.
+- `runGit` is package-local to `workspacetest/fixtures_test.go:161` and to `internal/server/api_test.go:11466`; the test in Task 3 uses the workspacetest version (no cross-package import).

--- a/docs/superpowers/specs/2026-05-19-wire-level-testing-discipline-design.md
+++ b/docs/superpowers/specs/2026-05-19-wire-level-testing-discipline-design.md
@@ -172,7 +172,7 @@ the path where the test deliberately violates a precondition the generated
 client always satisfies. The accompanying comment names the reason in the
 test source.
 
-### 3. Branch-conflict 409 — converted from in-package to apitest/
+### 3. Branch-conflict 409 — converted from in-package to workspacetest/
 
 **Bug class:** structured error JSON shape drifts away from the published
 OpenAPI contract.
@@ -183,35 +183,33 @@ the local `doJSON` helper, decodes the response into an in-package
 `rawProblemDetail` struct, and accesses package-internal fixture helpers
 (`setupWorkspaceServerFixture`, `runGit`, `testGitSHA`).
 
-**Migration:** create a sibling in `internal/server/apitest/` that exercises
-the same endpoint and behavior through the generated client. The migration
-is not a transport change — both shapes go through `srv.ServeHTTP` via the
-recorder transport — but a package-boundary change:
+**Migration target:** `internal/server/workspacetest/`, which is already a
+black-box test package (`package workspacetest`) and already has an
+exported-API workspace fixture (its own `setupWorkspaceServerFixture` that
+spins up a real git remote and constructs `server.Server` plus the
+generated `apiclient.Client`). It is the natural home for migrated
+workspace-touching tests; `apitest/` does not have git fixtures and would
+require duplicating them.
 
-- The apitest/ version cannot import `package server`'s unexported helpers
-  or types. It must construct the server using only the exported API
-  (`server.New`, `server.NewWithConfig`, exported fixtures) and parse the
-  response through the generated client's `ErrorModel` (see
-  `internal/apiclient/generated/client.gen.go`, type `ErrorModel`).
+The migration is not a transport change — both shapes go through
+`srv.ServeHTTP` via the recorder transport — but a package-boundary
+change:
+
+- The workspacetest/ version cannot import `package server`'s unexported
+  helpers or types. It uses the package-local `setupWorkspaceServerFixture`
+  (which already lives in `internal/server/workspacetest/fixtures_test.go`)
+  and the generated `apiclient.Client` for the request.
 - The asserted fields are: status 409, the problem `type` URN, status,
   detail substring, and the two `errors[]` location / value pairs
   (`body.git_head_ref` and `body.suggested_git_head_ref`).
-- The reuse-branch happy-path follow-up (existing test's second
+- The response is parsed through the generated client's `ErrorModel` shape
+  (see `internal/apiclient/generated/client.gen.go`, type `ErrorModel`).
+- The reuse-branch happy-path follow-up (existing in-package test's second
   assertion) becomes a separate test in the migrated file to keep
   scope narrow.
 
-The original test stays in place. The point of the migration is to show
-the side-by-side shape, not to replace coverage.
-
-Note on git fixtures: the original in-package test sets up a real git
-remote via `setupWorkspaceServerFixture`, which depends on package-internal
-helpers. The migrated test reuses the same exported configuration paths
-(create a temp dir, write a config that points to the workspace clone,
-load via `config.Load`). If the workspace fixture is too tied to internal
-helpers to extract cleanly, the migration may instead exercise a narrower
-slice of the conflict case using a stubbed workspace error path. The
-implementation plan resolves which approach is feasible without growing
-scope.
+The original in-package test stays in place. The point of the migration is
+to show the side-by-side shape, not to replace coverage.
 
 ## Lint target
 
@@ -247,14 +245,15 @@ a future lint can be added when there is measurable churn around the rule.
   pin paving test.
 - `internal/server/apitest/mutation_guard_test.go` — new file, 415
   mutation-guard paving test.
-- `internal/server/apitest/issue_workspace_conflict_test.go` — new file,
-  migrated branch-conflict example.
+- `internal/server/workspacetest/issue_workspace_conflict_test.go` — new
+  file, migrated branch-conflict example.
 
-If a `mockGH` or fixture helper is missing in apitest/ relative to what
-the migration needs, extend the existing `apitest/fixtures_test.go`
-minimally. Do not introduce a parallel set of mocks; reuse what
-`internal/server/apitest/fixtures_test.go` and the workspace fixture
-exports already provide.
+If a `mockGH` or fixture helper is missing in the chosen test package
+relative to what a new test needs, extend the existing
+`fixtures_test.go` in that package minimally. Do not introduce a parallel
+set of mocks; reuse what `internal/server/apitest/fixtures_test.go`,
+`internal/server/e2etest/fixtures_test.go`, and
+`internal/server/workspacetest/fixtures_test.go` already provide.
 
 ## Acceptance criteria
 
@@ -262,6 +261,11 @@ exports already provide.
   the two transports, the cultural rule, the fault-injection exception,
   and the bug-class table.
 - `CLAUDE.md` has one new bullet under Testing linking to the section.
-- The two paving tests pass under `make test` and `make test-short`.
-- The migrated test passes alongside (not replacing) the original.
+- The two paving tests pass under `make test`. The mutation-guard test in
+  apitest/ also passes under `make test-short`. The SSE contract test in
+  e2etest/ follows whatever the existing e2etest/ short-skip behavior is
+  for that package (do not introduce a new short-mode skip in the test).
+- The migrated branch-conflict test passes under `make test` (workspacetest
+  already skips itself under `-short`; the new test inherits that skip).
+  The original in-package test continues to pass unchanged.
 - `make vet` and `make lint` are clean.

--- a/docs/superpowers/specs/2026-05-19-wire-level-testing-discipline-design.md
+++ b/docs/superpowers/specs/2026-05-19-wire-level-testing-discipline-design.md
@@ -1,0 +1,267 @@
+# Wire-level HTTP testing discipline — design
+
+## Purpose
+
+middleman has three test-shape conventions for the HTTP layer today, and the
+boundary between them is unwritten:
+
+- `internal/server/*_test.go` — handler-internal tests in `package server`,
+  using `httptest.NewRecorder` + `srv.ServeHTTP` (via `doJSON` or a
+  `roundTripFunc` transport), or — rarely — direct handler-function calls.
+- `internal/server/apitest/` — black-box tests in a sibling package, using the
+  generated OpenAPI client through the same recorder transport.
+- `internal/server/e2etest/` — black-box tests using a real
+  `httptest.NewServer` socket, used today mostly for health and SSE flows.
+
+A class of bugs slips through because handler-internal tests inspect the
+handler's return value rather than the response a client would actually
+receive:
+
+- JSON time field serialization changes (`Z` vs `+00:00`).
+- New error codes that don't appear in the OpenAPI document.
+- Headers set in the handler but stripped or overridden by middleware later.
+- Status codes the handler returns but middleware overrides.
+
+This design documents a forward-looking discipline. It does not migrate the
+existing test suite. It adds doctrine plus three worked examples that show the
+shape new tests should take.
+
+## Operational definition
+
+A test is **wire-level** when both of the following hold:
+
+1. It exercises the request through `srv.ServeHTTP` — that is, every middleware
+   the production server installs runs against the test request.
+2. It asserts on the response a client would actually observe: status code,
+   response headers, and response body bytes. The handler function's return
+   value is not consulted.
+
+Two transports satisfy this definition:
+
+- **In-process via `httptest.NewRecorder`** is the default for request /
+  response tests. Used by `internal/server/apitest/` and the existing in-package
+  `doJSON` helper. Fast, no port allocation, deterministic. Fires every
+  middleware. Does not faithfully simulate streaming I/O: there is no
+  `net.Conn` behind the recorder, the recorder buffers writes until the
+  handler returns, and `Flush` on the wrapped writer does not push bytes
+  toward an attached reader.
+- **Real socket via `httptest.NewServer`** is required for streaming, hijack,
+  long-lived, or `Flush`-sensitive endpoints. Used by
+  `internal/server/e2etest/` and the existing `TestSSE_*` tests in
+  `internal/server/server_test.go`.
+
+Direct handler-function calls — for example, `s.handleSSE(w, r)` — are not
+wire-level. They bypass routing and every middleware. They are allowed only
+when the test injects a fault into the `http.ResponseWriter` (e.g.,
+`SetWriteDeadline` failure) or otherwise probes control flow that cannot be
+expressed against a real or simulated wire. Two such tests exist today
+(`TestSSE_TerminatesOnInitialDeadlineFailure` and
+`TestSSE_TerminatesOnMidStreamDeadlineFailure`); the discipline names this as
+the legitimate exception, not a path to avoid.
+
+## When to write what shape
+
+For new code that ships user-visible HTTP behavior:
+
+- **Default to a wire-level test in `internal/server/apitest/`** (recorder
+  transport, generated client). The OpenAPI contract is what consumers see,
+  and parsing through the generated types catches schema drift the test
+  author wouldn't catch with an ad-hoc struct.
+- **Use `internal/server/e2etest/` for any streaming, hijack, or
+  `Flush`-sensitive endpoint.** SSE, `roborev` proxy streams, future
+  WebSocket flows. Real socket is non-negotiable here because the recorder
+  collapses the `Flush` timing observable.
+- **Use a raw `http.Request` over the recorder transport when the test
+  exercises a path the generated client cannot construct**, such as a
+  deliberately wrong `Content-Type`, an intentionally malformed body, or
+  any preflight failure that only the runtime mutation guard can produce.
+- **Direct handler-function calls are allowed only for fault injection on
+  the `http.ResponseWriter`** (deadline failures, hijack errors, write
+  cancellation simulated by a wrapping writer). Add a comment naming the
+  fault being injected; this is the only signal a reader has that the test
+  is intentionally non-wire.
+
+For handler-internal helper unit tests (e.g., URL parsing helpers, label
+diff functions, capability resolution) — those are fine as plain function
+unit tests in `package server` and not in scope for this discipline. The
+rule applies to tests of user-visible HTTP behavior, not to tests of
+internal helpers that compose into a handler.
+
+## Bug classes this discipline catches
+
+| Bug class | Where wire-level catches it |
+|-----------|-----------------------------|
+| Time field serialization (`Z` vs `+00:00`) | Parses raw response body; handler-internal tests inspect `time.Time` values before marshaling. |
+| Error code missing from OpenAPI doc | apitest/ generated client surfaces unknown status variants and schema mismatches against generated.ErrorModel. |
+| Header set in handler but stripped by middleware | Asserts on `resp.Header`, not the handler's `w.Header()` before middleware ran. |
+| Status code overridden by middleware | Asserts on `resp.StatusCode`, not the handler's return. |
+| Mutation guard short-circuits before handler dispatch | `srv.ServeHTTP` runs the full middleware chain; handler-internal tests calling the handler directly miss this entirely. |
+| SSE Content-Type / Cache-Control drift | Real-socket read; recorder may not reflect what a real client sees on a buffered stream. |
+
+## Where the doctrine lives
+
+Extend `context/testing.md` with an "HTTP testing discipline" section that
+contains the operational definition, the per-shape guidance, and a short
+table mapping bug class to assertion target. Add one bullet to the Testing
+section of `CLAUDE.md` linking to that doctrine. The existing testing.md
+already covers provider work, race runtime, SQLite fixtures, and
+sleep / timer tests; HTTP testing is the matching topical section.
+
+## Worked examples
+
+The discipline ships with three concrete examples. Each demonstrates a
+distinct bug class.
+
+### 1. SSE contract pin — paving test in `internal/server/e2etest/`
+
+**Bug class:** middleware silently adds, drops, or rewrites a response
+header on a successful streaming response. Handler-internal tests inspect
+`w.Header()` before middleware runs and miss this.
+
+**Shape:** real socket via `httptest.NewServer`.
+
+**Mechanics:**
+
+1. Build the test server. Before starting `httptest.NewServer`, pre-broadcast
+   a `sync_status` event through `srv.Hub().Broadcast(...)`. The hub caches
+   the most recent `sync_status` event and delivers it as the first frame
+   on subscribe, removing the broadcast / read race that a non-cached
+   first event would introduce.
+2. Start `httptest.NewServer(srv)`. `GET /api/v1/events`.
+3. Assert response status 200, `Content-Type: text/event-stream`,
+   `Cache-Control: no-cache`. Do not assert `Connection` — it is
+   hop-by-hop and absent under HTTP/2.
+4. Read the first SSE frame from the response body using a `bufio.Scanner`.
+   Recognize the frame by the blank-line terminator. The frame must contain
+   an `event: sync_status` line and a `data: ` line.
+5. Strip the `data: ` prefix from the data line, decode the bytes as JSON
+   into a typed struct, and assert the cached payload.
+
+The test demonstrates: the contract pin is the bytes on the wire, not the
+handler's return value. If a middleware ever added `Cache-Control: max-age=300`
+on all responses (a real and plausible regression), this test fails.
+
+### 2. Mutation guard 415 — paving test in `internal/server/apitest/`
+
+**Bug class:** middleware short-circuits the request before handler dispatch.
+The handler is never invoked. A handler-internal test that calls the handler
+function directly cannot observe this at all; a recorder-transport test
+through `srv.ServeHTTP` does.
+
+**Shape:** in-process via `httptest.NewRecorder` (existing
+`roundTripFunc` transport). Uses a raw `http.Request`, not the generated
+client (which would set `Content-Type: application/json` automatically and
+defeat the test).
+
+**Mechanics:**
+
+1. Build the server fixture. Build a raw `http.Request`: method `POST`,
+   path `/api/v1/sync`, body `bytes.NewReader(nil)`, header
+   `Content-Type: text/plain`. The body is intentionally empty; `/api/v1/sync`
+   accepts zero-body POSTs.
+2. Send the request through `srv.ServeHTTP` via `httptest.NewRecorder`.
+3. Assert response status 415.
+4. Assert the response `Content-Type` header is `application/json`.
+   `writeError` in `internal/server/server.go` writes a JSON
+   `{"error": "..."}` body via `writeJSON`, which sets that header.
+5. Decode the body into `map[string]string` and assert the `error` field
+   contains the substring `Content-Type must be application/json`.
+
+The test is a paving example for one specific kind of negative-path test:
+the path where the test deliberately violates a precondition the generated
+client always satisfies. The accompanying comment names the reason in the
+test source.
+
+### 3. Branch-conflict 409 — converted from in-package to apitest/
+
+**Bug class:** structured error JSON shape drifts away from the published
+OpenAPI contract.
+
+**Existing test:** `TestWorkspaceCreateIssueBranchConflictReturnsTyped409`
+in `internal/server/api_test.go`. Today it lives in `package server`, uses
+the local `doJSON` helper, decodes the response into an in-package
+`rawProblemDetail` struct, and accesses package-internal fixture helpers
+(`setupWorkspaceServerFixture`, `runGit`, `testGitSHA`).
+
+**Migration:** create a sibling in `internal/server/apitest/` that exercises
+the same endpoint and behavior through the generated client. The migration
+is not a transport change — both shapes go through `srv.ServeHTTP` via the
+recorder transport — but a package-boundary change:
+
+- The apitest/ version cannot import `package server`'s unexported helpers
+  or types. It must construct the server using only the exported API
+  (`server.New`, `server.NewWithConfig`, exported fixtures) and parse the
+  response through the generated client's `ErrorModel` (see
+  `internal/apiclient/generated/client.gen.go`, type `ErrorModel`).
+- The asserted fields are: status 409, the problem `type` URN, status,
+  detail substring, and the two `errors[]` location / value pairs
+  (`body.git_head_ref` and `body.suggested_git_head_ref`).
+- The reuse-branch happy-path follow-up (existing test's second
+  assertion) becomes a separate test in the migrated file to keep
+  scope narrow.
+
+The original test stays in place. The point of the migration is to show
+the side-by-side shape, not to replace coverage.
+
+Note on git fixtures: the original in-package test sets up a real git
+remote via `setupWorkspaceServerFixture`, which depends on package-internal
+helpers. The migrated test reuses the same exported configuration paths
+(create a temp dir, write a config that points to the workspace clone,
+load via `config.Load`). If the workspace fixture is too tied to internal
+helpers to extract cleanly, the migration may instead exercise a narrower
+slice of the conflict case using a stubbed workspace error path. The
+implementation plan resolves which approach is feasible without growing
+scope.
+
+## Lint target
+
+Out of scope. The task allows an optional `make lint-wire`, but a useful
+implementation would either:
+
+- Flag direct handler-function calls and require an annotation comment to
+  suppress (creates one-time churn on the existing fault-injection tests
+  for low ongoing value), or
+- Enforce a no-internal-imports rule across apitest/ and e2etest/ (already
+  enforced informally by Go's package boundary).
+
+Neither carries its weight relative to the cultural shift the doctrine
+itself drives. The discipline section in `context/testing.md` notes that
+a future lint can be added when there is measurable churn around the rule.
+
+## Out of scope
+
+- Migrating existing handler-internal tests beyond the one converted
+  example.
+- Replacing the in-package `setupTestClient` / `doJSON` helpers. They are
+  legitimate scaffolding for in-package tests that probe unexported state.
+- Changes to provider-specific tests in `internal/platform/<provider>/`.
+- Adding a new error model, header, or response shape — the discipline
+  documents what to test, not what to ship.
+
+## File touchpoints
+
+- `context/testing.md` — new section.
+- `CLAUDE.md` — one bullet in the existing Testing section pointing to the
+  new section.
+- `internal/server/e2etest/sse_contract_test.go` — new file, SSE contract
+  pin paving test.
+- `internal/server/apitest/mutation_guard_test.go` — new file, 415
+  mutation-guard paving test.
+- `internal/server/apitest/issue_workspace_conflict_test.go` — new file,
+  migrated branch-conflict example.
+
+If a `mockGH` or fixture helper is missing in apitest/ relative to what
+the migration needs, extend the existing `apitest/fixtures_test.go`
+minimally. Do not introduce a parallel set of mocks; reuse what
+`internal/server/apitest/fixtures_test.go` and the workspace fixture
+exports already provide.
+
+## Acceptance criteria
+
+- `context/testing.md` has an "HTTP testing discipline" section that names
+  the two transports, the cultural rule, the fault-injection exception,
+  and the bug-class table.
+- `CLAUDE.md` has one new bullet under Testing linking to the section.
+- The two paving tests pass under `make test` and `make test-short`.
+- The migrated test passes alongside (not replacing) the original.
+- `make vet` and `make lint` are clean.

--- a/frontend/tests/e2e-full/issue-task-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-task-list.spec.ts
@@ -30,24 +30,43 @@ test.describe.serial("issue description task list", () => {
     const body = page.locator(".body-section .markdown-body");
     const cb0 = body.locator('input[type="checkbox"][data-task-index="0"]');
     const cb1 = body.locator('input[type="checkbox"][data-task-index="1"]');
+    const cb0Expected = !(await cb0.isChecked());
+    const cb1Expected = !(await cb1.isChecked());
+    const checkboxMarker = (checked: boolean) => checked ? "[x]" : "[ ]";
+    const patchRoute = /\/api\/v1\/issues\/[^/]+\/[^/]+\/[^/]+\/11$/;
+    const persisted = page.waitForResponse((resp) => {
+      if (
+        resp.request().method() !== "PATCH"
+        || !patchRoute.test(resp.url())
+        || !resp.ok()
+      ) {
+        return false;
+      }
+      const body = resp.request().postData() ?? "";
+      return body.includes(
+        `${checkboxMarker(cb0Expected)} System preference detected on first launch`,
+      )
+        && body.includes(
+          `${checkboxMarker(cb1Expected)} Manual toggle in settings overrides system`,
+        );
+    }, { timeout: 5_000 });
 
-    await expect(cb0).not.toBeChecked();
     await cb0.click();
-    await expect(cb0).toBeChecked();
+    await expect(cb0).toBeChecked({ checked: cb0Expected });
     await cb1.click();
-    await expect(cb1).toBeChecked();
+    await expect(cb1).toBeChecked({ checked: cb1Expected });
 
-    await page.waitForTimeout(900);
+    await persisted;
     await page.reload();
     const reloadedBody = page.locator(".body-section .markdown-body");
     await reloadedBody.waitFor({ state: "visible" });
 
     await expect(
       reloadedBody.locator('input[type="checkbox"][data-task-index="0"]'),
-    ).toBeChecked();
+    ).toBeChecked({ checked: cb0Expected });
     await expect(
       reloadedBody.locator('input[type="checkbox"][data-task-index="1"]'),
-    ).toBeChecked();
+    ).toBeChecked({ checked: cb1Expected });
   });
 
   test("drag handle reorders a task item and persists on reload", async ({

--- a/internal/server/apitest/mutation_guard_test.go
+++ b/internal/server/apitest/mutation_guard_test.go
@@ -1,0 +1,54 @@
+package apitest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMutationGuardRejectsNonJSONContentTypeWithProblemBody is a paving
+// wire-level test: it covers the path where the test deliberately violates
+// a precondition the generated client always satisfies. The generated
+// client sets Content-Type: application/json automatically on mutation
+// requests, so the only way to exercise the CSRF/Content-Type guard from
+// a wire-level test is to construct a raw http.Request.
+//
+// The request still flows through srv.ServeHTTP, which means the full
+// middleware chain runs. A handler-internal test that called the handler
+// function directly would never trigger the guard at all, because the
+// guard short-circuits the request before handler dispatch.
+//
+// The asserted shape is the wire response: status 415, the JSON error
+// envelope writeError produces, and the response Content-Type header
+// writeJSON sets.
+func TestMutationGuardRejectsNonJSONContentTypeWithProblemBody(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/sync",
+		bytes.NewReader(nil),
+	)
+	req.Header.Set("Content-Type", "text/plain")
+
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	resp := rr.Result()
+	defer resp.Body.Close()
+
+	require.Equal(http.StatusUnsupportedMediaType, resp.StatusCode)
+	assert.Equal("application/json", resp.Header.Get("Content-Type"))
+
+	var body map[string]string
+	require.NoError(json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(body["error"], "Content-Type must be application/json")
+}

--- a/internal/server/e2etest/sse_contract_test.go
+++ b/internal/server/e2etest/sse_contract_test.go
@@ -2,12 +2,14 @@ package e2etest
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,7 +42,14 @@ func TestSSEContractPinDeliversCachedSyncStatusFrame(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	resp, err := ts.Client().Get(ts.URL + "/api/v1/events")
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+
+	resp, err := ts.Client().Do(req)
 	require.NoError(err)
 	defer resp.Body.Close()
 
@@ -76,6 +85,7 @@ func readFirstSSEFrame(t *testing.T, r io.Reader) (string, string) {
 			return eventType, data
 		}
 	}
+	require.NoError(t, scanner.Err())
 	require.FailNow(t, "did not read a complete SSE frame")
 	return "", ""
 }

--- a/internal/server/e2etest/sse_contract_test.go
+++ b/internal/server/e2etest/sse_contract_test.go
@@ -1,0 +1,81 @@
+package e2etest
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/server"
+)
+
+// TestSSEContractPinDeliversCachedSyncStatusFrame is a paving wire-level test:
+// it exercises the /api/v1/events endpoint through a real httptest.NewServer
+// socket, which is the only transport that faithfully simulates flushed
+// streaming I/O. The in-process recorder buffers writes until the handler
+// returns, so a recorder-based test would not catch middleware that strips
+// or rewrites streaming response headers, nor would it observe the SSE frame
+// boundary.
+//
+// The test pins the visible contract for a single cached sync_status event:
+// status 200, the streaming Content-Type, Cache-Control: no-cache, and the
+// first SSE frame's event/data lines. Pre-broadcasting through the hub
+// before the server starts removes the broadcast / read race a non-cached
+// first event would introduce.
+func TestSSEContractPinDeliversCachedSyncStatusFrame(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	srv.Hub().Broadcast(server.Event{
+		Type: "sync_status",
+		Data: map[string]bool{"running": false},
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/api/v1/events")
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Equal("text/event-stream", resp.Header.Get("Content-Type"))
+	assert.Equal("no-cache", resp.Header.Get("Cache-Control"))
+
+	eventType, dataLine := readFirstSSEFrame(t, resp.Body)
+	require.Equal("sync_status", eventType)
+
+	var payload map[string]bool
+	require.NoError(json.Unmarshal([]byte(dataLine), &payload))
+	assert.Equal(map[string]bool{"running": false}, payload)
+}
+
+// readFirstSSEFrame reads from r until it sees a blank-line terminator,
+// returning the event type and the bytes after "data: " on the data line.
+// The SSE wire format is one or more "field: value" lines terminated by a
+// blank line.
+func readFirstSSEFrame(t *testing.T, r io.Reader) (string, string) {
+	t.Helper()
+	scanner := bufio.NewScanner(r)
+	var eventType, data string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if rest, ok := strings.CutPrefix(line, "event: "); ok {
+			eventType = rest
+		}
+		if rest, ok := strings.CutPrefix(line, "data: "); ok {
+			data = rest
+		}
+		if line == "" && eventType != "" {
+			return eventType, data
+		}
+	}
+	require.FailNow(t, "did not read a complete SSE frame")
+	return "", ""
+}

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -169,7 +169,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 
 func testGitSHA(t *testing.T, dir, ref string) string {
 	t.Helper()
-	cmd := exec.Command("git", "rev-parse", ref)
+	cmd := procutil.Command("git", "rev-parse", ref)
 	cmd.Dir = dir
 	cmd.Env = append(
 		gitenv.StripAll(os.Environ()),

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -167,6 +167,20 @@ func runGit(t *testing.T, dir string, args ...string) {
 	require.NoError(t, err, "git %v failed: %s", args, out)
 }
 
+func testGitSHA(t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = dir
+	cmd.Env = append(
+		gitenv.StripAll(os.Environ()),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
 func seedPROnHost(
 	t *testing.T, database *db.DB,
 	host, owner, name string, number int,
@@ -205,6 +219,39 @@ func seedPROnHost(
 	require.NoError(t, database.EnsureKanbanState(ctx, prID))
 
 	return prID
+}
+
+func seedIssue(
+	t *testing.T, database *db.DB,
+	owner, name string, number int, state string,
+) int64 {
+	t.Helper()
+	ctx := t.Context()
+
+	repoID, err := database.UpsertRepo(
+		ctx, db.GitHubRepoIdentity("github.com", owner, name),
+	)
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	issue := &db.Issue{
+		RepoID:         repoID,
+		PlatformID:     int64(number) * 1000,
+		Number:         number,
+		URL:            fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, name, number),
+		Title:          fmt.Sprintf("Test Issue #%d", number),
+		Author:         "testuser",
+		State:          state,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	}
+	if state == "closed" {
+		issue.ClosedAt = &now
+	}
+	issueID, err := database.UpsertIssue(ctx, issue)
+	require.NoError(t, err)
+	return issueID
 }
 
 func createReadyWorkspace(

--- a/internal/server/workspacetest/issue_workspace_conflict_test.go
+++ b/internal/server/workspacetest/issue_workspace_conflict_test.go
@@ -32,20 +32,20 @@ func TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient(t *testing.
 
 	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
 
-	// Pre-create the branch the handler would otherwise allocate, so
-	// the next workspace request hits the typed conflict path.
+	branch := "middleman/issue-7"
+
+	// Pre-create the requested branch so the next workspace request hits
+	// the typed conflict path regardless of the default branch style.
 	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
 	runGit(
 		t,
 		fixture.bare,
-		"update-ref",
-		"refs/heads/middleman/issue-7",
-		mainSHA,
+		"update-ref", "refs/heads/"+branch, mainSHA,
 	)
 
 	resp, err := fixture.client.HTTP.CreateIssueWorkspaceWithResponse(
 		t.Context(), "gh", "acme", "widget", 7,
-		generated.CreateIssueWorkspaceInputBody{},
+		generated.CreateIssueWorkspaceInputBody{GitHeadRef: &branch},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusConflict, resp.StatusCode(), string(resp.Body))
@@ -71,9 +71,9 @@ func TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient(t *testing.
 		}
 		locations[*e.Location] = e.Value
 	}
-	assert.Equal("middleman/issue-7", locations["body.git_head_ref"])
+	assert.Equal(branch, locations["body.git_head_ref"])
 	assert.Equal(
-		"middleman/issue-7-2",
+		branch+"-2",
 		locations["body.suggested_git_head_ref"],
 	)
 }

--- a/internal/server/workspacetest/issue_workspace_conflict_test.go
+++ b/internal/server/workspacetest/issue_workspace_conflict_test.go
@@ -1,0 +1,79 @@
+package workspacetest
+
+import (
+	"net/http"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/apiclient/generated"
+)
+
+// TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient is a
+// black-box migration of TestWorkspaceCreateIssueBranchConflictReturnsTyped409
+// (still in internal/server/api_test.go). The original asserts the same
+// behavior using a package-local rawProblemDetail struct; this version
+// decodes through generated.ErrorModel so a regression that drifts the
+// 409 response shape away from the published OpenAPI contract fails this
+// test.
+//
+// The migration is not a transport change — both shapes go through
+// srv.ServeHTTP via the recorder transport. It is a package-boundary
+// change: this file lives in package workspacetest, cannot reach into
+// package server's unexported helpers, and uses the generated apiclient
+// instead of the in-package doJSON helper. workspacetest/ is the natural
+// home because setupWorkspaceServerFixture already wires up a real git
+// remote, which apitest/ does not.
+func TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	fixture := setupWorkspaceServerFixture(t, nil)
+
+	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
+
+	// Pre-create the branch the handler would otherwise allocate, so
+	// the next workspace request hits the typed conflict path.
+	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
+	runGit(
+		t,
+		fixture.bare,
+		"update-ref",
+		"refs/heads/middleman/issue-7",
+		mainSHA,
+	)
+
+	resp, err := fixture.client.HTTP.CreateIssueWorkspaceWithResponse(
+		t.Context(), "gh", "acme", "widget", 7,
+		generated.CreateIssueWorkspaceInputBody{},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusConflict, resp.StatusCode(), string(resp.Body))
+
+	problem := resp.ApplicationproblemJSONDefault
+	require.NotNil(problem, "default error model must be populated for 409")
+
+	require.NotNil(problem.Type)
+	assert.Equal(
+		"urn:middleman:error:issue-workspace-branch-conflict",
+		*problem.Type,
+	)
+	require.NotNil(problem.Status)
+	assert.EqualValues(http.StatusConflict, *problem.Status)
+	require.NotNil(problem.Detail)
+	assert.NotEmpty(*problem.Detail)
+
+	require.NotNil(problem.Errors)
+	locations := map[string]any{}
+	for _, e := range *problem.Errors {
+		if e.Location == nil {
+			continue
+		}
+		locations[*e.Location] = e.Value
+	}
+	assert.Equal("middleman/issue-7", locations["body.git_head_ref"])
+	assert.Equal(
+		"middleman/issue-7-2",
+		locations["body.suggested_git_head_ref"],
+	)
+}


### PR DESCRIPTION
## Summary

- New "HTTP testing discipline" section in `context/testing.md` (linked from `CLAUDE.md`) covering when to test at the wire vs unit-test internals, transport choice, fault-injection exception, and the classes of bug wire tests catch (JSON time serialization drift, middleware-overridden statuses, headers stripped by middleware).
- Two paving wire-level examples added: a streaming/SSE shape (`internal/server/e2etest/sse_contract_test.go`) that pins the status line, `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and the cached `sync_status` frame; and a content-negotiation shape (`internal/server/apitest/mutation_guard_test.go`) that pins the 415 + error envelope for a wrong-`Content-Type` mutation.
- One handler-internal test converted to wire-level (`internal/server/workspacetest/issue_workspace_conflict_test.go`) as a side-by-side migration worked example.