### PR TITLE
Show PR lifecycle events in timelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ guardrail-check: frontend-api-client-check font-size-token-check huma-route-chec
 # Regenerate the checked-in OpenAPI document and generated clients
 api-generate:
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; GOCACHE="$${GOCACHE:-/tmp/middleman-gocache}" go run ./cmd/middleman-openapi -out "$$tmp" -format yaml; if [ -f frontend/openapi/openapi.yaml ] && cmp -s "$$tmp" frontend/openapi/openapi.yaml; then rm "$$tmp"; else mv "$$tmp" frontend/openapi/openapi.yaml; fi; trap - EXIT
+	mkdir -p internal/apiclient/spec
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; GOCACHE="$${GOCACHE:-/tmp/middleman-gocache}" go run ./cmd/middleman-openapi -out "$$tmp" -version 3.0 -format json; if [ -f internal/apiclient/spec/openapi.json ] && cmp -s "$$tmp" internal/apiclient/spec/openapi.json; then rm "$$tmp"; else mv "$$tmp" internal/apiclient/spec/openapi.json; fi; trap - EXIT
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; (cd frontend && bun ./node_modules/openapi-typescript/bin/cli.js openapi/openapi.yaml --enum-values -o "$$tmp"); if [ -f packages/ui/src/api/generated/schema.ts ] && cmp -s "$$tmp" packages/ui/src/api/generated/schema.ts; then rm "$$tmp"; else mv "$$tmp" packages/ui/src/api/generated/schema.ts; fi; trap - EXIT
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; printf '%s\n' \

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -326,7 +326,7 @@ const pullRequestTimelineEventsQuery = `
 query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
-      timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT], first: 100, after: $cursor) {
+      timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT, MERGED_EVENT, CLOSED_EVENT, REOPENED_EVENT], first: 100, after: $cursor) {
         nodes {
           __typename
           ... on Node {
@@ -403,6 +403,18 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
               ... on Organization { login }
               ... on User { login }
             }
+            createdAt
+          }
+          ... on MergedEvent {
+            actor { login }
+            createdAt
+          }
+          ... on ClosedEvent {
+            actor { login }
+            createdAt
+          }
+          ... on ReopenedEvent {
+            actor { login }
             createdAt
           }
         }
@@ -1487,6 +1499,12 @@ func (c *liveClient) ListPullRequestTimelineEvents(
 				event.EventType = "assigned"
 			case "UnassignedEvent":
 				event.EventType = "unassigned"
+			case "MergedEvent":
+				event.EventType = "merged"
+			case "ClosedEvent":
+				event.EventType = "closed"
+			case "ReopenedEvent":
+				event.EventType = "reopened"
 			default:
 				continue
 			}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -469,7 +469,7 @@ func TestListPullRequestTimelineEvents(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"HeadRefForcePushedEvent","id":"HFP_1","actor":{"login":"alice"},"beforeCommit":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"afterCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"createdAt":"2024-06-01T12:00:00Z","ref":{"name":"feature"}},{"__typename":"RenamedTitleEvent","id":"RTE_1","actor":{"login":"bob"},"createdAt":"2024-06-01T12:05:00Z","previousTitle":"Old title","currentTitle":"New title"}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}`))
 			return
 		}
