### PR TITLE
Tree navigation for the repo selector

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -141,6 +141,26 @@ Rows that contain buttons, links, or toggles need clear event ownership.
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.
 
+## Controlled Form Controls
+
+A native form control driven from app state must not also run its own default
+action, or the two fight and the control renders the inverse of its real state.
+
+- A native `<input type="checkbox">` with `checked={state}` still toggles itself
+  on a real click (the click default action). When app state owns the value,
+  cancel that default action (`onclick` `preventDefault`) so the box only ever
+  reflects `state`. The repo selector's tri-state checkbox
+  (`frontend/src/lib/components/TreeCheckbox.svelte`) is the reference: a
+  controlled custom control that suppresses the native toggle and drives
+  selection from `onmousedown`, not click.
+- Keep an underlying real `<input>` for accessibility and tests even when the
+  visuals are custom: set `indeterminate` imperatively for the partial state, and
+  expose `aria-checked` (`"mixed"` for partial) on the owning row.
+- Tri-state selection that cascades to descendants must keep parent and child
+  visuals consistent: a parent is checked only when all leaves are, partial when
+  some are, unchecked when none are. A parent disagreeing with all its children
+  is a desync bug.
+
 ## Filtering And Visibility Rules
 
 Not every visibility control means "remove this entity entirely."
@@ -188,6 +208,11 @@ breakage.
 - Store tests for persistence scope and normalization logic.
 - Playwright/e2e tests for navigation away/back, Escape behavior, nested button
   activation, and other multi-surface flows.
