### PR TITLE
Improve large repo sync feedback and refresh scaling

### DIFF
--- a/internal/db/migrations/000024_http_etags.down.sql
+++ b/internal/db/migrations/000024_http_etags.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS middleman_http_etags;

--- a/internal/db/migrations/000024_http_etags.up.sql
+++ b/internal/db/migrations/000024_http_etags.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS middleman_http_etags (
+    platform TEXT NOT NULL,
+    platform_host TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    name_key TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    resource_number INTEGER NOT NULL,
+    etag TEXT NOT NULL,
+    fetched_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (
+        platform,
+        platform_host,
+        owner_key,
+        name_key,
+        resource_type,
+        resource_number
+    )
+);

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2618,6 +2618,22 @@ func (d *DB) GetPreviouslyOpenMRNumbers(
 	return closed, rows.Err()
 }
 
+func (d *DB) HasOpenMergeRequestsForRepo(ctx context.Context, repoID int64) (bool, error) {
+	var exists bool
+	err := d.ro.QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM middleman_merge_requests
+			WHERE repo_id = ? AND state = 'open'
+			LIMIT 1
+		)`,
+		repoID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check open merge requests for repo: %w", err)
+	}
+	return exists, nil
+}
+
 // MRDerivedFields holds computed fields that are refreshed after fetching timeline events.
 type MRDerivedFields struct {
 	ReviewDecision string
@@ -3244,6 +3260,78 @@ func (d *DB) GetPreviouslyOpenIssueNumbers(
 		}
 	}
 	return closed, rows.Err()
+}
+
+func (d *DB) HasOpenIssuesForRepo(ctx context.Context, repoID int64) (bool, error) {
+	var exists bool
+	err := d.ro.QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM middleman_issues
+			WHERE repo_id = ? AND state = 'open'
+			LIMIT 1
+		)`,
+		repoID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("check open issues for repo: %w", err)
+	}
+	return exists, nil
+}
+
+func (d *DB) GetHTTPEtag(
+	ctx context.Context,
+	platform, platformHost, owner, name, resourceType string,
+	resourceNumber int,
+) (string, error) {
+	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
+	var etag string
+	err := d.ro.QueryRowContext(ctx,
+		`SELECT etag FROM middleman_http_etags
+		WHERE platform = ?
+		  AND platform_host = ?
+		  AND owner_key = ?
+		  AND name_key = ?
+		  AND resource_type = ?
+		  AND resource_number = ?`,
+		platform, platformHost, owner, name, resourceType, resourceNumber,
+	).Scan(&etag)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get http etag: %w", err)
+	}
+	return etag, nil
+}
+
+func (d *DB) UpsertHTTPEtag(
+	ctx context.Context,
+	platform, platformHost, owner, name, resourceType string,
+	resourceNumber int,
+	etag string,
+) error {
+	if etag == "" {
+		return nil
+	}
+	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
+	_, err := d.rw.ExecContext(ctx,
+		`INSERT INTO middleman_http_etags (
+			platform, platform_host, owner_key, name_key,
+			resource_type, resource_number, etag, fetched_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+		ON CONFLICT (
+			platform, platform_host, owner_key, name_key,
+			resource_type, resource_number
+		) DO UPDATE SET
+			etag = excluded.etag,
+			fetched_at = excluded.fetched_at`,
+		platform, platformHost, owner, name, resourceType, resourceNumber, etag,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert http etag: %w", err)
+	}
+	return nil
 }
 
 // --- Detail Fetch Tracking ---

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2618,20 +2618,17 @@ func (d *DB) GetPreviouslyOpenMRNumbers(
 	return closed, rows.Err()
 }
 
-func (d *DB) HasOpenMergeRequestsForRepo(ctx context.Context, repoID int64) (bool, error) {
-	var exists bool
+func (d *DB) CountOpenMergeRequestsForRepo(ctx context.Context, repoID int64) (int, error) {
+	var count int
 	err := d.ro.QueryRowContext(ctx,
-		`SELECT EXISTS (
-			SELECT 1 FROM middleman_merge_requests
-			WHERE repo_id = ? AND state = 'open'
-			LIMIT 1
-		)`,
+		`SELECT COUNT(*) FROM middleman_merge_requests
+		WHERE repo_id = ? AND state = 'open'`,
 		repoID,
-	).Scan(&exists)
+	).Scan(&count)
 	if err != nil {
-		return false, fmt.Errorf("check open merge requests for repo: %w", err)
+		return 0, fmt.Errorf("count open merge requests for repo: %w", err)
 	}
-	return exists, nil
+	return count, nil
 }
 
 // MRDerivedFields holds computed fields that are refreshed after fetching timeline events.
@@ -3262,20 +3259,17 @@ func (d *DB) GetPreviouslyOpenIssueNumbers(
 	return closed, rows.Err()
 }
 
