### PR TITLE
fix: persist Activity rail width across reloads

### DIFF
--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -1229,6 +1229,59 @@ test.describe("activity split view and detail drawers", () => {
     expect(resizedRailBox!.width).toBeGreaterThan(railBox!.width + 40);
   });
 
+  test("activity split rail keeps its dragged width after a reload", async ({ page }) => {
+    // The drawer selection lives in the URL, so a reload restores the
+    // split view. The rail width must come back at the width the user
+    // dragged to rather than snapping back to the 360px default.
+    await page.goto("/");
+    await waitForActivityTable(page);
+
+    await openActivityPRSplit(page);
+
+    const rail = page.locator(".activity-pane");
+    const resizeHandle = page.locator(".activity-split-resize-handle");
+
+    const initialBox = await rail.boundingBox();
+    expect(initialBox).not.toBeNull();
+    expect(Math.abs(initialBox!.width - 360)).toBeLessThan(2);
+
+    await expect(resizeHandle).toBeVisible();
+    const handleBox = await resizeHandle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox!.x + 140,
+      handleBox!.y + handleBox!.height / 2,
+      { steps: 10 },
+    );
+    await page.mouse.up();
+
+    const widenedBox = await rail.boundingBox();
+    expect(widenedBox).not.toBeNull();
+    expect(widenedBox!.width).toBeGreaterThan(initialBox!.width + 100);
+    const widenedWidth = widenedBox!.width;
+
+    await page.reload();
+    await expect(page.locator(".activity-shell.activity-shell--split"))
+      .toBeVisible();
+
+    // Before the fix the rail mounts at the hardcoded 360px default here.
+    await expect
+      .poll(async () => {
+        const box = await page.locator(".activity-pane").boundingBox();
+        return box ? Math.round(box.width) : 0;
+      })
+      .toBeGreaterThan(Math.round(initialBox!.width) + 100);
+
+    const reloadedBox = await page.locator(".activity-pane").boundingBox();
+    expect(reloadedBox).not.toBeNull();
+    expect(Math.abs(reloadedBox!.width - widenedWidth)).toBeLessThanOrEqual(2);
+  });
+
   test("activity split rail resizes past the old 560px cap on a wide viewport", async ({ page }) => {
     // Regression guard: the rail used to be clamped near 560px. On a
     // wide monitor it must now grow well past that, while still leaving

--- a/packages/ui/src/views/ActivityFeedView.svelte
+++ b/packages/ui/src/views/ActivityFeedView.svelte
@@ -58,6 +58,32 @@
     phone = false,
   }: Props = $props();
 
+  const ACTIVITY_PANE_WIDTH_KEY = "middleman-activity-pane-width";
+  const DEFAULT_ACTIVITY_PANE_WIDTH = 360;
+
+  function loadActivityPaneWidth(): number {
+    try {
+      const raw = localStorage.getItem(ACTIVITY_PANE_WIDTH_KEY);
+      if (raw) {
+        const parsed = Number(raw);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          return parsed;
+        }
+      }
+    } catch {
+      // Storage blocked (private mode / embedded host); use the default.
+    }
+    return DEFAULT_ACTIVITY_PANE_WIDTH;
+  }
+
+  function persistActivityPaneWidth(value: number): void {
+    try {
+      localStorage.setItem(ACTIVITY_PANE_WIDTH_KEY, String(Math.round(value)));
+    } catch {
+      // Storage blocked; the rail width just won't survive a reload.
+    }
+  }
+
   // Internal state used when no controlled props are
   // provided (standalone usage).
   let internalDrawer = $state<DrawerItem | null>(null);
@@ -65,9 +91,10 @@
   let internalDetailTab = $state<ActivityDetailTab>(
     "conversation",
   );
-  // The width the user has dragged the rail to. The effective width
-  // below re-clamps it reactively so it survives viewport changes.
-  let requestedActivityPaneWidth = $state(360);
+  // The width the user has dragged the rail to, restored from storage so it
+  // survives reloads. The effective width below re-clamps it reactively so it
+  // also survives viewport changes.
+  let requestedActivityPaneWidth = $state(loadActivityPaneWidth());
   let activityPaneCollapsed = $state(false);
   // Measured width of the whole split shell so the rail's upper bound
   // scales with the viewport rather than a fixed pixel cap.
@@ -204,6 +231,7 @@
     requestedActivityPaneWidth = clampActivityPaneWidth(
       activityResizeStartWidth + event.deltaX,
     );
+    persistActivityPaneWidth(requestedActivityPaneWidth);
   }
 
   function collapseActivityPane(): void {


### PR DESCRIPTION
The Activity view's left rail (the feed shown beside an open PR/issue detail) reset to its 360px default on every browser reload. Its width is now saved and restored, so it stays where you left it.

- Drag the Activity rail to a width and it survives a page reload.
- The PR/issue list and workspace sidebars already persisted their widths; this brings the Activity rail in line, using its own `middleman-activity-pane-width` key.

![rail-after-reload.png](https://github.com/user-attachments/assets/22c42398-c975-4117-9a4b-3e2f91cfbc50)

_Activity rail at its persisted width after a page reload (synthetic e2e data)._