### PR TITLE
test: run isolated workspace e2e tests in parallel

### DIFF
--- a/.agents/skills/optimize-go-test-duration
+++ b/.agents/skills/optimize-go-test-duration
@@ -1,0 +1,1 @@
+../../skills/optimize-go-test-duration

--- a/.claude/skills/optimize-go-test-duration
+++ b/.claude/skills/optimize-go-test-duration
@@ -1,0 +1,1 @@
+../../skills/optimize-go-test-duration

--- a/context/testing.md
+++ b/context/testing.md
@@ -88,6 +88,14 @@ slow packages. CI also writes race timing JSON and summarizes slow packages and
 tests in the `go test -race` job summary. When a PR regresses race runtime, use
 the CI timing artifact rather than guessing from local timings alone.
 
+New full-stack server tests should default to `t.Parallel()` when they build
+their own `t.TempDir` filesystem, SQLite fixture, provider fake, and server
+fixture. This especially applies to workspace/git e2e coverage where each test
+clones its own bare repo and worktree root. Keep tests serial when they call
+`t.Setenv`, mutate process-global state, rely on fixed ports or shared external
+resources, exercise real tmux/PTY sessions, or intentionally verify ordering
+against another test-visible shared resource.
+
 Keep splitting new high-volume tests into the existing black-box packages when
 they do not need unexported internals:
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -93,8 +93,14 @@ their own `t.TempDir` filesystem, SQLite fixture, provider fake, and server
 fixture. This especially applies to workspace/git e2e coverage where each test
 clones its own bare repo and worktree root. Keep tests serial when they call
 `t.Setenv`, mutate process-global state, rely on fixed ports or shared external
