### PR TITLE
Keep inline diff comment composers above the gutter

### DIFF
--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -469,6 +469,21 @@ test("keeps inline composer inside the visible diff pane on long lines", async (
     return target === textarea || textarea.contains(target);
   });
   expect(leftEdgeHitsTextarea).toBe(true);
+  const textarea = composer.locator("textarea");
+  const initialTextareaHeight = await textarea.evaluate((element) => element.clientHeight);
+  await textarea.fill([
+    "This comment has enough lines to grow.",
+    "It should expand the editor instead of adding an internal scrollbar.",
+    "That keeps the review text readable while the diff pane scrolls.",
+    "One more line makes the regression obvious.",
+    "And another line verifies the textarea keeps up.",
+  ].join("\n"));
+  const textareaMetrics = await textarea.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(textareaMetrics.clientHeight).toBeGreaterThan(initialTextareaHeight);
+  expect(textareaMetrics.scrollHeight).toBeLessThanOrEqual(textareaMetrics.clientHeight + 1);
 });
 
 test("shows saved draft comments inline and jumps from the tray", async ({ page }) => {

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -403,6 +403,16 @@ async function mockInlineReviewAPI(
   });
 }
 
+async function firstDiffGutterRight(page: Page): Promise<number> {
+  return page.locator(".pierre-diff").first().evaluate((host) => {
+    const gutter = host.shadowRoot?.querySelector("[data-gutter]");
+    if (!(gutter instanceof HTMLElement)) {
+      throw new Error("diff gutter not found");
+    }
+    return gutter.getBoundingClientRect().right;
+  });
+}
+
 test.beforeEach(async ({ page }) => {
   await mockApi(page);
 });
