### PR TITLE
Align daemon telemetry with PostHog spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ repository URL or needs to preserve provider-canonical casing.
 
 ## Telemetry
 
-Middleman sends limited anonymous telemetry to PostHog: `server_started` with repo count at startup and every 24 hours for long-running applications, and `app_loaded` with view name, plus version, commit, OS/arch, and an anonymous install ID.
-It does not send repo names, PR/issue content, provider tokens, usernames, or IP geolocation; set `TELEMETRY_ENABLED=0` to disable it.
+Middleman sends limited anonymous telemetry to PostHog: `daemon_active` with repo count and `app_loaded` with view name, plus version, commit, OS/arch, `application: "middleman"`, and an anonymous install ID.
+It disables PostHog person profile processing and IP geolocation for every capture. It does not send repo names, PR/issue content, provider tokens, usernames, hostnames, or paths; set `TELEMETRY_ENABLED=0` to disable it.
 
 ## Embedding
 

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -415,7 +415,7 @@ func run(opts serve.Options) error {
 		}
 	}()
 	if telemetryReporter.Enabled() {
-		if err := telemetryReporter.Capture("server_started", map[string]any{
+		if err := telemetryReporter.Capture("daemon_active", map[string]any{
 			"repo_count": len(repos),
 		}); err != nil {
 			slog.Warn("capture telemetry event", "err", err)
@@ -465,13 +465,6 @@ func run(opts serve.Options) error {
 		syscall.SIGINT,
 		syscall.SIGTERM,
 	)
-	telemetryReporter.StartServerStartedPingLoop(
-		ctx, telemetry.ServerPingInterval,
-		func() int {
-			return len(syncer.TrackedRepos())
-		},
-	)
-
 	syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(ctx, database, nil))
 	syncer.Start(ctx)
 	defer syncer.Stop()

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	EnabledEnv           = "TELEMETRY_ENABLED"
-	ServerPingInterval   = 24 * time.Hour
+	applicationSlug      = "middleman"
 	installIDMetadataKey = "telemetry.install_id"
 	postHogAPIKey        = "phc_AzHd9YvuHR7M5poKzC6eW654d3SgKyBdoQPuwkWhimUf"
 	postHogEndpoint      = "https://us.i.posthog.com"
@@ -34,7 +34,7 @@ var allowedEvents = map[string]map[string]propertyFilter{
 	"app_loaded": {
 		"view": safeTelemetryToken,
 	},
-	"server_started": {
+	"daemon_active": {
 		"repo_count": safeTelemetryNumber,
 	},
 }
@@ -49,6 +49,8 @@ type Reporter struct {
 	client     enqueueCloser
 	distinctID string
 	enabled    bool
+	version    string
+	commit     string
 }
 
 type enqueueCloser interface {
@@ -88,7 +90,9 @@ func SanitizeProperties(event string, properties map[string]any) (map[string]any
 			safeProperties[key] = safeValue
 		}
 	}
+	safeProperties["$process_person_profile"] = false
 	safeProperties["$geoip_disable"] = true
+	safeProperties["application"] = applicationSlug
 	return safeProperties, nil
 }
 
@@ -109,15 +113,6 @@ func NewReporter(opts Options) (*Reporter, error) {
 	client, err := posthog.NewWithConfig(postHogAPIKey, posthog.Config{
 		Endpoint:     postHogEndpoint,
 		DisableGeoIP: &disableGeoIP,
-		DefaultEventProperties: posthog.Properties{
-			"app":            "middleman",
-			"source":         "backend",
-			"version":        opts.Version,
-			"commit":         opts.Commit,
-			"goos":           runtime.GOOS,
-			"goarch":         runtime.GOARCH,
-			"$geoip_disable": true,
-		},
 	})
 	if err != nil {
 		return nil, err
@@ -127,6 +122,8 @@ func NewReporter(opts Options) (*Reporter, error) {
 		client:     client,
 		distinctID: distinctID,
 		enabled:    true,
+		version:    opts.Version,
+		commit:     opts.Commit,
 	}, nil
 }
 
@@ -164,6 +161,7 @@ func (r *Reporter) Capture(event string, properties map[string]any) error {
 
 	props := posthog.Properties{}
 	maps.Copy(props, safeProperties)
+	r.addDefaultProperties(event, props)
 
 	return r.client.Enqueue(posthog.Capture{
 		DistinctId: r.distinctID,
@@ -173,32 +171,22 @@ func (r *Reporter) Capture(event string, properties map[string]any) error {
 	})
 }
 
-func (r *Reporter) StartServerStartedPingLoop(
-	ctx context.Context,
-	interval time.Duration,
-	repoCount func() int,
-) {
-	if !r.Enabled() || interval <= 0 || repoCount == nil {
-		return
+func (r *Reporter) addDefaultProperties(event string, props posthog.Properties) {
+	props["$process_person_profile"] = false
+	props["$geoip_disable"] = true
+	props["application"] = applicationSlug
+	props["version"] = r.version
+	props["commit"] = r.commit
+	props["goos"] = runtime.GOOS
+	props["goarch"] = runtime.GOARCH
+	props["source"] = sourceForEvent(event)
+}
+
+func sourceForEvent(event string) string {
+	if event == "daemon_active" {
+		return "daemon"
 	}
-
-	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				if err := r.Capture("server_started", map[string]any{
-					"repo_count": repoCount(),
-				}); err != nil {
-					slog.Warn("capture telemetry ping", "err", err)
-				}
-			}
-		}
-	}()
+	return "backend"
 }
 
 func (r *Reporter) Close() error {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/posthog/posthog-go"
@@ -65,24 +66,39 @@ func TestReporterCaptureUsesAnonymousDistinctID(t *testing.T) {
 		client:     client,
 		distinctID: "anonymous-install-id",
 		enabled:    true,
+		version:    "1.2.3",
+		commit:     "abc123",
 	}
 
-	err := reporter.Capture("app_loaded", map[string]any{
-		"$geoip_disable": false,
-		"distinct_id":    "user-provided",
-		"repo":           "owner/name",
-		"view":           "pulls",
+	err := reporter.Capture("daemon_active", map[string]any{
+		"$geoip_disable":          false,
+		"$process_person_profile": true,
+		"application":             "caller-app",
+		"app":                     "caller-app",
+		"distinct_id":             "user-provided",
+		"repo":                    "owner/name",
+		"repo_count":              7,
+		"source":                  "caller",
+		"version":                 "caller-version",
 	})
 	require.NoError(err)
 
 	capture, ok := client.message.(posthog.Capture)
 	require.True(ok)
 	assert.Equal("anonymous-install-id", capture.DistinctId)
-	assert.Equal("app_loaded", capture.Event)
-	assert.Equal("pulls", capture.Properties["view"])
+	assert.Equal("daemon_active", capture.Event)
+	assert.Equal(7, capture.Properties["repo_count"])
 	assert.NotContains(capture.Properties, "distinct_id")
 	assert.NotContains(capture.Properties, "repo")
+	assert.NotContains(capture.Properties, "app")
+	assert.False(capture.Properties["$process_person_profile"].(bool))
 	assert.True(capture.Properties["$geoip_disable"].(bool))
+	assert.Equal("middleman", capture.Properties["application"])
+	assert.Equal("1.2.3", capture.Properties["version"])
+	assert.Equal("abc123", capture.Properties["commit"])
+	assert.Equal(runtime.GOOS, capture.Properties["goos"])
+	assert.Equal(runtime.GOARCH, capture.Properties["goarch"])
+	assert.Equal("daemon", capture.Properties["source"])
 }
 
 func TestReporterCaptureRejectsUnsupportedEvents(t *testing.T) {
@@ -95,7 +111,7 @@ func TestReporterCaptureRejectsUnsupportedEvents(t *testing.T) {
 		enabled:    true,
 	}
 
-	err := reporter.Capture("repo_opened", map[string]any{"view": "pulls"})
+	err := reporter.Capture("server_started", map[string]any{"repo_count": 7})
 	require.ErrorIs(err, ErrUnsupportedEvent)
 }
 
@@ -116,5 +132,26 @@ func TestReporterCaptureDropsUnsafePropertyValues(t *testing.T) {
 	capture, ok := client.message.(posthog.Capture)
 	require.True(ok)
 	assert.NotContains(capture.Properties, "view")
+	assert.False(capture.Properties["$process_person_profile"].(bool))
 	assert.True(capture.Properties["$geoip_disable"].(bool))
+	assert.Equal("middleman", capture.Properties["application"])
+	assert.Equal("backend", capture.Properties["source"])
+}
+
+func TestSanitizePropertiesAddsNonOverridablePrivacyAndApplication(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	properties, err := SanitizeProperties("app_loaded", map[string]any{
+		"$geoip_disable":          false,
+		"$process_person_profile": true,
+		"application":             "caller-app",
+		"view":                    "pulls",
+	})
+	require.NoError(err)
+
+	assert.Equal("pulls", properties["view"])
+	assert.False(properties["$process_person_profile"].(bool))
+	assert.True(properties["$geoip_disable"].(bool))
+	assert.Equal("middleman", properties["application"])
 }


### PR DESCRIPTION
- Emit `daemon_active` for daemon presence telemetry.
- Apply anonymous PostHog privacy properties and `application: "middleman"` on every capture.
- Update telemetry docs and unit coverage for the kwiki contract.