### PR TITLE
fix: queue subprocesses when limiter is full

### DIFF
--- a/internal/procutil/limiter_test.go
+++ b/internal/procutil/limiter_test.go
@@ -1,0 +1,46 @@
+package procutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiterWaitsForReleaseWhenAtCapacity(t *testing.T) {
+	require := require.New(t)
+
+	limiter := NewLimiter(1)
+	firstRelease, err := limiter.TryAcquire(context.Background(), "first subprocess")
+	require.NoError(err)
+	defer firstRelease()
+
+	type acquireResult struct {
+		release func()
+		err     error
+	}
+	acquired := make(chan acquireResult, 1)
+	go func() {
+		release, acquireErr := limiter.TryAcquire(t.Context(), "second subprocess")
+		acquired <- acquireResult{release: release, err: acquireErr}
+	}()
+
+	select {
+	case got := <-acquired:
+		require.NoError(got.err, "second acquire should wait for capacity instead of erroring")
+		require.Fail("second acquire returned before capacity was released")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	firstRelease()
+
+	select {
+	case got := <-acquired:
+		require.NoError(got.err)
+		require.NotNil(got.release)
+		got.release()
+	case <-time.After(time.Second):
+		require.Fail("second acquire did not complete after capacity was released")
+	}
+}

--- a/internal/procutil/limiter_test.go
+++ b/internal/procutil/limiter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	Assert "github.com/stretchr/testify/assert"
@@ -13,57 +14,104 @@ import (
 func TestLimiterWaitsForReleaseWhenAtCapacity(t *testing.T) {
 	require := require.New(t)
 
-	limiter := NewLimiter(1)
-	firstRelease, err := limiter.TryAcquire(context.Background(), "first subprocess")
-	require.NoError(err)
-	defer firstRelease()
-
 	type acquireResult struct {
 		release func()
 		err     error
 	}
-	acquired := make(chan acquireResult, 1)
-	go func() {
-		release, acquireErr := limiter.TryAcquire(t.Context(), "second subprocess")
-		acquired <- acquireResult{release: release, err: acquireErr}
-	}()
 
-	select {
-	case got := <-acquired:
-		require.NoError(got.err, "second acquire should wait for capacity instead of erroring")
-		require.Fail("second acquire returned before capacity was released")
-	case <-time.After(25 * time.Millisecond):
-	}
+	synctest.Test(t, func(t *testing.T) {
+		limiter := NewLimiter(1)
+		firstRelease, err := limiter.TryAcquire(context.Background(), "first subprocess")
+		require.NoError(err)
+		defer firstRelease()
 
-	firstRelease()
+		acquired := make(chan acquireResult, 1)
+		go func() {
+			release, acquireErr := limiter.TryAcquire(
+				context.Background(), "second subprocess",
+			)
+			acquired <- acquireResult{release: release, err: acquireErr}
+		}()
 
-	select {
-	case got := <-acquired:
-		require.NoError(got.err)
-		require.NotNil(got.release)
-		got.release()
-	case <-time.After(time.Second):
-		require.Fail("second acquire did not complete after capacity was released")
-	}
+		synctest.Wait()
+		select {
+		case got := <-acquired:
+			require.NoError(got.err, "second acquire should wait for capacity instead of erroring")
+			require.Fail("second acquire returned before capacity was released")
+		default:
+		}
+
+		firstRelease()
+		synctest.Wait()
+
+		select {
+		case got := <-acquired:
+			require.NoError(got.err)
+			require.NotNil(got.release)
+			got.release()
+		default:
+			require.Fail("second acquire did not complete after capacity was released")
+		}
+	})
 }
 
 func TestLimiterAcquireTimeoutIsResourceExhausted(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
-	limiter := NewLimiter(1)
+	type acquireResult struct {
+		release func()
+		err     error
+	}
+
+	var got acquireResult
+	synctest.Test(t, func(t *testing.T) {
+		limiter := NewLimiterWithAcquireTimeout(1, 10*time.Second)
+		firstRelease, err := limiter.TryAcquire(context.Background(), "first subprocess")
+		require.NoError(err)
+		defer firstRelease()
+
+		acquired := make(chan acquireResult, 1)
+		go func() {
+			release, acquireErr := limiter.TryAcquire(
+				context.Background(), "second subprocess",
+			)
+			acquired <- acquireResult{release: release, err: acquireErr}
+		}()
+
+		time.Sleep(10 * time.Second)
+		synctest.Wait()
+		select {
+		case got = <-acquired:
+		default:
+			require.Fail("second acquire did not time out")
+		}
+	})
+
+	require.Error(got.err)
+	require.Nil(got.release)
+	assert.ErrorIs(got.err, ErrProcessLimitReached)
+	assert.True(errors.Is(got.err, context.DeadlineExceeded))
+	assert.True(IsResourceExhausted(got.err))
+	assert.Contains(got.err.Error(), "second subprocess")
+}
+
+func TestLimiterAcquirePreservesCallerCancellation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	limiter := NewLimiterWithAcquireTimeout(1, time.Second)
 	firstRelease, err := limiter.TryAcquire(context.Background(), "first subprocess")
 	require.NoError(err)
 	defer firstRelease()
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
-	defer cancel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
 
 	release, err := limiter.TryAcquire(ctx, "second subprocess")
 	require.Error(err)
 	require.Nil(release)
 	assert.ErrorIs(err, ErrProcessLimitReached)
-	assert.True(errors.Is(err, context.DeadlineExceeded))
+	assert.True(errors.Is(err, context.Canceled))
 	assert.True(IsResourceExhausted(err))
-	assert.Contains(err.Error(), "second subprocess")
 }

--- a/internal/procutil/limiter_test.go
+++ b/internal/procutil/limiter_test.go
@@ -115,3 +115,24 @@ func TestLimiterAcquirePreservesCallerCancellation(t *testing.T) {
 	assert.True(errors.Is(err, context.Canceled))
 	assert.True(IsResourceExhausted(err))
 }
+
+func TestLimiterAcquireCanceledContextWithCapacityIsNotResourceExhausted(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	limiter := NewLimiterWithAcquireTimeout(1, time.Second)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	release, err := limiter.TryAcquire(ctx, "available subprocess")
+	require.Error(err)
+	require.Nil(release)
+	assert.True(errors.Is(err, context.Canceled))
+	assert.False(errors.Is(err, ErrProcessLimitReached))
+	assert.False(IsResourceExhausted(err))
+
+	release, err = limiter.TryAcquire(context.Background(), "subsequent subprocess")
+	require.NoError(err)
+	require.NotNil(release)
+	release()
+}

--- a/internal/procutil/limiter_test.go
+++ b/internal/procutil/limiter_test.go
@@ -2,9 +2,11 @@ package procutil
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,4 +45,25 @@ func TestLimiterWaitsForReleaseWhenAtCapacity(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail("second acquire did not complete after capacity was released")
 	}
+}
+
+func TestLimiterAcquireTimeoutIsResourceExhausted(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	limiter := NewLimiter(1)
+	firstRelease, err := limiter.TryAcquire(context.Background(), "first subprocess")
+	require.NoError(err)
+	defer firstRelease()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	defer cancel()
+
+	release, err := limiter.TryAcquire(ctx, "second subprocess")
+	require.Error(err)
+	require.Nil(release)
+	assert.ErrorIs(err, ErrProcessLimitReached)
+	assert.True(errors.Is(err, context.DeadlineExceeded))
+	assert.True(IsResourceExhausted(err))
+	assert.Contains(err.Error(), "second subprocess")
 }