-resources, exercise real tmux/PTY sessions, or intentionally verify ordering
-against another test-visible shared resource.
+resources, or intentionally verify ordering against another test-visible shared
+resource.
+
+Real tmux and PTY tests can still run in parallel when each test owns its
+session names, temp dirs, sockets, and cleanup. If the bottleneck is external
+resource pressure rather than correctness, keep `t.Parallel()` and gate the
+expensive section with a package-level `golang.org/x/sync/semaphore.Weighted`
+instead of serializing the whole test.
 
 Keep splitting new high-volume tests into the existing black-box packages when
 they do not need unexported internals:

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -13906,6 +13906,8 @@ func TestCleanupWorkspaceServerFixtureArtifactsKeepsDeletingAfterError(
 }
 
 func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -14495,6 +14497,8 @@ func cleanupPtyOwnerWorkspace(
 }
 
 func TestWorkspaceRuntimeLaunchUnavailableTargetE2E(t *testing.T) {
+	t.Parallel()
+
 	disabled := false
 	cfg := &config.Config{Agents: []config.Agent{{
 		Key:     "disabled",
@@ -14518,6 +14522,8 @@ func TestWorkspaceRuntimeLaunchUnavailableTargetE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeLaunchPlainShellUsesShellSessionE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -15668,6 +15674,8 @@ func TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E(t *testing.T) {
 // on these fields, so a regression here would silently turn the pills
 // off without any test failure at the unit-test layer.
 func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -15724,6 +15732,8 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -15797,6 +15807,8 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 }
 
 func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -15828,6 +15840,8 @@ func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
@@ -15899,6 +15913,8 @@ func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -15950,6 +15966,8 @@ func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
@@ -15974,6 +15992,8 @@ func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -16018,6 +16038,8 @@ func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.
 }
 
 func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -16057,6 +16079,8 @@ func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -17342,6 +17366,8 @@ type rawProblemDetail struct {
 }
 
 func TestWorkspaceCRUDE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -17417,6 +17443,8 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 }
 
 func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -17457,6 +17485,8 @@ func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
 }
 
 func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -17505,6 +17535,8 @@ func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateNotFound(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 
 	client, _, _, _ := setupTestServerWithWorkspaces(t)
@@ -17538,6 +17570,8 @@ func TestWorkspaceCreateNotFound(t *testing.T) {
 }
 
 func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -17583,6 +17617,8 @@ func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 }
 
 func TestWorkspaceCreateDuplicate(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 
 	client, _, _, _ := setupTestServerWithWorkspaces(t)
@@ -17607,6 +17643,8 @@ func TestWorkspaceCreateDuplicate(t *testing.T) {
 }
 
 func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -17646,6 +17684,8 @@ func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueE2E(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -17698,6 +17738,8 @@ func TestWorkspaceCreateIssueE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -17732,6 +17774,8 @@ func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -17767,6 +17811,8 @@ func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueIsIdempotent(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -17800,6 +17846,8 @@ func TestWorkspaceCreateIssueIsIdempotent(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -17853,6 +17901,8 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreatePRAndIssueCanCoexistForSameRepoNumber(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -17900,6 +17950,8 @@ func TestWorkspaceCreatePRAndIssueCanCoexistForSameRepoNumber(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueBranchConflictReturnsTyped409(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -18043,6 +18095,8 @@ func prepareIssueWorkspaceAssociationFixture(
 }
 
 func TestWorkspaceIssueMonitorAssociatesPRAndKeepsIssueOwnership(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 	ctx := context.Background()
@@ -18087,6 +18141,8 @@ func TestWorkspaceIssueMonitorAssociatesPRAndKeepsIssueOwnership(t *testing.T) {
 }
 
 func TestWorkspaceMonitorPassBroadcastsInvalidationEvents(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	ctx := t.Context()
 
@@ -18128,6 +18184,8 @@ func readEventMatching(
 }
 
 func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -18195,6 +18253,8 @@ func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -18249,6 +18309,8 @@ func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) 
 }
 
 func TestWorkspaceCreatePortQualifiedHostTracksOriginBranchE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -18297,6 +18359,8 @@ func TestWorkspaceCreatePortQualifiedHostTracksOriginBranchE2E(t *testing.T) {
 }
 
 func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -18385,6 +18449,8 @@ func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
 }
 
 func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -18423,6 +18489,8 @@ func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -18481,6 +18549,8 @@ func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
 }
 
 func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
+	t.Parallel()
+
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -18670,6 +18740,8 @@ func seedPROnHost(
 }
 
 func TestWorkspaceDeleteDirty(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -58,7 +58,16 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-var ptyE2ESemaphore = semaphore.NewWeighted(2)
+const serverRuntimeHelperMarker = "middleman-runtime-helper"
+
+var ptyE2ESemaphore = semaphore.NewWeighted(4)
+
+func runParallelPTYE2E(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	releasePTYSlot := acquirePTYE2ESlot(t)
+	t.Cleanup(releasePTYSlot)
+}
 
 func acquirePTYE2ESlot(t *testing.T) func() {
 	t.Helper()
@@ -13985,6 +13994,8 @@ func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreatesPtyOwnerSessionWhenTmuxUnavailableE2E(t *testing.T) {
+	runParallelPTYE2E(t)
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -14071,6 +14082,8 @@ func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("workspace clone fixture uses Unix-style local remotes")
 	}
+	runParallelPTYE2E(t)
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -14115,10 +14128,9 @@ func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		requirePTYAvailable(t)
-		t.Parallel()
-		releasePTYSlot := acquirePTYE2ESlot(t)
-		defer releasePTYSlot()
 	}
+	runParallelPTYE2E(t)
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -14185,7 +14197,8 @@ func TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		requirePTYAvailable(t)
 	}
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -14245,9 +14258,7 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 		t.Skip("concurrent attach coverage is exercised by the Rust owner tests on Windows")
 	}
 	requirePTYAvailable(t)
-	t.Parallel()
-	releasePTYSlot := acquirePTYE2ESlot(t)
-	defer releasePTYSlot()
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -14263,7 +14274,6 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 	firstNeedle := "got:before-second"
 	thirdNeedle := "got:after-close"
 	if runtime.GOOS == "windows" {
-		t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 		command = serverRuntimeHelperCommand("echo")
 		readyNeedle = ""
 		firstNeedle = "echo:before-second"
@@ -14345,6 +14355,8 @@ func readPtyOwnerOutputUntil(
 }
 
 func TestWorkspacePtyOwnerTerminalRejectsConcurrentAttachmentsE2E(t *testing.T) {
+	runParallelPTYE2E(t)
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -14380,6 +14392,8 @@ func TestWorkspacePtyOwnerTerminalRejectsConcurrentAttachmentsE2E(t *testing.T) 
 }
 
 func TestWorkspacePtyOwnerTerminalFlushesFinalOutputOnExitE2E(t *testing.T) {
+	runParallelPTYE2E(t)
+
 	require := require.New(t)
 
 	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
@@ -14426,8 +14440,6 @@ func setupPtyOwnerWorkspaceFixture(
 	cfg := &config.Config{Tmux: config.Tmux{
 		Command: []string{filepath.Join(dir, "missing-tmux")},
 	}}
-	t.Setenv("SHELL", "/bin/sh")
-	t.Setenv("MIDDLEMAN_SERVER_PTY_OWNER_HELPER", "1")
 	return setupWorkspaceServerFixtureWithOptions(
 		t, cfg, ptyOwnerServerOptions(ptyOwnerDir),
 	), dir, ptyOwnerDir
@@ -14441,6 +14453,7 @@ func ptyOwnerServerOptions(ptyOwnerDir string) ServerOptions {
 			"-test.run=TestServerPtyOwnerHelperProcess",
 			"--",
 		},
+		PtyOwnerCommand: []string{"/bin/sh"},
 	}
 }
 
@@ -14458,7 +14471,6 @@ func gitLocalRemoteURL(path string) string {
 func rustPtyManagerShellCommandForTest(t *testing.T) []string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
-		t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
 		return serverRuntimeHelperCommand("echo")
 	}
 	return []string{"/bin/sh"}
@@ -14574,7 +14586,7 @@ func TestWorkspaceRuntimeLaunchPlainShellUsesShellSessionE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeLaunchSingletonAndStopE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -14639,7 +14651,7 @@ func TestWorkspaceRuntimeLaunchSingletonAndStopE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeNaturalAgentExitRemovesSessionE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -15574,7 +15586,7 @@ exit 0
 }
 
 func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -15624,7 +15636,7 @@ func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 // survive — killing them on a delete that didn't actually happen would leave
 // the user with a workspace whose agent and shell were silently terminated.
 func TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -16424,7 +16436,7 @@ func TestWorkspaceRuntimeEnsureShellE2E(t *testing.T) {
 // filter; this test guards both the websocket route and the
 // config.Shell.Command -> manager.Options.ShellCommand wiring.
 func TestWorkspaceRuntimeShellTerminalWebSocketE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	cfg := &config.Config{
@@ -16487,7 +16499,7 @@ func TestWorkspaceRuntimeShellTerminalWebSocketE2E(t *testing.T) {
 // 100ms timeout fires before attachment.Done — exactly the systemd-
 // run-wrapped shell case the user hit.
 func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	cfg := &config.Config{
@@ -16576,7 +16588,7 @@ func TestWorkspaceRuntimeShellTerminalDeliversExitFrameE2E(t *testing.T) {
 // deterministic (~750ms) and the second EnsureShell is guaranteed to
 // land inside it.
 func TestWorkspaceRuntimeEnsureShellAfterExitStartsFreshE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -16715,7 +16727,7 @@ func TestBridgeRuntimeAttachmentSubscriberDropDoesNotEmitExitFrame(t *testing.T)
 }
 
 func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	disableTmuxAgentSessions := false
@@ -16771,7 +16783,7 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeSessionTerminalWebSocketBasePathE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	disableTmuxAgentSessions := false
@@ -16930,7 +16942,7 @@ func workspaceTerminalDialWithQuery(
 }
 
 func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -17032,7 +17044,7 @@ func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
-	t.Setenv("MIDDLEMAN_SERVER_RUNTIME_HELPER", "1")
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	// This intentionally goes through the generated HTTP client, the real
@@ -17100,9 +17112,7 @@ func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
 	if err != nil {
 		t.Skip("tmux not available")
 	}
-	t.Parallel()
-	releasePTYSlot := acquirePTYE2ESlot(t)
-	defer releasePTYSlot()
+	runParallelPTYE2E(t)
 
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -17221,16 +17231,25 @@ func serverRuntimeHelperCommand(mode string) []string {
 		os.Args[0],
 		"-test.run=TestServerRuntimeHelperProcess",
 		"--",
+		serverRuntimeHelperMarker,
 		mode,
 	}
 }
 
 func TestServerRuntimeHelperProcess(t *testing.T) {
-	if os.Getenv("MIDDLEMAN_SERVER_RUNTIME_HELPER") != "1" {
+	args := os.Args
+	if sep := slices.Index(args, "--"); sep >= 0 {
+		args = args[sep+1:]
+	}
+	if len(args) > 0 && args[0] == serverRuntimeHelperMarker {
+		args = args[1:]
+	} else if os.Getenv("MIDDLEMAN_SERVER_RUNTIME_HELPER") != "1" {
 		return
 	}
-	args := os.Args
-	mode := args[len(args)-1]
+	if len(args) == 0 {
+		os.Exit(2)
+	}
+	mode := args[0]
 	switch mode {
 	case "sleep":
 		blockServerRuntimeHelper()
@@ -17288,13 +17307,14 @@ func blockServerRuntimeHelper() {
 }
 
 func TestServerPtyOwnerHelperProcess(t *testing.T) {
-	if os.Getenv("MIDDLEMAN_SERVER_PTY_OWNER_HELPER") != "1" {
-		return
-	}
 	args := os.Args
 	sep := slices.Index(args, "--")
 	if sep >= 0 {
 		args = args[sep+1:]
+	}
+	if os.Getenv("MIDDLEMAN_SERVER_PTY_OWNER_HELPER") != "1" &&
+		(len(args) == 0 || args[0] != "pty-owner") {
+		return
 	}
 	if len(args) > 0 && args[0] == "pty-owner" {
 		args = args[1:]

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -55,7 +55,18 @@ import (
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 	"go.kenn.io/middleman/internal/workspace"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
+	"golang.org/x/sync/semaphore"
 )
+
+var ptyE2ESemaphore = semaphore.NewWeighted(2)
+
+func acquirePTYE2ESlot(t *testing.T) func() {
+	t.Helper()
+	require.NoError(t, ptyE2ESemaphore.Acquire(t.Context(), 1))
+	return func() {
+		ptyE2ESemaphore.Release(1)
+	}
+}
 
 func requirePTYAvailable(t *testing.T) {
 	t.Helper()
@@ -14104,6 +14115,9 @@ func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		requirePTYAvailable(t)
+		t.Parallel()
+		releasePTYSlot := acquirePTYE2ESlot(t)
+		defer releasePTYSlot()
 	}
 	require := require.New(t)
 	assert := Assert.New(t)
@@ -14231,6 +14245,10 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 		t.Skip("concurrent attach coverage is exercised by the Rust owner tests on Windows")
 	}
 	requirePTYAvailable(t)
+	t.Parallel()
+	releasePTYSlot := acquirePTYE2ESlot(t)
+	defer releasePTYSlot()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -17082,6 +17100,9 @@ func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
 	if err != nil {
 		t.Skip("tmux not available")
 	}
+	t.Parallel()
+	releasePTYSlot := acquirePTYE2ESlot(t)
+	defer releasePTYSlot()
 
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,6 +71,7 @@ type ServerOptions struct {
 	PtyOwnerExePath     string
 	PtyOwnerExeArgs     []string
 	PtyOwnerManagerPath string
+	PtyOwnerCommand     []string
 	PtyOwnerInProcess   bool
 }
 
@@ -460,6 +461,7 @@ func newServer(
 			ExePath:     options.PtyOwnerExePath,
 			ExeArgs:     append([]string(nil), options.PtyOwnerExeArgs...),
 			ManagerPath: options.PtyOwnerManagerPath,
+			Command:     append([]string(nil), options.PtyOwnerCommand...),
 			InProcess:   options.PtyOwnerInProcess,
 		}
 		if preferPtyOwnerForWorkspaces(runtime.GOOS, tmuxAvailable, options) {

--- a/internal/server/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspace_concurrent_e2e_test.go
@@ -22,6 +22,8 @@ import (
 // consistent state — no wedged worktree, no half-created branch, no
 // corrupt `worktrees/` metadata.
 func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	assert := Assert.New(t)
 

--- a/skills/optimize-go-test-duration/SKILL.md
+++ b/skills/optimize-go-test-duration/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: optimize-go-test-duration
+description: Use when Go test wall time is too high, CI test duration regresses, a package needs trace-driven test performance analysis, or tests should be made safely parallel with t.Parallel, package splitting, subprocess isolation, semaphores, or Go built-in tracing.
+---
+
+# Optimize Go Test Duration
+
+## Core Idea
+
+Optimize wall time from evidence, not guesses. Separate actual slow work from time spent waiting behind the Go test scheduler, package boundaries, subprocess startup, locks, I/O, sleeps, or scarce external resources.
+
+Keep coverage and realism unless the user explicitly asks to trade them away.
+
+## Baseline
+
+Use comparable commands before and after each change.
+
+For package timing:
+
+```bash
+go test ./path/to/pkg/... -shuffle=on
+```
+
+For per-test timing:
+
+```bash
+go test ./path/to/pkg -shuffle=on -json > /tmp/pkg-tests.json
+jq -r 'select(.Action=="pass" and .Test != null and .Elapsed != null) | [.Elapsed, .Test] | @tsv' /tmp/pkg-tests.json | sort -nr | head -60
+```
+
+Follow repository test rules first. In middleman, always pass `-shuffle=on` for direct `go test`, do not add `-count=1`, and do not use `-v` unless needed for a specific failure.
+
+## Trace Workflow
+
+Capture a Go trace for the slow package or focused group:
+
+```bash
+go test ./path/to/pkg -shuffle=on -trace /tmp/pkg.trace
+```
+
+Extract profiles that explain where wall time went:
+
+```bash
+go tool trace -pprof=sched /tmp/pkg.trace > /tmp/pkg-sched.pprof
+go tool trace -pprof=sync /tmp/pkg.trace > /tmp/pkg-sync.pprof
+go tool trace -pprof=syscall /tmp/pkg.trace > /tmp/pkg-syscall.pprof
+go tool trace -pprof=net /tmp/pkg.trace > /tmp/pkg-net.pprof
+go tool pprof -top /tmp/pkg-sched.pprof
+go tool pprof -top /tmp/pkg-sync.pprof
+go tool pprof -top /tmp/pkg-syscall.pprof
+go tool pprof -top /tmp/pkg-net.pprof
+```
+
+Read the results this way:
+
+- Large time in `testing.(*T).Parallel`, `testing.(*testState).waitParallel`, or scheduler delay means tests are queued behind serial work or the package parallelism limit.
+- Large `os/exec`, `os.StartProcess`, or `os.Process.Wait` time points at subprocess setup, helper processes, shell wrappers, or cleanup.
+- Large `sync.Mutex`, channel receive, or condition wait time points at shared fixtures, global locks, single-flight code, or test helpers that serialize work.
+- Large syscall or net time points at real I/O, sockets, PTY/tmux sessions, filesystem watchers, or cleanup.
+
+If the traced run fails but still writes a trace, inspect it anyway, then reproduce the failure with a focused command before editing.
+
+## Safe Parallelization
+
+Prefer `t.Parallel()` for isolated tests whose fixtures are independent. Call it near the top, after skips and before expensive setup.
+
+Do not use parent-process global mutation in parallel tests:
+
+- Avoid `t.Setenv` in tests that should run parallel; it changes the current test process environment and prevents safe parallelism.
+- Pass per-child environment with `exec.Cmd.Env` when only the child needs it.
+- Prefer argv markers for Go helper subprocesses, for example `os.Args[0] -test.run=TestHelper -- helper-marker mode`.
+- Avoid `os.Chdir`, global temp paths, package-level mutable state, shared ports, and shared database files in parallel tests.
+
+Use `t.TempDir()`, isolated SQLite files, loopback listeners on random ports, unique workspace names, and per-test command arguments.
+
+## Scarce Resources
+
+Real PTY, tmux, browser, container, or live-service tests can still run in parallel, but bound resource pressure.
+
+Use a package-level weighted semaphore:
+
+```go
+var ptySem = semaphore.NewWeighted(4)
+
+func runParallelPTYE2E(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	require.NoError(t, ptySem.Acquire(t.Context(), 1))
+	t.Cleanup(func() { ptySem.Release(1) })
+}
+```
+
+Pick the limit from observed stability and machine constraints. Start conservative, then raise only when repeated runs stay reliable.
+
+## Optimization Moves
+
+Use the trace to choose the smallest useful move:
+
+- Add `t.Parallel()` to isolated tests that are only waiting behind the test runner.
+- Remove `t.Setenv` or other parent-process global mutations by moving state into fixture structs, command args, or child `Env`.
+- Split large packages when independent test groups are blocked by unrelated serial tests and package boundaries are natural.
+- Replace fixed sleeps with readiness probes, channels, eventual assertions, or explicit synchronization.
+- Share expensive immutable setup only when it cannot leak mutable state between tests.
+- Keep full-stack/e2e coverage when the behavior needs real HTTP, SQLite, PTY, tmux, or subprocesses; make the realism concurrent instead of deleting it.
+
+## Verification
+
+After each meaningful change:
+
+1. Run the focused affected tests with `-shuffle=on`.
+2. Run the package or subtree baseline command again.
+3. Compare wall time, not just individual test elapsed time; parallel tests may report elapsed time that includes queueing.
+4. Re-run or trace again if the result is noisy or the bottleneck moved.
+5. Commit only after the relevant checks pass.
+
+Report the before/after numbers in seconds and percent reduction:
+
+```text
+before: 170s
+after: 66s
+improvement: 104s faster, 61% lower wall time, 2.6x faster
+```

--- a/skills/optimize-go-test-duration/agents/openai.yaml
+++ b/skills/optimize-go-test-duration/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Optimize Go Test Duration"
+  short_description: "Trace and reduce Go test wall time"
+  default_prompt: "Use $optimize-go-test-duration to analyze this Go test suite's wall time with built-in tracing and make safe test-duration optimizations."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
- Run isolated workspace and git-backed server E2E tests in parallel.\n- Keep env-mutating tmux/runtime helper coverage serialized.\n- Add testing guidance so future isolated server tests use the same parallel pattern.