### PR TITLE
fix: collapse comment and review runs in threaded activity

### DIFF
--- a/frontend/tests/e2e/activity-thread-runs.spec.ts
+++ b/frontend/tests/e2e/activity-thread-runs.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+const REPO = {
+  provider: "github",
+  platform_host: "github.com",
+  owner: "acme",
+  name: "widgets",
+  repo_path: "acme/widgets",
+  capabilities: {},
+};
+
+function prEvent(args: {
+  id: string;
+  type: "comment" | "review" | "commit" | "force_push" | "new_pr";
+  author: string;
+  createdAt: string;
+}): unknown {
+  return {
+    id: args.id,
+    cursor: args.id,
+    activity_type: args.type,
+    author: args.author,
+    body_preview: "",
+    created_at: args.createdAt,
+    item_number: 42,
+    item_state: "open",
+    item_title: "Add browser regression coverage",
+    item_type: "pr",
+    item_url: "https://github.com/acme/widgets/pull/42",
+    platform_host: "github.com",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    repo: REPO,
+  };
+}
+
+async function mockSettings(page: Page): Promise<void> {
+  await mockApi(page);
+  await page.route("**/api/v1/settings", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "widgets",
+            repo_path: "acme/widgets",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+        ],
+        activity: {
+          view_mode: "threaded",
+          time_range: "7d",
+          hide_closed: false,
+          hide_bots: false,
+          collapse_threads: false,
+        },
+        terminal: {
+          font_family: "",
+          font_size: 14,
+          scrollback: 1000,
+          line_height: 1,
+          letter_spacing: 0,
+          cursor_blink: true,
+          font_ligatures: false,
+          renderer: "xterm",
+        },
+        agents: [],
+      }),
+    });
+  });
+}
+
+async function mockActivity(page: Page, items: unknown[]): Promise<void> {
+  await page.route("**/api/v1/activity**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ capped: false, items }),
+    });
+  });
+}
+
+test.describe("threaded activity run collapse", () => {
+  test("collapses a run of three or more reviews from the same author", async ({
+    page,
+  }) => {
+    await mockSettings(page);
+    await mockActivity(page, [
+      prEvent({ id: "r5", type: "review", author: "alice", createdAt: "2026-04-27T15:00:00Z" }),
+      prEvent({ id: "r4", type: "review", author: "alice", createdAt: "2026-04-27T14:00:00Z" }),
+      prEvent({ id: "r3", type: "review", author: "alice", createdAt: "2026-04-27T13:00:00Z" }),
+      prEvent({ id: "r2", type: "review", author: "alice", createdAt: "2026-04-27T12:00:00Z" }),
+      prEvent({ id: "r1", type: "review", author: "alice", createdAt: "2026-04-27T11:00:00Z" }),
+    ]);
+    await page.goto("/?view=threaded");
+
+    const collapsed = page.locator(".event-row.collapsed-event", {
+      hasText: "5 reviews",
+    });
+    await expect(collapsed).toHaveCount(1);
+    await expect(collapsed.locator(".evt-review")).toBeVisible();
+    await expect(page.locator(".event-row:not(.collapsed-event)")).toHaveCount(0);
+  });
+
+  test("collapses comments and reviews into separate runs by event type", async ({
+    page,
+  }) => {
+    await mockSettings(page);
+    await mockActivity(page, [
+      prEvent({ id: "c3", type: "comment", author: "alice", createdAt: "2026-04-27T16:00:00Z" }),
+      prEvent({ id: "c2", type: "comment", author: "alice", createdAt: "2026-04-27T15:00:00Z" }),
+      prEvent({ id: "c1", type: "comment", author: "alice", createdAt: "2026-04-27T14:00:00Z" }),
+      prEvent({ id: "r3", type: "review", author: "alice", createdAt: "2026-04-27T13:00:00Z" }),
+      prEvent({ id: "r2", type: "review", author: "alice", createdAt: "2026-04-27T12:00:00Z" }),
+      prEvent({ id: "r1", type: "review", author: "alice", createdAt: "2026-04-27T11:00:00Z" }),
+    ]);
+    await page.goto("/?view=threaded");
+
+    await expect(
+      page.locator(".event-row.collapsed-event", { hasText: "3 comments" }),
+    ).toHaveCount(1);
+    await expect(
+      page.locator(".event-row.collapsed-event", { hasText: "3 reviews" }),
+    ).toHaveCount(1);
+  });
+
+  test("leaves short runs of comments unrolled", async ({ page }) => {
+    await mockSettings(page);
+    await mockActivity(page, [
+      prEvent({ id: "c2", type: "comment", author: "alice", createdAt: "2026-04-27T13:00:00Z" }),
+      prEvent({ id: "c1", type: "comment", author: "alice", createdAt: "2026-04-27T12:00:00Z" }),
+    ]);
+    await page.goto("/?view=threaded");
+
+    await expect(page.locator(".event-row.collapsed-event")).toHaveCount(0);
+    await expect(
+      page.locator(".event-row:not(.collapsed-event)"),
+    ).toHaveCount(2);
+  });
+});

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -2,7 +2,7 @@
   import type { ActivityItem } from "../api/types.js";
   import { getStores } from "../context.js";
   import {
-    collapseActivityCommitRuns,
+    collapseActivityRuns,
     isCollapsedActivityRow,
     activityItemKey,
     activityRepoKey,
@@ -80,7 +80,7 @@
     latestAuthor: string;
     events: ActivityItem[];
     displayEvents: ReturnType<
-      typeof collapseActivityCommitRuns
+      typeof collapseActivityRuns
     >;
   }
 
