### PR TITLE
Add live terminal display settings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@lucide/svelte": "1.3.0",
         "@middleman/ui": "workspace:*",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-ligatures": "^0.10.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "dompurify": "3.3.3",
@@ -433,6 +434,8 @@
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
+    "@xterm/addon-ligatures": ["@xterm/addon-ligatures@0.10.0", "", { "dependencies": { "font-finder": "^1.1.0", "font-ligatures": "^1.4.1" } }, "sha512-/Few8ZSHMib7sGjRJoc5l7bCtEB9XJfkNofvPpOcWADxKaUl8og8P172j67OoACSNJAXqeCLIuvj8WFCBkcTxg=="],
+
     "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
@@ -573,7 +576,13 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "font-finder": ["font-finder@1.1.0", "", { "dependencies": { "get-system-fonts": "^2.0.0", "promise-stream-reader": "^1.0.1" } }, "sha512-wpCL2uIbi6GurJbU7ZlQ3nGd61Ho+dSU6U83/xJT5UPFfN35EeCW/rOtS+5k+IuEZu2SYmHzDIPL9eA5tSYRAw=="],
+
+    "font-ligatures": ["font-ligatures@1.4.1", "", { "dependencies": { "font-finder": "^1.0.3", "lru-cache": "^6.0.0", "opentype.js": "^0.8.0" } }, "sha512-7W6zlfyhvCqShZ5ReUWqmSd9vBaUudW0Hxis+tqUjtHhsPU+L3Grf8mcZAtCiXHTzorhwdRTId2WeH/88gdFkw=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "get-system-fonts": ["get-system-fonts@2.0.2", "", {}, "sha512-zzlgaYnHMIEgHRrfC7x0Qp0Ylhw/sHpM6MHXeVBTYIsvGf5GpbnClB+Q6rAPdn+0gd2oZZIo6Tj3EaWrt4VhDQ=="],
 
     "ghostty-web": ["ghostty-web@0.4.0", "", {}, "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg=="],
 
@@ -669,7 +678,7 @@
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -719,6 +728,8 @@
 
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.1.0", "", {}, "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw=="],
 
+    "opentype.js": ["opentype.js@0.8.0", "", { "dependencies": { "tiny-inflate": "^1.0.2" }, "bin": { "ot": "./bin/ot" } }, "sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
@@ -764,6 +775,8 @@
     "prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "promise-stream-reader": ["promise-stream-reader@1.0.1", "", {}, "sha512-Tnxit5trUjBAqqZCGWwjyxhmgMN4hGrtpW3Oc/tRI4bpm/O2+ej72BB08l6JBnGQgVDGCLvHFGjGgQS6vzhwXg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -869,6 +882,8 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
@@ -961,6 +976,8 @@
 
     "xregexp": ["xregexp@5.1.2", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.9" } }, "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw=="],
 
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
@@ -972,6 +989,8 @@
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2824,12 +2824,36 @@ components:
     Terminal:
       additionalProperties: false
       properties:
+        cursor_blink:
+          type:
+            - boolean
+            - "null"
         font_family:
           type: string
+        font_ligatures:
+          type: boolean
+        font_size:
+          format: int64
+          type: integer
+        letter_spacing:
+          format: int64
+          type: integer
+        line_height:
+          format: double
+          type: number
         renderer:
           type: string
+        scrollback:
+          format: int64
+          type: integer
       required:
         - font_family
+        - font_size
+        - scrollback
+        - line_height
+        - letter_spacing
+        - cursor_blink
+        - font_ligatures
         - renderer
       type: object
     UpdateSettingsRequest:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@lucide/svelte": "1.3.0",
     "@middleman/ui": "workspace:*",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-ligatures": "^0.10.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "dompurify": "3.3.3",

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MockedFunction } from "vitest";
 import RepoImportModal from "./RepoImportModal.svelte";
@@ -13,10 +19,54 @@ const preview = previewRepos as MockedFunction<typeof previewRepos>;
 const bulk = bulkAddRepos as MockedFunction<typeof bulkAddRepos>;
 
 const rows = [
-  { provider: "github", platform_host: "github.com", owner: "acme", name: "worker", repo_path: "acme/worker", description: "Background jobs", private: false, fork: false, pushed_at: "2026-04-20T00:00:00Z", already_configured: false },
-  { provider: "github", platform_host: "github.com", owner: "acme", name: "api", repo_path: "acme/api", description: "HTTP API", private: true, fork: false, pushed_at: "2026-04-22T00:00:00Z", already_configured: false },
-  { provider: "github", platform_host: "github.com", owner: "acme", name: "widget", repo_path: "acme/widget", description: "Configured", private: false, fork: true, pushed_at: "2026-04-21T00:00:00Z", already_configured: true },
-  { provider: "github", platform_host: "github.com", owner: "acme", name: "empty", repo_path: "acme/empty", description: null, private: false, fork: false, pushed_at: null, already_configured: false },
+  {
+    provider: "github",
+    platform_host: "github.com",
+    owner: "acme",
+    name: "worker",
+    repo_path: "acme/worker",
+    description: "Background jobs",
+    private: false,
+    fork: false,
+    pushed_at: "2026-04-20T00:00:00Z",
+    already_configured: false,
+  },
+  {
+    provider: "github",
+    platform_host: "github.com",
+    owner: "acme",
+    name: "api",
+    repo_path: "acme/api",
+    description: "HTTP API",
+    private: true,
+    fork: false,
+    pushed_at: "2026-04-22T00:00:00Z",
+    already_configured: false,
+  },
+  {
+    provider: "github",
+    platform_host: "github.com",
+    owner: "acme",
+    name: "widget",
+    repo_path: "acme/widget",
+    description: "Configured",
+    private: false,
+    fork: true,
+    pushed_at: "2026-04-21T00:00:00Z",
+    already_configured: true,
+  },
+  {
+    provider: "github",
+    platform_host: "github.com",
+    owner: "acme",
+    name: "empty",
+    repo_path: "acme/empty",
+    description: null,
+    private: false,
+    fork: false,
+    pushed_at: null,
+    already_configured: false,
+  },
 ];
 
 describe("RepoImportModal", () => {
@@ -27,46 +77,140 @@ describe("RepoImportModal", () => {
   });
 
   it("previews rows and defaults selectable rows to selected", async () => {
-    preview.mockResolvedValue({ provider: "github", platform_host: "github.com", owner: "acme", pattern: "*", repos: rows });
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+    preview.mockResolvedValue({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: rows,
+    });
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
 
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
 
     await screen.findByText("acme/api");
     expect(screen.getByText("Selected 3 of 3")).toBeTruthy();
-    expect((screen.getByRole("checkbox", { name: "Select acme/widget" }) as HTMLInputElement).disabled).toBe(true);
+    expect(
+      (
+        screen.getByRole("checkbox", {
+          name: "Select acme/widget",
+        }) as HTMLInputElement
+      ).disabled,
+    ).toBe(true);
     expect(screen.getByText("Never pushed")).toBeTruthy();
   });
 
   it("filters, deselects visible rows, and submits remaining selected rows", async () => {
     const onImported = vi.fn();
-    preview.mockResolvedValue({ provider: "github", platform_host: "github.com", owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "", renderer: "xterm" }, agents: [] });
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported } });
+    preview.mockResolvedValue({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: rows,
+    });
+    bulk.mockResolvedValue({
+      repos: [],
+      activity: {
+        view_mode: "threaded",
+        time_range: "7d",
+        hide_closed: false,
+        hide_bots: false,
+      },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+      agents: [],
+    });
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported },
+    });
 
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
     await screen.findByText("acme/api");
 
-    await fireEvent.input(screen.getByLabelText("Filter repositories"), { target: { value: "worker" } });
+    await fireEvent.input(screen.getByLabelText("Filter repositories"), {
+      target: { value: "worker" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "None" }));
-    await fireEvent.input(screen.getByLabelText("Filter repositories"), { target: { value: "" } });
-    await fireEvent.click(screen.getByRole("button", { name: "Add selected repositories" }));
+    await fireEvent.input(screen.getByLabelText("Filter repositories"), {
+      target: { value: "" },
+    });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Add selected repositories" }),
+    );
 
