### PR TITLE
feat: refresh PR details after workspace pushes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ frontend/src/lib/api/generated/
 internal/apiclient/spec/openapi.json
 __pycache__/
 *.py[cod]
+# roborev snapshots
+/.roborev/
 .pi/superpowers-state.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ frontend/src/lib/api/generated/
 internal/apiclient/spec/openapi.json
 __pycache__/
 *.py[cod]
+.pi/superpowers-state.json

--- a/docs/superpowers/specs/2026-05-20-remote-head-refresh-design.md
+++ b/docs/superpowers/specs/2026-05-20-remote-head-refresh-design.md
@@ -1,20 +1,22 @@
-# Remote Head Refresh Design
+# Pushed Head Refresh Design
 
 ## Goal
 
-Refresh PR detail and CI state when a middleman-managed workspace's remote PR
-head changes.
+Refresh PR detail and CI state when a middleman-managed workspace pushes a new
+PR head.
 
-The trigger should be the provider-visible branch update, not a local command
-shape such as "an agent ran `git push`." Detecting the remote head makes the
-feature work for launched agents, base workspace terminals, IDE Git
-integrations, manual shells, and pushes from another machine. Failed pushes and
-local-only commits naturally do not trigger a refresh.
+The trigger should be the workspace's local remote-tracking ref moving, not a
+provider poll and not a command-shape signal such as "an agent ran `git push`."
+A successful push updates the local `refs/remotes/{remote}/{branch}` ref for
+the pushed branch, so middleman can observe the pushed head from the workspace's
+Git metadata without calling the remote. Failed pushes and local-only commits
+naturally do not trigger a refresh because the remote-tracking ref does not
+move.
 
 The user-visible result is:
 
-- A PR detail tab updates soon after the branch backing that PR moves on the
-  remote.
+- A PR detail tab updates soon after the workspace pushes the branch backing
+  that PR.
 - Pending CI starts refreshing without the user leaving and reopening the PR.
 - Issue workspaces that become associated with a PR can gain the PR tab from
   the same monitoring path.
@@ -23,7 +25,7 @@ The user-visible result is:
 
 ## Current Behavior
 
-Middleman already has several pieces of this flow, but no remote-head observer.
+Middleman already has several pieces of this flow, but no pushed-head observer.
 
 - `internal/workspace/monitor.go` runs once at startup and every minute. It
   only examines ready issue workspaces with no `associated_pr_number`. It
@@ -43,36 +45,35 @@ Middleman already has several pieces of this flow, but no remote-head observer.
   own EventSource for `workspace_status` and refetches the active workspace
   when the event's `id` matches.
 
-The current PR monitor does not ask the provider or remote repository whether a
-branch changed. It cannot detect that a PR-backed workspace was pushed, and it
-cannot discover a new PR unless a normal sync has already inserted the PR row.
+The current PR monitor does not inspect remote-tracking refs. It cannot detect
+that a PR-backed workspace was pushed, and it cannot discover a new PR unless a
+normal sync has already inserted the PR row.
 
 ## Design Decision
 
-Add a `RemoteHeadObserver` for middleman-owned workspaces.
+Add a `PushedHeadObserver` for middleman-owned workspaces.
 
-The observer checks the remote branch SHA for workspaces that either own a PR or
-can be associated with one. When the observed remote head for a PR changes, it
-enqueues a PR detail sync, then emits targeted SSE events so connected clients
-can refresh the right UI state without waiting for a broad `data_changed`
-reload.
+The observer checks the local remote-tracking ref for workspaces that either own
+a PR or can be associated with one. When the observed pushed head for a PR
+changes, it enqueues a PR detail sync, then emits targeted SSE events so
+connected clients can refresh the right UI state without waiting for a broad
+`data_changed` reload.
 
 This design deliberately keeps the observer provider-neutral:
 
-- Use the persisted PR row as the preferred source of branch identity:
-  `HeadRepoCloneURL`, `HeadBranch`, `PlatformHeadSHA`, provider kind, host, and
-  repo path.
-- Use local Git upstream state only as a fallback or as association evidence for
-  issue workspaces.
+- Use the persisted PR row and workspace branch state to identify which
+  remote-tracking ref represents the PR head.
+- Use local Git upstream state as the source of the remote name and branch ref,
+  and as association evidence for issue workspaces.
 - Use provider identity everywhere: `(provider, platform_host, repo_path,
   owner, name, number)`.
 - Keep provider-specific optimizations optional behind the platform capability
   model.
 
-The first implementation should use Git remote inspection as the common path:
-`git ls-remote <clone-url> refs/heads/<head-branch>`. Provider API fast paths
-can be added later only if they fit behind a neutral remote-head capability and
-respect existing rate-limit budgets.
+The first implementation should use local Git ref inspection only. It should not
+call `git ls-remote`, fetch, or provider branch APIs. External pushes from other
+machines remain the responsibility of the normal provider sync loop; this
+feature exists to make workspace-originated pushes refresh quickly.
 
 ## Alternatives Considered
 
@@ -81,19 +82,27 @@ respect existing rate-limit budgets.
 Middleman could prepend a private `git` wrapper to launched agent `PATH` and
 notify the server when `git push` exits successfully.
 
-This is useful as a future acceleration path, but it is not sufficient as the
-primary design. It misses absolute-path Git invocations, non-agent terminals,
-IDE pushes, and pushes from other machines. It also reports a command success,
-not the provider-visible branch state.
+This is unnecessary for the primary design. A successful push moves the
+workspace's remote-tracking ref, so middleman can observe the effect without
+wrapping commands. A wrapper also misses absolute-path Git invocations and
+non-agent terminals.
 
 ### Git Trace2 command observation
 
 Launched sessions can set Git Trace2 environment variables and stream
 successful `push` command exits back to middleman.
 
-This is less invasive than a wrapper, but it still observes local command
-execution rather than remote state. It also provides weak ref-level detail and
-does not cover external pushes.
+This is unnecessary for the same reason as a wrapper: command observation is an
+indirect proxy for a pushed ref that Git already records locally.
+
+### Remote polling
+
+Middleman could call `git ls-remote` or provider branch APIs to query the remote
+branch directly.
+
+This is broader than needed for the workspace-push refresh loop. It adds network
+traffic, auth failure cases, rate-limit pressure, and backoff state even though
+the local push already updates the ref middleman needs to observe.
 
 ### Existing PR monitor only
 
@@ -106,7 +115,7 @@ workspaces, relies on already-synced PR rows, and emits broad invalidations.
 The observer scans ready middleman workspaces. It does not discover arbitrary
 host worktrees and does not become a generic Git automation API.
 
-A workspace is eligible for remote-head observation when:
+A workspace is eligible for pushed-head observation when:
 
 - `status == "ready"`;
 - `worktree_path` is non-empty;
@@ -119,40 +128,42 @@ A workspace is eligible for remote-head observation when:
 
 For issue workspaces with no associated PR, the observer may share the current
 association logic with the PR monitor. If it finds a unique PR, it persists
-`associated_pr_number` before checking the remote head. That persistence still
+`associated_pr_number` before checking the pushed head. That persistence still
 emits `workspace_status` so the terminal PR tab becomes available.
 
-## Remote Head Resolution
+## Pushed Head Resolution
 
 For each eligible PR, resolve the branch to observe in this order:
 
-1. Use the synced PR row's head clone URL and head branch.
-2. If the PR row has no usable head clone URL, use the workspace branch's
-   upstream remote URL and upstream branch when they uniquely match the PR row.
-3. If neither source is available, skip the workspace for that pass and log at
+1. Read the workspace branch's configured upstream remote and merge ref.
+2. Require the upstream branch to match the synced PR row's head branch, or to
+   uniquely identify the PR during issue-workspace association.
+3. Resolve `refs/remotes/{remote}/{branch}` with local Git.
+4. If no upstream or remote-tracking ref is available, skip the workspace for
+   that pass and log at
    debug level.
 
-The observed ref is `refs/heads/{head_branch}` on the resolved head repository,
-not the base repository's default branch and not the local worktree's current
-`HEAD`.
+The observed ref is the local remote-tracking ref for the pushed branch, not the
+base repository's default branch and not the local worktree's current `HEAD`.
 
-Fork PRs are expected to work because the PR row carries the head repository
-clone URL. Nested GitLab namespaces work because the route and sync identity
-remain provider-aware even though the Git remote check uses a clone URL.
+Fork PRs are expected to work when the workspace branch tracks the fork remote's
+head branch. Nested GitLab namespaces work because the route and sync identity
+remain provider-aware even though the Git check reads local refs.
 
-When `git ls-remote` returns no matching ref, treat it as a soft miss. The
-branch may have been deleted, permissions may be stale, or the provider may be
-temporarily unavailable. Do not clear the last observed SHA based on a missing
-ref alone.
+When the remote-tracking ref is missing, treat it as a soft miss. The branch may
+not have been pushed yet, the upstream may not be configured, or the workspace
+may still be on an issue-only branch. Do not clear the last observed SHA based
+on a missing ref alone.
 
 ## Observation State
 
-Keep the last observed remote head in process memory, not SQLite.
+Keep the last observed pushed head in process memory, not SQLite.
 
 `platform_head_sha` remains the durable "provider state persisted by PR sync."
-The observer's last-seen SHA is only a debounce and edge-detection cache for the
-current middleman process. It does not need to survive daemon restart, does not
-belong in migrations, and should disappear when the process exits.
+The observer's last-seen remote-tracking SHA is only a debounce and
+edge-detection cache for the current middleman process. It does not need to
+survive daemon restart, does not belong in migrations, and should disappear when
+the process exits.
 
 Recommended in-memory shape:
 
