### PR TITLE
Add dev-ephemeral instance inspector skill

### DIFF
--- a/skills/dev-ephemeral-running-instances/SKILL.md
+++ b/skills/dev-ephemeral-running-instances/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: dev-ephemeral-running-instances
+description: Use only when the user explicitly invokes dev-ephemeral-running-instances. Lists middleman dev-ephemeral status files across git worktrees, checks recorded launcher/backend/frontend PIDs and backend/frontend URLs, and reports which worktree each running, degraded, stale, or invalid instance belongs to.
+---
+
+# Dev Ephemeral Running Instances
+
+## Overview
+
+List middleman `dev-ephemeral` instances across Codex git worktrees without stopping or cleaning up any process. Use the bundled Python script as the source of truth for process and URL checks.
+
+## Workflow
+
+1. Run the inspector from the skill directory or pass its absolute path:
+
+   ```sh
+   uv run --script skills/dev-ephemeral-running-instances/scripts/list_running_instances.py
+   ```
+
+2. If working outside a middleman checkout, pass the worktrees root explicitly:
+
+   ```sh
+   uv run --script /path/to/dev-ephemeral-running-instances/scripts/list_running_instances.py \
+     --worktrees-root "$HOME/.codex/worktrees"
+   ```
+
+3. Report the table grouped by status. Include each worktree, run directory, branch, backend/frontend ports or URLs, and the reason for degraded/stale status when present.
+
+## Script Behavior
+
+- Discovers `dev-ephemeral.json` files under `~/.codex/worktrees` by default.
+- Resolves the owning git worktree by walking upward to the nearest `.git` directory or file.
+- Reads the branch with `git -C <worktree> branch --show-current`; detached checkouts are reported as `detached HEAD`.
+- Checks each recorded `pid`, `backend_pid`, and `frontend_pid` with `os.kill(pid, 0)`.
+- Probes recorded `backend_url` and `frontend_url` with a short HTTP timeout.
+- Classifies rows:
+  - `live`: launcher/backend/frontend PIDs are alive and both URLs respond with HTTP 2xx or 3xx.
+  - `degraded`: at least one PID or URL check is alive/responding, but the full stack is not healthy.
+  - `stale`: no recorded PID is alive and neither URL responds.
+  - `invalid`: the status file cannot be parsed or does not contain the expected shape.
+
+## Safety
+
+Do not kill, stop, delete, terminate, or clean up any process, tmux session, service, daemon, server, job, status file, or worktree while using this skill. Only inspect and report.

--- a/skills/dev-ephemeral-running-instances/SKILL.md
+++ b/skills/dev-ephemeral-running-instances/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-ephemeral-running-instances
-description: Use only when the user explicitly invokes dev-ephemeral-running-instances. Lists middleman dev-ephemeral status files across git worktrees, checks recorded launcher/backend/frontend PIDs and backend/frontend URLs, reports which worktree each running, degraded, stale, or invalid instance belongs to, and prepares clean shutdown command lists when explicitly requested.
+description: Use only when the user explicitly invokes dev-ephemeral-running-instances. Must be run outside the Codex sandbox because sandboxed scans cannot reliably see all Codex worktrees, uv/Python state, or the process table. Lists middleman dev-ephemeral status files across git worktrees, checks recorded launcher/backend/frontend PIDs and backend/frontend URLs, reports which worktree each running, degraded, stale, or invalid instance belongs to, and prepares clean shutdown command lists when explicitly requested.
 ---
 
 # Dev Ephemeral Running Instances
@@ -8,6 +8,10 @@ description: Use only when the user explicitly invokes dev-ephemeral-running-ins
 ## Overview
 
 List middleman `dev-ephemeral` instances across Codex git worktrees without stopping or cleaning up any process by default. Use the bundled Python script as the source of truth for process and URL checks.
+
+## Sandbox Requirement
+
+Run this skill outside the Codex sandbox. The inspector needs read access to all `~/.codex/worktrees` entries, `uv`/Python runtime state, the process table, and loopback URLs. Sandboxed runs can falsely report no status files, fail to run `ps`, or fail to initialize `uv`; treat those results as invalid and rerun outside the sandbox.
 
 ## Workflow
 

