### PR TITLE
Polish draft review footer

### DIFF
--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -428,6 +428,7 @@ test("adds and publishes an inline draft review comment", async ({ page }) => {
 
   await expect(page.getByText("1 draft comment")).toBeVisible();
   await expect(page.locator(".inline-draft-comment")).toContainText("Please cover this line.");
+  await expect(page.getByRole("button", { name: "Show full comment" })).toHaveCount(0);
   await page.getByRole("button", { name: "Publish review" }).click();
   await expect(page.getByText("1 draft comment")).toBeHidden();
 });
@@ -467,6 +468,7 @@ test("keeps the draft review footer readable for long comments", async ({ page }
   const draftList = page.locator(".draft-list");
   const draftBody = page.locator(".draft-body").first();
   await expect(draftBody).toContainText("so i'd recommend");
+  await expect(page.getByRole("button", { name: "Show full comment" })).toBeVisible();
 
   await expect.poll(
     async () => draftList.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
@@ -477,6 +479,12 @@ test("keeps the draft review footer readable for long comments", async ({ page }
   const bodyBox = await draftBody.boundingBox();
   expect(bodyBox).not.toBeNull();
   expect(bodyBox!.height).toBeGreaterThan(24);
+
+  await page.getByRole("button", { name: "Show full comment" }).click();
+  await expect(page.getByRole("button", { name: "Show less" })).toBeVisible();
+  const expandedBodyBox = await draftBody.boundingBox();
+  expect(expandedBodyBox).not.toBeNull();
+  expect(expandedBodyBox!.height).toBeGreaterThan(bodyBox!.height);
 });
 
 test("keeps inline composer inside the visible diff pane on long lines", async ({ page }) => {

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -432,6 +432,53 @@ test("adds and publishes an inline draft review comment", async ({ page }) => {
   await expect(page.getByText("1 draft comment")).toBeHidden();
 });
 
+test("keeps the draft review footer readable for long comments", async ({ page }) => {
+  await page.setViewportSize({ width: 1000, height: 720 });
+  const longDraftBody = [
+    "so i'd recommend we use huma for this similar to what we do in middleman,",
+    "that generally means we can generate a nice typed client which makes more of the frontend safer",
+  ].join(" ");
+  await mockInlineReviewAPI(
+    page,
+    baseCapabilities,
+    "github",
+    "github.com",
+    diffResponse,
+    undefined,
+    {
+      initialDraftComments: [{
+        id: "draft-1",
+        body: longDraftBody,
+        path: "internal/server/server.go",
+        side: "right",
+        line: 1,
+        new_line: 1,
+        line_type: "add",
+        diff_head_sha: "diff-head",
+        created_at: "2026-03-30T14:01:00Z",
+        updated_at: "2026-03-30T14:01:00Z",
+      }],
+    },
+  );
+
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  await expect(page.getByText("1 draft comment")).toBeVisible();
+
+  const draftList = page.locator(".draft-list");
+  const draftBody = page.locator(".draft-body").first();
+  await expect(draftBody).toContainText("so i'd recommend");
+
+  await expect.poll(
+    async () => draftList.evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+  ).toBe(true);
+  await expect.poll(
+    async () => draftBody.evaluate((element) => getComputedStyle(element).whiteSpace),
+  ).not.toBe("nowrap");
+  const bodyBox = await draftBody.boundingBox();
+  expect(bodyBox).not.toBeNull();
+  expect(bodyBox!.height).toBeGreaterThan(24);
+});
+
 test("keeps inline composer inside the visible diff pane on long lines", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 720 });
   await page.addInitScript(() => {

--- a/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import SendIcon from "@lucide/svelte/icons/send";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
-  import XIcon from "@lucide/svelte/icons/x";
   import { getStores } from "../../context.js";
   import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
   import ActionButton from "../shared/ActionButton.svelte";
   import SelectDropdown from "../shared/SelectDropdown.svelte";
+  import DiffReviewDraftTrayItem from "./DiffReviewDraftTrayItem.svelte";
 
   interface Props {
     onjump?: ((comment: DiffReviewDraftComment) => void) | undefined;
@@ -71,28 +71,13 @@
     </div>
     <div class="draft-list">
       {#each comments as comment (comment.id)}
-        <div class="draft-item">
-          <div class="draft-content">
-            <button
-              class="draft-jump"
-              type="button"
-              onclick={() => onjump?.(comment)}
-            >
-              {commentLocation(comment)}
-            </button>
-            <p class="draft-body">{comment.body}</p>
-          </div>
-          <ActionButton
-            class="icon-btn"
-            title="Delete draft comment"
-            ariaLabel="Delete draft comment"
-            size="sm"
-            onclick={() => void diffReviewDraft.deleteComment(comment.id)}
-            disabled={submitting}
-          >
-            <XIcon size={13} />
-          </ActionButton>
-        </div>
+        <DiffReviewDraftTrayItem
+          {comment}
+          location={commentLocation(comment)}
+          disabled={submitting}
+          {onjump}
+          ondelete={(id) => void diffReviewDraft.deleteComment(id)}
+        />
       {/each}
     </div>
     <textarea
@@ -162,59 +147,6 @@
     padding-right: 2px;
   }
 
-  .draft-item {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 26px;
-    align-items: start;
-    gap: 10px;
-    min-width: 0;
-    padding: 8px 8px 8px 10px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
-    background: color-mix(in srgb, var(--bg-inset) 84%, var(--bg-surface));
-  }
-
-  .draft-content {
-    display: grid;
-    gap: 3px;
-    min-width: 0;
-  }
-
-  .draft-body {
-    display: -webkit-box;
-    margin: 0;
-    overflow: hidden;
-    color: var(--text-primary);
-    font-size: var(--font-size-sm);
-    line-height: 1.42;
-    overflow-wrap: anywhere;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-  }
-
-  .draft-jump {
-    display: block;
-    max-width: 100%;
-    padding: 0;
-    border: 0;
-    overflow: hidden;
-    background: transparent;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    line-height: 1.35;
-    text-align: left;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    cursor: pointer;
-  }
-
-  .draft-jump:hover {
-    color: var(--accent-blue);
-    text-decoration: underline;
-  }
-
   textarea {
     width: 100%;
     min-height: 64px;
@@ -254,13 +186,6 @@
     border-color: var(--accent-blue);
     background: var(--accent-blue);
     color: var(--bg-surface);
-  }
-
-  :global(.icon-btn.action-button) {
-    width: 26px;
-    height: 26px;
-    min-height: 26px;
-    padding: 0;
   }
 
   .tray-error {

--- a/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
@@ -72,7 +72,7 @@
     <div class="draft-list">
       {#each comments as comment (comment.id)}
         <div class="draft-item">
-          <div class="draft-meta">
+          <div class="draft-content">
             <button
               class="draft-jump"
               type="button"
@@ -80,8 +80,8 @@
             >
               {commentLocation(comment)}
             </button>
+            <p class="draft-body">{comment.body}</p>
           </div>
-          <p>{comment.body}</p>
           <ActionButton
             class="icon-btn"
             title="Delete draft comment"
@@ -140,8 +140,7 @@
   }
 
   .tray-header,
-  .publish-row,
-  .draft-item {
+  .publish-row {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -155,46 +154,56 @@
 
   .draft-list {
     display: grid;
-    gap: 6px;
-    max-height: 160px;
-    overflow: auto;
+    gap: 8px;
+    max-height: 188px;
+    overflow-x: hidden;
+    overflow-y: auto;
     margin-bottom: 8px;
+    padding-right: 2px;
   }
 
   .draft-item {
-    justify-content: space-between;
-    padding: 6px 8px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 26px;
+    align-items: start;
+    gap: 10px;
+    min-width: 0;
+    padding: 8px 8px 8px 10px;
     border: 1px solid var(--border-muted);
-    border-radius: 4px;
-    background: var(--bg-inset);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--bg-inset) 84%, var(--bg-surface));
   }
 
-  .draft-item p {
-    flex: 1;
+  .draft-content {
+    display: grid;
+    gap: 3px;
     min-width: 0;
+  }
+
+  .draft-body {
+    display: -webkit-box;
     margin: 0;
+    overflow: hidden;
     color: var(--text-primary);
     font-size: var(--font-size-sm);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .draft-meta {
-    min-width: 0;
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
+    line-height: 1.42;
+    overflow-wrap: anywhere;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
   }
 
   .draft-jump {
-    max-width: 28ch;
+    display: block;
+    max-width: 100%;
     padding: 0;
     border: 0;
     overflow: hidden;
     background: transparent;
-    color: inherit;
-    font: inherit;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    line-height: 1.35;
     text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -208,10 +217,11 @@
 
   textarea {
     width: 100%;
+    min-height: 64px;
     resize: vertical;
     padding: 7px 8px;
     border: 1px solid var(--border-muted);
-    border-radius: 4px;
+    border-radius: var(--radius-md);
     background: var(--bg-inset);
     color: var(--text-primary);
     font: inherit;
@@ -243,7 +253,7 @@
   :global(.publish-btn.action-button) {
     border-color: var(--accent-blue);
     background: var(--accent-blue);
-    color: #fff;
+    color: var(--bg-surface);
   }
 
   :global(.icon-btn.action-button) {
@@ -257,5 +267,20 @@
     margin-top: 6px;
     color: var(--accent-red);
     font-size: var(--font-size-sm);
+  }
+
+  @media (max-width: 680px) {
+    .publish-row {
+      align-items: stretch;
+      flex-wrap: wrap;
+    }
+
+    :global(.review-action-select) {
+      flex: 1 1 150px;
+    }
+
+    :global(.publish-btn.action-button) {
+      flex: 1 1 170px;
+    }
   }
 </style>

--- a/packages/ui/src/components/diff/DiffReviewDraftTrayItem.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftTrayItem.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import { onMount, tick } from "svelte";
+  import XIcon from "@lucide/svelte/icons/x";
+  import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
+  import ActionButton from "../shared/ActionButton.svelte";
+
+  interface Props {
+    comment: DiffReviewDraftComment;
+    location: string;
+    disabled: boolean;
+    onjump?: ((comment: DiffReviewDraftComment) => void) | undefined;
+    ondelete: (id: string) => void;
+  }
+
+  const { comment, location, disabled, onjump, ondelete }: Props = $props();
+
+  let expanded = $state(false);
+  let truncated = $state(false);
+  let bodyElement: HTMLParagraphElement | undefined = $state();
+  let measureFrame: number | undefined;
+
+  function measureTruncation(): void {
+    if (!bodyElement) {
+      truncated = false;
+      return;
+    }
+    truncated = bodyElement.scrollHeight > bodyElement.clientHeight + 1
+      || bodyElement.scrollWidth > bodyElement.clientWidth + 1;
+  }
+
+  function queueMeasure(): void {
+    if (measureFrame !== undefined) {
+      cancelAnimationFrame(measureFrame);
+    }
+    measureFrame = requestAnimationFrame(() => {
+      measureFrame = undefined;
+      measureTruncation();
+    });
+  }
+
+  function toggleExpanded(): void {
+    expanded = !expanded;
+    void tick().then(queueMeasure);
+  }
+
+  function scheduleMeasure(_body: string, _expanded: boolean): void {
+    void tick().then(queueMeasure);
+  }
+
+  onMount(() => {
+    const observer = typeof ResizeObserver === "undefined"
+      ? undefined
+      : new ResizeObserver(queueMeasure);
+    if (bodyElement) observer?.observe(bodyElement);
+    queueMeasure();
+
+    return () => {
+      observer?.disconnect();
+      if (measureFrame !== undefined) {
+        cancelAnimationFrame(measureFrame);
+      }
+    };
+  });
+
+  $effect(() => scheduleMeasure(comment.body, expanded));
+</script>
+
+<div class="draft-item">
+  <div class="draft-content">
+    <button
+      class="draft-jump"
+      type="button"
+      onclick={() => onjump?.(comment)}
+    >
+      {location}
+    </button>
+    <p
+      bind:this={bodyElement}
+      class={["draft-body", expanded && "draft-body--expanded"]}
+    >
+      {comment.body}
+    </p>
+    {#if truncated || expanded}
+      <button class="draft-expand" type="button" onclick={toggleExpanded}>
+        {expanded ? "Show less" : "Show full comment"}
+      </button>
+    {/if}
+  </div>
+  <ActionButton
+    class="icon-btn"
+    title="Delete draft comment"
+    ariaLabel="Delete draft comment"
+    size="sm"
+    onclick={() => ondelete(comment.id)}
+    disabled={disabled}
+  >
+    <XIcon size={13} />
+  </ActionButton>
+</div>
+
+<style>
+  .draft-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 26px;
+    align-items: start;
+    gap: 10px;
+    min-width: 0;
+    padding: 8px 8px 8px 10px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--bg-inset) 84%, var(--bg-surface));
+  }
+
+  .draft-content {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  .draft-body {
+    display: -webkit-box;
+    margin: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    line-height: 1.42;
+    overflow-wrap: anywhere;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .draft-body--expanded {
+    display: block;
+    line-clamp: unset;
+    -webkit-line-clamp: unset;
+  }
+
+  .draft-jump {
+    display: block;
+    max-width: 100%;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    line-height: 1.35;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .draft-jump:hover {
+    color: var(--accent-blue);
+    text-decoration: underline;
+  }
+
+  .draft-expand {
+    justify-self: start;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--accent-blue);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    line-height: 1.4;
+    cursor: pointer;
+  }
+
+  .draft-expand:hover {
+    text-decoration: underline;
+  }
+
+  :global(.icon-btn.action-button) {
+    width: 26px;
+    height: 26px;
+    min-height: 26px;
+    padding: 0;
+  }
+</style>


### PR DESCRIPTION
- Improve draft review footer rows so long comments wrap into a readable preview instead of forcing horizontal overflow.
- Add a conditional full-comment toggle that appears only when a draft comment is actually truncated.
- Keep publish controls usable on narrow viewports.