### PR TITLE
[codex] compress responses and hide Windows subprocesses

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,10 @@ linters:
           msg: Do not create backend timezone conversions outside tests.
         - pattern: '^db\.Open$'
           msg: Use internal/testutil/dbtest fixtures in tests instead of db.Open.
+        - pattern: '^exec\.Command$'
+          msg: Use internal/procutil.Command so Windows subprocesses do not flash console windows.
+        - pattern: '^exec\.CommandContext$'
+          msg: Use internal/procutil.CommandContext so Windows subprocesses do not flash console windows.
       analyze-types: true
   exclusions:
     generated: lax

--- a/Makefile
+++ b/Makefile
@@ -183,15 +183,15 @@ dev-ephemeral-stop:
 
 # Run tests
 test: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-output.json -- ./... -shuffle=on
+	$(GOTESTSUM)=tmp/test-output.json -- -p 1 ./... -shuffle=on
 
 # Run fast tests only
 test-short: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-short-output.json -- ./... -short -shuffle=on
+	$(GOTESTSUM)=tmp/test-short-output.json -- -p 1 ./... -short -shuffle=on
 
 # Run integration tests that execute real git commands (excluded from test-short)
 test-integration: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-integration-output.json -- -tags integration ./... -shuffle=on
+	$(GOTESTSUM)=tmp/test-integration-output.json -- -p 1 -tags integration ./... -shuffle=on
 
 # Report per-package wall time for the slow race-test packages.
 race-times: ensure-embed-dir

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"slices"
@@ -25,6 +24,7 @@ import (
 	"github.com/wesm/middleman/internal/gitenv"
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/server"
 	"github.com/wesm/middleman/internal/stacks"
 	"github.com/wesm/middleman/internal/testutil"
@@ -171,7 +171,7 @@ func e2eGit(dir string, args ...string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("git: no args")
 	}
-	cmd := exec.Command("git", args...)
+	cmd := procutil.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_TERMINAL_PROMPT=0",

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/runtimelock"
 )
 
@@ -24,7 +25,7 @@ func buildMiddleman(t *testing.T) string {
 	t.Helper()
 	binDir := t.TempDir()
 	binPath := filepath.Join(binDir, "middleman")
-	cmd := exec.Command("go", "build", "-o", binPath, ".")
+	cmd := procutil.Command("go", "build", "-o", binPath, ".")
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run(), "go build ./cmd/middleman")
@@ -88,7 +89,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 
 	// `middleman status` while the lock is held before WriteMetadata:
 	// reports running, but metadata is unavailable.
-	startupStatusCmd := exec.Command(bin, "status", "--config", cfgPath)
+	startupStatusCmd := procutil.Command(bin, "status", "--config", cfgPath)
 	var startupStatusOut bytes.Buffer
 	startupStatusCmd.Stdout = &startupStatusOut
 	startupStatusCmd.Stderr = os.Stderr
@@ -98,7 +99,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 	require.Contains(startupStatusOut.String(), runtimelock.LockPath(dataDir))
 
 	// `middleman status --json`: same lock-held/missing-metadata state.
-	startupJSONCmd := exec.Command(bin, "status", "--json", "--config", cfgPath)
+	startupJSONCmd := procutil.Command(bin, "status", "--json", "--config", cfgPath)
 	var startupJSONOut bytes.Buffer
 	startupJSONCmd.Stdout = &startupJSONOut
 	startupJSONCmd.Stderr = os.Stderr
@@ -116,7 +117,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 	// which bypasses signal.NotifyContext + defer chains in main.go and
 	// leaves the metadata file behind. Send SIGTERM explicitly when we
 	// want a graceful shutdown.
