### PR TITLE
Preserve multiline paste in both terminal renderers

### DIFF
--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
@@ -14,7 +14,10 @@
   import { getStores } from "@middleman/ui";
   import { FitAddon, Terminal } from "ghostty-web";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
-  import { isMultilinePaste } from "./bracketedPaste.js";
+  import {
+    isMultilinePaste,
+    sanitizeTerminalPasteText,
+  } from "./bracketedPaste.js";
   import { buildTerminalFontFamily } from "./terminalFontFamily.js";
   import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
@@ -206,7 +209,7 @@
 
     event.preventDefault();
     event.stopImmediatePropagation();
-    terminal.paste(pastedText);
+    terminal.paste(sanitizeTerminalPasteText(pastedText));
   }
 
   function refreshVisibleTerminal(): void {

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
@@ -14,6 +14,7 @@
   import { getStores } from "@middleman/ui";
   import { FitAddon, Terminal } from "ghostty-web";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
+  import { isMultilinePaste } from "./bracketedPaste.js";
   import { buildTerminalFontFamily } from "./terminalFontFamily.js";
   import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
@@ -194,6 +195,20 @@
     return bytes.slice().buffer;
   }
 
+  function handleTerminalPaste(event: ClipboardEvent): void {
+    if (ws?.readyState !== WebSocket.OPEN || !terminal) return;
+
+    const pastedText =
+      event.clipboardData?.getData("text/plain") ||
+      event.clipboardData?.getData("text") ||
+      "";
+    if (!isMultilinePaste(pastedText)) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    terminal.paste(pastedText);
+  }
+
   function refreshVisibleTerminal(): void {
     if (!terminal) return;
 
@@ -324,6 +339,7 @@
       ws.close();
       ws = null;
     }
