### PR TITLE
fix: keep cached PR CI decorations after restart

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -3393,6 +3393,25 @@ func (d *DB) UpdateMRDetailFetchedByRepoID(
 	return nil
 }
 
+// ClearMRDetailFetchedByRepoID marks an existing merge request as needing a
+// fresh detail fetch for an already resolved provider-qualified repo row.
+func (d *DB) ClearMRDetailFetchedByRepoID(
+	ctx context.Context,
+	repoID int64,
+	number int,
+) error {
+	_, err := d.rw.ExecContext(ctx, `
+		UPDATE middleman_merge_requests
+		SET detail_fetched_at = NULL
+		WHERE repo_id = ? AND number = ?`,
+		repoID, number,
+	)
+	if err != nil {
+		return fmt.Errorf("clear mr detail fetched by repo id: %w", err)
+	}
+	return nil
+}
+
 // UpdateMRWorkflowApproval persists the workflow-approval snapshot
 // for a merge request. The result is tied to headSHA: a later GET
 // must compare the stored head SHA to the merge request's current

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3083,11 +3083,12 @@ func (s *Syncer) indexUpsertMergeRequest(
 	}
 
 	// Preserve fields list endpoints commonly omit.
+	needsCIDetailRefresh := false
 	if existing != nil {
 		normalized.Additions = existing.Additions
 		normalized.Deletions = existing.Deletions
 		preserveMergeableStateIfOmitted(normalized, existing)
-		preserveCIStateIfOmitted(normalized, existing)
+		needsCIDetailRefresh = preserveCIStateIfOmitted(normalized, existing)
 	}
 
 	if normalized.Author != "" &&
