### PR TITLE
fix: align telemetry with daemon active standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ repository URL or needs to preserve provider-canonical casing.
 
 ## Telemetry
 
-Middleman sends limited anonymous telemetry to PostHog: `server_started` with repo count and `app_loaded` with view name, plus version, commit, OS/arch, and an anonymous install ID.
+Middleman sends limited anonymous telemetry to PostHog: `server_started` with repo count at startup and every 24 hours for long-running applications, and `app_loaded` with view name, plus version, commit, OS/arch, and an anonymous install ID.
 It does not send repo names, PR/issue content, provider tokens, usernames, or IP geolocation; set `TELEMETRY_ENABLED=0` to disable it.
 
 ## Embedding

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -465,6 +465,12 @@ func run(opts serve.Options) error {
 		syscall.SIGINT,
 		syscall.SIGTERM,
 	)
+	telemetryReporter.StartServerStartedPingLoop(
+		ctx, telemetry.ServerPingInterval,
+		func() int {
+			return len(syncer.TrackedRepos())
+		},
+	)
 
 	syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(ctx, database, nil))
 	syncer.Start(ctx)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	EnabledEnv           = "TELEMETRY_ENABLED"
+	ServerPingInterval   = 24 * time.Hour
 	installIDMetadataKey = "telemetry.install_id"
 	postHogAPIKey        = "phc_AzHd9YvuHR7M5poKzC6eW654d3SgKyBdoQPuwkWhimUf"
 	postHogEndpoint      = "https://us.i.posthog.com"
@@ -170,6 +171,34 @@ func (r *Reporter) Capture(event string, properties map[string]any) error {
 		Timestamp:  time.Now().UTC(),
 		Properties: props,
 	})
+}
+
+func (r *Reporter) StartServerStartedPingLoop(
+	ctx context.Context,
+	interval time.Duration,
+	repoCount func() int,
+) {
+	if !r.Enabled() || interval <= 0 || repoCount == nil {
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := r.Capture("server_started", map[string]any{
+					"repo_count": repoCount(),
+				}); err != nil {
+					slog.Warn("capture telemetry ping", "err", err)
+				}
+			}
+		}
+	}()
 }
 
 func (r *Reporter) Close() error {


### PR DESCRIPTION
- Send backend daemon activity as `daemon_active` with the stable anonymous install ID as PostHog `DistinctId`.
- Force `$process_person_profile=false`, `$geoip_disable=true`, and `application=middleman` after caller property sanitization so they cannot be overridden.
- Keep `version`, `commit`, `goos`, `goarch`, and `source=backend` on captures, and document the existing `TELEMETRY_ENABLED=0` opt-out.

Validation:
- `go test ./internal/telemetry -shuffle=on`
- `go test ./internal/server -run TestCaptureTelemetryEvent -shuffle=on`
- `go test ./internal/server/e2etest -run TestTelemetry -shuffle=on`
- `go test ./cmd/middleman -shuffle=on`
- commit hook: `go test (short)` passed
- pre-push hook: `nilaway` passed