-func (d *DB) HasOpenIssuesForRepo(ctx context.Context, repoID int64) (bool, error) {
-	var exists bool
+func (d *DB) CountOpenIssuesForRepo(ctx context.Context, repoID int64) (int, error) {
+	var count int
 	err := d.ro.QueryRowContext(ctx,
-		`SELECT EXISTS (
-			SELECT 1 FROM middleman_issues
-			WHERE repo_id = ? AND state = 'open'
-			LIMIT 1
-		)`,
+		`SELECT COUNT(*) FROM middleman_issues
+		WHERE repo_id = ? AND state = 'open'`,
 		repoID,
-	).Scan(&exists)
+	).Scan(&count)
 	if err != nil {
-		return false, fmt.Errorf("check open issues for repo: %w", err)
+		return 0, fmt.Errorf("count open issues for repo: %w", err)
 	}
-	return exists, nil
+	return count, nil
 }
 
 func (d *DB) GetHTTPEtag(

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -4351,3 +4351,38 @@ func TestUpdateMRTitleBodyIgnoresStaleUpdate(t *testing.T) {
 	assert.Equal("current body", got.Body, "stale update should be ignored")
 	assert.True(got.UpdatedAt.Equal(newerUpdatedAt), "updated_at should not regress")
 }
+
+func TestHTTPEtagPersistence(t *testing.T) {
+	assert := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "OWNER", "Repo",
+		"pull_request", 7,
+	)
+	assert.NoError(err)
+	assert.Empty(etag)
+
+	assert.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "OWNER", "Repo",
+		"pull_request", 7, `"etag-v1"`,
+	))
+	etag, err = d.GetHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 7,
+	)
+	assert.NoError(err)
+	assert.Equal(`"etag-v1"`, etag)
+
+	assert.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 7, `"etag-v2"`,
+	))
+	etag, err = d.GetHTTPEtag(
+		ctx, "github", "github.com", "OWNER", "Repo",
+		"pull_request", 7,
+	)
+	assert.NoError(err)
+	assert.Equal(`"etag-v2"`, etag)
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -458,17 +458,23 @@ func (c *liveClient) ListOpenPullRequests(ctx context.Context, owner, repo strin
 		State:       "open",
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
-	all, err := collectPages(ctx, func(pageOpts *gh.ListOptions) ([]*gh.PullRequest, *gh.Response, error) {
+	progress := newMergeRequestListFetchProgressLogger(RepoRef{
+		Owner:        owner,
+		Name:         repo,
+		PlatformHost: c.platformHost,
+	}, "rest")
+	all, err := collectPagesWithProgress(ctx, func(pageOpts *gh.ListOptions) ([]*gh.PullRequest, *gh.Response, error) {
 		opts.ListOptions = *pageOpts
 		page, resp, err := c.gh.PullRequests.List(ctx, owner, repo, opts)
 		if err != nil {
 			return nil, nil, fmt.Errorf("listing open pull requests for %s/%s: %w", owner, repo, err)
 		}
 		return page, resp, nil
-	}, c.trackRate)
+	}, c.trackRate, progress.recordPage)
 	if err != nil {
 		return nil, err
 	}
+	progress.done()
 	return all, nil
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -95,6 +95,15 @@ type Client interface {
 	InvalidateListETagsForRepo(owner, repo string, endpoints ...string)
 }
 
+type conditionalPullRequestGetter interface {
+	GetPullRequestIfChanged(
+		ctx context.Context,
+		owner, repo string,
+		number int,
+		etag string,
+	) (*gh.PullRequest, string, bool, error)
+}
+
 func graphQLEndpointForHost(platformHost string) string {
 	if platformHost == "" || platformHost == "github.com" {
 		return "https://api.github.com/graphql"
@@ -633,6 +642,36 @@ func (c *liveClient) GetPullRequest(ctx context.Context, owner, repo string, num
 		return nil, fmt.Errorf("getting pull request %s/%s#%d: %w", owner, repo, number, err)
 	}
 	return pr, nil
+}
+
+func (c *liveClient) GetPullRequestIfChanged(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	etag string,
+) (*gh.PullRequest, string, bool, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/%v", owner, repo, number)
+	req, err := c.gh.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	pr := new(gh.PullRequest)
+	resp, err := c.gh.Do(ctx, req, pr)
+	c.trackRate(resp)
+	if err != nil {
+		if IsNotModified(err) {
+			return nil, etag, true, nil
+		}
+		return nil, "", false, fmt.Errorf("getting pull request %s/%s#%d: %w", owner, repo, number, err)
+	}
+	if resp != nil && resp.Response != nil {
+		etag = resp.Header.Get("ETag")
+	}
+	return pr, etag, false, nil
 }
 
 func (c *liveClient) GetUser(ctx context.Context, login string) (*gh.User, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -144,6 +144,7 @@ func NewClient(
 		gh:              ghClient,
 		httpClient:      tc,
 		rateTracker:     rateTracker,
+		platformHost:    platformHost,
 		graphQLEndpoint: graphQLEndpointForHost(platformHost),
 		etag:            et,
 	}, nil
@@ -153,6 +154,7 @@ type liveClient struct {
 	gh              *gh.Client
 	httpClient      *http.Client
 	rateTracker     *RateTracker
+	platformHost    string
 	graphQLEndpoint string
 	etag            *etagTransport
 	viewerMu        sync.Mutex
@@ -479,7 +481,12 @@ func (c *liveClient) ListOpenIssues(
 		Direction:   "desc",
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
-	issues, err := collectPages(ctx, func(pageOpts *gh.ListOptions) ([]*gh.Issue, *gh.Response, error) {
+	progress := newIssueListFetchProgressLogger(RepoRef{
+		Owner:        owner,
+		Name:         repo,
+		PlatformHost: c.platformHost,
+	}, "rest")
+	issues, err := collectPagesWithProgress(ctx, func(pageOpts *gh.ListOptions) ([]*gh.Issue, *gh.Response, error) {
 		opts.ListOptions = *pageOpts
 		issues, resp, err := c.gh.Issues.ListByRepo(
 			ctx, owner, repo, opts,
@@ -490,10 +497,11 @@ func (c *liveClient) ListOpenIssues(
 			)
 		}
 		return issues, resp, nil
-	}, c.trackRate)
+	}, c.trackRate, progress.recordPage)
 	if err != nil {
 		return nil, err
 	}
+	progress.done()
 
 	var all []*gh.Issue
 	// GitHub's Issues API returns PRs too — filter them out.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -104,6 +104,15 @@ type conditionalPullRequestGetter interface {
 	) (*gh.PullRequest, string, bool, error)
 }
 
+type conditionalIssueGetter interface {
+	GetIssueIfChanged(
+		ctx context.Context,
+		owner, repo string,
+		number int,
+		etag string,
+	) (*gh.Issue, string, bool, error)
+}
+
 func graphQLEndpointForHost(platformHost string) string {
 	if platformHost == "" || platformHost == "github.com" {
 		return "https://api.github.com/graphql"
@@ -633,6 +642,38 @@ func (c *liveClient) GetIssue(
 		)
 	}
 	return issue, nil
+}
+
+func (c *liveClient) GetIssueIfChanged(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	etag string,
+) (*gh.Issue, string, bool, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v", owner, repo, number)
+	req, err := c.gh.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	issue := new(gh.Issue)
+	resp, err := c.gh.Do(ctx, req, issue)
+	c.trackRate(resp)
+	if err != nil {
+		if IsNotModified(err) {
+			return nil, etag, true, nil
+		}
+		return nil, "", false, fmt.Errorf(
+			"getting issue %s/%s#%d: %w", owner, repo, number, err,
+		)
+	}
+	if resp != nil && resp.Response != nil {
+		etag = resp.Header.Get("ETag")
+	}
+	return issue, etag, false, nil
 }
 
 func (c *liveClient) GetPullRequest(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {

--- a/internal/github/client_helpers.go
+++ b/internal/github/client_helpers.go
@@ -14,6 +14,15 @@ func collectPages[T any](
 	listPage func(*gh.ListOptions) ([]T, *gh.Response, error),
 	onResp func(*gh.Response),
 ) ([]T, error) {
+	return collectPagesWithProgress(ctx, listPage, onResp, nil)
+}
+
+func collectPagesWithProgress[T any](
+	ctx context.Context,
+	listPage func(*gh.ListOptions) ([]T, *gh.Response, error),
+	onResp func(*gh.Response),
+	onPage func(int, bool),
+) ([]T, error) {
 	var all []T
 	opts := &gh.ListOptions{PerPage: 100}
 	for {
@@ -25,7 +34,11 @@ func collectPages[T any](
 			return nil, err
 		}
 		all = append(all, page...)
-		if resp == nil || resp.NextPage == 0 {
+		hasMore := resp != nil && resp.NextPage != 0
+		if onPage != nil {
+			onPage(len(page), hasMore)
+		}
+		if !hasMore {
 			return all, nil
 		}
 		opts.Page = resp.NextPage

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,8 +1,11 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -12,6 +15,7 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v84/github"
+	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,6 +147,88 @@ func TestListTagsTracksRate(t *testing.T) {
 	require.Equal(1, rt.RequestsThisHour())
 	require.Equal(4997, rt.Remaining())
 	require.Equal(5000, rt.RateLimit())
+}
+
+func TestListOpenIssuesLogsFetchProgressForLargeIssueSet(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	var buf bytes.Buffer
+	sw := &syncedWriter{w: &buf}
+	h := slog.NewTextHandler(sw, &slog.HandlerOptions{Level: slog.LevelInfo})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	var serverURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/acme/widgets/issues", func(w http.ResponseWriter, r *http.Request) {
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil || page == 0 {
+			page = 1
+		}
+		if page < 3 {
+			nextURL := fmt.Sprintf(
+				"%s/api/v3/repos/acme/widgets/issues?page=%d&per_page=100",
+				serverURL, page+1,
+			)
+			w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(testIssuePage(page, now)); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	serverURL = srv.URL
+
+	ghClient, err := gh.NewClient(srv.Client()).WithEnterpriseURLs(
+		srv.URL+"/api/v3/", srv.URL+"/api/uploads/",
+	)
+	require.NoError(err)
+	c := &liveClient{gh: ghClient}
+
+	issues, err := c.ListOpenIssues(t.Context(), "acme", "widgets")
+	require.NoError(err)
+	require.Len(issues, 201)
+
+	logs := buf.String()
+	assert.Contains(logs, `msg="issue list fetch started"`)
+	assert.Contains(logs, "repo=acme/widgets")
+	assert.Contains(logs, "platform=github")
+	assert.Contains(logs, "host=github.com")
+	assert.Contains(logs, "source=rest")
+	assert.Contains(logs, "fetched=100")
+	assert.Contains(logs, `msg="issue list fetch progress"`)
+	assert.Contains(logs, "fetched=200")
+	assert.Contains(logs, `msg="issue list fetch completed"`)
+	assert.Contains(logs, "fetched=201")
+}
+
+func testIssuePage(page int, now string) []map[string]any {
+	count := 100
+	if page == 3 {
+		count = 1
+	}
+	start := ((page - 1) * 100) + 1
+	issues := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		number := start + i
+		issues = append(issues, map[string]any{
+			"id":         number * 1000,
+			"number":     number,
+			"title":      fmt.Sprintf("Issue %d", number),
+			"state":      "open",
+			"html_url":   fmt.Sprintf("https://github.com/acme/widgets/issues/%d", number),
+			"user":       map[string]any{"login": "alice"},
+			"created_at": now,
+			"updated_at": now,
+		})
+	}
+	return issues
 }
 
 func TestListRepositoriesByOwnerUsesAuthenticatedEndpointForViewer(t *testing.T) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -206,6 +206,7 @@ func TestListOpenIssuesLogsFetchProgressForLargeIssueSet(t *testing.T) {
 	assert.Contains(logs, "fetched=200")
 	assert.Contains(logs, `msg="issue list fetch completed"`)
 	assert.Contains(logs, "fetched=201")
+	assert.Contains(logs, "total=201")
 }
 
 func testIssuePage(page int, now string) []map[string]any {
@@ -229,6 +230,91 @@ func testIssuePage(page int, now string) []map[string]any {
 		})
 	}
 	return issues
+}
+
+func TestListOpenPullRequestsLogsFetchProgressForLargePullRequestSet(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	var buf bytes.Buffer
+	sw := &syncedWriter{w: &buf}
+	h := slog.NewTextHandler(sw, &slog.HandlerOptions{Level: slog.LevelInfo})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	var serverURL string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/conda-forge/staged-recipes/pulls", func(w http.ResponseWriter, r *http.Request) {
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil || page == 0 {
+			page = 1
+		}
+		if page < 3 {
+			nextURL := fmt.Sprintf(
+				"%s/api/v3/repos/conda-forge/staged-recipes/pulls?page=%d&per_page=100",
+				serverURL, page+1,
+			)
+			w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(testPullRequestPage(page, now)); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	serverURL = srv.URL
+
+	ghClient, err := gh.NewClient(srv.Client()).WithEnterpriseURLs(
+		srv.URL+"/api/v3/", srv.URL+"/api/uploads/",
+	)
+	require.NoError(err)
+	c := &liveClient{gh: ghClient}
+
+	prs, err := c.ListOpenPullRequests(t.Context(), "conda-forge", "staged-recipes")
+	require.NoError(err)
+	require.Len(prs, 201)
+
+	logs := buf.String()
+	assert.Contains(logs, `msg="merge request list fetch started"`)
+	assert.Contains(logs, "repo=conda-forge/staged-recipes")
+	assert.Contains(logs, "platform=github")
+	assert.Contains(logs, "host=github.com")
+	assert.Contains(logs, "source=rest")
+	assert.Contains(logs, "fetched=100")
+	assert.Contains(logs, `msg="merge request list fetch progress"`)
+	assert.Contains(logs, "fetched=200")
+	assert.Contains(logs, `msg="merge request list fetch completed"`)
+	assert.Contains(logs, "fetched=201")
+	assert.Contains(logs, "total=201")
+}
+
+func testPullRequestPage(page int, now string) []map[string]any {
+	count := 100
+	if page == 3 {
+		count = 1
+	}
+	start := ((page - 1) * 100) + 1
+	prs := make([]map[string]any, 0, count)
+	for i := 0; i < count; i++ {
+		number := start + i
+		prs = append(prs, map[string]any{
+			"id":         number * 1000,
+			"number":     number,
+			"title":      fmt.Sprintf("Pull request %d", number),
+			"state":      "open",
+			"html_url":   fmt.Sprintf("https://github.com/conda-forge/staged-recipes/pull/%d", number),
+			"user":       map[string]any{"login": "alice"},
+			"created_at": now,
+			"updated_at": now,
+			"head":       map[string]any{"ref": "recipe", "sha": "abc123"},
+			"base":       map[string]any{"ref": "main", "sha": "def456"},
+		})
+	}
+	return prs
 }
 
 func TestListRepositoriesByOwnerUsesAuthenticatedEndpointForViewer(t *testing.T) {

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -83,10 +83,10 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		etag := resp.Header.Get("ETag")
-		if responseHasNextPage(resp) {
-			// A page-1 validator does not prove the complete paginated
+		if responseHasPaginationLink(resp) {
+			// A page validator does not prove the complete paginated
 			// collection is unchanged. Evict instead of allowing a later
-			// 304 to stop pagination before later pages are checked.
+			// 304 for any page to leave the collection without a body.
 			t.cache.Delete(url)
 		} else if etag != "" {
 			t.cache.Store(url, etagEntry{etag: etag, cachedAt: time.Now()})
@@ -108,13 +108,15 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func responseHasNextPage(resp *http.Response) bool {
+func responseHasPaginationLink(resp *http.Response) bool {
 	if resp == nil {
 		return false
 	}
-	for part := range strings.SplitSeq(resp.Header.Get("Link"), ",") {
-		if strings.Contains(part, `rel="next"`) {
-			return true
+	for _, value := range resp.Header.Values("Link") {
+		for part := range strings.SplitSeq(value, ",") {
+			if strings.TrimSpace(part) != "" {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -83,12 +83,12 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		etag := resp.Header.Get("ETag")
-		if etag != "" && !hasLinkNext(resp) {
+		if etag != "" {
 			t.cache.Store(url, etagEntry{etag: etag, cachedAt: time.Now()})
 		} else {
-			// No ETag, or response is paginated — drop any stale
-			// validator so the next request fetches fresh data
-			// instead of asserting an out-of-date If-None-Match.
+			// No ETag — drop any stale validator so the next request
+			// fetches fresh data instead of asserting an out-of-date
+			// If-None-Match.
 			t.cache.Delete(url)
 		}
 	case http.StatusNotModified:
@@ -106,15 +106,6 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func isETagEligible(path string) bool {
 	return etagEligibleListPath.MatchString(path) ||
 		etagEligibleCommentPath.MatchString(path)
-}
-
-func hasLinkNext(resp *http.Response) bool {
-	for _, link := range resp.Header.Values("Link") {
-		if strings.Contains(link, `rel="next"`) {
-			return true
-		}
-	}
-	return false
 }
 
 // invalidateRepo drops cached ETag entries for the given repo's list

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -83,7 +83,12 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		etag := resp.Header.Get("ETag")
-		if etag != "" {
+		if responseHasNextPage(resp) {
+			// A page-1 validator does not prove the complete paginated
+			// collection is unchanged. Evict instead of allowing a later
+			// 304 to stop pagination before later pages are checked.
+			t.cache.Delete(url)
+		} else if etag != "" {
 			t.cache.Store(url, etagEntry{etag: etag, cachedAt: time.Now()})
 		} else {
 			// No ETag — drop any stale validator so the next request
@@ -101,6 +106,18 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	return resp, nil
+}
+
+func responseHasNextPage(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	for _, part := range strings.Split(resp.Header.Get("Link"), ",") {
+		if strings.Contains(part, `rel="next"`) {
+			return true
+		}
+	}
+	return false
 }
 
 func isETagEligible(path string) bool {

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -112,7 +112,7 @@ func responseHasNextPage(resp *http.Response) bool {
 	if resp == nil {
 		return false
 	}
-	for _, part := range strings.Split(resp.Header.Get("Link"), ",") {
+	for part := range strings.SplitSeq(resp.Header.Get("Link"), ",") {
 		if strings.Contains(part, `rel="next"`) {
 			return true
 		}

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -149,7 +149,7 @@ func TestETagTransport_EmptyETagEvictsCachedEntry(t *testing.T) {
 	assert.False(t, ok, "200 without ETag must evict cached entry")
 }
 
-func TestETagTransport_MultiPageEvictsCachedETag(t *testing.T) {
+func TestETagTransport_MultiPageCachesPageOneETag(t *testing.T) {
 	// First request: single page, cache ETag
 	et := &etagTransport{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		rec := httptest.NewRecorder()
@@ -164,7 +164,8 @@ func TestETagTransport_MultiPageEvictsCachedETag(t *testing.T) {
 	_, ok := et.cache.Load(url)
 	assert.True(t, ok, "single-page ETag should be cached")
 
-	// Second request: multi-page (Link: next), should evict
+	// Second request: multi-page (Link: next), should replace the
+	// previous validator with page 1's fresh ETag.
 	et.base = roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		rec := httptest.NewRecorder()
 		rec.Header().Set("ETag", `"multi"`)
@@ -175,8 +176,9 @@ func TestETagTransport_MultiPageEvictsCachedETag(t *testing.T) {
 
 	req2, _ := http.NewRequest("GET", url, nil)
 	_, _ = et.RoundTrip(req2)
-	_, ok = et.cache.Load(url)
-	assert.False(t, ok, "multi-page response should evict cached ETag")
+	val, ok := et.cache.Load(url)
+	require.True(t, ok, "multi-page page 1 ETag should be cached")
+	assert.Equal(t, `"multi"`, val.(etagEntry).etag)
 }
 
 func TestETagTransport_NonGETBypassesCache(t *testing.T) {
@@ -262,23 +264,27 @@ func TestETagTransport_SingleMultiSingleTransition(t *testing.T) {
 	_, ok := et.cache.Load(url)
 	assert.True(ok, "phase 0: single-page should cache")
 
-	// Phase 1: multi-page, should evict
+	// Phase 1: multi-page, should cache page 1's validator
 	phase = 1
 	req, _ = http.NewRequest("GET", url, nil)
 	_, _ = et.RoundTrip(req)
-	_, ok = et.cache.Load(url)
-	assert.False(ok, "phase 1: multi-page should evict")
+	val, ok := et.cache.Load(url)
+	assert.True(ok, "phase 1: multi-page should cache page 1")
+	assert.Equal(`"v2"`, val.(etagEntry).etag)
 
 	// Phase 2: back to single-page, should re-cache
 	phase = 2
 	req, _ = http.NewRequest("GET", url, nil)
 	_, _ = et.RoundTrip(req)
-	val, ok := et.cache.Load(url)
+	val, ok = et.cache.Load(url)
 	assert.True(ok, "phase 2: single-page again should cache")
 	assert.Equal(`"v3"`, val.(etagEntry).etag)
 }
 
 func TestETagTransport_TTLDrivenMultiPageDetection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
 	url := "https://api.github.com/repos/o/n/pulls"
 	requestCount := 0
 	et := &etagTransport{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -306,7 +312,7 @@ func TestETagTransport_TTLDrivenMultiPageDetection(t *testing.T) {
 	// Request with valid cache — sends If-None-Match, gets 304
 	req, _ := http.NewRequest("GET", url, nil)
 	resp, _ := et.RoundTrip(req)
-	assert.Equal(t, 304, resp.StatusCode)
+	assert.Equal(304, resp.StatusCode)
 
 	// Now expire the cache
 	et.cache.Store(url, etagEntry{
@@ -317,11 +323,14 @@ func TestETagTransport_TTLDrivenMultiPageDetection(t *testing.T) {
 	// Request with expired cache — no If-None-Match, gets 200 multi-page
 	req, _ = http.NewRequest("GET", url, nil)
 	resp, _ = et.RoundTrip(req)
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(200, resp.StatusCode)
 
-	// Cache should be evicted (multi-page detected)
-	_, ok := et.cache.Load(url)
-	assert.False(t, ok, "multi-page detection after TTL should evict")
+	// Cache should now hold the multi-page page 1 validator. The next
+	// requests may 304 within the TTL window, while the TTL still forces
+	// periodic unconditional fetches to detect page-shape changes.
+	val, ok := et.cache.Load(url)
+	require.True(ok, "multi-page detection after TTL should cache page 1")
+	assert.Equal(`"multi"`, val.(etagEntry).etag)
 }
 
 func TestETagTransport_ExpiredEntryTreatedAsUncached(t *testing.T) {

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -149,7 +149,7 @@ func TestETagTransport_EmptyETagEvictsCachedEntry(t *testing.T) {
 	assert.False(t, ok, "200 without ETag must evict cached entry")
 }
 
-func TestETagTransport_MultiPageCachesPageOneETag(t *testing.T) {
+func TestETagTransport_MultiPageEvictsPageOneETag(t *testing.T) {
 	// First request: single page, cache ETag
 	et := &etagTransport{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		rec := httptest.NewRecorder()
@@ -164,8 +164,9 @@ func TestETagTransport_MultiPageCachesPageOneETag(t *testing.T) {
 	_, ok := et.cache.Load(url)
 	assert.True(t, ok, "single-page ETag should be cached")
 
-	// Second request: multi-page (Link: next), should replace the
-	// previous validator with page 1's fresh ETag.
+	// Second request: multi-page (Link: next), should evict the
+	// previous validator so future syncs cannot treat page 1's 304
+	// as proof that later pages are unchanged.
 	et.base = roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		rec := httptest.NewRecorder()
 		rec.Header().Set("ETag", `"multi"`)
@@ -176,9 +177,8 @@ func TestETagTransport_MultiPageCachesPageOneETag(t *testing.T) {
 
 	req2, _ := http.NewRequest("GET", url, nil)
 	_, _ = et.RoundTrip(req2)
-	val, ok := et.cache.Load(url)
-	require.True(t, ok, "multi-page page 1 ETag should be cached")
-	assert.Equal(t, `"multi"`, val.(etagEntry).etag)
+	_, ok = et.cache.Load(url)
+	assert.False(t, ok, "multi-page page 1 ETag should not be cached")
 }
 
 func TestETagTransport_NonGETBypassesCache(t *testing.T) {
@@ -264,19 +264,18 @@ func TestETagTransport_SingleMultiSingleTransition(t *testing.T) {
 	_, ok := et.cache.Load(url)
 	assert.True(ok, "phase 0: single-page should cache")
 
-	// Phase 1: multi-page, should cache page 1's validator
+	// Phase 1: multi-page, should evict page 1's validator.
 	phase = 1
 	req, _ = http.NewRequest("GET", url, nil)
 	_, _ = et.RoundTrip(req)
-	val, ok := et.cache.Load(url)
-	assert.True(ok, "phase 1: multi-page should cache page 1")
-	assert.Equal(`"v2"`, val.(etagEntry).etag)
+	_, ok = et.cache.Load(url)
+	assert.False(ok, "phase 1: multi-page should not cache page 1")
 
 	// Phase 2: back to single-page, should re-cache
 	phase = 2
 	req, _ = http.NewRequest("GET", url, nil)
 	_, _ = et.RoundTrip(req)
-	val, ok = et.cache.Load(url)
+	val, ok := et.cache.Load(url)
 	assert.True(ok, "phase 2: single-page again should cache")
 	assert.Equal(`"v3"`, val.(etagEntry).etag)
 }
@@ -325,12 +324,10 @@ func TestETagTransport_TTLDrivenMultiPageDetection(t *testing.T) {
 	resp, _ = et.RoundTrip(req)
 	assert.Equal(200, resp.StatusCode)
 
-	// Cache should now hold the multi-page page 1 validator. The next
-	// requests may 304 within the TTL window, while the TTL still forces
-	// periodic unconditional fetches to detect page-shape changes.
-	val, ok := et.cache.Load(url)
-	require.True(ok, "multi-page detection after TTL should cache page 1")
-	assert.Equal(`"multi"`, val.(etagEntry).etag)
+	// Cache should now be empty because a page 1 validator is not enough
+	// to prove the complete paginated collection is unchanged.
+	_, ok := et.cache.Load(url)
+	require.False(ok, "multi-page detection after TTL should evict page 1")
 }
 
 func TestETagTransport_ExpiredEntryTreatedAsUncached(t *testing.T) {

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -181,6 +181,43 @@ func TestETagTransport_MultiPageEvictsPageOneETag(t *testing.T) {
 	assert.False(t, ok, "multi-page page 1 ETag should not be cached")
 }
 
+func TestETagTransport_MultiHeaderLinkEvictsETag(t *testing.T) {
+	et := &etagTransport{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		rec := httptest.NewRecorder()
+		rec.Header().Set("ETag", `"multi-header"`)
+		rec.Header().Add("Link", `<https://api.github.com/repos/o/n/pulls?page=1>; rel="prev"`)
+		rec.Header().Add("Link", `<https://api.github.com/repos/o/n/pulls?page=3>; rel="next"`)
+		rec.WriteHeader(200)
+		return rec.Result(), nil
+	})}
+
+	url := "https://api.github.com/repos/o/n/pulls?page=2"
+	req, _ := http.NewRequest("GET", url, nil)
+	_, err := et.RoundTrip(req)
+	require.NoError(t, err)
+
+	_, ok := et.cache.Load(url)
+	assert.False(t, ok, "any paginated Link header should prevent caching")
+}
+
+func TestETagTransport_FinalPageLinkEvictsETag(t *testing.T) {
+	et := &etagTransport{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		rec := httptest.NewRecorder()
+		rec.Header().Set("ETag", `"final-page"`)
+		rec.Header().Set("Link", `<https://api.github.com/repos/o/n/pulls?page=1>; rel="prev"`)
+		rec.WriteHeader(200)
+		return rec.Result(), nil
+	})}
+
+	url := "https://api.github.com/repos/o/n/pulls?page=2"
+	req, _ := http.NewRequest("GET", url, nil)
+	_, err := et.RoundTrip(req)
+	require.NoError(t, err)
+
+	_, ok := et.cache.Load(url)
+	assert.False(t, ok, "final paginated pages should not cache validators")
+}
+
 func TestETagTransport_NonGETBypassesCache(t *testing.T) {
 	et := &etagTransport{base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		assert.Empty(t, r.Header.Get("If-None-Match"))

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -27,8 +27,9 @@ const retryPageSize = 5
 type gqlPRQuery struct {
 	Repository struct {
 		PullRequests struct {
-			Nodes    []gqlPR
-			PageInfo pageInfo
+			TotalCount int
+			Nodes      []gqlPR
+			PageInfo   pageInfo
 		} `graphql:"pullRequests(first: $pageSize, states: OPEN, after: $cursor)"`
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
@@ -195,8 +196,9 @@ type gqlBaseRefChangedEvent struct {
 type gqlIssueQuery struct {
 	Repository struct {
 		Issues struct {
-			Nodes    []gqlIssue
-			PageInfo pageInfo
+			TotalCount int
+			Nodes      []gqlIssue
+			PageInfo   pageInfo
 		} `graphql:"issues(first: $pageSize, states: OPEN, after: $cursor)"`
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
@@ -659,7 +661,12 @@ func (g *GraphQLFetcher) FetchRepoPRs(
 func (g *GraphQLFetcher) fetchRepoPRsWithPageSize(
 	ctx context.Context, owner, name string, pageSize int,
 ) (*RepoBulkResult, error) {
-	gqlPRs, err := fetchAllPages(ctx, func(
+	progress := newMergeRequestListFetchProgressLogger(RepoRef{
+		Owner:        owner,
+		Name:         name,
+		PlatformHost: g.host,
+	}, "graphql")
+	gqlPRs, err := fetchAllPagesWithProgress(ctx, func(
 		ctx context.Context, cursor *string,
 	) ([]gqlPR, pageInfo, error) {
 		var q gqlPRQuery
@@ -672,12 +679,14 @@ func (g *GraphQLFetcher) fetchRepoPRsWithPageSize(
 		if err := g.client.Query(ctx, &q, vars); err != nil {
 			return nil, pageInfo{}, err
 		}
+		progress.setTotal(q.Repository.PullRequests.TotalCount)
 		return q.Repository.PullRequests.Nodes,
 			q.Repository.PullRequests.PageInfo, nil
-	})
+	}, progress.recordPage)
 	if err != nil {
 		return nil, err
 	}
+	progress.done()
 
 	result := &RepoBulkResult{
 		PullRequests: make([]BulkPR, 0, len(gqlPRs)),
@@ -728,6 +737,7 @@ func (g *GraphQLFetcher) fetchRepoIssuesWithPageSize(
 		if err := g.client.Query(ctx, &q, vars); err != nil {
 			return nil, pageInfo{}, err
 		}
+		progress.setTotal(q.Repository.Issues.TotalCount)
 		return q.Repository.Issues.Nodes,
 			q.Repository.Issues.PageInfo, nil
 	}, progress.recordPage)

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -564,6 +564,7 @@ func parseRateLimitHeaders(resp *http.Response) Rate {
 type GraphQLFetcher struct {
 	client      *githubv4.Client
 	rateTracker *RateTracker
+	host        string
 }
 
 // RateTracker returns the GraphQL rate tracker, or nil if none
@@ -614,6 +615,7 @@ func NewGraphQLFetcher(
 	return &GraphQLFetcher{
 		client:      gqlClient,
 		rateTracker: rateTracker,
+		host:        platformHost,
 	}
 }
 
@@ -708,7 +710,12 @@ func (g *GraphQLFetcher) FetchRepoIssues(
 func (g *GraphQLFetcher) fetchRepoIssuesWithPageSize(
 	ctx context.Context, owner, name string, pageSize int,
 ) (*RepoBulkResult, error) {
-	gqlIssues, err := fetchAllPages(ctx, func(
+	progress := newIssueListFetchProgressLogger(RepoRef{
+		Owner:        owner,
+		Name:         name,
+		PlatformHost: g.host,
+	}, "graphql")
+	gqlIssues, err := fetchAllPagesWithProgress(ctx, func(
 		ctx context.Context, cursor *string,
 	) ([]gqlIssue, pageInfo, error) {
 		var q gqlIssueQuery
@@ -723,10 +730,11 @@ func (g *GraphQLFetcher) fetchRepoIssuesWithPageSize(
 		}
 		return q.Repository.Issues.Nodes,
 			q.Repository.Issues.PageInfo, nil
-	})
+	}, progress.recordPage)
 	if err != nil {
 		return nil, err
 	}
+	progress.done()
 
 	result := &RepoBulkResult{
 		Issues: make([]BulkIssue, 0, len(gqlIssues)),

--- a/internal/github/graphql_pagination.go
+++ b/internal/github/graphql_pagination.go
@@ -20,6 +20,14 @@ func fetchAllPages[T any](
 	ctx context.Context,
 	queryFn func(ctx context.Context, cursor *string) ([]T, pageInfo, error),
 ) ([]T, error) {
+	return fetchAllPagesWithProgress(ctx, queryFn, nil)
+}
+
+func fetchAllPagesWithProgress[T any](
+	ctx context.Context,
+	queryFn func(ctx context.Context, cursor *string) ([]T, pageInfo, error),
+	onPage func(int, bool),
+) ([]T, error) {
 	var all []T
 	var cursor *string
 	for {
@@ -28,6 +36,9 @@ func fetchAllPages[T any](
 			return all, err
 		}
 		all = append(all, nodes...)
+		if onPage != nil {
+			onPage(len(nodes), pi.HasNextPage)
+		}
 		if !pi.HasNextPage {
 			break
 		}

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -2,8 +2,10 @@ package github
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -342,6 +344,95 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 	assert.Equal("main", event.PreviousRefName)
 	assert.Equal("release", event.CurrentRefName)
 	assert.True(result.PullRequests[0].TimelineComplete)
+}
+
+func TestGraphQLFetcherFetchRepoIssuesLogsFetchProgressForPaginatedIssueSet(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	var buf bytes.Buffer
+	sw := &syncedWriter{w: &buf}
+	h := slog.NewTextHandler(sw, &slog.HandlerOptions{Level: slog.LevelInfo})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		pageInfo := map[string]any{"hasNextPage": true, "endCursor": fmt.Sprintf("cursor-%d", calls)}
+		if calls == 3 {
+			pageInfo = map[string]any{"hasNextPage": false, "endCursor": ""}
+		}
+		count := 25
+		if calls == 3 {
+			count = 1
+		}
+		resp := map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"issues": map[string]any{
+						"nodes":    testGQLIssueNodes(((calls-1)*25)+1, count, now),
+						"pageInfo": pageInfo,
+					},
+				},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	fetcher := NewGraphQLFetcherWithClient(
+		githubv4.NewEnterpriseClient(srv.URL, srv.Client()), nil,
+	)
+
+	result, err := fetcher.FetchRepoIssues(t.Context(), "owner", "repo")
+	require.NoError(err)
+	require.NotNil(result)
+	require.Len(result.Issues, 51)
+
+	logs := buf.String()
+	assert.Contains(logs, `msg="issue list fetch started"`)
+	assert.Contains(logs, "repo=owner/repo")
+	assert.Contains(logs, "platform=github")
+	assert.Contains(logs, "host=github.com")
+	assert.Contains(logs, "source=graphql")
+	assert.Contains(logs, "fetched=25")
+	assert.Contains(logs, `msg="issue list fetch progress"`)
+	assert.Contains(logs, "fetched=50")
+	assert.Contains(logs, `msg="issue list fetch completed"`)
+	assert.Contains(logs, "fetched=51")
+}
+
+func testGQLIssueNodes(start, count int, now string) []map[string]any {
+	issues := make([]map[string]any, 0, count)
+	for i := range count {
+		number := start + i
+		issues = append(issues, map[string]any{
+			"databaseId": number * 1000,
+			"number":     number,
+			"title":      fmt.Sprintf("Issue %d", number),
+			"state":      "OPEN",
+			"body":       "",
+			"url":        fmt.Sprintf("https://github.com/owner/repo/issues/%d", number),
+			"author":     map[string]any{"login": "alice"},
+			"createdAt":  now,
+			"updatedAt":  now,
+			"closedAt":   nil,
+			"labels":     map[string]any{"nodes": []any{}},
+			"comments": map[string]any{
+				"totalCount": 0,
+				"nodes":      []any{},
+				"pageInfo":   map[string]any{"hasNextPage": false, "endCursor": ""},
+			},
+		})
+	}
+	return issues
 }
 
 func TestNormalizeBulkCI(t *testing.T) {

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -374,8 +374,9 @@ func TestGraphQLFetcherFetchRepoIssuesLogsFetchProgressForPaginatedIssueSet(t *t
 			"data": map[string]any{
 				"repository": map[string]any{
 					"issues": map[string]any{
-						"nodes":    testGQLIssueNodes(((calls-1)*25)+1, count, now),
-						"pageInfo": pageInfo,
+						"totalCount": 51,
+						"nodes":      testGQLIssueNodes(((calls-1)*25)+1, count, now),
+						"pageInfo":   pageInfo,
 					},
 				},
 			},
@@ -402,6 +403,7 @@ func TestGraphQLFetcherFetchRepoIssuesLogsFetchProgressForPaginatedIssueSet(t *t
 	assert.Contains(logs, "platform=github")
 	assert.Contains(logs, "host=github.com")
 	assert.Contains(logs, "source=graphql")
+	assert.Contains(logs, "total=51")
 	assert.Contains(logs, "fetched=25")
 	assert.Contains(logs, `msg="issue list fetch progress"`)
 	assert.Contains(logs, "fetched=50")
@@ -433,6 +435,108 @@ func testGQLIssueNodes(start, count int, now string) []map[string]any {
 		})
 	}
 	return issues
+}
+
+func TestGraphQLFetcherFetchRepoPRsLogsFetchProgressForPaginatedPullRequestSet(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	var buf bytes.Buffer
+	sw := &syncedWriter{w: &buf}
+	h := slog.NewTextHandler(sw, &slog.HandlerOptions{Level: slog.LevelInfo})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		pageInfo := map[string]any{"hasNextPage": true, "endCursor": fmt.Sprintf("cursor-%d", calls)}
+		if calls == 3 {
+			pageInfo = map[string]any{"hasNextPage": false, "endCursor": ""}
+		}
+		count := 25
+		if calls == 3 {
+			count = 1
+		}
+		resp := map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"pullRequests": map[string]any{
+						"totalCount": 51,
+						"nodes":      testGQLPRNodes(((calls-1)*25)+1, count, now),
+						"pageInfo":   pageInfo,
+					},
+				},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	fetcher := NewGraphQLFetcherWithClient(
+		githubv4.NewEnterpriseClient(srv.URL, srv.Client()), nil,
+	)
+
+	result, err := fetcher.FetchRepoPRs(t.Context(), "conda-forge", "staged-recipes")
+	require.NoError(err)
+	require.NotNil(result)
+	require.Len(result.PullRequests, 51)
+
+	logs := buf.String()
+	assert.Contains(logs, `msg="merge request list fetch started"`)
+	assert.Contains(logs, "repo=conda-forge/staged-recipes")
+	assert.Contains(logs, "platform=github")
+	assert.Contains(logs, "host=github.com")
+	assert.Contains(logs, "source=graphql")
+	assert.Contains(logs, "total=51")
+	assert.Contains(logs, "fetched=25")
+	assert.Contains(logs, `msg="merge request list fetch progress"`)
+	assert.Contains(logs, "fetched=50")
+	assert.Contains(logs, `msg="merge request list fetch completed"`)
+	assert.Contains(logs, "fetched=51")
+}
+
+func testGQLPRNodes(start, count int, now string) []map[string]any {
+	prs := make([]map[string]any, 0, count)
+	for i := range count {
+		number := start + i
+		prs = append(prs, map[string]any{
+			"databaseId":     number * 1000,
+			"number":         number,
+			"title":          fmt.Sprintf("Pull request %d", number),
+			"state":          "OPEN",
+			"isDraft":        false,
+			"body":           "",
+			"url":            fmt.Sprintf("https://github.com/conda-forge/staged-recipes/pull/%d", number),
+			"author":         map[string]any{"login": "alice"},
+			"createdAt":      now,
+			"updatedAt":      now,
+			"mergedAt":       nil,
+			"closedAt":       nil,
+			"additions":      1,
+			"deletions":      0,
+			"mergeable":      "MERGEABLE",
+			"reviewDecision": "",
+			"headRefName":    "recipe",
+			"baseRefName":    "main",
+			"headRefOid":     "abc123",
+			"baseRefOid":     "def456",
+			"headRepository": map[string]any{"url": "https://github.com/conda-forge/staged-recipes"},
+			"labels":         map[string]any{"nodes": []any{}},
+			"comments":       map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""}},
+			"reviews":        map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""}},
+			"allCommits":     map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""}},
+			"lastCommit":     map[string]any{"nodes": []any{}},
+			"timelineItems":  map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""}},
+		})
+	}
+	return prs
 }
 
 func TestNormalizeBulkCI(t *testing.T) {

--- a/internal/github/queue.go
+++ b/internal/github/queue.go
@@ -35,6 +35,7 @@ type QueueItem struct {
 	Starred         bool
 	Watched         bool
 	IsOpen          bool
+	LargeRepo       bool
 }
 
 // WorstCaseCost returns the maximum API calls this item's
@@ -106,6 +107,10 @@ func isEligible(qi *QueueItem, now time.Time) bool {
 	// Starred or watched: eligible if >15min since fetch.
 	if qi.Starred || qi.Watched {
 		return sinceLastFetch > starWatchInterval
+	}
+
+	if qi.LargeRepo {
+		return false
 	}
 
 	// Default: eligible if >30min since last fetch.

--- a/internal/github/queue_test.go
+++ b/internal/github/queue_test.go
@@ -176,6 +176,25 @@ func TestBuildQueueCIHadPendingMakesEligible(t *testing.T) {
 	assert.Greater(q[0].Score, 100.0)
 }
 
+func TestBuildQueueCIHadPendingBypassesLargeRepoGate(t *testing.T) {
+	assert := Assert.New(t)
+
+	fetched := testNow.Add(-10 * time.Minute)
+	items := []QueueItem{{
+		Type:            QueueItemPR,
+		Number:          9,
+		IsOpen:          true,
+		CIHadPending:    true,
+		LargeRepo:       true,
+		UpdatedAt:       testNow.Add(-1 * time.Hour),
+		DetailFetchedAt: &fetched,
+	}}
+
+	q := BuildQueue(items, testNow)
+	assert.Len(q, 1)
+	assert.Equal(9, q[0].Number)
+}
+
 func TestBuildQueueClosedRecentlyFetchedExcluded(t *testing.T) {
 	assert := Assert.New(t)
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -154,6 +154,13 @@ type issueSyncProgressLogger struct {
 	total  int
 }
 
+type issueListFetchProgressLogger struct {
+	repo    RepoRef
+	source  string
+	fetched int
+	started bool
+}
+
 func newIssueSyncProgressLogger(repo RepoRef, source string, total int) issueSyncProgressLogger {
 	progress := issueSyncProgressLogger{repo: repo, source: source, total: total}
 	if progress.enabled() {
@@ -187,6 +194,44 @@ func (p issueSyncProgressLogger) log(message string, processed int) {
 		"source", p.source,
 		"processed", processed,
 		"total", p.total,
+	)
+}
+
+func newIssueListFetchProgressLogger(repo RepoRef, source string) *issueListFetchProgressLogger {
+	return &issueListFetchProgressLogger{repo: repo, source: source}
+}
+
+func (p *issueListFetchProgressLogger) recordPage(fetched int, hasMore bool) {
+	if p == nil || fetched <= 0 {
+		return
+	}
+	p.fetched += fetched
+	if !p.started {
+		if !hasMore && p.fetched < issueSyncProgressLogInterval {
+			return
+		}
+		p.started = true
+		p.log("issue list fetch started")
+		return
+	}
+	if hasMore {
+		p.log("issue list fetch progress")
+	}
+}
+
+func (p *issueListFetchProgressLogger) done() {
+	if p != nil && p.started {
+		p.log("issue list fetch completed")
+	}
+}
+
+func (p *issueListFetchProgressLogger) log(message string) {
+	slog.Info(message,
+		"repo", p.repo.Owner+"/"+p.repo.Name,
+		"platform", string(repoPlatform(p.repo)),
+		"host", repoHost(p.repo),
+		"source", p.source,
+		"fetched", p.fetched,
 	)
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -146,6 +146,50 @@ const (
 	displayNameFailureTTL = 15 * time.Minute
 )
 
+const issueSyncProgressLogInterval = 100
+
+type issueSyncProgressLogger struct {
+	repo   RepoRef
+	source string
+	total  int
+}
+
+func newIssueSyncProgressLogger(repo RepoRef, source string, total int) issueSyncProgressLogger {
+	progress := issueSyncProgressLogger{repo: repo, source: source, total: total}
+	if progress.enabled() {
+		progress.log("issue sync started", 0)
+	}
+	return progress
+}
+
+func (p issueSyncProgressLogger) record(processed int) {
+	if !p.enabled() || processed >= p.total || processed%issueSyncProgressLogInterval != 0 {
+		return
+	}
+	p.log("issue sync progress", processed)
+}
+
+func (p issueSyncProgressLogger) done() {
+	if p.enabled() {
+		p.log("issue sync completed", p.total)
+	}
+}
+
+func (p issueSyncProgressLogger) enabled() bool {
+	return p.total >= issueSyncProgressLogInterval
+}
+
+func (p issueSyncProgressLogger) log(message string, processed int) {
+	slog.Info(message,
+		"repo", p.repo.Owner+"/"+p.repo.Name,
+		"platform", string(repoPlatform(p.repo)),
+		"host", repoHost(p.repo),
+		"source", p.source,
+		"processed", processed,
+		"total", p.total,
+	)
+}
+
 // Syncer periodically pulls PR data from GitHub into SQLite.
 type Syncer struct {
 	clients       *platform.Registry
@@ -3285,6 +3329,7 @@ func (s *Syncer) doSyncRepoGraphQLIssues(
 ) error {
 	var failedScope failScope
 	stillOpen := make(map[int]bool, len(result.Issues))
+	progress := newIssueSyncProgressLogger(repo, "graphql", len(result.Issues))
 
 	for i := range result.Issues {
 		bulk := &result.Issues[i]
@@ -3301,6 +3346,7 @@ func (s *Syncer) doSyncRepoGraphQLIssues(
 			)
 			failedScope |= failIssues
 		}
+		progress.record(i + 1)
 	}
 
 	// Detect closed issues — same as REST path.
@@ -3326,6 +3372,7 @@ func (s *Syncer) doSyncRepoGraphQLIssues(
 	if failedScope != 0 {
 		return fmt.Errorf("GraphQL issue sync had partial failures")
 	}
+	progress.done()
 	return nil
 }
 
@@ -4746,7 +4793,8 @@ func (s *Syncer) syncIssuesFromList(
 	}
 
 	var hadItemFailure bool
-	for _, ghIssue := range ghIssues {
+	progress := newIssueSyncProgressLogger(repo, "rest", len(ghIssues))
+	for i, ghIssue := range ghIssues {
 		if err := s.syncOpenIssue(ctx, client, repo, repoID, ghIssue, forceRefresh); err != nil {
 			slog.Error("sync issue failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -4755,6 +4803,7 @@ func (s *Syncer) syncIssuesFromList(
 			)
 			hadItemFailure = true
 		}
+		progress.record(i + 1)
 	}
 
 	closedNumbers, err := s.db.GetPreviouslyOpenIssueNumbers(
@@ -4779,6 +4828,7 @@ func (s *Syncer) syncIssuesFromList(
 	if hadItemFailure {
 		return fmt.Errorf("one or more issue sync items failed")
 	}
+	progress.done()
 	return nil
 }
 
@@ -4796,7 +4846,8 @@ func (s *Syncer) syncPlatformIssuesFromList(
 	}
 
 	var hadItemFailure bool
-	for _, issue := range issues {
+	progress := newIssueSyncProgressLogger(repo, "provider", len(issues))
+	for i, issue := range issues {
 		if err := s.syncOpenPlatformIssue(ctx, reader, repo, repoID, issue, forceRefresh); err != nil {
 			slog.Error("sync issue failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -4805,6 +4856,7 @@ func (s *Syncer) syncPlatformIssuesFromList(
 			)
 			hadItemFailure = true
 		}
+		progress.record(i + 1)
 	}
 
 	closedNumbers, err := s.db.GetPreviouslyOpenIssueNumbers(
@@ -4829,6 +4881,7 @@ func (s *Syncer) syncPlatformIssuesFromList(
 	if hadItemFailure {
 		return fmt.Errorf("one or more issue sync items failed")
 	}
+	progress.done()
 	return nil
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4009,19 +4009,6 @@ func (s *Syncer) fetchMRDetail(
 			"get full PR #%d: %w", number, err,
 		)
 	}
-	if newETag != "" {
-		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "pull_request", number, newETag,
-		); err != nil {
-			slog.Warn("persist pull request ETag failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"number", number,
-				"err", err,
-			)
-		}
-	}
-
 	normalized, err := NormalizePR(repoID, fullPR)
 	if err != nil {
 		return calls, fmt.Errorf("normalize full PR #%d: %w", number, err)
@@ -4059,16 +4046,16 @@ func (s *Syncer) fetchMRDetail(
 	}
 
 	// Diff SHAs if clone available.
-	repoHost := repo.PlatformHost
-	if repoHost == "" {
-		repoHost = "github.com"
+	cloneRepoHost := repo.PlatformHost
+	if cloneRepoHost == "" {
+		cloneRepoHost = "github.com"
 	}
 	if s.clones != nil && cloneFetchOK {
 		headSHA := normalized.PlatformHeadSHA
 		baseSHA := normalized.PlatformBaseSHA
 		if headSHA != "" && baseSHA != "" {
 			mb, mbErr := s.clones.MergeBase(
-				ctx, repoHost, repo.Owner,
+				ctx, cloneRepoHost, repo.Owner,
 				repo.Name, baseSHA, headSHA,
 			)
 			if mbErr != nil {
@@ -4154,6 +4141,19 @@ func (s *Syncer) fetchMRDetail(
 			)
 		} else {
 			s.onMRSynced(repo.Owner, repo.Name, fresh)
+		}
+	}
+
+	if newETag != "" {
+		if err := s.db.UpsertHTTPEtag(
+			ctx, string(repoPlatform(repo)), repoHost(repo),
+			repo.Owner, repo.Name, "pull_request", number, newETag,
+		); err != nil {
+			slog.Warn("persist pull request ETag failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
 		}
 	}
 
@@ -4400,19 +4400,6 @@ func (s *Syncer) fetchIssueDetail(
 			"get issue #%d: %w", number, err,
 		)
 	}
-	if newETag != "" {
-		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "issue", number, newETag,
-		); err != nil {
-			slog.Warn("persist issue ETag failed",
-				"repo", repo.Owner+"/"+repo.Name,
-				"number", number,
-				"err", err,
-			)
-		}
-	}
-
 	normalized, err := NormalizeIssue(repoID, ghIssue)
 	if err != nil {
 		return calls, fmt.Errorf("normalize issue #%d: %w", number, err)
@@ -4441,6 +4428,19 @@ func (s *Syncer) fetchIssueDetail(
 		return calls, fmt.Errorf(
 			"mark detail fetched for issue #%d: %w", number, err,
 		)
+	}
+
+	if newETag != "" {
+		if err := s.db.UpsertHTTPEtag(
+			ctx, string(repoPlatform(repo)), repoHost(repo),
+			repo.Owner, repo.Name, "issue", number, newETag,
+		); err != nil {
+			slog.Warn("persist issue ETag failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
+		}
 	}
 
 	return calls, nil

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -146,47 +146,63 @@ const (
 	displayNameFailureTTL = 15 * time.Minute
 )
 
-const issueSyncProgressLogInterval = 100
+const syncProgressLogInterval = 100
 
-type issueSyncProgressLogger struct {
+type itemSyncProgressLogger struct {
 	repo   RepoRef
 	source string
+	item   string
 	total  int
 }
 
-type issueListFetchProgressLogger struct {
+type listFetchProgressLogger struct {
 	repo    RepoRef
 	source  string
+	item    string
+	total   int
 	fetched int
 	started bool
 }
 
-func newIssueSyncProgressLogger(repo RepoRef, source string, total int) issueSyncProgressLogger {
-	progress := issueSyncProgressLogger{repo: repo, source: source, total: total}
+func newIssueSyncProgressLogger(repo RepoRef, source string, total int) itemSyncProgressLogger {
+	return newItemSyncProgressLogger(repo, source, "issue", total)
+}
+
+func newMergeRequestSyncProgressLogger(repo RepoRef, source string, total int) itemSyncProgressLogger {
+	return newItemSyncProgressLogger(repo, source, "merge request", total)
+}
+
+func newItemSyncProgressLogger(
+	repo RepoRef,
+	source string,
+	item string,
+	total int,
+) itemSyncProgressLogger {
+	progress := itemSyncProgressLogger{repo: repo, source: source, item: item, total: total}
 	if progress.enabled() {
-		progress.log("issue sync started", 0)
+		progress.log(progress.item+" sync started", 0)
 	}
 	return progress
 }
 
-func (p issueSyncProgressLogger) record(processed int) {
-	if !p.enabled() || processed >= p.total || processed%issueSyncProgressLogInterval != 0 {
+func (p itemSyncProgressLogger) record(processed int) {
+	if !p.enabled() || processed >= p.total || processed%syncProgressLogInterval != 0 {
 		return
 	}
-	p.log("issue sync progress", processed)
+	p.log(p.item+" sync progress", processed)
 }
 
-func (p issueSyncProgressLogger) done() {
+func (p itemSyncProgressLogger) done() {
 	if p.enabled() {
-		p.log("issue sync completed", p.total)
+		p.log(p.item+" sync completed", p.total)
 	}
 }
 
-func (p issueSyncProgressLogger) enabled() bool {
-	return p.total >= issueSyncProgressLogInterval
+func (p itemSyncProgressLogger) enabled() bool {
+	return p.total >= syncProgressLogInterval
 }
 
-func (p issueSyncProgressLogger) log(message string, processed int) {
+func (p itemSyncProgressLogger) log(message string, processed int) {
 	slog.Info(message,
 		"repo", p.repo.Owner+"/"+p.repo.Name,
 		"platform", string(repoPlatform(p.repo)),
@@ -197,42 +213,63 @@ func (p issueSyncProgressLogger) log(message string, processed int) {
 	)
 }
 
-func newIssueListFetchProgressLogger(repo RepoRef, source string) *issueListFetchProgressLogger {
-	return &issueListFetchProgressLogger{repo: repo, source: source}
+func newIssueListFetchProgressLogger(repo RepoRef, source string) *listFetchProgressLogger {
+	return newListFetchProgressLogger(repo, source, "issue")
 }
 
-func (p *issueListFetchProgressLogger) recordPage(fetched int, hasMore bool) {
+func newMergeRequestListFetchProgressLogger(repo RepoRef, source string) *listFetchProgressLogger {
+	return newListFetchProgressLogger(repo, source, "merge request")
+}
+
+func newListFetchProgressLogger(repo RepoRef, source, item string) *listFetchProgressLogger {
+	return &listFetchProgressLogger{repo: repo, source: source, item: item}
+}
+
+func (p *listFetchProgressLogger) setTotal(total int) {
+	if p != nil && total > 0 {
+		p.total = total
+	}
+}
+
+func (p *listFetchProgressLogger) recordPage(fetched int, hasMore bool) {
 	if p == nil || fetched <= 0 {
 		return
 	}
 	p.fetched += fetched
 	if !p.started {
-		if !hasMore && p.fetched < issueSyncProgressLogInterval {
+		if !hasMore && p.fetched < syncProgressLogInterval {
 			return
 		}
 		p.started = true
-		p.log("issue list fetch started")
+		p.log(p.item + " list fetch started")
 		return
 	}
 	if hasMore {
-		p.log("issue list fetch progress")
+		p.log(p.item + " list fetch progress")
 	}
 }
 
-func (p *issueListFetchProgressLogger) done() {
+func (p *listFetchProgressLogger) done() {
 	if p != nil && p.started {
-		p.log("issue list fetch completed")
+		if p.total == 0 {
+			p.total = p.fetched
+		}
+		p.log(p.item + " list fetch completed")
 	}
 }
 
-func (p *issueListFetchProgressLogger) log(message string) {
-	slog.Info(message,
-		"repo", p.repo.Owner+"/"+p.repo.Name,
+func (p *listFetchProgressLogger) log(message string) {
+	attrs := []any{
+		"repo", p.repo.Owner + "/" + p.repo.Name,
 		"platform", string(repoPlatform(p.repo)),
 		"host", repoHost(p.repo),
 		"source", p.source,
 		"fetched", p.fetched,
-	)
+	}
+	if p.total > 0 {
+		attrs = append(attrs, "total", p.total)
+	}
+	slog.Info(message, attrs...)
 }
 
 // Syncer periodically pulls PR data from GitHub into SQLite.
@@ -2921,7 +2958,8 @@ func (s *Syncer) syncMergeRequestsFromList(
 	}
 
 	var hadItemFailure bool
-	for _, mr := range mrs {
+	progress := newMergeRequestSyncProgressLogger(repo, "provider", len(mrs))
+	for i, mr := range mrs {
 		if err := s.indexUpsertMergeRequest(ctx, repo, repoID, mr); err != nil {
 			slog.Error("index upsert MR failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -2930,6 +2968,7 @@ func (s *Syncer) syncMergeRequestsFromList(
 			)
 			hadItemFailure = true
 		}
+		progress.record(i + 1)
 	}
 
 	closedNumbers, err := s.db.GetPreviouslyOpenMRNumbers(
@@ -2955,6 +2994,7 @@ func (s *Syncer) syncMergeRequestsFromList(
 	if hadItemFailure {
 		return fmt.Errorf("one or more merge request sync items failed")
 	}
+	progress.done()
 	return nil
 }
 
@@ -3321,6 +3361,7 @@ func (s *Syncer) doSyncRepoGraphQL(
 ) error {
 	var failedScope failScope
 	stillOpen := make(map[int]bool, len(result.PullRequests))
+	progress := newMergeRequestSyncProgressLogger(repo, "graphql", len(result.PullRequests))
 
 	for i := range result.PullRequests {
 		bulk := &result.PullRequests[i]
@@ -3337,6 +3378,7 @@ func (s *Syncer) doSyncRepoGraphQL(
 			)
 			failedScope |= failMR
 		}
+		progress.record(i + 1)
 	}
 
 	// Detect closed PRs — same as REST path.
@@ -3362,6 +3404,7 @@ func (s *Syncer) doSyncRepoGraphQL(
 	if failedScope != 0 {
 		return fmt.Errorf("GraphQL sync had partial failures")
 	}
+	progress.done()
 	return nil
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3010,25 +3010,23 @@ func (s *Syncer) shouldUseBulkGraphQLForMRs(
 	repoID int64,
 	listCount int,
 ) bool {
-	if listCount < largeRepoBulkGraphQLThreshold {
-		return true
-	}
-	hasExisting, err := s.db.HasOpenMergeRequestsForRepo(ctx, repoID)
+	localOpenCount, err := s.db.CountOpenMergeRequestsForRepo(ctx, repoID)
 	if err != nil {
-		slog.Warn("check existing merge requests before GraphQL bulk fetch failed",
+		slog.Warn("count existing merge requests before GraphQL bulk fetch failed",
 			"repo", repo.Owner+"/"+repo.Name,
 			"err", err,
 		)
 		return true
 	}
-	if !hasExisting {
+	if localOpenCount < largeRepoBulkGraphQLThreshold {
 		return true
 	}
 	slog.Info("skipping GraphQL merge request bulk fetch for large existing repo",
 		"repo", repo.Owner+"/"+repo.Name,
 		"platform", repoPlatform(repo),
 		"host", repoHost(repo),
-		"total", listCount,
+		"local_open_total", localOpenCount,
+		"fetched_total", listCount,
 	)
 	return false
 }
@@ -3039,25 +3037,23 @@ func (s *Syncer) shouldUseBulkGraphQLForIssues(
 	repoID int64,
 	listCount int,
 ) bool {
-	if listCount < largeRepoBulkGraphQLThreshold {
-		return true
-	}
-	hasExisting, err := s.db.HasOpenIssuesForRepo(ctx, repoID)
+	localOpenCount, err := s.db.CountOpenIssuesForRepo(ctx, repoID)
 	if err != nil {
-		slog.Warn("check existing issues before GraphQL bulk fetch failed",
+		slog.Warn("count existing issues before GraphQL bulk fetch failed",
 			"repo", repo.Owner+"/"+repo.Name,
 			"err", err,
 		)
 		return true
 	}
-	if !hasExisting {
+	if localOpenCount < largeRepoBulkGraphQLThreshold {
 		return true
 	}
 	slog.Info("skipping GraphQL issue bulk fetch for large existing repo",
 		"repo", repo.Owner+"/"+repo.Name,
 		"platform", repoPlatform(repo),
 		"host", repoHost(repo),
-		"total", listCount,
+		"local_open_total", localOpenCount,
+		"fetched_total", listCount,
 	)
 	return false
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -147,6 +147,7 @@ const (
 )
 
 const syncProgressLogInterval = 100
+const largeRepoBulkGraphQLThreshold = syncProgressLogInterval
 
 type itemSyncProgressLogger struct {
 	repo   RepoRef
@@ -2796,9 +2797,13 @@ func (s *Syncer) indexSyncRepo(
 		} else {
 			// GraphQL path: if fetcher available and not rate-limited,
 			// do a bulk fetch that replaces both index upsert and
-			// detail drain for complete PRs.
+			// detail drain for complete PRs. For large repos that
+			// already have indexed rows, keep the refresh incremental:
+			// the list phase updates timestamps and the detail drain
+			// conditionally fetches individual stale PRs.
 			graphQLDone := false
-			if fetcher := s.fetcherFor(repo); fetcher != nil {
+			if fetcher := s.fetcherFor(repo); fetcher != nil &&
+				s.shouldUseBulkGraphQLForMRs(ctx, repo, repoID, len(openMRs)) {
 				if backoff, _ := fetcher.ShouldBackoff(); !backoff {
 					result, gqlErr := fetcher.FetchRepoPRs(
 						ctx, repo.Owner, repo.Name,
@@ -2877,7 +2882,8 @@ func (s *Syncer) indexSyncRepo(
 			}
 		} else {
 			graphQLIssuesDone := false
-			if fetcher := s.fetcherFor(repo); fetcher != nil {
+			if fetcher := s.fetcherFor(repo); fetcher != nil &&
+				s.shouldUseBulkGraphQLForIssues(ctx, repo, repoID, len(openIssues)+len(ghIssues)) {
 				if backoff, _ := fetcher.ShouldBackoff(); !backoff {
 					issueResult, gqlErr := fetcher.FetchRepoIssues(
 						ctx, repo.Owner, repo.Name,
@@ -2996,6 +3002,64 @@ func (s *Syncer) syncMergeRequestsFromList(
 	}
 	progress.done()
 	return nil
+}
+
+func (s *Syncer) shouldUseBulkGraphQLForMRs(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	listCount int,
+) bool {
+	if listCount < largeRepoBulkGraphQLThreshold {
+		return true
+	}
+	hasExisting, err := s.db.HasOpenMergeRequestsForRepo(ctx, repoID)
+	if err != nil {
+		slog.Warn("check existing merge requests before GraphQL bulk fetch failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"err", err,
+		)
+		return true
+	}
+	if !hasExisting {
+		return true
+	}
+	slog.Info("skipping GraphQL merge request bulk fetch for large existing repo",
+		"repo", repo.Owner+"/"+repo.Name,
+		"platform", repoPlatform(repo),
+		"host", repoHost(repo),
+		"total", listCount,
+	)
+	return false
+}
+
+func (s *Syncer) shouldUseBulkGraphQLForIssues(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	listCount int,
+) bool {
+	if listCount < largeRepoBulkGraphQLThreshold {
+		return true
+	}
+	hasExisting, err := s.db.HasOpenIssuesForRepo(ctx, repoID)
+	if err != nil {
+		slog.Warn("check existing issues before GraphQL bulk fetch failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"err", err,
+		)
+		return true
+	}
+	if !hasExisting {
+		return true
+	}
+	slog.Info("skipping GraphQL issue bulk fetch for large existing repo",
+		"repo", repo.Owner+"/"+repo.Name,
+		"platform", repoPlatform(repo),
+		"host", repoHost(repo),
+		"total", listCount,
+	)
+	return false
 }
 
 func (s *Syncer) indexUpsertMergeRequest(
@@ -3923,24 +3987,6 @@ func (s *Syncer) fetchMRDetail(
 		return calls, fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 
-	fullPR, err := client.GetPullRequest(
-		ctx, repo.Owner, repo.Name, number,
-	)
-	calls++
-	if err == nil && fullPR == nil {
-		err = fmt.Errorf("client returned nil pull request")
-	}
-	if err != nil {
-		return calls, fmt.Errorf(
-			"get full PR #%d: %w", number, err,
-		)
-	}
-
-	normalized, err := NormalizePR(repoID, fullPR)
-	if err != nil {
-		return calls, fmt.Errorf("normalize full PR #%d: %w", number, err)
-	}
-
 	existing, err := s.db.GetMergeRequestByRepoIDAndNumber(
 		ctx, repoID, number,
 	)
@@ -3948,6 +3994,41 @@ func (s *Syncer) fetchMRDetail(
 		return calls, fmt.Errorf(
 			"get existing MR #%d: %w", number, err,
 		)
+	}
+
+	fullPR, newETag, notModified, err := s.getPullRequestForDetail(
+		ctx, client, repo, number,
+	)
+	calls++
+	if err == nil && fullPR == nil {
+		if notModified && existing != nil {
+			return s.markUnchangedMRDetailFetched(
+				ctx, repo, repoID, number, existing, calls,
+			)
+		}
+		err = fmt.Errorf("client returned nil pull request")
+	}
+	if err != nil {
+		return calls, fmt.Errorf(
+			"get full PR #%d: %w", number, err,
+		)
+	}
+	if newETag != "" {
+		if err := s.db.UpsertHTTPEtag(
+			ctx, string(repoPlatform(repo)), repoHost(repo),
+			repo.Owner, repo.Name, "pull_request", number, newETag,
+		); err != nil {
+			slog.Warn("persist pull request ETag failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
+		}
+	}
+
+	normalized, err := NormalizePR(repoID, fullPR)
+	if err != nil {
+		return calls, fmt.Errorf("normalize full PR #%d: %w", number, err)
 	}
 	preserveMergeableStateIfOmitted(normalized, existing)
 
@@ -4080,6 +4161,75 @@ func (s *Syncer) fetchMRDetail(
 		}
 	}
 
+	return calls, nil
+}
+
+func (s *Syncer) getPullRequestForDetail(
+	ctx context.Context,
+	client Client,
+	repo RepoRef,
+	number int,
+) (*gh.PullRequest, string, bool, error) {
+	conditional, ok := client.(conditionalPullRequestGetter)
+	if !ok {
+		pr, err := client.GetPullRequest(ctx, repo.Owner, repo.Name, number)
+		return pr, "", false, err
+	}
+
+	etag, err := s.db.GetHTTPEtag(
+		ctx, string(repoPlatform(repo)), repoHost(repo),
+		repo.Owner, repo.Name, "pull_request", number,
+	)
+	if err != nil {
+		slog.Warn("load pull request ETag failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"number", number,
+			"err", err,
+		)
+		pr, err := client.GetPullRequest(ctx, repo.Owner, repo.Name, number)
+		return pr, "", false, err
+	}
+	return conditional.GetPullRequestIfChanged(
+		ctx, repo.Owner, repo.Name, number, etag,
+	)
+}
+
+func (s *Syncer) markUnchangedMRDetailFetched(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	number int,
+	existing *db.MergeRequest,
+	calls int,
+) (int, error) {
+	pending := existing.CIHadPending
+	if existing.CIHadPending && existing.PlatformHeadSHA != "" {
+		if err := s.refreshCIStatus(
+			ctx, repo, repoID, number, existing.PlatformHeadSHA,
+		); err != nil {
+			calls += 2
+			return calls, err
+		}
+		calls += 2
+		fresh, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
+		if err == nil && fresh != nil {
+			pending = ciHasPending(fresh.CIChecksJSON)
+		}
+	}
+	if err := s.updateMRDetailFetchedByRepoID(ctx, repoID, number, pending); err != nil {
+		return calls, fmt.Errorf("mark unchanged detail fetched for MR #%d: %w", number, err)
+	}
+	if s.onMRSynced != nil {
+		fresh, fErr := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
+		if fErr != nil {
+			slog.Warn("get MR for onMRSynced hook failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number, "err", fErr,
+			)
+		} else {
+			s.onMRSynced(repo.Owner, repo.Name, fresh)
+		}
+	}
 	return calls, nil
 }
 
@@ -5449,6 +5599,10 @@ func (s *Syncer) buildDetailQueueItems(
 		)
 		return nil
 	}
+	prCountsByRepoID := make(map[int64]int, len(prs))
+	for _, pr := range prs {
+		prCountsByRepoID[pr.RepoID]++
+	}
 	for _, pr := range prs {
 		repo, rErr := s.db.GetRepoByID(ctx, pr.RepoID)
 		if rErr != nil || repo == nil {
@@ -5475,6 +5629,7 @@ func (s *Syncer) buildDetailQueueItems(
 			Starred:         pr.Starred,
 			Watched:         watched[watchKey],
 			IsOpen:          true,
+			LargeRepo:       prCountsByRepoID[pr.RepoID] >= largeRepoBulkGraphQLThreshold,
 		})
 	}
 
@@ -5487,6 +5642,10 @@ func (s *Syncer) buildDetailQueueItems(
 			"err", err,
 		)
 		return items
+	}
+	issueCountsByRepoID := make(map[int64]int, len(issues))
+	for _, issue := range issues {
+		issueCountsByRepoID[issue.RepoID]++
 	}
 	for _, issue := range issues {
 		repo, rErr := s.db.GetRepoByID(ctx, issue.RepoID)
@@ -5508,6 +5667,7 @@ func (s *Syncer) buildDetailQueueItems(
 			DetailFetchedAt: issue.DetailFetchedAt,
 			Starred:         issue.Starred,
 			IsOpen:          true,
+			LargeRepo:       issueCountsByRepoID[issue.RepoID] >= largeRepoBulkGraphQLThreshold,
 		})
 	}
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4382,17 +4382,39 @@ func (s *Syncer) fetchIssueDetail(
 		return calls, fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 
-	ghIssue, err := client.GetIssue(
-		ctx, repo.Owner, repo.Name, number,
+	ghIssue, newETag, notModified, err := s.getIssueForDetail(
+		ctx, client, repo, number,
 	)
 	calls++
 	if err == nil && ghIssue == nil {
+		if notModified {
+			if err := s.updateIssueDetailFetchedByRepoID(
+				ctx, repoID, number,
+			); err != nil {
+				return calls, fmt.Errorf(
+					"mark unchanged detail fetched for issue #%d: %w", number, err,
+				)
+			}
+			return calls, nil
+		}
 		err = fmt.Errorf("client returned nil issue")
 	}
 	if err != nil {
 		return calls, fmt.Errorf(
 			"get issue #%d: %w", number, err,
 		)
+	}
+	if newETag != "" {
+		if err := s.db.UpsertHTTPEtag(
+			ctx, string(repoPlatform(repo)), repoHost(repo),
+			repo.Owner, repo.Name, "issue", number, newETag,
+		); err != nil {
+			slog.Warn("persist issue ETag failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
+		}
 	}
 
 	normalized, err := NormalizeIssue(repoID, ghIssue)
@@ -4426,6 +4448,36 @@ func (s *Syncer) fetchIssueDetail(
 	}
 
 	return calls, nil
+}
+
+func (s *Syncer) getIssueForDetail(
+	ctx context.Context,
+	client Client,
+	repo RepoRef,
+	number int,
+) (*gh.Issue, string, bool, error) {
+	conditional, ok := client.(conditionalIssueGetter)
+	if !ok {
+		issue, err := client.GetIssue(ctx, repo.Owner, repo.Name, number)
+		return issue, "", false, err
+	}
+
+	etag, err := s.db.GetHTTPEtag(
+		ctx, string(repoPlatform(repo)), repoHost(repo),
+		repo.Owner, repo.Name, "issue", number,
+	)
+	if err != nil {
+		slog.Warn("load issue ETag failed",
+			"repo", repo.Owner+"/"+repo.Name,
+			"number", number,
+			"err", err,
+		)
+		issue, err := client.GetIssue(ctx, repo.Owner, repo.Name, number)
+		return issue, "", false, err
+	}
+	return conditional.GetIssueIfChanged(
+		ctx, repo.Owner, repo.Name, number, etag,
+	)
 }
 
 func (s *Syncer) fetchProviderIssueDetail(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4461,6 +4461,72 @@ func TestFetchIssueDetailPersistsIssueETag(t *testing.T) {
 	assert.Equal(`"issue-etag-v2"`, etag)
 }
 
+func TestBulkGraphQLGateUsesLocalMergeRequestCount(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	for number := 1; number <= largeRepoBulkGraphQLThreshold; number++ {
+		_, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID:         repoID,
+			PlatformID:     int64(number * 1000),
+			Number:         number,
+			URL:            fmt.Sprintf("https://github.com/owner/repo/pull/%d", number),
+			Title:          fmt.Sprintf("test PR %d", number),
+			Author:         "alice",
+			State:          "open",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			LastActivityAt: now,
+		})
+		require.NoError(err)
+	}
+
+	syncer := NewSyncer(nil, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
+
+	assert.False(syncer.shouldUseBulkGraphQLForMRs(ctx, repo, repoID, 1),
+		"local open count should gate large-repo bulk behavior even when the fetched set is small")
+}
+
+func TestBulkGraphQLGateUsesLocalIssueCount(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+
+	now := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	for number := 1; number <= largeRepoBulkGraphQLThreshold; number++ {
+		_, err := d.UpsertIssue(ctx, &db.Issue{
+			RepoID:         repoID,
+			PlatformID:     int64(number * 1000),
+			Number:         number,
+			URL:            fmt.Sprintf("https://github.com/owner/repo/issues/%d", number),
+			Title:          fmt.Sprintf("test issue %d", number),
+			Author:         "alice",
+			State:          "open",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			LastActivityAt: now,
+		})
+		require.NoError(err)
+	}
+
+	syncer := NewSyncer(nil, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
+
+	assert.False(syncer.shouldUseBulkGraphQLForIssues(ctx, repo, repoID, 1),
+		"local open count should gate large-repo bulk behavior even when the fetched set is small")
+}
+
 func TestRunOnceLargeExistingRepoSkipsBulkGraphQLAndFetchesChangedPRDetail(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4128,6 +4128,30 @@ func (c *detailTrackingClient) GetPullRequest(
 	return c.mockClient.GetPullRequest(ctx, owner, repo, number)
 }
 
+type conditionalPRTrackingClient struct {
+	detailTrackingClient
+	receivedETag     string
+	conditionalCalls atomic.Int32
+	notModified      bool
+	nextETag         string
+}
+
+func (c *conditionalPRTrackingClient) GetPullRequestIfChanged(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	etag string,
+) (*gh.PullRequest, string, bool, error) {
+	c.conditionalCalls.Add(1)
+	c.receivedETag = etag
+	if c.notModified {
+		return nil, etag, true, nil
+	}
+	c.getPRCalls.Add(1)
+	pr, err := c.mockClient.GetPullRequest(ctx, owner, repo, number)
+	return pr, c.nextETag, false, err
+}
+
 func TestRunOnceIndexOnly(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -4231,6 +4255,182 @@ func TestRunOnceDetailDrain(t *testing.T) {
 	require.NotNil(pr2)
 	assert.NotNil(pr2.DetailFetchedAt,
 		"detail_fetched_at should be set after detail drain")
+}
+
+func TestFetchMRDetailUsesPersistedPullRequestETag(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	detailFetchedAt := time.Date(2024, 6, 1, 9, 0, 0, 0, time.UTC)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           "open",
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	mc := &conditionalPRTrackingClient{notModified: true}
+	mc.comments = []*gh.IssueComment{{ID: new(int64)}}
+	mc.reviews = []*gh.PullRequestReview{{ID: new(int64)}}
+	mc.commits = []*gh.RepositoryCommit{{SHA: new(string)}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	_, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.NoError(err)
+
+	assert.Equal(int32(1), mc.conditionalCalls.Load())
+	assert.Equal(`"etag-v1"`, mc.receivedETag)
+	assert.Zero(int(mc.getPRCalls.Load()),
+		"304 should skip the unconditional PR detail fetch")
+	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
+		"304 should skip timeline/comment refresh")
+}
+
+func TestFetchMRDetailPersistsPullRequestETag(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	mc := &conditionalPRTrackingClient{nextETag: `"etag-v2"`}
+	mc.singlePR = buildOpenPR(1, updatedAt)
+	mc.comments = []*gh.IssueComment{}
+	mc.reviews = []*gh.PullRequestReview{}
+	mc.commits = []*gh.RepositoryCommit{}
+	mc.ciStatus = &gh.CombinedStatus{State: new(string)}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	_, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.NoError(err)
+
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1,
+	)
+	require.NoError(err)
+	assert.Equal(`"etag-v2"`, etag)
+}
+
+func TestRunOnceLargeExistingRepoSkipsBulkGraphQLAndFetchesChangedPRDetail(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{
+		Owner:        "owner",
+		Name:         "repo",
+		PlatformHost: "github.com",
+	}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+
+	unchangedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	changedAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	detailFetchedAt := time.Date(2024, 6, 1, 11, 0, 0, 0, time.UTC)
+	openPRs := make([]*gh.PullRequest, 0, syncProgressLogInterval+1)
+	for number := 1; number <= syncProgressLogInterval+1; number++ {
+		updatedAt := unchangedAt
+		if number == 1 {
+			updatedAt = changedAt
+		}
+		openPRs = append(openPRs, buildOpenPR(number, updatedAt))
+		_, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID:          repoID,
+			PlatformID:      int64(number * 1000),
+			Number:          number,
+			URL:             fmt.Sprintf("https://github.com/owner/repo/pull/%d", number),
+			Title:           fmt.Sprintf("test PR %d", number),
+			Author:          "alice",
+			State:           "open",
+			HeadBranch:      "feature-branch",
+			BaseBranch:      "main",
+			PlatformHeadSHA: "abc123def456",
+			CreatedAt:       unchangedAt,
+			UpdatedAt:       unchangedAt,
+			LastActivityAt:  unchangedAt,
+			DetailFetchedAt: &detailFetchedAt,
+		})
+		require.NoError(err)
+	}
+
+	mc := &detailTrackingClient{}
+	mc.openPRs = openPRs
+	mc.listOpenIssuesErr = notModifiedErr()
+	mc.comments = []*gh.IssueComment{}
+	mc.reviews = []*gh.PullRequestReview{}
+	mc.commits = []*gh.RepositoryCommit{}
+	mc.ciStatus = &gh.CombinedStatus{State: new(string)}
+
+	var graphQLPRCalls atomic.Int32
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), "pullRequests") {
+			graphQLPRCalls.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"bulk PR fetch should be skipped"}]}`))
+	}))
+	defer gqlSrv.Close()
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(10000),
+	)
+	syncer.SetFetchers(map[string]*GraphQLFetcher{
+		"github.com": NewGraphQLFetcherWithClient(
+			githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client()),
+			nil,
+		),
+	})
+
+	syncer.RunOnce(ctx)
+
+	assert.True(mc.listOpenPRsCalled,
+		"large repo refresh should still read the open PR index")
+	assert.Zero(int(graphQLPRCalls.Load()),
+		"large existing repo refresh should not bulk-fetch every PR through GraphQL")
+	assert.Equal(int32(1), mc.getPRCalls.Load(),
+		"only the changed PR should be fetched by the detail drain")
+	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(pr)
+	assert.True(pr.UpdatedAt.Equal(changedAt))
 }
 
 func TestDetailDrainUsesProviderReadersForNonGitHub(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4368,6 +4368,41 @@ func TestFetchMRDetailPersistsPullRequestETag(t *testing.T) {
 	assert.Equal(`"etag-v2"`, etag)
 }
 
+func TestFetchMRDetailDoesNotPersistPullRequestETagWhenDetailRefreshFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mc := &conditionalPRTrackingClient{nextETag: `"etag-v2"`}
+	mc.singlePR = buildOpenPR(1, updatedAt)
+	mc.listIssueCommentsErr = fmt.Errorf("transient comments failure")
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	_, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.Error(err)
+
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1,
+	)
+	require.NoError(err)
+	assert.Equal(`"etag-v1"`, etag)
+}
+
 func TestFetchIssueDetailUsesPersistedIssueETag(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -4459,6 +4494,57 @@ func TestFetchIssueDetailPersistsIssueETag(t *testing.T) {
 	)
 	require.NoError(err)
 	assert.Equal(`"issue-etag-v2"`, etag)
+}
+
+func TestFetchIssueDetailDoesNotPersistIssueETagWhenDetailRefreshFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"issue", 1, `"issue-etag-v1"`,
+	))
+
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	issueID := int64(1000)
+	issueNumber := 1
+	issueTitle := "test issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/1"
+
+	mc := &conditionalIssueTrackingClient{nextETag: `"issue-etag-v2"`}
+	mc.getIssueFn = func(context.Context, string, string, int) (*gh.Issue, error) {
+		return &gh.Issue{
+			ID:        &issueID,
+			Number:    &issueNumber,
+			Title:     &issueTitle,
+			State:     &issueState,
+			HTMLURL:   &issueURL,
+			CreatedAt: makeTimestamp(updatedAt),
+			UpdatedAt: makeTimestamp(updatedAt),
+		}, nil
+	}
+	mc.listIssueCommentsErr = fmt.Errorf("transient comments failure")
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	_, err = syncer.fetchIssueDetail(ctx, repo, repoID, 1)
+	require.Error(err)
+
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"issue", 1,
+	)
+	require.NoError(err)
+	assert.Equal(`"issue-etag-v1"`, etag)
 }
 
 func TestBulkGraphQLGateUsesLocalMergeRequestCount(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -658,6 +658,24 @@ func buildOpenPR(number int, updatedAt time.Time) *gh.PullRequest {
 	}
 }
 
+func buildOpenIssue(number int, updatedAt time.Time) *gh.Issue {
+	state := "open"
+	title := fmt.Sprintf("test issue %d", number)
+	url := fmt.Sprintf("https://github.com/owner/repo/issues/%d", number)
+	id := int64(number) * 1000
+	author := "alice"
+	return &gh.Issue{
+		ID:        &id,
+		Number:    &number,
+		Title:     &title,
+		HTMLURL:   &url,
+		State:     &state,
+		User:      &gh.User{Login: &author},
+		UpdatedAt: makeTimestamp(updatedAt),
+		CreatedAt: makeTimestamp(updatedAt),
+	}
+}
+
 func buildGitHubLabel(id int64, name, description, color string, isDefault bool) *gh.Label {
 	return &gh.Label{
 		ID:          &id,
@@ -7022,6 +7040,52 @@ func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *t
 	events, err = d.ListIssueEvents(ctx, issue.ID)
 	require.NoError(err)
 	assert.Empty(events)
+}
+
+func TestSyncIssuesFromListLogsProgressForLargeIssueSets(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	issues := make([]*gh.Issue, 0, 201)
+	for number := 1; number <= 201; number++ {
+		issues = append(issues, buildOpenIssue(number, now))
+	}
+
+	var buf bytes.Buffer
+	sw := &syncedWriter{w: &buf}
+	h := slog.NewTextHandler(sw, &slog.HandlerOptions{Level: slog.LevelInfo})
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	client := &mockClient{}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		d, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+
+	err = syncer.syncIssuesFromList(ctx, client, repo, repoID, issues, false)
+	require.NoError(err)
+
+	logs := buf.String()
+	assert.Contains(logs, `msg="issue sync started"`)
+	assert.Contains(logs, "repo=owner/repo")
+	assert.Contains(logs, "platform=github")
+	assert.Contains(logs, "host=github.com")
+	assert.Contains(logs, "source=rest")
+	assert.Contains(logs, "total=201")
+	assert.Contains(logs, `msg="issue sync progress"`)
+	assert.Contains(logs, "processed=100")
+	assert.Contains(logs, "processed=200")
+	assert.Contains(logs, `msg="issue sync completed"`)
+	assert.Contains(logs, "processed=201")
 }
 
 func TestSyncRepoGraphQLIssues(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -4152,6 +4152,29 @@ func (c *conditionalPRTrackingClient) GetPullRequestIfChanged(
 	return pr, c.nextETag, false, err
 }
 
+type conditionalIssueTrackingClient struct {
+	mockClient
+	receivedETag     string
+	conditionalCalls atomic.Int32
+	notModified      bool
+	nextETag         string
+}
+
+func (c *conditionalIssueTrackingClient) GetIssueIfChanged(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	etag string,
+) (*gh.Issue, string, bool, error) {
+	c.conditionalCalls.Add(1)
+	c.receivedETag = etag
+	if c.notModified {
+		return nil, etag, true, nil
+	}
+	issue, err := c.GetIssue(ctx, owner, repo, number)
+	return issue, c.nextETag, false, err
+}
+
 func TestRunOnceIndexOnly(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -4343,6 +4366,99 @@ func TestFetchMRDetailPersistsPullRequestETag(t *testing.T) {
 	)
 	require.NoError(err)
 	assert.Equal(`"etag-v2"`, etag)
+}
+
+func TestFetchIssueDetailUsesPersistedIssueETag(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	detailFetchedAt := time.Date(2024, 6, 1, 9, 0, 0, 0, time.UTC)
+	_, err = d.UpsertIssue(ctx, &db.Issue{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/issues/1",
+		Title:           "test issue",
+		Author:          "alice",
+		State:           "open",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"issue", 1, `"issue-etag-v1"`,
+	))
+
+	mc := &conditionalIssueTrackingClient{notModified: true}
+	mc.comments = []*gh.IssueComment{{ID: new(int64)}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	_, err = syncer.fetchIssueDetail(ctx, repo, repoID, 1)
+	require.NoError(err)
+
+	assert.Equal(int32(1), mc.conditionalCalls.Load())
+	assert.Equal(`"issue-etag-v1"`, mc.receivedETag)
+	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
+		"304 should skip issue comment refresh")
+}
+
+func TestFetchIssueDetailPersistsIssueETag(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	issueID := int64(1000)
+	issueNumber := 1
+	issueTitle := "test issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/1"
+
+	mc := &conditionalIssueTrackingClient{nextETag: `"issue-etag-v2"`}
+	mc.getIssueFn = func(context.Context, string, string, int) (*gh.Issue, error) {
+		return &gh.Issue{
+			ID:        &issueID,
+			Number:    &issueNumber,
+			Title:     &issueTitle,
+			State:     &issueState,
+			HTMLURL:   &issueURL,
+			CreatedAt: makeTimestamp(updatedAt),
+			UpdatedAt: makeTimestamp(updatedAt),
+		}, nil
+	}
+	mc.comments = []*gh.IssueComment{}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	_, err = syncer.fetchIssueDetail(ctx, repo, repoID, 1)
+	require.NoError(err)
+
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"issue", 1,
+	)
+	require.NoError(err)
+	assert.Equal(`"issue-etag-v2"`, etag)
 }
 
 func TestRunOnceLargeExistingRepoSkipsBulkGraphQLAndFetchesChangedPRDetail(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -6467,7 +6467,6 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
 
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
-	client := setupTestClient(t, srv)
 
 	srv.syncer.RunOnce(ctx)
 
@@ -6476,17 +6475,18 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
 	assert.Equal(int32(1), conditionalCalls.Load(),
 		"only the changed PR should run a conditional detail fetch")
 
-	detailResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
-		ctx, "gh", "acme", "widget", 1,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, detailResp.StatusCode())
-	require.NotNil(detailResp.JSON200)
-	assert.Equal("changed PR detail", detailResp.JSON200.MergeRequest.Title)
-	assert.Equal(int64(1), detailResp.JSON200.MergeRequest.CommentCount)
-	require.NotNil(detailResp.JSON200.Events)
-	require.Len(*detailResp.JSON200.Events, 1)
-	assert.Equal("detail comment", (*detailResp.JSON200.Events)[0].Body)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pulls/gh/acme/widget/1", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var detailResp mergeRequestDetailResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &detailResp))
+	require.NotNil(detailResp.MergeRequest)
+	assert.Equal("changed PR detail", detailResp.MergeRequest.Title)
+	assert.Equal(1, detailResp.MergeRequest.CommentCount)
+	require.Len(detailResp.Events, 1)
+	assert.Equal("detail comment", detailResp.Events[0].Body)
 
 	etag, err := database.GetHTTPEtag(
 		ctx, "github", "github.com", "acme", "widget",

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -84,6 +84,7 @@ type mockGH struct {
 	getPullRequestFn          func(context.Context, string, string, int) (*gh.PullRequest, error)
 	getPullRequestIfChangedFn func(context.Context, string, string, int, string) (*gh.PullRequest, string, bool, error)
 	getIssueFn                func(context.Context, string, string, int) (*gh.Issue, error)
+	getIssueIfChangedFn       func(context.Context, string, string, int, string) (*gh.Issue, string, bool, error)
 	createIssueFn             func(context.Context, string, string, string, string) (*gh.Issue, error)
 	getUserFn                 func(context.Context, string) (*gh.User, error)
 	markReadyForReviewFn      func(context.Context, string, string, int) (*gh.PullRequest, error)
@@ -132,6 +133,19 @@ func (m *mockGH) GetIssue(ctx context.Context, owner, repo string, number int) (
 		return m.getIssueFn(ctx, owner, repo, number)
 	}
 	return nil, nil
+}
+
+func (m *mockGH) GetIssueIfChanged(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	etag string,
+) (*gh.Issue, string, bool, error) {
+	if m.getIssueIfChangedFn != nil {
+		return m.getIssueIfChangedFn(ctx, owner, repo, number, etag)
+	}
+	issue, err := m.GetIssue(ctx, owner, repo, number)
+	return issue, "", false, err
 }
 
 func (m *mockGH) CreateIssue(
@@ -6494,6 +6508,167 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
 	)
 	require.NoError(err)
 	assert.Equal(`"etag-v2"`, etag)
+}
+
+func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalIssueDetail(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+
+	unchangedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	detailFetchedAt := time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC)
+	changedAt := time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC)
+
+	buildIssue := func(number int, updatedAt time.Time, title string) *gh.Issue {
+		id := int64(number * 1000)
+		state := "open"
+		url := fmt.Sprintf("https://github.com/acme/widget/issues/%d", number)
+		author := "alice"
+		body := fmt.Sprintf("issue body %d", number)
+		comments := 1
+		created := gh.Timestamp{Time: unchangedAt}
+		updated := gh.Timestamp{Time: updatedAt}
+		return &gh.Issue{
+			ID:        &id,
+			Number:    &number,
+			State:     &state,
+			Title:     &title,
+			Body:      &body,
+			HTMLURL:   &url,
+			User:      &gh.User{Login: &author},
+			Comments:  &comments,
+			CreatedAt: &created,
+			UpdatedAt: &updated,
+		}
+	}
+
+	openIssues := make([]*gh.Issue, 0, 100)
+	for number := 1; number <= 100; number++ {
+		openIssues = append(openIssues,
+			buildIssue(number, unchangedAt, fmt.Sprintf("existing issue %d", number)),
+		)
+	}
+
+	var conditionalCalls atomic.Int32
+	var graphQLIssueCalls atomic.Int32
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return openIssues, nil
+		},
+		getIssueIfChangedFn: func(_ context.Context, _, _ string, number int, etag string) (*gh.Issue, string, bool, error) {
+			conditionalCalls.Add(1)
+			require.Equal(1, number)
+			require.Equal(`"issue-etag-v1"`, etag)
+			return buildIssue(number, changedAt, "changed issue detail"), `"issue-etag-v2"`, false, nil
+		},
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			if number != 1 {
+				return nil, nil
+			}
+			id := int64(9101)
+			body := "issue detail comment"
+			author := "reviewer"
+			created := gh.Timestamp{Time: changedAt}
+			return []*gh.IssueComment{{
+				ID:        &id,
+				Body:      &body,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &created,
+				UpdatedAt: &created,
+			}}, nil
+		},
+	}
+
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if bytes.Contains(body, []byte("issues")) {
+			graphQLIssueCalls.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"bulk issue fetch should be skipped"}]}`))
+	}))
+	defer gqlSrv.Close()
+
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	for number := 1; number <= 100; number++ {
+		var fetchedAt *time.Time
+		if number != 1 {
+			fetchedAt = &detailFetchedAt
+		}
+		_, err := database.UpsertIssue(ctx, &db.Issue{
+			RepoID:          repoID,
+			PlatformID:      int64(number * 1000),
+			Number:          number,
+			URL:             fmt.Sprintf("https://github.com/acme/widget/issues/%d", number),
+			Title:           fmt.Sprintf("existing issue %d", number),
+			Author:          "alice",
+			State:           "open",
+			CreatedAt:       unchangedAt,
+			UpdatedAt:       unchangedAt,
+			LastActivityAt:  unchangedAt,
+			DetailFetchedAt: fetchedAt,
+		})
+		require.NoError(err)
+	}
+	require.NoError(database.UpsertHTTPEtag(
+		ctx, "github", "github.com", "acme", "widget",
+		"issue", 1, `"issue-etag-v1"`,
+	))
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+	syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcherWithClient(
+			githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client()),
+			nil,
+		),
+	})
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	srv.syncer.RunOnce(ctx)
+
+	assert.Zero(int(graphQLIssueCalls.Load()),
+		"large existing repo refresh should not bulk-fetch issues through GraphQL")
+	assert.Equal(int32(1), conditionalCalls.Load(),
+		"only the missing-detail issue should run a conditional detail fetch")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/gh/acme/widget/1", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var detailResp issueDetailResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &detailResp))
+	require.NotNil(detailResp.Issue)
+	assert.Equal("changed issue detail", detailResp.Issue.Title)
+	assert.Equal(1, detailResp.Issue.CommentCount)
+	require.Len(detailResp.Events, 1)
+	assert.Equal("issue detail comment", detailResp.Events[0].Body)
+
+	etag, err := database.GetHTTPEtag(
+		ctx, "github", "github.com", "acme", "widget",
+		"issue", 1,
+	)
+	require.NoError(err)
+	assert.Equal(`"issue-etag-v2"`, etag)
 }
 
 // TestE2EGraphQLIssueSyncTrustsTotalCount pre-seeds an issue with a

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -82,6 +82,7 @@ func gracefulShutdown(t *testing.T, srv interface{ Shutdown(context.Context) err
 type mockGH struct {
 	getRepositoryFn           func(context.Context, string, string) (*gh.Repository, error)
 	getPullRequestFn          func(context.Context, string, string, int) (*gh.PullRequest, error)
+	getPullRequestIfChangedFn func(context.Context, string, string, int, string) (*gh.PullRequest, string, bool, error)
 	getIssueFn                func(context.Context, string, string, int) (*gh.Issue, error)
 	createIssueFn             func(context.Context, string, string, string, string) (*gh.Issue, error)
 	getUserFn                 func(context.Context, string) (*gh.User, error)
@@ -195,6 +196,19 @@ func (m *mockGH) GetPullRequest(ctx context.Context, owner, repo string, number 
 		return m.getPullRequestFn(ctx, owner, repo, number)
 	}
 	return nil, nil
+}
+
+func (m *mockGH) GetPullRequestIfChanged(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	etag string,
+) (*gh.PullRequest, string, bool, error) {
+	if m.getPullRequestIfChangedFn != nil {
+		return m.getPullRequestIfChangedFn(ctx, owner, repo, number, etag)
+	}
+	pr, err := m.GetPullRequest(ctx, owner, repo, number)
+	return pr, "", false, err
 }
 
 func (m *mockGH) ListIssueComments(
@@ -6313,6 +6327,173 @@ func TestE2EGraphQLIssueSyncThroughAPI(t *testing.T) {
 	require.NotNil(detailResp.JSON200)
 	assert.Equal("Synced through the HTTP API", detailResp.JSON200.Issue.Body)
 	assert.Equal(int64(1), detailResp.JSON200.Issue.CommentCount)
+}
+
+func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+
+	unchangedAt := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	detailFetchedAt := time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC)
+	changedAt := time.Date(2026, 4, 12, 12, 0, 0, 0, time.UTC)
+
+	buildPR := func(number int, updatedAt time.Time, title string) *gh.PullRequest {
+		id := int64(number * 1000)
+		state := "open"
+		url := fmt.Sprintf("https://github.com/acme/widget/pull/%d", number)
+		author := "alice"
+		headSHA := fmt.Sprintf("head-%d", number)
+		headRef := fmt.Sprintf("feature-%d", number)
+		baseRef := "main"
+		created := gh.Timestamp{Time: unchangedAt}
+		updated := gh.Timestamp{Time: updatedAt}
+		comments := 1
+		return &gh.PullRequest{
+			ID:        &id,
+			Number:    &number,
+			State:     &state,
+			Title:     &title,
+			HTMLURL:   &url,
+			User:      &gh.User{Login: &author},
+			CreatedAt: &created,
+			UpdatedAt: &updated,
+			Comments:  &comments,
+			Head:      &gh.PullRequestBranch{SHA: &headSHA, Ref: &headRef},
+			Base:      &gh.PullRequestBranch{Ref: &baseRef},
+		}
+	}
+
+	openPRs := make([]*gh.PullRequest, 0, 100)
+	for number := 1; number <= 100; number++ {
+		updatedAt := unchangedAt
+		title := fmt.Sprintf("existing PR %d", number)
+		if number == 1 {
+			updatedAt = changedAt
+			title = "changed PR from list"
+		}
+		openPRs = append(openPRs, buildPR(number, updatedAt, title))
+	}
+
+	var conditionalCalls atomic.Int32
+	var graphQLPRCalls atomic.Int32
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return openPRs, nil
+		},
+		listOpenIssuesFn: func(_ context.Context, _, _ string) ([]*gh.Issue, error) {
+			return nil, &gh.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotModified},
+			}
+		},
+		getPullRequestIfChangedFn: func(_ context.Context, _, _ string, number int, etag string) (*gh.PullRequest, string, bool, error) {
+			conditionalCalls.Add(1)
+			require.Equal(1, number)
+			require.Equal(`"etag-v1"`, etag)
+			return buildPR(number, changedAt, "changed PR detail"), `"etag-v2"`, false, nil
+		},
+		listIssueCommentsFn: func(_ context.Context, _, _ string, number int) ([]*gh.IssueComment, error) {
+			if number != 1 {
+				return nil, nil
+			}
+			id := int64(9001)
+			body := "detail comment"
+			author := "reviewer"
+			created := gh.Timestamp{Time: changedAt}
+			return []*gh.IssueComment{{
+				ID:        &id,
+				Body:      &body,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &created,
+				UpdatedAt: &created,
+			}}, nil
+		},
+	}
+
+	gqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if bytes.Contains(body, []byte("pullRequests")) {
+			graphQLPRCalls.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"bulk PR fetch should be skipped"}]}`))
+	}))
+	defer gqlSrv.Close()
+
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	for number := 1; number <= 100; number++ {
+		_, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID:          repoID,
+			PlatformID:      int64(number * 1000),
+			Number:          number,
+			URL:             fmt.Sprintf("https://github.com/acme/widget/pull/%d", number),
+			Title:           fmt.Sprintf("existing PR %d", number),
+			Author:          "alice",
+			State:           "open",
+			HeadBranch:      fmt.Sprintf("feature-%d", number),
+			BaseBranch:      "main",
+			PlatformHeadSHA: fmt.Sprintf("head-%d", number),
+			CreatedAt:       unchangedAt,
+			UpdatedAt:       unchangedAt,
+			LastActivityAt:  unchangedAt,
+			DetailFetchedAt: &detailFetchedAt,
+		})
+		require.NoError(err)
+	}
+	require.NoError(database.UpsertHTTPEtag(
+		ctx, "github", "github.com", "acme", "widget",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		defaultTestRepos,
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{"github.com": ghclient.NewSyncBudget(10000)},
+	)
+	t.Cleanup(syncer.Stop)
+	syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcherWithClient(
+			githubv4.NewEnterpriseClient(gqlSrv.URL, gqlSrv.Client()),
+			nil,
+		),
+	})
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	assert.Zero(int(graphQLPRCalls.Load()),
+		"large existing repo refresh should not bulk-fetch PRs through GraphQL")
+	assert.Equal(int32(1), conditionalCalls.Load(),
+		"only the changed PR should run a conditional detail fetch")
+
+	detailResp, err := client.HTTP.GetPullsByProviderByOwnerByNameByNumberWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode())
+	require.NotNil(detailResp.JSON200)
+	assert.Equal("changed PR detail", detailResp.JSON200.MergeRequest.Title)
+	assert.Equal(int64(1), detailResp.JSON200.MergeRequest.CommentCount)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	assert.Equal("detail comment", (*detailResp.JSON200.Events)[0].Body)
+
+	etag, err := database.GetHTTPEtag(
+		ctx, "github", "github.com", "acme", "widget",
+		"pull_request", 1,
+	)
+	require.NoError(err)
+	assert.Equal(`"etag-v2"`, etag)
 }
 
 // TestE2EGraphQLIssueSyncTrustsTotalCount pre-seeds an issue with a


### PR DESCRIPTION
- Add structured progress logs for large issue and merge request list fetches and sync batches
- Persist per-PR and per-issue REST ETags and use conditional detail refreshes so unchanged items can skip comment/timeline work
- Keep large existing repo refreshes on the incremental index/detail-drain path instead of bulk-fetching every open PR or issue through GraphQL