@@ -3110,6 +3111,14 @@ func (s *Syncer) indexUpsertMergeRequest(
 		return fmt.Errorf(
 			"upsert MR #%d: %w", mr.Number, err,
 		)
+	}
+	if needsCIDetailRefresh {
+		if err := s.clearMRDetailFetchedByRepoID(ctx, repoID, mr.Number); err != nil {
+			return fmt.Errorf(
+				"clear detail fetch marker for MR #%d: %w",
+				mr.Number, err,
+			)
+		}
 	}
 	if err := s.replaceMergeRequestLabels(ctx, repoID, mrID, normalized.Labels); err != nil {
 		return fmt.Errorf("persist labels for MR #%d: %w", mr.Number, err)
@@ -3157,11 +3166,12 @@ func (s *Syncer) indexUpsertMR(
 	}
 
 	// Preserve fields the list endpoint doesn't return.
+	needsCIDetailRefresh := false
 	if existing != nil {
 		normalized.Additions = existing.Additions
 		normalized.Deletions = existing.Deletions
 		preserveMergeableStateIfOmitted(normalized, existing)
-		preserveCIStateIfOmitted(normalized, existing)
+		needsCIDetailRefresh = preserveCIStateIfOmitted(normalized, existing)
 	}
 
 	if normalized.Author != "" &&
@@ -3185,6 +3195,14 @@ func (s *Syncer) indexUpsertMR(
 		return fmt.Errorf(
 			"upsert MR #%d: %w", ghPR.GetNumber(), err,
 		)
+	}
+	if needsCIDetailRefresh {
+		if err := s.clearMRDetailFetchedByRepoID(ctx, repoID, ghPR.GetNumber()); err != nil {
+			return fmt.Errorf(
+				"clear detail fetch marker for MR #%d: %w",
+				ghPR.GetNumber(), err,
+			)
+		}
 	}
 	if err := s.replaceMergeRequestLabels(ctx, repoID, mrID, normalized.Labels); err != nil {
 		return fmt.Errorf("persist labels for MR #%d: %w", ghPR.GetNumber(), err)
@@ -4545,6 +4563,14 @@ func (s *Syncer) updateMRDetailFetchedByRepoID(
 	return s.db.UpdateMRDetailFetchedByRepoID(
 		ctx, repoID, number, ciHadPending,
 	)
+}
+
+func (s *Syncer) clearMRDetailFetchedByRepoID(
+	ctx context.Context,
+	repoID int64,
+	number int,
+) error {
+	return s.db.ClearMRDetailFetchedByRepoID(ctx, repoID, number)
 }
 
 func (s *Syncer) updateIssueDetailFetchedByRepoID(
@@ -6262,21 +6288,25 @@ func preserveMergeableStateIfOmitted(
 func preserveCIStateIfOmitted(
 	normalized *db.MergeRequest,
 	existing *db.MergeRequest,
-) {
+) bool {
 	if normalized == nil || existing == nil {
-		return
+		return false
 	}
 	if normalized.PlatformHeadSHA == "" ||
 		existing.PlatformHeadSHA == "" ||
 		normalized.PlatformHeadSHA != existing.PlatformHeadSHA {
-		return
+		return false
 	}
+	ciStatusOmitted := normalized.CIStatus == ""
+	ciStatusChanged := !ciStatusOmitted &&
+		normalized.CIStatus != existing.CIStatus
 	if normalized.CIStatus == "" {
 		normalized.CIStatus = existing.CIStatus
 	}
-	if normalized.CIChecksJSON == "" {
+	if normalized.CIChecksJSON == "" && !ciStatusChanged {
 		normalized.CIChecksJSON = existing.CIChecksJSON
 	}
+	return ciStatusChanged && normalized.CIChecksJSON == ""
 }
 
 // syncMRDiff fetches the bare clone and computes diff SHAs for a single PR.

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3087,6 +3087,7 @@ func (s *Syncer) indexUpsertMergeRequest(
 		normalized.Additions = existing.Additions
 		normalized.Deletions = existing.Deletions
 		preserveMergeableStateIfOmitted(normalized, existing)
+		preserveCIStateIfOmitted(normalized, existing)
 	}
 
 	if normalized.Author != "" &&
@@ -3133,7 +3134,7 @@ func (s *Syncer) indexUpsertMergeRequest(
 // indexUpsertMR upserts a PR from list endpoint data only. No
 // GetPullRequest, no timeline, no CI. Preserves fields that the
 // list endpoint does not return (additions, deletions,
-// mergeable_state) from the existing DB row.
+// mergeable_state, cached CI) from the existing DB row.
 func (s *Syncer) indexUpsertMR(
 	ctx context.Context,
 	client Client,
@@ -3160,6 +3161,7 @@ func (s *Syncer) indexUpsertMR(
 		normalized.Additions = existing.Additions
 		normalized.Deletions = existing.Deletions
 		preserveMergeableStateIfOmitted(normalized, existing)
+		preserveCIStateIfOmitted(normalized, existing)
 	}
 
 	if normalized.Author != "" &&
@@ -6253,6 +6255,26 @@ func preserveMergeableStateIfOmitted(
 	if normalized.MergeableState == "" ||
 		(normalized.MergeableState == "unknown" && existing.MergeableState != "") {
 		normalized.MergeableState = existing.MergeableState
+	}
+}
+
+func preserveCIStateIfOmitted(
+	normalized *db.MergeRequest,
+	existing *db.MergeRequest,
+) {
+	if normalized == nil || existing == nil {
+		return
+	}
+	if normalized.PlatformHeadSHA == "" ||
+		existing.PlatformHeadSHA == "" ||
+		normalized.PlatformHeadSHA != existing.PlatformHeadSHA {
+		return
+	}
+	if normalized.CIStatus == "" {
+		normalized.CIStatus = existing.CIStatus
+	}
+	if normalized.CIChecksJSON == "" {
+		normalized.CIChecksJSON = existing.CIChecksJSON
 	}
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5673,6 +5673,7 @@ func (s *Syncer) buildDetailQueueItems(
 			platform.Kind(repo.Platform), repo.PlatformHost,
 			repo.Owner, repo.Name,
 		) + fmt.Sprintf("#%d", pr.Number)
+		ciHadPending := pr.CIHadPending || ciHasPending(pr.CIChecksJSON)
 		items = append(items, QueueItem{
 			Type:            QueueItemPR,
 			Platform:        platform.Kind(repo.Platform),
@@ -5682,7 +5683,7 @@ func (s *Syncer) buildDetailQueueItems(
 			PlatformHost:    repo.PlatformHost,
 			UpdatedAt:       pr.UpdatedAt,
 			DetailFetchedAt: pr.DetailFetchedAt,
-			CIHadPending:    pr.CIHadPending,
+			CIHadPending:    ciHadPending,
 			Starred:         pr.Starred,
 			Watched:         watched[watchKey],
 			IsOpen:          true,

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5064,6 +5064,51 @@ func TestDetailQueueWatchedKeyIncludesProviderIdentity(t *testing.T) {
 	assert.True(watchedByPlatform[platform.KindGitLab])
 }
 
+func TestDetailQueueDerivesPendingCIFromCachedChecks(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	fetchedAt := now.Add(-5 * time.Minute)
+	repo := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "owner",
+		Name:         "repo",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1001,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "pending ci",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		CIChecksJSON:    `[{"name":"build","status":"in_progress","conclusion":""}]`,
+		CIHadPending:    false,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+		DetailFetchedAt: &fetchedAt,
+	})
+	require.NoError(err)
+
+	syncer := NewSyncer(nil, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
+
+	items := syncer.buildDetailQueueItems(ctx)
+	require.Len(items, 1)
+	assert.True(items[0].CIHadPending)
+	queue := BuildQueue(items, now)
+	require.Len(queue, 1)
+	assert.Equal(1, queue[0].Number)
+}
+
 func TestDetailDrainRespectsBudget(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -1668,6 +1668,62 @@ func TestIndexUpsertMergeRequestUpdatesKnownMergeableState(t *testing.T) {
 	assert.Equal("dirty", stored.MergeableState)
 }
 
+func TestIndexUpsertMergeRequestPreservesCachedCIForSameHead(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1001,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "Cached CI PR",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "same-head",
+		CIStatus:        "failure",
+		CIChecksJSON:    `[{"name":"build","status":"completed","conclusion":"failure"}]`,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	syncer := NewSyncer(nil, d, nil, nil, time.Minute, nil, testBudget(500))
+	err = syncer.indexUpsertMergeRequest(
+		ctx,
+		RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID,
+		platform.MergeRequest{
+			PlatformID:     1001,
+			Number:         1,
+			URL:            "https://github.com/owner/repo/pull/1",
+			Title:          "Cached CI PR",
+			State:          "open",
+			HeadBranch:     "feature",
+			BaseBranch:     "main",
+			HeadSHA:        "same-head",
+			CreatedAt:      now,
+			UpdatedAt:      now.Add(time.Minute),
+			LastActivityAt: now.Add(time.Minute),
+		},
+	)
+	require.NoError(err)
+
+	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("failure", stored.CIStatus)
+	assert.Contains(stored.CIChecksJSON, "build")
+}
+
 func TestPreserveMergeableStateSkipsChangedOrUnknownHeadOrBase(t *testing.T) {
 	assert := Assert.New(t)
 	tests := []struct {
@@ -1713,6 +1769,54 @@ func TestPreserveMergeableStateSkipsChangedOrUnknownHeadOrBase(t *testing.T) {
 			assert.Empty(tt.normalized.MergeableState)
 		})
 	}
+}
+
+func TestPreserveCIStateSkipsChangedOrUnknownHead(t *testing.T) {
+	assert := Assert.New(t)
+	tests := []struct {
+		name       string
+		normalized db.MergeRequest
+		existing   db.MergeRequest
+	}{
+		{
+			name:       "head changed",
+			normalized: db.MergeRequest{PlatformHeadSHA: "new-head"},
+			existing:   db.MergeRequest{PlatformHeadSHA: "old-head", CIStatus: "success", CIChecksJSON: `[{"name":"build"}]`},
+		},
+		{
+			name:       "refreshed head missing",
+			normalized: db.MergeRequest{},
+			existing:   db.MergeRequest{PlatformHeadSHA: "same-head", CIStatus: "success", CIChecksJSON: `[{"name":"build"}]`},
+		},
+		{
+			name:       "existing head missing",
+			normalized: db.MergeRequest{PlatformHeadSHA: "same-head"},
+			existing:   db.MergeRequest{CIStatus: "success", CIChecksJSON: `[{"name":"build"}]`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preserveCIStateIfOmitted(&tt.normalized, &tt.existing)
+			assert.Empty(tt.normalized.CIStatus)
+			assert.Empty(tt.normalized.CIChecksJSON)
+		})
+	}
+}
+
+func TestPreserveCIStateKeepsOmittedStateForMatchingHead(t *testing.T) {
+	assert := Assert.New(t)
+	normalized := db.MergeRequest{PlatformHeadSHA: "same-head"}
+	existing := db.MergeRequest{
+		PlatformHeadSHA: "same-head",
+		CIStatus:        "success",
+		CIChecksJSON:    `[{"name":"build","status":"completed","conclusion":"success"}]`,
+	}
+
+	preserveCIStateIfOmitted(&normalized, &existing)
+
+	assert.Equal("success", normalized.CIStatus)
+	assert.Contains(normalized.CIChecksJSON, "build")
 }
 
 func TestPreserveMergeableStateKeepsOmittedStateForMatchingKnownIdentity(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -1819,6 +1819,25 @@ func TestPreserveCIStateKeepsOmittedStateForMatchingHead(t *testing.T) {
 	assert.Contains(normalized.CIChecksJSON, "build")
 }
 
+func TestPreserveCIStateClearsCachedChecksWhenStatusChanges(t *testing.T) {
+	assert := Assert.New(t)
+	normalized := db.MergeRequest{
+		PlatformHeadSHA: "same-head",
+		CIStatus:        "success",
+	}
+	existing := db.MergeRequest{
+		PlatformHeadSHA: "same-head",
+		CIStatus:        "failure",
+		CIChecksJSON:    `[{"name":"build","status":"completed","conclusion":"failure"}]`,
+	}
+
+	needsCIDetailRefresh := preserveCIStateIfOmitted(&normalized, &existing)
+
+	assert.True(needsCIDetailRefresh)
+	assert.Equal("success", normalized.CIStatus)
+	assert.Empty(normalized.CIChecksJSON)
+}
+
 func TestPreserveMergeableStateKeepsOmittedStateForMatchingKnownIdentity(t *testing.T) {
 	assert := Assert.New(t)
 	normalized := db.MergeRequest{

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -755,6 +755,21 @@ func withSeedPRTitle(title string) seedPROpt {
 	return func(pr *db.MergeRequest) { pr.Title = title }
 }
 
+func withSeedPRCI(status, checksJSON string) seedPROpt {
+	return func(pr *db.MergeRequest) {
+		pr.CIStatus = status
+		pr.CIChecksJSON = checksJSON
+	}
+}
+
+func withSeedPRTimes(createdAt, updatedAt, lastActivityAt time.Time) seedPROpt {
+	return func(pr *db.MergeRequest) {
+		pr.CreatedAt = createdAt
+		pr.UpdatedAt = updatedAt
+		pr.LastActivityAt = lastActivityAt
+	}
+}
+
 // seedPR inserts a repo and a PR into the DB, returning the PR's internal ID.
 func seedPR(t *testing.T, database *db.DB, owner, name string, number int, opts ...seedPROpt) int64 {
 	t.Helper()
@@ -1089,6 +1104,56 @@ func TestAPIListPulls(t *testing.T) {
 	assert.Equal("github", body[0].Repo.Provider)
 	assert.Equal("github.com", body[0].Repo.PlatformHost)
 	assert.Equal("acme/widget", body[0].Repo.RepoPath)
+}
+
+func TestAPIListPullsKeepsCachedCIDecorationsAfterIndexSync(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	headSHA := "same-head"
+	baseSHA := "base-sha"
+	checksJSON := `[{"name":"build","status":"completed","conclusion":"failure"}]`
+
+	str := func(v string) *string { return &v }
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			number := 1
+			id := int64(1001)
+			return []*gh.PullRequest{{
+				ID:        &id,
+				Number:    &number,
+				Title:     str("Cached CI PR"),
+				State:     str("open"),
+				HTMLURL:   str("https://github.com/acme/widget/pull/1"),
+				User:      &gh.User{Login: str("octocat")},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				Head:      &gh.PullRequestBranch{Ref: str("feature"), SHA: &headSHA},
+				Base:      &gh.PullRequestBranch{Ref: str("main"), SHA: &baseSHA},
+			}}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRTitle("Cached CI PR"),
+		withSeedPRHeadSHA(headSHA),
+		withSeedPRBaseSHA(baseSHA),
+		withSeedPRCI("failure", checksJSON),
+		withSeedPRTimes(now, now, now),
+	)
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	resp, err := client.HTTP.ListPullsWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+	pull := (*resp.JSON200)[0]
+	assert.Equal("failure", pull.CIStatus)
+	assert.JSONEq(checksJSON, pull.CIChecksJSON)
 }
 
 func TestAPIGetPullIsDBOnly(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3149,6 +3149,124 @@ func TestAPISyncRefreshesStaleCachedChecksWhenAggregateCIChanges(t *testing.T) {
 	)
 }
 
+func TestAPISyncRefreshesCachedPendingChecksThroughDetailDrain(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	fetchedAt := now
+	database := dbtest.Open(t)
+
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4343,
+		PlatformExternalID: "gid://gitlab/Project/4343",
+		DefaultBranch:      "main",
+	}
+	provider := &apiTestGitLabProvider{
+		ref: ref,
+		mergeRequests: []platform.MergeRequest{{
+			Repo:           ref,
+			PlatformID:     7008,
+			Number:         8,
+			URL:            "https://gitlab.example.com/group/project/-/merge_requests/8",
+			Title:          "Refresh cached pending CI",
+			Author:         "ada",
+			State:          "open",
+			HeadBranch:     "feature",
+			BaseBranch:     "main",
+			HeadSHA:        "pending-head",
+			BaseSHA:        "base-sha",
+			CIStatus:       "pending",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			LastActivityAt: now,
+		}},
+		ciChecks: map[string][]platform.CICheck{
+			"pending-head": {{
+				Name:       "pipeline",
+				Status:     "completed",
+				Conclusion: "success",
+			}},
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	repoID, err := database.UpsertRepo(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7008,
+		Number:          8,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/8",
+		Title:           "Refresh cached pending CI",
+		Author:          "ada",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "pending-head",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "pending",
+		CIChecksJSON:    `[{"name":"pipeline","status":"in_progress","conclusion":""}]`,
+		CIHadPending:    false,
+		DetailFetchedAt: &fetchedAt,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindGitLab,
+			PlatformHost: ref.Host,
+			Owner:        ref.Owner,
+			Name:         ref.Name,
+			RepoPath:     ref.RepoPath,
+		}},
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{
+			ghclient.RateBucketKey("gitlab", ref.Host): ghclient.NewSyncBudget(100),
+		},
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+
+	resp, err := client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 8,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON200)
+	assert.Equal("success", resp.JSON200.MergeRequest.CIStatus)
+	assert.JSONEq(
+		`[{"name":"pipeline","status":"completed","conclusion":"success","url":"","app":""}]`,
+		resp.JSON200.MergeRequest.CIChecksJSON,
+	)
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 8)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.NotNil(stored.DetailFetchedAt)
+	assert.False(stored.CIHadPending)
+	assert.JSONEq(
+		`[{"name":"pipeline","status":"completed","conclusion":"success","url":"","app":""}]`,
+		stored.CIChecksJSON,
+	)
+}
+
 func TestProviderRefSyncEndpointsUseGitLabNestedRepoPath(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2950,12 +2950,14 @@ func TestAPICIRefreshWarnsAndPreservesCIWhenProviderFails(t *testing.T) {
 	database := dbtest.Open(t)
 
 	ref := platform.RepoRef{
-		Platform:      platform.KindGitLab,
-		Host:          "gitlab.example.com",
-		Owner:         "group",
-		Name:          "project",
-		RepoPath:      "group/project",
-		DefaultBranch: "main",
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
 	}
 	provider := &apiTestGitLabProvider{
 		ref:   ref,
@@ -3026,6 +3028,123 @@ func TestAPICIRefreshWarnsAndPreservesCIWhenProviderFails(t *testing.T) {
 	assert.Equal("pending", stored.CIStatus)
 	assert.JSONEq(
 		`[{"name":"pipeline","status":"in_progress","conclusion":""}]`,
+		stored.CIChecksJSON,
+	)
+}
+
+func TestAPISyncRefreshesStaleCachedChecksWhenAggregateCIChanges(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	fetchedAt := now
+	database := dbtest.Open(t)
+
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &apiTestGitLabProvider{
+		ref: ref,
+		mergeRequests: []platform.MergeRequest{{
+			Repo:           ref,
+			PlatformID:     7001,
+			Number:         7,
+			URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+			Title:          "Refresh changed CI",
+			Author:         "ada",
+			State:          "open",
+			HeadBranch:     "feature",
+			BaseBranch:     "main",
+			HeadSHA:        "head-sha",
+			BaseSHA:        "base-sha",
+			CIStatus:       "pending",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			LastActivityAt: now,
+		}},
+		ciChecks: map[string][]platform.CICheck{
+			"head-sha": {{
+				Name:   "pipeline",
+				Status: "in_progress",
+			}},
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	repoID, err := database.UpsertRepo(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Refresh changed CI",
+		Author:          "ada",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "failure",
+		CIChecksJSON:    `[{"name":"pipeline","status":"completed","conclusion":"failure"}]`,
+		CIHadPending:    false,
+		DetailFetchedAt: &fetchedAt,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindGitLab,
+			PlatformHost: ref.Host,
+			Owner:        ref.Owner,
+			Name:         ref.Name,
+			RepoPath:     ref.RepoPath,
+		}},
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{
+			ghclient.RateBucketKey("gitlab", ref.Host): ghclient.NewSyncBudget(100),
+		},
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+
+	resp, err := client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON200)
+	assert.Equal("pending", resp.JSON200.MergeRequest.CIStatus)
+	assert.JSONEq(
+		`[{"name":"pipeline","status":"in_progress","conclusion":"","url":"","app":""}]`,
+		resp.JSON200.MergeRequest.CIChecksJSON,
+	)
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.NotNil(stored.DetailFetchedAt)
+	assert.True(stored.CIHadPending)
+	assert.JSONEq(
+		`[{"name":"pipeline","status":"in_progress","conclusion":"","url":"","app":""}]`,
 		stored.CIChecksJSON,
 	)
 }


### PR DESCRIPTION
- Preserve cached PR CI status/check data when provider list sync omits check details for the same head SHA.
- Requeue PRs whose cached check JSON still contains pending checks after a restart.