### PR TITLE
fix: keep pty sockets within macOS path limits

### DIFF
--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -90,7 +90,7 @@ func RunOwner(ctx context.Context, opts Options) error {
 		return err
 	}
 	if paths.SocketDir != "" {
-		if err := createPrivateDir(paths.SocketDir); err != nil {
+		if err := createPrivateSocketDir(paths.SocketDir); err != nil {
 			killOwnerProcess(cmd.Process)
 			_ = p.Close()
 			return err

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -590,7 +590,7 @@ func TestExternalManagerAttachmentWritesUseAttachConnection(t *testing.T) {
 	require.NoError(err)
 	require.NoError(createPrivateDir(paths.Dir))
 	if paths.SocketDir != "" {
-		require.NoError(createPrivateDir(paths.SocketDir))
+		require.NoError(createPrivateSocketDir(paths.SocketDir))
 	}
 
 	listener, err := net.Listen("unix", paths.Socket)

--- a/internal/ptyowner/path_security_other.go
+++ b/internal/ptyowner/path_security_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package ptyowner
+
+func createPrivateSocketDir(path string) error {
+	return createPrivateDir(path)
+}

--- a/internal/ptyowner/path_security_unix.go
+++ b/internal/ptyowner/path_security_unix.go
@@ -1,0 +1,47 @@
+//go:build unix
+
+package ptyowner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func createPrivateSocketDir(path string) error {
+	if err := os.Mkdir(path, 0o700); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrExist) {
+		return err
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing fallback socket dir symlink %s", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("fallback socket path is not a directory: %s", path)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("cannot inspect fallback socket dir ownership: %s", path)
+	}
+	currentUID := uint32(os.Geteuid())
+	if stat.Uid != currentUID {
+		return fmt.Errorf(
+			"fallback socket dir %s is owned by uid %d, not current uid %d",
+			path, stat.Uid, currentUID,
+		)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf(
+			"fallback socket dir %s has permissions %03o; expected private directory",
+			path, info.Mode().Perm(),
+		)
+	}
+	return nil
+}

--- a/internal/ptyowner/paths.go
+++ b/internal/ptyowner/paths.go
@@ -37,7 +37,7 @@ func NewSessionPaths(root, session string) (SessionPaths, error) {
 	socket := filepath.Join(root, "sock-"+sessionSocketHash(session))
 	socketDir := ""
 	if len(socket) > maxUnixSocketPathLen {
-		socketDir = filepath.Join(os.TempDir(), "middleman-pty-"+sessionSocketHash(root+"-"+session))
+		socketDir = fallbackSocketDir(root, session, os.TempDir())
 		socket = filepath.Join(socketDir, "sock")
 	}
 	return SessionPaths{
@@ -51,6 +51,16 @@ func NewSessionPaths(root, session string) (SessionPaths, error) {
 }
 
 const maxUnixSocketPathLen = 100
+
+func fallbackSocketDir(root, session, primaryTempDir string) string {
+	for _, base := range []string{primaryTempDir, "/private/tmp", "/tmp"} {
+		candidate := filepath.Join(base, "middleman-pty-"+sessionSocketHash(root+"-"+session))
+		if len(filepath.Join(candidate, "sock")) <= maxUnixSocketPathLen {
+			return candidate
+		}
+	}
+	return filepath.Join("/tmp", "middleman-pty-"+sessionSocketHash(root+"-"+session))
+}
 
 func sessionDirName(session string) string {
 	if strings.ContainsAny(session, `<>:"|?*`) {

--- a/internal/ptyowner/paths.go
+++ b/internal/ptyowner/paths.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -53,7 +54,16 @@ func NewSessionPaths(root, session string) (SessionPaths, error) {
 const maxUnixSocketPathLen = 100
 
 func fallbackSocketDir(root, session, primaryTempDir string) string {
-	for _, base := range []string{primaryTempDir, "/private/tmp", "/tmp"} {
+	return fallbackSocketDirForOS(root, session, primaryTempDir, runtime.GOOS)
+}
+
+func fallbackSocketDirForOS(root, session, primaryTempDir, goos string) string {
+	bases := []string{primaryTempDir}
+	if goos == "darwin" {
+		bases = append(bases, "/private/tmp")
+	}
+	bases = append(bases, "/tmp")
+	for _, base := range bases {
 		candidate := filepath.Join(base, "middleman-pty-"+sessionSocketHash(root+"-"+session))
 		if len(filepath.Join(candidate, "sock")) <= maxUnixSocketPathLen {
 			return candidate

--- a/internal/ptyowner/protocol_test.go
+++ b/internal/ptyowner/protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -65,6 +66,9 @@ func TestSessionPathsUsePrivateSocketDirForLongRoots(t *testing.T) {
 }
 
 func TestSessionPathsUseShortPrivateTmpWhenTempDirIsTooLong(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("/private/tmp is a macOS-specific socket fallback")
+	}
 	assert := Assert.New(t)
 	require := require.New(t)
 	root := filepath.Join(t.TempDir(), strings.Repeat("x", maxUnixSocketPathLen))
@@ -81,6 +85,36 @@ func TestSessionPathsUseShortPrivateTmpWhenTempDirIsTooLong(t *testing.T) {
 	assert.Equal(expectedDir, paths.SocketDir)
 	assert.Equal(filepath.Join(expectedDir, "sock"), paths.Socket)
 	assert.LessOrEqual(len(paths.Socket), maxUnixSocketPathLen)
+}
+
+func TestFallbackSocketDirSkipsPrivateTmpOffDarwin(t *testing.T) {
+	assert := Assert.New(t)
+	root := filepath.Join(t.TempDir(), strings.Repeat("x", maxUnixSocketPathLen))
+	longTempDir := filepath.Join(t.TempDir(), strings.Repeat("long-temp-root-", 8))
+
+	socketDir := fallbackSocketDirForOS(root, "middleman-abc123", longTempDir, "linux")
+
+	expectedDir := filepath.Join(
+		"/tmp",
+		"middleman-pty-"+sessionSocketHash(root+"-middleman-abc123"),
+	)
+	assert.Equal(expectedDir, socketDir)
+	assert.LessOrEqual(len(filepath.Join(socketDir, "sock")), maxUnixSocketPathLen)
+}
+
+func TestFallbackSocketDirUsesPrivateTmpOnDarwin(t *testing.T) {
+	assert := Assert.New(t)
+	root := filepath.Join(t.TempDir(), strings.Repeat("x", maxUnixSocketPathLen))
+	longTempDir := filepath.Join(t.TempDir(), strings.Repeat("long-temp-root-", 8))
+
+	socketDir := fallbackSocketDirForOS(root, "middleman-abc123", longTempDir, "darwin")
+
+	expectedDir := filepath.Join(
+		"/private/tmp",
+		"middleman-pty-"+sessionSocketHash(root+"-middleman-abc123"),
+	)
+	assert.Equal(expectedDir, socketDir)
+	assert.LessOrEqual(len(filepath.Join(socketDir, "sock")), maxUnixSocketPathLen)
 }
 
 func TestProtocolRequestRoundTrip(t *testing.T) {

--- a/internal/ptyowner/protocol_test.go
+++ b/internal/ptyowner/protocol_test.go
@@ -60,7 +60,26 @@ func TestSessionPathsUsePrivateSocketDirForLongRoots(t *testing.T) {
 	require.NoError(err)
 	require.NotEmpty(paths.SocketDir)
 	assert.Equal(filepath.Join(paths.SocketDir, "sock"), paths.Socket)
-	assert.Contains(paths.SocketDir, filepath.Join(os.TempDir(), "middleman-pty-"))
+	assert.Equal(fallbackSocketDir(root, "middleman-abc123", os.TempDir()), paths.SocketDir)
+	assert.LessOrEqual(len(paths.Socket), maxUnixSocketPathLen)
+}
+
+func TestSessionPathsUseShortPrivateTmpWhenTempDirIsTooLong(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	root := filepath.Join(t.TempDir(), strings.Repeat("x", maxUnixSocketPathLen))
+	longTempDir := filepath.Join(t.TempDir(), strings.Repeat("long-temp-root-", 8))
+	t.Setenv("TMPDIR", longTempDir)
+
+	paths, err := NewSessionPaths(root, "middleman-abc123")
+
+	require.NoError(err)
+	expectedDir := filepath.Join(
+		"/private/tmp",
+		"middleman-pty-"+sessionSocketHash(root+"-middleman-abc123"),
+	)
+	assert.Equal(expectedDir, paths.SocketDir)
+	assert.Equal(filepath.Join(expectedDir, "sock"), paths.Socket)
 	assert.LessOrEqual(len(paths.Socket), maxUnixSocketPathLen)
 }
 

--- a/internal/ptyowner/protocol_test.go
+++ b/internal/ptyowner/protocol_test.go
@@ -117,6 +117,37 @@ func TestFallbackSocketDirUsesPrivateTmpOnDarwin(t *testing.T) {
 	assert.LessOrEqual(len(filepath.Join(socketDir, "sock")), maxUnixSocketPathLen)
 }
 
+func TestCreatePrivateSocketDirRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fallback socket hardening is Unix-specific")
+	}
+	require := require.New(t)
+	parent := t.TempDir()
+	target := filepath.Join(parent, "target")
+	socketDir := filepath.Join(parent, "middleman-pty-symlink")
+	require.NoError(os.Mkdir(target, 0o700))
+	require.NoError(os.Symlink(target, socketDir))
+
+	err := createPrivateSocketDir(socketDir)
+
+	require.Error(err)
+	require.ErrorContains(err, "refusing fallback socket dir symlink")
+}
+
+func TestCreatePrivateSocketDirRejectsSharedExistingDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode fallback socket hardening is Unix-specific")
+	}
+	require := require.New(t)
+	socketDir := filepath.Join(t.TempDir(), "middleman-pty-shared")
+	require.NoError(os.Mkdir(socketDir, 0o755))
+
+	err := createPrivateSocketDir(socketDir)
+
+	require.Error(err)
+	require.ErrorContains(err, "expected private directory")
+}
+
 func TestProtocolRequestRoundTrip(t *testing.T) {
 	assert := Assert.New(t)
 	want := Request{

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14730,13 +14730,15 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		requirePTYAvailable(t)
 	}
-	runParallelPTYE2E(t)
+	releasePTYSlot := acquirePTYE2ESlot(t)
+	t.Cleanup(releasePTYSlot)
 
 	require := require.New(t)
 	assert := Assert.New(t)
 
 	managerPath := buildRustPtyManagerForTest(t)
 	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
+	setLongUnixTempDirForTest(t)
 	cfg := &config.Config{
 		Tmux: config.Tmux{
 			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
@@ -14798,13 +14800,15 @@ func TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		requirePTYAvailable(t)
 	}
-	runParallelPTYE2E(t)
+	releasePTYSlot := acquirePTYE2ESlot(t)
+	t.Cleanup(releasePTYSlot)
 
 	require := require.New(t)
 	assert := Assert.New(t)
 
 	managerPath := buildRustPtyManagerForTest(t)
 	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
+	setLongUnixTempDirForTest(t)
 	disableTmuxAgentSessions := false
 	cfg := &config.Config{
 		Agents: []config.Agent{{
@@ -15112,6 +15116,16 @@ func longRustPtyOwnerDirForTest(t *testing.T) string {
 	dir := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	return dir
+}
+
+func setLongUnixTempDirForTest(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	dir := filepath.Join(t.TempDir(), strings.Repeat("long-temp-root-", 8))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	t.Setenv("TMPDIR", dir)
 }
 
 func cleanupPtyOwnerWorkspace(

--- a/rust/pty-manager/src/main.rs
+++ b/rust/pty-manager/src/main.rs
@@ -15,7 +15,7 @@ use std::io::{self, BufRead, BufReader, Write};
 #[cfg(windows)]
 use std::net::{TcpListener, TcpStream};
 #[cfg(unix)]
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
 #[cfg(windows)]
@@ -216,7 +216,7 @@ fn run_owner(args: Args) -> Result<()> {
     create_private_dir(&args.root).context("create pty manager root dir")?;
     create_private_dir(&paths.dir).context("create session state dir")?;
     if let Some(socket_dir) = &paths.socket_dir {
-        create_private_dir(socket_dir).context("create fallback socket dir")?;
+        create_private_socket_dir(socket_dir).context("create fallback socket dir")?;
     }
     let mut cleanup = OwnerCleanup::new(paths.clone());
 
@@ -870,6 +870,60 @@ fn create_private_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn create_private_socket_dir(path: &Path) -> Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(0o700);
+    match builder.create(path) {
+        Ok(()) => return Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(err) => return Err(err).with_context(|| format!("create {}", path.display())),
+    }
+
+    let metadata =
+        fs::symlink_metadata(path).with_context(|| format!("inspect {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        bail!("refusing fallback socket dir symlink {}", path.display());
+    }
+    if !metadata.is_dir() {
+        bail!(
+            "fallback socket path is not a directory: {}",
+            path.display()
+        );
+    }
+    let current_uid = current_uid();
+    if metadata.uid() != current_uid {
+        bail!(
+            "fallback socket dir {} is owned by uid {}, not current uid {}",
+            path.display(),
+            metadata.uid(),
+            current_uid
+        );
+    }
+    if metadata.mode() & 0o077 != 0 {
+        bail!(
+            "fallback socket dir {} has permissions {:o}; expected private directory",
+            path.display(),
+            metadata.mode() & 0o777
+        );
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn create_private_socket_dir(path: &Path) -> Result<()> {
+    create_private_dir(path)
+}
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    unsafe extern "C" {
+        fn geteuid() -> u32;
+    }
+    // SAFETY: geteuid has no preconditions and does not dereference pointers.
+    unsafe { geteuid() }
+}
+
 #[cfg(windows)]
 fn restrict_windows_acl(path: &Path, directory: bool) -> Result<()> {
     let current_user_sid = current_user_sid_string()?;
@@ -1366,6 +1420,37 @@ mod tests {
             ))
         );
         assert!(socket_dir.join("sock").to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_private_socket_dir_rejects_symlink() {
+        let parent = env::temp_dir().join(format!("mm-pty-symlink-test-{}", new_token()));
+        let target = parent.join("target");
+        let socket_dir = parent.join("middleman-pty-symlink");
+        fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &socket_dir).unwrap();
+
+        let err = create_private_socket_dir(&socket_dir).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("refusing fallback socket dir symlink")
+        );
+        let _ = fs::remove_dir_all(&parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_private_socket_dir_rejects_shared_existing_dir() {
+        let socket_dir = env::temp_dir().join(format!("mm-pty-shared-test-{}", new_token()));
+        fs::create_dir(&socket_dir).unwrap();
+        fs::set_permissions(&socket_dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = create_private_socket_dir(&socket_dir).unwrap_err();
+
+        assert!(err.to_string().contains("expected private directory"));
+        let _ = fs::remove_dir_all(&socket_dir);
     }
 
     #[cfg(windows)]

--- a/rust/pty-manager/src/main.rs
+++ b/rust/pty-manager/src/main.rs
@@ -1070,10 +1070,7 @@ fn session_paths(root: &Path, session: &str) -> Result<SessionPaths> {
     let mut socket = root.join(format!("sock-{}", socket_hash(session)));
     let mut socket_dir = None;
     if socket.to_string_lossy().len() > MAX_UNIX_SOCKET_PATH_LEN {
-        let fallback_dir = env::temp_dir().join(format!(
-            "middleman-pty-{}",
-            socket_hash(&format!("{}-{session}", root.display()))
-        ));
+        let fallback_dir = fallback_socket_dir(root, session, &env::temp_dir());
         socket = fallback_dir.join("sock");
         socket_dir = Some(fallback_dir);
     }
@@ -1084,6 +1081,24 @@ fn session_paths(root: &Path, session: &str) -> Result<SessionPaths> {
         socket,
         socket_dir,
     })
+}
+
+fn fallback_socket_dir(root: &Path, session: &str, primary_temp_dir: &Path) -> PathBuf {
+    let dir_name = format!(
+        "middleman-pty-{}",
+        socket_hash(&format!("{}-{session}", root.display()))
+    );
+    for base in [
+        primary_temp_dir,
+        Path::new("/private/tmp"),
+        Path::new("/tmp"),
+    ] {
+        let candidate = base.join(&dir_name);
+        if candidate.join("sock").to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN {
+            return candidate;
+        }
+    }
+    Path::new("/tmp").join(dir_name)
 }
 
 fn session_dir_name(session: &str) -> String {
@@ -1286,7 +1301,15 @@ mod tests {
 
         assert_eq!(paths.dir, root.join("middleman-abc123"));
         let socket_dir = paths.socket_dir.as_ref().unwrap();
-        assert!(socket_dir.starts_with(env::temp_dir()));
+        let temp_socket = env::temp_dir()
+            .join(format!(
+                "middleman-pty-{}",
+                socket_hash(&format!("{}-middleman-abc123", root.display()))
+            ))
+            .join("sock");
+        if temp_socket.to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN {
+            assert!(socket_dir.starts_with(env::temp_dir()));
+        }
         let expected_file_name = format!(
             "middleman-pty-{}",
             socket_hash(&format!("{}-middleman-abc123", root.display()))
@@ -1297,6 +1320,23 @@ mod tests {
         );
         assert_eq!(paths.socket, socket_dir.join("sock"));
         assert!(paths.socket.to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN);
+    }
+
+    #[test]
+    fn fallback_socket_dir_uses_private_tmp_when_temp_dir_is_too_long() {
+        let root = PathBuf::from("/tmp").join("x".repeat(MAX_UNIX_SOCKET_PATH_LEN));
+        let long_temp_dir = PathBuf::from("/tmp").join("long-temp-root-".repeat(8));
+
+        let socket_dir = fallback_socket_dir(&root, "middleman-abc123", &long_temp_dir);
+
+        assert_eq!(
+            socket_dir,
+            Path::new("/private/tmp").join(format!(
+                "middleman-pty-{}",
+                socket_hash(&format!("{}-middleman-abc123", root.display()))
+            ))
+        );
+        assert!(socket_dir.join("sock").to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN);
     }
 
     #[cfg(windows)]

--- a/rust/pty-manager/src/main.rs
+++ b/rust/pty-manager/src/main.rs
@@ -1084,15 +1084,25 @@ fn session_paths(root: &Path, session: &str) -> Result<SessionPaths> {
 }
 
 fn fallback_socket_dir(root: &Path, session: &str, primary_temp_dir: &Path) -> PathBuf {
+    fallback_socket_dir_for_platform(root, session, primary_temp_dir, cfg!(target_os = "macos"))
+}
+
+fn fallback_socket_dir_for_platform(
+    root: &Path,
+    session: &str,
+    primary_temp_dir: &Path,
+    include_darwin_private_tmp: bool,
+) -> PathBuf {
     let dir_name = format!(
         "middleman-pty-{}",
         socket_hash(&format!("{}-{session}", root.display()))
     );
-    for base in [
-        primary_temp_dir,
-        Path::new("/private/tmp"),
-        Path::new("/tmp"),
-    ] {
+    let mut bases = vec![primary_temp_dir];
+    if include_darwin_private_tmp {
+        bases.push(Path::new("/private/tmp"));
+    }
+    bases.push(Path::new("/tmp"));
+    for base in bases {
         let candidate = base.join(&dir_name);
         if candidate.join("sock").to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN {
             return candidate;
@@ -1327,11 +1337,30 @@ mod tests {
         let root = PathBuf::from("/tmp").join("x".repeat(MAX_UNIX_SOCKET_PATH_LEN));
         let long_temp_dir = PathBuf::from("/tmp").join("long-temp-root-".repeat(8));
 
-        let socket_dir = fallback_socket_dir(&root, "middleman-abc123", &long_temp_dir);
+        let socket_dir =
+            fallback_socket_dir_for_platform(&root, "middleman-abc123", &long_temp_dir, true);
 
         assert_eq!(
             socket_dir,
             Path::new("/private/tmp").join(format!(
+                "middleman-pty-{}",
+                socket_hash(&format!("{}-middleman-abc123", root.display()))
+            ))
+        );
+        assert!(socket_dir.join("sock").to_string_lossy().len() <= MAX_UNIX_SOCKET_PATH_LEN);
+    }
+
+    #[test]
+    fn fallback_socket_dir_skips_private_tmp_off_macos() {
+        let root = PathBuf::from("/tmp").join("x".repeat(MAX_UNIX_SOCKET_PATH_LEN));
+        let long_temp_dir = PathBuf::from("/tmp").join("long-temp-root-".repeat(8));
+
+        let socket_dir =
+            fallback_socket_dir_for_platform(&root, "middleman-abc123", &long_temp_dir, false);
+
+        assert_eq!(
+            socket_dir,
+            Path::new("/tmp").join(format!(
                 "middleman-pty-{}",
                 socket_hash(&format!("{}-middleman-abc123", root.display()))
             ))


### PR DESCRIPTION
- Fall back from long TMPDIR socket roots to /private/tmp and then /tmp.
- Keep Go and Rust PTY owner socket path selection in sync.