### PR TITLE
fix: return from settings cog to prior page

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -54,6 +54,27 @@
 
   const syncing = $derived(sync.getSyncState()?.running ?? false);
   const compactHeader = $derived(getContainerSize() !== "wide");
+  let settingsReturnPath = "/";
+
+  function currentAppPath(): string {
+    const base = getBasePath();
+    const basePrefix = base === "/" ? "" : base.replace(/\/$/, "");
+    const fullPath = window.location.pathname + window.location.search;
+    if (basePrefix && fullPath.startsWith(basePrefix)) {
+      return fullPath.slice(basePrefix.length) || "/";
+    }
+    return fullPath;
+  }
+
+  function toggleSettings(): void {
+    if (getPage() === "settings") {
+      navigate(settingsReturnPath);
+      return;
+    }
+    settingsReturnPath = currentAppPath();
+    navigate("/settings");
+  }
+
   const compactNavOptions = $derived.by(() => {
     const options = [
       { value: "activity", label: "Activity" },
@@ -252,7 +273,7 @@
     {#if !isEmbedded()}
       <HeaderIconButton
         active={getPage() === "settings"}
-        onclick={() => navigate("/settings")}
+        onclick={toggleSettings}
         title="Settings"
       >
         <SettingsIcon size="14" strokeWidth="1.75" aria-hidden="true" />

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -216,6 +216,20 @@ describe("AppHeader", () => {
     expect(moon).toBeTruthy();
   });
 
+  it("returns to the previous page when the settings button is clicked again", async () => {
+    initTheme();
+    navigate("/pulls/github/acme/widgets/1/files");
+    render(AppHeader);
+
+    await fireEvent.click(screen.getByTitle("Settings"));
+    expect(window.location.pathname + window.location.search).toBe("/settings");
+
+    await fireEvent.click(screen.getByTitle("Settings"));
+    expect(window.location.pathname + window.location.search).toBe(
+      "/pulls/github/acme/widgets/1/files",
+    );
+  });
+
   it("renders the collapsed sidebar toggle as a header icon button", () => {
     initTheme();
     setSidebarCollapsed(true);

--- a/frontend/tests/e2e-full/navigation.spec.ts
+++ b/frontend/tests/e2e-full/navigation.spec.ts
@@ -67,4 +67,19 @@ test.describe("view navigation", () => {
     // Detail pane should now show the issue detail.
     await page.locator(".issue-detail").waitFor({ state: "visible", timeout: 10_000 });
   });
+
+  test("settings button toggles back to the previous route", async ({ page }) => {
+    await page.goto("/pulls/github/acme/widgets/1/files");
+    await expect(page).toHaveURL(/\/pulls\/github\/acme\/widgets\/1\/files$/);
+
+    await page.getByTitle("Settings").click();
+    await expect(page).toHaveURL(/\/settings$/);
+    await page.locator(".settings-page")
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    await page.getByTitle("Settings").click();
+    await expect(page).toHaveURL(/\/pulls\/github\/acme\/widgets\/1\/files$/);
+    await page.locator(".diff-file").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+  });
 });


### PR DESCRIPTION
- Settings cog toggles back to the route that opened Settings.
- PR files/detail URLs are preserved when returning from Settings.