### PR TITLE
feat(sse): replay missed events on reconnect via Last-Event-ID

### DIFF
--- a/cmd/middleman/startup_token_e2e_test.go
+++ b/cmd/middleman/startup_token_e2e_test.go
@@ -22,6 +22,7 @@ import (
 // would run it on startup.
 func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 
 	// Fake gh on PATH. Records argv (one invocation per line) and
 	// emits a host-scoped token on stdout.
@@ -32,7 +33,7 @@ func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n" +
 		"printf '%s\\n' '" + fakeToken + "'\n"
-	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
+	require.NoError(os.WriteFile(ghPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir)
 	t.Setenv("FAKE_GH_ARGV", argvPath)
 
@@ -42,7 +43,7 @@ func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	// Config with a GHE repo. Loading via the public API exercises
 	// the same parsing path the daemon takes.
 	configPath := filepath.Join(t.TempDir(), "config.toml")
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+	require.NoError(os.WriteFile(configPath, []byte(`
 host = "127.0.0.1"
 port = 0
 
@@ -53,17 +54,17 @@ owner = "acme"
 name = "widget"
 `), 0o644))
 	cfg, err := config.Load(configPath)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	tokens, err := collectProviderTokens(cfg)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	key := providerHostKey("github", "ghe.example.com")
 	assert.Equal(fakeToken, tokens[key],
 		"GHE provider key should resolve to the gh-supplied host token")
 
 	data, err := os.ReadFile(argvPath)
-	require.NoError(t, err)
+	require.NoError(err)
 	invocations := strings.Split(
 		strings.TrimRight(string(data), "\n"), "\n",
 	)

--- a/docs/superpowers/plans/2026-05-19-sse-replay-on-reconnect.md
+++ b/docs/superpowers/plans/2026-05-19-sse-replay-on-reconnect.md
@@ -1,0 +1,173 @@
+# SSE Replay on Reconnect Implementation Plan
+
+Source spec: `docs/superpowers/specs/2026-05-19-sse-replay-on-reconnect-design.md`.
+
+The work is split into five tasks, each landed in its own commit. Tasks 1 through 4 are sequential because each builds on the previous structure; task 5 is the frontend counterpart that can land after task 4.
+
+## Task 1 — Hub event ids and ring buffer
+
+Add a process-scoped monotonic id to every event the hub broadcasts, and keep a fixed-size ring of the most recent events.
+
+Changes:
+
+- `internal/server/event_hub.go`:
+  - Define `RecordedEvent struct { ID uint64; Event Event }` as the in-hub representation.
+  - Add `nextEventID uint64`, `ring []RecordedEvent`, `ringHead int`, `ringCount int`, `ringCap int` to `EventHub`.
+  - Add `NewEventHubWithCapacity(capacity int) *EventHub` that panics on capacity < 1. Keep `NewEventHub()` defaulting to 256 by calling `NewEventHubWithCapacity(256)`.
+  - `Broadcast(Event)` returns the assigned `id` for testability and for the SSE handler to use. Internally:
+    - Take the lock, increment `nextEventID`, capture id.
+    - If event type is `sync_status`, set `lastSyncStatus` to a `RecordedEvent{ID: id, Event: event}`.
+    - Append into the ring; if full, overwrite the oldest slot (`ring[ringHead] = recorded; ringHead = (ringHead+1) % ringCap`); otherwise grow `ringCount` and place at the next free slot.
+    - Iterate subscribers and send the `RecordedEvent` over the per-subscriber channel; on full channel, evict via existing `unsubscribeLocked`.
+  - Change the subscriber channel element type from `Event` to `RecordedEvent`. Update channel buffer size constant if introduced; otherwise the inline `16` remains.
+  - `Subscribe` signature stays `(ctx) (<-chan RecordedEvent, <-chan struct{})`. Cached `sync_status` injection becomes a single `RecordedEvent` send.
+
+- `internal/server/event_hub_test.go`:
+  - Update existing tests to read `RecordedEvent` from the channel and assert on `.Event.Type`/`.Event.Data`.
+  - Add `TestEventHub_BroadcastAssignsMonotonicIDs`: 5 broadcasts return ids 1..5 in order.
+  - Add `TestEventHub_RingRetainsLastN`: with capacity 4, broadcast 10 events; assert `ringRange()` (new exported-for-test method `RingSnapshot() []RecordedEvent`) returns ids 7..10.
+  - Add `TestEventHub_CachedSyncStatusPreservesID`: broadcast sync_status with id N, new subscriber receives it carrying the same id.
+  - Adjust `TestEventHub_SlowConsumerEvicted` to expect `RecordedEvent` values.
+
+Acceptance:
+
+- `go test ./internal/server -run TestEventHub_ -shuffle=on` green.
+
+```sh
+git commit -m "feat: stamp SSE events with monotonic ids and ring-buffer them" -m "Step 1 of restoring durable live updates after a refresh, blip, or sleep/wake."
+```
+
+## Task 2 — SSE wire format includes id and ring replay path
+
+Wire the event id through the HTTP handler, accept reconnect cursors, and replay newer ring entries before resuming live delivery.
+
+Changes:
+
+- `internal/server/server.go`:
+  - `serveSSE` accepts an additional `cursor *uint64` parameter (nil = no cursor) and `staleEventID uint64` slot if any. Build it directly from the request inside `handleSSE` / `streamEvents`.
+  - Replace the `event:`/`data:` write block with `id: <id>\nevent: <type>\ndata: <json>\n\n`.
+  - Add a parsing helper `parseLastEventID(r *http.Request) (uint64, bool)` that checks `Last-Event-ID` header first, then `since` query parameter; on parse failure returns `(0, false)`.
+  - In `serveSSE`, after subscribe and the initial flush:
+    - If cursor present: pull a snapshot of the ring via `hub.RingSnapshotSince(cursor)` (new method, returns `[]RecordedEvent` with id > cursor, or a sentinel return value indicating "stale: cursor older than oldest"). Hub method holds the lock briefly.
+    - If sentinel-stale: write one `id: <next>\nevent: reconnect.stale\ndata: {}\n\n` frame using `hub.AssignSyntheticID()` (new method that increments and returns nextEventID under lock without recording in the ring). Skip cached sync_status injection.
+    - Else if cursor present and not stale: drain any cached `sync_status` already sitting on the subscriber channel (which Subscribe injected) and discard it to avoid duplicating with replay (alternative: Subscribe takes a flag `injectCached bool`).
+    - Else write replay entries in id order, then resume.
+  - Refactor: have `EventHub.Subscribe` take an option struct or a second parameter `injectCachedSyncStatus bool`. When the handler knows it will use ring replay, it passes `false`.
+
+- `internal/server/huma_routes.go`:
+  - `streamEvents`: unwrap to `*http.Request` via `humago.Unwrap`, pass it down so the SSE serve function can read headers/query.
+
+- `internal/server/event_hub.go`:
+  - Add `Subscribe(ctx, injectCached bool)`. Old call sites updated.
+  - Add `RingSnapshotSince(cursor uint64) ([]RecordedEvent, bool)`: returns `(replay, stale)`. `stale=true` indicates cursor predates the ring's oldest event AND the ring contains at least one event. If cursor equals the latest id or `>=` head, returns `(nil, false)`.
+  - Add `AssignSyntheticID() uint64`: increments nextEventID, returns the new value, does NOT touch the ring or cache. Used only for `reconnect.stale` framing.
+
+Tests added to `internal/server/server_test.go` and `event_hub_test.go`:
+
+- `TestEventHub_RingSnapshotSince_ReplaysNewer`: capacity 8, broadcast ids 1..5, cursor=2 returns events 3,4,5; stale=false.
+- `TestEventHub_RingSnapshotSince_StaleCursor`: capacity 4, broadcast ids 1..10, cursor=2 returns nil; stale=true (ring oldest is 7).
+- `TestEventHub_RingSnapshotSince_AtOrAheadHead`: cursor=10 with head=10 returns nil, stale=false.
+- `TestEventHub_AssignSyntheticIDIncrementsWithoutRecord`: synthetic id is current+1; ring is unchanged.
+- `TestSSE_WriteFramesIncludeID`: wire-level test reading the response body and asserting the first frame has `id: N`.
+- `TestSSE_NoCursorReplaysCachedSyncStatusOnly`: prime hub with sync_status, broadcast a data_changed, subscribe with no cursor — first frame is the cached sync_status (with its id), no replay of data_changed.
+- `TestSSE_LastEventIDHeaderReplays`: broadcast 3 data_changed; open a fresh connection with `Last-Event-ID: 1`; first two frames are events 2 and 3 with matching ids.
+- `TestSSE_SinceQueryReplays`: same as above with `?since=1`.
+- `TestSSE_HeaderOverridesQueryCursor`: when both present, header wins.
+- `TestSSE_StaleCursorEmitsReconnectStale`: capacity 4, broadcast ids 1..10, connect with `Last-Event-ID: 2`; first frame is `event: reconnect.stale` with id=11; subsequent broadcasts arrive normally.
+- `TestSSE_InvalidCursorFallsBackToLiveOnly`: `Last-Event-ID: not-a-number` is treated as no cursor (cached sync_status delivered if present, no replay, no stale).
+- `TestSSE_CursorAtHeadReplaysNothing`: broadcast 3 events, connect with `Last-Event-ID: 3`; only future events appear.
+
+Acceptance:
+
+- `go test ./internal/server -shuffle=on` green.
+- `make lint` and `make vet` clean.
+
+```sh
+git commit -m "feat: replay missed SSE events on reconnect via Last-Event-ID" -m "Live updates survive transient network blips and laptop sleep/wake by replaying buffered events when the cursor is still in range, or emitting reconnect.stale to trigger a frontend refetch when it is not."
+```
+
+## Task 3 — Config knob for ring size
+
+Surface the ring buffer capacity as a TOML setting and wire it into the hub constructor.
+
+Changes:
+
+- `internal/config/config.go`:
+  - Add `SSEBufferSize int` with `toml:"sse_buffer_size"` to the `Config` struct.
+  - Default to `defaultSSEBufferSize = 256` if zero on `Load`.
+  - In `Validate`, if `SSEBufferSize` is set, require `16 <= SSEBufferSize <= 16384`; otherwise leave the default. Error message: `"config: sse_buffer_size must be between 16 and 16384"`.
+  - Add a helper `func (c *Config) SSEBufferSizeOrDefault() int` returning the configured value or the default.
+  - Export-as-TOML form (`tomlForm` struct around line 1175): mirror the field with `omitempty`.
+
+- `internal/config/config_test.go` (or wherever validate tests live):
+  - Add `TestConfig_SSEBufferSize_DefaultWhenUnset` asserting `Load` produces 256 when absent.
+  - Add `TestConfig_SSEBufferSize_RejectsBelowMin` (size = 8) and `TestConfig_SSEBufferSize_RejectsAboveMax` (size = 17000).
+  - Add `TestConfig_SSEBufferSize_AcceptsValidRange` (size = 1024).
+
+- `internal/server/server.go`:
+  - In `newServer`, replace `hub: NewEventHub()` with `hub: NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault())`. When `cfg == nil` (test path via `server.New(... nil ...)`), fall back to `NewEventHub()` (defaults to 256).
+
+Acceptance:
+
+- `go test ./internal/config ./internal/server -shuffle=on` green.
+
+```sh
+git commit -m "feat: configure SSE replay buffer size via sse_buffer_size" -m "Operators who run many concurrent tabs or notice the ring rolling over on sleep/wake can tune the buffer. Default 256, range 16..16384."
+```
+
+## Task 4 — End-to-end wire tests via httptest.NewServer
+
+Add black-box e2e tests under `internal/server/e2etest/` that boot a real HTTP server, open an SSE connection, simulate a disconnect, reopen with `Last-Event-ID`, and assert on the parsed wire frames.
+
+Changes:
+
+- `internal/server/e2etest/sse_replay_test.go` (new):
+  - Helper `parseSSEFrames(t, r io.Reader, want int) []sseFrame` that reads up to `want` frames or times out, where `sseFrame { ID string; Event string; Data string }`.
+  - `TestE2E_SSEReconnectReplaysMissedEvents`: boot via `httptest.NewServer(srv)`. Broadcast ids 1..3, drain them on a first connection, close it. Broadcast ids 4..5 while disconnected. Open a second connection with `Last-Event-ID: 3`. Assert it receives exactly events 4 and 5 with the right ids, then receives a freshly broadcast event 6.
+  - `TestE2E_SSEStaleCursorEmitsReconnectStale`: configure a small buffer (capacity 4) via `newServerWithSSEBufferSize(t, 4)`; broadcast 10 events; second connection with `Last-Event-ID: 2`; assert first frame is `reconnect.stale` with id=11, then subsequent live frames flow.
+  - `TestE2E_SSESinceQueryWorks`: same as the header test but using `?since=N`.
+  - `TestE2E_SSEFirstConnectGetsCachedSyncStatus`: broadcast sync_status, then connect with no header/query; assert first frame is sync_status with the assigned id.
+
+  Helper `newServerWithSSEBufferSize(t, n int)` constructs a `*server.Server` whose hub has the requested ring size, by loading a tiny TOML config that sets `sse_buffer_size`.
+
+Acceptance:
+
+- `go test ./internal/server/e2etest -shuffle=on` green.
+- `make test-short` and `make test` green from repo root.
+
+```sh
+git commit -m "test: cover SSE replay end-to-end through a real HTTP server" -m "Wire-level e2e: open SSE, close, reconnect with Last-Event-ID, and assert on the actual id/event/data lines returned by the daemon."
+```
+
+## Task 5 — Frontend reconnect.stale handler
+
+Teach the events store to react to the new `reconnect.stale` event by re-running view loaders.
+
+Changes:
+
+- `packages/ui/src/stores/events.svelte.ts`:
+  - Add an option `onReconnectStale?: () => void`.
+  - Add an `EventSource.addEventListener("reconnect.stale", () => opts.onReconnectStale?.())` in `connect()`.
+  - Keep the existing `data_changed` and `sync_status` dispatch as-is.
+
+- `packages/ui/src/stores/container.svelte.ts` (or wherever the events store is wired into the app — call site identified by tracing `createEventsStore` consumers):
+  - On `reconnect.stale`, re-run the same actions a `data_changed` triggers (typically `pulls.loadPulls()` and `issues.loadIssues()`) AND force a fresh `sync.refresh()` to refetch `/api/v1/sync/status`.
+
+- `frontend/src/lib/stores/events.svelte.test.ts`:
+  - Add `it("fires onReconnectStale for reconnect.stale frames")` mirroring the existing `data_changed` test.
+  - Add `it("ignores unknown event types without throwing")` — defensive.
+
+Acceptance:
+
+- `cd frontend && bun install && bun run typecheck && bun run test` green.
+
+```sh
+git commit -m "feat(frontend): refetch view state on reconnect.stale events" -m "When the server signals that the SSE gap is too large to replay, the SPA reloads pull, issue, and sync state instead of staying on the stale snapshot."
+```
+
+## Out of Scope (Follow-Ups)
+
+- Structured `slog` line on every stale reconnect, with the cursor value, the ring's oldest id, and the assigned synthetic id. Useful for correlating with sleep/wake events.
+- Persisting the last seen id in `localStorage` so a hard refresh can also use `?since=N`. The reload path currently refetches everything anyway.
+- A `/api/v1/sync/status` follow-up call inside the frontend on `reconnect.stale` if not already implicitly covered by the `sync` store's refresh path.
+- Exposing `nextEventID` and `oldestRingID` over an admin endpoint for debugging.

--- a/docs/superpowers/specs/2026-05-19-sse-replay-on-reconnect-design.md
+++ b/docs/superpowers/specs/2026-05-19-sse-replay-on-reconnect-design.md
@@ -1,0 +1,123 @@
+# SSE Replay on Reconnect Design
+
+## Goal
+
+Make the SSE stream durable across browser refresh, transient network blips, and laptop sleep/wake so the dashboard catches up automatically instead of getting stuck on stale state until manual refresh.
+
+## Current Behavior
+
+`internal/server/event_hub.go` runs the live stream with two pieces of state:
+
+- A fan-out map of subscriber channels (`map[uint64]chan Event`, capacity 16 each), evicted on full-channel writes so a slow consumer never blocks the broadcaster.
+- A single cached `sync_status` `Event`, replayed once to every new subscriber on `Subscribe`.
+
+`internal/server/server.go` handles `/api/v1/events` by calling `s.hub.Subscribe(r.Context())` and forwarding each broadcast as `event: <type>\ndata: <json>\n\n`. No `id:` line. No buffer of recent events. Every event but the latest `sync_status` is fire-and-forget.
+
+When the connection drops, EventSource auto-reconnects (browser behavior) and the server starts a fresh subscription with no knowledge of what was missed. Anything broadcast during the gap is lost.
+
+## Symptom
+
+A user closes the laptop with a PR in "syncing" state, opens it thirty minutes later, and the UI is stuck on the pre-sleep view. A PR that merged on the server still shows as open. The sync status panel does not catch up because the events that would have driven it were broadcast to a dead subscriber and never reached the next one.
+
+## Design Decision
+
+Add a process-scoped, monotonically increasing event id to every SSE frame and keep a fixed-size ring buffer of recent events in the hub. On reconnect, the client passes the last id it saw (via the standard `Last-Event-ID` header or a `?since=N` query parameter), the server replays everything still in the ring that is newer, and only then resumes live delivery. If the requested cursor predates the ring, the server emits exactly one synthetic `reconnect.stale` frame before resuming, and the frontend interprets that as "the gap is too big, refetch view state from scratch."
+
+The cached-last-`sync_status` behavior stays in place for first-time subscribers who have no cursor: it remains the only way a brand-new tab learns the daemon's current sync state without a round-trip to `/api/v1/sync/status`.
+
+Slow-consumer eviction stays unchanged. A subscriber whose buffer fills is dropped from the live fan-out; its next reconnect goes through the same replay path as any other reconnect.
+
+## Wire Format
+
+Every broadcast frame carries an id:
+
+```
+id: 42
+event: data_changed
+data: {}
+
+```
+
+Ids are monotonically increasing `uint64` values scoped to the hub's lifetime. The first event after process start is id 1. Restarting the daemon resets the counter to 1, since a fresh `EventHub` starts at 1.
+
+The synthetic `reconnect.stale` frame is just another framed event with its own id; it carries no payload of its own (`data: {}`):
+
+```
+id: 124
+event: reconnect.stale
+data: {}
+
+```
+
+The `reconnect.stale` frame is the first frame the client sees on a stale reconnect. It is not buffered into the ring and never replayed; it is emitted only at the moment the server detects a stale cursor and is followed immediately by live delivery.
+
+## Ring Buffer
+
+The hub owns a fixed-size ring buffer of recently broadcast events. Size is configurable via a new top-level TOML field `sse_buffer_size`, default 256, validated to be `>= 16` and `<= 16384`. A size of zero is rejected; the feature is always on. The field lives at the same level as `port` and `base_path` rather than under a nested `[server]` table because no such table exists today and the project conventionally keeps server-shaped knobs at the top level.
+
+The buffer stores each broadcast event along with its assigned id. Inserts overwrite the oldest slot once full. The buffer is guarded by the hub's existing `sync.Mutex`; `Broadcast` already holds the lock while iterating subscribers, so the ring insert costs one slice write inside the same critical section.
+
+A `sync_status` event is still recorded as the cached latest-status entry in addition to being stored in the ring buffer. Cached delivery to new no-cursor subscribers happens before ring replay would; both paths are exclusive (a connection with a cursor never gets the cached entry).
+
+## Reconnect Protocol
+
+The client signals its cursor in one of two ways. The server checks them in this priority order:
+
+1. `Last-Event-ID` request header (HTML5 SSE standard; EventSource sets it automatically on reconnect).
+2. `since` query parameter (`/api/v1/events?since=42`), useful for explicit first-connect resumption from local-storage or for non-browser clients.
+
+If both are present, the header wins. If the value fails to parse as a non-negative `uint64`, the server logs at debug level and proceeds as if no cursor was sent.
+
+Server behavior on subscribe, in order:
+
+1. If no cursor is supplied:
+   - If a `sync_status` is cached, emit it as the first frame using its cached id (the id it had when broadcast).
+   - Resume live delivery.
+2. If a cursor `N` is supplied:
+   - If the ring is empty or the buffer's oldest id is `> N + 1`, emit one `reconnect.stale` frame with the current next-id assigned, then resume live delivery without replay or cached injection.
+   - Otherwise, walk the ring and emit every entry with id `> N`, in id order, then resume live delivery without cached injection. (If `N` is already at or above the hub's current head, the replay loop emits nothing, which is fine.)
+3. The handler then loops over the live channel exactly as it does today.
+
+`reconnect.stale` is emitted at most once per connection.
+
+The "next-id" assigned to a synthetic `reconnect.stale` frame consumes a real id slot. This keeps client cursors monotonic across stale boundaries: after a stale, the client's next observed id will be one greater than the stale frame's id.
+
+## Frontend Behavior
+
+The Svelte `createEventsStore` does not need to thread `Last-Event-ID` manually. `EventSource` injects the header on browser-driven reconnects. The store gains one new listener:
+
+- `reconnect.stale`: re-run the same loaders that run on a `data_changed` plus refetch `/api/v1/sync/status`. This is the catch-up path when the ring buffer could not bridge the gap.
+
+The store does not need to track or report the latest seen id back to the server explicitly; the browser carries it. For non-browser callers (smoke tests, future CLIs) the `?since=N` query parameter is the fallback.
+
+## Subscriber Channel Capacity
+
+The per-subscriber Go channel stays at capacity 16. Ring replay copies events from the ring into the subscriber's channel before the live broadcaster starts feeding it. If the channel fills during replay (subscriber is genuinely slow to read off the network), the subscriber is dropped and the connection is closed. From the client's standpoint this is the same as any other transport-level disconnect; its next reconnect goes through the same replay path with whatever cursor it carried.
+
+## Slow-Consumer Eviction
+
+The existing eviction path is unchanged. Slow-consumer events still trigger `unsubscribeLocked` and a channel close. Replay is bounded by the ring size (default 256, max 16384), so a worst-case replay of a maxed-out ring writes at most that many events into a 16-slot channel; the eviction path triggers if the client is too slow to keep up, exactly as it does in live operation.
+
+## Observability
+
+No new metrics in this change; the daemon log already records `sse: marshal event` failures, which is the dominant failure mode that would otherwise be invisible. A future follow-up may emit a structured log line when a stale reconnect happens so operators can correlate it with sleep/wake events.
+
+## Compatibility
+
+Adding `id:` lines to SSE frames is backwards-compatible: every conforming SSE client (including `EventSource` and `curl --silent`) tolerates additional fields.
+
+Older clients that do not understand the new `reconnect.stale` event type ignore unknown event names per the HTML5 spec, but lose the stale-cursor refetch behavior. Since the SPA ships from the same binary as the server, in practice the frontend update lands atomically with the server update. Cross-version skew is only a concern for the brief window of an in-place upgrade, where the worst case is the same as today's behavior: the next manual refresh or sync poll rehydrates state.
+
+## Configuration
+
+Default config in `EnsureDefault` does not need to mention `sse_buffer_size`; the feature is enabled with a sensible default and only power users adjusting it would set the field. Validation lives in `(*Config).Validate`, alongside the existing range checks for `port`, `sync_budget_per_hour`, and friends.
+
+If `sse_buffer_size` is set to a value outside the allowed range, `Load` fails with a descriptive error and the daemon refuses to start, matching the existing pattern for other server-shaped knobs.
+
+## Non-Goals
+
+- No persistent buffer. Events still live only in memory; restarting the daemon resets ids and clears the ring.
+- No delivery acknowledgement protocol. Best-effort in-memory replay is the contract; if the buffer rolls past the cursor the client refetches.
+- No per-subscriber backpressure beyond the existing slow-consumer eviction.
+- No change to the event schema or to which broadcasts the daemon emits.
+- No frontend-side persisting of the last seen id across reload. Browser reload starts a fresh `EventSource` connection, which, for a brand-new page load, is the correct moment to refetch state from scratch anyway. The reload case is covered by the SPA's existing startup data fetches.

--- a/frontend/src/lib/stores/events.svelte.test.ts
+++ b/frontend/src/lib/stores/events.svelte.test.ts
@@ -140,6 +140,28 @@ describe("createEventsStore event dispatch", () => {
     ).not.toThrow();
     expect(onSyncStatus).not.toHaveBeenCalled();
   });
+
+  it("fires onReconnectStale for reconnect.stale frames", () => {
+    const onReconnectStale = vi.fn();
+    const store = createEventsStore({ onReconnectStale });
+    store.connect();
+    const src = instances[0];
+    expect(src).toBeDefined();
+    emit(src as StubEventSource, "reconnect.stale", { data: "{}" });
+    expect(onReconnectStale).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores unknown event types without throwing", () => {
+    const onDataChanged = vi.fn();
+    const store = createEventsStore({ onDataChanged });
+    store.connect();
+    expect(() =>
+      emit(instances[0] as StubEventSource, "totally_unknown", {
+        data: "{}",
+      }),
+    ).not.toThrow();
+    expect(onDataChanged).not.toHaveBeenCalled();
+  });
 });
 
 describe("createEventsStore connection lifecycle", () => {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,9 @@ const (
 	defaultSyncBudgetPerHour = 500
 	defaultPlatform          = "github"
 	defaultPlatformHost      = platformpkg.DefaultGitHubHost
+	defaultSSEBufferSize     = 256
+	minSSEBufferSize         = 16
+	maxSSEBufferSize         = 16384
 )
 
 const (
@@ -518,23 +521,35 @@ type Shell struct {
 }
 
 type Config struct {
-	SyncInterval               string           `toml:"sync_interval"`
-	GitHubTokenEnv             string           `toml:"github_token_env"`
-	DefaultPlatformHost        string           `toml:"default_platform_host"`
-	Host                       string           `toml:"host"`
-	Port                       int              `toml:"port"`
-	BasePath                   string           `toml:"base_path"`
-	DataDir                    string           `toml:"data_dir"`
-	SyncBudgetPerHour          int              `toml:"sync_budget_per_hour"`
-	IssueWorkspaceBranchStyle  string           `toml:"issue_workspace_branch_style"`
-	Repos                      []Repo           `toml:"repos"`
-	Platforms                  []PlatformConfig `toml:"platforms"`
-	Activity                   Activity         `toml:"activity"`
-	Terminal                   Terminal         `toml:"terminal"`
-	Agents                     []Agent          `toml:"agents"`
-	Roborev                    Roborev          `toml:"roborev"`
-	Tmux                       Tmux             `toml:"tmux"`
-	Shell                      Shell            `toml:"shell"`
+	SyncInterval              string           `toml:"sync_interval"`
+	GitHubTokenEnv            string           `toml:"github_token_env"`
+	DefaultPlatformHost       string           `toml:"default_platform_host"`
+	Host                      string           `toml:"host"`
+	Port                      int              `toml:"port"`
+	BasePath                  string           `toml:"base_path"`
+	DataDir                   string           `toml:"data_dir"`
+	SyncBudgetPerHour         int              `toml:"sync_budget_per_hour"`
+	SSEBufferSize             int              `toml:"sse_buffer_size"`
+	IssueWorkspaceBranchStyle string           `toml:"issue_workspace_branch_style"`
+	Repos                     []Repo           `toml:"repos"`
+	Platforms                 []PlatformConfig `toml:"platforms"`
+	Activity                  Activity         `toml:"activity"`
+	Terminal                  Terminal         `toml:"terminal"`
+	Agents                    []Agent          `toml:"agents"`
+	Roborev                   Roborev          `toml:"roborev"`
+	Tmux                      Tmux             `toml:"tmux"`
+	Shell                     Shell            `toml:"shell"`
+}
+
+// SSEBufferSizeOrDefault returns the configured SSE replay ring size,
+// falling back to the package default. A nil receiver is treated as
+// fully default-configured so tests that pass cfg = nil into the
+// server still get a working ring size.
+func (c *Config) SSEBufferSizeOrDefault() int {
+	if c == nil || c.SSEBufferSize == 0 {
+		return defaultSSEBufferSize
+	}
+	return c.SSEBufferSize
 }
 
 func DefaultConfigPath() string {
@@ -711,6 +726,10 @@ func Load(path string) (*Config, error) {
 		cfg.IssueWorkspaceBranchStyle = defaultIssueWorkspaceBranchStyle
 	}
 
+	if cfg.SSEBufferSize == 0 {
+		cfg.SSEBufferSize = defaultSSEBufferSize
+	}
+
 	if cfg.BasePath == "" {
 		cfg.BasePath = defaultBasePath
 	} else {
@@ -815,6 +834,14 @@ func (c *Config) Validate() error {
 		return fmt.Errorf(
 			"config: sync_budget_per_hour must be >= 50 or omitted, got %d",
 			c.SyncBudgetPerHour,
+		)
+	}
+
+	if c.SSEBufferSize != 0 &&
+		(c.SSEBufferSize < minSSEBufferSize || c.SSEBufferSize > maxSSEBufferSize) {
+		return fmt.Errorf(
+			"config: sse_buffer_size must be between %d and %d or omitted, got %d",
+			minSSEBufferSize, maxSSEBufferSize, c.SSEBufferSize,
 		)
 	}
 
@@ -1280,6 +1307,7 @@ type configFile struct {
 	Host                      string           `toml:"host"`
 	Port                      int              `toml:"port"`
 	SyncBudgetPerHour         int              `toml:"sync_budget_per_hour,omitempty"`
+	SSEBufferSize             int              `toml:"sse_buffer_size,omitempty"`
 	BasePath                  string           `toml:"base_path,omitempty"`
 	DataDir                   string           `toml:"data_dir,omitempty"`
 	IssueWorkspaceBranchStyle string           `toml:"issue_workspace_branch_style,omitempty"`
@@ -1315,6 +1343,9 @@ func (c *Config) Save(path string) error {
 	}
 	if c.SyncBudgetPerHour != defaultSyncBudgetPerHour {
 		f.SyncBudgetPerHour = c.SyncBudgetPerHour
+	}
+	if c.SSEBufferSize != 0 && c.SSEBufferSize != defaultSSEBufferSize {
+		f.SSEBufferSize = c.SSEBufferSize
 	}
 	if c.BasePath != defaultBasePath {
 		f.BasePath = c.BasePath

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1805,6 +1805,124 @@ name = "b"
 	})
 }
 
+func TestSSEBufferSize(t *testing.T) {
+	t.Run("default is 256 when unset", func(t *testing.T) {
+		path := writeConfig(t, `
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+		Assert.Equal(t, 256, cfg.SSEBufferSize)
+		Assert.Equal(t, 256, cfg.SSEBufferSizeOrDefault())
+	})
+
+	t.Run("nil receiver returns default", func(t *testing.T) {
+		var cfg *Config
+		Assert.Equal(t, 256, cfg.SSEBufferSizeOrDefault())
+	})
+
+	t.Run("rejects below minimum", func(t *testing.T) {
+		path := writeConfig(t, `
+sse_buffer_size = 8
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		Assert.Contains(t, err.Error(), "sse_buffer_size must be between 16 and 16384")
+	})
+
+	t.Run("rejects above maximum", func(t *testing.T) {
+		path := writeConfig(t, `
+sse_buffer_size = 20000
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		Assert.Contains(t, err.Error(), "sse_buffer_size must be between 16 and 16384")
+	})
+
+	t.Run("accepts valid value in range", func(t *testing.T) {
+		path := writeConfig(t, `
+sse_buffer_size = 1024
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+		Assert.Equal(t, 1024, cfg.SSEBufferSize)
+		Assert.Equal(t, 1024, cfg.SSEBufferSizeOrDefault())
+	})
+
+	t.Run("accepts boundary minimum 16", func(t *testing.T) {
+		path := writeConfig(t, `
+sse_buffer_size = 16
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+		Assert.Equal(t, 16, cfg.SSEBufferSize)
+	})
+
+	t.Run("accepts boundary maximum 16384", func(t *testing.T) {
+		path := writeConfig(t, `
+sse_buffer_size = 16384
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+		Assert.Equal(t, 16384, cfg.SSEBufferSize)
+	})
+
+	t.Run("round-trips through Save", func(t *testing.T) {
+		require := require.New(t)
+		path := writeConfig(t, `
+sse_buffer_size = 1024
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		cfg, err := Load(path)
+		require.NoError(err)
+
+		savePath := filepath.Join(t.TempDir(), "saved.toml")
+		require.NoError(cfg.Save(savePath))
+
+		cfg2, err := Load(savePath)
+		require.NoError(err)
+		Assert.Equal(t, 1024, cfg2.SSEBufferSize)
+	})
+
+	t.Run("default value is omitted from Save output", func(t *testing.T) {
+		require := require.New(t)
+		path := writeConfig(t, `
+[[repos]]
+owner = "a"
+name = "b"
+`)
+		cfg, err := Load(path)
+		require.NoError(err)
+
+		savePath := filepath.Join(t.TempDir(), "saved.toml")
+		require.NoError(cfg.Save(savePath))
+
+		// Reload should still produce the default.
+		cfg2, err := Load(savePath)
+		require.NoError(err)
+		Assert.Equal(t, 256, cfg2.SSEBufferSize)
+	})
+}
+
 func TestRoborevEndpointDefault(t *testing.T) {
 	cfg := &Config{}
 	Assert.Equal(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -16904,7 +16904,7 @@ func TestWorkspaceMonitorPassBroadcastsInvalidationEvents(t *testing.T) {
 	ctx := t.Context()
 
 	fixture, created := prepareIssueWorkspaceAssociationFixture(t)
-	ch, _ := fixture.server.Hub().Subscribe(ctx)
+	ch, _ := fixture.server.Hub().Subscribe(ctx, true)
 
 	fixture.server.runWorkspacePRMonitorPass(ctx)
 
@@ -16923,16 +16923,16 @@ func TestWorkspaceMonitorPassBroadcastsInvalidationEvents(t *testing.T) {
 
 func readEventMatching(
 	t *testing.T,
-	ch <-chan Event,
+	ch <-chan RecordedEvent,
 	matches func(Event) bool,
 ) Event {
 	t.Helper()
 	timeout := time.After(2 * time.Second)
 	for {
 		select {
-		case ev := <-ch:
-			if matches(ev) {
-				return ev
+		case rec := <-ch:
+			if matches(rec.Event) {
+				return rec.Event
 			}
 		case <-timeout:
 			require.FailNow(t, "timed out waiting for matching event")

--- a/internal/server/e2etest/fixtures_test.go
+++ b/internal/server/e2etest/fixtures_test.go
@@ -31,6 +31,28 @@ func setupTestServer(t *testing.T) (*server.Server, *db.DB) {
 	return srv, database
 }
 
+// setupTestServerWithSSEBufferSize boots a server whose SSE replay
+// buffer holds the configured number of recent events. Used to exercise
+// the stale-cursor path with a small, deterministic ring.
+func setupTestServerWithSSEBufferSize(
+	t *testing.T, size int,
+) (*server.Server, *db.DB, *config.Config) {
+	t.Helper()
+	database := dbtest.Open(t)
+
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+
+	cfg := &config.Config{
+		Host:          "127.0.0.1",
+		Port:          8091,
+		BasePath:      "/",
+		SSEBufferSize: size,
+	}
+	srv := server.New(database, syncer, nil, "/", cfg, server.ServerOptions{})
+	return srv, database, cfg
+}
+
 func setupWithBasePath(t *testing.T, basePath string, _ any) *server.Server {
 	t.Helper()
 	database := dbtest.Open(t)

--- a/internal/server/e2etest/sse_replay_test.go
+++ b/internal/server/e2etest/sse_replay_test.go
@@ -186,6 +186,37 @@ func TestE2E_SSEStaleCursorEmitsReconnectStale(t *testing.T) {
 	assert.Equal("12", live.ID)
 }
 
+func TestE2E_SSEFutureCursorEmitsReconnectStale(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	defer gracefulShutdown(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "99")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	stale := readSSEFrame(t, scanner)
+	assert.Equal("reconnect.stale", stale.Event)
+	assert.Equal("1", stale.ID)
+
+	waitForSubscribe(t, srv, 1)
+	srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: "after-stale"})
+	live := readSSEFrame(t, scanner)
+	assert.Equal("2", live.ID)
+}
+
 func TestE2E_SSEFirstConnectGetsCachedSyncStatus(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/e2etest/sse_replay_test.go
+++ b/internal/server/e2etest/sse_replay_test.go
@@ -1,0 +1,278 @@
+package e2etest
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/server"
+)
+
+// sseFrame is one parsed SSE record. The hub's daemon-level tests parse
+// the same shape; this duplicate exists so the e2etest package does not
+// import the server package's test-only symbols.
+type sseFrame struct {
+	ID    string
+	Event string
+	Data  string
+}
+
+func readSSEFrame(t *testing.T, scanner *bufio.Scanner) sseFrame {
+	t.Helper()
+	var f sseFrame
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			f.ID = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			f.Event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			f.Data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if f.Event != "" {
+				return f
+			}
+		}
+	}
+	require.FailNow(t, "scanner ended before a complete frame")
+	return f
+}
+
+// waitForSubscribe spins until the hub has at least one subscriber
+// registered or the deadline fires. Broadcasting before this returns
+// would race with the subscribe call inside serveSSE.
+func waitForSubscribe(t *testing.T, srv *server.Server, want int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return srv.SubscriberCount() == want
+	}, 2*time.Second, 5*time.Millisecond,
+		"expected %d subscribers", want)
+}
+
+func TestE2E_SSEReconnectReplaysMissedEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	defer gracefulShutdown(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Connection #1: confirm we receive ids 1..3 live.
+	req1, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	resp1, err := ts.Client().Do(req1)
+	require.NoError(err)
+	waitForSubscribe(t, srv, 1)
+
+	for i := 1; i <= 3; i++ {
+		srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: i})
+	}
+
+	scanner1 := bufio.NewScanner(resp1.Body)
+	var seen []string
+	for range 3 {
+		f := readSSEFrame(t, scanner1)
+		seen = append(seen, f.ID)
+	}
+	assert.Equal([]string{"1", "2", "3"}, seen)
+
+	// Drop the first connection — the slow-consumer eviction path or
+	// context-cancel cleanup brings the subscriber count back to 0.
+	resp1.Body.Close()
+	require.Eventually(func() bool {
+		return srv.SubscriberCount() == 0
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Broadcast two more while disconnected.
+	for i := 4; i <= 5; i++ {
+		srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: i})
+	}
+
+	// Connection #2: reconnect with Last-Event-ID: 3.
+	req2, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req2.Header.Set("Last-Event-ID", "3")
+	resp2, err := ts.Client().Do(req2)
+	require.NoError(err)
+	defer resp2.Body.Close()
+
+	scanner2 := bufio.NewScanner(resp2.Body)
+	// First two frames are the replay of ids 4 and 5.
+	f4 := readSSEFrame(t, scanner2)
+	f5 := readSSEFrame(t, scanner2)
+	assert.Equal("4", f4.ID)
+	assert.Equal("5", f5.ID)
+
+	// Live event 6 also arrives.
+	waitForSubscribe(t, srv, 1)
+	srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: 6})
+	f6 := readSSEFrame(t, scanner2)
+	assert.Equal("6", f6.ID)
+}
+
+func TestE2E_SSESinceQueryWorks(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	defer gracefulShutdown(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Pre-broadcast so the ring has events 1..3.
+	for i := 1; i <= 3; i++ {
+		srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: i})
+	}
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events?since=2", nil,
+	)
+	require.NoError(err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("3", f.ID)
+	assert.Equal("data_changed", f.Event)
+}
+
+func TestE2E_SSEStaleCursorEmitsReconnectStale(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _, _ := setupTestServerWithSSEBufferSize(t, 4)
+	defer gracefulShutdown(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Roll the ring well past capacity.
+	for i := 1; i <= 10; i++ {
+		srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: i})
+	}
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "2")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("reconnect.stale", f.Event)
+	assert.Equal("11", f.ID, "synthetic id follows the last real broadcast")
+
+	// Live frame after the stale signal flows normally.
+	waitForSubscribe(t, srv, 1)
+	srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: "post-stale"})
+	live := readSSEFrame(t, scanner)
+	assert.Equal("12", live.ID)
+}
+
+func TestE2E_SSEFirstConnectGetsCachedSyncStatus(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	defer gracefulShutdown(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	srv.Hub().Broadcast(server.Event{
+		Type: "sync_status",
+		Data: map[string]any{"running": false},
+	})
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("sync_status", f.Event)
+	assert.Equal("1", f.ID, "cached event keeps its original assigned id")
+}
+
+func TestE2E_SSEFramesAlwaysIncludeID(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, _ := setupTestServer(t)
+	defer gracefulShutdown(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	waitForSubscribe(t, srv, 1)
+	srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: 1})
+
+	// Read raw bytes until we see a complete frame; the id: line must
+	// precede the event: line in the on-the-wire ordering the SSE spec
+	// allows.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	body := readUntilBlankLine(ctx, t, resp.Body)
+	assert.Contains(body, "id: 1\n", "frame must include the id field")
+	assert.Contains(body, "event: data_changed\n")
+}
+
+// readUntilBlankLine reads bytes until it sees \n\n indicating the end
+// of one frame, with a timeout to keep flaky tests from hanging.
+func readUntilBlankLine(
+	ctx context.Context, t *testing.T, r io.Reader,
+) string {
+	t.Helper()
+	done := make(chan struct{})
+	var buf strings.Builder
+	go func() {
+		defer close(done)
+		one := make([]byte, 1)
+		for {
+			n, err := r.Read(one)
+			if n > 0 {
+				buf.WriteByte(one[0])
+				if strings.HasSuffix(buf.String(), "\n\n") {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+		return buf.String()
+	case <-ctx.Done():
+		require.FailNow(t, "timed out reading SSE frame")
+		return ""
+	}
+}

--- a/internal/server/event_hub.go
+++ b/internal/server/event_hub.go
@@ -177,6 +177,33 @@ func (h *EventHub) RingSnapshotSince(
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	return h.ringSnapshotSinceLocked(cursor)
+}
+
+// ReplaySnapshotSince returns either the replay snapshot for cursor or,
+// when the cursor is stale, an already-assigned synthetic event id for a
+// reconnect.stale frame. The stale decision and synthetic id assignment
+// happen under the same hub lock so no real broadcast can receive an id
+// lower than the stale frame after stale has been observed.
+func (h *EventHub) ReplaySnapshotSince(
+	cursor uint64,
+) (events []RecordedEvent, staleID uint64, stale bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	events, stale = h.ringSnapshotSinceLocked(cursor)
+	if !stale {
+		return events, 0, false
+	}
+	h.nextEventID++
+	return nil, h.nextEventID, true
+}
+
+// ringSnapshotSinceLocked is the lock-held implementation of
+// RingSnapshotSince. Caller must hold mu.
+func (h *EventHub) ringSnapshotSinceLocked(
+	cursor uint64,
+) (events []RecordedEvent, stale bool) {
 	if h.ringCount == 0 {
 		if cursor > 0 {
 			return nil, true

--- a/internal/server/event_hub.go
+++ b/internal/server/event_hub.go
@@ -207,6 +207,15 @@ func (h *EventHub) AssignSyntheticID() uint64 {
 	return h.nextEventID
 }
 
+// SubscriberCount returns the current number of live subscribers.
+// Useful for tests that need to synchronize broadcasts with subscriber
+// registration.
+func (h *EventHub) SubscriberCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.subscribers)
+}
+
 // Close shuts down the hub: closes the done channel so SSE handlers
 // exit, marks the hub closed so future Subscribe calls fail fast,
 // then cleans up all subscriber channels.

--- a/internal/server/event_hub.go
+++ b/internal/server/event_hub.go
@@ -164,9 +164,11 @@ func (h *EventHub) ringStoreLocked(rec RecordedEvent) {
 // RingSnapshotSince returns the recorded events with ID greater than
 // cursor in chronological order, plus a stale flag.
 //
-//	stale=true  : the cursor predates the ring's oldest event AND the
-//	              ring contains at least one event. The caller should
-//	              emit a reconnect.stale frame and skip replay.
+//	stale=true  : the cursor cannot be verified against this hub's
+//	              retained history. It either predates the ring's
+//	              oldest event or points beyond this hub lifetime's
+//	              last assigned event. The caller should emit a
+//	              reconnect.stale frame and skip replay.
 //	stale=false : the returned slice is the (possibly empty) replay.
 //	              Empty means the cursor is at or ahead of head.
 func (h *EventHub) RingSnapshotSince(
@@ -176,9 +178,13 @@ func (h *EventHub) RingSnapshotSince(
 	defer h.mu.Unlock()
 
 	if h.ringCount == 0 {
-		// No history at all — treat as "nothing missed."
-		// The handler will still resume live delivery.
+		if cursor > 0 {
+			return nil, true
+		}
 		return nil, false
+	}
+	if cursor > h.nextEventID {
+		return nil, true
 	}
 
 	oldest := h.ring[h.ringHead].ID

--- a/internal/server/event_hub.go
+++ b/internal/server/event_hub.go
@@ -5,48 +5,88 @@ import (
 	"sync"
 )
 
+// DefaultSSEBufferSize is the ring-buffer capacity used when no explicit
+// size is configured. Sized to cover a typical sleep/wake window of
+// burst broadcasts (a few hundred PR refreshes) without being so large
+// that a maxed-out replay overwhelms a slow client.
+const DefaultSSEBufferSize = 256
+
 // Event represents an SSE event to broadcast.
 type Event struct {
 	Type string
 	Data any
 }
 
-// EventHub manages SSE subscribers with fan-out broadcasting.
+// RecordedEvent is an Event stamped with its monotonically-increasing
+// ID. The hub assigns the ID at broadcast time, scoped to its lifetime
+// (so daemon restart resets the sequence). Subscribers receive
+// RecordedEvent values so the SSE handler can write the id back out on
+// the wire and clients can carry it on reconnect.
+type RecordedEvent struct {
+	ID    uint64
+	Event Event
+}
+
+// EventHub manages SSE subscribers with fan-out broadcasting, monotonic
+// event ids, and a ring buffer of recent events for replay on reconnect.
 type EventHub struct {
 	mu             sync.Mutex
-	subscribers    map[uint64]chan Event
-	nextID         uint64
-	lastSyncStatus *Event
+	subscribers    map[uint64]chan RecordedEvent
+	nextSubID      uint64
+	nextEventID    uint64
+	lastSyncStatus *RecordedEvent
+	ring           []RecordedEvent
+	ringHead       int
+	ringCount      int
 	done           chan struct{}
 	closeOnce      sync.Once
 	closed         bool // guarded by mu
 }
 
-// NewEventHub creates a ready-to-use hub.
+// NewEventHub creates a ready-to-use hub with the default ring capacity.
 func NewEventHub() *EventHub {
+	return NewEventHubWithCapacity(DefaultSSEBufferSize)
+}
+
+// NewEventHubWithCapacity creates a hub whose ring buffer holds at most
+// capacity recent events. Capacity must be >= 1; values smaller than 1
+// would mean the hub cannot replay anything and break the stale-cursor
+// detection logic that needs at least one event to compare against.
+func NewEventHubWithCapacity(capacity int) *EventHub {
+	if capacity < 1 {
+		panic("server: NewEventHubWithCapacity requires capacity >= 1")
+	}
 	return &EventHub{
-		subscribers: make(map[uint64]chan Event),
+		subscribers: make(map[uint64]chan RecordedEvent),
+		ring:        make([]RecordedEvent, capacity),
 		done:        make(chan struct{}),
 	}
 }
 
-// Subscribe registers a new subscriber. Returns the event channel and
-// the hub's done channel. The event channel is pre-loaded with the
-// cached lastSyncStatus if available. If the hub is already closed,
-// returns an immediately-closed channel and the closed done channel
-// so callers can exit cleanly without leaking a goroutine.
-func (h *EventHub) Subscribe(ctx context.Context) (<-chan Event, <-chan struct{}) {
+// Subscribe registers a new subscriber. When injectCached is true and a
+// cached sync_status exists, it is pre-loaded onto the subscriber's
+// channel so a fresh client with no cursor learns the latest sync state
+// without a round-trip. Callers that handle replay themselves (the
+// cursor-bearing SSE path) pass false to avoid duplicating the cached
+// status with a ring-replay copy.
+//
+// Returns the event channel and the hub's done channel. If the hub is
+// already closed, returns an immediately-closed channel and the closed
+// done channel so callers can exit cleanly without leaking a goroutine.
+func (h *EventHub) Subscribe(
+	ctx context.Context, injectCached bool,
+) (<-chan RecordedEvent, <-chan struct{}) {
 	h.mu.Lock()
 	if h.closed {
 		h.mu.Unlock()
-		ch := make(chan Event)
+		ch := make(chan RecordedEvent)
 		close(ch)
 		return ch, h.done
 	}
-	id := h.nextID
-	h.nextID++
-	ch := make(chan Event, 16)
-	if h.lastSyncStatus != nil {
+	id := h.nextSubID
+	h.nextSubID++
+	ch := make(chan RecordedEvent, 16)
+	if injectCached && h.lastSyncStatus != nil {
 		ch <- *h.lastSyncStatus
 	}
 	h.subscribers[id] = ch
@@ -76,26 +116,95 @@ func (h *EventHub) unsubscribe(id uint64) {
 	h.unsubscribeLocked(id)
 }
 
-// Broadcast sends an event to all subscribers. If event.Type is
-// "sync_status", the event is cached for future subscribers.
-// Slow consumers (full channel) are evicted.
-func (h *EventHub) Broadcast(event Event) {
+// Broadcast sends an event to all subscribers, stamps it with the next
+// monotonic id, records it in the ring buffer, and (for sync_status
+// events) updates the cached latest-status pointer. Slow consumers
+// (full channel) are evicted. Returns the assigned id, which is useful
+// for tests and for callers that need to correlate the broadcast with
+// downstream state.
+func (h *EventHub) Broadcast(event Event) uint64 {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	h.nextEventID++
+	rec := RecordedEvent{ID: h.nextEventID, Event: event}
+
 	if event.Type == "sync_status" {
-		e := event // copy
-		h.lastSyncStatus = &e
+		copyRec := rec
+		h.lastSyncStatus = &copyRec
 	}
+
+	h.ringStoreLocked(rec)
 
 	for id, ch := range h.subscribers {
 		select {
-		case ch <- event:
+		case ch <- rec:
 		default:
 			// Slow consumer — evict
 			h.unsubscribeLocked(id)
 		}
 	}
+
+	return rec.ID
+}
+
+// ringStoreLocked appends rec to the ring buffer, overwriting the oldest
+// slot once full. Caller must hold mu.
+func (h *EventHub) ringStoreLocked(rec RecordedEvent) {
+	capacity := len(h.ring)
+	if h.ringCount < capacity {
+		h.ring[(h.ringHead+h.ringCount)%capacity] = rec
+		h.ringCount++
+		return
+	}
+	h.ring[h.ringHead] = rec
+	h.ringHead = (h.ringHead + 1) % capacity
+}
+
+// RingSnapshotSince returns the recorded events with ID greater than
+// cursor in chronological order, plus a stale flag.
+//
+//	stale=true  : the cursor predates the ring's oldest event AND the
+//	              ring contains at least one event. The caller should
+//	              emit a reconnect.stale frame and skip replay.
+//	stale=false : the returned slice is the (possibly empty) replay.
+//	              Empty means the cursor is at or ahead of head.
+func (h *EventHub) RingSnapshotSince(
+	cursor uint64,
+) (events []RecordedEvent, stale bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.ringCount == 0 {
+		// No history at all — treat as "nothing missed."
+		// The handler will still resume live delivery.
+		return nil, false
+	}
+
+	oldest := h.ring[h.ringHead].ID
+	if cursor+1 < oldest {
+		return nil, true
+	}
+
+	out := make([]RecordedEvent, 0, h.ringCount)
+	for i := 0; i < h.ringCount; i++ {
+		rec := h.ring[(h.ringHead+i)%len(h.ring)]
+		if rec.ID > cursor {
+			out = append(out, rec)
+		}
+	}
+	return out, false
+}
+
+// AssignSyntheticID consumes one event id without recording an entry in
+// the ring or updating the cached sync_status. Used by the SSE handler
+// to label the synthetic reconnect.stale frame so client cursors remain
+// monotonic across stale boundaries.
+func (h *EventHub) AssignSyntheticID() uint64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.nextEventID++
+	return h.nextEventID
 }
 
 // Close shuts down the hub: closes the done channel so SSE handlers

--- a/internal/server/event_hub_test.go
+++ b/internal/server/event_hub_test.go
@@ -328,6 +328,20 @@ func TestEventHub_AssignSyntheticIDIncrementsWithoutRecord(t *testing.T) {
 	assert.Equal(uint64(4), next)
 }
 
+func TestEventHub_ReplaySnapshotSinceAssignsStaleIDBeforeFutureBroadcast(t *testing.T) {
+	assert := assert.New(t)
+	hub := NewEventHub()
+	defer hub.Close()
+
+	replay, staleID, stale := hub.ReplaySnapshotSince(99)
+	assert.True(stale)
+	assert.Empty(replay)
+	assert.Equal(uint64(1), staleID)
+
+	next := hub.Broadcast(Event{Type: "data_changed", Data: "after-stale"})
+	assert.Equal(uint64(2), next)
+}
+
 func TestEventHub_CapacityRetainsLatest(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/event_hub_test.go
+++ b/internal/server/event_hub_test.go
@@ -13,12 +13,12 @@ func TestEventHub_SubscribeReceivesBroadcast(t *testing.T) {
 	hub := NewEventHub()
 	defer hub.Close()
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 	hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
 
 	select {
 	case ev := <-ch:
-		assert.Equal(t, "data_changed", ev.Type)
+		assert.Equal(t, "data_changed", ev.Event.Type)
 	case <-time.After(time.Second):
 		require.FailNow(t, "timed out waiting for event")
 	}
@@ -29,7 +29,7 @@ func TestEventHub_UnsubscribeOnContextCancel(t *testing.T) {
 	defer hub.Close()
 
 	ctx, cancel := context.WithCancel(t.Context())
-	ch, _ := hub.Subscribe(ctx)
+	ch, _ := hub.Subscribe(ctx, true)
 	cancel()
 
 	// Receive blocks until the cleanup goroutine closes the channel,
@@ -47,7 +47,7 @@ func TestEventHub_ConcurrentBroadcastSafety(t *testing.T) {
 	hub := NewEventHub()
 	defer hub.Close()
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 
 	done := make(chan struct{})
 	go func() {
@@ -73,7 +73,7 @@ func TestEventHub_SlowConsumerEvicted(t *testing.T) {
 	hub := NewEventHub()
 	defer hub.Close()
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 
 	// Fill buffer (16) + one more to trigger eviction
 	for i := range 17 {
@@ -94,11 +94,11 @@ func TestEventHub_SyncStatusCachedForNewSubscribers(t *testing.T) {
 
 	hub.Broadcast(Event{Type: "sync_status", Data: map[string]bool{"running": true}})
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 
 	select {
 	case ev := <-ch:
-		assert.Equal(t, "sync_status", ev.Type)
+		assert.Equal(t, "sync_status", ev.Event.Type)
 	case <-time.After(time.Second):
 		require.FailNow(t, "expected cached sync_status")
 	}
@@ -110,7 +110,7 @@ func TestEventHub_DataChangedNotCached(t *testing.T) {
 
 	hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 
 	select {
 	case <-ch:
@@ -124,7 +124,7 @@ func TestEventHub_NoCacheBeforeAnyBroadcast(t *testing.T) {
 	hub := NewEventHub()
 	defer hub.Close()
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 
 	select {
 	case <-ch:
@@ -141,10 +141,10 @@ func TestEventHub_CacheUpdatedOnLatestSyncStatus(t *testing.T) {
 	hub.Broadcast(Event{Type: "sync_status", Data: "t1"})
 	hub.Broadcast(Event{Type: "sync_status", Data: "t2"})
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 
 	ev := <-ch
-	assert.Equal(t, "t2", ev.Data, "new subscriber should get the latest cached status")
+	assert.Equal(t, "t2", ev.Event.Data, "new subscriber should get the latest cached status")
 }
 
 func TestEventHub_SubscribeOrderingWithBroadcast(t *testing.T) {
@@ -155,23 +155,23 @@ func TestEventHub_SubscribeOrderingWithBroadcast(t *testing.T) {
 
 	hub.Broadcast(Event{Type: "sync_status", Data: "cached"})
 
-	ch, _ := hub.Subscribe(t.Context())
+	ch, _ := hub.Subscribe(t.Context(), true)
 	hub.Broadcast(Event{Type: "data_changed", Data: "live"})
 
 	ev1 := <-ch
-	assert.Equal("sync_status", ev1.Type)
-	assert.Equal("cached", ev1.Data)
+	assert.Equal("sync_status", ev1.Event.Type)
+	assert.Equal("cached", ev1.Event.Data)
 
 	ev2 := <-ch
-	assert.Equal("data_changed", ev2.Type)
-	assert.Equal("live", ev2.Data)
+	assert.Equal("data_changed", ev2.Event.Type)
+	assert.Equal("live", ev2.Event.Data)
 }
 
 func TestEventHub_CloseUnsubscribesAll(t *testing.T) {
 	hub := NewEventHub()
 
-	ch1, done := hub.Subscribe(t.Context())
-	ch2, _ := hub.Subscribe(t.Context())
+	ch1, done := hub.Subscribe(t.Context(), true)
+	ch2, _ := hub.Subscribe(t.Context(), true)
 
 	hub.Close()
 
@@ -194,7 +194,7 @@ func TestEventHub_BroadcastAfterSlowConsumerEviction(t *testing.T) {
 	defer hub.Close()
 
 	// Subscribe slow consumer — never read
-	_, _ = hub.Subscribe(t.Context())
+	_, _ = hub.Subscribe(t.Context(), true)
 
 	// Fill + overflow to evict
 	for i := range 17 {
@@ -203,4 +203,172 @@ func TestEventHub_BroadcastAfterSlowConsumerEviction(t *testing.T) {
 
 	// New broadcast should not panic (evicted subscriber gone)
 	hub.Broadcast(Event{Type: "data_changed", Data: "after-eviction"})
+}
+
+func TestEventHub_BroadcastAssignsMonotonicIDs(t *testing.T) {
+	hub := NewEventHub()
+	defer hub.Close()
+
+	assert := assert.New(t)
+	for i := uint64(1); i <= 5; i++ {
+		got := hub.Broadcast(Event{Type: "data_changed", Data: i})
+		assert.Equal(i, got, "id %d should match broadcast order", i)
+	}
+}
+
+func TestEventHub_BroadcastIDStartsAtOne(t *testing.T) {
+	hub := NewEventHub()
+	defer hub.Close()
+	assert.Equal(t, uint64(1), hub.Broadcast(Event{Type: "data_changed", Data: nil}))
+}
+
+func TestEventHub_RingSnapshotSince_ReplaysNewer(t *testing.T) {
+	assert := assert.New(t)
+	hub := NewEventHubWithCapacity(8)
+	defer hub.Close()
+
+	for i := 1; i <= 5; i++ {
+		hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+
+	replay, stale := hub.RingSnapshotSince(2)
+	assert.False(stale)
+	assert.Len(replay, 3)
+	for i, want := range []uint64{3, 4, 5} {
+		assert.Equal(want, replay[i].ID)
+	}
+}
+
+func TestEventHub_RingSnapshotSince_StaleCursor(t *testing.T) {
+	hub := NewEventHubWithCapacity(4)
+	defer hub.Close()
+
+	for i := 1; i <= 10; i++ {
+		hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+
+	// Oldest in the ring is id 7 (10-4+1). Cursor 2 is stale.
+	replay, stale := hub.RingSnapshotSince(2)
+	assert.True(t, stale)
+	assert.Nil(t, replay)
+}
+
+func TestEventHub_RingSnapshotSince_AtOrAheadHead(t *testing.T) {
+	hub := NewEventHubWithCapacity(8)
+	defer hub.Close()
+
+	for i := 1; i <= 3; i++ {
+		hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+
+	replay, stale := hub.RingSnapshotSince(3)
+	assert.False(t, stale)
+	assert.Empty(t, replay)
+
+	replay, stale = hub.RingSnapshotSince(99)
+	assert.False(t, stale)
+	assert.Empty(t, replay)
+}
+
+func TestEventHub_RingSnapshotSince_EmptyRing(t *testing.T) {
+	hub := NewEventHub()
+	defer hub.Close()
+
+	replay, stale := hub.RingSnapshotSince(0)
+	assert.False(t, stale)
+	assert.Empty(t, replay)
+}
+
+func TestEventHub_RingSnapshotSince_AdjacentCursorIsLive(t *testing.T) {
+	// Cursor exactly one less than oldest is "the next event we missed
+	// is the oldest one in the ring" — not stale.
+	hub := NewEventHubWithCapacity(4)
+	defer hub.Close()
+
+	for i := 1; i <= 10; i++ {
+		hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+
+	// oldest = 7; cursor = 6 means client saw event 6 and missed 7,8,9,10.
+	replay, stale := hub.RingSnapshotSince(6)
+	assert.False(t, stale)
+	require.Len(t, replay, 4)
+	assert.Equal(t, uint64(7), replay[0].ID)
+	assert.Equal(t, uint64(10), replay[3].ID)
+}
+
+func TestEventHub_AssignSyntheticIDIncrementsWithoutRecord(t *testing.T) {
+	assert := assert.New(t)
+	hub := NewEventHub()
+	defer hub.Close()
+
+	hub.Broadcast(Event{Type: "data_changed", Data: 1})
+	hub.Broadcast(Event{Type: "data_changed", Data: 2})
+
+	syn := hub.AssignSyntheticID()
+	assert.Equal(uint64(3), syn)
+
+	// Ring should still contain 2 events (the synthetic id did not record).
+	replay, stale := hub.RingSnapshotSince(0)
+	assert.False(stale)
+	assert.Len(replay, 2)
+	assert.Equal(uint64(1), replay[0].ID)
+	assert.Equal(uint64(2), replay[1].ID)
+
+	// Next real broadcast continues from after the synthetic id.
+	next := hub.Broadcast(Event{Type: "data_changed", Data: 3})
+	assert.Equal(uint64(4), next)
+}
+
+func TestEventHub_CapacityRetainsLatest(t *testing.T) {
+	hub := NewEventHubWithCapacity(3)
+	defer hub.Close()
+
+	for i := 1; i <= 7; i++ {
+		hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+
+	replay, stale := hub.RingSnapshotSince(4)
+	assert.False(t, stale)
+	require.Len(t, replay, 3)
+	assert.Equal(t, uint64(5), replay[0].ID)
+	assert.Equal(t, uint64(6), replay[1].ID)
+	assert.Equal(t, uint64(7), replay[2].ID)
+}
+
+func TestNewEventHubWithCapacity_RejectsZero(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = NewEventHubWithCapacity(0)
+	})
+}
+
+func TestEventHub_CachedSyncStatusPreservesID(t *testing.T) {
+	hub := NewEventHub()
+	defer hub.Close()
+
+	wantID := hub.Broadcast(Event{Type: "sync_status", Data: "v1"})
+
+	ch, _ := hub.Subscribe(t.Context(), true)
+	select {
+	case ev := <-ch:
+		assert.Equal(t, wantID, ev.ID)
+		assert.Equal(t, "sync_status", ev.Event.Type)
+	case <-time.After(time.Second):
+		require.FailNow(t, "expected cached sync_status")
+	}
+}
+
+func TestEventHub_SubscribeWithoutCachedSkipsInjection(t *testing.T) {
+	hub := NewEventHub()
+	defer hub.Close()
+
+	hub.Broadcast(Event{Type: "sync_status", Data: "v1"})
+
+	ch, _ := hub.Subscribe(t.Context(), false)
+	select {
+	case ev := <-ch:
+		require.FailNowf(t, "unexpected", "expected no cached inject; got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
 }

--- a/internal/server/event_hub_test.go
+++ b/internal/server/event_hub_test.go
@@ -254,6 +254,7 @@ func TestEventHub_RingSnapshotSince_StaleCursor(t *testing.T) {
 }
 
 func TestEventHub_RingSnapshotSince_AtOrAheadHead(t *testing.T) {
+	assert := assert.New(t)
 	hub := NewEventHubWithCapacity(8)
 	defer hub.Close()
 
@@ -262,24 +263,31 @@ func TestEventHub_RingSnapshotSince_AtOrAheadHead(t *testing.T) {
 	}
 
 	replay, stale := hub.RingSnapshotSince(3)
-	assert.False(t, stale)
-	assert.Empty(t, replay)
+	assert.False(stale)
+	assert.Empty(replay)
 
 	replay, stale = hub.RingSnapshotSince(99)
-	assert.False(t, stale)
-	assert.Empty(t, replay)
+	assert.True(stale)
+	assert.Empty(replay)
 }
 
 func TestEventHub_RingSnapshotSince_EmptyRing(t *testing.T) {
+	assert := assert.New(t)
 	hub := NewEventHub()
 	defer hub.Close()
 
 	replay, stale := hub.RingSnapshotSince(0)
-	assert.False(t, stale)
-	assert.Empty(t, replay)
+	assert.False(stale)
+	assert.Empty(replay)
+
+	replay, stale = hub.RingSnapshotSince(1)
+	assert.True(stale)
+	assert.Empty(replay)
 }
 
 func TestEventHub_RingSnapshotSince_AdjacentCursorIsLive(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	// Cursor exactly one less than oldest is "the next event we missed
 	// is the oldest one in the ring" — not stale.
 	hub := NewEventHubWithCapacity(4)
@@ -291,10 +299,10 @@ func TestEventHub_RingSnapshotSince_AdjacentCursorIsLive(t *testing.T) {
 
 	// oldest = 7; cursor = 6 means client saw event 6 and missed 7,8,9,10.
 	replay, stale := hub.RingSnapshotSince(6)
-	assert.False(t, stale)
-	require.Len(t, replay, 4)
-	assert.Equal(t, uint64(7), replay[0].ID)
-	assert.Equal(t, uint64(10), replay[3].ID)
+	assert.False(stale)
+	require.Len(replay, 4)
+	assert.Equal(uint64(7), replay[0].ID)
+	assert.Equal(uint64(10), replay[3].ID)
 }
 
 func TestEventHub_AssignSyntheticIDIncrementsWithoutRecord(t *testing.T) {
@@ -321,6 +329,8 @@ func TestEventHub_AssignSyntheticIDIncrementsWithoutRecord(t *testing.T) {
 }
 
 func TestEventHub_CapacityRetainsLatest(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	hub := NewEventHubWithCapacity(3)
 	defer hub.Close()
 
@@ -329,11 +339,11 @@ func TestEventHub_CapacityRetainsLatest(t *testing.T) {
 	}
 
 	replay, stale := hub.RingSnapshotSince(4)
-	assert.False(t, stale)
-	require.Len(t, replay, 3)
-	assert.Equal(t, uint64(5), replay[0].ID)
-	assert.Equal(t, uint64(6), replay[1].ID)
-	assert.Equal(t, uint64(7), replay[2].ID)
+	assert.False(stale)
+	require.Len(replay, 3)
+	assert.Equal(uint64(5), replay[0].ID)
+	assert.Equal(uint64(6), replay[1].ID)
+	assert.Equal(uint64(7), replay[2].ID)
 }
 
 func TestNewEventHubWithCapacity_RejectsZero(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -899,9 +899,8 @@ func (s *Server) serveSSE(
 	// live broadcasts and never out of order with them.
 	deliveredThrough := cursor
 	if hasCursor {
-		replay, stale := s.hub.RingSnapshotSince(cursor)
+		replay, synID, stale := s.hub.ReplaySnapshotSince(cursor)
 		if stale {
-			synID := s.hub.AssignSyntheticID()
 			if !writeSSEFrame(w, rc, synID, "reconnect.stale", []byte("{}")) {
 				return
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -198,6 +198,12 @@ func (s *Server) trackHTTPConn(_ net.Conn, state http.ConnState) {
 // retain the returned pointer beyond the server's lifetime.
 func (s *Server) Hub() *EventHub { return s.hub }
 
+// SubscriberCount returns the number of live SSE subscribers. Intended
+// for tests that need to wait for a connection to register before
+// broadcasting (broadcasts issued before subscription would otherwise
+// race against the handler's Subscribe call).
+func (s *Server) SubscriberCount() int { return s.hub.SubscriberCount() }
+
 // SetVersion sets the version string returned by GET /api/v1/version.
 func (s *Server) SetVersion(v string) { s.version = v }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -410,7 +410,7 @@ func newServer(
 		cfgPath:                cfgPath,
 		options:                options,
 		now:                    time.Now,
-		hub:                    NewEventHub(),
+		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
 		tmuxActivity:           newTmuxActivityTracker(nil),
 		labelCatalogRefreshIDs: make(map[int64]struct{}),
 		bgCtx: shutdownAwareContext{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -897,6 +897,7 @@ func (s *Server) serveSSE(
 	// Resolve the replay path before entering the live loop so the
 	// client sees missed events (or a stale signal) before any new
 	// live broadcasts and never out of order with them.
+	deliveredThrough := cursor
 	if hasCursor {
 		replay, stale := s.hub.RingSnapshotSince(cursor)
 		if stale {
@@ -904,11 +905,13 @@ func (s *Server) serveSSE(
 			if !writeSSEFrame(w, rc, synID, "reconnect.stale", []byte("{}")) {
 				return
 			}
+			deliveredThrough = synID
 		} else {
 			for _, rec := range replay {
 				if !writeSSERecorded(w, rc, rec) {
 					return
 				}
+				deliveredThrough = rec.ID
 			}
 		}
 	}
@@ -931,7 +934,7 @@ func (s *Server) serveSSE(
 			if !ok {
 				return
 			}
-			if hasCursor && ev.ID <= cursor {
+			if hasCursor && ev.ID <= deliveredThrough {
 				// Already replayed; skip the duplicate that arrived
 				// via the cached-status pre-load or a race between
 				// the snapshot read and a fresh broadcast.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -815,7 +816,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
 		return
 	}
-	s.serveSSE(r.Context(), w, rc)
+	cursor, hasCursor := parseLastEventID(r)
+	s.serveSSE(r.Context(), w, rc, cursor, hasCursor)
 }
 
 func (s *Server) streamEvents(
@@ -827,10 +829,11 @@ func (s *Server) streamEvents(
 			ctx.SetHeader("Cache-Control", "no-cache")
 			ctx.SetHeader("Connection", "keep-alive")
 
-			_, w := humago.Unwrap(ctx)
+			r, w := humago.Unwrap(ctx)
 			rc := http.NewResponseController(w)
 			_ = rc.SetWriteDeadline(time.Time{})
-			s.serveSSE(ctx.Context(), w, rc)
+			cursor, hasCursor := parseLastEventID(r)
+			s.serveSSE(ctx.Context(), w, rc, cursor, hasCursor)
 		},
 	}, nil
 }
@@ -840,18 +843,68 @@ type sseController interface {
 	Flush() error
 }
 
+// parseLastEventID inspects an incoming SSE request for a reconnect
+// cursor. The Last-Event-ID header takes priority (HTML5 EventSource
+// emits it automatically on reconnect); the since= query parameter is
+// the fallback for non-browser callers and explicit first-connect
+// resumption. Returns (0, false) when no usable cursor is present, so
+// the handler can fall back to the no-cursor path (live + cached
+// sync_status) without further branching.
+func parseLastEventID(r *http.Request) (uint64, bool) {
+	candidates := []string{r.Header.Get("Last-Event-ID")}
+	if q := r.URL.Query().Get("since"); q != "" {
+		candidates = append(candidates, q)
+	}
+	for _, raw := range candidates {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		n, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			slog.Debug("sse: ignoring unparseable cursor", "value", raw, "err", err)
+			continue
+		}
+		return n, true
+	}
+	return 0, false
+}
+
 func (s *Server) serveSSE(
 	ctx context.Context,
 	w io.Writer,
 	rc sseController,
+	cursor uint64,
+	hasCursor bool,
 ) {
 	// Subscribe BEFORE the first flush so any broadcast issued between
 	// the headers landing on the wire and the subscriber being registered
-	// is delivered to this client instead of dropped.
-	ch, done := s.hub.Subscribe(ctx)
+	// is delivered to this client instead of dropped. When a cursor is
+	// supplied the handler replays the ring directly, so cached
+	// sync_status injection by Subscribe would duplicate; pass false.
+	ch, done := s.hub.Subscribe(ctx, !hasCursor)
 
 	if err := rc.Flush(); err != nil {
 		return
+	}
+
+	// Resolve the replay path before entering the live loop so the
+	// client sees missed events (or a stale signal) before any new
+	// live broadcasts and never out of order with them.
+	if hasCursor {
+		replay, stale := s.hub.RingSnapshotSince(cursor)
+		if stale {
+			synID := s.hub.AssignSyntheticID()
+			if !writeSSEFrame(w, rc, synID, "reconnect.stale", []byte("{}")) {
+				return
+			}
+		} else {
+			for _, rec := range replay {
+				if !writeSSERecorded(w, rc, rec) {
+					return
+				}
+			}
+		}
 	}
 
 	ticker := time.NewTicker(30 * time.Second)
@@ -872,21 +925,13 @@ func (s *Server) serveSSE(
 			if !ok {
 				return
 			}
-			data, err := json.Marshal(ev.Data)
-			if err != nil {
-				slog.Error("sse: marshal event", "type", ev.Type, "err", err)
+			if hasCursor && ev.ID <= cursor {
+				// Already replayed; skip the duplicate that arrived
+				// via the cached-status pre-load or a race between
+				// the snapshot read and a fresh broadcast.
 				continue
 			}
-			if err := rc.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
-				return
-			}
-			if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, data); err != nil {
-				return
-			}
-			if err := rc.Flush(); err != nil {
-				return
-			}
-			if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+			if !writeSSERecorded(w, rc, ev) {
 				return
 			}
 		case <-ticker.C:
@@ -906,6 +951,39 @@ func (s *Server) serveSSE(
 			return
 		}
 	}
+}
+
+// writeSSERecorded serializes a recorded event and writes it as a
+// framed SSE frame. Returns true on success, false if any write or
+// flush failed and the handler should exit.
+func writeSSERecorded(w io.Writer, rc sseController, rec RecordedEvent) bool {
+	data, err := json.Marshal(rec.Event.Data)
+	if err != nil {
+		slog.Error("sse: marshal event", "type", rec.Event.Type, "err", err)
+		// Skip the unmarshalable event but keep streaming.
+		return true
+	}
+	return writeSSEFrame(w, rc, rec.ID, rec.Event.Type, data)
+}
+
+func writeSSEFrame(
+	w io.Writer, rc sseController, id uint64, eventType string, data []byte,
+) bool {
+	if err := rc.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return false
+	}
+	if _, err := fmt.Fprintf(
+		w, "id: %d\nevent: %s\ndata: %s\n\n", id, eventType, data,
+	); err != nil {
+		return false
+	}
+	if err := rc.Flush(); err != nil {
+		return false
+	}
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		return false
+	}
+	return true
 }
 
 func (s *Server) getVersion(

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -425,6 +425,57 @@ func readSSEFrame(t *testing.T, scanner *bufio.Scanner) sseFrame {
 	return f
 }
 
+type sseReadResult struct {
+	frame sseFrame
+	err   error
+}
+
+func readSSEFrameWithin(
+	t *testing.T,
+	scanner *bufio.Scanner,
+	timeout time.Duration,
+	stop func(),
+) sseFrame {
+	t.Helper()
+	result := make(chan sseReadResult, 1)
+	go func() {
+		var f sseFrame
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "id: "):
+				f.ID = strings.TrimPrefix(line, "id: ")
+			case strings.HasPrefix(line, "event: "):
+				f.Event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				f.Data = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if f.Event != "" {
+					result <- sseReadResult{frame: f}
+					return
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			result <- sseReadResult{err: err}
+			return
+		}
+		result <- sseReadResult{err: io.ErrUnexpectedEOF}
+	}()
+
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		return got.frame
+	case <-time.After(timeout):
+		if stop != nil {
+			stop()
+		}
+		require.FailNow(t, "timed out reading SSE frame")
+		return sseFrame{}
+	}
+}
+
 func TestSSE_FrameIncludesID(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -628,6 +679,134 @@ func TestSSE_CursorAtHeadReplaysNothing(t *testing.T) {
 	f := readSSEFrame(t, scanner)
 	assert.Equal("4", f.ID)
 	assert.Equal(uint64(4), id)
+}
+
+type blockingFlushController struct {
+	mu               sync.Mutex
+	flushes          int
+	firstFlushCalled chan struct{}
+	releaseFirst     chan struct{}
+}
+
+func newBlockingFlushController() *blockingFlushController {
+	return &blockingFlushController{
+		firstFlushCalled: make(chan struct{}),
+		releaseFirst:     make(chan struct{}),
+	}
+}
+
+func (c *blockingFlushController) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func (c *blockingFlushController) Flush() error {
+	c.mu.Lock()
+	c.flushes++
+	flushes := c.flushes
+	if flushes == 1 {
+		close(c.firstFlushCalled)
+	}
+	c.mu.Unlock()
+
+	if flushes == 1 {
+		<-c.releaseFirst
+	}
+	return nil
+}
+
+func TestSSE_ReplaySkipsLiveEventQueuedBeforeSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	for i := 1; i <= 2; i++ {
+		s.hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	reader, writer := io.Pipe()
+	defer reader.Close()
+
+	rc := newBlockingFlushController()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer writer.Close()
+		s.serveSSE(ctx, writer, rc, 2, true)
+	}()
+
+	select {
+	case <-rc.firstFlushCalled:
+	case <-time.After(2 * time.Second):
+		require.FailNow("serveSSE did not reach the initial flush")
+	}
+
+	// This event is queued on the live subscriber and recorded in the
+	// replay ring before RingSnapshotSince runs.
+	id3 := s.hub.Broadcast(Event{Type: "data_changed", Data: 3})
+	assert.Equal(uint64(3), id3)
+	close(rc.releaseFirst)
+
+	scanner := bufio.NewScanner(reader)
+	f3 := readSSEFrameWithin(t, scanner, 2*time.Second, func() {
+		cancel()
+		writer.Close()
+	})
+	assert.Equal("3", f3.ID)
+
+	id4 := s.hub.Broadcast(Event{Type: "data_changed", Data: 4})
+	assert.Equal(uint64(4), id4)
+	f4 := readSSEFrameWithin(t, scanner, 2*time.Second, func() {
+		cancel()
+		writer.Close()
+	})
+	assert.Equal("4", f4.ID)
+
+	cancel()
+	writer.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow("serveSSE did not exit after cancellation")
+	}
+}
+
+func TestSSE_FutureCursorEmitsReconnectStaleThenLiveEvents(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "99")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	stale := readSSEFrameWithin(t, scanner, 2*time.Second, func() {
+		resp.Body.Close()
+	})
+	assert.Equal("reconnect.stale", stale.Event)
+	assert.Equal("1", stale.ID)
+
+	require.Eventually(func() bool {
+		s.hub.mu.Lock()
+		defer s.hub.mu.Unlock()
+		return len(s.hub.subscribers) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+	id := s.hub.Broadcast(Event{Type: "data_changed", Data: "after-stale"})
+	assert.Equal(uint64(2), id)
+	live := readSSEFrameWithin(t, scanner, 2*time.Second, func() {
+		resp.Body.Close()
+	})
+	assert.Equal("2", live.ID)
 }
 
 func TestParseLastEventID_HeaderWins(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -392,3 +392,288 @@ func TestSSE_TerminatesOnMidStreamDeadlineFailure(t *testing.T) {
 	// Deadline failed before event write — body must be empty
 	assert.Empty(t, rec.Body.String(), "no output should be written after deadline failure")
 }
+
+// sseFrame is the parsed form of one id:/event:/data: SSE record.
+type sseFrame struct {
+	ID    string
+	Event string
+	Data  string
+}
+
+// readSSEFrame reads from r until it has one complete frame (terminated
+// by a blank line) or the timeout fires. Returns the frame, or fails
+// the test if no frame arrives in time.
+func readSSEFrame(t *testing.T, scanner *bufio.Scanner) sseFrame {
+	t.Helper()
+	var f sseFrame
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "id: "):
+			f.ID = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			f.Event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			f.Data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if f.Event != "" {
+				return f
+			}
+		}
+	}
+	require.FailNow(t, "scanner ended before a complete frame")
+	return f
+}
+
+func TestSSE_FrameIncludesID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/events")
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	require.Eventually(func() bool {
+		s.hub.mu.Lock()
+		defer s.hub.mu.Unlock()
+		return len(s.hub.subscribers) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	gotID := s.hub.Broadcast(Event{Type: "data_changed", Data: map[string]string{"k": "v"}})
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("data_changed", f.Event)
+	assert.JSONEq(`{"k":"v"}`, f.Data)
+	assert.Equal("1", f.ID)
+	assert.Equal(uint64(1), gotID, "Broadcast should return the assigned id")
+}
+
+func TestSSE_LastEventIDHeaderReplaysMissedEvents(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	// Prime the ring with three events the client supposedly saw.
+	for i := 1; i <= 3; i++ {
+		s.hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "1")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f2 := readSSEFrame(t, scanner)
+	f3 := readSSEFrame(t, scanner)
+	assert.Equal("2", f2.ID)
+	assert.Equal("3", f3.ID)
+	assert.Equal("data_changed", f2.Event)
+	assert.Equal("data_changed", f3.Event)
+}
+
+func TestSSE_SinceQueryReplaysMissedEvents(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	for i := 1; i <= 3; i++ {
+		s.hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/events?since=2")
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("3", f.ID)
+	assert.Equal("data_changed", f.Event)
+}
+
+func TestSSE_LastEventIDHeaderOverridesSinceQuery(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	for i := 1; i <= 5; i++ {
+		s.hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events?since=1", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "4")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	// Header wins, only id=5 replays.
+	assert.Equal("5", f.ID)
+}
+
+func TestSSE_StaleCursorEmitsReconnectStale(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	database := openTestDB(t)
+	s := newServerWithHub(t, database, NewEventHubWithCapacity(4))
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Fill past capacity so cursor 2 falls out of the ring.
+	for i := 1; i <= 10; i++ {
+		s.hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "2")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("reconnect.stale", f.Event)
+	assert.Equal("11", f.ID, "synthetic id should follow last broadcast id")
+
+	// And a new broadcast continues from id 12.
+	require.Eventually(func() bool {
+		s.hub.mu.Lock()
+		defer s.hub.mu.Unlock()
+		return len(s.hub.subscribers) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+	s.hub.Broadcast(Event{Type: "data_changed", Data: "post-stale"})
+	live := readSSEFrame(t, scanner)
+	assert.Equal("12", live.ID)
+}
+
+func TestSSE_InvalidCursorTreatedAsNoCursor(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	// Cache a sync_status the no-cursor path delivers on subscribe.
+	s.hub.Broadcast(Event{Type: "sync_status", Data: map[string]bool{"running": false}})
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "not-a-number")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("sync_status", f.Event,
+		"unparsable cursor falls back to no-cursor + cached delivery")
+}
+
+func TestSSE_CursorAtHeadReplaysNothing(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := newTestServer(t)
+	for i := 1; i <= 3; i++ {
+		s.hub.Broadcast(Event{Type: "data_changed", Data: i})
+	}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "3")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	// Wait for subscribe so the broadcast below isn't dropped.
+	require.Eventually(func() bool {
+		s.hub.mu.Lock()
+		defer s.hub.mu.Unlock()
+		return len(s.hub.subscribers) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	id := s.hub.Broadcast(Event{Type: "data_changed", Data: "future"})
+
+	scanner := bufio.NewScanner(resp.Body)
+	f := readSSEFrame(t, scanner)
+	assert.Equal("4", f.ID)
+	assert.Equal(uint64(4), id)
+}
+
+func TestParseLastEventID_HeaderWins(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events?since=42", nil)
+	r.Header.Set("Last-Event-ID", "99")
+	got, ok := parseLastEventID(r)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(99), got)
+}
+
+func TestParseLastEventID_FallsBackToQuery(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events?since=42", nil)
+	got, ok := parseLastEventID(r)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(42), got)
+}
+
+func TestParseLastEventID_AbsentMeansNoCursor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events", nil)
+	_, ok := parseLastEventID(r)
+	assert.False(t, ok)
+}
+
+func TestParseLastEventID_InvalidHeaderFallsBackToQuery(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events?since=7", nil)
+	r.Header.Set("Last-Event-ID", "garbage")
+	got, ok := parseLastEventID(r)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(7), got)
+}
+
+func TestParseLastEventID_AllUnparsableMeansNoCursor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/events?since=abc", nil)
+	r.Header.Set("Last-Event-ID", "xyz")
+	_, ok := parseLastEventID(r)
+	assert.False(t, ok)
+}
+
+// newServerWithHub builds a Server bypassing newServer's
+// NewEventHub allocation, useful for tests that need a non-default
+// ring capacity.
+func newServerWithHub(t *testing.T, database *db.DB, hub *EventHub) *Server {
+	t.Helper()
+	s := New(database, nil, nil, "/", nil, ServerOptions{})
+	// Replace the hub atomically before any subscribers exist.
+	s.hub.Close()
+	s.hub = hub
+	return s
+}

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -206,6 +206,17 @@
       onSyncStatus: (status) => {
         syncStore.setSyncStatus(status);
       },
+      onReconnectStale: () => {
+        // The replay ring rolled past the client's cursor while it
+        // was disconnected (long sleep, extended network outage).
+        // Refetch view state from scratch instead of relying on the
+        // missed broadcasts. sync.refreshSyncStatus() picks up the
+        // current daemon state since no sync_status frame will replay.
+        void pullsStore.loadPulls();
+        void issuesStore.loadIssues();
+        void activityStore.loadActivity();
+        void syncStore.refreshSyncStatus();
+      },
     });
 
     const si: StoreInstances = {

--- a/packages/ui/src/stores/events.svelte.ts
+++ b/packages/ui/src/stores/events.svelte.ts
@@ -10,6 +10,15 @@ export interface EventsStoreOptions {
   onDataChanged?: () => void;
   /** Called on each `sync_status` SSE frame. */
   onSyncStatus?: (status: SyncStatus) => void;
+  /**
+   * Called on a `reconnect.stale` SSE frame. The server emits this
+   * when the client's Last-Event-ID cursor predates its replay ring,
+   * meaning the gap between disconnect and reconnect was too large to
+   * bridge from the in-memory buffer. The handler should refetch view
+   * state from scratch (pulls, issues, sync status) the same way it
+   * would after a hard refresh.
+   */
+  onReconnectStale?: () => void;
 }
 
 /**
@@ -53,6 +62,9 @@ export function createEventsStore(opts: EventsStoreOptions = {}) {
       } catch {
         // ignore malformed frames
       }
+    });
+    source.addEventListener("reconnect.stale", () => {
+      opts.onReconnectStale?.();
     });
   }
 


### PR DESCRIPTION
## Summary

- Every SSE frame now carries an `id:` line with a monotonically increasing generation scoped to the process lifetime. The event hub keeps a ring buffer of recent events (default 256, configurable via `sse_buffer_size`).
- On reconnect, a client may send `Last-Event-ID: <N>` or `?since=<N>`; the server replays buffered events with generation > N and resumes live delivery.
- If the cursor predates the ring's oldest event, the server emits exactly one `reconnect.stale` event before resuming live. The Svelte SSE store handles this by re-running view-state loaders (pulls, issues, activity, sync status) so the UI rebuilds from scratch instead of incrementally applying deltas it can't reconstruct.
- Existing slow-consumer eviction is preserved.
- Wire-level e2e test boots a real HTTP server, parses actual `id:` / `event:` / `data:` lines, and exercises the disconnect / reconnect / stale-cursor round trip.