### PR TITLE
fix: let inline comment button close empty composers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ make vet        # go vet
 - Use conventional commit messages whose subject explains the reason or user-visible outcome, not just the mechanical change. Good subjects answer "why does this commit exist?" (for example, `fix: restore workspace activity for launched agents`), while vague mechanics such as `fix: run agents under tmux` are not acceptable on their own
 - Commit bodies must add any important context about the bug, regression, constraint, or tradeoff that motivated the change; do not rely on the diff to explain intent
 - Run tests before committing when applicable
-- Before pushing UI changes, run the full affected Playwright e2e suite locally after the final UI/test edit; focused tests alone are not enough.
+- Before pushing any frontend change, you must have run the full affected Playwright e2e suite locally after the final frontend/test edit; focused component tests, type checks, and CI-only verification are not enough.
 - Never push new workstreams unless explicitly asked. When addressing review feedback or CI failures on an existing PR, an agent may push after the fix is implemented and relevant local validation has run.
 
 ## Pull Requests

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -389,8 +389,28 @@ describe("DiffFile", () => {
   }
 
   async function clickLineCommentButton(line: number, side: "left" | "right"): Promise<void> {
+    const button = await findLineCommentButton(line, side);
+    button.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    await fireEvent.mouseDown(button, { button: 0 });
+    await fireEvent.pointerUp(button, { pointerId: 1, pointerType: "mouse" });
+    await fireEvent.click(button);
+  }
+
+  async function keyboardActivateLineCommentButton(
+    line: number,
+    side: "left" | "right",
+  ): Promise<void> {
+    const button = await findLineCommentButton(line, side);
+    button.focus();
+    await fireEvent.click(button);
+  }
+
+  async function findLineCommentButton(
+    line: number,
+    side: "left" | "right",
+  ): Promise<HTMLButtonElement> {
     const sideLabel = side === "left" ? "old" : "new";
-    const button = await waitFor(() => {
+    return await waitFor(() => {
       const element = document
         .querySelector(".pierre-diff")
         ?.shadowRoot
@@ -400,10 +420,6 @@ describe("DiffFile", () => {
       expect(element).toBeTruthy();
       return element!;
     });
-    button.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
-    await fireEvent.mouseDown(button, { button: 0 });
-    await fireEvent.pointerUp(button, { pointerId: 1, pointerType: "mouse" });
-    await fireEvent.click(button);
   }
 
   function selectedPierreLines(): NodeListOf<Element> | undefined {
@@ -451,6 +467,24 @@ describe("DiffFile", () => {
     });
 
     await clickLineCommentButton(2, "right");
+
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+    expect(selectedPierreLines()).toHaveLength(0);
+  });
+
+  it("toggles an empty inline composer from keyboard line comment button activation", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+    });
+
+    await clickLineCommentButton(2, "right");
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+    await waitFor(() => {
+      expect(selectedPierreLines()).toHaveLength(4);
+    });
+
+    await keyboardActivateLineCommentButton(2, "right");
 
     expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
     expect(selectedPierreLines()).toHaveLength(0);

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -523,6 +523,27 @@ describe("DiffFile", () => {
     expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("toggles an active multiline composer from keyboard line comment button activation", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+      nativeMultilineRanges: true,
+    });
+
+    await selectPierreLine(1, "right");
+    await selectPierreLine(2, "right", { shiftKey: true });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+      expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
+    });
+
+    await keyboardActivateLineCommentButton(2, "right");
+
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+    expect(selectedPierreLines()).toHaveLength(0);
+  });
+
   it("does not create multiline review ranges across separate hunks", async () => {
     renderDiffFile(makeFile({
       additions: 2,

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -388,12 +388,24 @@ describe("DiffFile", () => {
     });
   }
 
-  async function clickLineCommentButton(line: number, side: "left" | "right"): Promise<void> {
+  async function clickLineCommentButton(
+    line: number,
+    side: "left" | "right",
+    options: { shiftKey?: boolean } = {},
+  ): Promise<void> {
     const button = await findLineCommentButton(line, side);
-    button.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
-    await fireEvent.mouseDown(button, { button: 0 });
-    await fireEvent.pointerUp(button, { pointerId: 1, pointerType: "mouse" });
-    await fireEvent.click(button);
+    button.dispatchEvent(new MouseEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      shiftKey: options.shiftKey,
+    }));
+    await fireEvent.mouseDown(button, { button: 0, shiftKey: options.shiftKey });
+    await fireEvent.pointerUp(button, {
+      pointerId: 1,
+      pointerType: "mouse",
+      shiftKey: options.shiftKey,
+    });
+    await fireEvent.click(button, { shiftKey: options.shiftKey });
   }
 
   async function keyboardActivateLineCommentButton(
@@ -488,6 +500,27 @@ describe("DiffFile", () => {
 
     expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
     expect(selectedPierreLines()).toHaveLength(0);
+  });
+
+  it("keeps shift-click line comment button selection from collapsing active ranges", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+      nativeMultilineRanges: true,
+    });
+
+    await selectPierreLine(1, "right");
+    await clickLineCommentButton(2, "right", { shiftKey: true });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+      expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
+    });
+
+    await clickLineCommentButton(2, "right", { shiftKey: true });
+
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+    expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
   });
 
   it("does not create multiline review ranges across separate hunks", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -388,6 +388,21 @@ describe("DiffFile", () => {
     });
   }
 