--- a/internal/procutil/limiter_test.go
+++ b/internal/procutil/limiter_test.go
@@ -2,7 +2,6 @@ package procutil
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -90,8 +89,8 @@ func TestLimiterAcquireTimeoutIsResourceExhausted(t *testing.T) {
 
 	require.Error(got.err)
 	require.Nil(got.release)
-	assert.ErrorIs(got.err, ErrProcessLimitReached)
-	assert.True(errors.Is(got.err, context.DeadlineExceeded))
+	require.ErrorIs(got.err, ErrProcessLimitReached)
+	require.ErrorIs(got.err, context.DeadlineExceeded)
 	assert.True(IsResourceExhausted(got.err))
 	assert.Contains(got.err.Error(), "second subprocess")
 }
@@ -111,8 +110,8 @@ func TestLimiterAcquirePreservesCallerCancellation(t *testing.T) {
 	release, err := limiter.TryAcquire(ctx, "second subprocess")
 	require.Error(err)
 	require.Nil(release)
-	assert.ErrorIs(err, ErrProcessLimitReached)
-	assert.True(errors.Is(err, context.Canceled))
+	require.ErrorIs(err, ErrProcessLimitReached)
+	require.ErrorIs(err, context.Canceled)
 	assert.True(IsResourceExhausted(err))
 }
 
