### PR TITLE
Add opt-in PR split view

### DIFF
--- a/frontend/tests/e2e/pr-split-view.spec.ts
+++ b/frontend/tests/e2e/pr-split-view.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+const capabilities = {
+  read_repositories: true,
+  read_merge_requests: true,
+  read_issues: true,
+  read_comments: true,
+  read_releases: true,
+  read_ci: true,
+  read_labels: true,
+  comment_mutation: true,
+  thread_reply: false,
+  thread_resolve: false,
+  label_mutation: true,
+  state_mutation: true,
+  merge_mutation: true,
+  review_mutation: true,
+  workflow_approval: true,
+  ready_for_review: true,
+  issue_mutation: true,
+  review_draft_mutation: false,
+  review_thread_resolution: false,
+  read_review_threads: false,
+  native_multiline_ranges: false,
+  supported_review_actions: [],
+};
+
+const diffResponse = {
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "src/split-view.ts",
+      old_path: "src/split-view.ts",
+      status: "modified",
+      is_binary: false,
+      is_generated: false,
+      is_whitespace_only: false,
+      additions: 1,
+      deletions: 1,
+      patch: "@@ -1,1 +1,1 @@\n-old\n+new\n",
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 1,
+          new_start: 1,
+          new_count: 1,
+          lines: [
+            { type: "removed", content: "old", old_num: 1 },
+            { type: "added", content: "new", new_num: 1 },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+async function fulfillJson(route: Route, body: unknown): Promise<void> {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockSplitViewPR(page: Page): Promise<void> {
+  const detailPath = "**/api/v1/pulls/github/acme/widgets/42";
+
+  await page.route(detailPath, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, {
+      detail_loaded: true,
+      detail_fetched_at: "2026-03-30T14:00:00Z",
+      diff_head_sha: "head",
+      platform_host: "github.com",
+      repo_owner: "acme",
+      repo_name: "widgets",
+      warnings: [],
+      workflow_approval: {
+        count: 0,
+        required: false,
+        runs: [],
+      },
+      workspace: undefined,
+      worktree_links: [],
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        capabilities,
+      },
+      merge_request: {
+        ID: 1,
+        RepoID: 1,
+        PlatformID: 101,
+        PlatformExternalID: "PR_42",
+        Number: 42,
+        URL: "https://github.com/acme/widgets/pull/42",
+        Title: "Add browser regression coverage",
+        Author: "marius",
+        AuthorDisplayName: "Marius",
+        State: "open",
+        IsDraft: false,
+        IsLocked: false,
+        Body: "Adds Playwright smoke tests for workspace panel.",
+        HeadBranch: "feature/playwright",
+        BaseBranch: "main",
+        HeadRepoCloneURL: "https://github.com/acme/widgets.git",
+        Additions: 120,
+        Deletions: 12,
+        CommentCount: 3,
+        ReviewDecision: "APPROVED",
+        CIStatus: "success",
+        CIChecksJSON: "[]",
+        CIHadPending: false,
+        CreatedAt: "2026-03-29T14:00:00Z",
+        UpdatedAt: "2026-03-30T14:00:00Z",
+        LastActivityAt: "2026-03-30T14:00:00Z",
+        MergedAt: null,
+        ClosedAt: null,
+        MergeableState: "clean",
+        DetailFetchedAt: "2026-03-30T14:00:00Z",
+        KanbanStatus: "reviewing",
+        Starred: false,
+        labels: [],
+      },
+      events: [],
+    });
+  });
+
+  await page.route(`${detailPath}/files`, async (route) => {
+    await fulfillJson(route, diffResponse);
+  });
+  await page.route(`${detailPath}/diff**`, async (route) => {
+    await fulfillJson(route, diffResponse);
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+  await mockSplitViewPR(page);
+});
+
+test("lets wide PR detail panes opt into split conversation and files", async ({ page }) => {
+  await page.setViewportSize({ width: 2200, height: 1000 });
+  await page.goto("/pulls/github/acme/widgets/42");
+
+  await expect(page.locator(".detail-title")).toContainText(
+    "Add browser regression coverage",
+  );
+  await expect(page.locator(".detail-split-layout")).toHaveCount(0);
+
+  const splitToggle = page.getByRole("button", { name: "Split view" });
+  await expect(splitToggle).toBeVisible();
+  await expect(splitToggle).toHaveAttribute("aria-pressed", "false");
+
+  await splitToggle.click();
+
+  await expect(splitToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator(".detail-split-layout")).toBeVisible();
+  await expect(page.locator(".detail-title")).toContainText(
+    "Add browser regression coverage",
+  );
+  await expect(page.locator(".files-view")).toBeVisible();
+  await expect(page.getByText("src/split-view.ts")).toBeVisible();
+});

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -30,6 +30,9 @@
   const { isSidebarToggleEnabled, toggleSidebar } = getSidebar();
   const navigate = getNavigate();
   const { detail: detailStore } = getStores();
+  const splitViewStorageKey = "pr-detail-split-view";
+  const regularConversationPanelWidth = 800 + 24 + 24;
+  const minSplitViewWidth = regularConversationPanelWidth * 2;
 
   const defaultProviderCapabilities: ProviderCapabilities = {
     read_repositories: true,
@@ -85,6 +88,38 @@
     onDetailTabChange,
     onStackMemberNavigate,
   }: Props = $props();
+
+  let detailHost: HTMLDivElement | undefined = $state();
+  let detailHostWidth = $state(0);
+  let splitViewEnabled = $state(loadSplitViewPreference());
+
+  const splitViewAvailable = $derived(selectedPR !== null && detailHostWidth >= minSplitViewWidth);
+  const splitViewActive = $derived(splitViewAvailable && splitViewEnabled);
+
+  function safeGetItem(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  function safeSetItem(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function loadSplitViewPreference(): boolean {
+    return safeGetItem(splitViewStorageKey) === "1";
+  }
+
+  function setSplitViewEnabled(enabled: boolean): void {
+    splitViewEnabled = enabled;
+    safeSetItem(splitViewStorageKey, enabled ? "1" : "0");
+  }
 
   function filesScrollKey(): string | null {
     if (selectedPR === null) return null;
@@ -146,7 +181,7 @@
   });
 
   $effect(() => {
-    if (selectedPR === null || detailTab !== "files") return;
+    if (selectedPR === null || (!splitViewActive && detailTab !== "files")) return;
     const ref = selectedPR;
     untrack(() => {
       if (detailMatchesSelected(detailStore.getDetail(), ref)) return;
@@ -162,6 +197,28 @@
         },
       );
     });
+  });
+
+  $effect(() => {
+    const host = detailHost;
+    if (!host) {
+      detailHostWidth = 0;
+      return;
+    }
+
+    detailHostWidth = Math.round(host.getBoundingClientRect().width);
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver((entries) => {
+      detailHostWidth = Math.round(
+        entries[0]?.contentRect.width ?? host.getBoundingClientRect().width,
+      );
+    });
+    observer.observe(host);
+
+    return () => {
+      observer.disconnect();
+    };
   });
 </script>
 