--- a/skills/dev-ephemeral-running-instances/SKILL.md
+++ b/skills/dev-ephemeral-running-instances/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: dev-ephemeral-running-instances
-description: Use only when the user explicitly invokes dev-ephemeral-running-instances. Lists middleman dev-ephemeral status files across git worktrees, checks recorded launcher/backend/frontend PIDs and backend/frontend URLs, and reports which worktree each running, degraded, stale, or invalid instance belongs to.
+description: Use only when the user explicitly invokes dev-ephemeral-running-instances. Lists middleman dev-ephemeral status files across git worktrees, checks recorded launcher/backend/frontend PIDs and backend/frontend URLs, reports which worktree each running, degraded, stale, or invalid instance belongs to, and prepares clean shutdown command lists when explicitly requested.
 ---
 
 # Dev Ephemeral Running Instances
 
 ## Overview
 
-List middleman `dev-ephemeral` instances across Codex git worktrees without stopping or cleaning up any process. Use the bundled Python script as the source of truth for process and URL checks.
+List middleman `dev-ephemeral` instances across Codex git worktrees without stopping or cleaning up any process by default. Use the bundled Python script as the source of truth for process and URL checks.
 
 ## Workflow
 
@@ -26,6 +26,26 @@ List middleman `dev-ephemeral` instances across Codex git worktrees without stop
 
 3. Report the table grouped by status. Include each worktree, run directory, branch, backend/frontend ports or URLs, and the reason for degraded/stale status when present.
 
+## Clean Shutdown Preparation
+
+When the user asks to shut down instances, prepare a target list and command list first. Do not execute the stop commands until the user explicitly approves the exact targets and intended command.
+
+Use the project launcher stop path rather than killing PIDs manually:
+
+```sh
+go run ./tools/devephemeral -stop -status /absolute/path/to/dev-ephemeral.json
+```
+
+To generate a shutdown plan while keeping one worktree, run:
+
+```sh
+uv run --script skills/dev-ephemeral-running-instances/scripts/list_running_instances.py \
+  --exclude-worktree /Users/mariusvniekerk/.codex/worktrees/e007/middleman \
+  --emit-stop-commands
+```
+
+Present the generated target list and commands to the user. After approval, run the commands from a middleman checkout. The `devephemeral` stop path verifies process identity from status-file start times, interrupts process groups first, escalates to terminate after the built-in grace period, and removes the status file only when shutdown succeeds or no matching live processes remain.
+
 ## Script Behavior
 
 - Discovers `dev-ephemeral.json` files under `~/.codex/worktrees` by default.
@@ -38,7 +58,8 @@ List middleman `dev-ephemeral` instances across Codex git worktrees without stop
   - `degraded`: at least one PID or URL check is alive/responding, but the full stack is not healthy.
   - `stale`: no recorded PID is alive and neither URL responds.
   - `invalid`: the status file cannot be parsed or does not contain the expected shape.
+- With `--emit-stop-commands`, prints clean `go run ./tools/devephemeral -stop -status ...` commands for matching, non-invalid rows. Use `--exclude-worktree` one or more times to keep specific worktrees running.
 
 ## Safety
 
-Do not kill, stop, delete, terminate, or clean up any process, tmux session, service, daemon, server, job, status file, or worktree while using this skill. Only inspect and report.
+Do not kill, stop, delete, terminate, or clean up any process, tmux session, service, daemon, server, job, status file, or worktree unless the user has explicitly approved the exact target list and intended command. When approval is missing, only inspect and report.

--- a/skills/dev-ephemeral-running-instances/agents/openai.yaml
+++ b/skills/dev-ephemeral-running-instances/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Dev Ephemeral Running Instances"
+  short_description: "List live middleman dev-ephemeral stacks and stale status files."
+  default_prompt: "Use $dev-ephemeral-running-instances to list middleman dev-ephemeral stacks and report which worktree each one belongs to."
+policy:
+  allow_implicit_invocation: false

