### PR TITLE
fix: keep air rebuilds from deleting dev binary

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,7 +7,7 @@ entrypoint = "./tmp/middleman"
 delay = 500
 exclude_dir = ["frontend", "internal/web/dist", "internal/apiclient/generated", "node_modules", "target", "tmp", "vendor", ".git"]
 include_ext = ["go", "tpl", "tmpl", "html"]
-stop_on_error = true
+stop_on_error = false
 send_interrupt = true
 kill_delay = "2s"
 

--- a/.air.windows.toml
+++ b/.air.windows.toml
@@ -7,7 +7,7 @@ entrypoint = "./tmp/middleman.exe"
 delay = 500
 exclude_dir = ["frontend", "internal/web/dist", "internal/apiclient/generated", "node_modules", "target", "tmp", "vendor", ".git"]
 include_ext = ["go", "tpl", "tmpl", "html"]
-stop_on_error = true
+stop_on_error = false
 send_interrupt = true
 kill_delay = "2s"
 


### PR DESCRIPTION
## Summary

- Keep backend live reload usable with the latest Air after source changes.
- Preserve the running backend when rebuilds fail so the frontend proxy does not fall into connection-refused loops.