@@ -183,53 +240,102 @@
   {/snippet}
 
   {#if selectedPR !== null}
-    <div class="detail-tabs">
-      <button
-        class="detail-tab"
-        class:detail-tab--active={detailTab === "conversation"}
-        onclick={() => selectDetailTab("conversation")}
-      >
-        Conversation
-      </button>
-      <button
-        class="detail-tab"
-        class:detail-tab--active={detailTab === "files"}
-        onclick={() => selectDetailTab("files")}
-      >
-        Files changed
-      </button>
-    </div>
-    {#if detailTab === "files"}
-      {#key `${selectedPR.provider}/${selectedPR.platformHost ?? ""}/${selectedPR.repoPath}/${selectedPR.number}`}
-        <DiffFilesLayout
+    <div class="detail-host" bind:this={detailHost}>
+      <div class="detail-tabs">
+        <button
+          class="detail-tab"
+          class:detail-tab--active={detailTab === "conversation"}
+          onclick={() => selectDetailTab("conversation")}
+        >
+          Conversation
+        </button>
+        <button
+          class="detail-tab"
+          class:detail-tab--active={detailTab === "files"}
+          onclick={() => selectDetailTab("files")}
+        >
+          Files changed
+        </button>
+        {#if splitViewAvailable}
+          <button
+            type="button"
+            class="detail-split-toggle"
+            class:detail-split-toggle--active={splitViewActive}
+            aria-pressed={splitViewActive}
+            onclick={() => setSplitViewEnabled(!splitViewEnabled)}
+          >
+            Split view
+          </button>
+        {/if}
+      </div>
+
+      {#if splitViewActive}
+        <div class="detail-split-layout">
+          <section class="detail-split-pane" aria-label="Conversation">
+            <PullDetail
+              owner={selectedPR.owner}
+              name={selectedPR.name}
+              number={selectedPR.number}
+              provider={selectedPR.provider}
+              platformHost={selectedPR.platformHost}
+              repoPath={selectedPR.repoPath}
+              autoSync={autoSyncDetail}
+              {workflowApprovalSync}
+              hideTabs={true}
+              hideStaleWhileLoading={hideStaleDetailWhileLoading}
+              onStackMemberNavigate={handleStackMemberNavigate}
+            />
+          </section>
+          <section class="detail-split-pane detail-split-pane--files" aria-label="Files changed">
+            {#key `${selectedPR.provider}/${selectedPR.platformHost ?? ""}/${selectedPR.repoPath}/${selectedPR.number}`}
+              <DiffFilesLayout
+                owner={selectedPR.owner}
+                name={selectedPR.name}
+                number={selectedPR.number}
+                provider={selectedPR.provider}
+                platformHost={selectedPR.platformHost}
+                repoPath={selectedPR.repoPath}
+                diffHeadSHA={selectedDetail?.diff_head_sha}
+                capabilities={selectedDetail?.repo?.capabilities ?? defaultProviderCapabilities}
+                reviewThreads={reviewThreadsFromEvents(selectedDetail?.events)}
+                initialScrollTop={filesScrollTop()}
+                onScrollTopChange={rememberFilesScroll}
+              />
+            {/key}
+          </section>
+        </div>
+      {:else if detailTab === "files"}
+        {#key `${selectedPR.provider}/${selectedPR.platformHost ?? ""}/${selectedPR.repoPath}/${selectedPR.number}`}
+          <DiffFilesLayout
+            owner={selectedPR.owner}
+            name={selectedPR.name}
+            number={selectedPR.number}
+            provider={selectedPR.provider}
+            platformHost={selectedPR.platformHost}
+            repoPath={selectedPR.repoPath}
+            diffHeadSHA={selectedDetail?.diff_head_sha}
+            capabilities={selectedDetail?.repo?.capabilities ?? defaultProviderCapabilities}
+            reviewThreads={reviewThreadsFromEvents(selectedDetail?.events)}
+            initialScrollTop={filesScrollTop()}
+            onScrollTopChange={rememberFilesScroll}
+          />
+        {/key}
+      {:else}
+        <PullDetail
           owner={selectedPR.owner}
           name={selectedPR.name}
           number={selectedPR.number}
           provider={selectedPR.provider}
           platformHost={selectedPR.platformHost}
           repoPath={selectedPR.repoPath}
-          diffHeadSHA={selectedDetail?.diff_head_sha}
-          capabilities={selectedDetail?.repo?.capabilities ?? defaultProviderCapabilities}
-          reviewThreads={reviewThreadsFromEvents(selectedDetail?.events)}
-          initialScrollTop={filesScrollTop()}
-          onScrollTopChange={rememberFilesScroll}
+          autoSync={autoSyncDetail}
+          {workflowApprovalSync}
+          hideTabs={true}
+          hideStaleWhileLoading={hideStaleDetailWhileLoading}
+          onStackMemberNavigate={handleStackMemberNavigate}
         />
-      {/key}
-    {:else}
-      <PullDetail
-        owner={selectedPR.owner}
-        name={selectedPR.name}
-        number={selectedPR.number}
-        provider={selectedPR.provider}
-        platformHost={selectedPR.platformHost}
-        repoPath={selectedPR.repoPath}
-        autoSync={autoSyncDetail}
-        {workflowApprovalSync}
-        hideTabs={true}
-        hideStaleWhileLoading={hideStaleDetailWhileLoading}
-        onStackMemberNavigate={handleStackMemberNavigate}
-      />
-    {/if}
+      {/if}
+    </div>
   {:else}
     <div class="placeholder-content">
       <p class="placeholder-text">Select a PR</p>
@@ -241,8 +347,18 @@
 </CollapsibleResizableSidebar>
 
 <style>
+  .detail-host {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
   .detail-tabs {
     display: flex;
+    align-items: center;
     gap: 0;
     border-bottom: 1px solid var(--border-default);
     background: var(--bg-surface);
@@ -282,5 +398,58 @@
   .detail-tab--active {
     color: var(--text-primary);
     border-bottom-color: var(--accent-blue);
+  }
+
+  .detail-split-toggle {
+    margin-left: auto;
+    margin-right: 8px;
+    min-height: 28px;
+    padding: 4px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    background: var(--bg-primary);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    transition:
+      color 0.1s,
+      border-color 0.1s,
+      background 0.1s;
+  }
+
+  .detail-split-toggle:hover {
+    color: var(--text-primary);
+    border-color: var(--border-strong, var(--border-default));
+    background: var(--bg-surface-hover);
+  }
+
+  .detail-split-toggle--active {
+    color: var(--accent-blue);
+    border-color: var(--accent-blue);
+    background: var(--accent-blue-soft, var(--bg-primary));
+  }
+
+  .detail-split-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .detail-split-pane {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .detail-split-pane--files {
+    border-left: 1px solid var(--border-default);
+  }
+
+  .detail-split-pane :global(.pull-detail-content) {
+    max-width: 800px;
   }
 </style>

--- a/packages/ui/src/views/PRListView.test.ts
+++ b/packages/ui/src/views/PRListView.test.ts
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NAVIGATE_KEY, SIDEBAR_KEY, STORES_KEY } from "../context.js";
+import type { PullRequestRouteRef } from "../routes.js";
+
+const observedWidth = vi.hoisted(() => ({ value: 0 }));
+
+vi.mock("../components/sidebar/PullList.svelte", async () => ({
+  default: (await import("./PRListViewTestPullList.svelte")).default,
+}));
+
+vi.mock("../components/detail/PullDetail.svelte", async () => ({
+  default: (await import("./PRListViewTestPullDetail.svelte")).default,
+}));
+
+vi.mock("../components/diff/DiffFilesLayout.svelte", async () => ({
+  default: (await import("./PRListViewTestDiffFilesLayout.svelte")).default,
+}));
+
+import PRListView from "./PRListView.svelte";
+
+const minSplitViewWidth = (800 + 24 + 24) * 2;
+
+const selectedPR: PullRequestRouteRef = {
+  provider: "github",
+  platformHost: "github.com",
+  owner: "acme",
+  name: "widgets",
+  repoPath: "acme/widgets",
+  number: 12,
+};
+
+class ResizeObserverMock {
+  constructor(private callback: ResizeObserverCallback) {}
+
+  observe(): void {
+    this.callback(
+      [{ contentRect: { width: observedWidth.value } } as ResizeObserverEntry],
+      this as unknown as ResizeObserver,
+    );
+  }
+
+  disconnect(): void {}
+}
+
+function renderPRListView(detailTab: "conversation" | "files" = "conversation") {
+  const detailStore = {
+    getDetail: () => null,
+    loadDetail: vi.fn(async () => undefined),
+  };
+
+  return {
+    detailStore,
+    ...render(PRListView, {
+      props: {
+        selectedPR,
+        detailTab,
+        hideSidebar: true,
+      },
+      context: new Map<symbol, unknown>([
+        [
+          SIDEBAR_KEY,
+          {
+            isSidebarToggleEnabled: () => false,
+            toggleSidebar: vi.fn(),
+          },
+        ],
+        [NAVIGATE_KEY, vi.fn()],
+        [STORES_KEY, { detail: detailStore }],
+      ]),
+    }),
+  };
+}
+
+describe("PRListView split view", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    observedWidth.value = minSplitViewWidth;
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not expose split view below twice the regular conversation width", async () => {
+    observedWidth.value = minSplitViewWidth - 1;
+
+    renderPRListView();
+    await tick();
+
+    expect(screen.queryByRole("button", { name: "Split view" })).toBeNull();
+    expect(screen.getByTestId("pull-detail").textContent).toContain("Conversation acme/widgets#12");
+    expect(screen.queryByTestId("diff-files")).toBeNull();
+  });
+
+  it("keeps wide split view off until the user enables it", async () => {
+    renderPRListView();
+    await tick();
+
+    const toggle = screen.getByRole("button", { name: "Split view" });
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    expect(screen.getByTestId("pull-detail")).toBeTruthy();
+    expect(screen.queryByTestId("diff-files")).toBeNull();
+
+    await fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByTestId("pull-detail")).toBeTruthy();
+    expect(screen.getByTestId("diff-files")).toBeTruthy();
+    expect(localStorage.getItem("pr-detail-split-view")).toBe("1");
+  });
+});

--- a/packages/ui/src/views/PRListViewTestDiffFilesLayout.svelte
+++ b/packages/ui/src/views/PRListViewTestDiffFilesLayout.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  interface Props {
+    owner: string;
+    name: string;
+    number: number;
+  }
+
+  const { owner, name, number }: Props = $props();
+</script>
+
+<div data-testid="diff-files">Files changed {owner}/{name}#{number}</div>

--- a/packages/ui/src/views/PRListViewTestPullDetail.svelte
+++ b/packages/ui/src/views/PRListViewTestPullDetail.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  interface Props {
+    owner: string;
+    name: string;
+    number: number;
+  }
+
+  const { owner, name, number }: Props = $props();
+</script>
+
+<div data-testid="pull-detail">Conversation {owner}/{name}#{number}</div>

--- a/packages/ui/src/views/PRListViewTestPullList.svelte
+++ b/packages/ui/src/views/PRListViewTestPullList.svelte
@@ -1,0 +1,1 @@
+<div data-testid="pull-list">Pull list</div>


### PR DESCRIPTION
- Add a Split view toggle for pull requests on sufficiently wide displays.
- Keep the existing conversation/files tab flow as the default and persist the split preference.
- Add component and browser coverage for the width gate and opt-in behavior.