### PR TITLE
Add workspace sidebar filtering

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -289,7 +289,8 @@
   </label>
   <div class="sidebar-list">
     {#each [...grouped] as [repoKey, items] (repoKey)}
-      {@const collapsed = collapsedGroups.has(repoKey)}
+      {@const collapsed =
+        !normalizedSearchQuery && collapsedGroups.has(repoKey)}
       <button
         class={["group-header", { collapsed }]}
         onclick={() => toggleGroup(repoKey)}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -5,6 +5,7 @@
   import GitBranchIcon from "@lucide/svelte/icons/git-branch";
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
+  import SearchIcon from "@lucide/svelte/icons/search";
   import { client } from "../../api/runtime.js";
   import {
     DiffStats,
@@ -72,12 +73,30 @@
 
   let workspaces = $state.raw<Workspace[]>([]);
   let collapsedGroups = $state<Set<string>>(new Set());
+  let searchQuery = $state("");
 
   type GroupedWorkspaces = Map<string, Workspace[]>;
 
+  const normalizedSearchQuery = $derived(
+    searchQuery.trim().toLowerCase(),
+  );
+
+  const visibleWorkspaces = $derived.by(() => {
+    if (!normalizedSearchQuery) return workspaces;
+    return workspaces.filter((ws) =>
+      workspaceMatchesSearch(ws, normalizedSearchQuery),
+    );
+  });
+
+  const sidebarCountLabel = $derived(
+    normalizedSearchQuery
+      ? `${visibleWorkspaces.length}/${workspaces.length}`
+      : `${workspaces.length}`,
+  );
+
   const grouped: GroupedWorkspaces = $derived.by(() => {
     const map = new Map<string, Workspace[]>();
-    for (const ws of workspaces) {
+    for (const ws of visibleWorkspaces) {
       const key =
         `${ws.platform_host}/${ws.repo_owner}` +
         `/${ws.repo_name}`;
@@ -122,6 +141,39 @@
 
   function displayName(ws: Workspace): string {
     return ws.mr_title ?? ws.git_head_ref;
+  }
+
+  function updateSearch(event: Event): void {
+    searchQuery = event.currentTarget instanceof HTMLInputElement
+      ? event.currentTarget.value
+      : "";
+  }
+
+  function workspaceMatchesSearch(
+    ws: Workspace,
+    query: string,
+  ): boolean {
+    const itemKind = ws.item_type === "issue" ? "issue" : "pr";
+    const itemNumber = String(ws.item_number);
+    const haystack = [
+      displayName(ws),
+      ws.git_head_ref,
+      shortBranch(ws.git_head_ref),
+      ws.platform_host,
+      ws.repo_owner,
+      ws.repo_name,
+      ws.repo?.repo_path,
+      `${ws.repo_owner}/${ws.repo_name}`,
+      `${ws.platform_host}/${ws.repo_owner}/${ws.repo_name}`,
+      itemNumber,
+      `#${itemNumber}`,
+      `${itemKind} ${itemNumber}`,
+      `${itemKind} #${itemNumber}`,
+    ];
+
+    return haystack.some((value) =>
+      value?.toLowerCase().includes(query),
+    );
   }
 
   function statusDotClass(ws: Workspace): string {
@@ -210,7 +262,7 @@
 <div class="workspace-list-sidebar">
   <div class="sidebar-header">
     <span class="sidebar-header-label">Workspaces</span>
-    <span class="sidebar-header-count">{workspaces.length}</span>
+    <span class="sidebar-header-count">{sidebarCountLabel}</span>
     {#if isSidebarToggleEnabled && onCollapseSidebar}
       <LeftSidebarToggle
         state="expanded"
@@ -220,6 +272,21 @@
       />
     {/if}
   </div>
+  <label class="workspace-filter">
+    <SearchIcon
+      class="workspace-filter-icon"
+      size="13"
+      strokeWidth="2.25"
+      aria-hidden="true"
+    />
+    <input
+      type="search"
+      value={searchQuery}
+      placeholder="Filter workspaces"
+      aria-label="Filter workspaces"
+      oninput={updateSearch}
+    />
+  </label>
   <div class="sidebar-list">
     {#each [...grouped] as [repoKey, items] (repoKey)}
       {@const collapsed = collapsedGroups.has(repoKey)}
@@ -364,6 +431,9 @@
         {/each}
       {/if}
     {/each}
+    {#if visibleWorkspaces.length === 0 && normalizedSearchQuery}
+      <p class="filter-empty">No workspaces match.</p>
+    {/if}
   </div>
 </div>
 
@@ -411,6 +481,46 @@
     opacity: 0.7;
   }
 
+  .workspace-filter {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    height: 28px;
+    margin: 6px 8px 4px;
+    padding: 0 8px;
+    border: 1px solid var(--border-muted);
+    border-radius: 6px;
+    background: var(--bg-surface);
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  :global(.workspace-filter-icon) {
+    flex-shrink: 0;
+  }
+
+  .workspace-filter input {
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    line-height: 1;
+  }
+
+  .workspace-filter input::placeholder {
+    color: var(--text-muted);
+    opacity: 0.8;
+  }
+
+  .workspace-filter:focus-within {
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 1px var(--accent-blue);
+  }
+
   .sidebar-list {
     flex: 1;
     overflow-y: auto;
@@ -429,6 +539,13 @@
 
   .sidebar-list::-webkit-scrollbar-thumb:hover {
     background: var(--text-muted);
+  }
+
+  .filter-empty {
+    margin: 14px 12px;
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
   }
 
   .group-header {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
@@ -30,6 +30,9 @@ interface WorkspaceFixtureOptions {
   owner: string;
   name: string;
   number: number;
+  title?: string;
+  branch?: string;
+  itemType?: "pull_request" | "issue";
 }
 
 function workspaceFixture({
@@ -39,6 +42,9 @@ function workspaceFixture({
   owner,
   name,
   number,
+  title = `PR ${number}`,
+  branch = `feature-${number}`,
+  itemType = "pull_request",
 }: WorkspaceFixtureOptions) {
   return {
     id,
@@ -52,14 +58,14 @@ function workspaceFixture({
     platform_host: platformHost,
     repo_owner: owner,
     repo_name: name,
-    item_type: "pull_request",
+    item_type: itemType,
     item_number: number,
-    git_head_ref: `feature-${number}`,
+    git_head_ref: branch,
     worktree_path: `/tmp/${id}`,
     tmux_session: id,
     status: "ready",
     created_at: "2026-05-12T12:00:00Z",
-    mr_title: `PR ${number}`,
+    mr_title: title,
     mr_state: "open",
   };
 }
@@ -135,5 +141,70 @@ describe("WorkspaceListSidebar", () => {
 
     await screen.findByText("acme/widgets");
     expect(screen.queryByRole("img", { name: "GitHub" })).toBeNull();
+  });
+
+  it("filters workspaces by title, repo, and item number", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-title",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kataflow",
+            number: 9,
+            title: "Migrate native HTTP surface to Huma v2",
+            branch: "feat/huma-adoption",
+          }),
+          workspaceFixture({
+            id: "ws-repo",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-platform",
+            number: 2,
+            title: "Hosted code fetch and caching strategy",
+          }),
+          workspaceFixture({
+            id: "ws-number",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            number: 224,
+            title: "Add notification inbox triage",
+            itemType: "issue",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-title" },
+    });
+    const filter = await screen.findByLabelText("Filter workspaces");
+
+    await fireEvent.input(filter, {
+      target: { value: "huma" },
+    });
+    expect(container.querySelectorAll(".ws-row")).toHaveLength(1);
+    expect(
+      screen.getByText("Migrate native HTTP surface to Huma v2"),
+    ).toBeTruthy();
+
+    await fireEvent.input(filter, {
+      target: { value: "kenn-platform" },
+    });
+    expect(container.querySelectorAll(".ws-row")).toHaveLength(1);
+    expect(
+      screen.getByText("Hosted code fetch and caching strategy"),
+    ).toBeTruthy();
+
+    await fireEvent.input(filter, {
+      target: { value: "#224" },
+    });
+    expect(container.querySelectorAll(".ws-row")).toHaveLength(1);
+    expect(screen.getByText("Add notification inbox triage")).toBeTruthy();
   });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -207,4 +207,46 @@ describe("WorkspaceListSidebar", () => {
     expect(container.querySelectorAll(".ws-row")).toHaveLength(1);
     expect(screen.getByText("Add notification inbox triage")).toBeTruthy();
   });
+
+  it("shows matching workspaces in collapsed groups while filtering", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-hidden",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            number: 224,
+            title: "Add notification inbox triage",
+            itemType: "issue",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-hidden" },
+    });
+    const groupHeader = await screen.findByRole("button", {
+      name: /kenn-io\/middleman/,
+    });
+    const filter = screen.getByLabelText("Filter workspaces");
+
+    expect(container.querySelectorAll(".ws-row")).toHaveLength(1);
+    await fireEvent.click(groupHeader);
+    expect(container.querySelectorAll(".ws-row")).toHaveLength(0);
+
+    await fireEvent.input(filter, {
+      target: { value: "#224" },
+    });
+    expect(container.querySelectorAll(".ws-row")).toHaveLength(1);
+    expect(screen.getByText("Add notification inbox triage")).toBeTruthy();
+
+    await fireEvent.input(filter, {
+      target: { value: "" },
+    });
+    expect(container.querySelectorAll(".ws-row")).toHaveLength(0);
+  });
 });

--- a/frontend/tests/e2e-full/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/workspace-sidebar.spec.ts
@@ -89,6 +89,23 @@ async function waitForWorkspaceReady(
   throw new Error(`workspace ${workspaceId} did not become ready`);
 }
 
+async function createIssueWorkspace(
+  api: APIRequestContext,
+  issueNumber: number,
+): Promise<WorkspaceStatusResponse> {
+  const response = await api.post(
+    `/api/v1/issues/github/acme/widgets/${issueNumber}/workspace`,
+    {
+      data: {},
+    },
+  );
+  expect(response.status()).toBe(202);
+
+  const workspace = (await response.json()) as WorkspaceStatusResponse;
+  await waitForWorkspaceReady(api, workspace.id);
+  return workspace;
+}
+
 test.describe("workspace sidebar full-stack", () => {
   test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
 
@@ -159,6 +176,64 @@ test.describe("workspace sidebar full-stack", () => {
       await expect(
         gitlabGroup.getByRole("img", { name: "GitLab" }),
       ).toBeVisible();
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("filters real workspace API results and expands collapsed matches during search", async ({
+    page,
+  }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const safariWorkspace = await createIssueWorkspace(api, 10);
+      await createIssueWorkspace(api, 11);
+
+      const workspacesResponse = await api.get("/api/v1/workspaces");
+      expect(workspacesResponse.ok()).toBe(true);
+      const workspacesPayload = (await workspacesResponse.json()) as {
+        workspaces: Array<{
+          item_number: number;
+          mr_title?: string | null;
+        }>;
+      };
+      expect(
+        workspacesPayload.workspaces.some(
+          (workspace) =>
+            workspace.item_number === 11 &&
+            workspace.mr_title === "Add dark mode support",
+        ),
+      ).toBe(true);
+
+      await page.goto(
+        `${isolatedServer.info.base_url}/terminal/${safariWorkspace.id}`,
+      );
+
+      const rows = page.locator(".workspace-list-sidebar .ws-row");
+      const groupHeader = page
+        .locator(".workspace-list-sidebar .group-header")
+        .filter({
+          has: page.locator(".group-label", { hasText: "acme/widgets" }),
+        });
+      const filter = page.getByLabel("Filter workspaces");
+
+      await expect(rows).toHaveCount(2);
+      await groupHeader.click();
+      await expect(rows).toHaveCount(0);
+
+      await filter.fill("#11");
+      await expect(rows).toHaveCount(1);
+      await expect(rows).toContainText("Add dark mode support");
+
+      await filter.fill("");
+      await expect(rows).toHaveCount(0);
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2323,6 +2323,96 @@ test.describe("workspace list bubble opens right sidebar", () => {
       expect(maxRight - minRight).toBeLessThanOrEqual(1);
     },
   );
+
+  test(
+    "filters workspace rows by repo, title, and item number",
+    async ({ page }) => {
+      const wsTitle = {
+        ...testWorkspace,
+        id: "ws-title",
+        repo_owner: "kenn-io",
+        repo_name: "kataflow",
+        repo: workspaceRepoRef("kenn-io", "kataflow"),
+        item_number: 9,
+        mr_title: "Migrate native HTTP surface to Huma v2",
+      };
+      const wsRepo = {
+        ...testWorkspace,
+        id: "ws-repo",
+        repo_owner: "kenn-io",
+        repo_name: "kenn-platform",
+        repo: workspaceRepoRef("kenn-io", "kenn-platform"),
+        item_number: 2,
+        mr_title: "Hosted code fetch and caching strategy",
+      };
+      const wsNumber = {
+        ...testIssueWorkspace,
+        id: "ws-number",
+        repo_owner: "kenn-io",
+        repo_name: "middleman",
+        repo: workspaceRepoRef("kenn-io", "middleman"),
+        item_number: 224,
+        mr_title: "Add notification inbox triage",
+      };
+      const list = [wsTitle, wsRepo, wsNumber];
+
+      await mockApi(page);
+      await page.route(
+        "**/api/v1/events",
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: "text/event-stream",
+            body: "",
+          });
+        },
+      );
+      await page.route(
+        "**/api/v1/workspaces",
+        async (route) => {
+          if (route.request().method() === "GET") {
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({ workspaces: list }),
+            });
+            return;
+          }
+          await route.fulfill({ status: 200 });
+        },
+      );
+
+      await page.goto("/workspaces");
+
+      const rows = page.locator(".workspace-list-sidebar .ws-row");
+      const filter = page.getByLabel("Filter workspaces");
+      await expect(rows).toHaveCount(3);
+
+      await filter.fill("huma");
+      await expect(rows).toHaveCount(1);
+      await expect(rows.first()).toContainText(
+        "Migrate native HTTP surface to Huma v2",
+      );
+
+      await filter.fill("kenn-platform");
+      await expect(rows).toHaveCount(1);
+      await expect(rows.first()).toContainText(
+        "Hosted code fetch and caching strategy",
+      );
+
+      await filter.fill("#224");
+      await expect(rows).toHaveCount(1);
+      await expect(rows.first()).toContainText(
+        "Add notification inbox triage",
+      );
+
+      await filter.fill("not-present");
+      await expect(rows).toHaveCount(0);
+      await expect(
+        page.locator(".workspace-list-sidebar"),
+      ).toContainText("No workspaces match.");
+    },
+  );
 });
 
 // -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a compact search field to the workspace sidebar so maintainers can filter the list by repo, title, branch, and PR or issue number.
- Keep the grouped sidebar layout intact while updating the header count and showing an empty state when no workspaces match.
- Add unit and Playwright coverage for the new filter behavior.

## Testing
- Svelte component tests for matching by title, repo, and item number.
- Playwright coverage for filtering and empty-state behavior in the workspace sidebar.
- Frontend typecheck and targeted UI validation passed.