-		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"BaseRefChangedEvent","id":"BRC_1","actor":{"login":"carol"},"createdAt":"2024-06-01T12:10:00Z","previousRefName":"main","currentRefName":"release"},{"__typename":"CommentDeletedEvent","id":"CDE_1","actor":{"login":"maintainer"},"createdAt":"2024-06-01T12:12:00Z","deletedCommentAuthor":{"login":"reviewer"}},{"__typename":"CrossReferencedEvent","id":"CRE_1","actor":{"login":"dave"},"createdAt":"2024-06-01T12:15:00Z","isCrossRepository":true,"willCloseTarget":false,"source":{"__typename":"Issue","number":77,"title":"Related bug","url":"https://github.com/other/repo/issues/77","repository":{"owner":{"login":"other"},"name":"repo"}}},{"__typename":"AssignedEvent","id":"AE_1","actor":{"login":"wesm"},"assignee":{"__typename":"User","login":"wesm"},"createdAt":"2024-06-01T12:20:00Z"},{"__typename":"UnassignedEvent","id":"UE_1","actor":{"login":"alice"},"assignee":{"__typename":"User","login":"bob"},"createdAt":"2024-06-01T12:25:00Z"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
+		_, _ = w.Write([]byte(`{"data":{"repository":{"pullRequest":{"timelineItems":{"nodes":[{"__typename":"BaseRefChangedEvent","id":"BRC_1","actor":{"login":"carol"},"createdAt":"2024-06-01T12:10:00Z","previousRefName":"main","currentRefName":"release"},{"__typename":"CommentDeletedEvent","id":"CDE_1","actor":{"login":"maintainer"},"createdAt":"2024-06-01T12:12:00Z","deletedCommentAuthor":{"login":"reviewer"}},{"__typename":"CrossReferencedEvent","id":"CRE_1","actor":{"login":"dave"},"createdAt":"2024-06-01T12:15:00Z","isCrossRepository":true,"willCloseTarget":false,"source":{"__typename":"Issue","number":77,"title":"Related bug","url":"https://github.com/other/repo/issues/77","repository":{"owner":{"login":"other"},"name":"repo"}}},{"__typename":"AssignedEvent","id":"AE_1","actor":{"login":"wesm"},"assignee":{"__typename":"User","login":"wesm"},"createdAt":"2024-06-01T12:20:00Z"},{"__typename":"UnassignedEvent","id":"UE_1","actor":{"login":"alice"},"assignee":{"__typename":"User","login":"bob"},"createdAt":"2024-06-01T12:25:00Z"},{"__typename":"MergedEvent","id":"ME_1","actor":{"login":"merger"},"createdAt":"2024-06-01T12:30:00Z"},{"__typename":"ClosedEvent","id":"CE_1","actor":{"login":"closer"},"createdAt":"2024-06-01T12:35:00Z"},{"__typename":"ReopenedEvent","id":"RE_1","actor":{"login":"opener"},"createdAt":"2024-06-01T12:40:00Z"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -481,7 +481,7 @@ func TestListPullRequestTimelineEvents(t *testing.T) {
 
 	events, err := c.ListPullRequestTimelineEvents(t.Context(), "owner", "repo", 42)
 	require.NoError(err)
-	require.Len(events, 7)
+	require.Len(events, 10)
 	require.Equal("force_push", events[0].EventType)
 	require.Equal("HFP_1", events[0].NodeID)
 	require.Equal("alice", events[0].Actor)
@@ -511,6 +511,12 @@ func TestListPullRequestTimelineEvents(t *testing.T) {
 	require.Equal("unassigned", events[6].EventType)
 	require.Equal("alice", events[6].Actor)
 	require.Equal("bob", events[6].Assignee)
+	require.Equal("merged", events[7].EventType)
+	require.Equal("merger", events[7].Actor)
+	require.Equal("closed", events[8].EventType)
+	require.Equal("closer", events[8].Actor)
+	require.Equal("reopened", events[9].EventType)
+	require.Equal("opener", events[9].Actor)
 	require.Equal(2, calls)
 	require.Equal([]string{http.MethodPost, http.MethodPost}, methods)
 	require.Equal([]string{"application/json", "application/json"}, contentTypes)

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -89,7 +89,7 @@ type gqlPR struct {
 	TimelineItems struct {
 		Nodes    []gqlPullRequestTimelineItem
 		PageInfo pageInfo
-	} `graphql:"timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT], first: 100)"`
+	} `graphql:"timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT, COMMENT_DELETED_EVENT, CROSS_REFERENCED_EVENT, RENAMED_TITLE_EVENT, BASE_REF_CHANGED_EVENT, ASSIGNED_EVENT, UNASSIGNED_EVENT, MERGED_EVENT, CLOSED_EVENT, REOPENED_EVENT], first: 100)"`
 }
 
 type gqlComment struct {
@@ -132,6 +132,9 @@ type gqlPullRequestTimelineItem struct {
 	BaseRefChangedEvent     gqlBaseRefChangedEvent     `graphql:"... on BaseRefChangedEvent"`
 	AssignedEvent           gqlAssignedEvent           `graphql:"... on AssignedEvent"`
 	UnassignedEvent         gqlAssignedEvent           `graphql:"... on UnassignedEvent"`
+	MergedEvent             gqlLifecycleEvent          `graphql:"... on MergedEvent"`
+	ClosedEvent             gqlLifecycleEvent          `graphql:"... on ClosedEvent"`
+	ReopenedEvent           gqlLifecycleEvent          `graphql:"... on ReopenedEvent"`
 }
 
 type gqlIssueTimelineItem struct {
@@ -212,6 +215,11 @@ type gqlBaseRefChangedEvent struct {
 type gqlAssignedEvent struct {
 	Actor     *gqlActorRef
 	Assignee  gqlAssignee
+	CreatedAt time.Time
+}
+
+type gqlLifecycleEvent struct {
+	Actor     *gqlActorRef
 	CreatedAt time.Time
 }
 
@@ -951,6 +959,12 @@ func adaptPullRequestTimelineEvent(gql *gqlPullRequestTimelineItem) (PullRequest
 		copyAssignmentEvent(&event, "assigned", gql.AssignedEvent)
 	case "UnassignedEvent":
 		copyAssignmentEvent(&event, "unassigned", gql.UnassignedEvent)
+	case "MergedEvent":
+		copyLifecycleEvent(&event, "merged", gql.MergedEvent)
+	case "ClosedEvent":
+		copyLifecycleEvent(&event, "closed", gql.ClosedEvent)
+	case "ReopenedEvent":
+		copyLifecycleEvent(&event, "reopened", gql.ReopenedEvent)
 	default:
 		return PullRequestTimelineEvent{}, false
 	}
@@ -960,6 +974,14 @@ func adaptPullRequestTimelineEvent(gql *gqlPullRequestTimelineItem) (PullRequest
 func copyAssignmentEvent(event *PullRequestTimelineEvent, eventType string, src gqlAssignedEvent) {
 	event.EventType = eventType
 	event.Assignee = src.Assignee.Login()
+	event.CreatedAt = src.CreatedAt
+	if src.Actor != nil {
+		event.Actor = src.Actor.Login
+	}
+}
+
+func copyLifecycleEvent(event *PullRequestTimelineEvent, eventType string, src gqlLifecycleEvent) {
+	event.EventType = eventType
 	event.CreatedAt = src.CreatedAt
 	if src.Actor != nil {
 		event.Actor = src.Actor.Login

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -333,6 +333,21 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 				"actor":{"login":"wesm"},
 				"assignee":{"__typename":"User","login":"wesm"},
 				"createdAt":"` + now + `"
+			},{
+				"__typename":"MergedEvent",
+				"id":"ME_1",
+				"actor":{"login":"merger"},
+				"createdAt":"` + now + `"
+			},{
+				"__typename":"ClosedEvent",
+				"id":"CE_1",
+				"actor":{"login":"closer"},
+				"createdAt":"` + now + `"
+			},{
+				"__typename":"ReopenedEvent",
+				"id":"RE_1",
+				"actor":{"login":"opener"},
+				"createdAt":"` + now + `"
 			}],"pageInfo":{"hasNextPage":false,"endCursor":""}}
 		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
 	}))
@@ -347,7 +362,7 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 	require.NotNil(result)
 	require.Len(result.PullRequests, 1)
 	require.True(sawTimelineItems)
-	require.Len(result.PullRequests[0].TimelineEvents, 3)
+	require.Len(result.PullRequests[0].TimelineEvents, 6)
 
 	event := result.PullRequests[0].TimelineEvents[0]
 	assert.Equal("base_ref_changed", event.EventType)
@@ -365,6 +380,18 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 	assert.Equal("AE_1", assigned.NodeID)
 	assert.Equal("wesm", assigned.Actor)
 	assert.Equal("wesm", assigned.Assignee)
+	merged := result.PullRequests[0].TimelineEvents[3]
+	assert.Equal("merged", merged.EventType)
+	assert.Equal("ME_1", merged.NodeID)
+	assert.Equal("merger", merged.Actor)
+	closed := result.PullRequests[0].TimelineEvents[4]
+	assert.Equal("closed", closed.EventType)
+	assert.Equal("CE_1", closed.NodeID)
+	assert.Equal("closer", closed.Actor)
+	reopened := result.PullRequests[0].TimelineEvents[5]
+	assert.Equal("reopened", reopened.EventType)
+	assert.Equal("RE_1", reopened.NodeID)
+	assert.Equal("opener", reopened.Actor)
 	assert.True(result.PullRequests[0].TimelineComplete)
 }
 

--- a/internal/github/normalize_test.go
+++ b/internal/github/normalize_test.go
@@ -375,6 +375,41 @@ func TestNormalizeTimelineEventAssigned(t *testing.T) {
 	assert.Contains(event.MetadataJSON, `"assignee":"wesm"`)
 }
 
+func TestNormalizeTimelineEventLifecycle(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	createdAt := time.Date(2024, 6, 1, 12, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		eventType string
+		nodeID    string
+		summary   string
+	}{
+		{name: "merged", eventType: "merged", nodeID: "ME_1", summary: "merged this"},
+		{name: "closed", eventType: "closed", nodeID: "CE_1", summary: "closed this"},
+		{name: "reopened", eventType: "reopened", nodeID: "RE_1", summary: "reopened this"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := NormalizeTimelineEvent(17, PullRequestTimelineEvent{
+				NodeID:    tt.nodeID,
+				EventType: tt.eventType,
+				Actor:     "maintainer",
+				CreatedAt: createdAt,
+			})
+
+			require.NotNil(event)
+			assert.Equal(int64(17), event.MergeRequestID)
+			assert.Equal(tt.eventType, event.EventType)
+			assert.Equal("maintainer", event.Author)
+			assert.Equal(tt.summary, event.Summary)
+			assert.Equal(createdAt, event.CreatedAt)
+			assert.Equal("timeline-"+tt.nodeID, event.DedupeKey)
+		})
+	}
+}
+
 func TestNormalizeIssueTimelineEventAssigned(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/platform/gitealike/normalize.go
+++ b/internal/platform/gitealike/normalize.go
@@ -302,6 +302,11 @@ func normalizeTimelineEvent(item TimelineEventDTO) (eventType, summary, metadata
 		return eventType, assignmentSummary(eventType, item.User.UserName, item.Assignee.UserName), "", true
 	}
 
+	eventType, ok = normalizeLifecycleEventType(item.Type)
+	if ok {
+		return eventType, lifecycleSummary(eventType), "", true
+	}
+
 	if !isTitleChangeEvent(item.Type) {
 		return "", "", "", false
 	}
@@ -320,6 +325,32 @@ func normalizeAssignmentEventType(value string) (string, bool) {
 		return "unassigned", true
 	default:
 		return "", false
+	}
+}
+
+func normalizeLifecycleEventType(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "merged":
+		return "merged", true
+	case "closed", "close":
+		return "closed", true
+	case "reopened", "reopen":
+		return "reopened", true
+	default:
+		return "", false
+	}
+}
+
+func lifecycleSummary(eventType string) string {
+	switch eventType {
+	case "merged":
+		return "merged this"
+	case "closed":
+		return "closed this"
+	case "reopened":
+		return "reopened this"
+	default:
+		return ""
 	}
 }
 

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -210,9 +210,12 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 		[]TimelineEventDTO{
 			{ID: 401, User: UserDTO{UserName: "grace"}, Type: "assigned", Assignee: UserDTO{UserName: "grace"}, Created: base},
 			{ID: 403, User: UserDTO{UserName: "ivy"}, Type: "change_title", PreviousTitle: "Old tea", CurrentTitle: "New tea", Created: base.Add(time.Minute)},
+			{ID: 405, User: UserDTO{UserName: "mona"}, Type: "merged", Created: base.Add(2 * time.Minute)},
+			{ID: 406, User: UserDTO{UserName: "nina"}, Type: "close", Created: base.Add(3 * time.Minute)},
+			{ID: 407, User: UserDTO{UserName: "otto"}, Type: "reopen", Created: base.Add(4 * time.Minute)},
 		},
 	)
-	require.Len(mrTimelineEvents, 2)
+	require.Len(mrTimelineEvents, 5)
 	assert.Equal("assigned", mrTimelineEvents[0].EventType)
 	assert.Equal("grace", mrTimelineEvents[0].Author)
 	assert.Equal("self-assigned this", mrTimelineEvents[0].Summary)
@@ -222,6 +225,18 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 	assert.Equal(`"Old tea" -> "New tea"`, mrTimelineEvents[1].Summary)
 	assert.JSONEq(`{"previous_title":"Old tea","current_title":"New tea"}`, mrTimelineEvents[1].MetadataJSON)
 	assert.Equal("gitea/gitea.com/gitea/tea/mr/7/renamed_title/403", mrTimelineEvents[1].DedupeKey)
+	assert.Equal("merged", mrTimelineEvents[2].EventType)
+	assert.Equal("mona", mrTimelineEvents[2].Author)
+	assert.Equal("merged this", mrTimelineEvents[2].Summary)
+	assert.Equal("gitea/gitea.com/gitea/tea/mr/7/merged/405", mrTimelineEvents[2].DedupeKey)
+	assert.Equal("closed", mrTimelineEvents[3].EventType)
+	assert.Equal("nina", mrTimelineEvents[3].Author)
+	assert.Equal("closed this", mrTimelineEvents[3].Summary)
+	assert.Equal("gitea/gitea.com/gitea/tea/mr/7/closed/406", mrTimelineEvents[3].DedupeKey)
+	assert.Equal("reopened", mrTimelineEvents[4].EventType)
+	assert.Equal("otto", mrTimelineEvents[4].Author)
+	assert.Equal("reopened this", mrTimelineEvents[4].Summary)
+	assert.Equal("gitea/gitea.com/gitea/tea/mr/7/reopened/407", mrTimelineEvents[4].DedupeKey)
 
 	issueTimelineEvents := NormalizeIssueTimelineEvents(
 		platform.KindGitea,

--- a/internal/platform/github/normalize.go
+++ b/internal/platform/github/normalize.go
@@ -307,8 +307,31 @@ func NormalizeTimelineEvent(
 			CreatedAt:          event.CreatedAt,
 			DedupeKey:          timelineDedupeKey(event),
 		}
+	case "merged", "closed", "reopened":
+		return &platform.MergeRequestEvent{
+			Repo:               repo,
+			MergeRequestNumber: mrNumber,
+			EventType:          event.EventType,
+			Author:             event.Actor,
+			Summary:            lifecycleSummary(event.EventType),
+			CreatedAt:          event.CreatedAt,
+			DedupeKey:          timelineDedupeKey(event),
+		}
 	default:
 		return nil
+	}
+}
+
+func lifecycleSummary(eventType string) string {
+	switch eventType {
+	case "merged":
+		return "merged this"
+	case "closed":
+		return "closed this"
+	case "reopened":
+		return "reopened this"
+	default:
+		return ""
 	}
 }
 

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -300,7 +300,10 @@ func TestReadClientFetchesMergeRequestsIssuesEventsReleasesTagsAndPipelines(t *t
 			writeJSON(w, `{"id": 1001, "iid": 7, "project_id": 42, "title": "MR detail", "state": "opened", "source_branch": "feature", "target_branch": "main", "sha": "abc", "draft": false, "work_in_progress": true, "pipeline": {"id": 501, "status": "success"}}`)
 		case "/api/v4/projects/42/merge_requests/7/discussions":
 			writeJSON(w, `[
-				{"id": "disc1", "notes": [{"id": 1, "body": "visible", "system": false, "author": {"username": "alice"}, "created_at": "2026-04-01T10:00:00Z"}]}
+				{"id": "disc1", "notes": [
+					{"id": 1, "body": "visible", "system": false, "author": {"username": "alice"}, "created_at": "2026-04-01T10:00:00Z"},
+					{"id": 2, "body": "merged", "system": true, "author": {"username": "maintainer"}, "created_at": "2026-04-01T10:30:00Z"}
+				]}
 			]`)
 		case "/api/v4/projects/42/merge_requests/7/commits":
 			writeJSON(w, `[{"id": "abcdef123456", "title": "commit title", "message": "commit body", "author_name": "Alice", "created_at": "2026-04-01T09:00:00Z"}]`)
@@ -341,9 +344,11 @@ func TestReadClientFetchesMergeRequestsIssuesEventsReleasesTagsAndPipelines(t *t
 
 	mrEvents, err := client.ListMergeRequestEvents(context.Background(), ref, 7)
 	require.NoError(err)
-	require.Len(mrEvents, 2)
+	require.Len(mrEvents, 3)
 	assert.Equal("issue_comment", mrEvents[0].EventType)
-	assert.Equal("commit", mrEvents[1].EventType)
+	assert.Equal("merged", mrEvents[1].EventType)
+	assert.Equal("maintainer", mrEvents[1].Author)
+	assert.Equal("commit", mrEvents[2].EventType)
 
 	issues, err := client.ListOpenIssues(context.Background(), ref)
 	require.NoError(err)

--- a/internal/platform/gitlab/normalize.go
+++ b/internal/platform/gitlab/normalize.go
@@ -413,7 +413,10 @@ func normalizeMergeRequestSystemNote(
 ) (platform.MergeRequestEvent, bool) {
 	eventType, ok := gitLabAssignmentEventType(note.Body)
 	if !ok {
-		return platform.MergeRequestEvent{}, false
+		eventType, ok = gitLabLifecycleEventType(note.Body)
+		if !ok {
+			return platform.MergeRequestEvent{}, false
+		}
 	}
 	externalID := strconv.FormatInt(note.ID, 10)
 	return platform.MergeRequestEvent{
@@ -458,6 +461,20 @@ func gitLabAssignmentEventType(body string) (string, bool) {
 		return "assigned", true
 	case strings.HasPrefix(normalized, "unassigned"):
 		return "unassigned", true
+	default:
+		return "", false
+	}
+}
+
+func gitLabLifecycleEventType(body string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(body))
+	switch {
+	case strings.HasPrefix(normalized, "merged"):
+		return "merged", true
+	case strings.HasPrefix(normalized, "closed"):
+		return "closed", true
+	case strings.HasPrefix(normalized, "reopened"):
+		return "reopened", true
 	default:
 		return "", false
 	}

--- a/internal/platform/gitlab/normalize.go
+++ b/internal/platform/gitlab/normalize.go
@@ -302,7 +302,14 @@ func NormalizeMergeRequestDiscussions(
 			continue
 		}
 		for _, note := range discussion.Notes {
-			if note == nil || note.System {
+			if note == nil {
+				continue
+			}
+			if note.System {
+				event, ok := normalizeMergeRequestSystemNote(repo, mrNumber, note)
+				if ok {
+					events = append(events, event)
+				}
 				continue
 			}
 			events = append(events, platform.MergeRequestEvent{

--- a/internal/platform/gitlab/normalize_test.go
+++ b/internal/platform/gitlab/normalize_test.go
@@ -268,16 +268,29 @@ func TestNormalizeNotesKeepsAssignmentSystemNotes(t *testing.T) {
 		{ID: 1, Body: "visible", System: false, Author: gitlab.NoteAuthor{Username: "alice"}, CreatedAt: &createdAt},
 		{ID: 2, Body: "assigned to @bob", System: true, Author: gitlab.NoteAuthor{Username: "root"}, CreatedAt: &createdAt},
 		{ID: 3, Body: "changed milestone", System: true, Author: gitlab.NoteAuthor{Username: "root"}, CreatedAt: &createdAt},
+		{ID: 4, Body: "merged", System: true, Author: gitlab.NoteAuthor{Username: "maintainer"}, CreatedAt: &createdAt},
+		{ID: 5, Body: "closed", System: true, Author: gitlab.NoteAuthor{Username: "closer"}, CreatedAt: &createdAt},
+		{ID: 6, Body: "reopened", System: true, Author: gitlab.NoteAuthor{Username: "opener"}, CreatedAt: &createdAt},
 	}
 
 	mrEvents := NormalizeMergeRequestNotes(testGitLabRepoRef(), 7, notes)
-	require.Len(mrEvents, 2)
+	require.Len(mrEvents, 5)
 	assert.Equal("issue_comment", mrEvents[0].EventType)
 	assert.Equal("visible", mrEvents[0].Body)
 	assert.Equal("gitlab:gitlab.example.com:group/project:mr:7:note:1", mrEvents[0].DedupeKey)
 	assert.Equal("assigned", mrEvents[1].EventType)
 	assert.Equal("assigned to @bob", mrEvents[1].Summary)
 	assert.Equal("gitlab:gitlab.example.com:group/project:mr:7:system_note:2", mrEvents[1].DedupeKey)
+	assert.Equal("merged", mrEvents[2].EventType)
+	assert.Equal("merged", mrEvents[2].Summary)
+	assert.Equal("maintainer", mrEvents[2].Author)
+	assert.Equal("gitlab:gitlab.example.com:group/project:mr:7:system_note:4", mrEvents[2].DedupeKey)
+	assert.Equal("closed", mrEvents[3].EventType)
+	assert.Equal("closed", mrEvents[3].Summary)
+	assert.Equal("closer", mrEvents[3].Author)
+	assert.Equal("reopened", mrEvents[4].EventType)
+	assert.Equal("reopened", mrEvents[4].Summary)
+	assert.Equal("opener", mrEvents[4].Author)
 
 	issueEvents := NormalizeIssueNotes(testGitLabRepoRef(), 5, notes)
 	require.Len(issueEvents, 2)

--- a/internal/platform/gitlab/normalize_test.go
+++ b/internal/platform/gitlab/normalize_test.go
@@ -488,7 +488,13 @@ func TestNormalizeMergeRequestDiscussions(t *testing.T) {
 			Notes: []*gitlab.Note{
 				{
 					ID:     201,
-					Body:   "system note",
+					Body:   "merged",
+					System: true,
+					Author: gitlab.NoteAuthor{Username: "maintainer"},
+				},
+				{
+					ID:     203,
+					Body:   "changed milestone",
 					System: true,
 					Author: gitlab.NoteAuthor{Username: "gitlab"},
 				},
@@ -506,8 +512,8 @@ func TestNormalizeMergeRequestDiscussions(t *testing.T) {
 
 	events := NormalizeMergeRequestDiscussions(repo, 7, discussions)
 
-	// Should have 3 events (system note filtered)
-	assert.Len(events, 3)
+	// Should have 4 events (unrecognized system note filtered)
+	assert.Len(events, 4)
 
 	// First note from first discussion
 	assert.Equal("disc-abc123", events[0].ThreadID)
@@ -523,10 +529,14 @@ func TestNormalizeMergeRequestDiscussions(t *testing.T) {
 	assert.Equal("author", events[1].Author)
 	assert.True(events[1].Resolved)
 
-	// Note from second discussion (system note skipped)
-	assert.Equal("disc-def456", events[2].ThreadID)
-	assert.Equal("commenter", events[2].Author)
-	assert.False(events[2].Resolvable)
+	assert.Equal("merged", events[2].EventType)
+	assert.Equal("maintainer", events[2].Author)
+	assert.Equal("merged", events[2].Summary)
+
+	// User note from second discussion
+	assert.Equal("disc-def456", events[3].ThreadID)
+	assert.Equal("commenter", events[3].Author)
+	assert.False(events[3].Resolvable)
 }
 
 func TestNormalizeIssueDiscussions(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1837,6 +1837,10 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 		withSeedPRTimes(createdAt, reopenedAt, reopenedAt),
 		withSeedPRLifecycle(db.MergeRequestStateOpen, nil, &previousClosedAt),
 	)
+	duplicateReopenedMRID := seedPR(t, database, "acme", "widget", 7,
+		withSeedPRTimes(createdAt, reopenedAt.Add(time.Hour), reopenedAt.Add(time.Hour)),
+		withSeedPRLifecycle(db.MergeRequestStateOpen, nil, &previousClosedAt),
+	)
 	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
 		MergeRequestID: duplicateMRID,
 		EventType:      "merged",
@@ -1856,8 +1860,15 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 		EventType:      "reopened",
 		Author:         "maintainer",
 		Summary:        "previously reopened by provider",
-		CreatedAt:      previousClosedAt.Add(30 * time.Minute),
+		CreatedAt:      previousClosedAt.Add(-30 * time.Minute),
 		DedupeKey:      "provider-reopened",
+	}, {
+		MergeRequestID: duplicateReopenedMRID,
+		EventType:      "reopened",
+		Author:         "maintainer",
+		Summary:        "reopened by provider",
+		CreatedAt:      previousClosedAt.Add(30 * time.Minute),
+		DedupeKey:      "provider-current-reopened",
 	}}))
 
 	mergedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 1)
@@ -1926,7 +1937,17 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 	assert.Equal("reopened this", (*repeatedReopenedResp.JSON200.Events)[0].Summary)
 	assert.True((*repeatedReopenedResp.JSON200.Events)[0].CreatedAt.Equal(reopenedAt))
 	assert.Equal("previously reopened by provider", (*repeatedReopenedResp.JSON200.Events)[1].Summary)
-	assert.True((*repeatedReopenedResp.JSON200.Events)[1].CreatedAt.Equal(previousClosedAt.Add(30 * time.Minute)))
+	assert.True((*repeatedReopenedResp.JSON200.Events)[1].CreatedAt.Equal(previousClosedAt.Add(-30 * time.Minute)))
+
+	duplicateReopenedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 7)
+	require.NoError(err)
+	require.Equal(http.StatusOK, duplicateReopenedResp.StatusCode())
+	require.NotNil(duplicateReopenedResp.JSON200)
+	require.NotNil(duplicateReopenedResp.JSON200.Events)
+	require.Len(*duplicateReopenedResp.JSON200.Events, 1)
+	assert.Equal("reopened", (*duplicateReopenedResp.JSON200.Events)[0].EventType)
+	assert.Equal("reopened by provider", (*duplicateReopenedResp.JSON200.Events)[0].Summary)
+	assert.NotEqual(int64(-3), (*duplicateReopenedResp.JSON200.Events)[0].ID)
 }
 
 func TestAPIGetPullIncludesDeletedCommentTimelineEvent(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -976,6 +976,18 @@ func withSeedPRTitle(title string) seedPROpt {
 	return func(pr *db.MergeRequest) { pr.Title = title }
 }
 
+func withSeedPRLifecycle(
+	state db.MergeRequestState,
+	mergedAt *time.Time,
+	closedAt *time.Time,
+) seedPROpt {
+	return func(pr *db.MergeRequest) {
+		pr.State = state
+		pr.MergedAt = mergedAt
+		pr.ClosedAt = closedAt
+	}
+}
+
 func withSeedPRCI(status, checksJSON string) seedPROpt {
 	return func(pr *db.MergeRequest) {
 		pr.CIStatus = status
@@ -1787,6 +1799,87 @@ func TestAPIGetPullIsDBOnly(t *testing.T) {
 	// returns early without checking workflows.
 	require.NotNil(resp.JSON200.WorkflowApproval)
 	assert.False(resp.JSON200.WorkflowApproval.Checked)
+}
+
+func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+	createdAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := createdAt.Add(2 * time.Hour)
+	closedAt := createdAt.Add(3 * time.Hour)
+	reopenedAt := createdAt.Add(4 * time.Hour)
+	previousClosedAt := createdAt.Add(time.Hour)
+
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRTimes(createdAt, mergedAt, mergedAt),
+		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
+	)
+	seedPR(t, database, "acme", "widget", 2,
+		withSeedPRTimes(createdAt, closedAt, closedAt),
+		withSeedPRLifecycle(db.MergeRequestStateClosed, nil, &closedAt),
+	)
+	seedPR(t, database, "acme", "widget", 3,
+		withSeedPRTimes(createdAt, reopenedAt, reopenedAt),
+		withSeedPRLifecycle(db.MergeRequestStateOpen, nil, &previousClosedAt),
+	)
+	duplicateMRID := seedPR(t, database, "acme", "widget", 4,
+		withSeedPRTimes(createdAt, mergedAt, mergedAt),
+		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
+	)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: duplicateMRID,
+		EventType:      "merged",
+		Author:         "maintainer",
+		Summary:        "merged by provider",
+		CreatedAt:      mergedAt,
+		DedupeKey:      "provider-merged",
+	}}))
+
+	mergedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 1)
+	require.NoError(err)
+	require.Equal(http.StatusOK, mergedResp.StatusCode())
+	require.NotNil(mergedResp.JSON200)
+	require.NotNil(mergedResp.JSON200.Events)
+	require.Len(*mergedResp.JSON200.Events, 1)
+	assert.Equal("merged", (*mergedResp.JSON200.Events)[0].EventType)
+	assert.Equal("merged this", (*mergedResp.JSON200.Events)[0].Summary)
+	assert.Equal(int64(-1), (*mergedResp.JSON200.Events)[0].ID)
+	assert.True((*mergedResp.JSON200.Events)[0].CreatedAt.Equal(mergedAt))
+
+	closedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 2)
+	require.NoError(err)
+	require.Equal(http.StatusOK, closedResp.StatusCode())
+	require.NotNil(closedResp.JSON200)
+	require.NotNil(closedResp.JSON200.Events)
+	require.Len(*closedResp.JSON200.Events, 1)
+	assert.Equal("closed", (*closedResp.JSON200.Events)[0].EventType)
+	assert.Equal("closed this", (*closedResp.JSON200.Events)[0].Summary)
+	assert.Equal(int64(-2), (*closedResp.JSON200.Events)[0].ID)
+	assert.True((*closedResp.JSON200.Events)[0].CreatedAt.Equal(closedAt))
+
+	reopenedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 3)
+	require.NoError(err)
+	require.Equal(http.StatusOK, reopenedResp.StatusCode())
+	require.NotNil(reopenedResp.JSON200)
+	require.NotNil(reopenedResp.JSON200.Events)
+	require.Len(*reopenedResp.JSON200.Events, 1)
+	assert.Equal("reopened", (*reopenedResp.JSON200.Events)[0].EventType)
+	assert.Equal("reopened this", (*reopenedResp.JSON200.Events)[0].Summary)
+	assert.Equal(int64(-3), (*reopenedResp.JSON200.Events)[0].ID)
+	assert.True((*reopenedResp.JSON200.Events)[0].CreatedAt.Equal(reopenedAt))
+
+	duplicateResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 4)
+	require.NoError(err)
+	require.Equal(http.StatusOK, duplicateResp.StatusCode())
+	require.NotNil(duplicateResp.JSON200)
+	require.NotNil(duplicateResp.JSON200.Events)
+	require.Len(*duplicateResp.JSON200.Events, 1)
+	assert.Equal("merged", (*duplicateResp.JSON200.Events)[0].EventType)
+	assert.Equal("merged by provider", (*duplicateResp.JSON200.Events)[0].Summary)
+	assert.NotEqual(int64(-1), (*duplicateResp.JSON200.Events)[0].ID)
 }
 
 func TestAPIGetPullIncludesDeletedCommentTimelineEvent(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1829,6 +1829,14 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 		withSeedPRTimes(createdAt, mergedAt, mergedAt),
 		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
 	)
+	repeatedClosedMRID := seedPR(t, database, "acme", "widget", 5,
+		withSeedPRTimes(createdAt, closedAt, closedAt),
+		withSeedPRLifecycle(db.MergeRequestStateClosed, nil, &closedAt),
+	)
+	repeatedReopenedMRID := seedPR(t, database, "acme", "widget", 6,
+		withSeedPRTimes(createdAt, reopenedAt, reopenedAt),
+		withSeedPRLifecycle(db.MergeRequestStateOpen, nil, &previousClosedAt),
+	)
 	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
 		MergeRequestID: duplicateMRID,
 		EventType:      "merged",
@@ -1836,6 +1844,20 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 		Summary:        "merged by provider",
 		CreatedAt:      mergedAt,
 		DedupeKey:      "provider-merged",
+	}, {
+		MergeRequestID: repeatedClosedMRID,
+		EventType:      "closed",
+		Author:         "maintainer",
+		Summary:        "previously closed by provider",
+		CreatedAt:      previousClosedAt,
+		DedupeKey:      "provider-closed",
+	}, {
+		MergeRequestID: repeatedReopenedMRID,
+		EventType:      "reopened",
+		Author:         "maintainer",
+		Summary:        "previously reopened by provider",
+		CreatedAt:      previousClosedAt.Add(30 * time.Minute),
+		DedupeKey:      "provider-reopened",
 	}}))
 
 	mergedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 1)
@@ -1846,6 +1868,7 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 	require.Len(*mergedResp.JSON200.Events, 1)
 	assert.Equal("merged", (*mergedResp.JSON200.Events)[0].EventType)
 	assert.Equal("merged this", (*mergedResp.JSON200.Events)[0].Summary)
+	assert.Empty((*mergedResp.JSON200.Events)[0].Author)
 	assert.Equal(int64(-1), (*mergedResp.JSON200.Events)[0].ID)
 	assert.True((*mergedResp.JSON200.Events)[0].CreatedAt.Equal(mergedAt))
 
@@ -1857,6 +1880,7 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 	require.Len(*closedResp.JSON200.Events, 1)
 	assert.Equal("closed", (*closedResp.JSON200.Events)[0].EventType)
 	assert.Equal("closed this", (*closedResp.JSON200.Events)[0].Summary)
+	assert.Empty((*closedResp.JSON200.Events)[0].Author)
 	assert.Equal(int64(-2), (*closedResp.JSON200.Events)[0].ID)
 	assert.True((*closedResp.JSON200.Events)[0].CreatedAt.Equal(closedAt))
 
@@ -1868,6 +1892,7 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 	require.Len(*reopenedResp.JSON200.Events, 1)
 	assert.Equal("reopened", (*reopenedResp.JSON200.Events)[0].EventType)
 	assert.Equal("reopened this", (*reopenedResp.JSON200.Events)[0].Summary)
+	assert.Empty((*reopenedResp.JSON200.Events)[0].Author)
 	assert.Equal(int64(-3), (*reopenedResp.JSON200.Events)[0].ID)
 	assert.True((*reopenedResp.JSON200.Events)[0].CreatedAt.Equal(reopenedAt))
 
@@ -1880,6 +1905,28 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 	assert.Equal("merged", (*duplicateResp.JSON200.Events)[0].EventType)
 	assert.Equal("merged by provider", (*duplicateResp.JSON200.Events)[0].Summary)
 	assert.NotEqual(int64(-1), (*duplicateResp.JSON200.Events)[0].ID)
+
+	repeatedClosedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 5)
+	require.NoError(err)
+	require.Equal(http.StatusOK, repeatedClosedResp.StatusCode())
+	require.NotNil(repeatedClosedResp.JSON200)
+	require.NotNil(repeatedClosedResp.JSON200.Events)
+	require.Len(*repeatedClosedResp.JSON200.Events, 2)
+	assert.Equal("closed this", (*repeatedClosedResp.JSON200.Events)[0].Summary)
+	assert.True((*repeatedClosedResp.JSON200.Events)[0].CreatedAt.Equal(closedAt))
+	assert.Equal("previously closed by provider", (*repeatedClosedResp.JSON200.Events)[1].Summary)
+	assert.True((*repeatedClosedResp.JSON200.Events)[1].CreatedAt.Equal(previousClosedAt))
+
+	repeatedReopenedResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 6)
+	require.NoError(err)
+	require.Equal(http.StatusOK, repeatedReopenedResp.StatusCode())
+	require.NotNil(repeatedReopenedResp.JSON200)
+	require.NotNil(repeatedReopenedResp.JSON200.Events)
+	require.Len(*repeatedReopenedResp.JSON200.Events, 2)
+	assert.Equal("reopened this", (*repeatedReopenedResp.JSON200.Events)[0].Summary)
+	assert.True((*repeatedReopenedResp.JSON200.Events)[0].CreatedAt.Equal(reopenedAt))
+	assert.Equal("previously reopened by provider", (*repeatedReopenedResp.JSON200.Events)[1].Summary)
+	assert.True((*repeatedReopenedResp.JSON200.Events)[1].CreatedAt.Equal(previousClosedAt.Add(30 * time.Minute)))
 }
 
 func TestAPIGetPullIncludesDeletedCommentTimelineEvent(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1172,6 +1173,7 @@ func (s *Server) buildPullDetailResponse(
 	if events == nil {
 		events = []db.MREvent{}
 	}
+	events = withSyntheticMRLifecycleEvents(*mr, events)
 	eventResponses, err := s.mergeRequestEventResponses(ctx, mr.ID, events)
 	if err != nil {
 		return mergeRequestDetailResponse{}, huma.Error500InternalServerError(
@@ -1237,6 +1239,58 @@ func (s *Server) buildPullDetailResponse(
 	}
 
 	return resp, nil
+}
+
+func withSyntheticMRLifecycleEvents(mr db.MergeRequest, events []db.MREvent) []db.MREvent {
+	hasEventType := func(eventType string) bool {
+		for _, event := range events {
+			if event.EventType == eventType {
+				return true
+			}
+		}
+		return false
+	}
+
+	out := append([]db.MREvent{}, events...)
+	switch mr.State {
+	case db.MergeRequestStateMerged:
+		if mr.MergedAt != nil && !hasEventType("merged") {
+			out = append(out, syntheticMRLifecycleEvent(mr, -1, "merged", "merged this", *mr.MergedAt))
+		}
+	case db.MergeRequestStateClosed:
+		if mr.ClosedAt != nil && !hasEventType("closed") {
+			out = append(out, syntheticMRLifecycleEvent(mr, -2, "closed", "closed this", *mr.ClosedAt))
+		}
+	case db.MergeRequestStateOpen:
+		if mr.ClosedAt != nil && !hasEventType("reopened") {
+			out = append(out, syntheticMRLifecycleEvent(mr, -3, "reopened", "reopened this", mr.UpdatedAt))
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.After(out[j].CreatedAt)
+		}
+		return out[i].ID > out[j].ID
+	})
+	return out
+}
+
+func syntheticMRLifecycleEvent(
+	mr db.MergeRequest,
+	id int64,
+	eventType string,
+	summary string,
+	createdAt time.Time,
+) db.MREvent {
+	return db.MREvent{
+		ID:             id,
+		MergeRequestID: mr.ID,
+		EventType:      eventType,
+		Summary:        summary,
+		CreatedAt:      createdAt.UTC(),
+		DedupeKey:      "synthetic:mr:lifecycle:" + eventType,
+	}
 }
 
 // diffWarnings returns warnings inferred from the persisted PR row. The

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1242,9 +1242,10 @@ func (s *Server) buildPullDetailResponse(
 }
 
 func withSyntheticMRLifecycleEvents(mr db.MergeRequest, events []db.MREvent) []db.MREvent {
-	hasEventType := func(eventType string) bool {
+	hasLifecycleEvent := func(eventType string, createdAt time.Time) bool {
+		createdAt = createdAt.UTC()
 		for _, event := range events {
-			if event.EventType == eventType {
+			if event.EventType == eventType && event.CreatedAt.UTC().Equal(createdAt) {
 				return true
 			}
 		}
@@ -1254,15 +1255,15 @@ func withSyntheticMRLifecycleEvents(mr db.MergeRequest, events []db.MREvent) []d
 	out := append([]db.MREvent{}, events...)
 	switch mr.State {
 	case db.MergeRequestStateMerged:
-		if mr.MergedAt != nil && !hasEventType("merged") {
+		if mr.MergedAt != nil && !hasLifecycleEvent("merged", *mr.MergedAt) {
 			out = append(out, syntheticMRLifecycleEvent(mr, -1, "merged", "merged this", *mr.MergedAt))
 		}
 	case db.MergeRequestStateClosed:
-		if mr.ClosedAt != nil && !hasEventType("closed") {
+		if mr.ClosedAt != nil && !hasLifecycleEvent("closed", *mr.ClosedAt) {
 			out = append(out, syntheticMRLifecycleEvent(mr, -2, "closed", "closed this", *mr.ClosedAt))
 		}
 	case db.MergeRequestStateOpen:
-		if mr.ClosedAt != nil && !hasEventType("reopened") {
+		if mr.ClosedAt != nil && !hasLifecycleEvent("reopened", mr.UpdatedAt) {
 			out = append(out, syntheticMRLifecycleEvent(mr, -3, "reopened", "reopened this", mr.UpdatedAt))
 		}
 	}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1251,6 +1251,19 @@ func withSyntheticMRLifecycleEvents(mr db.MergeRequest, events []db.MREvent) []d
 		}
 		return false
 	}
+	hasReopenedEventAfterClose := func(closedAt time.Time) bool {
+		closedAt = closedAt.UTC()
+		for _, event := range events {
+			if event.EventType != "reopened" {
+				continue
+			}
+			eventAt := event.CreatedAt.UTC()
+			if eventAt.Equal(closedAt) || eventAt.After(closedAt) {
+				return true
+			}
+		}
+		return false
+	}
 
 	out := append([]db.MREvent{}, events...)
 	switch mr.State {
@@ -1263,7 +1276,7 @@ func withSyntheticMRLifecycleEvents(mr db.MergeRequest, events []db.MREvent) []d
 			out = append(out, syntheticMRLifecycleEvent(mr, -2, "closed", "closed this", *mr.ClosedAt))
 		}
 	case db.MergeRequestStateOpen:
-		if mr.ClosedAt != nil && !hasLifecycleEvent("reopened", mr.UpdatedAt) {
+		if mr.ClosedAt != nil && !hasReopenedEventAfterClose(*mr.ClosedAt) {
 			out = append(out, syntheticMRLifecycleEvent(mr, -3, "reopened", "reopened this", mr.UpdatedAt))
 		}
 	}

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -109,6 +109,9 @@
     review_comment: "Review Comment",
     assigned: "Assigned",
     unassigned: "Unassigned",
+    merged: "Merged",
+    closed: "Closed",
+    reopened: "Reopened",
   };
 
   const typeColors: Record<string, string> = {
@@ -120,6 +123,9 @@
     force_push: "var(--accent-red)",
     assigned: "var(--accent-blue)",
     unassigned: "var(--text-muted)",
+    merged: "var(--accent-green)",
+    closed: "var(--text-muted)",
+    reopened: "var(--accent-blue)",
   };
 
   function shouldRenderMarkdown(eventType: string): boolean {
@@ -487,7 +493,10 @@
       eventType === "renamed_title" ||
       eventType === "base_ref_changed" ||
       eventType === "assigned" ||
-      eventType === "unassigned"
+      eventType === "unassigned" ||
+      eventType === "merged" ||
+      eventType === "closed" ||
+      eventType === "reopened"
     );
   }
 
@@ -517,6 +526,12 @@
         return "Assigned";
       case "unassigned":
         return "Unassigned";
+      case "merged":
+        return "Merged";
+      case "closed":
+        return "Closed";
+      case "reopened":
+        return "Reopened";
       case "force_push":
         return "Force-pushed";
       default:

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -189,6 +189,41 @@ describe("EventTimeline", () => {
     expect(screen.getByText("aaaaaaa -> bbbbbbb")).toBeTruthy();
   });
 
+  it("renders lifecycle event labels and summaries", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 3,
+            EventType: "merged",
+            Summary: "merged this",
+            CreatedAt: "2024-06-01T12:03:00Z",
+          }),
+          makeEvent({
+            ID: 2,
+            EventType: "closed",
+            Summary: "closed this",
+            CreatedAt: "2024-06-01T12:02:00Z",
+          }),
+          makeEvent({
+            ID: 1,
+            EventType: "reopened",
+            Summary: "reopened this",
+            CreatedAt: "2024-06-01T12:01:00Z",
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getByText("Merged")).toBeTruthy();
+    expect(screen.getByText("Closed")).toBeTruthy();
+    expect(screen.getByText("Reopened")).toBeTruthy();
+    expect(screen.getByText("merged this")).toBeTruthy();
+    expect(screen.getByText("closed this")).toBeTruthy();
+    expect(screen.getByText("reopened this")).toBeTruthy();
+    expect(document.querySelectorAll(".event--compact")).toHaveLength(3);
+  });
+
   it("keeps the timeline entry card while rendering body content without a nested card surface", () => {
     const { container } = render(EventTimeline, {
       props: {


### PR DESCRIPTION
- Show merged, closed, and reopened lifecycle events in PR detail timelines.
- Normalize lifecycle timeline events across GitHub, GitLab, Gitea, and Forgejo-style providers.
- Keep generated API artifacts in sync with the current generator output.