### PR TITLE
Include stack context in pull detail responses

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1707,6 +1707,8 @@ components:
           type: string
         repo_owner:
           type: string
+        stack:
+          $ref: "#/components/schemas/StackContextResponse"
         warnings:
           items:
             type: string

--- a/frontend/tests/e2e/stack-status.spec.ts
+++ b/frontend/tests/e2e/stack-status.spec.ts
@@ -197,12 +197,9 @@ async function fulfillJson(route: Route, body: unknown, status = 200): Promise<v
 async function mockStackedPR(
   page: Page,
   options: {
-    includeStackInDetail?: boolean;
     stackResponseDelays?: Map<number, Promise<void>>;
   } = {},
 ): Promise<void> {
-  const includeStackInDetail = options.includeStackInDetail ?? true;
-
   await page.route("**/api/v1/**", async (route) => {
     const url = new URL(route.request().url());
     const { pathname } = url;
@@ -241,7 +238,7 @@ async function mockStackedPR(
           count: 0,
           runs: [],
         },
-        stack: includeStackInDetail && member
+        stack: member
           ? {
               stack_id: 1,
               stack_name: "session-recovery",
@@ -262,10 +259,14 @@ async function mockStackedPR(
       const number = Number(stackMatch[1]!);
       const member = stackMembers.find((candidate) => candidate.number === number);
       await options.stackResponseDelays?.get(number);
+      if (!member) {
+        await fulfillJson(route, { error: "PR is not part of a stack" }, 404);
+        return;
+      }
       await fulfillJson(route, {
         stack_id: 1,
         stack_name: "session-recovery",
-        position: member?.position ?? 2,
+        position: member.position,
         size: 7,
         health: "blocked",
         members: stackMembers,
@@ -359,9 +360,9 @@ test("unstacked pull detail does not request stack context", async ({ page }) =>
       stackRequests += 1;
     }
   });
-  await mockStackedPR(page, { includeStackInDetail: false });
+  await mockStackedPR(page);
 
-  await page.goto("/pulls/github/acme/widgets/102");
+  await page.goto("/pulls/github/acme/widgets/108");
 
   await expect(page.getByTestId("ci-chip")).toBeVisible();
   await expect(page.getByTestId("stack-chip")).toHaveCount(0);

--- a/frontend/tests/e2e/stack-status.spec.ts
+++ b/frontend/tests/e2e/stack-status.spec.ts
@@ -88,8 +88,8 @@ const pr = {
   worktree_links: [],
 };
 
-function prForNumber(number: number) {
-  const member = stackMembers.find((candidate) => candidate.number === number);
+function prForNumber(number: number, members = stackMembers) {
+  const member = members.find((candidate) => candidate.number === number);
   return {
     ...pr,
     ID: number,
@@ -186,6 +186,8 @@ const stackMembers = [
   },
 ];
 
+type StackMember = (typeof stackMembers)[number];
+
 async function fulfillJson(route: Route, body: unknown, status = 200): Promise<void> {
   await route.fulfill({
     status,
@@ -197,6 +199,7 @@ async function fulfillJson(route: Route, body: unknown, status = 200): Promise<v
 async function mockStackedPR(
   page: Page,
   options: {
+    stackMembers?: () => StackMember[];
     stackResponseDelays?: Map<number, Promise<void>>;
   } = {},
 ): Promise<void> {
@@ -215,8 +218,9 @@ async function mockStackedPR(
     );
     if (method === "GET" && detailMatch) {
       const number = Number(detailMatch[1]!);
-      const detailPR = prForNumber(number);
-      const member = stackMembers.find((candidate) => candidate.number === number);
+      const currentStackMembers = options.stackMembers?.() ?? stackMembers;
+      const detailPR = prForNumber(number, currentStackMembers);
+      const member = currentStackMembers.find((candidate) => candidate.number === number);
       await fulfillJson(route, {
         merge_request: detailPR,
         repo: repoRef(),
@@ -243,9 +247,9 @@ async function mockStackedPR(
               stack_id: 1,
               stack_name: "session-recovery",
               position: member.position,
-              size: 7,
+              size: currentStackMembers.length,
               health: "blocked",
-              members: stackMembers,
+              members: currentStackMembers,
             }
           : undefined,
       });
@@ -257,7 +261,8 @@ async function mockStackedPR(
     );
     if (method === "GET" && stackMatch) {
       const number = Number(stackMatch[1]!);
-      const member = stackMembers.find((candidate) => candidate.number === number);
+      const currentStackMembers = options.stackMembers?.() ?? stackMembers;
+      const member = currentStackMembers.find((candidate) => candidate.number === number);
       await options.stackResponseDelays?.get(number);
       if (!member) {
         await fulfillJson(route, { error: "PR is not part of a stack" }, 404);
@@ -267,9 +272,9 @@ async function mockStackedPR(
         stack_id: 1,
         stack_name: "session-recovery",
         position: member.position,
-        size: 7,
+        size: currentStackMembers.length,
         health: "blocked",
-        members: stackMembers,
+        members: currentStackMembers,
       });
       return;
     }
@@ -353,6 +358,57 @@ async function mockStackedPR(
   });
 }
 
+async function emitPRDetailRefreshed(page: Page, number: number): Promise<void> {
+  await page.evaluate((ref) => {
+    const eventSources = (window as unknown as {
+      __middlemanEventSources?: EventTarget[];
+    }).__middlemanEventSources;
+    eventSources?.[0]?.dispatchEvent(new MessageEvent("pr_detail_refreshed", {
+      data: JSON.stringify(ref),
+    }));
+  }, {
+    provider: "github",
+    platform_host: "github.com",
+    repo_path: "acme/widgets",
+    owner: "acme",
+    name: "widgets",
+    number,
+  });
+}
+
+async function installMockEventSource(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const eventSources: EventTarget[] = [];
+
+    class MockEventSource extends EventTarget {
+      url: string;
+      readyState = 0;
+
+      constructor(url: string) {
+        super();
+        this.url = url;
+        eventSources.push(this);
+        setTimeout(() => {
+          this.readyState = 1;
+          this.dispatchEvent(new Event("open"));
+        }, 0);
+      }
+
+      close(): void {
+        this.readyState = 2;
+      }
+    }
+
+    (window as unknown as {
+      EventSource: typeof EventSource;
+      __middlemanEventSources: EventTarget[];
+    }).EventSource = MockEventSource as unknown as typeof EventSource;
+    (window as unknown as {
+      __middlemanEventSources: EventTarget[];
+    }).__middlemanEventSources = eventSources;
+  });
+}
+
 test("unstacked pull detail does not request stack context", async ({ page }) => {
   let stackRequests = 0;
   page.on("request", (request) => {
@@ -412,6 +468,33 @@ test("stack status shares the PR detail expandable slot with CI", async ({ page 
   await expect(page).toHaveURL(/\/pulls\/github\/acme\/widgets\/101$/);
   await expect(page.getByText("7 PRs · current 1/7")).toBeVisible();
   await expect(page.locator(".stack-base-name")).toHaveText("main");
+});
+
+test("stack status follows refreshed detail stack data", async ({ page }) => {
+  await installMockEventSource(page);
+  let currentStackMembers: StackMember[] = stackMembers;
+  await mockStackedPR(page, {
+    stackMembers: () => currentStackMembers,
+  });
+
+  await page.goto("/pulls/github/acme/widgets/102");
+  await expect(page.getByRole("button", {
+    name: /Stacked: 2\/7, 1 downstack CI failure/i,
+  })).toBeVisible();
+
+  currentStackMembers = [
+    { ...stackMembers[0]!, ci_status: "success" },
+    { ...stackMembers[1]!, ci_status: "success" },
+  ];
+  await emitPRDetailRefreshed(page, 102);
+
+  await expect(page.getByRole("button", { name: /Stacked: 2\/2/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Stacked: 2\/7/i })).toHaveCount(0);
+
+  currentStackMembers = [];
+  await emitPRDetailRefreshed(page, 102);
+
+  await expect(page.getByTestId("stack-chip")).toHaveCount(0);
 });
 
 test("stack status stays rendered while navigating to a stack member", async ({ page }) => {

--- a/frontend/tests/e2e/stack-status.spec.ts
+++ b/frontend/tests/e2e/stack-status.spec.ts
@@ -196,8 +196,13 @@ async function fulfillJson(route: Route, body: unknown, status = 200): Promise<v
 
 async function mockStackedPR(
   page: Page,
-  options: { stackResponseDelays?: Map<number, Promise<void>> } = {},
+  options: {
+    includeStackInDetail?: boolean;
+    stackResponseDelays?: Map<number, Promise<void>>;
+  } = {},
 ): Promise<void> {
+  const includeStackInDetail = options.includeStackInDetail ?? true;
+
   await page.route("**/api/v1/**", async (route) => {
     const url = new URL(route.request().url());
     const { pathname } = url;
@@ -214,6 +219,7 @@ async function mockStackedPR(
     if (method === "GET" && detailMatch) {
       const number = Number(detailMatch[1]!);
       const detailPR = prForNumber(number);
+      const member = stackMembers.find((candidate) => candidate.number === number);
       await fulfillJson(route, {
         merge_request: detailPR,
         repo: repoRef(),
@@ -235,6 +241,16 @@ async function mockStackedPR(
           count: 0,
           runs: [],
         },
+        stack: includeStackInDetail && member
+          ? {
+              stack_id: 1,
+              stack_name: "session-recovery",
+              position: member.position,
+              size: 7,
+              health: "blocked",
+              members: stackMembers,
+            }
+          : undefined,
       });
       return;
     }
@@ -335,6 +351,22 @@ async function mockStackedPR(
     await fulfillJson(route, { error: `Unhandled ${method} ${pathname}` }, 404);
   });
 }
+
+test("unstacked pull detail does not request stack context", async ({ page }) => {
+  let stackRequests = 0;
+  page.on("request", (request) => {
+    if (new URL(request.url()).pathname.endsWith("/stack")) {
+      stackRequests += 1;
+    }
+  });
+  await mockStackedPR(page, { includeStackInDetail: false });
+
+  await page.goto("/pulls/github/acme/widgets/102");
+
+  await expect(page.getByTestId("ci-chip")).toBeVisible();
+  await expect(page.getByTestId("stack-chip")).toHaveCount(0);
+  expect(stackRequests).toBe(0);
+});
 
 test("stack status shares the PR detail expandable slot with CI", async ({ page }) => {
   await page.setViewportSize({ width: 892, height: 998 });

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -938,6 +938,7 @@ type MergeRequestDetailResponse struct {
 	Repo             RepoRefResponse              `json:"repo"`
 	RepoName         string                       `json:"repo_name"`
 	RepoOwner        string                       `json:"repo_owner"`
+	Stack            *StackContextResponse        `json:"stack,omitempty"`
 	Warnings         *[]string                    `json:"warnings,omitempty"`
 	WorkflowApproval WorkflowApprovalResponse     `json:"workflow_approval"`
 	Workspace        *WorkspaceRef                `json:"workspace,omitempty"`

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -16095,6 +16095,37 @@ func TestAPIGetStackForPR(t *testing.T) {
 	assert.Equal(http.StatusNotFound, resp2.StatusCode())
 }
 
+func TestAPIGetPullDetailIncludesStackContext(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+
+	seedStackedPR(t, database, "acme", "widget", 10, "feat/api-base", "main", db.MergeRequestStateOpen, "failure", "")
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/api-retry", "feat/api-base", db.MergeRequestStateOpen, "success", "APPROVED")
+	runStackDetection(t, database, "acme", "widget")
+
+	resp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 11)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Stack)
+	assert.Equal("api", resp.JSON200.Stack.StackName)
+	assert.Equal(int64(2), resp.JSON200.Stack.Position)
+	assert.Equal(int64(2), resp.JSON200.Stack.Size)
+	assert.Equal("blocked", resp.JSON200.Stack.Health)
+	require.NotNil(resp.JSON200.Stack.Members)
+	assert.Len(*resp.JSON200.Stack.Members, 2)
+
+	seedPR(t, database, "acme", "widget", 99)
+	unstacked, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 99)
+	require.NoError(err)
+	require.Equal(http.StatusOK, unstacked.StatusCode())
+	require.NotNil(unstacked.JSON200)
+	assert.Nil(unstacked.JSON200.Stack)
+}
+
 func TestAPIGetStackForPR_DraftNotBaseReady(t *testing.T) {
 	assert := Assert.New(t)
 	srv, database := setupTestServer(t)

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -116,6 +116,7 @@ type mergeRequestDetailResponse struct {
 	DetailLoaded     bool                        `json:"detail_loaded"`
 	DetailFetchedAt  string                      `json:"detail_fetched_at,omitempty"`
 	Workspace        *workspaceRef               `json:"workspace,omitempty"`
+	Stack            *stackContextResponse       `json:"stack,omitempty"`
 }
 
 var validKanbanStates = map[string]bool{

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1182,6 +1182,15 @@ func (s *Server) buildPullDetailResponse(
 		resp.DetailFetchedAt = formatUTCRFC3339(*mr.DetailFetchedAt)
 	}
 
+	stack, members, err := s.db.GetStackForPRByRepoID(ctx, mr.RepoID, mr.Number)
+	if err != nil {
+		return mergeRequestDetailResponse{}, problemInternal("get stack for pr failed")
+	}
+	if stack != nil {
+		stackContext := stackContextForPR(mr.Number, stack, members)
+		resp.Stack = &stackContext
+	}
+
 	if s.workspaces != nil {
 		wsRef, wsErr := s.workspaces.GetByMR(
 			ctx, repo.PlatformHost, repo.Owner, repo.Name, mr.Number,
@@ -3903,6 +3912,25 @@ func (s *Server) listStacks(ctx context.Context, input *listStacksInput) (*listS
 	return &listStacksOutput{Body: out}, nil
 }
 
+func stackContextForPR(number int, stack *db.Stack, members []db.StackMemberWithPR) stackContextResponse {
+	var position int
+	for _, m := range members {
+		if m.Number == number {
+			position = m.Position
+			break
+		}
+	}
+
+	return stackContextResponse{
+		StackID:   stack.ID,
+		StackName: stack.Name,
+		Position:  position,
+		Size:      len(members),
+		Health:    computeStackHealth(members),
+		Members:   toStackMemberResponses(members),
+	}
+}
+
 func (s *Server) getStackForPR(ctx context.Context, input *repoNumberInput) (*getStackForPROutput, error) {
 	repo, err := s.lookupRepoByProviderRoute(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
@@ -3918,23 +3946,8 @@ func (s *Server) getStackForPR(ctx context.Context, input *repoNumberInput) (*ge
 		return nil, problemNotFound(CodeNotFound, "PR is not part of a stack", nil)
 	}
 
-	var position int
-	for _, m := range members {
-		if m.Number == input.Number {
-			position = m.Position
-			break
-		}
-	}
-
 	return &getStackForPROutput{
-		Body: stackContextResponse{
-			StackID:   stack.ID,
-			StackName: stack.Name,
-			Position:  position,
-			Size:      len(members),
-			Health:    computeStackHealth(members),
-			Members:   toStackMemberResponses(members),
-		},
+		Body: stackContextForPR(input.Number, stack, members),
 	}, nil
 }
 

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2785,6 +2785,7 @@ export interface components {
             repo: components["schemas"]["RepoRefResponse"];
             repo_name: string;
             repo_owner: string;
+            stack?: components["schemas"]["StackContextResponse"];
             warnings?: string[] | null;
             workflow_approval: components["schemas"]["WorkflowApprovalResponse"];
             workspace?: components["schemas"]["WorkspaceRef"];

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -1445,6 +1445,7 @@
           {provider}
           {platformHost}
           {repoPath}
+          initialStack={detail.stack ?? null}
           expanded={expandedPanel === "stack"}
           ontoggle={(next) => { expandedPanel = next ? "stack" : null; }}
           onmembernavigate={(ref) => {

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -273,6 +273,48 @@ describe("PullDetail approvals", () => {
   it("uses one shared expanded slot for CI and stack status", async () => {
     const detail = pullDetail();
     detail.merge_request.Number = 2;
+    detail.stack = {
+      stack_id: 1,
+      stack_name: "session-recovery",
+      position: 2,
+      size: 3,
+      health: "blocked",
+      members: [
+        {
+          number: 1,
+          title: "base schema",
+          state: "open",
+          ci_status: "failure",
+          review_decision: "APPROVED",
+          position: 1,
+          is_draft: false,
+          base_branch: "main",
+          blocked_by: null,
+        },
+        {
+          number: 2,
+          title: "session storage",
+          state: "open",
+          ci_status: "pending",
+          review_decision: "APPROVED",
+          position: 2,
+          is_draft: false,
+          base_branch: "feat/base-schema",
+          blocked_by: 1,
+        },
+        {
+          number: 3,
+          title: "UI polish",
+          state: "open",
+          ci_status: "success",
+          review_decision: "",
+          position: 3,
+          is_draft: false,
+          base_branch: "feat/session-storage",
+          blocked_by: 1,
+        },
+      ],
+    };
     detail.merge_request.CIStatus = "pending";
     detail.merge_request.CIChecksJSON = JSON.stringify([
       {
@@ -292,53 +334,7 @@ describe("PullDetail approvals", () => {
     ]);
 
     const apiClient = {
-      GET: vi.fn(async (path: string) => {
-        if (path.endsWith("/stack")) {
-          return {
-            data: {
-              stack_id: 1,
-              stack_name: "session-recovery",
-              position: 2,
-              size: 3,
-              health: "blocked",
-              members: [
-                {
-                  number: 1,
-                  title: "base schema",
-                  state: "open",
-                  ci_status: "failure",
-                  review_decision: "APPROVED",
-                  position: 1,
-                  is_draft: false,
-                  base_branch: "main",
-                  blocked_by: null,
-                },
-                {
-                  number: 2,
-                  title: "session storage",
-                  state: "open",
-                  ci_status: "pending",
-                  review_decision: "APPROVED",
-                  position: 2,
-                  is_draft: false,
-                  base_branch: "feat/base-schema",
-                  blocked_by: 1,
-                },
-                {
-                  number: 3,
-                  title: "UI polish",
-                  state: "open",
-                  ci_status: "success",
-                  review_decision: "",
-                  position: 3,
-                  is_draft: false,
-                  base_branch: "feat/session-storage",
-                  blocked_by: 1,
-                },
-              ],
-            },
-          };
-        }
+      GET: vi.fn(async () => {
         return {
           data: {
             AllowSquashMerge: false,
@@ -376,6 +372,24 @@ describe("PullDetail approvals", () => {
       "#1 base schema",
     ]);
     expect(document.querySelector(".stack-base-name")?.textContent?.trim()).toBe("main");
+  });
+
+  it("does not probe stack context for unstacked pull details", () => {
+    const apiClient = {
+      GET: vi.fn(async () => ({
+        data: {
+          AllowSquashMerge: false,
+          AllowMergeCommit: false,
+          AllowRebaseMerge: false,
+          ViewerCanMerge: true,
+        },
+      })),
+    };
+
+    renderPullDetail(pullDetail(), undefined, apiClient);
+
+    const paths = apiClient.GET.mock.calls.map(([path]) => String(path));
+    expect(paths.some((path) => path.endsWith("/stack"))).toBe(false);
   });
 
   it("closes the label picker when the labels action is clicked twice", async () => {

--- a/packages/ui/src/components/detail/StackStatus.svelte
+++ b/packages/ui/src/components/detail/StackStatus.svelte
@@ -33,7 +33,7 @@
     provider,
     platformHost,
     repoPath,
-    initialStack = null,
+    initialStack,
     expanded = $bindable(false),
     showButton = true,
     showPanel = true,
@@ -137,21 +137,27 @@
   $effect(() => {
     const num = number;
     const refKey = currentRefKey;
-    const cachedStack = untrack(() =>
-      dataRefKey === refKey && data ? stackWithPosition(data, num) : null
-    );
     const seededStack = initialStack ? stackWithPosition(initialStack, num) : null;
-    if (cachedStack) {
-      data = cachedStack;
-      visible = true;
-    } else if (seededStack) {
+    if (seededStack) {
       data = seededStack;
       dataRefKey = refKey;
       visible = true;
-    } else {
+    } else if (initialStack !== undefined) {
       visible = false;
       data = null;
       dataRefKey = refKey;
+    } else {
+      const cachedStack = untrack(() =>
+        dataRefKey === refKey && data ? stackWithPosition(data, num) : null
+      );
+      if (cachedStack) {
+        data = cachedStack;
+        visible = true;
+      } else {
+        visible = false;
+        data = null;
+        dataRefKey = refKey;
+      }
     }
     requestSeq += 1;
   });

--- a/packages/ui/src/components/detail/StackStatus.svelte
+++ b/packages/ui/src/components/detail/StackStatus.svelte
@@ -18,6 +18,7 @@
   const syncStore = stores.sync;
 
   type Props = PullRequestRouteRef & {
+    initialStack?: StackContext | null;
     expanded?: boolean;
     showButton?: boolean;
     showPanel?: boolean;
@@ -32,6 +33,7 @@
     provider,
     platformHost,
     repoPath,
+    initialStack = null,
     expanded = $bindable(false),
     showButton = true,
     showPanel = true,
@@ -133,25 +135,29 @@
   }
 
   $effect(() => {
-    const o = owner;
-    const n = name;
     const num = number;
     const refKey = currentRefKey;
     const cachedStack = untrack(() =>
       dataRefKey === refKey && data ? stackWithPosition(data, num) : null
     );
+    const seededStack = initialStack ? stackWithPosition(initialStack, num) : null;
     if (cachedStack) {
       data = cachedStack;
+      visible = true;
+    } else if (seededStack) {
+      data = seededStack;
+      dataRefKey = refKey;
       visible = true;
     } else {
       visible = false;
       data = null;
+      dataRefKey = refKey;
     }
-    fetchStack(o, n, num, refKey);
+    requestSeq += 1;
   });
 
   const unsubSync = syncStore?.subscribeSyncComplete?.(() =>
-    fetchStack(owner, name, number)
+    initialStack || data ? fetchStack(owner, name, number) : undefined
   );
   onDestroy(() => unsubSync?.());
 

--- a/packages/ui/src/components/detail/StackStatus.test.ts
+++ b/packages/ui/src/components/detail/StackStatus.test.ts
@@ -1,0 +1,134 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  API_CLIENT_KEY,
+  NAVIGATE_KEY,
+  STORES_KEY,
+} from "../../context.js";
+import StackStatus from "./StackStatus.svelte";
+
+interface StackMember {
+  number: number;
+  title: string;
+  state: string;
+  ci_status: string;
+  review_decision: string;
+  position: number;
+  is_draft: boolean;
+  base_branch: string;
+  blocked_by: number | null;
+}
+
+interface StackContext {
+  stack_id: number;
+  stack_name: string;
+  position: number;
+  size: number;
+  health: string;
+  members: StackMember[];
+}
+
+function member(
+  overrides: Partial<StackMember> & Pick<StackMember, "number" | "position">,
+): StackMember {
+  return {
+    number: overrides.number,
+    title: `PR ${overrides.number}`,
+    state: "open",
+    ci_status: "success",
+    review_decision: "APPROVED",
+    position: overrides.position,
+    is_draft: false,
+    base_branch: "main",
+    blocked_by: null,
+    ...overrides,
+  };
+}
+
+function stack(overrides: Partial<StackContext> = {}): StackContext {
+  return {
+    stack_id: 1,
+    stack_name: "feature-stack",
+    position: 2,
+    size: 3,
+    health: "blocked",
+    members: [
+      member({ number: 1, position: 1, ci_status: "failure" }),
+      member({ number: 2, position: 2, ci_status: "pending" }),
+      member({ number: 3, position: 3 }),
+    ],
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  owner: "acme",
+  name: "widget",
+  number: 2,
+  provider: "github",
+  platformHost: "github.com",
+  repoPath: "acme/widget",
+  expanded: true,
+};
+
+function renderStackStatus(initialStack: StackContext | null) {
+  return render(StackStatus, {
+    props: {
+      ...baseProps,
+      initialStack,
+    },
+    context: new Map<symbol, unknown>([
+      [
+        API_CLIENT_KEY,
+        {
+          GET: vi.fn(async () => ({ data: null })),
+        },
+      ],
+      [STORES_KEY, {}],
+      [NAVIGATE_KEY, vi.fn()],
+    ]),
+  });
+}
+
+describe("StackStatus", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("replaces cached stack data with the latest detail stack", async () => {
+    const rendered = renderStackStatus(stack());
+
+    expect(screen.getByRole("button", {
+      name: /Stacked: 2\/3, 1 downstack CI failure/i,
+    })).toBeTruthy();
+
+    await rendered.rerender({
+      ...baseProps,
+      initialStack: stack({
+        size: 2,
+        health: "healthy",
+        members: [
+          member({ number: 1, position: 1 }),
+          member({ number: 2, position: 2 }),
+        ],
+      }),
+    });
+
+    expect(screen.getByRole("button", { name: /Stacked: 2\/2/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Stacked: 2\/3/i })).toBeNull();
+    expect(screen.getByText(/2 PRs . current 2\/2/)).toBeTruthy();
+  });
+
+  it("clears cached stack data when the latest detail has no stack", async () => {
+    const rendered = renderStackStatus(stack());
+
+    expect(screen.getByRole("button", { name: /Stacked: 2\/3/i })).toBeTruthy();
+
+    await rendered.rerender({
+      ...baseProps,
+      initialStack: null,
+    });
+
+    expect(screen.queryByRole("button", { name: /Stacked:/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add optional stack context to pull detail payloads so the UI can render stacked PRs without probing the stack endpoint first.
- Seed stack status from the detail response and keep the standalone stack endpoint for explicit refreshes and member navigation.
- Tighten tests to cover both stacked and genuinely unstacked pull details, including the no-request path in Playwright.

## Testing
- Go API tests for pull detail and stack lookup behavior
- Svelte component tests for pull detail and stack status rendering
- Playwright stack-status coverage for stacked and unstacked PR detail flows
- Frontend and UI type checks passed