### PR TITLE
fix: disable telemetry in go test processes

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/posthog/posthog-go"
@@ -97,7 +98,7 @@ func SanitizeProperties(event string, properties map[string]any) (map[string]any
 }
 
 func NewReporter(opts Options) (*Reporter, error) {
-	if !EnabledFromEnv() {
+	if !EnabledFromEnv() || testing.Testing() {
 		return DisabledReporter(), nil
 	}
 	if opts.Database == nil {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -37,6 +37,22 @@ func TestNewReporterDisabledByEnvDoesNotCreateInstallID(t *testing.T) {
 	assert.False(found)
 }
 
+func TestNewReporterDisabledInGoTestEvenWhenEnvEnabled(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	t.Setenv(EnabledEnv, "1")
+	database := dbtest.Open(t)
+
+	reporter, err := NewReporter(Options{Database: database})
+	require.NoError(err)
+
+	assert.False(reporter.Enabled())
+	_, found, err := database.AppMetadataValue(t.Context(), installIDMetadataKey)
+	require.NoError(err)
+	assert.False(found)
+}
+
 func TestLoadOrCreateInstallIDIsStableAndAnonymous(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
- Disable the production PostHog reporter in Go test binaries even when `TELEMETRY_ENABLED=1` is present.
- Keep the guard before install ID persistence and PostHog client initialization so tests cannot create telemetry identity state or send pings.
- Add regression coverage for the forced test-process disable path.

Validation:
- `go test ./internal/telemetry -shuffle=on`
- `go test ./cmd/middleman -shuffle=on`
- `go test ./tools/devephemeral -shuffle=on`
- commit hook: `go test (short)` passed
- pre-push hook: `nilaway` passed