### PR TITLE
Prioritize filtered repos during manual sync

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -8589,6 +8589,16 @@ paths:
   /sync:
     post:
       operationId: trigger-sync
+      parameters:
+        - explode: false
+          in: query
+          name: priority_repo
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
       responses:
         "202":
           description: Accepted

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -8590,10 +8590,12 @@ paths:
     post:
       operationId: trigger-sync
       parameters:
-        - explode: false
+        - description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path.
+          explode: false
           in: query
           name: priority_repo
           schema:
+            description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path.
             items:
               type: string
             type:

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1783,6 +1783,7 @@ type ListStacksParams struct {
 
 // TriggerSyncParams defines parameters for TriggerSync.
 type TriggerSyncParams struct {
+	// PriorityRepo Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path.
 	PriorityRepo *[]string `form:"priority_repo,omitempty" json:"priority_repo,omitempty"`
 }
 

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1781,6 +1781,11 @@ type ListStacksParams struct {
 	Repo *string `form:"repo,omitempty" json:"repo,omitempty"`
 }
 
+// TriggerSyncParams defines parameters for TriggerSync.
+type TriggerSyncParams struct {
+	PriorityRepo *[]string `form:"priority_repo,omitempty" json:"priority_repo,omitempty"`
+}
+
 // DeleteWorkspaceParams defines parameters for DeleteWorkspace.
 type DeleteWorkspaceParams struct {
 	Force *bool `form:"force,omitempty" json:"force,omitempty"`
@@ -2496,7 +2501,7 @@ type ClientInterface interface {
 	SetStarred(ctx context.Context, body SetStarredJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// TriggerSync request
-	TriggerSync(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	TriggerSync(ctx context.Context, params *TriggerSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetSyncStatus request
 	GetSyncStatus(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4518,8 +4523,8 @@ func (c *Client) SetStarred(ctx context.Context, body SetStarredJSONRequestBody,
 	return c.Client.Do(req)
 }
 
-func (c *Client) TriggerSync(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewTriggerSyncRequest(c.Server)
+func (c *Client) TriggerSync(ctx context.Context, params *TriggerSyncParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTriggerSyncRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -12356,7 +12361,7 @@ func NewSetStarredRequestWithBody(server string, contentType string, body io.Rea
 }
 
 // NewTriggerSyncRequest generates requests for TriggerSync
-func NewTriggerSyncRequest(server string) (*http.Request, error) {
+func NewTriggerSyncRequest(server string, params *TriggerSyncParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -12372,6 +12377,28 @@ func NewTriggerSyncRequest(server string) (*http.Request, error) {
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PriorityRepo != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "priority_repo", *params.PriorityRepo, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
@@ -13598,7 +13625,7 @@ type ClientWithResponsesInterface interface {
 	SetStarredWithResponse(ctx context.Context, body SetStarredJSONRequestBody, reqEditors ...RequestEditorFn) (*SetStarredResponse, error)
 
 	// TriggerSyncWithResponse request
-	TriggerSyncWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*TriggerSyncResponse, error)
+	TriggerSyncWithResponse(ctx context.Context, params *TriggerSyncParams, reqEditors ...RequestEditorFn) (*TriggerSyncResponse, error)
 
 	// GetSyncStatusWithResponse request
 	GetSyncStatusWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetSyncStatusResponse, error)
@@ -18062,8 +18089,8 @@ func (c *ClientWithResponses) SetStarredWithResponse(ctx context.Context, body S
 }
 
 // TriggerSyncWithResponse request returning *TriggerSyncResponse
-func (c *ClientWithResponses) TriggerSyncWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*TriggerSyncResponse, error) {
-	rsp, err := c.TriggerSync(ctx, reqEditors...)
+func (c *ClientWithResponses) TriggerSyncWithResponse(ctx context.Context, params *TriggerSyncParams, reqEditors ...RequestEditorFn) (*TriggerSyncResponse, error) {
+	rsp, err := c.TriggerSync(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1570,6 +1570,15 @@ func (s *Syncer) fetcherFor(repo RepoRef) *GraphQLFetcher {
 // exit. The caller's ctx is honored too, so per-request deadlines
 // still apply.
 func (s *Syncer) TriggerRun(ctx context.Context) {
+	s.TriggerRunWithPriority(ctx, nil)
+}
+
+// TriggerRunWithPriority kicks off a non-blocking ad-hoc sync and dispatches
+// matching repos before the rest of the configured set.
+func (s *Syncer) TriggerRunWithPriority(
+	ctx context.Context,
+	priorityRepos []RepoRef,
+) {
 	s.lifecycleMu.Lock()
 	if s.stopped {
 		s.lifecycleMu.Unlock()
@@ -1582,7 +1591,7 @@ func (s *Syncer) TriggerRun(ctx context.Context) {
 	go func() {
 		defer s.wg.Done()
 		defer cancel()
-		s.runOnce(merged, true)
+		s.runOnce(merged, true, priorityRepos)
 	}()
 }
 
@@ -2419,12 +2428,13 @@ func (s *Syncer) publishMonotonicProgress(
 // per-host GitHub rate limit and abuse-detection thresholds happy
 // while still capturing most of the wall-clock win on network I/O.
 func (s *Syncer) RunOnce(ctx context.Context) {
-	s.runOnce(ctx, false)
+	s.runOnce(ctx, false, nil)
 }
 
 func (s *Syncer) runOnce(
 	ctx context.Context,
 	bypassNextSyncAfter bool,
+	priorityRepos []RepoRef,
 ) {
 	if !s.running.CompareAndSwap(false, true) {
 		return
@@ -2439,6 +2449,7 @@ func (s *Syncer) runOnce(
 	s.reposMu.Lock()
 	repos := slices.Clone(s.repos)
 	s.reposMu.Unlock()
+	repos = prioritizeRepos(repos, priorityRepos)
 
 	total := len(repos)
 	s.publishStatus(&SyncStatus{
@@ -2587,6 +2598,58 @@ dispatch:
 		LastRunAt: time.Now().UTC(),
 		LastError: lastErr,
 	})
+}
+
+func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
+	if len(repos) == 0 || len(priorityRepos) == 0 {
+		return repos
+	}
+
+	priorityKeys := make(map[string]int, len(priorityRepos))
+	for i, repo := range priorityRepos {
+		key := repoPriorityKey(repo)
+		if key == "" {
+			continue
+		}
+		if _, exists := priorityKeys[key]; !exists {
+			priorityKeys[key] = i
+		}
+	}
+	if len(priorityKeys) == 0 {
+		return repos
+	}
+
+	out := slices.Clone(repos)
+	slices.SortStableFunc(out, func(a, b RepoRef) int {
+		ai, aOK := priorityKeys[repoPriorityKey(a)]
+		bi, bOK := priorityKeys[repoPriorityKey(b)]
+		switch {
+		case aOK && bOK:
+			return ai - bi
+		case aOK:
+			return -1
+		case bOK:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return out
+}
+
+func repoPriorityKey(repo RepoRef) string {
+	repoPath := strings.Trim(strings.TrimSpace(repo.RepoPath), "/")
+	if repoPath == "" {
+		owner := strings.Trim(strings.TrimSpace(repo.Owner), "/")
+		name := strings.Trim(strings.TrimSpace(repo.Name), "/")
+		if owner == "" || name == "" {
+			return ""
+		}
+		repoPath = owner + "/" + name
+	}
+	return strings.ToLower(
+		string(repoPlatform(repo)) + "/" + repoHost(repo) + "/" + repoPath,
+	)
 }
 
 func (s *Syncer) syncRepoIdentity(ctx context.Context, repo RepoRef) (db.RepoIdentity, *platform.Repository, error) {

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -613,6 +614,82 @@ func TestSyncerTriggerRunRunsRunOnce(t *testing.T) {
 	s.Stop()
 	assert.True(mock.listOpenPRsCalled,
 		"TriggerRun should invoke ListOpenPullRequests")
+}
+
+func TestSyncerTriggerRunWithPrioritySyncsSelectedReposFirst(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	mock := &mockClient{
+		openPRs: []*gh.PullRequest{},
+		listOpenPRsFn: func(
+			_ context.Context, owner, repo string,
+		) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, owner+"/"+repo)
+			return []*gh.PullRequest{}, nil
+		},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			ids := map[string]int64{
+				"first":  1,
+				"second": 2,
+				"third":  3,
+			}
+			id := ids[repo]
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: new(bool),
+			}, nil
+		},
+	}
+	d := openTestDB(t)
+	repos := []ghclient.RepoRef{
+		{Owner: "o", Name: "first", PlatformHost: "github.com"},
+		{Owner: "o", Name: "second", PlatformHost: "github.com"},
+		{Owner: "o", Name: "third", PlatformHost: "github.com"},
+	}
+	s := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		d, nil, repos, time.Hour, nil, nil,
+	)
+	s.SetParallelism(1)
+
+	done := make(chan struct{}, 1)
+	s.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+		if !status.Running {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+
+	s.TriggerRunWithPriority(t.Context(), []ghclient.RepoRef{{
+		Owner:        "o",
+		Name:         "third",
+		PlatformHost: "github.com",
+	}})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow("priority TriggerRun did not complete within 1s")
+	}
+	s.Stop()
+
+	mu.Lock()
+	got := slices.Clone(calls)
+	mu.Unlock()
+	assert.Equal([]string{"o/third", "o/first", "o/second"}, got)
 }
 
 type blockingCtxMockClient struct {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5286,6 +5286,7 @@ func TestAPITriggerSyncBypassesNextSyncAfter(t *testing.T) {
 	client := setupTestClient(t, srv)
 	resp, err := client.HTTP.TriggerSyncWithResponse(
 		t.Context(),
+		nil,
 	)
 	require.NoError(err)
 	require.Equal(http.StatusAccepted, resp.StatusCode())
@@ -9810,7 +9811,9 @@ func TestOpenAPIDocumentsCustomStatusCodes(t *testing.T) {
 	require.Contains(spec, `"/sync":{"post":{"operationId":"trigger-sync"`)
 	require.Contains(spec, `"/starred":{"delete":{"operationId":"unset-starred"`)
 	require.Contains(spec, `"/pulls/{provider}/{owner}/{name}/{number}/comments":{"post":{"operationId":"post-pr-comment"`)
-	require.Contains(spec, `"trigger-sync","responses":{"202":{"description":"Accepted"}`)
+	require.Contains(spec, `"trigger-sync","parameters"`)
+	require.Contains(spec, `"name":"priority_repo"`)
+	require.Contains(spec, `"responses":{"202":{"description":"Accepted"}`)
 	require.Contains(spec, `"set-starred","requestBody"`)
 	require.Contains(spec, `"responses":{"200":{"description":"OK"}`)
 	require.True(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5298,6 +5298,37 @@ func TestAPITriggerSyncBypassesNextSyncAfter(t *testing.T) {
 	}
 }
 
+func TestMatchPriorityRepoSupportsNestedBareRepoPaths(t *testing.T) {
+	assert := Assert.New(t)
+
+	tracked := []ghclient.RepoRef{
+		{
+			Platform:     platform.KindGitLab,
+			PlatformHost: "gitlab.com",
+			Owner:        "group/subgroup",
+			Name:         "project",
+			RepoPath:     "group/subgroup/project",
+		},
+		{
+			Platform:     platform.KindGitHub,
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			RepoPath:     "acme/widget",
+		},
+	}
+
+	repo, ok := matchPriorityRepo("group/subgroup/project", tracked)
+	assert.True(ok)
+	assert.Equal(platform.KindGitLab, repo.Platform)
+	assert.Equal("group/subgroup/project", repo.RepoPath)
+
+	repo, ok = matchPriorityRepo("github.com/acme/widget", tracked)
+	assert.True(ok)
+	assert.Equal(platform.KindGitHub, repo.Platform)
+	assert.Equal("acme/widget", repo.RepoPath)
+}
+
 func TestAPIReadyForReview(t *testing.T) {
 	require := require.New(t)
 	database := dbtest.Open(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5316,6 +5316,13 @@ func TestMatchPriorityRepoSupportsNestedBareRepoPaths(t *testing.T) {
 			Name:         "widget",
 			RepoPath:     "acme/widget",
 		},
+		{
+			Platform:     platform.KindGitea,
+			PlatformHost: "gitea",
+			Owner:        "acme",
+			Name:         "widget",
+			RepoPath:     "acme/widget",
+		},
 	}
 
 	repo, ok := matchPriorityRepo("group/subgroup/project", tracked)
@@ -5326,6 +5333,12 @@ func TestMatchPriorityRepoSupportsNestedBareRepoPaths(t *testing.T) {
 	repo, ok = matchPriorityRepo("github.com/acme/widget", tracked)
 	assert.True(ok)
 	assert.Equal(platform.KindGitHub, repo.Platform)
+	assert.Equal("acme/widget", repo.RepoPath)
+
+	repo, ok = matchPriorityRepo("gitea/acme/widget", tracked)
+	assert.True(ok)
+	assert.Equal(platform.KindGitea, repo.Platform)
+	assert.Equal("gitea", repo.PlatformHost)
 	assert.Equal("acme/widget", repo.RepoPath)
 }
 

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -68,6 +69,70 @@ name = "widget"
 	case <-time.After(10 * time.Second):
 		require.Fail("second explicit sync did not bypass cooldown")
 	}
+}
+
+func TestTriggerSyncE2EPrioritizesFilteredRepos(t *testing.T) {
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	done := make(chan struct{})
+	var doneClosed atomic.Bool
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(
+			_ context.Context, owner, repo string,
+		) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			calls = append(calls, owner+"/"+repo)
+			callCount := len(calls)
+			mu.Unlock()
+			if callCount == 3 && doneClosed.CompareAndSwap(false, true) {
+				close(done)
+			}
+			return nil, nil
+		},
+	}
+	baseURL, client, _, syncer := startSyncCooldownE2EServerWithSyncer(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "first"
+
+[[repos]]
+owner = "acme"
+name = "second"
+
+[[repos]]
+owner = "acme"
+name = "third"
+`, mock)
+	syncer.SetParallelism(1)
+
+	status, body := postJSON(
+		t, client,
+		baseURL+"/api/v1/sync?priority_repo=github.com/acme/third,github.com/acme/second",
+		nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		require.Fail("explicit sync did not process all repos")
+	}
+
+	mu.Lock()
+	got := append([]string(nil), calls...)
+	mu.Unlock()
+	require.Equal([]string{
+		"acme/third",
+		"acme/second",
+		"acme/first",
+	}, got)
 }
 
 func TestAddRepoE2ETriggersImmediateSyncDuringCooldown(t *testing.T) {
@@ -165,6 +230,17 @@ func startSyncCooldownE2EServer(
 	cfgContent string,
 	mock *mockGH,
 ) (string, *http.Client, *db.DB) {
+	baseURL, client, database, _ := startSyncCooldownE2EServerWithSyncer(
+		t, cfgContent, mock,
+	)
+	return baseURL, client, database
+}
+
+func startSyncCooldownE2EServerWithSyncer(
+	t *testing.T,
+	cfgContent string,
+	mock *mockGH,
+) (string, *http.Client, *db.DB, *ghclient.Syncer) {
 	t.Helper()
 	require := require.New(t)
 
@@ -228,7 +304,7 @@ func startSyncCooldownE2EServer(
 		}
 	})
 
-	return baseURL, client, database
+	return baseURL, client, database, syncer
 }
 
 func postJSON(

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -169,18 +169,18 @@ name = "first"
 [[repos]]
 owner = "acme"
 name = "second"
-platform_host = "ghe.example.com"
+platform_host = "gitea"
 
 [[repos]]
 owner = "acme"
 name = "third"
-platform_host = "ghe.example.com"
+platform_host = "gitea"
 `, mock)
 	syncer.SetParallelism(1)
 
 	status, body := postJSON(
 		t, client,
-		baseURL+"/api/v1/sync?priority_repo=ghe.example.com/acme/second",
+		baseURL+"/api/v1/sync?priority_repo=gitea/acme/second",
 		nil,
 	)
 	require.Equal(http.StatusAccepted, status, body)

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -135,6 +135,72 @@ name = "third"
 	}, got)
 }
 
+func TestTriggerSyncE2EPrioritizesNonDefaultHostFilter(t *testing.T) {
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	done := make(chan struct{})
+	var doneClosed atomic.Bool
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(
+			_ context.Context, owner, repo string,
+		) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			calls = append(calls, owner+"/"+repo)
+			callCount := len(calls)
+			mu.Unlock()
+			if callCount == 3 && doneClosed.CompareAndSwap(false, true) {
+				close(done)
+			}
+			return nil, nil
+		},
+	}
+	baseURL, client, _, syncer := startSyncCooldownE2EServerWithSyncer(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "first"
+
+[[repos]]
+owner = "acme"
+name = "second"
+platform_host = "ghe.example.com"
+
+[[repos]]
+owner = "acme"
+name = "third"
+platform_host = "ghe.example.com"
+`, mock)
+	syncer.SetParallelism(1)
+
+	status, body := postJSON(
+		t, client,
+		baseURL+"/api/v1/sync?priority_repo=ghe.example.com/acme/second",
+		nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		require.Fail("explicit sync did not process all repos")
+	}
+
+	mu.Lock()
+	got := append([]string(nil), calls...)
+	mu.Unlock()
+	require.Equal([]string{
+		"acme/second",
+		"acme/first",
+		"acme/third",
+	}, got)
+}
+
 func TestAddRepoE2ETriggersImmediateSyncDuringCooldown(t *testing.T) {
 	require := require.New(t)
 
@@ -254,13 +320,17 @@ func startSyncCooldownE2EServerWithSyncer(
 	require.NoError(err)
 
 	clients := map[string]ghclient.Client{"github.com": mock}
+	for _, repo := range cfg.Repos {
+		clients[repo.PlatformHostOrDefault()] = mock
+	}
 	resolved := ghclient.ResolveConfiguredRepos(
 		t.Context(), clients, cfg.Repos,
 	)
-	trackers := map[string]*ghclient.RateTracker{
-		"github.com": ghclient.NewRateTracker(
-			database, "github.com", "rest",
-		),
+	trackers := make(map[string]*ghclient.RateTracker, len(clients))
+	for host := range clients {
+		trackers[host] = ghclient.NewRateTracker(
+			database, host, "rest",
+		)
 	}
 	syncer := ghclient.NewSyncer(
 		clients, database, nil, resolved.Expanded,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2891,23 +2891,31 @@ func matchPriorityRepo(
 	filter string,
 	tracked []ghclient.RepoRef,
 ) (ghclient.RepoRef, bool) {
-	parts := strings.Split(filter, "/")
 	for _, repo := range tracked {
-		repoPath := repoPathForPriority(repo)
-		if len(parts) >= 3 {
-			host := parts[0]
-			path := strings.Join(parts[1:], "/")
-			if strings.EqualFold(repoHostForPriority(repo), host) &&
-				strings.EqualFold(repoPath, path) {
-				return repo, true
-			}
-			continue
+		if strings.EqualFold(repoPathForPriority(repo), filter) {
+			return repo, true
 		}
-		if strings.EqualFold(repoPath, filter) {
+	}
+
+	parts := strings.Split(filter, "/")
+	if len(parts) < 3 || !looksLikePlatformHost(parts[0]) {
+		return ghclient.RepoRef{}, false
+	}
+
+	host := parts[0]
+	path := strings.Join(parts[1:], "/")
+	for _, repo := range tracked {
+		if strings.EqualFold(repoHostForPriority(repo), host) &&
+			strings.EqualFold(repoPathForPriority(repo), path) {
 			return repo, true
 		}
 	}
 	return ghclient.RepoRef{}, false
+}
+
+func looksLikePlatformHost(value string) bool {
+	return strings.ContainsAny(value, ".:") ||
+		strings.EqualFold(value, "localhost")
 }
 
 func priorityRepoIdentity(repo ghclient.RepoRef) string {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -540,6 +540,10 @@ type listActivityInput struct {
 	Since  string   `query:"since"`
 }
 
+type triggerSyncInput struct {
+	PriorityRepos []string `query:"priority_repo"`
+}
+
 type listActivityOutput = bodyOutput[activityResponse]
 
 func apiConfig(basePath string) huma.Config {
@@ -2837,9 +2841,108 @@ func (s *Server) listRepoSummaries(
 	return &listRepoSummariesOutput{Body: out}, nil
 }
 
-func (s *Server) triggerSync(ctx context.Context, _ *struct{}) (*acceptedOutput, error) {
-	s.syncer.TriggerRun(context.WithoutCancel(ctx))
+func (s *Server) triggerSync(
+	ctx context.Context,
+	input *triggerSyncInput,
+) (*acceptedOutput, error) {
+	s.syncer.TriggerRunWithPriority(
+		context.WithoutCancel(ctx),
+		s.priorityReposFromFilter(input.PriorityRepos),
+	)
 	return &acceptedOutput{Status: http.StatusAccepted}, nil
+}
+
+func (s *Server) priorityReposFromFilter(filters []string) []ghclient.RepoRef {
+	values := splitRepoFilterValues(filters)
+	if len(values) == 0 {
+		return nil
+	}
+
+	tracked := s.syncer.TrackedRepos()
+	out := make([]ghclient.RepoRef, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if repo, ok := matchPriorityRepo(value, tracked); ok {
+			key := priorityRepoIdentity(repo)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, repo)
+		}
+	}
+	return out
+}
+
+func splitRepoFilterValues(filters []string) []string {
+	values := make([]string, 0, len(filters))
+	for _, filter := range filters {
+		for value := range strings.SplitSeq(filter, ",") {
+			value = strings.Trim(value, "/ ")
+			if value != "" {
+				values = append(values, value)
+			}
+		}
+	}
+	return values
+}
+
+func matchPriorityRepo(
+	filter string,
+	tracked []ghclient.RepoRef,
+) (ghclient.RepoRef, bool) {
+	parts := strings.Split(filter, "/")
+	for _, repo := range tracked {
+		repoPath := repoPathForPriority(repo)
+		if len(parts) >= 3 {
+			host := parts[0]
+			path := strings.Join(parts[1:], "/")
+			if strings.EqualFold(repoHostForPriority(repo), host) &&
+				strings.EqualFold(repoPath, path) {
+				return repo, true
+			}
+			continue
+		}
+		if strings.EqualFold(repoPath, filter) {
+			return repo, true
+		}
+	}
+	return ghclient.RepoRef{}, false
+}
+
+func priorityRepoIdentity(repo ghclient.RepoRef) string {
+	return strings.ToLower(
+		string(repoPlatformForPriority(repo)) + "/" +
+			repoHostForPriority(repo) + "/" +
+			repoPathForPriority(repo),
+	)
+}
+
+func repoPathForPriority(repo ghclient.RepoRef) string {
+	path := strings.Trim(repo.RepoPath, "/ ")
+	if path != "" {
+		return path
+	}
+	return strings.Trim(repo.Owner, "/ ") + "/" + strings.Trim(repo.Name, "/ ")
+}
+
+func repoHostForPriority(repo ghclient.RepoRef) string {
+	host := strings.TrimSpace(repo.PlatformHost)
+	if host != "" {
+		return strings.ToLower(host)
+	}
+	kind := repoPlatformForPriority(repo)
+	if defaultHost, ok := platform.DefaultHost(kind); ok {
+		return defaultHost
+	}
+	return platform.DefaultGitHubHost
+}
+
+func repoPlatformForPriority(repo ghclient.RepoRef) platform.Kind {
+	if repo.Platform != "" {
+		return repo.Platform
+	}
+	return platform.KindGitHub
 }
 
 func (s *Server) syncStatus(_ context.Context, _ *struct{}) (*syncStatusOutput, error) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -541,7 +541,7 @@ type listActivityInput struct {
 }
 
 type triggerSyncInput struct {
-	PriorityRepos []string `query:"priority_repo"`
+	PriorityRepos []string `query:"priority_repo" doc:"Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path."`
 }
 
 type listActivityOutput = bodyOutput[activityResponse]

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2898,7 +2898,7 @@ func matchPriorityRepo(
 	}
 
 	parts := strings.Split(filter, "/")
-	if len(parts) < 3 || !looksLikePlatformHost(parts[0]) {
+	if len(parts) < 3 {
 		return ghclient.RepoRef{}, false
 	}
 
@@ -2911,11 +2911,6 @@ func matchPriorityRepo(
 		}
 	}
 	return ghclient.RepoRef{}, false
-}
-
-func looksLikePlatformHost(value string) bool {
-	return strings.ContainsAny(value, ".:") ||
-		strings.EqualFold(value, "localhost")
 }
 
 func priorityRepoIdentity(repo ghclient.RepoRef) string {

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -149,7 +149,10 @@
     }
     const pullsStore = createPullsStore(pullsOpts);
 
-    const syncStore = createSyncStore({ client: cl });
+    const syncStore = createSyncStore({
+      client: cl,
+      getPriorityRepos: hs.getGlobalRepo,
+    });
 
     const detailOpts: DetailStoreOptions = {
       client: cl,

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -7737,7 +7737,9 @@ export interface operations {
     };
     "trigger-sync": {
         parameters: {
-            query?: never;
+            query?: {
+                priority_repo?: string[] | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -7738,6 +7738,7 @@ export interface operations {
     "trigger-sync": {
         parameters: {
             query?: {
+                /** @description Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path. */
                 priority_repo?: string[] | null;
             };
             header?: never;

--- a/packages/ui/src/stores/sync.svelte.test.ts
+++ b/packages/ui/src/stores/sync.svelte.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MiddlemanClient } from "../types.js";
+import { createSyncStore } from "./sync.svelte.js";
+
+describe("sync store", () => {
+  it("passes selected repo filters as sync priorities", async () => {
+    const post = vi.fn(async () => ({ error: undefined }));
+    const get = vi.fn(async (path: string) => {
+      if (path === "/sync/status") {
+        return { data: { running: false, last_run_at: "", last_error: "" } };
+      }
+      return { data: { hosts: {} } };
+    });
+    const store = createSyncStore({
+      client: {
+        GET: get,
+        POST: post,
+      } as unknown as MiddlemanClient,
+      getPriorityRepos: () =>
+        "github.com/acme/first, github.com/acme/second",
+    });
+
+    await store.triggerSync();
+
+    expect(post).toHaveBeenCalledWith("/sync", {
+      params: {
+        query: {
+          priority_repo: [
+            "github.com/acme/first",
+            "github.com/acme/second",
+          ],
+        },
+      },
+    });
+  });
+});

--- a/packages/ui/src/stores/sync.svelte.ts
+++ b/packages/ui/src/stores/sync.svelte.ts
@@ -6,10 +6,13 @@ import type { MiddlemanClient } from "../types.js";
 
 export interface SyncStoreOptions {
   client: MiddlemanClient;
+  getPriorityRepos?: (() => string | undefined) | undefined;
 }
 
 export function createSyncStore(opts: SyncStoreOptions) {
   const apiClient = opts.client;
+  const getPriorityRepos =
+    opts.getPriorityRepos ?? (() => undefined);
 
   // --- state ---
 
@@ -117,7 +120,11 @@ export function createSyncStore(opts: SyncStoreOptions) {
     adjustPollingSpeed(true);
 
     try {
-      const { error } = await apiClient.POST("/sync");
+      const priorityRepos = parsePriorityRepos(getPriorityRepos());
+      const syncOptions = priorityRepos.length > 0
+        ? { params: { query: { priority_repo: priorityRepos } } }
+        : {};
+      const { error } = await apiClient.POST("/sync", syncOptions);
       if (error) {
         throw new Error(
           error.detail ??
@@ -139,6 +146,13 @@ export function createSyncStore(opts: SyncStoreOptions) {
       adjustPollingSpeed(false);
       throw err;
     }
+  }
+
+  function parsePriorityRepos(value: string | undefined): string[] {
+    return (value ?? "")
+      .split(",")
+      .map((part) => part.trim())
+      .filter((part) => part !== "");
   }
 
   function adjustPollingSpeed(running: boolean): void {


### PR DESCRIPTION
## Summary
- Pass the current repo filter through manual refresh so selected repos are synced first.
- Reorder the ad-hoc sync queue locally without changing the tracked repo set or sync cadence.
- Regenerate the OpenAPI/client artifacts and wire the UI sync store to send the priority list.
- Add coverage for the sync store, sync ordering, and the HTTP refresh path.

## Testing
- `go test ./internal/github/syncertest -run TestSyncerTriggerRunWithPrioritySyncsSelectedReposFirst -shuffle=on`
- `go test ./internal/server/e2etest -run TestTriggerSyncE2EPrioritizesFilteredRepos -shuffle=on`
- `go test ./internal/server -run 'TestOpenAPIDocumentsCustomStatusCodes|TestAPITriggerSyncBypassesNextSyncAfter' -shuffle=on`
- `bun --cwd frontend vitest run ../packages/ui/src/stores/sync.svelte.test.ts`
- `bun run typecheck` (frontend)
- Pre-commit hooks passed, including `test-short`