### PR TITLE
Show workspace indicators in item lists

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -112,6 +112,8 @@ components:
           type: string
         repo_owner:
           type: string
+        workspace:
+          $ref: "#/components/schemas/WorkspaceRef"
       required:
         - id
         - cursor
@@ -1280,6 +1282,8 @@ components:
           type: string
         repo_owner:
           type: string
+        workspace:
+          $ref: "#/components/schemas/WorkspaceRef"
       required:
         - repo
         - platform_host
@@ -1915,6 +1919,8 @@ components:
           type: string
         repo_owner:
           type: string
+        workspace:
+          $ref: "#/components/schemas/WorkspaceRef"
         worktree_links:
           items:
             $ref: "#/components/schemas/WorktreeLinkResponse"

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -365,6 +365,7 @@ type ActivityItemResponse struct {
 	Repo           RepoRefResponse `json:"repo"`
 	RepoName       string          `json:"repo_name"`
 	RepoOwner      string          `json:"repo_owner"`
+	Workspace      *WorkspaceRef   `json:"workspace,omitempty"`
 }
 
 // ActivityResponse defines model for ActivityResponse.
@@ -847,6 +848,7 @@ type IssueResponse struct {
 	Repo               RepoRefResponse `json:"repo"`
 	RepoName           string          `json:"repo_name"`
 	RepoOwner          string          `json:"repo_owner"`
+	Workspace          *WorkspaceRef   `json:"workspace,omitempty"`
 }
 
 // ItemLabelsResponse defines model for ItemLabelsResponse.