@@ -173,7 +173,7 @@
           latestTime: first.created_at,
           latestAuthor: eventAuthor(first),
           events,
-          displayEvents: collapseActivityCommitRuns(events),
+          displayEvents: collapseActivityRuns(events),
         },
       });
     }
@@ -275,7 +275,7 @@
         branchItems.push(branchRowRepresentative(branchEntry.row));
         j++;
       }
-      for (const row of collapseActivityCommitRuns(branchItems)) {
+      for (const row of collapseActivityRuns(branchItems)) {
         result.push(branchEntryFromRow(row));
       }
       i = j;
@@ -455,8 +455,27 @@
   }
 
   function branchRowTitle(row: ActivityRow): string {
-    if (isCollapsedActivityRow(row)) return `${row.count} commits`;
+    if (isCollapsedActivityRow(row)) return collapsedRunLabel(row);
     return eventSummary(row) || eventLabel(row.activity_type);
+  }
+
+  function collapsedRunLabel(row: {
+    count: number;
+    representative: ActivityItem;
+  }): string {
+    const noun = collapsedRunNoun(row.representative.activity_type);
+    return `${row.count} ${noun}`;
+  }
+
+  function collapsedRunNoun(type: string): string {
+    switch (type) {
+      case "commit":
+      case "default_branch_commit":
+        return "commits";
+      case "comment": return "comments";
+      case "review": return "reviews";
+      default: return type;
+    }
   }
 
   function rowLinkUrl(item: ActivityItem): string {
@@ -620,7 +639,7 @@
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             {#if isCollapsedActivityRow(row)}
               <div class="event-row collapsed-event" onclick={() => handleEventClick(row.representative)}>
-                <span class="event-type evt-commit">{row.count} commits</span>
+                <span class="event-type {eventClass(row.representative.activity_type)}">{collapsedRunLabel(row)}</span>
                 <span class="event-author">{row.author}</span>
                 <span class="event-time">{relativeTime(row.earliest)} - {relativeTime(row.latest)}</span>
               </div>

--- a/packages/ui/src/components/activityRows.test.ts
+++ b/packages/ui/src/components/activityRows.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ActivityItem } from "../api/types.js";
 import {
-  collapseActivityCommitRuns,
+  collapseActivityRuns,
   isCollapsedActivityRow,
 } from "./activityRows.js";
 import {
@@ -57,9 +57,9 @@ function branchItem(
   } as ActivityItem;
 }
 
-describe("collapseActivityCommitRuns", () => {
+describe("collapseActivityRuns", () => {
   it("collapses three consecutive commits from the same author", () => {
-    const rows = collapseActivityCommitRuns([
+    const rows = collapseActivityRuns([
       item("7", "commit", "alice"),
       item("6", "commit", "alice"),
       item("5", "commit", "alice"),
@@ -69,8 +69,68 @@ describe("collapseActivityCommitRuns", () => {
     expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
   });
 
+  it("collapses consecutive comments from the same author", () => {
+    const rows = collapseActivityRuns([
+      item("7", "comment", "alice"),
+      item("6", "comment", "alice"),
+      item("5", "comment", "alice"),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
+    expect(
+      isCollapsedActivityRow(rows[0]!)
+        ? rows[0].representative.activity_type
+        : undefined,
+    ).toBe("comment");
+  });
+
+  it("collapses consecutive reviews from the same author", () => {
+    const rows = collapseActivityRuns([
+      item("7", "review", "alice"),
+      item("6", "review", "alice"),
+      item("5", "review", "alice"),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
+    expect(
+      isCollapsedActivityRow(rows[0]!)
+        ? rows[0].representative.activity_type
+        : undefined,
+    ).toBe("review");
+  });
+
+  it("does not merge runs of different event types", () => {
+    const rows = collapseActivityRuns([
+      item("9", "review", "alice"),
+      item("8", "review", "alice"),
+      item("7", "review", "alice"),
+      item("6", "comment", "alice"),
+      item("5", "comment", "alice"),
+      item("4", "comment", "alice"),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
+    expect(isCollapsedActivityRow(rows[1]!)).toBe(true);
+  });
+
+  it("does not collapse runs of fewer than three events", () => {
+    const rows = collapseActivityRuns([
+      item("3", "comment", "alice"),
+      item("2", "review", "alice"),
+      item("1", "comment", "alice"),
+    ]);
+
+    expect(rows).toHaveLength(3);
+    expect(isCollapsedActivityRow(rows[0]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[1]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[2]!)).toBe(false);
+  });
+
   it("does not collapse across a force-push boundary", () => {
-    const rows = collapseActivityCommitRuns([
+    const rows = collapseActivityRuns([
       item("9", "commit", "alice"),
       item("8", "commit", "alice"),
       item("7", "commit", "alice"),
@@ -90,7 +150,7 @@ describe("collapseActivityCommitRuns", () => {
   });
 
   it("rolls up branch commit runs by repo branch and author", () => {
-    const rows = collapseActivityCommitRuns([
+    const rows = collapseActivityRuns([
       branchItem("9", "default_branch_commit", "alice"),
       branchItem("8", "default_branch_commit", "alice"),
       branchItem("7", "default_branch_commit", "alice"),
@@ -106,7 +166,7 @@ describe("collapseActivityCommitRuns", () => {
   });
 
   it("does not collapse branch commits across branches", () => {
-    const rows = collapseActivityCommitRuns([
+    const rows = collapseActivityRuns([
       branchItem("9", "default_branch_commit", "alice", "main"),
       branchItem("8", "default_branch_commit", "alice", "main"),
       branchItem("7", "default_branch_commit", "alice", "main"),

--- a/packages/ui/src/components/activityRows.ts
+++ b/packages/ui/src/components/activityRows.ts
@@ -1,6 +1,6 @@
 import type { ActivityItem } from "../api/types.js";
 
-export interface CollapsedActivityCommits {
+export interface CollapsedActivityRun {
   kind: "collapsed";
   id: string;
   author: string;
@@ -12,11 +12,11 @@ export interface CollapsedActivityCommits {
 
 export type ActivityRow =
   | ActivityItem
-  | CollapsedActivityCommits;
+  | CollapsedActivityRun;
 
 export function isCollapsedActivityRow(
   row: ActivityRow,
-): row is CollapsedActivityCommits {
+): row is CollapsedActivityRun {
   return "kind" in row && row.kind === "collapsed";
 }
 
@@ -52,15 +52,20 @@ function repoKeyForItem(item: ActivityItem): string {
   });
 }
 
-function commitRunAuthor(item: ActivityItem): string {
+function activityRunAuthor(item: ActivityItem): string {
   return item.author_name || item.author;
 }
 
-function commitRunGroupKey(item: ActivityItem): string | null {
-  const author = commitRunAuthor(item);
-  if (item.activity_type === "commit") {
+function activityRunGroupKey(item: ActivityItem): string | null {
+  const author = activityRunAuthor(item);
+  if (
+    item.activity_type === "commit"
+    || item.activity_type === "comment"
+    || item.activity_type === "review"
+  ) {
     return [
       "item",
+      item.activity_type,
       repoKeyForItem(item),
       item.item_type,
       item.item_number,
@@ -80,7 +85,7 @@ function commitRunGroupKey(item: ActivityItem): string | null {
   return null;
 }
 
-export function collapseActivityCommitRuns(
+export function collapseActivityRuns(
   items: ActivityItem[],
 ): ActivityRow[] {
   const result: ActivityRow[] = [];
@@ -88,7 +93,7 @@ export function collapseActivityCommitRuns(
 
   while (i < items.length) {
     const item = items[i]!;
-    const groupKey = commitRunGroupKey(item);
+    const groupKey = activityRunGroupKey(item);
     if (groupKey === null) {
       result.push(item);
       i++;
@@ -98,7 +103,7 @@ export function collapseActivityCommitRuns(
     let j = i + 1;
     while (j < items.length) {
       const next = items[j]!;
-      if (commitRunGroupKey(next) !== groupKey) break;
+      if (activityRunGroupKey(next) !== groupKey) break;
       j++;
     }
 
@@ -113,7 +118,7 @@ export function collapseActivityCommitRuns(
       result.push({
         kind: "collapsed",
         id: `collapsed-${latest.id}-${count}`,
-        author: commitRunAuthor(item),
+        author: activityRunAuthor(item),
         count,
         earliest: earliest.created_at,
         latest: latest.created_at,


### PR DESCRIPTION
## Summary
- In the threaded activity view, a run of three or more consecutive comments or reviews from the same author on a single PR now collapses into one "N comments" / "N reviews" row, matching the existing commit-run collapsing.
- The collapsed row is rendered in the event-type color so comment, review, and commit runs stay visually distinct.

![collapsed-runs.png](https://github.com/user-attachments/assets/4fef08a3-7947-4947-b2c2-24a554f95538)