-	first := exec.Command(bin, "--config", cfgPath)
+	first := procutil.Command(bin, "--config", cfgPath)
 	first.Stdout = os.Stderr
 	first.Stderr = os.Stderr
 	first.Env = append(os.Environ(),
@@ -138,7 +139,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 
 	// Second subprocess against the same data_dir + port. Should exit 1
 	// with the banner on stderr.
-	second := exec.Command(bin, "--config", cfgPath)
+	second := procutil.Command(bin, "--config", cfgPath)
 	var stderr bytes.Buffer
 	second.Stderr = &stderr
 	err = second.Run()
@@ -153,7 +154,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 
 	// `middleman status` against the same config: reports running with
 	// metadata.
-	statusCmd := exec.Command(bin, "status", "--config", cfgPath)
+	statusCmd := procutil.Command(bin, "status", "--config", cfgPath)
 	var statusOut bytes.Buffer
 	statusCmd.Stdout = &statusOut
 	statusCmd.Stderr = os.Stderr
@@ -164,7 +165,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 	require.Contains(statusOut.String(), "port:         "+strconv.Itoa(port))
 
 	// `middleman status --json`: same data, JSON shape.
-	jsonCmd := exec.Command(bin, "status", "--json", "--config", cfgPath)
+	jsonCmd := procutil.Command(bin, "status", "--json", "--config", cfgPath)
 	var jsonOut bytes.Buffer
 	jsonCmd.Stdout = &jsonOut
 	jsonCmd.Stderr = os.Stderr
@@ -184,7 +185,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 	waitForNoFile(t, runtimelock.MetadataPath(dataDir), 10*time.Second)
 
 	// `middleman status` now reports not-running.
-	statusCmd2 := exec.Command(bin, "status", "--config", cfgPath)
+	statusCmd2 := procutil.Command(bin, "status", "--config", cfgPath)
 	var statusOut2 bytes.Buffer
 	statusCmd2.Stdout = &statusOut2
 	statusCmd2.Stderr = os.Stderr

--- a/cmd/middleman/startup_token_e2e_test.go
+++ b/cmd/middleman/startup_token_e2e_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -29,10 +30,18 @@ func TestCollectProviderTokensInvokesGHWithHostnameForEnterprise(t *testing.T) {
 	dir := t.TempDir()
 	argvPath := filepath.Join(dir, "argv")
 	ghPath := filepath.Join(dir, "gh")
+	if runtime.GOOS == "windows" {
+		ghPath += ".cmd"
+	}
 	const fakeToken = "ghe-token-from-gh"
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n" +
 		"printf '%s\\n' '" + fakeToken + "'\n"
+	if runtime.GOOS == "windows" {
+		script = "@echo off\r\n" +
+			"echo %*>>\"%FAKE_GH_ARGV%\"\r\n" +
+			"echo " + fakeToken + "\r\n"
+	}
 	require.NoError(os.WriteFile(ghPath, []byte(script), 0o755))
 	t.Setenv("PATH", dir)
 	t.Setenv("FAKE_GH_ARGV", argvPath)
@@ -66,8 +75,11 @@ name = "widget"
 	data, err := os.ReadFile(argvPath)
 	require.NoError(err)
 	invocations := strings.Split(
-		strings.TrimRight(string(data), "\n"), "\n",
+		strings.TrimRight(string(data), "\r\n"), "\n",
 	)
+	for i := range invocations {
+		invocations[i] = strings.TrimRight(invocations[i], "\r")
+	}
 	assert.Contains(invocations, "auth token --hostname ghe.example.com",
 		"expected gh auth token --hostname ghe.example.com invocation; got: %v",
 		invocations,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.gitea.io/sdk/gitea v0.25.0
 	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3 v3.0.0
 	github.com/BurntSushi/toml v1.6.0
+	github.com/andybalholm/brotli v1.2.0
 	github.com/aymanbagabas/go-pty v0.2.2
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coder/websocket v1.8.14
@@ -14,6 +15,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-github/v84 v84.0.0
+	github.com/klauspost/compress v1.18.5
 	github.com/oapi-codegen/runtime v1.3.1
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
 	github.com/sourcegraph/go-diff v0.7.0
@@ -114,7 +116,6 @@ require (
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9dedlWa0OhD30=
 github.com/anchore/go-struct-converter v0.1.0/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
@@ -537,6 +539,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
+github.com/xyproto/randomstring v1.2.0 h1:y7PXAEBM3XlwJjPG2JQg4voxBYZ4+hPgRdGKCfU8wik=
+github.com/xyproto/randomstring v1.2.0/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	platformpkg "github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 const (
@@ -1155,7 +1156,7 @@ func appendTokenEnvName(names []string, name string) []string {
 	return append(names, name)
 }
 
-var execCommand = exec.CommandContext
+var execCommand = procutil.CommandContext
 
 // ghAuthExecTimeout bounds each gh subprocess invocation. gh auth
 // token is a local lookup and returns in milliseconds; 5s is generous

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,59 +61,24 @@ func setFakeGHCLIScript(t *testing.T, opts fakeGHCLIOptions) string {
 	t.Helper()
 	dir := t.TempDir()
 	argvPath := filepath.Join(dir, "argv")
-	ghPath := filepath.Join(dir, "gh")
-	script := "#!/bin/sh\n"
-	script += "printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n"
-	if opts.SleepSeconds > 0 {
-		// exec replaces the shell so there's no orphaned child
-		// holding stdout open after the parent gets SIGKILL'd by
-		// CommandContext; without exec, cmd.Output() blocks for
-		// the full sleep duration even after the shell is dead.
-		// SleepSeconds is therefore terminal in the script: any
-		// stderr/stdout/exit configured below is unreachable when
-		// SleepSeconds > 0, by design (the test stops the helper
-		// via context timeout, not by letting the fake finish).
-		sleepBin := resolveSleepBinary(t)
-		script += fmt.Sprintf("exec %s %d\n", sleepBin, opts.SleepSeconds)
-	}
-	if opts.Stderr != "" {
-		script += "printf '%s\\n' " + shellSingleQuote(opts.Stderr) + " 1>&2\n"
-	}
-	if opts.Stdout != "" {
-		script += "printf '%s\\n' " + shellSingleQuote(opts.Stdout) + "\n"
-	}
-	script += fmt.Sprintf("exit %d\n", opts.ExitCode)
-	require.NoError(t, os.WriteFile(ghPath, []byte(script), 0o755))
-	t.Setenv("PATH", dir)
+	writeFakeGHCLI(t, dir, fakeGHCLIScript(t, opts))
 	t.Setenv("FAKE_GH_ARGV", argvPath)
 	return argvPath
 }
 
-// resolveSleepBinary returns an absolute path to a `sleep` binary,
-// looked up under the test's original PATH before we replaced it with
-// the fake-gh dir. Tests that need sleep inline it as an absolute path
-// so the fake-gh script does not depend on the runtime PATH.
-func resolveSleepBinary(t *testing.T) string {
+func setFakeGHCLIWithScript(t *testing.T, script string) string {
 	t.Helper()
-	for _, dir := range filepath.SplitList(originalTestPATH) {
-		candidate := filepath.Join(dir, "sleep")
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			return candidate
-		}
-	}
-	require.FailNow(t, fmt.Sprintf("sleep binary not found on PATH %q", originalTestPATH))
-	return ""
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv")
+	writeFakeGHCLI(t, dir, script)
+	t.Setenv("FAKE_GH_ARGV", argvPath)
+	return argvPath
 }
 
-// originalTestPATH captures the test process's PATH at package init,
-// before any test mutates it via t.Setenv. Used to locate external
-// utilities the fake-gh script needs.
-var originalTestPATH = os.Getenv("PATH")
-
-// shellSingleQuote escapes s for safe inclusion inside single quotes
-// in a /bin/sh script.
-func shellSingleQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+func writeFakeGHCLI(t *testing.T, dir, script string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(fakeGHCLIPath(dir), []byte(script), 0o755))
+	t.Setenv("PATH", dir)
 }
 
 // readFakeGHArgv returns the recorded argv strings, one per
@@ -125,11 +90,15 @@ func readFakeGHArgv(t *testing.T, path string) []string {
 		return nil
 	}
 	require.NoError(t, err)
-	raw := strings.TrimRight(string(data), "\n")
+	raw := strings.TrimRight(string(data), "\r\n")
 	if raw == "" {
 		return nil
 	}
-	return strings.Split(raw, "\n")
+	lines := strings.Split(raw, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], "\r")
+	}
+	return lines
 }
 
 func TestLoadValid(t *testing.T) {
@@ -399,7 +368,7 @@ func TestMiddlemanHomeOverridesDefaultPaths(t *testing.T) {
 	t.Setenv("MIDDLEMAN_HOME", "/tmp/middleman-test")
 
 	assert.Equal(
-		"/tmp/middleman-test/config.toml",
+		filepath.FromSlash("/tmp/middleman-test/config.toml"),
 		DefaultConfigPath(),
 	)
 	assert.Equal("/tmp/middleman-test", DefaultDataDir())
@@ -411,15 +380,15 @@ func TestDefaultPathsWithoutMiddlemanHome(t *testing.T) {
 	t.Setenv("HOME", "/fakehome")
 
 	assert.Equal(
-		"/fakehome/.config/middleman/config.toml",
+		filepath.FromSlash("/fakehome/.config/middleman/config.toml"),
 		DefaultConfigPath(),
 	)
-	assert.Equal("/fakehome/.config/middleman", DefaultDataDir())
+	assert.Equal(filepath.FromSlash("/fakehome/.config/middleman"), DefaultDataDir())
 }
 
 func TestDBPath(t *testing.T) {
 	cfg := &Config{DataDir: "/tmp/middleman-test"}
-	expected := "/tmp/middleman-test/middleman.db"
+	expected := filepath.FromSlash("/tmp/middleman-test/middleman.db")
 	Assert.Equal(t, expected, cfg.DBPath())
 }
 
@@ -2463,26 +2432,9 @@ func TestGhAuthTokenForHostRetriesBareWhenOldGHRejectsHostnameFlag(t *testing.T)
 	assert := Assert.New(t)
 	require := require.New(t)
 
-	dir := t.TempDir()
-	argvPath := filepath.Join(dir, "argv")
-	ghPath := filepath.Join(dir, "gh")
-	// Older gh rejects --hostname; bare succeeds.
-	script := `#!/bin/sh
-printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
-case "$*" in
-*--hostname*)
-	printf 'unknown flag: --hostname\n' 1>&2
-	exit 2
-	;;
-*)
-	printf 'gh-secret-bare\n'
-	exit 0
-	;;
-esac
-`
-	require.NoError(os.WriteFile(ghPath, []byte(script), 0o755))
-	t.Setenv("PATH", dir)
-	t.Setenv("FAKE_GH_ARGV", argvPath)
+	argvPath := setFakeGHCLIWithScript(
+		t, fakeGHCLIRejectHostnameThenBareScript(),
+	)
 
 	got := ghAuthTokenForHost("github.com")
 	assert.Equal("gh-secret-bare", got)
@@ -2511,17 +2463,7 @@ func TestGhAuthTokenForHostDoesNotRetryBareOnGHEFlagRejection(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
-	dir := t.TempDir()
-	argvPath := filepath.Join(dir, "argv")
-	ghPath := filepath.Join(dir, "gh")
-	script := `#!/bin/sh
-printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
-printf 'unknown flag: --hostname\n' 1>&2
-exit 2
-`
-	require.NoError(os.WriteFile(ghPath, []byte(script), 0o755))
-	t.Setenv("PATH", dir)
-	t.Setenv("FAKE_GH_ARGV", argvPath)
+	argvPath := setFakeGHCLIWithScript(t, fakeGHCLIRejectHostnameScript())
 
 	got := ghAuthTokenForHost("ghe.example.com")
 	assert.Empty(got)

--- a/internal/config/config_unix_test.go
+++ b/internal/config/config_unix_test.go
@@ -4,7 +4,9 @@ package config
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -60,4 +62,19 @@ printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
 printf 'unknown flag: --hostname\n' 1>&2
 exit 2
 `
+}
+
+func resolveSleepBinary(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("sleep binary not found: %v", err)
+	}
+	return shellSingleQuote(path)
+}
+
+// shellSingleQuote escapes s for safe inclusion inside single quotes
+// in a /bin/sh script.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/internal/config/config_unix_test.go
+++ b/internal/config/config_unix_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func fakeGHCLIPath(dir string) string {
+	return filepath.Join(dir, "gh")
+}
+
+func fakeGHCLIScript(t *testing.T, opts fakeGHCLIOptions) string {
+	t.Helper()
+	script := "#!/bin/sh\n"
+	script += "printf '%s\\n' \"$*\" >> \"$FAKE_GH_ARGV\"\n"
+	if opts.SleepSeconds > 0 {
+		// exec replaces the shell so there's no orphaned child
+		// holding stdout open after the parent gets SIGKILL'd by
+		// CommandContext; without exec, cmd.Output() blocks for
+		// the full sleep duration even after the shell is dead.
+		// SleepSeconds is therefore terminal in the script: any
+		// stderr/stdout/exit configured below is unreachable when
+		// SleepSeconds > 0, by design (the test stops the helper
+		// via context timeout, not by letting the fake finish).
+		sleepBin := resolveSleepBinary(t)
+		script += fmt.Sprintf("exec %s %d\n", sleepBin, opts.SleepSeconds)
+	}
+	if opts.Stderr != "" {
+		script += "printf '%s\\n' " + shellSingleQuote(opts.Stderr) + " 1>&2\n"
+	}
+	if opts.Stdout != "" {
+		script += "printf '%s\\n' " + shellSingleQuote(opts.Stdout) + "\n"
+	}
+	script += fmt.Sprintf("exit %d\n", opts.ExitCode)
+	return script
+}
+
+func fakeGHCLIRejectHostnameThenBareScript() string {
+	return `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
+case "$*" in
+*--hostname*)
+	printf 'unknown flag: --hostname\n' 1>&2
+	exit 2
+	;;
+*)
+	printf 'gh-secret-bare\n'
+	exit 0
+	;;
+esac
+`
+}
+
+func fakeGHCLIRejectHostnameScript() string {
+	return `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_ARGV"
+printf 'unknown flag: --hostname\n' 1>&2
+exit 2
+`
+}

--- a/internal/config/config_windows_test.go
+++ b/internal/config/config_windows_test.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func fakeGHCLIPath(dir string) string {
+	return filepath.Join(dir, "gh.cmd")
+}
+
+func fakeGHCLIScript(t *testing.T, opts fakeGHCLIOptions) string {
+	t.Helper()
+	script := "@echo off\r\n"
+	script += "echo %*>>\"%FAKE_GH_ARGV%\"\r\n"
+	if opts.SleepSeconds > 0 {
+		script += ":loop\r\ngoto loop\r\n"
+	}
+	if opts.Stderr != "" {
+		script += "echo " + opts.Stderr + " 1>&2\r\n"
+	}
+	if opts.Stdout != "" {
+		script += "echo " + opts.Stdout + "\r\n"
+	}
+	script += fmt.Sprintf("exit /b %d\r\n", opts.ExitCode)
+	return script
+}
+
+func fakeGHCLIRejectHostnameThenBareScript() string {
+	return "@echo off\r\n" +
+		"set \"ARGS=%*\"\r\n" +
+		"echo %*>>\"%FAKE_GH_ARGV%\"\r\n" +
+		"if not \"%ARGS:--hostname=%\"==\"%ARGS%\" (\r\n" +
+		"  echo unknown flag: --hostname 1>&2\r\n" +
+		"  exit /b 2\r\n" +
+		")\r\n" +
+		"echo gh-secret-bare\r\n" +
+		"exit /b 0\r\n"
+}
+
+func fakeGHCLIRejectHostnameScript() string {
+	return "@echo off\r\n" +
+		"echo %*>>\"%FAKE_GH_ARGV%\"\r\n" +
+		"echo unknown flag: --hostname 1>&2\r\n" +
+		"exit /b 2\r\n"
+}

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -465,7 +464,7 @@ func (m *Manager) git(
 func (m *Manager) gitWithInput(
 	ctx context.Context, host, dir string, input []byte, args ...string,
 ) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := procutil.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 // setupTestRepo creates a bare "remote" repo with one commit and returns
@@ -43,7 +44,7 @@ func commitAndPush(t *testing.T, work, file, content, msg string) string {
 	run(t, work, "git", "add", ".")
 	run(t, work, "git", "commit", "-m", msg)
 	run(t, work, "git", "push", "origin", "main")
-	cmd := exec.Command("git", "-C", work, "rev-parse", "HEAD")
+	cmd := procutil.Command("git", "-C", work, "rev-parse", "HEAD")
 	cmd.Env = filteredGitTestEnv()
 	out, err := cmd.Output()
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func filteredGitTestEnv() []string {
 
 func run(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
-	cmd := exec.Command(name, args...)
+	cmd := procutil.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = filteredGitTestEnv()
 	out, err := cmd.CombinedOutput()
@@ -333,7 +334,7 @@ func TestEnsureCloneRestoresOriginHead(t *testing.T) {
 	clonePath, err := mgr.ClonePath("github.com", "testowner", "testrepo")
 	require.NoError(err)
 	run(t, clonePath, "git", "symbolic-ref", "--delete", "refs/remotes/origin/HEAD")
-	_, err = exec.Command(
+	_, err = procutil.Command(
 		"git", "-C", clonePath, "symbolic-ref", "refs/remotes/origin/HEAD",
 	).Output()
 	require.Error(err)
@@ -397,7 +398,7 @@ func TestEnsureCloneToleratesUnresolvedRemoteHead(t *testing.T) {
 // is unset; `git config --get-all` signals that with exit code 1.
 func getFetchRefspecs(t *testing.T, clonePath string) []string {
 	t.Helper()
-	cmd := exec.Command("git", "-C", clonePath,
+	cmd := procutil.Command("git", "-C", clonePath,
 		"config", "--get-all", "remote.origin.fetch")
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull)
@@ -420,7 +421,7 @@ func getFetchRefspecs(t *testing.T, clonePath string) []string {
 
 func gitSymbolicRef(t *testing.T, dir, ref string) string {
 	t.Helper()
-	cmd := exec.Command("git", "-C", dir, "symbolic-ref", ref)
+	cmd := procutil.Command("git", "-C", dir, "symbolic-ref", ref)
 	cmd.Env = filteredGitTestEnv()
 	out, err := cmd.Output()
 	require.NoError(t, err)
@@ -469,7 +470,7 @@ func TestMergeBase(t *testing.T) {
 	// Get the HEAD SHA.
 	clonePath, err := mgr.ClonePath("github.com", "testowner", "testrepo")
 	require.NoError(err)
-	cmd := exec.Command("git", "-C", clonePath, "rev-parse", "HEAD")
+	cmd := procutil.Command("git", "-C", clonePath, "rev-parse", "HEAD")
 	cmd.Env = filteredGitTestEnv()
 	out, err := cmd.Output()
 	require.NoError(err)

--- a/internal/gitclone/commits_test.go
+++ b/internal/gitclone/commits_test.go
@@ -2,7 +2,6 @@ package gitclone
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,11 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 func commitTestRun(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
-	cmd := exec.Command(name, args...)
+	cmd := procutil.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_CONFIG_GLOBAL="+os.DevNull,
@@ -65,7 +65,7 @@ func setupCommitTestRepo(t *testing.T) (string, string, string) {
 
 func gitSHA(t *testing.T, dir, ref string) string {
 	t.Helper()
-	cmd := exec.Command("git", "rev-parse", ref)
+	cmd := procutil.Command("git", "rev-parse", ref)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()), "GIT_CONFIG_GLOBAL="+os.DevNull, "GIT_CONFIG_SYSTEM="+os.DevNull)
 	out, err := cmd.Output()

--- a/internal/gitclone/diff_test.go
+++ b/internal/gitclone/diff_test.go
@@ -4,7 +4,6 @@ package gitclone
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 func TestDiff(t *testing.T) {
@@ -186,7 +186,7 @@ func TestDiffFilesEmpty(t *testing.T) {
 
 func getSHA(t *testing.T, dir, ref string) string {
 	t.Helper()
-	cmd := exec.Command("git", "-C", dir, "rev-parse", ref)
+	cmd := procutil.Command("git", "-C", dir, "rev-parse", ref)
 	cmd.Env = gitenv.StripAll(os.Environ())
 	out, err := cmd.Output()
 	require.NoError(t, err)

--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,6 +17,7 @@ import (
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitclone"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 // gitRun runs a git command in the given dir and returns trimmed stdout.
@@ -25,7 +25,7 @@ import (
 // cause test git operations to mutate the host repo's config.
 func gitRun(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := procutil.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_AUTHOR_NAME=test",

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -26,6 +25,7 @@ import (
 	"github.com/wesm/middleman/internal/gitclone"
 	"github.com/wesm/middleman/internal/gitenv"
 	"github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
 
@@ -39,7 +39,7 @@ func setupBareRemoteForSyncTest(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	remote := filepath.Join(dir, "remote.git")
-	cmd := exec.Command("git", "init", "--bare", "--initial-branch=main", remote)
+	cmd := procutil.Command("git", "init", "--bare", "--initial-branch=main", remote)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_CONFIG_GLOBAL="+os.DevNull,

--- a/internal/procutil/background_other.go
+++ b/internal/procutil/background_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package procutil
+
+import (
+	"os/exec"
+	"path/filepath"
+)
+
+func ConfigureBackgroundCommand(*exec.Cmd) {}
+
+func binaryPathCandidates(dir, name string) []string {
+	return []string{filepath.Join(dir, name)}
+}

--- a/internal/procutil/background_other.go
+++ b/internal/procutil/background_other.go
@@ -3,6 +3,7 @@
 package procutil
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 )
@@ -11,4 +12,8 @@ func ConfigureBackgroundCommand(*exec.Cmd) {}
 
 func binaryPathCandidates(dir, name string) []string {
 	return []string{filepath.Join(dir, name)}
+}
+
+func isExecutableCandidate(info os.FileInfo) bool {
+	return info.Mode().Perm()&0o111 != 0
 }

--- a/internal/procutil/background_windows.go
+++ b/internal/procutil/background_windows.go
@@ -38,3 +38,7 @@ func binaryPathCandidates(dir, name string) []string {
 	}
 	return candidates
 }
+
+func isExecutableCandidate(os.FileInfo) bool {
+	return true
+}

--- a/internal/procutil/background_windows.go
+++ b/internal/procutil/background_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package procutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// ConfigureBackgroundCommand prevents non-interactive helper processes from
+// flashing console windows when tests run under a GUI host on Windows.
+func ConfigureBackgroundCommand(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+}
+
+func binaryPathCandidates(dir, name string) []string {
+	candidates := []string{filepath.Join(dir, name)}
+	if filepath.Ext(name) != "" {
+		return candidates
+	}
+	for _, ext := range filepath.SplitList(os.Getenv("PATHEXT")) {
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		candidates = append(candidates, filepath.Join(dir, name+ext))
+	}
+	return candidates
+}

--- a/internal/procutil/procutil.go
+++ b/internal/procutil/procutil.go
@@ -94,13 +94,24 @@ func binaryNeedsPathResolution(name string) bool {
 }
 
 func resolveBinaryFromPath(name string) (string, bool) {
+	resolved, err := exec.LookPath(name)
+	if err == nil {
+		if abs, absErr := filepath.Abs(resolved); absErr == nil {
+			return abs, true
+		}
+		return resolved, true
+	}
+	if errors.Is(err, exec.ErrDot) {
+		return "", false
+	}
+
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
-		if dir == "" {
-			dir = "."
+		if dir == "" || !filepath.IsAbs(dir) {
+			continue
 		}
 		for _, candidate := range binaryPathCandidates(dir, name) {
 			info, err := os.Stat(candidate)
-			if err == nil && !info.IsDir() {
+			if err == nil && !info.IsDir() && isExecutableCandidate(info) {
 				return candidate, true
 			}
 		}

--- a/internal/procutil/procutil.go
+++ b/internal/procutil/procutil.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -56,9 +58,60 @@ func TryAcquire(
 	return defaultLimiter.TryAcquire(ctx, reason)
 }
 
+func Command(name string, arg ...string) *exec.Cmd {
+	resolvedName, resolvedArgs := ResolveCommand(name, arg...)
+	//nolint:forbidigo // This is the central wrapper forbidigo requires callers to use.
+	cmd := exec.Command(resolvedName, resolvedArgs...)
+	ConfigureBackgroundCommand(cmd)
+	return cmd
+}
+
+func CommandContext(
+	ctx context.Context, name string, arg ...string,
+) *exec.Cmd {
+	resolvedName, resolvedArgs := ResolveCommand(name, arg...)
+	//nolint:forbidigo // This is the central wrapper forbidigo requires callers to use.
+	cmd := exec.CommandContext(ctx, resolvedName, resolvedArgs...)
+	ConfigureBackgroundCommand(cmd)
+	return cmd
+}
+
+func ResolveCommand(name string, arg ...string) (string, []string) {
+	return resolveCommand(name, arg)
+}
+
+func ResolveBinary(name string) string {
+	if binaryNeedsPathResolution(name) {
+		if resolved, ok := resolveBinaryFromPath(name); ok {
+			return resolved
+		}
+	}
+	return name
+}
+
+func binaryNeedsPathResolution(name string) bool {
+	return name != "" && filepath.Base(name) == name
+}
+
+func resolveBinaryFromPath(name string) (string, bool) {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			dir = "."
+		}
+		for _, candidate := range binaryPathCandidates(dir, name) {
+			info, err := os.Stat(candidate)
+			if err == nil && !info.IsDir() {
+				return candidate, true
+			}
+		}
+	}
+	return "", false
+}
+
 func CombinedOutput(
 	ctx context.Context, cmd *exec.Cmd, reason string,
 ) ([]byte, error) {
+	ConfigureBackgroundCommand(cmd)
 	release, err := TryAcquire(ctx, reason)
 	if err != nil {
 		return nil, err
@@ -71,6 +124,7 @@ func CombinedOutput(
 func Output(
 	ctx context.Context, cmd *exec.Cmd, reason string,
 ) ([]byte, error) {
+	ConfigureBackgroundCommand(cmd)
 	release, err := TryAcquire(ctx, reason)
 	if err != nil {
 		return nil, err
@@ -83,6 +137,7 @@ func Output(
 func Run(
 	ctx context.Context, cmd *exec.Cmd, reason string,
 ) error {
+	ConfigureBackgroundCommand(cmd)
 	release, err := TryAcquire(ctx, reason)
 	if err != nil {
 		return err

--- a/internal/procutil/procutil.go
+++ b/internal/procutil/procutil.go
@@ -101,10 +101,6 @@ func resolveBinaryFromPath(name string) (string, bool) {
 		}
 		return resolved, true
 	}
-	if errors.Is(err, exec.ErrDot) {
-		return "", false
-	}
-
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		if dir == "" || !filepath.IsAbs(dir) {
 			continue

--- a/internal/procutil/procutil_other_test.go
+++ b/internal/procutil/procutil_other_test.go
@@ -28,6 +28,27 @@ func TestResolveBinaryRejectsRelativePathMatch(t *testing.T) {
 	assert.Equal("fake-tool", got)
 }
 
+func TestResolveBinarySkipsRelativePathMatchForLaterAbsoluteMatch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	root := t.TempDir()
+	safeDir := t.TempDir()
+	require.NoError(os.WriteFile(
+		filepath.Join(root, "fake-tool"),
+		[]byte("#!/bin/sh\nexit 0\n"),
+		0o755,
+	))
+	safeToolPath := filepath.Join(safeDir, "fake-tool")
+	require.NoError(os.WriteFile(safeToolPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Chdir(root)
+	t.Setenv("PATH", "."+string(os.PathListSeparator)+safeDir)
+
+	got := ResolveBinary("fake-tool")
+
+	assert.Equal(safeToolPath, got)
+}
+
 func TestResolveBinarySkipsNonExecutablePathMatch(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/procutil/procutil_other_test.go
+++ b/internal/procutil/procutil_other_test.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package procutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBinaryRejectsRelativePathMatch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	root := t.TempDir()
+	require.NoError(os.Mkdir(filepath.Join(root, "bin"), 0o755))
+	toolPath := filepath.Join(root, "bin", "fake-tool")
+	require.NoError(os.WriteFile(toolPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Chdir(root)
+	t.Setenv("PATH", "bin")
+
+	got := ResolveBinary("fake-tool")
+
+	assert.False(filepath.IsAbs(got), "relative PATH matches should not be returned: %s", got)
+	assert.Equal("fake-tool", got)
+}
+
+func TestResolveBinarySkipsNonExecutablePathMatch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	toolPath := filepath.Join(dir, "fake-tool")
+	require.NoError(os.WriteFile(toolPath, []byte("not executable"), 0o644))
+	t.Setenv("PATH", dir)
+
+	got := ResolveBinary("fake-tool")
+
+	assert.Equal("fake-tool", got)
+}

--- a/internal/procutil/procutil_windows_test.go
+++ b/internal/procutil/procutil_windows_test.go
@@ -57,3 +57,7 @@ func TestCommandResolvesWindowsPathextBinary(t *testing.T) {
 
 	assert.Equal(strings.ToLower(toolPath), strings.ToLower(cmd.Path))
 }
+
+func TestShouldRunShebangScriptWithShellRejectsBareName(t *testing.T) {
+	Assert.False(t, shouldRunShebangScriptWithShell("fake-gh"))
+}

--- a/internal/procutil/procutil_windows_test.go
+++ b/internal/procutil/procutil_windows_test.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package procutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestRunHidesBackgroundWindows(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	//nolint:forbidigo // This test verifies Run configures an externally-created Cmd.
+	cmd := exec.Command("cmd.exe", "/c", "exit 0")
+
+	err := Run(context.Background(), cmd, "hidden subprocess test")
+
+	require.NoError(err)
+	require.NotNil(cmd.SysProcAttr)
+	assert.True(cmd.SysProcAttr.HideWindow)
+	assert.NotZero(cmd.SysProcAttr.CreationFlags & windows.CREATE_NO_WINDOW)
+	assert.Zero(cmd.SysProcAttr.CreationFlags & windows.CREATE_NEW_CONSOLE)
+}
+
+func TestCommandHidesBackgroundWindows(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cmd := Command("cmd.exe", "/c", "exit 0")
+
+	require.NotNil(cmd.SysProcAttr)
+	assert.True(cmd.SysProcAttr.HideWindow)
+	assert.NotZero(cmd.SysProcAttr.CreationFlags & windows.CREATE_NO_WINDOW)
+	assert.Zero(cmd.SysProcAttr.CreationFlags & windows.CREATE_NEW_CONSOLE)
+}
+
+func TestCommandResolvesWindowsPathextBinary(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	toolPath := filepath.Join(dir, "fake-gh.cmd")
+	require.NoError(os.WriteFile(toolPath, []byte("@echo off\r\nexit /b 0\r\n"), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+
+	cmd := Command("fake-gh")
+
+	assert.Equal(strings.ToLower(toolPath), strings.ToLower(cmd.Path))
+}

--- a/internal/procutil/procutil_windows_test.go
+++ b/internal/procutil/procutil_windows_test.go
@@ -61,3 +61,22 @@ func TestCommandResolvesWindowsPathextBinary(t *testing.T) {
 func TestShouldRunShebangScriptWithShellRejectsBareName(t *testing.T) {
 	Assert.False(t, shouldRunShebangScriptWithShell("fake-gh"))
 }
+
+func TestResolveCommandRunsShebangScriptWithResolvedShellDirectly(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	shellPath := filepath.Join(dir, "sh.cmd")
+	scriptPath := filepath.Join(dir, "fake-gh")
+	require.NoError(os.WriteFile(shellPath, []byte("@echo off\r\nexit /b 0\r\n"), 0o755))
+	require.NoError(os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+
+	name, args := resolveCommand("fake-gh", []string{"arg-one"})
+
+	assert.Equal(strings.ToLower(shellPath), strings.ToLower(name))
+	assert.Equal([]string{scriptPath, "arg-one"}, args)
+	assert.NotContains(args, "-c")
+}

--- a/internal/procutil/resolve_command_other.go
+++ b/internal/procutil/resolve_command_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package procutil
+
+func resolveCommand(name string, arg []string) (string, []string) {
+	return ResolveBinary(name), arg
+}

--- a/internal/procutil/resolve_command_windows.go
+++ b/internal/procutil/resolve_command_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package procutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func resolveCommand(name string, arg []string) (string, []string) {
+	resolved := ResolveBinary(name)
+	if shouldRunShebangScriptWithShell(resolved) {
+		if shell := ResolveBinary("sh"); shell != "sh" {
+			return shell, append(
+				[]string{"-c", `exec sh "$0" "$@"`, resolved},
+				arg...,
+			)
+		}
+	}
+	return resolved, arg
+}
+
+func shouldRunShebangScriptWithShell(path string) bool {
+	if filepath.Ext(path) != "" {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) < 2 {
+		return false
+	}
+	return data[0] == '#' && data[1] == '!'
+}

--- a/internal/procutil/resolve_command_windows.go
+++ b/internal/procutil/resolve_command_windows.go
@@ -3,8 +3,10 @@
 package procutil
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func resolveCommand(name string, arg []string) (string, []string) {
@@ -21,12 +23,21 @@ func resolveCommand(name string, arg []string) (string, []string) {
 }
 
 func shouldRunShebangScriptWithShell(path string) bool {
+	if !filepath.IsAbs(path) && !strings.ContainsAny(path, `\/`) {
+		return false
+	}
 	if filepath.Ext(path) != "" {
 		return false
 	}
-	data, err := os.ReadFile(path)
-	if err != nil || len(data) < 2 {
+	f, err := os.Open(path)
+	if err != nil {
 		return false
 	}
-	return data[0] == '#' && data[1] == '!'
+	defer f.Close()
+	var header [2]byte
+	n, err := io.ReadFull(f, header[:])
+	if err != nil || n < len(header) {
+		return false
+	}
+	return header[0] == '#' && header[1] == '!'
 }

--- a/internal/procutil/resolve_command_windows.go
+++ b/internal/procutil/resolve_command_windows.go
@@ -13,10 +13,7 @@ func resolveCommand(name string, arg []string) (string, []string) {
 	resolved := ResolveBinary(name)
 	if shouldRunShebangScriptWithShell(resolved) {
 		if shell := ResolveBinary("sh"); shell != "sh" {
-			return shell, append(
-				[]string{"-c", `exec sh "$0" "$@"`, resolved},
-				arg...,
-			)
+			return shell, append([]string{resolved}, arg...)
 		}
 	}
 	return resolved, arg

--- a/internal/projects/identity.go
+++ b/internal/projects/identity.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitenv"
 	platformpkg "github.com/wesm/middleman/internal/platform"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 type KnownPlatformHost struct {
@@ -47,7 +48,7 @@ func ResolveIdentityFromPathWithKnownPlatforms(
 	if err != nil {
 		return nil, fmt.Errorf("resolve path: %w", err)
 	}
-	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	cmd := procutil.CommandContext(ctx, "git", "remote", "get-url", "origin")
 	cmd.Dir = abs
 	cmd.Env = gitenv.StripAll(os.Environ())
 	out, err := cmd.Output()

--- a/internal/projects/identity_test.go
+++ b/internal/projects/identity_test.go
@@ -10,6 +10,7 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 func TestParseRemoteURL_GitHubFormats(t *testing.T) {
@@ -208,7 +209,7 @@ func TestResolveIdentityFromPath_RequiresPath(t *testing.T) {
 }
 
 func runGit(dir string, args ...string) error {
-	cmd := exec.Command("git", args...)
+	cmd := procutil.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()),
 		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 type Client struct {
@@ -103,7 +104,7 @@ func (c *Client) Ensure(ctx context.Context, session, cwd string) error {
 		return c.waitReady(ctx, session, nil, nil, nil)
 	}
 	exe, args := c.ownerCommand(exe, session, cwd, string(commandJSON))
-	cmd := exec.Command(exe, args...)
+	cmd := procutil.Command(exe, args...)
 	cmd.Env = c.ownerHelperEnvironment(os.Environ())
 	detachCommand(cmd)
 	stdout := newBoundedOutputBuffer(ownerOutputLimit)

--- a/internal/ptyowner/detach_windows.go
+++ b/internal/ptyowner/detach_windows.go
@@ -5,6 +5,8 @@ package ptyowner
 import (
 	"os/exec"
 	"syscall"
+
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 const (
@@ -13,6 +15,7 @@ const (
 )
 
 func detachCommand(cmd *exec.Cmd) {
+	procutil.ConfigureBackgroundCommand(cmd)
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -488,7 +488,7 @@ func TestClientEnsuresExternalManagerWithPowerShell(t *testing.T) {
 		Root:        root,
 		ManagerPath: managerPath,
 		Command: []string{
-			"powershell.exe", "-NoLogo", "-NoProfile", "-NoExit",
+			"powershell.exe", "-NoLogo", "-NoProfile", "-WindowStyle", "Hidden", "-NoExit",
 		},
 	}
 

--- a/internal/ptyowner/process_windows.go
+++ b/internal/ptyowner/process_windows.go
@@ -3,19 +3,21 @@
 package ptyowner
 
 import (
+	"context"
 	"os"
-	"os/exec"
 	"strconv"
 
 	gopty "github.com/aymanbagabas/go-pty"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 func configureOwnerCommand(*gopty.Cmd) {}
 
 func killOwnerProcess(process *os.Process) {
-	err := exec.Command(
+	cmd := procutil.Command(
 		"taskkill", "/T", "/F", "/PID", strconv.Itoa(process.Pid),
-	).Run()
+	)
+	err := procutil.Run(context.Background(), cmd, "taskkill subprocess capacity")
 	if err != nil {
 		_ = process.Kill()
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -48,6 +48,7 @@ import (
 	forgejoplatform "github.com/wesm/middleman/internal/platform/forgejo"
 	giteaplatform "github.com/wesm/middleman/internal/platform/gitea"
 	"github.com/wesm/middleman/internal/platform/gitealike"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/stacks"
 	"github.com/wesm/middleman/internal/testutil"
@@ -11487,7 +11488,7 @@ func TestAPIActivityStartupRepairsLegacyTimestampStorage(t *testing.T) {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-c", "init.defaultBranch=main"}, args...)...)
+	cmd := procutil.Command("git", append([]string{"-c", "init.defaultBranch=main"}, args...)...)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 	out, err := cmd.CombinedOutput()
@@ -11496,7 +11497,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 
 func testGitSHA(t *testing.T, dir, ref string) string {
 	t.Helper()
-	cmd := exec.Command("git", "rev-parse", ref)
+	cmd := procutil.Command("git", "rev-parse", ref)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 	out, err := cmd.Output()
@@ -12946,7 +12947,7 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 		Tmux: config.Tmux{
 			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
 		},
-		Shell: config.Shell{Command: rustPtyManagerShellCommandForTest()},
+		Shell: config.Shell{Command: rustPtyManagerShellCommandForTest(t)},
 	}
 	fixture := setupWorkspaceServerFixtureWithOptions(t, cfg, ServerOptions{
 		PtyOwnerDir:         ptyOwnerDir,
@@ -12971,7 +12972,7 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		workspaceTerminalConnWriteRead(
-			t, ctx, conn, "Write-Output rust-owner-one\r", "rust-owner-one",
+			t, ctx, conn, "rust-owner-one\r", "echo:rust-owner-one",
 		)
 	} else {
 		workspaceTerminalConnWriteRead(
@@ -13269,9 +13270,11 @@ func gitLocalRemoteURL(path string) string {
 	return (&url.URL{Scheme: "file", Path: slashPath}).String()
 }
 
-func rustPtyManagerShellCommandForTest() []string {
+func rustPtyManagerShellCommandForTest(t *testing.T) []string {
+	t.Helper()
 	if runtime.GOOS == "windows" {
-		return []string{"powershell.exe", "-NoLogo", "-NoProfile", "-NoExit"}
+		t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+		return serverRuntimeHelperCommand("echo")
 	}
 	return []string{"/bin/sh"}
 }
@@ -13284,7 +13287,7 @@ func buildRustPtyManagerForTest(t *testing.T) string {
 		t.Skip("cargo not available")
 	}
 	root := repoRootForTest(t)
-	cmd := exec.Command(cargo, "build", "-p", "middleman-pty-manager")
+	cmd := procutil.Command(cargo, "build", "-p", "middleman-pty-manager")
 	cmd.Dir = root
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
@@ -13759,6 +13762,10 @@ exit 0
 }
 
 func TestServerStartupReapsUnrecordedRuntimeTmuxSessionE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("runtime tmux startup cleanup is Unix-only")
+	}
+
 	require := require.New(t)
 	assert := Assert.New(t)
 	dir := t.TempDir()
@@ -13832,6 +13839,10 @@ exit 0
 func TestWorkspaceResponseProbesStoredRuntimeTmuxSessionWithoutBaseE2E(
 	t *testing.T,
 ) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stored runtime tmux probing is Unix-only")
+	}
+
 	require := require.New(t)
 	assert := Assert.New(t)
 	dir := t.TempDir()
@@ -16106,7 +16117,7 @@ func TestServerPtyOwnerHelperProcess(t *testing.T) {
 
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := procutil.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = append(
 		gitenv.StripAll(os.Environ()),

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -12972,7 +12972,7 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		workspaceTerminalConnWriteRead(
-			t, ctx, conn, "rust-owner-one\r", "echo:rust-owner-one",
+			t, ctx, conn, "echo rust-owner-one\r", "rust-owner-one",
 		)
 	} else {
 		workspaceTerminalConnWriteRead(

--- a/internal/server/compression.go
+++ b/internal/server/compression.go
@@ -1,0 +1,307 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/andybalholm/brotli"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/klauspost/compress/zstd"
+)
+
+const responseCompressionMinSize = 1024
+
+type bufferedHumaContext struct {
+	inner  huma.Context
+	body   bytes.Buffer
+	status int
+}
+
+func (c *bufferedHumaContext) Operation() *huma.Operation {
+	return c.inner.Operation()
+}
+
+func (c *bufferedHumaContext) Context() context.Context {
+	return c.inner.Context()
+}
+
+func (c *bufferedHumaContext) TLS() *tls.ConnectionState {
+	return c.inner.TLS()
+}
+
+func (c *bufferedHumaContext) Version() huma.ProtoVersion {
+	return c.inner.Version()
+}
+
+func (c *bufferedHumaContext) Method() string {
+	return c.inner.Method()
+}
+
+func (c *bufferedHumaContext) Host() string {
+	return c.inner.Host()
+}
+
+func (c *bufferedHumaContext) RemoteAddr() string {
+	return c.inner.RemoteAddr()
+}
+
+func (c *bufferedHumaContext) URL() url.URL {
+	return c.inner.URL()
+}
+
+func (c *bufferedHumaContext) Param(name string) string {
+	return c.inner.Param(name)
+}
+
+func (c *bufferedHumaContext) Query(name string) string {
+	return c.inner.Query(name)
+}
+
+func (c *bufferedHumaContext) Header(name string) string {
+	return c.inner.Header(name)
+}
+
+func (c *bufferedHumaContext) EachHeader(cb func(name string, value string)) {
+	c.inner.EachHeader(cb)
+}
+
+func (c *bufferedHumaContext) BodyReader() io.Reader {
+	return c.inner.BodyReader()
+}
+
+func (c *bufferedHumaContext) GetMultipartForm() (*multipart.Form, error) {
+	return c.inner.GetMultipartForm()
+}
+
+func (c *bufferedHumaContext) SetReadDeadline(deadline time.Time) error {
+	return c.inner.SetReadDeadline(deadline)
+}
+
+func (c *bufferedHumaContext) SetStatus(code int) {
+	c.status = code
+}
+
+func (c *bufferedHumaContext) Status() int {
+	return c.status
+}
+
+func (c *bufferedHumaContext) SetHeader(name string, value string) {
+	c.inner.SetHeader(name, value)
+}
+
+func (c *bufferedHumaContext) AppendHeader(name string, value string) {
+	c.inner.AppendHeader(name, value)
+}
+
+func (c *bufferedHumaContext) BodyWriter() io.Writer {
+	return &c.body
+}
+
+func newResponseCompressionMiddleware(
+	minSize int,
+) func(huma.Context, func(huma.Context)) {
+	return func(ctx huma.Context, next func(huma.Context)) {
+		r, w := humago.Unwrap(ctx)
+		addVaryHeader(w.Header(), "Accept-Encoding")
+		encoding := selectResponseEncoding(r.Header.Get("Accept-Encoding"))
+
+		if encoding == "" || shouldBypassCompression(ctx, r) {
+			next(ctx)
+			return
+		}
+
+		buffered := &bufferedHumaContext{inner: ctx}
+		next(buffered)
+
+		status := buffered.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+
+		if shouldCompressResponse(w.Header(), status, buffered.body.Len(), minSize, encoding) {
+			w.Header().Set("Content-Encoding", encoding)
+			w.Header().Del("Content-Length")
+			w.WriteHeader(status)
+			if err := writeCompressedBody(w, encoding, buffered.body.Bytes()); err != nil {
+				return
+			}
+			return
+		}
+
+		w.WriteHeader(status)
+		_, _ = w.Write(buffered.body.Bytes())
+	}
+}
+
+func shouldBypassCompression(ctx huma.Context, r *http.Request) bool {
+	if r.Method == http.MethodHead {
+		return true
+	}
+	if strings.EqualFold(r.Header.Get("Connection"), "upgrade") ||
+		r.Header.Get("Upgrade") != "" {
+		return true
+	}
+	if ctx.Operation() != nil && ctx.Operation().Path == "/events" {
+		return true
+	}
+	return false
+}
+
+func shouldCompressResponse(
+	header http.Header,
+	status int,
+	bodyLen int,
+	minSize int,
+	encoding string,
+) bool {
+	if encoding == "" || bodyLen < minSize {
+		return false
+	}
+	if status == http.StatusNoContent || status == http.StatusNotModified {
+		return false
+	}
+	if header.Get("Content-Encoding") != "" || header.Get("Content-Range") != "" {
+		return false
+	}
+	if hasNoTransform(header.Get("Cache-Control")) {
+		return false
+	}
+	return isCompressibleContentType(header.Get("Content-Type"))
+}
+
+func selectResponseEncoding(header string) string {
+	const (
+		zstdEncoding   = "zstd"
+		brotliEncoding = "br"
+	)
+
+	best := ""
+	bestQ := 0.0
+	preferred := map[string]int{
+		zstdEncoding:   0,
+		brotliEncoding: 1,
+	}
+
+	for part := range strings.SplitSeq(header, ",") {
+		name, q := parseAcceptEncodingPart(part)
+		if q <= 0 {
+			continue
+		}
+		if name == "*" {
+			name = zstdEncoding
+		}
+		rank, ok := preferred[name]
+		if !ok {
+			continue
+		}
+		if best == "" || q > bestQ || (q == bestQ && rank < preferred[best]) {
+			best = name
+			bestQ = q
+		}
+	}
+
+	return best
+}
+
+func parseAcceptEncodingPart(part string) (string, float64) {
+	pieces := strings.Split(part, ";")
+	name := strings.ToLower(strings.TrimSpace(pieces[0]))
+	if name == "" {
+		return "", 0
+	}
+
+	q := 1.0
+	for _, param := range pieces[1:] {
+		param = strings.TrimSpace(param)
+		rawQ, ok := strings.CutPrefix(param, "q=")
+		if !ok {
+			continue
+		}
+		parsed, err := strconv.ParseFloat(rawQ, 64)
+		if err != nil {
+			return name, 0
+		}
+		q = parsed
+	}
+	return name, q
+}
+
+func hasNoTransform(cacheControl string) bool {
+	for directive := range strings.SplitSeq(cacheControl, ",") {
+		if strings.EqualFold(strings.TrimSpace(directive), "no-transform") {
+			return true
+		}
+	}
+	return false
+}
+
+func isCompressibleContentType(contentType string) bool {
+	if contentType == "" {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.ToLower(strings.TrimSpace(contentType))
+	}
+	if strings.HasPrefix(mediaType, "text/") {
+		return mediaType != "text/event-stream"
+	}
+	switch mediaType {
+	case "application/json",
+		"application/javascript",
+		"application/x-javascript",
+		"application/xml",
+		"application/xhtml+xml",
+		"application/x-ndjson",
+		"image/svg+xml":
+		return true
+	default:
+		return false
+	}
+}
+
+func writeCompressedBody(w io.Writer, encoding string, body []byte) error {
+	switch encoding {
+	case "zstd":
+		zw, err := zstd.NewWriter(w, zstd.WithEncoderLevel(zstd.SpeedFastest))
+		if err != nil {
+			return err
+		}
+		if _, err := zw.Write(body); err != nil {
+			zw.Close()
+			return err
+		}
+		return zw.Close()
+	case "br":
+		bw := brotli.NewWriterLevel(w, brotli.BestSpeed)
+		if _, err := bw.Write(body); err != nil {
+			bw.Close()
+			return err
+		}
+		return bw.Close()
+	default:
+		_, err := w.Write(body)
+		return err
+	}
+}
+
+func addVaryHeader(header http.Header, value string) {
+	for _, existing := range header.Values("Vary") {
+		for part := range strings.SplitSeq(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	header.Add("Vary", value)
+}

--- a/internal/server/compression.go
+++ b/internal/server/compression.go
@@ -19,12 +19,19 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-const responseCompressionMinSize = 1024
+const (
+	responseCompressionMinSize  = 1024
+	responseCompressionMaxBytes = 1 << 20
+)
 
 type bufferedHumaContext struct {
-	inner  huma.Context
-	body   bytes.Buffer
-	status int
+	inner     huma.Context
+	w         http.ResponseWriter
+	body      bytes.Buffer
+	status    int
+	maxBuffer int
+	streaming bool
+	writeErr  error
 }
 
 func (c *bufferedHumaContext) Operation() *huma.Operation {
@@ -104,11 +111,38 @@ func (c *bufferedHumaContext) AppendHeader(name string, value string) {
 }
 
 func (c *bufferedHumaContext) BodyWriter() io.Writer {
-	return &c.body
+	return c
 }
 
 func (c *bufferedHumaContext) Unwrap() huma.Context {
 	return c.inner
+}
+
+func (c *bufferedHumaContext) Write(p []byte) (int, error) {
+	if c.streaming {
+		return c.w.Write(p)
+	}
+	if c.body.Len()+len(p) <= c.maxBuffer {
+		return c.body.Write(p)
+	}
+	c.streaming = true
+	status := c.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	c.w.WriteHeader(status)
+	if c.body.Len() > 0 {
+		if _, err := c.w.Write(c.body.Bytes()); err != nil {
+			c.writeErr = err
+			return 0, err
+		}
+		c.body.Reset()
+	}
+	n, err := c.w.Write(p)
+	if err != nil {
+		c.writeErr = err
+	}
+	return n, err
 }
 
 func newResponseCompressionMiddleware(
@@ -124,8 +158,15 @@ func newResponseCompressionMiddleware(
 			return
 		}
 
-		buffered := &bufferedHumaContext{inner: ctx}
+		buffered := &bufferedHumaContext{
+			inner:     ctx,
+			w:         w,
+			maxBuffer: responseCompressionMaxBytes,
+		}
 		next(buffered)
+		if buffered.streaming || buffered.writeErr != nil {
+			return
+		}
 
 		status := buffered.status
 		if status == 0 {

--- a/internal/server/compression.go
+++ b/internal/server/compression.go
@@ -107,6 +107,10 @@ func (c *bufferedHumaContext) BodyWriter() io.Writer {
 	return &c.body
 }
 
+func (c *bufferedHumaContext) Unwrap() huma.Context {
+	return c.inner
+}
+
 func newResponseCompressionMiddleware(
 	minSize int,
 ) func(huma.Context, func(huma.Context)) {
@@ -188,8 +192,8 @@ func selectResponseEncoding(header string) string {
 	best := ""
 	bestQ := 0.0
 	preferred := map[string]int{
-		zstdEncoding:   0,
-		brotliEncoding: 1,
+		brotliEncoding: 0,
+		zstdEncoding:   1,
 	}
 
 	for part := range strings.SplitSeq(header, ",") {

--- a/internal/server/compression_test.go
+++ b/internal/server/compression_test.go
@@ -31,10 +31,10 @@ func TestHumaResponseCompressionNegotiatesZstdAndBrotli(t *testing.T) {
 		decode         func(t *testing.T, body io.Reader) string
 	}{
 		{
-			name:           "zstd preferred when both encodings are accepted equally",
+			name:           "brotli preferred when both encodings are accepted equally",
 			acceptEncoding: "br, zstd",
-			wantEncoding:   "zstd",
-			decode:         decodeZstdBody,
+			wantEncoding:   "br",
+			decode:         decodeBrotliBody,
 		},
 		{
 			name:           "brotli selected when client gives it higher quality",
@@ -90,6 +90,27 @@ func TestHumaResponseCompressionSkipsSmallResponses(t *testing.T) {
 	assert.Empty(rr.Header().Get("Content-Encoding"))
 	assert.Equal("Accept-Encoding", rr.Header().Get("Vary"))
 	assert.Contains(rr.Body.String(), `"text":"tiny"`)
+}
+
+func TestHumaResponseCompressionPreservesHumagoUnwrap(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.NewWithPrefix(mux, "/api/v1", apiConfig("/"))
+	api.UseMiddleware(newResponseCompressionMiddleware(128))
+	api.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+		_, w := humago.Unwrap(ctx)
+		w.Header().Set("X-Unwrapped", "true")
+		next(ctx)
+	})
+	registerCompressionTestRoutes(api)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/payload", nil)
+	req.Header.Set("Accept-Encoding", "br")
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, "true", rr.Header().Get("X-Unwrapped"))
+	assert.Equal(t, "br", rr.Header().Get("Content-Encoding"))
 }
 
 func TestServerUsesResponseCompressionMiddleware(t *testing.T) {

--- a/internal/server/compression_test.go
+++ b/internal/server/compression_test.go
@@ -113,6 +113,25 @@ func TestHumaResponseCompressionPreservesHumagoUnwrap(t *testing.T) {
 	assert.Equal(t, "br", rr.Header().Get("Content-Encoding"))
 }
 
+func TestHumaResponseCompressionStreamsUncompressedWhenBodyExceedsCap(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.NewWithPrefix(mux, "/api/v1", apiConfig("/"))
+	api.UseMiddleware(newResponseCompressionMiddleware(128))
+	registerCompressionTestRoutes(api)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/huge", nil)
+	req.Header.Set("Accept-Encoding", "br")
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusOK, rr.Code)
+	assert.Empty(rr.Header().Get("Content-Encoding"))
+	assert.Equal("Accept-Encoding", rr.Header().Get("Vary"))
+	assert.Contains(rr.Body.String(), strings.Repeat("huge-payload ", 20))
+}
+
 func TestServerUsesResponseCompressionMiddleware(t *testing.T) {
 	database := dbtest.Open(t)
 	_, err := testutil.SeedFixtures(t.Context(), database)
@@ -146,6 +165,11 @@ func registerCompressionTestRoutes(api huma.API) {
 	huma.Get(api, "/small", func(ctx context.Context, input *struct{}) (*output, error) {
 		resp := &output{}
 		resp.Body.Text = "tiny"
+		return resp, nil
+	})
+	huma.Get(api, "/huge", func(ctx context.Context, input *struct{}) (*output, error) {
+		resp := &output{}
+		resp.Body.Text = strings.Repeat("huge-payload ", 100_000)
 		return resp, nil
 	})
 }

--- a/internal/server/compression_test.go
+++ b/internal/server/compression_test.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/testutil"
+	"github.com/wesm/middleman/internal/testutil/dbtest"
+)
+
+func TestHumaResponseCompressionNegotiatesZstdAndBrotli(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.NewWithPrefix(mux, "/api/v1", apiConfig("/"))
+	api.UseMiddleware(newResponseCompressionMiddleware(128))
+	registerCompressionTestRoutes(api)
+
+	cases := []struct {
+		name           string
+		acceptEncoding string
+		wantEncoding   string
+		decode         func(t *testing.T, body io.Reader) string
+	}{
+		{
+			name:           "zstd preferred when both encodings are accepted equally",
+			acceptEncoding: "br, zstd",
+			wantEncoding:   "zstd",
+			decode:         decodeZstdBody,
+		},
+		{
+			name:           "brotli selected when client gives it higher quality",
+			acceptEncoding: "zstd;q=0.4, br;q=1.0",
+			wantEncoding:   "br",
+			decode:         decodeBrotliBody,
+		},
+		{
+			name:           "gzip is ignored",
+			acceptEncoding: "gzip",
+			wantEncoding:   "",
+			decode: func(t *testing.T, body io.Reader) string {
+				t.Helper()
+				data, err := io.ReadAll(body)
+				require.NoError(t, err)
+				return string(data)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/payload", nil)
+			req.Header.Set("Accept-Encoding", tc.acceptEncoding)
+			rr := httptest.NewRecorder()
+
+			mux.ServeHTTP(rr, req)
+
+			assert := assert.New(t)
+			assert.Equal(http.StatusOK, rr.Code)
+			assert.Equal(tc.wantEncoding, rr.Header().Get("Content-Encoding"))
+			assert.Equal("Accept-Encoding", rr.Header().Get("Vary"))
+			assert.Empty(rr.Header().Get("Content-Length"))
+			assert.Contains(tc.decode(t, rr.Body), strings.Repeat("frontend-payload ", 20))
+		})
+	}
+}
+
+func TestHumaResponseCompressionSkipsSmallResponses(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.NewWithPrefix(mux, "/api/v1", apiConfig("/"))
+	api.UseMiddleware(newResponseCompressionMiddleware(128))
+	registerCompressionTestRoutes(api)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/small", nil)
+	req.Header.Set("Accept-Encoding", "zstd, br")
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusOK, rr.Code)
+	assert.Empty(rr.Header().Get("Content-Encoding"))
+	assert.Equal("Accept-Encoding", rr.Header().Get("Vary"))
+	assert.Contains(rr.Body.String(), `"text":"tiny"`)
+}
+
+func TestServerUsesResponseCompressionMiddleware(t *testing.T) {
+	database := dbtest.Open(t)
+	_, err := testutil.SeedFixtures(t.Context(), database)
+	require.NoError(t, err)
+	srv := New(database, nil, nil, "/", nil, ServerOptions{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pulls", nil)
+	req.Header.Set("Accept-Encoding", "zstd")
+	rr := httptest.NewRecorder()
+
+	srv.ServeHTTP(rr, req)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusOK, rr.Code)
+	assert.Equal("zstd", rr.Header().Get("Content-Encoding"))
+	assert.Equal("Accept-Encoding", rr.Header().Get("Vary"))
+	assert.Contains(decodeZstdBody(t, rr.Body), "Add widget caching layer")
+}
+
+func registerCompressionTestRoutes(api huma.API) {
+	type output struct {
+		Body struct {
+			Text string `json:"text"`
+		}
+	}
+
+	huma.Get(api, "/payload", func(ctx context.Context, input *struct{}) (*output, error) {
+		resp := &output{}
+		resp.Body.Text = strings.Repeat("frontend-payload ", 300)
+		return resp, nil
+	})
+	huma.Get(api, "/small", func(ctx context.Context, input *struct{}) (*output, error) {
+		resp := &output{}
+		resp.Body.Text = "tiny"
+		return resp, nil
+	})
+}
+
+func decodeZstdBody(t *testing.T, body io.Reader) string {
+	t.Helper()
+	reader, err := zstd.NewReader(body)
+	require.NoError(t, err)
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func decodeBrotliBody(t *testing.T, body io.Reader) string {
+	t.Helper()
+	data, err := io.ReadAll(brotli.NewReader(body))
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/server/gitealike_container_e2e_test.go
+++ b/internal/server/gitealike_container_e2e_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,6 +18,7 @@ import (
 	"github.com/wesm/middleman/internal/platform"
 	platformforgejo "github.com/wesm/middleman/internal/platform/forgejo"
 	platformgitea "github.com/wesm/middleman/internal/platform/gitea"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
 
@@ -242,7 +242,7 @@ func runGiteaLikeContainerFixture(
 	require.NoError(err)
 
 	manifestPath := filepath.Join(t.TempDir(), cfg.ScriptDir+"-manifest.json")
-	cmd := exec.CommandContext(
+	cmd := procutil.CommandContext(
 		ctx,
 		filepath.Join(repoRoot(t), "scripts/e2e", cfg.ScriptDir, "bootstrap.sh"),
 		manifestPath,

--- a/internal/server/gitlab_container_e2e_test.go
+++ b/internal/server/gitlab_container_e2e_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -22,6 +21,7 @@ import (
 	ghclient "github.com/wesm/middleman/internal/github"
 	"github.com/wesm/middleman/internal/platform"
 	platformgitlab "github.com/wesm/middleman/internal/platform/gitlab"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
 
@@ -100,7 +100,7 @@ func TestGitLabContainerE2E(t *testing.T) {
 	require.NoError(err)
 
 	manifestPath := filepath.Join(t.TempDir(), "gitlab-manifest.json")
-	cmd := exec.CommandContext(
+	cmd := procutil.CommandContext(
 		ctx,
 		filepath.Join(repoRoot(t), "scripts/e2e/gitlab/bootstrap.sh"),
 		manifestPath,

--- a/internal/server/projects_handlers_test.go
+++ b/internal/server/projects_handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 // TestW1SliceAGate is the falsifiable capability gate from the convergence
@@ -760,7 +761,7 @@ func TestInitLocalOnlyGitRepoIgnoresInheritedGitEnv(t *testing.T) {
 	assert := Assert.New(t)
 
 	host := t.TempDir()
-	initCmd := exec.Command("git", "init", "-q", "-b", "main", host)
+	initCmd := procutil.Command("git", "init", "-q", "-b", "main", host)
 	initCmd.Env = gitenv.StripAll(os.Environ())
 	require.NoError(initCmd.Run(), "seed host repo")
 
@@ -784,7 +785,7 @@ func TestInitLocalOnlyGitRepoIgnoresInheritedGitEnv(t *testing.T) {
 // initLocalOnlyGitRepo runs `git init` in dir without configuring any remote,
 // matching the no-`gh` Add Existing path.
 func initLocalOnlyGitRepo(dir string) error {
-	cmd := exec.Command("git", "init", "-q")
+	cmd := procutil.Command("git", "init", "-q")
 	cmd.Dir = dir
 	cmd.Env = gitenv.StripAll(os.Environ())
 	if err := cmd.Run(); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -506,6 +506,7 @@ func newServer(
 	s.registerHealthAPI(healthAPI)
 
 	api := humago.NewWithPrefix(mux, "/api/v1", apiConfig(basePath))
+	api.UseMiddleware(newResponseCompressionMiddleware(responseCompressionMinSize))
 	s.registerAPI(api)
 	if s.workspaces != nil {
 		s.registerTerminalAPI(api, tmuxCmd)

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -126,10 +127,27 @@ func readTmuxRecord(t *testing.T, path string) [][]string {
 		}
 		i++
 		argv := parts[i : i+n]
+		for j := range argv {
+			argv[j] = normalizeRecordedTmuxArg(argv[j])
+		}
 		out = append(out, argv)
 		i += n
 	}
 	return out
+}
+
+func normalizeRecordedTmuxArg(arg string) string {
+	if runtime.GOOS != "windows" {
+		return arg
+	}
+	switch arg {
+	case "#session_name":
+		return "#{session_name}"
+	case "#pane_title":
+		return "#{pane_title}"
+	default:
+		return arg
+	}
 }
 
 func containsArg(argv []string, want string) bool {

--- a/internal/server/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspace_concurrent_e2e_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"net/http"
-	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/wesm/middleman/internal/apiclient/generated"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 // TestWorkspaceConcurrentSameRepoOperationsE2E exercises the per-repo
@@ -176,7 +176,7 @@ func (e *unexpectedStatusError) Error() string {
 // each managed worktree adds one more.
 func listBareWorktrees(t *testing.T, bare string) int {
 	t.Helper()
-	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd := procutil.Command("git", "worktree", "list", "--porcelain")
 	cmd.Dir = bare
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git worktree list: %s", out)

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,6 +20,7 @@ import (
 	"github.com/wesm/middleman/internal/gitclone"
 	"github.com/wesm/middleman/internal/gitenv"
 	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/server"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
@@ -160,7 +160,7 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-c", "init.defaultBranch=main"}, args...)...)
+	cmd := procutil.Command("git", append([]string{"-c", "init.defaultBranch=main"}, args...)...)
 	cmd.Dir = dir
 	cmd.Env = append(gitenv.StripAll(os.Environ()), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 	out, err := cmd.CombinedOutput()

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/exec"
 	"sync"
 	"time"
 
@@ -160,7 +159,7 @@ func (h *Handler) ServeHTTP(
 	argv := make([]string, 0, len(prefix)+3)
 	argv = append(argv, prefix...)
 	argv = append(argv, "attach-session", "-t", ws.TmuxSession)
-	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd := procutil.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 	logWebsocketDebug(
 		"workspace terminal starting tmux attach",

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitclone"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 // DiffRepoResult holds the SHAs from the test repo for use in assertions.
@@ -198,7 +198,7 @@ func git(dir string, args ...string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("git: no args")
 	}
-	cmd := exec.Command("git", args...)
+	cmd := procutil.Command("git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -223,7 +223,7 @@ func git(dir string, args ...string) error {
 }
 
 func revParse(dir, ref string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", ref)
+	cmd := procutil.Command("git", "rev-parse", ref)
 	cmd.Dir = dir
 	cmd.Env = gitenv.StripAll(os.Environ())
 	out, err := cmd.Output()

--- a/internal/testutil/diff_repo_test.go
+++ b/internal/testutil/diff_repo_test.go
@@ -2,11 +2,11 @@ package testutil
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
 
@@ -26,7 +26,7 @@ func TestSetupDiffRepoDoesNotLeakIntoHostGitDir(t *testing.T) {
 	r := require.New(t)
 
 	host := t.TempDir()
-	initCmd := exec.Command("git", "init", "-q", "-b", "main", host)
+	initCmd := procutil.Command("git", "init", "-q", "-b", "main", host)
 	initCmd.Env = []string{
 		"PATH=" + os.Getenv("PATH"),
 		"HOME=" + os.Getenv("HOME"),

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -817,7 +816,7 @@ func worktreeGitOutputWithInput(
 	if dir == "" {
 		return nil, errors.New("empty worktree dir")
 	}
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := procutil.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	if input != nil {
 		cmd.Stdin = bytes.NewReader(input)

--- a/internal/workspace/diff_test.go
+++ b/internal/workspace/diff_test.go
@@ -284,7 +284,7 @@ func TestWorktreeDiffRendersUntrackedSymlinkTarget(t *testing.T) {
 	runWorkspaceTestGit(t, work, "add", ".")
 	runWorkspaceTestGit(t, work, "commit", "-m", "init")
 	require.NoError(os.WriteFile(secret, []byte("do not expose\n"), 0o644))
-	require.NoError(os.Symlink(secret, filepath.Join(work, "secret-link")))
+	requireSymlink(t, secret, filepath.Join(work, "secret-link"))
 
 	diff, ok, err := WorktreeDiff(
 		t.Context(), work, WorktreeDiffBaseHead, false,
@@ -312,11 +312,23 @@ func TestOpenRegularUntrackedFileRejectsSymlinks(t *testing.T) {
 	secret := filepath.Join(root, "secret.txt")
 	link := filepath.Join(root, "secret-link")
 	require.NoError(os.WriteFile(secret, []byte("do not expose\n"), 0o644))
-	require.NoError(os.Symlink(secret, link))
+	requireSymlink(t, secret, link)
 
 	file, _, err := openRegularUntrackedFile(link)
 	require.Error(err)
 	require.Nil(file)
+}
+
+func requireSymlink(t *testing.T, oldname string, newname string) {
+	t.Helper()
+	err := os.Symlink(oldname, newname)
+	if err != nil && strings.Contains(
+		err.Error(),
+		"A required privilege is not held by the client",
+	) {
+		t.Skipf("symlink privilege unavailable: %v", err)
+	}
+	require.NoError(t, err)
 }
 
 func TestWorktreeDiffMarksLargeUntrackedFileBinary(t *testing.T) {

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/creack/pty/v2"
 
+	"github.com/wesm/middleman/internal/procutil"
 	ptyownerruntime "github.com/wesm/middleman/internal/ptyowner/runtime"
 )
 
@@ -664,10 +665,10 @@ func (m *Manager) killTmuxSession(
 		return nil
 	}
 	args := append(command[1:], "kill-session", "-t", session)
-	cmd := exec.CommandContext(ctx, command[0], args...)
+	cmd := procutil.CommandContext(ctx, command[0], args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	err := cmd.Run()
+	err := procutil.Run(ctx, cmd, "tmux subprocess capacity")
 	if err == nil || isTmuxSessionAbsent(stderr.Bytes(), err) {
 		return nil
 	}
@@ -711,12 +712,12 @@ func (m *Manager) refreshTmuxSessionClients(
 		command[1:],
 		"list-clients", "-t", session, "-F", "#{client_tty}",
 	)
-	listCmd := exec.CommandContext(ctx, command[0], listArgs...)
+	listCmd := procutil.CommandContext(ctx, command[0], listArgs...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	listCmd.Stdout = &stdout
 	listCmd.Stderr = &stderr
-	if err := listCmd.Run(); err != nil {
+	if err := procutil.Run(ctx, listCmd, "tmux subprocess capacity"); err != nil {
 		if isTmuxSessionAbsent(stderr.Bytes(), err) {
 			return nil
 		}
@@ -733,12 +734,14 @@ func (m *Manager) refreshTmuxSessionClients(
 			command[1:],
 			"refresh-client", "-t", client,
 		)
-		refreshCmd := exec.CommandContext(
+		refreshCmd := procutil.CommandContext(
 			ctx, command[0], refreshArgs...,
 		)
 		var refreshStderr bytes.Buffer
 		refreshCmd.Stderr = &refreshStderr
-		if err := refreshCmd.Run(); err != nil {
+		if err := procutil.Run(
+			ctx, refreshCmd, "tmux subprocess capacity",
+		); err != nil {
 			msg := strings.TrimSpace(refreshStderr.String())
 			if msg != "" {
 				err = fmt.Errorf("%w: %s", err, msg)
@@ -1516,7 +1519,7 @@ func startSession(
 	}
 
 	// Resolve the executable to an absolute path BEFORE setting
-	// cmd.Dir to the workspace worktree. exec.Command treats names
+	// cmd.Dir to the workspace worktree. procutil.Command treats names
 	// without separators as PATH lookups but treats names like
 	// "./agent" or "scripts/codex" as paths relative to cmd.Dir,
 	// which would let a malicious PR drop an executable into the
@@ -1537,7 +1540,7 @@ func startSession(
 		"cwd", cwd,
 	)
 
-	cmd := exec.Command(resolvedPath, command[1:]...)
+	cmd := procutil.Command(resolvedPath, command[1:]...)
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
@@ -1931,12 +1934,22 @@ func resolveExecutable(name string) (string, error) {
 	if filepath.IsAbs(name) {
 		return name, nil
 	}
-	if !strings.ContainsRune(name, filepath.Separator) {
-		path, err := exec.LookPath(name)
-		if err != nil {
+	if !strings.ContainsAny(name, `/\`) {
+		path := procutil.ResolveBinary(name)
+		if path == name {
+			var err error
+			path, err = exec.LookPath(name)
+			if err != nil {
+				return "", fmt.Errorf(
+					"resolve session command %q via PATH: %w",
+					name, err,
+				)
+			}
+		}
+		if path == name {
 			return "", fmt.Errorf(
-				"resolve session command %q via PATH: %w",
-				name, err,
+				"resolve session command %q via PATH: not found",
+				name,
 			)
 		}
 		// LookPath joins the matched PATH entry with name; a

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/creack/pty/v2"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/procutil"
 	ptyownerruntime "github.com/wesm/middleman/internal/ptyowner/runtime"
 )
 
@@ -295,6 +297,10 @@ func TestTmuxSessionNameUsesOpaqueTargetHash(t *testing.T) {
 }
 
 func TestManagerLaunchCommandCleansUpWhenOwnerMarkingFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux owner shell wrapper uses Unix shell semantics")
+	}
+
 	assert := Assert.New(t)
 	require := require.New(t)
 	dir := t.TempDir()
@@ -340,7 +346,7 @@ exit 0
 
 	launch, err := mgr.launchCommand(agent, "ws-1", t.TempDir())
 	require.NoError(err)
-	cmd := exec.Command(launch.Command[0], launch.Command[1:]...)
+	cmd := procutil.Command(launch.Command[0], launch.Command[1:]...)
 	cmd.Env = append(os.Environ(), "TMUX_RECORD="+record)
 
 	err = cmd.Run()
@@ -859,7 +865,7 @@ func TestSessionWatchLeavesOutputOpenForDrain(t *testing.T) {
 	_, err = writeEnd.WriteString("final output")
 	require.NoError(err)
 
-	cmd := exec.Command("sh", "-c", "exit 0")
+	cmd := procutil.Command("sh", "-c", "exit 0")
 	require.NoError(cmd.Start())
 	outputDone := make(chan struct{})
 	s := &session{
@@ -886,7 +892,7 @@ func TestSessionWatchClosesPTYAfterPostExitDrainTimeout(t *testing.T) {
 	defer readEnd.Close()
 	defer writeEnd.Close()
 
-	cmd := exec.Command("sh", "-c", "exit 0")
+	cmd := procutil.Command("sh", "-c", "exit 0")
 	require.NoError(cmd.Start())
 	outputDone := make(chan struct{})
 	s := &session{
@@ -1551,15 +1557,30 @@ func TestResolveExecutableRejectsRelativePaths(t *testing.T) {
 	assert := Assert.New(t)
 
 	// Absolute path: pass through unchanged.
-	got, err := resolveExecutable("/usr/local/bin/codex")
+	absCommand := "/usr/local/bin/codex"
+	if runtime.GOOS == "windows" {
+		absCommand = `C:\tools\codex.exe`
+	}
+	got, err := resolveExecutable(absCommand)
 	require.NoError(err)
-	assert.Equal("/usr/local/bin/codex", got)
+	assert.Equal(absCommand, got)
 
-	// PATH-resolvable: returns the full path. /bin/sh is present
-	// on every supported platform.
-	got, err = resolveExecutable("sh")
+	// PATH-resolvable: returns the full path.
+	exeName, exePath := writeFakeRuntimeTool(t, t.TempDir(), "fake-runtime-tool")
+	t.Setenv("PATH", filepath.Dir(exePath))
+	got, err = resolveExecutable(exeName)
 	require.NoError(err)
 	assert.True(filepath.IsAbs(got), "expected absolute path, got %q", got)
+	if runtime.GOOS == "windows" {
+		assert.True(
+			strings.EqualFold(exePath, got),
+			"expected %q, got %q",
+			exePath,
+			got,
+		)
+	} else {
+		assert.Equal(exePath, got)
+	}
 
 	// Relative paths must be rejected.
 	for _, rel := range []string{
@@ -1591,8 +1612,7 @@ func TestResolveExecutableForcesAbsoluteFromRelativePATH(t *testing.T) {
 	dir := t.TempDir()
 	binDir := filepath.Join(dir, "bin")
 	require.NoError(os.MkdirAll(binDir, 0o755))
-	exe := filepath.Join(binDir, "fake-runtime-tool")
-	require.NoError(os.WriteFile(exe, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	exeName, exe := writeFakeRuntimeTool(t, binDir, "fake-runtime-tool")
 
 	t.Chdir(dir)
 	t.Setenv("PATH", "bin")
@@ -1602,7 +1622,7 @@ func TestResolveExecutableForcesAbsoluteFromRelativePATH(t *testing.T) {
 	// rebinding is dangerous, so verify the absolute fallback runs.
 	t.Setenv("GODEBUG", "execerrdot=0")
 
-	got, err := resolveExecutable("fake-runtime-tool")
+	got, err := resolveExecutable(exeName)
 	require.NoError(err)
 	assert.True(
 		filepath.IsAbs(got),
@@ -1610,7 +1630,42 @@ func TestResolveExecutableForcesAbsoluteFromRelativePATH(t *testing.T) {
 			"inside cmd.Dir = the workspace worktree)",
 		got,
 	)
-	assert.Equal(exe, got)
+	if runtime.GOOS == "windows" {
+		assert.True(
+			strings.EqualFold(exe, got),
+			"expected %q, got %q",
+			exe,
+			got,
+		)
+	} else {
+		assert.Equal(exe, got)
+	}
+}
+
+func writeFakeRuntimeTool(
+	t *testing.T,
+	dir string,
+	name string,
+) (string, string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+		path := filepath.Join(dir, name+".cmd")
+		require.NoError(t, os.WriteFile(
+			path,
+			[]byte("@echo off\r\nexit /b 0\r\n"),
+			0o755,
+		))
+		return name, path
+	}
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte("#!/bin/sh\nexit 0\n"),
+		0o755,
+	))
+	return name, path
 }
 
 // TestSessionEnvironmentStripsCredentials verifies that the
@@ -1702,7 +1757,7 @@ func TestHelperProcess(t *testing.T) {
 		if len(helperArgs) < 2 {
 			os.Exit(2)
 		}
-		child := exec.Command(
+		child := procutil.Command(
 			os.Args[0], "-test.run=TestHelperProcess", "--", "sleep",
 		)
 		if err := child.Start(); err != nil {

--- a/internal/workspace/localruntime/process_alive_windows_test.go
+++ b/internal/workspace/localruntime/process_alive_windows_test.go
@@ -3,15 +3,16 @@
 package localruntime
 
 import (
-	"os/exec"
 	"strconv"
+
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 func processAlive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
-	cmd := exec.Command(
+	cmd := procutil.Command(
 		"powershell",
 		"-NoProfile",
 		"-Command",

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -168,12 +168,12 @@ func (m *Manager) tmuxExec(
 	ctx context.Context, extra ...string,
 ) *exec.Cmd {
 	if len(m.tmuxCmd) == 0 {
-		return exec.CommandContext(ctx, "tmux", extra...)
+		return procutil.CommandContext(ctx, "tmux", extra...)
 	}
 	args := make([]string, 0, len(m.tmuxCmd)-1+len(extra))
 	args = append(args, m.tmuxCmd[1:]...)
 	args = append(args, extra...)
-	return exec.CommandContext(ctx, m.tmuxCmd[0], args...)
+	return procutil.CommandContext(ctx, m.tmuxCmd[0], args...)
 }
 
 // Create persists a PR-backed middleman workspace.
@@ -665,7 +665,7 @@ func setBranchUpstream(
 func validateLocalBranchName(
 	ctx context.Context, dir, branch string,
 ) error {
-	cmd := exec.CommandContext(
+	cmd := procutil.CommandContext(
 		ctx, "git", "check-ref-format", "--branch", branch,
 	)
 	if dir != "" {
@@ -1742,7 +1742,7 @@ func userLoginShell() string {
 }
 
 func lookupPasswdShell(username string) string {
-	cmd := exec.Command("getent", "passwd", username)
+	cmd := procutil.Command("getent", "passwd", username)
 	out, err := procutil.Output(
 		context.Background(), cmd, "shell lookup subprocess capacity",
 	)
@@ -2153,7 +2153,7 @@ func localBranchExists(
 		"--quiet",
 		"refs/heads/"+branch,
 	)
-	err := cmd.Run()
+	err := procutil.Run(ctx, cmd, "git subprocess capacity")
 	if err == nil {
 		return true, nil
 	}
@@ -2167,7 +2167,7 @@ func localBranchExists(
 func workspaceGitCommand(
 	ctx context.Context, dir string, args ...string,
 ) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := procutil.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +20,7 @@ import (
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitclone"
 	"github.com/wesm/middleman/internal/gitenv"
+	"github.com/wesm/middleman/internal/procutil"
 	"github.com/wesm/middleman/internal/ptyowner"
 	"github.com/wesm/middleman/internal/testutil/dbtest"
 )
@@ -736,7 +737,7 @@ func configureForkPRRefs(
 
 func runWorkspaceTestGit(t *testing.T, dir string, args ...string) []byte {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := procutil.Command("git", args...)
 	cmd.Dir = dir
 	cmd.Env = append(
 		gitenv.StripAll(os.Environ()),
@@ -850,10 +851,27 @@ func readRecorderArgv(t *testing.T, path string) [][]string {
 		require.NoError(t, err)
 		i++
 		argv := parts[i : i+n]
+		for j := range argv {
+			argv[j] = normalizeRecordedTmuxArg(argv[j])
+		}
 		out = append(out, argv)
 		i += n
 	}
 	return out
+}
+
+func normalizeRecordedTmuxArg(arg string) string {
+	if runtime.GOOS != "windows" {
+		return arg
+	}
+	switch arg {
+	case "#session_name":
+		return "#{session_name}"
+	case "#pane_title":
+		return "#{pane_title}"
+	default:
+		return arg
+	}
 }
 
 func TestManagerEnsureTmuxHasSessionPrefix(t *testing.T) {

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -7,12 +7,12 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/wesm/middleman/internal/db"
 	"github.com/wesm/middleman/internal/gitenv"
 	ghclient "github.com/wesm/middleman/internal/github"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 type PRAssociationUpdate struct {
@@ -286,7 +286,7 @@ func gitOutput(
 	dir string,
 	args ...string,
 ) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := procutil.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = append(
 		gitenv.StripAll(os.Environ()),

--- a/prek.toml
+++ b/prek.toml
@@ -99,6 +99,7 @@ hooks = [
     entry = "make lint",
     files = "^(go\\.mod|go\\.sum|.*\\.go)$",
     pass_filenames = false,
+    require_serial = true,
     priority = 10,
   },
   {
@@ -108,6 +109,7 @@ hooks = [
     entry = "make testify-helper-check",
     files = "^(go\\.mod|go\\.sum|.*\\.go)$",
     pass_filenames = false,
+    require_serial = true,
     priority = 15,
   },
   {
@@ -126,6 +128,7 @@ hooks = [
     entry = "make test-short",
     files = "^(go\\.mod|go\\.sum|.*\\.go)$",
     pass_filenames = false,
+    require_serial = true,
     priority = 20,
   },
   {

--- a/tools/devephemeral/main.go
+++ b/tools/devephemeral/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/wesm/middleman/internal/config"
+	"github.com/wesm/middleman/internal/procutil"
 	_ "modernc.org/sqlite"
 )
 
@@ -621,7 +622,7 @@ func processStartTime(pid int) (string, error) {
 	if pid <= 0 {
 		return "", os.ErrProcessDone
 	}
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	out, err := procutil.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
 	startedAt := strings.TrimSpace(string(out))
 	if startedAt == "" {
 		return "", os.ErrProcessDone
@@ -735,7 +736,7 @@ func removeSQLiteFiles(path string) error {
 }
 
 func startCommand(ctx context.Context, spec commandSpec) (*exec.Cmd, error) {
-	cmd := exec.CommandContext(ctx, spec.name, spec.args...)
+	cmd := procutil.CommandContext(ctx, spec.name, spec.args...)
 	cmd.Env = spec.env
 	cmd.Dir = spec.dir
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/tools/migrationhistorycheck/main.go
+++ b/tools/migrationhistorycheck/main.go
@@ -5,10 +5,11 @@ import (
 	"io"
 	"maps"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 const (
@@ -240,7 +241,7 @@ func getenvDefault(key, fallback string) string {
 }
 
 func git(args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	cmd := procutil.Command("git", args...)
 	if gitEnv != nil {
 		cmd.Env = gitEnv
 	}

--- a/tools/migrationhistorycheck/main_test.go
+++ b/tools/migrationhistorycheck/main_test.go
@@ -3,13 +3,13 @@ package main
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 func TestAllowsNewMigration(t *testing.T) {
@@ -114,7 +114,7 @@ func gitCommandIn(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
 	gitArgs := append([]string{"-c", "core.hooksPath=/dev/null"}, args...)
-	cmd := exec.Command("git", gitArgs...)
+	cmd := procutil.Command("git", gitArgs...)
 	cmd.Dir = dir
 	cmd.Env = cleanGitEnv(os.Environ())
 	output, err := cmd.CombinedOutput()

--- a/tools/nohttpmux/main.go
+++ b/tools/nohttpmux/main.go
@@ -10,10 +10,11 @@ import (
 	"go/token"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/wesm/middleman/internal/procutil"
 )
 
 const diagnosticMessage = "non-Huma HTTP route registration is not allowed; register API routes through the Huma route layer"
@@ -317,7 +318,7 @@ type listedPackageError struct {
 }
 
 func packageGoFiles(pattern string) ([]string, error) {
-	cmd := exec.Command("go", "list", "-json", pattern)
+	cmd := procutil.Command("go", "list", "-json", pattern)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()


### PR DESCRIPTION
## Summary

- Add Huma response compression for large frontend/API payloads using Brotli or Zstd when accepted by the client, intentionally ignoring gzip.
- Route repository exec usage through `procutil.Command*` so Windows subprocesses run hidden, with PATH/PATHEXT resolution and a forbidigo guard against new raw `exec.Command*` calls.
- Make Windows tests less explosive by serializing the heavy hook/test path, using Windows-aware fake `gh`/tmux helpers, and skipping Unix-only tmux/symlink cases where Windows cannot exercise the behavior.

## Validation

- `go test ./internal/procutil ./internal/workspace/localruntime -run TestResolveExecutable -p 1`
- `go test ./internal/config ./internal/workspace/localruntime -run Test(MiddlemanHomeOverridesDefaultPaths|DefaultPathsWithoutMiddlemanHome|DBPath|ManagerLaunchCommandCleansUpWhenOwnerMarkingFails)$ -p 1`
- `go test ./internal/workspace -run '^TestManagerReapOrphanTmuxSessionsKillsUnknownManagedSessions$' -p 1`
- `go test ./internal/server -run '^(TestWorkspaceResponseProbesStoredRuntimeTmuxSessionWithoutBaseE2E|TestServerStartupReapsUnrecordedRuntimeTmuxSessionE2E)$' -p 1`
- Hook-enforced `git commit` passed, including `golangci-lint --fix`, `testify helper check`, and `go test (short)`.
- Pre-push hook passed, including `nilaway`.