### PR TITLE
fix(ui): sync repo dropdown and sidebar list when deep-linking to a PR/issue

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
+  import { onDestroy, untrack } from "svelte";
   import {
     Provider,
     PRListView,
@@ -33,6 +33,7 @@
   import { MonitorIcon, SpinnerIcon } from "./lib/icons.ts";
   import { showFlash } from "./lib/stores/flash.svelte.js";
   import { initItemRefHandler } from "./lib/utils/itemRefHandler.js";
+  import { globalRepoForSelectedRoute } from "./lib/utils/repoSelectionSync.js";
   import { runAppStartup } from "./lib/utils/appStartup.js";
   import {
     initTheme,
@@ -333,6 +334,20 @@
         stores.issues.clearIssueSelection();
       }
     }
+  });
+
+  // Keep the repo dropdown and sidebar list aligned with the item in
+  // the URL. Without this, navigating to a PR/issue link leaves the
+  // dropdown and left list pinned to whichever repo was picked before,
+  // even though the detail pane jumped to a different one.
+  $effect(() => {
+    if (!stores) return;
+    if (getUIConfig().hideRepoSelector) return;
+    if (!stores.settings.hasConfiguredRepos()) return;
+    const next = globalRepoForSelectedRoute(getRoute());
+    if (next === undefined) return;
+    if (untrack(getGlobalRepo) === next) return;
+    setGlobalRepo(next);
   });
 
   type DrawerItem = RoutedItemRef & {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -116,6 +116,18 @@
     appReady = false;
   }
 