+    containerEl?.removeEventListener("paste", handleTerminalPaste, true);
     if (terminal) {
       terminal.dispose();
       terminal = null;
@@ -368,6 +384,7 @@
       terminal = term;
 
       term.open(containerEl);
+      containerEl.addEventListener("paste", handleTerminalPaste, true);
 
       const fit = new FitAddon();
       fitAddon = fit;

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
@@ -6,6 +6,7 @@ const mockFit = vi.fn();
 const mockOpen = vi.fn();
 const mockLoadAddon = vi.fn();
 const mockOnData = vi.fn();
+const mockPaste = vi.fn();
 const mockDispose = vi.fn();
 const mockInit = vi.fn().mockResolvedValue(undefined);
 const terminalCtor = vi.fn();
@@ -67,6 +68,7 @@ vi.mock("ghostty-web", () => ({
       open: mockOpen,
       loadAddon: mockLoadAddon,
       onData: mockOnData,
+      paste: mockPaste,
       dispose: mockDispose,
       write: terminalWrite,
       options: { ...options },
@@ -89,6 +91,13 @@ describe("GhosttyTerminalPane", () => {
     mockOpen.mockReset();
     mockLoadAddon.mockReset();
     mockOnData.mockReset();
+    mockPaste.mockReset();
+    mockPaste.mockImplementation((text: string) => {
+      const dataHandler = mockOnData.mock.calls[0]?.[0] as
+        | ((data: string) => void)
+        | undefined;
+      dataHandler?.(`\x1b[200~${text}\x1b[201~`);
+    });
     mockDispose.mockReset();
     mockInit.mockClear();
     terminalWrite.mockReset();
@@ -284,6 +293,66 @@ describe("GhosttyTerminalPane", () => {
     expect(Array.from(new Uint8Array(sent as ArrayBuffer))).toEqual([
       0x80, 0x81,
     ]);
+  });
+
+  it("sends browser multiline paste through ghostty bracketed paste handling", async () => {
+    const { container } = await renderStarted({ workspaceId: "ws-123" });
+
+    socketAt(0).sent = [];
+    const terminalContainer = container.querySelector(".terminal-container");
+    expect(terminalContainer).toBeDefined();
+    const laterPasteListener = vi.fn();
+    terminalContainer!.addEventListener("paste", laterPasteListener, true);
+
+    const event = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+    }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        getData: vi.fn((type: string) =>
+          type === "text/plain" ? "first\nsecond\nthird" : "",
+        ),
+      },
+    });
+
+    const defaultAllowed = terminalContainer!.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(false);
+    expect(laterPasteListener).not.toHaveBeenCalled();
+    expect(mockPaste).toHaveBeenCalledWith("first\nsecond\nthird");
+    expect(sentText(socketAt(0), 0)).toBe(
+      "\x1b[200~first\nsecond\nthird\x1b[201~",
+    );
+  });
+
+  it("leaves single-line browser paste for ghostty default handling", async () => {
+    const { container } = await renderStarted({ workspaceId: "ws-123" });
+
+    socketAt(0).sent = [];
+    const terminalContainer = container.querySelector(".terminal-container");
+    expect(terminalContainer).toBeDefined();
+    const laterPasteListener = vi.fn();
+    terminalContainer!.addEventListener("paste", laterPasteListener, true);
+
+    const event = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+    }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        getData: vi.fn((type: string) =>
+          type === "text/plain" ? "single line" : "",
+        ),
+      },
+    });
+
+    const defaultAllowed = terminalContainer!.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(true);
+    expect(laterPasteListener).toHaveBeenCalledTimes(1);
+    expect(mockPaste).not.toHaveBeenCalled();
+    expect(socketAt(0).sent).toHaveLength(0);
   });
 
   it("does not open a websocket when initialStatus is exited", async () => {

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
@@ -311,7 +311,9 @@ describe("GhosttyTerminalPane", () => {
     Object.defineProperty(event, "clipboardData", {
       value: {
         getData: vi.fn((type: string) =>
-          type === "text/plain" ? "first\nsecond\nthird" : "",
+          type === "text/plain"
+            ? "first\x1b[201~\nsecond\nthird"
+            : "",
         ),
       },
     });
@@ -320,9 +322,9 @@ describe("GhosttyTerminalPane", () => {
 
     expect(defaultAllowed).toBe(false);
     expect(laterPasteListener).not.toHaveBeenCalled();
-    expect(mockPaste).toHaveBeenCalledWith("first\nsecond\nthird");
+    expect(mockPaste).toHaveBeenCalledWith("first[201~\nsecond\nthird");
     expect(sentText(socketAt(0), 0)).toBe(
-      "\x1b[200~first\nsecond\nthird\x1b[201~",
+      "\x1b[200~first[201~\nsecond\nthird\x1b[201~",
     );
   });
 

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -343,6 +343,70 @@ describe("TerminalPane", () => {
       expect.stringContaining("[Session unavailable]"),
     );
   });
+
+  it("sends browser multiline paste as one bracketed paste payload", async () => {
+    const { container } = render(TerminalPane, {
+      props: { workspaceId: "ws-123" },
+    });
+
+    await waitFor(() => expect(xtermOnDataHandlers).toHaveLength(1));
+    mockSockets[0]!.sent = [];
+    const terminalContainer = container.querySelector(".terminal-container");
+    expect(terminalContainer).toBeDefined();
+    const laterPasteListener = vi.fn();
+    terminalContainer!.addEventListener("paste", laterPasteListener, true);
+
+    const event = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+    }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        getData: vi.fn((type: string) =>
+          type === "text/plain" ? "first\nsecond\nthird" : "",
+        ),
+      },
+    });
+
+    const defaultAllowed = terminalContainer!.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(false);
+    expect(laterPasteListener).not.toHaveBeenCalled();
+    expect(sentText(mockSockets[0]!, 0)).toBe(
+      "\x1b[200~first\nsecond\nthird\x1b[201~",
+    );
+  });
+
+  it("leaves single-line browser paste for xterm.js default handling", async () => {
+    const { container } = render(TerminalPane, {
+      props: { workspaceId: "ws-123" },
+    });
+
+    await waitFor(() => expect(xtermOnDataHandlers).toHaveLength(1));
+    mockSockets[0]!.sent = [];
+    const terminalContainer = container.querySelector(".terminal-container");
+    expect(terminalContainer).toBeDefined();
+    const laterPasteListener = vi.fn();
+    terminalContainer!.addEventListener("paste", laterPasteListener, true);
+
+    const event = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+    }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        getData: vi.fn((type: string) =>
+          type === "text/plain" ? "single line" : "",
+        ),
+      },
+    });
+
+    const defaultAllowed = terminalContainer!.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(true);
+    expect(laterPasteListener).toHaveBeenCalledTimes(1);
+    expect(mockSockets[0]!.sent).toHaveLength(0);
+  });
 });
 
 function sentText(socket: MockWebSocket, index: number): string {

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -22,6 +22,7 @@ const {
   xtermInstances: [] as Array<{
     clearTextureAtlas: ReturnType<typeof vi.fn>;
     cols: number;
+    modes: { bracketedPasteMode: boolean };
     refresh: ReturnType<typeof vi.fn>;
     rows: number;
     write: ReturnType<typeof vi.fn>;
@@ -81,6 +82,7 @@ vi.mock("@xterm/xterm", () => ({
     const terminal = {
       cols: 80,
       rows: 24,
+      modes: { bracketedPasteMode: false },
       options: { ...options },
       clearTextureAtlas: vi.fn(),
       dispose: vi.fn(),
@@ -350,11 +352,45 @@ describe("TerminalPane", () => {
     });
 
     await waitFor(() => expect(xtermOnDataHandlers).toHaveLength(1));
+    xtermInstances[0]!.modes.bracketedPasteMode = true;
     mockSockets[0]!.sent = [];
     const terminalContainer = container.querySelector(".terminal-container");
     expect(terminalContainer).toBeDefined();
     const laterPasteListener = vi.fn();
     terminalContainer!.addEventListener("paste", laterPasteListener, true);
+
+    const event = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+    }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        getData: vi.fn((type: string) =>
+          type === "text/plain"
+            ? "first\x1b[201~\nsecond\nthird"
+            : "",
+        ),
+      },
+    });
+
+    const defaultAllowed = terminalContainer!.dispatchEvent(event);
+
+    expect(defaultAllowed).toBe(false);
+    expect(laterPasteListener).not.toHaveBeenCalled();
+    expect(sentText(mockSockets[0]!, 0)).toBe(
+      "\x1b[200~first[201~\nsecond\nthird\x1b[201~",
+    );
+  });
+
+  it("sends browser multiline paste raw when bracketed paste is disabled", async () => {
+    const { container } = render(TerminalPane, {
+      props: { workspaceId: "ws-123" },
+    });
+
+    await waitFor(() => expect(xtermOnDataHandlers).toHaveLength(1));
+    mockSockets[0]!.sent = [];
+    const terminalContainer = container.querySelector(".terminal-container");
+    expect(terminalContainer).toBeDefined();
 
     const event = new Event("paste", {
       bubbles: true,
@@ -371,10 +407,7 @@ describe("TerminalPane", () => {
     const defaultAllowed = terminalContainer!.dispatchEvent(event);
 
     expect(defaultAllowed).toBe(false);
-    expect(laterPasteListener).not.toHaveBeenCalled();
-    expect(sentText(mockSockets[0]!, 0)).toBe(
-      "\x1b[200~first\nsecond\nthird\x1b[201~",
-    );
+    expect(sentText(mockSockets[0]!, 0)).toBe("first\nsecond\nthird");
   });
 
   it("leaves single-line browser paste for xterm.js default handling", async () => {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -7,6 +7,10 @@
   import { WebglAddon } from "@xterm/addon-webgl";
   import "@xterm/xterm/css/xterm.css";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
+  import {
+    createBracketedPastePayload,
+    isMultilinePaste,
+  } from "./bracketedPaste.js";
   import { buildTerminalFontFamily } from "./terminalFontFamily.js";
   import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
@@ -251,6 +255,20 @@
     sendResize(terminal.cols, terminal.rows);
   }
 
+  function handleTerminalPaste(event: ClipboardEvent): void {
+    if (ws?.readyState !== WebSocket.OPEN) return;
+
+    const pastedText =
+      event.clipboardData?.getData("text/plain") ||
+      event.clipboardData?.getData("text") ||
+      "";
+    if (!isMultilinePaste(pastedText)) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    ws.send(encoder.encode(createBracketedPastePayload(pastedText)));
+  }
+
   function connect(): void {
     if (disposed || !terminal) return;
 
@@ -368,6 +386,7 @@
       ws.close();
       ws = null;
     }
+    containerEl?.removeEventListener("paste", handleTerminalPaste, true);
     if (terminal) {
       ligaturesAddon?.dispose();
       ligaturesAddon = null;
@@ -449,6 +468,7 @@
       terminal = term;
 
       term.open(containerEl);
+      containerEl.addEventListener("paste", handleTerminalPaste, true);
 
       const fit = new FitAddon();
       fitAddon = fit;

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -8,7 +8,7 @@
   import "@xterm/xterm/css/xterm.css";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
   import {
-    createBracketedPastePayload,
+    createTerminalPastePayload,
     isMultilinePaste,
   } from "./bracketedPaste.js";
   import { buildTerminalFontFamily } from "./terminalFontFamily.js";
@@ -266,7 +266,14 @@
 
     event.preventDefault();
     event.stopImmediatePropagation();
-    ws.send(encoder.encode(createBracketedPastePayload(pastedText)));
+    ws.send(
+      encoder.encode(
+        createTerminalPastePayload(
+          pastedText,
+          terminal?.modes.bracketedPasteMode ?? false,
+        ),
+      ),
+    );
   }
 
   function connect(): void {

--- a/frontend/src/lib/components/terminal/bracketedPaste.test.ts
+++ b/frontend/src/lib/components/terminal/bracketedPaste.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { createBracketedPastePayload, isMultilinePaste } from "./bracketedPaste";
+
+describe("bracketed paste payloads", () => {
+  it("detects line-feed and carriage-return multiline paste text", () => {
+    expect(isMultilinePaste("single line")).toBe(false);
+    expect(isMultilinePaste("one\ntwo")).toBe(true);
+    expect(isMultilinePaste("one\rtwo")).toBe(true);
+  });
+
+  it("wraps pasted text without normalizing literal newlines", () => {
+    expect(createBracketedPastePayload("one\r\ntwo\nthree")).toBe(
+      "\x1b[200~one\r\ntwo\nthree\x1b[201~",
+    );
+  });
+});

--- a/frontend/src/lib/components/terminal/bracketedPaste.test.ts
+++ b/frontend/src/lib/components/terminal/bracketedPaste.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { createBracketedPastePayload, isMultilinePaste } from "./bracketedPaste";
+import {
+  createBracketedPastePayload,
+  createTerminalPastePayload,
+  isMultilinePaste,
+  sanitizeTerminalPasteText,
+} from "./bracketedPaste";
 
 describe("bracketed paste payloads", () => {
   it("detects line-feed and carriage-return multiline paste text", () => {
@@ -12,6 +17,26 @@ describe("bracketed paste payloads", () => {
   it("wraps pasted text without normalizing literal newlines", () => {
     expect(createBracketedPastePayload("one\r\ntwo\nthree")).toBe(
       "\x1b[200~one\r\ntwo\nthree\x1b[201~",
+    );
+  });
+
+  it("strips terminal control bytes while preserving tabs and newlines", () => {
+    expect(
+      sanitizeTerminalPasteText(
+        "one\t\n\x1b[201~\nmalicious-command\r\n\x9b200~\x07two",
+      ),
+    ).toBe("one\t\n[201~\nmalicious-command\r\n200~two");
+  });
+
+  it("sanitizes pasted text before building bracketed paste payloads", () => {
+    expect(createBracketedPastePayload("one\x1b[201~\ntwo")).toBe(
+      "\x1b[200~one[201~\ntwo\x1b[201~",
+    );
+  });
+
+  it("builds raw sanitized payloads when bracketed paste mode is disabled", () => {
+    expect(createTerminalPastePayload("one\x1b[201~\ntwo", false)).toBe(
+      "one[201~\ntwo",
     );
   });
 });

--- a/frontend/src/lib/components/terminal/bracketedPaste.ts
+++ b/frontend/src/lib/components/terminal/bracketedPaste.ts
@@ -1,0 +1,10 @@
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
+
+export function isMultilinePaste(text: string): boolean {
+  return text.includes("\n") || text.includes("\r");
+}
+
+export function createBracketedPastePayload(text: string): string {
+  return `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`;
+}

--- a/frontend/src/lib/components/terminal/bracketedPaste.ts
+++ b/frontend/src/lib/components/terminal/bracketedPaste.ts
@@ -6,5 +6,36 @@ export function isMultilinePaste(text: string): boolean {
 }
 
 export function createBracketedPastePayload(text: string): string {
-  return `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`;
+  return `${BRACKETED_PASTE_START}${sanitizeTerminalPasteText(text)}${BRACKETED_PASTE_END}`;
+}
+
+export function createTerminalPastePayload(
+  text: string,
+  bracketedPasteMode: boolean,
+): string {
+  const sanitizedText = sanitizeTerminalPasteText(text);
+  if (!bracketedPasteMode) return sanitizedText;
+  return `${BRACKETED_PASTE_START}${sanitizedText}${BRACKETED_PASTE_END}`;
+}
+
+export function sanitizeTerminalPasteText(text: string): string {
+  let sanitizedText = "";
+  for (const character of text) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined || isUnsafeTerminalControlByte(codePoint)) {
+      continue;
+    }
+    sanitizedText += character;
+  }
+  return sanitizedText;
+}
+
+function isUnsafeTerminalControlByte(codePoint: number): boolean {
+  return (
+    codePoint <= 0x08 ||
+    codePoint === 0x0b ||
+    codePoint === 0x0c ||
+    (codePoint >= 0x0e && codePoint <= 0x1f) ||
+    (codePoint >= 0x7f && codePoint <= 0x9f)
+  );
 }

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2040,6 +2040,152 @@ test.describe("workspace launch home", () => {
   );
 
   test(
+    "xterm workspace terminal sends multiline browser paste as one payload",
+    async ({ page }) => {
+      await page.addInitScript(() => {
+        type RecordedSocket = {
+          sent: unknown[];
+          url: string;
+        };
+        const recordedSockets: RecordedSocket[] = [];
+        Object.defineProperty(
+          window,
+          "__middlemanRecordedTerminalSockets",
+          {
+            value: recordedSockets,
+          },
+        );
+        const NativeWebSocket = window.WebSocket;
+
+        class MockTerminalWebSocket extends EventTarget {
+          static CONNECTING = 0;
+          static OPEN = 1;
+          static CLOSING = 2;
+          static CLOSED = 3;
+
+          binaryType = "arraybuffer";
+          extensions = "";
+          onclose: ((event: CloseEvent) => void) | null = null;
+          onerror: ((event: Event) => void) | null = null;
+          onmessage: ((event: MessageEvent) => void) | null = null;
+          onopen: ((event: Event) => void) | null = null;
+          protocol = "";
+          readyState = MockTerminalWebSocket.OPEN;
+          readonly url: string;
+          private readonly record?: RecordedSocket;
+
+          constructor(
+            url: string | URL,
+            protocols?: string | string[],
+          ) {
+            super();
+            this.url = String(url);
+            if (!this.url.includes("/ws/v1/workspaces/")) {
+              return new NativeWebSocket(url, protocols);
+            }
+            this.record = { url: this.url, sent: [] };
+            recordedSockets.push(this.record);
+            queueMicrotask(() => {
+              const event = new Event("open");
+              this.dispatchEvent(event);
+              this.onopen?.(event);
+            });
+          }
+
+          close(): void {
+            this.readyState = MockTerminalWebSocket.CLOSED;
+            const event = new CloseEvent("close");
+            this.dispatchEvent(event);
+            this.onclose?.(event);
+          }
+
+          send(data: unknown): void {
+            if (!this.record) return;
+            if (data instanceof ArrayBuffer) {
+              this.record.sent.push(
+                Array.from(new Uint8Array(data)),
+              );
+              return;
+            }
+            if (ArrayBuffer.isView(data)) {
+              this.record.sent.push(
+                Array.from(
+                  new Uint8Array(
+                    data.buffer,
+                    data.byteOffset,
+                    data.byteLength,
+                  ),
+                ),
+              );
+              return;
+            }
+            this.record.sent.push(data);
+          }
+        }
+
+        window.WebSocket =
+          MockTerminalWebSocket as unknown as typeof WebSocket;
+      });
+
+      await page.goto("/terminal/ws-123", {
+        waitUntil: "domcontentloaded",
+      });
+      const launchTarget = page.getByRole("button", { name: "Codex" });
+      await expect(launchTarget).toBeVisible();
+      await launchTarget.click();
+
+      await expect(page.locator(".terminal-container .xterm")).toBeVisible();
+      await page.evaluate(() => {
+        for (const socket of (
+          window as unknown as {
+            __middlemanRecordedTerminalSockets: Array<{
+              sent: unknown[];
+            }>;
+          }
+        ).__middlemanRecordedTerminalSockets) {
+          socket.sent = [];
+        }
+      });
+
+      const terminal = page.locator(".terminal-container").first();
+      await terminal.evaluate((element) => {
+        const event = new Event("paste", {
+          bubbles: true,
+          cancelable: true,
+        }) as ClipboardEvent;
+        Object.defineProperty(event, "clipboardData", {
+          value: {
+            getData: (type: string) =>
+              type === "text/plain" ? "first\nsecond\nthird" : "",
+          },
+        });
+        element.dispatchEvent(event);
+      });
+
+      await expect
+        .poll(async () =>
+          page.evaluate(() => {
+            const decoder = new TextDecoder();
+            return (
+              window as unknown as {
+                __middlemanRecordedTerminalSockets: Array<{
+                  sent: unknown[];
+                }>;
+              }
+            ).__middlemanRecordedTerminalSockets
+              .flatMap((socket) => socket.sent)
+              .map((frame) =>
+                Array.isArray(frame)
+                  ? decoder.decode(new Uint8Array(frame))
+                  : frame,
+              );
+          }),
+        )
+        .toContainEqual("first\nsecond\nthird");
+    },
+  );
+
+  test(
     "opens the plain shell from the bottom terminal panel",
     async ({ page }) => {
       const terminalSockets: string[] = [];


### PR DESCRIPTION
## Summary
- Intercept multiline browser paste in the xterm terminal pane and send it as one bracketed-paste payload so PTY apps see literal newlines instead of separate submits.
- Apply the same browser-paste handling in the Ghostty terminal pane, delegating to `ghostty-web`'s paste API so it can emit bracketed paste when supported.
- Keep single-line paste and normal typing on the existing renderer input paths.
- Add focused unit coverage for the shared bracketed-paste helper and both terminal panes.

## Testing
- `bun run typecheck`
- Targeted frontend tests for the shared paste helper, `TerminalPane`, and `GhosttyTerminalPane`
- Commit hooks passed, including TypeScript/Svelte lint and `git diff --check`