-    await waitFor(() => expect(bulk).toHaveBeenCalledWith([
-      { provider: "github", host: "github.com", owner: "acme", name: "api", repo_path: "acme/api" },
-      { provider: "github", host: "github.com", owner: "acme", name: "empty", repo_path: "acme/empty" },
-    ]));
+    await waitFor(() =>
+      expect(bulk).toHaveBeenCalledWith([
+        {
+          provider: "github",
+          host: "github.com",
+          owner: "acme",
+          name: "api",
+          repo_path: "acme/api",
+        },
+        {
+          provider: "github",
+          host: "github.com",
+          owner: "acme",
+          name: "empty",
+          repo_path: "acme/empty",
+        },
+      ]),
+    );
     expect(onImported).toHaveBeenCalled();
   });
 
   it("hides private repositories and forks from preview selection", async () => {
-    preview.mockResolvedValue({ provider: "github", platform_host: "github.com", owner: "acme", pattern: "*", repos: rows });
-    bulk.mockResolvedValue({ repos: [], activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false }, terminal: { font_family: "", renderer: "xterm" }, agents: [] });
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+    preview.mockResolvedValue({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: rows,
+    });
+    bulk.mockResolvedValue({
+      repos: [],
+      activity: {
+        view_mode: "threaded",
+        time_range: "7d",
+        hide_closed: false,
+        hide_bots: false,
+      },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+      agents: [],
+    });
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
 
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
     await screen.findByText("acme/api");
 
@@ -76,17 +220,35 @@ describe("RepoImportModal", () => {
     expect(screen.queryByText("acme/widget")).toBeNull();
     expect(screen.getByText("Selected 2 of 2")).toBeTruthy();
 
-    await fireEvent.click(screen.getByRole("button", { name: "Add selected repositories" }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Add selected repositories" }),
+    );
 
-    await waitFor(() => expect(bulk).toHaveBeenCalledWith([
-      { provider: "github", host: "github.com", owner: "acme", name: "worker", repo_path: "acme/worker" },
-      { provider: "github", host: "github.com", owner: "acme", name: "empty", repo_path: "acme/empty" },
-    ]));
+    await waitFor(() =>
+      expect(bulk).toHaveBeenCalledWith([
+        {
+          provider: "github",
+          host: "github.com",
+          owner: "acme",
+          name: "worker",
+          repo_path: "acme/worker",
+        },
+        {
+          provider: "github",
+          host: "github.com",
+          owner: "acme",
+          name: "empty",
+          repo_path: "acme/empty",
+        },
+      ]),
+    );
   });
 
   it("does not start duplicate previews while loading", async () => {
     preview.mockReturnValue(new Promise(() => {}));
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
 
     const input = screen.getByLabelText("Repository pattern");
     await fireEvent.input(input, { target: { value: "acme/*" } });
@@ -97,7 +259,9 @@ describe("RepoImportModal", () => {
   });
 
   it("sets Forgejo and Gitea default hosts and keeps owner patterns non-nested", async () => {
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
 
     const provider = screen.getByLabelText("Provider");
     const host = screen.getByLabelText("Host") as HTMLInputElement;
@@ -105,9 +269,13 @@ describe("RepoImportModal", () => {
 
     await fireEvent.change(provider, { target: { value: "forgejo" } });
     expect(host.value).toBe("codeberg.org");
-    await fireEvent.input(pattern, { target: { value: "team/subgroup/project-*" } });
+    await fireEvent.input(pattern, {
+      target: { value: "team/subgroup/project-*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
-    expect((await screen.findByRole("alert")).textContent).toContain("Format: owner/pattern");
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Format: owner/pattern",
+    );
     expect(preview).not.toHaveBeenCalled();
 
     await fireEvent.change(provider, { target: { value: "gitea" } });
@@ -122,14 +290,18 @@ describe("RepoImportModal", () => {
     });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
 
-    await waitFor(() => expect(preview).toHaveBeenCalledWith("team", "service-*", {
-      provider: "gitea",
-      host: "gitea.com",
-    }));
+    await waitFor(() =>
+      expect(preview).toHaveBeenCalledWith("team", "service-*", {
+        provider: "gitea",
+        host: "gitea.com",
+      }),
+    );
   });
 
   it("keeps tab focus inside the modal", async () => {
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
 
     const input = screen.getByLabelText("Repository pattern");
     await waitFor(() => expect(document.activeElement).toBe(input));
@@ -137,35 +309,69 @@ describe("RepoImportModal", () => {
     close.focus();
     await fireEvent.keyDown(close, { key: "Tab", shiftKey: true });
 
-    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Cancel" }));
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Cancel" }),
+    );
   });
 
   it("ignores stale preview responses after input changes", async () => {
-    let resolveFirst: (value: Awaited<ReturnType<typeof previewRepos>>) => void = () => {};
-    preview.mockReturnValueOnce(new Promise((resolve) => { resolveFirst = resolve; }));
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+    let resolveFirst: (
+      value: Awaited<ReturnType<typeof previewRepos>>,
+    ) => void = () => {};
+    preview.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
 
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/api-*" } });
-    resolveFirst({ provider: "github", platform_host: "github.com", owner: "acme", pattern: "*", repos: rows });
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/api-*" },
+    });
+    resolveFirst({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: rows,
+    });
 
     await waitFor(() => expect(screen.queryByText("acme/api")).toBeNull());
     expect(screen.getByText("Selected 0 of 0")).toBeTruthy();
   });
 
   it("clears stale rows on failed preview", async () => {
-    preview.mockResolvedValueOnce({ provider: "github", platform_host: "github.com", owner: "acme", pattern: "*", repos: rows });
+    preview.mockResolvedValueOnce({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: rows,
+    });
     preview.mockRejectedValueOnce(new Error("GitHub API error: boom"));
-    render(RepoImportModal, { props: { open: true, onClose: vi.fn(), onImported: vi.fn() } });
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
 
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
     await screen.findByText("acme/api");
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/worker*" } });
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/worker*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
 
-    expect((await screen.findByRole("alert")).textContent).toContain("GitHub API error: boom");
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "GitHub API error: boom",
+    );
     expect(screen.queryByText("acme/api")).toBeNull();
   });
 });

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mockRefreshSyncStatus = vi.fn();
@@ -46,20 +52,26 @@ describe("RepoSettings", () => {
   it("renders the glob count and refresh action", () => {
     render(RepoSettings, {
       props: {
-        repos: [{
-          provider: "github",
-          platform_host: "github.com",
-          owner: "roborev-dev",
-          name: "*",
-          repo_path: "roborev-dev/*",
-          is_glob: true,
-          matched_repo_count: 2,
-        }],
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "roborev-dev",
+            name: "*",
+            repo_path: "roborev-dev/*",
+            is_glob: true,
+            matched_repo_count: 2,
+          },
+        ],
         onUpdate: vi.fn(),
       },
     });
 
-    expect(screen.getByText((_, element) => element?.textContent === "roborev-dev/* (2)")).toBeTruthy();
+    expect(
+      screen.getByText(
+        (_, element) => element?.textContent === "roborev-dev/* (2)",
+      ),
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Refresh" })).toBeTruthy();
   });
 
@@ -135,7 +147,9 @@ describe("RepoSettings", () => {
     const trigger = screen.getByRole("button", { name: "Add repositories…" });
     await fireEvent.click(trigger);
 
-    expect(screen.getByRole("dialog", { name: "Add repositories" })).toBeTruthy();
+    expect(
+      screen.getByRole("dialog", { name: "Add repositories" }),
+    ).toBeTruthy();
     expect(screen.getByLabelText("Repository pattern")).toBeTruthy();
 
     await fireEvent.click(screen.getByRole("button", { name: "Close" }));
@@ -150,7 +164,9 @@ describe("RepoSettings", () => {
       },
     });
 
-    const summary = screen.getByText("Advanced: add provider-scoped repo or tracking glob directly");
+    const summary = screen.getByText(
+      "Advanced: add provider-scoped repo or tracking glob directly",
+    );
     expect(summary).toBeTruthy();
     expect(summary.closest("details")?.hasAttribute("open")).toBe(false);
   });
@@ -164,7 +180,16 @@ describe("RepoSettings", () => {
         hide_closed: false,
         hide_bots: false,
       },
-      terminal: { font_family: "", renderer: "xterm" },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
       agents: [],
     });
     mockRefreshRepo.mockResolvedValue({
@@ -175,21 +200,32 @@ describe("RepoSettings", () => {
         hide_closed: false,
         hide_bots: false,
       },
-      terminal: { font_family: "", renderer: "xterm" },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
       agents: [],
     });
 
     render(RepoSettings, {
       props: {
-        repos: [{
-          provider: "github",
-          platform_host: "github.com",
-          owner: "acme",
-          name: "*",
-          repo_path: "acme/*",
-          is_glob: true,
-          matched_repo_count: 1,
-        }],
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "*",
+            repo_path: "acme/*",
+            is_glob: true,
+            matched_repo_count: 1,
+          },
+        ],
         onUpdate: vi.fn(),
       },
     });
@@ -209,33 +245,37 @@ describe("RepoSettings", () => {
   });
 
   it("updates repos and refreshes sync status after import", async () => {
-    const importedRepos = [{
-      provider: "github",
-      platform_host: "github.com",
-      owner: "acme",
-      name: "api",
-      repo_path: "acme/api",
-      is_glob: false,
-      matched_repo_count: 1,
-    }];
+    const importedRepos = [
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "api",
+        repo_path: "acme/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ];
     const onUpdate = vi.fn();
     mockPreviewRepos.mockResolvedValue({
       provider: "github",
       platform_host: "github.com",
       owner: "acme",
       pattern: "*",
-      repos: [{
-        provider: "github",
-        platform_host: "github.com",
-        owner: "acme",
-        name: "api",
-        repo_path: "acme/api",
-        description: "HTTP API",
-        private: false,
-        fork: false,
-        pushed_at: null,
-        already_configured: false,
-      }],
+      repos: [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "api",
+          repo_path: "acme/api",
+          description: "HTTP API",
+          private: false,
+          fork: false,
+          pushed_at: null,
+          already_configured: false,
+        },
+      ],
     });
     mockBulkAddRepos.mockResolvedValue({
       repos: importedRepos,
@@ -245,7 +285,16 @@ describe("RepoSettings", () => {
         hide_closed: false,
         hide_bots: false,
       },
-      terminal: { font_family: "", renderer: "xterm" },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
       agents: [],
     });
     render(RepoSettings, {
@@ -255,11 +304,17 @@ describe("RepoSettings", () => {
       },
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Add repositories…" }));
-    await fireEvent.input(screen.getByLabelText("Repository pattern"), { target: { value: "acme/*" } });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Add repositories…" }),
+    );
+    await fireEvent.input(screen.getByLabelText("Repository pattern"), {
+      target: { value: "acme/*" },
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
     await screen.findByText("acme/api");
-    await fireEvent.click(screen.getByRole("button", { name: "Add selected repositories" }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Add selected repositories" }),
+    );
 
     await waitFor(() => expect(onUpdate).toHaveBeenCalledWith(importedRepos));
     expect(mockRefreshSyncStatus).toHaveBeenCalled();

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -23,10 +23,7 @@
     try {
       settings = await getSettings();
       settingsStore.setConfiguredRepos(settings.repos);
-      settingsStore.setTerminalFontFamily(
-        settings.terminal.font_family,
-      );
-      settingsStore.setTerminalRenderer(settings.terminal.renderer);
+      settingsStore.setTerminalSettings(settings.terminal);
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -56,10 +53,7 @@
         terminal={settings.terminal}
         onUpdate={(terminal) => {
           settings = { ...settings!, terminal };
-          settingsStore.setTerminalFontFamily(
-            terminal.font_family,
-          );
-          settingsStore.setTerminalRenderer(terminal.renderer);
+          settingsStore.setTerminalSettings(terminal);
         }}
       />
     </SettingsSection>

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -1,69 +1,294 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { getStores } from "@middleman/ui";
+  import {
+    DEFAULT_TERMINAL_SETTINGS,
+    getStores,
+    normalizeTerminalSettings,
+  } from "@middleman/ui";
+  import XIcon from "@lucide/svelte/icons/x";
   import type { TerminalSettings as TerminalSettingsType } from "@middleman/ui/api/types";
+  import type { TerminalSettingsInput } from "@middleman/ui";
   import { updateSettings } from "../../api/settings.js";
-
   import { isEmbedded } from "../../stores/embed-config.svelte.js";
 
-  interface Props {
-    terminal: TerminalSettingsType;
-    onUpdate: (terminal: TerminalSettingsType) => void;
+  interface FontData {
+    family: string;
+    fullName: string;
+    postscriptName: string;
+    style: string;
   }
 
-  let { terminal, onUpdate }: Props = $props();
+  interface Props {
+    terminal: TerminalSettingsInput;
+    onUpdate: (terminal: TerminalSettingsType) => void;
+    compact?: boolean;
+    livePreview?: boolean;
+  }
+
+  const {
+    terminal,
+    onUpdate,
+    compact = false,
+    livePreview = false,
+  }: Props = $props();
 
   const { settings: settingsStore } = getStores();
   const embedded = isEmbedded();
 
+  const commonMonospaceFonts = [
+    "JetBrains Mono",
+    "SF Mono",
+    "Iosevka Term",
+    "Fira Code",
+    "Cascadia Code",
+    "Source Code Pro",
+    "Menlo",
+    "Monaco",
+    "Consolas",
+    "Courier New",
+  ];
+
+  let draftReady = $state(false);
   let saving = $state(false);
-  let draft = $state("");
+  let fontFamilyDraft = $state("");
+  let fontSizeDraft = $state(DEFAULT_TERMINAL_SETTINGS.font_size);
+  let scrollbackDraft = $state(DEFAULT_TERMINAL_SETTINGS.scrollback);
+  let lineHeightDraft = $state(DEFAULT_TERMINAL_SETTINGS.line_height);
+  let letterSpacingDraft = $state(
+    DEFAULT_TERMINAL_SETTINGS.letter_spacing,
+  );
+  let cursorBlinkDraft = $state(
+    DEFAULT_TERMINAL_SETTINGS.cursor_blink,
+  );
+  let fontLigaturesDraft = $state(
+    DEFAULT_TERMINAL_SETTINGS.font_ligatures,
+  );
   let rendererDraft = $state<TerminalSettingsType["renderer"]>("xterm");
+  let fontDialogOpen = $state(false);
+  let localFonts = $state<FontData[] | null>(null);
+  let fontLoadError = $state<string | null>(null);
+  let loadingFonts = $state(false);
 
   function normalizeFontFamily(value: string): string {
     return value.trim();
   }
 
-  const currentFontFamily = $derived(terminal.font_family);
-  const currentRenderer = $derived(
-    terminal.renderer === "ghostty-web" ? "ghostty-web" : "xterm",
+  function quoteFontFamily(family: string): string {
+    return `${quoteSingleFontFamily(family)}, monospace`;
+  }
+
+  function quoteSingleFontFamily(family: string): string {
+    const escaped = family.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+    return `"${escaped}"`;
+  }
+
+  function firstFontFamilySeparatorIndex(value: string): number {
+    let quote: "'" | "\"" | null = null;
+    let escaped = false;
+    for (let index = 0; index < value.length; index += 1) {
+      const char = value[index];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (quote) {
+        if (char === quote) quote = null;
+        continue;
+      }
+      if (char === "'" || char === "\"") {
+        quote = char;
+        continue;
+      }
+      if (char === ",") return index;
+    }
+    return -1;
+  }
+
+  function replacePreferredFontFamily(
+    currentValue: string,
+    family: string,
+  ): string {
+    const separatorIndex = firstFontFamilySeparatorIndex(currentValue);
+    if (separatorIndex === -1) return quoteFontFamily(family);
+
+    const fallbacks = currentValue.slice(separatorIndex + 1).trim();
+    if (!fallbacks) return quoteFontFamily(family);
+    return `${quoteSingleFontFamily(family)}, ${fallbacks}`;
+  }
+
+  function isLikelyMonospaceFont(font: FontData): boolean {
+    const name = `${font.family} ${font.fullName} ${font.postscriptName}`;
+    return /\b(mono|code|console|terminal|typewriter|courier|menlo|monaco|consolas|iosevka|hack)\b/i
+      .test(name);
+  }
+
+  const currentTerminal = $derived(
+    normalizeTerminalSettings(terminal),
   );
-  const normalizedDraft = $derived(normalizeFontFamily(draft));
+  const normalizedFontFamilyDraft = $derived(
+    normalizeFontFamily(fontFamilyDraft),
+  );
+  const normalizedDraft = $derived({
+    font_family: normalizedFontFamilyDraft,
+    font_size: fontSizeDraft,
+    scrollback: scrollbackDraft,
+    line_height: lineHeightDraft,
+    letter_spacing: letterSpacingDraft,
+    cursor_blink: cursorBlinkDraft,
+    font_ligatures: fontLigaturesDraft,
+    renderer: rendererDraft,
+  });
   const isDirty = $derived(
-    normalizedDraft !== currentFontFamily ||
-      rendererDraft !== currentRenderer,
+    normalizedDraft.font_family !== currentTerminal.font_family ||
+      normalizedDraft.font_size !== currentTerminal.font_size ||
+      normalizedDraft.scrollback !== currentTerminal.scrollback ||
+      normalizedDraft.line_height !== currentTerminal.line_height ||
+      normalizedDraft.letter_spacing !== currentTerminal.letter_spacing ||
+      normalizedDraft.cursor_blink !== currentTerminal.cursor_blink ||
+      normalizedDraft.font_ligatures !== currentTerminal.font_ligatures ||
+      normalizedDraft.renderer !== currentTerminal.renderer,
   );
-  const canSave = $derived(
-    !saving && isDirty,
+  const isDefaultDraft = $derived(
+    normalizedDraft.font_family === DEFAULT_TERMINAL_SETTINGS.font_family &&
+      normalizedDraft.font_size === DEFAULT_TERMINAL_SETTINGS.font_size &&
+      normalizedDraft.scrollback === DEFAULT_TERMINAL_SETTINGS.scrollback &&
+      normalizedDraft.line_height === DEFAULT_TERMINAL_SETTINGS.line_height &&
+      normalizedDraft.letter_spacing ===
+        DEFAULT_TERMINAL_SETTINGS.letter_spacing &&
+      normalizedDraft.cursor_blink ===
+        DEFAULT_TERMINAL_SETTINGS.cursor_blink &&
+      normalizedDraft.font_ligatures ===
+        DEFAULT_TERMINAL_SETTINGS.font_ligatures &&
+      normalizedDraft.renderer === DEFAULT_TERMINAL_SETTINGS.renderer,
+  );
+  const xtermOnlyControlsEnabled = $derived(rendererDraft === "xterm");
+  const canSave = $derived(!saving && isDirty);
+  const localMonospaceFonts = $derived.by(() => {
+    if (!localFonts) return [];
+    const fonts: FontData[] = [];
+    for (const font of localFonts) {
+      if (!isLikelyMonospaceFont(font)) continue;
+      if (fonts.some((existing) => existing.family === font.family)) continue;
+      fonts.push(font);
+    }
+    return fonts.sort((left, right) =>
+      left.family.localeCompare(right.family),
+    );
+  });
+  const supportsLocalFontPicker = $derived(
+    typeof window !== "undefined" &&
+      typeof (window as Window & {
+        queryLocalFonts?: () => Promise<FontData[]>;
+      }).queryLocalFonts === "function",
   );
 
-  onMount(() => {
-    draft = terminal.font_family;
-    rendererDraft = currentRenderer;
+  function syncDraftFromTerminal(value: TerminalSettingsInput): void {
+    const normalized = normalizeTerminalSettings(value);
+    fontFamilyDraft = normalized.font_family;
+    fontSizeDraft = normalized.font_size;
+    scrollbackDraft = normalized.scrollback;
+    lineHeightDraft = normalized.line_height;
+    letterSpacingDraft = normalized.letter_spacing;
+    cursorBlinkDraft = normalized.cursor_blink;
+    fontLigaturesDraft = normalized.font_ligatures;
+    rendererDraft = normalized.renderer;
+  }
+
+  $effect(() => {
+    if (draftReady) return;
+    syncDraftFromTerminal(terminal);
+    draftReady = true;
   });
+
+  $effect(() => {
+    if (!draftReady) return;
+    if (!livePreview) return;
+    settingsStore.setTerminalSettings(normalizedDraft);
+  });
+
+  async function loadLocalFonts(): Promise<void> {
+    if (!supportsLocalFontPicker) {
+      fontLoadError = "Local font access is not available in this browser.";
+      return;
+    }
+    loadingFonts = true;
+    fontLoadError = null;
+    try {
+      const queryLocalFonts = (window as unknown as Window & {
+        queryLocalFonts: () => Promise<FontData[]>;
+      }).queryLocalFonts;
+      localFonts = await queryLocalFonts();
+    } catch (err) {
+      fontLoadError = err instanceof Error ? err.message : String(err);
+    } finally {
+      loadingFonts = false;
+    }
+  }
+
+  function openFontDialog(): void {
+    fontDialogOpen = true;
+    if (localFonts === null) {
+      void loadLocalFonts();
+    }
+  }
+
+  function selectFontFamily(family: string): void {
+    fontFamilyDraft = replacePreferredFontFamily(fontFamilyDraft, family);
+    fontDialogOpen = false;
+  }
+
+  function mergeSavedTerminal(
+    returned: TerminalSettingsInput,
+    fallback: TerminalSettingsType,
+  ): TerminalSettingsType {
+    return normalizeTerminalSettings({
+      font_family: returned.font_family ?? fallback.font_family,
+      font_size: returned.font_size ?? fallback.font_size,
+      scrollback: returned.scrollback ?? fallback.scrollback,
+      line_height: returned.line_height ?? fallback.line_height,
+      letter_spacing: returned.letter_spacing ?? fallback.letter_spacing,
+      cursor_blink: returned.cursor_blink ?? fallback.cursor_blink,
+      font_ligatures: returned.font_ligatures ?? fallback.font_ligatures,
+      renderer: returned.renderer ?? fallback.renderer,
+    });
+  }
+
+  async function persistTerminalSettings(
+    draft: TerminalSettingsType,
+  ): Promise<TerminalSettingsInput> {
+    try {
+      const settings = await updateSettings({ terminal: draft });
+      return settings.terminal;
+    } catch (err) {
+      const settings = await updateSettings({
+        terminal: ({
+          font_family: draft.font_family,
+          renderer: draft.renderer,
+        }) as TerminalSettingsType,
+      });
+      return settings.terminal;
+    }
+  }
 
   async function save(): Promise<void> {
     if (embedded) return;
-    draft = normalizedDraft;
-    if (normalizedDraft === currentFontFamily && rendererDraft === currentRenderer) return;
+    if (!isDirty) return;
 
     saving = true;
     try {
-      const settings = await updateSettings({
-        terminal: {
-          font_family: normalizedDraft,
-          renderer: rendererDraft,
-        },
-      });
-      draft = settings.terminal.font_family;
-      onUpdate(settings.terminal);
-      settingsStore.setTerminalFontFamily(
-        settings.terminal.font_family,
-      );
-      settingsStore.setTerminalRenderer(settings.terminal.renderer);
+      const saved = await persistTerminalSettings(normalizedDraft);
+      const updated = mergeSavedTerminal(saved, normalizedDraft);
+      syncDraftFromTerminal(updated);
+      onUpdate(updated);
+      settingsStore.setTerminalSettings(updated);
     } catch (err) {
-      draft = currentFontFamily;
-      rendererDraft = currentRenderer;
+      syncDraftFromTerminal(currentTerminal);
+      if (livePreview) {
+        settingsStore.setTerminalSettings(currentTerminal);
+      }
       console.warn("Failed to save terminal settings:", err);
     } finally {
       saving = false;
@@ -71,51 +296,133 @@
   }
 
   function reset(): void {
-    draft = "";
-    void save();
+    syncDraftFromTerminal(DEFAULT_TERMINAL_SETTINGS);
   }
 
-  function handleKeydown(event: KeyboardEvent): void {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      void save();
-    } else if (event.key === "Escape") {
-      draft = currentFontFamily;
-      rendererDraft = currentRenderer;
-    }
-  }
 </script>
 
-<div class="terminal-settings">
+<div
+  class:compact
+  class="terminal-settings"
+>
   <label class="font-field" for="terminal-font-family">
     <span class="setting-label">Monospace font family</span>
-    <input
-      id="terminal-font-family"
-      class="font-input"
-      type="text"
-      bind:value={draft}
-      placeholder='"JetBrains Mono", "SF Mono", Menlo, Consolas, monospace'
-      disabled={saving}
-      onkeydown={handleKeydown}
-    />
+    <div class="font-row">
+      <input
+        id="terminal-font-family"
+        class="font-input"
+        type="text"
+        bind:value={fontFamilyDraft}
+        placeholder='"JetBrains Mono", "SF Mono", Menlo, Consolas, monospace'
+        disabled={saving}
+      />
+      <button
+        class="choose-btn"
+        type="button"
+        disabled={saving}
+        onclick={openFontDialog}
+      >
+        Choose
+      </button>
+    </div>
   </label>
 
-  <label class="renderer-field" for="terminal-renderer">
-    <span class="setting-label">Terminal renderer</span>
-    <select
-      id="terminal-renderer"
-      class="renderer-select"
-      bind:value={rendererDraft}
+  <div class="control-grid">
+    <label class="control-field" for="terminal-font-size">
+      <span class="setting-label">Font size</span>
+      <input
+        id="terminal-font-size"
+        class="number-input"
+        type="number"
+        min="8"
+        max="32"
+        step="1"
+        bind:value={fontSizeDraft}
+        disabled={saving}
+      />
+    </label>
+
+    <label class="control-field" for="terminal-line-height">
+      <span class="setting-label">Line height</span>
+      <input
+        id="terminal-line-height"
+        class="number-input"
+        type="number"
+        min="0.8"
+        max="2"
+        step="0.05"
+        bind:value={lineHeightDraft}
+        disabled={saving || !xtermOnlyControlsEnabled}
+      />
+    </label>
+
+    <label class="control-field" for="terminal-scrollback">
+      <span class="setting-label">Scrollback</span>
+      <input
+        id="terminal-scrollback"
+        class="number-input"
+        type="number"
+        min="100"
+        max="100000"
+        step="100"
+        bind:value={scrollbackDraft}
+        disabled={saving}
+      />
+    </label>
+
+    <label class="control-field" for="terminal-letter-spacing">
+      <span class="setting-label">Letter spacing</span>
+      <input
+        id="terminal-letter-spacing"
+        class="number-input"
+        type="number"
+        min="-2"
+        max="8"
+        step="1"
+        bind:value={letterSpacingDraft}
+        disabled={saving || !xtermOnlyControlsEnabled}
+      />
+    </label>
+
+    <label class="renderer-field" for="terminal-renderer">
+      <span class="setting-label">Terminal renderer</span>
+      <select
+        id="terminal-renderer"
+        class="renderer-select"
+        bind:value={rendererDraft}
+        disabled={saving}
+      >
+        <option value="xterm">xterm.js</option>
+        <option value="ghostty-web">ghostty-web</option>
+      </select>
+    </label>
+  </div>
+
+  <label class="toggle-field">
+    <input
+      type="checkbox"
+      bind:checked={cursorBlinkDraft}
       disabled={saving}
-    >
-      <option value="xterm">xterm.js</option>
-      <option value="ghostty-web">ghostty-web</option>
-    </select>
+    />
+    <span>Cursor blink</span>
+  </label>
+
+  <label class="toggle-field">
+    <input
+      type="checkbox"
+      bind:checked={fontLigaturesDraft}
+      disabled={saving || !xtermOnlyControlsEnabled}
+    />
+    <span>Font ligatures</span>
   </label>
 
   <div class="setting-actions">
     <p class="setting-help">
-      Leave blank to use the app default monospace stack.
+      {#if xtermOnlyControlsEnabled}
+        Leave the font blank to use the app default monospace stack.
+      {:else}
+        ghostty-web does not expose line height, letter spacing, or ligature controls.
+      {/if}
     </p>
     <div class="button-row">
       <button
@@ -129,7 +436,7 @@
       <button
         class="reset-btn"
         type="button"
-        disabled={saving || !currentFontFamily}
+        disabled={saving || isDefaultDraft}
         onclick={reset}
       >
         Reset
@@ -138,6 +445,91 @@
   </div>
 </div>
 
+{#if fontDialogOpen}
+  <div
+    class="font-dialog-backdrop"
+    role="presentation"
+    onclick={(event) => {
+      if (event.currentTarget === event.target) fontDialogOpen = false;
+    }}
+  >
+    <div
+      class="font-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="terminal-font-dialog-title"
+    >
+      <div class="font-dialog-header">
+        <h2 id="terminal-font-dialog-title">Choose monospace font</h2>
+        <button
+          class="close-btn"
+          type="button"
+          aria-label="Close font picker"
+          onclick={() => {
+            fontDialogOpen = false;
+          }}
+        >
+          <XIcon size="14" strokeWidth="2" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div class="font-section">
+        <div class="font-section-title">Common fonts</div>
+        <div class="font-list">
+          {#each commonMonospaceFonts as family (family)}
+            <button
+              class="font-option"
+              type="button"
+              style:font-family={quoteFontFamily(family)}
+              onclick={() => selectFontFamily(family)}
+            >
+              <span>{family}</span>
+              <code>abc 123</code>
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      <div class="font-section">
+        <div class="font-section-title">Local monospace fonts</div>
+        {#if loadingFonts}
+          <p class="font-state">Loading local fonts...</p>
+        {:else if fontLoadError}
+          <p class="font-state error">{fontLoadError}</p>
+          {#if supportsLocalFontPicker}
+            <button
+              class="retry-fonts-btn"
+              type="button"
+              onclick={() => void loadLocalFonts()}
+            >
+              Try again
+            </button>
+          {/if}
+        {:else if localMonospaceFonts.length > 0}
+          <div class="font-list local">
+            {#each localMonospaceFonts as font (font.family)}
+              <button
+                class="font-option"
+                type="button"
+                style:font-family={quoteFontFamily(font.family)}
+                onclick={() => selectFontFamily(font.family)}
+              >
+                <span>{font.family}</span>
+                <code>{font.style || "Regular"}</code>
+              </button>
+            {/each}
+          </div>
+        {:else}
+          <p class="font-state">
+            No local monospace fonts were found. You can still type a font
+            family manually.
+          </p>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
 <style>
   .terminal-settings {
     display: flex;
@@ -145,22 +537,61 @@
     gap: 10px;
   }
 
+  .terminal-settings.compact {
+    width: 340px;
+  }
+
   .font-field,
-  .renderer-field {
+  .renderer-field,
+  .control-field {
     display: flex;
     flex-direction: column;
     gap: 6px;
   }
 
   .setting-label {
-    font-size: var(--font-size-md);
+    font-size: var(--font-size-sm);
     color: var(--text-secondary);
+    font-weight: 600;
+  }
+
+  .font-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 6px;
+  }
+
+  .control-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
   }
 
   .font-input,
+  .number-input,
   .renderer-select {
     width: 100%;
+    height: 28px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    padding: 0 8px;
+  }
+
+  .font-input {
     font-family: var(--font-mono);
+  }
+
+  .toggle-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
   }
 
   .setting-actions {
@@ -177,15 +608,20 @@
   }
 
   .setting-help {
-    font-size: var(--font-size-sm);
+    margin: 0;
+    font-size: var(--font-size-xs);
     color: var(--text-muted);
+    line-height: 1.4;
   }
 
   .save-btn,
-  .reset-btn {
-    padding: 5px 10px;
+  .reset-btn,
+  .choose-btn,
+  .retry-fonts-btn {
+    height: 28px;
+    padding: 0 10px;
     font-size: var(--font-size-sm);
-    font-weight: 500;
+    font-weight: 600;
     border-radius: var(--radius-sm);
     transition: background 0.12s, color 0.12s, opacity 0.12s,
       border-color 0.12s;
@@ -200,23 +636,161 @@
     opacity: 0.9;
   }
 
-  .save-btn:disabled {
+  .save-btn:disabled,
+  .reset-btn:disabled,
+  .choose-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
 
-  .reset-btn {
+  .reset-btn,
+  .choose-btn,
+  .retry-fonts-btn {
     color: var(--text-secondary);
     border: 1px solid var(--border-muted);
+    background: var(--bg-surface);
   }
 
-  .reset-btn:hover:not(:disabled) {
+  .reset-btn:hover:not(:disabled),
+  .choose-btn:hover:not(:disabled),
+  .retry-fonts-btn:hover {
     background: var(--bg-surface-hover);
     color: var(--text-primary);
   }
 
-  .reset-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+  .font-dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 70;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    background: color-mix(in srgb, black 48%, transparent);
+  }
+
+  .font-dialog {
+    width: min(560px, 100%);
+    max-height: min(680px, calc(100vh - 40px));
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .font-dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .font-dialog-header h2 {
+    margin: 0;
+    font-size: var(--font-size-lg);
+    font-weight: 700;
+  }
+
+  .close-btn {
+    width: 26px;
+    height: 26px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+  }
+
+  .close-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .font-section {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .font-section-title {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .font-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    min-height: 0;
+  }
+
+  .font-list.local {
+    overflow-y: auto;
+    max-height: 240px;
+    padding-right: 2px;
+  }
+
+  .font-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    height: 34px;
+    padding: 0 10px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    text-align: left;
+  }
+
+  .font-option:hover,
+  .font-option:focus-visible {
+    border-color: var(--accent-blue);
+    background: color-mix(in srgb, var(--accent-blue) 9%, var(--bg-primary));
+    outline: none;
+  }
+
+  .font-option span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .font-option code {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .font-state {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+
+  .font-state.error {
+    color: var(--accent-red);
+  }
+
+  @media (max-width: 620px) {
+    .terminal-settings.compact {
+      width: min(340px, calc(100vw - 32px));
+    }
+
+    .control-grid,
+    .font-list {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -23,6 +23,7 @@
     onUpdate: (terminal: TerminalSettingsType) => void;
     compact?: boolean;
     livePreview?: boolean;
+    onSavingChange?: (saving: boolean) => void;
   }
 
   const {
@@ -30,6 +31,7 @@
     onUpdate,
     compact = false,
     livePreview = false,
+    onSavingChange,
   }: Props = $props();
 
   const { settings: settingsStore } = getStores();
@@ -249,6 +251,7 @@
 
   onDestroy(() => {
     if (!livePreview) return;
+    if (saving) return;
     settingsStore.setTerminalSettings(livePreviewBaseline ?? currentTerminal);
   });
 
@@ -324,6 +327,7 @@
     if (!isDirty) return;
 
     saving = true;
+    onSavingChange?.(true);
     try {
       const saved = await persistTerminalSettings(normalizedDraft);
       const updated = mergeSavedTerminal(saved, normalizedDraft);
@@ -341,6 +345,7 @@
       console.warn("Failed to save terminal settings:", err);
     } finally {
       saving = false;
+      onSavingChange?.(false);
     }
   }
 

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import {
     DEFAULT_TERMINAL_SETTINGS,
     getStores,
@@ -50,10 +51,16 @@
   let draftReady = $state(false);
   let saving = $state(false);
   let fontFamilyDraft = $state("");
-  let fontSizeDraft = $state(DEFAULT_TERMINAL_SETTINGS.font_size);
-  let scrollbackDraft = $state(DEFAULT_TERMINAL_SETTINGS.scrollback);
-  let lineHeightDraft = $state(DEFAULT_TERMINAL_SETTINGS.line_height);
-  let letterSpacingDraft = $state(
+  let fontSizeDraft = $state<number | null>(
+    DEFAULT_TERMINAL_SETTINGS.font_size,
+  );
+  let scrollbackDraft = $state<number | null>(
+    DEFAULT_TERMINAL_SETTINGS.scrollback,
+  );
+  let lineHeightDraft = $state<number | null>(
+    DEFAULT_TERMINAL_SETTINGS.line_height,
+  );
+  let letterSpacingDraft = $state<number | null>(
     DEFAULT_TERMINAL_SETTINGS.letter_spacing,
   );
   let cursorBlinkDraft = $state(
@@ -67,6 +74,7 @@
   let localFonts = $state<FontData[] | null>(null);
   let fontLoadError = $state<string | null>(null);
   let loadingFonts = $state(false);
+  let livePreviewBaseline = $state<TerminalSettingsType | null>(null);
 
   function normalizeFontFamily(value: string): string {
     return value.trim();
@@ -125,22 +133,31 @@
       .test(name);
   }
 
+  function draftInput(): TerminalSettingsInput {
+    const draft: TerminalSettingsInput = {
+      font_family: normalizedFontFamilyDraft,
+      cursor_blink: cursorBlinkDraft,
+      font_ligatures: fontLigaturesDraft,
+      renderer: rendererDraft,
+    };
+    if (fontSizeDraft !== null) draft.font_size = fontSizeDraft;
+    if (scrollbackDraft !== null) draft.scrollback = scrollbackDraft;
+    if (lineHeightDraft !== null) draft.line_height = lineHeightDraft;
+    if (letterSpacingDraft !== null) {
+      draft.letter_spacing = letterSpacingDraft;
+    }
+    return draft;
+  }
+
   const currentTerminal = $derived(
     normalizeTerminalSettings(terminal),
   );
   const normalizedFontFamilyDraft = $derived(
     normalizeFontFamily(fontFamilyDraft),
   );
-  const normalizedDraft = $derived({
-    font_family: normalizedFontFamilyDraft,
-    font_size: fontSizeDraft,
-    scrollback: scrollbackDraft,
-    line_height: lineHeightDraft,
-    letter_spacing: letterSpacingDraft,
-    cursor_blink: cursorBlinkDraft,
-    font_ligatures: fontLigaturesDraft,
-    renderer: rendererDraft,
-  });
+  const normalizedDraft = $derived.by(() =>
+    normalizeTerminalSettings(draftInput()),
+  );
   const isDirty = $derived(
     normalizedDraft.font_family !== currentTerminal.font_family ||
       normalizedDraft.font_size !== currentTerminal.font_size ||
@@ -197,9 +214,30 @@
     rendererDraft = normalized.renderer;
   }
 
+  function errorMessage(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  function isLegacyTerminalSettingsError(err: unknown): boolean {
+    const message = errorMessage(err).toLowerCase();
+    if (!message) return false;
+    const mentionsUnknownField =
+      /\b(unknown|unrecognized|unsupported|unexpected|additional)\b/.test(
+        message,
+      );
+    const mentionsTerminalSetting =
+      /\b(terminal|font_family|font_size|scrollback|line_height|letter_spacing|cursor_blink|font_ligatures|renderer)\b/.test(
+        message,
+      );
+    return mentionsUnknownField && mentionsTerminalSetting;
+  }
+
   $effect(() => {
     if (draftReady) return;
     syncDraftFromTerminal(terminal);
+    if (livePreview) {
+      livePreviewBaseline = currentTerminal;
+    }
     draftReady = true;
   });
 
@@ -207,6 +245,11 @@
     if (!draftReady) return;
     if (!livePreview) return;
     settingsStore.setTerminalSettings(normalizedDraft);
+  });
+
+  onDestroy(() => {
+    if (!livePreview) return;
+    settingsStore.setTerminalSettings(livePreviewBaseline ?? currentTerminal);
   });
 
   async function loadLocalFonts(): Promise<void> {
@@ -263,6 +306,9 @@
       const settings = await updateSettings({ terminal: draft });
       return settings.terminal;
     } catch (err) {
+      if (!isLegacyTerminalSettingsError(err)) {
+        throw err;
+      }
       const settings = await updateSettings({
         terminal: ({
           font_family: draft.font_family,
@@ -282,6 +328,9 @@
       const saved = await persistTerminalSettings(normalizedDraft);
       const updated = mergeSavedTerminal(saved, normalizedDraft);
       syncDraftFromTerminal(updated);
+      if (livePreview) {
+        livePreviewBaseline = updated;
+      }
       onUpdate(updated);
       settingsStore.setTerminalSettings(updated);
     } catch (err) {

--- a/frontend/src/lib/components/settings/TerminalSettings.test.ts
+++ b/frontend/src/lib/components/settings/TerminalSettings.test.ts
@@ -30,10 +30,10 @@ vi.mock("@middleman/ui", () => ({
   }),
   normalizeTerminalSettings: (terminal: {
     font_family?: string;
-    font_size?: number;
-    scrollback?: number;
-    line_height?: number;
-    letter_spacing?: number;
+    font_size?: number | null;
+    scrollback?: number | null;
+    line_height?: number | null;
+    letter_spacing?: number | null;
     cursor_blink?: boolean | null;
     font_ligatures?: boolean | null;
     renderer?: string | null;
@@ -412,7 +412,9 @@ describe("TerminalSettings", () => {
 
   it("retries save with legacy terminal fields for older backends", async () => {
     mockUpdateSettings
-      .mockRejectedValueOnce(new Error("validation failed"))
+      .mockRejectedValueOnce(
+        new Error("unknown field terminal.font_size"),
+      )
       .mockResolvedValueOnce({
         terminal: {
           font_family: "",
@@ -454,6 +456,202 @@ describe("TerminalSettings", () => {
     expect(onUpdate).toHaveBeenCalledWith({
       font_family: "",
       font_size: 17,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
+    });
+  });
+
+  it("does not retry validation failures with legacy terminal fields", async () => {
+    mockUpdateSettings.mockRejectedValueOnce(new Error("validation failed"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onUpdate = vi.fn();
+
+    try {
+      render(TerminalSettings, {
+        props: {
+          terminal: {
+            font_family: "",
+            font_size: 14,
+            scrollback: 1000,
+            line_height: 1,
+            letter_spacing: 0,
+            cursor_blink: true,
+            font_ligatures: false,
+            renderer: "xterm",
+          },
+          onUpdate,
+        },
+      });
+
+      await fireEvent.input(screen.getByLabelText("Font size"), {
+        target: { value: "17" },
+      });
+      await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(mockUpdateSettings).toHaveBeenCalledTimes(1);
+      });
+      expect(onUpdate).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("normalizes empty numeric drafts before saving", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+    });
+
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 18,
+          scrollback: 5000,
+          line_height: 1.15,
+          letter_spacing: 1,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "" },
+    });
+    await fireEvent.input(screen.getByLabelText("Scrollback"), {
+      target: { value: "" },
+    });
+    await fireEvent.input(screen.getByLabelText("Line height"), {
+      target: { value: "" },
+    });
+    await fireEvent.input(screen.getByLabelText("Letter spacing"), {
+      target: { value: "" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+      });
+    });
+  });
+
+  it("reverts unsaved live preview settings on unmount", async () => {
+    const { unmount } = render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        livePreview: true,
+        onUpdate: vi.fn(),
+      },
+    });
+    mockSetTerminalSettings.mockClear();
+
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "19" },
+    });
+    expect(mockSetTerminalSettings).toHaveBeenLastCalledWith({
+      font_family: "",
+      font_size: 19,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
+    });
+
+    unmount();
+
+    expect(mockSetTerminalSettings).toHaveBeenLastCalledWith({
+      font_family: "",
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
+    });
+  });
+
+  it("keeps the saved live preview baseline when unmounted after saving", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        font_family: "",
+        font_size: 19,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+    });
+    const { unmount } = render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        livePreview: true,
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "19" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledTimes(1);
+    });
+    mockSetTerminalSettings.mockClear();
+
+    unmount();
+
+    expect(mockSetTerminalSettings).toHaveBeenLastCalledWith({
+      font_family: "",
+      font_size: 19,
       scrollback: 1000,
       line_height: 1,
       letter_spacing: 0,

--- a/frontend/src/lib/components/settings/TerminalSettings.test.ts
+++ b/frontend/src/lib/components/settings/TerminalSettings.test.ts
@@ -5,30 +5,47 @@ import {
   screen,
   waitFor,
 } from "@testing-library/svelte";
-import {
-  afterEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-const {
-  mockSetTerminalFontFamily,
-  mockSetTerminalRenderer,
-  mockUpdateSettings,
-} = vi.hoisted(() => ({
-  mockSetTerminalFontFamily: vi.fn(),
-  mockSetTerminalRenderer: vi.fn(),
+const { mockSetTerminalSettings, mockUpdateSettings } = vi.hoisted(() => ({
+  mockSetTerminalSettings: vi.fn(),
   mockUpdateSettings: vi.fn(),
 }));
 
 vi.mock("@middleman/ui", () => ({
+  DEFAULT_TERMINAL_SETTINGS: {
+    font_family: "",
+    font_size: 14,
+    scrollback: 1000,
+    line_height: 1,
+    letter_spacing: 0,
+    cursor_blink: true,
+    font_ligatures: false,
+    renderer: "xterm",
+  },
   getStores: () => ({
     settings: {
-      setTerminalFontFamily: mockSetTerminalFontFamily,
-      setTerminalRenderer: mockSetTerminalRenderer,
+      setTerminalSettings: mockSetTerminalSettings,
     },
+  }),
+  normalizeTerminalSettings: (terminal: {
+    font_family?: string;
+    font_size?: number;
+    scrollback?: number;
+    line_height?: number;
+    letter_spacing?: number;
+    cursor_blink?: boolean | null;
+    font_ligatures?: boolean | null;
+    renderer?: string | null;
+  }) => ({
+    font_family: terminal?.font_family ?? "",
+    font_size: terminal?.font_size ?? 14,
+    scrollback: terminal?.scrollback ?? 1000,
+    line_height: terminal?.line_height ?? 1,
+    letter_spacing: terminal?.letter_spacing ?? 0,
+    cursor_blink: terminal?.cursor_blink ?? true,
+    font_ligatures: terminal?.font_ligatures ?? false,
+    renderer: terminal?.renderer === "ghostty-web" ? "ghostty-web" : "xterm",
   }),
 }));
 
@@ -45,15 +62,20 @@ import TerminalSettings from "./TerminalSettings.svelte";
 describe("TerminalSettings", () => {
   afterEach(() => {
     cleanup();
-    mockSetTerminalFontFamily.mockReset();
-    mockSetTerminalRenderer.mockReset();
+    mockSetTerminalSettings.mockReset();
     mockUpdateSettings.mockReset();
   });
 
   it("enables save after editing and persists the font family", async () => {
     mockUpdateSettings.mockResolvedValue({
       terminal: {
-        font_family: "\"Iosevka Term\", monospace",
+        font_family: '"Iosevka Term", monospace',
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
         renderer: "xterm",
       },
     });
@@ -61,7 +83,16 @@ describe("TerminalSettings", () => {
 
     render(TerminalSettings, {
       props: {
-        terminal: { font_family: "", renderer: "xterm" },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
         onUpdate,
       },
     });
@@ -70,13 +101,11 @@ describe("TerminalSettings", () => {
     const saveButton = screen.getByRole("button", { name: "Save" });
 
     await fireEvent.input(input, {
-      target: { value: "\"Iosevka Term\", monospace" },
+      target: { value: '"Iosevka Term", monospace' },
     });
 
     await waitFor(() => {
-      expect(
-        (saveButton as HTMLButtonElement).disabled,
-      ).toBe(false);
+      expect((saveButton as HTMLButtonElement).disabled).toBe(false);
     });
 
     await fireEvent.click(saveButton);
@@ -84,25 +113,49 @@ describe("TerminalSettings", () => {
     await waitFor(() => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({
         terminal: {
-          font_family: "\"Iosevka Term\", monospace",
+          font_family: '"Iosevka Term", monospace',
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
           renderer: "xterm",
         },
       });
     });
     expect(onUpdate).toHaveBeenCalledWith({
-      font_family: "\"Iosevka Term\", monospace",
+      font_family: '"Iosevka Term", monospace',
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
       renderer: "xterm",
     });
-    expect(mockSetTerminalFontFamily).toHaveBeenCalledWith(
-      "\"Iosevka Term\", monospace",
-    );
-    expect(mockSetTerminalRenderer).toHaveBeenCalledWith("xterm");
+    expect(mockSetTerminalSettings).toHaveBeenCalledWith({
+      font_family: '"Iosevka Term", monospace',
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
+    });
   });
 
   it("persists the selected terminal renderer", async () => {
     mockUpdateSettings.mockResolvedValue({
       terminal: {
         font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
         renderer: "ghostty-web",
       },
     });
@@ -110,7 +163,16 @@ describe("TerminalSettings", () => {
 
     render(TerminalSettings, {
       props: {
-        terminal: { font_family: "", renderer: "xterm" },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
         onUpdate,
       },
     });
@@ -124,14 +186,367 @@ describe("TerminalSettings", () => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({
         terminal: {
           font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
           renderer: "ghostty-web",
         },
       });
     });
     expect(onUpdate).toHaveBeenCalledWith({
       font_family: "",
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
       renderer: "ghostty-web",
     });
-    expect(mockSetTerminalRenderer).toHaveBeenCalledWith("ghostty-web");
+    expect(mockSetTerminalSettings).toHaveBeenCalledWith({
+      font_family: "",
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "ghostty-web",
+    });
+  });
+
+  it("persists terminal sizing options", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        font_family: "",
+        font_size: 18,
+        scrollback: 5000,
+        line_height: 1.15,
+        letter_spacing: 1,
+        cursor_blink: false,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+    });
+    const onUpdate = vi.fn();
+
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        onUpdate,
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "18" },
+    });
+    await fireEvent.input(screen.getByLabelText("Scrollback"), {
+      target: { value: "5000" },
+    });
+    await fireEvent.input(screen.getByLabelText("Line height"), {
+      target: { value: "1.15" },
+    });
+    await fireEvent.input(screen.getByLabelText("Letter spacing"), {
+      target: { value: "1" },
+    });
+    await fireEvent.click(screen.getByLabelText("Cursor blink"));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        terminal: {
+          font_family: "",
+          font_size: 18,
+          scrollback: 5000,
+          line_height: 1.15,
+          letter_spacing: 1,
+          cursor_blink: false,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+      });
+    });
+  });
+
+  it("persists font ligatures for xterm.js", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: true,
+        renderer: "xterm",
+      },
+    });
+    const onUpdate = vi.fn();
+
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        onUpdate,
+      },
+    });
+
+    await fireEvent.click(screen.getByLabelText("Font ligatures"));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: true,
+          renderer: "xterm",
+        },
+      });
+    });
+  });
+
+  it("disables xterm-only controls for ghostty-web", async () => {
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "ghostty-web",
+        },
+        onUpdate: vi.fn(),
+      },
+    });
+
+    expect(
+      (screen.getByLabelText("Line height") as HTMLInputElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByLabelText("Letter spacing") as HTMLInputElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByLabelText("Font ligatures") as HTMLInputElement).disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText(
+        "ghostty-web does not expose line height, letter spacing, or ligature controls.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("keeps saved draft values when an older backend omits new fields", async () => {
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        font_family: "",
+        renderer: "xterm",
+      },
+    });
+    const onUpdate = vi.fn();
+
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        onUpdate,
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "18" },
+    });
+    await fireEvent.input(screen.getByLabelText("Line height"), {
+      target: { value: "1.15" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith({
+        font_family: "",
+        font_size: 18,
+        scrollback: 1000,
+        line_height: 1.15,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      });
+    });
+  });
+
+  it("retries save with legacy terminal fields for older backends", async () => {
+    mockUpdateSettings
+      .mockRejectedValueOnce(new Error("validation failed"))
+      .mockResolvedValueOnce({
+        terminal: {
+          font_family: "",
+          renderer: "xterm",
+        },
+      });
+    const onUpdate = vi.fn();
+
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        onUpdate,
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "17" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledTimes(2);
+    });
+    expect(mockUpdateSettings).toHaveBeenNthCalledWith(2, {
+      terminal: {
+        font_family: "",
+        renderer: "xterm",
+      },
+    });
+    expect(onUpdate).toHaveBeenCalledWith({
+      font_family: "",
+      font_size: 17,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
+    });
+  });
+
+  it("previews draft terminal settings when live preview is enabled", async () => {
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        livePreview: true,
+        onUpdate: vi.fn(),
+      },
+    });
+    mockSetTerminalSettings.mockClear();
+
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "19" },
+    });
+
+    expect(mockSetTerminalSettings).toHaveBeenLastCalledWith({
+      font_family: "",
+      font_size: 19,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
+    });
+  });
+
+  it("selects a common monospace font from the chooser", async () => {
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Choose" }));
+    await fireEvent.click(screen.getByRole("button", { name: /Fira Code/ }));
+
+    expect(
+      (screen.getByLabelText("Monospace font family") as HTMLInputElement)
+        .value,
+    ).toBe('"Fira Code", monospace');
+  });
+
+  it("replaces the preferred font while preserving fallbacks", async () => {
+    render(TerminalSettings, {
+      props: {
+        terminal: {
+          font_family: '"Iosevka Term", "SF Mono", Menlo, monospace',
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Choose" }));
+    await fireEvent.click(screen.getByRole("button", { name: /Fira Code/ }));
+
+    expect(
+      (screen.getByLabelText("Monospace font family") as HTMLInputElement)
+        .value,
+    ).toBe('"Fira Code", "SF Mono", Menlo, monospace');
   });
 });

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
@@ -74,6 +74,11 @@
       .trim();
     return buildTerminalFontFamily(configured, defaultTerminalFontFamily());
   });
+  const terminalFontSize = $derived(settingsStore.getTerminalFontSize());
+  const terminalScrollback = $derived(settingsStore.getTerminalScrollback());
+  const terminalCursorBlink = $derived(
+    settingsStore.getTerminalCursorBlink(),
+  );
 
   function defaultWebsocketPath(): string {
     if (!workspaceId) return "";
@@ -320,6 +325,9 @@
   $effect(() => {
     if (!terminal) return;
     terminal.options.fontFamily = terminalFontFamily;
+    terminal.options.fontSize = terminalFontSize;
+    terminal.options.scrollback = terminalScrollback;
+    terminal.options.cursorBlink = terminalCursorBlink;
     fitAddon?.fit();
   });
 
@@ -344,9 +352,10 @@
           foreground: "#c9d1d9",
           cursor: "#58a6ff",
         },
-        cursorBlink: true,
+        cursorBlink: terminalCursorBlink,
         fontFamily: terminalFontFamily,
-        fontSize: 14,
+        fontSize: terminalFontSize,
+        scrollback: terminalScrollback,
       });
       terminal = term;
 

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
@@ -12,6 +12,9 @@ const terminalCtor = vi.fn();
 const terminalWrite = vi.fn();
 
 let configuredFontFamily = "";
+let configuredFontSize = 14;
+let configuredScrollback = 1000;
+let configuredCursorBlink = true;
 let sockets: MockWebSocket[] = [];
 
 class MockWebSocket {
@@ -44,6 +47,9 @@ vi.mock("@middleman/ui", () => ({
   getStores: () => ({
     settings: {
       getTerminalFontFamily: () => configuredFontFamily,
+      getTerminalFontSize: () => configuredFontSize,
+      getTerminalScrollback: () => configuredScrollback,
+      getTerminalCursorBlink: () => configuredCursorBlink,
     },
   }),
 }));
@@ -73,6 +79,9 @@ import GhosttyTerminalPane from "./GhosttyTerminalPane.svelte";
 describe("GhosttyTerminalPane", () => {
   beforeEach(() => {
     configuredFontFamily = "";
+    configuredFontSize = 14;
+    configuredScrollback = 1000;
+    configuredCursorBlink = true;
     delete window.__BASE_PATH__;
     window.__MIDDLEMAN_DEV_API_URL__ = "http://127.0.0.1:8091";
     terminalCtor.mockReset();
@@ -85,19 +94,19 @@ describe("GhosttyTerminalPane", () => {
     terminalWrite.mockReset();
     sockets = [];
 
-    vi.stubGlobal("ResizeObserver", class {
-      observe(): void {}
-      disconnect(): void {}
-    });
-
-    vi.stubGlobal("WebSocket", MockWebSocket);
     vi.stubGlobal(
-      "requestAnimationFrame",
-      (callback: FrameRequestCallback) => {
-        callback(0);
-        return 1;
+      "ResizeObserver",
+      class {
+        observe(): void {}
+        disconnect(): void {}
       },
     );
+
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
     vi.stubGlobal("cancelAnimationFrame", () => undefined);
   });
 
@@ -115,13 +124,19 @@ describe("GhosttyTerminalPane", () => {
   }
 
   it("uses the configured settings font family for ghostty-web", async () => {
-    configuredFontFamily = "\"Fira Code\", monospace";
+    configuredFontFamily = '"Fira Code", monospace';
+    configuredFontSize = 16;
+    configuredScrollback = 5000;
+    configuredCursorBlink = false;
 
     await renderStarted({ workspaceId: "ws-123" });
 
     expect(terminalCtor).toHaveBeenCalledWith(
       expect.objectContaining({
-        fontFamily: "\"Fira Code\", monospace",
+        cursorBlink: false,
+        fontFamily: '"Fira Code", monospace',
+        fontSize: 16,
+        scrollback: 5000,
       }),
     );
   });
@@ -154,9 +169,7 @@ describe("GhosttyTerminalPane", () => {
     expect(sockets).toHaveLength(1);
     const url = new URL(socketAt(0).url);
     expect(url.origin).toBe("ws://localhost:3000");
-    expect(url.pathname).toBe(
-      "/middleman/ws/v1/workspaces/ws-123/terminal",
-    );
+    expect(url.pathname).toBe("/middleman/ws/v1/workspaces/ws-123/terminal");
   });
 
   it("connects to an explicit websocket path", async () => {

--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import SettingsIcon from "@lucide/svelte/icons/settings";
+  import { getStores } from "@middleman/ui";
+  import type { TerminalSettings as TerminalSettingsType } from "@middleman/ui/api/types";
+  import TerminalSettings from "../settings/TerminalSettings.svelte";
+
+  const { settings: settingsStore } = getStores();
+
+  let open = $state(false);
+  let rootEl = $state<HTMLDivElement | null>(null);
+  let terminal = $state<TerminalSettingsType>(
+    settingsStore.getTerminalSettings(),
+  );
+
+  function toggleOpen(): void {
+    if (!open) {
+      terminal = settingsStore.getTerminalSettings();
+    }
+    open = !open;
+  }
+
+  $effect(() => {
+    if (!open) return;
+
+    function onPointerDown(ev: PointerEvent): void {
+      if (rootEl && ev.target instanceof Node && rootEl.contains(ev.target)) {
+        return;
+      }
+      open = false;
+    }
+    function onKeydown(ev: KeyboardEvent): void {
+      if (ev.key === "Escape") {
+        open = false;
+      }
+    }
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("keydown", onKeydown);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("keydown", onKeydown);
+    };
+  });
+</script>
+
+<div class="terminal-options-menu" bind:this={rootEl}>
+  <button
+    class="options-trigger"
+    type="button"
+    aria-label="Terminal options"
+    aria-haspopup="true"
+    aria-expanded={open}
+    title="Terminal options"
+    onclick={toggleOpen}
+  >
+    <SettingsIcon size="13" strokeWidth="2" aria-hidden="true" />
+  </button>
+  {#if open}
+    <div
+      class="options-popover"
+      role="dialog"
+      aria-label="Terminal options"
+    >
+      <div class="popover-heading">Terminal options</div>
+      <TerminalSettings
+        {terminal}
+        compact={true}
+        livePreview={true}
+        onUpdate={(updated) => {
+          terminal = updated;
+        }}
+      />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .terminal-options-menu {
+    position: relative;
+  }
+
+  .options-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 22px;
+    border: 1px solid var(--border-default);
+    border-radius: 3px;
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background-color 80ms ease, border-color 80ms ease,
+      color 80ms ease;
+  }
+
+  .options-trigger:hover,
+  .options-trigger[aria-expanded="true"] {
+    background: var(--bg-surface-hover);
+    border-color: var(--accent-blue);
+    color: var(--text-primary);
+  }
+
+  .options-popover {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    z-index: 25;
+    width: 372px;
+    padding: 10px;
+    border: 1px solid var(--border-default);
+    border-radius: 4px;
+    background: var(--bg-surface);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.04),
+      0 4px 16px rgba(0, 0, 0, 0.12);
+  }
+
+  .popover-heading {
+    padding: 0 0 8px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-bottom: 1px solid var(--border-muted);
+    margin-bottom: 8px;
+  }
+
+  @media (max-width: 620px) {
+    .options-popover {
+      width: min(372px, calc(100vw - 24px));
+      right: -6px;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
@@ -11,10 +11,13 @@
   let terminal = $state<TerminalSettingsType>(
     settingsStore.getTerminalSettings(),
   );
+  let childSaving = $state(false);
 
   function toggleOpen(): void {
+    if (childSaving) return;
     if (!open) {
       terminal = settingsStore.getTerminalSettings();
+      childSaving = false;
     }
     open = !open;
   }
@@ -26,10 +29,12 @@
       if (rootEl && ev.target instanceof Node && rootEl.contains(ev.target)) {
         return;
       }
+      if (childSaving) return;
       open = false;
     }
     function onKeydown(ev: KeyboardEvent): void {
       if (ev.key === "Escape") {
+        if (childSaving) return;
         open = false;
       }
     }
@@ -67,6 +72,9 @@
         livePreview={true}
         onUpdate={(updated) => {
           terminal = updated;
+        }}
+        onSavingChange={(saving) => {
+          childSaving = saving;
         }}
       />
     </div>

--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.test.ts
@@ -1,0 +1,149 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type TerminalSettings = {
+  font_family: string;
+  font_size: number;
+  scrollback: number;
+  line_height: number;
+  letter_spacing: number;
+  cursor_blink: boolean;
+  font_ligatures: boolean;
+  renderer: "xterm" | "ghostty-web";
+};
+
+const {
+  currentTerminal,
+  mockSetTerminalSettings,
+  mockUpdateSettings,
+  normalizeTerminalSettings,
+} = vi.hoisted(() => {
+  const defaults: TerminalSettings = {
+    font_family: "",
+    font_size: 14,
+    scrollback: 1000,
+    line_height: 1,
+    letter_spacing: 0,
+    cursor_blink: true,
+    font_ligatures: false,
+    renderer: "xterm",
+  };
+  const normalize = (
+    terminal: Partial<TerminalSettings> | null | undefined,
+  ): TerminalSettings => ({
+    font_family: terminal?.font_family ?? defaults.font_family,
+    font_size: terminal?.font_size ?? defaults.font_size,
+    scrollback: terminal?.scrollback ?? defaults.scrollback,
+    line_height: terminal?.line_height ?? defaults.line_height,
+    letter_spacing: terminal?.letter_spacing ?? defaults.letter_spacing,
+    cursor_blink: terminal?.cursor_blink ?? defaults.cursor_blink,
+    font_ligatures:
+      terminal?.font_ligatures ?? defaults.font_ligatures,
+    renderer:
+      terminal?.renderer === "ghostty-web" ? "ghostty-web" : "xterm",
+  });
+  return {
+    currentTerminal: { value: { ...defaults } },
+    mockSetTerminalSettings: vi.fn(
+      (settings: Partial<TerminalSettings> | null | undefined) => {
+        currentTerminal.value = normalize(settings);
+      },
+    ),
+    mockUpdateSettings: vi.fn(),
+    normalizeTerminalSettings: normalize,
+  };
+});
+
+vi.mock("@middleman/ui", () => ({
+  DEFAULT_TERMINAL_SETTINGS: {
+    font_family: "",
+    font_size: 14,
+    scrollback: 1000,
+    line_height: 1,
+    letter_spacing: 0,
+    cursor_blink: true,
+    font_ligatures: false,
+    renderer: "xterm",
+  },
+  getStores: () => ({
+    settings: {
+      getTerminalSettings: () => currentTerminal.value,
+      setTerminalSettings: mockSetTerminalSettings,
+    },
+  }),
+  normalizeTerminalSettings,
+}));
+
+vi.mock("../../api/settings.js", () => ({
+  updateSettings: mockUpdateSettings,
+}));
+
+vi.mock("../../stores/embed-config.svelte.js", () => ({
+  isEmbedded: () => false,
+}));
+
+import TerminalOptionsMenu from "./TerminalOptionsMenu.svelte";
+
+describe("TerminalOptionsMenu", () => {
+  afterEach(() => {
+    cleanup();
+    currentTerminal.value = normalizeTerminalSettings(null);
+    mockSetTerminalSettings.mockClear();
+    mockUpdateSettings.mockReset();
+  });
+
+  it("keeps the popover mounted while a save is in flight", async () => {
+    let resolveSave:
+      | ((settings: { terminal: TerminalSettings }) => void)
+      | undefined;
+    mockUpdateSettings.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    render(TerminalOptionsMenu);
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Terminal options" }),
+    );
+    await fireEvent.input(screen.getByLabelText("Font size"), {
+      target: { value: "19" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Saving..." })).toBeTruthy();
+    });
+
+    await fireEvent.keyDown(window, { key: "Escape" });
+    expect(
+      screen.getByRole("dialog", { name: "Terminal options" }),
+    ).toBeTruthy();
+
+    resolveSave?.({
+      terminal: {
+        ...currentTerminal.value,
+        font_size: 19,
+      },
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+    });
+
+    await fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Terminal options" }),
+      ).toBeNull();
+    });
+    expect(currentTerminal.value.font_size).toBe(19);
+  });
+});

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   ghosttyTerminalCtor,
+  ligaturesAddonCtor,
   mockGhosttyInit,
   mockWebglCtor,
   resizeObserverCallbacks,
@@ -13,6 +14,7 @@ const {
   xtermOpen,
 } = vi.hoisted(() => ({
   ghosttyTerminalCtor: vi.fn(),
+  ligaturesAddonCtor: vi.fn(),
   mockGhosttyInit: vi.fn().mockResolvedValue(undefined),
   mockWebglCtor: vi.fn(),
   resizeObserverCallbacks: [] as ResizeObserverCallback[],
@@ -30,6 +32,12 @@ const {
 
 let configuredRenderer: "xterm" | "ghostty-web" = "xterm";
 let configuredFontFamily = "";
+let configuredFontSize = 14;
+let configuredScrollback = 1000;
+let configuredLineHeight = 1;
+let configuredLetterSpacing = 0;
+let configuredCursorBlink = true;
+let configuredFontLigatures = false;
 let mockSockets: MockWebSocket[] = [];
 
 class MockWebSocket {
@@ -55,6 +63,12 @@ vi.mock("@middleman/ui", () => ({
   getStores: () => ({
     settings: {
       getTerminalFontFamily: () => configuredFontFamily,
+      getTerminalFontSize: () => configuredFontSize,
+      getTerminalScrollback: () => configuredScrollback,
+      getTerminalLineHeight: () => configuredLineHeight,
+      getTerminalLetterSpacing: () => configuredLetterSpacing,
+      getTerminalCursorBlink: () => configuredCursorBlink,
+      getTerminalFontLigatures: () => configuredFontLigatures,
       getTerminalRenderer: () => configuredRenderer,
     },
   }),
@@ -89,6 +103,13 @@ vi.mock("@xterm/addon-fit", () => ({
     const addon = { fit: vi.fn() };
     xtermFitAddons.push(addon);
     return addon;
+  }),
+}));
+
+vi.mock("@xterm/addon-ligatures/lib/addon-ligatures.mjs", () => ({
+  LigaturesAddon: vi.fn().mockImplementation(() => {
+    ligaturesAddonCtor();
+    return { dispose: vi.fn() };
   }),
 }));
 
@@ -130,7 +151,14 @@ describe("TerminalPane", () => {
   beforeEach(() => {
     configuredRenderer = "xterm";
     configuredFontFamily = "";
+    configuredFontSize = 14;
+    configuredScrollback = 1000;
+    configuredLineHeight = 1;
+    configuredLetterSpacing = 0;
+    configuredCursorBlink = true;
+    configuredFontLigatures = false;
     ghosttyTerminalCtor.mockReset();
+    ligaturesAddonCtor.mockReset();
     mockGhosttyInit.mockClear();
     mockWebglCtor.mockReset();
     resizeObserverCallbacks.length = 0;
@@ -141,21 +169,21 @@ describe("TerminalPane", () => {
     xtermOnDataHandlers.length = 0;
     mockSockets = [];
 
-    vi.stubGlobal("ResizeObserver", class {
-      constructor(callback: ResizeObserverCallback) {
-        resizeObserverCallbacks.push(callback);
-      }
-      observe(): void {}
-      disconnect(): void {}
-    });
-    vi.stubGlobal("WebSocket", MockWebSocket);
     vi.stubGlobal(
-      "requestAnimationFrame",
-      (callback: FrameRequestCallback) => {
-        callback(0);
-        return 1;
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallbacks.push(callback);
+        }
+        observe(): void {}
+        disconnect(): void {}
       },
     );
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
     vi.stubGlobal("cancelAnimationFrame", () => undefined);
   });
 
@@ -182,6 +210,11 @@ describe("TerminalPane", () => {
       expect.objectContaining({
         allowTransparency: false,
         customGlyphs: true,
+        cursorBlink: true,
+        fontSize: 14,
+        scrollback: 1000,
+        letterSpacing: 0,
+        lineHeight: 1,
         minimumContrastRatio: 4.5,
         rescaleOverlappingGlyphs: true,
         scrollOnEraseInDisplay: true,
@@ -189,6 +222,38 @@ describe("TerminalPane", () => {
       }),
     );
     expect(mockWebglCtor).toHaveBeenCalledWith(undefined);
+  });
+
+  it("uses configured terminal metrics for xterm.js", async () => {
+    configuredFontSize = 17;
+    configuredScrollback = 5000;
+    configuredLineHeight = 1.2;
+    configuredLetterSpacing = 1;
+    configuredCursorBlink = false;
+
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+
+    expect(xtermTerminalCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursorBlink: false,
+        fontSize: 17,
+        scrollback: 5000,
+        lineHeight: 1.2,
+        letterSpacing: 1,
+      }),
+    );
+  });
+
+  it("loads the ligatures addon for xterm.js when enabled", async () => {
+    configuredFontLigatures = true;
+
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+
+    expect(ligaturesAddonCtor).toHaveBeenCalledTimes(1);
   });
 
   it("does not rebuild the WebGL atlas during initial mount refresh", async () => {
@@ -239,7 +304,9 @@ describe("TerminalPane", () => {
 
     xtermOnDataHandlers[0]!("\x1b[<0;10;5M\x1b[<32;12;5M\x1b[<0;12;5m");
 
-    expect(sentText(mockSockets[0]!, mockSockets[0]!.sent.length - 1)).toBe("\x1b[<0;10;5M\x1b[<0;12;5m");
+    expect(sentText(mockSockets[0]!, mockSockets[0]!.sent.length - 1)).toBe(
+      "\x1b[<0;10;5M\x1b[<0;12;5m",
+    );
   });
 
   it("does not update drag filter state while disconnected", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -7,6 +7,7 @@
   import WorkspaceHome from "./WorkspaceHome.svelte";
   import WorkspaceTabs from "./WorkspaceTabs.svelte";
   import LaunchMenu from "./LaunchMenu.svelte";
+  import TerminalOptionsMenu from "./TerminalOptionsMenu.svelte";
   import ShellDrawer from "./ShellDrawer.svelte";
   import type { RuntimeSession } from "@middleman/ui/api/types";
   import {
@@ -1187,6 +1188,7 @@
                   }}
                 />
                 <div class="workspace-actions">
+                  <TerminalOptionsMenu />
                   <LaunchMenu
                     launchTargets={launchTargets}
                     {launchingKey}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -93,7 +93,24 @@ vi.mock("@middleman/ui", async (importOriginal) => {
     ...actual,
     getStores: () => ({
       settings: {
+        getTerminalSettings: () => ({
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "ghostty-web",
+        }),
+        setTerminalSettings: vi.fn(),
         getTerminalFontFamily: () => "",
+        getTerminalFontSize: () => 14,
+        getTerminalScrollback: () => 1000,
+        getTerminalLineHeight: () => 1,
+        getTerminalLetterSpacing: () => 0,
+        getTerminalCursorBlink: () => true,
+        getTerminalFontLigatures: () => false,
         getTerminalRenderer: () => "ghostty-web",
       },
     }),
@@ -215,29 +232,34 @@ describe("WorkspaceTerminalView", () => {
           return Promise.resolve(Response.json(workspaceResponse));
         }
         if (pathname.endsWith("/api/v1/workspaces")) {
-          return Promise.resolve(Response.json({
-            workspaces: [workspaceResponse],
-          }));
+          return Promise.resolve(
+            Response.json({
+              workspaces: [workspaceResponse],
+            }),
+          );
         }
         return Promise.resolve(Response.json({}));
       }),
     );
-    vi.stubGlobal("EventSource", class {
-      addEventListener(): void {}
-      close(): void {}
-    });
-    vi.stubGlobal("ResizeObserver", class {
-      observe(): void {}
-      disconnect(): void {}
-    });
-    vi.stubGlobal("WebSocket", MockWebSocket);
     vi.stubGlobal(
-      "requestAnimationFrame",
-      (callback: FrameRequestCallback) => {
-        callback(0);
-        return 1;
+      "EventSource",
+      class {
+        addEventListener(): void {}
+        close(): void {}
       },
     );
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe(): void {}
+        disconnect(): void {}
+      },
+    );
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
     vi.stubGlobal("cancelAnimationFrame", () => undefined);
   });
 
@@ -265,11 +287,12 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() =>
       expect(screen.queryByRole("tab", { name: /Helper/ })).toBeNull(),
     );
-    expect(screen.getByRole("tab", { name: /Home/ }).getAttribute(
-      "aria-selected",
-    )).toBe("true");
-    expect(localStorage.getItem("middleman-workspace-active-tab:ws-1"))
-      .toBe("home");
+    expect(
+      screen.getByRole("tab", { name: /Home/ }).getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(localStorage.getItem("middleman-workspace-active-tab:ws-1")).toBe(
+      "home",
+    );
   });
 
   it("shows a relaunched agent with the same key and a new generation", async () => {
@@ -324,9 +347,11 @@ describe("WorkspaceTerminalView", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole("button", {
-        name: "Open shell drawer",
-      })).toBeTruthy(),
+      expect(
+        screen.getByRole("button", {
+          name: "Open shell drawer",
+        }),
+      ).toBeTruthy(),
     );
   });
 
@@ -353,9 +378,11 @@ describe("WorkspaceTerminalView", () => {
       }),
     );
     await waitFor(() =>
-      expect(screen.getByRole("button", {
-        name: "Open shell drawer",
-      })).toBeTruthy(),
+      expect(
+        screen.getByRole("button", {
+          name: "Open shell drawer",
+        }),
+      ).toBeTruthy(),
     );
 
     await fireEvent.click(shellButton);
@@ -369,9 +396,8 @@ describe("WorkspaceTerminalView", () => {
   it("ignores older runtime responses after shell cleanup refreshes", async () => {
     localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
     const staleRefresh = deferred<ReturnType<typeof runtimeWithShellSession>>();
-    const freshRefresh = deferred<
-      ReturnType<typeof runtimeWithoutShellSession>
-    >();
+    const freshRefresh =
+      deferred<ReturnType<typeof runtimeWithoutShellSession>>();
     mocks.getWorkspaceRuntime
       .mockResolvedValueOnce(runtimeWithShellSession())
       .mockResolvedValueOnce(runtimeWithShellSession())
@@ -397,9 +423,11 @@ describe("WorkspaceTerminalView", () => {
       }),
     );
     await waitFor(() =>
-      expect(screen.getByRole("button", {
-        name: "Open shell drawer",
-      })).toBeTruthy(),
+      expect(
+        screen.getByRole("button", {
+          name: "Open shell drawer",
+        }),
+      ).toBeTruthy(),
     );
 
     await fireEvent.click(shellButton);

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
@@ -10,20 +10,8 @@
 // props themselves. Mocking the api/runtime module here avoids the
 // captured-fetch problem entirely.
 
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/svelte";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   runtimeClient: {
@@ -82,7 +70,27 @@ vi.mock("@middleman/ui", async (importOriginal) => {
   return {
     ...actual,
     getStores: () => ({
-      settings: { getTerminalFontFamily: () => "" },
+      settings: {
+        getTerminalSettings: () => ({
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        }),
+        setTerminalSettings: vi.fn(),
+        getTerminalFontFamily: () => "",
+        getTerminalFontSize: () => 14,
+        getTerminalScrollback: () => 1000,
+        getTerminalLineHeight: () => 1,
+        getTerminalLetterSpacing: () => 0,
+        getTerminalCursorBlink: () => true,
+        getTerminalFontLigatures: () => false,
+        getTerminalRenderer: () => "xterm",
+      },
     }),
   };
 });
@@ -128,13 +136,10 @@ describe("WorkspaceTerminalView embed props", () => {
         disconnect(): void {}
       },
     );
-    vi.stubGlobal(
-      "requestAnimationFrame",
-      (callback: FrameRequestCallback) => {
-        callback(0);
-        return 1;
-      },
-    );
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
   });
 
   afterEach(() => {
@@ -154,9 +159,9 @@ describe("WorkspaceTerminalView embed props", () => {
     // workspace payload resolves; this confirms the component reached
     // steady state rather than failing the load early.
     await waitFor(() =>
-      expect(
-        screen.getAllByText("feature/embed-props").length,
-      ).toBeGreaterThan(0),
+      expect(screen.getAllByText("feature/embed-props").length).toBeGreaterThan(
+        0,
+      ),
     );
 
     // The workspace-list column header reads "Workspaces"; with
@@ -171,9 +176,9 @@ describe("WorkspaceTerminalView embed props", () => {
     });
 
     await waitFor(() =>
-      expect(
-        screen.getAllByText("feature/embed-props").length,
-      ).toBeGreaterThan(0),
+      expect(screen.getAllByText("feature/embed-props").length).toBeGreaterThan(
+        0,
+      ),
     );
 
     expect(screen.queryByText("Workspaces")).not.toBeNull();
@@ -189,15 +194,13 @@ describe("WorkspaceTerminalView embed props", () => {
     });
 
     await waitFor(() =>
-      expect(
-        screen.getAllByText("feature/embed-props").length,
-      ).toBeGreaterThan(0),
+      expect(screen.getAllByText("feature/embed-props").length).toBeGreaterThan(
+        0,
+      ),
     );
 
     expect(screen.queryByRole("button", { name: "PR" })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Reviews" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reviews" })).toBeNull();
   });
 
   it("renders the PR/Reviews segmented control by default", async () => {
@@ -206,14 +209,12 @@ describe("WorkspaceTerminalView embed props", () => {
     });
 
     await waitFor(() =>
-      expect(
-        screen.getAllByText("feature/embed-props").length,
-      ).toBeGreaterThan(0),
+      expect(screen.getAllByText("feature/embed-props").length).toBeGreaterThan(
+        0,
+      ),
     );
 
     expect(screen.getByRole("button", { name: "PR" })).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Reviews" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reviews" })).toBeTruthy();
   });
 });

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -3,6 +3,7 @@
   import { getStores } from "@middleman/ui";
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
+  import { LigaturesAddon } from "@xterm/addon-ligatures/lib/addon-ligatures.mjs";
   import { WebglAddon } from "@xterm/addon-webgl";
   import "@xterm/xterm/css/xterm.css";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
@@ -36,6 +37,8 @@
   let containerEl: HTMLDivElement;
   let terminal: Terminal | null = $state(null);
   let fitAddon: FitAddon | null = null;
+  let ligaturesAddon: LigaturesAddon | null = null;
+  let webglAddon: WebglAddon | null = null;
   let ws: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let restartTimer: ReturnType<typeof setTimeout> | null = null;
@@ -44,6 +47,12 @@
   let refreshFrame: number | null = null;
   let resizeFrame: number | null = null;
   let appliedTerminalFontFamily = "";
+  let appliedFontSize = 0;
+  let appliedScrollback = 0;
+  let appliedLineHeight = 0;
+  let appliedLetterSpacing = 0;
+  let appliedCursorBlink = true;
+  let appliedFontLigatures = false;
   let disposed = false;
   let exited = false;
   const encoder = new TextEncoder();
@@ -68,6 +77,18 @@
       .trim();
     return buildTerminalFontFamily(configured, defaultTerminalFontFamily());
   });
+  const terminalFontSize = $derived(settingsStore.getTerminalFontSize());
+  const terminalScrollback = $derived(settingsStore.getTerminalScrollback());
+  const terminalLineHeight = $derived(settingsStore.getTerminalLineHeight());
+  const terminalLetterSpacing = $derived(
+    settingsStore.getTerminalLetterSpacing(),
+  );
+  const terminalCursorBlink = $derived(
+    settingsStore.getTerminalCursorBlink(),
+  );
+  const terminalFontLigatures = $derived(
+    settingsStore.getTerminalFontLigatures(),
+  );
 
   function defaultWebsocketPath(): string {
     if (!workspaceId) return "";
@@ -162,6 +183,36 @@
 
     terminal.clearTextureAtlas();
     terminal.refresh(0, Math.max(0, terminal.rows - 1));
+  }
+
+  function recreateWebglAddon(): void {
+    if (!terminal) return;
+    webglAddon?.dispose();
+    webglAddon = null;
+    try {
+      const wgl = new WebglAddon();
+      wgl.onContextLoss(() => {
+        wgl.dispose();
+        if (webglAddon === wgl) webglAddon = null;
+        scheduleTerminalResize();
+      });
+      terminal.loadAddon(wgl);
+      webglAddon = wgl;
+      scheduleTerminalResize();
+    } catch {
+      // WebGL unavailable; canvas renderer used as fallback.
+    }
+  }
+
+  function syncLigaturesAddon(): void {
+    if (!terminal) return;
+    ligaturesAddon?.dispose();
+    ligaturesAddon = null;
+    if (terminalFontLigatures) {
+      ligaturesAddon = new LigaturesAddon();
+      terminal.loadAddon(ligaturesAddon);
+    }
+    recreateWebglAddon();
   }
 
   function scheduleTerminalRefresh(): void {
@@ -310,6 +361,10 @@
       ws = null;
     }
     if (terminal) {
+      ligaturesAddon?.dispose();
+      ligaturesAddon = null;
+      webglAddon?.dispose();
+      webglAddon = null;
       terminal.dispose();
       terminal = null;
     }
@@ -317,9 +372,32 @@
 
   $effect(() => {
     if (!terminal) return;
-    if (terminalFontFamily === appliedTerminalFontFamily) return;
+    if (
+      terminalFontFamily === appliedTerminalFontFamily &&
+      terminalFontSize === appliedFontSize &&
+      terminalScrollback === appliedScrollback &&
+      terminalLineHeight === appliedLineHeight &&
+      terminalLetterSpacing === appliedLetterSpacing &&
+      terminalCursorBlink === appliedCursorBlink &&
+      terminalFontLigatures === appliedFontLigatures
+    ) return;
+    const ligaturesChanged = terminalFontLigatures !== appliedFontLigatures;
     appliedTerminalFontFamily = terminalFontFamily;
+    appliedFontSize = terminalFontSize;
+    appliedScrollback = terminalScrollback;
+    appliedLineHeight = terminalLineHeight;
+    appliedLetterSpacing = terminalLetterSpacing;
+    appliedCursorBlink = terminalCursorBlink;
+    appliedFontLigatures = terminalFontLigatures;
     terminal.options.fontFamily = terminalFontFamily;
+    terminal.options.fontSize = terminalFontSize;
+    terminal.options.scrollback = terminalScrollback;
+    terminal.options.lineHeight = terminalLineHeight;
+    terminal.options.letterSpacing = terminalLetterSpacing;
+    terminal.options.cursorBlink = terminalCursorBlink;
+    if (ligaturesChanged) {
+      syncLigaturesAddon();
+    }
     redrawTerminalTextureAtlas();
     fitAddon?.fit();
   });
@@ -344,12 +422,13 @@
         },
         allowTransparency: false,
         customGlyphs: true,
-        cursorBlink: true,
+        cursorBlink: terminalCursorBlink,
         drawBoldTextInBrightColors: true,
         fontFamily: terminalFontFamily,
-        fontSize: 14,
-        letterSpacing: 0,
-        lineHeight: 1,
+        fontSize: terminalFontSize,
+        scrollback: terminalScrollback,
+        letterSpacing: terminalLetterSpacing,
+        lineHeight: terminalLineHeight,
         minimumContrastRatio: TERMINAL_MINIMUM_CONTRAST_RATIO,
         rescaleOverlappingGlyphs: true,
         scrollOnEraseInDisplay: true,
@@ -363,19 +442,19 @@
       fitAddon = fit;
       term.loadAddon(fit);
 
-      try {
-        const wgl = new WebglAddon();
-        wgl.onContextLoss(() => {
-          wgl.dispose();
-          scheduleTerminalResize();
-        });
-        term.loadAddon(wgl);
-        scheduleTerminalResize();
-      } catch {
-        // WebGL unavailable; canvas renderer used as fallback.
+      if (terminalFontLigatures) {
+        ligaturesAddon = new LigaturesAddon();
+        term.loadAddon(ligaturesAddon);
       }
+      recreateWebglAddon();
 
       appliedTerminalFontFamily = terminalFontFamily;
+      appliedFontSize = terminalFontSize;
+      appliedScrollback = terminalScrollback;
+      appliedLineHeight = terminalLineHeight;
+      appliedLetterSpacing = terminalLetterSpacing;
+      appliedCursorBlink = terminalCursorBlink;
+      appliedFontLigatures = terminalFontLigatures;
       fit.fit();
 
       term.onData((data: string) => {

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -7,6 +7,7 @@ function makeStores(): StoreInstances {
   return {
     settings: {
       setConfiguredRepos: vi.fn(),
+      setTerminalSettings: vi.fn(),
       setTerminalFontFamily: vi.fn(),
       setTerminalRenderer: vi.fn(),
     },
@@ -42,7 +43,13 @@ function makeSettings(): Settings {
       hide_bots: false,
     },
     terminal: {
-      font_family: "\"Fira Code\", monospace",
+      font_family: '"Fira Code", monospace',
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
       renderer: "xterm",
     },
     agents: [],
@@ -75,11 +82,8 @@ describe("runAppStartup", () => {
     expect(stores.settings.setConfiguredRepos).toHaveBeenCalledWith(
       settings.repos,
     );
-    expect(stores.settings.setTerminalFontFamily).toHaveBeenCalledWith(
-      settings.terminal.font_family,
-    );
-    expect(stores.settings.setTerminalRenderer).toHaveBeenCalledWith(
-      settings.terminal.renderer,
+    expect(stores.settings.setTerminalSettings).toHaveBeenCalledWith(
+      settings.terminal,
     );
     expect(stores.activity.hydrateDefaults).toHaveBeenCalledWith(
       settings.activity,
@@ -108,10 +112,10 @@ describe("runAppStartup", () => {
     expect(beforeInitialLoad).toHaveBeenCalledTimes(1);
     const beforeOrder = beforeInitialLoad.mock.invocationCallOrder[0] ?? 0;
     const readyOrder = onReady.mock.invocationCallOrder[0] ?? 0;
-    const pullLoadOrder = vi.mocked(stores.pulls.loadPulls)
-      .mock.invocationCallOrder[0] ?? 0;
-    const issueLoadOrder = vi.mocked(stores.issues.loadIssues)
-      .mock.invocationCallOrder[0] ?? 0;
+    const pullLoadOrder =
+      vi.mocked(stores.pulls.loadPulls).mock.invocationCallOrder[0] ?? 0;
+    const issueLoadOrder =
+      vi.mocked(stores.issues.loadIssues).mock.invocationCallOrder[0] ?? 0;
     expect(beforeOrder).toBeLessThan(readyOrder);
     expect(beforeOrder).toBeLessThan(pullLoadOrder);
     expect(beforeOrder).toBeLessThan(issueLoadOrder);

--- a/frontend/src/lib/utils/appStartup.ts
+++ b/frontend/src/lib/utils/appStartup.ts
@@ -55,10 +55,7 @@ export function runAppStartup(deps: AppStartupDeps): () => void {
       const stores = deps.getStores();
       if (stores) {
         stores.settings.setConfiguredRepos(settings.repos);
-        stores.settings.setTerminalFontFamily(
-          settings.terminal.font_family,
-        );
-        stores.settings.setTerminalRenderer(settings.terminal.renderer);
+        stores.settings.setTerminalSettings(settings.terminal);
         stores.activity.hydrateDefaults(settings.activity);
       }
     } catch (err) {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
 
+declare module "@xterm/addon-ligatures/lib/addon-ligatures.mjs" {
+  export { LigaturesAddon } from "@xterm/addon-ligatures";
+}
+
 interface MiddlemanConfig {
   theme?: {
     mode?: "light" | "dark" | "system";
@@ -125,11 +129,7 @@ interface ToolingStatus {
 interface WorkspaceHost {
   key: string;
   label: string;
-  connectionState:
-    | "connected"
-    | "connecting"
-    | "disconnected"
-    | "error";
+  connectionState: "connected" | "connecting" | "disconnected" | "error";
   transport?: "ssh" | "local";
   platform?: string;
   projects: WorkspaceProject[];
@@ -216,7 +216,14 @@ interface WorkspaceDetailContext {
 }
 
 interface MiddlemanNavigateEvent {
-  type: "pull" | "issue" | "activity" | "repos" | "board" | "reviews" | "workspaces";
+  type:
+    | "pull"
+    | "issue"
+    | "activity"
+    | "repos"
+    | "board"
+    | "reviews"
+    | "workspaces";
   owner?: string;
   name?: string;
   number?: number;
@@ -238,12 +245,10 @@ interface Window {
   __middleman_set_repo_filter?: (
     repo: { owner: string; name: string } | null,
   ) => void;
-  __middleman_update_selection?: (
-    selection: {
-      hostKey?: string | null;
-      worktreeKey?: string | null;
-    },
-  ) => void;
+  __middleman_update_selection?: (selection: {
+    hostKey?: string | null;
+    worktreeKey?: string | null;
+  }) => void;
   __middleman_update_host_state?: (
     hostKey: string,
     patch: {

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -1,5 +1,13 @@
-import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
-import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+} from "@playwright/test";
+import {
+  startIsolatedE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
 
 type RepoSummary = {
   Platform: string;
@@ -25,49 +33,61 @@ test.afterEach(async () => {
   isolatedServer = undefined;
 });
 
-test("settings shows glob match counts and refresh updates tracked repos", async ({ page }) => {
+test("settings shows glob match counts and refresh updates tracked repos", async ({
+  page,
+}) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
 
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
 
   const row = page.locator(".repo-row", { hasText: "roborev-dev/*" });
   await expect(row).toContainText("roborev-dev/*");
   await expect(row).toContainText("(2)");
-  await expect.poll(async () => {
-    if (!api) {
-      throw new Error("settings-globs API context not initialized");
-    }
-    const response = await api.get("/api/v1/repos");
-    const repos = await response.json() as RepoSummary[];
-    return repos
-      .filter((repo) => repo.Owner === "roborev-dev")
-      .map((repo) => repo.Name)
-      .sort()
-      .join(",");
-  }).toBe("middleman,worker");
+  await expect
+    .poll(async () => {
+      if (!api) {
+        throw new Error("settings-globs API context not initialized");
+      }
+      const response = await api.get("/api/v1/repos");
+      const repos = (await response.json()) as RepoSummary[];
+      return repos
+        .filter((repo) => repo.Owner === "roborev-dev")
+        .map((repo) => repo.Name)
+        .sort()
+        .join(",");
+    })
+    .toBe("middleman,worker");
 
   const selector = page.getByTitle("Select repository");
   await expect(selector).toBeVisible();
   await selector.click();
-  await expect(page.getByRole("option", { name: /roborev-dev\/middleman/ })).toBeVisible();
-  await expect(page.getByRole("option", { name: /roborev-dev\/worker/ })).toBeVisible();
+  await expect(
+    page.getByRole("option", { name: /roborev-dev\/middleman/ }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("option", { name: /roborev-dev\/worker/ }),
+  ).toBeVisible();
   await page.keyboard.press("Escape");
 
   await row.getByRole("button", { name: "Refresh" }).click();
 
   await expect(row).toContainText("(3)");
-  await expect.poll(async () => {
-    if (!api) {
-      throw new Error("settings-globs API context not initialized");
-    }
-    const response = await api.get("/api/v1/repos");
-    const repos = await response.json() as RepoSummary[];
-    return repos
-      .filter((repo) => repo.Owner === "roborev-dev")
-      .map((repo) => repo.Name)
-      .sort()
-      .join(",");
-  }).toBe("middleman,review-bot,worker");
+  await expect
+    .poll(async () => {
+      if (!api) {
+        throw new Error("settings-globs API context not initialized");
+      }
+      const response = await api.get("/api/v1/repos");
+      const repos = (await response.json()) as RepoSummary[];
+      return repos
+        .filter((repo) => repo.Owner === "roborev-dev")
+        .map((repo) => repo.Name)
+        .sort()
+        .join(",");
+    })
+    .toBe("middleman,review-bot,worker");
 
   await page.screenshot({
     path: "test-results/settings-globs-pr.png",
@@ -75,12 +95,18 @@ test("settings shows glob match counts and refresh updates tracked repos", async
   });
 });
 
-test("settings imports a selected subset from a repository glob", async ({ page }) => {
+test("settings imports a selected subset from a repository glob", async ({
+  page,
+}) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
 
   await page.getByRole("button", { name: "Add repositories…" }).click();
-  await expect(page.getByRole("dialog", { name: "Add repositories" })).toBeVisible();
+  await expect(
+    page.getByRole("dialog", { name: "Add repositories" }),
+  ).toBeVisible();
   await page.getByLabel("Repository pattern").fill("import-lab/*");
   await page.getByRole("button", { name: "Preview" }).click();
 
@@ -93,16 +119,24 @@ test("settings imports a selected subset from a repository glob", async ({ page 
   await page.getByLabel("Filter repositories").fill("");
   await page.getByRole("button", { name: "Add selected repositories" }).click();
 
-  await expect(page.getByRole("dialog", { name: "Add repositories" })).toHaveCount(0);
-  await expect(page.locator(".repo-row", { hasText: "import-lab/api" })).toBeVisible();
-  await expect(page.locator(".repo-row", { hasText: "import-lab/worker" })).toHaveCount(0);
+  await expect(
+    page.getByRole("dialog", { name: "Add repositories" }),
+  ).toHaveCount(0);
+  await expect(
+    page.locator(".repo-row", { hasText: "import-lab/api" }),
+  ).toBeVisible();
+  await expect(
+    page.locator(".repo-row", { hasText: "import-lab/worker" }),
+  ).toHaveCount(0);
 
   const selector = page.getByTitle("Select repository");
   await expect(selector).toBeVisible();
   await selector.click();
   const apiOption = page.getByRole("option", { name: /import-lab\/api/ });
   await expect(apiOption).toBeVisible();
-  await expect(page.getByRole("option", { name: /import-lab\/worker/ })).toHaveCount(0);
+  await expect(
+    page.getByRole("option", { name: /import-lab\/worker/ }),
+  ).toHaveCount(0);
   await apiOption.click();
   await expect(apiOption.locator("input[type='checkbox']")).toBeChecked();
   await page.keyboard.press("Escape");
@@ -110,21 +144,25 @@ test("settings imports a selected subset from a repository glob", async ({ page 
 
   if (!api) throw new Error("settings-globs API context not initialized");
   const settingsResponse = await api.get("/api/v1/settings");
-  const settings = await settingsResponse.json() as { repos: Array<{ owner: string; name: string; is_glob: boolean }> };
+  const settings = (await settingsResponse.json()) as {
+    repos: Array<{ owner: string; name: string; is_glob: boolean }>;
+  };
   const exactNames = settings.repos
     .filter((repo) => repo.owner === "import-lab" && !repo.is_glob)
     .map((repo) => repo.name)
     .sort();
   expect(exactNames).toEqual(["api"]);
-  await expect.poll(async () => {
-    const response = await api!.get("/api/v1/repos");
-    const repos = await response.json() as RepoSummary[];
-    return repos
-      .filter((repo) => repo.Owner === "import-lab")
-      .map((repo) => repo.Name)
-      .sort()
-      .join(",");
-  }).toBe("api");
+  await expect
+    .poll(async () => {
+      const response = await api!.get("/api/v1/repos");
+      const repos = (await response.json()) as RepoSummary[];
+      return repos
+        .filter((repo) => repo.Owner === "import-lab")
+        .map((repo) => repo.Name)
+        .sort()
+        .join(",");
+    })
+    .toBe("api");
 
   const repoRow = page.locator(".repo-row", { hasText: "import-lab/api" });
   await repoRow.getByTitle("Remove github/github.com/import-lab/api").click();
@@ -132,19 +170,31 @@ test("settings imports a selected subset from a repository glob", async ({ page 
 
   await expect(repoRow).toHaveCount(0);
   await expect(selector).toContainText("All repos");
-  await expect.poll(async () => {
-    const response = await api!.get("/api/v1/repos");
-    const repos = await response.json() as RepoSummary[];
-    return repos
-      .filter((repo) => repo.Owner === "import-lab")
-      .map((repo) => repo.Name)
-      .sort()
-      .join(",");
-  }).toBe("");
+  await expect
+    .poll(async () => {
+      const response = await api!.get("/api/v1/repos");
+      const repos = (await response.json()) as RepoSummary[];
+      return repos
+        .filter((repo) => repo.Owner === "import-lab")
+        .map((repo) => repo.Name)
+        .sort()
+        .join(",");
+    })
+    .toBe("");
 });
 
-test("repository import can hide forks and private repositories before adding", async ({ page }) => {
-  let bulkRepos: Array<{ provider: string; host: string; owner: string; name: string; repo_path: string }> | undefined;
+test("repository import can hide forks and private repositories before adding", async ({
+  page,
+}) => {
+  let bulkRepos:
+    | Array<{
+        provider: string;
+        host: string;
+        owner: string;
+        name: string;
+        repo_path: string;
+      }>
+    | undefined;
   await page.route("**/api/v1/repos/preview", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -193,21 +243,52 @@ test("repository import can hide forks and private repositories before adding", 
     });
   });
   await page.route("**/api/v1/repos/bulk", async (route) => {
-    const body = route.request().postDataJSON() as { repos: Array<{ provider: string; host: string; owner: string; name: string; repo_path: string }> };
+    const body = route.request().postDataJSON() as {
+      repos: Array<{
+        provider: string;
+        host: string;
+        owner: string;
+        name: string;
+        repo_path: string;
+      }>;
+    };
     bulkRepos = body.repos;
     await route.fulfill({
       contentType: "application/json",
       status: 201,
       body: JSON.stringify({
-        repos: [{ owner: "import-lab", name: "public-source", is_glob: false, matched_repo_count: 1 }],
-        activity: { view_mode: "threaded", time_range: "7d", hide_closed: false, hide_bots: false },
-        terminal: { font_family: "" },
+        repos: [
+          {
+            owner: "import-lab",
+            name: "public-source",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+        ],
+        activity: {
+          view_mode: "threaded",
+          time_range: "7d",
+          hide_closed: false,
+          hide_bots: false,
+        },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
       }),
     });
   });
 
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
 
   await page.getByRole("button", { name: "Add repositories…" }).click();
   const dialog = page.getByRole("dialog", { name: "Add repositories" });
@@ -225,20 +306,30 @@ test("repository import can hide forks and private repositories before adding", 
   await expect(dialog.getByText("import-lab/public-fork")).toHaveCount(0);
   await expect(dialog.getByText("Selected 1 of 1")).toBeVisible();
 
-  await dialog.getByRole("button", { name: "Add selected repositories" }).click();
+  await dialog
+    .getByRole("button", { name: "Add selected repositories" })
+    .click();
 
-  await expect.poll(() => bulkRepos).toEqual([{
-    provider: "github",
-    host: "github.com",
-    owner: "import-lab",
-    name: "public-source",
-    repo_path: "import-lab/public-source",
-  }]);
+  await expect
+    .poll(() => bulkRepos)
+    .toEqual([
+      {
+        provider: "github",
+        host: "github.com",
+        owner: "import-lab",
+        name: "public-source",
+        repo_path: "import-lab/public-source",
+      },
+    ]);
 });
 
-test("repository import previews and adds Forgejo and Gitea repositories through the API", async ({ page }) => {
+test("repository import previews and adds Forgejo and Gitea repositories through the API", async ({
+  page,
+}) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
   await page.getByRole("button", { name: "Add repositories…" }).click();
   const dialog = page.getByRole("dialog", { name: "Add repositories" });
 
@@ -246,19 +337,27 @@ test("repository import previews and adds Forgejo and Gitea repositories through
   await expect(dialog.getByLabel("Host")).toHaveValue("codeberg.org");
   await dialog.getByLabel("Repository pattern").fill("team/subgroup/service-*");
   await dialog.getByRole("button", { name: "Preview" }).click();
-  await expect(dialog.getByRole("alert")).toContainText("Format: owner/pattern");
+  await expect(dialog.getByRole("alert")).toContainText(
+    "Format: owner/pattern",
+  );
 
   await dialog.getByLabel("Repository pattern").fill("forge-lab/*");
   await dialog.getByRole("button", { name: "Preview" }).click();
   await expect(dialog.getByText("forge-lab/service")).toBeVisible();
   await expect(dialog.getByText("forge-lab/archived")).toHaveCount(0);
-  await dialog.getByRole("button", { name: "Add selected repositories" }).click();
-  await expect(page.getByRole("dialog", { name: "Add repositories" })).toHaveCount(0);
-  await expect(page.locator(".repo-row", { hasText: "forge-lab/service" })).toBeVisible();
+  await dialog
+    .getByRole("button", { name: "Add selected repositories" })
+    .click();
+  await expect(
+    page.getByRole("dialog", { name: "Add repositories" }),
+  ).toHaveCount(0);
+  await expect(
+    page.locator(".repo-row", { hasText: "forge-lab/service" }),
+  ).toBeVisible();
 
   if (!api) throw new Error("settings-globs API context not initialized");
   let settingsResponse = await api.get("/api/v1/settings");
-  let settings = await settingsResponse.json() as {
+  let settings = (await settingsResponse.json()) as {
     repos: Array<{
       provider: string;
       platform_host: string;
@@ -268,23 +367,32 @@ test("repository import previews and adds Forgejo and Gitea repositories through
       is_glob: boolean;
     }>;
   };
-  expect(settings.repos).toContainEqual(expect.objectContaining({
-    provider: "forgejo",
-    platform_host: "codeberg.org",
-    owner: "forge-lab",
-    name: "service",
-    repo_path: "forge-lab/service",
-    is_glob: false,
-  }));
-  await expect.poll(async () => {
-    const response = await api!.get("/api/v1/repos");
-    const repos = await response.json() as RepoSummary[];
-    return repos
-      .filter((repo) => repo.Platform === "forgejo" && repo.PlatformHost === "codeberg.org" && repo.Owner === "forge-lab")
-      .map((repo) => repo.Name)
-      .sort()
-      .join(",");
-  }).toBe("service");
+  expect(settings.repos).toContainEqual(
+    expect.objectContaining({
+      provider: "forgejo",
+      platform_host: "codeberg.org",
+      owner: "forge-lab",
+      name: "service",
+      repo_path: "forge-lab/service",
+      is_glob: false,
+    }),
+  );
+  await expect
+    .poll(async () => {
+      const response = await api!.get("/api/v1/repos");
+      const repos = (await response.json()) as RepoSummary[];
+      return repos
+        .filter(
+          (repo) =>
+            repo.Platform === "forgejo" &&
+            repo.PlatformHost === "codeberg.org" &&
+            repo.Owner === "forge-lab",
+        )
+        .map((repo) => repo.Name)
+        .sort()
+        .join(",");
+    })
+    .toBe("service");
 
   await page.getByRole("button", { name: "Add repositories…" }).click();
   const giteaDialog = page.getByRole("dialog", { name: "Add repositories" });
@@ -293,42 +401,60 @@ test("repository import previews and adds Forgejo and Gitea repositories through
   await giteaDialog.getByLabel("Repository pattern").fill("gitea-team/*");
   await giteaDialog.getByRole("button", { name: "Preview" }).click();
   await expect(giteaDialog.getByText("gitea-team/service")).toBeVisible();
-  await expect(giteaDialog.getByText("gitea-team/private-service")).toBeVisible();
+  await expect(
+    giteaDialog.getByText("gitea-team/private-service"),
+  ).toBeVisible();
   await expect(giteaDialog.getByText("gitea-team/archived")).toHaveCount(0);
 
   await giteaDialog.getByLabel("Hide private").check();
   await expect(giteaDialog.getByText("gitea-team/service")).toBeVisible();
-  await expect(giteaDialog.getByText("gitea-team/private-service")).toHaveCount(0);
-  await giteaDialog.getByRole("button", { name: "Add selected repositories" }).click();
+  await expect(giteaDialog.getByText("gitea-team/private-service")).toHaveCount(
+    0,
+  );
+  await giteaDialog
+    .getByRole("button", { name: "Add selected repositories" })
+    .click();
 
-  await expect(page.getByRole("dialog", { name: "Add repositories" })).toHaveCount(0);
-  await expect(page.locator(".repo-row", { hasText: "gitea-team/service" })).toBeVisible();
+  await expect(
+    page.getByRole("dialog", { name: "Add repositories" }),
+  ).toHaveCount(0);
+  await expect(
+    page.locator(".repo-row", { hasText: "gitea-team/service" }),
+  ).toBeVisible();
 
   settingsResponse = await api.get("/api/v1/settings");
-  settings = await settingsResponse.json() as typeof settings;
-  expect(settings.repos).toContainEqual(expect.objectContaining({
-    provider: "gitea",
-    platform_host: "gitea.com",
-    owner: "gitea-team",
-    name: "service",
-    repo_path: "gitea-team/service",
-    is_glob: false,
-  }));
+  settings = (await settingsResponse.json()) as typeof settings;
+  expect(settings.repos).toContainEqual(
+    expect.objectContaining({
+      provider: "gitea",
+      platform_host: "gitea.com",
+      owner: "gitea-team",
+      name: "service",
+      repo_path: "gitea-team/service",
+      is_glob: false,
+    }),
+  );
 
-  await expect.poll(async () => {
-    const response = await api!.get("/api/v1/repos");
-    const repos = await response.json() as RepoSummary[];
-    return repos
-      .filter((repo) => repo.Owner === "gitea-team")
-      .map((repo) => repo.Name)
-      .sort()
-      .join(",");
-  }).toBe("service");
+  await expect
+    .poll(async () => {
+      const response = await api!.get("/api/v1/repos");
+      const repos = (await response.json()) as RepoSummary[];
+      return repos
+        .filter((repo) => repo.Owner === "gitea-team")
+        .map((repo) => repo.Name)
+        .sort()
+        .join(",");
+    })
+    .toBe("service");
 });
 
-test("repository import traps keyboard focus inside the dialog", async ({ page }) => {
+test("repository import traps keyboard focus inside the dialog", async ({
+  page,
+}) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
 
   await page.getByRole("button", { name: "Add repositories…" }).click();
   const dialog = page.getByRole("dialog", { name: "Add repositories" });
@@ -342,9 +468,13 @@ test("repository import traps keyboard focus inside the dialog", async ({ page }
   await expect(dialog.getByRole("button", { name: "Close" })).toBeFocused();
 });
 
-test("repository import clears stale preview results after failed preview", async ({ page }) => {
+test("repository import clears stale preview results after failed preview", async ({
+  page,
+}) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
 
   await page.getByRole("button", { name: "Add repositories…" }).click();
   const dialog = page.getByRole("dialog", { name: "Add repositories" });
@@ -354,7 +484,9 @@ test("repository import clears stale preview results after failed preview", asyn
 
   await dialog.getByLabel("Repository pattern").fill("bad-owner/[invalid");
   await dialog.getByRole("button", { name: "Preview" }).click();
-  await expect(dialog.getByText(/invalid glob pattern|GitHub API error|glob syntax/)).toBeVisible();
+  await expect(
+    dialog.getByText(/invalid glob pattern|GitHub API error|glob syntax/),
+  ).toBeVisible();
   await expect(dialog.getByText("roborev-dev/middleman")).toHaveCount(0);
 });
 
@@ -363,26 +495,33 @@ test("repository import ignores older preview responses", async ({ page }) => {
   let previewCalls = 0;
   await page.route("**/api/v1/repos/preview", async (route) => {
     previewCalls += 1;
-    const request = route.request().postDataJSON() as { owner: string; pattern: string };
+    const request = route.request().postDataJSON() as {
+      owner: string;
+      pattern: string;
+    };
     if (previewCalls === 1) {
-      await new Promise<void>((resolve) => { firstPreviewRelease = resolve; });
+      await new Promise<void>((resolve) => {
+        firstPreviewRelease = resolve;
+      });
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({
           owner: request.owner,
           pattern: request.pattern,
-          repos: [{
-            provider: "github",
-            platform_host: "github.com",
-            owner: "roborev-dev",
-            name: "middleman",
-            repo_path: "roborev-dev/middleman",
-            description: "Main dashboard",
-            private: false,
-            fork: false,
-            pushed_at: "2026-04-22T10:00:00Z",
-            already_configured: false,
-          }],
+          repos: [
+            {
+              provider: "github",
+              platform_host: "github.com",
+              owner: "roborev-dev",
+              name: "middleman",
+              repo_path: "roborev-dev/middleman",
+              description: "Main dashboard",
+              private: false,
+              fork: false,
+              pushed_at: "2026-04-22T10:00:00Z",
+              already_configured: false,
+            },
+          ],
         }),
       });
       return;
@@ -392,24 +531,28 @@ test("repository import ignores older preview responses", async ({ page }) => {
       body: JSON.stringify({
         owner: request.owner,
         pattern: request.pattern,
-        repos: [{
-          provider: "github",
-          platform_host: "github.com",
-          owner: "roborev-dev",
-          name: "review-bot",
-          repo_path: "roborev-dev/review-bot",
-          description: "Review automation",
-          private: false,
-          fork: false,
-          pushed_at: "2026-04-24T09:15:00Z",
-          already_configured: false,
-        }],
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "roborev-dev",
+            name: "review-bot",
+            repo_path: "roborev-dev/review-bot",
+            description: "Review automation",
+            private: false,
+            fork: false,
+            pushed_at: "2026-04-24T09:15:00Z",
+            already_configured: false,
+          },
+        ],
       }),
     });
   });
 
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  await page
+    .locator(".settings-page")
+    .waitFor({ state: "visible", timeout: 10_000 });
   await page.getByRole("button", { name: "Add repositories…" }).click();
   const dialog = page.getByRole("dialog", { name: "Add repositories" });
 

--- a/frontend/tests/e2e-full/settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/settings-terminal-font.spec.ts
@@ -28,24 +28,39 @@ test("settings saves and reloads workspace terminal options", async ({
   page,
 }) => {
   await page.goto(`${isolatedServer!.info.base_url}/settings`);
-  await page.locator(".settings-page")
+  await page
+    .locator(".settings-page")
     .waitFor({ state: "visible", timeout: 10_000 });
 
   const input = page.getByLabel("Monospace font family");
+  const fontSize = page.getByLabel("Font size");
+  const scrollback = page.getByLabel("Scrollback");
+  const lineHeight = page.getByLabel("Line height");
+  const letterSpacing = page.getByLabel("Letter spacing");
+  const cursorBlink = page.getByLabel("Cursor blink");
   const renderer = page.getByLabel("Terminal renderer");
   const saveButton = page.getByRole("button", { name: "Save", exact: true });
   await expect(input).toHaveValue("");
+  await expect(fontSize).toHaveValue("14");
+  await expect(scrollback).toHaveValue("1000");
+  await expect(lineHeight).toHaveValue("1");
+  await expect(letterSpacing).toHaveValue("0");
+  await expect(cursorBlink).toBeChecked();
   await expect(renderer).toHaveValue("xterm");
 
+  await fontSize.fill("18");
+  await scrollback.fill("5000");
+  await lineHeight.fill("1.15");
+  await letterSpacing.fill("1");
   await renderer.selectOption("ghostty-web");
+  await cursorBlink.uncheck();
   await input.click();
-  await input.pressSequentially(
-    "\"Iosevka Term\", monospace",
-  );
+  await input.pressSequentially('"Iosevka Term", monospace');
   await expect(saveButton).toBeEnabled();
-  const saveResponsePromise = page.waitForResponse((response) =>
-    response.url().endsWith("/api/v1/settings") &&
-    response.request().method() === "PUT"
+  const saveResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/settings") &&
+      response.request().method() === "PUT",
   );
   await saveButton.click();
   const saveResponse = await saveResponsePromise;
@@ -55,25 +70,48 @@ test("settings saves and reloads workspace terminal options", async ({
     `PUT /api/v1/settings failed: ${saveBody}`,
   ).toBe(200);
 
-  await expect.poll(async () => {
-    if (!api) {
-      throw new Error("settings terminal API context not initialized");
-    }
-    const response = await api.get("/api/v1/settings");
-    const settings = await response.json() as {
-      terminal: { font_family: string; renderer: string };
-    };
-    return settings.terminal;
-  }).toEqual({
-    font_family: "\"Iosevka Term\", monospace",
-    renderer: "ghostty-web",
-  });
+  await expect
+    .poll(async () => {
+      if (!api) {
+        throw new Error("settings terminal API context not initialized");
+      }
+      const response = await api.get("/api/v1/settings");
+      const settings = (await response.json()) as {
+        terminal: {
+          font_family: string;
+          font_size: number;
+          scrollback: number;
+          line_height: number;
+          letter_spacing: number;
+          cursor_blink: boolean;
+          font_ligatures: boolean;
+          renderer: string;
+        };
+      };
+      return settings.terminal;
+    })
+    .toEqual({
+      font_family: '"Iosevka Term", monospace',
+      font_size: 18,
+      scrollback: 5000,
+      line_height: 1.15,
+      letter_spacing: 1,
+      cursor_blink: false,
+      font_ligatures: false,
+      renderer: "ghostty-web",
+    });
 
   await page.reload();
-  await page.locator(".settings-page")
+  await page
+    .locator(".settings-page")
     .waitFor({ state: "visible", timeout: 10_000 });
-  await expect(page.getByLabel("Monospace font family"))
-    .toHaveValue("\"Iosevka Term\", monospace");
-  await expect(page.getByLabel("Terminal renderer"))
-    .toHaveValue("ghostty-web");
+  await expect(page.getByLabel("Monospace font family")).toHaveValue(
+    '"Iosevka Term", monospace',
+  );
+  await expect(page.getByLabel("Font size")).toHaveValue("18");
+  await expect(page.getByLabel("Scrollback")).toHaveValue("5000");
+  await expect(page.getByLabel("Line height")).toHaveValue("1.15");
+  await expect(page.getByLabel("Letter spacing")).toHaveValue("1");
+  await expect(page.getByLabel("Cursor blink")).not.toBeChecked();
+  await expect(page.getByLabel("Terminal renderer")).toHaveValue("ghostty-web");
 });

--- a/frontend/tests/e2e-full/settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/settings-terminal-font.spec.ts
@@ -1,16 +1,68 @@
+import { execFileSync } from "node:child_process";
 import {
   expect,
   request as playwrightRequest,
   test,
   type APIRequestContext,
+  type Page,
 } from "@playwright/test";
 import {
   startIsolatedE2EServer,
+  startIsolatedWorkspaceE2EServer,
   type IsolatedE2EServer,
 } from "./support/e2eServer";
 
 let isolatedServer: IsolatedE2EServer | undefined;
 let api: APIRequestContext | undefined;
+
+type WorkspaceStatusResponse = {
+  id: string;
+  status: string;
+  error_message?: string | null;
+};
+
+const lockedWorkspaceTestTimeoutMs = 120_000;
+
+function hasCommand(command: string, args: string[] = ["--version"]): boolean {
+  try {
+    execFileSync(command, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForWorkspaceReady(
+  context: APIRequestContext,
+  workspaceId: string,
+): Promise<WorkspaceStatusResponse> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const response = await context.get(`/api/v1/workspaces/${workspaceId}`);
+    expect(response.ok()).toBe(true);
+    const workspace = (await response.json()) as WorkspaceStatusResponse;
+    if (workspace.status === "ready") {
+      return workspace;
+    }
+    if (workspace.status === "error") {
+      throw new Error(
+        workspace.error_message ??
+          `workspace ${workspaceId} failed to become ready`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(`workspace ${workspaceId} did not become ready`);
+}
+
+async function terminalScreenSizeKey(page: Page): Promise<string> {
+  return await page
+    .locator(".terminal-container .xterm-screen")
+    .evaluate((element) => {
+      const style = getComputedStyle(element);
+      return `${style.width}x${style.height}`;
+    });
+}
 
 test.beforeAll(async () => {
   isolatedServer = await startIsolatedE2EServer();
@@ -114,4 +166,110 @@ test("settings saves and reloads workspace terminal options", async ({
   await expect(page.getByLabel("Letter spacing")).toHaveValue("1");
   await expect(page.getByLabel("Cursor blink")).not.toBeChecked();
   await expect(page.getByLabel("Terminal renderer")).toHaveValue("ghostty-web");
+});
+
+test.describe("terminal options popover", () => {
+  test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
+
+  test("live previews, reverts unsaved changes, and saves from the toolbar", async ({
+    page,
+  }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let workspaceServer: IsolatedE2EServer | null = null;
+    let workspaceApi: APIRequestContext | null = null;
+    try {
+      workspaceServer = await startIsolatedWorkspaceE2EServer();
+      workspaceApi = await playwrightRequest.newContext({
+        baseURL: workspaceServer.info.base_url,
+      });
+
+      const createResponse = await workspaceApi.post(
+        "/api/v1/issues/github/acme/widgets/10/workspace",
+        { data: {} },
+      );
+      expect(createResponse.status()).toBe(202);
+      const workspace =
+        (await createResponse.json()) as WorkspaceStatusResponse;
+      await waitForWorkspaceReady(workspaceApi, workspace.id);
+
+      await page.addInitScript((workspaceId) => {
+        localStorage.setItem(
+          `middleman-workspace-active-tab:${workspaceId}`,
+          "tmux",
+        );
+      }, workspace.id);
+
+      await page.goto(
+        `${workspaceServer.info.base_url}/terminal/${workspace.id}`,
+      );
+      await expect(
+        page.locator(".terminal-container .xterm-screen"),
+      ).toBeVisible();
+      await expect
+        .poll(() => terminalScreenSizeKey(page))
+        .not.toBe("0pxx0px");
+      const initialScreenSize = await terminalScreenSizeKey(page);
+
+      await page
+        .getByRole("button", { name: "Terminal options" })
+        .click();
+      await expect(
+        page.getByRole("dialog", { name: "Terminal options" }),
+      ).toBeVisible();
+      await page.getByLabel("Font size").fill("20");
+      await expect
+        .poll(() => terminalScreenSizeKey(page))
+        .not.toBe(initialScreenSize);
+
+      await page.keyboard.press("Escape");
+      await expect(
+        page.getByRole("dialog", { name: "Terminal options" }),
+      ).toBeHidden();
+      await expect
+        .poll(() => terminalScreenSizeKey(page))
+        .toBe(initialScreenSize);
+
+      await page
+        .getByRole("button", { name: "Terminal options" })
+        .click();
+      await page.getByLabel("Font size").fill("18");
+      await expect
+        .poll(() => terminalScreenSizeKey(page))
+        .not.toBe(initialScreenSize);
+      const saveResponsePromise = page.waitForResponse(
+        (response) =>
+          response.url().endsWith("/api/v1/settings") &&
+          response.request().method() === "PUT",
+      );
+      await page.getByRole("button", { name: "Save", exact: true }).click();
+      const saveResponse = await saveResponsePromise;
+      const saveBody = await saveResponse.text();
+      expect(
+        saveResponse.status(),
+        `PUT /api/v1/settings failed: ${saveBody}`,
+      ).toBe(200);
+
+      await expect
+        .poll(async () => {
+          const response = await workspaceApi!.get("/api/v1/settings");
+          const settings = (await response.json()) as {
+            terminal: { font_size: number };
+          };
+          return settings.terminal.font_size;
+        })
+        .toBe(18);
+
+      await page.keyboard.press("Escape");
+      await expect
+        .poll(() => terminalScreenSizeKey(page))
+        .not.toBe(initialScreenSize);
+    } finally {
+      await workspaceApi?.dispose();
+      await workspaceServer?.stop();
+    }
+  });
 });

--- a/frontend/tests/e2e-full/settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/settings-terminal-font.spec.ts
@@ -240,12 +240,27 @@ test.describe("terminal options popover", () => {
       await expect
         .poll(() => terminalScreenSizeKey(page))
         .not.toBe(initialScreenSize);
+      let delayedSettingsSave = false;
+      await page.route("**/api/v1/settings", async (route) => {
+        if (
+          route.request().method() === "PUT" &&
+          !delayedSettingsSave
+        ) {
+          delayedSettingsSave = true;
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+        await route.continue();
+      });
       const saveResponsePromise = page.waitForResponse(
         (response) =>
           response.url().endsWith("/api/v1/settings") &&
           response.request().method() === "PUT",
       );
       await page.getByRole("button", { name: "Save", exact: true }).click();
+      await page.keyboard.press("Escape");
+      await expect(
+        page.getByRole("dialog", { name: "Terminal options" }),
+      ).toBeVisible();
       const saveResponse = await saveResponsePromise;
       const saveBody = await saveResponse.text();
       expect(

--- a/frontend/tests/e2e-full/settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/settings-terminal-font.spec.ts
@@ -240,14 +240,15 @@ test.describe("terminal options popover", () => {
       await expect
         .poll(() => terminalScreenSizeKey(page))
         .not.toBe(initialScreenSize);
-      let delayedSettingsSave = false;
+      let releaseSettingsSave: (() => void) | undefined;
       await page.route("**/api/v1/settings", async (route) => {
         if (
           route.request().method() === "PUT" &&
-          !delayedSettingsSave
+          releaseSettingsSave === undefined
         ) {
-          delayedSettingsSave = true;
-          await new Promise((resolve) => setTimeout(resolve, 300));
+          await new Promise<void>((resolve) => {
+            releaseSettingsSave = resolve;
+          });
         }
         await route.continue();
       });
@@ -257,10 +258,14 @@ test.describe("terminal options popover", () => {
           response.request().method() === "PUT",
       );
       await page.getByRole("button", { name: "Save", exact: true }).click();
+      await expect
+        .poll(() => releaseSettingsSave !== undefined)
+        .toBe(true);
       await page.keyboard.press("Escape");
       await expect(
         page.getByRole("dialog", { name: "Terminal options" }),
       ).toBeVisible();
+      releaseSettingsSave?.();
       const saveResponse = await saveResponsePromise;
       const saveBody = await saveResponse.text();
       expect(

--- a/frontend/tests/e2e-full/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/workspace-sidebar.spec.ts
@@ -45,9 +45,7 @@ async function readTerminalCanvasStats(
       const alpha = data[i + 3] ?? 0;
       if (
         alpha > 0 &&
-        Math.abs(red - 0x0d) +
-          Math.abs(green - 0x11) +
-          Math.abs(blue - 0x17) >
+        Math.abs(red - 0x0d) + Math.abs(green - 0x11) + Math.abs(blue - 0x17) >
           24
       ) {
         paintedPixels += 1;
@@ -78,7 +76,7 @@ async function waitForWorkspaceReady(
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const response = await api.get(`/api/v1/workspaces/${workspaceId}`);
     expect(response.ok()).toBe(true);
-    const workspace = await response.json() as WorkspaceStatusResponse;
+    const workspace = (await response.json()) as WorkspaceStatusResponse;
     if (workspace.status === "ready") {
       return;
     }
@@ -94,7 +92,9 @@ async function waitForWorkspaceReady(
 test.describe("workspace sidebar full-stack", () => {
   test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
 
-  test("shows provider icons in group headers when workspaces span multiple providers", async ({ page }) => {
+  test("shows provider icons in group headers when workspaces span multiple providers", async ({
+    page,
+  }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
@@ -110,7 +110,8 @@ test.describe("workspace sidebar full-stack", () => {
         },
       );
       expect(githubResponse.status()).toBe(202);
-      const githubWorkspace = await githubResponse.json() as WorkspaceStatusResponse;
+      const githubWorkspace =
+        (await githubResponse.json()) as WorkspaceStatusResponse;
       await waitForWorkspaceReady(api, githubWorkspace.id);
 
       const gitlabResponse = await api.post(
@@ -120,36 +121,41 @@ test.describe("workspace sidebar full-stack", () => {
         },
       );
       expect(gitlabResponse.status()).toBe(202);
-      const gitlabWorkspace = await gitlabResponse.json() as WorkspaceStatusResponse;
+      const gitlabWorkspace =
+        (await gitlabResponse.json()) as WorkspaceStatusResponse;
       await waitForWorkspaceReady(api, gitlabWorkspace.id);
 
       const workspacesResponse = await api.get("/api/v1/workspaces");
       expect(workspacesResponse.ok()).toBe(true);
-      const workspacesPayload = await workspacesResponse.json() as {
+      const workspacesPayload = (await workspacesResponse.json()) as {
         workspaces: Array<{ repo: { provider: string } }>;
       };
       expect(
-        new Set(workspacesPayload.workspaces.map((workspace) => workspace.repo.provider)),
+        new Set(
+          workspacesPayload.workspaces.map(
+            (workspace) => workspace.repo.provider,
+          ),
+        ),
       ).toEqual(new Set(["github", "gitlab"]));
 
       await page.goto(
         `${isolatedServer.info.base_url}/terminal/${githubWorkspace.id}`,
       );
 
-      const githubGroup = page.locator(
-        ".workspace-list-sidebar .group-header",
-      ).filter({
-        has: page.locator(".group-label", { hasText: "acme/widgets" }),
-      });
+      const githubGroup = page
+        .locator(".workspace-list-sidebar .group-header")
+        .filter({
+          has: page.locator(".group-label", { hasText: "acme/widgets" }),
+        });
       await expect(
         githubGroup.getByRole("img", { name: "GitHub" }),
       ).toBeVisible();
 
-      const gitlabGroup = page.locator(
-        ".workspace-list-sidebar .group-header",
-      ).filter({
-        has: page.locator(".group-label", { hasText: "group/project" }),
-      });
+      const gitlabGroup = page
+        .locator(".workspace-list-sidebar .group-header")
+        .filter({
+          has: page.locator(".group-label", { hasText: "group/project" }),
+        });
       await expect(
         gitlabGroup.getByRole("img", { name: "GitLab" }),
       ).toBeVisible();
@@ -159,7 +165,9 @@ test.describe("workspace sidebar full-stack", () => {
     }
   });
 
-  test("issue workspaces expose the Issue tab and hide Reviews", async ({ page }) => {
+  test("issue workspaces expose the Issue tab and hide Reviews", async ({
+    page,
+  }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
@@ -176,7 +184,8 @@ test.describe("workspace sidebar full-stack", () => {
       );
       expect(createResponse.status()).toBe(202);
 
-      const createdWorkspace = await createResponse.json() as WorkspaceStatusResponse;
+      const createdWorkspace =
+        (await createResponse.json()) as WorkspaceStatusResponse;
       await waitForWorkspaceReady(api, createdWorkspace.id);
 
       await page.goto(
@@ -193,18 +202,22 @@ test.describe("workspace sidebar full-stack", () => {
         page.locator(".terminal-view .seg-btn", { hasText: "Reviews" }),
       ).toHaveCount(0);
 
-      await page.locator(".terminal-view .seg-btn", { hasText: "Issue" }).click();
+      await page
+        .locator(".terminal-view .seg-btn", { hasText: "Issue" })
+        .click();
       await expect(page.locator(".right-sidebar")).toBeVisible();
-      await expect(
-        page.locator(".right-sidebar .detail-title"),
-      ).toContainText("Widget rendering broken on Safari");
+      await expect(page.locator(".right-sidebar .detail-title")).toContainText(
+        "Widget rendering broken on Safari",
+      );
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();
     }
   });
 
-  test("ghostty shell terminal paints output and accepts browser keyboard input", async ({ page }) => {
+  test("ghostty shell terminal paints output and accepts browser keyboard input", async ({
+    page,
+  }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
@@ -216,6 +229,12 @@ test.describe("workspace sidebar full-stack", () => {
         data: {
           terminal: {
             font_family: "",
+            font_size: 14,
+            scrollback: 1000,
+            line_height: 1,
+            letter_spacing: 0,
+            cursor_blink: true,
+            font_ligatures: false,
             renderer: "ghostty-web",
           },
         },
@@ -230,15 +249,14 @@ test.describe("workspace sidebar full-stack", () => {
       );
       expect(createResponse.status()).toBe(202);
 
-      const createdWorkspace = await createResponse.json() as WorkspaceStatusResponse;
+      const createdWorkspace =
+        (await createResponse.json()) as WorkspaceStatusResponse;
       await waitForWorkspaceReady(api, createdWorkspace.id);
 
       await page.goto(
         `${isolatedServer.info.base_url}/terminal/${createdWorkspace.id}`,
       );
-      await page
-        .getByRole("button", { name: "Open shell drawer" })
-        .click();
+      await page.getByRole("button", { name: "Open shell drawer" }).click();
 
       const canvas = page.locator(".shell-drawer .terminal-container canvas");
       await expect(canvas).toBeVisible();
@@ -257,13 +275,16 @@ test.describe("workspace sidebar full-stack", () => {
       await page.keyboard.press("Enter");
 
       await expect
-        .poll(async () => {
-          const stats = await readTerminalCanvasStats(canvas);
-          return (
-            stats.hash !== beforeInput.hash &&
-            Math.abs(stats.paintedPixels - beforeInput.paintedPixels) > 300
-          );
-        }, { timeout: 10_000 })
+        .poll(
+          async () => {
+            const stats = await readTerminalCanvasStats(canvas);
+            return (
+              stats.hash !== beforeInput.hash &&
+              Math.abs(stats.paintedPixels - beforeInput.paintedPixels) > 300
+            );
+          },
+          { timeout: 10_000 },
+        )
         .toBe(true);
     } finally {
       await api?.dispose();

--- a/frontend/tests/e2e/detail-stale-actions.spec.ts
+++ b/frontend/tests/e2e/detail-stale-actions.spec.ts
@@ -214,7 +214,16 @@ async function mockSettings(page: Page): Promise<void> {
           },
         ],
         activity: { hidden_authors: [] },
-        terminal: { font_family: "" },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
       }),
     });
   });
@@ -260,37 +269,31 @@ async function setupHeldPR(
   });
 
   // Fast PR: instant detail GET.
-  await page.route(
-    pullDetailApiPath(fast),
-    async (route: Route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(detailEnvelopePR(fast)),
-        });
-        return;
-      }
-      await route.fallback();
-    },
-  );
+  await page.route(pullDetailApiPath(fast), async (route: Route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(detailEnvelopePR(fast)),
+      });
+      return;
+    }
+    await route.fallback();
+  });
 
   // Slow PR: held until release().
-  await page.route(
-    pullDetailApiPath(slow),
-    async (route: Route) => {
-      if (route.request().method() === "GET") {
-        await slowDelay;
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(detailEnvelopePR(slow)),
-        });
-        return;
-      }
-      await route.fallback();
-    },
-  );
+  await page.route(pullDetailApiPath(slow), async (route: Route) => {
+    if (route.request().method() === "GET") {
+      await slowDelay;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(detailEnvelopePR(slow)),
+      });
+      return;
+    }
+    await route.fallback();
+  });
 
   return { release };
 }
@@ -307,55 +310,46 @@ async function setupHeldIssue(
     release = resolve;
   });
 
-  await page.route(
-    issueDetailApiPath(fast),
-    async (route: Route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(detailEnvelopeIssue(fast)),
-        });
-        return;
-      }
-      await route.fallback();
-    },
-  );
+  await page.route(issueDetailApiPath(fast), async (route: Route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(detailEnvelopeIssue(fast)),
+      });
+      return;
+    }
+    await route.fallback();
+  });
 
-  await page.route(
-    issueDetailApiPath(slow),
-    async (route: Route) => {
-      if (route.request().method() === "GET") {
-        await slowDelay;
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(detailEnvelopeIssue(slow)),
-        });
-        return;
-      }
-      await route.fallback();
-    },
-  );
+  await page.route(issueDetailApiPath(slow), async (route: Route) => {
+    if (route.request().method() === "GET") {
+      await slowDelay;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(detailEnvelopeIssue(slow)),
+      });
+      return;
+    }
+    await route.fallback();
+  });
 
   return { release };
 }
 
 async function mockPullDetail(page: Page, pr: typeof prA): Promise<void> {
-  await page.route(
-    pullDetailApiPath(pr),
-    async (route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(detailEnvelopePR(pr)),
-        });
-        return;
-      }
-      await route.fallback();
-    },
-  );
+  await page.route(pullDetailApiPath(pr), async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(detailEnvelopePR(pr)),
+      });
+      return;
+    }
+    await route.fallback();
+  });
 }
 
 async function gotoPullDetail(page: Page, pr: typeof prA): Promise<void> {
@@ -365,7 +359,9 @@ async function gotoPullDetail(page: Page, pr: typeof prA): Promise<void> {
 }
 
 test.describe("PR detail merge modal route reset", () => {
-  test("merge button is disabled when the PR has merge conflicts", async ({ page }) => {
+  test("merge button is disabled when the PR has merge conflicts", async ({
+    page,
+  }) => {
     await mockApi(page);
     await mockSettings(page);
 
@@ -468,25 +464,24 @@ test.describe("PR detail merge modal route reset", () => {
     });
   }
 
-  test("merge modal closes when the route changes and does not reopen for the new PR", async ({ page }) => {
+  test("merge modal closes when the route changes and does not reopen for the new PR", async ({
+    page,
+  }) => {
     await mockApi(page);
     await mockSettings(page);
 
     for (const pr of [prA, prB]) {
-      await page.route(
-        pullDetailApiPath(pr),
-        async (route) => {
-          if (route.request().method() === "GET") {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify(detailEnvelopePR(pr)),
-            });
-            return;
-          }
-          await route.fallback();
-        },
-      );
+      await page.route(pullDetailApiPath(pr), async (route) => {
+        if (route.request().method() === "GET") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(detailEnvelopePR(pr)),
+          });
+          return;
+        }
+        await route.fallback();
+      });
     }
 
     await page.goto(
@@ -502,14 +497,17 @@ test.describe("PR detail merge modal route reset", () => {
 
     // Navigate to PR B. The action-local reset must close the
     // modal as soon as the props change.
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/pulls/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/pulls/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [prB.repo_owner, prB.repo_name, prB.Number] as const,
+    );
 
     await expect(page.locator(".detail-title")).toContainText(prB.Title);
     await expect(
@@ -517,7 +515,9 @@ test.describe("PR detail merge modal route reset", () => {
     ).toHaveCount(0);
   });
 
-  test("hides merge actions when repo permissions disallow merging", async ({ page }) => {
+  test("hides merge actions when repo permissions disallow merging", async ({
+    page,
+  }) => {
     await mockApi(page);
     await mockSettings(page);
 
@@ -567,25 +567,24 @@ test.describe("PR detail merge modal route reset", () => {
     ).toHaveCount(0);
   });
 
-  test("merge actions wait for settings that match the selected repo", async ({ page }) => {
+  test("merge actions wait for settings that match the selected repo", async ({
+    page,
+  }) => {
     await mockApi(page);
     await mockSettings(page);
 
     for (const pr of [prA, prSquashOnly]) {
-      await page.route(
-        pullDetailApiPath(pr),
-        async (route) => {
-          if (route.request().method() === "GET") {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify(detailEnvelopePR(pr)),
-            });
-            return;
-          }
-          await route.fallback();
-        },
-      );
+      await page.route(pullDetailApiPath(pr), async (route) => {
+        if (route.request().method() === "GET") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(detailEnvelopePR(pr)),
+          });
+          return;
+        }
+        await route.fallback();
+      });
     }
 
     let releaseSquashSettings!: () => void;
@@ -593,33 +592,30 @@ test.describe("PR detail merge modal route reset", () => {
       releaseSquashSettings = resolve;
     });
 
-    await page.route(
-      repoSettingsApiPath(prSquashOnly),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await squashSettingsReady;
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({
-              ID: prSquashOnly.RepoID,
-              Owner: prSquashOnly.repo_owner,
-              Name: prSquashOnly.repo_name,
-              AllowSquashMerge: true,
-              AllowMergeCommit: false,
-              AllowRebaseMerge: false,
-              ViewerCanMerge: true,
-              LastSyncStartedAt: "2026-04-01T12:00:00Z",
-              LastSyncCompletedAt: "2026-04-01T12:00:30Z",
-              LastSyncError: "",
-              CreatedAt: "2026-03-01T00:00:00Z",
-            }),
-          });
-          return;
-        }
-        await route.fallback();
-      },
-    );
+    await page.route(repoSettingsApiPath(prSquashOnly), async (route) => {
+      if (route.request().method() === "GET") {
+        await squashSettingsReady;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ID: prSquashOnly.RepoID,
+            Owner: prSquashOnly.repo_owner,
+            Name: prSquashOnly.repo_name,
+            AllowSquashMerge: true,
+            AllowMergeCommit: false,
+            AllowRebaseMerge: false,
+            ViewerCanMerge: true,
+            LastSyncStartedAt: "2026-04-01T12:00:00Z",
+            LastSyncCompletedAt: "2026-04-01T12:00:30Z",
+            LastSyncError: "",
+            CreatedAt: "2026-03-01T00:00:00Z",
+          }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
 
     await page.goto(
       `/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`,
@@ -627,14 +623,21 @@ test.describe("PR detail merge modal route reset", () => {
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
     await expect(page.locator(".btn--merge")).toBeVisible();
 
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/pulls/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [prSquashOnly.repo_owner, prSquashOnly.repo_name, prSquashOnly.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/pulls/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [
+        prSquashOnly.repo_owner,
+        prSquashOnly.repo_name,
+        prSquashOnly.Number,
+      ] as const,
+    );
 
     await expect(page.locator(".detail-title")).toContainText(
       prSquashOnly.Title,
@@ -662,52 +665,51 @@ test.describe("PR detail merge modal route reset", () => {
 });
 
 test.describe("detail load-error banner", () => {
-  test("PR: failing route shows banner over the previous PR", async ({ page }) => {
+  test("PR: failing route shows banner over the previous PR", async ({
+    page,
+  }) => {
     await mockApi(page);
     await mockSettings(page);
 
-    await page.route(
-      pullDetailApiPath(prA),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify(detailEnvelopePR(prA)),
-          });
-          return;
-        }
-        await route.fallback();
-      },
-    );
-    await page.route(
-      pullDetailApiPath(prB),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await route.fulfill({
-            status: 500,
-            contentType: "application/json",
-            body: JSON.stringify({ detail: "upstream offline" }),
-          });
-          return;
-        }
-        await route.fallback();
-      },
-    );
+    await page.route(pullDetailApiPath(prA), async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(detailEnvelopePR(prA)),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+    await page.route(pullDetailApiPath(prB), async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "upstream offline" }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
 
     await page.goto(
       `/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`,
     );
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
 
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/pulls/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/pulls/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [prB.repo_owner, prB.repo_name, prB.Number] as const,
+    );
 
     const banner = page.getByTestId("detail-load-error");
     await expect(banner).toBeVisible();
@@ -715,38 +717,34 @@ test.describe("detail load-error banner", () => {
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
   });
 
-  test("issue: failing route shows banner over the previous issue", async ({ page }) => {
+  test("issue: failing route shows banner over the previous issue", async ({
+    page,
+  }) => {
     await mockApi(page);
     await mockSettings(page);
 
-    await page.route(
-      issueDetailApiPath(issueX),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify(detailEnvelopeIssue(issueX)),
-          });
-          return;
-        }
-        await route.fallback();
-      },
-    );
-    await page.route(
-      issueDetailApiPath(issueY),
-      async (route) => {
-        if (route.request().method() === "GET") {
-          await route.fulfill({
-            status: 500,
-            contentType: "application/json",
-            body: JSON.stringify({ detail: "upstream offline" }),
-          });
-          return;
-        }
-        await route.fallback();
-      },
-    );
+    await page.route(issueDetailApiPath(issueX), async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(detailEnvelopeIssue(issueX)),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+    await page.route(issueDetailApiPath(issueY), async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "upstream offline" }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
 
     await page.goto(
       `/issues/github/${issueX.repo_owner}/${issueX.repo_name}/${issueX.Number}`,
@@ -755,14 +753,17 @@ test.describe("detail load-error banner", () => {
       issueX.Title,
     );
 
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/issues/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [issueY.repo_owner, issueY.repo_name, issueY.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/issues/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [issueY.repo_owner, issueY.repo_name, issueY.Number] as const,
+    );
 
     const banner = page.getByTestId("detail-load-error");
     await expect(banner).toBeVisible();
@@ -774,7 +775,9 @@ test.describe("detail load-error banner", () => {
 });
 
 test.describe("PR detail stale-action gating", () => {
-  test("conflict warning hides while a clean PR is loading", async ({ page }) => {
+  test("conflict warning hides while a clean PR is loading", async ({
+    page,
+  }) => {
     const conflictedPR = {
       ...prA,
       MergeableState: "dirty",
@@ -793,14 +796,17 @@ test.describe("PR detail stale-action gating", () => {
     );
     await expect(page.getByText("This branch has conflicts")).toBeVisible();
 
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/pulls/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [cleanPR.repo_owner, cleanPR.repo_name, cleanPR.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/pulls/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [cleanPR.repo_owner, cleanPR.repo_name, cleanPR.Number] as const,
+    );
 
     await expect(page.locator(".detail-title")).toContainText(
       conflictedPR.Title,
@@ -812,22 +818,29 @@ test.describe("PR detail stale-action gating", () => {
     await expect(page.getByText("This branch has conflicts")).toHaveCount(0);
   });
 
-  test("close, comment, and create-workspace are inert while the new PR is loading", async ({ page }) => {
+  test("close, comment, and create-workspace are inert while the new PR is loading", async ({
+    page,
+  }) => {
     const userMutations = recordUserMutations(page);
     const { release } = await setupHeldPR(page, prA, prB);
 
-    await page.goto(`/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`);
+    await page.goto(
+      `/pulls/github/${prA.repo_owner}/${prA.repo_name}/${prA.Number}`,
+    );
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
 
     // Trigger an in-place navigation to the slow PR via popstate.
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/pulls/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/pulls/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [prB.repo_owner, prB.repo_name, prB.Number] as const,
+    );
 
     // PR A is still on screen because B is held.
     await expect(page.locator(".detail-title")).toContainText(prA.Title);
@@ -847,9 +860,7 @@ test.describe("PR detail stale-action gating", () => {
     await createWs.click({ force: true }).catch(() => {});
 
     // Comment submit: disabled.
-    const commentSubmit = page
-      .locator(".comment-box .submit-btn")
-      .first();
+    const commentSubmit = page.locator(".comment-box .submit-btn").first();
     await expect(commentSubmit).toBeDisabled();
 
     // Release the slow load. PR B now displays and the controls
@@ -862,7 +873,9 @@ test.describe("PR detail stale-action gating", () => {
     expect(userMutations).toEqual([]);
   });
 
-  test("existing workspace navigation is inert while the new PR is loading", async ({ page }) => {
+  test("existing workspace navigation is inert while the new PR is loading", async ({
+    page,
+  }) => {
     const prWithWorkspace = {
       ...prA,
       workspace: { id: "ws-pr-a" },
@@ -876,14 +889,17 @@ test.describe("PR detail stale-action gating", () => {
       prWithWorkspace.Title,
     );
 
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/pulls/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [prB.repo_owner, prB.repo_name, prB.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/pulls/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [prB.repo_owner, prB.repo_name, prB.Number] as const,
+    );
 
     await expect(page.locator(".detail-title")).toContainText(
       prWithWorkspace.Title,
@@ -900,7 +916,9 @@ test.describe("PR detail stale-action gating", () => {
 });
 
 test.describe("issue detail stale-action gating", () => {
-  test("star, close, comment, and create-workspace are inert while the new issue is loading", async ({ page }) => {
+  test("star, close, comment, and create-workspace are inert while the new issue is loading", async ({
+    page,
+  }) => {
     const userMutations = recordUserMutations(page);
     const { release } = await setupHeldIssue(page, issueX, issueY);
 
@@ -911,14 +929,17 @@ test.describe("issue detail stale-action gating", () => {
       issueX.Title,
     );
 
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/issues/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [issueY.repo_owner, issueY.repo_name, issueY.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/issues/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [issueY.repo_owner, issueY.repo_name, issueY.Number] as const,
+    );
 
     // Issue X is still on screen because Y is held.
     await expect(page.locator(".issue-detail .detail-title")).toContainText(
@@ -932,8 +953,7 @@ test.describe("issue detail stale-action gating", () => {
     await expect(closeBtn).toBeDisabled();
     await closeBtn.click({ force: true }).catch(() => {});
 
-    const createWs = page
-      .locator(".issue-detail button.btn--workspace");
+    const createWs = page.locator(".issue-detail button.btn--workspace");
     await expect(createWs).toBeDisabled();
     await createWs.click({ force: true }).catch(() => {});
 
@@ -951,7 +971,9 @@ test.describe("issue detail stale-action gating", () => {
     expect(userMutations).toEqual([]);
   });
 
-  test("existing workspace navigation is inert while the new issue is loading", async ({ page }) => {
+  test("existing workspace navigation is inert while the new issue is loading", async ({
+    page,
+  }) => {
     const issueWithWorkspace = {
       ...issueX,
       workspace: { id: "ws-issue-x" },
@@ -965,14 +987,17 @@ test.describe("issue detail stale-action gating", () => {
       issueWithWorkspace.Title,
     );
 
-    await page.evaluate(([owner, name, number]) => {
-      window.history.pushState(
-        null,
-        "",
-        `/issues/github/${owner}/${name}/${number}`,
-      );
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    }, [issueY.repo_owner, issueY.repo_name, issueY.Number] as const);
+    await page.evaluate(
+      ([owner, name, number]) => {
+        window.history.pushState(
+          null,
+          "",
+          `/issues/github/${owner}/${name}/${number}`,
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      },
+      [issueY.repo_owner, issueY.repo_name, issueY.Number] as const,
+    );
 
     await expect(page.locator(".issue-detail .detail-title")).toContainText(
       issueWithWorkspace.Title,

--- a/frontend/tests/e2e/issue-routing.spec.ts
+++ b/frontend/tests/e2e/issue-routing.spec.ts
@@ -47,7 +47,16 @@ async function mockIssueDetailAndTrackHosts(page: Page): Promise<string[]> {
           },
         ],
         activity: { hidden_authors: [] },
-        terminal: { font_family: "" },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
       }),
     });
   });
@@ -68,17 +77,22 @@ async function mockIssueDetailAndTrackHosts(page: Page): Promise<string[]> {
 }
 
 test.describe("issue route platform host", () => {
-  test("direct issue load preserves platform_host in detail requests", async ({ page }) => {
+  test("direct issue load preserves platform_host in detail requests", async ({
+    page,
+  }) => {
     const seenHosts = await mockIssueDetailAndTrackHosts(page);
 
     await page.goto("/host/ghe.example.com/issues/github/acme/widgets/7");
 
-    await expect(page.locator(".issue-detail .detail-title"))
-      .toContainText("Mirror host issue");
+    await expect(page.locator(".issue-detail .detail-title")).toContainText(
+      "Mirror host issue",
+    );
     await expect.poll(() => seenHosts).toContain("ghe.example.com");
   });
 
-  test("popstate preserves platform_host in detail requests", async ({ page }) => {
+  test("popstate preserves platform_host in detail requests", async ({
+    page,
+  }) => {
     const seenHosts = await mockIssueDetailAndTrackHosts(page);
 
     await page.goto("/issues");
@@ -91,8 +105,9 @@ test.describe("issue route platform host", () => {
       window.dispatchEvent(new PopStateEvent("popstate"));
     });
 
-    await expect(page.locator(".issue-detail .detail-title"))
-      .toContainText("Mirror host issue");
+    await expect(page.locator(".issue-detail .detail-title")).toContainText(
+      "Mirror host issue",
+    );
     await expect.poll(() => seenHosts).toContain("ghe.example.com");
   });
 });

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -46,7 +46,16 @@ async function mockMobileRepoSettings(page: Page): Promise<string[]> {
           hide_closed: false,
           hide_bots: false,
         },
-        terminal: { font_family: "", renderer: "xterm" },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
         agents: [],
       }),
     });
@@ -68,7 +77,9 @@ async function mockMobileRepoSettings(page: Page): Promise<string[]> {
 test.use({ ...devices["iPhone 13"] });
 
 test.describe("mobile activity repository selector", () => {
-  test("uses host-qualified concrete repos and excludes glob rows", async ({ page }) => {
+  test("uses host-qualified concrete repos and excludes glob rows", async ({
+    page,
+  }) => {
     const activityRepos = await mockMobileRepoSettings(page);
 
     await page.goto("/m?range=30d&view=threaded");
@@ -77,21 +88,28 @@ test.describe("mobile activity repository selector", () => {
 
     await repoSelect.click();
     await expect(page.getByRole("option", { name: "All repos" })).toBeVisible();
-    await expect(page.getByRole("option", { name: "github.com/acme/widgets" }))
-      .toBeVisible();
-    await expect(page.getByRole("option", { name: "ghe.example.com/acme/widgets" }))
-      .toBeVisible();
-    await expect(page.getByRole("option", { name: "acme/*" }))
-      .toHaveCount(0);
+    await expect(
+      page.getByRole("option", { name: "github.com/acme/widgets" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "ghe.example.com/acme/widgets" }),
+    ).toBeVisible();
+    await expect(page.getByRole("option", { name: "acme/*" })).toHaveCount(0);
 
-    await page.getByRole("option", { name: "ghe.example.com/acme/widgets" }).click();
-    await expect(page.getByRole("combobox", { name: "Repository: acme/widgets" }))
-      .toHaveText("acme/widgets");
-    await expect.poll(() => activityRepos)
+    await page
+      .getByRole("option", { name: "ghe.example.com/acme/widgets" })
+      .click();
+    await expect(
+      page.getByRole("combobox", { name: "Repository: acme/widgets" }),
+    ).toHaveText("acme/widgets");
+    await expect
+      .poll(() => activityRepos)
       .toContain("ghe.example.com/acme/widgets");
   });
 
-  test("groups and labels activity from nested repo identity", async ({ page }) => {
+  test("groups and labels activity from nested repo identity", async ({
+    page,
+  }) => {
     await mockMobileRepoSettings(page);
     await page.route("**/api/v1/activity**", async (route) => {
       await route.fulfill({
@@ -150,13 +168,20 @@ test.describe("mobile activity repository selector", () => {
     await page.goto("/m?range=30d&view=threaded");
 
     await expect(page.locator(".mobile-activity-card")).toHaveCount(2);
-    await expect(page.locator(".mobile-activity-card__meta", { hasText: "github.com/acme/widgets" }))
-      .toBeVisible();
-    await expect(page.locator(".mobile-activity-card__meta", { hasText: "ghe.example.com/acme/widgets" }))
-      .toBeVisible();
+    await expect(
+      page.locator(".mobile-activity-card__meta", {
+        hasText: "github.com/acme/widgets",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".mobile-activity-card__meta", {
+        hasText: "ghe.example.com/acme/widgets",
+      }),
+    ).toBeVisible();
     await expect(page.getByText("undefined/undefined")).toHaveCount(0);
-    await expect(page.locator(".mobile-activity-card__event-count", { hasText: "2" }))
-      .toHaveCount(0);
+    await expect(
+      page.locator(".mobile-activity-card__event-count", { hasText: "2" }),
+    ).toHaveCount(0);
   });
 });
 

--- a/frontend/tests/e2e/support/mockApi.ts
+++ b/frontend/tests/e2e/support/mockApi.ts
@@ -195,7 +195,16 @@ const settings = {
     hide_closed: false,
     hide_bots: false,
   },
-  terminal: { font_family: "", renderer: "xterm" },
+  terminal: {
+    font_family: "",
+    font_size: 14,
+    scrollback: 1000,
+    line_height: 1,
+    letter_spacing: 0,
+    cursor_blink: true,
+    font_ligatures: false,
+    renderer: "xterm",
+  },
   agents: [],
 };
 
@@ -225,7 +234,11 @@ function makeRateLimits() {
   };
 }
 
-async function fulfillJson(route: Route, body: unknown, status = 200): Promise<void> {
+async function fulfillJson(
+  route: Route,
+  body: unknown,
+  status = 200,
+): Promise<void> {
   await route.fulfill({
     status,
     contentType: "application/json",
@@ -270,11 +283,7 @@ export async function mockApi(page: Page): Promise<void> {
           worktree_links: pr.worktree_links,
         });
       } else {
-        await fulfillJson(
-          route,
-          { error: "Not found" },
-          404,
-        );
+        await fulfillJson(route, { error: "Not found" }, 404);
       }
       return;
     }
@@ -352,9 +361,7 @@ export async function mockApi(page: Page): Promise<void> {
     );
     if (method === "GET" && singleRepoMatch) {
       const repo = repos.find(
-        (r) =>
-          r.Owner === singleRepoMatch[1] &&
-          r.Name === singleRepoMatch[2],
+        (r) => r.Owner === singleRepoMatch[1] && r.Name === singleRepoMatch[2],
       );
       if (!repo) {
         await fulfillJson(route, { error: "Not found" }, 404);
@@ -415,9 +422,7 @@ export async function mockApi(page: Page): Promise<void> {
         await fulfillJson(route, { title: "Not found" }, 404);
         return;
       }
-      const reqBody = JSON.parse(
-        (await route.request().postData()) ?? "{}",
-      );
+      const reqBody = JSON.parse((await route.request().postData()) ?? "{}");
       if (reqBody.title !== undefined) pr.Title = reqBody.title;
       if (reqBody.body !== undefined) pr.Body = reqBody.body;
       await fulfillJson(route, {

--- a/frontend/tests/e2e/workspaces.spec.ts
+++ b/frontend/tests/e2e/workspaces.spec.ts
@@ -6,14 +6,18 @@ test.beforeEach(async ({ page }) => {
   await mockApi(page);
 });
 
-test("workspaces route renders the terminal workspace list shell", async ({ page }) => {
+test("workspaces route renders the terminal workspace list shell", async ({
+  page,
+}) => {
   await page.goto("/workspaces");
   await expect(
     page.getByText("Select a workspace from the sidebar"),
   ).toBeVisible();
 });
 
-test("workspaces sidebar collapses and expands through the shared control", async ({ page }) => {
+test("workspaces sidebar collapses and expands through the shared control", async ({
+  page,
+}) => {
   await page.goto("/workspaces");
 
   const sidebar = page.locator(".sidebar").first();
@@ -24,54 +28,45 @@ test("workspaces sidebar collapses and expands through the shared control", asyn
     .click();
   await expect(sidebar).toHaveClass(/sidebar--collapsed/);
 
-  await sidebar
-    .getByRole("button", { name: "Expand sidebar" })
-    .click();
+  await sidebar.getByRole("button", { name: "Expand sidebar" }).click();
   await expect(sidebar).not.toHaveClass(/sidebar--collapsed/);
 });
 
 test("AppHeader workspaces tab navigates to /workspaces", async ({ page }) => {
   await page.goto("/pulls");
-  await page
-    .getByRole("button", { name: "Workspaces" })
-    .click();
+  await page.getByRole("button", { name: "Workspaces" }).click();
   await expect(page).toHaveURL(/\/workspaces$/);
 });
 
-test(
-  "repo selector renders icon and still filters repos",
-  async ({ page }) => {
-    await page.goto("/pulls");
+test("repo selector renders icon and still filters repos", async ({ page }) => {
+  await page.goto("/pulls");
 
-    const selector = page.getByTitle(
-      "Select repository",
-    );
-    await expect(selector).toBeVisible();
-    await expect(selector.locator("svg")).toBeVisible();
+  const selector = page.getByTitle("Select repository");
+  await expect(selector).toBeVisible();
+  await expect(selector.locator("svg")).toBeVisible();
 
-    await selector.click();
+  await selector.click();
 
-    const input = page.getByLabel("Filter repos");
-    await expect(input).toBeVisible();
-    await input.fill("widg");
+  const input = page.getByLabel("Filter repos");
+  await expect(input).toBeVisible();
+  await input.fill("widg");
 
-    const option = page.getByRole("option", {
-      name: "github.com/acme/widgets",
-    });
-    await expect(option).toBeVisible();
-    await option.click();
-    await expect(option.locator("input[type='checkbox']")).toBeChecked();
+  const option = page.getByRole("option", {
+    name: "github.com/acme/widgets",
+  });
+  await expect(option).toBeVisible();
+  await option.click();
+  await expect(option.locator("input[type='checkbox']")).toBeChecked();
 
-    await page.keyboard.press("Escape");
-    await expect(selector).toContainText("acme/widgets");
-    await expect(selector.locator("svg")).toBeVisible();
-    await expect(
-      page.getByText("Add browser regression coverage"),
-    ).toBeVisible();
-  },
-);
+  await page.keyboard.press("Escape");
+  await expect(selector).toContainText("acme/widgets");
+  await expect(selector.locator("svg")).toBeVisible();
+  await expect(page.getByText("Add browser regression coverage")).toBeVisible();
+});
 
-test("hideHeader suppresses AppHeader on the workspaces page", async ({ page }) => {
+test("hideHeader suppresses AppHeader on the workspaces page", async ({
+  page,
+}) => {
   await page.addInitScript(() => {
     window.__middleman_config = {
       embed: { hideHeader: true },
@@ -79,9 +74,7 @@ test("hideHeader suppresses AppHeader on the workspaces page", async ({ page }) 
   });
 
   await page.goto("/workspaces");
-  await expect(
-    page.locator("header.app-header"),
-  ).toHaveCount(0);
+  await expect(page.locator("header.app-header")).toHaveCount(0);
 });
 
 test("navigateToRoute bridge method works", async ({ page }) => {
@@ -110,7 +103,9 @@ test("workspace bridge methods are registered on startup", async ({ page }) => {
   });
 });
 
-test("provider-explicit embed detail route uses provider in detail request", async ({ page }) => {
+test("provider-explicit embed detail route uses provider in detail request", async ({
+  page,
+}) => {
   const detailRequest = page.waitForRequest(
     (request) =>
       request.method() === "GET" &&
@@ -168,7 +163,9 @@ test("provider-explicit embed detail route uses provider in detail request", asy
   await expect(page.getByText("Provider-explicit GitLab issue")).toBeVisible();
 });
 
-test("nested repo_path embed detail route loads matching detail content", async ({ page }) => {
+test("nested repo_path embed detail route loads matching detail content", async ({
+  page,
+}) => {
   const detailRequest = page.waitForRequest(
     (request) =>
       request.method() === "GET" &&
@@ -227,7 +224,9 @@ test("nested repo_path embed detail route loads matching detail content", async 
   await expect(page.getByText("Nested GitLab issue")).toBeVisible();
 });
 
-test("embed initialRoute opens detail surface without full app chrome", async ({ page }) => {
+test("embed initialRoute opens detail surface without full app chrome", async ({
+  page,
+}) => {
   await page.addInitScript(() => {
     window.__middleman_config = {
       embed: {
@@ -297,7 +296,9 @@ test("embed initialRoute opens detail surface without full app chrome", async ({
   await expect(page.getByText("Initial route GitLab issue")).toBeVisible();
 });
 
-test("full app initializes after navigating away from an initial embed route", async ({ page }) => {
+test("full app initializes after navigating away from an initial embed route", async ({
+  page,
+}) => {
   await page.route("**/api/v1/settings", async (route) => {
     await route.fulfill({
       status: 200,
@@ -312,6 +313,12 @@ test("full app initializes after navigating away from an initial embed route", a
         },
         terminal: {
           font_family: '"Fira Code", monospace',
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
           renderer: "xterm",
         },
         agents: [],
@@ -342,7 +349,9 @@ test("full app initializes after navigating away from an initial embed route", a
   await expect(page.locator("header.app-header")).toBeVisible();
 });
 
-test("full app reinitializes after navigating through an embed route", async ({ page }) => {
+test("full app reinitializes after navigating through an embed route", async ({
+  page,
+}) => {
   let settingsRequests = 0;
   await page.addInitScript(() => {
     const OriginalEventSource = window.EventSource;
@@ -379,6 +388,12 @@ test("full app reinitializes after navigating through an embed route", async ({ 
         },
         terminal: {
           font_family: '"Fira Code", monospace',
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
           renderer: "xterm",
         },
         agents: [],
@@ -389,8 +404,8 @@ test("full app reinitializes after navigating through an embed route", async ({ 
   await page.goto("/pulls");
   await expect(page.locator("header.app-header")).toBeVisible();
   await expect.poll(() => settingsRequests).toBe(1);
-  const initialEventSources = await page.evaluate(() =>
-    window.__middleman_event_source_counts?.().created ?? 0,
+  const initialEventSources = await page.evaluate(
+    () => window.__middleman_event_source_counts?.().created ?? 0,
   );
   expect(initialEventSources).toBeGreaterThan(0);
 
@@ -399,9 +414,13 @@ test("full app reinitializes after navigating through an embed route", async ({ 
   });
   await expect(page).toHaveURL(/\/workspaces\/embed\/list$/);
   await expect(page.locator("header.app-header")).toHaveCount(0);
-  await expect.poll(async () => page.evaluate(() =>
-    window.__middleman_event_source_counts?.().closed ?? 0,
-  )).toBeGreaterThanOrEqual(initialEventSources);
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () => window.__middleman_event_source_counts?.().closed ?? 0,
+      ),
+    )
+    .toBeGreaterThanOrEqual(initialEventSources);
 
   await page.evaluate(() => {
     window.__middleman_navigate_to_route?.("/pulls");
@@ -409,10 +428,18 @@ test("full app reinitializes after navigating through an embed route", async ({ 
   await expect(page).toHaveURL(/\/pulls$/);
   await expect(page.locator("header.app-header")).toBeVisible();
   await expect.poll(() => settingsRequests).toBe(2);
-  await expect.poll(async () => page.evaluate(() =>
-    window.__middleman_event_source_counts?.().created ?? 0,
-  )).toBeGreaterThan(initialEventSources);
-  await expect.poll(async () => page.evaluate(() =>
-    window.__middleman_event_source_counts?.().closed ?? 0,
-  )).toBeGreaterThanOrEqual(initialEventSources);
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () => window.__middleman_event_source_counts?.().created ?? 0,
+      ),
+    )
+    .toBeGreaterThan(initialEventSources);
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () => window.__middleman_event_source_counts?.().closed ?? 0,
+      ),
+    )
+    .toBeGreaterThanOrEqual(initialEventSources);
 });

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1275,8 +1275,14 @@ type SyncStatus struct {
 
 // Terminal defines model for Terminal.
 type Terminal struct {
-	FontFamily string `json:"font_family"`
-	Renderer   string `json:"renderer"`
+	CursorBlink   *bool   `json:"cursor_blink"`
+	FontFamily    string  `json:"font_family"`
+	FontLigatures bool    `json:"font_ligatures"`
+	FontSize      int64   `json:"font_size"`
+	LetterSpacing int64   `json:"letter_spacing"`
+	LineHeight    float64 `json:"line_height"`
+	Renderer      string  `json:"renderer"`
+	Scrollback    int64   `json:"scrollback"`
 }
 
 // UpdateSettingsRequest defines model for UpdateSettingsRequest.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -482,11 +482,24 @@ type Activity struct {
 const (
 	TerminalRendererXterm   = "xterm"
 	TerminalRendererGhostty = "ghostty-web"
+
+	DefaultTerminalFontSize      = 14
+	DefaultTerminalScrollback    = 1000
+	DefaultTerminalLineHeight    = 1.0
+	DefaultTerminalLetterSpacing = 0
+	DefaultTerminalCursorBlink   = true
+	DefaultTerminalFontLigatures = false
 )
 
 type Terminal struct {
-	FontFamily string `toml:"font_family,omitempty" json:"font_family"`
-	Renderer   string `toml:"renderer,omitempty" json:"renderer"`
+	FontFamily    string  `toml:"font_family,omitempty" json:"font_family"`
+	FontSize      int     `toml:"font_size,omitempty" json:"font_size"`
+	Scrollback    int     `toml:"scrollback,omitempty" json:"scrollback"`
+	LineHeight    float64 `toml:"line_height,omitempty" json:"line_height"`
+	LetterSpacing int     `toml:"letter_spacing,omitempty" json:"letter_spacing"`
+	CursorBlink   *bool   `toml:"cursor_blink,omitempty" json:"cursor_blink"`
+	FontLigatures bool    `toml:"font_ligatures,omitempty" json:"font_ligatures"`
+	Renderer      string  `toml:"renderer,omitempty" json:"renderer"`
 }
 
 type Agent struct {
@@ -890,6 +903,43 @@ func (c *Config) Validate() error {
 	}
 
 	c.Terminal.FontFamily = strings.TrimSpace(c.Terminal.FontFamily)
+	if c.Terminal.FontSize == 0 {
+		c.Terminal.FontSize = DefaultTerminalFontSize
+	}
+	if c.Terminal.FontSize < 8 || c.Terminal.FontSize > 32 {
+		return fmt.Errorf(
+			"config: invalid terminal.font_size %d: must be between 8 and 32",
+			c.Terminal.FontSize,
+		)
+	}
+	if c.Terminal.Scrollback == 0 {
+		c.Terminal.Scrollback = DefaultTerminalScrollback
+	}
+	if c.Terminal.Scrollback < 100 || c.Terminal.Scrollback > 100000 {
+		return fmt.Errorf(
+			"config: invalid terminal.scrollback %d: must be between 100 and 100000",
+			c.Terminal.Scrollback,
+		)
+	}
+	if c.Terminal.LineHeight == 0 {
+		c.Terminal.LineHeight = DefaultTerminalLineHeight
+	}
+	if c.Terminal.LineHeight < 0.8 || c.Terminal.LineHeight > 2 {
+		return fmt.Errorf(
+			"config: invalid terminal.line_height %.2f: must be between 0.8 and 2",
+			c.Terminal.LineHeight,
+		)
+	}
+	if c.Terminal.LetterSpacing < -2 || c.Terminal.LetterSpacing > 8 {
+		return fmt.Errorf(
+			"config: invalid terminal.letter_spacing %d: must be between -2 and 8",
+			c.Terminal.LetterSpacing,
+		)
+	}
+	if c.Terminal.CursorBlink == nil {
+		cursorBlink := DefaultTerminalCursorBlink
+		c.Terminal.CursorBlink = &cursorBlink
+	}
 	c.Terminal.Renderer = strings.TrimSpace(c.Terminal.Renderer)
 	if c.Terminal.Renderer == "" {
 		c.Terminal.Renderer = TerminalRendererXterm

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1583,6 +1583,7 @@ endpoint = "http://custom:9999"
 
 func TestTerminalConfigRoundTrip(t *testing.T) {
 	assert := Assert.New(t)
+	require := require.New(t)
 	path := writeConfig(t, `
 [[repos]]
 owner = "a"
@@ -1590,32 +1591,61 @@ name = "b"
 
 [terminal]
 font_family = '  "Iosevka Term", monospace  '
+font_size = 16
+scrollback = 5000
+line_height = 1.2
+letter_spacing = 1
+cursor_blink = false
+font_ligatures = true
 renderer = "ghostty-web"
 `)
 	cfg, err := Load(path)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal("\"Iosevka Term\", monospace", cfg.Terminal.FontFamily)
+	assert.Equal(16, cfg.Terminal.FontSize)
+	assert.Equal(5000, cfg.Terminal.Scrollback)
+	assert.InDelta(1.2, cfg.Terminal.LineHeight, 0.001)
+	assert.Equal(1, cfg.Terminal.LetterSpacing)
+	require.NotNil(cfg.Terminal.CursorBlink)
+	assert.False(*cfg.Terminal.CursorBlink)
+	assert.True(cfg.Terminal.FontLigatures)
 	assert.Equal("ghostty-web", cfg.Terminal.Renderer)
 
 	savePath := filepath.Join(t.TempDir(), "saved.toml")
-	require.NoError(t, cfg.Save(savePath))
+	require.NoError(cfg.Save(savePath))
 
 	cfg2, err := Load(savePath)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal("\"Iosevka Term\", monospace", cfg2.Terminal.FontFamily)
+	assert.Equal(16, cfg2.Terminal.FontSize)
+	assert.Equal(5000, cfg2.Terminal.Scrollback)
+	assert.InDelta(1.2, cfg2.Terminal.LineHeight, 0.001)
+	assert.Equal(1, cfg2.Terminal.LetterSpacing)
+	require.NotNil(cfg2.Terminal.CursorBlink)
+	assert.False(*cfg2.Terminal.CursorBlink)
+	assert.True(cfg2.Terminal.FontLigatures)
 	assert.Equal("ghostty-web", cfg2.Terminal.Renderer)
 }
 
 func TestTerminalRendererDefaultsToXterm(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
 	path := writeConfig(t, `
 [[repos]]
 owner = "a"
 name = "b"
 `)
 	cfg, err := Load(path)
-	require.NoError(t, err)
+	require.NoError(err)
 
-	Assert.Equal(t, "xterm", cfg.Terminal.Renderer)
+	assert.Equal("xterm", cfg.Terminal.Renderer)
+	assert.Equal(14, cfg.Terminal.FontSize)
+	assert.Equal(1000, cfg.Terminal.Scrollback)
+	assert.InDelta(1.0, cfg.Terminal.LineHeight, 0.001)
+	assert.Equal(0, cfg.Terminal.LetterSpacing)
+	require.NotNil(cfg.Terminal.CursorBlink)
+	assert.True(*cfg.Terminal.CursorBlink)
+	assert.False(cfg.Terminal.FontLigatures)
 }
 
 func TestIssueWorkspaceBranchStyleDefaultsToSlug(t *testing.T) {

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -91,7 +91,11 @@ func TestSettingsAPIE2EReadUpdateAndValidation(t *testing.T) {
 				HideBots:   true,
 			},
 			Terminal: &generated.Terminal{
-				FontFamily: "\"Iosevka Term\", monospace",
+				FontFamily:    "\"Iosevka Term\", monospace",
+				FontSize:      18,
+				Scrollback:    5000,
+				LineHeight:    1.15,
+				FontLigatures: true,
 			},
 		},
 	)
@@ -108,6 +112,10 @@ func TestSettingsAPIE2EReadUpdateAndValidation(t *testing.T) {
 		"\"Iosevka Term\", monospace",
 		cfgAfterUpdate.Terminal.FontFamily,
 	)
+	assert.Equal(18, cfgAfterUpdate.Terminal.FontSize)
+	assert.Equal(5000, cfgAfterUpdate.Terminal.Scrollback)
+	assert.InDelta(1.15, cfgAfterUpdate.Terminal.LineHeight, 0.001)
+	assert.True(cfgAfterUpdate.Terminal.FontLigatures)
 }
 
 func TestRepoConfigAPIE2EAddDeleteAndErrors(t *testing.T) {

--- a/internal/server/e2etest/sse_contract_test.go
+++ b/internal/server/e2etest/sse_contract_test.go
@@ -13,7 +13,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/middleman/internal/server"
+	"go.kenn.io/middleman/internal/server"
 )
 
 // TestSSEContractPinDeliversCachedSyncStatusFrame is a paving wire-level test:

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -53,10 +53,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	s.cfgMu.Lock()
 	repos := slices.Clone(s.cfg.Repos)
 	activity := s.cfg.Activity
-	terminal := s.cfg.Terminal
-	if terminal.Renderer == "" {
-		terminal.Renderer = config.TerminalRendererXterm
-	}
+	terminal := normalizeTerminalSettingsForResponse(s.cfg.Terminal)
 	agents := cloneConfigAgents(s.cfg.Agents)
 	s.cfgMu.Unlock()
 
@@ -81,6 +78,29 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		Terminal: terminal,
 		Agents:   agents,
 	}
+}
+
+func normalizeTerminalSettingsForResponse(
+	terminal config.Terminal,
+) config.Terminal {
+	if terminal.FontSize == 0 {
+		terminal.FontSize = config.DefaultTerminalFontSize
+	}
+	if terminal.Scrollback == 0 {
+		terminal.Scrollback = config.DefaultTerminalScrollback
+	}
+	if terminal.LineHeight == 0 {
+		terminal.LineHeight = config.DefaultTerminalLineHeight
+	}
+	if terminal.CursorBlink == nil {
+		cursorBlink := config.DefaultTerminalCursorBlink
+		terminal.CursorBlink = &cursorBlink
+	}
+	terminal.Renderer = strings.TrimSpace(terminal.Renderer)
+	if terminal.Renderer == "" {
+		terminal.Renderer = config.TerminalRendererXterm
+	}
+	return terminal
 }
 
 func matchedRepoCount(

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -332,6 +332,16 @@ command = ["codex", "--full-auto"]
 	assert.Equal(1, resp.Repos[0].MatchedRepoCount)
 	assert.Equal("threaded", resp.Activity.ViewMode)
 	assert.Empty(resp.Terminal.FontFamily)
+	assert.Equal(config.DefaultTerminalFontSize, resp.Terminal.FontSize)
+	assert.Equal(config.DefaultTerminalScrollback, resp.Terminal.Scrollback)
+	assert.InDelta(
+		config.DefaultTerminalLineHeight,
+		resp.Terminal.LineHeight,
+		0.001,
+	)
+	require.NotNil(resp.Terminal.CursorBlink)
+	assert.True(*resp.Terminal.CursorBlink)
+	assert.False(resp.Terminal.FontLigatures)
 	require.Len(resp.Agents, 1)
 	assert.Equal("codex", resp.Agents[0].Key)
 	assert.Equal([]string{"codex", "--full-auto"}, resp.Agents[0].Command)
@@ -348,7 +358,11 @@ func TestHandleUpdateSettings(t *testing.T) {
 		HideBots:   true,
 	}
 	terminal := config.Terminal{
-		FontFamily: "\"Fira Code\", monospace",
+		FontFamily:    "\"Fira Code\", monospace",
+		FontSize:      16,
+		Scrollback:    5000,
+		LineHeight:    1.15,
+		FontLigatures: true,
 	}
 	body := updateSettingsRequest{
 		Activity: &activity,
@@ -365,6 +379,10 @@ func TestHandleUpdateSettings(t *testing.T) {
 	assert.Equal("threaded", cfg2.Activity.ViewMode)
 	assert.Equal("30d", cfg2.Activity.TimeRange)
 	assert.Equal("\"Fira Code\", monospace", cfg2.Terminal.FontFamily)
+	assert.Equal(16, cfg2.Terminal.FontSize)
+	assert.Equal(5000, cfg2.Terminal.Scrollback)
+	assert.InDelta(1.15, cfg2.Terminal.LineHeight, 0.001)
+	assert.True(cfg2.Terminal.FontLigatures)
 }
 
 func TestHandleUpdateTerminalSettingsPreservesActivity(t *testing.T) {
@@ -387,7 +405,10 @@ hide_bots = true
 `, &mockGH{})
 
 	terminal := config.Terminal{
-		FontFamily: "\"Iosevka Term\", monospace",
+		FontFamily:    "\"Iosevka Term\", monospace",
+		FontSize:      15,
+		Scrollback:    2000,
+		LetterSpacing: 1,
 	}
 	body := updateSettingsRequest{
 		Terminal: &terminal,
@@ -404,6 +425,9 @@ hide_bots = true
 	assert.True(cfg2.Activity.HideClosed)
 	assert.True(cfg2.Activity.HideBots)
 	assert.Equal("\"Iosevka Term\", monospace", cfg2.Terminal.FontFamily)
+	assert.Equal(15, cfg2.Terminal.FontSize)
+	assert.Equal(2000, cfg2.Terminal.Scrollback)
+	assert.Equal(1, cfg2.Terminal.LetterSpacing)
 }
 
 func TestHandleUpdateSettingsPersistsAgents(t *testing.T) {

--- a/internal/server/workspacetest/issue_workspace_conflict_test.go
+++ b/internal/server/workspacetest/issue_workspace_conflict_test.go
@@ -6,7 +6,7 @@ import (
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/middleman/internal/apiclient/generated"
+	"go.kenn.io/middleman/internal/apiclient/generated"
 )
 
 // TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient is a

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -70,7 +70,11 @@
   import {
     createEventsStore,
   } from "./stores/events.svelte.js";
-  import type { ActivitySettings, ConfigRepo } from "./api/types.js";
+  import type {
+    ActivitySettings,
+    ConfigRepo,
+    TerminalSettingsInput,
+  } from "./api/types.js";
 
   interface Props {
     client: MiddlemanClient;
@@ -198,13 +202,10 @@
     function hydrateSettings(
       repos: ConfigRepo[],
       activity: ActivitySettings,
-      terminal: { font_family: string; renderer: string },
+      terminal: TerminalSettingsInput,
     ): void {
       settingsStore.setConfiguredRepos(repos);
-      settingsStore.setTerminalFontFamily(terminal.font_family);
-      settingsStore.setTerminalRenderer(
-        terminal.renderer === "ghostty-web" ? "ghostty-web" : "xterm",
-      );
+      settingsStore.setTerminalSettings(terminal);
       activityStore.hydrateDefaults(activity);
     }
 

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2932,8 +2932,18 @@ export interface components {
             running: boolean;
         };
         Terminal: {
+            cursor_blink: boolean | null;
             font_family: string;
+            font_ligatures: boolean;
+            /** Format: int64 */
+            font_size: number;
+            /** Format: int64 */
+            letter_spacing: number;
+            /** Format: double */
+            line_height: number;
             renderer: string;
+            /** Format: int64 */
+            scrollback: number;
         };
         UpdateSettingsRequest: {
             /**

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -1,8 +1,7 @@
 import type { components, operations } from "./generated/schema.js";
 
 export type Repo = components["schemas"]["RepoResponse"];
-export type RepoSummary =
-  components["schemas"]["RepoSummaryResponse"];
+export type RepoSummary = components["schemas"]["RepoSummaryResponse"];
 export type RepoSummaryAuthor =
   components["schemas"]["RepoSummaryAuthorResponse"];
 export type RepoSummaryIssue =
@@ -11,38 +10,34 @@ export type RepoSummaryCommitPointResponse =
   components["schemas"]["RepoSummaryCommitPointResponse"];
 export type RepoSummaryReleaseResponse =
   components["schemas"]["RepoSummaryReleaseResponse"];
-export type PullRequest =
-  components["schemas"]["MergeRequestResponse"];
+export type PullRequest = components["schemas"]["MergeRequestResponse"];
 export type ProviderCapabilities =
   components["schemas"]["ProviderCapabilitiesResponse"];
 export type OperationAvailability =
   components["schemas"]["OperationAvailability"];
-export type RepoOperations =
-  components["schemas"]["RepoOperations"];
-export type Issue =
-  components["schemas"]["IssueResponse"];
+export type RepoOperations = components["schemas"]["RepoOperations"];
+export type Issue = components["schemas"]["IssueResponse"];
 export type IssueEvent = components["schemas"]["IssueEvent"];
 export type IssueDetail = components["schemas"]["IssueDetailResponse"];
 export type PREvent = components["schemas"]["MREvent"];
 export type PullDetail = components["schemas"]["MergeRequestDetailResponse"];
 export type SyncStatus = components["schemas"]["SyncStatus"];
-export type RateLimitHostStatus =
-  components["schemas"]["RateLimitHostStatus"];
-export type RateLimitsResponse =
-  components["schemas"]["RateLimitsResponse"];
+export type RateLimitHostStatus = components["schemas"]["RateLimitHostStatus"];
+export type RateLimitsResponse = components["schemas"]["RateLimitsResponse"];
 export type ActivityItem = components["schemas"]["ActivityItemResponse"];
 export type ActivityResponse = components["schemas"]["ActivityResponse"];
 export type CommentAutocompleteResponse =
   components["schemas"]["CommentAutocompleteResponse"];
 export type CommentAutocompleteReference =
   components["schemas"]["CommentAutocompleteReference"];
-export type ActivityParams = NonNullable<operations["list-activity"]["parameters"]["query"]>;
+export type ActivityParams = NonNullable<
+  operations["list-activity"]["parameters"]["query"]
+>;
 export type PullsParams = operations["list-pulls"]["parameters"]["query"];
 export type IssuesParams = operations["list-issues"]["parameters"]["query"];
 export type MergeParams = components["schemas"]["MergePRInputBody"];
 
-export type WorktreeLink =
-  components["schemas"]["WorktreeLinkResponse"];
+export type WorktreeLink = components["schemas"]["WorktreeLinkResponse"];
 export type LaunchTarget = components["schemas"]["LaunchTarget"];
 export type RuntimeSession = components["schemas"]["SessionInfo"];
 export type WorkspaceRuntime =
@@ -77,7 +72,49 @@ export type TerminalRenderer = "xterm" | "ghostty-web";
 
 export interface TerminalSettings {
   font_family: string;
+  font_size: number;
+  scrollback: number;
+  line_height: number;
+  letter_spacing: number;
+  cursor_blink: boolean;
+  font_ligatures: boolean;
   renderer: TerminalRenderer;
+}
+
+export const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
+  font_family: "",
+  font_size: 14,
+  scrollback: 1000,
+  line_height: 1,
+  letter_spacing: 0,
+  cursor_blink: true,
+  font_ligatures: false,
+  renderer: "xterm",
+};
+
+export type TerminalSettingsInput = Partial<
+  Omit<TerminalSettings, "cursor_blink" | "renderer">
+> & {
+  cursor_blink?: boolean | null;
+  renderer?: string | null;
+};
+
+export function normalizeTerminalSettings(
+  terminal: TerminalSettingsInput | null | undefined,
+): TerminalSettings {
+  return {
+    font_family: terminal?.font_family ?? DEFAULT_TERMINAL_SETTINGS.font_family,
+    font_size: terminal?.font_size ?? DEFAULT_TERMINAL_SETTINGS.font_size,
+    scrollback: terminal?.scrollback ?? DEFAULT_TERMINAL_SETTINGS.scrollback,
+    line_height: terminal?.line_height ?? DEFAULT_TERMINAL_SETTINGS.line_height,
+    letter_spacing:
+      terminal?.letter_spacing ?? DEFAULT_TERMINAL_SETTINGS.letter_spacing,
+    cursor_blink:
+      terminal?.cursor_blink ?? DEFAULT_TERMINAL_SETTINGS.cursor_blink,
+    font_ligatures:
+      terminal?.font_ligatures ?? DEFAULT_TERMINAL_SETTINGS.font_ligatures,
+    renderer: terminal?.renderer === "ghostty-web" ? "ghostty-web" : "xterm",
+  };
 }
 
 export interface AgentSettings {
@@ -157,11 +194,7 @@ export interface CommitInfo {
 export interface WorkspaceHost {
   key: string;
   label: string;
-  connectionState:
-    | "connected"
-    | "connecting"
-    | "disconnected"
-    | "error";
+  connectionState: "connected" | "connecting" | "disconnected" | "error";
   transport?: "ssh" | "local";
   platform?: string;
   projects: WorkspaceProject[];

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,6 +50,10 @@ export {
   buildRoutedItemRoute,
 } from "./routes.js";
 export { supportsLocked } from "./api/provider-capabilities.js";
+export {
+  DEFAULT_TERMINAL_SETTINGS,
+  normalizeTerminalSettings,
+} from "./api/types.js";
 export type {
   FocusListRouteRef,
   IssueRouteRef,
@@ -58,6 +62,7 @@ export type {
   RepositoryRouteRef,
   RoutedItemRef,
 } from "./routes.js";
+export type { TerminalSettingsInput } from "./api/types.js";
 
 // Store factories
 export { createPullsStore } from "./stores/pulls.svelte.js";

--- a/packages/ui/src/stores/settings.svelte.ts
+++ b/packages/ui/src/stores/settings.svelte.ts
@@ -1,13 +1,17 @@
-import type {
-  ConfigRepo,
-  TerminalRenderer,
-  TerminalSettings,
+import {
+  DEFAULT_TERMINAL_SETTINGS,
+  normalizeTerminalSettings,
+  type ConfigRepo,
+  type TerminalRenderer,
+  type TerminalSettingsInput,
+  type TerminalSettings,
 } from "../api/types.js";
 
 export function createSettingsStore() {
   let repos = $state<ConfigRepo[]>([]);
-  let terminalFontFamily = $state("");
-  let terminalRenderer = $state<TerminalRenderer>("xterm");
+  let terminalSettings = $state<TerminalSettings>({
+    ...DEFAULT_TERMINAL_SETTINGS,
+  });
   let loaded = $state(false);
 
   function getConfiguredRepos(): ConfigRepo[] {
@@ -19,24 +23,64 @@ export function createSettingsStore() {
     loaded = true;
   }
 
+  function getTerminalSettings(): TerminalSettings {
+    return terminalSettings;
+  }
+
+  function setTerminalSettings(
+    settings: TerminalSettingsInput | null | undefined,
+  ): void {
+    terminalSettings = normalizeTerminalSettings(settings);
+  }
+
   function getTerminalFontFamily(): string {
-    return terminalFontFamily;
+    return terminalSettings.font_family;
   }
 
   function setTerminalFontFamily(
     fontFamily: TerminalSettings["font_family"] | null | undefined,
   ): void {
-    terminalFontFamily = fontFamily ?? "";
+    terminalSettings = {
+      ...terminalSettings,
+      font_family: fontFamily ?? "",
+    };
+  }
+
+  function getTerminalFontSize(): number {
+    return terminalSettings.font_size;
+  }
+
+  function getTerminalScrollback(): number {
+    return terminalSettings.scrollback;
+  }
+
+  function getTerminalLineHeight(): number {
+    return terminalSettings.line_height;
+  }
+
+  function getTerminalLetterSpacing(): number {
+    return terminalSettings.letter_spacing;
+  }
+
+  function getTerminalCursorBlink(): boolean {
+    return terminalSettings.cursor_blink;
+  }
+
+  function getTerminalFontLigatures(): boolean {
+    return terminalSettings.font_ligatures;
   }
 
   function getTerminalRenderer(): TerminalRenderer {
-    return terminalRenderer;
+    return terminalSettings.renderer;
   }
 
   function setTerminalRenderer(
     renderer: TerminalSettings["renderer"] | null | undefined,
   ): void {
-    terminalRenderer = renderer === "ghostty-web" ? "ghostty-web" : "xterm";
+    terminalSettings = {
+      ...terminalSettings,
+      renderer: renderer === "ghostty-web" ? "ghostty-web" : "xterm",
+    };
   }
 
   function hasConfiguredRepos(): boolean {
@@ -50,8 +94,16 @@ export function createSettingsStore() {
   return {
     getConfiguredRepos,
     setConfiguredRepos,
+    getTerminalSettings,
+    setTerminalSettings,
     getTerminalFontFamily,
     setTerminalFontFamily,
+    getTerminalFontSize,
+    getTerminalScrollback,
+    getTerminalLineHeight,
+    getTerminalLetterSpacing,
+    getTerminalCursorBlink,
+    getTerminalFontLigatures,
     getTerminalRenderer,
     setTerminalRenderer,
     hasConfiguredRepos,
@@ -59,6 +111,4 @@ export function createSettingsStore() {
   };
 }
 
-export type SettingsStore = ReturnType<
-  typeof createSettingsStore
->;
+export type SettingsStore = ReturnType<typeof createSettingsStore>;


### PR DESCRIPTION
- Add a terminal options pane with live preview for font, sizing, scrollback, cursor blink, renderer, and ligatures.
- Persist terminal display settings through config and API-generated clients.
- Keep ghostty-web controls aligned with renderer support and preserve font fallback stacks when choosing a font.