@@ -1072,6 +1074,7 @@ type MergeRequestResponse struct {
 	Repo               RepoRefResponse                  `json:"repo"`
 	RepoName           string                           `json:"repo_name"`
 	RepoOwner          string                           `json:"repo_owner"`
+	Workspace          *WorkspaceRef                    `json:"workspace,omitempty"`
 	WorktreeLinks      *[]WorktreeLinkResponse          `json:"worktree_links"`
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1316,6 +1316,62 @@ func TestAPIListPulls(t *testing.T) {
 	assert.Equal("acme/widget", body[0].Repo.RepoPath)
 }
 
+func TestAPIListItemsIncludeWorkspaceRefs(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+
+	seedPR(t, database, "acme", "widget", 1)
+	seedIssue(t, database, "acme", "widget", 2, "open")
+	seedWorkspace(
+		t, database, "ws-pr-1", "acme", "widget",
+		db.WorkspaceItemTypePullRequest, 1,
+	)
+	seedWorkspace(
+		t, database, "ws-issue-2", "acme", "widget",
+		db.WorkspaceItemTypeIssue, 2,
+	)
+	client := setupTestClient(t, srv)
+
+	pulls, err := client.HTTP.ListPullsWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pulls.StatusCode())
+	require.NotNil(pulls.JSON200)
+	require.Len(*pulls.JSON200, 1)
+	require.NotNil((*pulls.JSON200)[0].Workspace)
+	assert.Equal("ws-pr-1", (*pulls.JSON200)[0].Workspace.Id)
+	assert.Equal("ready", (*pulls.JSON200)[0].Workspace.Status)
+
+	issues, err := client.HTTP.ListIssuesWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, issues.StatusCode())
+	require.NotNil(issues.JSON200)
+	require.Len(*issues.JSON200, 1)
+	require.NotNil((*issues.JSON200)[0].Workspace)
+	assert.Equal("ws-issue-2", (*issues.JSON200)[0].Workspace.Id)
+	assert.Equal("ready", (*issues.JSON200)[0].Workspace.Status)
+
+	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
+	activity, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, activity.StatusCode())
+	require.NotNil(activity.JSON200)
+	require.NotNil(activity.JSON200.Items)
+
+	workspaceByItem := make(map[string]string)
+	for _, item := range *activity.JSON200.Items {
+		if item.Workspace == nil {
+			continue
+		}
+		workspaceByItem[item.ItemType+":"+strconv.FormatInt(item.ItemNumber, 10)] = item.Workspace.Id
+	}
+	assert.Equal("ws-pr-1", workspaceByItem["pr:1"])
+	assert.Equal("ws-issue-2", workspaceByItem["issue:2"])
+}
+
 func TestAPIListPullsKeepsCachedCIDecorationsAfterIndexSync(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -5516,6 +5572,29 @@ func seedIssue(t *testing.T, database *db.DB, owner, name string, number int, st
 	issueID, err := database.UpsertIssue(ctx, issue)
 	require.NoError(t, err)
 	return issueID
+}
+
+func seedWorkspace(
+	t *testing.T,
+	database *db.DB,
+	id, owner, name, itemType string,
+	number int,
+) {
+	t.Helper()
+	require.NoError(t, database.InsertWorkspace(t.Context(), &db.Workspace{
+		ID:              id,
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       owner,
+		RepoName:        name,
+		ItemType:        itemType,
+		ItemNumber:      number,
+		GitHeadRef:      "feature/" + id,
+		WorkspaceBranch: "middleman/" + id,
+		WorktreePath:    filepath.Join(t.TempDir(), id),
+		TmuxSession:     id,
+		Status:          "ready",
+	}))
 }
 
 func seedIssueWithLabels(t *testing.T, database *db.DB, owner, name string, number int, state string, labels []db.Label) int64 {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -71,6 +71,7 @@ type mergeRequestResponse struct {
 	RepoName        string                 `json:"repo_name"`
 	PlatformHost    string                 `json:"platform_host"`
 	WorktreeLinks   []worktreeLinkResponse `json:"worktree_links"`
+	Workspace       *workspaceRef          `json:"workspace,omitempty"`
 	DetailLoaded    bool                   `json:"detail_loaded"`
 	DetailFetchedAt string                 `json:"detail_fetched_at,omitempty"`
 }
@@ -131,6 +132,7 @@ type issueResponse struct {
 	PlatformHost    string          `json:"platform_host"`
 	RepoOwner       string          `json:"repo_owner"`
 	RepoName        string          `json:"repo_name"`
+	Workspace       *workspaceRef   `json:"workspace,omitempty"`
 	DetailLoaded    bool            `json:"detail_loaded"`
 	DetailFetchedAt string          `json:"detail_fetched_at,omitempty"`
 }
@@ -471,6 +473,7 @@ type activityItemResponse struct {
 	ItemTitle      string          `json:"item_title"`
 	ItemURL        string          `json:"item_url"`
 	ItemState      string          `json:"item_state"`
+	Workspace      *workspaceRef   `json:"workspace,omitempty"`
 	Author         string          `json:"author"`
 	ItemAuthor     string          `json:"item_author,omitempty"`
 	CreatedAt      string          `json:"created_at"`

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/platform"
 )
 
 type repoNumberPathRef struct {
@@ -35,6 +36,92 @@ func buildRepoLookup(repos []db.Repo) map[int64]db.Repo {
 		lookup[repo.ID] = repo
 	}
 	return lookup
+}
+
+func workspaceLookupKey(
+	provider, host, owner, name, itemType string,
+	number int,
+) string {
+	if provider == "" {
+		provider = string(platform.KindGitHub)
+	}
+	if host == "" {
+		if defaultHost, ok := platform.DefaultHost(platform.Kind(provider)); ok {
+			host = defaultHost
+		}
+	}
+	return strings.ToLower(provider) + "\x00" +
+		strings.ToLower(host) + "\x00" +
+		strings.ToLower(owner) + "\x00" +
+		strings.ToLower(name) + "\x00" +
+		itemType + "\x00" +
+		fmt.Sprint(number)
+}
+
+func (s *Server) buildWorkspaceRefLookup(
+	ctx context.Context,
+) (map[string]workspaceRef, error) {
+	workspaces, err := s.db.ListWorkspaces(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list workspaces: %w", err)
+	}
+	lookup := make(map[string]workspaceRef, len(workspaces))
+	for _, ws := range workspaces {
+		key := workspaceLookupKey(
+			ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+			ws.ItemType, ws.ItemNumber,
+		)
+		if _, exists := lookup[key]; exists {
+			continue
+		}
+		lookup[key] = workspaceRef{ID: ws.ID, Status: ws.Status}
+	}
+	return lookup, nil
+}
+
+func workspaceRefForRepoItem(
+	lookup map[string]workspaceRef,
+	repo db.Repo,
+	itemType string,
+	number int,
+) *workspaceRef {
+	ref, ok := lookup[workspaceLookupKey(
+		repo.Platform, repoProviderHost(repo), repo.Owner, repo.Name,
+		itemType, number,
+	)]
+	if !ok {
+		return nil
+	}
+	return &ref
+}
+
+func workspaceItemTypeFromActivity(itemType string) string {
+	switch itemType {
+	case "pr":
+		return db.WorkspaceItemTypePullRequest
+	case "issue":
+		return db.WorkspaceItemTypeIssue
+	default:
+		return ""
+	}
+}
+
+func workspaceRefForActivityItem(
+	lookup map[string]workspaceRef,
+	item db.ActivityItem,
+) *workspaceRef {
+	workspaceItemType := workspaceItemTypeFromActivity(item.ItemType)
+	if workspaceItemType == "" {
+		return nil
+	}
+	ref, ok := lookup[workspaceLookupKey(
+		item.Platform, item.PlatformHost, item.RepoOwner, item.RepoName,
+		workspaceItemType, item.ItemNumber,
+	)]
+	if !ok {
+		return nil
+	}
+	return &ref
 }
 
 // lookupRepoMap fetches repos and returns an ID-keyed map. When config is

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -996,6 +996,10 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 		return nil, problemInternal("load worktree links failed")
 	}
 	linksByMR := indexWorktreeLinksByMR(links)
+	workspacesByItem, err := s.buildWorkspaceRefLookup(ctx)
+	if err != nil {
+		return nil, problemInternal("load workspace refs failed")
+	}
 
 	out := make([]mergeRequestResponse, 0, len(mrs))
 	for _, mr := range mrs {
@@ -1014,6 +1018,7 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 			RepoName:      rp.Name,
 			PlatformHost:  rp.PlatformHost,
 			WorktreeLinks: wl,
+			Workspace:     workspaceRefForRepoItem(workspacesByItem, rp, db.WorkspaceItemTypePullRequest, mr.Number),
 			DetailLoaded:  mr.DetailFetchedAt != nil,
 		}
 		if mr.DetailFetchedAt != nil {
@@ -1825,6 +1830,10 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 	if err != nil {
 		return nil, problemInternal("repo lookup failed")
 	}
+	workspacesByItem, err := s.buildWorkspaceRefLookup(ctx)
+	if err != nil {
+		return nil, problemInternal("load workspace refs failed")
+	}
 
 	out := make([]issueResponse, 0, len(issues))
 	for _, issue := range issues {
@@ -1838,6 +1847,7 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 			PlatformHost: rp.PlatformHost,
 			RepoOwner:    rp.Owner,
 			RepoName:     rp.Name,
+			Workspace:    workspaceRefForRepoItem(workspacesByItem, rp, db.WorkspaceItemTypeIssue, issue.Number),
 			DetailLoaded: issue.DetailFetchedAt != nil,
 		}
 		if issue.DetailFetchedAt != nil {
@@ -3299,6 +3309,11 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 		items = items[:activitySafetyCap]
 	}
 
+	workspacesByItem, err := s.buildWorkspaceRefLookup(ctx)
+	if err != nil {
+		return nil, problemInternal("load workspace refs failed")
+	}
+
 	out := make([]activityItemResponse, len(items))
 	for i, it := range items {
 		item := activityItemResponse{
@@ -3316,6 +3331,7 @@ func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*l
 			ItemTitle:    it.ItemTitle,
 			ItemURL:      it.ItemURL,
 			ItemState:    it.ItemState,
+			Workspace:    workspaceRefForActivityItem(workspacesByItem, it),
 			Author:       it.Author,
 			ItemAuthor:   it.ItemAuthor,
 			CreatedAt:    formatUTCRFC3339(it.CreatedAt),

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2033,6 +2033,7 @@ export interface components {
             repo: components["schemas"]["RepoRefResponse"];
             repo_name: string;
             repo_owner: string;
+            workspace?: components["schemas"]["WorkspaceRef"];
         };
         ActivityResponse: {
             /**
@@ -2607,6 +2608,7 @@ export interface components {
             repo: components["schemas"]["RepoRefResponse"];
             repo_name: string;
             repo_owner: string;
+            workspace?: components["schemas"]["WorkspaceRef"];
         };
         ItemLabelsResponse: {
             /**
@@ -2873,6 +2875,7 @@ export interface components {
             repo: components["schemas"]["RepoRefResponse"];
             repo_name: string;
             repo_owner: string;
+            workspace?: components["schemas"]["WorkspaceRef"];
             worktree_links: components["schemas"]["WorktreeLinkResponse"][] | null;
         };
         MrImportMetadataResponse: {

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -25,6 +25,7 @@
   import Chip from "./shared/Chip.svelte";
   import ItemKindChip from "./shared/ItemKindChip.svelte";
   import ItemStateChip from "./shared/ItemStateChip.svelte";
+  import WorkspaceIndicator from "./shared/WorkspaceIndicator.svelte";
   import ArrowUpRightIcon from "@lucide/svelte/icons/arrow-up-right";
   import ChevronsDownUpIcon from "@lucide/svelte/icons/chevrons-down-up";
   import ChevronsUpDownIcon from "@lucide/svelte/icons/chevrons-up-down";
@@ -570,6 +571,12 @@
                   {:else}
                     <ItemKindChip kind={row.representative.item_type} />
                     <span class="item-number">#{row.representative.item_number}</span>
+                    {#if row.representative.workspace}
+                      <WorkspaceIndicator
+                        status={row.representative.workspace.status}
+                        size={12}
+                      />
+                    {/if}
                   {/if}
                   <span class="compact-time">{relativeTime(row.latest)}</span>
                 </span>
@@ -604,6 +611,9 @@
                   {:else}
                     <ItemKindChip kind={row.item_type} />
                     <span class="item-number">#{row.item_number}</span>
+                    {#if row.workspace}
+                      <WorkspaceIndicator status={row.workspace.status} size={12} />
+                    {/if}
                     {#if hasStateChip(row)}
                       <ItemStateChip state={row.item_state} />
                     {/if}
@@ -686,6 +696,12 @@
                     <span class="item-title">{row.count} commits</span>
                   {:else}
                     <span class="item-ref">#{row.representative.item_number}</span>
+                    {#if row.representative.workspace}
+                      <WorkspaceIndicator
+                        status={row.representative.workspace.status}
+                        size={12}
+                      />
+                    {/if}
                     <span class="item-title">{row.representative.item_title}</span>
                   {/if}
                 </span>
@@ -741,6 +757,9 @@
                       <ItemStateChip state={row.item_state} />
                     {/if}
                     <span class="item-ref">#{row.item_number}</span>
+                    {#if row.workspace}
+                      <WorkspaceIndicator status={row.workspace.status} size={12} />
+                    {/if}
                     <span class="item-title">{row.item_title}</span>
                   {/if}
                 </span>

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -247,6 +247,28 @@ describe("ActivityFeed compact mode", () => {
     expect(row?.querySelector(".state-badge")).not.toBeNull();
   });
 
+  it("shows workspace indicators in flat activity rows", () => {
+    items.value = [
+      activityItem("pr-workspace", {
+        workspace: { id: "ws-pr-1", status: "ready" },
+      }),
+      activityItem("issue-workspace", {
+        item_number: 2,
+        item_title: "Track workspace setup",
+        item_type: "issue",
+        item_url: "https://github.com/acme/widgets/issues/2",
+        workspace: { id: "ws-issue-2", status: "creating" },
+      }),
+    ];
+
+    render(ActivityFeed, {
+      props: { compact: false },
+    });
+
+    expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
+    expect(screen.getByLabelText("Workspace attached (creating)")).toBeTruthy();
+  });
+
   it("renders branch commits in compact rows without a fake item number", () => {
     items.value = [branchActivityItem("branch-commit")];
 

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -19,6 +19,7 @@
   import Chip from "./shared/Chip.svelte";
   import ItemKindChip from "./shared/ItemKindChip.svelte";
   import ItemStateChip from "./shared/ItemStateChip.svelte";
+  import WorkspaceIndicator from "./shared/WorkspaceIndicator.svelte";
 
   const { grouping, activity } = getStores();
   import { repoColor } from "../utils/repo-color.js";
@@ -78,6 +79,7 @@
     platformHost: string;
     latestTime: string;
     itemAuthor: string;
+    workspace: ActivityItem["workspace"];
     events: ActivityItem[];
     displayEvents: ReturnType<
       typeof collapseActivityRuns
@@ -172,6 +174,7 @@
           platformHost: first.repo.platform_host,
           latestTime: first.created_at,
           itemAuthor: itemAuthor(first),
+          workspace: first.workspace,
           events,
           displayEvents: collapseActivityRuns(events),
         },
@@ -622,6 +625,9 @@
               <ItemStateChip state="closed" />
             {/if}
             <span class="item-ref">#{itemGroup.itemNumber}</span>
+            {#if itemGroup.workspace}
+              <WorkspaceIndicator status={itemGroup.workspace.status} size={12} />
+            {/if}
             <span class="item-title">{itemGroup.itemTitle}</span>
           </span>
           <span class="cell cell--time">{relativeTime(itemGroup.latestTime)}</span>

--- a/packages/ui/src/components/ActivityThreaded.test.ts
+++ b/packages/ui/src/components/ActivityThreaded.test.ts
@@ -266,6 +266,21 @@ describe("ActivityThreaded collapse", () => {
     expect(eventAuthors).toEqual(["Bob Example", "Alice Example"]);
   });
 
+  it("shows a workspace indicator on item threads with attached workspaces", () => {
+    const { getByLabelText } = render(ActivityThreaded, {
+      props: {
+        items: [
+          activityItem("c1", {
+            workspace: { id: "ws-pr-1", status: "ready" },
+          }),
+        ],
+        onSelectItem: undefined,
+      },
+    });
+
+    expect(getByLabelText("Workspace attached (ready)")).toBeTruthy();
+  });
+
   it("shows the commit author on branch rows", () => {
     const { container } = render(ActivityThreaded, {
       props: {

--- a/packages/ui/src/components/shared/WorkspaceIndicator.svelte
+++ b/packages/ui/src/components/shared/WorkspaceIndicator.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import MonitorUpIcon from "@lucide/svelte/icons/monitor-up";
+
+  interface Props {
+    status?: string | undefined;
+    size?: number | undefined;
+  }
+
+  const { status = "", size = 13 }: Props = $props();
+
+  const label = $derived(
+    status ? `Workspace attached (${status})` : "Workspace attached",
+  );
+</script>
+
+<span
+  class="workspace-indicator"
+  aria-label={label}
+  title={label}
+>
+  <MonitorUpIcon {size} strokeWidth={2.2} aria-hidden="true" />
+</span>
+
+<style>
+  .workspace-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    color: var(--accent-teal, var(--accent-green));
+  }
+</style>

--- a/packages/ui/src/components/sidebar/IssueItem.svelte
+++ b/packages/ui/src/components/sidebar/IssueItem.svelte
@@ -5,6 +5,7 @@
   import { repoColor } from "../../utils/repo-color.js";
   import Chip from "../shared/Chip.svelte";
   import GitHubLabels from "../shared/GitHubLabels.svelte";
+  import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
 
   const { issues } = getStores();
 
@@ -67,6 +68,9 @@
       #{issue.Number} · {issue.Author}
     </span>
     <span class="meta-right">
+      {#if issue.workspace}
+        <WorkspaceIndicator status={issue.workspace.status} />
+      {/if}
       <span
         class="star-btn"
         role="button"

--- a/packages/ui/src/components/sidebar/IssueItem.test.ts
+++ b/packages/ui/src/components/sidebar/IssueItem.test.ts
@@ -1,0 +1,48 @@
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Issue } from "../../api/types.js";
+import { STORES_KEY } from "../../context.js";
+import IssueItem from "./IssueItem.svelte";
+
+const mkIssue = (overrides: Record<string, unknown>): Issue =>
+  ({
+    Number: 2,
+    Title: "Track workspace setup",
+    Author: "alice",
+    State: "open",
+    LastActivityAt: "2026-05-01T12:00:00Z",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    Starred: false,
+    labels: [],
+    ...overrides,
+  }) as unknown as Issue;
+
+function renderItem(issue: Issue): void {
+  render(IssueItem, {
+    props: {
+      issue,
+      selected: false,
+      showRepo: false,
+      onclick: () => {},
+    },
+    context: new Map<symbol, unknown>([
+      [STORES_KEY, { issues: { toggleIssueStar: vi.fn() } }],
+    ]),
+  });
+}
+
+describe("IssueItem", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a workspace indicator when the issue has an attached workspace", () => {
+    renderItem(mkIssue({
+      workspace: { id: "ws-issue-2", status: "ready" },
+    }));
+
+    expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -13,6 +13,7 @@
   import CircleAlertIcon from "@lucide/svelte/icons/circle-alert";
   import Chip from "../shared/Chip.svelte";
   import GitHubLabels from "../shared/GitHubLabels.svelte";
+  import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
 
   const { pulls } = getStores();
   const hostState = getHostState();
@@ -179,6 +180,9 @@
             <path d="M8 1a.75.75 0 01.75.75v6.19l1.72-1.72a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 011.06-1.06l1.72 1.72V1.75A.75.75 0 018 1zM3.5 10a.75.75 0 01.75.75v1.5c0 .138.112.25.25.25h7a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 0111.5 14h-7A1.75 1.75 0 012.75 12.25v-1.5A.75.75 0 013.5 10z"/>
           </svg>
         </span>
+      {/if}
+      {#if pr.workspace}
+        <WorkspaceIndicator status={pr.workspace.status} />
       {/if}
       {#if hasWorktree && worktreeName}
         <span class="worktree-name" title="Linked to {worktreeName}">{worktreeName}</span>

--- a/packages/ui/src/components/sidebar/PullItem.test.ts
+++ b/packages/ui/src/components/sidebar/PullItem.test.ts
@@ -143,6 +143,15 @@ describe("PullItem kanban status", () => {
     cleanup();
   });
 
+  it("shows a workspace indicator when the PR has an attached workspace", () => {
+    renderItem(mkPR({
+      Title: "Cache widget details",
+      workspace: { id: "ws-pr-1", status: "ready" },
+    }));
+
+    expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
+  });
+
   it("shows the kanban status for open PRs", () => {
     renderItem(mkPR({
       Title: "Cache widget details",

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -13,6 +13,7 @@
   import ItemKindChip from "../components/shared/ItemKindChip.svelte";
   import ItemStateChip from "../components/shared/ItemStateChip.svelte";
   import SelectDropdown from "../components/shared/SelectDropdown.svelte";
+  import WorkspaceIndicator from "../components/shared/WorkspaceIndicator.svelte";
   import {
     activityBranchKey,
     isDefaultBranchActivity,
@@ -434,6 +435,9 @@
                   {:else}
                     <ItemKindChip kind={item.item_type === "issue" ? "issue" : "pr"} size="md" />
                     <span class="mobile-activity-number">#{item.item_number}</span>
+                    {#if item.workspace}
+                      <WorkspaceIndicator status={item.workspace.status} size={16} />
+                    {/if}
                     {#if item.item_state === "merged" || item.item_state === "closed"}
                       <ItemStateChip state={item.item_state} size="md" />
                     {/if}


### PR DESCRIPTION
- Add workspace markers to pull request, issue, and activity list rows.
- Include lightweight workspace refs in list API responses so the UI can show attached-workspace state without opening details.
- Regenerate API clients for the new optional workspace field.