### PR TITLE
Add side-by-side diff view option

### DIFF
--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -736,6 +736,7 @@ test.describe("diff view", () => {
     await page.addInitScript(() => {
       localStorage.removeItem("diff-tab-width");
       localStorage.removeItem("diff-hide-whitespace");
+      localStorage.removeItem("diff-view-mode");
       localStorage.removeItem("diff-word-wrap");
       localStorage.removeItem("diff-rich-preview");
       localStorage.removeItem("diff-collapsed-files");
@@ -1226,6 +1227,26 @@ test.describe("diff view", () => {
 
     // Wait for the re-fetch to land and assert it actually happened.
     await expect.poll(() => fetchCount).toBeGreaterThan(initialCount);
+  });
+
+  test("side-by-side toggle renders Pierre split diffs", async ({ page }) => {
+    await mockDiffApi(page, smallDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+
+    const firstFile = page.locator('[data-file-path="internal/server/handler.go"]');
+    await firstFile.scrollIntoViewIfNeeded();
+
+    await openDiffFilterMenu(page);
+    const sideBySide = page.getByRole("switch", { name: "Side-by-side diffs" });
+    await expect(sideBySide).toHaveAttribute("aria-checked", "false");
+    await sideBySide.click();
+    await expect(sideBySide).toHaveAttribute("aria-checked", "true");
+    await expect.poll(async () => {
+      return await firstFile.locator(".pierre-diff").evaluate((host) => {
+        return host.shadowRoot?.querySelector("pre")?.getAttribute("data-diff-type");
+      });
+    }).toBe("split");
   });
 
   test("j/k keyboard navigation moves between files", async ({ page }) => {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -58,6 +58,7 @@
   const collapsed = $derived(diffStore.isFileCollapsed(owner, name, number, file.path));
   const richPreview = $derived(diffStore.getRichPreview());
   const wordWrap = $derived(diffStore.getWordWrap());
+  const viewMode = $derived(diffStore.getViewMode());
   const tabWidth = $derived(diffStore.getTabWidth());
   const filePreviewGeneration = $derived(diffStore.getFilePreviewGeneration());
   const showRichPreview = $derived(
@@ -530,6 +531,7 @@
         <PierreFileDiff
           {file}
           active={inViewport}
+          {viewMode}
           {wordWrap}
           {tabWidth}
           loadFileText={contextExpansionEnabled ? loadDiffText : undefined}

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -151,6 +151,23 @@
       class="compact-switch-row"
       type="button"
       role="switch"
+      aria-label="Side-by-side diffs"
+      aria-checked={diff.getViewMode() === "split"}
+      onclick={() => diff.setViewMode(diff.getViewMode() === "split" ? "unified" : "split")}
+    >
+      <span>Side-by-side</span>
+      <span
+        class="toggle-switch"
+        class:toggle-switch--on={diff.getViewMode() === "split"}
+        aria-hidden="true"
+      >
+        <span class="toggle-knob"></span>
+      </span>
+    </button>
+    <button
+      class="compact-switch-row"
+      type="button"
+      role="switch"
       aria-checked={diff.getWordWrap()}
       onclick={() => diff.setWordWrap(!diff.getWordWrap())}
     >

--- a/packages/ui/src/components/diff/DiffToolbar.test.ts
+++ b/packages/ui/src/components/diff/DiffToolbar.test.ts
@@ -23,6 +23,7 @@ describe("DiffToolbar", () => {
   afterEach(() => {
     cleanup();
     localStorage.removeItem("diff-word-wrap");
+    localStorage.removeItem("diff-view-mode");
   });
 
   it("defaults the changed file category filter to all and renders category buttons", async () => {
@@ -74,6 +75,30 @@ describe("DiffToolbar", () => {
     expect(diff.getWordWrap()).toBe(true);
     expect(wordWrap.getAttribute("aria-checked")).toBe("true");
     expect(localStorage.getItem("diff-word-wrap")).toBe("true");
+  });
+
+  it("toggles the side-by-side diff preference", async () => {
+    const { diff } = renderToolbar();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "More diff filters" }),
+    );
+    const sideBySide = screen.getByRole("switch", { name: "Side-by-side diffs" });
+
+    expect(diff.getViewMode()).toBe("unified");
+    expect(sideBySide.getAttribute("aria-checked")).toBe("false");
+
+    await fireEvent.click(sideBySide);
+
+    expect(diff.getViewMode()).toBe("split");
+    expect(sideBySide.getAttribute("aria-checked")).toBe("true");
+    expect(localStorage.getItem("diff-view-mode")).toBe("split");
+
+    await fireEvent.click(sideBySide);
+
+    expect(diff.getViewMode()).toBe("unified");
+    expect(sideBySide.getAttribute("aria-checked")).toBe("false");
+    expect(localStorage.getItem("diff-view-mode")).toBe("unified");
   });
 
   it("hides rich preview controls when disabled", async () => {

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -18,6 +18,7 @@
   interface Props {
     file: DiffFile | null | undefined;
     active?: boolean;
+    viewMode?: "unified" | "split";
     wordWrap?: boolean;
     tabWidth?: number;
     loadFileText?: ((side: "old" | "new") => Promise<string>) | undefined;
@@ -56,6 +57,7 @@
   const {
     file,
     active = true,
+    viewMode = "unified",
     wordWrap = false,
     tabWidth = 4,
     loadFileText,
@@ -106,7 +108,7 @@
   });
 
   const pierreOptions = $derived.by<FileDiffOptions<unknown>>(() => ({
-    diffStyle: "unified",
+    diffStyle: viewMode,
     diffIndicators: "bars",
     disableFileHeader: true,
     enableLineSelection,
@@ -287,6 +289,7 @@
     pierreDiff.setOptions(pierreOptions);
     const nextRenderAttemptKey = [
       fileKey,
+      viewMode,
       wordWrap,
       tabWidth,
       fullContext ? "full" : "patch",

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -5,7 +5,7 @@ import {
   waitFor,
 } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { DiffLineAnnotation } from "@pierre/diffs";
+import type { DiffLineAnnotation, FileDiffOptions } from "@pierre/diffs";
 import type { DiffFile } from "../../api/types.js";
 
 const pierre = (() => {
@@ -14,6 +14,7 @@ const pierre = (() => {
     render: 0,
   };
   let renderResults: boolean[] = [];
+  let lastOptions: FileDiffOptions<unknown> | undefined;
   const cleanUp = () => {
     counts.cleanUp += 1;
   };
@@ -30,11 +31,16 @@ const pierre = (() => {
     }],
   };
   class FileDiff {
+    constructor(options?: FileDiffOptions<unknown>) {
+      lastOptions = options;
+    }
     cleanUp = cleanUp;
     expandHunk = () => {};
     getLineIndex = (lineNumber: number): [number, number] => [lineNumber, lineNumber];
     render = renderDiff;
-    setOptions = () => {};
+    setOptions = (options?: FileDiffOptions<unknown>) => {
+      lastOptions = options;
+    };
     setSelectedLines = () => {};
     setThemeType = () => {};
   }
@@ -42,6 +48,7 @@ const pierre = (() => {
     cleanUp,
     cleanUpCount: () => counts.cleanUp,
     FileDiff,
+    lastOptions: () => lastOptions,
     metadata,
     parsePatchFiles: () => [{ files: [metadata] }],
     processFile: () => metadata,
@@ -51,6 +58,7 @@ const pierre = (() => {
       counts.cleanUp = 0;
       counts.render = 0;
       renderResults = [];
+      lastOptions = undefined;
     },
     setRenderResults: (results: boolean[]) => {
       renderResults = [...results];
@@ -196,6 +204,20 @@ describe("PierreFileDiff", () => {
       Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
       diffArea.remove();
     }
+  });
+
+  it("passes split diff style to Pierre when side-by-side mode is enabled", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+
+    render(PierreFileDiff, {
+      props: { active: true, file: makeFile(), viewMode: "split" },
+    });
+
+    await waitFor(() => {
+      expect(pierre.renderCount()).toBe(1);
+    });
+
+    expect(pierre.lastOptions()?.diffStyle).toBe("split");
   });
 
   it("rerenders when annotation metadata changes without moving lines", async () => {

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -26,6 +26,7 @@ export type DiffScope =
   | { kind: "range"; fromSha: string; toSha: string };
 
 export type WorkspaceDiffBase = "head" | "pushed" | "merge-target";
+export type DiffViewMode = "unified" | "split";
 
 export type DiffScrollTarget = {
   path: string;
@@ -97,6 +98,7 @@ function safeSetItem(key: string, value: string): void {
 }
 
 const VALID_TAB_WIDTHS = [1, 2, 4, 8];
+const VALID_DIFF_VIEW_MODES: DiffViewMode[] = ["unified", "split"];
 
 function loadTabWidth(): number {
   const raw = parseInt(
@@ -104,6 +106,13 @@ function loadTabWidth(): number {
     10,
   );
   return VALID_TAB_WIDTHS.includes(raw) ? raw : 4;
+}
+
+function loadDiffViewMode(): DiffViewMode {
+  const raw = safeGetItem("diff-view-mode");
+  return VALID_DIFF_VIEW_MODES.includes(raw as DiffViewMode)
+    ? raw as DiffViewMode
+    : "unified";
 }
 
 function loadCollapsedFiles(): Record<string, string[]> {
@@ -167,6 +176,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let hideWhitespace = $state(
     safeGetItem("diff-hide-whitespace") === "true",
   );
+  let viewMode = $state<DiffViewMode>(loadDiffViewMode());
   let collapsedFiles = $state<Record<string, string[]>>(
     loadCollapsedFiles(),
   );
@@ -276,6 +286,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
   function getHideWhitespace(): boolean {
     return hideWhitespace;
+  }
+  function getViewMode(): DiffViewMode {
+    return viewMode;
   }
   function getFileCategoryFilter(): DiffFileCategoryFilter {
     return fileCategoryFilter;
@@ -394,6 +407,11 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     } else if (currentWorkspaceID) {
       void reloadWorkspaceDiffOnly();
     }
+  }
+
+  function setViewMode(mode: DiffViewMode): void {
+    viewMode = mode;
+    safeSetItem("diff-view-mode", mode);
   }
 
   async function reloadDiffOnly(): Promise<void> {
@@ -1087,6 +1105,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     getRichPreview,
     getFilePreviewGeneration,
     getHideWhitespace,
+    getViewMode,
     getFileCategoryFilter,
     getActiveFile,
     setActiveFile,
@@ -1101,6 +1120,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     setWordWrap,
     setRichPreview,
     setHideWhitespace,
+    setViewMode,
     isFileCollapsed,
     areAllVisibleFilesCollapsed,
     toggleFileCollapsed,


### PR DESCRIPTION
- Add a side-by-side option to the existing diff options menu.
- Keep unified diffs as the default and persist the selected layout.
- Verify Pierre renders split diffs when the option is enabled.