+  function syncGlobalRepoWithRoute(
+    routeStores: StoreInstances | undefined = stores,
+  ): void {
+    if (!routeStores) return;
+    if (getUIConfig().hideRepoSelector) return;
+    if (!routeStores.settings.hasConfiguredRepos()) return;
+    const next = globalRepoForSelectedRoute(getRoute());
+    if (next === undefined) return;
+    if (untrack(getGlobalRepo) === next) return;
+    setGlobalRepo(next);
+  }
+
   function startFullAppShell(startupStores: StoreInstances) {
     if (cleanupFullAppShell) return;
     fullShellStores = startupStores;
@@ -131,6 +143,7 @@
     const cancelStartup = runAppStartup({
       getSettings,
       getStores: () => startupStores,
+      beforeInitialLoad: () => syncGlobalRepoWithRoute(startupStores),
       onReady: () => {
         appReady = true;
       },
@@ -341,13 +354,7 @@
   // dropdown and left list pinned to whichever repo was picked before,
   // even though the detail pane jumped to a different one.
   $effect(() => {
-    if (!stores) return;
-    if (getUIConfig().hideRepoSelector) return;
-    if (!stores.settings.hasConfiguredRepos()) return;
-    const next = globalRepoForSelectedRoute(getRoute());
-    if (next === undefined) return;
-    if (untrack(getGlobalRepo) === next) return;
-    setGlobalRepo(next);
+    syncGlobalRepoWithRoute();
   });
 
   type DrawerItem = RoutedItemRef & {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -122,9 +122,11 @@
     if (!routeStores) return;
     if (getUIConfig().hideRepoSelector) return;
     if (!routeStores.settings.hasConfiguredRepos()) return;
+    const currentRepo = untrack(getGlobalRepo);
+    if (currentRepo === undefined) return;
     const next = globalRepoForSelectedRoute(getRoute());
     if (next === undefined) return;
-    if (untrack(getGlobalRepo) === next) return;
+    if (currentRepo === next) return;
     setGlobalRepo(next);
   }
 

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -91,6 +91,32 @@ describe("runAppStartup", () => {
     expect(stores.events.connect).toHaveBeenCalledTimes(1);
   });
 
+  it("runs the pre-load hook before marking the app ready and loading lists", async () => {
+    const stores = makeStores();
+    const beforeInitialLoad = vi.fn();
+    const onReady = vi.fn();
+
+    runAppStartup({
+      getSettings: () => Promise.resolve(makeSettings()),
+      getStores: () => stores,
+      beforeInitialLoad,
+      onReady,
+    });
+
+    await flushMicrotasks();
+
+    expect(beforeInitialLoad).toHaveBeenCalledTimes(1);
+    const beforeOrder = beforeInitialLoad.mock.invocationCallOrder[0] ?? 0;
+    const readyOrder = onReady.mock.invocationCallOrder[0] ?? 0;
+    const pullLoadOrder = vi.mocked(stores.pulls.loadPulls)
+      .mock.invocationCallOrder[0] ?? 0;
+    const issueLoadOrder = vi.mocked(stores.issues.loadIssues)
+      .mock.invocationCallOrder[0] ?? 0;
+    expect(beforeOrder).toBeLessThan(readyOrder);
+    expect(beforeOrder).toBeLessThan(pullLoadOrder);
+    expect(beforeOrder).toBeLessThan(issueLoadOrder);
+  });
+
   it("skips every post-await side effect when cancelled before settings resolve", async () => {
     const stores = makeStores();
     let resolveSettings: (value: Settings) => void = () => {};

--- a/frontend/src/lib/utils/appStartup.ts
+++ b/frontend/src/lib/utils/appStartup.ts
@@ -5,6 +5,7 @@ export interface AppStartupDeps {
   getSettings: () => Promise<Settings>;
   getStores: () => StoreInstances | undefined;
   onReady: () => void;
+  beforeInitialLoad?: () => void;
 }
 
 const SETTINGS_STARTUP_TIMEOUT_MS = 8_000;
@@ -67,6 +68,8 @@ export function runAppStartup(deps: AppStartupDeps): () => void {
         err,
       );
     }
+    if (cancelled) return;
+    deps.beforeInitialLoad?.();
     if (cancelled) return;
     deps.onReady();
     const stores = deps.getStores();

--- a/frontend/src/lib/utils/repoSelectionSync.test.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.test.ts
@@ -21,7 +21,7 @@ const issueSelected = {
 };
 
 describe("globalRepoForSelectedRoute", () => {
-  it("returns platformHost/owner/name for a pulls route with a selected PR", () => {
+  it("returns platformHost/repoPath for a pulls route with a selected PR", () => {
     const route: Route = {
       page: "pulls", view: "list", selected: prSelected,
     };
@@ -30,7 +30,7 @@ describe("globalRepoForSelectedRoute", () => {
     );
   });
 
-  it("returns platformHost/owner/name for an issues route with a selected issue", () => {
+  it("returns platformHost/repoPath for an issues route with a selected issue", () => {
     const route: Route = {
       page: "issues", selected: issueSelected,
     };
@@ -39,7 +39,7 @@ describe("globalRepoForSelectedRoute", () => {
     );
   });
 
-  it("returns platformHost/owner/name for a focus PR route", () => {
+  it("returns platformHost/repoPath for a focus PR route", () => {
     const route: Route = {
       page: "focus",
       itemType: "pr",
@@ -55,7 +55,7 @@ describe("globalRepoForSelectedRoute", () => {
     );
   });
 
-  it("returns platformHost/owner/name for a focus issue route", () => {
+  it("returns platformHost/repoPath for a focus issue route", () => {
     const route: Route = {
       page: "focus",
       itemType: "issue",
@@ -68,6 +68,23 @@ describe("globalRepoForSelectedRoute", () => {
     };
     expect(globalRepoForSelectedRoute(route)).toBe(
       "gitlab.example.com/team/infra",
+    );
+  });
+
+  it("keeps nested repo paths intact", () => {
+    const route: Route = {
+      page: "issues",
+      selected: {
+        provider: "gitlab",
+        platformHost: "gitlab.example.com",
+        owner: "Group/SubGroup",
+        name: "Project.Special",
+        repoPath: "Group/SubGroup/Project.Special",
+        number: 17,
+      },
+    };
+    expect(globalRepoForSelectedRoute(route)).toBe(
+      "gitlab.example.com/Group/SubGroup/Project.Special",
     );
   });
 

--- a/frontend/src/lib/utils/repoSelectionSync.test.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { globalRepoForSelectedRoute } from "./repoSelectionSync.js";
+import type { Route } from "../stores/router.svelte.ts";
+
+const prSelected = {
+  provider: "github",
+  platformHost: "github.com",
+  owner: "acme",
+  name: "tools",
+  repoPath: "acme/tools",
+  number: 42,
+};
+
+const issueSelected = {
+  provider: "gitlab",
+  platformHost: "gitlab.example.com",
+  owner: "team",
+  name: "infra",
+  repoPath: "team/infra",
+  number: 7,
+};
+
+describe("globalRepoForSelectedRoute", () => {
+  it("returns platformHost/owner/name for a pulls route with a selected PR", () => {
+    const route: Route = {
+      page: "pulls", view: "list", selected: prSelected,
+    };
+    expect(globalRepoForSelectedRoute(route)).toBe(
+      "github.com/acme/tools",
+    );
+  });
+
+  it("returns platformHost/owner/name for an issues route with a selected issue", () => {
+    const route: Route = {
+      page: "issues", selected: issueSelected,
+    };
+    expect(globalRepoForSelectedRoute(route)).toBe(
+      "gitlab.example.com/team/infra",
+    );
+  });
+
+  it("returns platformHost/owner/name for a focus PR route", () => {
+    const route: Route = {
+      page: "focus",
+      itemType: "pr",
+      provider: "github",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "tools",
+      repoPath: "acme/tools",
+      number: 42,
+    };
+    expect(globalRepoForSelectedRoute(route)).toBe(
+      "github.com/acme/tools",
+    );
+  });
+
+  it("returns platformHost/owner/name for a focus issue route", () => {
+    const route: Route = {
+      page: "focus",
+      itemType: "issue",
+      provider: "gitlab",
+      platformHost: "gitlab.example.com",
+      owner: "team",
+      name: "infra",
+      repoPath: "team/infra",
+      number: 7,
+    };
+    expect(globalRepoForSelectedRoute(route)).toBe(
+      "gitlab.example.com/team/infra",
+    );
+  });
+
+  it("returns undefined for a pulls list route without a selection", () => {
+    const route: Route = { page: "pulls", view: "list" };
+    expect(globalRepoForSelectedRoute(route)).toBeUndefined();
+  });
+
+  it("returns undefined for an issues list route without a selection", () => {
+    const route: Route = { page: "issues" };
+    expect(globalRepoForSelectedRoute(route)).toBeUndefined();
+  });
+
+  it("returns undefined for activity, repos, settings, reviews, workspaces", () => {
+    const pages: Route[] = [
+      { page: "activity" },
+      { page: "repos" },
+      { page: "settings" },
+      { page: "reviews" },
+      { page: "workspaces" },
+    ];
+    for (const route of pages) {
+      expect(globalRepoForSelectedRoute(route)).toBeUndefined();
+    }
+  });
+
+  it("returns undefined for focus list-only routes (mrs/issues without a specific item)", () => {
+    expect(globalRepoForSelectedRoute({
+      page: "focus", itemType: "mrs",
+    })).toBeUndefined();
+    expect(globalRepoForSelectedRoute({
+      page: "focus", itemType: "issues",
+    })).toBeUndefined();
+  });
+
+  it("returns undefined when platformHost is missing on the selected item", () => {
+    const route: Route = {
+      page: "pulls",
+      view: "list",
+      selected: {
+        provider: "custom",
+        owner: "acme",
+        name: "tools",
+        repoPath: "acme/tools",
+        number: 42,
+      },
+    };
+    expect(globalRepoForSelectedRoute(route)).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/utils/repoSelectionSync.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.ts
@@ -1,0 +1,28 @@
+import type { Route } from "../stores/router.svelte.ts";
+
+// When the URL points at a specific PR or issue, returns the repo
+// key (`platformHost/owner/name`) that the global repo filter and
+// dropdown should follow. Returns undefined for routes that don't
+// nail down a single item, or when the selected item has no
+// platformHost (which leaves the dropdown without a stable match).
+export function globalRepoForSelectedRoute(route: Route): string | undefined {
+  let selected:
+    | { platformHost?: string | undefined; owner: string; name: string }
+    | undefined;
+  if (route.page === "pulls" && "selected" in route && route.selected) {
+    selected = route.selected;
+  } else if (route.page === "issues" && route.selected) {
+    selected = route.selected;
+  } else if (
+    route.page === "focus"
+    && (route.itemType === "pr" || route.itemType === "issue")
+  ) {
+    selected = {
+      platformHost: route.platformHost,
+      owner: route.owner,
+      name: route.name,
+    };
+  }
+  if (!selected || !selected.platformHost) return undefined;
+  return `${selected.platformHost}/${selected.owner}/${selected.name}`;
+}

--- a/frontend/src/lib/utils/repoSelectionSync.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.ts
@@ -1,13 +1,13 @@
 import type { Route } from "../stores/router.svelte.ts";
 
-// When the URL points at a specific PR or issue, returns the repo
-// key (`platformHost/owner/name`) that the global repo filter and
-// dropdown should follow. Returns undefined for routes that don't
-// nail down a single item, or when the selected item has no
-// platformHost (which leaves the dropdown without a stable match).
+// When the URL points at a specific PR or issue, returns the repo key
+// (`platformHost/repoPath`) that the global repo filter and dropdown should
+// follow. Returns undefined for routes that don't nail down a single item, or
+// when the selected item has no platformHost (which leaves the dropdown
+// without a stable match).
 export function globalRepoForSelectedRoute(route: Route): string | undefined {
   let selected:
-    | { platformHost?: string | undefined; owner: string; name: string }
+    | { platformHost?: string | undefined; repoPath: string }
     | undefined;
   if (route.page === "pulls" && "selected" in route && route.selected) {
     selected = route.selected;
@@ -19,10 +19,9 @@ export function globalRepoForSelectedRoute(route: Route): string | undefined {
   ) {
     selected = {
       platformHost: route.platformHost,
-      owner: route.owner,
-      name: route.name,
+      repoPath: route.repoPath,
     };
   }
   if (!selected || !selected.platformHost) return undefined;
-  return `${selected.platformHost}/${selected.owner}/${selected.name}`;
+  return `${selected.platformHost}/${selected.repoPath}`;
 }

--- a/frontend/tests/e2e-full/container-layout.spec.ts
+++ b/frontend/tests/e2e-full/container-layout.spec.ts
@@ -56,7 +56,7 @@ test.describe("container-aware layout", () => {
     await expect(page.getByRole("button", { name: "Sync" })).toBeVisible();
     await expect(page.locator(".sync-btn .sync-label")).not.toBeVisible();
 
-    await page.getByRole("button", { name: "All repos" }).click();
+    await page.locator(".typeahead-trigger").click();
     await expect(page.locator(".typeahead-list")).toBeVisible();
     const repoMenuStyle = await page.evaluate(() => {
       const list = document.querySelector(".typeahead-list");

--- a/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
+++ b/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Regression coverage: deep-linking to a PR or issue used to leave the
+// repo dropdown and the left sidebar list pinned to whichever repo was
+// previously picked, even though the detail pane jumped to the new repo.
+// App.svelte now syncs globalRepo to match the route's selected item.
+// Seed: acme/widgets and acme/tools on github.com (cmd/e2e-server).
+
+async function waitForPullDetail(page: Page): Promise<void> {
+  await page.locator(".pull-detail")
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+async function waitForIssueDetail(page: Page): Promise<void> {
+  await page.locator(".issue-detail")
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+test.describe("deep-link repo dropdown + sidebar sync", () => {
+  test("navigating to a PR in a different repo updates the dropdown and list", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "middleman-filter-repo", "github.com/acme/widgets",
+      );
+    });
+
+    await page.goto("/pulls/github/acme/tools/1");
+    await waitForPullDetail(page);
+
+    await expect(page.locator(".typeahead-value")).toHaveText(
+      "github.com/acme/tools",
+      { timeout: 5_000 },
+    );
+
+    const repoHeaders = page.locator(".repo-header__name");
+    await expect(repoHeaders).toHaveCount(1, { timeout: 5_000 });
+    await expect(repoHeaders.first()).toHaveText("acme/tools");
+  });
+
+  test("navigating to an issue in a different repo updates the dropdown and list", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "middleman-filter-repo", "github.com/acme/tools",
+      );
+    });
+
+    await page.goto("/issues/github/acme/widgets/1");
+    await waitForIssueDetail(page);
+
+    await expect(page.locator(".typeahead-value")).toHaveText(
+      "github.com/acme/widgets",
+      { timeout: 5_000 },
+    );
+  });
+
+  test("navigating between PRs in different repos updates the dropdown each time", async ({ page }) => {
+    await page.goto("/pulls/github/acme/widgets/1");
+    await waitForPullDetail(page);
+    await expect(page.locator(".typeahead-value")).toHaveText(
+      "github.com/acme/widgets",
+      { timeout: 5_000 },
+    );
+
+    await page.goto("/pulls/github/acme/tools/1");
+    await waitForPullDetail(page);
+    await expect(page.locator(".typeahead-value")).toHaveText(
+      "github.com/acme/tools",
+      { timeout: 5_000 },
+    );
+  });
+
+  test("opening /pulls without a selection preserves the user's chosen repo", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "middleman-filter-repo", "github.com/acme/widgets",
+      );
+    });
+
+    await page.goto("/pulls");
+    await page.locator(".pull-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    await expect(page.locator(".typeahead-value")).toHaveText(
+      "github.com/acme/widgets",
+    );
+  });
+});

--- a/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
+++ b/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
@@ -54,6 +54,12 @@ test.describe("deep-link repo dropdown + sidebar sync", () => {
   });
 
   test("navigating between PRs in different repos updates the dropdown each time", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "middleman-filter-repo", "github.com/acme/widgets",
+      );
+    });
+
     await page.goto("/pulls/github/acme/widgets/1");
     await waitForPullDetail(page);
     await expect(page.locator(".typeahead-value")).toHaveText(
@@ -67,6 +73,20 @@ test.describe("deep-link repo dropdown + sidebar sync", () => {
       "github.com/acme/tools",
       { timeout: 5_000 },
     );
+  });
+
+  test("selecting an item from All repos keeps the all-repo filter", async ({ page }) => {
+    await page.goto("/pulls");
+    await page.locator(".pull-item").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    await expect(page.locator(".typeahead-value")).toHaveText("All repos");
+    await page.locator(".pull-item").filter({
+      hasText: "Add widget caching layer",
+    }).first().click();
+    await waitForPullDetail(page);
+
+    await expect(page.locator(".typeahead-value")).toHaveText("All repos");
   });
 
   test("opening /pulls without a selection preserves the user's chosen repo", async ({ page }) => {

--- a/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
+++ b/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
@@ -44,7 +44,7 @@ test.describe("deep-link repo dropdown + sidebar sync", () => {
       );
     });
 
-    await page.goto("/issues/github/acme/widgets/1");
+    await page.goto("/issues/github/acme/widgets/10");
     await waitForIssueDetail(page);
 
     await expect(page.locator(".typeahead-value")).toHaveText(

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2278,7 +2278,15 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 		args = append(args, state)
 	}
 
-	if opts.RepoOwner != "" && opts.RepoName != "" {
+	if opts.RepoPath != "" {
+		host, _, _ := canonicalRepoLookupIdentifier(opts.PlatformHost, "", "")
+		if host != "" {
+			conds = append(conds, "r.platform_host = ?")
+			args = append(args, host)
+		}
+		conds = append(conds, "r.repo_path_key = ?")
+		args = append(args, canonicalRepoPathKey(opts.RepoPath))
+	} else if opts.RepoOwner != "" && opts.RepoName != "" {
 		_, owner, name := canonicalRepoLookupIdentifier(
 			"", opts.RepoOwner, opts.RepoName,
 		)
@@ -3071,7 +3079,15 @@ func (d *DB) ListIssues(
 		args = append(args, state)
 	}
 
-	if opts.RepoOwner != "" && opts.RepoName != "" {
+	if opts.RepoPath != "" {
+		host, _, _ := canonicalRepoLookupIdentifier(opts.PlatformHost, "", "")
+		if host != "" {
+			conds = append(conds, "r.platform_host = ?")
+			args = append(args, host)
+		}
+		conds = append(conds, "r.repo_path_key = ?")
+		args = append(args, canonicalRepoPathKey(opts.RepoPath))
+	} else if opts.RepoOwner != "" && opts.RepoName != "" {
 		host, owner, name := canonicalRepoLookupIdentifier(opts.PlatformHost, opts.RepoOwner, opts.RepoName)
 		if host != "" {
 			conds = append(conds, "r.platform_host = ?")

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2067,6 +2067,31 @@ func TestListPullRequestsFilterByRepoIncludesAllHostsByDefault(t *testing.T) {
 	assert.Equal(enterpriseRepo, enterpriseOnly[0].RepoID)
 }
 
+func TestListPullRequestsFilterByHostedRepoPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	base := baseTime()
+
+	nestedRepo := insertTestRepoWithHost(
+		t, d, "Group/SubGroup", "Project.Special", "ghe.example.com",
+	)
+	otherRepo := insertTestRepoWithHost(
+		t, d, "Other", "Project.Special", "ghe.example.com",
+	)
+	insertTestMR(t, d, nestedRepo, 1, "nested pr", base)
+	insertTestMR(t, d, otherRepo, 2, "other pr", base.Add(time.Hour))
+
+	filtered, err := d.ListMergeRequests(ctx, ListMergeRequestsOpts{
+		PlatformHost: "GHE.EXAMPLE.COM",
+		RepoPath:     "Group/SubGroup/Project.Special",
+	})
+	require.NoError(err)
+	require.Len(filtered, 1)
+	assert.Equal(nestedRepo, filtered[0].RepoID)
+}
+
 func TestPullRequestRepoScopedQueriesCanonicalizeOwnerName(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -3120,6 +3145,31 @@ func TestIssueRepoScopedQueriesCanonicalizeOwnerName(t *testing.T) {
 	gotID, err := d.GetIssueIDByRepoAndNumber(ctx, "Owner", "Repo", 7)
 	require.NoError(err)
 	assert.Equal(issueID, gotID)
+}
+
+func TestListIssuesFilterByHostedRepoPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	base := baseTime()
+
+	nestedRepo := insertTestRepoWithHost(
+		t, d, "Group/SubGroup", "Project.Special", "ghe.example.com",
+	)
+	otherRepo := insertTestRepoWithHost(
+		t, d, "Other", "Project.Special", "ghe.example.com",
+	)
+	insertTestIssue(t, d, nestedRepo, 1, "nested issue", base)
+	insertTestIssue(t, d, otherRepo, 2, "other issue", base.Add(time.Hour))
+
+	filtered, err := d.ListIssues(ctx, ListIssuesOpts{
+		PlatformHost: "GHE.EXAMPLE.COM",
+		RepoPath:     "Group/SubGroup/Project.Special",
+	})
+	require.NoError(err)
+	require.Len(filtered, 1)
+	assert.Equal(nestedRepo, filtered[0].RepoID)
 }
 
 func TestListIssuesFilterBySearch(t *testing.T) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -248,6 +248,7 @@ type ListMergeRequestsOpts struct {
 	PlatformHost string
 	RepoOwner    string
 	RepoName     string
+	RepoPath     string
 	State        string
 	KanbanState  string
 	Starred      bool
@@ -303,6 +304,7 @@ type ListIssuesOpts struct {
 	PlatformHost string
 	RepoOwner    string
 	RepoName     string
+	RepoPath     string
 	State        string
 	Starred      bool
 	Search       string

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5745,6 +5745,30 @@ func TestAPIListPullsCasefoldsRepoNames(t *testing.T) {
 	assert.Equal("foo", (*resp.JSON200)[0].RepoName)
 }
 
+func TestAPIListPullsFiltersHostedNestedRepoPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "Group/SubGroup", Name: "Project.Special", PlatformHost: "ghe.example.com"},
+		{Owner: "other", Name: "repo", PlatformHost: "ghe.example.com"},
+	})
+
+	seedPROnHost(t, database, "ghe.example.com", "Group/SubGroup", "Project.Special", 1)
+	seedPROnHost(t, database, "ghe.example.com", "other", "repo", 2)
+
+	client := setupTestClient(t, srv)
+	repo := "ghe.example.com/Group/SubGroup/Project.Special"
+	resp, err := client.HTTP.ListPullsWithResponse(t.Context(), &generated.ListPullsParams{
+		Repo: &repo,
+	})
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+	assert.Equal("group/subgroup", (*resp.JSON200)[0].RepoOwner)
+	assert.Equal("project.special", (*resp.JSON200)[0].RepoName)
+}
+
 func TestAPIListIssuesIncludesLabels(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -5823,6 +5847,40 @@ func TestAPIListIssuesAcceptsHostQualifiedRepoFilter(t *testing.T) {
 	assert.Equal("acme", (*resp.JSON200)[0].RepoOwner)
 	assert.Equal("widget", (*resp.JSON200)[0].RepoName)
 	assert.EqualValues(7, (*resp.JSON200)[0].Number)
+}
+
+func TestAPIListIssuesFiltersHostedNestedRepoPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
+		{Owner: "Group/SubGroup", Name: "Project.Special", PlatformHost: "ghe.example.com"},
+		{Owner: "other", Name: "repo", PlatformHost: "ghe.example.com"},
+	})
+	seedIssueOnHost(
+		t, database,
+		"ghe.example.com", "Group/SubGroup", "Project.Special", 1,
+		"open", "Nested issue",
+	)
+	seedIssueOnHost(
+		t, database,
+		"ghe.example.com", "other", "repo", 2,
+		"open", "Other issue",
+	)
+	client := setupTestClient(t, srv)
+
+	repo := "ghe.example.com/Group/SubGroup/Project.Special"
+	resp, err := client.HTTP.ListIssuesWithResponse(
+		t.Context(), &generated.ListIssuesParams{Repo: &repo},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+	assert.Equal("ghe.example.com", (*resp.JSON200)[0].PlatformHost)
+	assert.Equal("group/subgroup", (*resp.JSON200)[0].RepoOwner)
+	assert.Equal("project.special", (*resp.JSON200)[0].RepoName)
+	assert.EqualValues(1, (*resp.JSON200)[0].Number)
 }
 
 func TestAPIGetIssueUsesPlatformHostQuery(t *testing.T) {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -175,17 +175,19 @@ func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int6
 }
 
 // parseRepoFilter splits the repo query parameter when it is in owner/name or
-// platform_host/owner/name form and otherwise returns empty parts so callers
-// can ignore invalid input.
-func parseRepoFilter(repo string) (platformHost, owner, name string) {
-	parts := strings.Split(repo, "/")
+// platform_host/repo_path form and otherwise returns empty parts so callers can
+// ignore invalid input. Repo paths can contain slashes, so hosted filters keep
+// everything after the host together as repoPath.
+func parseRepoFilter(repo string) (platformHost, owner, name, repoPath string) {
+	parts := strings.Split(strings.Trim(repo, "/ "), "/")
 	switch len(parts) {
 	case 2:
-		return "", parts[0], parts[1]
-	case 3:
-		return parts[0], parts[1], parts[2]
+		return "", parts[0], parts[1], ""
 	default:
-		return "", "", ""
+		if len(parts) >= 3 {
+			return parts[0], "", "", strings.Join(parts[1:], "/")
+		}
+		return "", "", "", ""
 	}
 }
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -795,7 +795,10 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 		Limit:       input.Limit,
 		Offset:      input.Offset,
 	}
-	if platformHost, owner, name := parseRepoFilter(input.Repo); owner != "" {
+	if platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
+		opts.PlatformHost = platformHost
+		opts.RepoPath = repoPath
+	} else if owner != "" {
 		opts.PlatformHost = platformHost
 		opts.RepoOwner = owner
 		opts.RepoName = name
@@ -1351,7 +1354,10 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 		Limit:   input.Limit,
 		Offset:  input.Offset,
 	}
-	if platformHost, owner, name := parseRepoFilter(input.Repo); owner != "" {
+	if platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
+		opts.PlatformHost = platformHost
+		opts.RepoPath = repoPath
+	} else if owner != "" {
 		opts.PlatformHost = platformHost
 		opts.RepoOwner = owner
 		opts.RepoName = name


### PR DESCRIPTION
## Summary

- Navigating directly to a PR/issue URL (link click, deep link, browser back/forward) used to leave the repo dropdown and the left sidebar list pinned to whichever repo had been picked before. The detail pane loaded the right item but the surrounding chrome lied about the focus and the sidebar's 15s refresh kept re-querying with the stale filter.
- `App.svelte` now syncs the global repo filter to the route's selected item via a new effect, so the dropdown follows and the sidebar list reloads against the correct repo.
- Skipped for embed hosts that hide the repo selector and when no repos are configured.

## Test plan

- [x] `bun run test --run repoSelectionSync` — 9/9 (unit coverage for the route → repo-key mapping, written test-first)
- [x] `bun run check` — 0 errors, 0 warnings
- [x] `bun run lint` — clean
- [x] Manual verification against the ephemeral middleman dev stack
- [ ] CI: new Playwright spec `tests/e2e-full/link-navigation-repo-sync.spec.ts` runs the full deep-link flow (chromium/firefox/webkit)