+- For controlled native form controls, assert behavior under a real
+  `fireEvent.click`, not only `fireEvent.mouseDown`. A mousedown-only test skips
+  the native default action (e.g. a checkbox's own toggle) and will pass while a
+  real click desyncs the control. A real-browser visual check catches this class
+  of bug when the suite is green.
 - Keyboard e2e tests should cover conflicting scopes, modal frame ownership,
   async action failure, overflow scroll-into-view, and mobile redirect cases
   when those behaviors are part of the feature.

--- a/docs/superpowers/plans/2026-05-30-repo-tree-nav.md
+++ b/docs/superpowers/plans/2026-05-30-repo-tree-nav.md
@@ -738,6 +738,12 @@ dumb presenter: all logic stays in the parent. The checkbox uses a native
 `<input type="checkbox">` with `indeterminate` set for the partial state (the
 deferred-styling note in the spec explicitly allows this technique).
 
+The label honors the spec's filter match-highlighting: when the parent passes
+`segments` (the output of the existing `highlightSegments` helper), the row renders
+`<mark>` runs; with no `segments` it renders the plain label. Keeping the highlight in
+the presenter is what lets Task 7 keep reusing `highlightSegments` instead of
+orphaning it.
+
 - [ ] **Step 1: Write the failing test**
 
 Create `frontend/src/lib/components/RepoTreeNode.test.ts`:
@@ -832,6 +838,29 @@ describe("RepoTreeNode", () => {
     await fireEvent.mouseDown(screen.getByRole("checkbox"));
     expect(onToggleSelect).toHaveBeenCalledOnce();
   });
+
+  it("renders highlighted match segments when given segments", () => {
+    render(RepoTreeNode, {
+      props: {
+        kind: "repo",
+        label: "web-ui",
+        ariaLabel: "github.com/acme/web-ui",
+        depth: 1,
+        hasChildren: false,
+        expanded: false,
+        selectionState: "unchecked",
+        highlighted: false,
+        segments: [
+          { text: "web", match: true },
+          { text: "-ui", match: false },
+        ],
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    const mark = document.querySelector("mark");
+    expect(mark?.textContent).toBe("web");
+  });
 });
 ```
 
@@ -849,6 +878,11 @@ Create `frontend/src/lib/components/RepoTreeNode.svelte`:
   import ProviderIcon from "./provider/ProviderIcon.svelte";
   import type { SelectionState } from "./repoTree.js";
 
+  interface LabelSegment {
+    text: string;
+    match: boolean;
+  }
+
   interface Props {
     kind: "host" | "owner" | "repo";
     label: string;
@@ -859,8 +893,10 @@ Create `frontend/src/lib/components/RepoTreeNode.svelte`:
     expanded: boolean;
     selectionState: SelectionState;
     highlighted: boolean;
+    segments?: LabelSegment[];
     onToggleExpand: () => void;
     onToggleSelect: () => void;
+    onHover?: () => void;
   }
 
   let {
@@ -873,8 +909,10 @@ Create `frontend/src/lib/components/RepoTreeNode.svelte`:
     expanded,
     selectionState,
     highlighted,
+    segments,
     onToggleExpand,
     onToggleSelect,
+    onHover,
   }: Props = $props();
 
   let checkboxEl = $state<HTMLInputElement>();
@@ -912,6 +950,7 @@ Create `frontend/src/lib/components/RepoTreeNode.svelte`:
   aria-expanded={hasChildren ? expanded : undefined}
   style:padding-left={`${6 + depth * 14}px`}
   onmousedown={rowMouseDown}
+  onmouseenter={() => onHover?.()}
 >
   {#if hasChildren}
     <button
@@ -948,7 +987,9 @@ Create `frontend/src/lib/components/RepoTreeNode.svelte`:
     <ProviderIcon {provider} size={14} class="repo-tree-logo" />
   {/if}
 
-  <span class="repo-tree-label">{label}</span>
+  <span class="repo-tree-label">
+    {#if segments}{#each segments as seg, segIndex (`${ariaLabel}-${segIndex}-${seg.text}-${seg.match}`)}{#if seg.match}<mark class="match">{seg.text}</mark>{:else}{seg.text}{/if}{/each}{:else}{label}{/if}
+  </span>
 </li>
 
 <style>
@@ -994,7 +1035,7 @@ Create `frontend/src/lib/components/RepoTreeNode.svelte`:
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd frontend && bun run test src/lib/components/RepoTreeNode.test.ts`
-Expected: PASS (4 tests).
+Expected: PASS (5 tests).
 
 - [ ] **Step 5: Commit**
 
@@ -1224,6 +1265,12 @@ Note: `row.node.id` for a leaf equals its `value`; `nodeSelectionState(row.node,
 gives the per-row tri-state. `selectedValues` / `selectedSet` / `serializeRepoFilterValue`
 already exist in the component.
 
+Leave the existing `handleKeydown`, `filtered`, and `toggleRepo` in place for now — the
+old `handleKeydown` still references `filtered`/`toggleRepo`, so removing them here would
+break this task's own typecheck. Task 8 replaces `handleKeydown` and removes the dead
+declarations together. After this task, `rows` and `filtered` both exist; that is
+expected and temporary.
+
 - [ ] **Step 4: Replace the flat list markup with tree rows**
 
 In the open-dropdown block, replace the `{#each filtered as option ...}` list (the
@@ -1250,24 +1297,23 @@ In the open-dropdown block, replace the `{#each filtered as option ...}` list (t
     <span>All repos</span>
   </li>
   {#each rows as row, i (row.node.id)}
-    <div
-      role="presentation"
-      onmouseenter={() => (highlightIndex = i + 1)}
-    >
-      <RepoTreeNode
-        kind={row.node.kind}
-        label={row.node.label}
-        ariaLabel={rowAriaLabel(row)}
-        provider={row.node.kind === "host" ? row.node.provider : undefined}
-        depth={row.depth}
-        hasChildren={row.hasChildren}
-        expanded={row.expanded}
-        selectionState={nodeSelectionState(row.node, selectedSet)}
-        highlighted={i + 1 === highlightIndex}
-        onToggleExpand={() => toggleRowExpand(row)}
-        onToggleSelect={() => toggleRowSelect(row)}
-      />
-    </div>
+    <RepoTreeNode
+      kind={row.node.kind}
+      label={row.node.label}
+      ariaLabel={rowAriaLabel(row)}
+      provider={row.node.kind === "host" ? row.node.provider : undefined}
+      depth={row.depth}
+      hasChildren={row.hasChildren}
+      expanded={row.expanded}
+      selectionState={nodeSelectionState(row.node, selectedSet)}
+      highlighted={i + 1 === highlightIndex}
+      segments={query !== "" && row.node.kind === "repo"
+        ? highlightSegments(row.node.label, query)
+        : undefined}
+      onToggleExpand={() => toggleRowExpand(row)}
+      onToggleSelect={() => toggleRowSelect(row)}
+      onHover={() => (highlightIndex = i + 1)}
+    />
   {:else}
     <li class="typeahead-empty">No matching repos</li>
   {/each}
@@ -1447,6 +1493,12 @@ function handleKeydown(e: KeyboardEvent) {
 }
 ```
 
+With this replacement, `filtered` and `toggleRepo` are no longer referenced anywhere.
+Delete both — the `filtered` `$derived.by(...)` block and the `toggleRepo` function —
+so `bun run typecheck` (`svelte-check --fail-on-warnings`) and `bun run lint` stay
+clean. Keep `highlightSegments` (now feeds the leaf `segments` prop from Task 7),
+`handleInput`, `query`, `selectedValues`, and `selectedSet`.
+
 - [ ] **Step 4: Add cheatsheet entries for the new bindings**
 
 In the `registerCheatsheetEntries("repo-typeahead", [...])` array (inside `onMount`),
@@ -1470,10 +1522,10 @@ add two entries after the existing `next`/`prev` entries:
 - [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.test.ts`
-Expected: PASS (all RepoTypeahead tests, including the existing cheatsheet test in `RepoTypeahead.svelte.test.ts`).
+Expected: PASS (all RepoTypeahead behavior tests).
 
 Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.svelte.test.ts`
-Expected: PASS.
+Expected: PASS (the separate cheatsheet-registration test file — the two new entries register without disturbing the existing `next`/`prev` assertions).
 
 - [ ] **Step 6: Typecheck**
 

--- a/docs/superpowers/plans/2026-05-30-repo-tree-nav.md
+++ b/docs/superpowers/plans/2026-05-30-repo-tree-nav.md
@@ -1,0 +1,1593 @@
+# Repo Tree Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat repo list in the header repo selector with a collapsible `host -> owner -> repo` tree whose interior rows expand on name-click and select their whole subtree via a tri-state checkbox.
+
+**Architecture:** A pure tree-building module turns the existing `RepoOption[]` into a `host -> owner -> repo` structure; a pure projection flattens single-child levels and applies expansion + filtering into an ordered visible-row list; pure selection helpers derive tri-state and cascade selection. A small Svelte store persists collapsed-node ids (mirroring `collapsedRepos`). `RepoTreeNode.svelte` renders one row. `RepoTypeahead.svelte` is rewired to render the projected rows and drive selection through the unchanged global-filter contract (`setGlobalRepo` with a comma-separated set of leaf `platformHost/repoPath` strings).
+
+**Tech Stack:** Svelte 5 (runes), TypeScript, Vitest + `@testing-library/svelte` for unit/component tests, Playwright (`tests/e2e-full/`) for e2e. Build/test via `bun`.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-repo-tree-nav-design.md`
+
+---
+
+## Conventions for this plan
+
+- Run a single frontend test file with: `cd frontend && bun run test <path-relative-to-frontend>`.
+  (`bun run test` runs `vitest run`; a trailing path filters to that file.)
+- Run type-checking with: `cd frontend && bun run typecheck`.
+- Pure modules and their `*.test.ts` are colocated under `frontend/src/lib/`.
+- Do not use `npm`. Use `bun`.
+
+## ARIA decision (locked for this plan)
+
+The spec left ARIA roles open. To avoid churning the existing component tests and the
+`tests/e2e-full/` specs that drive the selector by `role="option"` + accessible name,
+keep the current semantics:
+
+- container keeps `role="listbox"` and the `.typeahead-list` class;
+- every tree row (host, owner, repo, and "All repos") is `role="option"` with the
+  `.typeahead-option` class;
+- a row's **accessible name** (`aria-label`) is its full path: leaf = its `value`
+  (e.g. `github.com/import-lab/api`), owner = `${platformHost}/${ownerPath}`, host =
+  `platformHost`. Visible text stays short (just the repo or owner name);
+- interior rows carry `aria-expanded`; selected rows carry `aria-selected` and
+  `aria-checked` ("true" | "false" | "mixed").
+
+## File Structure
+
+- Create `frontend/src/lib/components/repoTree.ts` — pure tree builder, visible-row projection, selection helpers, and the exported types.
+- Create `frontend/src/lib/components/repoTree.test.ts` — unit tests for the above.
+- Create `frontend/src/lib/stores/repoTreeExpansion.svelte.ts` — persisted collapsed-id store.
+- Create `frontend/src/lib/stores/repoTreeExpansion.test.ts` — store tests.
+- Create `frontend/src/lib/components/RepoTreeNode.svelte` — single-row presenter.
+- Create `frontend/src/lib/components/RepoTreeNode.test.ts` — row component tests.
+- Modify `frontend/src/lib/components/RepoTypeahead.svelte` — extend `RepoOption`, render the tree, mouse + keyboard + filter wiring.
+- Modify `frontend/src/lib/components/RepoTypeahead.test.ts` — adapt flat-list assertions to tree rows; add tree behaviors.
+- Modify `frontend/tests/e2e-full/repo-filter-multiselect.spec.ts` — add group-select coverage.
+
+---
+
+### Task 1: Tree builder and types
+
+**Files:**
+- Create: `frontend/src/lib/components/repoTree.ts`
+- Test: `frontend/src/lib/components/repoTree.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/lib/components/repoTree.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { buildRepoTree, type RepoTreeOption } from "./repoTree.js";
+
+function opt(
+  platformHost: string,
+  repoPath: string,
+  provider = "github",
+): RepoTreeOption {
+  const segments = repoPath.split("/");
+  return {
+    value: `${platformHost}/${repoPath}`,
+    owner: segments.slice(0, -1).join("/"),
+    name: segments[segments.length - 1] ?? repoPath,
+    provider,
+    platformHost,
+  };
+}
+
+describe("buildRepoTree", () => {
+  it("groups host -> owner -> repo and sorts each level", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/web"),
+      opt("github.com", "acme/api"),
+      opt("github.com", "widgets/sdk"),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    const host = tree[0];
+    expect(host.kind).toBe("host");
+    expect(host.id).toBe("github.com");
+    expect(host.label).toBe("github.com");
+    expect(host.provider).toBe("github");
+    expect(host.children.map((o) => o.label)).toEqual(["acme", "widgets"]);
+
+    const acme = host.children[0];
+    expect(acme.id).toBe("github.com/acme");
+    expect(acme.children.map((r) => r.label)).toEqual(["api", "web"]);
+    expect(acme.children[0].value).toBe("github.com/acme/api");
+    expect(acme.children[0].id).toBe("github.com/acme/api");
+  });
+
+  it("keeps GitLab nested groups as one slashed owner node", () => {
+    const tree = buildRepoTree([
+      opt("gitlab.com", "platform/frontend/web-ui", "gitlab"),
+    ]);
+
+    const host = tree[0];
+    expect(host.children).toHaveLength(1);
+    const owner = host.children[0];
+    expect(owner.label).toBe("platform/frontend");
+    expect(owner.id).toBe("gitlab.com/platform/frontend");
+    expect(owner.children[0].label).toBe("web-ui");
+    expect(owner.children[0].value).toBe("gitlab.com/platform/frontend/web-ui");
+  });
+
+  it("separates hosts and sorts them by label", () => {
+    const tree = buildRepoTree([
+      opt("gitlab.com", "g/x", "gitlab"),
+      opt("github.com", "a/y"),
+    ]);
+    expect(tree.map((h) => h.label)).toEqual(["github.com", "gitlab.com"]);
+  });
+
+  it("uses the first option's provider when a host's providers disagree", () => {
+    const tree = buildRepoTree([
+      opt("ghe.example.com", "a/x", "github"),
+      opt("ghe.example.com", "b/y", "gitlab"),
+    ]);
+    expect(tree[0].provider).toBe("github");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && bun run test src/lib/components/repoTree.test.ts`
+Expected: FAIL — cannot find module `./repoTree.js` / `buildRepoTree` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `frontend/src/lib/components/repoTree.ts`:
+
+```ts
+export interface RepoTreeOption {
+  value: string; // `${platformHost}/${repoPath}`
+  owner: string;
+  name: string;
+  provider: string; // canonical, lowercase
+  platformHost: string;
+}
+
+export interface RepoLeaf {
+  kind: "repo";
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface OwnerNode {
+  kind: "owner";
+  id: string;
+  label: string;
+  children: RepoLeaf[];
+}
+
+export interface HostNode {
+  kind: "host";
+  id: string;
+  label: string;
+  provider: string;
+  platformHost: string;
+  children: OwnerNode[];
+}
+
+export type RepoTreeNodeData = HostNode | OwnerNode | RepoLeaf;
+
+function stripHostPrefix(value: string, platformHost: string): string {
+  const prefix = `${platformHost}/`;
+  if (value.startsWith(prefix)) return value.slice(prefix.length);
+  // Defensive fallback: drop everything up to and including the first slash.
+  return value.replace(/^[^/]+\//, "");
+}
+
+export function buildRepoTree(
+  options: readonly RepoTreeOption[],
+): HostNode[] {
+  const hosts = new Map<string, HostNode>();
+
+  for (const option of options) {
+    const repoPath = stripHostPrefix(option.value, option.platformHost);
+    const segments = repoPath.split("/");
+    const name = segments[segments.length - 1] ?? repoPath;
+    const ownerPath = segments.slice(0, -1).join("/");
+    if (ownerPath === "") continue; // malformed value with no owner segment
+
+    let host = hosts.get(option.platformHost);
+    if (!host) {
+      host = {
+        kind: "host",
+        id: option.platformHost,
+        label: option.platformHost,
+        provider: option.provider,
+        platformHost: option.platformHost,
+        children: [],
+      };
+      hosts.set(option.platformHost, host);
+    }
+
+    let owner = host.children.find((node) => node.label === ownerPath);
+    if (!owner) {
+      owner = {
+        kind: "owner",
+        id: `${option.platformHost}/${ownerPath}`,
+        label: ownerPath,
+        children: [],
+      };
+      host.children.push(owner);
+    }
+
+    owner.children.push({
+      kind: "repo",
+      id: option.value,
+      label: name,
+      value: option.value,
+    });
+  }
+
+  const sorted = [...hosts.values()].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+  for (const host of sorted) {
+    host.children.sort((a, b) => a.label.localeCompare(b.label));
+    for (const owner of host.children) {
+      owner.children.sort((a, b) => a.label.localeCompare(b.label));
+    }
+  }
+  return sorted;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && bun run test src/lib/components/repoTree.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/components/repoTree.ts frontend/src/lib/components/repoTree.test.ts
+git commit -m "feat: build host/owner/repo tree from repo options"
+```
+
+---
+
+### Task 2: Visible-row projection (flatten + expansion + filter)
+
+**Files:**
+- Modify: `frontend/src/lib/components/repoTree.ts`
+- Test: `frontend/src/lib/components/repoTree.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/lib/components/repoTree.test.ts`:
+
+```ts
+import { visibleRows, type VisibleRow } from "./repoTree.js";
+
+const neverCollapsed = () => false;
+
+function labelsAtDepth(rows: VisibleRow[]): Array<[string, number]> {
+  return rows.map((row) => [row.node.label, row.depth]);
+}
+
+describe("visibleRows", () => {
+  it("omits the host node when there is only one host", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: neverCollapsed });
+    // owner at depth 0 (host omitted), two leaves at depth 1
+    expect(labelsAtDepth(rows)).toEqual([
+      ["acme", 0],
+      ["api", 1],
+      ["web", 1],
+    ]);
+  });
+
+  it("shows host nodes at depth 0 when more than one host exists", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("gitlab.com", "g/x", "gitlab"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: neverCollapsed });
+    expect(rows[0].node.kind).toBe("host");
+    expect(rows[0].depth).toBe(0);
+    expect(rows.find((r) => r.node.label === "acme")?.depth).toBe(1);
+  });
+
+  it("flattens a single-repo owner into one leaf row with no children", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("github.com", "solo/only"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: neverCollapsed });
+    const soloRow = rows.find((r) => r.node.label === "only");
+    expect(soloRow).toBeTruthy();
+    expect(soloRow!.depth).toBe(0); // at the owner's depth (single host)
+    expect(soloRow!.hasChildren).toBe(false);
+    // the "solo" owner node itself is not rendered
+    expect(rows.some((r) => r.node.label === "solo")).toBe(false);
+  });
+
+  it("hides children of a collapsed node", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+    ]);
+    const collapsed = (id: string) => id === "github.com/acme";
+    const rows = visibleRows(tree, { isCollapsed: collapsed });
+    expect(labelsAtDepth(rows)).toEqual([["acme", 0]]);
+    expect(rows[0].expanded).toBe(false);
+  });
+
+  it("prunes non-matching repos and force-expands matches when filtering", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("github.com", "widgets/web-sdk"),
+    ]);
+    // collapse everything; filtering must override collapse
+    const rows = visibleRows(tree, {
+      isCollapsed: () => true,
+      query: "web",
+    });
+    const labels = rows.map((r) => r.node.label);
+    expect(labels).toContain("web");
+    expect(labels).toContain("web-sdk");
+    expect(labels).not.toContain("api");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && bun run test src/lib/components/repoTree.test.ts`
+Expected: FAIL — `visibleRows` / `VisibleRow` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `frontend/src/lib/components/repoTree.ts`:
+
+```ts
+export interface VisibleRow {
+  node: RepoTreeNodeData;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+}
+
+export interface VisibleRowsOptions {
+  isCollapsed: (id: string) => boolean;
+  query?: string;
+}
+
+export function visibleRows(
+  tree: readonly HostNode[],
+  { isCollapsed, query }: VisibleRowsOptions,
+): VisibleRow[] {
+  const q = query?.trim().toLowerCase() ?? "";
+  const filtering = q !== "";
+  const matches = (leaf: RepoLeaf) =>
+    !filtering || leaf.value.toLowerCase().includes(q);
+
+  // Prune to owners/hosts that still have a matching leaf.
+  const pruned = tree
+    .map((host) => ({
+      ...host,
+      children: host.children
+        .map((owner) => ({
+          ...owner,
+          children: owner.children.filter(matches),
+        }))
+        .filter((owner) => owner.children.length > 0),
+    }))
+    .filter((host) => host.children.length > 0);
+
+  const expandedOf = (id: string) => filtering || !isCollapsed(id);
+  const singleHost = pruned.length === 1;
+  const rows: VisibleRow[] = [];
+
+  for (const host of pruned) {
+    const ownerDepth = singleHost ? 0 : 1;
+    if (!singleHost) {
+      const hostExpanded = expandedOf(host.id);
+      rows.push({ node: host, depth: 0, hasChildren: true, expanded: hostExpanded });
+      if (!hostExpanded) continue;
+    }
+    for (const owner of host.children) {
+      if (owner.children.length === 1) {
+        rows.push({
+          node: owner.children[0],
+          depth: ownerDepth,
+          hasChildren: false,
+          expanded: false,
+        });
+        continue;
+      }
+      const ownerExpanded = expandedOf(owner.id);
+      rows.push({
+        node: owner,
+        depth: ownerDepth,
+        hasChildren: true,
+        expanded: ownerExpanded,
+      });
+      if (!ownerExpanded) continue;
+      for (const leaf of owner.children) {
+        rows.push({
+          node: leaf,
+          depth: ownerDepth + 1,
+          hasChildren: false,
+          expanded: false,
+        });
+      }
+    }
+  }
+  return rows;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && bun run test src/lib/components/repoTree.test.ts`
+Expected: PASS (all Task 1 + Task 2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/components/repoTree.ts frontend/src/lib/components/repoTree.test.ts
+git commit -m "feat: project repo tree into a flattened, filtered visible-row list"
+```
+
+---
+
+### Task 3: Selection helpers (tri-state + cascade)
+
+**Files:**
+- Modify: `frontend/src/lib/components/repoTree.ts`
+- Test: `frontend/src/lib/components/repoTree.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/lib/components/repoTree.test.ts`:
+
+```ts
+import {
+  collectLeafValues,
+  nodeSelectionState,
+  toggleSubtree,
+} from "./repoTree.js";
+
+describe("selection helpers", () => {
+  const tree = buildRepoTree([
+    opt("github.com", "acme/api"),
+    opt("github.com", "acme/web"),
+    opt("github.com", "acme/infra"),
+  ]);
+  const acme = tree[0].children[0];
+
+  it("collects all descendant leaf values", () => {
+    expect(collectLeafValues(acme).sort()).toEqual([
+      "github.com/acme/api",
+      "github.com/acme/infra",
+      "github.com/acme/web",
+    ]);
+    expect(collectLeafValues(acme.children[0])).toEqual([
+      "github.com/acme/api",
+    ]);
+  });
+
+  it("computes tri-state from the active set", () => {
+    expect(nodeSelectionState(acme, new Set())).toBe("unchecked");
+    expect(
+      nodeSelectionState(acme, new Set(["github.com/acme/api"])),
+    ).toBe("partial");
+    expect(
+      nodeSelectionState(
+        acme,
+        new Set([
+          "github.com/acme/api",
+          "github.com/acme/web",
+          "github.com/acme/infra",
+        ]),
+      ),
+    ).toBe("checked");
+  });
+
+  it("adds all subtree leaves when not fully checked", () => {
+    expect(toggleSubtree(acme, ["github.com/acme/api"]).sort()).toEqual([
+      "github.com/acme/api",
+      "github.com/acme/infra",
+      "github.com/acme/web",
+    ]);
+  });
+
+  it("removes all subtree leaves when fully checked", () => {
+    const all = [
+      "github.com/acme/api",
+      "github.com/acme/web",
+      "github.com/acme/infra",
+    ];
+    expect(toggleSubtree(acme, all)).toEqual([]);
+  });
+
+  it("toggles a single leaf without touching siblings", () => {
+    expect(
+      toggleSubtree(acme.children[0], ["github.com/acme/web"]).sort(),
+    ).toEqual(["github.com/acme/api", "github.com/acme/web"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && bun run test src/lib/components/repoTree.test.ts`
+Expected: FAIL — selection helpers not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `frontend/src/lib/components/repoTree.ts`:
+
+```ts
+export type SelectionState = "checked" | "partial" | "unchecked";
+
+export function collectLeafValues(node: RepoTreeNodeData): string[] {
+  if (node.kind === "repo") return [node.value];
+  const values: string[] = [];
+  for (const child of node.children) values.push(...collectLeafValues(child));
+  return values;
+}
+
+export function nodeSelectionState(
+  node: RepoTreeNodeData,
+  active: ReadonlySet<string>,
+): SelectionState {
+  const leaves = collectLeafValues(node);
+  if (leaves.length === 0) return "unchecked";
+  let selected = 0;
+  for (const value of leaves) if (active.has(value)) selected += 1;
+  if (selected === 0) return "unchecked";
+  if (selected === leaves.length) return "checked";
+  return "partial";
+}
+
+export function toggleSubtree(
+  node: RepoTreeNodeData,
+  activeValues: readonly string[],
+): string[] {
+  const leaves = collectLeafValues(node);
+  if (nodeSelectionState(node, new Set(activeValues)) === "checked") {
+    const remove = new Set(leaves);
+    return activeValues.filter((value) => !remove.has(value));
+  }
+  const next = [...activeValues];
+  const present = new Set(activeValues);
+  for (const value of leaves) if (!present.has(value)) next.push(value);
+  return next;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && bun run test src/lib/components/repoTree.test.ts`
+Expected: PASS (all repoTree tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/components/repoTree.ts frontend/src/lib/components/repoTree.test.ts
+git commit -m "feat: derive tri-state selection and subtree toggling for the repo tree"
+```
+
+---
+
+### Task 4: Expansion-state store
+
+**Files:**
+- Create: `frontend/src/lib/stores/repoTreeExpansion.svelte.ts`
+- Test: `frontend/src/lib/stores/repoTreeExpansion.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/lib/stores/repoTreeExpansion.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createRepoTreeExpansionStore } from "./repoTreeExpansion.svelte.js";
+
+const KEY = "middleman:repoTreeCollapsed";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createRepoTreeExpansionStore", () => {
+  it("reports every node expanded on a fresh store", () => {
+    const store = createRepoTreeExpansionStore();
+    expect(store.isCollapsed("github.com/acme")).toBe(false);
+  });
+
+  it("flips collapsed state on each toggle", () => {
+    const store = createRepoTreeExpansionStore();
+    store.toggle("github.com/acme");
+    expect(store.isCollapsed("github.com/acme")).toBe(true);
+    store.toggle("github.com/acme");
+    expect(store.isCollapsed("github.com/acme")).toBe(false);
+  });
+
+  it("persists collapsed ids to localStorage", () => {
+    const store = createRepoTreeExpansionStore();
+    store.toggle("github.com/acme");
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(["github.com/acme"]);
+  });
+
+  it("reads pre-seeded collapsed ids", () => {
+    localStorage.setItem(KEY, JSON.stringify(["github.com/acme"]));
+    const store = createRepoTreeExpansionStore();
+    expect(store.isCollapsed("github.com/acme")).toBe(true);
+  });
+
+  it("falls back to expanded on malformed JSON", () => {
+    localStorage.setItem(KEY, "{not json");
+    const store = createRepoTreeExpansionStore();
+    expect(store.isCollapsed("github.com/acme")).toBe(false);
+  });
+
+  it("keeps working in memory when setItem throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+    const store = createRepoTreeExpansionStore();
+    expect(() => store.toggle("github.com/acme")).not.toThrow();
+    expect(store.isCollapsed("github.com/acme")).toBe(true);
+    spy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && bun run test src/lib/stores/repoTreeExpansion.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `frontend/src/lib/stores/repoTreeExpansion.svelte.ts`:
+
+```ts
+const STORAGE_KEY = "middleman:repoTreeCollapsed";
+
+function readFromStorage(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is string => typeof v === "string"));
+  } catch {
+    // localStorage unavailable or corrupt JSON.
+    return new Set();
+  }
+}
+
+function writeToStorage(value: Set<string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...value]));
+  } catch {
+    // localStorage unavailable (e.g. private browsing quota).
+  }
+}
+
+export function createRepoTreeExpansionStore() {
+  let collapsed = $state<Set<string>>(readFromStorage());
+
+  function isCollapsed(id: string): boolean {
+    return collapsed.has(id);
+  }
+
+  function toggle(id: string): void {
+    const next = new Set(collapsed);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    collapsed = next;
+    writeToStorage(next);
+  }
+
+  return { isCollapsed, toggle };
+}
+
+export type RepoTreeExpansionStore = ReturnType<
+  typeof createRepoTreeExpansionStore
+>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && bun run test src/lib/stores/repoTreeExpansion.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/stores/repoTreeExpansion.svelte.ts frontend/src/lib/stores/repoTreeExpansion.test.ts
+git commit -m "feat: persist repo tree collapsed-node state"
+```
+
+---
+
+### Task 5: Row presenter component
+
+**Files:**
+- Create: `frontend/src/lib/components/RepoTreeNode.svelte`
+- Test: `frontend/src/lib/components/RepoTreeNode.test.ts`
+
+This component renders ONE row from a `VisibleRow` plus derived selection state. It is a
+dumb presenter: all logic stays in the parent. The checkbox uses a native
+`<input type="checkbox">` with `indeterminate` set for the partial state (the
+deferred-styling note in the spec explicitly allows this technique).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/lib/components/RepoTreeNode.test.ts`:
+
+```ts
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import RepoTreeNode from "./RepoTreeNode.svelte";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RepoTreeNode", () => {
+  it("renders a provider icon for host rows", () => {
+    render(RepoTreeNode, {
+      props: {
+        kind: "host",
+        label: "github.com",
+        ariaLabel: "github.com",
+        provider: "github",
+        depth: 0,
+        hasChildren: true,
+        expanded: true,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    expect(screen.getByText("github.com")).toBeTruthy();
+    expect(document.querySelector(".provider-icon")).toBeTruthy();
+  });
+
+  it("marks the checkbox indeterminate for the partial state", () => {
+    render(RepoTreeNode, {
+      props: {
+        kind: "owner",
+        label: "acme",
+        ariaLabel: "github.com/acme",
+        depth: 0,
+        hasChildren: true,
+        expanded: true,
+        selectionState: "partial",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    const box = screen.getByRole("checkbox") as HTMLInputElement;
+    expect(box.indeterminate).toBe(true);
+    expect(box.checked).toBe(false);
+  });
+
+  it("calls onToggleExpand when the caret is clicked", async () => {
+    const onToggleExpand = vi.fn();
+    render(RepoTreeNode, {
+      props: {
+        kind: "owner",
+        label: "acme",
+        ariaLabel: "github.com/acme",
+        depth: 0,
+        hasChildren: true,
+        expanded: true,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand,
+        onToggleSelect: vi.fn(),
+      },
+    });
+    await fireEvent.click(screen.getByLabelText("Toggle acme"));
+    expect(onToggleExpand).toHaveBeenCalledOnce();
+  });
+
+  it("calls onToggleSelect when the checkbox is clicked", async () => {
+    const onToggleSelect = vi.fn();
+    render(RepoTreeNode, {
+      props: {
+        kind: "repo",
+        label: "api",
+        ariaLabel: "github.com/acme/api",
+        depth: 1,
+        hasChildren: false,
+        expanded: false,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect,
+      },
+    });
+    await fireEvent.mouseDown(screen.getByRole("checkbox"));
+    expect(onToggleSelect).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && bun run test src/lib/components/RepoTreeNode.test.ts`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `frontend/src/lib/components/RepoTreeNode.svelte`:
+
+```svelte
+<script lang="ts">
+  import ProviderIcon from "./provider/ProviderIcon.svelte";
+  import type { SelectionState } from "./repoTree.js";
+
+  interface Props {
+    kind: "host" | "owner" | "repo";
+    label: string;
+    ariaLabel: string;
+    provider?: string;
+    depth: number;
+    hasChildren: boolean;
+    expanded: boolean;
+    selectionState: SelectionState;
+    highlighted: boolean;
+    onToggleExpand: () => void;
+    onToggleSelect: () => void;
+  }
+
+  let {
+    kind,
+    label,
+    ariaLabel,
+    provider,
+    depth,
+    hasChildren,
+    expanded,
+    selectionState,
+    highlighted,
+    onToggleExpand,
+    onToggleSelect,
+  }: Props = $props();
+
+  let checkboxEl = $state<HTMLInputElement>();
+
+  $effect(() => {
+    if (checkboxEl) checkboxEl.indeterminate = selectionState === "partial";
+  });
+
+  function rowMouseDown() {
+    // Name/body click expands interior rows, selects leaves.
+    if (hasChildren) onToggleExpand();
+    else onToggleSelect();
+  }
+
+  function checkboxMouseDown(event: MouseEvent) {
+    event.stopPropagation();
+    onToggleSelect();
+  }
+
+  function caretClick(event: MouseEvent) {
+    event.stopPropagation();
+    onToggleExpand();
+  }
+</script>
+
+<li
+  class="typeahead-option repo-tree-row"
+  class:highlighted
+  role="option"
+  aria-label={ariaLabel}
+  aria-selected={selectionState === "checked"}
+  aria-checked={selectionState === "partial"
+    ? "mixed"
+    : selectionState === "checked"}
+  aria-expanded={hasChildren ? expanded : undefined}
+  style:padding-left={`${6 + depth * 14}px`}
+  onmousedown={rowMouseDown}
+>
+  {#if hasChildren}
+    <button
+      class="repo-tree-caret"
+      class:expanded
+      aria-label={`Toggle ${label}`}
+      onclick={caretClick}
+      onmousedown={(event) => event.stopPropagation()}
+      type="button"
+    >
+      <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
+        <polyline
+          points="2,3 5,7 8,3"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+      </svg>
+    </button>
+  {:else}
+    <span class="repo-tree-caret repo-tree-caret--leaf" aria-hidden="true"></span>
+  {/if}
+
+  <input
+    bind:this={checkboxEl}
+    class="typeahead-checkbox"
+    type="checkbox"
+    checked={selectionState === "checked"}
+    tabindex="-1"
+    onmousedown={checkboxMouseDown}
+  />
+
+  {#if kind === "host" && provider}
+    <ProviderIcon {provider} size={14} class="repo-tree-logo" />
+  {/if}
+
+  <span class="repo-tree-label">{label}</span>
+</li>
+
+<style>
+  .repo-tree-row {
+    gap: 6px;
+  }
+
+  .repo-tree-caret {
+    width: 12px;
+    height: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .repo-tree-caret svg {
+    transform: rotate(-90deg);
+    transition: transform 0.12s ease;
+  }
+
+  .repo-tree-caret.expanded svg {
+    transform: rotate(0deg);
+  }
+
+  .repo-tree-caret--leaf {
+    cursor: default;
+  }
+
+  .repo-tree-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && bun run test src/lib/components/RepoTreeNode.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/components/RepoTreeNode.svelte frontend/src/lib/components/RepoTreeNode.test.ts
+git commit -m "feat: add repo tree row presenter component"
+```
+
+---
+
+### Task 6: Extend `RepoOption` with provider and platformHost
+
+**Files:**
+- Modify: `frontend/src/lib/components/RepoTypeahead.svelte:49` (the `RepoOption` type and the two `optionFrom*` functions)
+
+This is a prep change: thread the two fields the tree builder needs. Behavior is
+unchanged, so existing tests stay green; this task is verified by typecheck plus the
+existing test suite.
+
+- [ ] **Step 1: Add the import and extend the type**
+
+In `frontend/src/lib/components/RepoTypeahead.svelte`, add to the existing imports near the top of `<script>`:
+
+```ts
+import { canonicalProvider } from "@middleman/ui/api/provider-routes";
+import type { RepoTreeOption } from "./repoTree.js";
+```
+
+Replace the local `RepoOption` type (currently
+`type RepoOption = { value: string; owner: string; name: string };`) with an alias of
+the builder's input type, so the two never drift and `buildRepoTree(options)` in Task 7
+type-checks without a cast:
+
+```ts
+type RepoOption = RepoTreeOption;
+```
+
+- [ ] **Step 2: Populate the new fields in both factories**
+
+Replace `optionFromRepo` and `optionFromConfigRepo` with:
+
+```ts
+function optionFromRepo(repo: Repo): RepoOption {
+  return {
+    value: `${repo.PlatformHost}/${repo.Owner}/${repo.Name}`,
+    owner: repo.Owner,
+    name: repo.Name,
+    provider: canonicalProvider(repo.Platform),
+    platformHost: repo.PlatformHost,
+  };
+}
+
+function optionFromConfigRepo(repo: ConfigRepo): RepoOption {
+  const path = repo.repo_path || `${repo.owner}/${repo.name}`;
+  return {
+    value: `${repo.platform_host}/${path}`,
+    owner: repo.owner,
+    name: repo.name,
+    provider: canonicalProvider(repo.provider),
+    platformHost: repo.platform_host,
+  };
+}
+```
+
+- [ ] **Step 3: Verify typecheck and existing tests pass**
+
+Run: `cd frontend && bun run typecheck`
+Expected: no errors.
+
+Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.test.ts`
+Expected: PASS (existing suite still green — behavior unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/lib/components/RepoTypeahead.svelte
+git commit -m "feat: carry provider and platform host on repo options"
+```
+
+---
+
+### Task 7: Render the tree with mouse selection and filtering
+
+**Files:**
+- Modify: `frontend/src/lib/components/RepoTypeahead.svelte` (open-dropdown markup + state)
+- Modify: `frontend/src/lib/components/RepoTypeahead.test.ts`
+
+Replace the flat `{#each filtered}` list with the projected tree rows. Keep the trigger
+button, the filter input, the "All repos" row, the `.typeahead-*` classes, blur
+handling, and the global-filter contract intact. `visibleRows` already applies
+prune + auto-expand for the filter, so wiring `query` into it delivers the filter
+behavior.
+
+- [ ] **Step 1: Update component tests for the tree (write failing tests)**
+
+In `frontend/src/lib/components/RepoTypeahead.test.ts`, the existing test
+`"allows selecting multiple repositories with checkboxes"` already drives leaf rows by
+their full-path accessible name and asserts the comma-separated `onchange` format —
+keep it as the leaf-selection regression. Add these tests inside the
+`describe("RepoTypeahead", ...)` block:
+
+```ts
+it("selecting an owner row selects all repos beneath it", async () => {
+  const onchange = vi.fn();
+  settingsStore.setConfiguredRepos([
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "api",
+      repo_path: "import-lab/api",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "web",
+      repo_path: "import-lab/web",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+  ]);
+
+  render(RepoTypeahead, { props: { selected: undefined, onchange } });
+
+  await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+  await fireEvent.mouseDown(
+    screen.getByRole("option", { name: "github.com/import-lab" }),
+  );
+
+  expect(onchange).toHaveBeenLastCalledWith(
+    "github.com/import-lab/api,github.com/import-lab/web",
+  );
+});
+
+it("filters to matching leaves while keeping their owner visible", async () => {
+  settingsStore.setConfiguredRepos([
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "api",
+      repo_path: "import-lab/api",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "web",
+      repo_path: "import-lab/web",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+  ]);
+
+  render(RepoTypeahead, {
+    props: { selected: undefined, onchange: vi.fn() },
+  });
+
+  await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+  await fireEvent.input(screen.getByPlaceholderText("Filter repos..."), {
+    target: { value: "web" },
+  });
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole("option", { name: "github.com/import-lab/web" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("option", { name: "github.com/import-lab/api" }),
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.test.ts`
+Expected: FAIL — owner row `github.com/import-lab` is not found / no cascade yet.
+
+- [ ] **Step 3: Wire the tree into the component script**
+
+In `frontend/src/lib/components/RepoTypeahead.svelte`, add to the imports:
+
+```ts
+import RepoTreeNode from "./RepoTreeNode.svelte";
+import {
+  buildRepoTree,
+  visibleRows,
+  nodeSelectionState,
+  toggleSubtree,
+  type VisibleRow,
+} from "./repoTree.js";
+import { createRepoTreeExpansionStore } from "../stores/repoTreeExpansion.svelte.js";
+```
+
+Add derived tree state near the other `$derived` declarations (after `filtered` /
+`selectedSet` exist):
+
+```ts
+const expansion = createRepoTreeExpansionStore();
+
+const tree = $derived(buildRepoTree(options));
+
+const rows = $derived(
+  visibleRows(tree, { isCollapsed: expansion.isCollapsed, query }),
+);
+
+function rowAriaLabel(row: VisibleRow): string {
+  return row.node.kind === "host" ? row.node.platformHost : row.node.id;
+}
+
+function toggleRowSelect(row: VisibleRow) {
+  onchange(serializeRepoFilterValue(toggleSubtree(row.node, selectedValues)));
+}
+
+function toggleRowExpand(row: VisibleRow) {
+  if (row.hasChildren) expansion.toggle(row.node.id);
+}
+```
+
+Note: `row.node.id` for a leaf equals its `value`; `nodeSelectionState(row.node, selectedSet)`
+gives the per-row tri-state. `selectedValues` / `selectedSet` / `serializeRepoFilterValue`
+already exist in the component.
+
+- [ ] **Step 4: Replace the flat list markup with tree rows**
+
+In the open-dropdown block, replace the `{#each filtered as option ...}` list (the
+`<ul class="typeahead-list">` body after the "All repos" `<li>`) so the list reads:
+
+```svelte
+<ul class="typeahead-list" role="listbox" onmousedown={preventBlur}>
+  <li
+    class="typeahead-option"
+    class:highlighted={highlightIndex === 0}
+    class:selected={selectedValues.length === 0}
+    role="option"
+    aria-selected={selectedValues.length === 0}
+    onmousedown={clearSelection}
+    onmouseenter={() => (highlightIndex = 0)}
+  >
+    <input
+      class="typeahead-checkbox"
+      type="checkbox"
+      checked={selectedValues.length === 0}
+      tabindex="-1"
+      aria-hidden="true"
+    />
+    <span>All repos</span>
+  </li>
+  {#each rows as row, i (row.node.id)}
+    <div
+      role="presentation"
+      onmouseenter={() => (highlightIndex = i + 1)}
+    >
+      <RepoTreeNode
+        kind={row.node.kind}
+        label={row.node.label}
+        ariaLabel={rowAriaLabel(row)}
+        provider={row.node.kind === "host" ? row.node.provider : undefined}
+        depth={row.depth}
+        hasChildren={row.hasChildren}
+        expanded={row.expanded}
+        selectionState={nodeSelectionState(row.node, selectedSet)}
+        highlighted={i + 1 === highlightIndex}
+        onToggleExpand={() => toggleRowExpand(row)}
+        onToggleSelect={() => toggleRowSelect(row)}
+      />
+    </div>
+  {:else}
+    <li class="typeahead-empty">No matching repos</li>
+  {/each}
+</ul>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.test.ts`
+Expected: PASS (existing leaf-selection regression + the two new tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `cd frontend && bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/lib/components/RepoTypeahead.svelte frontend/src/lib/components/RepoTypeahead.test.ts
+git commit -m "feat: render the repo selector as an expandable tree with subtree selection"
+```
+
+---
+
+### Task 8: Keyboard navigation for the tree
+
+**Files:**
+- Modify: `frontend/src/lib/components/RepoTypeahead.svelte` (`handleKeydown`, cheatsheet registration)
+- Modify: `frontend/src/lib/components/RepoTypeahead.test.ts`
+
+Extend the existing keyboard handler so arrows move across the visible rows,
+left/right expand/collapse, and space/enter act contextually. The existing
+`ArrowUp`/`ArrowDown`/`Enter`/`Space`/`Escape` handling iterates a flat list today;
+update it to iterate `rows`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `frontend/src/lib/components/RepoTypeahead.test.ts`:
+
+```ts
+it("collapses and expands the focused owner with arrow keys", async () => {
+  settingsStore.setConfiguredRepos([
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "api",
+      repo_path: "import-lab/api",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "web",
+      repo_path: "import-lab/web",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+  ]);
+
+  render(RepoTypeahead, { props: { selected: undefined, onchange: vi.fn() } });
+
+  await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+  const input = screen.getByPlaceholderText("Filter repos...");
+
+  // leaves visible by default
+  expect(
+    screen.getByRole("option", { name: "github.com/import-lab/api" }),
+  ).toBeTruthy();
+
+  // move highlight onto the owner row (index 1) and collapse it
+  await fireEvent.keyDown(input, { key: "ArrowDown" });
+  await fireEvent.keyDown(input, { key: "ArrowLeft" });
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("option", { name: "github.com/import-lab/api" }),
+    ).toBeNull();
+  });
+
+  await fireEvent.keyDown(input, { key: "ArrowRight" });
+  await waitFor(() => {
+    expect(
+      screen.getByRole("option", { name: "github.com/import-lab/api" }),
+    ).toBeTruthy();
+  });
+});
+
+it("toggles selection of the focused row with space", async () => {
+  const onchange = vi.fn();
+  settingsStore.setConfiguredRepos([
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "api",
+      repo_path: "import-lab/api",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+    {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "import-lab",
+      name: "web",
+      repo_path: "import-lab/web",
+      is_glob: false,
+      matched_repo_count: 1,
+    },
+  ]);
+
+  render(RepoTypeahead, { props: { selected: undefined, onchange } });
+
+  await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+  const input = screen.getByPlaceholderText("Filter repos...");
+
+  // highlight the owner row and select its subtree
+  await fireEvent.keyDown(input, { key: "ArrowDown" });
+  await fireEvent.keyDown(input, { key: " " });
+
+  expect(onchange).toHaveBeenLastCalledWith(
+    "github.com/import-lab/api,github.com/import-lab/web",
+  );
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.test.ts`
+Expected: FAIL — arrow-left/right do not expand/collapse; space on owner does not cascade.
+
+- [ ] **Step 3: Replace `handleKeydown`**
+
+Replace the existing `handleKeydown` function with:
+
+```ts
+function handleKeydown(e: KeyboardEvent) {
+  const total = rows.length + 1; // +1 for the "All repos" row at index 0
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    highlightIndex = Math.min(highlightIndex + 1, total - 1);
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    highlightIndex = Math.max(highlightIndex - 1, 0);
+  } else if (e.key === "ArrowRight") {
+    e.preventDefault();
+    const row = rows[highlightIndex - 1];
+    if (row?.hasChildren && !row.expanded) expansion.toggle(row.node.id);
+  } else if (e.key === "ArrowLeft") {
+    e.preventDefault();
+    const row = rows[highlightIndex - 1];
+    if (row?.hasChildren && row.expanded) expansion.toggle(row.node.id);
+  } else if (e.key === "Enter") {
+    e.preventDefault();
+    if (highlightIndex === 0) {
+      clearSelection();
+      return;
+    }
+    const row = rows[highlightIndex - 1];
+    if (!row) return;
+    if (row.hasChildren) expansion.toggle(row.node.id);
+    else toggleRowSelect(row);
+  } else if (e.key === " ") {
+    e.preventDefault();
+    if (highlightIndex === 0) {
+      clearSelection();
+      return;
+    }
+    const row = rows[highlightIndex - 1];
+    if (row) toggleRowSelect(row);
+  } else if (e.key === "Escape") {
+    closeDropdown();
+  }
+}
+```
+
+- [ ] **Step 4: Add cheatsheet entries for the new bindings**
+
+In the `registerCheatsheetEntries("repo-typeahead", [...])` array (inside `onMount`),
+add two entries after the existing `next`/`prev` entries:
+
+```ts
+{
+  id: "repo-typeahead.expand",
+  label: "Expand / collapse group",
+  binding: { key: "ArrowRight" },
+  scope: "view-pulls",
+},
+{
+  id: "repo-typeahead.toggle-select",
+  label: "Select / deselect",
+  binding: { key: " " },
+  scope: "view-pulls",
+},
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.test.ts`
+Expected: PASS (all RepoTypeahead tests, including the existing cheatsheet test in `RepoTypeahead.svelte.test.ts`).
+
+Run: `cd frontend && bun run test src/lib/components/RepoTypeahead.svelte.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `cd frontend && bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/lib/components/RepoTypeahead.svelte frontend/src/lib/components/RepoTypeahead.test.ts
+git commit -m "feat: add keyboard navigation and selection to the repo tree"
+```
+
+---
+
+### Task 9: End-to-end group selection
+
+**Files:**
+- Modify: `frontend/tests/e2e-full/repo-filter-multiselect.spec.ts`
+
+Add a test that opens the selector, selects an owner group, and asserts the PR/issue
+list filters to that group's repos against the real backend. The existing single-leaf
+multiselect test in this file stays as the leaf regression.
+
+- [ ] **Step 1: Inspect the available fixture repos**
+
+Run: `cd frontend && rg -n "acme/|getByRole\\(\"option\"" tests/e2e-full/repo-filter-multiselect.spec.ts`
+Expected: shows the existing fixtures used (`github.com/acme/widgets`, `github.com/acme/tools`) and the option-based selection helper.
+
+- [ ] **Step 2: Add the group-select e2e test**
+
+Append to `frontend/tests/e2e-full/repo-filter-multiselect.spec.ts`:
+
+```ts
+test("selecting an owner group filters lists to that group's repos", async ({
+  page,
+}) => {
+  await page.goto("/issues");
+  await waitForIssueList(page);
+
+  const selector = page.getByTitle("Select repository");
+  await selector.click();
+
+  // The owner row's accessible name is the full `${platformHost}/${owner}` path.
+  const ownerRow = page.getByRole("option", { name: "github.com/acme" });
+  await expect(ownerRow).toBeVisible();
+  await ownerRow.click();
+
+  await page.keyboard.press("Escape");
+
+  // Both acme repos end up in the persisted filter set.
+  await expect(
+    page.evaluate(() => localStorage.getItem("middleman-filter-repo")),
+  ).resolves.toContain("github.com/acme/widgets");
+  await expect(
+    page.evaluate(() => localStorage.getItem("middleman-filter-repo")),
+  ).resolves.toContain("github.com/acme/tools");
+
+  await expect(page.getByText("GitLab read-only issue")).toHaveCount(0);
+});
+```
+
+If the `acme` owner is auto-flattened (only one acme repo in the fixture) or the host
+node is shown (more than one host in the fixture), adjust the accessible name to the
+actual owner/host path reported by `page.getByRole("option")` — run the test once and
+read the failure's available options. Do not change the assertion that the persisted
+set contains the group's repos.
+
+- [ ] **Step 3: Run the e2e spec**
+
+Run: `cd frontend && bun run test:e2e -- repo-filter-multiselect`
+Expected: PASS (existing multiselect test + the new group-select test).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
+git commit -m "test: cover owner-group selection in the repo tree end-to-end"
+```
+
+---
+
+### Task 10: Full regression sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full frontend unit suite**
+
+Run: `cd frontend && bun run test`
+Expected: PASS. Pay attention to the selector-adjacent specs (`container-layout`,
+`settings-globs`, `mobile-activity-repos`, `link-navigation-repo-sync`,
+`embedded-config`) — they rely on `.typeahead-*` classes and option roles that this
+plan preserves.
+
+- [ ] **Step 2: Run lint and typecheck**
+
+Run: `cd frontend && bun run lint`
+Expected: no errors.
+
+Run: `cd frontend && bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Run the affected e2e specs**
+
+Run: `cd frontend && bun run test:e2e -- repo-filter-multiselect container-layout settings-globs link-navigation-repo-sync`
+Expected: PASS.
+
+- [ ] **Step 4: Commit any lint fixes**
+
+If steps 1-3 required fixes, commit them:
+
+```bash
+git add -A
+git commit -m "fix: resolve lint and test fallout from repo tree nav"
+```
+
+If nothing changed, skip this commit.

--- a/docs/superpowers/specs/2026-05-30-repo-tree-nav-design.md
+++ b/docs/superpowers/specs/2026-05-30-repo-tree-nav-design.md
@@ -1,0 +1,247 @@
+# Repo Tree Navigation for the Repo Selector
+
+## Summary
+
+Replace the flat repo list inside the header repo selector with a collapsible
+`host -> owner -> repo` tree. Interior rows get two distinct affordances: clicking
+the name expands/collapses the node, and a tri-state checkbox selects or deselects
+every repo beneath it. Leaf repo rows toggle their own selection. The selector's
+shell (trigger button, open/close, blur handling, filter input, keyboard cheatsheet)
+is preserved.
+
+The global filter contract does not change. Selection is still a comma-separated set
+of leaf `platformHost/repoPath` strings written through `setGlobalRepo`. Group
+selection expands to its member leaves before writing. No API, store-format, or
+downstream list-view changes: this is a presentation and interaction layer over data
+the selector already fetches.
+
+## Decisions (locked)
+
+- **Placement:** tree lives inside the existing dropdown, not a new persistent rail.
+- **Build:** bespoke component. `@pierre/trees` (already a dependency, used by
+  `PierreFileTree.svelte`) does not model checkboxes, tri-state/indeterminate, or
+  cascade selection, and hardwires directory clicks to expand. The exact interaction
+  this feature needs is the one thing the library works against. Its virtualization
+  strength is irrelevant for a maintainer's fixed, small repo set.
+- **Row anatomy:** name click = expand/collapse; tri-state checkbox = select subtree.
+- **Tree shape:** fixed three levels (`host -> owner -> repo`). GitLab nested groups
+  collapse into a single owner node whose label keeps the slashes
+  (e.g. `platform/frontend`). Single-child grouping levels auto-flatten.
+- **Filter behavior:** prune and auto-expand. Typing hides non-matching groups and
+  force-expands groups containing a match. Clearing restores prior expansion.
+- **Host rows** show the real provider logo via `ProviderIcon`. Owner and repo rows
+  have no leading glyph: caret, checkbox, name only.
+- **No per-row count badges.** The current selector has none; adding them is out of
+  scope. Tri-state is carried by the checkbox alone.
+
+### Deferred
+
+- **Checkbox / glyph visual styling.** The locked contract is three visually
+  distinct states (off / on / partial), checkbox toggles subtree selection, name
+  toggles expand. The rendering technique (native checkbox with the `indeterminate`
+  DOM property vs. a custom element with pseudo-element glyphs) and exact pixels are
+  deferred to a styling pass against the running app, after the functional surface
+  lands non-wedged. Any later styling must keep the three distinguishable states and
+  use design tokens; it must not reopen behavior.
+
+## Current State (what exists today)
+
+- `frontend/src/lib/components/RepoTypeahead.svelte`: the selector. A trigger button
+  ("All repos" / one repo / "N repos") that opens a filter `<input>` over a flat
+  `<ul role="listbox">` of checkable `platformHost/owner/name` options. Owns
+  open/close, blur-to-close, arrow/space/enter/esc keys, substring filtering with
+  `highlightSegments` + `<mark>`, and cheatsheet registration.
+- `frontend/src/lib/stores/filter.svelte.ts`: `parseRepoFilterValue` /
+  `serializeRepoFilterValue` (comma-separated set), `getGlobalRepo` / `setGlobalRepo`
+  persisted to localStorage key `middleman-filter-repo`.
+- `packages/ui/src/stores/collapsedRepos.svelte.ts`: the persisted collapse-state
+  pattern to mirror (per-surface `Set<string>` in localStorage, defensive try/catch).
+- `frontend/src/lib/components/provider/ProviderIcon.svelte`: renders a provider
+  logo from `simple-icons` by canonical provider name.
+- `packages/ui/src/api/provider-routes.ts`: `ProviderRouteRef`, `canonicalProvider`.
+- `internal/platform/metadata.go`: `AllowNestedOwner` is true for GitLab only; the
+  others are flat. Confirms owner segments can contain slashes for GitLab.
+
+A `RepoOption` today is `{ value, owner, name }` where
+`value = ${platformHost}/${repoPath}` (repoPath falling back to `owner/name`). The
+architecture below extends it with `provider` and `platformHost`.
+
+## Architecture
+
+All changes are frontend: a pure tree-building module, an expansion-state store, and
+a recursive row renderer, plus edits to the existing component (where the derived
+selection logic also lives).
+
+### `repoTree.ts` (pure module)
+
+`frontend/src/lib/components/repoTree.ts` (or `utils/`), framework-free and
+unit-testable.
+
+Input: `RepoOption[]`, extended so each option carries `provider` (the canonical
+provider string) and `platformHost`. The component already has these at the source
+(`optionFromRepo` / `optionFromConfigRepo`); thread them onto `RepoOption` rather
+than re-parsing the value string.
+
+Parsing each option (use the threaded `platformHost` field as the source of truth,
+not the value's first segment). Note `value` is `${platformHost}/${repoPath}` today,
+where the host has no slashes and `repoPath` may have several (GitLab groups):
+- split `value` on the first slash: the head is the host, the tail is `repoPath`
+  (equivalently, drop the known `platformHost` prefix). Do not split on all slashes.
+- repo name = last segment of `repoPath`.
+- owner = everything in `repoPath` before the last segment, slashes intact (one node,
+  so GitLab `group/subgroup` becomes a single owner labelled `group/subgroup`).
+
+Dedup stays keyed on `value` exactly as `mergeOptions` does today; the tree's node
+`id`s are derived for rendering/expansion, not a new dedup key.
+
+Output types:
+
+```ts
+type RepoLeaf = { kind: "repo"; id: string; label: string; value: string };
+type OwnerNode = { kind: "owner"; id: string; label: string; children: RepoLeaf[] };
+type HostNode = {
+  kind: "host"; id: string; label: string; provider: string;
+  platformHost: string; children: OwnerNode[];
+};
+```
+
+- `id` is the full path prefix (stable across renders; used as expansion key and
+  Svelte `{#each}` key).
+- Hosts and owners are sorted alphabetically; leaves alphabetically by name.
+
+Auto-flatten reduces pointless single-child nesting. Two independent rules, each keyed
+on a different count:
+- **Single host (keyed on host count):** when only one host exists, omit the host node
+  entirely (no logo row) and render its owners at the top level, however many owners
+  there are. With two or more hosts, every host node is shown.
+- **Single-repo owner (keyed on that owner's repo count):** an owner with exactly one
+  repo renders as a single row at the owner's depth, with no separate caret to expand.
+  The label may show the repo name or the `owner/repo` path; that is a display choice
+  left to the styling pass.
+
+Express this as a derived view over the built tree rather than mutating it: keep
+`buildRepoTree` returning the full `HostNode[]`, and compute the flattened, visible
+row list (which also accounts for expansion and filtering) separately. That keeps the
+build output type stable and makes flattening, expansion, and filtering one testable
+projection instead of three mutations. Cover both rules with unit tests.
+
+Provider for the host logo comes from each repo's own provider field, not from any
+host-to-provider guess: configured repos carry `provider` (snake_case), and fetched
+repos carry `Repo.Platform`. Thread that value onto `RepoOption` at the merge site
+and normalize it once with `canonicalProvider` so `ProviderIcon`/`providerIcon`
+(which keys on lowercase `github`/`gitlab`/`forgejo`/`gitea`) resolves it. If a host
+somehow mixes providers, the first canonical provider wins; document it.
+
+### Expansion-state store
+
+`frontend/src/lib/stores/repoTreeExpansion.svelte.ts`, mirroring
+`collapsedRepos.svelte.ts` directly: a `$state<Set<string>>` of *collapsed* node ids
+persisted to localStorage key `middleman:repoTreeCollapsed`, with `isCollapsed(id)`
+and `toggle(id)`, wrapped in try/catch. Tracking collapsed ids (not expanded) means an
+empty set on first run reads as fully expanded, so the tree looks like a tree
+immediately and the persisted set only ever records the user's explicit collapses.
+This is the same polarity and shape as `collapsedRepos`, minus the per-surface split
+(the selector is a single surface).
+
+### Row rendering
+
+A recursive renderer for caret / checkbox / logo / name. Either a `RepoTreeNode.svelte`
+child component or an inline recursive snippet; prefer a child component for testability
+and to keep `RepoTypeahead.svelte` focused. Host rows render `ProviderIcon`; owner and
+repo rows omit the logo slot.
+
+### Selection and tri-state (derived)
+
+Selection state is derived from the active leaf set, never stored separately.
+
+- Active set: `parseRepoFilterValue(selected)` as a `Set`.
+- For any node, collect its descendant leaf `value`s: all in set -> `checked`; some
+  -> `partial`; none -> `unchecked`. Leaves are `checked` / `unchecked`.
+- Checkbox click on a node: if `checked`, remove all its leaves from the set; else add
+  all its leaves. Then `serializeRepoFilterValue(next)` and `onchange`.
+- Leaf checkbox / name click: toggle that single leaf (today's behavior).
+- "All repos" remains the `undefined` sentinel via `clearSelection`.
+
+## Interaction
+
+### Mouse
+- Interior name or caret: toggle expand/collapse.
+- Interior checkbox: toggle subtree selection (tri-state).
+- Leaf name or checkbox: toggle that repo's selection.
+
+### Keyboard (extends the existing handler)
+- `ArrowUp` / `ArrowDown`: move highlight across currently *visible* rows (the
+  flattened, expansion-aware, filter-aware row list).
+- `ArrowRight` / `ArrowLeft`: expand / collapse the focused node; on a leaf,
+  `ArrowLeft` moves focus to its parent.
+- `Space`: toggle selection of the focused row (subtree for interior, single for leaf).
+- `Enter`: contextual: interior -> expand/collapse; leaf -> toggle selection.
+- `Escape`: close the dropdown (unchanged).
+- Existing cheatsheet entries are extended with the expand/collapse and select
+  bindings via `registerCheatsheetEntries`.
+
+### Filter (prune and auto-expand)
+- Substring match on leaf `value` (reuse current lowercase `includes`).
+- A host/owner with at least one surviving descendant stays and force-expands so
+  matches are visible; groups with no match are hidden.
+- Clearing the query restores the persisted expansion state.
+- Match highlighting reuses `highlightSegments` + `<mark>` on leaf labels.
+- Empty result: keep the existing "No matching repos" empty state.
+
+## Data Flow
+
+```
+/repos + configured repos
+  -> RepoOption[] (value, owner, name + new: provider, platformHost)  [merge, extended]
+  -> buildRepoTree(options)  -> HostNode[]                            [new, pure]
+  -> filter(query) + expansion store + active-leaf set
+  -> recursive rows (caret / checkbox / ProviderIcon / name)
+  -> checkbox click -> add/remove subtree leaves
+  -> serializeRepoFilterValue -> onchange -> setGlobalRepo        [existing contract]
+  -> downstream list views read the same comma-separated set      [unchanged]
+```
+
+## Error and Edge Handling
+
+- localStorage failures for expansion state are swallowed exactly as
+  `collapsedRepos` and `filter` already do (feature still works for the session).
+- Stale selected values: the existing effect that drops selected values no longer in
+  `options` is preserved; it operates on leaf values, which the tree still produces.
+- Empty repo set / still loading: keep current behavior (empty list, "All repos"
+  available).
+- Single host (one host total) or single-repo owner: auto-flatten avoids a pointless
+  one-child level (see the two flatten rules above).
+- Mixed providers under one host: first canonical provider wins for the logo.
+
+## Testing
+
+Per the repo's e2e-non-negotiable rule and `context/testing.md`.
+
+- **`repoTree.ts` unit (table-driven):** host/owner/repo splitting; GitLab nested
+  group -> single slashed owner label; single-child auto-flatten at host and owner
+  levels; provider derivation; multi-host and multi-provider sets; sort order.
+- **Selection unit:** tri-state computation for host/owner/leaf; subtree add/remove;
+  partial -> full -> empty transitions; round-trip through
+  `serialize`/`parseRepoFilterValue`.
+- **Component (Vitest + Testing Library):** expand/collapse via name and caret;
+  checkbox cascade and tri-state display; prune-on-filter with auto-expand and
+  highlight; keyboard nav (arrows, space, enter, esc); selection still writes the
+  existing comma-separated format via `onchange`; "All repos" clears.
+- **E2E (frontend Playwright, `tests/e2e-full/`):** selecting an owner group filters
+  the PR list to that group's repos against the real backend. The existing
+  `tests/e2e-full/repo-filter-multiselect.spec.ts` already covers flat multi-select of
+  the selector and is the natural place to extend; the `e2e-full` suite
+  (`playwright-e2e.config.ts`) boots the real server, unlike the mocked `tests/e2e/`
+  suite. The tree is client-side, so this is the vehicle, not a Go server e2e.
+
+Checkbox/glyph *visual* assertions are intentionally minimal: test the three logical
+states are distinguishable (e.g. by attribute / class / `indeterminate` property), not
+exact pixels, since styling is deferred.
+
+## Out of Scope
+
+- Per-row PR/issue count badges.
+- A persistent repo rail or any layout change outside the dropdown.
+- Changes to the global filter format or any list view.
+- Final checkbox visual styling (deferred to a post-functional pass).
+- Adopting `@pierre/trees`.

--- a/frontend/src/lib/components/RepoTreeNode.svelte
+++ b/frontend/src/lib/components/RepoTreeNode.svelte
@@ -86,6 +86,7 @@
       class="repo-tree-caret"
       class:expanded
       aria-label={`Toggle ${label}`}
+      aria-expanded={expanded}
       onclick={caretClick}
       onmousedown={caretMouseDown}
       type="button"

--- a/frontend/src/lib/components/RepoTreeNode.svelte
+++ b/frontend/src/lib/components/RepoTreeNode.svelte
@@ -11,13 +11,13 @@
     kind: "host" | "owner" | "repo";
     label: string;
     ariaLabel: string;
-    provider?: string;
+    provider?: string | undefined;
     depth: number;
     hasChildren: boolean;
     expanded: boolean;
     selectionState: SelectionState;
     highlighted: boolean;
-    segments?: LabelSegment[];
+    segments?: LabelSegment[] | undefined;
     onToggleExpand: () => void;
     onToggleSelect: () => void;
     onHover?: () => void;

--- a/frontend/src/lib/components/RepoTreeNode.svelte
+++ b/frontend/src/lib/components/RepoTreeNode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ProviderIcon from "./provider/ProviderIcon.svelte";
+  import TreeCheckbox from "./TreeCheckbox.svelte";
   import type { SelectionState } from "./repoTree.js";
 
   interface LabelSegment {
@@ -38,12 +39,6 @@
     onToggleSelect,
     onHover,
   }: Props = $props();
-
-  let checkboxEl = $state<HTMLInputElement>();
-
-  $effect(() => {
-    if (checkboxEl) checkboxEl.indeterminate = selectionState === "partial";
-  });
 
   function rowMouseDown() {
     // Name/body click expands interior rows, selects leaves.
@@ -97,14 +92,7 @@
     <span class="repo-tree-caret repo-tree-caret--leaf" aria-hidden="true"></span>
   {/if}
 
-  <input
-    bind:this={checkboxEl}
-    class="typeahead-checkbox"
-    type="checkbox"
-    checked={selectionState === "checked"}
-    tabindex="-1"
-    onmousedown={checkboxMouseDown}
-  />
+  <TreeCheckbox value={selectionState} onmousedown={checkboxMouseDown} />
 
   {#if kind === "host" && provider}
     <ProviderIcon {provider} size={14} />

--- a/frontend/src/lib/components/RepoTreeNode.svelte
+++ b/frontend/src/lib/components/RepoTreeNode.svelte
@@ -47,8 +47,19 @@
   }
 
   function checkboxMouseDown(event: MouseEvent) {
+    // stopPropagation keeps the row from also toggling expand; preventDefault
+    // keeps focus on the filter input (the checkbox is a real focusable input,
+    // and stopping propagation skips the list's preventBlur handler). Without
+    // it a real click steals focus and breaks keyboard navigation.
     event.stopPropagation();
+    event.preventDefault();
     onToggleSelect();
+  }
+
+  function caretMouseDown(event: MouseEvent) {
+    // Same reasoning as the checkbox: keep focus on the filter input.
+    event.stopPropagation();
+    event.preventDefault();
   }
 
   function caretClick(event: MouseEvent) {
@@ -76,7 +87,7 @@
       class:expanded
       aria-label={`Toggle ${label}`}
       onclick={caretClick}
-      onmousedown={(event) => event.stopPropagation()}
+      onmousedown={caretMouseDown}
       type="button"
     >
       <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">

--- a/frontend/src/lib/components/RepoTreeNode.svelte
+++ b/frontend/src/lib/components/RepoTreeNode.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import ProviderIcon from "./provider/ProviderIcon.svelte";
+  import type { SelectionState } from "./repoTree.js";
+
+  interface LabelSegment {
+    text: string;
+    match: boolean;
+  }
+
+  interface Props {
+    kind: "host" | "owner" | "repo";
+    label: string;
+    ariaLabel: string;
+    provider?: string;
+    depth: number;
+    hasChildren: boolean;
+    expanded: boolean;
+    selectionState: SelectionState;
+    highlighted: boolean;
+    segments?: LabelSegment[];
+    onToggleExpand: () => void;
+    onToggleSelect: () => void;
+    onHover?: () => void;
+  }
+
+  let {
+    kind,
+    label,
+    ariaLabel,
+    provider,
+    depth,
+    hasChildren,
+    expanded,
+    selectionState,
+    highlighted,
+    segments,
+    onToggleExpand,
+    onToggleSelect,
+    onHover,
+  }: Props = $props();
+
+  let checkboxEl = $state<HTMLInputElement>();
+
+  $effect(() => {
+    if (checkboxEl) checkboxEl.indeterminate = selectionState === "partial";
+  });
+
+  function rowMouseDown() {
+    // Name/body click expands interior rows, selects leaves.
+    if (hasChildren) onToggleExpand();
+    else onToggleSelect();
+  }
+
+  function checkboxMouseDown(event: MouseEvent) {
+    event.stopPropagation();
+    onToggleSelect();
+  }
+
+  function caretClick(event: MouseEvent) {
+    event.stopPropagation();
+    onToggleExpand();
+  }
+</script>
+
+<li
+  class="typeahead-option repo-tree-row"
+  class:highlighted
+  role="option"
+  aria-label={ariaLabel}
+  aria-selected={selectionState === "checked"}
+  aria-checked={selectionState === "partial"
+    ? "mixed"
+    : selectionState === "checked"}
+  style:padding-left={`${6 + depth * 14}px`}
+  onmousedown={rowMouseDown}
+  onmouseenter={() => onHover?.()}
+>
+  {#if hasChildren}
+    <button
+      class="repo-tree-caret"
+      class:expanded
+      aria-label={`Toggle ${label}`}
+      onclick={caretClick}
+      onmousedown={(event) => event.stopPropagation()}
+      type="button"
+    >
+      <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
+        <polyline
+          points="2,3 5,7 8,3"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+        />
+      </svg>
+    </button>
+  {:else}
+    <span class="repo-tree-caret repo-tree-caret--leaf" aria-hidden="true"></span>
+  {/if}
+
+  <input
+    bind:this={checkboxEl}
+    class="typeahead-checkbox"
+    type="checkbox"
+    checked={selectionState === "checked"}
+    tabindex="-1"
+    onmousedown={checkboxMouseDown}
+  />
+
+  {#if kind === "host" && provider}
+    <ProviderIcon {provider} size={14} />
+  {/if}
+
+  <span class="repo-tree-label">
+    {#if segments}{#each segments as seg, segIndex (`${ariaLabel}-${segIndex}-${seg.text}-${seg.match}`)}{#if seg.match}<mark class="match">{seg.text}</mark>{:else}{seg.text}{/if}{/each}{:else}{label}{/if}
+  </span>
+</li>
+
+<style>
+  .repo-tree-row {
+    gap: 6px;
+  }
+
+  .repo-tree-caret {
+    width: 12px;
+    height: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .repo-tree-caret svg {
+    transform: rotate(-90deg);
+    transition: transform 0.12s ease;
+  }
+
+  .repo-tree-caret.expanded svg {
+    transform: rotate(0deg);
+  }
+
+  .repo-tree-caret--leaf {
+    cursor: default;
+  }
+
+  .repo-tree-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/frontend/src/lib/components/RepoTreeNode.test.ts
+++ b/frontend/src/lib/components/RepoTreeNode.test.ts
@@ -68,6 +68,48 @@ describe("RepoTreeNode", () => {
     expect(onToggleExpand).toHaveBeenCalledOnce();
   });
 
+  it("exposes expanded state via aria-expanded on the caret control", () => {
+    // aria-expanded lives on the caret <button>, not the role=option row
+    // (which does not support the attribute), so assistive tech can tell
+    // whether a collapsible group is open.
+    const { unmount } = render(RepoTreeNode, {
+      props: {
+        kind: "owner",
+        label: "acme",
+        ariaLabel: "github.com/acme",
+        depth: 0,
+        hasChildren: true,
+        expanded: true,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    expect(screen.getByLabelText("Toggle acme").getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    unmount();
+
+    render(RepoTreeNode, {
+      props: {
+        kind: "owner",
+        label: "acme",
+        ariaLabel: "github.com/acme",
+        depth: 0,
+        hasChildren: true,
+        expanded: false,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    expect(screen.getByLabelText("Toggle acme").getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+  });
+
   it("calls onToggleSelect when the checkbox is clicked", async () => {
     const onToggleSelect = vi.fn();
     render(RepoTreeNode, {

--- a/frontend/src/lib/components/RepoTreeNode.test.ts
+++ b/frontend/src/lib/components/RepoTreeNode.test.ts
@@ -88,6 +88,35 @@ describe("RepoTreeNode", () => {
     expect(onToggleSelect).toHaveBeenCalledOnce();
   });
 
+  it("stays controlled when really clicked (native toggle suppressed)", async () => {
+    // A real browser click is mousedown + mouseup + click; a native checkbox's
+    // click default action toggles its own .checked, which desyncs it from the
+    // controlled `checked={selectionState}` binding (selectionState only changes
+    // via the parent's onToggleSelect). The component must cancel that default
+    // action so the box reflects selectionState alone. Earlier tests fired
+    // mousedown only, which skips the native toggle and hid this bug.
+    render(RepoTreeNode, {
+      props: {
+        kind: "repo",
+        label: "api",
+        ariaLabel: "github.com/acme/api",
+        depth: 1,
+        hasChildren: false,
+        expanded: false,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    const box = screen.getByRole("checkbox") as HTMLInputElement;
+    expect(box.checked).toBe(false);
+    await fireEvent.click(box);
+    // selectionState is still "unchecked" (parent's onToggleSelect is a stub),
+    // so a correctly controlled box stays false. A native toggle would flip it.
+    expect(box.checked).toBe(false);
+  });
+
   it("renders highlighted match segments when given segments", () => {
     render(RepoTreeNode, {
       props: {

--- a/frontend/src/lib/components/RepoTreeNode.test.ts
+++ b/frontend/src/lib/components/RepoTreeNode.test.ts
@@ -1,0 +1,113 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import RepoTreeNode from "./RepoTreeNode.svelte";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RepoTreeNode", () => {
+  it("renders a provider icon for host rows", () => {
+    render(RepoTreeNode, {
+      props: {
+        kind: "host",
+        label: "github.com",
+        ariaLabel: "github.com",
+        provider: "github",
+        depth: 0,
+        hasChildren: true,
+        expanded: true,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    expect(screen.getByText("github.com")).toBeTruthy();
+    expect(document.querySelector(".provider-icon")).toBeTruthy();
+  });
+
+  it("marks the checkbox indeterminate for the partial state", () => {
+    render(RepoTreeNode, {
+      props: {
+        kind: "owner",
+        label: "acme",
+        ariaLabel: "github.com/acme",
+        depth: 0,
+        hasChildren: true,
+        expanded: true,
+        selectionState: "partial",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    const box = screen.getByRole("checkbox") as HTMLInputElement;
+    expect(box.indeterminate).toBe(true);
+    expect(box.checked).toBe(false);
+  });
+
+  it("calls onToggleExpand when the caret is clicked", async () => {
+    const onToggleExpand = vi.fn();
+    render(RepoTreeNode, {
+      props: {
+        kind: "owner",
+        label: "acme",
+        ariaLabel: "github.com/acme",
+        depth: 0,
+        hasChildren: true,
+        expanded: true,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand,
+        onToggleSelect: vi.fn(),
+      },
+    });
+    await fireEvent.click(screen.getByLabelText("Toggle acme"));
+    expect(onToggleExpand).toHaveBeenCalledOnce();
+  });
+
+  it("calls onToggleSelect when the checkbox is clicked", async () => {
+    const onToggleSelect = vi.fn();
+    render(RepoTreeNode, {
+      props: {
+        kind: "repo",
+        label: "api",
+        ariaLabel: "github.com/acme/api",
+        depth: 1,
+        hasChildren: false,
+        expanded: false,
+        selectionState: "unchecked",
+        highlighted: false,
+        onToggleExpand: vi.fn(),
+        onToggleSelect,
+      },
+    });
+    await fireEvent.mouseDown(screen.getByRole("checkbox"));
+    expect(onToggleSelect).toHaveBeenCalledOnce();
+  });
+
+  it("renders highlighted match segments when given segments", () => {
+    render(RepoTreeNode, {
+      props: {
+        kind: "repo",
+        label: "web-ui",
+        ariaLabel: "github.com/acme/web-ui",
+        depth: 1,
+        hasChildren: false,
+        expanded: false,
+        selectionState: "unchecked",
+        highlighted: false,
+        segments: [
+          { text: "web", match: true },
+          { text: "-ui", match: false },
+        ],
+        onToggleExpand: vi.fn(),
+        onToggleSelect: vi.fn(),
+      },
+    });
+    const mark = document.querySelector("mark");
+    expect(mark?.textContent).toBe("web");
+  });
+});

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -3,6 +3,8 @@
   import { getStores } from "@middleman/ui";
   import { client } from "../api/runtime.js";
   import type { ConfigRepo, Repo } from "@middleman/ui/api/types";
+  import { canonicalProvider } from "@middleman/ui/api/provider-routes";
+  import type { RepoTreeOption } from "./repoTree.js";
   import { ChevronDownIcon } from "../icons.ts";
   import {
     parseRepoFilterValue,
@@ -46,7 +48,7 @@
   let repoFetchVersion = 0;
   let latestRepoFetchKey = "";
 
-  type RepoOption = { value: string; owner: string; name: string };
+  type RepoOption = RepoTreeOption;
 
   $effect(() => {
     const configuredRepoKey = configuredRepos
@@ -78,6 +80,8 @@
       value: `${repo.PlatformHost}/${repo.Owner}/${repo.Name}`,
       owner: repo.Owner,
       name: repo.Name,
+      provider: canonicalProvider(repo.Platform),
+      platformHost: repo.PlatformHost,
     };
   }
 
@@ -87,6 +91,8 @@
       value: `${repo.platform_host}/${path}`,
       owner: repo.owner,
       name: repo.name,
+      provider: canonicalProvider(repo.provider),
+      platformHost: repo.platform_host,
     };
   }
 

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -6,6 +6,7 @@
   import { canonicalProvider } from "@middleman/ui/api/provider-routes";
   import type { RepoTreeOption } from "./repoTree.js";
   import RepoTreeNode from "./RepoTreeNode.svelte";
+  import TreeCheckbox from "./TreeCheckbox.svelte";
   import {
     buildRepoTree,
     visibleRows,
@@ -297,12 +298,9 @@
         onmousedown={clearSelection}
         onmouseenter={() => (highlightIndex = 0)}
       >
-        <input
-          class="typeahead-checkbox"
-          type="checkbox"
-          checked={selectedValues.length === 0}
-          tabindex="-1"
-          aria-hidden="true"
+        <TreeCheckbox
+          value={selectedValues.length === 0 ? "checked" : "unchecked"}
+          decorative
         />
         <span>All repos</span>
       </li>
@@ -434,22 +432,6 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  .typeahead-list :global(.typeahead-checkbox) {
-    width: 12px;
-    height: 12px;
-    margin: 0;
-    flex-shrink: 0;
-    accent-color: var(--accent-blue);
-  }
-
-  /* The "All repos" row's checkbox is decorative (aria-hidden); its */
-  /* clicks are handled by the row. RepoTreeNode's checkboxes have a real */
-  /* onmousedown, so pointer-events must stay enabled for them. This rule */
-  /* is scoped (no :global) so it only matches RepoTypeahead's own row. */
-  .typeahead-option:not(.repo-tree-row) .typeahead-checkbox {
-    pointer-events: none;
   }
 
   .typeahead-list :global(.typeahead-option.highlighted) {

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -44,6 +44,18 @@
         binding: { key: "ArrowUp" },
         scope: "view-pulls",
       },
+      {
+        id: "repo-typeahead.expand",
+        label: "Expand / collapse group",
+        binding: { key: "ArrowRight" },
+        scope: "view-pulls",
+      },
+      {
+        id: "repo-typeahead.toggle-select",
+        label: "Select / deselect",
+        binding: { key: " " },
+        scope: "view-pulls",
+      },
     ]),
   );
 
@@ -135,14 +147,6 @@
     return fetchedRepos.map(optionFromRepo);
   });
 
-  const filtered = $derived.by(() => {
-    if (!query) return options;
-    const q = query.toLowerCase();
-    return options.filter(
-      (o) => o.value.toLowerCase().includes(q),
-    );
-  });
-
   const selectedValues = $derived(parseRepoFilterValue(selected));
   const selectedSet = $derived(new Set(selectedValues));
   const displayValue = $derived.by(() => {
@@ -196,36 +200,40 @@
     onchange(undefined);
   }
 
-  function toggleRepo(value: string) {
-    const next = selectedSet.has(value)
-      ? selectedValues.filter((repo) => repo !== value)
-      : [...selectedValues, value];
-    onchange(serializeRepoFilterValue(next));
-  }
-
   function handleKeydown(e: KeyboardEvent) {
-    const total = filtered.length + 1;
+    const total = rows.length + 1; // +1 for the "All repos" row at index 0
     if (e.key === "ArrowDown") {
       e.preventDefault();
       highlightIndex = Math.min(highlightIndex + 1, total - 1);
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       highlightIndex = Math.max(highlightIndex - 1, 0);
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      const row = rows[highlightIndex - 1];
+      if (row?.hasChildren && !row.expanded) expansion.toggle(row.node.id);
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      const row = rows[highlightIndex - 1];
+      if (row?.hasChildren && row.expanded) expansion.toggle(row.node.id);
     } else if (e.key === "Enter") {
       e.preventDefault();
       if (highlightIndex === 0) {
         clearSelection();
-      } else {
-        const item = filtered[highlightIndex - 1];
-        if (item) toggleRepo(item.value);
+        return;
       }
+      const row = rows[highlightIndex - 1];
+      if (!row) return;
+      if (row.hasChildren) expansion.toggle(row.node.id);
+      else toggleRowSelect(row);
     } else if (e.key === " ") {
       e.preventDefault();
-      if (highlightIndex === 0) clearSelection();
-      else {
-        const item = filtered[highlightIndex - 1];
-        if (item) toggleRepo(item.value);
+      if (highlightIndex === 0) {
+        clearSelection();
+        return;
       }
+      const row = rows[highlightIndex - 1];
+      if (row) toggleRowSelect(row);
     } else if (e.key === "Escape") {
       closeDropdown();
     }

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -215,8 +215,21 @@
       if (row?.hasChildren && !row.expanded) expansion.toggle(row.node.id);
     } else if (e.key === "ArrowLeft") {
       e.preventDefault();
-      const row = rows[highlightIndex - 1];
-      if (row?.hasChildren && row.expanded) expansion.toggle(row.node.id);
+      const idx = highlightIndex - 1;
+      const row = rows[idx];
+      if (row?.hasChildren && row.expanded) {
+        expansion.toggle(row.node.id);
+      } else if (row) {
+        // On a leaf (or an already-collapsed group), move focus to the parent:
+        // the nearest preceding visible row at a shallower depth.
+        for (let i = idx - 1; i >= 0; i -= 1) {
+          const candidate = rows[i];
+          if (candidate && candidate.depth < row.depth) {
+            highlightIndex = i + 1;
+            break;
+          }
+        }
+      }
     } else if (e.key === "Enter") {
       e.preventDefault();
       if (highlightIndex === 0) {

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -320,7 +320,7 @@
       {#each rows as row, i (row.node.id)}
         <RepoTreeNode
           kind={row.node.kind}
-          label={row.node.label}
+          label={row.displayLabel ?? row.node.label}
           ariaLabel={rowAriaLabel(row)}
           provider={row.node.kind === "host" ? row.node.provider : undefined}
           depth={row.depth}
@@ -329,7 +329,7 @@
           selectionState={nodeSelectionState(row.node, selectedSet)}
           highlighted={i + 1 === highlightIndex}
           segments={query !== "" && row.node.kind === "repo"
-            ? highlightSegments(row.node.label, query)
+            ? highlightSegments(row.displayLabel ?? row.node.label, query)
             : undefined}
           onToggleExpand={() => toggleRowExpand(row)}
           onToggleSelect={() => toggleRowSelect(row)}

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -5,6 +5,15 @@
   import type { ConfigRepo, Repo } from "@middleman/ui/api/types";
   import { canonicalProvider } from "@middleman/ui/api/provider-routes";
   import type { RepoTreeOption } from "./repoTree.js";
+  import RepoTreeNode from "./RepoTreeNode.svelte";
+  import {
+    buildRepoTree,
+    visibleRows,
+    nodeSelectionState,
+    toggleSubtree,
+    type VisibleRow,
+  } from "./repoTree.js";
+  import { createRepoTreeExpansionStore } from "../stores/repoTreeExpansion.svelte.js";
   import { ChevronDownIcon } from "../icons.ts";
   import {
     parseRepoFilterValue,
@@ -142,6 +151,26 @@
     return `${selectedValues.length} repos`;
   });
 
+  const expansion = createRepoTreeExpansionStore();
+
+  const tree = $derived(buildRepoTree(options));
+
+  const rows = $derived(
+    visibleRows(tree, { isCollapsed: expansion.isCollapsed, query }),
+  );
+
+  function rowAriaLabel(row: VisibleRow): string {
+    return row.node.kind === "host" ? row.node.platformHost : row.node.id;
+  }
+
+  function toggleRowSelect(row: VisibleRow) {
+    onchange(serializeRepoFilterValue(toggleSubtree(row.node, selectedValues)));
+  }
+
+  function toggleRowExpand(row: VisibleRow) {
+    if (row.hasChildren) expansion.toggle(row.node.id);
+  }
+
   $effect(() => {
     if (selectedValues.length === 0 || reposLoading) return;
     const validValues = new Set(options.map((option) => option.value));
@@ -269,27 +298,24 @@
         />
         <span>All repos</span>
       </li>
-      {#each filtered as option, i (option.value)}
-        <li
-          class="typeahead-option"
-          class:highlighted={i + 1 === highlightIndex}
-          class:selected={selectedSet.has(option.value)}
-          role="option"
-          aria-selected={selectedSet.has(option.value)}
-          onmousedown={() => toggleRepo(option.value)}
-          onmouseenter={() => (highlightIndex = i + 1)}
-        >
-          <input
-            class="typeahead-checkbox"
-            type="checkbox"
-            checked={selectedSet.has(option.value)}
-            tabindex="-1"
-            aria-hidden="true"
-          />
-          <span class="typeahead-option-label">
-            {#each highlightSegments(option.value, query) as seg, segIndex (`${option.value}-${segIndex}-${seg.text}-${seg.match}`)}{#if seg.match}<mark class="match">{seg.text}</mark>{:else}{seg.text}{/if}{/each}
-          </span>
-        </li>
+      {#each rows as row, i (row.node.id)}
+        <RepoTreeNode
+          kind={row.node.kind}
+          label={row.node.label}
+          ariaLabel={rowAriaLabel(row)}
+          provider={row.node.kind === "host" ? row.node.provider : undefined}
+          depth={row.depth}
+          hasChildren={row.hasChildren}
+          expanded={row.expanded}
+          selectionState={nodeSelectionState(row.node, selectedSet)}
+          highlighted={i + 1 === highlightIndex}
+          segments={query !== "" && row.node.kind === "repo"
+            ? highlightSegments(row.node.label, query)
+            : undefined}
+          onToggleExpand={() => toggleRowExpand(row)}
+          onToggleSelect={() => toggleRowSelect(row)}
+          onHover={() => (highlightIndex = i + 1)}
+        />
       {:else}
         <li class="typeahead-empty">No matching repos</li>
       {/each}
@@ -384,7 +410,11 @@
     padding: 2px;
   }
 
-  .typeahead-option {
+  /* RepoTreeNode renders rows as a child component, so the shared row, */
+  /* checkbox, and match-highlight rules are scoped to descendants of */
+  /* the RepoTypeahead-owned .typeahead-list rather than this component */
+  /* alone. The :global() escape keeps them off the rest of the app. */
+  .typeahead-list :global(.typeahead-option) {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -398,32 +428,33 @@
     text-overflow: ellipsis;
   }
 
-  .typeahead-checkbox {
+  .typeahead-list :global(.typeahead-checkbox) {
     width: 12px;
     height: 12px;
     margin: 0;
     flex-shrink: 0;
     accent-color: var(--accent-blue);
+  }
+
+  /* The "All repos" row's checkbox is decorative (aria-hidden); its */
+  /* clicks are handled by the row. RepoTreeNode's checkboxes have a real */
+  /* onmousedown, so pointer-events must stay enabled for them. This rule */
+  /* is scoped (no :global) so it only matches RepoTypeahead's own row. */
+  .typeahead-option:not(.repo-tree-row) .typeahead-checkbox {
     pointer-events: none;
   }
 
-  .typeahead-option-label {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .typeahead-option.highlighted {
+  .typeahead-list :global(.typeahead-option.highlighted) {
     background: var(--bg-surface-hover);
     color: var(--text-primary);
   }
 
-  .typeahead-option.selected {
+  .typeahead-list :global(.typeahead-option.selected) {
     color: var(--accent-blue);
     font-weight: 600;
   }
 
-  .match {
+  .typeahead-list :global(.match) {
     background: color-mix(in srgb, var(--accent-blue) 40%, transparent);
     color: var(--accent-blue);
     font-weight: 600;

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -24,6 +24,9 @@ const getRepos = client.GET as unknown as Mock<() => Promise<{ data: Repo[]; err
 
 describe("RepoTypeahead", () => {
   beforeEach(() => {
+    // The expansion store persists collapsed nodes to localStorage, so clear
+    // it between tests to keep each case from inheriting another's tree state.
+    localStorage.clear();
     settingsStore = createSettingsStore();
     settingsStore.setConfiguredRepos([]);
     getRepos.mockResolvedValue({ data: [], error: undefined });
@@ -151,6 +154,130 @@ describe("RepoTypeahead", () => {
     expect(onchange).toHaveBeenLastCalledWith(
       "github.com/import-lab/api,github.com/import-lab/web",
     );
+  });
+
+  it("selecting an owner row selects all repos beneath it", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "api",
+        repo_path: "import-lab/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "web",
+        repo_path: "import-lab/web",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, { props: { selected: undefined, onchange } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    const ownerCheckbox = screen
+      .getByRole("option", { name: "github.com/import-lab" })
+      .querySelector("input[type='checkbox']") as HTMLInputElement;
+    await fireEvent.mouseDown(ownerCheckbox);
+
+    expect(onchange).toHaveBeenLastCalledWith(
+      "github.com/import-lab/api,github.com/import-lab/web",
+    );
+  });
+
+  it("filters to matching leaves while keeping their owner visible", async () => {
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "api",
+        repo_path: "import-lab/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "web",
+        repo_path: "import-lab/web",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, {
+      props: { selected: undefined, onchange: vi.fn() },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    await fireEvent.input(screen.getByPlaceholderText("Filter repos..."), {
+      target: { value: "web" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", { name: "github.com/import-lab/web" }),
+      ).toBeTruthy();
+      expect(
+        screen.queryByRole("option", { name: "github.com/import-lab/api" }),
+      ).toBeNull();
+    });
+  });
+
+  it("clicking an owner row body expands/collapses without selecting", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github", platform_host: "github.com", owner: "import-lab",
+        name: "api", repo_path: "import-lab/api", is_glob: false, matched_repo_count: 1,
+      },
+      {
+        provider: "github", platform_host: "github.com", owner: "import-lab",
+        name: "web", repo_path: "import-lab/web", is_glob: false, matched_repo_count: 1,
+      },
+    ]);
+    render(RepoTypeahead, { props: { selected: undefined, onchange } });
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+
+    // leaves visible initially
+    expect(screen.getByRole("option", { name: "github.com/import-lab/api" })).toBeTruthy();
+    // click the owner row body (its caret button has aria-label "Toggle import-lab";
+    // click the row <li> itself, not the caret) -> collapses, hides leaves, selects nothing
+    await fireEvent.mouseDown(screen.getByRole("option", { name: "github.com/import-lab" }));
+    // NOTE: owner row body mousedown should toggle EXPAND, not select. After collapse the leaves are gone.
+    await waitFor(() => {
+      expect(screen.queryByRole("option", { name: "github.com/import-lab/api" })).toBeNull();
+    });
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it("clicking a leaf checkbox selects only that leaf", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github", platform_host: "github.com", owner: "import-lab",
+        name: "api", repo_path: "import-lab/api", is_glob: false, matched_repo_count: 1,
+      },
+      {
+        provider: "github", platform_host: "github.com", owner: "import-lab",
+        name: "web", repo_path: "import-lab/web", is_glob: false, matched_repo_count: 1,
+      },
+    ]);
+    render(RepoTypeahead, { props: { selected: undefined, onchange } });
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    const leaf = screen.getByRole("option", { name: "github.com/import-lab/api" });
+    const checkbox = leaf.querySelector("input[type='checkbox']") as HTMLInputElement;
+    await fireEvent.mouseDown(checkbox);
+    expect(onchange).toHaveBeenLastCalledWith("github.com/import-lab/api");
   });
 
   it("drops removed repos after settings remove matching entries", async () => {

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -235,6 +235,8 @@ describe("RepoTypeahead", () => {
 
   it("clicking an owner row body expands/collapses without selecting", async () => {
     const onchange = vi.fn();
+    // Two repos under import-lab so it renders a collapsible owner row; a
+    // single-repo owner auto-flattens to one leaf and has no caret to toggle.
     settingsStore.setConfiguredRepos([
       {
         provider: "github", platform_host: "github.com", owner: "import-lab",
@@ -332,5 +334,94 @@ describe("RepoTypeahead", () => {
       expect(screen.queryByRole("option", { name: /roborev-dev\/middleman/i })).toBeNull();
       expect(onchange).toHaveBeenCalledWith(undefined);
     });
+  });
+
+  it("collapses and expands the focused owner with arrow keys", async () => {
+    // Two repos under import-lab so it renders a collapsible owner row; a
+    // single-repo owner auto-flattens to one leaf and has no caret to toggle.
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "api",
+        repo_path: "import-lab/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "web",
+        repo_path: "import-lab/web",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, { props: { selected: undefined, onchange: vi.fn() } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    const input = screen.getByPlaceholderText("Filter repos...");
+
+    // leaves visible by default
+    expect(
+      screen.getByRole("option", { name: "github.com/import-lab/api" }),
+    ).toBeTruthy();
+
+    // move highlight onto the owner row (index 1) and collapse it
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "ArrowLeft" });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("option", { name: "github.com/import-lab/api" }),
+      ).toBeNull();
+    });
+
+    await fireEvent.keyDown(input, { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("option", { name: "github.com/import-lab/api" }),
+      ).toBeTruthy();
+    });
+  });
+
+  it("toggles selection of the focused row with space", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "api",
+        repo_path: "import-lab/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "web",
+        repo_path: "import-lab/web",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, { props: { selected: undefined, onchange } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    const input = screen.getByPlaceholderText("Filter repos...");
+
+    // highlight the owner row and select its subtree
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: " " });
+
+    expect(onchange).toHaveBeenLastCalledWith(
+      "github.com/import-lab/api,github.com/import-lab/web",
+    );
   });
 });

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -388,6 +388,55 @@ describe("RepoTypeahead", () => {
     });
   });
 
+  it("moves focus from a leaf to its parent owner on ArrowLeft", async () => {
+    // Single host auto-flattens, so rows are: [All repos], import-lab (owner,
+    // depth 0), api (leaf, depth 1), web (leaf, depth 1). ArrowLeft on a leaf
+    // should jump focus up to the owner row, per the keyboard contract.
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "api",
+        repo_path: "import-lab/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "import-lab",
+        name: "web",
+        repo_path: "import-lab/web",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, { props: { selected: undefined, onchange: vi.fn() } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    const input = screen.getByPlaceholderText("Filter repos...");
+
+    // ArrowDown onto the owner row, then onto the first leaf (api).
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    await fireEvent.keyDown(input, { key: "ArrowDown" });
+    const leaf = screen.getByRole("option", { name: "github.com/import-lab/api" });
+    await waitFor(() => expect(leaf.classList.contains("highlighted")).toBe(true));
+
+    // ArrowLeft on the leaf moves focus to its parent owner.
+    await fireEvent.keyDown(input, { key: "ArrowLeft" });
+    await waitFor(() => {
+      const owner = screen.getByRole("option", { name: "github.com/import-lab" });
+      expect(owner.classList.contains("highlighted")).toBe(true);
+      expect(
+        screen
+          .getByRole("option", { name: "github.com/import-lab/api" })
+          .classList.contains("highlighted"),
+      ).toBe(false);
+    });
+  });
+
   it("toggles selection of the focused row with space", async () => {
     const onchange = vi.fn();
     settingsStore.setConfiguredRepos([

--- a/frontend/src/lib/components/TreeCheckbox.svelte
+++ b/frontend/src/lib/components/TreeCheckbox.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import type { SelectionState } from "./repoTree.js";
+
+  interface Props {
+    /** Tri-state value. Drives the visual and the native input's properties. */
+    value: SelectionState;
+    /**
+     * Decorative checkboxes (e.g. the "All repos" row) are not interactive:
+     * the input is hidden from assistive tech and the control ignores pointer
+     * events so clicks fall through to the owning row.
+     */
+    decorative?: boolean;
+    /** Fires on the input's mousedown; selection happens here, never on click. */
+    onmousedown?: (event: MouseEvent) => void;
+  }
+
+  let { value, decorative = false, onmousedown }: Props = $props();
+
+  let inputEl = $state<HTMLInputElement>();
+
+  // `indeterminate` is a DOM property, not an attribute, so it must be set
+  // imperatively. Keeping it on the real input preserves the partial state for
+  // assistive tech and for tests that read `.indeterminate`.
+  $effect(() => {
+    if (inputEl) inputEl.indeterminate = value === "partial";
+  });
+
+  // A native checkbox toggles its own `checked` as the click default action,
+  // which would fight the controlled `checked={state === "checked"}` binding and
+  // leave the box showing the inverse of the real selection. Cancel that default
+  // action so the input is purely controlled by `state`.
+  function suppressNativeToggle(event: MouseEvent): void {
+    event.preventDefault();
+  }
+</script>
+
+<span
+  class="tree-check"
+  class:tree-check--checked={value === "checked"}
+  class:tree-check--partial={value === "partial"}
+  class:tree-check--decorative={decorative}
+>
+  <input
+    bind:this={inputEl}
+    class="tree-check__input"
+    type="checkbox"
+    checked={value === "checked"}
+    tabindex="-1"
+    aria-hidden={decorative ? "true" : undefined}
+    onmousedown={onmousedown}
+    onclick={suppressNativeToggle}
+  />
+  <span class="tree-check__box" aria-hidden="true">
+    {#if value === "checked"}
+      <svg
+        class="tree-check__glyph"
+        viewBox="0 0 16 16"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M4 8.5l2.6 2.6L12 5.4"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    {:else if value === "partial"}
+      <svg
+        class="tree-check__glyph"
+        viewBox="0 0 16 16"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path d="M4.5 8h7" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      </svg>
+    {/if}
+  </span>
+</span>
+
+<style>
+  .tree-check {
+    position: relative;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    display: inline-flex;
+  }
+
+  .tree-check--decorative {
+    pointer-events: none;
+  }
+
+  /* The real input sits transparently on top of the drawn box and is the click
+     target; the box behind it carries all the visuals. */
+  .tree-check__input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+
+  .tree-check__box {
+    pointer-events: none;
+    box-sizing: border-box;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1.5px solid var(--border-default);
+    border-radius: 5px;
+    background: var(--bg-surface);
+    /* Glyph color: surface-colored so it contrasts against the accent fill in
+       both themes (white check on dark-blue light theme; dark check on
+       light-blue dark theme). */
+    color: var(--bg-surface);
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .tree-check:hover .tree-check__box {
+    border-color: var(--accent-blue);
+  }
+
+  .tree-check--checked .tree-check__box,
+  .tree-check--partial .tree-check__box {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+  }
+
+  .tree-check__glyph {
+    width: 12px;
+    height: 12px;
+    animation: tree-check-pop 0.14s ease-out;
+  }
+
+  @keyframes tree-check-pop {
+    from {
+      transform: scale(0.5);
+      opacity: 0;
+    }
+    to {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .tree-check__glyph {
+      animation: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildRepoTree, type RepoTreeOption } from "./repoTree.js";
+import { visibleRows, type VisibleRow } from "./repoTree.js";
 
 function opt(
   platformHost: string,
@@ -68,5 +69,98 @@ describe("buildRepoTree", () => {
       opt("ghe.example.com", "b/y", "gitlab"),
     ]);
     expect(tree[0]!.provider).toBe("github");
+  });
+});
+
+const neverCollapsed = () => false;
+
+function labelsAtDepth(rows: VisibleRow[]): Array<[string, number]> {
+  return rows.map((row) => [row.node.label, row.depth]);
+}
+
+describe("visibleRows", () => {
+  it("omits the host node when there is only one host", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: neverCollapsed });
+    // owner at depth 0 (host omitted), two leaves at depth 1
+    expect(labelsAtDepth(rows)).toEqual([
+      ["acme", 0],
+      ["api", 1],
+      ["web", 1],
+    ]);
+  });
+
+  it("shows host nodes at depth 0 when more than one host exists", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("gitlab.com", "g/x", "gitlab"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: neverCollapsed });
+    expect(rows[0]!.node.kind).toBe("host");
+    expect(rows[0]!.depth).toBe(0);
+    expect(rows.find((r) => r.node.label === "acme")?.depth).toBe(1);
+  });
+
+  it("flattens a single-repo owner even when multiple hosts exist", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("gitlab.com", "solo/only", "gitlab"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: neverCollapsed });
+    // gitlab.com host shows, its single-repo owner "solo" flattens to the "only"
+    // leaf at the owner's depth (1); no "solo" owner row.
+    const onlyRow = rows.find((r) => r.node.label === "only");
+    expect(onlyRow).toBeTruthy();
+    expect(onlyRow!.depth).toBe(1);
+    expect(onlyRow!.hasChildren).toBe(false);
+    expect(rows.some((r) => r.node.label === "solo")).toBe(false);
+  });
+
+  it("flattens a single-repo owner into one leaf row with no children", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("github.com", "solo/only"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: neverCollapsed });
+    const soloRow = rows.find((r) => r.node.label === "only");
+    expect(soloRow).toBeTruthy();
+    expect(soloRow!.depth).toBe(0); // at the owner's depth (single host)
+    expect(soloRow!.hasChildren).toBe(false);
+    // the "solo" owner node itself is not rendered
+    expect(rows.some((r) => r.node.label === "solo")).toBe(false);
+  });
+
+  it("hides children of a collapsed node", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+    ]);
+    const collapsed = (id: string) => id === "github.com/acme";
+    const rows = visibleRows(tree, { isCollapsed: collapsed });
+    expect(labelsAtDepth(rows)).toEqual([["acme", 0]]);
+    expect(rows[0]!.expanded).toBe(false);
+  });
+
+  it("prunes non-matching repos and force-expands matches when filtering", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("github.com", "widgets/web-sdk"),
+    ]);
+    // collapse everything; filtering must override collapse
+    const rows = visibleRows(tree, {
+      isCollapsed: () => true,
+      query: "web",
+    });
+    const labels = rows.map((r) => r.node.label);
+    expect(labels).toContain("web");
+    expect(labels).toContain("web-sdk");
+    expect(labels).not.toContain("api");
   });
 });

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -195,6 +195,36 @@ describe("visibleRows", () => {
     expect(rows.some((r) => r.node.label === "web")).toBe(false);
   });
 
+  it("exposes the full subtree on a filtered owner row for selection", () => {
+    // While filtering, the owner row must carry its ORIGINAL node (full child
+    // set), not just the matching leaves, so tri-state and group-toggle apply
+    // to the whole owner rather than only the visible matches.
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("github.com", "acme/infra"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: () => false, query: "api" });
+    const acme = rows.find((r) => r.node.label === "acme")!;
+    // selection logic sees all three repos, not just the matching "api"
+    expect(collectLeafValues(acme.node).sort()).toEqual([
+      "github.com/acme/api",
+      "github.com/acme/infra",
+      "github.com/acme/web",
+    ]);
+    // with only "api" selected, the owner is partial (not "checked"), proving
+    // tri-state reflects hidden siblings too
+    expect(nodeSelectionState(acme.node, new Set(["github.com/acme/api"]))).toBe(
+      "partial",
+    );
+    // toggling the owner cascades to the entire subtree, including hidden repos
+    expect(toggleSubtree(acme.node, ["github.com/acme/api"]).sort()).toEqual([
+      "github.com/acme/api",
+      "github.com/acme/infra",
+      "github.com/acme/web",
+    ]);
+  });
+
   it("still flattens a genuinely single-repo owner under a filter", () => {
     // solo really has one repo, so flattening it remains correct even mid-filter.
     const tree = buildRepoTree([

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRepoTree, type RepoTreeOption } from "./repoTree.js";
+
+function opt(
+  platformHost: string,
+  repoPath: string,
+  provider = "github",
+): RepoTreeOption {
+  const segments = repoPath.split("/");
+  return {
+    value: `${platformHost}/${repoPath}`,
+    owner: segments.slice(0, -1).join("/"),
+    name: segments[segments.length - 1] ?? repoPath,
+    provider,
+    platformHost,
+  };
+}
+
+describe("buildRepoTree", () => {
+  it("groups host -> owner -> repo and sorts each level", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/web"),
+      opt("github.com", "acme/api"),
+      opt("github.com", "widgets/sdk"),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    const host = tree[0]!;
+    expect(host.kind).toBe("host");
+    expect(host.id).toBe("github.com");
+    expect(host.label).toBe("github.com");
+    expect(host.provider).toBe("github");
+    expect(host.children.map((o) => o.label)).toEqual(["acme", "widgets"]);
+
+    const acme = host.children[0]!;
+    expect(acme.id).toBe("github.com/acme");
+    expect(acme.children.map((r) => r.label)).toEqual(["api", "web"]);
+    expect(acme.children[0]!.value).toBe("github.com/acme/api");
+    expect(acme.children[0]!.id).toBe("github.com/acme/api");
+  });
+
+  it("keeps GitLab nested groups as one slashed owner node", () => {
+    const tree = buildRepoTree([
+      opt("gitlab.com", "platform/frontend/web-ui", "gitlab"),
+    ]);
+
+    const host = tree[0]!;
+    expect(host.children).toHaveLength(1);
+    const owner = host.children[0]!;
+    expect(owner.label).toBe("platform/frontend");
+    expect(owner.id).toBe("gitlab.com/platform/frontend");
+    expect(owner.children[0]!.label).toBe("web-ui");
+    expect(owner.children[0]!.value).toBe("gitlab.com/platform/frontend/web-ui");
+  });
+
+  it("separates hosts and sorts them by label", () => {
+    const tree = buildRepoTree([
+      opt("gitlab.com", "g/x", "gitlab"),
+      opt("github.com", "a/y"),
+    ]);
+    expect(tree.map((h) => h.label)).toEqual(["github.com", "gitlab.com"]);
+  });
+
+  it("uses the first option's provider when a host's providers disagree", () => {
+    const tree = buildRepoTree([
+      opt("ghe.example.com", "a/x", "github"),
+      opt("ghe.example.com", "b/y", "gitlab"),
+    ]);
+    expect(tree[0]!.provider).toBe("github");
+  });
+});

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -225,6 +225,24 @@ describe("visibleRows", () => {
     ]);
   });
 
+  it("labels flattened single-repo owners as owner/repo to keep them distinct", () => {
+    // team-a and team-b each have one repo named "api". Flattened to leaves,
+    // bare "api" rows would be indistinguishable; the displayLabel disambiguates
+    // while the underlying node/value stays the leaf for selection.
+    const tree = buildRepoTree([
+      opt("github.com", "team-a/api"),
+      opt("github.com", "team-b/api"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: () => false });
+    const labels = rows.map((r) => r.displayLabel ?? r.node.label);
+    expect(labels).toContain("team-a/api");
+    expect(labels).toContain("team-b/api");
+    // node identity is still the leaf (value/id unchanged for selection)
+    const teamA = rows.find((r) => r.displayLabel === "team-a/api")!;
+    expect(teamA.node.kind).toBe("repo");
+    expect((teamA.node as { value: string }).value).toBe("github.com/team-a/api");
+  });
+
   it("still flattens a genuinely single-repo owner under a filter", () => {
     // solo really has one repo, so flattening it remains correct even mid-filter.
     const tree = buildRepoTree([

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -175,6 +175,39 @@ describe("visibleRows", () => {
     expect(labels).not.toContain("api");
   });
 
+  it("keeps a multi-repo owner as an owner row when a filter matches only one repo", () => {
+    // acme genuinely has 3 repos; the query matches only "api". The owner must
+    // stay a visible owner row (not collapse into a lone leaf), so its context
+    // is preserved and same-named repos under other owners stay unambiguous.
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("github.com", "acme/infra"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: () => false, query: "api" });
+    const acme = rows.find((r) => r.node.label === "acme");
+    expect(acme).toBeTruthy();
+    expect(acme!.hasChildren).toBe(true);
+    expect(acme!.node.kind).toBe("owner");
+    // the single matching leaf is shown beneath the still-visible owner
+    const api = rows.find((r) => r.node.label === "api");
+    expect(api?.node.kind).toBe("repo");
+    expect(rows.some((r) => r.node.label === "web")).toBe(false);
+  });
+
+  it("still flattens a genuinely single-repo owner under a filter", () => {
+    // solo really has one repo, so flattening it remains correct even mid-filter.
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("github.com", "solo/onlyrepo"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: () => false, query: "only" });
+    expect(rows.some((r) => r.node.label === "solo")).toBe(false);
+    const leaf = rows.find((r) => r.node.label === "onlyrepo");
+    expect(leaf?.hasChildren).toBe(false);
+  });
+
   it("omits a collapsed host's owners in multi-host mode", () => {
     const tree = buildRepoTree([
       opt("github.com", "acme/api"),

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { buildRepoTree, type RepoTreeOption } from "./repoTree.js";
-import { visibleRows, type VisibleRow } from "./repoTree.js";
+import {
+  buildRepoTree,
+  collectLeafValues,
+  nodeSelectionState,
+  toggleSubtree,
+  visibleRows,
+  type RepoTreeOption,
+  type VisibleRow,
+} from "./repoTree.js";
 
 function opt(
   platformHost: string,
@@ -69,6 +76,10 @@ describe("buildRepoTree", () => {
       opt("ghe.example.com", "b/y", "gitlab"),
     ]);
     expect(tree[0]!.provider).toBe("github");
+  });
+
+  it("returns an empty array for no options", () => {
+    expect(buildRepoTree([])).toEqual([]);
   });
 });
 
@@ -162,5 +173,105 @@ describe("visibleRows", () => {
     expect(labels).toContain("web");
     expect(labels).toContain("web-sdk");
     expect(labels).not.toContain("api");
+  });
+
+  it("omits a collapsed host's owners in multi-host mode", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+      opt("gitlab.com", "g/x", "gitlab"),
+    ]);
+    const collapsed = (id: string) => id === "github.com";
+    const rows = visibleRows(tree, { isCollapsed: collapsed });
+    // github.com host row present but collapsed -> its owners/leaves omitted
+    const githubHost = rows.find((r) => r.node.label === "github.com");
+    expect(githubHost?.expanded).toBe(false);
+    expect(rows.some((r) => r.node.label === "acme")).toBe(false);
+    // gitlab.com still shows
+    expect(rows.some((r) => r.node.label === "gitlab.com")).toBe(true);
+  });
+
+  it("drops an entire host when a filter matches nothing under it", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/web"),
+      opt("gitlab.com", "g/api", "gitlab"),
+    ]);
+    const rows = visibleRows(tree, { isCollapsed: () => false, query: "web" });
+    // only github.com/acme/web matches; gitlab.com host is dropped entirely,
+    // and with one host remaining it auto-flattens (host row omitted)
+    expect(rows.some((r) => r.node.label === "gitlab.com")).toBe(false);
+    expect(rows.some((r) => r.node.label === "web")).toBe(true);
+  });
+
+  it("treats a whitespace-only query as no filter", () => {
+    const tree = buildRepoTree([
+      opt("github.com", "acme/api"),
+      opt("github.com", "acme/web"),
+    ]);
+    const collapsed = (id: string) => id === "github.com/acme";
+    const rows = visibleRows(tree, { isCollapsed: collapsed, query: "   " });
+    // whitespace trims to empty -> not filtering -> collapse is honored, leaves hidden
+    expect(rows.some((r) => r.node.label === "api")).toBe(false);
+    expect(rows.find((r) => r.node.label === "acme")?.expanded).toBe(false);
+  });
+});
+
+describe("selection helpers", () => {
+  const tree = buildRepoTree([
+    opt("github.com", "acme/api"),
+    opt("github.com", "acme/web"),
+    opt("github.com", "acme/infra"),
+  ]);
+  const acme = tree[0]!.children[0]!;
+
+  it("collects all descendant leaf values", () => {
+    expect(collectLeafValues(acme).sort()).toEqual([
+      "github.com/acme/api",
+      "github.com/acme/infra",
+      "github.com/acme/web",
+    ]);
+    expect(collectLeafValues(acme.children[0]!)).toEqual([
+      "github.com/acme/api",
+    ]);
+  });
+
+  it("computes tri-state from the active set", () => {
+    expect(nodeSelectionState(acme, new Set())).toBe("unchecked");
+    expect(
+      nodeSelectionState(acme, new Set(["github.com/acme/api"])),
+    ).toBe("partial");
+    expect(
+      nodeSelectionState(
+        acme,
+        new Set([
+          "github.com/acme/api",
+          "github.com/acme/web",
+          "github.com/acme/infra",
+        ]),
+      ),
+    ).toBe("checked");
+  });
+
+  it("adds all subtree leaves when not fully checked", () => {
+    expect(toggleSubtree(acme, ["github.com/acme/api"]).sort()).toEqual([
+      "github.com/acme/api",
+      "github.com/acme/infra",
+      "github.com/acme/web",
+    ]);
+  });
+
+  it("removes all subtree leaves when fully checked", () => {
+    const all = [
+      "github.com/acme/api",
+      "github.com/acme/web",
+      "github.com/acme/infra",
+    ];
+    expect(toggleSubtree(acme, all)).toEqual([]);
+  });
+
+  it("toggles a single leaf without touching siblings", () => {
+    expect(
+      toggleSubtree(acme.children[0]!, ["github.com/acme/web"]).sort(),
+    ).toEqual(["github.com/acme/api", "github.com/acme/web"]);
   });
 });

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -115,28 +115,19 @@ export function visibleRows(
   const matches = (leaf: RepoLeaf) =>
     !filtering || leaf.value.toLowerCase().includes(q);
 
-  // Single-repo-owner flattening keys on the owner's TRUE repo count, captured
-  // before filtering prunes children. Otherwise an owner with several repos but
-  // only one match would collapse into a lone leaf and lose its owner context.
-  const originalChildCount = new Map<string, number>();
-  for (const host of tree) {
-    for (const owner of host.children) {
-      originalChildCount.set(owner.id, owner.children.length);
-    }
-  }
-
-  // Prune to owners/hosts that still have a matching leaf.
+  // Prune to the owners/hosts that still have a matching leaf, but keep a
+  // reference to the ORIGINAL (unpruned) node alongside the matching leaves.
+  // Rendering uses `matchingLeaves` (visibility); selection and tri-state use
+  // the original node so a filtered parent still reflects and toggles its FULL
+  // subtree, and single-repo-owner flattening keys on the true repo count.
   const pruned = tree
     .map((host) => ({
-      ...host,
-      children: host.children
-        .map((owner) => ({
-          ...owner,
-          children: owner.children.filter(matches),
-        }))
-        .filter((owner) => owner.children.length > 0),
+      original: host,
+      owners: host.children
+        .map((owner) => ({ original: owner, matchingLeaves: owner.children.filter(matches) }))
+        .filter((owner) => owner.matchingLeaves.length > 0),
     }))
-    .filter((host) => host.children.length > 0);
+    .filter((host) => host.owners.length > 0);
 
   const expandedOf = (id: string) => filtering || !isCollapsed(id);
   const singleHost = pruned.length === 1;
@@ -145,33 +136,31 @@ export function visibleRows(
   for (const host of pruned) {
     const ownerDepth = singleHost ? 0 : 1;
     if (!singleHost) {
-      const hostExpanded = expandedOf(host.id);
-      rows.push({ node: host, depth: 0, hasChildren: true, expanded: hostExpanded });
+      const hostExpanded = expandedOf(host.original.id);
+      rows.push({ node: host.original, depth: 0, hasChildren: true, expanded: hostExpanded });
       if (!hostExpanded) continue;
     }
-    for (const owner of host.children) {
+    for (const owner of host.owners) {
       // Flatten only owners that genuinely have a single repo, not owners
       // narrowed to one match by the active filter.
-      const isSingleRepoOwner =
-        (originalChildCount.get(owner.id) ?? owner.children.length) === 1;
-      if (isSingleRepoOwner) {
+      if (owner.original.children.length === 1) {
         rows.push({
-          node: owner.children[0]!,
+          node: owner.original.children[0]!,
           depth: ownerDepth,
           hasChildren: false,
           expanded: false,
         });
         continue;
       }
-      const ownerExpanded = expandedOf(owner.id);
+      const ownerExpanded = expandedOf(owner.original.id);
       rows.push({
-        node: owner,
+        node: owner.original,
         depth: ownerDepth,
         hasChildren: true,
         expanded: ownerExpanded,
       });
       if (!ownerExpanded) continue;
-      for (const leaf of owner.children) {
+      for (const leaf of owner.matchingLeaves) {
         rows.push({
           node: leaf,
           depth: ownerDepth + 1,

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -169,3 +169,40 @@ export function visibleRows(
   }
   return rows;
 }
+
+export type SelectionState = "checked" | "partial" | "unchecked";
+
+export function collectLeafValues(node: RepoTreeNodeData): string[] {
+  if (node.kind === "repo") return [node.value];
+  const values: string[] = [];
+  for (const child of node.children) values.push(...collectLeafValues(child));
+  return values;
+}
+
+export function nodeSelectionState(
+  node: RepoTreeNodeData,
+  active: ReadonlySet<string>,
+): SelectionState {
+  const leaves = collectLeafValues(node);
+  if (leaves.length === 0) return "unchecked";
+  let selected = 0;
+  for (const value of leaves) if (active.has(value)) selected += 1;
+  if (selected === 0) return "unchecked";
+  if (selected === leaves.length) return "checked";
+  return "partial";
+}
+
+export function toggleSubtree(
+  node: RepoTreeNodeData,
+  activeValues: readonly string[],
+): string[] {
+  const leaves = collectLeafValues(node);
+  if (nodeSelectionState(node, new Set(activeValues)) === "checked") {
+    const remove = new Set(leaves);
+    return activeValues.filter((value) => !remove.has(value));
+  }
+  const next = [...activeValues];
+  const present = new Set(activeValues);
+  for (const value of leaves) if (!present.has(value)) next.push(value);
+  return next;
+}

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -99,6 +99,13 @@ export interface VisibleRow {
   depth: number;
   hasChildren: boolean;
   expanded: boolean;
+  /**
+   * Overrides the visible label when set. Used for flattened single-repo owners,
+   * which render `owner/repo` instead of the bare repo name so two owners that
+   * each have one identically-named repo stay distinguishable. `node` is
+   * unchanged (identity, value, and selection still use the leaf).
+   */
+  displayLabel?: string;
 }
 
 export interface VisibleRowsOptions {
@@ -142,13 +149,16 @@ export function visibleRows(
     }
     for (const owner of host.owners) {
       // Flatten only owners that genuinely have a single repo, not owners
-      // narrowed to one match by the active filter.
+      // narrowed to one match by the active filter. Show `owner/repo` as the
+      // label so two single-repo owners with the same repo name stay distinct.
       if (owner.original.children.length === 1) {
+        const leaf = owner.original.children[0]!;
         rows.push({
-          node: owner.original.children[0]!,
+          node: leaf,
           depth: ownerDepth,
           hasChildren: false,
           expanded: false,
+          displayLabel: `${owner.original.label}/${leaf.label}`,
         });
         continue;
       }

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -93,3 +93,79 @@ export function buildRepoTree(
   }
   return sorted;
 }
+
+export interface VisibleRow {
+  node: RepoTreeNodeData;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+}
+
+export interface VisibleRowsOptions {
+  isCollapsed: (id: string) => boolean;
+  query?: string;
+}
+
+export function visibleRows(
+  tree: readonly HostNode[],
+  { isCollapsed, query }: VisibleRowsOptions,
+): VisibleRow[] {
+  const q = query?.trim().toLowerCase() ?? "";
+  const filtering = q !== "";
+  const matches = (leaf: RepoLeaf) =>
+    !filtering || leaf.value.toLowerCase().includes(q);
+
+  // Prune to owners/hosts that still have a matching leaf.
+  const pruned = tree
+    .map((host) => ({
+      ...host,
+      children: host.children
+        .map((owner) => ({
+          ...owner,
+          children: owner.children.filter(matches),
+        }))
+        .filter((owner) => owner.children.length > 0),
+    }))
+    .filter((host) => host.children.length > 0);
+
+  const expandedOf = (id: string) => filtering || !isCollapsed(id);
+  const singleHost = pruned.length === 1;
+  const rows: VisibleRow[] = [];
+
+  for (const host of pruned) {
+    const ownerDepth = singleHost ? 0 : 1;
+    if (!singleHost) {
+      const hostExpanded = expandedOf(host.id);
+      rows.push({ node: host, depth: 0, hasChildren: true, expanded: hostExpanded });
+      if (!hostExpanded) continue;
+    }
+    for (const owner of host.children) {
+      if (owner.children.length === 1) {
+        rows.push({
+          node: owner.children[0]!,
+          depth: ownerDepth,
+          hasChildren: false,
+          expanded: false,
+        });
+        continue;
+      }
+      const ownerExpanded = expandedOf(owner.id);
+      rows.push({
+        node: owner,
+        depth: ownerDepth,
+        hasChildren: true,
+        expanded: ownerExpanded,
+      });
+      if (!ownerExpanded) continue;
+      for (const leaf of owner.children) {
+        rows.push({
+          node: leaf,
+          depth: ownerDepth + 1,
+          hasChildren: false,
+          expanded: false,
+        });
+      }
+    }
+  }
+  return rows;
+}

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -1,0 +1,95 @@
+export interface RepoTreeOption {
+  value: string; // `${platformHost}/${repoPath}`
+  owner: string;
+  name: string;
+  provider: string; // canonical, lowercase
+  platformHost: string;
+}
+
+export interface RepoLeaf {
+  kind: "repo";
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface OwnerNode {
+  kind: "owner";
+  id: string;
+  label: string;
+  children: RepoLeaf[];
+}
+
+export interface HostNode {
+  kind: "host";
+  id: string;
+  label: string;
+  provider: string;
+  platformHost: string;
+  children: OwnerNode[];
+}
+
+export type RepoTreeNodeData = HostNode | OwnerNode | RepoLeaf;
+
+function stripHostPrefix(value: string, platformHost: string): string {
+  const prefix = `${platformHost}/`;
+  if (value.startsWith(prefix)) return value.slice(prefix.length);
+  // Defensive fallback: drop everything up to and including the first slash.
+  return value.replace(/^[^/]+\//, "");
+}
+
+export function buildRepoTree(
+  options: readonly RepoTreeOption[],
+): HostNode[] {
+  const hosts = new Map<string, HostNode>();
+
+  for (const option of options) {
+    const repoPath = stripHostPrefix(option.value, option.platformHost);
+    const segments = repoPath.split("/");
+    const name = segments[segments.length - 1] ?? repoPath;
+    const ownerPath = segments.slice(0, -1).join("/");
+    if (ownerPath === "") continue; // malformed value with no owner segment
+
+    let host = hosts.get(option.platformHost);
+    if (!host) {
+      host = {
+        kind: "host",
+        id: option.platformHost,
+        label: option.platformHost,
+        provider: option.provider,
+        platformHost: option.platformHost,
+        children: [],
+      };
+      hosts.set(option.platformHost, host);
+    }
+
+    let owner = host.children.find((node) => node.label === ownerPath);
+    if (!owner) {
+      owner = {
+        kind: "owner",
+        id: `${option.platformHost}/${ownerPath}`,
+        label: ownerPath,
+        children: [],
+      };
+      host.children.push(owner);
+    }
+
+    owner.children.push({
+      kind: "repo",
+      id: option.value,
+      label: name,
+      value: option.value,
+    });
+  }
+
+  const sorted = [...hosts.values()].sort((a, b) =>
+    a.label.localeCompare(b.label),
+  );
+  for (const host of sorted) {
+    host.children.sort((a, b) => a.label.localeCompare(b.label));
+    for (const owner of host.children) {
+      owner.children.sort((a, b) => a.label.localeCompare(b.label));
+    }
+  }
+  return sorted;
+}

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -115,6 +115,16 @@ export function visibleRows(
   const matches = (leaf: RepoLeaf) =>
     !filtering || leaf.value.toLowerCase().includes(q);
 
+  // Single-repo-owner flattening keys on the owner's TRUE repo count, captured
+  // before filtering prunes children. Otherwise an owner with several repos but
+  // only one match would collapse into a lone leaf and lose its owner context.
+  const originalChildCount = new Map<string, number>();
+  for (const host of tree) {
+    for (const owner of host.children) {
+      originalChildCount.set(owner.id, owner.children.length);
+    }
+  }
+
   // Prune to owners/hosts that still have a matching leaf.
   const pruned = tree
     .map((host) => ({
@@ -140,7 +150,11 @@ export function visibleRows(
       if (!hostExpanded) continue;
     }
     for (const owner of host.children) {
-      if (owner.children.length === 1) {
+      // Flatten only owners that genuinely have a single repo, not owners
+      // narrowed to one match by the active filter.
+      const isSingleRepoOwner =
+        (originalChildCount.get(owner.id) ?? owner.children.length) === 1;
+      if (isSingleRepoOwner) {
         rows.push({
           node: owner.children[0]!,
           depth: ownerDepth,

--- a/frontend/src/lib/stores/repoTreeExpansion.svelte.ts
+++ b/frontend/src/lib/stores/repoTreeExpansion.svelte.ts
@@ -1,0 +1,44 @@
+const STORAGE_KEY = "middleman:repoTreeCollapsed";
+
+function readFromStorage(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is string => typeof v === "string"));
+  } catch {
+    // localStorage unavailable or corrupt JSON.
+    return new Set();
+  }
+}
+
+function writeToStorage(value: Set<string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...value]));
+  } catch {
+    // localStorage unavailable (e.g. private browsing quota).
+  }
+}
+
+export function createRepoTreeExpansionStore() {
+  let collapsed = $state<Set<string>>(readFromStorage());
+
+  function isCollapsed(id: string): boolean {
+    return collapsed.has(id);
+  }
+
+  function toggle(id: string): void {
+    const next = new Set(collapsed);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    collapsed = next;
+    writeToStorage(next);
+  }
+
+  return { isCollapsed, toggle };
+}
+
+export type RepoTreeExpansionStore = ReturnType<
+  typeof createRepoTreeExpansionStore
+>;

--- a/frontend/src/lib/stores/repoTreeExpansion.test.ts
+++ b/frontend/src/lib/stores/repoTreeExpansion.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createRepoTreeExpansionStore } from "./repoTreeExpansion.svelte.js";
+
+const KEY = "middleman:repoTreeCollapsed";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createRepoTreeExpansionStore", () => {
+  it("reports every node expanded on a fresh store", () => {
+    const store = createRepoTreeExpansionStore();
+    expect(store.isCollapsed("github.com/acme")).toBe(false);
+  });
+
+  it("flips collapsed state on each toggle", () => {
+    const store = createRepoTreeExpansionStore();
+    store.toggle("github.com/acme");
+    expect(store.isCollapsed("github.com/acme")).toBe(true);
+    store.toggle("github.com/acme");
+    expect(store.isCollapsed("github.com/acme")).toBe(false);
+  });
+
+  it("persists collapsed ids to localStorage", () => {
+    const store = createRepoTreeExpansionStore();
+    store.toggle("github.com/acme");
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(["github.com/acme"]);
+  });
+
+  it("reads pre-seeded collapsed ids", () => {
+    localStorage.setItem(KEY, JSON.stringify(["github.com/acme"]));
+    const store = createRepoTreeExpansionStore();
+    expect(store.isCollapsed("github.com/acme")).toBe(true);
+  });
+
+  it("falls back to expanded on malformed JSON", () => {
+    localStorage.setItem(KEY, "{not json");
+    const store = createRepoTreeExpansionStore();
+    expect(store.isCollapsed("github.com/acme")).toBe(false);
+  });
+
+  it("falls back to expanded on non-array JSON", () => {
+    localStorage.setItem(KEY, JSON.stringify({ bad: "shape" }));
+    const store = createRepoTreeExpansionStore();
+    expect(store.isCollapsed("github.com/acme")).toBe(false);
+  });
+
+  it("keeps working in memory when setItem throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+    const store = createRepoTreeExpansionStore();
+    expect(() => store.toggle("github.com/acme")).not.toThrow();
+    expect(store.isCollapsed("github.com/acme")).toBe(true);
+    spy.mockRestore();
+  });
+});

--- a/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
+++ b/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
@@ -42,6 +42,39 @@ test("repository selector filters dashboard lists by multiple selected repos", a
   ).resolves.toBe("github.com/acme/widgets,github.com/acme/tools");
 });
 
+test("keyboard navigation survives a real checkbox click", async ({ page }) => {
+  // A real click (not just mousedown) on a row checkbox must not steal focus
+  // from the filter input. The checkbox is a focusable native input and its
+  // mousedown stops propagation (skipping the list's preventBlur), so without
+  // preventDefault the click would blur the input and kill keyboard handling,
+  // which is bound only to that input.
+  await page.goto("/issues");
+  await waitForIssueList(page);
+
+  const selector = page.getByTitle("Select repository");
+  await selector.click();
+
+  const input = page.getByPlaceholder("Filter repos...");
+  await expect(input).toBeFocused();
+
+  // Real click on a leaf repo's checkbox.
+  await page
+    .getByRole("option", { name: "github.com/acme/widgets", exact: true })
+    .locator("input[type='checkbox']")
+    .click();
+  await expect(
+    page
+      .getByRole("option", { name: "github.com/acme/widgets", exact: true })
+      .locator("input[type='checkbox']"),
+  ).toBeChecked();
+
+  // Focus must still be on the input, and keyboard handling must still work:
+  // Escape closes the dropdown.
+  await expect(input).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".typeahead-list")).toHaveCount(0);
+});
+
 test("repository selector cascades an owner group to all its repos", async ({ page }) => {
   await page.goto("/issues");
   await waitForIssueList(page);

--- a/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
+++ b/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
@@ -75,6 +75,25 @@ test("keyboard navigation survives a real checkbox click", async ({ page }) => {
   await expect(page.locator(".typeahead-list")).toHaveCount(0);
 });
 
+test("flattened single-repo owner shows the owner/repo path, not a bare repo name", async ({ page }) => {
+  // gitlab.example.com/group has one repo "project", so it auto-flattens to a
+  // single row. That row must read "group/project" (visible text) to stay
+  // distinguishable from a same-named repo under another owner, while its
+  // accessible name remains the full path.
+  await page.goto("/issues");
+  await waitForIssueList(page);
+
+  await page.getByTitle("Select repository").click();
+
+  const row = page.getByRole("option", {
+    name: "gitlab.example.com/group/project",
+    exact: true,
+  });
+  await expect(row).toBeVisible();
+  // visible label is "group/project", not the bare "project"
+  await expect(row.locator(".repo-tree-label")).toHaveText("group/project");
+});
+
 test("repository selector cascades an owner group to all its repos", async ({ page }) => {
   await page.goto("/issues");
   await waitForIssueList(page);

--- a/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
+++ b/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
@@ -41,3 +41,38 @@ test("repository selector filters dashboard lists by multiple selected repos", a
     page.evaluate(() => localStorage.getItem("middleman-filter-repo")),
   ).resolves.toBe("github.com/acme/widgets,github.com/acme/tools");
 });
+
+test("repository selector cascades an owner group to all its repos", async ({ page }) => {
+  await page.goto("/issues");
+  await waitForIssueList(page);
+
+  const selector = page.getByTitle("Select repository");
+  await selector.click();
+
+  // The owner row's checkbox cascades selection to every repo under that
+  // owner. The row body would only toggle expand/collapse, so the checkbox
+  // is the deliberate target. Selection is wired to mousedown (see
+  // RepoTreeNode.checkboxMouseDown), so dispatch that event directly rather
+  // than a click, mirroring the component test's fireEvent.mouseDown.
+  const ownerCheckbox = page
+    .getByRole("option", { name: "github.com/acme", exact: true })
+    .locator("input[type='checkbox']");
+  await expect(ownerCheckbox).toBeVisible();
+  await ownerCheckbox.dispatchEvent("mousedown");
+  await expect(ownerCheckbox).toBeChecked();
+
+  await page.keyboard.press("Escape");
+
+  const stored = await page.evaluate(() =>
+    localStorage.getItem("middleman-filter-repo"),
+  );
+  expect(stored).toContain("github.com/acme/widgets");
+  expect(stored).toContain("github.com/acme/tools");
+  expect(stored).toContain("github.com/acme/archived");
+
+  // The group selection keeps acme's issues visible and excludes repos
+  // outside the group, such as the GitLab read-only fixture.
+  await expect(page.getByText("Widget rendering broken on Safari")).toBeVisible();
+  await expect(page.getByText("Support config file loading")).toBeVisible();
+  await expect(page.getByText("GitLab read-only issue")).toHaveCount(0);
+});

--- a/packages/ui/src/components/keyboard/useKbdLabel.test.ts
+++ b/packages/ui/src/components/keyboard/useKbdLabel.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { kbdAriaLabel, kbdGlyph } from "./useKbdLabel.js";
+
+describe("kbdGlyph", () => {
+  it("renders the space key as 'Space'", () => {
+    expect(kbdGlyph({ key: " " })).toBe("Space");
+  });
+
+  it("uppercases a single character key", () => {
+    expect(kbdGlyph({ key: "a" })).toBe("A");
+  });
+
+  it("passes a named key through unchanged", () => {
+    expect(kbdGlyph({ key: "ArrowRight" })).toBe("ArrowRight");
+  });
+});
+
+describe("kbdAriaLabel", () => {
+  it("labels the space key as 'Space'", () => {
+    expect(kbdAriaLabel({ key: " " })).toBe("Space");
+  });
+
+  it("labels a plain key by its key name", () => {
+    expect(kbdAriaLabel({ key: "ArrowRight" })).toBe("ArrowRight");
+  });
+});

--- a/packages/ui/src/components/keyboard/useKbdLabel.ts
+++ b/packages/ui/src/components/keyboard/useKbdLabel.ts
@@ -13,7 +13,8 @@ export function kbdGlyph(spec: KeySpec): string {
   if (spec.ctrlOrMeta) parts.push(isMac ? "⌘" : "Ctrl");
   if (spec.shift) parts.push(isMac ? "⇧" : "Shift");
   if (spec.alt) parts.push(isMac ? "⌥" : "Alt");
-  parts.push(spec.key.length === 1 ? spec.key.toUpperCase() : spec.key);
+  if (spec.key === " ") parts.push("Space");
+  else parts.push(spec.key.length === 1 ? spec.key.toUpperCase() : spec.key);
   return parts.join(isMac ? "" : "+");
 }
 
@@ -23,6 +24,6 @@ export function kbdAriaLabel(spec: KeySpec): string {
   if (spec.ctrlOrMeta) parts.push(isMac ? "Command" : "Control");
   if (spec.shift) parts.push("Shift");
   if (spec.alt) parts.push(isMac ? "Option" : "Alt");
-  parts.push(spec.key);
+  parts.push(spec.key === " " ? "Space" : spec.key);
   return parts.join("-");
 }


### PR DESCRIPTION
Replaces the flat repo dropdown in the header with a collapsible `host → owner → repo` tree.

- Group repositories by host and owner; expand/collapse a group by clicking its name.
- Tri-state checkbox on every row: selecting an owner or host selects all repos beneath it, with a partial (dash) state when only some are selected.
- GitLab nested groups fold into a single owner node; single-host and single-repo-owner levels auto-flatten so small setups stay shallow.
- Filtering prunes non-matching repos, auto-expands groups with matches, and highlights the match.
- Full keyboard navigation (arrows to move, left/right to expand/collapse, space to select) and persisted collapse state.
- Selection still drives the existing global repo filter unchanged; no API, storage-format, or downstream list changes.

The tri-state checkbox is a controlled custom control (`TreeCheckbox`) rather than a native input, so a real click can't desync it from the selection state.

![repo tree with tri-state checkboxes — partial selection](https://github.com/user-attachments/assets/8495a11c-77ea-41ff-b1f1-362e767a303e)

![selecting an owner cascades to all its repos](https://github.com/user-attachments/assets/032718fd-59a8-4441-afd6-2f984c4b9220)