### PR TITLE
Show review decision icons in PR sidebar

### DIFF
--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -130,6 +130,19 @@ test.describe("PR list view", () => {
     await waitForPullList(page);
 
     await selectPullGrouping(page, "All");
+    const approvedItem = page.locator(".pull-item", {
+      hasText: "Add widget caching layer",
+    });
+    const changesRequestedItem = page.locator(".pull-item", {
+      hasText: "Fix race condition in event loop",
+    });
+    await expect(
+      approvedItem.locator("[aria-label='PR approved']"),
+    ).toBeVisible();
+    await expect(
+      changesRequestedItem.locator("[aria-label='Changes requested']"),
+    ).toBeVisible();
+
     const firstItem = page.locator(".pull-item").first();
     const repoChip = firstItem.locator(".repo-chip");
     await expect(repoChip).toBeVisible();

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test, type Browser, type Page } from "@playwright/test";
+import {
+  startIsolatedE2EServer,
+  type IsolatedE2EServer,
+} from "./support/e2eServer";
 
 // Seeded data summary:
 //   open PRs (8): widgets#1, #2, #6, #7, tools#1, tools#10, #11, #12 (last three form a stack)
@@ -41,7 +45,7 @@ async function selectPullGrouping(page: Page, label: string): Promise<void> {
 const longRepoName = "widgets-with-an-extremely-long-repository-name";
 const longRepoPath = `acme/${longRepoName}`;
 
-async function mockSidebarPullPayload(page: Page): Promise<void> {
+async function mockLongPullRepoSlug(page: Page): Promise<void> {
   await page.route(
     (url) =>
       url.pathname.endsWith("/api/v1/pulls")
@@ -49,8 +53,6 @@ async function mockSidebarPullPayload(page: Page): Promise<void> {
     async (route) => {
       const response = await route.fetch();
       const pulls = await response.json() as Array<{
-        ReviewDecision?: string;
-        Title?: string;
         repo?: { owner?: string; name?: string; repo_path?: string };
         repo_owner?: string;
         repo_name?: string;
@@ -63,13 +65,6 @@ async function mockSidebarPullPayload(page: Page): Promise<void> {
           firstPull.repo.owner = "acme";
           firstPull.repo.name = longRepoName;
           firstPull.repo.repo_path = longRepoPath;
-        }
-      }
-      for (const pull of pulls) {
-        if (pull.Title === "Add widget caching layer") {
-          pull.ReviewDecision = "APPROVED";
-        } else if (pull.Title === "Fix race condition in event loop") {
-          pull.ReviewDecision = "CHANGES_REQUESTED";
         }
       }
       await route.fulfill({ response, json: pulls });
@@ -132,14 +127,6 @@ async function expectPullReviewIndicator(
 }
 
 test.describe("PR list view", () => {
-  test.beforeAll(async ({ browser }, testInfo) => {
-    const baseURL = testInfo.project.use.baseURL;
-    if (typeof baseURL !== "string") {
-      throw new Error("PR list e2e setup requires a configured baseURL");
-    }
-    await primeKanbanStateRows(browser, baseURL);
-  });
-
   test.beforeEach(async ({ page }) => {
     await page.goto("/pulls");
     await waitForPullList(page);
@@ -148,36 +135,6 @@ test.describe("PR list view", () => {
   test("renders open PRs by default with correct count", async ({ page }) => {
     const countBadge = page.locator(".filter-bar .list-count-chip");
     await expect(countBadge).toHaveText(/^8 PRs$/);
-  });
-
-  test("sidebar status pills use the shared chip component", async ({
-    page,
-  }) => {
-    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(
-      /^8 PRs$/,
-    );
-
-    await mockSidebarPullPayload(page);
-    await page.goto("/pulls");
-    await waitForPullList(page);
-
-    await selectPullGrouping(page, "All");
-    await expectPullReviewIndicator(
-      page,
-      "Add widget caching layer",
-      "PR approved",
-    );
-    await expectPullReviewIndicator(
-      page,
-      "Fix race condition in event loop",
-      "Changes requested",
-    );
-
-    const firstItem = page.locator(".pull-item").first();
-    const repoChip = firstItem.locator(".repo-chip");
-    await expect(repoChip).toBeVisible();
-    await expectRepoChipToClipSafely(firstItem, repoChip, longRepoPath);
-    await expect(firstItem.locator(".status-chip")).toBeVisible();
   });
 
   test("closed state shows closed and merged PRs with correct count", async ({
@@ -280,5 +237,50 @@ test.describe("PR list view", () => {
       expect(Math.abs(headerCenter - scrollportCenter)).toBeLessThan(2);
       expect(headerBox.width).toBeLessThanOrEqual(800);
     }
+  });
+});
+
+test.describe("PR list sidebar", () => {
+  let server: IsolatedE2EServer | undefined;
+
+  test.beforeAll(async ({ browser }) => {
+    server = await startIsolatedE2EServer();
+    await primeKanbanStateRows(browser, server.info.base_url);
+  });
+
+  test.afterAll(async () => {
+    await server?.stop();
+  });
+
+  test("sidebar status pills use the shared chip component", async ({
+    page,
+  }) => {
+    if (!server) {
+      throw new Error("PR list sidebar e2e server was not started");
+    }
+    await mockLongPullRepoSlug(page);
+    await page.goto(`${server.info.base_url}/pulls`);
+    await waitForPullList(page);
+
+    await expect(page.locator(".filter-bar .list-count-chip")).toHaveText(
+      /^8 PRs$/,
+    );
+    await selectPullGrouping(page, "All");
+    await expectPullReviewIndicator(
+      page,
+      "Add widget caching layer",
+      "PR approved",
+    );
+    await expectPullReviewIndicator(
+      page,
+      "Fix race condition in event loop",
+      "Changes requested",
+    );
+
+    const firstItem = page.locator(".pull-item").first();
+    const repoChip = firstItem.locator(".repo-chip");
+    await expect(repoChip).toBeVisible();
+    await expectRepoChipToClipSafely(firstItem, repoChip, longRepoPath);
+    await expect(firstItem.locator(".status-chip")).toBeVisible();
   });
 });

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Browser, type Page } from "@playwright/test";
 
 // Seeded data summary:
 //   open PRs (8): widgets#1, #2, #6, #7, tools#1, tools#10, #11, #12 (last three form a stack)
@@ -96,7 +96,41 @@ async function expectRepoChipToClipSafely(
   expect(labelOverflow.scrollWidth).toBeGreaterThan(labelOverflow.clientWidth);
 }
 
+async function primeKanbanStateRows(
+  browser: Browser,
+  baseURL: string,
+): Promise<void> {
+  const page = await browser.newPage({ baseURL });
+  try {
+    await page.goto("/pulls");
+    await waitForPullList(page);
+    await page.locator(".pull-item").first().click();
+    await page
+      .locator(".pull-detail")
+      .waitFor({ state: "visible", timeout: 5_000 });
+  } finally {
+    await page.close();
+  }
+}
+
+async function expectPullReviewIndicator(
+  page: Page,
+  title: string,
+  label: string,
+): Promise<void> {
+  const item = page.locator(".pull-item", { hasText: title });
+  await expect(item.locator(`[aria-label='${label}']`)).toBeVisible();
+}
+
 test.describe("PR list view", () => {
+  test.beforeAll(async ({ browser }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL;
+    if (typeof baseURL !== "string") {
+      throw new Error("PR list e2e setup requires a configured baseURL");
+    }
+    await primeKanbanStateRows(browser, baseURL);
+  });
+
   test.beforeEach(async ({ page }) => {
     await page.goto("/pulls");
     await waitForPullList(page);
@@ -114,34 +148,21 @@ test.describe("PR list view", () => {
       /^8 PRs$/,
     );
 
-    // Seeded fixtures have no kanban_state rows; visiting a PR detail
-    // creates the row server-side via EnsureKanbanState. Without this,
-    // .status-chip never renders because PullItem hides it for empty
-    // KanbanStatus.
-    await page.locator(".pull-item").first().click();
-    await page
-      .locator(".pull-detail")
-      .waitFor({ state: "visible", timeout: 5_000 });
-    await page.goto("/pulls");
-    await waitForPullList(page);
-
     await mockLongPullRepoSlug(page);
     await page.goto("/pulls");
     await waitForPullList(page);
 
     await selectPullGrouping(page, "All");
-    const approvedItem = page.locator(".pull-item", {
-      hasText: "Add widget caching layer",
-    });
-    const changesRequestedItem = page.locator(".pull-item", {
-      hasText: "Fix race condition in event loop",
-    });
-    await expect(
-      approvedItem.locator("[aria-label='PR approved']"),
-    ).toBeVisible();
-    await expect(
-      changesRequestedItem.locator("[aria-label='Changes requested']"),
-    ).toBeVisible();
+    await expectPullReviewIndicator(
+      page,
+      "Add widget caching layer",
+      "PR approved",
+    );
+    await expectPullReviewIndicator(
+      page,
+      "Fix race condition in event loop",
+      "Changes requested",
+    );
 
     const firstItem = page.locator(".pull-item").first();
     const repoChip = firstItem.locator(".repo-chip");

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -41,7 +41,7 @@ async function selectPullGrouping(page: Page, label: string): Promise<void> {
 const longRepoName = "widgets-with-an-extremely-long-repository-name";
 const longRepoPath = `acme/${longRepoName}`;
 
-async function mockLongPullRepoSlug(page: Page): Promise<void> {
+async function mockSidebarPullPayload(page: Page): Promise<void> {
   await page.route(
     (url) =>
       url.pathname.endsWith("/api/v1/pulls")
@@ -49,6 +49,8 @@ async function mockLongPullRepoSlug(page: Page): Promise<void> {
     async (route) => {
       const response = await route.fetch();
       const pulls = await response.json() as Array<{
+        ReviewDecision?: string;
+        Title?: string;
         repo?: { owner?: string; name?: string; repo_path?: string };
         repo_owner?: string;
         repo_name?: string;
@@ -61,6 +63,13 @@ async function mockLongPullRepoSlug(page: Page): Promise<void> {
           firstPull.repo.owner = "acme";
           firstPull.repo.name = longRepoName;
           firstPull.repo.repo_path = longRepoPath;
+        }
+      }
+      for (const pull of pulls) {
+        if (pull.Title === "Add widget caching layer") {
+          pull.ReviewDecision = "APPROVED";
+        } else if (pull.Title === "Fix race condition in event loop") {
+          pull.ReviewDecision = "CHANGES_REQUESTED";
         }
       }
       await route.fulfill({ response, json: pulls });
@@ -148,7 +157,7 @@ test.describe("PR list view", () => {
       /^8 PRs$/,
     );
 
-    await mockLongPullRepoSlug(page);
+    await mockSidebarPullPayload(page);
     await page.goto("/pulls");
     await waitForPullList(page);
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3753,6 +3753,7 @@ func (s *Syncer) indexUpsertMergeRequest(
 	if existing != nil {
 		normalized.Additions = existing.Additions
 		normalized.Deletions = existing.Deletions
+		preserveReviewDecisionIfOmitted(normalized, existing)
 		preserveMergeableStateIfOmitted(normalized, existing)
 		needsCIDetailRefresh = preserveCIStateIfOmitted(normalized, existing)
 	}
@@ -3836,6 +3837,7 @@ func (s *Syncer) indexUpsertMR(
 	if existing != nil {
 		normalized.Additions = existing.Additions
 		normalized.Deletions = existing.Deletions
+		preserveReviewDecisionIfOmitted(normalized, existing)
 		preserveMergeableStateIfOmitted(normalized, existing)
 		needsCIDetailRefresh = preserveCIStateIfOmitted(normalized, existing)
 	}
@@ -7116,6 +7118,24 @@ func preserveMergeableStateIfOmitted(
 		(normalized.MergeableState == "unknown" && existing.MergeableState != "") {
 		normalized.MergeableState = existing.MergeableState
 	}
+}
+
+func preserveReviewDecisionIfOmitted(
+	normalized *db.MergeRequest,
+	existing *db.MergeRequest,
+) {
+	if normalized == nil || existing == nil {
+		return
+	}
+	if normalized.ReviewDecision != "" || existing.ReviewDecision == "" {
+		return
+	}
+	if normalized.PlatformHeadSHA != "" &&
+		existing.PlatformHeadSHA != "" &&
+		normalized.PlatformHeadSHA != existing.PlatformHeadSHA {
+		return
+	}
+	normalized.ReviewDecision = existing.ReviewDecision
 }
 
 func preserveCIStateIfOmitted(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -2303,6 +2303,60 @@ func TestIndexUpsertMergeRequestPreservesCachedCIForSameHead(t *testing.T) {
 	assert.Contains(stored.CIChecksJSON, "build")
 }
 
+func TestIndexUpsertMergeRequestPreservesReviewDecisionWhenOmitted(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1001,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "Approved PR",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "same-head",
+		ReviewDecision:  "APPROVED",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+
+	syncer := NewSyncer(nil, d, nil, nil, time.Minute, nil, testBudget(500))
+	err = syncer.indexUpsertMergeRequest(
+		ctx,
+		RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"},
+		repoID,
+		platform.MergeRequest{
+			PlatformID:     1001,
+			Number:         1,
+			URL:            "https://github.com/owner/repo/pull/1",
+			Title:          "Approved PR",
+			State:          "open",
+			HeadBranch:     "feature",
+			BaseBranch:     "main",
+			HeadSHA:        "same-head",
+			CreatedAt:      now,
+			UpdatedAt:      now.Add(time.Minute),
+			LastActivityAt: now.Add(time.Minute),
+		},
+	)
+	require.NoError(err)
+
+	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("APPROVED", stored.ReviewDecision)
+}
+
 func TestPreserveMergeableStateSkipsChangedOrUnknownHeadOrBase(t *testing.T) {
 	assert := Assert.New(t)
 	tests := []struct {
@@ -2396,6 +2450,32 @@ func TestPreserveCIStateKeepsOmittedStateForMatchingHead(t *testing.T) {
 
 	assert.Equal("success", normalized.CIStatus)
 	assert.Contains(normalized.CIChecksJSON, "build")
+}
+
+func TestPreserveReviewDecisionKeepsOmittedDecisionForMatchingHead(t *testing.T) {
+	assert := Assert.New(t)
+	normalized := db.MergeRequest{PlatformHeadSHA: "same-head"}
+	existing := db.MergeRequest{
+		PlatformHeadSHA: "same-head",
+		ReviewDecision:  "CHANGES_REQUESTED",
+	}
+
+	preserveReviewDecisionIfOmitted(&normalized, &existing)
+
+	assert.Equal("CHANGES_REQUESTED", normalized.ReviewDecision)
+}
+
+func TestPreserveReviewDecisionSkipsChangedHead(t *testing.T) {
+	assert := Assert.New(t)
+	normalized := db.MergeRequest{PlatformHeadSHA: "new-head"}
+	existing := db.MergeRequest{
+		PlatformHeadSHA: "old-head",
+		ReviewDecision:  "APPROVED",
+	}
+
+	preserveReviewDecisionIfOmitted(&normalized, &existing)
+
+	assert.Empty(normalized.ReviewDecision)
 }
 
 func TestPreserveCIStateClearsCachedChecksWhenStatusChanges(t *testing.T) {

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -186,6 +186,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Additions:         55,
 		Deletions:         12,
 		CommentCount:      2,
+		ReviewDecision:    "CHANGES_REQUESTED",
 		MergeableState:    "dirty",
 		CreatedAt:         w2Created,
 		UpdatedAt:         now.Add(-20 * time.Hour),

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -11,6 +11,8 @@
   } from "../../utils/ci-buckets-warn.js";
   import CITokenCluster, { composeAriaLabel } from "../shared/CITokenCluster.svelte";
   import CircleAlertIcon from "@lucide/svelte/icons/circle-alert";
+  import CircleCheckBigIcon from "@lucide/svelte/icons/circle-check-big";
+  import OctagonXIcon from "@lucide/svelte/icons/octagon-x";
   import Chip from "../shared/Chip.svelte";
   import GitHubLabels from "../shared/GitHubLabels.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
@@ -104,6 +106,21 @@
     pr.State === "open",
   );
   const labels = $derived(pr.labels ?? []);
+  const reviewDecision = $derived(pr.ReviewDecision.trim().toUpperCase());
+  const reviewIndicator = $derived.by(
+    ():
+      | { kind: "approved"; label: string }
+      | { kind: "changes-requested"; label: string }
+      | null => {
+      if (reviewDecision === "APPROVED") {
+        return { kind: "approved", label: "PR approved" };
+      }
+      if (reviewDecision === "CHANGES_REQUESTED") {
+        return { kind: "changes-requested", label: "Changes requested" };
+      }
+      return null;
+    },
+  );
 
   function handleImportClick(e: MouseEvent): void {
     e.stopPropagation();
@@ -183,6 +200,19 @@
       {/if}
       {#if pr.workspace}
         <WorkspaceIndicator status={pr.workspace.status} />
+      {/if}
+      {#if reviewIndicator}
+        <span
+          class={["review-indicator", `review-indicator--${reviewIndicator.kind}`]}
+          aria-label={reviewIndicator.label}
+          title={reviewIndicator.label}
+        >
+          {#if reviewIndicator.kind === "approved"}
+            <CircleCheckBigIcon size={13} strokeWidth={2.2} aria-hidden="true" />
+          {:else}
+            <OctagonXIcon size={13} strokeWidth={2.2} aria-hidden="true" />
+          {/if}
+        </span>
       {/if}
       {#if hasWorktree && worktreeName}
         <span class="worktree-name" title="Linked to {worktreeName}">{worktreeName}</span>
@@ -380,6 +410,21 @@
     max-width: 80px;
     flex-shrink: 1;
     min-width: 0;
+  }
+
+  .review-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+  }
+
+  .review-indicator--approved {
+    color: var(--accent-green);
+  }
+
+  .review-indicator--changes-requested {
+    color: var(--accent-red);
   }
 
   .ci-unavailable {

--- a/packages/ui/src/components/sidebar/PullItem.test.ts
+++ b/packages/ui/src/components/sidebar/PullItem.test.ts
@@ -17,6 +17,7 @@ const mkPR = (overrides: Record<string, unknown>): PullRequest =>
     CIStatus: "",
     CIChecksJSON: "",
     MergeableState: "clean",
+    ReviewDecision: "",
     LastActivityAt: new Date().toISOString(),
     PlatformExternalID: "ext-1",
     repo_owner: "o",
@@ -150,6 +151,40 @@ describe("PullItem kanban status", () => {
     }));
 
     expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
+  });
+
+  it("shows an approved indicator when the PR is approved", () => {
+    renderItem(
+      mkPR({
+        Title: "Cache widget details",
+        ReviewDecision: "APPROVED",
+      }),
+    );
+
+    expect(screen.getByLabelText("PR approved")).toBeTruthy();
+  });
+
+  it("shows a changes requested indicator when the PR explicitly requests changes", () => {
+    renderItem(
+      mkPR({
+        Title: "Cache widget details",
+        ReviewDecision: "CHANGES_REQUESTED",
+      }),
+    );
+
+    expect(screen.getByLabelText("Changes requested")).toBeTruthy();
+  });
+
+  it("hides the review indicator when the PR has no terminal review decision", () => {
+    renderItem(
+      mkPR({
+        Title: "Cache widget details",
+        ReviewDecision: "REVIEW_REQUIRED",
+      }),
+    );
+
+    expect(screen.queryByLabelText("PR approved")).toBeNull();
+    expect(screen.queryByLabelText("Changes requested")).toBeNull();
   });
 
   it("shows the kanban status for open PRs", () => {


### PR DESCRIPTION
- Show approved PRs with a compact check icon in the sidebar.
- Show changes-requested PRs with a compact red X icon.
- Keep non-terminal review states visually quiet.

![pr-sidebar-review-icons-sanitized.png](https://github.com/user-attachments/assets/55f1e145-1bd4-4a9e-b6d9-cabde7a3e0a2)
