### PR TITLE
Unify flat and threaded activity layouts with aligned columns and sticky headers

### DIFF
--- a/frontend/tests/e2e-full/activity-collapse.spec.ts
+++ b/frontend/tests/e2e-full/activity-collapse.spec.ts
@@ -25,7 +25,7 @@ async function selectActivityViewItem(
 
 async function gotoThreadedActivity(page: Page): Promise<void> {
   await page.goto("/");
-  await page.locator(".activity-table tbody .activity-row").first()
+  await page.locator(".activity-table .activity-row").first()
     .waitFor({ state: "visible", timeout: 10_000 });
   await selectActivityViewItem(page, "Threaded");
   await page.locator(".threaded-view .item-row").first()

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -525,6 +525,32 @@ test.describe("activity split view and detail drawers", () => {
     await page.unrouteAll({ behavior: "ignoreErrors" });
   });
 
+  test("compact flat activity rows respect hide org name", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem("middleman:hideOrgName");
+    });
+    await page.goto("/?view=flat");
+    await waitForActivityTable(page);
+
+    await openActivityPRSplit(page);
+
+    const row = page.locator(".activity-compact-row", {
+      has: page.locator(".compact-title", { hasText: "Add widget caching layer" }),
+    }).first();
+    await expect(row).toBeVisible();
+
+    const repoLabel = row.locator(".compact-meta > span").first();
+    await expect(repoLabel).toHaveText("acme/widgets");
+
+    await page.locator(".activity-feed .filter-btn", { hasText: "View" }).click();
+    await page.locator(".activity-feed .filter-dropdown .filter-item", {
+      hasText: "Hide org name",
+    }).click();
+
+    await expect(repoLabel).toHaveText("widgets");
+    await expect(repoLabel).not.toHaveText("acme/widgets");
+  });
+
   test("Activity PR switching uses background sync without foreground fanout", async ({ page }) => {
     const detailBodies = new Map<string, string>();
     const detailGets = new Map<string, number>();

--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -347,7 +347,7 @@ function isGheIssueRoute(url: URL, suffix = ""): boolean {
 }
 
 async function waitForActivityTable(page: Page): Promise<void> {
-  await page.locator(".activity-table tbody .activity-row").first()
+  await page.locator(".activity-table .activity-row").first()
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 

--- a/frontend/tests/e2e-full/activity-filters.spec.ts
+++ b/frontend/tests/e2e-full/activity-filters.spec.ts
@@ -11,7 +11,7 @@ import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eSer
 //   bot authors: 2 (dependabot[bot] on PR#7 and issue#13)
 
 async function waitForTable(page: Page): Promise<void> {
-  await page.locator(".activity-table tbody .activity-row").first()
+  await page.locator(".activity-table .activity-row").first()
     .waitFor({ state: "visible", timeout: 10_000 });
 }
 

--- a/frontend/tests/e2e-full/activity-row-link.spec.ts
+++ b/frontend/tests/e2e-full/activity-row-link.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Full-stack coverage that flat and threaded activity rows still expose a
+// "Open activity" affordance that jumps directly to the provider URL
+// without going through the in-app drawer. Regression guard for the
+// dropped link column during the flat/threaded layout unification.
+
+async function openActivityViewDropdown(page: Page) {
+  const dropdown = page.locator(".activity-feed .filter-dropdown");
+  if (await dropdown.isVisible()) {
+    return dropdown;
+  }
+  await page.locator(".activity-feed .filter-btn", { hasText: "View" }).click();
+  await expect(dropdown).toBeVisible();
+  return dropdown;
+}
+
+async function selectActivityViewItem(page: Page, label: string): Promise<void> {
+  const dropdown = await openActivityViewDropdown(page);
+  await dropdown.locator(".filter-item", { hasText: label }).click();
+}
+
+async function captureWindowOpen(page: Page): Promise<() => Promise<string | null>> {
+  // Intercept window.open before the click handler runs so we can assert
+  // exactly what URL the row's link button would have opened.
+  await page.evaluate(() => {
+    delete (globalThis as unknown as { __lastOpen?: string }).__lastOpen;
+    window.open = ((url: string) => {
+      (globalThis as unknown as { __lastOpen?: string }).__lastOpen =
+        typeof url === "string" ? url : String(url);
+      return null;
+    }) as typeof window.open;
+  });
+  return () =>
+    page.evaluate(
+      () =>
+        (globalThis as unknown as { __lastOpen?: string }).__lastOpen ?? null,
+    );
+}
+
+test.describe("activity row link button", () => {
+  test("flat row link button opens activity URL without triggering row select", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const firstRow = page.locator(".activity-table .activity-row").first();
+    await firstRow.waitFor({ state: "visible", timeout: 10_000 });
+
+    const lastOpen = await captureWindowOpen(page);
+
+    const linkBtn = firstRow.locator(".link-btn");
+    await expect(linkBtn).toBeVisible();
+    await linkBtn.click();
+
+    const opened = await lastOpen();
+    expect(opened).toBeTruthy();
+    // Seed activity events all target github.com/acme/... URLs.
+    expect(opened).toContain("github.com/acme/");
+
+    // The detail drawer must not have opened (row click was suppressed).
+    await expect(page.locator(".activity-drawer")).toHaveCount(0);
+  });
+
+  test("threaded item row link button opens item URL without expanding the item", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.locator(".activity-table .activity-row").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+    await selectActivityViewItem(page, "Threaded");
+    await page.keyboard.press("Escape");
+    const itemRow = page.locator(".threaded-view .item-row:not(.branch-activity-row)")
+      .first();
+    await itemRow.waitFor({ state: "visible", timeout: 10_000 });
+
+    const lastOpen = await captureWindowOpen(page);
+
+    const linkBtn = itemRow.locator(".link-btn");
+    await expect(linkBtn).toBeVisible();
+    await linkBtn.click();
+
+    const opened = await lastOpen();
+    expect(opened).toBeTruthy();
+    // Threaded item-rows link to the underlying item URL (PR or issue).
+    expect(opened).toMatch(/github\.com\/acme\/[^/]+\/(pull|issues)\/\d+/);
+
+    // The detail drawer must not have opened (caret/row click suppressed).
+    await expect(page.locator(".activity-drawer")).toHaveCount(0);
+  });
+});

--- a/frontend/tests/e2e-full/activity-threaded-sticky.spec.ts
+++ b/frontend/tests/e2e-full/activity-threaded-sticky.spec.ts
@@ -57,18 +57,26 @@ test.describe("threaded activity sticky headers", () => {
     expect(Math.abs(afterBox!.y - beforeTop)).toBeLessThan(4);
 
     // The first column header cell ("Type") must line up with the type
-    // chips in the later section's rows. After scrolling, find a PR/Issue
-    // chip inside an .item-row that's in the viewport and compare x-edges.
+    // chips in a LATER section's rows. Scope to the second .repo-section
+    // explicitly (seed has acme/widgets + acme/tools) and additionally
+    // verify the chip is in the viewport below the sticky header — using
+    // .first() on the whole view could pick a section-1 chip that no
+    // longer matches the scrolled layout, hiding a real regression.
     const typeHeader = columnHeaders.locator(".cell--type");
-    const headerX = (await typeHeader.boundingBox())!.x;
-    const firstVisibleItemChip = page
-      .locator(".threaded-view .item-row .cell--type :is(.chip--kind-pr, .chip--kind-issue)")
+    const headerBox = (await typeHeader.boundingBox())!;
+    const secondSection = page.locator(".threaded-view .repo-section").nth(1);
+    await expect(secondSection).toBeVisible();
+    const laterSectionChip = secondSection
+      .locator(".item-row .cell--type :is(.chip--kind-pr, .chip--kind-issue)")
       .first();
-    await expect(firstVisibleItemChip).toBeVisible();
-    const chipX = (await firstVisibleItemChip.boundingBox())!.x;
-    // Allow ~2px sub-pixel slack; large mismatches would mean each section
-    // has its own column tracks again (the regression we are guarding against).
-    expect(Math.abs(chipX - headerX)).toBeLessThan(4);
+    await expect(laterSectionChip).toBeVisible();
+    const chipBox = (await laterSectionChip.boundingBox())!;
+    // The chip we picked must actually be below the sticky header in the
+    // viewport so we are comparing alignment against post-scroll layout.
+    expect(chipBox.y).toBeGreaterThan(headerBox.y + headerBox.height);
+    // Allow ~2px sub-pixel slack; large mismatches would mean the second
+    // section regressed to its own column tracks (the bug we guard against).
+    expect(Math.abs(chipBox.x - headerBox.x)).toBeLessThan(4);
   });
 
   test("each repo header is bounded to its own section instead of stacking", async ({

--- a/frontend/tests/e2e-full/activity-threaded-sticky.spec.ts
+++ b/frontend/tests/e2e-full/activity-threaded-sticky.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Full-stack coverage (real HTTP API + SQLite) for the threaded view's
+// sticky column header and per-section sticky repo headers. The shared e2e
+// server seeds two repos (acme/widgets, acme/tools) in 7d, so grouped
+// threaded mode has multiple sections that the scroll behavior can exercise.
+
+async function openActivityViewDropdown(page: Page) {
+  const dropdown = page.locator(".activity-feed .filter-dropdown");
+  if (await dropdown.isVisible()) {
+    return dropdown;
+  }
+  await page.locator(".activity-feed .filter-btn", { hasText: "View" }).click();
+  await expect(dropdown).toBeVisible();
+  return dropdown;
+}
+
+async function selectActivityViewItem(page: Page, label: string): Promise<void> {
+  const dropdown = await openActivityViewDropdown(page);
+  await dropdown.locator(".filter-item", { hasText: label }).click();
+}
+
+async function gotoThreadedGrouped(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.locator(".activity-table .activity-row").first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await selectActivityViewItem(page, "Threaded");
+  await page.keyboard.press("Escape");
+  await page.locator(".threaded-view .repo-header").first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+test.describe("threaded activity sticky headers", () => {
+  test("column header stays visible after scrolling and aligns with later sections", async ({
+    page,
+  }) => {
+    await gotoThreadedGrouped(page);
+
+    const columnHeaders = page.locator(".threaded-view .activity-column-headers");
+    await expect(columnHeaders).toBeVisible();
+    const beforeBox = await columnHeaders.boundingBox();
+    expect(beforeBox).not.toBeNull();
+    const beforeTop = beforeBox!.y;
+
+    // Scroll the view far enough that the first section is out of view
+    // and a later section is in view; the sticky column header must remain
+    // at (or near) its original top y to stay in viewport.
+    await page.evaluate(() => {
+      const view = document.querySelector(".threaded-view");
+      if (view) view.scrollTop = 500;
+    });
+
+    await expect(columnHeaders).toBeVisible();
+    const afterBox = await columnHeaders.boundingBox();
+    expect(afterBox).not.toBeNull();
+    // Sticky behavior keeps the column header at the same viewport y.
+    expect(Math.abs(afterBox!.y - beforeTop)).toBeLessThan(4);
+
+    // The first column header cell ("Type") must line up with the type
+    // chips in the later section's rows. After scrolling, find a PR/Issue
+    // chip inside an .item-row that's in the viewport and compare x-edges.
+    const typeHeader = columnHeaders.locator(".cell--type");
+    const headerX = (await typeHeader.boundingBox())!.x;
+    const firstVisibleItemChip = page
+      .locator(".threaded-view .item-row .cell--type :is(.chip--kind-pr, .chip--kind-issue)")
+      .first();
+    await expect(firstVisibleItemChip).toBeVisible();
+    const chipX = (await firstVisibleItemChip.boundingBox())!.x;
+    // Allow ~2px sub-pixel slack; large mismatches would mean each section
+    // has its own column tracks again (the regression we are guarding against).
+    expect(Math.abs(chipX - headerX)).toBeLessThan(4);
+  });
+
+  test("each repo header is bounded to its own section instead of stacking", async ({
+    page,
+  }) => {
+    await gotoThreadedGrouped(page);
+
+    const repoHeaders = page.locator(".threaded-view .repo-header");
+    const count = await repoHeaders.count();
+    // The seed produces at least acme/widgets and acme/tools sections.
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Scroll into the second section so it has the chance to stick.
+    await page.evaluate(() => {
+      const view = document.querySelector(".threaded-view");
+      if (view) view.scrollTop = 400;
+    });
+
+    // After scrolling mid-list, only ONE repo header can be "stuck" at the
+    // sticky top. If sections were display: contents, two sticky headers
+    // would both pin at the same y and visibly overlap.
+    const boxes = await Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        repoHeaders.nth(i).boundingBox(),
+      ),
+    );
+    const yValues = boxes
+      .filter((b): b is NonNullable<typeof b> => b !== null)
+      .map((b) => Math.round(b.y));
+    const distinct = new Set(yValues);
+    expect(distinct.size).toBe(yValues.length);
+  });
+});

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -209,6 +209,29 @@ test.describe("grouping toggle", () => {
     ).toHaveCount(0);
   });
 
+  test("activity threaded ungrouped rows show latest author and hide org repo chips", async ({ page }) => {
+    await page.goto("/");
+
+    await selectActivityViewItem(page, "Threaded");
+    await page.locator(".threaded-view .item-row").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+    await selectActivityViewItem(page, "All");
+
+    const row = page.locator(".threaded-view .item-row", {
+      has: page.locator(".item-title", { hasText: "Add widget caching layer" }),
+    }).first();
+    await expect(row).toBeVisible();
+    await expect(row.locator(".cell--author")).toHaveText("bob");
+
+    const repoLabel = row.locator(".repo-chip__label");
+    await expect(repoLabel).toHaveText("acme/widgets");
+
+    await selectActivityViewItem(page, "Hide org name");
+
+    await expect(repoLabel).toHaveText("widgets");
+    await expect(repoLabel).not.toHaveText("acme/widgets");
+  });
+
   test("threaded ungrouped empty state shows message", async ({ page }) => {
     await page.goto("/");
 

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -58,6 +58,7 @@ test.describe("grouping toggle", () => {
       }
       localStorage.removeItem("middleman:groupingMode");
       localStorage.removeItem("middleman:groupByRepo");
+      localStorage.removeItem("middleman:hideOrgName");
       sessionStorage.setItem("middleman:test:grouping:init", "1");
     });
     await page.goto("/pulls");
@@ -179,6 +180,33 @@ test.describe("grouping toggle", () => {
     dropdown = await openActivityViewDropdown(page);
     await expect(dropdown.locator(".filter-item", { hasText: /By repo/i }))
       .toBeVisible();
+  });
+
+  test("activity threaded grouped headers respect hide org name", async ({ page }) => {
+    await page.goto("/");
+
+    await selectActivityViewItem(page, "Threaded");
+    await page.locator(".threaded-view .repo-header").first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    await expect(
+      page.locator(".threaded-view .repo-header .repo-name", {
+        hasText: "acme/widgets",
+      }),
+    ).toBeVisible();
+
+    await selectActivityViewItem(page, "Hide org name");
+
+    await expect(
+      page.locator(".threaded-view .repo-header .repo-name", {
+        hasText: /^widgets$/,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".threaded-view .repo-header .repo-name", {
+        hasText: "acme/widgets",
+      }),
+    ).toHaveCount(0);
   });
 
   test("threaded ungrouped empty state shows message", async ({ page }) => {

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -185,7 +185,7 @@ test.describe("grouping toggle", () => {
   test("activity flat table rows respect hide org name", async ({ page }) => {
     await page.goto("/?view=flat");
 
-    const row = page.locator(".activity-table tbody .activity-row", {
+    const row = page.locator(".activity-table .activity-row", {
       has: page.locator(".item-title", { hasText: "Add widget caching layer" }),
     }).first();
     await expect(row).toBeVisible({ timeout: 10_000 });

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -182,6 +182,23 @@ test.describe("grouping toggle", () => {
       .toBeVisible();
   });
 
+  test("activity flat table rows respect hide org name", async ({ page }) => {
+    await page.goto("/?view=flat");
+
+    const row = page.locator(".activity-table tbody .activity-row", {
+      has: page.locator(".item-title", { hasText: "Add widget caching layer" }),
+    }).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    const repoLabel = row.locator(".col-repo");
+    await expect(repoLabel).toHaveText("acme/widgets");
+
+    await selectActivityViewItem(page, "Hide org name");
+
+    await expect(repoLabel).toHaveText("widgets");
+    await expect(repoLabel).not.toHaveText("acme/widgets");
+  });
+
   test("activity threaded grouped headers respect hide org name", async ({ page }) => {
     await page.goto("/");
 

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -340,6 +340,43 @@ test.describe("phone routes", () => {
     await activityForRepo;
   });
 
+  test("mobile activity hide-org toggle updates card repo labels and persists", async ({ page }) => {
+    await page.addInitScript(() => {
+      if (sessionStorage.getItem("middleman:test:mobile-hide-org:init") === "1") {
+        return;
+      }
+      localStorage.removeItem("middleman:hideOrgName");
+      sessionStorage.setItem("middleman:test:mobile-hide-org:init", "1");
+    });
+
+    await page.goto("/m?range=30d&view=threaded");
+    await expect(page.locator(".mobile-activity-inbox")).toBeVisible();
+
+    const card = page.locator(".mobile-activity-card", {
+      has: page.locator(".mobile-activity-card__title", {
+        hasText: "Add widget caching layer",
+      }),
+    }).first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    const repoLabel = card.locator(".mobile-activity-card__meta span").first();
+    const hideOrgToggle = page.getByRole("button", { name: "Hide org" });
+    await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(repoLabel).toHaveText("github.com/acme/widgets");
+
+    await hideOrgToggle.click();
+
+    await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(repoLabel).toHaveText("widgets");
+    await expect(repoLabel).not.toHaveText("github.com/acme/widgets");
+
+    await page.reload();
+
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(repoLabel).toHaveText("widgets");
+  });
+
   test("mobile activity card routes to a focused thread detail", async ({ page }) => {
     await page.goto("/m?range=30d&view=threaded");
     await expect(page.getByRole("button", { name: "Open thread" })).toHaveCount(0);

--- a/frontend/tests/e2e/activity-threaded-columns.spec.ts
+++ b/frontend/tests/e2e/activity-threaded-columns.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+const REPO = {
+  provider: "github",
+  platform_host: "github.com",
+  owner: "acme",
+  name: "widgets",
+  repo_path: "acme/widgets",
+  capabilities: {},
+};
+
+function itemEvent(args: {
+  id: string;
+  number: number;
+  type: "comment" | "review" | "new_pr";
+  author: string;
+  authorName: string;
+  createdAt: string;
+  title: string;
+}) {
+  return {
+    id: args.id,
+    cursor: args.id,
+    activity_type: args.type,
+    author: args.author,
+    author_name: args.authorName,
+    body_preview: "",
+    created_at: args.createdAt,
+    item_number: args.number,
+    item_state: "open",
+    item_title: args.title,
+    item_type: "pr",
+    item_url: `https://github.com/acme/widgets/pull/${args.number}`,
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    repo: REPO,
+  };
+}
+
+function branchCommit(args: {
+  id: string;
+  author: string;
+  authorName: string;
+  createdAt: string;
+  bodyPreview: string;
+  sha: string;
+}) {
+  return {
+    id: args.id,
+    cursor: args.id,
+    activity_type: "default_branch_commit",
+    author: args.author,
+    author_name: args.authorName,
+    body_preview: args.bodyPreview,
+    created_at: args.createdAt,
+    committed_at: args.createdAt,
+    item_number: 0,
+    item_state: "",
+    item_title: "",
+    item_type: "",
+    item_url: "",
+    activity_url: `https://github.com/acme/widgets/commit/${args.sha}`,
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    repo: REPO,
+    branch_name: "main",
+    commit_sha: args.sha,
+  };
+}
+
+async function mockSettings(page: Page): Promise<void> {
+  await mockApi(page);
+  await page.route("**/api/v1/settings", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "widgets",
+            repo_path: "acme/widgets",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+        ],
+        activity: {
+          view_mode: "threaded",
+          time_range: "7d",
+          hide_closed: false,
+          hide_bots: false,
+          collapse_threads: true,
+        },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        agents: [],
+      }),
+    });
+  });
+}
+
+async function mockActivity(page: Page, items: unknown[]): Promise<void> {
+  await page.route("**/api/v1/activity**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ capped: false, items }),
+    });
+  });
+}
+
+test.describe("threaded activity columns", () => {
+  test("item row author column shows the latest event author, not the earliest", async ({
+    page,
+  }) => {
+    await mockSettings(page);
+    // Two events on the same PR: an older opening event by "alice" and a
+    // newer review by "bob". The threaded row should attribute the activity
+    // to the most recent contributor.
+    await mockActivity(page, [
+      itemEvent({
+        id: "evt-new",
+        number: 42,
+        type: "review",
+        author: "bob",
+        authorName: "Bob Reviewer",
+        createdAt: "2026-04-27T13:00:00Z",
+        title: "Add browser regression coverage",
+      }),
+      itemEvent({
+        id: "evt-old",
+        number: 42,
+        type: "new_pr",
+        author: "alice",
+        authorName: "Alice Author",
+        createdAt: "2026-04-27T12:00:00Z",
+        title: "Add browser regression coverage",
+      }),
+    ]);
+    await page.goto("/?view=threaded");
+
+    const row = page
+      .locator(".item-row:not(.branch-activity-row)")
+      .first();
+    await expect(row).toBeVisible();
+    const authorCell = row.locator(".cell--author");
+    await expect(authorCell).toHaveText("Bob Reviewer");
+  });
+
+  test("branch commit row shows the commit author in the author column", async ({
+    page,
+  }) => {
+    await mockSettings(page);
+    await mockActivity(page, [
+      branchCommit({
+        id: "cmt-1",
+        author: "carol",
+        authorName: "Carol Committer",
+        createdAt: "2026-04-27T12:00:00Z",
+        bodyPreview: "Refresh cache warmer",
+        sha: "abcdef0123456789abcdef0123456789abcdef01",
+      }),
+    ]);
+    await page.goto("/?view=threaded");
+
+    const row = page.locator(".branch-activity-row").first();
+    await expect(row).toBeVisible();
+    await expect(row.locator(".cell--author")).toHaveText("Carol Committer");
+    await expect(row.locator(".cell--type")).toHaveText("Commit");
+  });
+
+  test("hide-org toggle swaps the repo chip between owner/name and bare name", async ({
+    page,
+  }) => {
+    await mockSettings(page);
+    await mockActivity(page, [
+      itemEvent({
+        id: "evt-only",
+        number: 7,
+        type: "comment",
+        author: "alice",
+        authorName: "Alice",
+        createdAt: "2026-04-27T12:00:00Z",
+        title: "Comment-only PR",
+      }),
+    ]);
+    // Start in ungrouped mode so the repo chip is rendered next to each row.
+    await page.goto("/?view=threaded");
+    await page.evaluate(() => {
+      localStorage.setItem("middleman:groupingMode", "flat");
+      localStorage.removeItem("middleman:hideOrgName");
+    });
+    await page.reload();
+
+    const repoLabel = page.locator(".item-row .repo-chip__label").first();
+    await expect(repoLabel).toHaveText("acme/widgets");
+
+    // Toggle "Hide org name" via the View dropdown.
+    await page.getByRole("button", { name: "View", exact: true }).click();
+    await page
+      .locator(".filter-item", { hasText: "Hide org name" })
+      .click();
+    await page.keyboard.press("Escape");
+
+    await expect(repoLabel).toHaveText("widgets");
+
+    // Reload to verify the toggle persists via localStorage.
+    await page.reload();
+    await expect(
+      page.locator(".item-row .repo-chip__label").first(),
+    ).toHaveText("widgets");
+  });
+});

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -21,6 +21,7 @@
     localDateLabel,
     parseAPITimestamp,
   } from "../utils/time.js";
+  import { repoColor } from "../utils/repo-color.js";
   import Chip from "./shared/Chip.svelte";
   import ItemKindChip from "./shared/ItemKindChip.svelte";
   import ItemStateChip from "./shared/ItemStateChip.svelte";
@@ -458,10 +459,6 @@
         || selectedItem.platformHost === item.platform_host);
   }
 
-  function handleLinkClick(e: Event, url: string): void {
-    e.stopPropagation();
-    window.open(url, "_blank", "noopener");
-  }
 </script>
 
 <div
@@ -627,105 +624,111 @@
           {/each}
         </div>
       {:else}
-        <table class="activity-table">
-          <thead>
-            <tr>
-              <th class="col-kind">Kind</th>
-              <th class="col-event">Event</th>
-              <th class="col-repo">Repository</th>
-              <th class="col-item">Item</th>
-              <th class="col-author">Author</th>
-              <th class="col-when">When</th>
-              <th class="col-link"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each flatRows as row (row.id)}
+        <div class="activity-table">
+          <div class="activity-column-headers" aria-hidden="true">
+            <span class="cell cell--caret-spacer"></span>
+            <span class="cell cell--type">Type</span>
+            <span class="cell cell--repo col-repo">Repo</span>
+            <span class="cell cell--author col-author">Author</span>
+            <span class="cell cell--title">Item</span>
+            <span class="cell cell--time col-when">When</span>
+          </div>
+          {#each flatRows as row (row.id)}
+            {@const rep = isCollapsedActivityRow(row) ? row.representative : row}
+            {@const repoStyle =
+              `color: ${repoColor(`${rep.repo_owner}/${rep.repo_name}`)}; `
+              + `background: color-mix(in srgb, `
+              + `${repoColor(`${rep.repo_owner}/${rep.repo_name}`)} 15%, transparent);`}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="activity-row"
+              class:collapsed-row={isCollapsedActivityRow(row)}
+              onclick={() =>
+                handleRowClick(isCollapsedActivityRow(row) ? row.representative : row)}
+            >
+              <span class="cell cell--caret-spacer"></span>
               {#if isCollapsedActivityRow(row)}
-                <tr class="activity-row collapsed-row" onclick={() => handleRowClick(row.representative)}>
-                  <td class="col-kind">
-                    {#if isDefaultBranchActivity(row.representative)}
-                      <Chip size="sm" uppercase={false} class="chip--muted branch-chip">Branch</Chip>
-                    {:else}
-                      <ItemKindChip kind={row.representative.item_type} />
-                    {/if}
-                  </td>
-                  <td class="col-event">
-                    <Chip
-                      size="sm"
-                      uppercase={false}
-                      class="evt-label evt-commit chip--teal"
-                    >{row.count} commits</Chip>
-                  </td>
-                  <td class="col-repo">{repoLabel(row.representative.repo_owner, row.representative.repo_name)}</td>
-                  <td class="col-item">
-                    {#if isDefaultBranchActivity(row.representative)}
-                      <span class="branch-name">{branchName(row.representative)}</span>
-                      <span class="item-title">{row.count} commits</span>
-                    {:else}
-                      <span class="item-number">#{row.representative.item_number}</span>
-                      <span class="item-title">{row.representative.item_title}</span>
-                    {/if}
-                  </td>
-                  <td class="col-author">{row.author}</td>
-                  <td class="col-when">{relativeTime(row.earliest)} - {relativeTime(row.latest)}</td>
-                  <td class="col-link">
-                    <button
-                      class="link-btn"
-                      title="Open activity"
-                      disabled={!activityLink(row.representative)}
-                      onclick={(e) => handleLinkClick(e, activityLink(row.representative))}
-                    >&#x2197;</button>
-                  </td>
-                </tr>
+                <span class="cell cell--type">
+                  {#if isDefaultBranchActivity(row.representative)}
+                    <Chip size="xs" uppercase={false} class="chip--muted branch-chip">Branch</Chip>
+                  {:else}
+                    <ItemKindChip kind={row.representative.item_type} />
+                  {/if}
+                  <Chip
+                    size="xs"
+                    uppercase={false}
+                    class="evt-label evt-commit chip--teal"
+                  >{row.count} commits</Chip>
+                </span>
+                <span class="cell cell--repo col-repo">
+                  <Chip
+                    size="xs"
+                    uppercase={false}
+                    class="repo-chip repo-tag"
+                    style={repoStyle}
+                  >
+                    <span class="repo-chip__label"
+                      >{repoLabel(row.representative.repo_owner, row.representative.repo_name)}</span>
+                  </Chip>
+                </span>
+                <span class="cell cell--author col-author">{row.author}</span>
+                <span class="cell cell--title">
+                  {#if isDefaultBranchActivity(row.representative)}
+                    <span class="item-ref">{branchName(row.representative)}</span>
+                    <span class="item-title">{row.count} commits</span>
+                  {:else}
+                    <span class="item-ref">#{row.representative.item_number}</span>
+                    <span class="item-title">{row.representative.item_title}</span>
+                  {/if}
+                </span>
+                <span class="cell cell--time col-when"
+                  >{relativeTime(row.earliest)} – {relativeTime(row.latest)}</span>
               {:else}
-                <tr class="activity-row" onclick={() => handleRowClick(row)}>
-                  <td class="col-kind">
-                    {#if isDefaultBranchActivity(row)}
-                      <Chip size="sm" uppercase={false} class="chip--muted branch-chip">Branch</Chip>
-                    {:else}
-                      <ItemKindChip kind={row.item_type} />
-                      {#if hasStateChip(row)}
-                        <ItemStateChip state={row.item_state} />
-                      {/if}
+                <span class="cell cell--type">
+                  {#if isDefaultBranchActivity(row)}
+                    <Chip size="xs" uppercase={false} class="chip--muted branch-chip">Branch</Chip>
+                  {:else}
+                    <ItemKindChip kind={row.item_type} />
+                  {/if}
+                  <Chip
+                    size="xs"
+                    uppercase={false}
+                    class={eventChipClass(row.activity_type)}
+                  >{eventLabel(row)}</Chip>
+                </span>
+                <span class="cell cell--repo col-repo">
+                  <Chip
+                    size="xs"
+                    uppercase={false}
+                    class="repo-chip repo-tag"
+                    style={repoStyle}
+                  >
+                    <span class="repo-chip__label"
+                      >{repoLabel(row.repo_owner, row.repo_name)}</span>
+                  </Chip>
+                </span>
+                <span class="cell cell--author col-author">{activityAuthor(row)}</span>
+                <span class="cell cell--title">
+                  {#if isDefaultBranchActivity(row)}
+                    <span class="item-ref">{branchName(row)}</span>
+                    {#if branchActivityDetail(row)}
+                      <span class="sha">{branchActivityDetail(row)}</span>
                     {/if}
-                  </td>
-                  <td class="col-event">
-                    <Chip
-                      size="sm"
-                      uppercase={false}
-                      class={eventChipClass(row.activity_type)}
-                    >{eventLabel(row)}</Chip>
-                  </td>
-                  <td class="col-repo">{repoLabel(row.repo_owner, row.repo_name)}</td>
-                  <td class="col-item">
-                    {#if isDefaultBranchActivity(row)}
-                      <span class="branch-name">{branchName(row)}</span>
-                      {#if branchActivityDetail(row)}
-                        <span class="sha">{branchActivityDetail(row)}</span>
-                      {/if}
-                      <span class="item-title">{branchActivityTitle(row)}</span>
-                    {:else}
-                      <span class="item-number">#{row.item_number}</span>
-                      <span class="item-title">{row.item_title}</span>
+                    <span class="item-title">{branchActivityTitle(row)}</span>
+                  {:else}
+                    {#if hasStateChip(row)}
+                      <ItemStateChip state={row.item_state} />
                     {/if}
-                  </td>
-                  <td class="col-author">{activityAuthor(row)}</td>
-                  <td class="col-when">{relativeTime(row.created_at)}</td>
-                  <td class="col-link">
-                    {#if activityLink(row)}
-                      <button
-                        class="link-btn"
-                        title="Open activity"
-                        onclick={(e) => handleLinkClick(e, activityLink(row))}
-                      >&#x2197;</button>
-                    {/if}
-                  </td>
-                </tr>
+                    <span class="item-ref">#{row.item_number}</span>
+                    <span class="item-title">{row.item_title}</span>
+                  {/if}
+                </span>
+                <span class="cell cell--time col-when">{relativeTime(row.created_at)}</span>
               {/if}
-            {/each}
-          </tbody>
-        </table>
+            </div>
+          {/each}
+        </div>
       {/if}
 
       {#if flatRows.length === 0 && !activity.isActivityLoading()}
@@ -945,48 +948,53 @@
     white-space: nowrap;
   }
 
+  /* The flat view shares the threaded view's grid layout so toggling between
+   * modes doesn't shift the columns. The first column is an 18px spacer that
+   * lines up with the threaded view's chevron caret so the type chip starts
+   * at the same x-coordinate in both layouts. Widths come from the same CSS
+   * custom properties so the column caps stay in lockstep. */
   .activity-table {
-    width: 100%;
-    border-collapse: collapse;
+    display: grid;
+    grid-template-columns:
+      18px
+      fit-content(140px)
+      fit-content(var(--threaded-col-repo-max, 220px))
+      fit-content(var(--threaded-col-author-max, 140px))
+      minmax(0, 1fr)
+      auto;
+    column-gap: 6px;
   }
 
-  .activity-table thead {
+  .cell--caret-spacer {
+    width: 18px;
+  }
+
+  .activity-column-headers {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    align-items: center;
+    padding: 6px 0 4px;
+    font-size: var(--font-size-2xs);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border-default);
     position: sticky;
     top: 0;
     background: var(--bg-primary);
     z-index: 1;
   }
 
-  .activity-table th {
-    text-align: left;
-    padding: 6px 10px;
-    font-size: var(--font-size-xs);
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-muted);
-    border-bottom: 1px solid var(--border-default);
-    white-space: nowrap;
-  }
-
-  .activity-table td {
-    padding: 5px 10px;
-    border-bottom: 1px solid var(--border-muted);
-    white-space: nowrap;
-  }
-
-  .col-item {
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 0;
-  }
-  .col-when { text-align: right; }
-  th.col-when { text-align: right; }
-  .col-link { text-align: center; }
-
   .activity-row {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    align-items: center;
+    padding: 5px 0;
     cursor: pointer;
+    border-bottom: 1px solid var(--border-muted);
     transition: background 0.1s;
   }
 
@@ -998,12 +1006,76 @@
     background: var(--bg-inset);
   }
 
-  .col-kind :global(.chip + .chip) {
-    margin-left: 3px;
+  .cell {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cell--type {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    overflow: visible;
+  }
+
+  .cell--repo {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    font-size: var(--font-size-sm);
+  }
+
+  .cell--repo :global(.repo-chip) {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .cell--repo :global(.repo-chip .repo-chip__label) {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cell--author {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .cell--title {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .item-ref {
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .item-title {
+    font-size: var(--font-size-sm);
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .cell--time {
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+    text-align: right;
+    padding-right: 4px;
   }
 
   :global(.evt-label) {
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-xs);
     color: var(--text-secondary);
   }
 
@@ -1012,50 +1084,21 @@
   :global(.evt-label.evt-commit) { color: var(--accent-teal); }
   :global(.evt-label.evt-force-push) { color: var(--accent-red); }
 
-  .col-repo {
-    color: var(--text-muted);
-    font-size: var(--font-size-sm);
-  }
-
-  .item-number {
-    color: var(--text-muted);
-    margin-right: 4px;
-  }
-
-  .branch-name,
   .sha {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  /* Compact-list-only labels (rendered by the sidebar card layout). The
+   * table layout uses .item-ref instead. */
+  .branch-name,
+  .item-number {
     color: var(--text-muted);
     margin-right: 4px;
   }
 
   :global(.branch-chip) {
     flex-shrink: 0;
-  }
-
-  .item-title {
-    color: var(--text-primary);
-  }
-
-  .col-author {
-    color: var(--text-secondary);
-    font-size: var(--font-size-sm);
-  }
-
-  .col-when {
-    color: var(--text-muted);
-    font-size: var(--font-size-sm);
-  }
-
-  .link-btn {
-    color: var(--text-muted);
-    font-size: var(--font-size-md);
-    padding: 2px 4px;
-    border-radius: var(--radius-sm);
-  }
-
-  .link-btn:hover {
-    color: var(--accent-blue);
-    background: var(--bg-surface-hover);
   }
 
   .empty-state {

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -97,7 +97,8 @@
     (EVENT_TYPES.length - activity.getEnabledEvents().size)
     + (activity.getHideClosedMerged() ? 1 : 0)
     + (activity.getHideBots() ? 1 : 0)
-    + (activity.getHideDefaultBranchActivity() ? 1 : 0),
+    + (activity.getHideDefaultBranchActivity() ? 1 : 0)
+    + (grouping.getHideOrgName() ? 1 : 0),
   );
 
   let unsubSync: (() => void) | undefined;
@@ -254,6 +255,7 @@
     activity.setHideClosedMerged(false);
     activity.setHideBots(false);
     activity.setHideDefaultBranchActivity(false);
+    grouping.setHideOrgName(false);
     applyFilters();
   }
 
@@ -301,6 +303,15 @@
           color: "var(--accent-purple)",
           onSelect: () => {
             activity.setHideBots(!activity.getHideBots());
+          },
+        },
+        {
+          id: "hide-org-name",
+          label: "Hide org name",
+          active: grouping.getHideOrgName(),
+          color: "var(--accent-blue)",
+          onSelect: () => {
+            grouping.setHideOrgName(!grouping.getHideOrgName());
           },
         },
       ],

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -227,6 +227,10 @@
     return item.activity_url || item.item_url;
   }
 
+  function repoLabel(owner: string, name: string): string {
+    return grouping.getHideOrgName() ? name : `${owner}/${name}`;
+  }
+
   const displayItems = $derived.by(() => {
     let result = activity.getActivityItems();
     const filter = activity.getItemFilter();
@@ -574,7 +578,7 @@
                   {/if}
                 </span>
                 <span class="compact-meta">
-                  <span>{row.representative.repo_owner}/{row.representative.repo_name}</span>
+                  <span>{repoLabel(row.representative.repo_owner, row.representative.repo_name)}</span>
                   <Chip
                     size="sm"
                     uppercase={false}
@@ -607,7 +611,7 @@
                   {isDefaultBranchActivity(row) ? branchActivityTitle(row) : row.item_title}
                 </span>
                 <span class="compact-meta">
-                  <span>{row.repo_owner}/{row.repo_name}</span>
+                  <span>{repoLabel(row.repo_owner, row.repo_name)}</span>
                   {#if isDefaultBranchActivity(row) && branchActivityDetail(row)}
                     <span class="sha">{branchActivityDetail(row)}</span>
                   {/if}
@@ -653,7 +657,7 @@
                       class="evt-label evt-commit chip--teal"
                     >{row.count} commits</Chip>
                   </td>
-                  <td class="col-repo">{row.representative.repo_owner}/{row.representative.repo_name}</td>
+                  <td class="col-repo">{repoLabel(row.representative.repo_owner, row.representative.repo_name)}</td>
                   <td class="col-item">
                     {#if isDefaultBranchActivity(row.representative)}
                       <span class="branch-name">{branchName(row.representative)}</span>
@@ -693,7 +697,7 @@
                       class={eventChipClass(row.activity_type)}
                     >{eventLabel(row)}</Chip>
                   </td>
-                  <td class="col-repo">{row.repo_owner}/{row.repo_name}</td>
+                  <td class="col-repo">{repoLabel(row.repo_owner, row.repo_name)}</td>
                   <td class="col-item">
                     {#if isDefaultBranchActivity(row)}
                       <span class="branch-name">{branchName(row)}</span>

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -25,6 +25,7 @@
   import Chip from "./shared/Chip.svelte";
   import ItemKindChip from "./shared/ItemKindChip.svelte";
   import ItemStateChip from "./shared/ItemStateChip.svelte";
+  import ArrowUpRightIcon from "@lucide/svelte/icons/arrow-up-right";
   import ChevronsDownUpIcon from "@lucide/svelte/icons/chevrons-down-up";
   import ChevronsUpDownIcon from "@lucide/svelte/icons/chevrons-up-down";
 
@@ -230,6 +231,11 @@
 
   function repoLabel(owner: string, name: string): string {
     return grouping.getHideOrgName() ? name : `${owner}/${name}`;
+  }
+
+  function handleLinkClick(e: Event, url: string): void {
+    e.stopPropagation();
+    if (url) window.open(url, "_blank", "noopener");
   }
 
   const displayItems = $derived.by(() => {
@@ -632,6 +638,7 @@
             <span class="cell cell--author col-author">Author</span>
             <span class="cell cell--title">Item</span>
             <span class="cell cell--time col-when">When</span>
+            <span class="cell cell--link" aria-hidden="true"></span>
           </div>
           {#each flatRows as row (row.id)}
             {@const rep = isCollapsedActivityRow(row) ? row.representative : row}
@@ -684,6 +691,19 @@
                 </span>
                 <span class="cell cell--time col-when"
                   >{relativeTime(row.earliest)} – {relativeTime(row.latest)}</span>
+                <span class="cell cell--link">
+                  {#if activityLink(row.representative)}
+                    <button
+                      class="link-btn"
+                      type="button"
+                      aria-label="Open activity in provider"
+                      title="Open activity"
+                      onclick={(e) => handleLinkClick(e, activityLink(row.representative))}
+                    >
+                      <ArrowUpRightIcon size="14" strokeWidth="2" aria-hidden="true" />
+                    </button>
+                  {/if}
+                </span>
               {:else}
                 <span class="cell cell--type">
                   {#if isDefaultBranchActivity(row)}
@@ -725,6 +745,19 @@
                   {/if}
                 </span>
                 <span class="cell cell--time col-when">{relativeTime(row.created_at)}</span>
+                <span class="cell cell--link">
+                  {#if activityLink(row)}
+                    <button
+                      class="link-btn"
+                      type="button"
+                      aria-label="Open activity in provider"
+                      title="Open activity"
+                      onclick={(e) => handleLinkClick(e, activityLink(row))}
+                    >
+                      <ArrowUpRightIcon size="14" strokeWidth="2" aria-hidden="true" />
+                    </button>
+                  {/if}
+                </span>
               {/if}
             </div>
           {/each}
@@ -961,7 +994,8 @@
       fit-content(var(--threaded-col-repo-max, 220px))
       fit-content(var(--threaded-col-author-max, 140px))
       minmax(0, 1fr)
-      auto;
+      auto
+      24px;
     column-gap: 6px;
   }
 
@@ -1071,7 +1105,36 @@
     font-size: var(--font-size-xs);
     color: var(--text-muted);
     text-align: right;
-    padding-right: 4px;
+  }
+
+  .cell--link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: visible;
+  }
+
+  .link-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    background: none;
+    border: 0;
+    padding: 2px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .link-btn:hover {
+    color: var(--accent-blue);
+    background: var(--bg-surface-hover);
+  }
+
+  .link-btn:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 1px;
   }
 
   :global(.evt-label) {

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -624,9 +624,9 @@
           {/each}
         </div>
       {:else}
-        <div class="activity-table">
-          <div class="activity-column-headers" aria-hidden="true">
-            <span class="cell cell--caret-spacer"></span>
+        <div class="activity-table" aria-label="Activity events">
+          <div class="activity-column-headers">
+            <span class="cell cell--caret-spacer" aria-hidden="true"></span>
             <span class="cell cell--type">Type</span>
             <span class="cell cell--repo col-repo">Repo</span>
             <span class="cell cell--author col-author">Author</span>

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -113,6 +113,8 @@ vi.mock("../context.js", () => ({
     grouping: {
       getGroupByRepo: () => true,
       setGroupByRepo: vi.fn(),
+      getHideOrgName: () => false,
+      setHideOrgName: vi.fn(),
     },
   }),
 }));

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -61,6 +61,7 @@ const collapseThreads = vi.hoisted(() => ({ value: false }));
 const collapseAllThreads = vi.hoisted(() => vi.fn());
 const expandAllThreads = vi.hoisted(() => vi.fn());
 const hideDefaultBranchActivity = vi.hoisted(() => ({ value: false }));
+const hideOrgName = vi.hoisted(() => ({ value: false }));
 const setActivityFilterTypes = vi.hoisted(() => vi.fn());
 
 vi.mock("../context.js", () => ({
@@ -113,8 +114,10 @@ vi.mock("../context.js", () => ({
     grouping: {
       getGroupByRepo: () => true,
       setGroupByRepo: vi.fn(),
-      getHideOrgName: () => false,
-      setHideOrgName: vi.fn(),
+      getHideOrgName: () => hideOrgName.value,
+      setHideOrgName: vi.fn((value: boolean) => {
+        hideOrgName.value = value;
+      }),
     },
   }),
 }));
@@ -124,6 +127,7 @@ describe("ActivityFeed compact mode", () => {
     viewMode.value = "flat";
     collapseThreads.value = false;
     hideDefaultBranchActivity.value = false;
+    hideOrgName.value = false;
     setActivityFilterTypes.mockClear();
     items.value = [
       activityItem("selected"),
@@ -156,6 +160,34 @@ describe("ActivityFeed compact mode", () => {
     expect(container.querySelector(".activity-table")).toBeNull();
     expect(container.querySelectorAll(".activity-compact-row")).toHaveLength(2);
     expect(screen.getByText("Add widget caching layer")).toBeTruthy();
+  });
+
+  it("respects hide org name in compact flat rows", () => {
+    hideOrgName.value = true;
+
+    const { container } = render(ActivityFeed, {
+      props: { compact: true },
+    });
+
+    const repoLabels = Array.from(
+      container.querySelectorAll(".compact-meta > span:first-child"),
+    ).map((el) => el.textContent?.trim());
+    expect(repoLabels).toEqual(["widgets", "widgets"]);
+    expect(container.textContent).not.toContain("acme/widgets");
+  });
+
+  it("respects hide org name in table flat rows", () => {
+    hideOrgName.value = true;
+
+    const { container } = render(ActivityFeed, {
+      props: { compact: false },
+    });
+
+    const repoCells = Array.from(
+      container.querySelectorAll(".activity-row .col-repo"),
+    ).map((el) => el.textContent?.trim());
+    expect(repoCells).toEqual(["widgets", "widgets"]);
+    expect(container.textContent).not.toContain("acme/widgets");
   });
 
   it("highlights all compact rows for the selected item", () => {

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -463,6 +463,7 @@
   class="threaded-view"
   class:threaded-view--compact={compact}
   class:threaded-view--grouped={grouping.getGroupByRepo()}
+  class:threaded-view--hide-org={grouping.getHideOrgName()}
 >
   {#each grouped as repoGroup (repoGroup.key)}
     <div class="repo-section">
@@ -602,9 +603,13 @@
     flex: 1;
     overflow-y: auto;
     padding: 0 16px;
-    --threaded-col-type: 84px;
-    --threaded-col-repo: 180px;
-    --threaded-col-author: 110px;
+    --threaded-col-type: 76px;
+    --threaded-col-repo: 168px;
+    --threaded-col-author: 88px;
+  }
+
+  .threaded-view--hide-org {
+    --threaded-col-repo: 116px;
   }
 
   .threaded-view--grouped {
@@ -612,9 +617,13 @@
   }
 
   .threaded-view--compact {
-    --threaded-col-type: 76px;
-    --threaded-col-repo: 110px;
-    --threaded-col-author: 88px;
+    --threaded-col-type: 70px;
+    --threaded-col-repo: 112px;
+    --threaded-col-author: 72px;
+  }
+
+  .threaded-view--compact.threaded-view--hide-org {
+    --threaded-col-repo: 80px;
   }
 
   .threaded-view--compact.threaded-view--grouped {
@@ -658,7 +667,7 @@
       minmax(0, 1fr)
       auto;
     align-items: center;
-    column-gap: 8px;
+    column-gap: 6px;
     padding: 5px 0 5px 6px;
     cursor: pointer;
     border-bottom: 1px solid var(--border-muted);

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -76,6 +76,7 @@
     repoPath: string;
     platformHost: string;
     latestTime: string;
+    latestAuthor: string;
     events: ActivityItem[];
     displayEvents: ReturnType<
       typeof collapseActivityCommitRuns
@@ -169,6 +170,7 @@
           repoPath: first.repo.repo_path,
           platformHost: first.repo.platform_host,
           latestTime: first.created_at,
+          latestAuthor: eventAuthor(first),
           events,
           displayEvents: collapseActivityCommitRuns(events),
         },
@@ -423,6 +425,16 @@
     return event.author_name || event.author;
   }
 
+  function repoLabel(owner: string, name: string): string {
+    return grouping.getHideOrgName() ? name : `${owner}/${name}`;
+  }
+
+  function branchRowAuthor(row: ActivityRow): string {
+    return isCollapsedActivityRow(row)
+      ? row.author
+      : eventAuthor(row);
+  }
+
   function eventSummary(event: ActivityItem): string {
     if (!isDefaultBranchActivity(event)) return "";
     if (isDefaultBranchForcePushActivity(event)) {
@@ -447,7 +459,11 @@
   }
 </script>
 
-<div class="threaded-view" class:threaded-view--compact={compact}>
+<div
+  class="threaded-view"
+  class:threaded-view--compact={compact}
+  class:threaded-view--grouped={grouping.getGroupByRepo()}
+>
   {#each grouped as repoGroup (repoGroup.key)}
     <div class="repo-section">
       {#if grouping.getGroupByRepo()}
@@ -468,23 +484,28 @@
             class:selected={isSelectedBranchRow(row)}
             onclick={() => handleBranchRowClick(row)}
           >
-            <span class="thread-caret-spacer" aria-hidden="true"></span>
-            <span class="branch-event-type {eventClass(item.activity_type)}">
+            <span class="thread-caret-spacer cell cell--caret" aria-hidden="true"></span>
+            <span class="branch-event-type cell cell--type {eventClass(item.activity_type)}">
               {isDefaultBranchCommitActivity(item) ? "Commit" : eventLabel(item.activity_type)}
             </span>
             {#if !grouping.getGroupByRepo()}
-              <Chip
-                size="xs"
-                uppercase={false}
-                class="repo-chip repo-tag"
-                style="color: {repoColor(`${entry.repoOwner}/${entry.repoName}`)}; background: color-mix(in srgb, {repoColor(`${entry.repoOwner}/${entry.repoName}`)} 15%, transparent);"
-              >
-                <span class="repo-chip__label">{entry.repoOwner}/{entry.repoName}</span>
-              </Chip>
+              <span class="cell cell--repo">
+                <Chip
+                  size="xs"
+                  uppercase={false}
+                  class="repo-chip repo-tag"
+                  style="color: {repoColor(`${entry.repoOwner}/${entry.repoName}`)}; background: color-mix(in srgb, {repoColor(`${entry.repoOwner}/${entry.repoName}`)} 15%, transparent);"
+                >
+                  <span class="repo-chip__label">{repoLabel(entry.repoOwner, entry.repoName)}</span>
+                </Chip>
+              </span>
             {/if}
-            <span class="item-ref">{branchName(item)}</span>
-            <span class="item-title">{branchRowTitle(row)}</span>
-            <span class="item-time">{relativeTime(entry.latestTime)}</span>
+            <span class="cell cell--author">{branchRowAuthor(row)}</span>
+            <span class="cell cell--title">
+              <span class="item-ref">{branchName(item)}</span>
+              <span class="item-title">{branchRowTitle(row)}</span>
+            </span>
+            <span class="cell cell--time">{relativeTime(entry.latestTime)}</span>
           </div>
         {:else}
           {@const itemGroup = entry.group}
@@ -497,7 +518,7 @@
           onclick={() => handleItemClick(itemGroup)}
         >
           <button
-            class="thread-caret"
+            class="thread-caret cell cell--caret"
             type="button"
             aria-label={activity.isThreadItemExpanded(key)
               ? "Collapse item activity"
@@ -514,27 +535,34 @@
               <ChevronRightIcon size="14" strokeWidth="2" aria-hidden="true" />
             {/if}
           </button>
-          <ItemKindChip
-            kind={itemGroup.itemType === "pr" ? "pr" : "issue"}
-          />
+          <span class="cell cell--type">
+            <ItemKindChip
+              kind={itemGroup.itemType === "pr" ? "pr" : "issue"}
+            />
+          </span>
           {#if !grouping.getGroupByRepo()}
-            <Chip
-              size="xs"
-              uppercase={false}
-              class="repo-chip repo-tag"
-              style="color: {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)}; background: color-mix(in srgb, {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)} 15%, transparent);"
-            >
-              <span class="repo-chip__label">{itemGroup.repoOwner}/{itemGroup.repoName}</span>
-            </Chip>
+            <span class="cell cell--repo">
+              <Chip
+                size="xs"
+                uppercase={false}
+                class="repo-chip repo-tag"
+                style="color: {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)}; background: color-mix(in srgb, {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)} 15%, transparent);"
+              >
+                <span class="repo-chip__label">{repoLabel(itemGroup.repoOwner, itemGroup.repoName)}</span>
+              </Chip>
+            </span>
           {/if}
-          {#if itemGroup.itemState === "merged"}
-            <ItemStateChip state="merged" />
-          {:else if itemGroup.itemState === "closed"}
-            <ItemStateChip state="closed" />
-          {/if}
-          <span class="item-ref">#{itemGroup.itemNumber}</span>
-          <span class="item-title">{itemGroup.itemTitle}</span>
-          <span class="item-time">{relativeTime(itemGroup.latestTime)}</span>
+          <span class="cell cell--author">{itemGroup.latestAuthor}</span>
+          <span class="cell cell--title">
+            {#if itemGroup.itemState === "merged"}
+              <ItemStateChip state="merged" />
+            {:else if itemGroup.itemState === "closed"}
+              <ItemStateChip state="closed" />
+            {/if}
+            <span class="item-ref">#{itemGroup.itemNumber}</span>
+            <span class="item-title">{itemGroup.itemTitle}</span>
+          </span>
+          <span class="cell cell--time">{relativeTime(itemGroup.latestTime)}</span>
         </div>
 
         {#if activity.isThreadItemExpanded(key)}
@@ -574,6 +602,23 @@
     flex: 1;
     overflow-y: auto;
     padding: 0 16px;
+    --threaded-col-type: 84px;
+    --threaded-col-repo: 180px;
+    --threaded-col-author: 110px;
+  }
+
+  .threaded-view--grouped {
+    --threaded-col-repo: 0px;
+  }
+
+  .threaded-view--compact {
+    --threaded-col-type: 76px;
+    --threaded-col-repo: 110px;
+    --threaded-col-author: 88px;
+  }
+
+  .threaded-view--compact.threaded-view--grouped {
+    --threaded-col-repo: 0px;
   }
 
   .repo-section {
@@ -604,13 +649,30 @@
   }
 
   .item-row {
-    display: flex;
+    display: grid;
+    grid-template-columns:
+      18px
+      var(--threaded-col-type)
+      minmax(0, var(--threaded-col-repo))
+      minmax(0, var(--threaded-col-author))
+      minmax(0, 1fr)
+      auto;
     align-items: center;
-    gap: 6px;
-    padding: 5px 0 5px 24px;
+    column-gap: 8px;
+    padding: 5px 0 5px 6px;
     cursor: pointer;
     border-bottom: 1px solid var(--border-muted);
     transition: background 0.1s;
+  }
+
+  .threaded-view--grouped .item-row {
+    grid-template-columns:
+      18px
+      var(--threaded-col-type)
+      minmax(0, var(--threaded-col-author))
+      minmax(0, 1fr)
+      auto;
+    padding-left: 24px;
   }
 
   .item-row:hover {
@@ -622,6 +684,14 @@
     box-shadow: inset 3px 0 0 var(--accent-blue);
   }
 
+  .cell {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cell--caret,
   .thread-caret {
     display: inline-flex;
     align-items: center;
@@ -629,6 +699,10 @@
     width: 18px;
     height: 18px;
     flex-shrink: 0;
+    overflow: visible;
+  }
+
+  .thread-caret {
     color: var(--text-muted);
     background: none;
     border-radius: var(--radius-sm);
@@ -645,10 +719,29 @@
     outline-offset: 1px;
   }
 
-  .thread-caret-spacer {
-    width: 18px;
-    height: 18px;
-    flex-shrink: 0;
+  .cell--type {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    overflow: visible;
+  }
+
+  .cell--repo {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .cell--author {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .cell--title {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
   }
 
   .item-ref {
@@ -663,15 +756,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex: 1;
     min-width: 0;
   }
 
-  .item-time {
+  .cell--time {
     font-size: var(--font-size-xs);
     color: var(--text-muted);
-    flex-shrink: 0;
-    margin-left: auto;
+    text-align: right;
   }
 
   .event-row {
@@ -744,13 +835,12 @@
     font-size: var(--font-size-md);
   }
 
-  :global(.repo-chip) {
-    flex-shrink: 1;
-    max-width: 40%;
+  .cell--repo :global(.repo-chip) {
     min-width: 0;
+    max-width: 100%;
   }
 
-  :global(.repo-chip) .repo-chip__label {
+  .cell--repo :global(.repo-chip .repo-chip__label) {
     display: block;
     min-width: 0;
     overflow: hidden;
@@ -768,6 +858,10 @@
 
   .threaded-view--compact .item-row {
     padding: 7px 10px;
+  }
+
+  .threaded-view--compact.threaded-view--grouped .item-row {
+    padding-left: 24px;
   }
 
   .threaded-view--compact .event-row {

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -463,7 +463,6 @@
   class="threaded-view"
   class:threaded-view--compact={compact}
   class:threaded-view--grouped={grouping.getGroupByRepo()}
-  class:threaded-view--hide-org={grouping.getHideOrgName()}
 >
   {#each grouped as repoGroup (repoGroup.key)}
     <div class="repo-section">
@@ -603,38 +602,46 @@
     flex: 1;
     overflow-y: auto;
     padding: 0 16px;
-    --threaded-col-type: 76px;
-    --threaded-col-repo: 168px;
-    --threaded-col-author: 88px;
-  }
-
-  .threaded-view--hide-org {
-    --threaded-col-repo: 116px;
-  }
-
-  .threaded-view--grouped {
-    --threaded-col-repo: 0px;
+    --threaded-col-repo-max: 220px;
+    --threaded-col-author-max: 140px;
   }
 
   .threaded-view--compact {
-    --threaded-col-type: 70px;
-    --threaded-col-repo: 112px;
-    --threaded-col-author: 72px;
+    --threaded-col-repo-max: 140px;
+    --threaded-col-author-max: 96px;
   }
 
-  .threaded-view--compact.threaded-view--hide-org {
-    --threaded-col-repo: 80px;
-  }
-
-  .threaded-view--compact.threaded-view--grouped {
-    --threaded-col-repo: 0px;
-  }
-
+  /* The section is the grid container so every `.item-row` inside shares
+   * column widths. Each non-fixed column uses `fit-content(...)` so it
+   * sizes to its widest cell content, capped to a sensible maximum. Long
+   * repo names expand the project column up to its cap; hiding the org
+   * name shrinks the column automatically because the cell content is
+   * shorter. */
   .repo-section {
+    display: grid;
+    grid-template-columns:
+      18px
+      fit-content(120px)
+      fit-content(var(--threaded-col-repo-max))
+      fit-content(var(--threaded-col-author-max))
+      minmax(0, 1fr)
+      auto;
+    column-gap: 6px;
     margin-bottom: 4px;
   }
 
+  .threaded-view--grouped .repo-section {
+    grid-template-columns:
+      18px
+      fit-content(120px)
+      fit-content(var(--threaded-col-author-max))
+      minmax(0, 1fr)
+      auto;
+    padding-left: 18px;
+  }
+
   .repo-header {
+    grid-column: 1 / -1;
     display: flex;
     align-items: center;
     gap: 8px;
@@ -659,29 +666,13 @@
 
   .item-row {
     display: grid;
-    grid-template-columns:
-      18px
-      var(--threaded-col-type)
-      minmax(0, var(--threaded-col-repo))
-      minmax(0, var(--threaded-col-author))
-      minmax(0, 1fr)
-      auto;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
     align-items: center;
-    column-gap: 6px;
-    padding: 5px 0 5px 6px;
+    padding: 5px 0;
     cursor: pointer;
     border-bottom: 1px solid var(--border-muted);
     transition: background 0.1s;
-  }
-
-  .threaded-view--grouped .item-row {
-    grid-template-columns:
-      18px
-      var(--threaded-col-type)
-      minmax(0, var(--threaded-col-author))
-      minmax(0, 1fr)
-      auto;
-    padding-left: 24px;
   }
 
   .item-row:hover {
@@ -775,6 +766,7 @@
   }
 
   .event-row {
+    grid-column: 1 / -1;
     display: flex;
     align-items: center;
     gap: 8px;

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -22,6 +22,7 @@
 
   const { grouping, activity } = getStores();
   import { repoColor } from "../utils/repo-color.js";
+  import ArrowUpRightIcon from "@lucide/svelte/icons/arrow-up-right";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
 
@@ -457,6 +458,15 @@
     if (isCollapsedActivityRow(row)) return `${row.count} commits`;
     return eventSummary(row) || eventLabel(row.activity_type);
   }
+
+  function rowLinkUrl(item: ActivityItem): string {
+    return item.activity_url || item.item_url;
+  }
+
+  function handleLinkClick(e: Event, url: string): void {
+    e.stopPropagation();
+    if (url) window.open(url, "_blank", "noopener");
+  }
 </script>
 
 <div
@@ -474,6 +484,7 @@
     <span class="cell cell--author">Author</span>
     <span class="cell cell--title">Item</span>
     <span class="cell cell--time">When</span>
+    <span class="cell cell--link" aria-hidden="true"></span>
   </div>
 
   {#each grouped as repoGroup (repoGroup.key)}
@@ -518,6 +529,19 @@
               <span class="item-title">{branchRowTitle(row)}</span>
             </span>
             <span class="cell cell--time">{relativeTime(entry.latestTime)}</span>
+            <span class="cell cell--link">
+              {#if rowLinkUrl(item)}
+                <button
+                  class="link-btn"
+                  type="button"
+                  aria-label="Open activity in provider"
+                  title="Open activity"
+                  onclick={(e) => handleLinkClick(e, rowLinkUrl(item))}
+                >
+                  <ArrowUpRightIcon size="14" strokeWidth="2" aria-hidden="true" />
+                </button>
+              {/if}
+            </span>
           </div>
         {:else}
           {@const itemGroup = entry.group}
@@ -575,6 +599,19 @@
             <span class="item-title">{itemGroup.itemTitle}</span>
           </span>
           <span class="cell cell--time">{relativeTime(itemGroup.latestTime)}</span>
+          <span class="cell cell--link">
+            {#if itemGroup.itemUrl}
+              <button
+                class="link-btn"
+                type="button"
+                aria-label="Open item in provider"
+                title="Open item"
+                onclick={(e) => handleLinkClick(e, itemGroup.itemUrl)}
+              >
+                <ArrowUpRightIcon size="14" strokeWidth="2" aria-hidden="true" />
+              </button>
+            {/if}
+          </span>
         </div>
 
         {#if activity.isThreadItemExpanded(key)}
@@ -631,7 +668,8 @@
       fit-content(var(--threaded-col-repo-max))
       fit-content(var(--threaded-col-author-max))
       minmax(0, 1fr)
-      auto;
+      auto
+      24px;
     column-gap: 6px;
     align-content: start;
   }
@@ -642,7 +680,8 @@
       fit-content(120px)
       fit-content(var(--threaded-col-author-max))
       minmax(0, 1fr)
-      auto;
+      auto
+      24px;
   }
 
   .threaded-view--compact {
@@ -803,6 +842,36 @@
     font-size: var(--font-size-xs);
     color: var(--text-muted);
     text-align: right;
+  }
+
+  .cell--link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: visible;
+  }
+
+  .link-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    background: none;
+    border: 0;
+    padding: 2px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .link-btn:hover {
+    color: var(--accent-blue);
+    background: var(--bg-surface-hover);
+  }
+
+  .link-btn:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 1px;
   }
 
   .event-row {

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -463,26 +463,25 @@
   class="threaded-view"
   class:threaded-view--compact={compact}
   class:threaded-view--grouped={grouping.getGroupByRepo()}
+  aria-label="Activity items"
 >
-  {#each grouped as repoGroup, sectionIdx (repoGroup.key)}
+  <div class="activity-column-headers">
+    <span class="cell cell--caret" aria-hidden="true"></span>
+    <span class="cell cell--type">Type</span>
+    {#if !grouping.getGroupByRepo()}
+      <span class="cell cell--repo">Repo</span>
+    {/if}
+    <span class="cell cell--author">Author</span>
+    <span class="cell cell--title">Item</span>
+    <span class="cell cell--time">When</span>
+  </div>
+
+  {#each grouped as repoGroup (repoGroup.key)}
     <div class="repo-section">
       {#if grouping.getGroupByRepo()}
         <div class="repo-header">
           <span class="repo-name">{repoGroup.repo}</span>
           <span class="repo-stats">{repoGroup.itemCount} items, {repoGroup.eventCount} events</span>
-        </div>
-      {/if}
-
-      {#if sectionIdx === 0}
-        <div class="activity-column-headers" aria-hidden="true">
-          <span class="cell cell--caret"></span>
-          <span class="cell cell--type">Type</span>
-          {#if !grouping.getGroupByRepo()}
-            <span class="cell cell--repo">Repo</span>
-          {/if}
-          <span class="cell cell--author">Author</span>
-          <span class="cell cell--title">Item</span>
-          <span class="cell cell--time">When</span>
         </div>
       {/if}
 
@@ -611,26 +610,19 @@
 </div>
 
 <style>
+  /* The threaded view is one grid so every row — column headers, item
+   * rows, and event rows alike — shares the same column widths. Sections
+   * are display: contents wrappers that exist only to keep Svelte's
+   * keyed each block stable across re-renders. fit-content keeps each
+   * non-fixed column sized to its widest cell content, capped to a
+   * sensible maximum; the cap means hiding the org name automatically
+   * shrinks the repo column because cell content is shorter. */
   .threaded-view {
     flex: 1;
     overflow-y: auto;
     padding: 0 16px;
     --threaded-col-repo-max: 220px;
     --threaded-col-author-max: 140px;
-  }
-
-  .threaded-view--compact {
-    --threaded-col-repo-max: 140px;
-    --threaded-col-author-max: 96px;
-  }
-
-  /* The section is the grid container so every `.item-row` inside shares
-   * column widths. Each non-fixed column uses `fit-content(...)` so it
-   * sizes to its widest cell content, capped to a sensible maximum. Long
-   * repo names expand the project column up to its cap; hiding the org
-   * name shrinks the column automatically because the cell content is
-   * shorter. */
-  .repo-section {
     display: grid;
     grid-template-columns:
       18px
@@ -640,17 +632,25 @@
       minmax(0, 1fr)
       auto;
     column-gap: 6px;
-    margin-bottom: 4px;
+    align-content: start;
   }
 
-  .threaded-view--grouped .repo-section {
+  .threaded-view--grouped {
     grid-template-columns:
       18px
       fit-content(120px)
       fit-content(var(--threaded-col-author-max))
       minmax(0, 1fr)
       auto;
-    padding-left: 18px;
+  }
+
+  .threaded-view--compact {
+    --threaded-col-repo-max: 140px;
+    --threaded-col-author-max: 96px;
+  }
+
+  .repo-section {
+    display: contents;
   }
 
   .repo-header {
@@ -659,10 +659,11 @@
     align-items: center;
     gap: 8px;
     padding: 8px 0 4px;
+    margin-top: 4px;
     position: sticky;
-    top: 0;
+    top: 26px;
     background: var(--bg-primary);
-    z-index: 2;
+    z-index: 1;
     border-bottom: 1px solid var(--border-default);
   }
 
@@ -703,14 +704,7 @@
     position: sticky;
     top: 0;
     background: var(--bg-primary);
-    z-index: 1;
-  }
-
-  .threaded-view--grouped .activity-column-headers {
-    /* Sit below the repo header (which is also sticky at top: 0) so both
-     * stay readable when the user scrolls long sections. */
-    top: 28px;
-    z-index: 1;
+    z-index: 2;
   }
 
   .item-row:hover {

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -649,8 +649,15 @@
     --threaded-col-author-max: 96px;
   }
 
+  /* Sections are subgrids of the view so all sections share one column
+   * track set (so the column headers' widths line up with every section),
+   * and each section is a real box so its sticky repo header is bounded
+   * by section contents instead of competing with other sections' sticky
+   * headers for the same top: 26px slot. */
   .repo-section {
-    display: contents;
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
   }
 
   .repo-header {
@@ -862,6 +869,7 @@
   }
 
   .empty-state {
+    grid-column: 1 / -1;
     padding: 40px;
     text-align: center;
     color: var(--text-muted);

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -611,9 +611,10 @@
 
 <style>
   /* The threaded view is one grid so every row — column headers, item
-   * rows, and event rows alike — shares the same column widths. Sections
-   * are display: contents wrappers that exist only to keep Svelte's
-   * keyed each block stable across re-renders. fit-content keeps each
+   * rows, and event rows alike — shares the same column widths. Each
+   * .repo-section is a subgrid that spans 1 / -1 (see its rule below),
+   * so its rows inherit the view's tracks while the section's box
+   * still bounds its sticky repo header. fit-content keeps each
    * non-fixed column sized to its widest cell content, capped to a
    * sensible maximum; the cap means hiding the org name automatically
    * shrinks the repo column because cell content is shorter. */

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -464,12 +464,25 @@
   class:threaded-view--compact={compact}
   class:threaded-view--grouped={grouping.getGroupByRepo()}
 >
-  {#each grouped as repoGroup (repoGroup.key)}
+  {#each grouped as repoGroup, sectionIdx (repoGroup.key)}
     <div class="repo-section">
       {#if grouping.getGroupByRepo()}
         <div class="repo-header">
           <span class="repo-name">{repoGroup.repo}</span>
           <span class="repo-stats">{repoGroup.itemCount} items, {repoGroup.eventCount} events</span>
+        </div>
+      {/if}
+
+      {#if sectionIdx === 0}
+        <div class="activity-column-headers" aria-hidden="true">
+          <span class="cell cell--caret"></span>
+          <span class="cell cell--type">Type</span>
+          {#if !grouping.getGroupByRepo()}
+            <span class="cell cell--repo">Repo</span>
+          {/if}
+          <span class="cell cell--author">Author</span>
+          <span class="cell cell--title">Item</span>
+          <span class="cell cell--time">When</span>
         </div>
       {/if}
 
@@ -673,6 +686,31 @@
     cursor: pointer;
     border-bottom: 1px solid var(--border-muted);
     transition: background 0.1s;
+  }
+
+  .activity-column-headers {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    align-items: center;
+    padding: 6px 0 4px;
+    font-size: var(--font-size-2xs);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border-default);
+    position: sticky;
+    top: 0;
+    background: var(--bg-primary);
+    z-index: 1;
+  }
+
+  .threaded-view--grouped .activity-column-headers {
+    /* Sit below the repo header (which is also sticky at top: 0) so both
+     * stay readable when the user scrolls long sections. */
+    top: 28px;
+    z-index: 1;
   }
 
   .item-row:hover {

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -208,7 +208,7 @@
         owner: entryRepoOwner(entry),
         name: entryRepoName(entry),
       });
-      repoLabels.set(repoKey, `${entryRepoOwner(entry)}/${entryRepoName(entry)}`);
+      repoLabels.set(repoKey, repoLabel(entryRepoOwner(entry), entryRepoName(entry)));
       let bucket = repoMap.get(repoKey);
       if (!bucket) {
         bucket = [];

--- a/packages/ui/src/components/ActivityThreaded.test.ts
+++ b/packages/ui/src/components/ActivityThreaded.test.ts
@@ -57,11 +57,16 @@ function branchActivityItem(
 }
 
 const expanded = vi.hoisted(() => ({ value: true }));
+const groupByRepo = vi.hoisted(() => ({ value: false }));
+const hideOrgName = vi.hoisted(() => ({ value: false }));
 const toggleThreadItem = vi.hoisted(() => vi.fn());
 
 vi.mock("../context.js", () => ({
   getStores: () => ({
-    grouping: { getGroupByRepo: () => false },
+    grouping: {
+      getGroupByRepo: () => groupByRepo.value,
+      getHideOrgName: () => hideOrgName.value,
+    },
     activity: {
       isThreadItemExpanded: () => expanded.value,
       toggleThreadItem,
@@ -73,6 +78,8 @@ describe("ActivityThreaded collapse", () => {
   afterEach(() => {
     cleanup();
     expanded.value = true;
+    groupByRepo.value = false;
+    hideOrgName.value = false;
     toggleThreadItem.mockClear();
   });
 
@@ -224,6 +231,55 @@ describe("ActivityThreaded collapse", () => {
     expect(
       container.querySelector(".branch-activity-row.selected"),
     ).not.toBeNull();
+  });
+
+  it("shows the latest event author on the item row", () => {
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [
+          activityItem("c-late", {
+            created_at: "2026-04-27T13:00:00Z",
+            author: "bob",
+            author_name: "Bob Example",
+          }),
+          activityItem("c-early", {
+            created_at: "2026-04-27T12:00:00Z",
+            author: "alice",
+            author_name: "Alice Example",
+          }),
+        ],
+        onSelectItem: undefined,
+      },
+    });
+
+    const row = container.querySelector(".item-row:not(.branch-activity-row)");
+    expect(row).not.toBeNull();
+    const authorCell = row?.querySelector(".cell--author");
+    expect(authorCell?.textContent?.trim()).toBe("Bob Example");
+  });
+
+  it("shows the commit author on branch rows", () => {
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [branchActivityItem("c1")],
+        onSelectItem: undefined,
+      },
+    });
+
+    const row = container.querySelector(".branch-activity-row");
+    const authorCell = row?.querySelector(".cell--author");
+    expect(authorCell?.textContent?.trim()).toBe("Alice Example");
+  });
+
+  it("shows just the repo name when hideOrgName is on", () => {
+    hideOrgName.value = true;
+    const { container } = render(ActivityThreaded, {
+      props: { items: [activityItem("c1")], onSelectItem: undefined },
+    });
+    const label = container.querySelector(
+      ".repo-chip.repo-tag .repo-chip__label",
+    );
+    expect(label?.textContent).toBe("widgets");
   });
 
   it("keeps force-push rows as provider compare links", async () => {

--- a/packages/ui/src/components/ActivityThreaded.test.ts
+++ b/packages/ui/src/components/ActivityThreaded.test.ts
@@ -282,6 +282,19 @@ describe("ActivityThreaded collapse", () => {
     expect(label?.textContent).toBe("widgets");
   });
 
+  it("shows just the repo name in grouped headers when hideOrgName is on", () => {
+    groupByRepo.value = true;
+    hideOrgName.value = true;
+
+    const { container } = render(ActivityThreaded, {
+      props: { items: [activityItem("c1")], onSelectItem: undefined },
+    });
+
+    const repoName = container.querySelector(".repo-header .repo-name");
+    expect(repoName?.textContent).toBe("widgets");
+    expect(container.textContent).not.toContain("acme/widgets");
+  });
+
   it("keeps force-push rows as provider compare links", async () => {
     const onSelectBranchCommit = vi.fn();
     const open = vi

--- a/packages/ui/src/stores/grouping.svelte.ts
+++ b/packages/ui/src/stores/grouping.svelte.ts
@@ -1,6 +1,7 @@
 export type GroupingMode = "flat" | "byRepo" | "byWorkflow";
 
 const STORAGE_KEY = "middleman:groupingMode";
+const HIDE_ORG_KEY = "middleman:hideOrgName";
 
 // Legacy key for backward-compat reads.
 const LEGACY_KEY = "middleman:groupByRepo";
@@ -24,8 +25,17 @@ function readFromStorage(): GroupingMode {
   }
 }
 
+function readHideOrgNameFromStorage(): boolean {
+  try {
+    return localStorage.getItem(HIDE_ORG_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
 export function createGroupingStore() {
   let mode = $state<GroupingMode>(readFromStorage());
+  let hideOrgName = $state<boolean>(readHideOrgNameFromStorage());
 
   function getGroupingMode(): GroupingMode {
     return mode;
@@ -50,11 +60,26 @@ export function createGroupingStore() {
     setGroupingMode(value ? "byRepo" : "flat");
   }
 
+  function getHideOrgName(): boolean {
+    return hideOrgName;
+  }
+
+  function setHideOrgName(value: boolean): void {
+    hideOrgName = value;
+    try {
+      localStorage.setItem(HIDE_ORG_KEY, value ? "1" : "0");
+    } catch {
+      // localStorage unavailable.
+    }
+  }
+
   return {
     getGroupingMode,
     setGroupingMode,
     getGroupByRepo,
     setGroupByRepo,
+    getHideOrgName,
+    setHideOrgName,
   };
 }
 

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -23,7 +23,7 @@
     buildMobileActivityRepoOptions,
   } from "./mobileActivityRepoOptions.js";
 
-  const { activity, settings, sync } = getStores();
+  const { activity, settings, sync, grouping } = getStores();
 
   interface Props {
     selectedRepo?: string | undefined;
@@ -215,6 +215,10 @@
     applyFilters();
   }
 
+  function toggleHideOrgName(): void {
+    grouping.setHideOrgName(!grouping.getHideOrgName());
+  }
+
   function handleSearchInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
     searchInput = value;
@@ -294,6 +298,7 @@
   }
 
   function repoLabel(item: ActivityItem): string {
+    if (grouping.getHideOrgName()) return item.repo.name;
     return `${item.repo.platform_host}/${item.repo.repo_path}`;
   }
 
@@ -388,6 +393,14 @@
         aria-pressed={activity.getHideDefaultBranchActivity()}
         onclick={toggleHideDefaultBranchActivity}
       >Hide branch</button>
+
+      <button
+        type="button"
+        class="mobile-filter-toggle"
+        class:active={grouping.getHideOrgName()}
+        aria-pressed={grouping.getHideOrgName()}
+        onclick={toggleHideOrgName}
+      >Hide org</button>
     </div>
 
 

--- a/packages/ui/src/views/MobileActivityView.test.ts
+++ b/packages/ui/src/views/MobileActivityView.test.ts
@@ -40,6 +40,10 @@ function branchActivityItem(
 
 const items = vi.hoisted(() => ({ value: [] as ActivityItem[] }));
 const onSelectItem = vi.hoisted(() => vi.fn());
+const hideOrgName = vi.hoisted(() => ({ value: false }));
+const setHideOrgName = vi.hoisted(() => vi.fn((value: boolean) => {
+  hideOrgName.value = value;
+}));
 
 vi.mock("../context.js", () => ({
   getStores: () => ({
@@ -76,13 +80,19 @@ vi.mock("../context.js", () => ({
     sync: {
       subscribeSyncComplete: vi.fn(() => () => undefined),
     },
+    grouping: {
+      getHideOrgName: () => hideOrgName.value,
+      setHideOrgName,
+    },
   }),
 }));
 
 describe("MobileActivityView branch activity", () => {
   beforeEach(() => {
     items.value = [branchActivityItem("branch-commit")];
+    hideOrgName.value = false;
     onSelectItem.mockClear();
+    setHideOrgName.mockClear();
   });
 
   afterEach(() => {
@@ -101,6 +111,44 @@ describe("MobileActivityView branch activity", () => {
     expect(card?.textContent).not.toContain("#0");
     expect(card?.querySelector(".chip--kind-pr")).toBeNull();
     expect(card?.querySelector(".chip--kind-issue")).toBeNull();
+  });
+
+  it("uses the full hosted repo path by default", () => {
+    const { container } = render(MobileActivityView, {
+      props: { onSelectItem },
+    });
+
+    const repoLabel = container.querySelector(
+      ".mobile-activity-card__meta span",
+    );
+    expect(repoLabel?.textContent).toBe("github.com/acme/widgets");
+  });
+
+  it("respects hide org name in mobile activity cards", () => {
+    hideOrgName.value = true;
+
+    const { container } = render(MobileActivityView, {
+      props: { onSelectItem },
+    });
+
+    const repoLabel = container.querySelector(
+      ".mobile-activity-card__meta span",
+    );
+    expect(repoLabel?.textContent).toBe("widgets");
+    expect(container.textContent).not.toContain("github.com/acme/widgets");
+  });
+
+  it("exposes a mobile hide org toggle", async () => {
+    const { getByRole } = render(MobileActivityView, {
+      props: { onSelectItem },
+    });
+
+    const button = getByRole("button", { name: "Hide org" });
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+
+    await fireEvent.click(button);
+
+    expect(setHideOrgName).toHaveBeenCalledWith(true);
   });
 
   it("does not select a PR or issue when tapping a branch event", async () => {


### PR DESCRIPTION
## Summary

- Reshape the threaded activity view into aligned columns (type · repo · author · item · time) so PR, issue, and commit rows line up instead of drifting with each row's prefix length.
- Show the latest event author on each PR/issue row (last commenter, reviewer, or commit author); branch-commit rows show the commit author.
- Add a "Hide org name" toggle in the View → Visibility section that strips the owner from repo chips and grouped repo headers and narrows the project column to free up horizontal space for titles.
- Unify the flat ("table") view with the threaded view: same column order, same widths (driven by shared `--threaded-col-*` custom properties), same colored repo chip, and a leading caret-spacer so the type chip lands at the same x in both modes.
- Add a sticky column-header row to both views. In threaded grouped mode the headers sit at the top of the scroll container and remain visible across sections; each repo header is bounded to its own section so they don't overlap during the scroll hand-off.
- Restore the row-level "Open activity" affordance (Lucide arrow-up-right icon) on every row in both views so users can jump straight to the provider URL without going through the drawer; the button stops propagation so it does not trigger the row's own select/expand.

### Flat view

![activity-flat.png](https://github.com/user-attachments/assets/e1bf5ff5-7963-4958-aaae-b4bab157ab90)

### Threaded, grouped by repo

![activity-threaded-grouped.png](https://github.com/user-attachments/assets/43af2653-19be-4129-bc0f-43b8a9847bf9)

### Threaded, ungrouped

![activity-threaded-ungrouped.png](https://github.com/user-attachments/assets/f2c2137e-ca92-47a4-a3c9-5a2cc90929a6)

### Threaded grouped, scrolled mid-list (column header stays sticky, repo headers don't overlap)

![activity-threaded-grouped-scrolled.png](https://github.com/user-attachments/assets/e49772a1-76a7-4ae6-a2a5-98ab0bedc9f5)