@@ -164,16 +175,15 @@ type remoteHeadKey struct {
 	RepoPath     string
 	ItemType     string
 	ItemNumber   int
-	RemoteURL    string
+	RemoteName   string
 	BranchName   string
+	TrackingRef  string
 }
 
 type remoteHeadObservation struct {
 	SHA                   string
 	ObservedAt            time.Time
 	LastRefreshEnqueuedAt time.Time
-	FailureCount          int
-	BackoffUntil          time.Time
 }
 ```
 
@@ -185,31 +195,32 @@ on different provider hosts do not collide.
 On the first successful observation for a workspace/PR pair in a process, record
 the SHA but do not emit a refresh event unless it differs from the current
 synced PR `platform_head_sha`. This prevents startup from producing a burst of
-refreshes for already-current rows while still catching remote moves that
-happened while middleman was stopped.
+refreshes for already-current rows while still catching pushed heads that moved
+while middleman was stopped.
 
 When middleman restarts, the observer starts with an empty map. The first pass
-compares the remote SHA to the durable PR row's `platform_head_sha`; that is
-enough to catch remote movement that happened while middleman was offline. After
-detail sync persists the new provider head, subsequent first observations are
-quiet.
+compares the local remote-tracking SHA to the durable PR row's
+`platform_head_sha`; that is enough to catch workspace pushes that happened
+while middleman was offline. After detail sync persists the new provider head,
+subsequent first observations are quiet.
 
 ## Scheduling
 
 Run the observer as a background loop when workspace support is configured.
 
 - Initial pass: after server startup, once the workspace manager is available.
-- Steady-state pass: every 20-30 seconds, with jitter to avoid synchronized
-  remote requests across many repos.
+- Steady-state pass: every few seconds. The check is local Git ref inspection,
+  so it should be cheap enough to feel live without adding network traffic.
 - Manual kick: after workspace setup completes and after an issue workspace gains
   an associated PR.
-- Backoff: per `(provider, platform_host, repo_path, branch)` after transient Git
-  failures.
+- Backoff: only for repeated local Git inspection failures such as missing or
+  unreadable worktrees.
 
-Remote checks should be bounded:
+Local checks should be bounded:
 
-- Limit concurrent `ls-remote` calls per provider host.
-- Deduplicate checks for workspaces that point at the same remote URL and branch.
+- Do not fetch, call `ls-remote`, or contact provider APIs.
+- Deduplicate checks for workspaces that point at the same worktree and
+  remote-tracking ref.
 - Use short command timeouts.
 - Strip Git environment using the same `gitenv.StripAll` pattern used by the
   existing workspace monitor.
@@ -220,10 +231,10 @@ noise.
 
 ## Refresh Queues
 
-When a changed remote SHA is detected:
+When a changed pushed SHA is detected:
 
-1. Persist the new observed SHA and observation time.
-2. Emit `workspace_remote_head_changed`.
+1. Record the new observed SHA and observation time in memory.
+2. Emit `workspace_pushed_head_changed`.
 3. Enqueue a high-priority PR detail sync for the changed PR.
 4. Emit `workspace_pr_refresh_queued`.
 5. When detail sync completes, emit `pr_detail_refreshed` and the existing
@@ -234,7 +245,7 @@ When a changed remote SHA is detected:
 
 The visible PR should win over background work. If the active detail tab matches
 the changed PR, the client may call the existing detail refresh path immediately
-after receiving `workspace_remote_head_changed` or
+after receiving `workspace_pushed_head_changed` or
 `workspace_pr_refresh_queued`. Other clients can wait for `pr_detail_refreshed`
 or broad `data_changed`.
 
@@ -249,9 +260,10 @@ All new events go through the existing `EventHub`. They receive monotonic ids,
 are stored in the replay ring, and participate in `Last-Event-ID` replay. They
 must use JSON-serializable payloads.
 
-### `workspace_remote_head_changed`
+### `workspace_pushed_head_changed`
 
-Sent when the observer sees a PR head branch SHA change on the remote.
+Sent when the observer sees the workspace's remote-tracking ref for a PR head
+branch move.
 
 ```json
 {
@@ -264,7 +276,9 @@ Sent when the observer sees a PR head branch SHA change on the remote.
   "number": 42,
   "old_sha": "1111111",
   "new_sha": "2222222",
+  "remote": "origin",
   "branch": "feature/widgets",
+  "tracking_ref": "refs/remotes/origin/feature/widgets",
   "observed_at": "2026-05-20T14:15:00Z"
 }
 ```
@@ -308,7 +322,7 @@ contains enough context to avoid guessing why the workspace changed.
 
 ### `workspace_pr_refresh_queued`
 
-Sent after a remote-head change enqueues PR detail sync.
+Sent after a pushed-head change enqueues PR detail sync.
 
 ```json
 {
@@ -421,11 +435,11 @@ second delivery mechanism.
 Client handling of `reconnect.stale` remains broad: reload pulls, issues,
 activity, and sync status. Workspace terminal views should also refetch their
 active workspace and runtime state when they add stale handling. This guarantees
-that a slept laptop does not miss a remote-head refresh forever.
+that a slept laptop does not miss a pushed-head refresh forever.
 
 Targeted events must be idempotent. A client may receive:
 
-- `workspace_remote_head_changed`, then `workspace_pr_refresh_queued`, then
+- `workspace_pushed_head_changed`, then `workspace_pr_refresh_queued`, then
   `pr_detail_refreshed`;
 - only `pr_detail_refreshed` after replay if earlier events were outside the
   buffer and `reconnect.stale` caused a broad reload;
@@ -462,16 +476,16 @@ initial implementation if it keeps the change smaller.
 
 ## Error Handling
 
-Remote-head observation errors must not fail normal sync.
+Pushed-head observation errors must not fail normal sync.
 
 - Missing ref: debug log and keep the previous observed SHA.
-- Auth or network failure: warn only after repeated failures for the same
-  remote/ref and apply backoff.
-- Invalid clone URL or branch name: debug log and skip until the next PR sync
-  updates the row.
-- Detail sync failure after a detected remote move: emit no completion event,
-  keep the queued/stale state bounded by existing detail sync retries and user
-  refresh actions.
+- Local Git inspection failure: warn only after repeated failures for the same
+  workspace/ref and apply backoff.
+- Missing upstream or branch name: debug log and skip until workspace setup or a
+  later local push configures the tracking ref.
+- Detail sync failure after a detected pushed-head change: emit no completion
+  event, keep the queued/stale state bounded by existing detail sync retries and
+  user refresh actions.
 - CI refresh failure: emit `pr_ci_refreshed` with warnings only if a response was
   persisted; otherwise rely on the existing warning/toast paths when the user
   opens or refreshes the PR.
@@ -483,18 +497,18 @@ worktree, checkout branches, update refs, or change branch upstreams.
 
 Backend tests:
 
-- Observer detects a remote SHA change via a fake `ls-remote` runner and
+- Observer detects a pushed SHA change via a fake local Git ref reader and
   enqueues one PR detail refresh for the provider-aware PR ref.
 - First observation records SHA in memory without enqueueing when it equals
   `platform_head_sha`.
 - First observation enqueues refresh when it differs from `platform_head_sha`.
-- Multiple workspaces pointing at the same remote branch dedupe remote checks
-  and do not enqueue duplicate in-flight detail syncs.
+- Multiple workspaces pointing at the same remote-tracking ref dedupe local
+  checks and do not enqueue duplicate in-flight detail syncs.
 - Issue workspace with a newly detected PR emits `workspace_pr_associated`,
   preserves the existing `workspace_status` compatibility event, and then
   observes the associated PR head.
-- Missing remote ref and transient command failure do not clear in-memory
-  observation state.
+- Missing tracking ref and transient local Git command failure do not clear
+  in-memory observation state.
 
 Server/SSE tests:
 
@@ -516,14 +530,15 @@ Frontend tests:
 
 E2E tests:
 
-- A ready PR workspace whose remote branch moves causes the active PR detail to
-  refresh without navigating away from the terminal or PR tab.
+- A ready PR workspace whose remote-tracking branch moves after push causes the
+  active PR detail to refresh without navigating away from the terminal or PR
+  tab.
 - An issue workspace that creates/pushes a branch and later gains a synced PR
   shows the PR tab after the association event.
 
 ## Acceptance Criteria
 
-- Remote PR head changes are detected without relying on local `git push`
+- Pushed PR head changes are detected without remote polling or local `git push`
   command interception.
 - PR detail sync is enqueued once per changed provider-aware PR head while work
   is already in flight.
@@ -539,8 +554,8 @@ E2E tests:
 - Replacing provider webhooks. Middleman remains local-first and pull-based.
 - Generic discovery of arbitrary Git worktrees outside middleman-managed
   workspaces.
-- A Git wrapper or Trace2 command observer. These can be added later as latency
-  optimizations, not correctness mechanisms.
+- A Git wrapper or Trace2 command observer.
+- Remote polling with `git ls-remote`, fetch, or provider branch APIs.
 - Removing broad `data_changed` invalidation in the first implementation.
 - A dedicated frontend CI slice store. Detail refresh is acceptable until store
   boundaries justify a narrower API.

--- a/docs/superpowers/specs/2026-05-20-remote-head-refresh-design.md
+++ b/docs/superpowers/specs/2026-05-20-remote-head-refresh-design.md
@@ -145,48 +145,54 @@ branch may have been deleted, permissions may be stale, or the provider may be
 temporarily unavailable. Do not clear the last observed SHA based on a missing
 ref alone.
 
-## Persistence
+## Observation State
 
-Store the last observed remote head separately from the PR's synced
-`platform_head_sha`.
+Keep the last observed remote head in process memory, not SQLite.
 
-`platform_head_sha` means "the provider state persisted by PR sync."
-`observed_remote_head_sha` means "the latest branch SHA seen by the workspace
-observer." Keeping them separate lets the observer detect a remote move before
-detail sync has caught up, and lets tests assert the observer's behavior without
-overloading provider-sync semantics.
+`platform_head_sha` remains the durable "provider state persisted by PR sync."
+The observer's last-seen SHA is only a debounce and edge-detection cache for the
+current middleman process. It does not need to survive daemon restart, does not
+belong in migrations, and should disappear when the process exits.
 
-Recommended schema:
+Recommended in-memory shape:
 
-```sql
-CREATE TABLE middleman_workspace_remote_heads (
-  workspace_id TEXT NOT NULL,
-  provider TEXT NOT NULL,
-  platform_host TEXT NOT NULL,
-  repo_path TEXT NOT NULL,
-  item_type TEXT NOT NULL,
-  item_number INTEGER NOT NULL,
-  remote_url TEXT NOT NULL,
-  branch_name TEXT NOT NULL,
-  observed_sha TEXT NOT NULL,
-  observed_at TEXT NOT NULL,
-  last_refresh_enqueued_at TEXT,
-  PRIMARY KEY (workspace_id, item_type, item_number),
-  FOREIGN KEY (workspace_id) REFERENCES middleman_workspaces(id) ON DELETE CASCADE
-);
+```go
+type remoteHeadKey struct {
+	WorkspaceID  string
+	Provider     platform.Kind
+	PlatformHost string
+	RepoPath     string
+	ItemType     string
+	ItemNumber   int
+	RemoteURL    string
+	BranchName   string
+}
+
+type remoteHeadObservation struct {
+	SHA                   string
+	ObservedAt            time.Time
+	LastRefreshEnqueuedAt time.Time
+	FailureCount          int
+	BackoffUntil          time.Time
+}
 ```
 
-The table is workspace-scoped because issue workspaces can become associated
-with a PR after creation and because workspace deletion should clean up local
-observation state. The provider fields are repeated to make debugging and future
-queries straightforward; the source of truth for item data remains the repo and
-PR tables.
+The map is workspace-scoped because issue workspaces can become associated with
+a PR after creation and because workspace deletion should drop local observation
+state. The provider fields are part of the key so duplicate-looking branch names
+on different provider hosts do not collide.
 
-On the first successful observation for a workspace/PR pair, store the SHA but
-do not emit a refresh event unless it differs from the current synced PR
-`platform_head_sha`. This prevents startup from producing a burst of refreshes
-for already-current rows while still catching remote moves that happened while
-middleman was stopped.
+On the first successful observation for a workspace/PR pair in a process, record
+the SHA but do not emit a refresh event unless it differs from the current
+synced PR `platform_head_sha`. This prevents startup from producing a burst of
+refreshes for already-current rows while still catching remote moves that
+happened while middleman was stopped.
+
+When middleman restarts, the observer starts with an empty map. The first pass
+compares the remote SHA to the durable PR row's `platform_head_sha`; that is
+enough to catch remote movement that happened while middleman was offline. After
+detail sync persists the new provider head, subsequent first observations are
+quiet.
 
 ## Scheduling
 
@@ -479,7 +485,7 @@ Backend tests:
 
 - Observer detects a remote SHA change via a fake `ls-remote` runner and
   enqueues one PR detail refresh for the provider-aware PR ref.
-- First observation stores SHA without enqueueing when it equals
+- First observation records SHA in memory without enqueueing when it equals
   `platform_head_sha`.
 - First observation enqueues refresh when it differs from `platform_head_sha`.
 - Multiple workspaces pointing at the same remote branch dedupe remote checks
@@ -487,7 +493,7 @@ Backend tests:
 - Issue workspace with a newly detected PR emits `workspace_pr_associated`,
   preserves the existing `workspace_status` compatibility event, and then
   observes the associated PR head.
-- Missing remote ref and transient command failure do not clear stored
+- Missing remote ref and transient command failure do not clear in-memory
   observation state.
 
 Server/SSE tests:

--- a/docs/superpowers/specs/2026-05-20-remote-head-refresh-design.md
+++ b/docs/superpowers/specs/2026-05-20-remote-head-refresh-design.md
@@ -1,0 +1,540 @@
+# Remote Head Refresh Design
+
+## Goal
+
+Refresh PR detail and CI state when a middleman-managed workspace's remote PR
+head changes.
+
+The trigger should be the provider-visible branch update, not a local command
+shape such as "an agent ran `git push`." Detecting the remote head makes the
+feature work for launched agents, base workspace terminals, IDE Git
+integrations, manual shells, and pushes from another machine. Failed pushes and
+local-only commits naturally do not trigger a refresh.
+
+The user-visible result is:
+
+- A PR detail tab updates soon after the branch backing that PR moves on the
+  remote.
+- Pending CI starts refreshing without the user leaving and reopening the PR.
+- Issue workspaces that become associated with a PR can gain the PR tab from
+  the same monitoring path.
+- Long-disconnected browser clients either replay the missed refresh events or
+  receive the existing `reconnect.stale` signal and refetch from scratch.
+
+## Current Behavior
+
+Middleman already has several pieces of this flow, but no remote-head observer.
+
+- `internal/workspace/monitor.go` runs once at startup and every minute. It
+  only examines ready issue workspaces with no `associated_pr_number`. It
+  matches the current branch/upstream against open PR rows already present in
+  SQLite, then stores the first unique match.
+- `internal/server/server.go` broadcasts `workspace_status` and `data_changed`
+  when that association changes.
+- `internal/server/detail_sync.go` deduplicates background PR and issue detail
+  syncs and broadcasts `data_changed` after a detail sync completes.
+- `internal/server/event_hub.go` assigns every SSE event a monotonic id, keeps a
+  replay ring, replays events newer than `Last-Event-ID`, and emits
+  `reconnect.stale` when the cursor is outside the retained history.
+- `packages/ui/src/stores/events.svelte.ts` handles `data_changed`,
+  `sync_status`, and `reconnect.stale`. `data_changed` currently causes broad
+  pull, issue, and activity reloads.
+- `frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte` opens its
+  own EventSource for `workspace_status` and refetches the active workspace
+  when the event's `id` matches.
+
+The current PR monitor does not ask the provider or remote repository whether a
+branch changed. It cannot detect that a PR-backed workspace was pushed, and it
+cannot discover a new PR unless a normal sync has already inserted the PR row.
+
+## Design Decision
+
+Add a `RemoteHeadObserver` for middleman-owned workspaces.
+
+The observer checks the remote branch SHA for workspaces that either own a PR or
+can be associated with one. When the observed remote head for a PR changes, it
+enqueues a PR detail sync, then emits targeted SSE events so connected clients
+can refresh the right UI state without waiting for a broad `data_changed`
+reload.
+
+This design deliberately keeps the observer provider-neutral:
+
+- Use the persisted PR row as the preferred source of branch identity:
+  `HeadRepoCloneURL`, `HeadBranch`, `PlatformHeadSHA`, provider kind, host, and
+  repo path.
+- Use local Git upstream state only as a fallback or as association evidence for
+  issue workspaces.
+- Use provider identity everywhere: `(provider, platform_host, repo_path,
+  owner, name, number)`.
+- Keep provider-specific optimizations optional behind the platform capability
+  model.
+
+The first implementation should use Git remote inspection as the common path:
+`git ls-remote <clone-url> refs/heads/<head-branch>`. Provider API fast paths
+can be added later only if they fit behind a neutral remote-head capability and
+respect existing rate-limit budgets.
+
+## Alternatives Considered
+
+### Git wrapper around launched agents
+
+Middleman could prepend a private `git` wrapper to launched agent `PATH` and
+notify the server when `git push` exits successfully.
+
+This is useful as a future acceleration path, but it is not sufficient as the
+primary design. It misses absolute-path Git invocations, non-agent terminals,
+IDE pushes, and pushes from other machines. It also reports a command success,
+not the provider-visible branch state.
+
+### Git Trace2 command observation
+
+Launched sessions can set Git Trace2 environment variables and stream
+successful `push` command exits back to middleman.
+
+This is less invasive than a wrapper, but it still observes local command
+execution rather than remote state. It also provides weak ref-level detail and
+does not cover external pushes.
+
+### Existing PR monitor only
+
+The existing PR monitor can remain as a narrow association helper, but it should
+not be stretched into remote-change detection. It only handles issue
+workspaces, relies on already-synced PR rows, and emits broad invalidations.
+
+## Workspace Eligibility
+
+The observer scans ready middleman workspaces. It does not discover arbitrary
+host worktrees and does not become a generic Git automation API.
+
+A workspace is eligible for remote-head observation when:
+
+- `status == "ready"`;
+- `worktree_path` is non-empty;
+- the workspace belongs to a tracked repo with full provider identity;
+- either:
+  - `item_type == "pull_request"`, using `item_number` as the PR number;
+  - `item_type == "issue"` and `associated_pr_number` is set;
+  - `item_type == "issue"` and local branch/upstream evidence can identify one
+    open PR uniquely, as the current PR monitor does.
+
+For issue workspaces with no associated PR, the observer may share the current
+association logic with the PR monitor. If it finds a unique PR, it persists
+`associated_pr_number` before checking the remote head. That persistence still
+emits `workspace_status` so the terminal PR tab becomes available.
+
+## Remote Head Resolution
+
+For each eligible PR, resolve the branch to observe in this order:
+
+1. Use the synced PR row's head clone URL and head branch.
+2. If the PR row has no usable head clone URL, use the workspace branch's
+   upstream remote URL and upstream branch when they uniquely match the PR row.
+3. If neither source is available, skip the workspace for that pass and log at
+   debug level.
+
+The observed ref is `refs/heads/{head_branch}` on the resolved head repository,
+not the base repository's default branch and not the local worktree's current
+`HEAD`.
+
+Fork PRs are expected to work because the PR row carries the head repository
+clone URL. Nested GitLab namespaces work because the route and sync identity
+remain provider-aware even though the Git remote check uses a clone URL.
+
+When `git ls-remote` returns no matching ref, treat it as a soft miss. The
+branch may have been deleted, permissions may be stale, or the provider may be
+temporarily unavailable. Do not clear the last observed SHA based on a missing
+ref alone.
+
+## Persistence
+
+Store the last observed remote head separately from the PR's synced
+`platform_head_sha`.
+
+`platform_head_sha` means "the provider state persisted by PR sync."
+`observed_remote_head_sha` means "the latest branch SHA seen by the workspace
+observer." Keeping them separate lets the observer detect a remote move before
+detail sync has caught up, and lets tests assert the observer's behavior without
+overloading provider-sync semantics.
+
+Recommended schema:
+
+```sql
+CREATE TABLE middleman_workspace_remote_heads (
+  workspace_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  platform_host TEXT NOT NULL,
+  repo_path TEXT NOT NULL,
+  item_type TEXT NOT NULL,
+  item_number INTEGER NOT NULL,
+  remote_url TEXT NOT NULL,
+  branch_name TEXT NOT NULL,
+  observed_sha TEXT NOT NULL,
+  observed_at TEXT NOT NULL,
+  last_refresh_enqueued_at TEXT,
+  PRIMARY KEY (workspace_id, item_type, item_number),
+  FOREIGN KEY (workspace_id) REFERENCES middleman_workspaces(id) ON DELETE CASCADE
+);
+```
+
+The table is workspace-scoped because issue workspaces can become associated
+with a PR after creation and because workspace deletion should clean up local
+observation state. The provider fields are repeated to make debugging and future
+queries straightforward; the source of truth for item data remains the repo and
+PR tables.
+
+On the first successful observation for a workspace/PR pair, store the SHA but
+do not emit a refresh event unless it differs from the current synced PR
+`platform_head_sha`. This prevents startup from producing a burst of refreshes
+for already-current rows while still catching remote moves that happened while
+middleman was stopped.
+
+## Scheduling
+
+Run the observer as a background loop when workspace support is configured.
+
+- Initial pass: after server startup, once the workspace manager is available.
+- Steady-state pass: every 20-30 seconds, with jitter to avoid synchronized
+  remote requests across many repos.
+- Manual kick: after workspace setup completes and after an issue workspace gains
+  an associated PR.
+- Backoff: per `(provider, platform_host, repo_path, branch)` after transient Git
+  failures.
+
+Remote checks should be bounded:
+
+- Limit concurrent `ls-remote` calls per provider host.
+- Deduplicate checks for workspaces that point at the same remote URL and branch.
+- Use short command timeouts.
+- Strip Git environment using the same `gitenv.StripAll` pattern used by the
+  existing workspace monitor.
+
+The observer should not block normal sync or workspace setup. Failures log a
+warning only when they persist past the first failure; otherwise they are debug
+noise.
+
+## Refresh Queues
+
+When a changed remote SHA is detected:
+
+1. Persist the new observed SHA and observation time.
+2. Emit `workspace_remote_head_changed`.
+3. Enqueue a high-priority PR detail sync for the changed PR.
+4. Emit `workspace_pr_refresh_queued`.
+5. When detail sync completes, emit `pr_detail_refreshed` and the existing
+   `data_changed`.
+6. If the refreshed PR has pending CI or workflow approval uncertainty, enqueue
+   lower-priority CI refresh work.
+7. Emit `pr_ci_refresh_queued` and `pr_ci_refreshed` around CI refresh work.
+
+The visible PR should win over background work. If the active detail tab matches
+the changed PR, the client may call the existing detail refresh path immediately
+after receiving `workspace_remote_head_changed` or
+`workspace_pr_refresh_queued`. Other clients can wait for `pr_detail_refreshed`
+or broad `data_changed`.
+
+The first implementation may route all detail work through the existing
+`enqueueDetailSync` dedupe map. If CI refresh remains synchronous-only, add a
+small background wrapper that calls the existing CI refresh logic and broadcasts
+completion.
+
+## SSE Events
+
+All new events go through the existing `EventHub`. They receive monotonic ids,
+are stored in the replay ring, and participate in `Last-Event-ID` replay. They
+must use JSON-serializable payloads.
+
+### `workspace_remote_head_changed`
+
+Sent when the observer sees a PR head branch SHA change on the remote.
+
+```json
+{
+  "workspace_id": "ws_123",
+  "provider": "github",
+  "platform_host": "github.com",
+  "repo_path": "acme/widgets",
+  "owner": "acme",
+  "name": "widgets",
+  "number": 42,
+  "old_sha": "1111111",
+  "new_sha": "2222222",
+  "branch": "feature/widgets",
+  "observed_at": "2026-05-20T14:15:00Z"
+}
+```
+
+Client behavior:
+
+- If the active workspace id matches, refetch the workspace summary only if
+  workspace fields changed in the same pass.
+- If the active PR detail matches, mark the detail stale or start an immediate
+  detail refresh spinner.
+- Do not reload pull, issue, and activity lists solely because this event
+  arrived.
+
+### `workspace_pr_associated`
+
+Sent when an issue workspace gains `associated_pr_number`.
+
+```json
+{
+  "workspace_id": "ws_123",
+  "provider": "github",
+  "platform_host": "github.com",
+  "repo_path": "acme/widgets",
+  "owner": "acme",
+  "name": "widgets",
+  "issue_number": 7,
+  "pr_number": 42,
+  "associated_at": "2026-05-20T14:15:00Z"
+}
+```
+
+Client behavior:
+
+- Terminal workspace views refetch that workspace and show the PR tab.
+- List and activity views do not need to reload unless followed by
+  `data_changed`.
+
+The server may also keep the existing `workspace_status` event for compatibility
+in the same pass. New clients should prefer `workspace_pr_associated` because it
+contains enough context to avoid guessing why the workspace changed.
+
+### `workspace_pr_refresh_queued`
+
+Sent after a remote-head change enqueues PR detail sync.
+
+```json
+{
+  "workspace_id": "ws_123",
+  "provider": "github",
+  "platform_host": "github.com",
+  "repo_path": "acme/widgets",
+  "owner": "acme",
+  "name": "widgets",
+  "number": 42,
+  "head_sha": "2222222",
+  "priority": "high",
+  "queued_at": "2026-05-20T14:15:01Z"
+}
+```
+
+Client behavior:
+
+- Active PR detail can show a syncing state.
+- Passive views do not reload yet; they should wait for completion or stale
+  replay recovery.
+
+### `pr_detail_refreshed`
+
+Sent after background PR detail sync completes.
+
+```json
+{
+  "provider": "github",
+  "platform_host": "github.com",
+  "repo_path": "acme/widgets",
+  "owner": "acme",
+  "name": "widgets",
+  "number": 42,
+  "head_sha": "2222222",
+  "synced_at": "2026-05-20T14:15:04Z",
+  "warnings": []
+}
+```
+
+Client behavior:
+
+- Matching PR detail reloads only itself.
+- Pull list and activity stores may reload if they currently contain that repo
+  or if they do not yet support targeted item invalidation.
+- The existing broad `data_changed` remains during the migration so old clients
+  keep working.
+
+### `pr_ci_refresh_queued`
+
+Sent when lower-priority CI refresh work is scheduled after a head change or
+after detail sync finds pending checks.
+
+```json
+{
+  "provider": "github",
+  "platform_host": "github.com",
+  "repo_path": "acme/widgets",
+  "owner": "acme",
+  "name": "widgets",
+  "number": 42,
+  "head_sha": "2222222",
+  "priority": "low",
+  "queued_at": "2026-05-20T14:15:05Z"
+}
+```
+
+Client behavior:
+
+- Matching PR detail may keep CI spinners visible.
+- Do not refetch broad lists yet.
+
+### `pr_ci_refreshed`
+
+Sent after a background CI refresh completes.
+
+```json
+{
+  "provider": "github",
+  "platform_host": "github.com",
+  "repo_path": "acme/widgets",
+  "owner": "acme",
+  "name": "widgets",
+  "number": 42,
+  "head_sha": "2222222",
+  "refreshed_at": "2026-05-20T14:15:20Z",
+  "warnings": []
+}
+```
+
+Client behavior:
+
+- Matching PR detail reloads itself or only the CI slice if that store boundary
+  exists by implementation time.
+- Pull list can reload if the aggregate CI status changed.
+- Existing pending-CI polling remains as a fallback, but the event-driven path
+  should make it less visible.
+
+## SSE Replay And Stale Cursors
+
+New events rely on the current SSE replay contract rather than inventing a
+second delivery mechanism.
+
+- Each event is assigned an id by `EventHub.Broadcast`.
+- Browser EventSource automatically sends `Last-Event-ID` after reconnect.
+- The server replays ring-buffered events newer than that cursor.
+- If the cursor is too old or ahead of the server lifetime, the server emits
+  `reconnect.stale`.
+
+Client handling of `reconnect.stale` remains broad: reload pulls, issues,
+activity, and sync status. Workspace terminal views should also refetch their
+active workspace and runtime state when they add stale handling. This guarantees
+that a slept laptop does not miss a remote-head refresh forever.
+
+Targeted events must be idempotent. A client may receive:
+
+- `workspace_remote_head_changed`, then `workspace_pr_refresh_queued`, then
+  `pr_detail_refreshed`;
+- only `pr_detail_refreshed` after replay if earlier events were outside the
+  buffer and `reconnect.stale` caused a broad reload;
+- duplicate-looking payloads for the same SHA if two workspaces point at the
+  same PR.
+
+Clients should dedupe by provider ref plus SHA where needed, not by SSE id.
+
+## Frontend Store Changes
+
+Extend `createEventsStore` with optional callbacks for the new event types.
+
+Keep the existing `onDataChanged` behavior until targeted invalidation is proven.
+Then move high-traffic views toward targeted reloads:
+
+- `onPRDetailRefreshed(ref)`: if the visible detail matches, call
+  `detail.refreshDetailOnly`.
+- `onPRCIRefreshed(ref)`: if the visible detail matches, refresh detail or CI.
+- `onWorkspacePRAssociated(payload)`: active terminal workspace refetches its
+  workspace summary.
+- `onReconnectStale`: also refetch active workspace state when the terminal view
+  owns an EventSource.
+
+The terminal view currently opens a separate EventSource only for
+`workspace_status`. It should either:
+
+- continue using a local EventSource but subscribe to
+  `workspace_pr_associated` and `reconnect.stale`; or
+- move workspace-status handling into the shared events store so the app has one
+  EventSource.
+
+The second option is cleaner long-term, but the first is acceptable for the
+initial implementation if it keeps the change smaller.
+
+## Error Handling
+
+Remote-head observation errors must not fail normal sync.
+
+- Missing ref: debug log and keep the previous observed SHA.
+- Auth or network failure: warn only after repeated failures for the same
+  remote/ref and apply backoff.
+- Invalid clone URL or branch name: debug log and skip until the next PR sync
+  updates the row.
+- Detail sync failure after a detected remote move: emit no completion event,
+  keep the queued/stale state bounded by existing detail sync retries and user
+  refresh actions.
+- CI refresh failure: emit `pr_ci_refreshed` with warnings only if a response was
+  persisted; otherwise rely on the existing warning/toast paths when the user
+  opens or refreshes the PR.
+
+The observer should never mutate local Git state. It must not fetch into the
+worktree, checkout branches, update refs, or change branch upstreams.
+
+## Testing
+
+Backend tests:
+
+- Observer detects a remote SHA change via a fake `ls-remote` runner and
+  enqueues one PR detail refresh for the provider-aware PR ref.
+- First observation stores SHA without enqueueing when it equals
+  `platform_head_sha`.
+- First observation enqueues refresh when it differs from `platform_head_sha`.
+- Multiple workspaces pointing at the same remote branch dedupe remote checks
+  and do not enqueue duplicate in-flight detail syncs.
+- Issue workspace with a newly detected PR emits `workspace_pr_associated`,
+  preserves the existing `workspace_status` compatibility event, and then
+  observes the associated PR head.
+- Missing remote ref and transient command failure do not clear stored
+  observation state.
+
+Server/SSE tests:
+
+- New events are framed with ids and replayed through `Last-Event-ID`.
+- `reconnect.stale` remains the only stale-cursor signal and is emitted before
+  live events after reconnect.
+- Payloads include provider, platform host, repo path, owner, name, number, and
+  SHA fields.
+
+Frontend tests:
+
+- Events store parses the new event payloads and routes them to optional
+  callbacks.
+- Active PR detail refreshes on `pr_detail_refreshed` for the same provider ref
+  and ignores other PRs.
+- Workspace terminal refetches on `workspace_pr_associated` for the active
+  workspace and shows the PR segment.
+- `reconnect.stale` refetches broad app state and active workspace state.
+
+E2E tests:
+
+- A ready PR workspace whose remote branch moves causes the active PR detail to
+  refresh without navigating away from the terminal or PR tab.
+- An issue workspace that creates/pushes a branch and later gains a synced PR
+  shows the PR tab after the association event.
+
+## Acceptance Criteria
+
+- Remote PR head changes are detected without relying on local `git push`
+  command interception.
+- PR detail sync is enqueued once per changed provider-aware PR head while work
+  is already in flight.
+- CI refresh work is lower priority than detail sync and does not block the UI.
+- SSE events are targeted, replayable, JSON-serializable, and provider-aware.
+- Existing `data_changed`, `workspace_status`, `sync_status`, and
+  `reconnect.stale` behavior continues to work for old clients.
+- Long-disconnected clients recover through replay or broad stale refetch.
+- The observer never mutates local Git state.
+
+## Out Of Scope
+
+- Replacing provider webhooks. Middleman remains local-first and pull-based.
+- Generic discovery of arbitrary Git worktrees outside middleman-managed
+  workspaces.
+- A Git wrapper or Trace2 command observer. These can be added later as latency
+  optimizations, not correctness mechanisms.
+- Removing broad `data_changed` invalidation in the first implementation.
+- A dedicated frontend CI slice store. Detail refresh is acceptable until store
+  boundaries justify a narrower API.

--- a/frontend/src/Provider.test.ts
+++ b/frontend/src/Provider.test.ts
@@ -35,6 +35,8 @@ const loadPulls = vi.fn(async () => undefined);
 const loadIssues = vi.fn(async () => undefined);
 const loadActivity = vi.fn(async () => undefined);
 const setSyncStatus = vi.fn();
+const refreshDetailOnly = vi.fn(async () => undefined);
+let currentDetail: unknown = null;
 
 vi.mock("@middleman/ui/stores/pulls", () => ({
   createPullsStore: () => ({
@@ -78,9 +80,9 @@ vi.mock("@middleman/ui/stores/sync", () => ({
 vi.mock("@middleman/ui/stores/detail", () => ({
   createDetailStore: () => ({
     loadDetail: vi.fn(),
-    refreshDetailOnly: vi.fn(),
+    refreshDetailOnly,
     isDetailLoading: () => false,
-    getDetail: () => null,
+    getDetail: () => currentDetail,
   }),
 }));
 
@@ -124,6 +126,8 @@ beforeEach(() => {
   loadIssues.mockClear();
   loadActivity.mockClear();
   setSyncStatus.mockClear();
+  refreshDetailOnly.mockClear();
+  currentDetail = null;
 });
 
 afterEach(() => {
@@ -161,6 +165,72 @@ describe("Provider events store wiring", () => {
 
     expect(setSyncStatus).toHaveBeenCalledTimes(1);
     expect(setSyncStatus).toHaveBeenCalledWith(status);
+  });
+
+  it("refreshes only the visible PR detail for matching targeted refresh events", () => {
+    currentDetail = {
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widget",
+      },
+      repo_owner: "acme",
+      repo_name: "widget",
+      merge_request: { Number: 42 },
+    };
+    render(Provider, { props: { client: stubClient } });
+
+    captured.store?.options.onPRDetailRefreshed?.({
+      provider: "github",
+      platform_host: "github.com",
+      repo_path: "acme/widget",
+      owner: "acme",
+      name: "widget",
+      number: 42,
+      head_sha: "2222222",
+      synced_at: "2026-05-20T14:15:04Z",
+      warnings: [],
+    });
+
+    expect(refreshDetailOnly).toHaveBeenCalledTimes(1);
+    expect(refreshDetailOnly).toHaveBeenCalledWith(
+      "acme",
+      "widget",
+      42,
+      {
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/widget",
+      },
+    );
+  });
+
+  it("ignores targeted PR detail refreshes for non-visible PRs", () => {
+    currentDetail = {
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widget",
+      },
+      repo_owner: "acme",
+      repo_name: "widget",
+      merge_request: { Number: 42 },
+    };
+    render(Provider, { props: { client: stubClient } });
+
+    captured.store?.options.onPRDetailRefreshed?.({
+      provider: "github",
+      platform_host: "github.com",
+      repo_path: "acme/widget",
+      owner: "acme",
+      name: "widget",
+      number: 99,
+      head_sha: "2222222",
+      synced_at: "2026-05-20T14:15:04Z",
+      warnings: [],
+    });
+
+    expect(refreshDetailOnly).not.toHaveBeenCalled();
   });
 
   it("forwards basePath getter when config.basePath is set", () => {

--- a/frontend/src/Provider.test.ts
+++ b/frontend/src/Provider.test.ts
@@ -205,6 +205,48 @@ describe("Provider events store wiring", () => {
     );
   });
 
+  it("ignores targeted PR refreshes while an issue detail is visible", () => {
+    currentDetail = {
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widget",
+      },
+      repo_owner: "acme",
+      repo_name: "widget",
+      issue: { Number: 7 },
+    };
+    render(Provider, { props: { client: stubClient } });
+
+    expect(() =>
+      captured.store?.options.onPRDetailRefreshed?.({
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widget",
+        owner: "acme",
+        name: "widget",
+        number: 42,
+        head_sha: "2222222",
+        synced_at: "2026-05-20T14:15:04Z",
+        warnings: [],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      captured.store?.options.onPRCIRefreshed?.({
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widget",
+        owner: "acme",
+        name: "widget",
+        number: 42,
+        head_sha: "2222222",
+        refreshed_at: "2026-05-20T14:15:20Z",
+        warnings: [],
+      }),
+    ).not.toThrow();
+    expect(refreshDetailOnly).not.toHaveBeenCalled();
+  });
+
   it("ignores targeted PR detail refreshes for non-visible PRs", () => {
     currentDetail = {
       repo: {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1017,6 +1017,25 @@
         }
       },
     );
+    source.addEventListener(
+      "workspace_pr_associated",
+      (e: MessageEvent) => {
+        try {
+          const data = JSON.parse(
+            e.data as string,
+          ) as { workspace_id?: string };
+          if (data.workspace_id === id) {
+            void fetchWorkspace();
+          }
+        } catch {
+          // Malformed SSE data; ignore.
+        }
+      },
+    );
+    source.addEventListener("reconnect.stale", () => {
+      void fetchWorkspace();
+      void fetchRuntime();
+    });
 
     void fetchWorkspace().then(() => {
       if (workspace?.status === "creating") {

--- a/frontend/src/lib/stores/events.svelte.test.ts
+++ b/frontend/src/lib/stores/events.svelte.test.ts
@@ -151,6 +151,140 @@ describe("createEventsStore event dispatch", () => {
     expect(onReconnectStale).toHaveBeenCalledTimes(1);
   });
 
+  it("parses pushed-head refresh events and routes them to callbacks", () => {
+    const onWorkspacePushedHeadChanged = vi.fn();
+    const onWorkspacePRRefreshQueued = vi.fn();
+    const onPRDetailRefreshed = vi.fn();
+    const onPRCIRefreshQueued = vi.fn();
+    const onPRCIRefreshed = vi.fn();
+    const onWorkspacePRAssociated = vi.fn();
+    const store = createEventsStore({
+      onWorkspacePushedHeadChanged,
+      onWorkspacePRRefreshQueued,
+      onPRDetailRefreshed,
+      onPRCIRefreshQueued,
+      onPRCIRefreshed,
+      onWorkspacePRAssociated,
+    });
+    store.connect();
+    const source = instances[0] as StubEventSource;
+
+    emit(source, "workspace_pushed_head_changed", {
+      data: JSON.stringify({
+        workspace_id: "ws_123",
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        number: 42,
+        old_sha: "1111111",
+        new_sha: "2222222",
+        remote: "origin",
+        branch: "feature/widgets",
+        tracking_ref: "refs/remotes/origin/feature/widgets",
+        observed_at: "2026-05-20T14:15:00Z",
+      }),
+    });
+    emit(source, "workspace_pr_refresh_queued", {
+      data: JSON.stringify({
+        workspace_id: "ws_123",
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        number: 42,
+        head_sha: "2222222",
+        priority: "high",
+        queued_at: "2026-05-20T14:15:01Z",
+      }),
+    });
+    emit(source, "pr_detail_refreshed", {
+      data: JSON.stringify({
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        number: 42,
+        head_sha: "2222222",
+        synced_at: "2026-05-20T14:15:04Z",
+        warnings: [],
+      }),
+    });
+    emit(source, "pr_ci_refresh_queued", {
+      data: JSON.stringify({
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        number: 42,
+        head_sha: "2222222",
+        priority: "low",
+        queued_at: "2026-05-20T14:15:05Z",
+      }),
+    });
+    emit(source, "pr_ci_refreshed", {
+      data: JSON.stringify({
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        number: 42,
+        head_sha: "2222222",
+        refreshed_at: "2026-05-20T14:15:20Z",
+        warnings: [],
+      }),
+    });
+    emit(source, "workspace_pr_associated", {
+      data: JSON.stringify({
+        workspace_id: "ws_123",
+        provider: "github",
+        platform_host: "github.com",
+        repo_path: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        issue_number: 7,
+        pr_number: 42,
+        associated_at: "2026-05-20T14:15:00Z",
+      }),
+    });
+
+    expect(onWorkspacePushedHeadChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace_id: "ws_123", new_sha: "2222222" }),
+    );
+    expect(onWorkspacePRRefreshQueued).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace_id: "ws_123", priority: "high" }),
+    );
+    expect(onPRDetailRefreshed).toHaveBeenCalledWith(
+      expect.objectContaining({ repo_path: "acme/widgets", number: 42 }),
+    );
+    expect(onPRCIRefreshQueued).toHaveBeenCalledWith(
+      expect.objectContaining({ head_sha: "2222222", priority: "low" }),
+    );
+    expect(onPRCIRefreshed).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshed_at: "2026-05-20T14:15:20Z" }),
+    );
+    expect(onWorkspacePRAssociated).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 7, pr_number: 42 }),
+    );
+  });
+
+  it("swallows malformed pushed-head refresh event frames", () => {
+    const onPRDetailRefreshed = vi.fn();
+    const store = createEventsStore({ onPRDetailRefreshed });
+    store.connect();
+    expect(() =>
+      emit(instances[0] as StubEventSource, "pr_detail_refreshed", {
+        data: "not-json",
+      }),
+    ).not.toThrow();
+    expect(onPRDetailRefreshed).not.toHaveBeenCalled();
+  });
+
   it("ignores unknown event types without throwing", () => {
     const onDataChanged = vi.fn();
     const store = createEventsStore({ onDataChanged });

--- a/internal/server/detail_sync.go
+++ b/internal/server/detail_sync.go
@@ -13,6 +13,15 @@ func (s *Server) enqueueDetailSync(
 	attrs []any,
 	fn func(context.Context) error,
 ) bool {
+	return s.enqueueDetailSyncWithCompletion(key, attrs, fn, nil)
+}
+
+func (s *Server) enqueueDetailSyncWithCompletion(
+	key string,
+	attrs []any,
+	fn func(context.Context) error,
+	after func(context.Context),
+) bool {
 	s.detailSyncMu.Lock()
 	if s.detailSyncInFlight == nil {
 		s.detailSyncInFlight = make(map[string]struct{})
@@ -42,6 +51,9 @@ func (s *Server) enqueueDetailSync(
 				"background PR diff sync failed",
 				append(attrs, "code", diffErr.Code, "err", diffErr.Err)...,
 			)
+		}
+		if after != nil {
+			after(ctx)
 		}
 		s.hub.Broadcast(Event{
 			Type: "data_changed",

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -65,7 +65,7 @@ name = "widget"
 
 	select {
 	case <-secondSync:
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		require.Fail("second explicit sync did not bypass cooldown")
 	}
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3692,6 +3692,9 @@ func (s *Server) runWorkspaceSetup(ws *workspace.Workspace) {
 				Type: "workspace_status",
 				Data: resp,
 			})
+			if setupErr == nil {
+				s.runWorkspacePushedHeadObserverPass(bgCtx)
+			}
 
 			next, queued, queueErr := s.workspaces.StartQueuedRetryIfErrored(
 				bgCtx, ws.ID,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -132,17 +132,18 @@ func (c shutdownAwareContext) Value(key any) any {
 
 // Server holds the HTTP mux and its dependencies.
 type Server struct {
-	db                 *db.DB
-	syncer             *ghclient.Syncer
-	clones             *gitclone.Manager
-	workspaces         *workspace.Manager
-	workspacePRMonitor *workspace.PRMonitor
-	tmuxActivity       *tmuxActivityTracker
-	runtime            *localruntime.Manager
-	cfg                *config.Config
-	cfgPath            string
-	cfgMu              sync.Mutex
-	configReloadMu     sync.Mutex
+	db                          *db.DB
+	syncer                      *ghclient.Syncer
+	clones                      *gitclone.Manager
+	workspaces                  *workspace.Manager
+	workspacePRMonitor          *workspace.PRMonitor
+	workspacePushedHeadObserver *workspace.PushedHeadObserver
+	tmuxActivity                *tmuxActivityTracker
+	runtime                     *localruntime.Manager
+	cfg                         *config.Config
+	cfgPath                     string
+	cfgMu                       sync.Mutex
+	configReloadMu              sync.Mutex
 	// bootCfgSnapshot freezes the subset of config fields that are
 	// bound at startup (registry, listeners, clone manager, etc.) so a
 	// config-file watcher reload can detect when those changed and
@@ -266,12 +267,88 @@ func (s *Server) runWorkspacePRMonitorPass(ctx context.Context) {
 	}
 	for i := range updates {
 		update := updates[i]
-		s.hub.Broadcast(Event{
-			Type: "workspace_status",
-			Data: map[string]string{"id": update.WorkspaceID},
-		})
+		s.broadcastWorkspaceStatus(update.WorkspaceID)
 		s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
 	}
+}
+
+func (s *Server) runWorkspacePushedHeadObserverLoop(ctx context.Context) {
+	if s.workspacePushedHeadObserver == nil {
+		return
+	}
+
+	s.runWorkspacePushedHeadObserverPass(ctx)
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.runWorkspacePushedHeadObserverPass(ctx)
+		}
+	}
+}
+
+func (s *Server) runWorkspacePushedHeadObserverPass(ctx context.Context) {
+	if s.workspacePushedHeadObserver == nil {
+		return
+	}
+
+	result, err := s.workspacePushedHeadObserver.RunOnce(ctx)
+	if err != nil {
+		slog.Warn("workspace pushed-head observer pass failed", "err", err)
+		return
+	}
+	for i := range result.Associations {
+		association := result.Associations[i]
+		s.hub.Broadcast(Event{
+			Type: "workspace_pr_associated",
+			Data: workspacePRAssociatedPayload{
+				WorkspaceID:  association.WorkspaceID,
+				Provider:     string(association.Provider),
+				PlatformHost: association.PlatformHost,
+				RepoPath:     association.RepoPath,
+				Owner:        association.Owner,
+				Name:         association.Name,
+				IssueNumber:  association.IssueNumber,
+				PRNumber:     association.PRNumber,
+				AssociatedAt: formatUTCRFC3339(association.AssociatedAt),
+			},
+		})
+		s.broadcastWorkspaceStatus(association.WorkspaceID)
+		s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
+	}
+	for i := range result.HeadChanges {
+		change := result.HeadChanges[i]
+		s.hub.Broadcast(Event{
+			Type: "workspace_pushed_head_changed",
+			Data: workspacePushedHeadChangedPayload{
+				WorkspaceID:  change.WorkspaceID,
+				Provider:     string(change.Provider),
+				PlatformHost: change.PlatformHost,
+				RepoPath:     change.RepoPath,
+				Owner:        change.Owner,
+				Name:         change.Name,
+				Number:       change.Number,
+				OldSHA:       change.OldSHA,
+				NewSHA:       change.NewSHA,
+				Remote:       change.RemoteName,
+				Branch:       change.BranchName,
+				TrackingRef:  change.TrackingRef,
+				ObservedAt:   formatUTCRFC3339(change.ObservedAt),
+			},
+		})
+		s.enqueueWorkspacePushedHeadRefresh(change)
+	}
+}
+
+func (s *Server) broadcastWorkspaceStatus(workspaceID string) {
+	s.hub.Broadcast(Event{
+		Type: "workspace_status",
+		Data: map[string]string{"id": workspaceID},
+	})
 }
 
 // Shutdown stops the HTTP listener (if started via ListenAndServe
@@ -446,6 +523,7 @@ func newServer(
 	if options.WorktreeDir != "" {
 		s.workspaces = workspace.NewManager(database, options.WorktreeDir)
 		s.workspacePRMonitor = workspace.NewPRMonitor(database)
+		s.workspacePushedHeadObserver = workspace.NewPushedHeadObserver(database)
 		s.workspaces.SetTmuxCommand(tmuxCmd)
 		s.workspaces.SetIssueBranchSlugEnabled(
 			cfg.IssueWorkspaceBranchSlugEnabled(),
@@ -511,6 +589,7 @@ func newServer(
 
 	if s.workspaces != nil {
 		s.runBackground(s.runWorkspacePRMonitorLoop)
+		s.runBackground(s.runWorkspacePushedHeadObserverLoop)
 	}
 
 	// Watch the config file so an external edit (vim, dotfiles deploy,

--- a/internal/server/workspace_pushed_head.go
+++ b/internal/server/workspace_pushed_head.go
@@ -115,6 +115,9 @@ func (s *Server) enqueueWorkspacePushedHeadRefresh(change workspace.PushedHeadUp
 			)
 		},
 		func(ctx context.Context) {
+			if s.workspacePushedHeadObserver != nil {
+				s.workspacePushedHeadObserver.MarkRefreshSucceeded(change, s.now().UTC())
+			}
 			s.broadcastPRDetailRefreshed(ctx, change)
 			s.maybeEnqueuePushedHeadCIRefresh(ctx, change)
 		},

--- a/internal/server/workspace_pushed_head.go
+++ b/internal/server/workspace_pushed_head.go
@@ -1,0 +1,268 @@
+package server
+
+import (
+	"context"
+	"strconv"
+
+	"go.kenn.io/middleman/internal/db"
+	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/workspace"
+)
+
+type workspacePushedHeadChangedPayload struct {
+	WorkspaceID  string `json:"workspace_id"`
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	RepoPath     string `json:"repo_path"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	Number       int    `json:"number"`
+	OldSHA       string `json:"old_sha"`
+	NewSHA       string `json:"new_sha"`
+	Remote       string `json:"remote"`
+	Branch       string `json:"branch"`
+	TrackingRef  string `json:"tracking_ref"`
+	ObservedAt   string `json:"observed_at"`
+}
+
+type workspacePRAssociatedPayload struct {
+	WorkspaceID  string `json:"workspace_id"`
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	RepoPath     string `json:"repo_path"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	IssueNumber  int    `json:"issue_number"`
+	PRNumber     int    `json:"pr_number"`
+	AssociatedAt string `json:"associated_at"`
+}
+
+type workspacePRRefreshQueuedPayload struct {
+	WorkspaceID  string `json:"workspace_id"`
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	RepoPath     string `json:"repo_path"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	Number       int    `json:"number"`
+	HeadSHA      string `json:"head_sha"`
+	Priority     string `json:"priority"`
+	QueuedAt     string `json:"queued_at"`
+}
+
+type prDetailRefreshedPayload struct {
+	Provider     string   `json:"provider"`
+	PlatformHost string   `json:"platform_host"`
+	RepoPath     string   `json:"repo_path"`
+	Owner        string   `json:"owner"`
+	Name         string   `json:"name"`
+	Number       int      `json:"number"`
+	HeadSHA      string   `json:"head_sha"`
+	SyncedAt     string   `json:"synced_at"`
+	Warnings     []string `json:"warnings"`
+}
+
+type prCIRefreshQueuedPayload struct {
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	RepoPath     string `json:"repo_path"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	Number       int    `json:"number"`
+	HeadSHA      string `json:"head_sha"`
+	Priority     string `json:"priority"`
+	QueuedAt     string `json:"queued_at"`
+}
+
+type prCIRefreshedPayload struct {
+	Provider     string   `json:"provider"`
+	PlatformHost string   `json:"platform_host"`
+	RepoPath     string   `json:"repo_path"`
+	Owner        string   `json:"owner"`
+	Name         string   `json:"name"`
+	Number       int      `json:"number"`
+	HeadSHA      string   `json:"head_sha"`
+	RefreshedAt  string   `json:"refreshed_at"`
+	Warnings     []string `json:"warnings"`
+}
+
+func (s *Server) enqueueWorkspacePushedHeadRefresh(change workspace.PushedHeadUpdate) bool {
+	if s.syncer == nil {
+		return false
+	}
+	key := pushedHeadPRKey(change)
+	attrs := []any{
+		"type", "pr",
+		"provider", string(change.Provider),
+		"platform_host", change.PlatformHost,
+		"repo_path", change.RepoPath,
+		"owner", change.Owner,
+		"name", change.Name,
+		"number", change.Number,
+	}
+	queuedAt := s.now().UTC()
+	started := s.enqueueDetailSyncWithCompletion(
+		key,
+		attrs,
+		func(ctx context.Context) error {
+			return s.syncer.SyncMROnProvider(
+				ctx,
+				change.Provider,
+				change.PlatformHost,
+				change.Owner,
+				change.Name,
+				change.Number,
+			)
+		},
+		func(ctx context.Context) {
+			s.broadcastPRDetailRefreshed(ctx, change)
+			s.maybeEnqueuePushedHeadCIRefresh(ctx, change)
+		},
+	)
+	if !started {
+		return false
+	}
+	if s.workspacePushedHeadObserver != nil {
+		s.workspacePushedHeadObserver.MarkRefreshEnqueued(change, queuedAt)
+	}
+	s.hub.Broadcast(Event{
+		Type: "workspace_pr_refresh_queued",
+		Data: workspacePRRefreshQueuedPayload{
+			WorkspaceID:  change.WorkspaceID,
+			Provider:     string(change.Provider),
+			PlatformHost: change.PlatformHost,
+			RepoPath:     change.RepoPath,
+			Owner:        change.Owner,
+			Name:         change.Name,
+			Number:       change.Number,
+			HeadSHA:      change.NewSHA,
+			Priority:     "high",
+			QueuedAt:     formatUTCRFC3339(queuedAt),
+		},
+	})
+	return true
+}
+
+func (s *Server) broadcastPRDetailRefreshed(ctx context.Context, change workspace.PushedHeadUpdate) {
+	repo, mr := s.lookupPushedHeadMR(ctx, change)
+	headSHA := change.NewSHA
+	if mr != nil && mr.PlatformHeadSHA != "" {
+		headSHA = mr.PlatformHeadSHA
+	}
+	payload := prDetailRefreshedPayload{
+		Provider:     string(change.Provider),
+		PlatformHost: change.PlatformHost,
+		RepoPath:     change.RepoPath,
+		Owner:        change.Owner,
+		Name:         change.Name,
+		Number:       change.Number,
+		HeadSHA:      headSHA,
+		SyncedAt:     formatUTCRFC3339(s.now().UTC()),
+		Warnings:     []string{},
+	}
+	if repo != nil {
+		payload.Provider = repo.Platform
+		payload.PlatformHost = repo.PlatformHost
+		payload.RepoPath = repo.RepoPath
+		payload.Owner = repo.Owner
+		payload.Name = repo.Name
+	}
+	s.hub.Broadcast(Event{Type: "pr_detail_refreshed", Data: payload})
+}
+
+func (s *Server) maybeEnqueuePushedHeadCIRefresh(ctx context.Context, change workspace.PushedHeadUpdate) {
+	if s.syncer == nil {
+		return
+	}
+	repo, mr := s.lookupPushedHeadMR(ctx, change)
+	if repo == nil || mr == nil || !pushedHeadMRNeedsCIRefresh(mr.CIStatus, mr.CIHadPending, mr.WorkflowApprovalRequired) {
+		return
+	}
+	headSHA := mr.PlatformHeadSHA
+	if headSHA == "" {
+		headSHA = change.NewSHA
+	}
+	queuedAt := s.now().UTC()
+	key := "pr-ci:" + string(change.Provider) + ":" + change.PlatformHost + ":" + change.RepoPath + "#" + strconv.Itoa(change.Number)
+	started := s.enqueueDetailSyncWithCompletion(
+		key,
+		[]any{"type", "pr-ci", "provider", string(change.Provider), "platform_host", change.PlatformHost, "repo_path", change.RepoPath, "number", change.Number},
+		func(ctx context.Context) error {
+			_, err := s.syncer.RefreshMRCIStatusOnProvider(
+				ctx,
+				ghclient.RepoRef{
+					Platform:           repoProviderKind(*repo),
+					Owner:              repo.Owner,
+					Name:               repo.Name,
+					PlatformHost:       repoProviderHost(*repo),
+					RepoPath:           repo.RepoPath,
+					PlatformExternalID: repo.PlatformRepoID,
+					WebURL:             repo.WebURL,
+					CloneURL:           repo.CloneURL,
+					DefaultBranch:      repo.DefaultBranch,
+				},
+				repo.ID,
+				change.Number,
+				headSHA,
+			)
+			return err
+		},
+		func(context.Context) {
+			s.hub.Broadcast(Event{
+				Type: "pr_ci_refreshed",
+				Data: prCIRefreshedPayload{
+					Provider:     string(repoProviderKind(*repo)),
+					PlatformHost: repoProviderHost(*repo),
+					RepoPath:     repo.RepoPath,
+					Owner:        repo.Owner,
+					Name:         repo.Name,
+					Number:       change.Number,
+					HeadSHA:      headSHA,
+					RefreshedAt:  formatUTCRFC3339(s.now().UTC()),
+					Warnings:     []string{},
+				},
+			})
+		},
+	)
+	if !started {
+		return
+	}
+	s.hub.Broadcast(Event{
+		Type: "pr_ci_refresh_queued",
+		Data: prCIRefreshQueuedPayload{
+			Provider:     string(repoProviderKind(*repo)),
+			PlatformHost: repoProviderHost(*repo),
+			RepoPath:     repo.RepoPath,
+			Owner:        repo.Owner,
+			Name:         repo.Name,
+			Number:       change.Number,
+			HeadSHA:      headSHA,
+			Priority:     "low",
+			QueuedAt:     formatUTCRFC3339(queuedAt),
+		},
+	})
+}
+
+func (s *Server) lookupPushedHeadMR(ctx context.Context, change workspace.PushedHeadUpdate) (*db.Repo, *db.MergeRequest) {
+	repo, err := s.db.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     string(change.Provider),
+		PlatformHost: change.PlatformHost,
+		RepoPath:     change.RepoPath,
+	})
+	if err != nil || repo == nil {
+		return nil, nil
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, change.Number)
+	if err != nil {
+		return repo, nil
+	}
+	return repo, mr
+}
+
+func pushedHeadMRNeedsCIRefresh(status string, hadPending, approvalRequired bool) bool {
+	return status == "pending" || hadPending || approvalRequired
+}
+
+func pushedHeadPRKey(change workspace.PushedHeadUpdate) string {
+	return "pr:" + string(change.Provider) + ":" + change.PlatformHost + ":" + change.RepoPath + "#" + strconv.Itoa(change.Number)
+}

--- a/internal/server/workspace_pushed_head_e2e_test.go
+++ b/internal/server/workspace_pushed_head_e2e_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v84/github"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/db"
+	ghclient "go.kenn.io/middleman/internal/github"
+)
+
+func TestWorkspacePushedHeadObserverE2ERefreshesPRDetailAndSSE(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	var newHead string
+	newTitle := "Updated after push"
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, owner, name string, number int) (*gh.PullRequest, error) {
+			require.Equal("acme", owner)
+			require.Equal("widget", name)
+			require.Equal(1, number)
+			state := "open"
+			body := "updated body"
+			url := "https://github.com/acme/widget/pull/1"
+			now := gh.Timestamp{Time: time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)}
+			return &gh.PullRequest{
+				ID:        new(int64(1001)),
+				Number:    new(1),
+				Title:     &newTitle,
+				Body:      &body,
+				State:     &state,
+				HTMLURL:   &url,
+				User:      &gh.User{Login: new("octocat")},
+				CreatedAt: &now,
+				UpdatedAt: &now,
+				Head:      &gh.PullRequestBranch{Ref: new("feature"), SHA: &newHead},
+				Base:      &gh.PullRequestBranch{Ref: new("main"), SHA: new("base-sha")},
+			}, nil
+		},
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		[]ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{WorktreeDir: t.TempDir()})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	worktreePath, oldHead := setupPushedHeadE2EWorktree(t)
+	repoID := seedPushedHeadE2ERepoAndPR(t, database, oldHead)
+	insertPushedHeadE2EWorkspace(t, database, worktreePath)
+	newHead = pushNewPushedHeadE2ECommit(t, worktreePath)
+
+	httpServer := httptest.NewServer(srv)
+	defer httpServer.Close()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL+"/api/v1/events", nil)
+	require.NoError(err)
+	resp, err := httpServer.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+	require.Equal(http.StatusOK, resp.StatusCode)
+	scanner := bufio.NewScanner(resp.Body)
+
+	srv.runWorkspacePushedHeadObserverPass(ctx)
+	changed := readSSEFrameWithin(t, scanner, 5*time.Second, nil)
+	queued := readSSEFrameWithin(t, scanner, 5*time.Second, nil)
+	refreshed := readSSEFrameWithin(t, scanner, 5*time.Second, nil)
+	assert.Equal("workspace_pushed_head_changed", changed.Event)
+	assert.Equal("workspace_pr_refresh_queued", queued.Event)
+	assert.Equal("pr_detail_refreshed", refreshed.Event)
+
+	var changedPayload workspacePushedHeadChangedPayload
+	require.NoError(json.Unmarshal([]byte(changed.Data), &changedPayload))
+	assert.Equal("ws-pr", changedPayload.WorkspaceID)
+	assert.Equal("github", changedPayload.Provider)
+	assert.Equal("github.com", changedPayload.PlatformHost)
+	assert.Equal("acme/widget", changedPayload.RepoPath)
+	assert.Equal(oldHead, changedPayload.OldSHA)
+	assert.Equal(newHead, changedPayload.NewSHA)
+
+	pullResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 1)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pullResp.StatusCode())
+	require.NotNil(pullResp.JSON200)
+	assert.Equal(newTitle, pullResp.JSON200.MergeRequest.Title)
+	assert.True(pullResp.JSON200.DetailLoaded)
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 1)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(newHead, stored.PlatformHeadSHA)
+}
+
+func seedPushedHeadE2ERepoAndPR(t *testing.T, database *db.DB, oldHead string) int64 {
+	t.Helper()
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(t, err)
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	_, err = database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1001,
+		Number:          1,
+		URL:             "https://github.com/acme/widget/pull/1",
+		Title:           "Old title",
+		Author:          "octocat",
+		State:           db.MergeRequestStateOpen,
+		Body:            "old body",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: oldHead,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(t, err)
+	return repoID
+}
+
+func setupPushedHeadE2EWorktree(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	worktree := filepath.Join(dir, "worktree")
+	runGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	runGit(t, dir, "clone", remote, worktree)
+	runGit(t, worktree, "config", "user.email", "test@test.com")
+	runGit(t, worktree, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "base.txt"), []byte("base\n"), 0o644))
+	runGit(t, worktree, "add", ".")
+	runGit(t, worktree, "commit", "-m", "base commit")
+	runGit(t, worktree, "push", "origin", "main")
+	runGit(t, worktree, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("first\n"), 0o644))
+	runGit(t, worktree, "add", ".")
+	runGit(t, worktree, "commit", "-m", "feature commit")
+	runGit(t, worktree, "push", "-u", "origin", "feature")
+	return worktree, testGitSHA(t, worktree, "refs/remotes/origin/feature")
+}
+
+func pushNewPushedHeadE2ECommit(t *testing.T, worktree string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("second\n"), 0o644))
+	runGit(t, worktree, "add", ".")
+	runGit(t, worktree, "commit", "-m", "second feature commit")
+	runGit(t, worktree, "push", "origin", "feature")
+	return testGitSHA(t, worktree, "refs/remotes/origin/feature")
+}
+
+func insertPushedHeadE2EWorkspace(t *testing.T, database *db.DB, worktreePath string) {
+	t.Helper()
+	require.NoError(t, database.InsertWorkspace(t.Context(), &db.Workspace{
+		ID:              "ws-pr",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      1,
+		GitHeadRef:      "feature",
+		WorkspaceBranch: "feature",
+		WorktreePath:    worktreePath,
+		TmuxSession:     "middleman-ws-pr",
+		Status:          "ready",
+	}))
+}
+
+//go:fix inline
+func ptr[T any](value T) *T {
+	return new(value)
+}

--- a/internal/server/workspace_pushed_head_e2e_test.go
+++ b/internal/server/workspace_pushed_head_e2e_test.go
@@ -180,8 +180,3 @@ func insertPushedHeadE2EWorkspace(t *testing.T, database *db.DB, worktreePath st
 		Status:          "ready",
 	}))
 }
-
-//go:fix inline
-func ptr[T any](value T) *T {
-	return new(value)
-}

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -25,9 +25,10 @@ type remoteHeadKey struct {
 }
 
 type remoteHeadObservation struct {
-	SHA                   string
-	ObservedAt            time.Time
-	LastRefreshEnqueuedAt time.Time
+	SHA                    string
+	ObservedAt             time.Time
+	LastRefreshEnqueuedAt  time.Time
+	LastRefreshSucceededAt time.Time
 }
 
 type PushedHeadUpdate struct {
@@ -69,7 +70,10 @@ type remoteHeadGitReader interface {
 	RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error)
 }
 
-const pushedHeadGitTimeout = 2 * time.Second
+const (
+	pushedHeadGitTimeout           = 2 * time.Second
+	pushedHeadRefreshRetryInterval = 30 * time.Second
+)
 
 type gitRemoteHeadReader struct{}
 
@@ -130,7 +134,18 @@ func (o *PushedHeadObserver) MarkRefreshEnqueued(update PushedHeadUpdate, at tim
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	obs := o.observed[key]
+	obs.SHA = update.NewSHA
 	obs.LastRefreshEnqueuedAt = at
+	o.observed[key] = obs
+}
+
+func (o *PushedHeadObserver) MarkRefreshSucceeded(update PushedHeadUpdate, at time.Time) {
+	key := update.remoteHeadKey()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	obs := o.observed[key]
+	obs.SHA = update.NewSHA
+	obs.LastRefreshSucceededAt = at
 	o.observed[key] = obs
 }
 
@@ -351,7 +366,15 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 	if strings.EqualFold(prior.SHA, lookup.sha) {
 		prior.ObservedAt = observedAt
 		o.observed[key] = prior
-		return PushedHeadUpdate{}, false, nil
+		providerSHA := strings.TrimSpace(mr.PlatformHeadSHA)
+		if providerSHA == "" || strings.EqualFold(providerSHA, lookup.sha) {
+			return PushedHeadUpdate{}, false, nil
+		}
+		if !prior.LastRefreshEnqueuedAt.IsZero() && observedAt.Sub(prior.LastRefreshEnqueuedAt) < pushedHeadRefreshRetryInterval {
+			return PushedHeadUpdate{}, false, nil
+		}
+		update.OldSHA = providerSHA
+		return update, true, nil
 	}
 	update.OldSHA = prior.SHA
 	prior.SHA = lookup.sha

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -1,0 +1,407 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/platform"
+)
+
+type remoteHeadKey struct {
+	WorkspaceID  string
+	Provider     platform.Kind
+	PlatformHost string
+	RepoPath     string
+	ItemType     string
+	ItemNumber   int
+	RemoteName   string
+	BranchName   string
+	TrackingRef  string
+}
+
+type remoteHeadObservation struct {
+	SHA                   string
+	ObservedAt            time.Time
+	LastRefreshEnqueuedAt time.Time
+}
+
+type PushedHeadUpdate struct {
+	WorkspaceID  string
+	Provider     platform.Kind
+	PlatformHost string
+	RepoPath     string
+	Owner        string
+	Name         string
+	Number       int
+	OldSHA       string
+	NewSHA       string
+	RemoteName   string
+	BranchName   string
+	TrackingRef  string
+	ObservedAt   time.Time
+}
+
+type WorkspacePRAssociation struct {
+	WorkspaceID  string
+	Provider     platform.Kind
+	PlatformHost string
+	RepoPath     string
+	Owner        string
+	Name         string
+	IssueNumber  int
+	PRNumber     int
+	AssociatedAt time.Time
+}
+
+type PushedHeadPassResult struct {
+	Associations []WorkspacePRAssociation
+	HeadChanges  []PushedHeadUpdate
+}
+
+type remoteHeadGitReader interface {
+	BranchName(ctx context.Context, dir string) (string, error)
+	UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error)
+	RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error)
+}
+
+const pushedHeadGitTimeout = 2 * time.Second
+
+type gitRemoteHeadReader struct{}
+
+func (gitRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
+	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
+	defer cancel()
+	return gitBranchName(gitCtx, dir)
+}
+
+func (gitRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
+	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
+	defer cancel()
+	return gitUpstreamState(gitCtx, dir, branch)
+}
+
+func (gitRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
+	trackingRef := "refs/remotes/" + remote + "/" + branch
+	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
+	defer cancel()
+	out, err := gitOutput(gitCtx, dir, "rev-parse", "--verify", "--quiet", trackingRef+"^{commit}")
+	if err != nil {
+		return "", trackingRef, false, nil
+	}
+	return strings.TrimSpace(out), trackingRef, true, nil
+}
+
+type PushedHeadObserver struct {
+	db       *db.DB
+	monitor  *PRMonitor
+	git      remoteHeadGitReader
+	now      func() time.Time
+	mu       sync.Mutex
+	observed map[remoteHeadKey]remoteHeadObservation
+	failures map[string]int
+}
+
+func NewPushedHeadObserver(database *db.DB) *PushedHeadObserver {
+	return &PushedHeadObserver{
+		db:       database,
+		monitor:  NewPRMonitor(database),
+		git:      gitRemoteHeadReader{},
+		now:      time.Now,
+		observed: make(map[remoteHeadKey]remoteHeadObservation),
+		failures: make(map[string]int),
+	}
+}
+
+func (o *PushedHeadObserver) SetGitReaderForTest(reader remoteHeadGitReader) {
+	o.git = reader
+}
+
+func (o *PushedHeadObserver) SetNowForTest(now func() time.Time) {
+	o.now = now
+}
+
+func (o *PushedHeadObserver) MarkRefreshEnqueued(update PushedHeadUpdate, at time.Time) {
+	key := update.remoteHeadKey()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	obs := o.observed[key]
+	obs.LastRefreshEnqueuedAt = at
+	o.observed[key] = obs
+}
+
+func (u PushedHeadUpdate) remoteHeadKey() remoteHeadKey {
+	return remoteHeadKey{
+		WorkspaceID:  u.WorkspaceID,
+		Provider:     u.Provider,
+		PlatformHost: u.PlatformHost,
+		RepoPath:     u.RepoPath,
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   u.Number,
+		RemoteName:   u.RemoteName,
+		BranchName:   u.BranchName,
+		TrackingRef:  u.TrackingRef,
+	}
+}
+
+func (o *PushedHeadObserver) RunOnce(ctx context.Context) (PushedHeadPassResult, error) {
+	workspaces, err := o.db.ListWorkspaces(ctx)
+	if err != nil {
+		return PushedHeadPassResult{}, fmt.Errorf("list workspaces: %w", err)
+	}
+
+	result := PushedHeadPassResult{}
+	trackingCache := make(map[string]trackingLookup)
+	for i := range workspaces {
+		ws := workspaces[i]
+		if !pushedHeadWorkspaceEligible(&ws) {
+			continue
+		}
+
+		assoc, repo, mr, ok, err := o.resolveWorkspacePR(ctx, &ws)
+		if err != nil {
+			o.recordFailure(ws.ID, err)
+			continue
+		}
+		if assoc != nil {
+			result.Associations = append(result.Associations, *assoc)
+		}
+		if !ok || repo == nil || mr == nil {
+			continue
+		}
+
+		update, changed, observeErr := o.observeWorkspacePR(ctx, &ws, *repo, *mr, trackingCache)
+		if observeErr != nil {
+			o.recordFailure(ws.ID, observeErr)
+			continue
+		}
+		o.clearFailure(ws.ID)
+		if changed {
+			result.HeadChanges = append(result.HeadChanges, update)
+		}
+	}
+	return result, nil
+}
+
+func pushedHeadWorkspaceEligible(ws *Workspace) bool {
+	if ws == nil || ws.Status != "ready" || strings.TrimSpace(ws.WorktreePath) == "" {
+		return false
+	}
+	if strings.TrimSpace(ws.PlatformHost) == "" || strings.TrimSpace(ws.RepoOwner) == "" || strings.TrimSpace(ws.RepoName) == "" {
+		return false
+	}
+	return ws.ItemType == db.WorkspaceItemTypePullRequest || ws.ItemType == db.WorkspaceItemTypeIssue
+}
+
+func (o *PushedHeadObserver) resolveWorkspacePR(ctx context.Context, ws *Workspace) (*WorkspacePRAssociation, *db.Repo, *db.MergeRequest, bool, error) {
+	repo, err := o.db.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     workspaceProvider(ws),
+		PlatformHost: ws.PlatformHost,
+		Owner:        ws.RepoOwner,
+		Name:         ws.RepoName,
+	})
+	if err != nil {
+		return nil, nil, nil, false, fmt.Errorf("get repo: %w", err)
+	}
+	if repo == nil {
+		return nil, nil, nil, false, nil
+	}
+
+	prNumber := 0
+	var assoc *WorkspacePRAssociation
+	switch ws.ItemType {
+	case db.WorkspaceItemTypePullRequest:
+		prNumber = ws.ItemNumber
+	case db.WorkspaceItemTypeIssue:
+		if ws.AssociatedPRNumber != nil {
+			prNumber = *ws.AssociatedPRNumber
+		} else {
+			detected, ok, err := o.monitor.detectAssociatedPR(ctx, ws)
+			if err != nil {
+				return nil, repo, nil, false, err
+			}
+			if !ok {
+				return nil, repo, nil, false, nil
+			}
+			changed, err := o.db.SetWorkspaceAssociatedPRNumberIfNull(ctx, ws.ID, detected)
+			if err != nil {
+				return nil, repo, nil, false, fmt.Errorf("set associated PR: %w", err)
+			}
+			prNumber = detected
+			if changed {
+				assoc = &WorkspacePRAssociation{
+					WorkspaceID:  ws.ID,
+					Provider:     workspaceProviderKind(ws),
+					PlatformHost: repoProviderHost(*repo),
+					RepoPath:     repo.RepoPath,
+					Owner:        repo.Owner,
+					Name:         repo.Name,
+					IssueNumber:  ws.ItemNumber,
+					PRNumber:     detected,
+					AssociatedAt: o.now().UTC(),
+				}
+			}
+		}
+	default:
+		return nil, repo, nil, false, nil
+	}
+	if prNumber == 0 {
+		return assoc, repo, nil, false, nil
+	}
+
+	mr, err := o.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, prNumber)
+	if err != nil {
+		return assoc, repo, nil, false, fmt.Errorf("get merge request: %w", err)
+	}
+	if mr == nil || mr.State != db.MergeRequestStateOpen {
+		return assoc, repo, nil, false, nil
+	}
+	return assoc, repo, mr, true, nil
+}
+
+type trackingLookup struct {
+	sha string
+	ref string
+	ok  bool
+	err error
+}
+
+func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspace, repo db.Repo, mr db.MergeRequest, trackingCache map[string]trackingLookup) (PushedHeadUpdate, bool, error) {
+	branch, err := o.git.BranchName(ctx, ws.WorktreePath)
+	if err != nil {
+		return PushedHeadUpdate{}, false, err
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return PushedHeadUpdate{}, false, nil
+	}
+
+	upstream, err := o.git.UpstreamState(ctx, ws.WorktreePath, branch)
+	if err != nil {
+		return PushedHeadUpdate{}, false, err
+	}
+	if !upstream.hasTracking || upstream.remoteName == "" || upstream.branchName == "" {
+		slog.Debug("workspace pushed-head observer missing upstream", "workspace_id", ws.ID, "branch", branch)
+		return PushedHeadUpdate{}, false, nil
+	}
+	if upstream.branchName != mr.HeadBranch {
+		return PushedHeadUpdate{}, false, nil
+	}
+
+	cacheKey := ws.WorktreePath + "\x00" + upstream.remoteName + "\x00" + upstream.branchName
+	lookup, cached := trackingCache[cacheKey]
+	if !cached {
+		sha, ref, ok, err := o.git.RemoteTrackingSHA(ctx, ws.WorktreePath, upstream.remoteName, upstream.branchName)
+		lookup = trackingLookup{sha: strings.TrimSpace(sha), ref: ref, ok: ok, err: err}
+		trackingCache[cacheKey] = lookup
+	}
+	if lookup.err != nil {
+		return PushedHeadUpdate{}, false, lookup.err
+	}
+	if !lookup.ok || lookup.sha == "" {
+		slog.Debug("workspace pushed-head observer missing tracking ref", "workspace_id", ws.ID, "remote", upstream.remoteName, "branch", upstream.branchName)
+		return PushedHeadUpdate{}, false, nil
+	}
+
+	provider := repoProviderKind(repo)
+	host := repoProviderHost(repo)
+	observedAt := o.now().UTC()
+	key := remoteHeadKey{
+		WorkspaceID:  ws.ID,
+		Provider:     provider,
+		PlatformHost: host,
+		RepoPath:     repo.RepoPath,
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   mr.Number,
+		RemoteName:   upstream.remoteName,
+		BranchName:   upstream.branchName,
+		TrackingRef:  lookup.ref,
+	}
+	update := PushedHeadUpdate{
+		WorkspaceID:  ws.ID,
+		Provider:     provider,
+		PlatformHost: host,
+		RepoPath:     repo.RepoPath,
+		Owner:        repo.Owner,
+		Name:         repo.Name,
+		Number:       mr.Number,
+		NewSHA:       lookup.sha,
+		RemoteName:   upstream.remoteName,
+		BranchName:   upstream.branchName,
+		TrackingRef:  lookup.ref,
+		ObservedAt:   observedAt,
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	prior, seen := o.observed[key]
+	if !seen {
+		o.observed[key] = remoteHeadObservation{SHA: lookup.sha, ObservedAt: observedAt}
+		providerSHA := strings.TrimSpace(mr.PlatformHeadSHA)
+		if providerSHA == "" || strings.EqualFold(lookup.sha, providerSHA) {
+			return PushedHeadUpdate{}, false, nil
+		}
+		update.OldSHA = providerSHA
+		return update, true, nil
+	}
+	if strings.EqualFold(prior.SHA, lookup.sha) {
+		prior.ObservedAt = observedAt
+		o.observed[key] = prior
+		return PushedHeadUpdate{}, false, nil
+	}
+	update.OldSHA = prior.SHA
+	prior.SHA = lookup.sha
+	prior.ObservedAt = observedAt
+	o.observed[key] = prior
+	return update, true, nil
+}
+
+func (o *PushedHeadObserver) recordFailure(workspaceID string, err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.failures[workspaceID]++
+	if o.failures[workspaceID] > 1 {
+		slog.Warn("workspace pushed-head observer git inspection failed", "workspace_id", workspaceID, "err", err)
+		return
+	}
+	slog.Debug("workspace pushed-head observer git inspection failed", "workspace_id", workspaceID, "err", err)
+}
+
+func (o *PushedHeadObserver) clearFailure(workspaceID string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	delete(o.failures, workspaceID)
+}
+
+func workspaceProvider(ws *Workspace) string {
+	provider := strings.TrimSpace(ws.Platform)
+	if provider == "" {
+		return string(platform.KindGitHub)
+	}
+	return provider
+}
+
+func workspaceProviderKind(ws *Workspace) platform.Kind {
+	return platform.Kind(workspaceProvider(ws))
+}
+
+func repoProviderKind(repo db.Repo) platform.Kind {
+	if strings.TrimSpace(repo.Platform) == "" {
+		return platform.KindGitHub
+	}
+	return platform.Kind(repo.Platform)
+}
+
+func repoProviderHost(repo db.Repo) string {
+	if strings.TrimSpace(repo.PlatformHost) != "" {
+		return repo.PlatformHost
+	}
+	if host, ok := platform.DefaultHost(repoProviderKind(repo)); ok {
+		return host
+	}
+	return platform.DefaultGitHubHost
+}

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -1,0 +1,274 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/middleman/internal/db"
+)
+
+type fakeRemoteHeadReader struct {
+	branchCalls   int
+	upstreamCalls int
+	trackingCalls int
+	branch        string
+	upstream      upstreamState
+	trackingSHA   string
+	trackingRef   string
+	trackingOK    bool
+	trackingErr   error
+}
+
+func (r *fakeRemoteHeadReader) BranchName(context.Context, string) (string, error) {
+	r.branchCalls++
+	return r.branch, nil
+}
+
+func (r *fakeRemoteHeadReader) UpstreamState(context.Context, string, string) (upstreamState, error) {
+	r.upstreamCalls++
+	return r.upstream, nil
+}
+
+func (r *fakeRemoteHeadReader) RemoteTrackingSHA(context.Context, string, string, string) (string, string, bool, error) {
+	r.trackingCalls++
+	return r.trackingSHA, r.trackingRef, r.trackingOK, r.trackingErr
+}
+
+func insertPushedHeadWorkspace(
+	t *testing.T,
+	d *db.DB,
+	id, itemType string,
+	itemNumber int,
+	associatedPRNumber *int,
+) {
+	t.Helper()
+	require.NoError(t, d.InsertWorkspace(t.Context(), &db.Workspace{
+		ID:                 id,
+		Platform:           "github",
+		PlatformHost:       "github.com",
+		RepoOwner:          "acme",
+		RepoName:           "widget",
+		ItemType:           itemType,
+		ItemNumber:         itemNumber,
+		AssociatedPRNumber: associatedPRNumber,
+		GitHeadRef:         "feature/remote-head",
+		WorkspaceBranch:    "feature/remote-head",
+		WorktreePath:       "/tmp/worktree",
+		TmuxSession:        "middleman-" + id,
+		Status:             "ready",
+	}))
+}
+
+func seedMRWithPlatformHead(
+	t *testing.T,
+	d *db.DB,
+	repoID int64,
+	number int,
+	branch, sha string,
+) {
+	t.Helper()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	_, err := d.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      repoID*10000 + int64(number),
+		Number:          number,
+		Title:           "Refresh me",
+		Author:          "author",
+		State:           db.MergeRequestStateOpen,
+		HeadBranch:      branch,
+		PlatformHeadSHA: sha,
+		BaseBranch:      "main",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(t, err)
+}
+
+func newPushedHeadObserverForTest(
+	t *testing.T,
+	d *db.DB,
+	reader *fakeRemoteHeadReader,
+) *PushedHeadObserver {
+	t.Helper()
+	observer := NewPushedHeadObserver(d)
+	observer.SetGitReaderForTest(reader)
+	observer.SetNowForTest(func() time.Time {
+		return time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	})
+	return observer
+}
+
+func TestPushedHeadObserverFirstObservationSkipsWhenProviderHeadMatches(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch: "feature/remote-head",
+		upstream: upstreamState{
+			hasTracking: true,
+			remoteName:  "origin",
+			branchName:  "feature/remote-head",
+		},
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	observer := newPushedHeadObserverForTest(t, d, reader)
+
+	result, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(result.Associations)
+	assert.Empty(result.HeadChanges)
+	assert.Equal(1, reader.trackingCalls)
+}
+
+func TestPushedHeadObserverFirstObservationEnqueuesWhenProviderHeadDiffers(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch: "feature/remote-head",
+		upstream: upstreamState{
+			hasTracking: true,
+			remoteName:  "origin",
+			branchName:  "feature/remote-head",
+		},
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	observer := newPushedHeadObserverForTest(t, d, reader)
+
+	result, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(result.HeadChanges, 1)
+	change := result.HeadChanges[0]
+	assert.Equal("ws-pr", change.WorkspaceID)
+	assert.Equal("github", string(change.Provider))
+	assert.Equal("github.com", change.PlatformHost)
+	assert.Equal("acme/widget", change.RepoPath)
+	assert.Equal(42, change.Number)
+	assert.Equal("1111111", change.OldSHA)
+	assert.Equal("2222222", change.NewSHA)
+	assert.Equal("origin", change.RemoteName)
+	assert.Equal("feature/remote-head", change.BranchName)
+	assert.Equal("refs/remotes/origin/feature/remote-head", change.TrackingRef)
+}
+
+func TestPushedHeadObserverDetectsSubsequentTrackingRefMove(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch: "feature/remote-head",
+		upstream: upstreamState{
+			hasTracking: true,
+			remoteName:  "origin",
+			branchName:  "feature/remote-head",
+		},
+		trackingSHA: "1111111",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	observer := newPushedHeadObserverForTest(t, d, reader)
+	first, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(first.HeadChanges)
+
+	reader.trackingSHA = "2222222"
+	second, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(second.HeadChanges, 1)
+	assert.Equal("1111111", second.HeadChanges[0].OldSHA)
+	assert.Equal("2222222", second.HeadChanges[0].NewSHA)
+}
+
+func TestPushedHeadObserverAssociatesIssueWorkspaceAndObservesHead(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedIssue(t, d, repoID, 7, "Track pushed branch")
+	seedMRWithHeadRepo(
+		t, d, repoID, 42,
+		"feature/remote-head", "https://github.com/acme/widget.git",
+	)
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/remote-head")
+	runWorkspaceTestGit(t, worktreePath, "push", "-u", "origin", "feature/remote-head")
+	runWorkspaceTestGit(t, worktreePath, "remote", "set-url", "origin", "git@github.com:acme/widget.git")
+	insertMonitorWorkspace(t, d, worktreePath, nil)
+
+	observer := NewPushedHeadObserver(d)
+	observer.SetNowForTest(func() time.Time {
+		return time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	})
+	result, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(result.Associations, 1)
+	assert.Equal("ws-issue", result.Associations[0].WorkspaceID)
+	assert.Equal(7, result.Associations[0].IssueNumber)
+	assert.Equal(42, result.Associations[0].PRNumber)
+	assert.Equal("acme/widget", result.Associations[0].RepoPath)
+	assert.Empty(result.HeadChanges)
+
+	ws, err := d.GetWorkspace(context.Background(), "ws-issue")
+	require.NoError(err)
+	require.NotNil(ws)
+	require.NotNil(ws.AssociatedPRNumber)
+	assert.Equal(42, *ws.AssociatedPRNumber)
+}
+
+func TestPushedHeadObserverMissingRefAndTransientErrorKeepObservationState(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch:      "feature/remote-head",
+		upstream:    upstreamState{hasTracking: true, remoteName: "origin", branchName: "feature/remote-head"},
+		trackingSHA: "1111111",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	observer := newPushedHeadObserverForTest(t, d, reader)
+	_, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+
+	reader.trackingSHA = ""
+	reader.trackingOK = false
+	missing, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(missing.HeadChanges)
+
+	reader.trackingOK = true
+	reader.trackingErr = errors.New("transient git failure")
+	failed, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(failed.HeadChanges)
+
+	reader.trackingErr = nil
+	reader.trackingSHA = "2222222"
+	recovered, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(recovered.HeadChanges, 1)
+	assert.Equal("1111111", recovered.HeadChanges[0].OldSHA)
+	assert.Equal("2222222", recovered.HeadChanges[0].NewSHA)
+}

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -167,6 +167,70 @@ func TestPushedHeadObserverFirstObservationEnqueuesWhenProviderHeadDiffers(t *te
 	assert.Equal("refs/remotes/origin/feature/remote-head", change.TrackingRef)
 }
 
+func TestPushedHeadObserverRetriesObservedSHAUntilProviderHeadMatches(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch:      "feature/remote-head",
+		upstream:    upstreamState{hasTracking: true, remoteName: "origin", branchName: "feature/remote-head"},
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	now := time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	observer := NewPushedHeadObserver(d)
+	observer.SetGitReaderForTest(reader)
+	observer.SetNowForTest(func() time.Time { return now })
+
+	first, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(first.HeadChanges, 1)
+	observer.MarkRefreshEnqueued(first.HeadChanges[0], now)
+
+	suppressed, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(suppressed.HeadChanges)
+
+	now = now.Add(pushedHeadRefreshRetryInterval + time.Second)
+	retry, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(retry.HeadChanges, 1)
+	assert.Equal("1111111", retry.HeadChanges[0].OldSHA)
+	assert.Equal("2222222", retry.HeadChanges[0].NewSHA)
+}
+
+func TestPushedHeadObserverDoesNotRetryAfterRefreshSucceeds(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch:      "feature/remote-head",
+		upstream:    upstreamState{hasTracking: true, remoteName: "origin", branchName: "feature/remote-head"},
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	observer := newPushedHeadObserverForTest(t, d, reader)
+
+	first, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(first.HeadChanges, 1)
+	now := time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	observer.MarkRefreshSucceeded(first.HeadChanges[0], now)
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222")
+
+	retry, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(retry.HeadChanges)
+}
+
 func TestPushedHeadObserverDetectsSubsequentTrackingRefMove(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -264,6 +264,50 @@
       onConfigChanged: (event) => {
         void handleConfigChanged(event);
       },
+      onPRDetailRefreshed: (ref) => {
+        const detail = detailStore.getDetail();
+        if (
+          detail?.repo?.provider === ref.provider &&
+          detail.repo.platform_host === ref.platform_host &&
+          detail.repo.repo_path === ref.repo_path &&
+          detail.repo_owner === ref.owner &&
+          detail.repo_name === ref.name &&
+          detail.merge_request.Number === ref.number
+        ) {
+          void detailStore.refreshDetailOnly(
+            ref.owner,
+            ref.name,
+            ref.number,
+            {
+              provider: ref.provider,
+              platformHost: ref.platform_host,
+              repoPath: ref.repo_path,
+            },
+          );
+        }
+      },
+      onPRCIRefreshed: (ref) => {
+        const detail = detailStore.getDetail();
+        if (
+          detail?.repo?.provider === ref.provider &&
+          detail.repo.platform_host === ref.platform_host &&
+          detail.repo.repo_path === ref.repo_path &&
+          detail.repo_owner === ref.owner &&
+          detail.repo_name === ref.name &&
+          detail.merge_request.Number === ref.number
+        ) {
+          void detailStore.refreshDetailOnly(
+            ref.owner,
+            ref.name,
+            ref.number,
+            {
+              provider: ref.provider,
+              platformHost: ref.platform_host,
+              repoPath: ref.repo_path,
+            },
+          );
+        }
+      },
       onReconnectStale: () => {
         // The replay ring rolled past the client's cursor while it
         // was disconnected (long sleep, extended network outage).

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -272,7 +272,7 @@
           detail.repo.repo_path === ref.repo_path &&
           detail.repo_owner === ref.owner &&
           detail.repo_name === ref.name &&
-          detail.merge_request.Number === ref.number
+          detail.merge_request?.Number === ref.number
         ) {
           void detailStore.refreshDetailOnly(
             ref.owner,
@@ -294,7 +294,7 @@
           detail.repo.repo_path === ref.repo_path &&
           detail.repo_owner === ref.owner &&
           detail.repo_name === ref.name &&
-          detail.merge_request.Number === ref.number
+          detail.merge_request?.Number === ref.number
         ) {
           void detailStore.refreshDetailOnly(
             ref.owner,

--- a/packages/ui/src/stores/events.svelte.ts
+++ b/packages/ui/src/stores/events.svelte.ts
@@ -6,6 +6,83 @@ export interface ConfigChangedEvent {
   restart_required: boolean;
 }
 
+export interface WorkspacePushedHeadChangedEvent {
+  workspace_id: string;
+  provider: string;
+  platform_host: string;
+  repo_path: string;
+  owner: string;
+  name: string;
+  number: number;
+  old_sha: string;
+  new_sha: string;
+  remote: string;
+  branch: string;
+  tracking_ref: string;
+  observed_at: string;
+}
+
+export interface WorkspacePRAssociatedEvent {
+  workspace_id: string;
+  provider: string;
+  platform_host: string;
+  repo_path: string;
+  owner: string;
+  name: string;
+  issue_number: number;
+  pr_number: number;
+  associated_at: string;
+}
+
+export interface WorkspacePRRefreshQueuedEvent {
+  workspace_id: string;
+  provider: string;
+  platform_host: string;
+  repo_path: string;
+  owner: string;
+  name: string;
+  number: number;
+  head_sha: string;
+  priority: string;
+  queued_at: string;
+}
+
+export interface PRDetailRefreshedEvent {
+  provider: string;
+  platform_host: string;
+  repo_path: string;
+  owner: string;
+  name: string;
+  number: number;
+  head_sha: string;
+  synced_at: string;
+  warnings: string[];
+}
+
+export interface PRCIRefreshQueuedEvent {
+  provider: string;
+  platform_host: string;
+  repo_path: string;
+  owner: string;
+  name: string;
+  number: number;
+  head_sha: string;
+  priority: string;
+  queued_at: string;
+}
+
+export interface PRCIRefreshedEvent {
+  provider: string;
+  platform_host: string;
+  repo_path: string;
+  owner: string;
+  name: string;
+  number: number;
+  head_sha: string;
+  refreshed_at: string;
+  warnings: string[];
+}
+
 export interface EventsStoreOptions {
   /**
    * Base URL path (typically from config.basePath). Trailing
@@ -27,6 +104,18 @@ export interface EventsStoreOptions {
    * would after a hard refresh.
    */
   onReconnectStale?: () => void;
+  onWorkspacePushedHeadChanged?: (
+    event: WorkspacePushedHeadChangedEvent,
+  ) => void;
+  onWorkspacePRAssociated?: (
+    event: WorkspacePRAssociatedEvent,
+  ) => void;
+  onWorkspacePRRefreshQueued?: (
+    event: WorkspacePRRefreshQueuedEvent,
+  ) => void;
+  onPRDetailRefreshed?: (event: PRDetailRefreshedEvent) => void;
+  onPRCIRefreshQueued?: (event: PRCIRefreshQueuedEvent) => void;
+  onPRCIRefreshed?: (event: PRCIRefreshedEvent) => void;
 }
 
 /**
@@ -84,6 +173,36 @@ export function createEventsStore(opts: EventsStoreOptions = {}) {
     source.addEventListener("reconnect.stale", () => {
       opts.onReconnectStale?.();
     });
+    addJSONListener<WorkspacePushedHeadChangedEvent>(
+      source,
+      "workspace_pushed_head_changed",
+      opts.onWorkspacePushedHeadChanged,
+    );
+    addJSONListener<WorkspacePRAssociatedEvent>(
+      source,
+      "workspace_pr_associated",
+      opts.onWorkspacePRAssociated,
+    );
+    addJSONListener<WorkspacePRRefreshQueuedEvent>(
+      source,
+      "workspace_pr_refresh_queued",
+      opts.onWorkspacePRRefreshQueued,
+    );
+    addJSONListener<PRDetailRefreshedEvent>(
+      source,
+      "pr_detail_refreshed",
+      opts.onPRDetailRefreshed,
+    );
+    addJSONListener<PRCIRefreshQueuedEvent>(
+      source,
+      "pr_ci_refresh_queued",
+      opts.onPRCIRefreshQueued,
+    );
+    addJSONListener<PRCIRefreshedEvent>(
+      source,
+      "pr_ci_refreshed",
+      opts.onPRCIRefreshed,
+    );
   }
 
   function disconnect(): void {
@@ -98,6 +217,21 @@ export function createEventsStore(opts: EventsStoreOptions = {}) {
   }
 
   return { connect, disconnect, isConnected };
+}
+
+function addJSONListener<T>(
+  source: EventSource,
+  eventName: string,
+  callback: ((event: T) => void) | undefined,
+): void {
+  source.addEventListener(eventName, (ev) => {
+    if (!callback) return;
+    try {
+      callback(JSON.parse((ev as MessageEvent).data) as T);
+    } catch {
+      // ignore malformed frames
+    }
+  });
 }
 
 export type EventsStore = ReturnType<typeof createEventsStore>;


### PR DESCRIPTION
Observe middleman workspace remote-tracking refs so successful local pushes enqueue provider-aware PR detail refreshes without polling remotes or intercepting git commands. Broadcast targeted SSE events for head changes, workspace PR association, detail refresh completion, and follow-up CI refresh while preserving existing broad invalidation for older clients.