### PR TITLE
fix: load Pierre diff worker under non-root base_path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ frontend-deps:
 # Build frontend SPA and copy into embed directory
 frontend: frontend-deps
 	cd frontend && bun run build
+	bun scripts/check-asset-base-paths.mjs
 	rm -rf internal/web/dist
 	cp -r frontend/dist internal/web/dist
 	printf 'ok\n' > internal/web/dist/stub.html

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -169,6 +169,21 @@ function terminalWebSocketProxy(url: string): ProxyOptions {
 
 const config = {
   base: "/",
+  // The Go server serves this build under a configurable base_path (default
+  // "/", e.g. "/middleman/" behind a reverse proxy) by rewriting index.html's
+  // <script src>/<link href> at request time. That rewrite only reaches HTML,
+  // not URLs baked inside JS bundles. An asset URL emitted as an absolute root
+  // path -- new URL("/assets/x.js", import.meta.url) -- resolves against the
+  // origin and drops the base path prefix, so it 404s behind a subpath proxy
+  // (notably the Pierre diff web worker). Emitting JS-referenced asset URLs as
+  // relative makes them resolve against the entry chunk's own already-prefixed
+  // location instead. HTML keeps default absolute URLs so the server-side
+  // index.html rewrite still applies. Guarded by scripts/check-asset-base-paths.mjs.
+  experimental: {
+    renderBuiltUrl(_filename, { hostType }) {
+      return hostType === "js" ? { relative: true } : undefined;
+    },
+  },
   plugins: [
     healthcheckPlugin(),
     devApiUrlPlugin(apiUrl),

--- a/scripts/check-asset-base-paths.mjs
+++ b/scripts/check-asset-base-paths.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The built SPA is served under a configurable base path (config base_path,
+// e.g. /middleman/) by rewriting index.html's <script src>/<link href> at
+// request time. That rewrite only reaches HTML, not URLs baked inside JS
+// bundles. An asset URL written as `new URL("/assets/x.js", import.meta.url)`
+// uses an absolute root path, so the browser resolves it against the origin
+// and drops the base path prefix -- the request 404s under any non-root
+// base_path. Worker URLs are the common offender (see pierre-worker-pool.ts).
+//
+// Base-path-safe asset URLs are relative (`new URL("./x.js", import.meta.url)`)
+// so they resolve against the entry chunk's already-prefixed location. This
+// guard fails the build if any absolute import.meta.url asset URL survives.
+
+const DEFAULT_SCAN_PATHS = ["frontend/dist/assets"];
+
+// new URL("<absolute path>", <...>import.meta.url): the first argument is a
+// root-absolute path (starts with a single "/", excluding "//" protocol-
+// relative URLs), and the base is import.meta.url. Bundlers minify the base to
+// forms like ``+import.meta.url, so allow a short gap before import.meta.url.
+const ABSOLUTE_IMPORT_META_URL =
+  /new URL\(\s*(["'`])(\/[^/][^"'`]*)\1\s*,\s*[^,)]{0,40}import\.meta\.url/g;
+
+function toPosix(path) {
+  return path.split(sep).join("/");
+}
+
+async function collectJsFiles(path) {
+  const info = await stat(path).catch(() => null);
+  if (!info) return [];
+  if (info.isFile()) return path.endsWith(".js") ? [path] : [];
+  if (!info.isDirectory()) return [];
+
+  const entries = await readdir(path, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map((entry) => collectJsFiles(resolve(path, entry.name))),
+  );
+  return nested.flat();
+}
+
+export async function findAbsoluteAssetUrls({
+  root = process.cwd(),
+  paths = DEFAULT_SCAN_PATHS,
+} = {}) {
+  const rootPath = resolve(root);
+  const scanPaths = paths.map((path) => resolve(rootPath, path));
+  const files = (await Promise.all(scanPaths.map(collectJsFiles))).flat();
+  const findings = [];
+
+  for (const file of files.sort()) {
+    const content = await readFile(file, "utf8");
+    for (const match of content.matchAll(ABSOLUTE_IMPORT_META_URL)) {
+      findings.push({
+        file: toPosix(relative(rootPath, file)),
+        url: match[2],
+      });
+    }
+  }
+
+  return findings;
+}
+
+function parseArgs(argv) {
+  const paths = [];
+  let root = process.cwd();
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--root") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--root requires a path");
+      root = value;
+      i += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      return { help: true, root, paths };
+    }
+    paths.push(arg);
+  }
+
+  return {
+    help: false,
+    root,
+    paths: paths.length > 0 ? paths : DEFAULT_SCAN_PATHS,
+  };
+}
+
+function printHelp() {
+  console.log(`Usage: bun scripts/check-asset-base-paths.mjs [--root DIR] [PATH...]
+
+Fail the build when a bundled asset URL uses an absolute root path with
+import.meta.url (e.g. new URL("/assets/x.js", import.meta.url)). Such URLs
+ignore the configured base_path and 404 behind a subpath reverse proxy.
+Defaults to scanning ${DEFAULT_SCAN_PATHS.join(", ")}.
+`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const findings = await findAbsoluteAssetUrls(options);
+  if (findings.length === 0) return;
+
+  console.error(
+    "Absolute import.meta.url asset URLs ignore base_path and break " +
+      "subpath deployments. Make them relative (vite renderBuiltUrl):",
+  );
+  for (const finding of findings) {
+    console.error(`  ${finding.file}: new URL("${finding.url}", import.meta.url)`);
+  }
+  process.exitCode = 1;
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (resolve(process.argv[1] ?? "") === currentFile) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-asset-base-paths.test.mjs
+++ b/scripts/check-asset-base-paths.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+
+import { findAbsoluteAssetUrls } from "./check-asset-base-paths.mjs";
+
+async function write(root, file, content) {
+  const fullPath = join(root, file);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, content);
+}
+
+async function makeRoot() {
+  return mkdtemp("/tmp/middleman-asset-base-");
+}
+
+test("flags the minified worker URL that breaks subpath deploys", async () => {
+  const root = await makeRoot();
+  // Exact shape Vite emits for new Worker(new URL(...)) with base "/".
+  await write(
+    root,
+    "assets/index-abc.js",
+    "x();new Worker(new URL(`/assets/worker-DXy4-71H.js`,``+import.meta.url),{type:`module`});y();",
+  );
+
+  const findings = await findAbsoluteAssetUrls({ root, paths: ["assets"] });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].url, "/assets/worker-DXy4-71H.js");
+  assert.match(findings[0].file, /index-abc\.js$/);
+});
+
+test("flags double-quoted absolute import.meta.url asset URLs", async () => {
+  const root = await makeRoot();
+  await write(
+    root,
+    "assets/chunk.js",
+    'const u = new URL("/assets/img-9.png", import.meta.url);',
+  );
+
+  const findings = await findAbsoluteAssetUrls({ root, paths: ["assets"] });
+
+  assert.deepEqual(
+    findings.map((f) => f.url),
+    ["/assets/img-9.png"],
+  );
+});
+
+test("accepts the relative worker URL produced by the renderBuiltUrl fix", async () => {
+  const root = await makeRoot();
+  await write(
+    root,
+    "assets/index-fixed.js",
+    "new Worker(new URL(``+new URL(`worker-DXy4-71H.js`,import.meta.url),import.meta.url),{type:`module`});",
+  );
+
+  const findings = await findAbsoluteAssetUrls({ root, paths: ["assets"] });
+
+  assert.deepEqual(findings, []);
+});
+
+test("ignores absolute paths resolved against a non import.meta.url base", async () => {
+  const root = await makeRoot();
+  // Legit runtime URL building (e.g. API calls) must not be flagged: only
+  // import.meta.url-relative asset references drop the base path.
+  await write(
+    root,
+    "assets/api.js",
+    'const u = new URL("/api/v1/pulls", window.location.origin);',
+  );
+
+  const findings = await findAbsoluteAssetUrls({ root, paths: ["assets"] });
+
+  assert.deepEqual(findings, []);
+});
+
+test("ignores absolute external URLs and protocol-relative URLs", async () => {
+  const root = await makeRoot();
+  await write(
+    root,
+    "assets/ext.js",
+    [
+      'new URL("https://cdn.example.com/x.js", import.meta.url);',
+      'new URL("//cdn.example.com/y.js", import.meta.url);',
+    ].join("\n"),
+  );
+
+  const findings = await findAbsoluteAssetUrls({ root, paths: ["assets"] });
+
+  assert.deepEqual(findings, []);
+});


### PR DESCRIPTION
Diff views did not render on deployments served under a `base_path` (e.g. behind a reverse proxy at `/middleman`). The Pierre diff web worker was bundled with an absolute URL (`new URL("/assets/worker-*.js", import.meta.url)`) that resolves against the origin and drops the `base_path` prefix. Behind a subpath proxy the browser requested `/assets/worker-*.js` instead of `/middleman/assets/worker-*.js`; that path returns non-JS content, so the worker and the syntax-highlighting chunks it loads were rejected as module scripts and the diff never rendered.

- Emit JS-referenced asset URLs as relative (Vite `experimental.renderBuiltUrl`) so they resolve against the entry chunk's already-prefixed `import.meta.url`. `index.html` keeps absolute `/assets/` URLs so the server's request-time `base_path` rewrite still applies.
- Add a build check (`scripts/check-asset-base-paths.mjs`, run by `make frontend`) that fails if an absolute `import.meta.url` asset URL regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)