### PR TITLE
Fix diff file ordering and expanded render stalls

### DIFF
--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -8,6 +8,8 @@ type DiffFixture = Omit<DiffResult, "files"> & {
   files: DiffFixtureFile[];
 };
 
+const gitBackedDiffTestTimeoutMs = 120_000;
+
 // --- Fixtures ---
 
 // Small fixture: 4 files covering modified (multi-hunk), added, deleted, binary.
@@ -1893,11 +1895,13 @@ test.describe("diff view performance", () => {
 //   - README.md: whitespace-only change
 
 test.describe("diff view (git-backed)", () => {
-  test.describe.configure({ mode: "serial" });
+  test.describe.configure({ mode: "serial", timeout: gitBackedDiffTestTimeoutMs });
 
   let releaseLock: (() => Promise<void>) | null = null;
 
-  test.beforeAll(async () => {
+  // eslint-disable-next-line no-empty-pattern -- Playwright requires fixture destructuring to access testInfo.
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(gitBackedDiffTestTimeoutMs);
     releaseLock = await acquireExclusiveLock("git-backed-diff");
   });
 

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2082,7 +2082,7 @@ test.describe("diff view (git-backed)", () => {
     }
   });
 
-  test("inline review comments persist selected left and right diff targets", async ({ page }) => {
+  test("inline review composer opens and persists selected left and right diff targets", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {
       const baseURL = server.info.base_url;
@@ -2102,6 +2102,7 @@ test.describe("diff view (git-backed)", () => {
       await selectPierreReviewLine(cacheFile, 1, "right");
       await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
       await expect(page.getByPlaceholder("Leave a comment")).toBeFocused();
+      await expectPierreDiffFirstVisible(cacheFile, diffAdditionsSelector);
       const cacheContentBox = await cacheFile.locator(".file-content").boundingBox();
       const composerBox = await cacheFile.locator(".inline-composer").boundingBox();
       expect(cacheContentBox).not.toBeNull();

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -61,7 +61,7 @@ import (
 
 const serverRuntimeHelperMarker = "middleman-runtime-helper"
 
-var ptyE2ESemaphore = semaphore.NewWeighted(4)
+var ptyE2ESemaphore = semaphore.NewWeighted(1)
 
 func runParallelPTYE2E(t *testing.T) {
 	t.Helper()

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -505,6 +505,7 @@ func TestWorkspaceResponseTracksTmuxOutputActivity(t *testing.T) {
 		0o644,
 	))
 	probeAt := now.Add(tmuxSampleMinInterval + time.Second)
+	firstProbeAt := probeAt
 	setClock(probeAt)
 	var second struct {
 		TmuxPaneTitle      *string `json:"tmux_pane_title"`
@@ -526,10 +527,11 @@ func TestWorkspaceResponseTracksTmuxOutputActivity(t *testing.T) {
 	assert.True(second.TmuxWorking)
 	assert.Equal(tmuxActivitySourceOutput, second.TmuxActivitySource)
 	require.NotNil(second.TmuxLastOutputAt)
-	assert.Equal(probeAt.Format(time.RFC3339), *second.TmuxLastOutputAt)
 
 	lastOutputAt, err := time.Parse(time.RFC3339, *second.TmuxLastOutputAt)
 	require.NoError(err)
+	assert.False(lastOutputAt.Before(firstProbeAt), "last output must be observed at or after the first eligible probe")
+	assert.False(lastOutputAt.After(probeAt), "last output must not be newer than the final poll clock")
 	setClock(lastOutputAt.Add(tmuxActivityTTL + time.Second))
 	expired := getRawWorkspaceActivity(t, client, ctx, wsID)
 	assert.False(expired.TmuxWorking)

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -144,6 +144,7 @@ type session struct {
 	mu                    sync.Mutex
 	info                  SessionInfo
 	cmd                   *exec.Cmd
+	cancel                context.CancelFunc
 	ptmx                  *os.File
 	ptyOwner              ptyownerruntime.Owner
 	pty                   ptyownerruntime.PTY
@@ -1080,6 +1081,7 @@ func (m *Manager) Shutdown() {
 	for _, s := range sessions {
 		if s.tmuxSession != "" {
 			s.detach()
+			waiting = append(waiting, s)
 			continue
 		}
 		s.stop()
@@ -1540,7 +1542,18 @@ func startSession(
 		"cwd", cwd,
 	)
 
-	cmd := procutil.Command(resolvedPath, command[1:]...)
+	// Runtime sessions outlive the launch request, so they get their own
+	// lifecycle context. Shutdown cancels this to stop the local PTY client
+	// without running tmux kill-session against tmux-backed agents.
+	sessionCtx, cancelSession := context.WithCancel(context.Background())
+	cmd := procutil.CommandContext(sessionCtx, resolvedPath, command[1:]...)
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		return terminateSessionProcess(cmd.Process)
+	}
+	cmd.WaitDelay = 2 * time.Second
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
@@ -1557,6 +1570,7 @@ func startSession(
 		Cols: 120,
 	})
 	if err != nil {
+		cancelSession()
 		return nil, fmt.Errorf("start pty: %w", err)
 	}
 	slog.Debug(
@@ -1571,6 +1585,7 @@ func startSession(
 	s := &session{
 		info:        info,
 		cmd:         cmd,
+		cancel:      cancelSession,
 		ptmx:        ptmx,
 		done:        make(chan struct{}),
 		outputDone:  make(chan struct{}),
@@ -1602,6 +1617,9 @@ func (s *session) watch() SessionInfo {
 		return s.watchPtyOwner()
 	}
 	exitCode := waitExitCode(s.cmd.Wait())
+	if s.cancel != nil {
+		s.cancel()
+	}
 	now := time.Now().UTC()
 
 	s.mu.Lock()
@@ -1864,6 +1882,9 @@ func (s *session) closeSubscribers() {
 
 func (s *session) stop() {
 	s.stopOnce.Do(func() {
+		if s.cancel != nil {
+			s.cancel()
+		}
 		if s.pty != nil {
 			if s.ptyOwner != nil {
 				ctx, cancel := context.WithTimeout(
@@ -1897,6 +1918,9 @@ func (s *session) wasStopRequested() bool {
 
 func (s *session) detach() {
 	s.stopOnce.Do(func() {
+		if s.cancel != nil {
+			s.cancel()
+		}
 		if s.pty != nil {
 			s.pty.Close()
 		}

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -600,35 +600,55 @@ func TestManagerStopIgnoresAbsentTmuxSession(t *testing.T) {
 }
 
 func TestManagerShutdownLeavesTmuxSessionsRunning(t *testing.T) {
+	requirePTYAvailable(t)
+	t.Setenv("MIDDLEMAN_LOCALRUNTIME_HELPER", "1")
+
+	require := require.New(t)
 	assert := Assert.New(t)
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	tmuxPath := filepath.Join(dir, "tmux-records")
-	require.NoError(t, os.WriteFile(
+	require.NoError(os.WriteFile(
 		tmuxPath,
 		[]byte("#!/bin/sh\nprintf '%s\\0' \"$@\" >> \"$TMUX_RECORD\"\n"),
 		0o755,
 	))
 	t.Setenv("TMUX_RECORD", record)
-	done := make(chan struct{})
-	close(done)
-	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
-	mgr.sessions["ws-1:codex"] = &session{
-		info: SessionInfo{
-			Key:         "ws-1:codex",
-			WorkspaceID: "ws-1",
-			TargetKey:   "codex",
-			Kind:        LaunchTargetAgent,
+	mgr := NewManager(Options{
+		Targets: []LaunchTarget{
+			helperTarget("codex", "sleep"),
 		},
-		cmd:         &exec.Cmd{},
-		tmuxSession: "middleman-ws-1-codex",
-		done:        done,
+		TmuxCommand: []string{tmuxPath},
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	info, err := mgr.Launch(
+		context.Background(), "ws-1", t.TempDir(), "codex",
+	)
+	require.NoError(err)
+
+	var pid int
+	mgr.mu.Lock()
+	s := mgr.sessions[info.Key]
+	require.NotNil(s)
+	mgr.mu.Unlock()
+
+	s.mu.Lock()
+	s.tmuxSession = "middleman-ws-1-codex"
+	if s.cmd != nil && s.cmd.Process != nil {
+		pid = s.cmd.Process.Pid
 	}
+	s.mu.Unlock()
+	require.Positive(pid)
+	require.True(processAlive(pid), "local attach client should be alive")
 
 	mgr.Shutdown()
 
-	_, err := os.Stat(record)
-	assert.True(os.IsNotExist(err), "shutdown should not invoke tmux cleanup")
+	_, statErr := os.Stat(record)
+	assert.True(os.IsNotExist(statErr), "shutdown should not invoke tmux cleanup")
+	assert.Eventually(func() bool {
+		return !processAlive(pid)
+	}, 5*time.Second, 25*time.Millisecond)
 	assert.Empty(mgr.ListSessions("ws-1"))
 }
 

--- a/internal/workspace/localruntime/process_unix.go
+++ b/internal/workspace/localruntime/process_unix.go
@@ -3,9 +3,20 @@
 package localruntime
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
+
+func terminateSessionProcess(process *os.Process) error {
+	if err := syscall.Kill(-process.Pid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return process.Signal(syscall.SIGTERM)
+	}
+	return nil
+}
 
 func killSessionProcess(process *os.Process) error {
 	// pty.StartWithSize sets Setsid, so the launched process is a

--- a/internal/workspace/localruntime/process_windows.go
+++ b/internal/workspace/localruntime/process_windows.go
@@ -4,6 +4,10 @@ package localruntime
 
 import "os"
 
+func terminateSessionProcess(process *os.Process) error {
+	return process.Kill()
+}
+
 func killSessionProcess(process *os.Process) error {
 	return process.Kill()
 }

--- a/packages/ui/src/components/diff/DiffFile.inline-comment.bench.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.inline-comment.bench.test.ts
@@ -1,0 +1,278 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { DiffFile as DiffFileType } from "../../api/types.js";
+import { STORES_KEY } from "../../context.js";
+import { createDiffStore } from "../../stores/diff.svelte.js";
+import type { DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
+import DiffFile from "./DiffFile.svelte";
+
+type GlobalWithIO = { IntersectionObserver?: unknown };
+type GlobalWithResizeObserver = { ResizeObserver?: unknown };
+type GlobalWithCSSStyleSheet = {
+  CSSStyleSheet?: {
+    prototype: CSSStyleSheet & { replaceSync?: (text: string) => void };
+  };
+};
+
+let originalIntersectionObserver: unknown;
+let originalIntersectionObserverExisted = false;
+let originalResizeObserver: unknown;
+let originalResizeObserverExisted = false;
+let originalReplaceSync: unknown;
+
+beforeAll(() => {
+  originalIntersectionObserverExisted = "IntersectionObserver" in globalThis;
+  originalIntersectionObserver = (globalThis as GlobalWithIO).IntersectionObserver;
+  class IntersectionObserverStub {
+    private readonly callback: IntersectionObserverCallback;
+    root: Element | null = null;
+    rootMargin = "";
+    thresholds: readonly number[] = [];
+
+    constructor(callback: IntersectionObserverCallback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element): void {
+      const entry = {
+        isIntersecting: true,
+        intersectionRatio: 1,
+        target,
+        boundingClientRect: {} as DOMRectReadOnly,
+        intersectionRect: {} as DOMRectReadOnly,
+        rootBounds: null,
+        time: 0,
+      } as IntersectionObserverEntry;
+      this.callback([entry], this as unknown as IntersectionObserver);
+    }
+
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  }
+  (globalThis as GlobalWithIO).IntersectionObserver = IntersectionObserverStub;
+
+  originalResizeObserverExisted = "ResizeObserver" in globalThis;
+  originalResizeObserver = (globalThis as GlobalWithResizeObserver).ResizeObserver;
+  class ResizeObserverStub {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  (globalThis as GlobalWithResizeObserver).ResizeObserver = ResizeObserverStub;
+
+  originalReplaceSync = (globalThis as GlobalWithCSSStyleSheet).CSSStyleSheet
+    ?.prototype.replaceSync;
+  if ((globalThis as GlobalWithCSSStyleSheet).CSSStyleSheet?.prototype) {
+    (globalThis as GlobalWithCSSStyleSheet).CSSStyleSheet.prototype.replaceSync
+      ??= function replaceSync(): void {};
+  }
+});
+
+afterAll(() => {
+  if (originalIntersectionObserverExisted) {
+    (globalThis as GlobalWithIO).IntersectionObserver = originalIntersectionObserver;
+  } else {
+    delete (globalThis as GlobalWithIO).IntersectionObserver;
+  }
+  if (originalResizeObserverExisted) {
+    (globalThis as GlobalWithResizeObserver).ResizeObserver = originalResizeObserver;
+  } else {
+    delete (globalThis as GlobalWithResizeObserver).ResizeObserver;
+  }
+  if ((globalThis as GlobalWithCSSStyleSheet).CSSStyleSheet?.prototype) {
+    if (originalReplaceSync) {
+      (globalThis as GlobalWithCSSStyleSheet).CSSStyleSheet.prototype.replaceSync =
+        originalReplaceSync as (text: string) => void;
+    } else {
+      delete (globalThis as GlobalWithCSSStyleSheet).CSSStyleSheet.prototype.replaceSync;
+    }
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeLargeFile(lineCount: number): DiffFileType {
+  const lines = [
+    { type: "context" as const, content: "export function render() {", old_num: 1, new_num: 1 },
+    ...Array.from({ length: lineCount }, (_, index) => ({
+      type: "add" as const,
+      content: `  renderLine(${index}, "value-${index}");`,
+      new_num: index + 2,
+    })),
+  ];
+  const patchLines = [
+    "diff --git a/src/large.ts b/src/large.ts",
+    "--- a/src/large.ts",
+    "+++ b/src/large.ts",
+    `@@ -1,1 +1,${lineCount + 1} @@`,
+    " export function render() {",
+    ...Array.from({ length: lineCount }, (_, index) =>
+      `+  renderLine(${index}, "value-${index}");`
+    ),
+  ];
+
+  return {
+    path: "src/large.ts",
+    old_path: "src/large.ts",
+    status: "modified",
+    is_binary: false,
+    is_whitespace_only: false,
+    additions: lineCount,
+    deletions: 0,
+    patch: `${patchLines.join("\n")}\n`,
+    hunks: [{
+      old_start: 1,
+      old_count: 1,
+      new_start: 1,
+      new_count: lineCount + 1,
+      lines,
+    }],
+  };
+}
+
+function renderDiffFile(file: DiffFileType) {
+  const diff = createDiffStore();
+  const diffReviewDraft = {
+    getComments: () => [],
+    isSubmitting: () => false,
+    getError: () => null,
+    createComment: (_body: string, _range: DiffReviewLineRange) => Promise.resolve(true),
+    deleteComment: () => Promise.resolve(true),
+  };
+
+  return render(DiffFile, {
+    props: {
+      file,
+      provider: "github",
+      platformHost: "github.com",
+      owner: `bench-owner-${file.additions}`,
+      name: "widgets",
+      repoPath: "bench-owner/widgets",
+      number: 42,
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+      nativeMultilineRanges: true,
+    },
+    context: new Map([[
+      STORES_KEY,
+      {
+        diff,
+        diffReviewDraft,
+        detail: {
+          replyToDiscussion: () => Promise.resolve(true),
+        },
+      },
+    ]]),
+  });
+}
+
+async function waitForRenderedDiff(): Promise<void> {
+  await waitFor(() => {
+    const host = document.querySelector(".pierre-diff");
+    expect(host?.shadowRoot?.querySelector("[data-content]")).toBeTruthy();
+  }, { timeout: 30_000 });
+}
+
+async function findLineTarget(line: number): Promise<HTMLElement> {
+  return await waitFor(() => {
+    const target = document
+      .querySelector(".pierre-diff")
+      ?.shadowRoot
+      ?.querySelector<HTMLElement>(
+        `[data-column-number="${line}"][data-line-type="change-addition"]`,
+      );
+    expect(target).toBeTruthy();
+    return target!;
+  }, { timeout: 30_000 });
+}
+
+async function openAndCloseComposer(line: number): Promise<number> {
+  const target = await findLineTarget(line);
+  const startedAt = performance.now();
+
+  await fireEvent.pointerDown(target, {
+    button: 0,
+    pointerId: 1,
+    pointerType: "mouse",
+  });
+  await fireEvent.pointerUp(document, {
+    pointerId: 1,
+    pointerType: "mouse",
+  });
+  await waitFor(() => {
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+  }, { timeout: 30_000 });
+
+  const elapsedMs = performance.now() - startedAt;
+  await fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+  await waitFor(() => {
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+  }, { timeout: 30_000 });
+
+  return elapsedMs;
+}
+
+function percentile(values: number[], p: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+  );
+  return sorted[index] ?? 0;
+}
+
+function benchmarkLineCounts(): number[] {
+  const raw = process.env.DIFF_INLINE_COMMENT_BENCH_LINES;
+  if (!raw) return [100, 500, 1_000];
+  const counts = raw
+    .split(",")
+    .map((part) => Number(part.trim()))
+    .filter((value) => Number.isInteger(value) && value > 0);
+  if (counts.length === 0) {
+    throw new Error(`invalid DIFF_INLINE_COMMENT_BENCH_LINES=${JSON.stringify(raw)}`);
+  }
+  return counts;
+}
+
+const benchDescribe = process.env.RUN_DIFF_INLINE_COMMENT_BENCH === "1"
+  ? describe
+  : describe.skip;
+
+benchDescribe("DiffFile inline comment opening benchmark", () => {
+  it("measures opening and closing an inline composer by diff size", async () => {
+    const results = [];
+    const samples = Number(process.env.DIFF_INLINE_COMMENT_BENCH_SAMPLES ?? "7");
+    const warmups = Number(process.env.DIFF_INLINE_COMMENT_BENCH_WARMUPS ?? "2");
+    const sizes = benchmarkLineCounts();
+
+    for (const lineCount of sizes) {
+      renderDiffFile(makeLargeFile(lineCount));
+      await waitForRenderedDiff();
+      const line = lineCount + 1;
+      for (let i = 0; i < warmups; i += 1) {
+        await openAndCloseComposer(line);
+      }
+      const timings = [];
+      for (let i = 0; i < samples; i += 1) {
+        timings.push(await openAndCloseComposer(line));
+      }
+      results.push({
+        lineCount,
+        samples,
+        medianMs: Number(percentile(timings, 50).toFixed(2)),
+        p95Ms: Number(percentile(timings, 95).toFixed(2)),
+        minMs: Number(Math.min(...timings).toFixed(2)),
+        maxMs: Number(Math.max(...timings).toFixed(2)),
+      });
+      cleanup();
+    }
+
+    console.log(`[diff-inline-comment-bench] ${JSON.stringify(results)}`);
+    expect(results).toHaveLength(sizes.length);
+  }, 180_000);
+});

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -126,20 +126,24 @@
         metadata: { kind: "thread", id: thread.id, thread, canReply: canReplyToThreads },
       });
     }
-    if (reviewEnabled && composerRange) {
-      annotations.push({
-        side: pierreSide(reviewSideFromValue(composerRange.side)),
-        lineNumber: composerRange.line,
-        metadata: {
-          kind: "composer",
-          id: `composer:${rangeKey(composerRange)}`,
-          range: composerRange,
-        },
-      });
-    }
     return annotations;
   });
   const pierreLineAnnotations = $derived(lineAnnotations as DiffLineAnnotation<unknown>[]);
+  const composerAnnotation = $derived.by<DiffLineAnnotation<DiffAnnotation> | null>(() => {
+    if (!reviewEnabled || !composerRange) return null;
+    return {
+      side: pierreSide(reviewSideFromValue(composerRange.side)),
+      lineNumber: composerRange.line,
+      metadata: {
+        kind: "composer",
+        id: `composer:${rangeKey(composerRange)}`,
+        range: composerRange,
+      },
+    };
+  });
+  const pierreComposerAnnotation = $derived(
+    composerAnnotation as DiffLineAnnotation<unknown> | null,
+  );
   const draftSelectedRanges = $derived.by<SelectedLineRange[]>(() => {
     if (!reviewEnabled) return [];
     const ranges: SelectedLineRange[] = [];
@@ -530,6 +534,7 @@
           {tabWidth}
           loadFileText={contextExpansionEnabled ? loadDiffText : undefined}
           lineAnnotations={pierreLineAnnotations}
+          transientLineAnnotation={pierreComposerAnnotation}
           selectedRange={selectedRange}
           selectedRanges={draftSelectedRanges}
           enableLineSelection={reviewEnabled && !!diffHeadSHA}

--- a/packages/ui/src/components/diff/DiffSidebar.test.ts
+++ b/packages/ui/src/components/diff/DiffSidebar.test.ts
@@ -111,6 +111,29 @@ describe("DiffSidebar", () => {
     );
   });
 
+  it("preserves diff file order without folding case", async () => {
+    const files = [
+      makeFile("src/B.ts"),
+      makeFile("src/C.ts"),
+      makeFile("src/a.ts"),
+    ];
+    renderSidebar(makeDiffStore(files));
+
+    const wantedPaths = new Set(files.map((file) => file.path));
+    await waitFor(() => {
+      const renderedPaths = Array.from(
+        treeRoot()?.querySelectorAll<HTMLElement>("[data-item-path]") ?? [],
+      )
+        .map((item) => item.dataset.itemPath ?? "")
+        .filter((path) => wantedPaths.has(path));
+      expect(renderedPaths).toEqual([
+        "src/B.ts",
+        "src/C.ts",
+        "src/a.ts",
+      ]);
+    });
+  });
+
   it("filters both visible rows and tree status data without rebuilding in a loop", async () => {
     const files = Array.from({ length: 11 }, (_, i) =>
       makeFile(i === 10 ? "docs/readme.md" : `src/file-${i}.ts`),

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -83,6 +83,8 @@
   let reviewRangeFrame: number | undefined;
   let renderRetryFrame: number | undefined;
   let renderRetryTick = $state(0);
+  let viewportProbeFrame: number | undefined;
+  let viewportProbeTick = $state(0);
   let renderRetryCount = 0;
   let renderedLineRows = new Map<number, RenderedLinePair[]>();
   let selectedRangeElements = new Set<HTMLElement>();
@@ -231,6 +233,7 @@
       cancelInactiveCleanup();
       cancelSelectedRangesApplication();
       cancelRenderRetry();
+      cancelViewportProbe();
       cleanUpPierreDiff();
       contextLoadPromise = undefined;
     };
@@ -263,8 +266,9 @@
   });
 
   $effect(() => {
+    const currentViewportProbeTick = viewportProbeTick;
     const currentRenderRetryTick = renderRetryTick;
-    if (currentRenderRetryTick < 0) return;
+    if (currentRenderRetryTick < 0 || currentViewportProbeTick < 0) return;
     if (!active && !isHostNearViewport()) {
       scheduleInactiveCleanup();
       return;
@@ -329,6 +333,20 @@
   });
 
   $effect(() => {
+    if (!host || active || rendered) return;
+    const root = host.closest(".diff-area");
+    if (!(root instanceof HTMLElement)) return;
+    root.addEventListener("scroll", scheduleViewportProbe, { passive: true });
+    window.addEventListener("resize", scheduleViewportProbe);
+    scheduleViewportProbe();
+    return () => {
+      root.removeEventListener("scroll", scheduleViewportProbe);
+      window.removeEventListener("resize", scheduleViewportProbe);
+      cancelViewportProbe();
+    };
+  });
+
+  $effect(() => {
     if (active && pierreDiff && pierreFile) {
       pierreDiff.setThemeType(themeType);
     }
@@ -387,6 +405,20 @@
     if (renderRetryFrame == null) return;
     cancelAnimationFrame(renderRetryFrame);
     renderRetryFrame = undefined;
+  }
+
+  function scheduleViewportProbe(): void {
+    if (viewportProbeFrame != null) return;
+    viewportProbeFrame = requestAnimationFrame(() => {
+      viewportProbeFrame = undefined;
+      viewportProbeTick += 1;
+    });
+  }
+
+  function cancelViewportProbe(): void {
+    if (viewportProbeFrame == null) return;
+    cancelAnimationFrame(viewportProbeFrame);
+    viewportProbeFrame = undefined;
   }
 
   function scheduleRenderRetry(): void {

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -333,7 +333,7 @@
   });
 
   $effect(() => {
-    if (!host || active || rendered) return;
+    if (!host || rendered) return;
     const root = host.closest(".diff-area");
     if (!(root instanceof HTMLElement)) return;
     root.addEventListener("scroll", scheduleViewportProbe, { passive: true });

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -22,6 +22,7 @@
     tabWidth?: number;
     loadFileText?: ((side: "old" | "new") => Promise<string>) | undefined;
     lineAnnotations?: DiffLineAnnotation<unknown>[];
+    transientLineAnnotation?: DiffLineAnnotation<unknown> | null;
     selectedRange?: SelectedLineRange | null;
     selectedRanges?: SelectedLineRange[];
     enableLineSelection?: boolean;
@@ -30,6 +31,16 @@
   }
 
   type PierreSide = NonNullable<Parameters<GetLineIndexUtility>[1]>;
+  type RenderedLinePair = {
+    content: HTMLElement;
+    gutter: HTMLElement;
+  };
+  type TransientAnnotationRow = {
+    content?: HTMLElement;
+    gutter?: HTMLElement;
+    key: string;
+    wrapper: HTMLElement;
+  };
   const emptyFile: DiffFile = {
     path: "",
     old_path: "",
@@ -49,6 +60,7 @@
     tabWidth = 4,
     loadFileText,
     lineAnnotations = [],
+    transientLineAnnotation = null,
     selectedRange = null,
     selectedRanges = [],
     enableLineSelection = false,
@@ -72,6 +84,9 @@
   let renderRetryFrame: number | undefined;
   let renderRetryTick = $state(0);
   let renderRetryCount = 0;
+  let renderedLineRows = new Map<number, RenderedLinePair[]>();
+  let selectedRangeElements = new Set<HTMLElement>();
+  let transientAnnotationRow: TransientAnnotationRow | undefined;
   const inactiveCleanupDelayMs = 10_000;
   const maxImmediateRenderRetries = 5;
 
@@ -280,6 +295,7 @@
       return;
     }
     rendered = false;
+    clearRenderedDomState();
     if (fullContext) {
       if (renderFullContext(fullContext)) {
         renderAttemptKey = nextRenderAttemptKey;
@@ -330,6 +346,17 @@
     }
   });
 
+  $effect(() => {
+    const transientAnnotationKey = transientLineAnnotation
+      ? stableAnnotationKey(transientLineAnnotation)
+      : "";
+    if (!transientAnnotationKey && !transientAnnotationRow) return;
+    if (!rendered || !host?.shadowRoot) return;
+    cancelSelectedRangesApplication();
+    applyTransientLineAnnotation();
+    applySelectedRanges();
+  });
+
   function installDemandContextHandler(): void {
     const root = host?.shadowRoot;
     if (!root || root === demandContextHandlerRoot) return;
@@ -349,6 +376,9 @@
     removeDemandContextHandler();
     cancelSelectedRangesApplication();
     cancelRenderRetry();
+    clearSelectedRangeElements();
+    clearTransientLineAnnotation();
+    renderedLineRows = new Map();
     pierreDiff?.cleanUp();
     pierreDiff = undefined;
   }
@@ -379,6 +409,7 @@
     cancelSelectedRangesApplication();
     reviewRangeFrame = requestAnimationFrame(() => {
       reviewRangeFrame = undefined;
+      applyTransientLineAnnotation();
       applySelectedRanges();
     });
   }
@@ -387,11 +418,7 @@
     const root = host?.shadowRoot;
     const pre = root?.querySelector("pre");
     if (!root || !pre) return;
-    for (const element of root.querySelectorAll<HTMLElement>("[data-review-range-line]")) {
-      element.removeAttribute("data-review-range-line");
-      element.removeAttribute("data-selected-line");
-      element.classList.remove("gutter--selected", "gutter-new", "gutter-old");
-    }
+    clearSelectedRangeElements();
     const ranges = selectedRange ? [selectedRange, ...selectedRanges] : selectedRanges;
     if (!ranges.length || !pierreDiff) return;
 
@@ -407,37 +434,21 @@
       const startIndex = split ? startIndexes[1] : startIndexes[0];
       const endIndex = split ? endIndexes[1] : endIndexes[0];
       markSelectedLineIndexes(
-        pre,
         Math.min(startIndex, endIndex),
         Math.max(startIndex, endIndex),
-        split,
         range.side as PierreSide,
       );
     }
   }
 
   function markSelectedLineIndexes(
-    pre: HTMLPreElement,
     first: number,
     last: number,
-    split: boolean,
     side: PierreSide,
   ): void {
     const isSingle = first === last;
-    for (const code of Array.from(pre.children)) {
-      const [gutter, content] = Array.from(code.children);
-      if (!gutter || !content) continue;
-      const contentRows = Array.from(content.children);
-      const gutterRows = Array.from(gutter.children);
-      for (let i = 0; i < contentRows.length; i++) {
-        const contentElement = contentRows[i];
-        const gutterElement = gutterRows[i];
-        if (!(contentElement instanceof HTMLElement) || !(gutterElement instanceof HTMLElement)) {
-          continue;
-        }
-        const lineIndex = parseRenderedLineIndex(contentElement, split);
-        if ((lineIndex ?? 0) > last) break;
-        if (lineIndex == null || lineIndex < first) continue;
+    for (let lineIndex = first; lineIndex <= last; lineIndex += 1) {
+      for (const { content: contentElement, gutter: gutterElement } of renderedLineRows.get(lineIndex) ?? []) {
         let value = isSingle ? "single" : lineIndex === first ? "first" : lineIndex === last ? "last" : "";
         markSelectedRangeElement(contentElement, value);
         markSelectedRangeElement(gutterElement, value, side);
@@ -464,11 +475,27 @@
     value: string,
     side?: PierreSide,
   ): void {
+    selectedRangeElements.add(element);
     element.setAttribute("data-review-range-line", "");
     element.setAttribute("data-selected-line", value);
     if (side && element.hasAttribute("data-column-number")) {
       element.classList.add("gutter--selected", side === "deletions" ? "gutter-old" : "gutter-new");
     }
+  }
+
+  function clearSelectedRangeElements(): void {
+    for (const element of selectedRangeElements) {
+      element.removeAttribute("data-review-range-line");
+      element.removeAttribute("data-selected-line");
+      element.classList.remove("gutter--selected", "gutter-new", "gutter-old");
+    }
+    selectedRangeElements.clear();
+  }
+
+  function clearRenderedDomState(): void {
+    clearSelectedRangeElements();
+    clearTransientLineAnnotation();
+    renderedLineRows = new Map();
   }
 
   function parseRenderedLineIndex(element: HTMLElement, split: boolean): number | undefined {
@@ -564,15 +591,18 @@
     if (!context || fileKey !== requestFileKey) return;
     renderFullContext(context);
     if (fileKey !== requestFileKey) return;
+    clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
     applyLineTargetAttributes();
     applyHunkHeaderLabels();
     applyLineCommentButtons();
+    scheduleSelectedRangesApplication();
   }
 
   function renderFullContext(context: { oldFile: FileContents; newFile: FileContents }): boolean {
     if (!pierreDiff || !host) return false;
     rendered = false;
+    clearRenderedDomState();
     const didRender = pierreDiff.render({
       fileContainer: host,
       oldFile: context.oldFile,
@@ -681,6 +711,7 @@
     }
 
     const split = pre.getAttribute("data-diff-type") === "split";
+    refreshRenderedLineRows(pre, split);
     const getLineIndex = getPierreLineIndex(pierreDiff);
     for (const hunk of fileHunks) {
       for (const line of hunk.lines) {
@@ -779,6 +810,101 @@
     };
   }
 
+  function applyTransientLineAnnotation(): void {
+    const annotation = transientLineAnnotation;
+    if (!annotation || !host || !renderAnnotation) {
+      clearTransientLineAnnotation();
+      return;
+    }
+
+    const slotName = annotationSlotName(annotation);
+    const key = [
+      slotName,
+      stableAnnotationKey(annotation.metadata),
+    ].join(":");
+    if (transientAnnotationRow?.key === key) return;
+
+    clearTransientLineAnnotation();
+
+    const existingSlot = hasAnnotationSlot(slotName);
+    const row = existingSlot ? undefined : insertTransientAnnotationRow(annotation);
+    if (!existingSlot && !row) return;
+
+    const content = renderAnnotation(annotation);
+    if (!content) return;
+
+    const wrapper = document.createElement("div");
+    wrapper.dataset.transientAnnotationSlot = "";
+    wrapper.slot = slotName;
+    wrapper.style.whiteSpace = "normal";
+    wrapper.appendChild(content);
+
+    // eslint-disable-next-line svelte/no-dom-manipulating -- Pierre owns this custom element; annotations are passed through its light-DOM slot API.
+    host.appendChild(wrapper);
+    transientAnnotationRow = {
+      key,
+      wrapper,
+      ...row,
+    };
+  }
+
+  function clearTransientLineAnnotation(): void {
+    transientAnnotationRow?.wrapper.remove();
+    transientAnnotationRow?.content?.remove();
+    transientAnnotationRow?.gutter?.remove();
+    transientAnnotationRow = undefined;
+  }
+
+  function hasAnnotationSlot(slotName: string): boolean {
+    const root = host?.shadowRoot;
+    if (!root) return false;
+    for (const slot of root.querySelectorAll<HTMLSlotElement>("slot")) {
+      if (slot.name === slotName) return true;
+    }
+    return false;
+  }
+
+  function insertTransientAnnotationRow(
+    annotation: DiffLineAnnotation<unknown>,
+  ): { content: HTMLElement; gutter: HTMLElement } | undefined {
+    const root = host?.shadowRoot;
+    const pre = root?.querySelector("pre");
+    if (!pre || !pierreDiff) return undefined;
+
+    const split = pre.getAttribute("data-diff-type") === "split";
+    const indexes = getPierreLineIndex(pierreDiff)(
+      annotation.lineNumber,
+      annotation.side as PierreSide,
+    );
+    if (!indexes) return undefined;
+
+    const lineIndex = split ? indexes[1] : indexes[0];
+    const target = renderedLinePair(pre, lineIndex, split);
+    if (!target) return undefined;
+
+    const gutter = document.createElement("div");
+    gutter.setAttribute("data-gutter-buffer", "annotation");
+    gutter.setAttribute("data-buffer-size", "1");
+    gutter.style.gridRow = "span 1";
+
+    const content = document.createElement("div");
+    content.setAttribute("data-line-annotation", `0,${lineIndex}`);
+    const annotationContent = document.createElement("div");
+    annotationContent.setAttribute("data-annotation-content", "");
+    const slot = document.createElement("slot");
+    slot.name = annotationSlotName(annotation);
+    annotationContent.appendChild(slot);
+    content.appendChild(annotationContent);
+
+    target.gutter.after(gutter);
+    target.content.after(content);
+    return { content, gutter };
+  }
+
+  function annotationSlotName(annotation: DiffLineAnnotation<unknown>): string {
+    return `annotation-${annotation.side}-${annotation.lineNumber}`;
+  }
+
   function markLineTarget(
     pre: HTMLPreElement,
     indexes: [number, number] | undefined,
@@ -788,27 +914,59 @@
     if (!indexes) return;
     const lineIndex = split ? indexes[1] : indexes[0];
     if (!Number.isFinite(lineIndex)) return;
-    const row = renderedLineRow(pre, lineIndex, split);
-    if (!row) return;
-    row.setAttribute("data-diff-path", renderFile.path);
-    row.tabIndex = -1;
+    const pair = renderedLinePair(pre, lineIndex, split);
+    if (!pair) return;
+    pair.content.setAttribute("data-diff-path", renderFile.path);
+    pair.content.tabIndex = -1;
     for (const [name, value] of Object.entries(attributes)) {
-      row.setAttribute(name, value);
+      pair.content.setAttribute(name, value);
     }
   }
 
-  function renderedLineRow(
+  function refreshRenderedLineRows(pre: HTMLPreElement, split: boolean): void {
+    const next = new Map<number, RenderedLinePair[]>();
+    for (const code of Array.from(pre.children)) {
+      const [gutter, content] = Array.from(code.children);
+      if (!gutter || !content) continue;
+      const contentRows = Array.from(content.children);
+      const gutterRows = Array.from(gutter.children);
+      for (let index = 0; index < contentRows.length; index += 1) {
+        const contentElement = contentRows[index];
+        const gutterElement = gutterRows[index];
+        if (!(contentElement instanceof HTMLElement) || !(gutterElement instanceof HTMLElement)) {
+          continue;
+        }
+        const lineIndex = parseRenderedLineIndex(contentElement, split);
+        if (lineIndex == null) continue;
+        const rows = next.get(lineIndex) ?? [];
+        rows.push({ content: contentElement, gutter: gutterElement });
+        next.set(lineIndex, rows);
+      }
+    }
+    renderedLineRows = next;
+  }
+
+  function renderedLinePair(
     pre: HTMLPreElement,
     targetIndex: number,
     split: boolean,
-  ): HTMLElement | undefined {
+  ): RenderedLinePair | undefined {
+    const cached = renderedLineRows.get(targetIndex)?.[0];
+    if (cached) return cached;
     for (const code of Array.from(pre.children)) {
-      const [, content] = Array.from(code.children);
-      if (!content) continue;
+      const [gutter, content] = Array.from(code.children);
+      if (!gutter || !content) continue;
+      const gutterRows = Array.from(gutter.children);
       for (const contentElement of Array.from(content.children)) {
         if (!(contentElement instanceof HTMLElement)) continue;
         const lineIndex = parseRenderedLineIndex(contentElement, split);
-        if (lineIndex === targetIndex) return contentElement;
+        if (lineIndex === targetIndex) {
+          const index = Array.prototype.indexOf.call(content.children, contentElement);
+          const gutterElement = gutterRows[index];
+          if (gutterElement instanceof HTMLElement) {
+            return { content: contentElement, gutter: gutterElement };
+          }
+        }
         if ((lineIndex ?? 0) > targetIndex) return undefined;
       }
     }

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -31,6 +31,7 @@ const pierre = (() => {
   class FileDiff {
     cleanUp = cleanUp;
     expandHunk = () => {};
+    getLineIndex = (lineNumber: number): [number, number] => [lineNumber, lineNumber];
     render = renderDiff;
     setOptions = () => {};
     setSelectedLines = () => {};
@@ -183,5 +184,32 @@ describe("PierreFileDiff", () => {
     await waitFor(() => {
       expect(pierre.renderCount()).toBe(2);
     });
+  });
+
+  it("does not rerender when transient annotation metadata changes", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const file = makeFile();
+
+    const { rerender } = render(PierreFileDiff, {
+      props: { active: true, file },
+    });
+
+    await waitFor(() => {
+      expect(pierre.renderCount()).toBe(1);
+    });
+
+    await rerender({
+      active: true,
+      file,
+      selectedRange: { start: 2, end: 2, side: "additions" },
+      transientLineAnnotation: {
+        side: "additions",
+        lineNumber: 2,
+        metadata: { id: "composer:additions:2", body: "draft text" },
+      },
+    });
+    await Promise.resolve();
+
+    expect(pierre.renderCount()).toBe(1);
   });
 });

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -1,5 +1,6 @@
 import {
   cleanup,
+  fireEvent,
   render,
   waitFor,
 } from "@testing-library/svelte";
@@ -157,6 +158,46 @@ describe("PierreFileDiff", () => {
     });
   });
 
+  it("renders an inactive expanded file after a fallback viewport probe", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    const diffArea = document.createElement("div");
+    diffArea.className = "diff-area";
+    document.body.appendChild(diffArea);
+    let fileNearViewport = false;
+    Element.prototype.getBoundingClientRect = function () {
+      if (this instanceof HTMLElement && this.classList.contains("diff-area")) {
+        return rect({ top: 0, bottom: 400, height: 400 });
+      }
+      if (this instanceof HTMLElement && this.tagName === "DIFFS-CONTAINER") {
+        return fileNearViewport
+          ? rect({ top: 80, bottom: 180, height: 100 })
+          : rect({ top: 1_200, bottom: 1_300, height: 100 });
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    try {
+      render(PierreFileDiff, {
+        target: diffArea,
+        props: { active: false, file: makeFile() },
+      });
+
+      await Promise.resolve();
+      expect(pierre.renderCount()).toBe(0);
+
+      fileNearViewport = true;
+      await fireEvent.scroll(diffArea);
+
+      await waitFor(() => {
+        expect(pierre.renderCount()).toBe(1);
+      });
+    } finally {
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+      diffArea.remove();
+    }
+  });
+
   it("rerenders when annotation metadata changes without moving lines", async () => {
     const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
     const file = makeFile();
@@ -213,3 +254,25 @@ describe("PierreFileDiff", () => {
     expect(pierre.renderCount()).toBe(1);
   });
 });
+
+function rect({
+  top,
+  bottom,
+  height,
+}: {
+  top: number;
+  bottom: number;
+  height: number;
+}): DOMRect {
+  return {
+    top,
+    bottom,
+    height,
+    left: 0,
+    right: 500,
+    width: 500,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}

--- a/packages/ui/src/components/diff/PierreFileTree.svelte
+++ b/packages/ui/src/components/diff/PierreFileTree.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileTree } from "@pierre/trees";
+  import { FileTree, preparePresortedFileTreeInput } from "@pierre/trees";
   import type { FileTreeOptions } from "@pierre/trees";
   import { onMount, untrack } from "svelte";
   import type { DiffFile } from "../../api/types.js";
@@ -27,6 +27,7 @@
 
   const safeFiles = $derived(files ?? []);
   const treePaths = $derived(safeFiles.map((file) => file.path));
+  const preparedTreeInput = $derived(preparePresortedFileTreeInput(treePaths));
   const treeGitStatus = $derived(
     safeFiles.map((file): TreeGitStatus => ({
       path: file.path,
@@ -37,7 +38,7 @@
     `${treePaths.join("\0")}\n${treeGitStatus.map((item) => `${item.path}:${item.status}`).join("\0")}`,
   );
   const treeOptions = $derived<FileTreeOptions>({
-    paths: treePaths,
+    preparedInput: preparedTreeInput,
     initialExpansion: "open",
     initialVisibleRowCount: Math.max(100, treePaths.length * 4),
     overscan: Math.max(100, treePaths.length * 4),


### PR DESCRIPTION
- Preserve diff API file ordering in the file browser.
- Keep inline review composers from rerendering full diffs.
- Retry expanded diff files that initially miss their render window.
- Stabilize tmux runtime race checks for CI.