@@ -446,11 +456,13 @@ test("keeps inline composer inside the visible diff pane on long lines", async (
   const composerBox = await composer.boundingBox();
   expect(scrollBox).not.toBeNull();
   expect(composerBox).not.toBeNull();
-  expect(composerBox!.x).toBeGreaterThanOrEqual(scrollBox!.x);
+  const gutterRight = await firstDiffGutterRight(page);
+  const contentWidth = scrollBox!.x + scrollBox!.width - gutterRight;
+  expect(composerBox!.x).toBeGreaterThanOrEqual(gutterRight - 1);
   expect(composerBox!.x + composerBox!.width).toBeLessThanOrEqual(
     scrollBox!.x + scrollBox!.width + 1,
   );
-  expect(composerBox!.width).toBeGreaterThan(scrollBox!.width * 0.9);
+  expect(composerBox!.width).toBeGreaterThan(contentWidth * 0.85);
   const leftEdgeHitsTextarea = await composer.locator("textarea").evaluate((textarea) => {
     const rect = textarea.getBoundingClientRect();
     const target = document.elementFromPoint(rect.left + 8, rect.top + 16);
@@ -483,11 +495,13 @@ test("shows saved draft comments inline and jumps from the tray", async ({ page 
   const inlineBox = await inlineDraft.boundingBox();
   expect(scrollBox).not.toBeNull();
   expect(inlineBox).not.toBeNull();
-  expect(inlineBox!.x).toBeGreaterThanOrEqual(scrollBox!.x);
+  const gutterRight = await firstDiffGutterRight(page);
+  const contentWidth = scrollBox!.x + scrollBox!.width - gutterRight;
+  expect(inlineBox!.x).toBeGreaterThanOrEqual(gutterRight - 1);
   expect(inlineBox!.x + inlineBox!.width).toBeLessThanOrEqual(
     scrollBox!.x + scrollBox!.width + 1,
   );
-  expect(inlineBox!.width).toBeGreaterThan(scrollBox!.width * 0.9);
+  expect(inlineBox!.width).toBeGreaterThan(contentWidth * 0.85);
 
   await page.getByRole("button", { name: "src/main.ts:1-2" }).click();
   await expect(inlineDraft).toBeFocused();

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -451,6 +451,12 @@ test("keeps inline composer inside the visible diff pane on long lines", async (
     scrollBox!.x + scrollBox!.width + 1,
   );
   expect(composerBox!.width).toBeGreaterThan(scrollBox!.width * 0.9);
+  const leftEdgeHitsTextarea = await composer.locator("textarea").evaluate((textarea) => {
+    const rect = textarea.getBoundingClientRect();
+    const target = document.elementFromPoint(rect.left + 8, rect.top + 16);
+    return target === textarea || textarea.contains(target);
+  });
+  expect(leftEdgeHitsTextarea).toBe(true);
 });
 
 test("shows saved draft comments inline and jumps from the tray", async ({ page }) => {

--- a/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
+++ b/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
@@ -124,8 +124,9 @@
     width: 100%;
     max-width: 100%;
     min-height: 72px;
+    max-height: 75vh;
     resize: none;
-    overflow: hidden;
+    overflow-y: auto;
     padding: 8px;
     border: 1px solid var(--border-muted);
     border-radius: 4px;

--- a/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
+++ b/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
@@ -16,14 +16,19 @@
 
   let body = $state("");
   let textareaEl: HTMLTextAreaElement | undefined = $state();
+  let autosizeFrame = 0;
   const submitting = $derived(diffReviewDraft.isSubmitting());
   const error = $derived(diffReviewDraft.getError());
 
   onMount(() => {
     void tick().then(() => {
       textareaEl?.focus({ preventScroll: true });
-      autosizeTextarea();
+      scheduleAutosizeTextarea();
     });
+
+    return () => {
+      if (autosizeFrame) cancelAnimationFrame(autosizeFrame);
+    };
   });
 
   function autosizeTextarea(): void {
@@ -33,6 +38,15 @@
       Number.parseFloat(style.borderBottomWidth);
     textareaEl.style.height = "auto";
     textareaEl.style.height = `${textareaEl.scrollHeight + borderHeight}px`;
+  }
+
+  function scheduleAutosizeTextarea(): void {
+    autosizeTextarea();
+    if (autosizeFrame) cancelAnimationFrame(autosizeFrame);
+    autosizeFrame = requestAnimationFrame(() => {
+      autosizeFrame = 0;
+      autosizeTextarea();
+    });
   }
 
   async function submit(): Promise<void> {
@@ -54,7 +68,7 @@
     placeholder="Leave a comment"
     disabled={submitting}
     rows="3"
-    oninput={autosizeTextarea}
+    oninput={scheduleAutosizeTextarea}
   ></textarea>
   {#if error}
     <p class="composer-error">{error}</p>

--- a/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
+++ b/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
@@ -22,8 +22,18 @@
   onMount(() => {
     void tick().then(() => {
       textareaEl?.focus({ preventScroll: true });
+      autosizeTextarea();
     });
   });
+
+  function autosizeTextarea(): void {
+    if (!textareaEl) return;
+    const style = getComputedStyle(textareaEl);
+    const borderHeight = Number.parseFloat(style.borderTopWidth) +
+      Number.parseFloat(style.borderBottomWidth);
+    textareaEl.style.height = "auto";
+    textareaEl.style.height = `${textareaEl.scrollHeight + borderHeight}px`;
+  }
 
   async function submit(): Promise<void> {
     const nextBody = body.trim();
@@ -44,6 +54,7 @@
     placeholder="Leave a comment"
     disabled={submitting}
     rows="3"
+    oninput={autosizeTextarea}
   ></textarea>
   {#if error}
     <p class="composer-error">{error}</p>
@@ -99,7 +110,8 @@
     width: 100%;
     max-width: 100%;
     min-height: 72px;
-    resize: vertical;
+    resize: none;
+    overflow: hidden;
     padding: 8px;
     border: 1px solid var(--border-muted);
     border-radius: 4px;

--- a/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
+++ b/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
@@ -15,44 +15,14 @@
   const { diffReviewDraft } = getStores();
 
   let body = $state("");
-  let composerEl: HTMLDivElement | undefined = $state();
   let textareaEl: HTMLTextAreaElement | undefined = $state();
-  let composerWidth = $state<string | undefined>();
-  let composerOffset = $state<string | undefined>();
   const submitting = $derived(diffReviewDraft.isSubmitting());
   const error = $derived(diffReviewDraft.getError());
 
   onMount(() => {
-    let animationFrame = 0;
-    const scheduleLayout = () => {
-      if (animationFrame) cancelAnimationFrame(animationFrame);
-      animationFrame = requestAnimationFrame(() => {
-        animationFrame = 0;
-        updateComposerWidth();
-      });
-    };
-    const container = composerEl ? layoutContainer(composerEl) : null;
-    const resizeObserver = typeof ResizeObserver !== "undefined"
-      ? new ResizeObserver(scheduleLayout)
-      : undefined;
-    if (container) {
-      container.addEventListener("scroll", scheduleLayout, { passive: true });
-      resizeObserver?.observe(container);
-    }
-    if (composerEl) resizeObserver?.observe(composerEl);
-    window.addEventListener("resize", scheduleLayout);
-
     void tick().then(() => {
       textareaEl?.focus({ preventScroll: true });
-      scheduleLayout();
     });
-
-    return () => {
-      if (animationFrame) cancelAnimationFrame(animationFrame);
-      container?.removeEventListener("scroll", scheduleLayout);
-      window.removeEventListener("resize", scheduleLayout);
-      resizeObserver?.disconnect();
-    };
   });
 
   async function submit(): Promise<void> {
@@ -65,38 +35,9 @@
     }
   }
 
-  function updateComposerWidth(): void {
-    if (!composerEl) return;
-    const container = layoutContainer(composerEl);
-    if (!container) {
-      composerWidth = undefined;
-      return;
-    }
-    const containerRect = container.getBoundingClientRect();
-    const composerRect = composerEl.getBoundingClientRect();
-    const currentOffset = Number.parseFloat(composerOffset ?? "0") || 0;
-    const naturalLeft = composerRect.left - currentOffset;
-    const available = Math.floor(containerRect.width - 24);
-    const offset = Math.round(containerRect.left + 12 - naturalLeft);
-    composerWidth = available > 0 ? `${available}px` : undefined;
-    composerOffset = offset === 0 ? undefined : `${offset}px`;
-  }
-
-  function layoutContainer(element: HTMLElement): HTMLElement | null {
-    const root = element.getRootNode();
-    if (root instanceof ShadowRoot && root.host instanceof HTMLElement) {
-      return root.host.closest(".file-content") ?? root.host.closest(".diff-area");
-    }
-    return element.closest(".file-content") ?? element.closest(".diff-area");
-  }
 </script>
 
-<div
-  class="inline-composer"
-  bind:this={composerEl}
-  style:--inline-composer-width={composerWidth}
-  style:--inline-composer-offset={composerOffset}
->
+<div class="inline-composer">
   <textarea
     bind:this={textareaEl}
     bind:value={body}
@@ -133,25 +74,23 @@
 
 <style>
   .inline-composer {
-    position: sticky;
-    left: 12px;
     box-sizing: border-box;
-    margin: 6px 0 8px;
+    margin: 6px 12px 8px;
     padding: 8px;
     border: 1px solid var(--border-default);
     border-radius: 6px;
     background: var(--bg-surface);
-    width: var(--inline-composer-width, calc(100% - 24px));
-    max-width: var(--inline-composer-width, calc(100% - 24px));
+    width: calc(100% - 24px);
+    max-width: calc(100% - 24px);
     min-width: 0;
     overflow: hidden;
-    transform: translateX(var(--inline-composer-offset, 0));
   }
 
   @container (max-width: 520px) {
     .inline-composer {
-      left: 8px;
-      margin: 6px 0 8px;
+      margin: 6px 8px 8px;
+      width: calc(100% - 16px);
+      max-width: calc(100% - 16px);
     }
   }
 

--- a/packages/ui/src/components/diff/DiffReviewDraftInlineComment.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftInlineComment.svelte
@@ -42,16 +42,14 @@
 
 <style>
   .inline-draft-comment {
-    position: sticky;
-    left: 12px;
     box-sizing: border-box;
-    margin: 6px 0 8px;
+    margin: 6px 12px 8px;
     padding: 8px;
     border: 1px solid color-mix(in srgb, var(--accent-blue) 46%, var(--border-muted));
     border-radius: 6px;
     background: color-mix(in srgb, var(--accent-blue) 10%, var(--bg-surface));
-    width: calc(100% - 36px);
-    max-width: calc(100% - 36px);
+    width: calc(100% - 24px);
+    max-width: calc(100% - 24px);
     min-width: 0;
     scroll-margin-block: 96px;
   }
@@ -61,19 +59,11 @@
     outline-offset: 2px;
   }
 
-  @supports (width: 100cqw) {
-    .inline-draft-comment {
-      width: calc(100cqw - 36px);
-      max-width: calc(100cqw - 36px);
-    }
-  }
-
   @container (max-width: 520px) {
     .inline-draft-comment {
-      left: 8px;
-      margin: 6px 0 8px;
-      width: calc(100cqw - 16px);
-      max-width: calc(100cqw - 16px);
+      margin: 6px 8px 8px;
+      width: calc(100% - 16px);
+      max-width: calc(100% - 16px);
     }
   }
 

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -196,10 +196,6 @@
       [data-middleman-line-comment-button]::before {
         content: "+";
       }
-      [data-line-annotation],
-      [data-annotation-content] {
-        z-index: 4;
-      }
     `,
   }));
 

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -196,6 +196,10 @@
       [data-middleman-line-comment-button]::before {
         content: "+";
       }
+      [data-line-annotation],
+      [data-annotation-content] {
+        z-index: 4;
+      }
     `,
   }));
 


### PR DESCRIPTION
## Summary
- Raise Pierre diff annotation rows above the sticky gutter so inline comment composers and draft blocks render without their left edge being covered.
- Tighten the inline-review Playwright regression to verify the textarea is actually clickable at its left edge, not just inside its bounding box.

## Testing
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd frontend test:e2e:mock tests/e2e/inline-review.spec.ts --project=chromium`
- `bun run --cwd frontend test:e2e:mock tests/e2e/inline-review.spec.ts -g "keeps inline composer inside the visible diff pane on long lines" --project=chromium`