### PR TITLE
Update setup-go pin to the current main commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 
@@ -69,7 +69,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 
@@ -142,7 +142,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 
@@ -172,7 +172,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 
@@ -240,7 +240,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 
@@ -272,7 +272,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 
@@ -324,7 +324,7 @@ jobs:
           path: .roborev-src
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 
@@ -94,7 +94,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      - uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290  # main
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Summary
- Update all `actions/setup-go` references in CI and release workflows to the current `main` commit pin.
- Remove the stale `v6.3.0` comment so the workflows reflect the actual upstream ref being used.

## Testing
- YAML parsing passed for `.github/workflows/ci.yml` and `.github/workflows/release.yml`.
- `git diff --check` passed.
- `actionlint` was not available locally.