+  async function clickLineCommentButton(line: number, side: "left" | "right"): Promise<void> {
+    const sideLabel = side === "left" ? "old" : "new";
+    const button = await waitFor(() => {
+      const element = document
+        .querySelector(".pierre-diff")
+        ?.shadowRoot
+        ?.querySelector<HTMLButtonElement>(
+          `[data-middleman-line-comment-button][aria-label="Comment on ${sideLabel} line ${line}"]`,
+        );
+      expect(element).toBeTruthy();
+      return element!;
+    });
+    await fireEvent.click(button);
+  }
+
   function selectedPierreLines(): NodeListOf<Element> | undefined {
     return document
       .querySelector(".pierre-diff")
@@ -418,6 +433,22 @@ describe("DiffFile", () => {
     await selectPierreLine(2, "right", { shiftKey: true });
 
     expect(selectedPierreLines()).toHaveLength(4);
+  });
+
+  it("toggles an empty inline composer from the line comment button", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+    });
+
+    await clickLineCommentButton(2, "right");
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+    expect(selectedPierreLines()).toHaveLength(4);
+
+    await clickLineCommentButton(2, "right");
+
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+    expect(selectedPierreLines()).toHaveLength(0);
   });
 
   it("does not create multiline review ranges across separate hunks", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -563,6 +563,41 @@ describe("DiffFile", () => {
     });
   });
 
