### PR TITLE
Let the activity rail resize wider on wide viewports

### DIFF
--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -1229,6 +1229,48 @@ test.describe("activity split view and detail drawers", () => {
     expect(resizedRailBox!.width).toBeGreaterThan(railBox!.width + 40);
   });
 
+  test("activity split rail resizes past the old 560px cap on a wide viewport", async ({ page }) => {
+    // Regression guard: the rail used to be clamped near 560px. On a
+    // wide monitor it must now grow well past that, while still leaving
+    // the detail pane a usable width.
+    await page.setViewportSize({ width: 1920, height: 1000 });
+
+    await page.goto("/");
+    await waitForActivityTable(page);
+
+    await openActivityPRSplit(page);
+
+    const rail = page.locator(".activity-pane");
+    const detail = page.locator(".activity-detail");
+    const resizeHandle = page.locator(".activity-split-resize-handle");
+    await expect(resizeHandle).toBeVisible();
+
+    const handleBox = await resizeHandle.boundingBox();
+    expect(handleBox).not.toBeNull();
+
+    // Drag the splitter far to the right, past where the old fixed cap
+    // would have stopped it.
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox!.x + 760,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.up();
+
+    const railBox = await rail.boundingBox();
+    const detailBox = await detail.boundingBox();
+    expect(railBox).not.toBeNull();
+    expect(detailBox).not.toBeNull();
+    // Well past the previous ~560px ceiling.
+    expect(railBox!.width).toBeGreaterThan(600);
+    // The detail pane keeps a usable minimum and is never squeezed away.
+    expect(detailBox!.width).toBeGreaterThan(300);
+  });
+
   test("activity split view lets the View dropdown float past the rail splitter", async ({ page }) => {
     await page.goto("/");
     await waitForActivityTable(page);

--- a/packages/ui/src/views/ActivityFeedView.svelte
+++ b/packages/ui/src/views/ActivityFeedView.svelte
@@ -65,12 +65,42 @@
   let internalDetailTab = $state<ActivityDetailTab>(
     "conversation",
   );
-  let activityPaneWidth = $state(360);
+  // The width the user has dragged the rail to. The effective width
+  // below re-clamps it reactively so it survives viewport changes.
+  let requestedActivityPaneWidth = $state(360);
   let activityPaneCollapsed = $state(false);
+  // Measured width of the whole split shell so the rail's upper bound
+  // scales with the viewport rather than a fixed pixel cap.
+  let activityShellWidth = $state(0);
 
   const minActivityPaneWidth = 280;
-  const maxActivityPaneWidth = 560;
+  // Space always kept for the detail pane so the rail can never be
+  // dragged wide enough to squeeze it to nothing.
+  const minDetailPaneWidth = 360;
   let activityResizeStartWidth = 0;
+
+  // No fixed ceiling: on a wide monitor the rail grows until only
+  // minDetailPaneWidth remains for the detail pane. Before the shell is
+  // measured the bound is open so the initial width is never clamped.
+  const maxActivityPaneWidth = $derived(
+    activityShellWidth > 0
+      ? Math.max(minActivityPaneWidth, activityShellWidth - minDetailPaneWidth)
+      : Number.POSITIVE_INFINITY,
+  );
+
+  function clampActivityPaneWidth(width: number): number {
+    return Math.max(
+      minActivityPaneWidth,
+      Math.min(maxActivityPaneWidth, width),
+    );
+  }
+
+  // Effective rail width: the requested width re-clamped to the current
+  // maximum, so narrowing the viewport keeps the detail pane visible and
+  // widening it restores the rail toward the requested width.
+  const activityPaneWidth = $derived(
+    clampActivityPaneWidth(requestedActivityPaneWidth),
+  );
 
   const controlled = $derived(
     controlledDrawer !== undefined || onCloseDrawer !== undefined,
@@ -164,13 +194,6 @@
     onCloseDrawer?.();
   }
 
-  function clampActivityPaneWidth(width: number): number {
-    return Math.max(
-      minActivityPaneWidth,
-      Math.min(maxActivityPaneWidth, width),
-    );
-  }
-
   function handleActivityPaneResizeStart(): void {
     activityResizeStartWidth = activityPaneWidth;
   }
@@ -178,7 +201,7 @@
   function handleActivityPaneResize(
     event: SplitResizeEvent,
   ): void {
-    activityPaneWidth = clampActivityPaneWidth(
+    requestedActivityPaneWidth = clampActivityPaneWidth(
       activityResizeStartWidth + event.deltaX,
     );
   }
@@ -214,6 +237,7 @@
   class:activity-shell--split={hasActiveDetail}
   class:activity-shell--full={!hasActiveDetail}
   class:activity-shell--phone={phone}
+  bind:clientWidth={activityShellWidth}
 >
   <section
     class="activity-pane"


### PR DESCRIPTION
The Activity split-view rail (the left feed shown beside an open PR/issue detail) was capped at a fixed ~560px, so it could not be widened on a large maximized window.

- The rail's maximum width now scales with the window width instead of a fixed cap, so it can be dragged much wider on large monitors.
- A minimum width is always reserved for the detail pane, so the rail can never squeeze it away.
- Narrowing the window pulls an over-wide rail back in; widening it restores the rail toward the width you last set.

## Screenshot

Activity rail dragged to ~880px on a 1680px viewport (past the old 560px cap), with the detail pane beside it:

![activity-rail-wide.png](https://github.com/user-attachments/assets/c34ba699-7087-4b1b-9d72-95a6dcd8e92b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)