### PR TITLE
fix: surface stack base conflicts downstream

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -3148,6 +3148,8 @@ components:
           type: string
         is_draft:
           type: boolean
+        mergeable_state:
+          type: string
         number:
           format: int64
           type: integer
@@ -3166,6 +3168,7 @@ components:
         - state
         - ci_status
         - review_decision
+        - mergeable_state
         - position
         - is_draft
         - base_branch

--- a/frontend/tests/e2e-full/stack-status.spec.ts
+++ b/frontend/tests/e2e-full/stack-status.spec.ts
@@ -5,11 +5,13 @@ test("stack status renders a passive base row from the full-stack API", async ({
 
   const detail = page.locator(".pull-detail");
   await expect(detail).toBeVisible();
+  await expect(detail.getByText("This branch has conflicts")).toBeVisible();
 
   await detail.getByTestId("stack-chip").click();
 
   const panel = detail.locator(".stack-panel");
-  await expect(panel).toContainText("3 PRs · current 2/3");
+  await expect(panel).toContainText("3 PRs · current 2/3 · downstack conflict");
+  await expect(panel.getByText("× Conflicts")).toHaveCount(3);
   await expect(panel.locator(".stack-member-link")).toHaveText([
     "#12 Auth: error handling UI",
     "#11 Auth: add retry with backoff",

--- a/frontend/tests/e2e/stack-status.spec.ts
+++ b/frontend/tests/e2e/stack-status.spec.ts
@@ -103,6 +103,7 @@ function prForNumber(number: number, members = stackMembers) {
       : member?.base_branch.replace("feat/", "feat/child-") ?? pr.HeadBranch,
     CIStatus: member?.ci_status ?? pr.CIStatus,
     ReviewDecision: member?.review_decision ?? pr.ReviewDecision,
+    MergeableState: member?.mergeable_state ?? pr.MergeableState,
   };
 }
 
@@ -113,6 +114,7 @@ const stackMembers = [
     state: "open",
     ci_status: "failure",
     review_decision: "APPROVED",
+    mergeable_state: "",
     position: 1,
     is_draft: false,
     base_branch: "main",
@@ -124,6 +126,7 @@ const stackMembers = [
     state: "open",
     ci_status: "pending",
     review_decision: "APPROVED",
+    mergeable_state: "",
     position: 2,
     is_draft: false,
     base_branch: "feat/base-schema",
@@ -135,6 +138,7 @@ const stackMembers = [
     state: "open",
     ci_status: "success",
     review_decision: "APPROVED",
+    mergeable_state: "",
     position: 3,
     is_draft: false,
     base_branch: "feat/session-storage",
@@ -146,6 +150,7 @@ const stackMembers = [
     state: "open",
     ci_status: "success",
     review_decision: "APPROVED",
+    mergeable_state: "",
     position: 4,
     is_draft: false,
     base_branch: "feat/auth-flow",
@@ -157,6 +162,7 @@ const stackMembers = [
     state: "open",
     ci_status: "success",
     review_decision: "APPROVED",
+    mergeable_state: "",
     position: 5,
     is_draft: false,
     base_branch: "feat/cache-api",
@@ -168,6 +174,7 @@ const stackMembers = [
     state: "open",
     ci_status: "success",
     review_decision: "",
+    mergeable_state: "",
     position: 6,
     is_draft: false,
     base_branch: "feat/logs",
@@ -179,6 +186,7 @@ const stackMembers = [
     state: "open",
     ci_status: "pending",
     review_decision: "",
+    mergeable_state: "",
     position: 7,
     is_draft: false,
     base_branch: "feat/agent-retries",
@@ -468,6 +476,27 @@ test("stack status shares the PR detail expandable slot with CI", async ({ page 
   await expect(page).toHaveURL(/\/pulls\/github\/acme\/widgets\/101$/);
   await expect(page.getByText("7 PRs · current 1/7")).toBeVisible();
   await expect(page.locator(".stack-base-name")).toHaveText("main");
+});
+
+test("stack status surfaces inherited downstack merge conflicts", async ({ page }) => {
+  await mockStackedPR(page, {
+    stackMembers: () => [
+      { ...stackMembers[0]!, ci_status: "success", mergeable_state: "dirty" },
+      { ...stackMembers[1]!, ci_status: "success", mergeable_state: "dirty" },
+      ...stackMembers.slice(2),
+    ],
+  });
+
+  await page.goto("/pulls/github/acme/widgets/102");
+
+  await expect(page.getByText("This branch has conflicts")).toBeVisible();
+  await expect(page.getByRole("button", {
+    name: /Stacked: 2\/7, 1 downstack merge conflict/i,
+  })).toBeVisible();
+
+  await page.getByTestId("stack-chip").click();
+  await expect(page.getByText("7 PRs · current 2/7 · downstack conflict")).toBeVisible();
+  await expect(page.getByText("× Conflicts")).toHaveCount(2);
 });
 
 test("stack status follows refreshed detail stack data", async ({ page }) => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1549,6 +1549,7 @@ type StackMemberResponse struct {
 	BlockedBy      *int64 `json:"blocked_by"`
 	CiStatus       string `json:"ci_status"`
 	IsDraft        bool   `json:"is_draft"`
+	MergeableState string `json:"mergeable_state"`
 	Number         int64  `json:"number"`
 	Position       int64  `json:"position"`
 	ReviewDecision string `json:"review_decision"`

--- a/internal/db/fixtures_test.go
+++ b/internal/db/fixtures_test.go
@@ -59,6 +59,10 @@ func withMRState(state MergeRequestState) testMROpt {
 	return func(mr *MergeRequest) { mr.State = state }
 }
 
+func withMRMergeableState(state string) testMROpt {
+	return func(mr *MergeRequest) { mr.MergeableState = state }
+}
+
 func withMRAuthor(author string) testMROpt {
 	return func(mr *MergeRequest) { mr.Author = author }
 }

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -172,7 +172,8 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 	}
 	memberQuery := `
 		SELECT sm.stack_id, sm.merge_request_id, sm.position,
-		       p.number, p.title, p.state, p.ci_status, p.review_decision, p.is_draft, p.base_branch
+		       p.number, p.title, p.state, p.ci_status, p.review_decision,
+		       p.is_draft, p.base_branch, p.mergeable_state
 		FROM middleman_stack_members sm
 		JOIN middleman_merge_requests p ON p.id = sm.merge_request_id
 		WHERE sm.stack_id IN (` + sqlPlaceholders(len(stackIDs)) + `)
@@ -189,7 +190,8 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		var m StackMemberWithPR
 		if err := mRows.Scan(
 			&m.StackID, &m.MergeRequestID, &m.Position,
-			&m.Number, &m.Title, &m.State, &m.CIStatus, &m.ReviewDecision, &m.IsDraft, &m.BaseBranch,
+			&m.Number, &m.Title, &m.State, &m.CIStatus, &m.ReviewDecision,
+			&m.IsDraft, &m.BaseBranch, &m.MergeableState,
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan stack member: %w", err)
 		}
@@ -264,7 +266,8 @@ func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) 
 
 	rows, err := d.ro.QueryContext(ctx, `
 		SELECT sm.stack_id, sm.merge_request_id, sm.position,
-		       p.number, p.title, p.state, p.ci_status, p.review_decision, p.is_draft, p.base_branch
+		       p.number, p.title, p.state, p.ci_status, p.review_decision,
+		       p.is_draft, p.base_branch, p.mergeable_state
 		FROM middleman_stack_members sm
 		JOIN middleman_merge_requests p ON p.id = sm.merge_request_id
 		WHERE sm.stack_id = ?
@@ -280,11 +283,55 @@ func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) 
 		var m StackMemberWithPR
 		if err := rows.Scan(
 			&m.StackID, &m.MergeRequestID, &m.Position,
-			&m.Number, &m.Title, &m.State, &m.CIStatus, &m.ReviewDecision, &m.IsDraft, &m.BaseBranch,
+			&m.Number, &m.Title, &m.State, &m.CIStatus, &m.ReviewDecision,
+			&m.IsDraft, &m.BaseBranch, &m.MergeableState,
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan stack member: %w", err)
 		}
 		members = append(members, m)
 	}
 	return &stack, members, rows.Err()
+}
+
+// ListMRsBlockedByStackConflicts returns merge request IDs whose stack has an
+// earlier non-merged dirty member. It is used by API response assembly to
+// surface the stack-root conflict without mutating the provider-sourced PR row.
+func (d *DB) ListMRsBlockedByStackConflicts(ctx context.Context, mrIDs []int64) (map[int64]bool, error) {
+	blocked := make(map[int64]bool)
+	if len(mrIDs) == 0 {
+		return blocked, nil
+	}
+
+	args := make([]any, len(mrIDs))
+	for i, id := range mrIDs {
+		args[i] = id
+	}
+
+	rows, err := d.ro.QueryContext(ctx, `
+		SELECT DISTINCT target.merge_request_id
+		FROM middleman_stack_members target
+		JOIN middleman_merge_requests target_pr ON target_pr.id = target.merge_request_id
+		JOIN middleman_stack_members blocker
+		  ON blocker.stack_id = target.stack_id
+		 AND blocker.position < target.position
+		JOIN middleman_merge_requests blocker_pr ON blocker_pr.id = blocker.merge_request_id
+		WHERE target.merge_request_id IN (`+sqlPlaceholders(len(mrIDs))+`)
+		  AND target_pr.state = 'open'
+		  AND blocker_pr.state != 'merged'
+		  AND blocker_pr.mergeable_state = 'dirty'`,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list mrs blocked by stack conflicts: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan stack conflict blocker: %w", err)
+		}
+		blocked[id] = true
+	}
+	return blocked, rows.Err()
 }

--- a/internal/db/queries_stacks_test.go
+++ b/internal/db/queries_stacks_test.go
@@ -7,9 +7,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func insertTestMRWithBranches(t *testing.T, d *DB, repoID int64, number int, head, base string, state MergeRequestState) int64 {
+func insertTestMRWithBranches(
+	t *testing.T,
+	d *DB,
+	repoID int64,
+	number int,
+	head, base string,
+	state MergeRequestState,
+	opts ...testMROpt,
+) int64 {
 	t.Helper()
-	return insertTestMRWithOptions(t, d, testMR(repoID, number, withMRTitle("PR "+head), withMRBranches(head, base), withMRState(state)))
+	allOpts := []testMROpt{withMRTitle("PR " + head), withMRBranches(head, base), withMRState(state)}
+	allOpts = append(allOpts, opts...)
+	return insertTestMRWithOptions(t, d, testMR(repoID, number, allOpts...))
 }
 
 func TestListPRsForStackDetection(t *testing.T) {
@@ -69,6 +79,60 @@ func TestUpsertStackAndReplaceMembers(t *testing.T) {
 	assert.Len(memberMap[stackID], 2)
 	assert.Equal(1, memberMap[stackID][0].Position)
 	assert.Equal(2, memberMap[stackID][1].Position)
+}
+
+func TestStackMembersIncludeMergeableState(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "org", "repo")
+
+	mrID1 := insertTestMRWithBranches(
+		t, d, repoID, 1, "feature/a", "main", "open", withMRMergeableState("dirty"),
+	)
+	mrID2 := insertTestMRWithBranches(t, d, repoID, 2, "feature/b", "feature/a", "open")
+	stackID, err := d.UpsertStack(ctx, repoID, 1, "feature")
+	require.NoError(err)
+	err = d.ReplaceStackMembers(ctx, stackID, []StackMember{
+		{StackID: stackID, MergeRequestID: mrID1, Position: 1},
+		{StackID: stackID, MergeRequestID: mrID2, Position: 2},
+	})
+	require.NoError(err)
+
+	_, members, err := d.GetStackForPRByRepoID(ctx, repoID, 2)
+	require.NoError(err)
+	require.Len(members, 2)
+	assert.Equal("dirty", members[0].MergeableState)
+	assert.Empty(members[1].MergeableState)
+}
+
+func TestListMRsBlockedByStackConflicts(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "org", "repo")
+
+	mrID1 := insertTestMRWithBranches(
+		t, d, repoID, 1, "feature/a", "main", "open", withMRMergeableState("dirty"),
+	)
+	mrID2 := insertTestMRWithBranches(t, d, repoID, 2, "feature/b", "feature/a", "open")
+	mrID3 := insertTestMRWithBranches(t, d, repoID, 3, "feature/c", "feature/b", "open")
+	stackID, err := d.UpsertStack(ctx, repoID, 1, "feature")
+	require.NoError(err)
+	err = d.ReplaceStackMembers(ctx, stackID, []StackMember{
+		{StackID: stackID, MergeRequestID: mrID1, Position: 1},
+		{StackID: stackID, MergeRequestID: mrID2, Position: 2},
+		{StackID: stackID, MergeRequestID: mrID3, Position: 3},
+	})
+	require.NoError(err)
+
+	blocked, err := d.ListMRsBlockedByStackConflicts(ctx, []int64{mrID1, mrID2, mrID3})
+	require.NoError(err)
+	assert.False(blocked[mrID1])
+	assert.True(blocked[mrID2])
+	assert.True(blocked[mrID3])
 }
 
 func TestDeleteStaleStacks(t *testing.T) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -521,6 +521,7 @@ type StackMemberWithPR struct {
 	ReviewDecision string
 	IsDraft        bool
 	BaseBranch     string
+	MergeableState string
 }
 
 const (

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -16124,7 +16124,7 @@ func seedStackedPR(
 	owner, name string, number int,
 	head, base string, state db.MergeRequestState, ci, review string,
 ) int64 {
-	return seedStackedPRDraft(t, database, owner, name, number, head, base, state, ci, review, false)
+	return seedStackedPRState(t, database, owner, name, number, head, base, state, ci, review, false, "")
 }
 
 func seedStackedPRDraft(
@@ -16132,6 +16132,24 @@ func seedStackedPRDraft(
 	owner, name string, number int,
 	head, base string, state db.MergeRequestState, ci, review string,
 	isDraft bool,
+) int64 {
+	return seedStackedPRState(t, database, owner, name, number, head, base, state, ci, review, isDraft, "")
+}
+
+func seedStackedPRMergeable(
+	t *testing.T, database *db.DB,
+	owner, name string, number int,
+	head, base string, state db.MergeRequestState, ci, review, mergeableState string,
+) int64 {
+	return seedStackedPRState(t, database, owner, name, number, head, base, state, ci, review, false, mergeableState)
+}
+
+func seedStackedPRState(
+	t *testing.T, database *db.DB,
+	owner, name string, number int,
+	head, base string, state db.MergeRequestState, ci, review string,
+	isDraft bool,
+	mergeableState string,
 ) int64 {
 	t.Helper()
 	ctx := t.Context()
@@ -16150,6 +16168,7 @@ func seedStackedPRDraft(
 		BaseBranch:     base,
 		CIStatus:       ci,
 		ReviewDecision: review,
+		MergeableState: mergeableState,
 		CreatedAt:      now,
 		UpdatedAt:      now,
 		LastActivityAt: now,
@@ -16289,6 +16308,52 @@ func TestAPIGetPullDetailIncludesStackContext(t *testing.T) {
 	require.Equal(http.StatusOK, unstacked.StatusCode())
 	require.NotNil(unstacked.JSON200)
 	assert.Nil(unstacked.JSON200.Stack)
+}
+
+func TestAPIStackBaseConflictMarksDownstreamPRsDirty(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+
+	seedStackedPRMergeable(
+		t, database, "acme", "widget", 10,
+		"feat/api-base", "main", db.MergeRequestStateOpen, "success", "APPROVED", "dirty",
+	)
+	seedStackedPR(t, database, "acme", "widget", 11, "feat/api-retry", "feat/api-base", db.MergeRequestStateOpen, "success", "APPROVED")
+	runStackDetection(t, database, "acme", "widget")
+
+	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	require.NoError(err)
+	require.NotNil(repo)
+	assert.Empty(requireMR(t, database, repo.ID, 11).MergeableState)
+
+	listResp, err := client.HTTP.ListPullsWithResponse(ctx, &generated.ListPullsParams{})
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode(), string(listResp.Body))
+	require.NotNil(listResp.JSON200)
+	require.Len(*listResp.JSON200, 2)
+	assert.Equal("dirty", (*listResp.JSON200)[0].MergeableState)
+	assert.Equal("dirty", (*listResp.JSON200)[1].MergeableState)
+
+	stackResp, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "widget", 11)
+	require.NoError(err)
+	require.Equal(http.StatusOK, stackResp.StatusCode(), string(stackResp.Body))
+	require.NotNil(stackResp.JSON200)
+	require.NotNil(stackResp.JSON200.Members)
+	assert.Equal("blocked", stackResp.JSON200.Health)
+	assert.Equal("dirty", (*stackResp.JSON200.Members)[0].MergeableState)
+	assert.Equal("dirty", (*stackResp.JSON200.Members)[1].MergeableState)
+	require.NotNil((*stackResp.JSON200.Members)[1].BlockedBy)
+	assert.Equal(int64(10), *(*stackResp.JSON200.Members)[1].BlockedBy)
+
+	detailResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 11)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	assert.Equal("dirty", detailResp.JSON200.MergeRequest.MergeableState)
+	assert.Empty(requireMR(t, database, repo.ID, 11).MergeableState)
 }
 
 func TestAPIGetStackForPR_DraftNotBaseReady(t *testing.T) {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -437,6 +437,7 @@ type stackMemberResponse struct {
 	State          string `json:"state"`
 	CIStatus       string `json:"ci_status"`
 	ReviewDecision string `json:"review_decision"`
+	MergeableState string `json:"mergeable_state"`
 	Position       int    `json:"position"`
 	IsDraft        bool   `json:"is_draft"`
 	BaseBranch     string `json:"base_branch"`

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -991,6 +991,10 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 	for i, mr := range mrs {
 		mrIDs[i] = mr.ID
 	}
+	stackConflictBlocked, err := s.db.ListMRsBlockedByStackConflicts(ctx, mrIDs)
+	if err != nil {
+		return nil, problemInternal("load stack conflict state failed")
+	}
 	links, err := s.db.GetWorktreeLinksForMRs(ctx, mrIDs)
 	if err != nil {
 		return nil, problemInternal("load worktree links failed")
@@ -1011,8 +1015,12 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 		if wl == nil {
 			wl = []worktreeLinkResponse{}
 		}
+		responseMR := mr
+		if stackConflictBlocked[mr.ID] {
+			responseMR.MergeableState = "dirty"
+		}
 		resp := mergeRequestResponse{
-			MergeRequest:  mr,
+			MergeRequest:  responseMR,
 			Repo:          s.repoRefFromRepo(rp),
 			RepoOwner:     rp.Owner,
 			RepoName:      rp.Name,
@@ -1172,7 +1180,6 @@ func (s *Server) buildPullDetailResponse(
 		return mergeRequestDetailResponse{}, problemInternal("load repo failed")
 	}
 	resp := mergeRequestDetailResponse{
-		MergeRequest:     mr,
 		Events:           eventResponses,
 		Repo:             s.repoRefFromRepo(*repo),
 		RepoOwner:        repo.Owner,
@@ -1199,6 +1206,14 @@ func (s *Server) buildPullDetailResponse(
 		stackContext := stackContextForPR(mr.Number, stack, members)
 		resp.Stack = &stackContext
 	}
+	responseMR := *mr
+	if stack != nil {
+		blockedBy := computeConflictBlockedBy(members)
+		if _, ok := blockedBy[mr.Number]; ok && mr.State == db.MergeRequestStateOpen {
+			responseMR.MergeableState = "dirty"
+		}
+	}
+	resp.MergeRequest = &responseMR
 
 	if s.workspaces != nil {
 		wsRef, wsErr := s.workspaces.GetByMR(

--- a/internal/server/stack_health.go
+++ b/internal/server/stack_health.go
@@ -22,12 +22,12 @@ func computeStackHealth(members []db.StackMemberWithPR) string {
 		}
 
 		// Drafts cannot be merged, so they never count as green.
-		isGreen := !m.IsDraft && m.CIStatus == "success" && m.ReviewDecision == "APPROVED"
+		isGreen := stackMemberReady(m)
 		if !isGreen {
 			allGreen = false
 		}
 
-		if m.CIStatus == "failure" || m.ReviewDecision == "CHANGES_REQUESTED" {
+		if stackMemberBlocksDownstream(m) {
 			// A PR only counts as "blocked" when it actually blocks something
 			// downstream — i.e. has at least one non-merged descendant. A
 			// failing tip with nothing below it is not blocking anything.
@@ -49,22 +49,41 @@ func computeStackHealth(members []db.StackMemberWithPR) string {
 		return "all_green"
 	case lowestOpenIdx >= 0:
 		m := members[lowestOpenIdx]
-		if !m.IsDraft && m.CIStatus == "success" && m.ReviewDecision == "APPROVED" {
+		if stackMemberReady(m) {
 			return "base_ready"
 		}
 	}
 	return "in_progress"
 }
 
+func stackMemberReady(m db.StackMemberWithPR) bool {
+	return !m.IsDraft &&
+		m.CIStatus == "success" &&
+		m.ReviewDecision == "APPROVED" &&
+		m.MergeableState != "dirty"
+}
+
 func computeBlockedBy(members []db.StackMemberWithPR) map[int]int {
+	return computeBlockedByPredicate(members, stackMemberBlocksDownstream)
+}
+
+func computeConflictBlockedBy(members []db.StackMemberWithPR) map[int]int {
+	return computeBlockedByPredicate(members, func(m db.StackMemberWithPR) bool {
+		return m.MergeableState == "dirty"
+	})
+}
+
+func computeBlockedByPredicate(
+	members []db.StackMemberWithPR,
+	blocks func(db.StackMemberWithPR) bool,
+) map[int]int {
 	blockedBy := make(map[int]int)
 	var rootBlocker int
 	for _, m := range members {
 		if m.State == "merged" {
 			continue
 		}
-		isBlocked := m.CIStatus == "failure" || m.ReviewDecision == "CHANGES_REQUESTED"
-		if isBlocked && rootBlocker == 0 {
+		if blocks(m) && rootBlocker == 0 {
 			rootBlocker = m.Number
 		} else if rootBlocker != 0 && m.Number != rootBlocker {
 			blockedBy[m.Number] = rootBlocker
@@ -73,8 +92,25 @@ func computeBlockedBy(members []db.StackMemberWithPR) map[int]int {
 	return blockedBy
 }
 
+func stackMemberBlocksDownstream(m db.StackMemberWithPR) bool {
+	return m.CIStatus == "failure" ||
+		m.ReviewDecision == "CHANGES_REQUESTED" ||
+		m.MergeableState == "dirty"
+}
+
+func effectiveStackMemberMergeableState(m db.StackMemberWithPR, blockedBy map[int]int) string {
+	if m.MergeableState == "dirty" {
+		return "dirty"
+	}
+	if _, ok := blockedBy[m.Number]; ok && m.State == "open" {
+		return "dirty"
+	}
+	return m.MergeableState
+}
+
 func toStackMemberResponses(members []db.StackMemberWithPR) []stackMemberResponse {
 	blocked := computeBlockedBy(members)
+	conflictBlocked := computeConflictBlockedBy(members)
 	out := make([]stackMemberResponse, len(members))
 	for i, m := range members {
 		out[i] = stackMemberResponse{
@@ -83,6 +119,7 @@ func toStackMemberResponses(members []db.StackMemberWithPR) []stackMemberRespons
 			State:          m.State,
 			CIStatus:       m.CIStatus,
 			ReviewDecision: m.ReviewDecision,
+			MergeableState: effectiveStackMemberMergeableState(m, conflictBlocked),
 			Position:       m.Position,
 			IsDraft:        m.IsDraft,
 			BaseBranch:     m.BaseBranch,

--- a/internal/server/stack_health_test.go
+++ b/internal/server/stack_health_test.go
@@ -21,6 +21,13 @@ func draftMember(number, pos int, ci, review string) db.StackMemberWithPR {
 	}
 }
 
+func conflictMember(number, pos int) db.StackMemberWithPR {
+	return db.StackMemberWithPR{
+		Number: number, Position: pos, State: "open",
+		CIStatus: "success", ReviewDecision: "APPROVED", MergeableState: "dirty",
+	}
+}
+
 func TestComputeStackHealth(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -59,6 +66,17 @@ func TestComputeStackHealth(t *testing.T) {
 			member(1, 1, "open", "success", "CHANGES_REQUESTED"),
 			member(2, 2, "open", "success", "APPROVED"),
 		}, "blocked"},
+		{"merge conflict with descendant is blocked", []db.StackMemberWithPR{
+			conflictMember(1, 1),
+			member(2, 2, "open", "success", "APPROVED"),
+		}, "blocked"},
+		{"single conflicted PR is not all green", []db.StackMemberWithPR{
+			conflictMember(1, 1),
+		}, "in_progress"},
+		{"conflicted tip does not block base", []db.StackMemberWithPR{
+			member(1, 1, "open", "success", "APPROVED"),
+			conflictMember(2, 2),
+		}, "base_ready"},
 		{"in progress", []db.StackMemberWithPR{
 			member(1, 1, "open", "pending", ""),
 			member(2, 2, "open", "pending", ""),
@@ -116,4 +134,25 @@ func TestComputeBlockedBy(t *testing.T) {
 	}
 	blocked = computeBlockedBy(members)
 	assert.Equal(1, blocked[2])
+
+	// Merge conflicts trigger both blocked_by and effective dirty state.
+	members = []db.StackMemberWithPR{
+		conflictMember(1, 1),
+		member(2, 2, "open", "success", "APPROVED"),
+	}
+	blocked = computeBlockedBy(members)
+	assert.Equal(1, blocked[2])
+	conflictBlocked := computeConflictBlockedBy(members)
+	assert.Equal(1, conflictBlocked[2])
+	responses := toStackMemberResponses(members)
+	assert.Equal("dirty", responses[0].MergeableState)
+	assert.Equal("dirty", responses[1].MergeableState)
+
+	// CI blockers do not turn mergeable_state into dirty.
+	members = []db.StackMemberWithPR{
+		member(1, 1, "open", "failure", ""),
+		member(2, 2, "open", "success", "APPROVED"),
+	}
+	responses = toStackMemberResponses(members)
+	assert.Empty(responses[1].MergeableState)
 }

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -371,17 +371,18 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		num                int
 		title, head, base  string
 		ci, review, author string
+		mergeableState     string
 	}{
-		{10, "Auth: extract token refresh helper", "feat/auth-base", "main", "success", "APPROVED", "alice"},
-		{11, "Auth: add retry with backoff", "feat/auth-retry", "feat/auth-base", "success", "", "alice"},
-		{12, "Auth: error handling UI", "feat/auth-ui", "feat/auth-retry", "pending", "", "alice"},
+		{10, "Auth: extract token refresh helper", "feat/auth-base", "main", "success", "APPROVED", "alice", "dirty"},
+		{11, "Auth: add retry with backoff", "feat/auth-retry", "feat/auth-base", "success", "", "alice", ""},
+		{12, "Auth: error handling UI", "feat/auth-ui", "feat/auth-retry", "pending", "", "alice", ""},
 	}
 	buildToolsStackFixturePR := func(i int) *gh.PullRequest {
 		pr := stackPRs[i]
 		created := stackBase.Add(time.Duration(i) * time.Hour)
 		return setPRBranches(
 			setPRStats(
-				buildGHPR("acme", "tools", int64(2010+i), pr.num, pr.title, pr.author, "open", false, "", created, created),
+				buildGHPR("acme", "tools", int64(2010+i), pr.num, pr.title, pr.author, "open", false, pr.mergeableState, created, created),
 				50+i*10,
 				5,
 			),
@@ -404,6 +405,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			BaseBranch:        pr.base,
 			CIStatus:          pr.ci,
 			ReviewDecision:    pr.review,
+			MergeableState:    pr.mergeableState,
 			Additions:         50 + i*10,
 			Deletions:         5,
 			CreatedAt:         created,

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -3426,6 +3426,7 @@ export interface components {
             blocked_by: number | null;
             ci_status: string;
             is_draft: boolean;
+            mergeable_state: string;
             /** Format: int64 */
             number: number;
             /** Format: int64 */

--- a/packages/ui/src/components/detail/StackStatus.svelte
+++ b/packages/ui/src/components/detail/StackStatus.svelte
@@ -47,6 +47,7 @@
     state: string;
     ci_status: string;
     review_decision: string;
+    mergeable_state: string;
     position: number;
     is_draft: boolean;
     base_branch: string;
@@ -88,12 +89,40 @@
       member.state !== "merged"
     ),
   );
+  const downstackConflicts = $derived(
+    members.filter((member) =>
+      member.position < (data?.position ?? 0) &&
+      member.mergeable_state === "dirty" &&
+      member.state !== "merged"
+    ),
+  );
+  const downstackBlockerCount = $derived.by(() => {
+    return members.filter((member) =>
+      member.position < (data?.position ?? 0) &&
+      member.state !== "merged" &&
+      (member.ci_status === "failure" || member.mergeable_state === "dirty")
+    ).length;
+  });
   const summary = $derived.by(() => {
     if (!data) return "";
     const failureText = downstackFailures.length > 0
       ? ` · downstack CI ${downstackFailures.length === 1 ? "failure" : "failures"}`
       : "";
-    return `${data.size} PRs · current ${data.position}/${data.size}${failureText}`;
+    const conflictText = downstackConflicts.length > 0
+      ? ` · downstack ${downstackConflicts.length === 1 ? "conflict" : "conflicts"}`
+      : "";
+    return `${data.size} PRs · current ${data.position}/${data.size}${failureText}${conflictText}`;
+  });
+  const chipAriaLabel = $derived.by(() => {
+    if (!data) return "Stacked";
+    const parts = [`Stacked: ${data.position}/${data.size}`];
+    if (downstackFailures.length > 0) {
+      parts.push(`${downstackFailures.length} downstack CI failure${downstackFailures.length === 1 ? "" : "s"}`);
+    }
+    if (downstackConflicts.length > 0) {
+      parts.push(`${downstackConflicts.length} downstack merge conflict${downstackConflicts.length === 1 ? "" : "s"}`);
+    }
+    return parts.join(", ");
   });
 
   function stackWithPosition(stack: StackContext, num: number): StackContext | null {
@@ -201,10 +230,17 @@
     return { text: "○ Review", className: "stack-status-label--muted" };
   }
 
+  function mergeableLabel(member: StackMember): { text: string; className: string } | null {
+    if (member.state === "merged" || member.mergeable_state !== "dirty") return null;
+    return { text: "× Conflicts", className: "stack-status-label--red" };
+  }
+
   function dotClass(member: StackMember, isCurrent: boolean): string {
     if (isCurrent) return "stack-dot stack-dot--current";
     if (member.state === "merged") return "stack-dot stack-dot--merged";
-    if (member.ci_status === "failure") return "stack-dot stack-dot--red";
+    if (member.mergeable_state === "dirty" || member.ci_status === "failure") {
+      return "stack-dot stack-dot--red";
+    }
     if (member.ci_status === "pending" || member.review_decision === "CHANGES_REQUESTED") {
       return "stack-dot stack-dot--amber";
     }
@@ -240,7 +276,7 @@
         interactive={true}
         tone="neutral"
         uppercase={false}
-        ariaLabel={`Stacked: ${data.position}/${data.size}${downstackFailures.length > 0 ? `, ${downstackFailures.length} downstack CI failure${downstackFailures.length === 1 ? "" : "s"}` : ""}`}
+        ariaLabel={chipAriaLabel}
         dataTestid="stack-chip"
         onclick={toggleExpanded}
         title={expanded ? "Collapse stack" : "Expand stack"}
@@ -248,10 +284,10 @@
       >
         <Layers2Icon size={12} strokeWidth={2.3} aria-hidden="true" />
         <span class="stack-chip-label">Stacked: {data.position}/{data.size}</span>
-        {#if downstackFailures.length > 0}
+        {#if downstackBlockerCount > 0}
           <span class="stack-chip-failure" aria-hidden="true">
             <XIcon size={12} strokeWidth={2.8} />
-            <span>{downstackFailures.length}</span>
+            <span>{downstackBlockerCount}</span>
           </span>
         {/if}
         <ChevronDownIcon
@@ -272,6 +308,7 @@
               {@const isCurrent = member.number === number}
               {@const ci = statusLabel(member)}
               {@const review = reviewLabel(member)}
+              {@const mergeable = mergeableLabel(member)}
               <div
                 class="stack-row"
                 class:stack-row--current={isCurrent}
@@ -294,6 +331,7 @@
                   </button>
                 </span>
                 <span class="stack-badges">
+                  {#if mergeable}<span class={`stack-status-label ${mergeable.className}`}>{mergeable.text}</span>{/if}
                   {#if ci}<span class={`stack-status-label ${ci.className}`}>{ci.text}</span>{/if}
                   {#if review}<span class={`stack-status-label ${review.className}`}>{review.text}</span>{/if}
                   {#if member.blocked_by != null && isCurrent}

--- a/packages/ui/src/components/detail/StackStatus.test.ts
+++ b/packages/ui/src/components/detail/StackStatus.test.ts
@@ -13,6 +13,7 @@ interface StackMember {
   state: string;
   ci_status: string;
   review_decision: string;
+  mergeable_state: string;
   position: number;
   is_draft: boolean;
   base_branch: string;
@@ -37,6 +38,7 @@ function member(
     state: "open",
     ci_status: "success",
     review_decision: "APPROVED",
+    mergeable_state: "",
     position: overrides.position,
     is_draft: false,
     base_branch: "main",
@@ -130,5 +132,21 @@ describe("StackStatus", () => {
     });
 
     expect(screen.queryByRole("button", { name: /Stacked:/i })).toBeNull();
+  });
+
+  it("surfaces downstack merge conflicts on the chip and stack row", () => {
+    renderStackStatus(stack({
+      members: [
+        member({ number: 1, position: 1, mergeable_state: "dirty" }),
+        member({ number: 2, position: 2, mergeable_state: "dirty" }),
+        member({ number: 3, position: 3 }),
+      ],
+    }));
+
+    expect(screen.getByRole("button", {
+      name: /Stacked: 2\/3, 1 downstack merge conflict/i,
+    })).toBeTruthy();
+    expect(screen.getAllByText("× Conflicts")).toHaveLength(2);
+    expect(screen.getByText(/3 PRs . current 2\/3 . downstack conflict/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
- Show stack-root merge conflicts on downstream PR list and detail responses without changing stored provider state.
- Add conflict badges and warning state to stack status so every PR in the stack reflects the root conflict.