@@ -127,8 +126,8 @@ func TestLimiterAcquireCanceledContextWithCapacityIsNotResourceExhausted(t *test
 	release, err := limiter.TryAcquire(ctx, "available subprocess")
 	require.Error(err)
 	require.Nil(release)
-	assert.True(errors.Is(err, context.Canceled))
-	assert.False(errors.Is(err, ErrProcessLimitReached))
+	require.ErrorIs(err, context.Canceled)
+	require.NotErrorIs(err, ErrProcessLimitReached)
 	assert.False(IsResourceExhausted(err))
 
 	release, err = limiter.TryAcquire(context.Background(), "subsequent subprocess")

--- a/internal/procutil/procutil.go
+++ b/internal/procutil/procutil.go
@@ -50,6 +50,14 @@ func (l *Limiter) TryAcquire(
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if l.sem.TryAcquire(1) {
+		if err := ctx.Err(); err != nil {
+			l.sem.Release(1)
+			return nil, err
+		}
+		return releaseOnce(l.sem), nil
+	}
+
 	acquireCtx := ctx
 	cancel := func() {}
 	if l.acquireTimeout > 0 {
@@ -66,12 +74,16 @@ func (l *Limiter) TryAcquire(
 		}
 		return nil, fmt.Errorf("%w: %w", ErrProcessLimitReached, err)
 	}
+	return releaseOnce(l.sem), nil
+}
+
+func releaseOnce(sem *semaphore.Weighted) func() {
 	var once sync.Once
 	return func() {
 		once.Do(func() {
-			l.sem.Release(1)
+			sem.Release(1)
 		})
-	}, nil
+	}
 }
 
 var (

--- a/internal/procutil/procutil.go
+++ b/internal/procutil/procutil.go
@@ -32,15 +32,18 @@ func NewLimiter(max int) *Limiter {
 }
 
 func (l *Limiter) TryAcquire(
-	_ context.Context, reason string,
+	ctx context.Context, reason string,
 ) (func(), error) {
-	if !l.sem.TryAcquire(1) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := l.sem.Acquire(ctx, 1); err != nil {
 		if reason != "" {
 			return nil, fmt.Errorf(
-				"%w: %s", ErrProcessLimitReached, reason,
+				"wait for subprocess capacity %s: %w", reason, err,
 			)
 		}
-		return nil, ErrProcessLimitReached
+		return nil, err
 	}
 	var once sync.Once
 	return func() {

--- a/internal/procutil/procutil.go
+++ b/internal/procutil/procutil.go
@@ -40,10 +40,11 @@ func (l *Limiter) TryAcquire(
 	if err := l.sem.Acquire(ctx, 1); err != nil {
 		if reason != "" {
 			return nil, fmt.Errorf(
-				"wait for subprocess capacity %s: %w", reason, err,
+				"%w: wait for subprocess capacity %s: %w",
+				ErrProcessLimitReached, reason, err,
 			)
 		}
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrProcessLimitReached, err)
 	}
 	var once sync.Once
 	return func() {

--- a/internal/procutil/procutil.go
+++ b/internal/procutil/procutil.go
@@ -10,24 +10,37 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"golang.org/x/sync/semaphore"
 )
 
 const DefaultMaxProcesses = 32
 
+// DefaultAcquireTimeout is the maximum time a subprocess waits for limiter
+// capacity before surfacing host process exhaustion.
+const DefaultAcquireTimeout = 5 * time.Second
+
 var ErrProcessLimitReached = errors.New("host process limit reached")
 
 type Limiter struct {
-	sem *semaphore.Weighted
+	sem            *semaphore.Weighted
+	acquireTimeout time.Duration
 }
 
 func NewLimiter(max int) *Limiter {
+	return NewLimiterWithAcquireTimeout(max, DefaultAcquireTimeout)
+}
+
+// NewLimiterWithAcquireTimeout creates a subprocess limiter with bounded
+// acquisition waits. Non-positive timeouts wait until the caller's context ends.
+func NewLimiterWithAcquireTimeout(max int, acquireTimeout time.Duration) *Limiter {
 	if max <= 0 {
 		max = 1
 	}
 	return &Limiter{
-		sem: semaphore.NewWeighted(int64(max)),
+		sem:            semaphore.NewWeighted(int64(max)),
+		acquireTimeout: acquireTimeout,
 	}
 }
 
@@ -37,7 +50,14 @@ func (l *Limiter) TryAcquire(
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := l.sem.Acquire(ctx, 1); err != nil {
+	acquireCtx := ctx
+	cancel := func() {}
+	if l.acquireTimeout > 0 {
+		acquireCtx, cancel = context.WithTimeout(ctx, l.acquireTimeout)
+	}
+	defer cancel()
+
+	if err := l.sem.Acquire(acquireCtx, 1); err != nil {
 		if reason != "" {
 			return nil, fmt.Errorf(
 				"%w: wait for subprocess capacity %s: %w",
@@ -54,12 +74,35 @@ func (l *Limiter) TryAcquire(
 	}, nil
 }
 
-var defaultLimiter = NewLimiter(DefaultMaxProcesses)
+var (
+	defaultLimiterMu sync.RWMutex
+	defaultLimiter   = NewLimiter(DefaultMaxProcesses)
+)
 
 func TryAcquire(
 	ctx context.Context, reason string,
 ) (func(), error) {
-	return defaultLimiter.TryAcquire(ctx, reason)
+	defaultLimiterMu.RLock()
+	limiter := defaultLimiter
+	defaultLimiterMu.RUnlock()
+	return limiter.TryAcquire(ctx, reason)
+}
+
+// SetDefaultLimiterForTest replaces the package default limiter and returns a
+// restore function for tests that need deterministic process-capacity pressure.
+func SetDefaultLimiterForTest(limiter *Limiter) func() {
+	if limiter == nil {
+		panic("nil procutil limiter")
+	}
+	defaultLimiterMu.Lock()
+	previous := defaultLimiter
+	defaultLimiter = limiter
+	defaultLimiterMu.Unlock()
+	return func() {
+		defaultLimiterMu.Lock()
+		defaultLimiter = previous
+		defaultLimiterMu.Unlock()
+	}
 }
 
 func Command(name string, arg ...string) *exec.Cmd {

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -30,6 +30,7 @@ import (
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/gitclone"
 	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
 
@@ -1745,6 +1746,133 @@ func TestWorkspaceSetupResourceExhaustionGetsHelpfulErrorViaAPI(t *testing.T) {
 	require.NotNil(failed)
 	require.NotNil(failed.ErrorMessage)
 	assert.Contains(*failed.ErrorMessage, "host process limit reached")
+}
+
+func TestWorkspaceListWaitsForSubprocessCapacityThenCompletesViaAPI(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	restoreLimiter := procutil.SetDefaultLimiterForTest(
+		procutil.NewLimiterWithAcquireTimeout(1, 500*time.Millisecond),
+	)
+	t.Cleanup(restoreLimiter)
+
+	client, _, _ := setupWrapperServer(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	waitForWorkspaceReady(t, ctx, client, createResp.JSON202.Id)
+
+	releaseHeld, err := procutil.TryAcquire(
+		context.Background(), "test-held subprocess capacity",
+	)
+	require.NoError(err)
+	defer releaseHeld()
+
+	type listResult struct {
+		resp *http.Response
+		err  error
+	}
+	listDone := make(chan listResult, 1)
+	go func() {
+		resp, listErr := client.HTTP.ListWorkspaces(ctx)
+		listDone <- listResult{resp: resp, err: listErr}
+	}()
+
+	select {
+	case got := <-listDone:
+		if got.resp != nil && got.resp.Body != nil {
+			got.resp.Body.Close()
+		}
+		require.Fail("workspace list returned before subprocess capacity was released")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseHeld()
+
+	select {
+	case got := <-listDone:
+		require.NoError(got.err)
+		defer got.resp.Body.Close()
+		require.Equal(http.StatusOK, got.resp.StatusCode)
+
+		var listed struct {
+			Workspaces []struct {
+				ID string `json:"id"`
+			} `json:"workspaces"`
+		}
+		require.NoError(json.NewDecoder(got.resp.Body).Decode(&listed))
+		require.Len(listed.Workspaces, 1)
+		assert.Equal(createResp.JSON202.Id, listed.Workspaces[0].ID)
+	case <-time.After(time.Second):
+		require.Fail("workspace list did not complete after subprocess capacity was released")
+	}
+}
+
+func TestWorkspaceSetupLimiterTimeoutSurfacesResourceExhaustionViaAPI(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	restoreLimiter := procutil.SetDefaultLimiterForTest(
+		procutil.NewLimiterWithAcquireTimeout(1, 25*time.Millisecond),
+	)
+	t.Cleanup(restoreLimiter)
+
+	client, _, _ := setupWrapperServer(t)
+	ctx := context.Background()
+
+	releaseHeld, err := procutil.TryAcquire(
+		context.Background(), "test-held subprocess capacity",
+	)
+	require.NoError(err)
+	defer releaseHeld()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	var failed *generated.WorkspaceResponse
+	require.Eventually(
+		func() bool {
+			getResp, getErr := client.HTTP.GetWorkspaceWithResponse(
+				ctx, createResp.JSON202.Id,
+			)
+			require.NoError(getErr)
+			if getResp.StatusCode() != http.StatusOK || getResp.JSON200 == nil {
+				return false
+			}
+			if getResp.JSON200.Status != "error" {
+				return false
+			}
+			failed = getResp.JSON200
+			return true
+		},
+		5*time.Second, 25*time.Millisecond,
+	)
+	require.NotNil(failed)
+	require.NotNil(failed.ErrorMessage)
+	assert.Contains(*failed.ErrorMessage, "host process limit reached")
+	assert.Contains(*failed.ErrorMessage, "subprocess capacity")
 }
 
 // TestReadTmuxRecordPreservesEmptyArgs pins down the parser's


### PR DESCRIPTION
- Queue subprocess launches on the in-process limiter instead of returning host process limit errors when capacity is full.
- Preserve real resource exhaustion handling for fork/exec failures.