### PR TITLE
Keep PR file jumps inside the diff pane

### DIFF
--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -454,6 +454,30 @@ test.describe("diff view", () => {
     await expect(secondRow).toHaveClass(/diff-file-row--active/);
   });
 
+  test("sidebar file jumps keep the outer detail frame pinned", async ({ page }) => {
+    await mockDiffApi(page, largeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const mainArea = page.locator(".main-area");
+    const diffArea = page.locator(".diff-area");
+    await expect.poll(() =>
+      mainArea.evaluate((el) => Math.round(el.scrollTop)),
+    ).toBe(0);
+
+    await page.locator(".diff-file-row", { hasText: "file_45.go" }).click();
+
+    await expect(page.locator('[data-file-path="src/pkg9/file_45.go"]'))
+      .toBeVisible();
+    await expect.poll(() =>
+      diffArea.evaluate((el) => Math.round(el.scrollTop)),
+    ).toBeGreaterThan(0);
+    await expect.poll(() =>
+      mainArea.evaluate((el) => Math.round(el.scrollTop)),
+    ).toBe(0);
+  });
+
   test("deleted file name has strikethrough in sidebar", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -63,7 +63,9 @@
     if (!diffArea) return false;
     const el = diffArea.querySelector(`[data-file-path="${CSS.escape(path)}"]`);
     if (el) {
-      el.scrollIntoView({ behavior: "instant", block: "start" });
+      const areaRect = diffArea.getBoundingClientRect();
+      const elRect = el.getBoundingClientRect();
+      diffArea.scrollTop += elRect.top - areaRect.top;
     } else {
       return false;
     }

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -116,4 +116,70 @@ describe("DiffView", () => {
 
     expect(consumeScrollTarget).not.toHaveBeenCalled();
   });
+
+  it("scrolls only the diff area for a sidebar file jump", async () => {
+    const consumeScrollTarget = vi.fn();
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.scrollIntoView = scrollIntoView;
+    Element.prototype.getBoundingClientRect = function () {
+      if (this instanceof HTMLElement && this.classList.contains("diff-area")) {
+        return {
+          top: 100,
+          bottom: 500,
+          left: 0,
+          right: 500,
+          width: 500,
+          height: 400,
+          x: 0,
+          y: 100,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+      if (
+        this instanceof HTMLElement &&
+        this.dataset.filePath === "b.ts"
+      ) {
+        return {
+          top: 460,
+          bottom: 500,
+          left: 0,
+          right: 500,
+          width: 500,
+          height: 40,
+          x: 0,
+          y: 460,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    try {
+      const files = [makeFile("a.ts"), makeFile("b.ts")];
+      const result: DiffResult = {
+        stale: false,
+        whitespace_only_count: 0,
+        files,
+      };
+      const diff = makeDiffStore({
+        getDiff: () => result,
+        getVisibleDiffFiles: () => files,
+        getScrollTarget: () => "b.ts",
+        consumeScrollTarget,
+      });
+
+      const { container } = renderDiffView(diff);
+      await Promise.resolve();
+
+      const diffArea = container.querySelector(".diff-area") as HTMLDivElement;
+      expect(diffArea.scrollTop).toBe(360);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(consumeScrollTarget).toHaveBeenCalled();
+    } finally {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
+  });
 });

--- a/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
+++ b/packages/ui/src/components/shared/CollapsibleResizableSidebar.svelte
@@ -119,6 +119,7 @@
   .list-layout {
     display: flex;
     flex: 1;
+    min-height: 0;
     overflow: hidden;
   }
 
@@ -141,6 +142,7 @@
   .main-area {
     flex: 1;
     min-width: 0;
+    min-height: 0;
     overflow-y: auto;
     background: var(--bg-primary);
     display: flex;


### PR DESCRIPTION
## Summary
- Keep file navigation in the PR files view scoped to the diff pane.
- Prevent the detail frame from shifting and leaving empty space when jumping between files.
