### PR TITLE
Expose opt-in pprof listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ owner = "your-org"
 name = "another-repo"
 ```
 
+To expose Go profiler endpoints for local diagnostics, start a separate listener:
+
+```sh
+MIDDLEMAN_PPROF_ADDR=127.0.0.1:6060 ./middleman
+# or
+./middleman serve -pprof-addr 127.0.0.1:6060
+```
+
+The listener is disabled when the address is empty and serves the standard `/debug/pprof/` endpoints.
+
 ### Install to PATH
 
 ```sh

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -456,9 +456,13 @@ func run(opts serve.Options) error {
 		return err
 	}
 	if profilerSrv != nil {
+		profilerAddr := ""
+		if addr := profilerSrv.Addr(); addr != nil {
+			profilerAddr = addr.String()
+		}
 		slog.Info(
 			"starting profiler listener",
-			"addr", profilerSrv.Addr().String(),
+			"addr", profilerAddr,
 		)
 		defer func() {
 			shutdownCtx, cancel := context.WithTimeout(

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -25,6 +25,7 @@ import (
 	"go.kenn.io/middleman/internal/gitclone"
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/platform"
+	"go.kenn.io/middleman/internal/profiler"
 	"go.kenn.io/middleman/internal/ptyowner"
 	"go.kenn.io/middleman/internal/runtimelock"
 	"go.kenn.io/middleman/internal/server"
@@ -320,7 +321,8 @@ func runStatusCLI(args []string, stdout io.Writer) error {
 	return runtimelock.FormatStatus(stdout, st, *asJSON)
 }
 
-func run(configPath string) error {
+func run(opts serve.Options) error {
+	configPath := opts.ConfigPath
 	if err := config.EnsureDefault(configPath); err != nil {
 		return fmt.Errorf("ensure config: %w", err)
 	}
@@ -449,6 +451,26 @@ func run(configPath string) error {
 	defer syncer.Stop()
 	defer stop()
 
+	profilerSrv, err := profiler.Start(opts.ProfilerAddr)
+	if err != nil {
+		return err
+	}
+	if profilerSrv != nil {
+		slog.Info(
+			"starting profiler listener",
+			"addr", profilerSrv.Addr().String(),
+		)
+		defer func() {
+			shutdownCtx, cancel := context.WithTimeout(
+				context.Background(), 5*time.Second,
+			)
+			defer cancel()
+			if err := profilerSrv.Shutdown(shutdownCtx); err != nil {
+				slog.Warn("profiler shutdown", "err", err)
+			}
+		}()
+	}
+
 	// srv.Shutdown MUST be the last-registered defer so LIFO runs
 	// it FIRST on return: close the HTTP listener (and SSE hub)
 	// before syncer.Stop blocks for up to 30 s, otherwise the
@@ -493,9 +515,18 @@ func run(configPath string) error {
 	case <-ctx.Done():
 		slog.Info("shutting down")
 		return nil
+	case err := <-profilerSrvDone(profilerSrv):
+		return fmt.Errorf("profiler: %w", err)
 	case err := <-errCh:
 		return fmt.Errorf("server: %w", err)
 	}
+}
+
+func profilerSrvDone(srv *profiler.Server) <-chan error {
+	if srv == nil {
+		return nil
+	}
+	return srv.Done()
 }
 
 // writeRuntimeMetadata snapshots the bound listener and process state

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -14,6 +14,7 @@ import (
 	gh "github.com/google/go-github/v84/github"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/cli/serve"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/db"
 	ghclient "go.kenn.io/middleman/internal/github"
@@ -434,9 +435,9 @@ func TestRunCLIDefaultsToServe(t *testing.T) {
 	require := require.New(t)
 	original := runServer
 	t.Cleanup(func() { runServer = original })
-	var gotPath string
-	runServer = func(configPath string) error {
-		gotPath = configPath
+	var got serve.Options
+	runServer = func(opts serve.Options) error {
+		got = opts
 		return nil
 	}
 
@@ -444,7 +445,8 @@ func TestRunCLIDefaultsToServe(t *testing.T) {
 	err := runCLI(nil, &stdout)
 
 	require.NoError(err)
-	assert.Equal(config.DefaultConfigPath(), gotPath)
+	assert.Equal(config.DefaultConfigPath(), got.ConfigPath)
+	assert.Empty(got.ProfilerAddr)
 	assert.Empty(stdout.String())
 }
 
@@ -453,9 +455,9 @@ func TestRunCLIServeSubcommandUsesServerRunner(t *testing.T) {
 	require := require.New(t)
 	original := runServer
 	t.Cleanup(func() { runServer = original })
-	var gotPath string
-	runServer = func(configPath string) error {
-		gotPath = configPath
+	var got serve.Options
+	runServer = func(opts serve.Options) error {
+		got = opts
 		return nil
 	}
 
@@ -464,7 +466,55 @@ func TestRunCLIServeSubcommandUsesServerRunner(t *testing.T) {
 	err := runCLI([]string{"serve", "-config", cfgPath}, &stdout)
 
 	require.NoError(err)
-	assert.Equal(cfgPath, gotPath)
+	assert.Equal(cfgPath, got.ConfigPath)
+	assert.Empty(got.ProfilerAddr)
+	assert.Empty(stdout.String())
+}
+
+func TestRunCLIServePassesProfilerAddress(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	original := runServer
+	t.Cleanup(func() { runServer = original })
+	t.Setenv("MIDDLEMAN_PPROF_ADDR", "127.0.0.1:6060")
+	var got serve.Options
+	runServer = func(opts serve.Options) error {
+		got = opts
+		return nil
+	}
+
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	var stdout bytes.Buffer
+	err := runCLI([]string{
+		"serve",
+		"-config", cfgPath,
+		"-pprof-addr", "127.0.0.1:7070",
+	}, &stdout)
+
+	require.NoError(err)
+	assert.Equal(cfgPath, got.ConfigPath)
+	assert.Equal("127.0.0.1:7070", got.ProfilerAddr)
+	assert.Empty(stdout.String())
+}
+
+func TestRunCLIServeDefaultsProfilerAddressFromEnv(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	original := runServer
+	t.Cleanup(func() { runServer = original })
+	t.Setenv("MIDDLEMAN_PPROF_ADDR", "127.0.0.1:6060")
+	var got serve.Options
+	runServer = func(opts serve.Options) error {
+		got = opts
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	err := runCLI([]string{"serve"}, &stdout)
+
+	require.NoError(err)
+	assert.Equal(config.DefaultConfigPath(), got.ConfigPath)
+	assert.Equal("127.0.0.1:6060", got.ProfilerAddr)
 	assert.Empty(stdout.String())
 }
 
@@ -473,7 +523,7 @@ func TestRunCLIControlCommandsDoNotStartServer(t *testing.T) {
 	require := require.New(t)
 	original := runServer
 	t.Cleanup(func() { runServer = original })
-	runServer = func(string) error {
+	runServer = func(serve.Options) error {
 		return errors.New("serve should not start")
 	}
 

--- a/cmd/middleman/profiler_e2e_test.go
+++ b/cmd/middleman/profiler_e2e_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/middleman/internal/procutil"
+	"go.kenn.io/middleman/internal/runtimelock"
+)
+
+func TestServeStartsProfilerListenerE2E(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	bin := buildMiddleman(t)
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	require.NoError(os.MkdirAll(dataDir, 0o700))
+	cfgPath := filepath.Join(root, "config.toml")
+
+	appPort := reserveFreePort(t)
+	profilerPort := reserveFreePort(t)
+	writeMinimalConfig(t, cfgPath, dataDir, appPort)
+
+	cmd := procutil.Command(
+		bin,
+		"serve",
+		"--config", cfgPath,
+		"--pprof-addr", "127.0.0.1:"+strconv.Itoa(profilerPort),
+	)
+	var stderr bytes.Buffer
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(),
+		"MIDDLEMAN_LOG_LEVEL=warn",
+		"MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_LOCK_E2E=",
+	)
+	require.NoError(cmd.Start())
+	stopped := false
+	t.Cleanup(func() {
+		if !stopped && cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+			_ = cmd.Wait()
+		}
+	})
+
+	waitForFile(t, runtimelock.MetadataPath(dataDir), 10*time.Second)
+	healthBody := waitForHTTPBody(
+		t,
+		fmt.Sprintf("http://127.0.0.1:%d/healthz", appPort),
+		10*time.Second,
+	)
+	profilerBody := waitForHTTPBody(
+		t,
+		fmt.Sprintf(
+			"http://127.0.0.1:%d/debug/pprof/",
+			profilerPort,
+		),
+		10*time.Second,
+	)
+
+	assert.Contains(healthBody, `"status":"ok"`)
+	assert.Contains(profilerBody, "Types of profiles available")
+
+	require.NoError(cmd.Process.Signal(syscall.SIGTERM))
+	require.NoError(cmd.Wait(), stderr.String())
+	stopped = true
+}
+
+func waitForHTTPBody(
+	t *testing.T,
+	url string,
+	timeout time.Duration,
+) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			lastErr = readErr
+		} else if closeErr != nil {
+			lastErr = closeErr
+		} else if resp.StatusCode == http.StatusOK {
+			return string(body)
+		} else {
+			lastErr = fmt.Errorf(
+				"GET %s returned %d: %s",
+				url, resp.StatusCode, body,
+			)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(t, lastErr, "timed out waiting for %s", url)
+	require.FailNowf(t, "timed out waiting for HTTP", "url=%s", url)
+	return ""
+}

--- a/cmd/middleman/profiler_e2e_test.go
+++ b/cmd/middleman/profiler_e2e_test.go
@@ -72,10 +72,91 @@ func TestServeStartsProfilerListenerE2E(t *testing.T) {
 
 	assert.Contains(healthBody, `"status":"ok"`)
 	assert.Contains(profilerBody, "Types of profiles available")
+	profilerURL := fmt.Sprintf("http://127.0.0.1:%d", profilerPort)
+	assert.Equal(
+		http.StatusForbidden,
+		profilerStatus(
+			t,
+			profilerURL+"/debug/pprof/",
+			"localhost:"+strconv.Itoa(profilerPort),
+			nil,
+		),
+	)
+	assert.Equal(
+		http.StatusForbidden,
+		profilerStatus(
+			t,
+			profilerURL+"/debug/pprof/",
+			"",
+			map[string]string{"Sec-Fetch-Site": "cross-site"},
+		),
+	)
+	assert.Equal(
+		http.StatusForbidden,
+		profilerStatus(
+			t,
+			profilerURL+"/debug/pprof/",
+			"",
+			map[string]string{"Origin": "http://example.com"},
+		),
+	)
+	assert.Equal(
+		http.StatusForbidden,
+		profilerStatus(
+			t,
+			profilerURL+"/debug/pprof/",
+			"",
+			map[string]string{
+				"User-Agent": "Mozilla/5.0 AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36",
+			},
+		),
+	)
+	assert.Equal(
+		http.StatusBadRequest,
+		profilerStatus(
+			t,
+			profilerURL+"/debug/pprof/profile?seconds=31",
+			"",
+			nil,
+		),
+	)
+	assert.Equal(
+		http.StatusBadRequest,
+		profilerStatus(
+			t,
+			profilerURL+"/debug/pprof/heap?seconds=31",
+			"",
+			nil,
+		),
+	)
 
 	require.NoError(cmd.Process.Signal(syscall.SIGTERM))
 	require.NoError(cmd.Wait(), stderr.String())
 	stopped = true
+}
+
+func profilerStatus(
+	t *testing.T,
+	url string,
+	host string,
+	headers map[string]string,
+) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	if host != "" {
+		req.Host = host
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode
 }
 
 func waitForHTTPBody(

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -3,11 +3,18 @@ package serve
 import (
 	"flag"
 	"io"
+	"os"
+	"strings"
 
 	"go.kenn.io/middleman/internal/config"
 )
 
-type Runner func(configPath string) error
+type Options struct {
+	ConfigPath   string
+	ProfilerAddr string
+}
+
+type Runner func(opts Options) error
 
 func Run(args []string, run Runner) error {
 	fs := flag.NewFlagSet("middleman serve", flag.ContinueOnError)
@@ -16,8 +23,16 @@ func Run(args []string, run Runner) error {
 		"config", config.DefaultConfigPath(),
 		"path to config file",
 	)
+	profilerAddr := fs.String(
+		"pprof-addr",
+		strings.TrimSpace(os.Getenv("MIDDLEMAN_PPROF_ADDR")),
+		"address for optional net/http/pprof listener (empty disables)",
+	)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	return run(*configPath)
+	return run(Options{
+		ConfigPath:   *configPath,
+		ProfilerAddr: strings.TrimSpace(*profilerAddr),
+	})
 }

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -1,0 +1,97 @@
+package profiler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"strings"
+	"time"
+)
+
+// Server owns the optional diagnostics HTTP listener.
+type Server struct {
+	httpSrv *http.Server
+	ln      net.Listener
+	done    chan error
+}
+
+// NewHandler returns a mux with the standard net/http/pprof endpoints.
+func NewHandler() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	return mux
+}
+
+// Start begins serving the standard profiler endpoints on addr.
+func Start(addr string) (*Server, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return nil, nil
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen on profiler address %s: %w", addr, err)
+	}
+
+	httpSrv := &http.Server{
+		Handler:           NewHandler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	srv := &Server{
+		httpSrv: httpSrv,
+		ln:      ln,
+		done:    make(chan error, 1),
+	}
+	go func() {
+		err := httpSrv.Serve(ln)
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		srv.done <- err
+	}()
+	return srv, nil
+}
+
+// Addr returns the bound listener address.
+func (s *Server) Addr() net.Addr {
+	if s == nil || s.ln == nil {
+		return nil
+	}
+	return s.ln.Addr()
+}
+
+// Done reports unexpected serving errors.
+func (s *Server) Done() <-chan error {
+	if s == nil {
+		return nil
+	}
+	return s.done
+}
+
+// Shutdown stops the diagnostics listener and waits for Serve to return.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	shutdownErr := s.httpSrv.Shutdown(ctx)
+	select {
+	case serveErr := <-s.done:
+		if shutdownErr != nil {
+			return shutdownErr
+		}
+		return serveErr
+	case <-ctx.Done():
+		if shutdownErr != nil {
+			return shutdownErr
+		}
+		return ctx.Err()
+	}
+}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -171,8 +171,7 @@ func isBrowserUserAgent(userAgent string) bool {
 
 func limitExpensiveProfiles(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/debug/pprof/profile" &&
-			r.URL.Path != "/debug/pprof/trace" {
+		if !strings.HasPrefix(r.URL.Path, "/debug/pprof/") {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -45,7 +45,7 @@ func Start(addr string) (*Server, error) {
 	}
 
 	httpSrv := &http.Server{
-		Handler:           NewHandler(),
+		Handler:           allowBoundHostOnly(NewHandler(), ln.Addr()),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	srv := &Server{
@@ -76,6 +76,31 @@ func validateLoopbackAddress(addr string) error {
 		)
 	}
 	return nil
+}
+
+func allowBoundHostOnly(next http.Handler, addr net.Addr) http.Handler {
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	if !ok || tcpAddr.IP == nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "profiler host not allowed", http.StatusForbidden)
+		})
+	}
+	allowedIP := tcpAddr.IP
+	allowedPort := fmt.Sprint(tcpAddr.Port)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host, port, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			http.Error(w, "profiler host not allowed", http.StatusForbidden)
+			return
+		}
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.Equal(allowedIP) || port != allowedPort {
+			http.Error(w, "profiler host not allowed", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Addr returns the bound listener address.

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -68,13 +68,10 @@ func validateLoopbackAddress(addr string) error {
 	if err != nil {
 		return fmt.Errorf("invalid profiler address %s: %w", addr, err)
 	}
-	if strings.EqualFold(host, "localhost") {
-		return nil
-	}
 	ip := net.ParseIP(host)
 	if ip == nil || !ip.IsLoopback() {
 		return fmt.Errorf(
-			"profiler address %s must bind to a loopback host",
+			"profiler address %s must bind to a literal loopback IP",
 			addr,
 		)
 	}

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -7,9 +7,13 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
+
+const maxExpensiveProfileSeconds = 30
 
 // Server owns the optional diagnostics HTTP listener.
 type Server struct {
@@ -45,7 +49,10 @@ func Start(addr string) (*Server, error) {
 	}
 
 	httpSrv := &http.Server{
-		Handler:           allowBoundHostOnly(NewHandler(), ln.Addr()),
+		Handler: allowBoundHostOnly(
+			limitExpensiveProfiles(rejectCrossSiteBrowserRequests(NewHandler())),
+			ln.Addr(),
+		),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	srv := &Server{
@@ -99,6 +106,66 @@ func allowBoundHostOnly(next http.Handler, addr net.Addr) http.Handler {
 			http.Error(w, "profiler host not allowed", http.StatusForbidden)
 			return
 		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func rejectCrossSiteBrowserRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("Sec-Fetch-Site") {
+		case "", "none", "same-origin":
+		default:
+			http.Error(
+				w,
+				"profiler cross-site browser request not allowed",
+				http.StatusForbidden,
+			)
+			return
+		}
+
+		origin := r.Header.Get("Origin")
+		if origin != "" {
+			originURL, err := url.Parse(origin)
+			if err != nil || originURL.Scheme != "http" || originURL.Host != r.Host {
+				http.Error(
+					w,
+					"profiler origin not allowed",
+					http.StatusForbidden,
+				)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func limitExpensiveProfiles(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/debug/pprof/profile" &&
+			r.URL.Path != "/debug/pprof/trace" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		seconds := r.URL.Query().Get("seconds")
+		if seconds == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		value, err := strconv.Atoi(seconds)
+		if err == nil && value > maxExpensiveProfileSeconds {
+			http.Error(
+				w,
+				fmt.Sprintf(
+					"profiler seconds must be <= %d",
+					maxExpensiveProfileSeconds,
+				),
+				http.StatusBadRequest,
+			)
+			return
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -112,7 +112,10 @@ func allowBoundHostOnly(next http.Handler, addr net.Addr) http.Handler {
 
 func rejectCrossSiteBrowserRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Header.Get("Sec-Fetch-Site") {
+		fetchSite := r.Header.Get("Sec-Fetch-Site")
+		origin := r.Header.Get("Origin")
+
+		switch fetchSite {
 		case "", "none", "same-origin":
 		default:
 			http.Error(
@@ -123,7 +126,6 @@ func rejectCrossSiteBrowserRequests(next http.Handler) http.Handler {
 			return
 		}
 
-		origin := r.Header.Get("Origin")
 		if origin != "" {
 			originURL, err := url.Parse(origin)
 			if err != nil || originURL.Scheme != "http" || originURL.Host != r.Host {
@@ -136,8 +138,35 @@ func rejectCrossSiteBrowserRequests(next http.Handler) http.Handler {
 			}
 		}
 
+		if fetchSite == "" && origin == "" && isBrowserUserAgent(r.UserAgent()) {
+			http.Error(
+				w,
+				"profiler browser request metadata required",
+				http.StatusForbidden,
+			)
+			return
+		}
+
 		next.ServeHTTP(w, r)
 	})
+}
+
+func isBrowserUserAgent(userAgent string) bool {
+	userAgent = strings.ToLower(userAgent)
+	for _, marker := range []string{
+		"mozilla/",
+		"firefox/",
+		"chrome/",
+		"chromium/",
+		"safari/",
+		"edg/",
+		"opr/",
+	} {
+		if strings.Contains(userAgent, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func limitExpensiveProfiles(next http.Handler) http.Handler {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -35,6 +35,9 @@ func Start(addr string) (*Server, error) {
 	if addr == "" {
 		return nil, nil
 	}
+	if err := validateLoopbackAddress(addr); err != nil {
+		return nil, err
+	}
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -58,6 +61,24 @@ func Start(addr string) (*Server, error) {
 		srv.done <- err
 	}()
 	return srv, nil
+}
+
+func validateLoopbackAddress(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid profiler address %s: %w", addr, err)
+	}
+	if strings.EqualFold(host, "localhost") {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf(
+			"profiler address %s must bind to a loopback host",
+			addr,
+		)
+	}
+	return nil
 }
 
 // Addr returns the bound listener address.

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -97,3 +97,31 @@ func TestStartServesProfilerIndex(t *testing.T) {
 	assert.Equal(http.StatusOK, resp.StatusCode)
 	assert.Contains(string(body), "Types of profiles available")
 }
+
+func TestStartRejectsNonBoundHostHeader(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"http://"+srv.Addr().String()+"/debug/pprof/",
+		nil,
+	)
+	require.NoError(err)
+	req.Host = "localhost" + srv.Addr().String()[len("127.0.0.1"):]
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusForbidden, resp.StatusCode)
+}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -39,6 +39,7 @@ func TestStartRejectsNonLoopbackAddress(t *testing.T) {
 		"[::]:6060",
 		"192.0.2.10:6060",
 		"example.com:6060",
+		"localhost:6060",
 	}
 
 	for _, addr := range tests {
@@ -55,7 +56,7 @@ func TestStartRejectsNonLoopbackAddress(t *testing.T) {
 func TestStartAcceptsLoopbackAddress(t *testing.T) {
 	tests := []string{
 		"127.0.0.1:0",
-		"localhost:0",
+		"[::1]:0",
 	}
 
 	for _, addr := range tests {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1,0 +1,56 @@
+package profiler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHandlerRegistersStandardProfilerEndpoints(t *testing.T) {
+	mux := NewHandler()
+
+	for _, path := range []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile",
+		"/debug/pprof/symbol",
+		"/debug/pprof/trace",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, path, nil)
+			require.NoError(t, err)
+
+			_, pattern := mux.Handler(req)
+
+			Assert.Equal(t, path, pattern)
+		})
+	}
+}
+
+func TestStartServesProfilerIndex(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	resp, err := http.Get("http://" + srv.Addr().String() + "/debug/pprof/")
+	require.NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Contains(string(body), "Types of profiles available")
+}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -262,3 +262,25 @@ func TestStartCapsExpensiveProfileSeconds(t *testing.T) {
 
 	assert.Equal(http.StatusBadRequest, resp.StatusCode)
 }
+
+func TestStartCapsRuntimeProfileSeconds(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	resp, err := http.Get(
+		"http://" + srv.Addr().String() + "/debug/pprof/heap?seconds=31",
+	)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+}

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -32,6 +32,48 @@ func TestNewHandlerRegistersStandardProfilerEndpoints(t *testing.T) {
 	}
 }
 
+func TestStartRejectsNonLoopbackAddress(t *testing.T) {
+	tests := []string{
+		":6060",
+		"0.0.0.0:6060",
+		"[::]:6060",
+		"192.0.2.10:6060",
+		"example.com:6060",
+	}
+
+	for _, addr := range tests {
+		t.Run(addr, func(t *testing.T) {
+			srv, err := Start(addr)
+
+			require.Error(t, err)
+			Assert.Nil(t, srv)
+			Assert.Contains(t, err.Error(), "loopback")
+		})
+	}
+}
+
+func TestStartAcceptsLoopbackAddress(t *testing.T) {
+	tests := []string{
+		"127.0.0.1:0",
+		"localhost:0",
+	}
+
+	for _, addr := range tests {
+		t.Run(addr, func(t *testing.T) {
+			srv, err := Start(addr)
+			require.NoError(t, err)
+			require.NotNil(t, srv)
+			t.Cleanup(func() {
+				ctx, cancel := context.WithTimeout(
+					context.Background(), time.Second,
+				)
+				defer cancel()
+				require.NoError(t, srv.Shutdown(ctx))
+			})
+		})
+	}
+}
+
 func TestStartServesProfilerIndex(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -182,6 +182,65 @@ func TestStartRejectsMismatchedOrigin(t *testing.T) {
 	assert.Equal(http.StatusForbidden, resp.StatusCode)
 }
 
+func TestStartRejectsBrowserRequestWithoutMetadata(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"http://"+srv.Addr().String()+"/debug/pprof/",
+		nil,
+	)
+	require.NoError(err)
+	req.Header.Set(
+		"User-Agent",
+		"Mozilla/5.0 AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36",
+	)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusForbidden, resp.StatusCode)
+}
+
+func TestStartAllowsNonBrowserRequestWithoutMetadata(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"http://"+srv.Addr().String()+"/debug/pprof/",
+		nil,
+	)
+	require.NoError(err)
+	req.Header.Set("User-Agent", "curl/8.7.1")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusOK, resp.StatusCode)
+}
+
 func TestStartCapsExpensiveProfileSeconds(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -125,3 +125,81 @@ func TestStartRejectsNonBoundHostHeader(t *testing.T) {
 
 	assert.Equal(http.StatusForbidden, resp.StatusCode)
 }
+
+func TestStartRejectsCrossSiteBrowserRequest(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"http://"+srv.Addr().String()+"/debug/pprof/",
+		nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusForbidden, resp.StatusCode)
+}
+
+func TestStartRejectsMismatchedOrigin(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"http://"+srv.Addr().String()+"/debug/pprof/",
+		nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Origin", "http://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusForbidden, resp.StatusCode)
+}
+
+func TestStartCapsExpensiveProfileSeconds(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, err := Start("127.0.0.1:0")
+	require.NoError(err)
+	require.NotNil(srv)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	resp, err := http.Get(
+		"http://" + srv.Addr().String() + "/debug/pprof/profile?seconds=31",
+	)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+}

--- a/tools/nohttpmux/main.go
+++ b/tools/nohttpmux/main.go
@@ -245,10 +245,13 @@ func isHTTPDefaultServeMux(expr ast.Expr, httpImports map[string]struct{}) bool 
 }
 
 func allowedRegistration(path string, call *ast.CallExpr) bool {
-	if !pathHasSuffix(path, "internal/server/server.go") {
+	if len(call.Args) == 0 {
 		return false
 	}
-	if len(call.Args) == 0 {
+	if pathHasSuffix(path, "internal/profiler/profiler.go") {
+		return isProfilerRoute(routePattern(call.Args[0]))
+	}
+	if !pathHasSuffix(path, "internal/server/server.go") {
 		return false
 	}
 
@@ -256,6 +259,19 @@ func allowedRegistration(path string, call *ast.CallExpr) bool {
 	case "/", "/healthz", "/livez":
 		return true
 	case "basePath":
+		return true
+	default:
+		return false
+	}
+}
+
+func isProfilerRoute(pattern string) bool {
+	switch pattern {
+	case "/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile",
+		"/debug/pprof/symbol",
+		"/debug/pprof/trace":
 		return true
 	default:
 		return false

--- a/tools/nohttpmux/main_test.go
+++ b/tools/nohttpmux/main_test.go
@@ -62,6 +62,34 @@ func newServer(basePath string) {
 	assert.Empty(diagnostics)
 }
 
+func TestCheckSourceAllowsProfilerMuxRoutes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	src := `package profiler
+
+import "net/http"
+
+func NewHandler() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", nil)
+	mux.HandleFunc("/debug/pprof/cmdline", nil)
+	mux.HandleFunc("/debug/pprof/profile", nil)
+	mux.HandleFunc("/debug/pprof/symbol", nil)
+	mux.HandleFunc("/debug/pprof/trace", nil)
+	mux.HandleFunc("/api/v1/pulls", nil)
+}
+`
+
+	diagnostics, err := checkSource(
+		"internal/profiler/profiler.go", src,
+	)
+
+	require.NoError(err)
+	require.Len(diagnostics, 1)
+	assert.Equal(12, diagnostics[0].Line)
+}
+
 func TestCheckSourceIgnoresTestsAndUntrackedHttptestMuxes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
Middleman needs Go's standard profiler endpoints available on demand when investigating local runtime behavior, but those diagnostics should not be exposed on the normal UI/API listener by default. This adds an explicit opt-in listener so maintainers can bind profiling to loopback only when they need it.

- Add a separate pprof listener gated by MIDDLEMAN_PPROF_ADDR or serve -pprof-addr.
- Serve the standard /debug/pprof/ endpoints from that listener.
- Document usage and keep the route guard limited to the standard profiler paths.