### PR TITLE
Preserve pull request activity during sync

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2167,7 +2167,7 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 		    detail_fetched_at    = COALESCE(middleman_merge_requests.detail_fetched_at, excluded.detail_fetched_at),
 		    ci_had_pending       = middleman_merge_requests.ci_had_pending,
 		    updated_at           = excluded.updated_at,
-		    last_activity_at     = excluded.last_activity_at,
+		    last_activity_at     = MAX(middleman_merge_requests.last_activity_at, excluded.last_activity_at),
 		    merged_at            = excluded.merged_at,
 		    closed_at            = excluded.closed_at,
 		    mergeable_state      = excluded.mergeable_state

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2077,6 +2077,46 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 	assert.Nil(missing)
 }
 
+func TestUpsertMergeRequestPreservesNewerLastActivity(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+	newerActivity := base.Add(2 * time.Hour)
+	pr := &MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     42,
+		Number:         7,
+		URL:            "https://github.com/owner/repo/pull/7",
+		Title:          "fix: something",
+		Author:         "alice",
+		State:          "open",
+		Body:           "body text",
+		HeadBranch:     "fix/something",
+		BaseBranch:     "main",
+		CreatedAt:      base,
+		UpdatedAt:      base,
+		LastActivityAt: newerActivity,
+	}
+
+	_, err := d.UpsertMergeRequest(ctx, pr)
+	require.NoError(err)
+
+	pr.Title = "fix: something synced"
+	pr.LastActivityAt = base
+	_, err = d.UpsertMergeRequest(ctx, pr)
+	require.NoError(err)
+
+	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("fix: something synced", got.Title)
+	assert.True(got.LastActivityAt.Equal(newerActivity))
+}
+
 func TestListPullRequests(t *testing.T) {
 	d := openTestDB(t)
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1398,6 +1398,72 @@ func TestAPIListPullsOrdersByLastActivityDescending(t *testing.T) {
 	assert.Equal(int64(1), (*resp.JSON200)[2].Number)
 }
 
+func TestAPIListPullsPreservesNewerActivityAfterIndexSync(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	base := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	preservedActivity := base.Add(2 * time.Hour)
+	otherActivity := base.Add(time.Hour)
+
+	str := func(v string) *string { return &v }
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			firstNumber := 1
+			firstID := int64(1001)
+			secondNumber := 2
+			secondID := int64(1002)
+			return []*gh.PullRequest{
+				{
+					ID:        &firstID,
+					Number:    &firstNumber,
+					Title:     str("Preserve activity"),
+					State:     str("open"),
+					HTMLURL:   str("https://github.com/acme/widget/pull/1"),
+					User:      &gh.User{Login: str("octocat")},
+					CreatedAt: &gh.Timestamp{Time: base},
+					UpdatedAt: &gh.Timestamp{Time: base},
+					Head:      &gh.PullRequestBranch{Ref: str("feature-one"), SHA: str("head-one")},
+					Base:      &gh.PullRequestBranch{Ref: str("main"), SHA: str("base-one")},
+				},
+				{
+					ID:        &secondID,
+					Number:    &secondNumber,
+					Title:     str("Other activity"),
+					State:     str("open"),
+					HTMLURL:   str("https://github.com/acme/widget/pull/2"),
+					User:      &gh.User{Login: str("octocat")},
+					CreatedAt: &gh.Timestamp{Time: base},
+					UpdatedAt: &gh.Timestamp{Time: otherActivity},
+					Head:      &gh.PullRequestBranch{Ref: str("feature-two"), SHA: str("head-two")},
+					Base:      &gh.PullRequestBranch{Ref: str("main"), SHA: str("base-two")},
+				},
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRTitle("Preserve activity"),
+		withSeedPRTimes(base, base, preservedActivity),
+	)
+	seedPR(t, database, "acme", "widget", 2,
+		withSeedPRTitle("Other activity"),
+		withSeedPRTimes(base, otherActivity, otherActivity),
+	)
+	client := setupTestClient(t, srv)
+
+	srv.syncer.RunOnce(ctx)
+
+	resp, err := client.HTTP.ListPullsWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 2)
+	assert.Equal(int64(1), (*resp.JSON200)[0].Number)
+	assert.Equal(preservedActivity, (*resp.JSON200)[0].LastActivityAt.UTC())
+	assert.Equal(int64(2), (*resp.JSON200)[1].Number)
+}
+
 func TestAPIListPullsKeepsCachedCIDecorationsAfterIndexSync(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1372,6 +1372,32 @@ func TestAPIListItemsIncludeWorkspaceRefs(t *testing.T) {
 	assert.Equal("ws-issue-2", workspaceByItem["issue:2"])
 }
 
+func TestAPIListPullsOrdersByLastActivityDescending(t *testing.T) {
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	base := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRTimes(base, base, base.Add(time.Hour)),
+	)
+	seedPR(t, database, "acme", "widget", 2,
+		withSeedPRTimes(base, base, base.Add(3*time.Hour)),
+	)
+	seedPR(t, database, "acme", "widget", 3,
+		withSeedPRTimes(base, base, base.Add(2*time.Hour)),
+	)
+	client := setupTestClient(t, srv)
+
+	resp, err := client.HTTP.ListPullsWithResponse(t.Context(), nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 3)
+	assert := Assert.New(t)
+	assert.Equal(int64(2), (*resp.JSON200)[0].Number)
+	assert.Equal(int64(3), (*resp.JSON200)[1].Number)
+	assert.Equal(int64(1), (*resp.JSON200)[2].Number)
+}
+
 func TestAPIListPullsKeepsCachedCIDecorationsAfterIndexSync(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -121,7 +121,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	if err := d.UpsertMREvents(ctx, []db.MREvent{
 		{
 			MergeRequestID: w1ID,
-			PlatformID:     int64Ptr(5011),
+			PlatformID:     new(int64(5011)),
 			EventType:      "review",
 			Author:         "alice",
 			Summary:        "APPROVED",
@@ -130,7 +130,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		},
 		{
 			MergeRequestID: w1ID,
-			PlatformID:     int64Ptr(5012),
+			PlatformID:     new(int64(5012)),
 			EventType:      "review",
 			Author:         "bob",
 			Summary:        "CHANGES_REQUESTED",
@@ -139,7 +139,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		},
 		{
 			MergeRequestID: w1ID,
-			PlatformID:     int64Ptr(5013),
+			PlatformID:     new(int64(5013)),
 			EventType:      "review",
 			Author:         "bob",
 			Summary:        "APPROVED",
@@ -148,7 +148,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		},
 		{
 			MergeRequestID: w1ID,
-			PlatformID:     int64Ptr(5014),
+			PlatformID:     new(int64(5014)),
 			EventType:      "review",
 			Author:         "carol",
 			Summary:        "APPROVED",
@@ -160,7 +160,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	}
 	if err := d.UpsertMREvents(ctx, []db.MREvent{{
 		MergeRequestID: w1ID,
-		PlatformID:     int64Ptr(5014),
+		PlatformID:     new(int64(5014)),
 		EventType:      "review",
 		Author:         "carol",
 		Summary:        "DISMISSED",
@@ -1039,11 +1039,6 @@ func setPRStats(pr *gh.PullRequest, additions, deletions int) *gh.PullRequest {
 	pr.Additions = &additions
 	pr.Deletions = &deletions
 	return pr
-}
-
-//go:fix inline
-func int64Ptr(value int64) *int64 {
-	return new(value)
 }
 
 func setPRHeadSHA(pr *gh.PullRequest, sha string) *gh.PullRequest {

--- a/packages/ui/src/stores/pulls.svelte.test.ts
+++ b/packages/ui/src/stores/pulls.svelte.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PullRequest } from "../api/types.js";
+import type { MiddlemanClient } from "../types.js";
+import { createPullsStore } from "./pulls.svelte.js";
+
+function pull(
+  id: number,
+  repoName: string,
+  lastActivityAt: string,
+): PullRequest {
+  return {
+    ID: id,
+    Number: id,
+    Title: `PR ${id}`,
+    LastActivityAt: lastActivityAt,
+    repo_owner: "acme",
+    repo_name: repoName,
+    repo: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: repoName,
+      repo_path: `acme/${repoName}`,
+    },
+  } as PullRequest;
+}
+
+function clientWithPulls(data: PullRequest[]): MiddlemanClient {
+  return {
+    GET: vi.fn(async () => ({ data, error: undefined })),
+  } as unknown as MiddlemanClient;
+}
+
+describe("pulls store display order", () => {
+  it("preserves the API order for flat display", async () => {
+    const store = createPullsStore({
+      client: clientWithPulls([
+        pull(1, "api", "2026-05-20T15:00:00Z"),
+        pull(2, "web", "2026-05-20T14:00:00Z"),
+        pull(3, "api", "2026-05-20T13:00:00Z"),
+      ]),
+      getGroupByRepo: () => false,
+    });
+
+    await store.loadPulls();
+
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 2, 3]);
+  });
+
+  it("groups by repo in first-seen order rather than global activity order", async () => {
+    const store = createPullsStore({
+      client: clientWithPulls([
+        pull(1, "api", "2026-05-20T15:00:00Z"),
+        pull(2, "web", "2026-05-20T14:00:00Z"),
+        pull(3, "api", "2026-05-20T13:00:00Z"),
+      ]),
+      getGroupByRepo: () => true,
+    });
+
+    await store.loadPulls();
+
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 3, 2]);
+  });
+});


### PR DESCRIPTION
- Preserve newer `last_activity_at` values during pull request upserts so list sync cannot regress activity ordering.\n- Add DB, sync/API, and UI-store coverage for pull list activity ordering.\n- Inline fixture pointer values required by the current Go lint path.