+  it("opens a new inline composer on a line that already has a saved draft", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+      draftComments: [{
+        id: "draft-existing",
+        body: "Existing draft on this line",
+        path: "src/foo.ts",
+        side: "right",
+        line: 2,
+        new_line: 2,
+        line_type: "add",
+        diff_head_sha: "diff-head",
+        created_at: "2026-03-30T14:01:00Z",
+        updated_at: "2026-03-30T14:01:00Z",
+      }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Existing draft on this line")).toBeTruthy();
+      const selectedDraftLine = document
+        .querySelector(".pierre-diff")
+        ?.shadowRoot
+        ?.querySelector('[data-selected-line][data-diff-new-line="2"]');
+      expect(selectedDraftLine).toBeTruthy();
+    });
+
+    await clickLineCommentButton(2, "right");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+    });
+    expect(screen.getByText("Existing draft on this line")).toBeTruthy();
+  });
+
   it("renders published review threads under their matching diff line", async () => {
     renderDiffFile(makeFile(), {
       reviewEnabled: true,

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -400,6 +400,9 @@ describe("DiffFile", () => {
       expect(element).toBeTruthy();
       return element!;
     });
+    button.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    await fireEvent.mouseDown(button, { button: 0 });
+    await fireEvent.pointerUp(button, { pointerId: 1, pointerType: "mouse" });
     await fireEvent.click(button);
   }
 
@@ -443,7 +446,9 @@ describe("DiffFile", () => {
 
     await clickLineCommentButton(2, "right");
     expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
-    expect(selectedPierreLines()).toHaveLength(4);
+    await waitFor(() => {
+      expect(selectedPierreLines()).toHaveLength(4);
+    });
 
     await clickLineCommentButton(2, "right");
 

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -851,7 +851,7 @@
       event.stopPropagation();
       const collapse = lineCommentButtonHasPointerSnapshot
         ? lineCommentButtonWasSelectedOnPointerDown
-        : selectedRangeMatchesLineCommentTarget(target, event);
+        : lineCommentTargetIsSelected(target, event);
       lineCommentButtonHasPointerSnapshot = false;
       lineCommentButtonWasSelectedOnPointerDown = false;
       onLineSelected?.(

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -456,39 +456,52 @@
     const pre = root?.querySelector("pre");
     if (!root || !pre) return;
     clearSelectedRangeElements();
-    const ranges = selectedRange ? [selectedRange, ...selectedRanges] : selectedRanges;
-    if (!ranges.length || !pierreDiff) return;
+    if ((!selectedRange && !selectedRanges.length) || !pierreDiff) return;
 
     const split = pre.getAttribute("data-diff-type") === "split";
     const getLineIndex = getPierreLineIndex(pierreDiff);
-    for (const range of ranges) {
-      const startIndexes = getLineIndex(range.start, range.side as PierreSide);
-      const endIndexes = getLineIndex(
-        range.end,
-        (range.endSide ?? range.side) as PierreSide,
-      );
-      if (!startIndexes || !endIndexes) continue;
-      const startIndex = split ? startIndexes[1] : startIndexes[0];
-      const endIndex = split ? endIndexes[1] : endIndexes[0];
-      markSelectedLineIndexes(
-        Math.min(startIndex, endIndex),
-        Math.max(startIndex, endIndex),
-        range.side as PierreSide,
-      );
+    if (selectedRange) {
+      markSelectedRange(getLineIndex, split, selectedRange, true);
     }
+    for (const range of selectedRanges) {
+      markSelectedRange(getLineIndex, split, range, false);
+    }
+  }
+
+  function markSelectedRange(
+    getLineIndex: GetLineIndexUtility,
+    split: boolean,
+    range: SelectedLineRange,
+    active: boolean,
+  ): void {
+    const startIndexes = getLineIndex(range.start, range.side as PierreSide);
+    const endIndexes = getLineIndex(
+      range.end,
+      (range.endSide ?? range.side) as PierreSide,
+    );
+    if (!startIndexes || !endIndexes) return;
+    const startIndex = split ? startIndexes[1] : startIndexes[0];
+    const endIndex = split ? endIndexes[1] : endIndexes[0];
+    markSelectedLineIndexes(
+      Math.min(startIndex, endIndex),
+      Math.max(startIndex, endIndex),
+      range.side as PierreSide,
+      active,
+    );
   }
 
   function markSelectedLineIndexes(
     first: number,
     last: number,
     side: PierreSide,
+    active: boolean,
   ): void {
     const isSingle = first === last;
     for (let lineIndex = first; lineIndex <= last; lineIndex += 1) {
       for (const { content: contentElement, gutter: gutterElement } of renderedLineRows.get(lineIndex) ?? []) {
         let value = isSingle ? "single" : lineIndex === first ? "first" : lineIndex === last ? "last" : "";
-        markSelectedRangeElement(contentElement, value);
-        markSelectedRangeElement(gutterElement, value, side);
+        markSelectedRangeElement(contentElement, value, undefined, active);
+        markSelectedRangeElement(gutterElement, value, side, active);
         if (
           contentElement.nextSibling instanceof HTMLElement &&
           gutterElement.nextSibling instanceof HTMLElement &&
@@ -500,8 +513,8 @@
           } else if (lineIndex === first || lineIndex === last) {
             value = "";
           }
-          markSelectedRangeElement(contentElement.nextSibling, value);
-          markSelectedRangeElement(gutterElement.nextSibling, value, side);
+          markSelectedRangeElement(contentElement.nextSibling, value, undefined, active);
+          markSelectedRangeElement(gutterElement.nextSibling, value, side, active);
         }
       }
     }
@@ -511,10 +524,14 @@
     element: HTMLElement,
     value: string,
     side?: PierreSide,
+    active = false,
   ): void {
     selectedRangeElements.add(element);
     element.setAttribute("data-review-range-line", "");
     element.setAttribute("data-selected-line", value);
+    if (active) {
+      element.setAttribute("data-active-review-range-line", "");
+    }
     if (side && element.hasAttribute("data-column-number")) {
       element.classList.add("gutter--selected", side === "deletions" ? "gutter-old" : "gutter-new");
     }
@@ -524,6 +541,7 @@
     for (const element of selectedRangeElements) {
       element.removeAttribute("data-review-range-line");
       element.removeAttribute("data-selected-line");
+      element.removeAttribute("data-active-review-range-line");
       element.classList.remove("gutter--selected", "gutter-new", "gutter-old");
     }
     selectedRangeElements.clear();
@@ -869,7 +887,7 @@
   function selectedLineTargetExists(target: { lineNumber: number; side: PierreSide }): boolean {
     const attr = target.side === "additions" ? "data-diff-new-line" : "data-diff-old-line";
     return host?.shadowRoot?.querySelector(
-      `[data-selected-line][${attr}="${target.lineNumber}"]`,
+      `[data-active-review-range-line][${attr}="${target.lineNumber}"]`,
     ) != null;
   }
 

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -821,9 +821,26 @@
     button.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
-      onLineSelected?.(lineCommentSelection(target, event));
+      onLineSelected?.(
+        selectedRangeMatchesLineCommentTarget(target, event)
+          ? null
+          : lineCommentSelection(target, event),
+      );
     });
     return button;
+  }
+
+  function selectedRangeMatchesLineCommentTarget(
+    target: { lineNumber: number; side: PierreSide },
+    event: MouseEvent,
+  ): boolean {
+    if (event.shiftKey || !selectedRange) return false;
+    const selectedSide = selectedRange.side ?? target.side;
+    const selectedEndSide = selectedRange.endSide ?? selectedSide;
+    return selectedSide === target.side &&
+      selectedEndSide === target.side &&
+      selectedRange.start === target.lineNumber &&
+      selectedRange.end === target.lineNumber;
   }
 
   function lineCommentSelection(

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -91,6 +91,7 @@
   let renderedLineRows = new Map<number, RenderedLinePair[]>();
   let selectedRangeElements = new Set<HTMLElement>();
   let transientAnnotationRow: TransientAnnotationRow | undefined;
+  let lineCommentButtonWasSelectedOnPointerDown = false;
   const inactiveCleanupDelayMs = 10_000;
   const maxImmediateRenderRetries = 5;
 
@@ -818,11 +819,19 @@
     button.title = label;
     button.setAttribute("aria-label", label);
     button.setAttribute("data-middleman-line-comment-button", "");
+    button.addEventListener("pointerdown", (event) => {
+      lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
+    });
+    button.addEventListener("mousedown", (event) => {
+      lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
+    });
     button.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
+      const collapse = lineCommentButtonWasSelectedOnPointerDown;
+      lineCommentButtonWasSelectedOnPointerDown = false;
       onLineSelected?.(
-        selectedRangeMatchesLineCommentTarget(target, event)
+        collapse
           ? null
           : lineCommentSelection(target, event),
       );
@@ -841,6 +850,21 @@
       selectedEndSide === target.side &&
       selectedRange.start === target.lineNumber &&
       selectedRange.end === target.lineNumber;
+  }
+
+  function lineCommentTargetIsSelected(
+    target: { lineNumber: number; side: PierreSide },
+    event: MouseEvent,
+  ): boolean {
+    return selectedRangeMatchesLineCommentTarget(target, event) ||
+      selectedLineTargetExists(target);
+  }
+
+  function selectedLineTargetExists(target: { lineNumber: number; side: PierreSide }): boolean {
+    const attr = target.side === "additions" ? "data-diff-new-line" : "data-diff-old-line";
+    return host?.shadowRoot?.querySelector(
+      `[data-selected-line][${attr}="${target.lineNumber}"]`,
+    ) != null;
   }
 
   function lineCommentSelection(

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -91,6 +91,7 @@
   let renderedLineRows = new Map<number, RenderedLinePair[]>();
   let selectedRangeElements = new Set<HTMLElement>();
   let transientAnnotationRow: TransientAnnotationRow | undefined;
+  let lineCommentButtonHasPointerSnapshot = false;
   let lineCommentButtonWasSelectedOnPointerDown = false;
   const inactiveCleanupDelayMs = 10_000;
   const maxImmediateRenderRetries = 5;
@@ -820,15 +821,20 @@
     button.setAttribute("aria-label", label);
     button.setAttribute("data-middleman-line-comment-button", "");
     button.addEventListener("pointerdown", (event) => {
+      lineCommentButtonHasPointerSnapshot = true;
       lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
     });
     button.addEventListener("mousedown", (event) => {
+      lineCommentButtonHasPointerSnapshot = true;
       lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
     });
     button.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
-      const collapse = lineCommentButtonWasSelectedOnPointerDown;
+      const collapse = lineCommentButtonHasPointerSnapshot
+        ? lineCommentButtonWasSelectedOnPointerDown
+        : selectedRangeMatchesLineCommentTarget(target, event);
+      lineCommentButtonHasPointerSnapshot = false;
       lineCommentButtonWasSelectedOnPointerDown = false;
       onLineSelected?.(
         collapse

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -881,7 +881,7 @@
     event: MouseEvent,
   ): boolean {
     return selectedRangeMatchesLineCommentTarget(target, event) ||
-      selectedLineTargetExists(target);
+      (!event.shiftKey && selectedLineTargetExists(target));
   }
 
   function selectedLineTargetExists(target: { lineNumber: number; side: PierreSide }): boolean {


### PR DESCRIPTION
- Let the inline diff + button close an untouched composer when clicked again.
- Keep shift/range selection behavior unchanged.