### PR TITLE
fix: sort workspace diff files

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -15785,6 +15785,10 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 		[]byte("package dirty\n"), 0o644,
 	))
 	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, ".workspace-state.json"),
+		[]byte("{}\n"), 0o644,
+	))
+	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "z-blank.txt"),
 		[]byte(" \t\n"), 0o644,
 	))
@@ -15803,7 +15807,13 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assertWorkspaceDiffPaths(
 		t,
 		*headFiles.Files,
-		[]string{"base.txt", "dirty.go", "z-blank.txt", "z-empty.txt"},
+		[]string{
+			".workspace-state.json",
+			"base.txt",
+			"dirty.go",
+			"z-blank.txt",
+			"z-empty.txt",
+		},
 	)
 
 	headFilesHideWhitespace := requestWorkspaceFiles(
@@ -15813,7 +15823,7 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assertWorkspaceDiffPaths(
 		t,
 		*headFilesHideWhitespace.Files,
-		[]string{"dirty.go", "z-empty.txt"},
+		[]string{".workspace-state.json", "dirty.go", "z-empty.txt"},
 	)
 
 	headDiffHideWhitespace := requestWorkspaceDiff(
@@ -15823,7 +15833,7 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assertWorkspaceDiffPaths(
 		t,
 		*headDiffHideWhitespace.Files,
-		[]string{"dirty.go", "z-empty.txt"},
+		[]string{".workspace-state.json", "dirty.go", "z-empty.txt"},
 	)
 
 	pushedDiff := requestWorkspaceDiff(t, srv, ws.Id, "pushed")
@@ -15831,7 +15841,14 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assertWorkspaceDiffPaths(
 		t,
 		*pushedDiff.Files,
-		[]string{"base.txt", "committed.go", "dirty.go", "z-blank.txt", "z-empty.txt"},
+		[]string{
+			".workspace-state.json",
+			"base.txt",
+			"committed.go",
+			"dirty.go",
+			"z-blank.txt",
+			"z-empty.txt",
+		},
 	)
 	assert.Equal(int64(1), pushedDiff.WhitespaceOnlyCount)
 }

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -162,6 +163,7 @@ func worktreeDiffFilesFromRefs(
 		files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
 	}
 	markWorktreeGeneratedFiles(ctx, dir, files)
+	sortWorktreeDiffFiles(files)
 	return files, nil
 }
 
@@ -348,11 +350,21 @@ func worktreeDiffFromRefsPath(
 		}
 	}
 	markWorktreeGeneratedFiles(ctx, dir, files)
+	sortWorktreeDiffFiles(files)
 
 	return &gitclone.DiffResult{
 		WhitespaceOnlyCount: wsCount,
 		Files:               files,
 	}, nil
+}
+
+func sortWorktreeDiffFiles(files []gitclone.DiffFile) {
+	slices.SortFunc(files, func(a, b gitclone.DiffFile) int {
+		if cmp := strings.Compare(a.Path, b.Path); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.OldPath, b.OldPath)
+	})
 }
 
 func markWorktreeGeneratedFiles(

--- a/internal/workspace/diff_test.go
+++ b/internal/workspace/diff_test.go
@@ -29,12 +29,12 @@ func TestWorktreeDiffFilesAgainstHead(t *testing.T) {
 	require.NoError(err)
 	require.True(ok)
 	require.Len(files, 2)
-	assert.Equal("f.txt", files[0].Path)
-	assert.Equal("modified", files[0].Status)
-	assert.Equal(1, files[0].Additions)
-	assert.Equal(1, files[0].Deletions)
-	assert.Equal("dirty-test.txt", files[1].Path)
-	assert.Equal("added", files[1].Status)
+	assert.Equal("dirty-test.txt", files[0].Path)
+	assert.Equal("added", files[0].Status)
+	assert.Equal("f.txt", files[1].Path)
+	assert.Equal("modified", files[1].Status)
+	assert.Equal(1, files[1].Additions)
+	assert.Equal(1, files[1].Deletions)
 }
 
 func TestWorktreeDiffFilesHidesWhitespaceOnlyChanges(t *testing.T) {


### PR DESCRIPTION
- Sort workspace compare file responses by path after tracked and untracked files are combined.
- Keep the fast files endpoint and full diff endpoint in the same predictable order.