### PR TITLE
fix: allow xterm ligature initialization

### DIFF
--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -208,6 +208,7 @@ describe("TerminalPane", () => {
 
     expect(xtermTerminalCtor).toHaveBeenCalledWith(
       expect.objectContaining({
+        allowProposedApi: true,
         allowTransparency: false,
         customGlyphs: true,
         cursorBlink: true,

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -420,6 +420,10 @@
           foreground: "#c9d1d9",
           cursor: "#58a6ff",
         },
+        // The ligatures addon registers a character joiner, which xterm
+        // exposes as proposed API. This is constructor-only and must be on
+        // before a user enables ligatures at runtime.
+        allowProposedApi: true,
         allowTransparency: false,
         customGlyphs: true,
         cursorBlink: terminalCursorBlink,


### PR DESCRIPTION
- Prevent xterm workspace terminals from throwing when font ligatures are enabled.
- Keep the terminal ligature setting usable at mount time and when toggled later.