--- a/skills/dev-ephemeral-running-instances/scripts/list_running_instances.py
+++ b/skills/dev-ephemeral-running-instances/scripts/list_running_instances.py
@@ -10,6 +10,7 @@ import argparse
 import errno
 import json
 import os
+import shlex
 import subprocess
 import sys
 import urllib.error
@@ -71,6 +72,17 @@ def parse_args() -> argparse.Namespace:
         choices=("all", "live", "degraded", "stale", "invalid"),
         default="all",
         help="Filter rows by classification.",
+    )
+    parser.add_argument(
+        "--exclude-worktree",
+        action="append",
+        default=[],
+        help="Worktree path to exclude from output; may be passed more than once.",
+    )
+    parser.add_argument(
+        "--emit-stop-commands",
+        action="store_true",
+        help="Print clean dev-ephemeral stop commands for matching non-invalid rows.",
     )
     return parser.parse_args()
 
@@ -303,14 +315,51 @@ def print_text(instances: list[Instance]) -> None:
         print()
 
 
+def print_stop_commands(instances: list[Instance]) -> None:
+    targets = [instance for instance in instances if instance.status != "invalid"]
+    if not targets:
+        print("No stoppable dev-ephemeral status files matched.")
+        return
+
+    print("STOP TARGETS")
+    for instance in targets:
+        print(f"- {instance.worktree}")
+        print(f"  run: {instance.run_dir}")
+        print(f"  status: {instance.status}")
+        print(f"  status_file: {instance.status_file}")
+        print(f"  backend: {instance.backend_url} ({instance.backend_http_check.detail})")
+        print(f"  frontend: {instance.frontend_url} ({instance.frontend_http_check.detail})")
+        if instance.reason:
+            print(f"  reason: {instance.reason}")
+
+    print()
+    print("STOP COMMANDS")
+    for instance in targets:
+        print(f"go run ./tools/devephemeral -stop -status {shlex.quote(instance.status_file)}")
+
+
+def filter_excluded_worktrees(instances: list[Instance], excluded: list[str]) -> list[Instance]:
+    if not excluded:
+        return instances
+    excluded_paths = {str(Path(path).expanduser().resolve()) for path in excluded}
+    return [
+        instance
+        for instance in instances
+        if str(Path(instance.worktree).expanduser().resolve()) not in excluded_paths
+    ]
+
+
 def main() -> int:
     args = parse_args()
     status_files = discover_status_files(Path(args.worktrees_root).expanduser())
     instances = [make_instance(path, args.timeout) for path in status_files]
+    instances = filter_excluded_worktrees(instances, args.exclude_worktree)
     if args.status != "all":
         instances = [instance for instance in instances if instance.status == args.status]
 
-    if args.format == "json":
+    if args.emit_stop_commands:
+        print_stop_commands(instances)
+    elif args.format == "json":
         print(json.dumps([instance_to_dict(instance) for instance in instances], indent=2))
     else:
         print_text(instances)

