### PR TITLE
Show assignment and title timeline events

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -27,6 +27,7 @@ type PullRequestTimelineEvent struct {
 	NodeID               string
 	EventType            string
 	Actor                string
+	Assignee             string
 	CreatedAt            time.Time
 	DeletedCommentAuthor string
 	BeforeSHA            string
@@ -112,6 +113,14 @@ type conditionalIssueGetter interface {
 		number int,
 		etag string,
 	) (*gh.Issue, string, bool, error)
+}
+
+type issueTimelineLister interface {
+	ListIssueTimelineEvents(
+		ctx context.Context,
+		owner, repo string,
+		number int,
+	) ([]PullRequestTimelineEvent, error)
 }
 
 func graphQLEndpointForHost(platformHost string) string {
@@ -275,7 +284,7 @@ const pullRequestTimelineEventsQuery = `
 query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
-      timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT], first: 100, after: $cursor) {
+      timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT], first: 100, after: $cursor) {
         nodes {
           __typename
           ... on Node {
@@ -331,6 +340,70 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
             createdAt
             previousRefName
             currentRefName
+          }
+          ... on AssignedEvent {
+            actor { login }
+            assignee {
+              __typename
+              ... on Bot { login }
+              ... on Mannequin { login }
+              ... on Organization { login }
+              ... on User { login }
+            }
+            createdAt
+          }
+          ... on UnassignedEvent {
+            actor { login }
+            assignee {
+              __typename
+              ... on Bot { login }
+              ... on Mannequin { login }
+              ... on Organization { login }
+              ... on User { login }
+            }
+            createdAt
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}`
+
+const issueTimelineEventsQuery = `
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      timelineItems(itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT], first: 100, after: $cursor) {
+        nodes {
+          __typename
+          ... on Node {
+            id
+          }
+          ... on AssignedEvent {
+            actor { login }
+            assignee {
+              __typename
+              ... on Bot { login }
+              ... on Mannequin { login }
+              ... on Organization { login }
+              ... on User { login }
+            }
+            createdAt
+          }
+          ... on UnassignedEvent {
+            actor { login }
+            assignee {
+              __typename
+              ... on Bot { login }
+              ... on Mannequin { login }
+              ... on Organization { login }
+              ... on User { login }
+            }
+            createdAt
           }
         }
         pageInfo {
@@ -809,6 +882,10 @@ func (c *liveClient) ListPullRequestTimelineEvents(
 							Actor    *struct {
 								Login string `json:"login"`
 							} `json:"actor"`
+							Assignee *struct {
+								TypeName string `json:"__typename"`
+								Login    string `json:"login"`
+							} `json:"assignee"`
 							BeforeCommit *struct {
 								OID string `json:"oid"`
 							} `json:"beforeCommit"`
@@ -945,11 +1022,18 @@ func (c *liveClient) ListPullRequestTimelineEvents(
 				event.EventType = "renamed_title"
 			case "BaseRefChangedEvent":
 				event.EventType = "base_ref_changed"
+			case "AssignedEvent":
+				event.EventType = "assigned"
+			case "UnassignedEvent":
+				event.EventType = "unassigned"
 			default:
 				continue
 			}
 			if node.Actor != nil {
 				event.Actor = node.Actor.Login
+			}
+			if node.Assignee != nil {
+				event.Assignee = node.Assignee.Login
 			}
 			if node.BeforeCommit != nil {
 				event.BeforeSHA = node.BeforeCommit.OID
@@ -979,6 +1063,142 @@ func (c *liveClient) ListPullRequestTimelineEvents(
 		}
 
 		pageInfo := decoded.Data.Repository.PullRequest.TimelineItems.PageInfo
+		if !pageInfo.HasNextPage {
+			break
+		}
+		cursor = pageInfo.EndCursor
+	}
+
+	return events, nil
+}
+
+func (c *liveClient) ListIssueTimelineEvents(
+	ctx context.Context, owner, repo string, number int,
+) ([]PullRequestTimelineEvent, error) {
+	type graphQLResponse struct {
+		Errors []graphQLError `json:"errors"`
+		Data   struct {
+			Repository *struct {
+				Issue *struct {
+					TimelineItems struct {
+						Nodes []struct {
+							TypeName string `json:"__typename"`
+							ID       string `json:"id"`
+							Actor    *struct {
+								Login string `json:"login"`
+							} `json:"actor"`
+							Assignee *struct {
+								TypeName string `json:"__typename"`
+								Login    string `json:"login"`
+							} `json:"assignee"`
+							CreatedAt time.Time `json:"createdAt"`
+						} `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool    `json:"hasNextPage"`
+							EndCursor   *string `json:"endCursor"`
+						} `json:"pageInfo"`
+					} `json:"timelineItems"`
+				} `json:"issue"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	var events []PullRequestTimelineEvent
+	var cursor *string
+	for {
+		payload, err := json.Marshal(graphQLRequest{
+			Query: issueTimelineEventsQuery,
+			Variables: map[string]any{
+				"owner":  owner,
+				"repo":   repo,
+				"number": number,
+				"cursor": cursor,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("marshal issue timeline query: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			c.graphQLEndpoint,
+			bytes.NewReader(payload),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create issue timeline request: %w", err)
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"list issue timeline events for %s/%s#%d: %w",
+				owner, repo, number, err,
+			)
+		}
+		c.trackRateHeaders(resp)
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf(
+				"list issue timeline events for %s/%s#%d: graphql status %s",
+				owner, repo, number, resp.Status,
+			)
+		}
+
+		var decoded graphQLResponse
+		if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf(
+				"decode issue timeline events for %s/%s#%d: %w",
+				owner, repo, number, err,
+			)
+		}
+		_ = resp.Body.Close()
+
+		if len(decoded.Errors) > 0 {
+			return nil, fmt.Errorf(
+				"list issue timeline events for %s/%s#%d: graphql errors: %s",
+				owner, repo, number, joinGraphQLErrorMessages(decoded.Errors),
+			)
+		}
+		if decoded.Data.Repository == nil {
+			return nil, fmt.Errorf(
+				"list issue timeline events for %s/%s#%d: missing repository in graphql response",
+				owner, repo, number,
+			)
+		}
+		if decoded.Data.Repository.Issue == nil {
+			return nil, fmt.Errorf(
+				"list issue timeline events for %s/%s#%d: missing issue in graphql response",
+				owner, repo, number,
+			)
+		}
+
+		for _, node := range decoded.Data.Repository.Issue.TimelineItems.Nodes {
+			event := PullRequestTimelineEvent{
+				NodeID:    node.ID,
+				CreatedAt: node.CreatedAt,
+			}
+			switch node.TypeName {
+			case "AssignedEvent":
+				event.EventType = "assigned"
+			case "UnassignedEvent":
+				event.EventType = "unassigned"
+			default:
+				continue
+			}
+			if node.Actor != nil {
+				event.Actor = node.Actor.Login
+			}
+			if node.Assignee != nil {
+				event.Assignee = node.Assignee.Login
+			}
+			events = append(events, event)
+		}
+
+		pageInfo := decoded.Data.Repository.Issue.TimelineItems.PageInfo
 		if !pageInfo.HasNextPage {
 			break
 		}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -464,7 +464,7 @@ func TestListPullRequestTimelineEvents(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"HeadRefForcePushedEvent","id":"HFP_1","actor":{"login":"alice"},"beforeCommit":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"afterCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"createdAt":"2024-06-01T12:00:00Z","ref":{"name":"feature"}},{"__typename":"RenamedTitleEvent","id":"RTE_1","actor":{"login":"bob"},"createdAt":"2024-06-01T12:05:00Z","previousTitle":"Old title","currentTitle":"New title"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"BaseRefChangedEvent","id":"BRC_1","actor":{"login":"carol"},"createdAt":"2024-06-01T12:10:00Z","previousRefName":"main","currentRefName":"release"},{"__typename":"CommentDeletedEvent","id":"CDE_1","actor":{"login":"maintainer"},"createdAt":"2024-06-01T12:12:00Z","deletedCommentAuthor":{"login":"reviewer"}},{"__typename":"CrossReferencedEvent","id":"CRE_1","actor":{"login":"dave"},"createdAt":"2024-06-01T12:15:00Z","isCrossRepository":true,"willCloseTarget":false,"source":{"__typename":"Issue","number":77,"title":"Related bug","url":"https://github.com/other/repo/issues/77","repository":{"owner":{"login":"other"},"name":"repo"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"BaseRefChangedEvent","id":"BRC_1","actor":{"login":"carol"},"createdAt":"2024-06-01T12:10:00Z","previousRefName":"main","currentRefName":"release"},{"__typename":"CommentDeletedEvent","id":"CDE_1","actor":{"login":"maintainer"},"createdAt":"2024-06-01T12:12:00Z","deletedCommentAuthor":{"login":"reviewer"}},{"__typename":"CrossReferencedEvent","id":"CRE_1","actor":{"login":"dave"},"createdAt":"2024-06-01T12:15:00Z","isCrossRepository":true,"willCloseTarget":false,"source":{"__typename":"Issue","number":77,"title":"Related bug","url":"https://github.com/other/repo/issues/77","repository":{"owner":{"login":"other"},"name":"repo"}}},{"__typename":"AssignedEvent","id":"AE_1","actor":{"login":"wesm"},"assignee":{"__typename":"User","login":"wesm"},"createdAt":"2024-06-01T12:20:00Z"},{"__typename":"UnassignedEvent","id":"UE_1","actor":{"login":"alice"},"assignee":{"__typename":"User","login":"bob"},"createdAt":"2024-06-01T12:25:00Z"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -476,7 +476,7 @@ func TestListPullRequestTimelineEvents(t *testing.T) {
 
 	events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
 	require.NoError(err)
-	require.Len(events, 5)
+	require.Len(events, 7)
 	require.Equal("force_push", events[0].EventType)
 	require.Equal("HFP_1", events[0].NodeID)
 	require.Equal("alice", events[0].Actor)
@@ -500,6 +500,12 @@ func TestListPullRequestTimelineEvents(t *testing.T) {
 	require.Equal("Related bug", events[4].SourceTitle)
 	require.True(events[4].IsCrossRepository)
 	require.False(events[4].WillCloseTarget)
+	require.Equal("assigned", events[5].EventType)
+	require.Equal("wesm", events[5].Actor)
+	require.Equal("wesm", events[5].Assignee)
+	require.Equal("unassigned", events[6].EventType)
+	require.Equal("alice", events[6].Actor)
+	require.Equal("bob", events[6].Assignee)
 	require.Equal(2, calls)
 	require.Equal([]string{http.MethodPost, http.MethodPost}, methods)
 	require.Equal([]string{"application/json", "application/json"}, contentTypes)
@@ -521,6 +527,41 @@ func TestListPullRequestTimelineEventsReturnsGraphQLErrors(t *testing.T) {
 	events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
 	require.Nil(events)
 	require.ErrorContains(err, "permission denied")
+}
+
+func TestListIssueTimelineEvents(t *testing.T) {
+	require := require.New(t)
+	var calls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			_, _ = w.Write([]byte(`{"data":{"repository":{"issue":{"timelineItems":{"nodes":[{"__typename":"AssignedEvent","id":"AE_1","actor":{"login":"wesm"},"assignee":{"__typename":"User","login":"wesm"},"createdAt":"2024-06-01T12:20:00Z"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"repository":{"issue":{"timelineItems":{"nodes":[{"__typename":"UnassignedEvent","id":"UE_1","actor":{"login":"alice"},"assignee":{"__typename":"Mannequin","login":"bob"},"createdAt":"2024-06-01T12:25:00Z"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &liveClient{
+		httpClient:      srv.Client(),
+		graphQLEndpoint: srv.URL + "/graphql",
+	}
+
+	events, err := c.ListIssueTimelineEvents(t.Context(), "owner", "repo", 42)
+	require.NoError(err)
+	require.Len(events, 2)
+	require.Equal("assigned", events[0].EventType)
+	require.Equal("AE_1", events[0].NodeID)
+	require.Equal("wesm", events[0].Actor)
+	require.Equal("wesm", events[0].Assignee)
+	require.Equal("unassigned", events[1].EventType)
+	require.Equal("UE_1", events[1].NodeID)
+	require.Equal("alice", events[1].Actor)
+	require.Equal("bob", events[1].Assignee)
+	require.Equal(2, calls)
 }
 
 func TestListPullRequestTimelineEventsRejectsNullGraphQLNodes(t *testing.T) {

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -134,6 +134,13 @@ type gqlPullRequestTimelineItem struct {
 	UnassignedEvent         gqlAssignedEvent           `graphql:"... on UnassignedEvent"`
 }
 
+type gqlIssueTimelineItem struct {
+	Typename        string           `graphql:"__typename"`
+	Node            gqlNodeFragment  `graphql:"... on Node"`
+	AssignedEvent   gqlAssignedEvent `graphql:"... on AssignedEvent"`
+	UnassignedEvent gqlAssignedEvent `graphql:"... on UnassignedEvent"`
+}
+
 type gqlNodeFragment struct {
 	ID string
 }
@@ -265,7 +272,7 @@ type gqlIssue struct {
 		PageInfo   pageInfo
 	} `graphql:"comments(first: 100)"`
 	TimelineItems struct {
-		Nodes    []gqlPullRequestTimelineItem
+		Nodes    []gqlIssueTimelineItem
 		PageInfo pageInfo
 	} `graphql:"timelineItems(itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT], first: 100)"`
 }
@@ -568,7 +575,7 @@ func convertGQLIssue(gql *gqlIssue) BulkIssue {
 		bulk.Comments = append(bulk.Comments, adaptComment(&gql.Comments.Nodes[i]))
 	}
 	for i := range gql.TimelineItems.Nodes {
-		event, ok := adaptPullRequestTimelineEvent(&gql.TimelineItems.Nodes[i])
+		event, ok := adaptIssueTimelineEvent(&gql.TimelineItems.Nodes[i])
 		if ok {
 			bulk.TimelineEvents = append(bulk.TimelineEvents, event)
 		}
@@ -858,6 +865,22 @@ func convertGQLPR(gql *gqlPR) BulkPR {
 	return bulk
 }
 
+func adaptIssueTimelineEvent(gql *gqlIssueTimelineItem) (PullRequestTimelineEvent, bool) {
+	if gql == nil {
+		return PullRequestTimelineEvent{}, false
+	}
+	event := PullRequestTimelineEvent{NodeID: gql.Node.ID}
+	switch gql.Typename {
+	case "AssignedEvent":
+		copyAssignmentEvent(&event, "assigned", gql.AssignedEvent)
+	case "UnassignedEvent":
+		copyAssignmentEvent(&event, "unassigned", gql.UnassignedEvent)
+	default:
+		return PullRequestTimelineEvent{}, false
+	}
+	return event, true
+}
+
 func adaptPullRequestTimelineEvent(gql *gqlPullRequestTimelineItem) (PullRequestTimelineEvent, bool) {
 	if gql == nil {
 		return PullRequestTimelineEvent{}, false
@@ -925,25 +948,22 @@ func adaptPullRequestTimelineEvent(gql *gqlPullRequestTimelineItem) (PullRequest
 			event.Actor = src.Actor.Login
 		}
 	case "AssignedEvent":
-		src := gql.AssignedEvent
-		event.EventType = "assigned"
-		event.Assignee = src.Assignee.Login()
-		event.CreatedAt = src.CreatedAt
-		if src.Actor != nil {
-			event.Actor = src.Actor.Login
-		}
+		copyAssignmentEvent(&event, "assigned", gql.AssignedEvent)
 	case "UnassignedEvent":
-		src := gql.UnassignedEvent
-		event.EventType = "unassigned"
-		event.Assignee = src.Assignee.Login()
-		event.CreatedAt = src.CreatedAt
-		if src.Actor != nil {
-			event.Actor = src.Actor.Login
-		}
+		copyAssignmentEvent(&event, "unassigned", gql.UnassignedEvent)
 	default:
 		return PullRequestTimelineEvent{}, false
 	}
 	return event, true
+}
+
+func copyAssignmentEvent(event *PullRequestTimelineEvent, eventType string, src gqlAssignedEvent) {
+	event.EventType = eventType
+	event.Assignee = src.Assignee.Login()
+	event.CreatedAt = src.CreatedAt
+	if src.Actor != nil {
+		event.Actor = src.Actor.Login
+	}
 }
 
 func copyReferencedSubject(event *PullRequestTimelineEvent, source gqlReferencedIssueOrPR) {

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -89,7 +89,7 @@ type gqlPR struct {
 	TimelineItems struct {
 		Nodes    []gqlPullRequestTimelineItem
 		PageInfo pageInfo
-	} `graphql:"timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT], first: 100)"`
+	} `graphql:"timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT], first: 100)"`
 }
 
 type gqlComment struct {
@@ -130,6 +130,8 @@ type gqlPullRequestTimelineItem struct {
 	CrossReferencedEvent    gqlCrossReferencedEvent    `graphql:"... on CrossReferencedEvent"`
 	RenamedTitleEvent       gqlRenamedTitleEvent       `graphql:"... on RenamedTitleEvent"`
 	BaseRefChangedEvent     gqlBaseRefChangedEvent     `graphql:"... on BaseRefChangedEvent"`
+	AssignedEvent           gqlAssignedEvent           `graphql:"... on AssignedEvent"`
+	UnassignedEvent         gqlAssignedEvent           `graphql:"... on UnassignedEvent"`
 }
 
 type gqlNodeFragment struct {
@@ -200,6 +202,39 @@ type gqlBaseRefChangedEvent struct {
 	CurrentRefName  string
 }
 
+type gqlAssignedEvent struct {
+	Actor     *gqlActorRef
+	Assignee  gqlAssignee
+	CreatedAt time.Time
+}
+
+type gqlAssignee struct {
+	Typename     string        `graphql:"__typename"`
+	Bot          gqlAssigneeID `graphql:"... on Bot"`
+	Mannequin    gqlAssigneeID `graphql:"... on Mannequin"`
+	Organization gqlAssigneeID `graphql:"... on Organization"`
+	User         gqlAssigneeID `graphql:"... on User"`
+}
+
+type gqlAssigneeID struct {
+	Login string
+}
+
+func (a gqlAssignee) Login() string {
+	switch a.Typename {
+	case "Bot":
+		return a.Bot.Login
+	case "Mannequin":
+		return a.Mannequin.Login
+	case "Organization":
+		return a.Organization.Login
+	case "User":
+		return a.User.Login
+	default:
+		return ""
+	}
+}
+
 type gqlIssueQuery struct {
 	Repository struct {
 		Issues struct {
@@ -229,6 +264,10 @@ type gqlIssue struct {
 		Nodes      []gqlComment
 		PageInfo   pageInfo
 	} `graphql:"comments(first: 100)"`
+	TimelineItems struct {
+		Nodes    []gqlPullRequestTimelineItem
+		PageInfo pageInfo
+	} `graphql:"timelineItems(itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT], first: 100)"`
 }
 
 type gqlLabel struct {
@@ -494,7 +533,9 @@ type RepoBulkResult struct {
 type BulkIssue struct {
 	Issue            *gh.Issue
 	Comments         []*gh.IssueComment
+	TimelineEvents   []PullRequestTimelineEvent
 	CommentsComplete bool
+	TimelineComplete bool
 }
 
 // BulkPR holds a PR and its nested data from a single GraphQL query.
@@ -520,10 +561,17 @@ func convertGQLIssue(gql *gqlIssue) BulkIssue {
 	bulk := BulkIssue{
 		Issue:            adaptIssue(gql),
 		CommentsComplete: !gql.Comments.PageInfo.HasNextPage,
+		TimelineComplete: !gql.TimelineItems.PageInfo.HasNextPage,
 	}
 
 	for i := range gql.Comments.Nodes {
 		bulk.Comments = append(bulk.Comments, adaptComment(&gql.Comments.Nodes[i]))
+	}
+	for i := range gql.TimelineItems.Nodes {
+		event, ok := adaptPullRequestTimelineEvent(&gql.TimelineItems.Nodes[i])
+		if ok {
+			bulk.TimelineEvents = append(bulk.TimelineEvents, event)
+		}
 	}
 
 	return bulk
@@ -873,6 +921,22 @@ func adaptPullRequestTimelineEvent(gql *gqlPullRequestTimelineItem) (PullRequest
 		event.CreatedAt = src.CreatedAt
 		event.PreviousRefName = src.PreviousRefName
 		event.CurrentRefName = src.CurrentRefName
+		if src.Actor != nil {
+			event.Actor = src.Actor.Login
+		}
+	case "AssignedEvent":
+		src := gql.AssignedEvent
+		event.EventType = "assigned"
+		event.Assignee = src.Assignee.Login()
+		event.CreatedAt = src.CreatedAt
+		if src.Actor != nil {
+			event.Actor = src.Actor.Login
+		}
+	case "UnassignedEvent":
+		src := gql.UnassignedEvent
+		event.EventType = "unassigned"
+		event.Assignee = src.Assignee.Login()
+		event.CreatedAt = src.CreatedAt
 		if src.Actor != nil {
 			event.Actor = src.Actor.Login
 		}

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -327,6 +327,12 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 				"actor":{"login":"maintainer"},
 				"createdAt":"` + now + `",
 				"deletedCommentAuthor":{"login":"reviewer"}
+			},{
+				"__typename":"AssignedEvent",
+				"id":"AE_1",
+				"actor":{"login":"wesm"},
+				"assignee":{"__typename":"User","login":"wesm"},
+				"createdAt":"` + now + `"
 			}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
 		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
 	}))
@@ -341,7 +347,7 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 	require.NotNil(result)
 	require.Len(result.PullRequests, 1)
 	require.True(sawTimelineItems)
-	require.Len(result.PullRequests[0].TimelineEvents, 2)
+	require.Len(result.PullRequests[0].TimelineEvents, 3)
 
 	event := result.PullRequests[0].TimelineEvents[0]
 	assert.Equal("base_ref_changed", event.EventType)
@@ -354,6 +360,11 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 	assert.Equal("CDE_1", deleted.NodeID)
 	assert.Equal("maintainer", deleted.Actor)
 	assert.Equal("reviewer", deleted.DeletedCommentAuthor)
+	assigned := result.PullRequests[0].TimelineEvents[2]
+	assert.Equal("assigned", assigned.EventType)
+	assert.Equal("AE_1", assigned.NodeID)
+	assert.Equal("wesm", assigned.Actor)
+	assert.Equal("wesm", assigned.Assignee)
 	assert.True(result.PullRequests[0].TimelineComplete)
 }
 
@@ -442,6 +453,10 @@ func testGQLIssueNodes(start, count int, now string) []map[string]any {
 				"totalCount": 0,
 				"nodes":      []any{},
 				"pageInfo":   map[string]any{"hasNextPage": false, "endCursor": ""},
+			},
+			"timelineItems": map[string]any{
+				"nodes":    []any{},
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
 			},
 		})
 	}
@@ -695,6 +710,7 @@ func TestConvertGQLIssue(t *testing.T) {
 	// All complete (no next page)
 	bulk := convertGQLIssue(&gql)
 	assert.True(bulk.CommentsComplete)
+	assert.True(bulk.TimelineComplete)
 	assert.NotNil(bulk.Issue)
 	assert.Equal(5, bulk.Issue.GetNumber())
 	assert.Empty(bulk.Comments)
@@ -710,6 +726,24 @@ func TestConvertGQLIssue(t *testing.T) {
 	assert.False(bulk.CommentsComplete)
 	require.Len(t, bulk.Comments, 1)
 	assert.Equal("hello", bulk.Comments[0].GetBody())
+
+	gql.Comments.PageInfo.HasNextPage = false
+	gql.TimelineItems.Nodes = []gqlPullRequestTimelineItem{{
+		Typename: "AssignedEvent",
+		Node:     gqlNodeFragment{ID: "AE_1"},
+		AssignedEvent: gqlAssignedEvent{
+			Actor:     &gqlActorRef{Login: "wesm"},
+			Assignee:  gqlAssignee{Typename: "User", User: gqlAssigneeID{Login: "wesm"}},
+			CreatedAt: now,
+		},
+	}}
+	gql.TimelineItems.PageInfo.HasNextPage = true
+
+	bulk = convertGQLIssue(&gql)
+	assert.False(bulk.TimelineComplete)
+	require.Len(t, bulk.TimelineEvents, 1)
+	assert.Equal("assigned", bulk.TimelineEvents[0].EventType)
+	assert.Equal("wesm", bulk.TimelineEvents[0].Assignee)
 }
 
 func TestStateConversion(t *testing.T) {

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -368,6 +368,64 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 	assert.True(result.PullRequests[0].TimelineComplete)
 }
 
+func TestGraphQLFetcherFetchRepoIssuesUsesIssueTimelineFragments(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	now := time.Date(2024, 6, 3, 15, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	var requestBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		requestBody = body
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[{
+			"databaseId":2001,
+			"number":2,
+			"title":"Timeline issue",
+			"state":"OPEN",
+			"body":"",
+			"url":"https://github.com/owner/repo/issues/2",
+			"author":{"login":"alice"},
+			"createdAt":"` + now + `",
+			"updatedAt":"` + now + `",
+			"closedAt":null,
+			"labels":{"nodes":[]},
+			"comments":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+			"timelineItems":{"nodes":[{
+				"__typename":"AssignedEvent",
+				"id":"AE_issue_1",
+				"actor":{"login":"alice"},
+				"assignee":{"__typename":"User","login":"bob"},
+				"createdAt":"` + now + `"
+			}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+	}))
+	defer srv.Close()
+
+	fetcher := NewGraphQLFetcherWithClient(
+		githubv4.NewEnterpriseClient(srv.URL, srv.Client()), nil,
+	)
+
+	result, err := fetcher.FetchRepoIssues(t.Context(), "owner", "repo")
+	require.NoError(err)
+	require.NotNil(result)
+	require.Len(result.Issues, 1)
+	require.Len(result.Issues[0].TimelineEvents, 1)
+	assert.Equal("assigned", result.Issues[0].TimelineEvents[0].EventType)
+	assert.Equal("bob", result.Issues[0].TimelineEvents[0].Assignee)
+
+	assert.Contains(string(requestBody), "AssignedEvent")
+	assert.NotContains(string(requestBody), "HeadRefForcePushedEvent")
+	assert.NotContains(string(requestBody), "CommentDeletedEvent")
+	assert.NotContains(string(requestBody), "BaseRefChangedEvent")
+}
+
 func TestGraphQLFetcherFetchRepoIssuesLogsFetchProgressForPaginatedIssueSet(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -728,7 +786,7 @@ func TestConvertGQLIssue(t *testing.T) {
 	assert.Equal("hello", bulk.Comments[0].GetBody())
 
 	gql.Comments.PageInfo.HasNextPage = false
-	gql.TimelineItems.Nodes = []gqlPullRequestTimelineItem{{
+	gql.TimelineItems.Nodes = []gqlIssueTimelineItem{{
 		Typename: "AssignedEvent",
 		Node:     gqlNodeFragment{ID: "AE_1"},
 		AssignedEvent: gqlAssignedEvent{

--- a/internal/github/normalize.go
+++ b/internal/github/normalize.go
@@ -145,6 +145,7 @@ func NormalizeTimelineEvent(mrID int64, event PullRequestTimelineEvent) *db.MREv
 			NodeID:               event.NodeID,
 			EventType:            event.EventType,
 			Actor:                event.Actor,
+			Assignee:             event.Assignee,
 			CreatedAt:            event.CreatedAt,
 			DeletedCommentAuthor: event.DeletedCommentAuthor,
 			BeforeSHA:            event.BeforeSHA,
@@ -168,6 +169,25 @@ func NormalizeTimelineEvent(mrID int64, event PullRequestTimelineEvent) *db.MREv
 		return nil
 	}
 	eventDB := dbMREvent(mrID, *normalized)
+	return &eventDB
+}
+
+func NormalizeIssueTimelineEvent(issueID int64, event PullRequestTimelineEvent) *db.IssueEvent {
+	normalized := platformgithub.NormalizeIssueTimelineEvent(
+		platform.RepoRef{},
+		0,
+		platformgithub.PullRequestTimelineEvent{
+			NodeID:    event.NodeID,
+			EventType: event.EventType,
+			Actor:     event.Actor,
+			Assignee:  event.Assignee,
+			CreatedAt: event.CreatedAt,
+		},
+	)
+	if normalized == nil {
+		return nil
+	}
+	eventDB := dbIssueEvent(issueID, *normalized)
 	return &eventDB
 }
 

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -354,6 +354,49 @@ func TestNormalizeTimelineEventBaseRefChanged(t *testing.T) {
 	assert.Contains(event.MetadataJSON, `"current_ref_name":"release"`)
 }
 
+func TestNormalizeTimelineEventAssigned(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 22, 0, 0, time.UTC)
+
+	event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+		NodeID:    "AE_1",
+		EventType: "assigned",
+		Actor:     "wesm",
+		Assignee:  "wesm",
+		CreatedAt: createdAt,
+	})
+
+	require.NotNil(event)
+	assert.Equal("assigned", event.EventType)
+	assert.Equal("wesm", event.Author)
+	assert.Equal("self-assigned this", event.Summary)
+	assert.Equal("timeline-AE_1", event.DedupeKey)
+	assert.Contains(event.MetadataJSON, `"assignee":"wesm"`)
+}
+
+func TestNormalizeIssueTimelineEventAssigned(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 22, 0, 0, time.UTC)
+
+	event := NormalizeIssueTimelineEvent(23, PullRequestTimelineEvent{
+		NodeID:    "AE_1",
+		EventType: "assigned",
+		Actor:     "alice",
+		Assignee:  "bob",
+		CreatedAt: createdAt,
+	})
+
+	require.NotNil(event)
+	assert.Equal(int64(23), event.IssueID)
+	assert.Equal("assigned", event.EventType)
+	assert.Equal("alice", event.Author)
+	assert.Equal("assigned bob", event.Summary)
+	assert.Equal("timeline-AE_1", event.DedupeKey)
+	assert.Contains(event.MetadataJSON, `"assignee":"bob"`)
+}
+
 func TestNormalizeTimelineEventForcePush(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -771,11 +771,71 @@ func (p gitHubClientProvider) GetGitHubPullRequest(
 }
 
 func (p gitHubClientProvider) ListMergeRequestEvents(
-	context.Context,
-	platform.RepoRef,
-	int,
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
 ) ([]platform.MergeRequestEvent, error) {
-	return nil, platform.UnsupportedCapability(platform.KindGitHub, p.host, "read_merge_request_events")
+	comments, err := p.client.ListIssueComments(ctx, ref.Owner, ref.Name, number)
+	if err != nil {
+		return nil, err
+	}
+	reviews, err := p.client.ListReviews(ctx, ref.Owner, ref.Name, number)
+	if err != nil {
+		return nil, err
+	}
+	commits, err := p.client.ListCommits(ctx, ref.Owner, ref.Name, number)
+	if err != nil {
+		return nil, err
+	}
+	timelineEvents, err := p.client.ListPullRequestTimelineEvents(ctx, ref.Owner, ref.Name, number)
+	if err != nil {
+		slog.Warn("github provider timeline event fetch failed",
+			"repo", ref.DisplayName(),
+			"number", number,
+			"err", err,
+		)
+		timelineEvents = nil
+	}
+
+	out := make([]platform.MergeRequestEvent, 0, len(comments)+len(reviews)+len(commits)+len(timelineEvents))
+	for _, comment := range comments {
+		out = append(out, platformgithub.NormalizeCommentEvent(ref, number, comment))
+	}
+	for _, review := range reviews {
+		out = append(out, platformgithub.NormalizeReviewEvent(ref, number, review))
+	}
+	for _, commit := range commits {
+		out = append(out, platformgithub.NormalizeCommitEvent(ref, number, commit))
+	}
+	for _, timelineEvent := range timelineEvents {
+		event := platformgithub.NormalizeTimelineEvent(ref, number, platformgithub.PullRequestTimelineEvent{
+			NodeID:               timelineEvent.NodeID,
+			EventType:            timelineEvent.EventType,
+			Actor:                timelineEvent.Actor,
+			Assignee:             timelineEvent.Assignee,
+			CreatedAt:            timelineEvent.CreatedAt,
+			DeletedCommentAuthor: timelineEvent.DeletedCommentAuthor,
+			BeforeSHA:            timelineEvent.BeforeSHA,
+			AfterSHA:             timelineEvent.AfterSHA,
+			Ref:                  timelineEvent.Ref,
+			PreviousTitle:        timelineEvent.PreviousTitle,
+			CurrentTitle:         timelineEvent.CurrentTitle,
+			PreviousRefName:      timelineEvent.PreviousRefName,
+			CurrentRefName:       timelineEvent.CurrentRefName,
+			SourceType:           timelineEvent.SourceType,
+			SourceOwner:          timelineEvent.SourceOwner,
+			SourceRepo:           timelineEvent.SourceRepo,
+			SourceNumber:         timelineEvent.SourceNumber,
+			SourceTitle:          timelineEvent.SourceTitle,
+			SourceURL:            timelineEvent.SourceURL,
+			IsCrossRepository:    timelineEvent.IsCrossRepository,
+			WillCloseTarget:      timelineEvent.WillCloseTarget,
+		})
+		if event != nil {
+			out = append(out, *event)
+		}
+	}
+	return out, nil
 }
 
 func (p gitHubClientProvider) ListOpenIssues(
@@ -840,11 +900,44 @@ func (p gitHubClientProvider) GetGitHubIssue(
 }
 
 func (p gitHubClientProvider) ListIssueEvents(
-	context.Context,
-	platform.RepoRef,
-	int,
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
 ) ([]platform.IssueEvent, error) {
-	return nil, platform.UnsupportedCapability(platform.KindGitHub, p.host, "read_issue_events")
+	comments, err := p.client.ListIssueComments(ctx, ref.Owner, ref.Name, number)
+	if err != nil {
+		return nil, err
+	}
+	var timelineEvents []PullRequestTimelineEvent
+	if timelineClient, ok := p.client.(issueTimelineLister); ok {
+		timelineEvents, err = timelineClient.ListIssueTimelineEvents(ctx, ref.Owner, ref.Name, number)
+		if err != nil {
+			slog.Warn("github provider issue timeline event fetch failed",
+				"repo", ref.DisplayName(),
+				"number", number,
+				"err", err,
+			)
+			timelineEvents = nil
+		}
+	}
+
+	out := make([]platform.IssueEvent, 0, len(comments)+len(timelineEvents))
+	for _, comment := range comments {
+		out = append(out, platformgithub.NormalizeIssueCommentEvent(ref, number, comment))
+	}
+	for _, timelineEvent := range timelineEvents {
+		event := platformgithub.NormalizeIssueTimelineEvent(ref, number, platformgithub.PullRequestTimelineEvent{
+			NodeID:    timelineEvent.NodeID,
+			EventType: timelineEvent.EventType,
+			Actor:     timelineEvent.Actor,
+			Assignee:  timelineEvent.Assignee,
+			CreatedAt: timelineEvent.CreatedAt,
+		})
+		if event != nil {
+			out = append(out, *event)
+		}
+	}
+	return out, nil
 }
 
 func (p gitHubClientProvider) CreateMergeRequestComment(
@@ -3830,10 +3923,10 @@ func (s *Syncer) syncOpenIssueFromBulk(
 		)
 	}
 	if existing != nil {
-		// Only preserve DetailFetchedAt when comments are complete.
+		// Only preserve DetailFetchedAt when timeline data is complete.
 		// When incomplete, clear it so the detail drain re-queues
 		// this issue if the REST fallback fails.
-		if bulk.CommentsComplete {
+		if bulk.CommentsComplete && bulk.TimelineComplete {
 			normalized.DetailFetchedAt = existing.DetailFetchedAt
 		}
 		// CommentCount comes from GraphQL Comments.TotalCount via
@@ -3849,7 +3942,7 @@ func (s *Syncer) syncOpenIssueFromBulk(
 	// so passing nil doesn't clear it. When comments are incomplete,
 	// explicitly clear it so the detail drain re-queues this issue
 	// if the REST fallback fails.
-	if !bulk.CommentsComplete {
+	if !bulk.CommentsComplete || !bulk.TimelineComplete {
 		_, err = s.db.WriteDB().ExecContext(ctx,
 			`UPDATE middleman_issues SET detail_fetched_at = NULL WHERE id = ?`,
 			issueID,
@@ -3869,10 +3962,15 @@ func (s *Syncer) syncOpenIssueFromBulk(
 		)
 	}
 
-	if bulk.CommentsComplete {
+	if bulk.CommentsComplete && bulk.TimelineComplete {
 		if err := s.replaceIssueCommentEvents(ctx, issueID, bulk.Comments); err != nil {
 			return fmt.Errorf(
 				"replace issue comment events for #%d: %w", number, err,
+			)
+		}
+		if err := s.upsertIssueTimelineEvents(ctx, issueID, bulk.TimelineEvents); err != nil {
+			return fmt.Errorf(
+				"upsert issue timeline events for #%d: %w", number, err,
 			)
 		}
 		if err := s.db.UpdateIssueDerivedFields(
@@ -3897,7 +3995,7 @@ func (s *Syncer) syncOpenIssueFromBulk(
 			)
 		}
 	} else {
-		// Comments truncated — fall back to REST.
+		// Timeline data truncated — fall back to detail fetch.
 		if err := s.refreshIssueTimeline(
 			ctx, repo, issueID, bulk.Issue,
 		); err != nil {
@@ -5590,6 +5688,23 @@ func (s *Syncer) refreshIssueTimeline(
 		)
 	}
 
+	if timelineClient, ok := client.(issueTimelineLister); ok {
+		timelineEvents, err := timelineClient.ListIssueTimelineEvents(
+			ctx, repo.Owner, repo.Name, number,
+		)
+		if err != nil {
+			slog.Warn("issue timeline event fetch failed during timeline refresh",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
+		} else if err := s.upsertIssueTimelineEvents(ctx, issueID, timelineEvents); err != nil {
+			return fmt.Errorf(
+				"upsert issue timeline events for #%d: %w", number, err,
+			)
+		}
+	}
+
 	lastActivity := computeIssueCommentLastActivity(ghIssue, comments)
 
 	_, err = s.db.WriteDB().ExecContext(ctx,
@@ -5598,6 +5713,25 @@ func (s *Syncer) refreshIssueTimeline(
 		len(comments), lastActivity, issueID,
 	)
 	return err
+}
+
+func (s *Syncer) upsertIssueTimelineEvents(
+	ctx context.Context,
+	issueID int64,
+	timelineEvents []PullRequestTimelineEvent,
+) error {
+	events := make([]db.IssueEvent, 0, len(timelineEvents))
+	for _, timelineEvent := range timelineEvents {
+		event := NormalizeIssueTimelineEvent(issueID, timelineEvent)
+		if event == nil {
+			continue
+		}
+		events = append(events, *event)
+	}
+	if err := s.db.UpsertIssueEvents(ctx, events); err != nil {
+		return fmt.Errorf("upsert issue timeline events: %w", err)
+	}
+	return nil
 }
 
 func (s *Syncer) refreshRepoPRComments(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7977,6 +7977,7 @@ func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *t
 			UpdatedAt: &commentTime,
 		}},
 		CommentsComplete: true,
+		TimelineComplete: true,
 	})
 	require.NoError(err)
 
@@ -8005,6 +8006,7 @@ func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *t
 		},
 		Comments:         []*gh.IssueComment{},
 		CommentsComplete: true,
+		TimelineComplete: true,
 	})
 	require.NoError(err)
 
@@ -8122,6 +8124,7 @@ func TestSyncRepoGraphQLIssues(t *testing.T) {
 					},
 				},
 				CommentsComplete: true,
+				TimelineComplete: true,
 			},
 		},
 	}

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -328,6 +328,55 @@ func TestClientReadsOpenPullRequestsIssuesAndCIChecks(t *testing.T) {
 	assert.Len(checks, 2)
 }
 
+func TestClientReadsTimelineAssignmentEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := Require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("token gitea-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/repos/owner/repo/issues/3/comments":
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 10, "body": "comment", "user": map[string]any{"login": "alice"},
+				"created_at": "2026-05-01T10:00:00Z",
+			}}))
+		case "/api/v1/repos/owner/repo/pulls/3/reviews":
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{}))
+		case "/api/v1/repos/owner/repo/pulls/3/commits":
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{}))
+		case "/api/v1/repos/owner/repo/issues/3/timeline":
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
+				"id": 11, "type": "assigned", "user": map[string]any{"login": "bob"},
+				"created_at": "2026-05-01T10:01:00Z",
+			}}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient("gitea.test", "gitea-token", WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	ref := platform.RepoRef{Owner: "owner", Name: "repo", RepoPath: "owner/repo"}
+
+	mrEvents, err := client.ListMergeRequestEvents(context.Background(), ref, 3)
+	require.NoError(err)
+	require.Len(mrEvents, 2)
+	assert.Equal("issue_comment", mrEvents[0].EventType)
+	assert.Equal("assigned", mrEvents[1].EventType)
+	assert.Equal("bob", mrEvents[1].Author)
+	assert.Equal("assigned someone", mrEvents[1].Summary)
+
+	issueEvents, err := client.ListIssueEvents(context.Background(), ref, 3)
+	require.NoError(err)
+	require.Len(issueEvents, 2)
+	assert.Equal("issue_comment", issueEvents[0].EventType)
+	assert.Equal("assigned", issueEvents[1].EventType)
+	assert.Equal("bob", issueEvents[1].Author)
+	assert.Equal("assigned someone", issueEvents[1].Summary)
+}
+
 func TestClientFallsBackToStatusesWhenActionsRequireNewerGitea(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -328,7 +328,7 @@ func TestClientReadsOpenPullRequestsIssuesAndCIChecks(t *testing.T) {
 	assert.Len(checks, 2)
 }
 
-func TestClientReadsTimelineAssignmentEvents(t *testing.T) {
+func TestClientReadsTimelineAssignmentAndTitleEvents(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
 
@@ -346,10 +346,17 @@ func TestClientReadsTimelineAssignmentEvents(t *testing.T) {
 		case "/api/v1/repos/owner/repo/pulls/3/commits":
 			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{}))
 		case "/api/v1/repos/owner/repo/issues/3/timeline":
-			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{{
-				"id": 11, "type": "assigned", "user": map[string]any{"login": "bob"},
-				"created_at": "2026-05-01T10:01:00Z",
-			}}))
+			assert.NoError(json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id": 11, "type": "assigned", "user": map[string]any{"login": "bob"},
+					"created_at": "2026-05-01T10:01:00Z",
+				},
+				{
+					"id": 12, "type": "change_title", "user": map[string]any{"login": "carol"},
+					"old_title": "Old title", "new_title": "New title",
+					"created_at": "2026-05-01T10:02:00Z",
+				},
+			}))
 		default:
 			http.NotFound(w, r)
 		}
@@ -362,19 +369,27 @@ func TestClientReadsTimelineAssignmentEvents(t *testing.T) {
 
 	mrEvents, err := client.ListMergeRequestEvents(context.Background(), ref, 3)
 	require.NoError(err)
-	require.Len(mrEvents, 2)
+	require.Len(mrEvents, 3)
 	assert.Equal("issue_comment", mrEvents[0].EventType)
 	assert.Equal("assigned", mrEvents[1].EventType)
 	assert.Equal("bob", mrEvents[1].Author)
 	assert.Equal("assigned someone", mrEvents[1].Summary)
+	assert.Equal("renamed_title", mrEvents[2].EventType)
+	assert.Equal("carol", mrEvents[2].Author)
+	assert.Equal(`"Old title" -> "New title"`, mrEvents[2].Summary)
+	assert.JSONEq(`{"previous_title":"Old title","current_title":"New title"}`, mrEvents[2].MetadataJSON)
 
 	issueEvents, err := client.ListIssueEvents(context.Background(), ref, 3)
 	require.NoError(err)
-	require.Len(issueEvents, 2)
+	require.Len(issueEvents, 3)
 	assert.Equal("issue_comment", issueEvents[0].EventType)
 	assert.Equal("assigned", issueEvents[1].EventType)
 	assert.Equal("bob", issueEvents[1].Author)
 	assert.Equal("assigned someone", issueEvents[1].Summary)
+	assert.Equal("renamed_title", issueEvents[2].EventType)
+	assert.Equal("carol", issueEvents[2].Author)
+	assert.Equal(`"Old title" -> "New title"`, issueEvents[2].Summary)
+	assert.JSONEq(`{"previous_title":"Old title","current_title":"New title"}`, issueEvents[2].MetadataJSON)
 }
 
 func TestClientFallsBackToStatusesWhenActionsRequireNewerGitea(t *testing.T) {

--- a/internal/platform/gitea/convert.go
+++ b/internal/platform/gitea/convert.go
@@ -100,6 +100,20 @@ func convertComment(comment *giteasdk.Comment) gitealike.CommentDTO {
 	}
 }
 
+func convertTimelineEvent(comment *giteasdk.TimelineComment) gitealike.TimelineEventDTO {
+	if comment == nil {
+		return gitealike.TimelineEventDTO{}
+	}
+	return gitealike.TimelineEventDTO{
+		ID:      comment.ID,
+		User:    convertUser(comment.Poster),
+		Type:    comment.Type,
+		Body:    comment.Body,
+		Created: comment.Created,
+		Updated: comment.Updated,
+	}
+}
+
 func convertReview(review *giteasdk.PullReview) gitealike.ReviewDTO {
 	if review == nil {
 		return gitealike.ReviewDTO{}
@@ -244,6 +258,14 @@ func convertComments(comments []*giteasdk.Comment) []gitealike.CommentDTO {
 	out := make([]gitealike.CommentDTO, 0, len(comments))
 	for _, comment := range comments {
 		out = append(out, convertComment(comment))
+	}
+	return out
+}
+
+func convertTimelineEvents(comments []*giteasdk.TimelineComment) []gitealike.TimelineEventDTO {
+	out := make([]gitealike.TimelineEventDTO, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, convertTimelineEvent(comment))
 	}
 	return out
 }

--- a/internal/platform/gitea/convert.go
+++ b/internal/platform/gitea/convert.go
@@ -105,12 +105,14 @@ func convertTimelineEvent(comment *giteasdk.TimelineComment) gitealike.TimelineE
 		return gitealike.TimelineEventDTO{}
 	}
 	return gitealike.TimelineEventDTO{
-		ID:      comment.ID,
-		User:    convertUser(comment.Poster),
-		Type:    comment.Type,
-		Body:    comment.Body,
-		Created: comment.Created,
-		Updated: comment.Updated,
+		ID:            comment.ID,
+		User:          convertUser(comment.Poster),
+		Type:          comment.Type,
+		Body:          comment.Body,
+		PreviousTitle: comment.OldTitle,
+		CurrentTitle:  comment.NewTitle,
+		Created:       comment.Created,
+		Updated:       comment.Updated,
 	}
 }
 

--- a/internal/platform/gitea/read.go
+++ b/internal/platform/gitea/read.go
@@ -317,6 +317,28 @@ func (t *transport) ListIssueComments(
 	return t.ListPullRequestComments(ctx, ref, number, opts)
 }
 
+func (t *transport) ListIssueTimeline(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.PageOptions,
+) ([]gitealike.TimelineEventDTO, gitealike.Page, error) {
+	t.spendSyncBudget(ctx)
+	var comments []*giteasdk.TimelineComment
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		comments, resp, err = t.api.ListIssueTimeline(ref.Owner, ref.Name, int64(number), giteasdk.ListIssueCommentOptions{
+			ListOptions: giteaListOptions(opts),
+		})
+		return err
+	})
+	if err != nil {
+		return nil, gitealike.Page{}, giteaHTTPError(resp, err)
+	}
+	return convertTimelineEvents(comments), giteaPage(resp), nil
+}
+
 func (t *transport) ListReleases(
 	ctx context.Context,
 	ref platform.RepoRef,

--- a/internal/platform/gitealike/normalize.go
+++ b/internal/platform/gitealike/normalize.go
@@ -1,6 +1,7 @@
 package gitealike
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -181,7 +182,7 @@ func NormalizeIssueTimelineEvents(
 ) []platform.IssueEvent {
 	events := make([]platform.IssueEvent, 0, len(timeline))
 	for _, item := range timeline {
-		eventType, ok := normalizeAssignmentEventType(item.Type)
+		eventType, summary, metadataJSON, ok := normalizeTimelineEvent(item)
 		if !ok {
 			continue
 		}
@@ -193,7 +194,8 @@ func NormalizeIssueTimelineEvents(
 			IssueNumber:        number,
 			EventType:          eventType,
 			Author:             item.User.UserName,
-			Summary:            assignmentSummary(eventType, item.User.UserName, item.Assignee.UserName),
+			Summary:            summary,
+			MetadataJSON:       metadataJSON,
 			CreatedAt:          item.Created.UTC(),
 			DedupeKey: NoteDedupeKey(
 				kind, repo.Host, repo.RepoPath, "issue", number, eventType,
@@ -265,7 +267,7 @@ func NormalizeMergeRequestTimelineEvents(
 ) []platform.MergeRequestEvent {
 	events := make([]platform.MergeRequestEvent, 0, len(timeline))
 	for _, item := range timeline {
-		eventType, ok := normalizeAssignmentEventType(item.Type)
+		eventType, summary, metadataJSON, ok := normalizeTimelineEvent(item)
 		if !ok {
 			continue
 		}
@@ -277,7 +279,8 @@ func NormalizeMergeRequestTimelineEvents(
 			MergeRequestNumber: number,
 			EventType:          eventType,
 			Author:             item.User.UserName,
-			Summary:            assignmentSummary(eventType, item.User.UserName, item.Assignee.UserName),
+			Summary:            summary,
+			MetadataJSON:       metadataJSON,
 			CreatedAt:          item.Created.UTC(),
 			DedupeKey: NoteDedupeKey(
 				kind, repo.Host, repo.RepoPath, "mr", number, eventType,
@@ -288,6 +291,27 @@ func NormalizeMergeRequestTimelineEvents(
 	return events
 }
 
+type renamedTitleMetadata struct {
+	PreviousTitle string `json:"previous_title"`
+	CurrentTitle  string `json:"current_title"`
+}
+
+func normalizeTimelineEvent(item TimelineEventDTO) (eventType, summary, metadataJSON string, ok bool) {
+	eventType, ok = normalizeAssignmentEventType(item.Type)
+	if ok {
+		return eventType, assignmentSummary(eventType, item.User.UserName, item.Assignee.UserName), "", true
+	}
+
+	if !isTitleChangeEvent(item.Type) {
+		return "", "", "", false
+	}
+	metadata, _ := json.Marshal(renamedTitleMetadata{
+		PreviousTitle: item.PreviousTitle,
+		CurrentTitle:  item.CurrentTitle,
+	})
+	return "renamed_title", fmt.Sprintf("%q -> %q", item.PreviousTitle, item.CurrentTitle), string(metadata), true
+}
+
 func normalizeAssignmentEventType(value string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "assigned":
@@ -296,6 +320,15 @@ func normalizeAssignmentEventType(value string) (string, bool) {
 		return "unassigned", true
 	default:
 		return "", false
+	}
+}
+
+func isTitleChangeEvent(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "change_title", "renamed_title":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/platform/gitealike/normalize.go
+++ b/internal/platform/gitealike/normalize.go
@@ -173,6 +173,37 @@ func NormalizeIssueComments(
 	return events
 }
 
+func NormalizeIssueTimelineEvents(
+	kind platform.Kind,
+	repo platform.RepoRef,
+	number int,
+	timeline []TimelineEventDTO,
+) []platform.IssueEvent {
+	events := make([]platform.IssueEvent, 0, len(timeline))
+	for _, item := range timeline {
+		eventType, ok := normalizeAssignmentEventType(item.Type)
+		if !ok {
+			continue
+		}
+		externalID := strconv.FormatInt(item.ID, 10)
+		events = append(events, platform.IssueEvent{
+			Repo:               repo,
+			PlatformID:         item.ID,
+			PlatformExternalID: externalID,
+			IssueNumber:        number,
+			EventType:          eventType,
+			Author:             item.User.UserName,
+			Summary:            assignmentSummary(eventType, item.User.UserName, item.Assignee.UserName),
+			CreatedAt:          item.Created.UTC(),
+			DedupeKey: NoteDedupeKey(
+				kind, repo.Host, repo.RepoPath, "issue", number, eventType,
+				externalID,
+			),
+		})
+	}
+	return events
+}
+
 func NormalizeMergeRequestEvents(
 	kind platform.Kind,
 	repo platform.RepoRef,
@@ -224,6 +255,71 @@ func NormalizeMergeRequestEvents(
 		})
 	}
 	return events
+}
+
+func NormalizeMergeRequestTimelineEvents(
+	kind platform.Kind,
+	repo platform.RepoRef,
+	number int,
+	timeline []TimelineEventDTO,
+) []platform.MergeRequestEvent {
+	events := make([]platform.MergeRequestEvent, 0, len(timeline))
+	for _, item := range timeline {
+		eventType, ok := normalizeAssignmentEventType(item.Type)
+		if !ok {
+			continue
+		}
+		externalID := strconv.FormatInt(item.ID, 10)
+		events = append(events, platform.MergeRequestEvent{
+			Repo:               repo,
+			PlatformID:         item.ID,
+			PlatformExternalID: externalID,
+			MergeRequestNumber: number,
+			EventType:          eventType,
+			Author:             item.User.UserName,
+			Summary:            assignmentSummary(eventType, item.User.UserName, item.Assignee.UserName),
+			CreatedAt:          item.Created.UTC(),
+			DedupeKey: NoteDedupeKey(
+				kind, repo.Host, repo.RepoPath, "mr", number, eventType,
+				externalID,
+			),
+		})
+	}
+	return events
+}
+
+func normalizeAssignmentEventType(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "assigned":
+		return "assigned", true
+	case "unassigned":
+		return "unassigned", true
+	default:
+		return "", false
+	}
+}
+
+func assignmentSummary(eventType, actor, assignee string) string {
+	switch eventType {
+	case "assigned":
+		if actor != "" && actor == assignee {
+			return "self-assigned this"
+		}
+		if assignee != "" {
+			return "assigned " + assignee
+		}
+		return "assigned someone"
+	case "unassigned":
+		if actor != "" && actor == assignee {
+			return "unassigned themselves"
+		}
+		if assignee != "" {
+			return "unassigned " + assignee
+		}
+		return "removed an assignment"
+	default:
+		return ""
+	}
 }
 
 func NormalizeRelease(repo platform.RepoRef, release ReleaseDTO) platform.Release {

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -63,6 +63,7 @@ func TestNormalizeRepositoryMapsSharedDTO(t *testing.T) {
 
 func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 	assert := Assert.New(t)
+	require := Require.New(t)
 	base := time.Date(2026, 5, 1, 2, 3, 4, 0, time.UTC)
 	closed := base.Add(2 * time.Hour)
 	mergeable := true
@@ -201,6 +202,30 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 	assert.Len(issueEvents, 1)
 	assert.Equal("issue_comment", issueEvents[0].EventType)
 	assert.Equal("frank", issueEvents[0].Author)
+
+	mrTimelineEvents := NormalizeMergeRequestTimelineEvents(
+		platform.KindGitea,
+		repo,
+		7,
+		[]TimelineEventDTO{{ID: 401, User: UserDTO{UserName: "grace"}, Type: "assigned", Assignee: UserDTO{UserName: "grace"}, Created: base}},
+	)
+	require.Len(mrTimelineEvents, 1)
+	assert.Equal("assigned", mrTimelineEvents[0].EventType)
+	assert.Equal("grace", mrTimelineEvents[0].Author)
+	assert.Equal("self-assigned this", mrTimelineEvents[0].Summary)
+	assert.Equal("gitea/gitea.com/gitea/tea/mr/7/assigned/401", mrTimelineEvents[0].DedupeKey)
+
+	issueTimelineEvents := NormalizeIssueTimelineEvents(
+		platform.KindGitea,
+		repo,
+		9,
+		[]TimelineEventDTO{{ID: 402, User: UserDTO{UserName: "hank"}, Type: "unassigned", Created: base}},
+	)
+	require.Len(issueTimelineEvents, 1)
+	assert.Equal("unassigned", issueTimelineEvents[0].EventType)
+	assert.Equal("hank", issueTimelineEvents[0].Author)
+	assert.Equal("removed an assignment", issueTimelineEvents[0].Summary)
+	assert.Equal("gitea/gitea.com/gitea/tea/issue/9/unassigned/402", issueTimelineEvents[0].DedupeKey)
 
 	release := NormalizeRelease(repo, ReleaseDTO{
 		ID:          500,

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -207,25 +207,41 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 		platform.KindGitea,
 		repo,
 		7,
-		[]TimelineEventDTO{{ID: 401, User: UserDTO{UserName: "grace"}, Type: "assigned", Assignee: UserDTO{UserName: "grace"}, Created: base}},
+		[]TimelineEventDTO{
+			{ID: 401, User: UserDTO{UserName: "grace"}, Type: "assigned", Assignee: UserDTO{UserName: "grace"}, Created: base},
+			{ID: 403, User: UserDTO{UserName: "ivy"}, Type: "change_title", PreviousTitle: "Old tea", CurrentTitle: "New tea", Created: base.Add(time.Minute)},
+		},
 	)
-	require.Len(mrTimelineEvents, 1)
+	require.Len(mrTimelineEvents, 2)
 	assert.Equal("assigned", mrTimelineEvents[0].EventType)
 	assert.Equal("grace", mrTimelineEvents[0].Author)
 	assert.Equal("self-assigned this", mrTimelineEvents[0].Summary)
 	assert.Equal("gitea/gitea.com/gitea/tea/mr/7/assigned/401", mrTimelineEvents[0].DedupeKey)
+	assert.Equal("renamed_title", mrTimelineEvents[1].EventType)
+	assert.Equal("ivy", mrTimelineEvents[1].Author)
+	assert.Equal(`"Old tea" -> "New tea"`, mrTimelineEvents[1].Summary)
+	assert.JSONEq(`{"previous_title":"Old tea","current_title":"New tea"}`, mrTimelineEvents[1].MetadataJSON)
+	assert.Equal("gitea/gitea.com/gitea/tea/mr/7/renamed_title/403", mrTimelineEvents[1].DedupeKey)
 
 	issueTimelineEvents := NormalizeIssueTimelineEvents(
 		platform.KindGitea,
 		repo,
 		9,
-		[]TimelineEventDTO{{ID: 402, User: UserDTO{UserName: "hank"}, Type: "unassigned", Created: base}},
+		[]TimelineEventDTO{
+			{ID: 402, User: UserDTO{UserName: "hank"}, Type: "unassigned", Created: base},
+			{ID: 404, User: UserDTO{UserName: "jane"}, Type: "change_title", PreviousTitle: "Old issue", CurrentTitle: "New issue", Created: base.Add(time.Minute)},
+		},
 	)
-	require.Len(issueTimelineEvents, 1)
+	require.Len(issueTimelineEvents, 2)
 	assert.Equal("unassigned", issueTimelineEvents[0].EventType)
 	assert.Equal("hank", issueTimelineEvents[0].Author)
 	assert.Equal("removed an assignment", issueTimelineEvents[0].Summary)
 	assert.Equal("gitea/gitea.com/gitea/tea/issue/9/unassigned/402", issueTimelineEvents[0].DedupeKey)
+	assert.Equal("renamed_title", issueTimelineEvents[1].EventType)
+	assert.Equal("jane", issueTimelineEvents[1].Author)
+	assert.Equal(`"Old issue" -> "New issue"`, issueTimelineEvents[1].Summary)
+	assert.JSONEq(`{"previous_title":"Old issue","current_title":"New issue"}`, issueTimelineEvents[1].MetadataJSON)
+	assert.Equal("gitea/gitea.com/gitea/tea/issue/9/renamed_title/404", issueTimelineEvents[1].DedupeKey)
 
 	release := NormalizeRelease(repo, ReleaseDTO{
 		ID:          500,

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -164,7 +164,13 @@ func (p *Provider) ListMergeRequestEvents(
 	if err != nil {
 		return nil, p.mapError(err)
 	}
-	return NormalizeMergeRequestEvents(p.kind, ref, number, comments, reviews, commits), nil
+	events := NormalizeMergeRequestEvents(p.kind, ref, number, comments, reviews, commits)
+	timeline, err := p.listTimelineEvents(ctx, ref, number)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, NormalizeMergeRequestTimelineEvents(p.kind, ref, number, timeline)...)
+	return events, nil
 }
 
 func (p *Provider) ListOpenIssues(
@@ -210,7 +216,35 @@ func (p *Provider) ListIssueEvents(
 	if err != nil {
 		return nil, p.mapError(err)
 	}
-	return NormalizeIssueComments(p.kind, ref, number, comments), nil
+	events := NormalizeIssueComments(p.kind, ref, number, comments)
+	timeline, err := p.listTimelineEvents(ctx, ref, number)
+	if err != nil {
+		return nil, err
+	}
+	events = append(events, NormalizeIssueTimelineEvents(p.kind, ref, number, timeline)...)
+	return events, nil
+}
+
+func (p *Provider) listTimelineEvents(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+) ([]TimelineEventDTO, error) {
+	timelineTransport, ok := p.transport.(TimelineTransport)
+	if !ok {
+		return nil, nil
+	}
+	timeline, err := collectPages(ctx, func(opts PageOptions) ([]TimelineEventDTO, Page, error) {
+		return timelineTransport.ListIssueTimeline(ctx, ref, number, opts)
+	})
+	if err != nil {
+		err = p.mapError(err)
+		if errors.Is(err, platform.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return timeline, nil
 }
 
 func (p *Provider) ListReleases(

--- a/internal/platform/gitealike/types.go
+++ b/internal/platform/gitealike/types.go
@@ -142,13 +142,15 @@ type CommentDTO struct {
 }
 
 type TimelineEventDTO struct {
-	ID       int64
-	User     UserDTO
-	Type     string
-	Body     string
-	Assignee UserDTO
-	Created  time.Time
-	Updated  time.Time
+	ID            int64
+	User          UserDTO
+	Type          string
+	Body          string
+	Assignee      UserDTO
+	PreviousTitle string
+	CurrentTitle  string
+	Created       time.Time
+	Updated       time.Time
 }
 
 type ReviewDTO struct {

--- a/internal/platform/gitealike/types.go
+++ b/internal/platform/gitealike/types.go
@@ -28,6 +28,10 @@ type Transport interface {
 	ListStatuses(ctx context.Context, ref platform.RepoRef, sha string, opts PageOptions) ([]StatusDTO, Page, error)
 }
 
+type TimelineTransport interface {
+	ListIssueTimeline(ctx context.Context, ref platform.RepoRef, number int, opts PageOptions) ([]TimelineEventDTO, Page, error)
+}
+
 type MutationTransport interface {
 	CreateIssueComment(ctx context.Context, ref platform.RepoRef, number int, body string) (CommentDTO, error)
 	EditIssueComment(ctx context.Context, ref platform.RepoRef, commentID int64, body string) (CommentDTO, error)
@@ -135,6 +139,16 @@ type CommentDTO struct {
 	Body    string
 	Created time.Time
 	Updated time.Time
+}
+
+type TimelineEventDTO struct {
+	ID       int64
+	User     UserDTO
+	Type     string
+	Body     string
+	Assignee UserDTO
+	Created  time.Time
+	Updated  time.Time
 }
 
 type ReviewDTO struct {

--- a/internal/platform/github/adapter.go
+++ b/internal/platform/github/adapter.go
@@ -22,6 +22,7 @@ type PullRequestTimelineEvent struct {
 	NodeID               string
 	EventType            string
 	Actor                string
+	Assignee             string
 	CreatedAt            time.Time
 	DeletedCommentAuthor string
 	BeforeSHA            string

--- a/internal/platform/github/normalize.go
+++ b/internal/platform/github/normalize.go
@@ -272,8 +272,47 @@ func NormalizeTimelineEvent(
 			CreatedAt:          event.CreatedAt,
 			DedupeKey:          timelineDedupeKey(event),
 		}
+	case "assigned", "unassigned":
+		metadata, _ := json.Marshal(assignmentMetadata{
+			Assignee: event.Assignee,
+		})
+		return &platform.MergeRequestEvent{
+			Repo:               repo,
+			MergeRequestNumber: mrNumber,
+			EventType:          event.EventType,
+			Author:             event.Actor,
+			Summary:            assignmentSummary(event.EventType, event.Actor, event.Assignee),
+			MetadataJSON:       string(metadata),
+			CreatedAt:          event.CreatedAt,
+			DedupeKey:          timelineDedupeKey(event),
+		}
 	default:
 		return nil
+	}
+}
+
+func NormalizeIssueTimelineEvent(
+	repo platform.RepoRef,
+	issueNumber int,
+	event PullRequestTimelineEvent,
+) *platform.IssueEvent {
+	switch event.EventType {
+	case "assigned", "unassigned":
+	default:
+		return nil
+	}
+	metadata, _ := json.Marshal(assignmentMetadata{
+		Assignee: event.Assignee,
+	})
+	return &platform.IssueEvent{
+		Repo:         repo,
+		IssueNumber:  issueNumber,
+		EventType:    event.EventType,
+		Author:       event.Actor,
+		Summary:      assignmentSummary(event.EventType, event.Actor, event.Assignee),
+		MetadataJSON: string(metadata),
+		CreatedAt:    event.CreatedAt,
+		DedupeKey:    timelineDedupeKey(event),
 	}
 }
 
@@ -358,6 +397,33 @@ type renamedTitleMetadata struct {
 type baseRefChangedMetadata struct {
 	PreviousRefName string `json:"previous_ref_name"`
 	CurrentRefName  string `json:"current_ref_name"`
+}
+
+type assignmentMetadata struct {
+	Assignee string `json:"assignee"`
+}
+
+func assignmentSummary(eventType, actor, assignee string) string {
+	switch eventType {
+	case "assigned":
+		if actor != "" && actor == assignee {
+			return "self-assigned this"
+		}
+		if assignee != "" {
+			return "assigned " + assignee
+		}
+		return "assigned someone"
+	case "unassigned":
+		if actor != "" && actor == assignee {
+			return "unassigned themselves"
+		}
+		if assignee != "" {
+			return "unassigned " + assignee
+		}
+		return "removed an assignment"
+	default:
+		return ""
+	}
 }
 
 type ciCheckCandidate struct {
@@ -504,6 +570,7 @@ func timelineDedupeKey(event PullRequestTimelineEvent) string {
 		event.EventType,
 		event.CreatedAt.UTC().Format(time.RFC3339Nano),
 		event.Actor,
+		event.Assignee,
 		event.DeletedCommentAuthor,
 		event.BeforeSHA,
 		event.AfterSHA,

--- a/internal/platform/gitlab/normalize.go
+++ b/internal/platform/gitlab/normalize.go
@@ -263,7 +263,14 @@ func NormalizeMergeRequestNotes(
 ) []platform.MergeRequestEvent {
 	events := make([]platform.MergeRequestEvent, 0, len(notes))
 	for _, note := range notes {
-		if note == nil || note.System {
+		if note == nil {
+			continue
+		}
+		if note.System {
+			event, ok := normalizeMergeRequestSystemNote(repo, mrNumber, note)
+			if ok {
+				events = append(events, event)
+			}
 			continue
 		}
 		events = append(events, platform.MergeRequestEvent{
@@ -340,7 +347,14 @@ func NormalizeIssueNotes(
 ) []platform.IssueEvent {
 	events := make([]platform.IssueEvent, 0, len(notes))
 	for _, note := range notes {
-		if note == nil || note.System {
+		if note == nil {
+			continue
+		}
+		if note.System {
+			event, ok := normalizeIssueSystemNote(repo, issueNumber, note)
+			if ok {
+				events = append(events, event)
+			}
 			continue
 		}
 		events = append(events, platform.IssueEvent{
@@ -387,6 +401,63 @@ func NormalizeIssueDiscussions(
 		}
 	}
 	return events
+}
+
+func normalizeMergeRequestSystemNote(
+	repo platform.RepoRef,
+	mrNumber int,
+	note *gitlab.Note,
+) (platform.MergeRequestEvent, bool) {
+	eventType, ok := gitLabAssignmentEventType(note.Body)
+	if !ok {
+		return platform.MergeRequestEvent{}, false
+	}
+	externalID := strconv.FormatInt(note.ID, 10)
+	return platform.MergeRequestEvent{
+		Repo:               repo,
+		PlatformID:         note.ID,
+		PlatformExternalID: externalID,
+		MergeRequestNumber: mrNumber,
+		EventType:          eventType,
+		Author:             note.Author.Username,
+		Summary:            strings.TrimSpace(note.Body),
+		CreatedAt:          timeValue(note.CreatedAt),
+		DedupeKey:          noteDedupeKey(repo, "mr", mrNumber, "system_note", externalID),
+	}, true
+}
+
+func normalizeIssueSystemNote(
+	repo platform.RepoRef,
+	issueNumber int, note *gitlab.Note,
+) (platform.IssueEvent, bool) {
+	eventType, ok := gitLabAssignmentEventType(note.Body)
+	if !ok {
+		return platform.IssueEvent{}, false
+	}
+	externalID := strconv.FormatInt(note.ID, 10)
+	return platform.IssueEvent{
+		Repo:               repo,
+		PlatformID:         note.ID,
+		PlatformExternalID: externalID,
+		IssueNumber:        issueNumber,
+		EventType:          eventType,
+		Author:             note.Author.Username,
+		Summary:            strings.TrimSpace(note.Body),
+		CreatedAt:          timeValue(note.CreatedAt),
+		DedupeKey:          noteDedupeKey(repo, "issue", issueNumber, "system_note", externalID),
+	}, true
+}
+
+func gitLabAssignmentEventType(body string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(body))
+	switch {
+	case strings.HasPrefix(normalized, "assigned"):
+		return "assigned", true
+	case strings.HasPrefix(normalized, "unassigned"):
+		return "unassigned", true
+	default:
+		return "", false
+	}
 }
 
 func noteDedupeKey(

--- a/internal/platform/gitlab/normalize_test.go
+++ b/internal/platform/gitlab/normalize_test.go
@@ -260,26 +260,33 @@ func TestNormalizeIssueMapsGitLabStates(t *testing.T) {
 	}
 }
 
-func TestNormalizeNotesDropsSystemNotes(t *testing.T) {
+func TestNormalizeNotesKeepsAssignmentSystemNotes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	createdAt := time.Date(2026, 4, 4, 10, 0, 0, 0, time.UTC)
 	notes := []*gitlab.Note{
 		{ID: 1, Body: "visible", System: false, Author: gitlab.NoteAuthor{Username: "alice"}, CreatedAt: &createdAt},
-		{ID: 2, Body: "assigned", System: true, Author: gitlab.NoteAuthor{Username: "root"}, CreatedAt: &createdAt},
+		{ID: 2, Body: "assigned to @bob", System: true, Author: gitlab.NoteAuthor{Username: "root"}, CreatedAt: &createdAt},
+		{ID: 3, Body: "changed milestone", System: true, Author: gitlab.NoteAuthor{Username: "root"}, CreatedAt: &createdAt},
 	}
 
 	mrEvents := NormalizeMergeRequestNotes(testGitLabRepoRef(), 7, notes)
-	require.Len(mrEvents, 1)
+	require.Len(mrEvents, 2)
 	assert.Equal("issue_comment", mrEvents[0].EventType)
 	assert.Equal("visible", mrEvents[0].Body)
 	assert.Equal("gitlab:gitlab.example.com:group/project:mr:7:note:1", mrEvents[0].DedupeKey)
+	assert.Equal("assigned", mrEvents[1].EventType)
+	assert.Equal("assigned to @bob", mrEvents[1].Summary)
+	assert.Equal("gitlab:gitlab.example.com:group/project:mr:7:system_note:2", mrEvents[1].DedupeKey)
 
 	issueEvents := NormalizeIssueNotes(testGitLabRepoRef(), 5, notes)
-	require.Len(issueEvents, 1)
+	require.Len(issueEvents, 2)
 	assert.Equal("issue_comment", issueEvents[0].EventType)
 	assert.Equal("visible", issueEvents[0].Body)
 	assert.Equal("gitlab:gitlab.example.com:group/project:issue:5:note:1", issueEvents[0].DedupeKey)
+	assert.Equal("assigned", issueEvents[1].EventType)
+	assert.Equal("assigned to @bob", issueEvents[1].Summary)
+	assert.Equal("gitlab:gitlab.example.com:group/project:issue:5:system_note:2", issueEvents[1].DedupeKey)
 }
 
 func TestNormalizeNotesDedupeKeyIncludesRepositoryAndParent(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18715,7 +18715,9 @@ func prepareIssueWorkspaceAssociationFixture(
 	t.Helper()
 	require := require.New(t)
 
-	fixture := setupWorkspaceServerFixture(t, nil)
+	fixture := setupWorkspaceServerFixtureWithOptions(t, nil, ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+	})
 	ctx := context.Background()
 
 	seedIssue(t, fixture.database, "acme", "widget", 7, "open")

--- a/internal/server/e2etest/timeline_assignment_test.go
+++ b/internal/server/e2etest/timeline_assignment_test.go
@@ -1,0 +1,125 @@
+package e2etest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/db"
+)
+
+type timelineDetailResponse struct {
+	Events []struct {
+		EventType    string `json:"EventType"`
+		Author       string `json:"Author"`
+		Summary      string `json:"Summary"`
+		MetadataJSON string `json:"MetadataJSON"`
+	} `json:"events"`
+}
+
+func TestE2E_DetailTimelineReturnsAssignmentEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, database := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	mrID, issueID := seedAssignmentTimelineItems(t, database)
+
+	require.NoError(database.UpsertMREvents(t.Context(), []db.MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "assigned",
+		Author:         "wesm",
+		Summary:        "self-assigned this",
+		MetadataJSON:   `{"assignee":"wesm"}`,
+		CreatedAt:      time.Now().UTC(),
+		DedupeKey:      "timeline-pr-assigned",
+	}}))
+	require.NoError(database.UpsertIssueEvents(t.Context(), []db.IssueEvent{{
+		IssueID:      issueID,
+		EventType:    "assigned",
+		Author:       "alice",
+		Summary:      "assigned bob",
+		MetadataJSON: `{"assignee":"bob"}`,
+		CreatedAt:    time.Now().UTC(),
+		DedupeKey:    "timeline-issue-assigned",
+	}}))
+
+	prDetail := getTimelineDetail(t, ts, "/api/v1/pulls/github/acme/widget/1")
+	require.Len(prDetail.Events, 1)
+	assert.Equal("assigned", prDetail.Events[0].EventType)
+	assert.Equal("wesm", prDetail.Events[0].Author)
+	assert.Equal("self-assigned this", prDetail.Events[0].Summary)
+	assert.JSONEq(`{"assignee":"wesm"}`, prDetail.Events[0].MetadataJSON)
+
+	issueDetail := getTimelineDetail(t, ts, "/api/v1/issues/github/acme/widget/5")
+	require.Len(issueDetail.Events, 1)
+	assert.Equal("assigned", issueDetail.Events[0].EventType)
+	assert.Equal("alice", issueDetail.Events[0].Author)
+	assert.Equal("assigned bob", issueDetail.Events[0].Summary)
+	assert.JSONEq(`{"assignee":"bob"}`, issueDetail.Events[0].MetadataJSON)
+}
+
+func seedAssignmentTimelineItems(t *testing.T, database *db.DB) (int64, int64) {
+	t.Helper()
+	ctx := t.Context()
+	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	mrID, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     1001,
+		Number:         1,
+		URL:            "https://github.com/acme/widget/pull/1",
+		Title:          "Assignment PR",
+		Author:         "testuser",
+		State:          "open",
+		HeadBranch:     "feature",
+		BaseBranch:     "main",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.EnsureKanbanState(ctx, mrID))
+
+	issueNumber := 5
+	issueID, err := database.UpsertIssue(ctx, &db.Issue{
+		RepoID:         repoID,
+		PlatformID:     5001,
+		Number:         issueNumber,
+		URL:            "https://github.com/acme/widget/issues/" + strconv.Itoa(issueNumber),
+		Title:          "Assignment issue",
+		Author:         "testuser",
+		State:          "open",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(t, err)
+
+	return mrID, issueID
+}
+
+func getTimelineDetail(
+	t *testing.T,
+	ts *httptest.Server,
+	path string,
+) timelineDetailResponse {
+	t.Helper()
+	resp, err := ts.Client().Get(ts.URL + path)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var detail timelineDetailResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&detail))
+	return detail
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,15 +64,16 @@ type versionOutputBody struct {
 type versionOutput = bodyOutput[versionOutputBody]
 
 type ServerOptions struct {
-	EmbedConfig         *EmbedConfig
-	Clones              *gitclone.Manager // optional clone manager for diff view
-	WorktreeDir         string            // base dir for workspace worktrees
-	PtyOwnerDir         string
-	PtyOwnerExePath     string
-	PtyOwnerExeArgs     []string
-	PtyOwnerManagerPath string
-	PtyOwnerCommand     []string
-	PtyOwnerInProcess   bool
+	EmbedConfig                        *EmbedConfig
+	Clones                             *gitclone.Manager // optional clone manager for diff view
+	WorktreeDir                        string            // base dir for workspace worktrees
+	DisableWorkspaceBackgroundMonitors bool
+	PtyOwnerDir                        string
+	PtyOwnerExePath                    string
+	PtyOwnerExeArgs                    []string
+	PtyOwnerManagerPath                string
+	PtyOwnerCommand                    []string
+	PtyOwnerInProcess                  bool
 }
 
 type shutdownDeadline struct {
@@ -587,7 +588,7 @@ func newServer(
 		}
 	}
 
-	if s.workspaces != nil {
+	if s.workspaces != nil && !options.DisableWorkspaceBackgroundMonitors {
 		s.runBackground(s.runWorkspacePRMonitorLoop)
 		s.runBackground(s.runWorkspacePushedHeadObserverLoop)
 	}

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -47,6 +47,8 @@
     commit: "Commit",
     force_push: "Force-pushed",
     review_comment: "Review Comment",
+    assigned: "Assigned",
+    unassigned: "Unassigned",
   };
 
   const typeColors: Record<string, string> = {
@@ -56,6 +58,8 @@
     review_comment: "var(--accent-purple)",
     commit: "var(--accent-green)",
     force_push: "var(--accent-red)",
+    assigned: "var(--accent-blue)",
+    unassigned: "var(--text-muted)",
   };
 
   function shouldRenderMarkdown(eventType: string): boolean {
@@ -146,7 +150,9 @@
       eventType === "force_push" ||
       eventType === "cross_referenced" ||
       eventType === "renamed_title" ||
-      eventType === "base_ref_changed"
+      eventType === "base_ref_changed" ||
+      eventType === "assigned" ||
+      eventType === "unassigned"
     );
   }
 
@@ -172,6 +178,10 @@
         return "Title changed";
       case "base_ref_changed":
         return "Base changed";
+      case "assigned":
+        return "Assigned";
+      case "unassigned":
+        return "Unassigned";
       case "force_push":
         return "Force-pushed";
       default:
@@ -480,7 +490,7 @@
           {@const commitDetails = event.EventType === "commit" ? commitDetailsBody(event.Body) : ""}
           <div class="event-card event-card--compact">
             <div class="event-header event-header--compact">
-              {#if event.EventType !== "comment_deleted"}
+              {#if event.EventType !== "comment_deleted" && event.EventType !== "assigned" && event.EventType !== "unassigned"}
                 <span
                   class="event-type"
                   style="color: {typeColors[event.EventType] ?? 'var(--text-muted)'}"
@@ -498,6 +508,12 @@
                 {/if}
                 <span class="event-time">{timeAgo(event.CreatedAt)}</span>
               {:else if event.EventType === "comment_deleted"}
+                {#if event.Author}
+                  <span class="event-author">{event.Author}</span>
+                {/if}
+                <span class="system-event-summary system-event-summary--sentence">{event.Summary}</span>
+                <span class="event-time">{timeAgo(event.CreatedAt)}</span>
+              {:else if event.EventType === "assigned" || event.EventType === "unassigned"}
                 {#if event.Author}
                   <span class="event-author">{event.Author}</span>
                 {/if}

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -336,6 +336,15 @@ describe("EventTimeline", () => {
               source_url: "https://github.com/other/repo/issues/77",
             }),
           }),
+          makeEvent({
+            ID: 5,
+            EventType: "assigned",
+            Author: "wesm",
+            Summary: "self-assigned this",
+            MetadataJSON: JSON.stringify({
+              assignee: "wesm",
+            }),
+          }),
         ],
       },
     });
@@ -354,7 +363,9 @@ describe("EventTimeline", () => {
     expect(screen.getByText("Base changed")).toBeTruthy();
     expect(screen.getByText("Referenced")).toBeTruthy();
     expect(screen.getByText("Related bug")).toBeTruthy();
-    expect(document.querySelectorAll(".event--compact").length).toBe(4);
+    expect(screen.queryByText("Assigned")).toBeNull();
+    expect(screen.getByText("self-assigned this")).toBeTruthy();
+    expect(document.querySelectorAll(".event--compact").length).toBe(5);
   });
 
   it("renders cross-repository events as internal item references when metadata identifies the source item", () => {

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -151,6 +151,12 @@ describe("prTimelineFilter", () => {
     expect(timelineEventBucket(event({ EventType: "base_ref_changed" }))).toBe(
       "events",
     );
+    expect(timelineEventBucket(event({ EventType: "assigned" }))).toBe(
+      "events",
+    );
+    expect(timelineEventBucket(event({ EventType: "unassigned" }))).toBe(
+      "events",
+    );
   });
 
   it("keeps commit title rows when commit details are disabled", () => {
@@ -178,6 +184,7 @@ describe("prTimelineFilter", () => {
       event({ ID: 3, EventType: "commit", Author: "alice" }),
       event({ ID: 4, EventType: "force_push", Author: "alice" }),
       event({ ID: 5, EventType: "base_ref_changed", Author: "alice" }),
+      event({ ID: 6, EventType: "assigned", Author: "alice" }),
     ];
 
     expect(
@@ -189,7 +196,7 @@ describe("prTimelineFilter", () => {
         showForcePushes: false,
         hideBots: true,
       }).map((item) => item.ID),
-    ).toEqual([1, 3, 5]);
+    ).toEqual([1, 3, 5, 6]);
   });
 
   it("filters threaded replies while keeping the root comment", () => {


### PR DESCRIPTION
- Show assignment and unassignment changes in PR and issue timelines.
- Include Gitea timeline assignment events and Gitea title changes using the existing compact system event rows.
- Keep GitLab assignment notes and existing GitHub system events on the shared timeline path.