--- a/skills/dev-ephemeral-running-instances/scripts/list_running_instances.py
+++ b/skills/dev-ephemeral-running-instances/scripts/list_running_instances.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""List middleman dev-ephemeral instances across Codex worktrees."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Check:
+    alive: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class Instance:
+    status: str
+    worktree: str
+    run_dir: str
+    branch: str
+    status_file: str
+    pid: str
+    pid_check: Check
+    backend_pid: str
+    backend_pid_check: Check
+    frontend_pid: str
+    frontend_pid_check: Check
+    backend_url: str
+    backend_http_check: Check
+    frontend_url: str
+    frontend_http_check: Check
+    reason: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="List middleman dev-ephemeral instances and health checks."
+    )
+    parser.add_argument(
+        "--worktrees-root",
+        default=str(Path.home() / ".codex" / "worktrees"),
+        help="Root directory containing Codex git worktrees.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=1.5,
+        help="HTTP probe timeout in seconds.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--status",
+        choices=("all", "live", "degraded", "stale", "invalid"),
+        default="all",
+        help="Filter rows by classification.",
+    )
+    return parser.parse_args()
+
+
+def discover_status_files(worktrees_root: Path) -> list[Path]:
+    if not worktrees_root.exists():
+        return []
+    return sorted(worktrees_root.glob("*/middleman/tmp/**/dev-ephemeral.json"))
+
+
+def find_worktree(path: Path) -> Path:
+    for parent in path.parents:
+        if (parent / ".git").exists():
+            return parent
+    marker = "/tmp/"
+    text = str(path)
+    if marker in text:
+        return Path(text.split(marker, 1)[0])
+    return path.parent
+
+
+def branch_name(worktree: Path) -> str:
+    branch = run_git(worktree, ["branch", "--show-current"])
+    if branch:
+        return branch
+    short_sha = run_git(worktree, ["rev-parse", "--short", "HEAD"])
+    if short_sha:
+        return f"detached HEAD ({short_sha})"
+    return "unknown"
+
+
+def run_git(worktree: Path, args: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(worktree), *args],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def pid_check(value: Any) -> Check:
+    try:
+        pid = int(value)
+    except (TypeError, ValueError):
+        return Check(False, "missing")
+    if pid <= 0:
+        return Check(False, "missing")
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return Check(False, "missing")
+    except PermissionError:
+        return Check(True, "alive:permission-denied")
+    except OSError as exc:
+        if exc.errno == errno.EPERM:
+            return Check(True, "alive:permission-denied")
+        return Check(False, f"error:{exc.errno}")
+    return Check(True, "alive")
+
+
+def http_check(url: Any, timeout: float) -> Check:
+    if not isinstance(url, str) or not url:
+        return Check(False, "missing")
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = response.getcode()
+    except urllib.error.HTTPError as exc:
+        return Check(200 <= exc.code < 400, f"http:{exc.code}")
+    except Exception as exc:
+        return Check(False, type(exc).__name__)
+    return Check(200 <= status < 400, f"http:{status}")
+
+
+def make_instance(status_file: Path, timeout: float) -> Instance:
+    worktree = find_worktree(status_file)
+    run_dir = status_file.parent.name
+    try:
+        data = json.loads(status_file.read_text())
+    except Exception as exc:
+        failed = Check(False, type(exc).__name__)
+        return Instance(
+            status="invalid",
+            worktree=str(worktree),
+            run_dir=run_dir,
+            branch=branch_name(worktree),
+            status_file=str(status_file),
+            pid="",
+            pid_check=failed,
+            backend_pid="",
+            backend_pid_check=failed,
+            frontend_pid="",
+            frontend_pid_check=failed,
+            backend_url="",
+            backend_http_check=failed,
+            frontend_url="",
+            frontend_http_check=failed,
+            reason=f"cannot parse status file: {type(exc).__name__}",
+        )
+    if not isinstance(data, dict):
+        failed = Check(False, "not-object")
+        return Instance(
+            status="invalid",
+            worktree=str(worktree),
+            run_dir=run_dir,
+            branch=branch_name(worktree),
+            status_file=str(status_file),
+            pid="",
+            pid_check=failed,
+            backend_pid="",
+            backend_pid_check=failed,
+            frontend_pid="",
+            frontend_pid_check=failed,
+            backend_url="",
+            backend_http_check=failed,
+            frontend_url="",
+            frontend_http_check=failed,
+            reason="status file JSON is not an object",
+        )
+
+    launcher = pid_check(data.get("pid"))
+    backend_pid = pid_check(data.get("backend_pid"))
+    frontend_pid = pid_check(data.get("frontend_pid"))
+    backend_http = http_check(data.get("backend_url"), timeout)
+    frontend_http = http_check(data.get("frontend_url"), timeout)
+
+    pid_checks = (launcher, backend_pid, frontend_pid)
+    http_checks = (backend_http, frontend_http)
+    full_health = all(check.alive for check in (*pid_checks, *http_checks))
+    any_health = any(check.alive for check in (*pid_checks, *http_checks))
+
+    if full_health:
+        status = "live"
+        reason = ""
+    elif any_health:
+        status = "degraded"
+        reason = summarize_failures(
+            {
+                "launcher pid": launcher,
+                "backend pid": backend_pid,
+                "frontend pid": frontend_pid,
+                "backend url": backend_http,
+                "frontend url": frontend_http,
+            }
+        )
+    else:
+        status = "stale"
+        reason = "no recorded PIDs are alive and neither URL responds"
+
+    return Instance(
+        status=status,
+        worktree=str(worktree),
+        run_dir=run_dir,
+        branch=branch_name(worktree),
+        status_file=str(status_file),
+        pid=str(data.get("pid", "")),
+        pid_check=launcher,
+        backend_pid=str(data.get("backend_pid", "")),
+        backend_pid_check=backend_pid,
+        frontend_pid=str(data.get("frontend_pid", "")),
+        frontend_pid_check=frontend_pid,
+        backend_url=str(data.get("backend_url", "")),
+        backend_http_check=backend_http,
+        frontend_url=str(data.get("frontend_url", "")),
+        frontend_http_check=frontend_http,
+        reason=reason,
+    )
+
+
+def summarize_failures(checks: dict[str, Check]) -> str:
+    failures = [f"{name} {check.detail}" for name, check in checks.items() if not check.alive]
+    return "; ".join(failures)
+
+
+def instance_to_dict(instance: Instance) -> dict[str, Any]:
+    return {
+        "status": instance.status,
+        "worktree": instance.worktree,
+        "run_dir": instance.run_dir,
+        "branch": instance.branch,
+        "status_file": instance.status_file,
+        "pid": instance.pid,
+        "pid_status": instance.pid_check.detail,
+        "backend_pid": instance.backend_pid,
+        "backend_pid_status": instance.backend_pid_check.detail,
+        "frontend_pid": instance.frontend_pid,
+        "frontend_pid_status": instance.frontend_pid_check.detail,
+        "backend_url": instance.backend_url,
+        "backend_url_status": instance.backend_http_check.detail,
+        "frontend_url": instance.frontend_url,
+        "frontend_url_status": instance.frontend_http_check.detail,
+        "reason": instance.reason,
+    }
+
+
+def print_text(instances: list[Instance]) -> None:
+    if not instances:
+        print("No dev-ephemeral status files found.")
+        return
+
+    for status in ("live", "degraded", "stale", "invalid"):
+        rows = [instance for instance in instances if instance.status == status]
+        if not rows:
+            continue
+        print(f"{status.upper()} ({len(rows)})")
+        for instance in rows:
+            print(f"- worktree: {instance.worktree}")
+            print(f"  run: {instance.run_dir}")
+            print(f"  branch: {instance.branch}")
+            print(
+                "  pids: "
+                f"launcher {instance.pid} ({instance.pid_check.detail}), "
+                f"backend {instance.backend_pid} ({instance.backend_pid_check.detail}), "
+                f"frontend {instance.frontend_pid} ({instance.frontend_pid_check.detail})"
+            )
+            print(
+                "  urls: "
+                f"backend {instance.backend_url} ({instance.backend_http_check.detail}), "
+                f"frontend {instance.frontend_url} ({instance.frontend_http_check.detail})"
+            )
+            if instance.reason:
+                print(f"  reason: {instance.reason}")
+        print()
+
+
+def main() -> int:
+    args = parse_args()
+    status_files = discover_status_files(Path(args.worktrees_root).expanduser())
+    instances = [make_instance(path, args.timeout) for path in status_files]
+    if args.status != "all":
+        instances = [instance for instance in instances if instance.status == args.status]
+
+    if args.format == "json":
+        print(json.dumps([instance_to_dict(instance) for instance in instances], indent=2))
+    else:
+        print_text(instances)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Add a manually invoked skill for listing middleman dev-ephemeral stacks across Codex worktrees.
- Include a deterministic inspector script that classifies live, degraded, stale, and invalid status files.
- Add guarded shutdown planning that emits clean stop commands without bypassing approval requirements.