### PR TITLE
Fix virtualized diff context scrolling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,8 +52,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@lucide/svelte": "1.3.0",
-        "@pierre/diffs": "1.2.4",
-        "@pierre/trees": "1.0.0-beta.3",
+        "@pierre/diffs": "1.2.7",
+        "@pierre/trees": "1.0.0-beta.4",
         "@tiptap/core": "3.22.3",
         "@tiptap/extension-document": "3.22.3",
         "@tiptap/extension-hard-break": "3.22.3",
@@ -265,11 +265,11 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.51.0", "", { "os": "win32", "cpu": "x64" }, "sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.4", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-SEuYxGpSCHVvfoLly/Q/OYpJSBLWaVLV3M3wI/VBW7aZmzYenNe4aXjOf5sIKJMWW5gbZe9WdLvtKUt6cQ1k1A=="],
+    "@pierre/diffs": ["@pierre/diffs@1.2.7", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-YrHmFZLDtiLZ4DkiVqMDUFqTFIct3ML3t20nMp0UeuiUtqrmRcenYVxPb4IafiNkhZZURhCiwcs89tVb/HrSDA=="],
 
     "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
 
-    "@pierre/trees": ["@pierre/trees@1.0.0-beta.3", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ=="],
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
 
     "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@lucide/svelte": "1.3.0",
-        "@pierre/diffs": "1.1.22",
+        "@pierre/diffs": "1.2.4",
         "@pierre/trees": "1.0.0-beta.3",
         "@tiptap/core": "3.22.3",
         "@tiptap/extension-document": "3.22.3",
@@ -265,9 +265,9 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.51.0", "", { "os": "win32", "cpu": "x64" }, "sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.1.22", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-1Iv7kdl6OABFCd1n2HQbGUiRHouXPaHoIjcb7Lwg8zeJKY5ph+cESFcGEyIiwW0NCbKGtYS2bTnXmI+Eze5dwg=="],
+    "@pierre/diffs": ["@pierre/diffs@1.2.4", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-SEuYxGpSCHVvfoLly/Q/OYpJSBLWaVLV3M3wI/VBW7aZmzYenNe4aXjOf5sIKJMWW5gbZe9WdLvtKUt6cQ1k1A=="],
 
-    "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
+    "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
 
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.3", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ=="],
 

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -918,6 +918,27 @@ test.describe("diff view", () => {
     ).toBe(0);
   });
 
+  test("sidebar jump to the last file preserves expanded body space above it", async ({ page }) => {
+    await mockDiffApi(page, largeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await treeFileItem(page, "src/pkg9/file_49.go").click();
+    await expect(page.locator('[data-file-path="src/pkg9/file_49.go"]'))
+      .toBeVisible();
+
+    const earlierFile = page.locator('[data-file-path="src/pkg5/file_25.go"]');
+    await expect(earlierFile.locator(".file-header"))
+      .toHaveAttribute("title", "Collapse file");
+    await expect(earlierFile.locator(".file-content")).toBeAttached();
+    await expect.poll(async () =>
+      earlierFile.locator(".pierre-diff-shell").evaluate((el) =>
+        Math.round(el.getBoundingClientRect().height),
+      ),
+    ).toBeGreaterThan(300);
+  });
+
   test("deleted file name has strikethrough in sidebar", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);
@@ -2236,6 +2257,7 @@ test.describe("diff view (git-backed)", () => {
     const configFile = page.locator(
       '[data-file-path="config.yaml"]',
     );
+    await configFile.scrollIntoViewIfNeeded();
     await expect(configFile).toBeVisible();
 
     // Only deletion lines -- no additions or context.

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -312,6 +312,13 @@ async function pierreDiffCount(file: ReturnType<Page["locator"]>, selector: stri
   }, selector);
 }
 
+async function pierreDiffTexts(file: ReturnType<Page["locator"]>, selector: string) {
+  return await file.locator(".pierre-diff").evaluate((host, selector) => {
+    return Array.from(host.shadowRoot?.querySelectorAll(selector) ?? [])
+      .map((element) => element.textContent?.trim() ?? "");
+  }, selector);
+}
+
 async function expectPierreDiffCount(
   file: ReturnType<Page["locator"]>,
   selector: string,
@@ -937,6 +944,50 @@ test.describe("diff view", () => {
         Math.round(el.getBoundingClientRect().height),
       ),
     ).toBeGreaterThan(300);
+  });
+
+  test("manual paging and wheel scrolling override sidebar file jumps", async ({ page }) => {
+    await mockDiffApi(page, largeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const diffArea = page.locator(".diff-area");
+
+    await treeFileItem(page, "src/pkg8/file_40.go").click();
+    await expect(page.locator('[data-file-path="src/pkg8/file_40.go"]'))
+      .toBeVisible();
+    const firstJumpTop = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+
+    await page.keyboard.press("PageDown");
+    await expect.poll(async () =>
+      diffArea.evaluate((area) => Math.round(area.scrollTop)),
+    ).toBeGreaterThan(firstJumpTop + 100);
+    await expect(page.locator(".diff-file-tree [data-item-type='file'][aria-selected='true']"))
+      .toBeInViewport();
+    const afterPageDownTop = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+    await page.waitForTimeout(400);
+    await expect.poll(async () =>
+      diffArea.evaluate((area) => Math.round(area.scrollTop)),
+    ).toBeGreaterThan(afterPageDownTop - 10);
+
+    await treeFileItem(page, "src/pkg8/file_41.go").click();
+    await expect(page.locator('[data-file-path="src/pkg8/file_41.go"]'))
+      .toBeVisible();
+    const secondJumpTop = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+
+    await diffArea.hover();
+    await page.mouse.wheel(0, 900);
+    await expect.poll(async () =>
+      diffArea.evaluate((area) => Math.round(area.scrollTop)),
+    ).toBeGreaterThan(secondJumpTop + 100);
+    await expect(page.locator(".diff-file-tree [data-item-type='file'][aria-selected='true']"))
+      .toBeInViewport();
+    const afterWheelTop = await diffArea.evaluate((area) => Math.round(area.scrollTop));
+    await page.waitForTimeout(400);
+    await expect.poll(async () =>
+      diffArea.evaluate((area) => Math.round(area.scrollTop)),
+    ).toBeGreaterThan(afterWheelTop - 10);
   });
 
   test("deleted file name has strikethrough in sidebar", async ({ page }) => {
@@ -2117,6 +2168,13 @@ test.describe("diff view (git-backed)", () => {
       await expect.poll(() =>
         pierreDiffCount(handlerFile, "[data-line-type='context-expanded']")
       ).toBeGreaterThan(expandedContextRowsBefore);
+      await expect.poll(async () => {
+        const texts = await pierreDiffTexts(
+          handlerFile,
+          "[data-content] [data-line-type='context-expanded']",
+        );
+        return texts.filter((text) => text.length > 0).length;
+      }).toBeGreaterThan(0);
       await expect.poll(() => [...new Set(previewSides)].sort())
         .toEqual(["new", "old"]);
     } finally {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -373,12 +373,17 @@ async function expectPierreCodeTabSize(
   }).toBe(tabSize);
 }
 
-async function clickPierreContextExpander(file: ReturnType<Page["locator"]>): Promise<void> {
-  const expander = file
-    .locator(".pierre-diff [data-separator][data-expand-index] [data-expand-button]")
-    .first();
+async function clickPierreContextExpander(
+  file: ReturnType<Page["locator"]>,
+  separatorIndex = 0,
+): Promise<void> {
+  const separator = file
+    .locator(".pierre-diff [data-separator][data-expand-index]")
+    .filter({ visible: true })
+    .nth(separatorIndex);
+  const expander = separator.locator("[data-expand-button]").filter({ visible: true }).first();
   await expect(expander).toBeVisible();
-  await expander.click({ modifiers: ["Shift"] });
+  await expander.click();
 }
 
 async function expectPierreDarkBackgroundMatchesAppSurface(

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -319,6 +319,29 @@ async function pierreDiffTexts(file: ReturnType<Page["locator"]>, selector: stri
   }, selector);
 }
 
+async function pierreVisibleDiffTextStats(
+  file: ReturnType<Page["locator"]>,
+  selector = "[data-content] [data-line-type]",
+) {
+  return await file.locator(".pierre-diff").evaluate((host, selector) => {
+    const rows = Array.from(host.shadowRoot?.querySelectorAll(selector) ?? [])
+      .filter((element): element is HTMLElement => {
+        if (!(element instanceof HTMLElement)) return false;
+        const rect = element.getBoundingClientRect();
+        return rect.width > 0
+          && rect.height > 0
+          && rect.bottom > 0
+          && rect.top < window.innerHeight;
+      })
+      .map((element) => element.textContent?.trim() ?? "");
+    return {
+      blank: rows.filter((text) => text.length === 0).length,
+      nonBlank: rows.filter((text) => text.length > 0).length,
+      texts: rows.filter((text) => text.length > 0),
+    };
+  }, selector);
+}
+
 async function expectPierreDiffCount(
   file: ReturnType<Page["locator"]>,
   selector: string,
@@ -380,6 +403,48 @@ async function expectPierreDiffVisibleText(
   }).toBe(true);
 }
 
+async function expectVisibleNonBlankRows(
+  file: ReturnType<Page["locator"]>,
+  textFragment: string,
+) {
+  await expect.poll(async () => {
+    const stats = await pierreVisibleDiffTextStats(file);
+    return {
+      blank: stats.blank,
+      hasText: stats.texts.some((text) => text.includes(textFragment)),
+      nonBlankPositive: stats.nonBlank > 0,
+    };
+  }).toEqual({
+    blank: 0,
+    hasText: true,
+    nonBlankPositive: true,
+  });
+}
+
+async function scrollDiffAreaUntilPierreText(
+  page: Page,
+  diffArea: Locator,
+  file: ReturnType<Page["locator"]>,
+  selector: string,
+  text: string,
+  scrollDelta: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const hasText = await file.locator(".pierre-diff").evaluate((host, { selector, text }) => {
+      return Array.from(host.shadowRoot?.querySelectorAll(selector) ?? [])
+        .some((element) => element.textContent?.includes(text));
+    }, { selector, text });
+    if (hasText) return;
+    await diffArea.evaluate((area, delta) => {
+      area.scrollTop += delta;
+      area.dispatchEvent(new Event("scroll", { bubbles: true }));
+    }, scrollDelta);
+    await page.waitForTimeout(50);
+  }
+  const texts = await pierreDiffTexts(file, selector);
+  expect(texts.join("\n")).toContain(text);
+}
+
 async function expectPierreCodeTabSize(
   file: ReturnType<Page["locator"]>,
   tabSize: string,
@@ -395,12 +460,13 @@ async function expectPierreCodeTabSize(
 async function clickPierreContextExpander(
   file: ReturnType<Page["locator"]>,
   separatorIndex = 0,
+  buttonSelector = "[data-expand-button]",
 ): Promise<void> {
   const separator = file
     .locator(".pierre-diff [data-separator][data-expand-index]")
     .filter({ visible: true })
     .nth(separatorIndex);
-  const expander = separator.locator("[data-expand-button]").filter({ visible: true }).first();
+  const expander = separator.locator(buttonSelector).filter({ visible: true }).first();
   await expect(expander).toBeVisible();
   await expander.click();
 }
@@ -1485,6 +1551,201 @@ test.describe("diff view", () => {
     await expectPierreDiffFirstText(file, diffHunkSeparatorsSelector, "999999 unmodified lines");
     await expectPierreDiffCount(file, "[data-expand-button]", 0);
     await expect.poll(() => previewRequests).toBe(0);
+  });
+
+  test("context expansion keeps earlier virtualized file rows rendered", async ({ page }) => {
+    await page.setViewportSize({ width: 1852, height: 918 });
+
+    const schemaLines: DiffLine[] = Array.from({ length: 140 }, (_, index) => ({
+      type: "context" as const,
+      content: `schema response row ${index + 1}`,
+      old_num: index + 1,
+      new_num: index + 1,
+    }));
+    schemaLines.splice(118, 0, {
+      type: "add",
+      content: "schema inserted response row",
+      new_num: 119,
+    });
+
+    const oldDetailText = Array.from({ length: 1_000 }, (_, index) =>
+      `detail filler row ${index + 1}`
+    );
+    oldDetailText[909] = "function onActionMenuKeydown(e: KeyboardEvent): void {";
+    oldDetailText[910] = "  if (actionMenuOpen && e.key === \"Escape\") {";
+    oldDetailText[911] = "    actionMenuOpen = false;";
+    oldDetailText[948] = "\"/workspaces\",";
+    oldDetailText[949] = "{";
+    oldDetailText[950] = "  body: {";
+    oldDetailText[951] = "    platform_host: detail.platform_host,";
+    oldDetailText[952] = "    owner: detail.repo_owner,";
+    oldDetailText[953] = "    name: detail.repo_name,";
+    const newDetailText = [...oldDetailText];
+    newDetailText.splice(951, 0, "    provider,");
+
+    const expandableDiff = withServerDiffData({
+      stale: false,
+      whitespace_only_count: 0,
+      files: [
+        {
+          path: "src/api/generated/schema.ts",
+          old_path: "src/api/generated/schema.ts",
+          status: "modified",
+          is_binary: false,
+          is_whitespace_only: false,
+          additions: 1,
+          deletions: 0,
+          hunks: [{
+            old_start: 1,
+            old_count: 140,
+            new_start: 1,
+            new_count: 141,
+            lines: schemaLines,
+          }],
+        },
+        {
+          path: "src/api/provider-routes.ts",
+          old_path: "src/api/provider-routes.ts",
+          status: "modified",
+          is_binary: false,
+          is_whitespace_only: false,
+          additions: 1,
+          deletions: 0,
+          hunks: [{
+            old_start: 1,
+            old_count: 4,
+            new_start: 1,
+            new_count: 5,
+            lines: [
+              { type: "context", content: "export const routes = [", old_num: 1, new_num: 1 },
+              { type: "context", content: "  \"/commits/{sha}/diff\",", old_num: 2, new_num: 2 },
+              { type: "add", content: "  \"/worktree-base\",", new_num: 3 },
+              { type: "context", content: "  \"/resolve/{number}\",", old_num: 3, new_num: 4 },
+              { type: "context", content: "];", old_num: 4, new_num: 5 },
+            ],
+          }],
+        },
+        {
+          path: "src/components/detail/PullDetail.svelte",
+          old_path: "src/components/detail/PullDetail.svelte",
+          status: "modified",
+          is_binary: false,
+          is_whitespace_only: false,
+          additions: 1,
+          deletions: 0,
+          hunks: [{
+            old_start: 949,
+            old_count: 6,
+            new_start: 949,
+            new_count: 7,
+            lines: [
+              { type: "context", content: "\"/workspaces\",", old_num: 949, new_num: 949 },
+              { type: "context", content: "{", old_num: 950, new_num: 950 },
+              { type: "context", content: "  body: {", old_num: 951, new_num: 951 },
+              { type: "add", content: "    provider,", new_num: 952 },
+              {
+                type: "context",
+                content: "    platform_host: detail.platform_host,",
+                old_num: 952,
+                new_num: 953,
+              },
+              {
+                type: "context",
+                content: "    owner: detail.repo_owner,",
+                old_num: 953,
+                new_num: 954,
+              },
+              {
+                type: "context",
+                content: "    name: detail.repo_name,",
+                old_num: 954,
+                new_num: 955,
+              },
+            ],
+          }],
+        },
+      ],
+    });
+
+    await mockDiffApi(page, expandableDiff);
+    const previewSides: string[] = [];
+    await page.route("**/api/v1/pulls/github/acme/widgets/1/file-preview**", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("path") !== "src/components/detail/PullDetail.svelte") {
+        await route.fulfill({ status: 404, body: JSON.stringify({ detail: "not found" }) });
+        return;
+      }
+      const side = url.searchParams.get("side");
+      previewSides.push(side ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          path: "src/components/detail/PullDetail.svelte",
+          media_type: "text/plain; charset=utf-8",
+          encoding: "base64",
+          content: Buffer.from(
+            side === "old" ? oldDetailText.join("\n") : newDetailText.join("\n"),
+          ).toString("base64"),
+        }),
+      });
+    });
+
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const diffArea = page.locator(".diff-area");
+    const schemaFile = page.locator('[data-file-path="src/api/generated/schema.ts"]');
+    const detailFile = page.locator('[data-file-path="src/components/detail/PullDetail.svelte"]');
+
+    await treeFileItem(page, "src/components/detail/PullDetail.svelte").click();
+    await expect(detailFile).toBeInViewport();
+    await diffArea.evaluate((area) => {
+      area.scrollTop = Math.max(0, area.scrollTop - 220);
+      area.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    await expect.poll(async () =>
+      detailFile.evaluate((detail) => {
+        const rect = detail.getBoundingClientRect();
+        return rect.bottom > 0 && rect.top < window.innerHeight;
+      })
+    ).toBe(true);
+    await expectPierreDiffCountAtLeast(detailFile, "[data-line-type]", 1);
+    await expectPierreDiffCountAtLeast(detailFile, "[data-expand-button]", 1);
+    await expectVisibleNonBlankRows(schemaFile, "schema response row");
+
+    const beforeExpansionScrollTop = await diffArea.evaluate((area) => area.scrollTop);
+    await clickPierreContextExpander(detailFile, 0, "[data-expand-down]");
+    await expect.poll(() => [...new Set(previewSides)].sort())
+      .toEqual(["new", "old"]);
+    await expectVisibleNonBlankRows(schemaFile, "schema response row");
+    await scrollDiffAreaUntilPierreText(
+      page,
+      diffArea,
+      detailFile,
+      "[data-content] [data-line-type='context-expanded']",
+      "function onActionMenuKeydown(e: KeyboardEvent): void {",
+      90,
+    );
+
+    await diffArea.evaluate((area, scrollTop) => {
+      area.scrollTop = scrollTop;
+      area.dispatchEvent(new Event("scroll", { bubbles: true }));
+    }, beforeExpansionScrollTop);
+    await expectVisibleNonBlankRows(schemaFile, "schema response row");
+    await clickPierreContextExpander(detailFile);
+    await expectVisibleNonBlankRows(schemaFile, "schema response row");
+    await scrollDiffAreaUntilPierreText(
+      page,
+      diffArea,
+      detailFile,
+      "[data-content] [data-line-type='context-expanded']",
+      "detail filler row 870",
+      90,
+    );
+    await expectVisibleNonBlankRows(schemaFile, "schema response row");
   });
 
   test("deleted file path has strikethrough styling in diff header", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -361,6 +361,25 @@ async function expectPierreDiffFirstText(
   }).toContain(text);
 }
 
+async function expectPierreDiffVisibleText(
+  file: ReturnType<Page["locator"]>,
+  selector: string,
+  text: string,
+) {
+  await expect.poll(async () => {
+    return await file.locator(".pierre-diff").evaluate((host, { selector, text }) => {
+      return Array.from(host.shadowRoot?.querySelectorAll(selector) ?? [])
+        .some((element) => {
+          if (!(element instanceof HTMLElement)) return false;
+          const rect = element.getBoundingClientRect();
+          return rect.width > 0
+            && rect.height > 0
+            && element.textContent?.includes(text);
+        });
+    }, { selector, text });
+  }).toBe(true);
+}
+
 async function expectPierreCodeTabSize(
   file: ReturnType<Page["locator"]>,
   tabSize: string,
@@ -2180,6 +2199,11 @@ test.describe("diff view (git-backed)", () => {
         );
         return texts.filter((text) => text.length > 0).length;
       }).toBeGreaterThan(0);
+      await expectPierreDiffVisibleText(
+        handlerFile,
+        "[data-content] [data-line-type='context-expanded']",
+        "// line 1",
+      );
       await expect.poll(() => [...new Set(previewSides)].sort())
         .toEqual(["new", "old"]);
     } finally {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -725,7 +725,7 @@ async function selectPierreReviewLine(
   ].join(",");
   const target = file.locator(`.pierre-diff ${selector}`).first();
   await expect(target).toBeVisible({ timeout: 10_000 });
-  await target.click();
+  await target.locator("[data-middleman-line-comment-button]").click();
 }
 
 // --- Functional tests ---
@@ -2119,6 +2119,30 @@ test.describe("diff view (git-backed)", () => {
       ).toBeGreaterThan(expandedContextRowsBefore);
       await expect.poll(() => [...new Set(previewSides)].sort())
         .toEqual(["new", "old"]);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("inline review composer only opens from the gutter comment button", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const baseURL = server.info.base_url;
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/1/files`);
+      await waitForDiffLoaded(page);
+      await waitForSidebarFilesLoaded(page);
+
+      const cacheFile = page.locator('[data-file-path="internal/cache.go"]');
+      await cacheFile.scrollIntoViewIfNeeded();
+      const lineContent = cacheFile
+        .locator('.pierre-diff [data-line][data-diff-new-line="1"]')
+        .first();
+      await expect(lineContent).toBeVisible();
+      await lineContent.click();
+      await expect(page.getByPlaceholder("Leave a comment")).toHaveCount(0);
+
+      await selectPierreReviewLine(cacheFile, 1, "right");
+      await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
     } finally {
       await server.stop();
     }

--- a/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
@@ -209,7 +209,7 @@ test.describe("workspace tab persistence", () => {
       expect(workspaceDetail.worktree_path).toBeTruthy();
       await writeFile(
         join(workspaceDetail.worktree_path!, "alpha.ts"),
-        Array.from({ length: 120 }, (_, index) => `alpha ${index + 1}`)
+        Array.from({ length: 360 }, (_, index) => `alpha ${index + 1}`)
           .join("\n") + "\n",
       );
       await writeFile(
@@ -320,6 +320,26 @@ test.describe("workspace tab persistence", () => {
             ?.getBoundingClientRect().width ?? 0;
         });
       }).toBeLessThanOrEqual(56);
+      const rightDiffArea = page.locator(".right-sidebar .diff-area");
+      await expect.poll(async () =>
+        rightDiffArea.evaluate((area) => area.scrollHeight > area.clientHeight),
+      ).toBe(true);
+      const beforePageDownScrollTop = await rightDiffArea.evaluate((area) =>
+        area.scrollTop
+      );
+      await rightDiffHost.click();
+      await rightDiffHost.press("PageDown");
+      await expect.poll(async () =>
+        rightDiffArea.evaluate((area) => area.scrollTop),
+      ).toBeGreaterThan(beforePageDownScrollTop);
+      const afterPageDownScrollTop = await rightDiffArea.evaluate((area) =>
+        area.scrollTop
+      );
+      await rightDiffHost.press("j");
+      await rightDiffHost.press("k");
+      await page.waitForTimeout(100);
+      expect(await rightDiffArea.evaluate((area) => area.scrollTop))
+        .toBe(afterPageDownScrollTop);
       const diffToolbar = page.locator(".right-sidebar .diff-toolbar");
       await expect(diffToolbar.locator(".compact-more-btn")).toBeVisible();
       await expect(

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,8 +42,8 @@
   },
   "dependencies": {
     "@lucide/svelte": "1.3.0",
-    "@pierre/diffs": "1.2.4",
-    "@pierre/trees": "1.0.0-beta.3",
+    "@pierre/diffs": "1.2.7",
+    "@pierre/trees": "1.0.0-beta.4",
     "@tiptap/core": "3.22.3",
     "@tiptap/extension-document": "3.22.3",
     "@tiptap/extension-hard-break": "3.22.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@lucide/svelte": "1.3.0",
-    "@pierre/diffs": "1.1.22",
+    "@pierre/diffs": "1.2.4",
     "@pierre/trees": "1.0.0-beta.3",
     "@tiptap/core": "3.22.3",
     "@tiptap/extension-document": "3.22.3",

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
+  import type { DiffLineAnnotation, SelectedLineRange, Virtualizer } from "@pierre/diffs";
   import { mount, onMount, unmount } from "svelte";
   import type { DiffFile as DiffFileType } from "../../api/types.js";
   import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
@@ -36,6 +36,7 @@
     diffHeadSHA?: string | undefined;
     nativeMultilineRanges?: boolean;
     reviewThreads?: ReviewThread[];
+    virtualizer?: Virtualizer | undefined;
   }
 
   const {
@@ -53,6 +54,7 @@
     diffHeadSHA = undefined,
     nativeMultilineRanges = false,
     reviewThreads = [],
+    virtualizer,
   }: Props = $props();
 
   const collapsed = $derived(diffStore.isFileCollapsed(owner, name, number, file.path));
@@ -542,6 +544,7 @@
           enableLineSelection={reviewEnabled && !!diffHeadSHA}
           onLineSelected={handlePierreSelection}
           renderAnnotation={renderUnknownAnnotation}
+          {virtualizer}
         />
       {/if}
     </div>

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -67,6 +67,7 @@
     richPreviewEnabled && richPreview && supportsRichPreview(file.path),
   );
   const richPreviewKey = $derived(`${file.path}:${filePreviewGeneration}`);
+  const textDiffKey = $derived(`${file.path}:${file.old_path ?? ""}:${filePreviewGeneration}`);
   const fileDraftComments = $derived(
     diffReviewDraft.getComments().filter((comment) => comment.path === file.path),
   );
@@ -530,22 +531,24 @@
       {:else if file.is_binary}
         <div class="binary-notice">Binary file changed</div>
       {:else}
-        <PierreFileDiff
-          {file}
-          active={inViewport}
-          {viewMode}
-          {wordWrap}
-          {tabWidth}
-          loadFileText={contextExpansionEnabled ? loadDiffText : undefined}
-          lineAnnotations={pierreLineAnnotations}
-          transientLineAnnotation={pierreComposerAnnotation}
-          selectedRange={selectedRange}
-          selectedRanges={draftSelectedRanges}
-          enableLineSelection={reviewEnabled && !!diffHeadSHA}
-          onLineSelected={handlePierreSelection}
-          renderAnnotation={renderUnknownAnnotation}
-          {virtualizer}
-        />
+        {#key textDiffKey}
+          <PierreFileDiff
+            {file}
+            active={inViewport}
+            {viewMode}
+            {wordWrap}
+            {tabWidth}
+            loadFileText={contextExpansionEnabled ? loadDiffText : undefined}
+            lineAnnotations={pierreLineAnnotations}
+            transientLineAnnotation={pierreComposerAnnotation}
+            selectedRange={selectedRange}
+            selectedRanges={draftSelectedRanges}
+            enableLineSelection={reviewEnabled && !!diffHeadSHA}
+            onLineSelected={handlePierreSelection}
+            renderAnnotation={renderUnknownAnnotation}
+            {virtualizer}
+          />
+        {/key}
       {/if}
     </div>
   {/if}

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -943,7 +943,7 @@ describe("DiffFile", () => {
       ],
     });
     const { diff } = renderDiffFile(file);
-    vi.spyOn(diff, "loadFilePreview")
+    const loadFilePreview = vi.spyOn(diff, "loadFilePreview")
       .mockImplementation(async (_owner, _name, _number, path, side) => {
         return textPreview(path, side === "old" ? oldText.join("\n") : newText.join("\n"));
       });
@@ -988,6 +988,7 @@ describe("DiffFile", () => {
       expect(expandedLines.every((line) => line.length > 0)).toBe(true);
       expect(expandedLines.some((line) => line.includes("shared 50"))).toBe(true);
     });
+    expect(loadFilePreview).toHaveBeenCalledTimes(2);
   });
 
   it("hides Pierre context expansion when file text loading is disabled", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -359,33 +359,7 @@ describe("DiffFile", () => {
     side: "left" | "right",
     options: { shiftKey?: boolean } = {},
   ): Promise<void> {
-    const type = side === "left" ? "change-deletion" : "change-addition";
-    const fallback = side === "left" ? "context" : "context,context-expanded";
-    const selector = [
-      `[data-column-number="${line}"][data-line-type="${type}"]`,
-      ...fallback.split(",").map((lineType) =>
-        `[data-column-number="${line}"][data-line-type="${lineType}"]`
-      ),
-    ].join(",");
-    const target = await waitFor(() => {
-      const element = document
-        .querySelector(".pierre-diff")
-        ?.shadowRoot
-        ?.querySelector<HTMLElement>(selector);
-      expect(element).toBeTruthy();
-      return element!;
-    });
-    await fireEvent.pointerDown(target, {
-      button: 0,
-      pointerId: 1,
-      pointerType: "mouse",
-      shiftKey: options.shiftKey,
-    });
-    await fireEvent.pointerUp(document, {
-      pointerId: 1,
-      pointerType: "mouse",
-      shiftKey: options.shiftKey,
-    });
+    await clickLineCommentButton(line, side, options);
   }
 
   async function clickLineCommentButton(
@@ -439,6 +413,16 @@ describe("DiffFile", () => {
       .querySelector(".pierre-diff")
       ?.shadowRoot
       ?.querySelectorAll("[data-selected-line]");
+  }
+
+  function expandedContextLineTexts(): string[] {
+    return Array.from(
+      document
+        .querySelector(".pierre-diff")
+        ?.shadowRoot
+        ?.querySelectorAll<HTMLElement>("[data-content] [data-line-type='context-expanded']")
+        ?? [],
+    ).map((line) => line.textContent?.trim() ?? "");
   }
 
   it("allows shift-selecting ranges only when native multiline ranges are supported", async () => {
@@ -885,6 +869,10 @@ describe("DiffFile", () => {
       const text = document.querySelector(".pierre-diff")?.shadowRoot?.textContent ?? "";
       expect(text).toContain("shared 10");
       expect(text).toContain("@@ -77,3 +77,3 @@ lateContext");
+      const expandedLines = expandedContextLineTexts();
+      expect(expandedLines.length).toBeGreaterThan(0);
+      expect(expandedLines.every((line) => line.length > 0)).toBe(true);
+      expect(expandedLines.some((line) => line.includes("shared 10"))).toBe(true);
     });
     expect(loadFilePreview).toHaveBeenCalledWith(
       expect.any(String),
@@ -900,6 +888,106 @@ describe("DiffFile", () => {
       "src/context.ts",
       "new",
     );
+  });
+
+  it("continues expanding context after full file text is loaded", async () => {
+    const oldText = Array.from({ length: 90 }, (_, index) => `shared ${index + 1}`);
+    const newText = [...oldText];
+    oldText[1] = "old early";
+    newText[1] = "new early";
+    oldText[77] = "old late";
+    newText[77] = "new late";
+
+    const file = makeFile({
+      path: "src/context.ts",
+      old_path: "src/context.ts",
+      patch: `diff --git a/src/context.ts b/src/context.ts
+--- a/src/context.ts
++++ b/src/context.ts
+@@ -1,3 +1,3 @@
+ shared 1
+-old early
++new early
+ shared 3
+@@ -77,3 +77,3 @@ lateContext
+ shared 77
+-old late
++new late
+ shared 79
+`,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 3,
+          new_start: 1,
+          new_count: 3,
+          lines: [
+            { type: "context", content: "shared 1", old_num: 1, new_num: 1 },
+            { type: "delete", content: "old early", old_num: 2 },
+            { type: "add", content: "new early", new_num: 2 },
+            { type: "context", content: "shared 3", old_num: 3, new_num: 3 },
+          ],
+        },
+        {
+          old_start: 77,
+          old_count: 3,
+          new_start: 77,
+          new_count: 3,
+          lines: [
+            { type: "context", content: "shared 77", old_num: 77, new_num: 77 },
+            { type: "delete", content: "old late", old_num: 78 },
+            { type: "add", content: "new late", new_num: 78 },
+            { type: "context", content: "shared 79", old_num: 79, new_num: 79 },
+          ],
+        },
+      ],
+    });
+    const { diff } = renderDiffFile(file);
+    vi.spyOn(diff, "loadFilePreview")
+      .mockImplementation(async (_owner, _name, _number, path, side) => {
+        return textPreview(path, side === "old" ? oldText.join("\n") : newText.join("\n"));
+      });
+
+    const firstExpandButton = await waitFor(() => {
+      const button = document
+        .querySelector(".pierre-diff")
+        ?.shadowRoot
+        ?.querySelector<HTMLElement>("[data-expand-button]");
+      expect(button).toBeTruthy();
+      return button!;
+    });
+    await fireEvent.click(firstExpandButton);
+
+    await waitFor(() => {
+      const text = document.querySelector(".pierre-diff")?.shadowRoot?.textContent ?? "";
+      expect(text).toContain("shared 10");
+      expect(text).not.toContain("shared 50");
+      const expandedLines = expandedContextLineTexts();
+      expect(expandedLines.length).toBeGreaterThan(0);
+      expect(expandedLines.every((line) => line.length > 0)).toBe(true);
+      expect(expandedLines.some((line) => line.includes("shared 10"))).toBe(true);
+    });
+
+    const nextExpandButton = await waitFor(() => {
+      const buttons = Array.from(
+        document
+          .querySelector(".pierre-diff")
+          ?.shadowRoot
+          ?.querySelectorAll<HTMLElement>("[data-expand-button]") ?? [],
+      );
+      const button = buttons.find((candidate) => candidate !== firstExpandButton);
+      expect(button).toBeTruthy();
+      return button!;
+    });
+    await fireEvent.click(nextExpandButton);
+
+    await waitFor(() => {
+      const text = document.querySelector(".pierre-diff")?.shadowRoot?.textContent ?? "";
+      expect(text).toContain("shared 50");
+      const expandedLines = expandedContextLineTexts();
+      expect(expandedLines.every((line) => line.length > 0)).toBe(true);
+      expect(expandedLines.some((line) => line.includes("shared 50"))).toBe(true);
+    });
   });
 
   it("hides Pierre context expansion when file text loading is disabled", async () => {

--- a/packages/ui/src/components/diff/DiffSidebar.test.ts
+++ b/packages/ui/src/components/diff/DiffSidebar.test.ts
@@ -10,6 +10,7 @@ import type { DiffFile, FilesResult } from "../../api/types.js";
 import { STORES_KEY } from "../../context.js";
 import type { DiffStore } from "../../stores/diff.svelte.js";
 import DiffSidebar from "./DiffSidebar.svelte";
+import PierreFileTree from "./PierreFileTree.svelte";
 
 if (!globalThis.CSS) {
   globalThis.CSS = {} as typeof CSS;
@@ -148,5 +149,41 @@ describe("DiffSidebar", () => {
     await waitFor(() => {
       expect(treeRoot()?.querySelector('[data-item-path="src/file-0.ts"]')).toBeNull();
     });
+  });
+
+  it("scrolls the selected file tree row into view when active path changes", async () => {
+    const files = Array.from({ length: 12 }, (_, i) => makeFile(`src/file-${i}.ts`));
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrolledPaths: string[] = [];
+    HTMLElement.prototype.scrollIntoView = function scrollIntoView() {
+      scrolledPaths.push(this.dataset.itemPath ?? "");
+    };
+
+    try {
+      const { rerender } = render(PierreFileTree, {
+        props: {
+          files,
+          selectedPath: "src/file-0.ts",
+        },
+      });
+
+      await findTreeItem("src/file-0.ts");
+      await waitFor(() => {
+        expect(scrolledPaths).toContain("src/file-0.ts");
+      });
+      scrolledPaths.length = 0;
+
+      await rerender({
+        files,
+        selectedPath: "src/file-8.ts",
+      });
+
+      await findTreeItem("src/file-8.ts");
+      await waitFor(() => {
+        expect(scrolledPaths).toContain("src/file-8.ts");
+      });
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
   });
 });

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -18,6 +18,7 @@
     number: number;
     loadOnMount?: boolean;
     keyboardActive?: boolean;
+    pageKeyboardActive?: boolean;
     richPreviewEnabled?: boolean;
     contextExpansionEnabled?: boolean;
     provider: string;
@@ -40,6 +41,7 @@
     number,
     loadOnMount = true,
     keyboardActive = true,
+    pageKeyboardActive = keyboardActive,
     richPreviewEnabled = true,
     contextExpansionEnabled = true,
     provider,
@@ -480,16 +482,22 @@
     cancelProgrammaticScrollIfUserOverrides();
   }
 
-  // j/k keyboard navigation between files; PageUp/PageDown page the diff pane.
-  function handleKeydown(e: KeyboardEvent): void {
-    if (isTextEntryTarget(e.target)) return;
+  function handlePageKeydown(e: KeyboardEvent): boolean {
+    if (isTextEntryTarget(e.target)) return false;
 
     if (e.key === "PageDown" || e.key === "PageUp") {
-      if (e.metaKey || e.ctrlKey || e.altKey || !diff) return;
+      if (e.metaKey || e.ctrlKey || e.altKey || !diff) return false;
       e.preventDefault();
       pageDiffArea(e.key === "PageDown" ? 1 : -1);
-      return;
+      return true;
     }
+    return false;
+  }
+
+  // j/k keyboard navigation between files; PageUp/PageDown page the diff pane.
+  function handleKeydown(e: KeyboardEvent): void {
+    if (handlePageKeydown(e)) return;
+    if (isTextEntryTarget(e.target)) return;
 
     if (e.key === "j" || e.key === "k") {
       if (!diff || navigationFiles.length === 0) return;
@@ -517,6 +525,11 @@
     }
   }
 
+  function handleDiffAreaKeydown(e: KeyboardEvent): void {
+    if (!pageKeyboardActive || keyboardActive) return;
+    handlePageKeydown(e);
+  }
+
   $effect(() => {
     if (!keyboardActive) return;
     window.addEventListener("keydown", handleKeydown);
@@ -531,11 +544,13 @@
     area.addEventListener("wheel", onDiffUserScrollIntent);
     area.addEventListener("touchstart", onDiffUserScrollIntent);
     area.addEventListener("pointerdown", onDiffUserScrollIntent);
+    area.addEventListener("keydown", handleDiffAreaKeydown);
 
     return () => {
       area.removeEventListener("wheel", onDiffUserScrollIntent);
       area.removeEventListener("touchstart", onDiffUserScrollIntent);
       area.removeEventListener("pointerdown", onDiffUserScrollIntent);
+      area.removeEventListener("keydown", handleDiffAreaKeydown);
     };
   });
 </script>

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -522,6 +522,22 @@
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
   });
+
+  $effect(() => {
+    const area = diffArea;
+    if (!area) return;
+
+    area.tabIndex = -1;
+    area.addEventListener("wheel", onDiffUserScrollIntent);
+    area.addEventListener("touchstart", onDiffUserScrollIntent);
+    area.addEventListener("pointerdown", onDiffUserScrollIntent);
+
+    return () => {
+      area.removeEventListener("wheel", onDiffUserScrollIntent);
+      area.removeEventListener("touchstart", onDiffUserScrollIntent);
+      area.removeEventListener("pointerdown", onDiffUserScrollIntent);
+    };
+  });
 </script>
 
 <div class="diff-view">
@@ -551,12 +567,8 @@
           class:diff-area--word-wrap={wordWrap}
           bind:this={diffArea}
           onscroll={onDiffScroll}
-          onwheel={onDiffUserScrollIntent}
-          ontouchstart={onDiffUserScrollIntent}
-          onpointerdown={onDiffUserScrollIntent}
           role="region"
           aria-label="Changed file diffs"
-          tabindex="-1"
           style:tab-size={tabWidth}
         >
           <div class="diff-content" bind:this={diffContent}>

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Virtualizer } from "@pierre/diffs";
   import { onMount, tick, untrack } from "svelte";
   import { getStores } from "../../context.js";
   import type { DiffScrollTarget } from "../../stores/diff.svelte.js";
@@ -56,9 +57,12 @@
   }: Props = $props();
 
   let diffArea: HTMLDivElement | undefined = $state();
+  let diffContent: HTMLDivElement | undefined = $state();
+  let diffVirtualizer: Virtualizer | undefined = $state();
   let scrollClearRaf = 0;
   let scrollRestoreRaf = 0;
   let scrollTargetRaf = 0;
+  let virtualizerWakeRaf = 0;
   let scrollTargetRun = 0;
   let scrollingToTarget: DiffScrollTarget | null = null;
   let restoredScrollScope = "";
@@ -82,6 +86,7 @@
       cancelAnimationFrame(scrollClearRaf);
       cancelAnimationFrame(scrollRestoreRaf);
       cancelAnimationFrame(scrollTargetRaf);
+      cancelAnimationFrame(virtualizerWakeRaf);
       diffStore.clearDiff();
       diffReviewDraft?.clear();
     };
@@ -138,7 +143,33 @@
       scrollRestoreRaf = 0;
       if (diffArea !== area) return;
       area.scrollTop = Math.max(0, restoreTop);
+      wakeDiffVirtualizer();
     });
+  });
+
+  $effect(() => {
+    const area = diffArea;
+    const content = diffContent;
+    if (
+      !area ||
+      !content ||
+      typeof ResizeObserver === "undefined" ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      diffVirtualizer = undefined;
+      return;
+    }
+
+    const virtualizer = new Virtualizer();
+    virtualizer.setup(area, content);
+    diffVirtualizer = virtualizer;
+
+    return () => {
+      virtualizer.cleanUp();
+      if (diffVirtualizer === virtualizer) {
+        diffVirtualizer = undefined;
+      }
+    };
   });
 
   function scrollWithinDiffArea(el: Element, offset = 0): void {
@@ -146,6 +177,7 @@
     const areaRect = diffArea.getBoundingClientRect();
     const elRect = el.getBoundingClientRect();
     diffArea.scrollTop += elRect.top - areaRect.top - offset;
+    wakeDiffVirtualizer();
   }
 
   function diffFileElement(path: string): HTMLElement | null {
@@ -175,6 +207,7 @@
         return false;
       }
       diffArea.scrollTop += elRect.top - areaRect.top;
+      wakeDiffVirtualizer();
     } else {
       return false;
     }
@@ -234,6 +267,17 @@
       elRect.top < areaRect.bottom;
   }
 
+  function isScrollTargetReady(target: DiffScrollTarget): boolean {
+    if (target.line != null) return true;
+    const el = diffFileElement(target.path);
+    if (!el) return false;
+    if (el.querySelector(".binary-notice, .empty-textual-diff")) return true;
+    const shell = el.querySelector(".pierre-diff-shell");
+    if (shell?.getAttribute("aria-busy") === "true") return false;
+    const host = el.querySelector<HTMLElement>(".pierre-diff");
+    return !host || host.shadowRoot?.querySelector("pre[data-diff]") != null;
+  }
+
   function jumpToDraftComment(comment: DiffReviewDraftComment): void {
     if (!diffArea) return;
     const el = queryDiffElement(
@@ -246,8 +290,22 @@
     const areaRect = diffArea.getBoundingClientRect();
     const elRect = el.getBoundingClientRect();
     diffArea.scrollTop += elRect.top - areaRect.top - 72;
+    wakeDiffVirtualizer();
     el.focus({ preventScroll: true });
     finishProgrammaticScroll();
+  }
+
+  function wakeDiffVirtualizer(): void {
+    const area = diffArea;
+    if (!area) return;
+    area.dispatchEvent(new Event("scroll"));
+    cancelAnimationFrame(virtualizerWakeRaf);
+    virtualizerWakeRaf = requestAnimationFrame(() => {
+      virtualizerWakeRaf = 0;
+      if (diffArea === area) {
+        area.dispatchEvent(new Event("scroll"));
+      }
+    });
   }
 
   // Watch for scroll requests from the sidebar file list (via the store).
@@ -296,7 +354,7 @@
         visibleFrames = 0;
         continue;
       }
-      if (isScrollTargetVisible(target)) {
+      if (isScrollTargetVisible(target) && isScrollTargetReady(target)) {
         if (target.line == null) {
           targetReached = scrollToTarget(target);
           if (!targetReached) {
@@ -448,35 +506,38 @@
           onscroll={onDiffScroll}
           style:tab-size={tabWidth}
         >
-          {#if visibleFiles.length === 0}
-            <div class="diff-state diff-state--empty">
-              <p class="diff-state-msg">No changed files match this category.</p>
-            </div>
-          {/if}
-          {#each visibleFiles as file (file.path)}
-            <DiffFileComponent
-              {file}
-              {provider}
-              {platformHost}
-              {owner}
-              {name}
-              {repoPath}
-              {number}
-              {richPreviewEnabled}
-              {contextExpansionEnabled}
-              {reviewEnabled}
-              canReplyToThreads={canReplyToThreads && !diff?.stale}
-              {diffHeadSHA}
-              {nativeMultilineRanges}
-              {reviewThreads}
-            />
-          {/each}
-          {#if reviewEnabled && diffReviewDraft}
-            {#if reviewWarning}
-              <div class="review-warning">{reviewWarning}</div>
+          <div class="diff-content" bind:this={diffContent}>
+            {#if visibleFiles.length === 0}
+              <div class="diff-state diff-state--empty">
+                <p class="diff-state-msg">No changed files match this category.</p>
+              </div>
             {/if}
-            <DiffReviewDraftTray onjump={jumpToDraftComment} />
-          {/if}
+            {#each visibleFiles as file (file.path)}
+              <DiffFileComponent
+                {file}
+                {provider}
+                {platformHost}
+                {owner}
+                {name}
+                {repoPath}
+                {number}
+                {richPreviewEnabled}
+                {contextExpansionEnabled}
+                {reviewEnabled}
+                canReplyToThreads={canReplyToThreads && !diff?.stale}
+                {diffHeadSHA}
+                {nativeMultilineRanges}
+                {reviewThreads}
+                virtualizer={diffVirtualizer}
+              />
+            {/each}
+            {#if reviewEnabled && diffReviewDraft}
+              {#if reviewWarning}
+                <div class="review-warning">{reviewWarning}</div>
+              {/if}
+              <DiffReviewDraftTray onjump={jumpToDraftComment} />
+            {/if}
+          </div>
         </div>
       </div>
     {/if}
@@ -527,6 +588,10 @@
   .diff-area {
     flex: 1;
     overflow: auto;
+  }
+
+  .diff-content {
+    min-width: 0;
   }
 
   .diff-state {

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -220,6 +220,25 @@
     scrollClearRaf = requestAnimationFrame(() => diffStore.clearScrolling());
   }
 
+  function cancelPendingProgrammaticScroll(): void {
+    scrollTargetRun += 1;
+    scrollingToTarget = null;
+    diffStore.consumeScrollTarget();
+    diffStore.clearScrolling();
+    cancelAnimationFrame(scrollClearRaf);
+    scrollClearRaf = 0;
+  }
+
+  function cancelProgrammaticScrollIfUserOverrides(): void {
+    if (
+      scrollingToTarget ||
+      normalizeScrollTarget(diffStore.getScrollTarget()) ||
+      diffStore.isScrolling()
+    ) {
+      cancelPendingProgrammaticScroll();
+    }
+  }
+
   function queryDiffElement(selector: string): HTMLElement | null {
     if (!diffArea) return null;
     const lightMatch = diffArea.querySelector<HTMLElement>(selector);
@@ -436,12 +455,40 @@
     }
   }
 
-  // j/k keyboard navigation between files.
+  function isTextEntryTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    return tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT" ||
+      target.isContentEditable;
+  }
+
+  function pageDiffArea(direction: 1 | -1): void {
+    const area = diffArea;
+    if (!area) return;
+    cancelPendingProgrammaticScroll();
+    const maxTop = Math.max(0, area.scrollHeight - area.clientHeight);
+    const pageSize = Math.max(1, area.clientHeight - 64);
+    area.scrollTop = Math.min(maxTop, Math.max(0, area.scrollTop + pageSize * direction));
+    area.focus({ preventScroll: true });
+    wakeDiffVirtualizer();
+    onScrollTopChange?.(area.scrollTop);
+  }
+
+  function onDiffUserScrollIntent(): void {
+    cancelProgrammaticScrollIfUserOverrides();
+  }
+
+  // j/k keyboard navigation between files; PageUp/PageDown page the diff pane.
   function handleKeydown(e: KeyboardEvent): void {
-    if (e.target instanceof HTMLElement) {
-      const tag = e.target.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
-      if (e.target.isContentEditable) return;
+    if (isTextEntryTarget(e.target)) return;
+
+    if (e.key === "PageDown" || e.key === "PageUp") {
+      if (e.metaKey || e.ctrlKey || e.altKey || !diff) return;
+      e.preventDefault();
+      pageDiffArea(e.key === "PageDown" ? 1 : -1);
+      return;
     }
 
     if (e.key === "j" || e.key === "k") {
@@ -504,6 +551,12 @@
           class:diff-area--word-wrap={wordWrap}
           bind:this={diffArea}
           onscroll={onDiffScroll}
+          onwheel={onDiffUserScrollIntent}
+          ontouchstart={onDiffUserScrollIntent}
+          onpointerdown={onDiffUserScrollIntent}
+          role="region"
+          aria-label="Changed file diffs"
+          tabindex="-1"
           style:tab-size={tabWidth}
         >
           <div class="diff-content" bind:this={diffContent}>

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -101,7 +101,13 @@ function makeDiffStore(
   } as unknown as DiffStore;
 }
 
-function renderDiffView(diff: DiffStore) {
+function renderDiffView(
+  diff: DiffStore,
+  props: {
+    keyboardActive?: boolean;
+    pageKeyboardActive?: boolean;
+  } = {},
+) {
   return render(DiffView, {
     props: {
       provider: "github",
@@ -111,6 +117,7 @@ function renderDiffView(diff: DiffStore) {
       repoPath: "acme/widgets",
       number: 1,
       loadOnMount: false,
+      ...props,
     },
     context: new Map([[STORES_KEY, { diff }]]),
   });
@@ -152,6 +159,42 @@ describe("DiffView", () => {
 
       expect(diffArea.scrollTop).toBe(336);
       expect(document.activeElement).toBe(diffArea);
+    } finally {
+      outsideButton.remove();
+    }
+  });
+
+  it("pages the focused diff area when only local page keys are active", async () => {
+    const requestScrollToFile = vi.fn();
+    const diff = makeDiffStore({ requestScrollToFile });
+    const { container } = renderDiffView(diff, {
+      keyboardActive: false,
+      pageKeyboardActive: true,
+    });
+    const diffArea = container.querySelector(".diff-area") as HTMLDivElement;
+    Object.defineProperty(diffArea, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(diffArea, "scrollHeight", {
+      configurable: true,
+      value: 2_000,
+    });
+    const outsideButton = document.createElement("button");
+    document.body.append(outsideButton);
+
+    try {
+      outsideButton.focus();
+      await fireEvent.keyDown(window, { key: "PageDown" });
+      expect(diffArea.scrollTop).toBe(0);
+
+      diffArea.focus();
+      await fireEvent.keyDown(diffArea, { key: "PageDown" });
+      await fireEvent.keyDown(diffArea, { key: "j" });
+
+      expect(diffArea.scrollTop).toBe(336);
+      expect(document.activeElement).toBe(diffArea);
+      expect(requestScrollToFile).not.toHaveBeenCalled();
     } finally {
       outsideButton.remove();
     }

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -131,6 +131,60 @@ describe("DiffView", () => {
     expect(requestScrollToFile).toHaveBeenCalledWith("b.ts");
   });
 
+  it("pages the diff area with PageDown even when focus is outside the diff pane", async () => {
+    const diff = makeDiffStore();
+    const { container } = renderDiffView(diff);
+    const diffArea = container.querySelector(".diff-area") as HTMLDivElement;
+    Object.defineProperty(diffArea, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(diffArea, "scrollHeight", {
+      configurable: true,
+      value: 2_000,
+    });
+    const outsideButton = document.createElement("button");
+    document.body.append(outsideButton);
+    outsideButton.focus();
+
+    try {
+      await fireEvent.keyDown(window, { key: "PageDown" });
+
+      expect(diffArea.scrollTop).toBe(336);
+      expect(document.activeElement).toBe(diffArea);
+    } finally {
+      outsideButton.remove();
+    }
+  });
+
+  it("cancels pending programmatic scroll when the user wheels the diff pane", async () => {
+    let scrollTarget: DiffScrollTarget | null = { path: "b.ts" };
+    const consumeScrollTarget = vi.fn(() => {
+      scrollTarget = null;
+    });
+    const clearScrolling = vi.fn();
+    const files = [makeFile("a.ts"), makeFile("b.ts")];
+    const result: DiffResult = {
+      stale: false,
+      whitespace_only_count: 0,
+      files,
+    };
+    const diff = makeDiffStore({
+      getDiff: () => result,
+      getVisibleDiffFiles: () => files,
+      getScrollTarget: () => scrollTarget,
+      consumeScrollTarget,
+      clearScrolling,
+    });
+
+    const { container } = renderDiffView(diff);
+    const diffArea = container.querySelector(".diff-area") as HTMLDivElement;
+    await fireEvent.wheel(diffArea);
+
+    expect(consumeScrollTarget).toHaveBeenCalledOnce();
+    expect(clearScrolling).toHaveBeenCalledOnce();
+  });
+
   it("keeps a scroll target pending until the file is rendered", async () => {
     const consumeScrollTarget = vi.fn();
     const diff = makeDiffStore({

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -611,20 +611,8 @@
   ): void {
     clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
-    if (pierreDiff instanceof VirtualizedFileDiff && host && fullContext) {
-      if (isHostInScrollViewport()) {
-        pierreDiff.setVisibility(true);
-      }
-      const didRender = pierreDiff.render({
-        fileContainer: host,
-        oldFile: fullContext.oldFile,
-        newFile: fullContext.newFile,
-        forceRender: true,
-        lineAnnotations,
-      });
-      if (!didRender) {
-        scheduleRenderRetry();
-      }
+    if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
+      pierreDiff.setVisibility(true);
     }
     removeStalePlaceholderPres();
     applyLineTargetAttributes();

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -100,6 +100,7 @@
   const fileKey = $derived(`${renderFile.path}\0${renderFile.old_path}\0${renderFile.patch}`);
   const fileHunks = $derived(renderFile.hunks ?? []);
   const emptyTextualDiff = $derived(!renderFile.patch.trim() || fileHunks.length === 0);
+  const reservedHeight = $derived(placeholderHeight || estimatedDiffHeight(renderFile));
   const pierreFile = $derived.by<FileDiffMetadata | undefined>(() => {
     return parsePierreFileDiff(renderFile, {
       // Pierre marks patch-only diffs as partial and hides expansion controls.
@@ -594,6 +595,15 @@
   function measuredRenderedHeight(): number {
     const height = host?.getBoundingClientRect().height ?? 0;
     return Number.isFinite(height) && height > 0 ? Math.ceil(height) : placeholderHeight;
+  }
+
+  function estimatedDiffHeight(f: DiffFile): number {
+    if (f.is_binary || !f.hunks.length) return 96;
+    const lineCount = f.hunks.reduce((count, hunk) => count + hunk.lines.length, 0);
+    const separatorCount = Math.max(1, f.hunks.length);
+    const estimatedLineHeight = 22;
+    const verticalPadding = 12;
+    return Math.max(96, (lineCount + separatorCount) * estimatedLineHeight + verticalPadding);
   }
 
   function handleDemandContextClick(event: Event): void {
@@ -1128,7 +1138,7 @@
 <div
   class="pierre-diff-shell"
   class:pierre-diff-shell--loading={!rendered}
-  style:min-height={placeholderHeight ? `${placeholderHeight}px` : undefined}
+  style:min-height={reservedHeight ? `${reservedHeight}px` : undefined}
   aria-busy={!rendered}
 >
   {#if !emptyTextualDiff}

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -112,13 +112,10 @@
     diffStyle: viewMode,
     diffIndicators: "bars",
     disableFileHeader: true,
-    enableLineSelection,
+    enableLineSelection: false,
     hunkSeparators: "line-info",
     lineDiffType: "word",
-    lineHoverHighlight: enableLineSelection ? "both" : "disabled",
-    ...(onLineSelected && {
-      onLineSelected,
-    }),
+    lineHoverHighlight: "disabled",
     ...(renderAnnotation && { renderAnnotation }),
     overflow: wordWrap ? "wrap" : "scroll",
     theme: { dark: "pierre-dark", light: "pierre-light" },
@@ -763,28 +760,10 @@
         }
         const target = lineCommentTarget(contentElement);
         if (!target) continue;
-        installLineSelectionHandler(contentElement);
-        installLineSelectionHandler(gutterElement);
         gutterElement.setAttribute("data-middleman-line-comment-cell", "");
         gutterElement.appendChild(lineCommentButton(target));
       }
     }
-  }
-
-  function installLineSelectionHandler(element: HTMLElement): void {
-    if (element.hasAttribute("data-middleman-line-selection-target")) return;
-    element.setAttribute("data-middleman-line-selection-target", "");
-    element.addEventListener("click", handleLineSelectionClick);
-  }
-
-  function handleLineSelectionClick(event: MouseEvent): void {
-    if (!enableLineSelection || !onLineSelected || event.defaultPrevented) return;
-    const element = event.currentTarget;
-    if (!(element instanceof HTMLElement)) return;
-    const target = lineCommentTarget(element);
-    if (!target) return;
-    const collapse = lineCommentTargetIsSelected(target, event);
-    onLineSelected(collapse ? null : lineCommentSelection(target, event));
   }
 
   function lineCommentTarget(
@@ -811,10 +790,12 @@
     button.setAttribute("aria-label", label);
     button.setAttribute("data-middleman-line-comment-button", "");
     button.addEventListener("pointerdown", (event) => {
+      event.stopPropagation();
       lineCommentButtonHasPointerSnapshot = true;
       lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
     });
     button.addEventListener("mousedown", (event) => {
+      event.stopPropagation();
       lineCommentButtonHasPointerSnapshot = true;
       lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
     });

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -13,7 +13,13 @@
   } from "@pierre/diffs";
   import { onMount } from "svelte";
   import type { DiffFile } from "../../api/types.js";
-  import { appThemeType, diffFileWithPatch, parsePierreFileDiff } from "./pierre-diff.js";
+  import {
+    appThemeType,
+    diffFileWithPatch,
+    parsePierreFileDiff,
+    parsePierreFileDiffWithContents,
+    pierreFileContents,
+  } from "./pierre-diff.js";
   import { getPierreDiffWorkerPool } from "./pierre-worker-pool.js";
 
   interface Props {
@@ -58,6 +64,7 @@
 
   const {
     file = null,
+    active = true,
     viewMode = "unified",
     wordWrap = false,
     tabWidth = 4,
@@ -77,6 +84,7 @@
   let pierreDiffVirtualizer: Virtualizer | undefined;
   let demandContextHandlerRoot: ShadowRoot | undefined;
   let fullContext: { oldFile: FileContents; newFile: FileContents } | undefined = $state();
+  let fullContextRendered = false;
   let contextLoadPromise: Promise<{ oldFile: FileContents; newFile: FileContents }> | undefined;
   let contextError: string | null = $state(null);
   let themeType = $state<ThemeTypes>(appThemeType());
@@ -247,6 +255,7 @@
     contextLoadPromise = undefined;
     contextError = null;
     fullContext = undefined;
+    fullContextRendered = false;
     rendered = emptyTextualDiff;
     renderAttemptKey = "";
     renderRetryCount = 0;
@@ -275,6 +284,7 @@
     }
     if (!host) return;
     if (!pierreFile) return;
+    if (!active && !virtualizer) return;
     pierreDiff ??= createPierreDiff();
     pierreDiff.setOptions(pierreOptions);
     if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
@@ -542,7 +552,6 @@
   }
 
   function handleDemandContextClick(event: Event): void {
-    if (fullContext) return;
     const target = closestFromEvent(event, "[data-expand-button], [data-unmodified-lines]");
     if (!target) return;
     const separator = target.closest("[data-separator][data-expand-index]");
@@ -587,10 +596,21 @@
     expansionLineCount: number | undefined,
   ): Promise<void> {
     const requestFileKey = fileKey;
+    const alreadyRendered = fullContextRendered;
     const context = await loadFullContext(requestFileKey);
     if (!context || fileKey !== requestFileKey) return;
-    renderFullContext(context);
-    if (fileKey !== requestFileKey) return;
+    if (!alreadyRendered) {
+      const didRender = renderFullContext(context);
+      if (!didRender || fileKey !== requestFileKey) return;
+    }
+    expandRenderedHunk(hunkIndex, direction, expansionLineCount);
+  }
+
+  function expandRenderedHunk(
+    hunkIndex: number,
+    direction: ExpansionDirections,
+    expansionLineCount: number | undefined,
+  ): void {
     clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
     removeStalePlaceholderPres();
@@ -603,13 +623,20 @@
 
   function renderFullContext(context: { oldFile: FileContents; newFile: FileContents }): boolean {
     if (!pierreDiff || !host) return false;
+    fullContextRendered = false;
     rendered = false;
     clearRenderedDomState();
+    if (pierreDiff instanceof VirtualizedFileDiff) {
+      recreatePierreDiffForFullContext();
+    }
     if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
       pierreDiff.setVisibility(true);
     }
+    const fullContextFileDiff = parsePierreFileDiffWithContents(renderFile, context) ?? pierreFile;
+    if (!fullContextFileDiff) return false;
     const didRender = pierreDiff.render({
       fileContainer: host,
+      fileDiff: fullContextFileDiff,
       oldFile: context.oldFile,
       newFile: context.newFile,
       forceRender: true,
@@ -617,6 +644,7 @@
     });
     pierreDiff.setSelectedLines(selectedRange);
     if (didRender) {
+      fullContextRendered = true;
       removeStalePlaceholderPres();
       applyLineTargetAttributes();
       applyHunkHeaderLabels();
@@ -626,6 +654,17 @@
       scheduleSelectedRangesApplication();
     }
     return didRender;
+  }
+
+  function recreatePierreDiffForFullContext(): void {
+    removeDemandContextHandler();
+    clearSelectedRangeElements();
+    clearTransientLineAnnotation();
+    clearLineAnnotationWrappers();
+    renderedLineRows = new Map();
+    pierreDiff?.cleanUp();
+    pierreDiff = createPierreDiff();
+    pierreDiff.setOptions(pierreOptions);
   }
 
   async function loadFullContext(
@@ -657,14 +696,8 @@
       renderFile.status === "deleted" ? Promise.resolve("") : loadFileText("new"),
     ]);
     return {
-      oldFile: {
-        name: renderFile.old_path || renderFile.path,
-        contents: oldContents,
-      },
-      newFile: {
-        name: renderFile.path,
-        contents: newContents,
-      },
+      oldFile: pierreFileContents(renderFile.old_path || renderFile.path, oldContents, "full-old"),
+      newFile: pierreFileContents(renderFile.path, newContents, "full-new"),
     };
   }
 

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -137,9 +137,7 @@
       applyLineCommentButtons();
       syncLineAnnotationWrappers();
       rendered = true;
-      if (!fullContext) {
-        installDemandContextHandler();
-      }
+      installDemandContextHandler();
       scheduleSelectedRangesApplication();
     },
     unsafeCSS: `
@@ -613,11 +611,27 @@
   ): void {
     clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
+    if (pierreDiff instanceof VirtualizedFileDiff && host && fullContext) {
+      if (isHostInScrollViewport()) {
+        pierreDiff.setVisibility(true);
+      }
+      const didRender = pierreDiff.render({
+        fileContainer: host,
+        oldFile: fullContext.oldFile,
+        newFile: fullContext.newFile,
+        forceRender: true,
+        lineAnnotations,
+      });
+      if (!didRender) {
+        scheduleRenderRetry();
+      }
+    }
     removeStalePlaceholderPres();
     applyLineTargetAttributes();
     applyHunkHeaderLabels();
     applyLineCommentButtons();
     syncLineAnnotationWrappers();
+    installDemandContextHandler();
     scheduleSelectedRangesApplication();
   }
 
@@ -651,6 +665,7 @@
       applyLineCommentButtons();
       syncLineAnnotationWrappers();
       rendered = true;
+      installDemandContextHandler();
       scheduleSelectedRangesApplication();
     }
     return didRender;

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -84,6 +84,7 @@
   let pierreDiffVirtualizer: Virtualizer | undefined;
   let demandContextHandlerRoot: ShadowRoot | undefined;
   let fullContext: { oldFile: FileContents; newFile: FileContents } | undefined = $state();
+  let fullContextFileDiff: FileDiffMetadata | undefined;
   let fullContextRendered = false;
   let contextLoadPromise: Promise<{ oldFile: FileContents; newFile: FileContents }> | undefined;
   let contextError: string | null = $state(null);
@@ -253,6 +254,7 @@
     contextLoadPromise = undefined;
     contextError = null;
     fullContext = undefined;
+    fullContextFileDiff = undefined;
     fullContextRendered = false;
     rendered = emptyTextualDiff;
     renderAttemptKey = "";
@@ -389,6 +391,7 @@
     clearTransientLineAnnotation();
     clearLineAnnotationWrappers();
     renderedLineRows = new Map();
+    fullContextFileDiff = undefined;
     pierreDiff?.cleanUp();
     pierreDiff = undefined;
   }
@@ -611,8 +614,11 @@
   ): void {
     clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
-    if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
-      pierreDiff.setVisibility(true);
+    if (pierreDiff instanceof VirtualizedFileDiff && fullContext && fullContextFileDiff) {
+      const didRender = renderFullContextRange(fullContext, fullContextFileDiff);
+      if (!didRender) {
+        scheduleRenderRetry();
+      }
     }
     removeStalePlaceholderPres();
     applyLineTargetAttributes();
@@ -628,22 +634,9 @@
     fullContextRendered = false;
     rendered = false;
     clearRenderedDomState();
-    if (pierreDiff instanceof VirtualizedFileDiff) {
-      recreatePierreDiffForFullContext();
-    }
-    if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
-      pierreDiff.setVisibility(true);
-    }
-    const fullContextFileDiff = parsePierreFileDiffWithContents(renderFile, context) ?? pierreFile;
+    fullContextFileDiff = parsePierreFileDiffWithContents(renderFile, context) ?? pierreFile;
     if (!fullContextFileDiff) return false;
-    const didRender = pierreDiff.render({
-      fileContainer: host,
-      fileDiff: fullContextFileDiff,
-      oldFile: context.oldFile,
-      newFile: context.newFile,
-      forceRender: true,
-      lineAnnotations,
-    });
+    const didRender = renderFullContextRange(context, fullContextFileDiff);
     pierreDiff.setSelectedLines(selectedRange);
     if (didRender) {
       fullContextRendered = true;
@@ -659,15 +652,36 @@
     return didRender;
   }
 
-  function recreatePierreDiffForFullContext(): void {
-    removeDemandContextHandler();
-    clearSelectedRangeElements();
-    clearTransientLineAnnotation();
-    clearLineAnnotationWrappers();
-    renderedLineRows = new Map();
-    pierreDiff?.cleanUp();
-    pierreDiff = createPierreDiff();
-    pierreDiff.setOptions(pierreOptions);
+  function renderFullContextRange(
+    context: { oldFile: FileContents; newFile: FileContents },
+    fileDiff: FileDiffMetadata,
+  ): boolean {
+    if (!pierreDiff || !host) return false;
+    const props = {
+      fileContainer: host,
+      fileDiff,
+      oldFile: context.oldFile,
+      newFile: context.newFile,
+      forceRender: true,
+      lineAnnotations,
+      renderRange: {
+        startingLine: 0,
+        totalLines: Number.POSITIVE_INFINITY,
+        bufferBefore: 0,
+        bufferAfter: 0,
+      },
+    } satisfies Parameters<FileDiff<unknown>["render"]>[0];
+    if (!(pierreDiff instanceof VirtualizedFileDiff)) {
+      return pierreDiff.render(props);
+    }
+    if (isHostInScrollViewport()) {
+      pierreDiff.setVisibility(true);
+    }
+    const render = FileDiff.prototype.render as (
+      this: FileDiff<unknown>,
+      props: Parameters<FileDiff<unknown>["render"]>[0],
+    ) => boolean;
+    return render.call(pierreDiff as unknown as FileDiff<unknown>, props);
   }
 
   async function loadFullContext(

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileDiff } from "@pierre/diffs";
+  import { FileDiff, VirtualizedFileDiff } from "@pierre/diffs";
   import type {
     DiffLineAnnotation,
     ExpansionDirections,
@@ -9,6 +9,7 @@
     GetLineIndexUtility,
     SelectedLineRange,
     ThemeTypes,
+    Virtualizer,
   } from "@pierre/diffs";
   import { onMount } from "svelte";
   import type { DiffFile } from "../../api/types.js";
@@ -29,6 +30,7 @@
     enableLineSelection?: boolean;
     onLineSelected?: (selection: SelectedLineRange | null) => void;
     renderAnnotation?: (annotation: DiffLineAnnotation<unknown>) => HTMLElement | undefined;
+    virtualizer?: Virtualizer | undefined;
   }
 
   type PierreSide = NonNullable<Parameters<GetLineIndexUtility>[1]>;
@@ -55,52 +57,48 @@
   };
 
   const {
-    file,
-    active = true,
+    file = null,
     viewMode = "unified",
     wordWrap = false,
     tabWidth = 4,
-    loadFileText,
+    loadFileText = undefined,
     lineAnnotations = [],
     transientLineAnnotation = null,
     selectedRange = null,
     selectedRanges = [],
     enableLineSelection = false,
-    onLineSelected,
-    renderAnnotation,
+    onLineSelected = undefined,
+    renderAnnotation = undefined,
+    virtualizer = undefined,
   }: Props = $props();
 
-  let host: HTMLDivElement | undefined = $state();
-  let pierreDiff: FileDiff<unknown> | undefined;
+  let host: HTMLElement | undefined = $state();
+  let pierreDiff: FileDiff<unknown> | VirtualizedFileDiff<unknown> | undefined;
+  let pierreDiffVirtualizer: Virtualizer | undefined;
   let demandContextHandlerRoot: ShadowRoot | undefined;
   let fullContext: { oldFile: FileContents; newFile: FileContents } | undefined = $state();
   let contextLoadPromise: Promise<{ oldFile: FileContents; newFile: FileContents }> | undefined;
   let contextError: string | null = $state(null);
   let themeType = $state<ThemeTypes>(appThemeType());
   let rendered = $state(false);
-  let placeholderHeight = $state(0);
   let renderedFileKey = "";
   let renderAttemptKey = "";
-  let inactiveCleanupTimer: ReturnType<typeof setTimeout> | undefined;
   let reviewRangeFrame: number | undefined;
   let renderRetryFrame: number | undefined;
   let renderRetryTick = $state(0);
-  let viewportProbeFrame: number | undefined;
-  let viewportProbeTick = $state(0);
   let renderRetryCount = 0;
   let renderedLineRows = new Map<number, RenderedLinePair[]>();
   let selectedRangeElements = new Set<HTMLElement>();
+  let lineAnnotationWrappers = new Map<string, HTMLElement>();
   let transientAnnotationRow: TransientAnnotationRow | undefined;
   let lineCommentButtonHasPointerSnapshot = false;
   let lineCommentButtonWasSelectedOnPointerDown = false;
-  const inactiveCleanupDelayMs = 10_000;
   const maxImmediateRenderRetries = 5;
 
   const renderFile = $derived(file ? diffFileWithPatch(file) : emptyFile);
   const fileKey = $derived(`${renderFile.path}\0${renderFile.old_path}\0${renderFile.patch}`);
   const fileHunks = $derived(renderFile.hunks ?? []);
   const emptyTextualDiff = $derived(!renderFile.patch.trim() || fileHunks.length === 0);
-  const reservedHeight = $derived(placeholderHeight || estimatedDiffHeight(renderFile));
   const pierreFile = $derived.by<FileDiffMetadata | undefined>(() => {
     return parsePierreFileDiff(renderFile, {
       // Pierre marks patch-only diffs as partial and hides expansion controls.
@@ -128,9 +126,11 @@
     expansionLineCount: 40,
     tokenizeMaxLineLength: 2_000,
     onPostRender: () => {
+      removeStalePlaceholderPres();
       applyLineTargetAttributes();
       applyHunkHeaderLabels();
       applyLineCommentButtons();
+      syncLineAnnotationWrappers();
       rendered = true;
       if (!fullContext) {
         installDemandContextHandler();
@@ -235,25 +235,22 @@
 
     return () => {
       themeObserver?.disconnect();
-      cancelInactiveCleanup();
       cancelSelectedRangesApplication();
       cancelRenderRetry();
-      cancelViewportProbe();
       cleanUpPierreDiff();
       contextLoadPromise = undefined;
     };
   });
 
   $effect(() => {
-    if (renderedFileKey === fileKey) return;
+    if (renderedFileKey === fileKey && pierreDiffVirtualizer === virtualizer) return;
     renderedFileKey = fileKey;
-    cancelInactiveCleanup();
+    pierreDiffVirtualizer = virtualizer;
     cleanUpPierreDiff();
     contextLoadPromise = undefined;
     contextError = null;
     fullContext = undefined;
-    rendered = false;
-    placeholderHeight = 0;
+    rendered = emptyTextualDiff;
     renderAttemptKey = "";
     renderRetryCount = 0;
     cancelRenderRetry();
@@ -271,25 +268,21 @@
   });
 
   $effect(() => {
-    const currentViewportProbeTick = viewportProbeTick;
     const currentRenderRetryTick = renderRetryTick;
-    if (currentRenderRetryTick < 0 || currentViewportProbeTick < 0) return;
-    if (!active && !isHostNearViewport()) {
-      scheduleInactiveCleanup();
-      return;
-    }
-    cancelInactiveCleanup();
+    if (currentRenderRetryTick < 0) return;
     if (emptyTextualDiff) {
       cleanUpPierreDiff();
       renderAttemptKey = "";
       rendered = true;
-      placeholderHeight = 0;
       return;
     }
     if (!host) return;
     if (!pierreFile) return;
-    pierreDiff ??= new FileDiff<unknown>(pierreOptions, getPierreDiffWorkerPool());
+    pierreDiff ??= createPierreDiff();
     pierreDiff.setOptions(pierreOptions);
+    if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
+      pierreDiff.setVisibility(true);
+    }
     const nextRenderAttemptKey = [
       fileKey,
       viewMode,
@@ -323,11 +316,12 @@
       if (didRender) {
         renderAttemptKey = nextRenderAttemptKey;
         renderRetryCount = 0;
+        removeStalePlaceholderPres();
         applyLineTargetAttributes();
         applyHunkHeaderLabels();
         applyLineCommentButtons();
+        syncLineAnnotationWrappers();
         rendered = true;
-        placeholderHeight = 0;
         installDemandContextHandler();
         scheduleSelectedRangesApplication();
       } else {
@@ -339,21 +333,7 @@
   });
 
   $effect(() => {
-    if (!host || rendered) return;
-    const root = host.closest(".diff-area");
-    if (!(root instanceof HTMLElement)) return;
-    root.addEventListener("scroll", scheduleViewportProbe, { passive: true });
-    window.addEventListener("resize", scheduleViewportProbe);
-    scheduleViewportProbe();
-    return () => {
-      root.removeEventListener("scroll", scheduleViewportProbe);
-      window.removeEventListener("resize", scheduleViewportProbe);
-      cancelViewportProbe();
-    };
-  });
-
-  $effect(() => {
-    if (active && pierreDiff && pierreFile) {
+    if (pierreDiff && pierreFile) {
       pierreDiff.setThemeType(themeType);
     }
   });
@@ -402,29 +382,28 @@
     cancelRenderRetry();
     clearSelectedRangeElements();
     clearTransientLineAnnotation();
+    clearLineAnnotationWrappers();
     renderedLineRows = new Map();
     pierreDiff?.cleanUp();
     pierreDiff = undefined;
+  }
+
+  function createPierreDiff(): FileDiff<unknown> | VirtualizedFileDiff<unknown> {
+    const workerPool = getPierreDiffWorkerPool();
+    if (!virtualizer) return new FileDiff<unknown>(pierreOptions, workerPool, true);
+    return new VirtualizedFileDiff<unknown>(
+      pierreOptions,
+      virtualizer,
+      undefined,
+      workerPool,
+      true,
+    );
   }
 
   function cancelRenderRetry(): void {
     if (renderRetryFrame == null) return;
     cancelAnimationFrame(renderRetryFrame);
     renderRetryFrame = undefined;
-  }
-
-  function scheduleViewportProbe(): void {
-    if (viewportProbeFrame != null) return;
-    viewportProbeFrame = requestAnimationFrame(() => {
-      viewportProbeFrame = undefined;
-      viewportProbeTick += 1;
-    });
-  }
-
-  function cancelViewportProbe(): void {
-    if (viewportProbeFrame == null) return;
-    cancelAnimationFrame(viewportProbeFrame);
-    viewportProbeFrame = undefined;
   }
 
   function scheduleRenderRetry(): void {
@@ -454,7 +433,7 @@
 
   function applySelectedRanges(): void {
     const root = host?.shadowRoot;
-    const pre = root?.querySelector("pre");
+    const pre = renderedDiffPre(root);
     if (!root || !pre) return;
     clearSelectedRangeElements();
     if ((!selectedRange && !selectedRanges.length) || !pierreDiff) return;
@@ -551,6 +530,7 @@
   function clearRenderedDomState(): void {
     clearSelectedRangeElements();
     clearTransientLineAnnotation();
+    clearLineAnnotationWrappers();
     renderedLineRows = new Map();
   }
 
@@ -562,48 +542,6 @@
     if (split && indexes.length === 2) return indexes[1];
     if (!split) return indexes[0];
     return undefined;
-  }
-
-  function scheduleInactiveCleanup(): void {
-    if (!pierreDiff || inactiveCleanupTimer) return;
-    inactiveCleanupTimer = setTimeout(() => {
-      inactiveCleanupTimer = undefined;
-      if (active || !pierreDiff) return;
-      placeholderHeight = measuredRenderedHeight();
-      cleanUpPierreDiff();
-      renderAttemptKey = "";
-      rendered = false;
-    }, inactiveCleanupDelayMs);
-  }
-
-  function cancelInactiveCleanup(): void {
-    if (!inactiveCleanupTimer) return;
-    clearTimeout(inactiveCleanupTimer);
-    inactiveCleanupTimer = undefined;
-  }
-
-  function isHostNearViewport(): boolean {
-    if (!host) return false;
-    const root = host.closest(".diff-area");
-    if (!(root instanceof HTMLElement)) return false;
-    const rootRect = root.getBoundingClientRect();
-    const hostRect = host.getBoundingClientRect();
-    return hostRect.bottom > rootRect.top - 600 &&
-      hostRect.top < rootRect.bottom + 600;
-  }
-
-  function measuredRenderedHeight(): number {
-    const height = host?.getBoundingClientRect().height ?? 0;
-    return Number.isFinite(height) && height > 0 ? Math.ceil(height) : placeholderHeight;
-  }
-
-  function estimatedDiffHeight(f: DiffFile): number {
-    if (f.is_binary || !f.hunks.length) return 96;
-    const lineCount = f.hunks.reduce((count, hunk) => count + hunk.lines.length, 0);
-    const separatorCount = Math.max(1, f.hunks.length);
-    const estimatedLineHeight = 22;
-    const verticalPadding = 12;
-    return Math.max(96, (lineCount + separatorCount) * estimatedLineHeight + verticalPadding);
   }
 
   function handleDemandContextClick(event: Event): void {
@@ -658,9 +596,11 @@
     if (fileKey !== requestFileKey) return;
     clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
+    removeStalePlaceholderPres();
     applyLineTargetAttributes();
     applyHunkHeaderLabels();
     applyLineCommentButtons();
+    syncLineAnnotationWrappers();
     scheduleSelectedRangesApplication();
   }
 
@@ -668,6 +608,9 @@
     if (!pierreDiff || !host) return false;
     rendered = false;
     clearRenderedDomState();
+    if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
+      pierreDiff.setVisibility(true);
+    }
     const didRender = pierreDiff.render({
       fileContainer: host,
       oldFile: context.oldFile,
@@ -677,11 +620,12 @@
     });
     pierreDiff.setSelectedLines(selectedRange);
     if (didRender) {
+      removeStalePlaceholderPres();
       applyLineTargetAttributes();
       applyHunkHeaderLabels();
       applyLineCommentButtons();
+      syncLineAnnotationWrappers();
       rendered = true;
-      placeholderHeight = 0;
       scheduleSelectedRangesApplication();
     }
     return didRender;
@@ -767,7 +711,7 @@
 
   function applyLineTargetAttributes(): void {
     const root = host?.shadowRoot;
-    const pre = root?.querySelector("pre");
+    const pre = renderedDiffPre(root);
     if (!root || !pre || !pierreDiff) return;
     for (const line of root.querySelectorAll<HTMLElement>("[data-diff-path]")) {
       line.removeAttribute("data-diff-path");
@@ -796,7 +740,7 @@
 
   function applyLineCommentButtons(): void {
     const root = host?.shadowRoot;
-    const pre = root?.querySelector("pre");
+    const pre = renderedDiffPre(root);
     if (!root || !pre) return;
     for (const button of root.querySelectorAll("[data-middleman-line-comment-button]")) {
       button.remove();
@@ -819,10 +763,28 @@
         }
         const target = lineCommentTarget(contentElement);
         if (!target) continue;
+        installLineSelectionHandler(contentElement);
+        installLineSelectionHandler(gutterElement);
         gutterElement.setAttribute("data-middleman-line-comment-cell", "");
         gutterElement.appendChild(lineCommentButton(target));
       }
     }
+  }
+
+  function installLineSelectionHandler(element: HTMLElement): void {
+    if (element.hasAttribute("data-middleman-line-selection-target")) return;
+    element.setAttribute("data-middleman-line-selection-target", "");
+    element.addEventListener("click", handleLineSelectionClick);
+  }
+
+  function handleLineSelectionClick(event: MouseEvent): void {
+    if (!enableLineSelection || !onLineSelected || event.defaultPrevented) return;
+    const element = event.currentTarget;
+    if (!(element instanceof HTMLElement)) return;
+    const target = lineCommentTarget(element);
+    if (!target) return;
+    const collapse = lineCommentTargetIsSelected(target, event);
+    onLineSelected(collapse ? null : lineCommentSelection(target, event));
   }
 
   function lineCommentTarget(
@@ -932,13 +894,23 @@
       slotName,
       stableAnnotationKey(annotation.metadata),
     ].join(":");
-    if (transientAnnotationRow?.key === key) return;
+    if (transientAnnotationRow?.key === key) {
+      if (!hasAnnotationSlot(slotName)) {
+        const row = insertTransientAnnotationRow(annotation);
+        if (row) {
+          transientAnnotationRow = {
+            ...transientAnnotationRow,
+            ...row,
+          };
+        }
+      }
+      return;
+    }
 
     clearTransientLineAnnotation();
 
-    const existingSlot = hasAnnotationSlot(slotName);
-    const row = existingSlot ? undefined : insertTransientAnnotationRow(annotation);
-    if (!existingSlot && !row) return;
+    const row = hasAnnotationSlot(slotName) ? undefined : insertTransientAnnotationRow(annotation);
+    if (!hasAnnotationSlot(slotName) && !row) return;
 
     const content = renderAnnotation(annotation);
     if (!content) return;
@@ -965,6 +937,45 @@
     transientAnnotationRow = undefined;
   }
 
+  function syncLineAnnotationWrappers(): void {
+    if (!host || !renderAnnotation) {
+      clearLineAnnotationWrappers();
+      return;
+    }
+    const activeKeys = new Set<string>();
+    for (const annotation of lineAnnotations) {
+      const slotName = annotationSlotName(annotation);
+      const key = `${slotName}:${stableAnnotationKey(annotation)}`;
+      activeKeys.add(key);
+      if (lineAnnotationWrappers.has(key)) continue;
+
+      const content = renderAnnotation(annotation);
+      if (!content) continue;
+
+      const wrapper = document.createElement("div");
+      wrapper.dataset.middlemanLineAnnotationWrapper = "";
+      wrapper.slot = slotName;
+      wrapper.style.whiteSpace = "normal";
+      wrapper.appendChild(content);
+      // eslint-disable-next-line svelte/no-dom-manipulating -- Pierre owns this custom element; annotations are passed through its light-DOM slot API.
+      host.appendChild(wrapper);
+      lineAnnotationWrappers.set(key, wrapper);
+    }
+
+    for (const [key, wrapper] of lineAnnotationWrappers) {
+      if (activeKeys.has(key)) continue;
+      lineAnnotationWrappers.delete(key);
+      wrapper.remove();
+    }
+  }
+
+  function clearLineAnnotationWrappers(): void {
+    for (const wrapper of lineAnnotationWrappers.values()) {
+      wrapper.remove();
+    }
+    lineAnnotationWrappers.clear();
+  }
+
   function hasAnnotationSlot(slotName: string): boolean {
     const root = host?.shadowRoot;
     if (!root) return false;
@@ -978,7 +989,7 @@
     annotation: DiffLineAnnotation<unknown>,
   ): { content: HTMLElement; gutter: HTMLElement } | undefined {
     const root = host?.shadowRoot;
-    const pre = root?.querySelector("pre");
+    const pre = renderedDiffPre(root);
     if (!pre || !pierreDiff) return undefined;
 
     const split = pre.getAttribute("data-diff-type") === "split";
@@ -1026,10 +1037,38 @@
     if (!Number.isFinite(lineIndex)) return;
     const pair = renderedLinePair(pre, lineIndex, split);
     if (!pair) return;
-    pair.content.setAttribute("data-diff-path", renderFile.path);
     pair.content.tabIndex = -1;
+    pair.gutter.tabIndex = -1;
+    pair.content.setAttribute("data-diff-path", renderFile.path);
+    pair.gutter.setAttribute("data-diff-path", renderFile.path);
     for (const [name, value] of Object.entries(attributes)) {
       pair.content.setAttribute(name, value);
+      pair.gutter.setAttribute(name, value);
+    }
+  }
+
+  function isHostInScrollViewport(): boolean {
+    if (!host) return false;
+    const root = host.closest(".diff-area");
+    const hostRect = host.getBoundingClientRect();
+    const rootRect = root?.getBoundingClientRect() ?? {
+      top: 0,
+      bottom: window.innerHeight,
+    };
+    return hostRect.bottom > rootRect.top && hostRect.top < rootRect.bottom;
+  }
+
+  function renderedDiffPre(root = host?.shadowRoot): HTMLPreElement | null {
+    return root?.querySelector<HTMLPreElement>("pre[data-diff]") ?? null;
+  }
+
+  function removeStalePlaceholderPres(): void {
+    const root = host?.shadowRoot;
+    if (!root) return;
+    for (const pre of root.querySelectorAll<HTMLPreElement>("pre:not([data-diff])")) {
+      if (pre.childElementCount === 0 && !pre.textContent?.trim()) {
+        pre.remove();
+      }
     }
   }
 
@@ -1138,16 +1177,14 @@
 <div
   class="pierre-diff-shell"
   class:pierre-diff-shell--loading={!rendered}
-  style:min-height={reservedHeight ? `${reservedHeight}px` : undefined}
   aria-busy={!rendered}
 >
-  {#if !emptyTextualDiff}
-    <diffs-container
-      class="pierre-diff"
-      class:pierre-diff--pending={!rendered}
-      bind:this={host}
-    ></diffs-container>
-  {/if}
+  <diffs-container
+    class="pierre-diff"
+    class:pierre-diff--pending={!rendered}
+    hidden={emptyTextualDiff}
+    bind:this={host}
+  ></diffs-container>
   {#if rendered && emptyTextualDiff}
     <div class="empty-textual-diff">No textual changes</div>
   {/if}

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -50,6 +50,12 @@
     key: string;
     wrapper: HTMLElement;
   };
+  type PendingContextExpansion = {
+    direction: ExpansionDirections;
+    expansionLineCount: number | undefined;
+    fileKey: string;
+    hunkIndex: number;
+  };
   const emptyFile: DiffFile = {
     path: "",
     old_path: "",
@@ -100,6 +106,7 @@
   let selectedRangeElements = new Set<HTMLElement>();
   let lineAnnotationWrappers = new Map<string, HTMLElement>();
   let transientAnnotationRow: TransientAnnotationRow | undefined;
+  let pendingContextExpansion: PendingContextExpansion | undefined;
   let lineCommentButtonHasPointerSnapshot = false;
   let lineCommentButtonWasSelectedOnPointerDown = false;
   const maxImmediateRenderRetries = 5;
@@ -256,6 +263,7 @@
     fullContext = undefined;
     fullContextFileDiff = undefined;
     fullContextRendered = false;
+    pendingContextExpansion = undefined;
     rendered = emptyTextualDiff;
     renderAttemptKey = "";
     renderRetryCount = 0;
@@ -607,7 +615,14 @@
       if (fileKey !== requestFileKey) return;
       if (!didRender) {
         if (!fullContextFileDiff) return;
+        pendingContextExpansion = {
+          direction,
+          expansionLineCount,
+          fileKey: requestFileKey,
+          hunkIndex,
+        };
         scheduleRenderRetry();
+        return;
       }
     }
     expandRenderedHunk(hunkIndex, direction, expansionLineCount);
@@ -654,8 +669,20 @@
       rendered = true;
       installDemandContextHandler();
       scheduleSelectedRangesApplication();
+      replayPendingContextExpansion();
     }
     return didRender;
+  }
+
+  function replayPendingContextExpansion(): void {
+    const pending = pendingContextExpansion;
+    if (!pending || pending.fileKey !== fileKey) return;
+    pendingContextExpansion = undefined;
+    expandRenderedHunk(
+      pending.hunkIndex,
+      pending.direction,
+      pending.expansionLineCount,
+    );
   }
 
   function renderFullContextRange(

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -11,7 +11,7 @@
     ThemeTypes,
     Virtualizer,
   } from "@pierre/diffs";
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import type { DiffFile } from "../../api/types.js";
   import {
     appThemeType,
@@ -600,9 +600,15 @@
     const alreadyRendered = fullContextRendered;
     const context = await loadFullContext(requestFileKey);
     if (!context || fileKey !== requestFileKey) return;
-    if (!alreadyRendered) {
+    await tick();
+    if (fileKey !== requestFileKey) return;
+    if (!alreadyRendered && !fullContextRendered) {
       const didRender = renderFullContext(context);
-      if (!didRender || fileKey !== requestFileKey) return;
+      if (fileKey !== requestFileKey) return;
+      if (!didRender) {
+        if (!fullContextFileDiff) return;
+        scheduleRenderRetry();
+      }
     }
     expandRenderedHunk(hunkIndex, direction, expansionLineCount);
   }
@@ -615,10 +621,10 @@
     clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
     if (pierreDiff instanceof VirtualizedFileDiff && fullContext && fullContextFileDiff) {
+      pierreDiff.rerender();
+    } else if (fullContext && fullContextFileDiff) {
       const didRender = renderFullContextRange(fullContext, fullContextFileDiff);
-      if (!didRender) {
-        scheduleRenderRetry();
-      }
+      if (!didRender) scheduleRenderRetry();
     }
     removeStalePlaceholderPres();
     applyLineTargetAttributes();
@@ -664,24 +670,26 @@
       newFile: context.newFile,
       forceRender: true,
       lineAnnotations,
-      renderRange: {
-        startingLine: 0,
-        totalLines: Number.POSITIVE_INFINITY,
-        bufferBefore: 0,
-        bufferAfter: 0,
-      },
     } satisfies Parameters<FileDiff<unknown>["render"]>[0];
     if (!(pierreDiff instanceof VirtualizedFileDiff)) {
-      return pierreDiff.render(props);
+      return pierreDiff.render({
+        ...props,
+        renderRange: {
+          startingLine: 0,
+          totalLines: Number.POSITIVE_INFINITY,
+          bufferBefore: 0,
+          bufferAfter: 0,
+        },
+      });
     }
     if (isHostInScrollViewport()) {
       pierreDiff.setVisibility(true);
     }
-    const render = FileDiff.prototype.render as (
-      this: FileDiff<unknown>,
-      props: Parameters<FileDiff<unknown>["render"]>[0],
-    ) => boolean;
-    return render.call(pierreDiff as unknown as FileDiff<unknown>, props);
+    if (pierreDiff.fileDiff !== fileDiff) {
+      pierreDiff.fileDiff = fileDiff;
+      pierreDiff.setMetrics(undefined, true);
+    }
+    return pierreDiff.render(props);
   }
 
   async function loadFullContext(

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -1,6 +1,5 @@
 import {
   cleanup,
-  fireEvent,
   render,
   waitFor,
 } from "@testing-library/svelte";
@@ -12,9 +11,11 @@ const pierre = (() => {
   const counts = {
     cleanUp: 0,
     render: 0,
+    virtualized: 0,
   };
   let renderResults: boolean[] = [];
   let lastOptions: FileDiffOptions<unknown> | undefined;
+  let lastVirtualizer: unknown;
   const cleanUp = () => {
     counts.cleanUp += 1;
   };
@@ -44,11 +45,19 @@ const pierre = (() => {
     setSelectedLines = () => {};
     setThemeType = () => {};
   }
+  class VirtualizedFileDiff extends FileDiff {
+    constructor(options?: FileDiffOptions<unknown>, virtualizer?: unknown) {
+      super(options);
+      counts.virtualized += 1;
+      lastVirtualizer = virtualizer;
+    }
+  }
   return {
     cleanUp,
     cleanUpCount: () => counts.cleanUp,
     FileDiff,
     lastOptions: () => lastOptions,
+    lastVirtualizer: () => lastVirtualizer,
     metadata,
     parsePatchFiles: () => [{ files: [metadata] }],
     processFile: () => metadata,
@@ -57,12 +66,16 @@ const pierre = (() => {
     reset: () => {
       counts.cleanUp = 0;
       counts.render = 0;
+      counts.virtualized = 0;
       renderResults = [];
       lastOptions = undefined;
+      lastVirtualizer = undefined;
     },
     setRenderResults: (results: boolean[]) => {
       renderResults = [...results];
     },
+    virtualizedCount: () => counts.virtualized,
+    VirtualizedFileDiff,
   };
 })();
 
@@ -70,6 +83,7 @@ vi.doMock("@pierre/diffs", () => ({
   FileDiff: pierre.FileDiff,
   parsePatchFiles: pierre.parsePatchFiles,
   processFile: pierre.processFile,
+  VirtualizedFileDiff: pierre.VirtualizedFileDiff,
 }));
 
 function makeFile(): DiffFile {
@@ -110,47 +124,20 @@ describe("PierreFileDiff", () => {
     pierre.reset();
   });
 
-  it("cleans up rendered Pierre instances when deactivated", async () => {
+  it("uses Pierre virtualized diffs when a viewer virtualizer is provided", async () => {
     const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
-    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
-    Element.prototype.getBoundingClientRect = function () {
-      if (this instanceof HTMLElement && this.tagName === "DIFFS-CONTAINER") {
-        return {
-          top: 0,
-          bottom: 240,
-          left: 0,
-          right: 500,
-          width: 500,
-          height: 240,
-          x: 0,
-          y: 0,
-          toJSON: () => ({}),
-        } as DOMRect;
-      }
-      return originalGetBoundingClientRect.call(this);
-    };
+    const virtualizer = { type: "simple" };
 
-    try {
-      const file = makeFile();
-      const { container, rerender } = render(PierreFileDiff, {
-        props: { active: true, file },
-      });
+    render(PierreFileDiff, {
+      props: { file: makeFile(), virtualizer: virtualizer as never },
+    });
 
-      await waitFor(() => {
-        expect(pierre.renderCount()).toBe(1);
-      });
+    await waitFor(() => {
+      expect(pierre.renderCount()).toBe(1);
+    });
 
-      vi.useFakeTimers();
-      await rerender({ active: false, file });
-      await vi.advanceTimersByTimeAsync(10_000);
-
-      expect(pierre.cleanUpCount()).toBe(1);
-      expect(
-        container.querySelector<HTMLElement>(".pierre-diff-shell")?.style.minHeight,
-      ).toBe("240px");
-    } finally {
-      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
-    }
+    expect(pierre.virtualizedCount()).toBe(1);
+    expect(pierre.lastVirtualizer()).toEqual(virtualizer);
   });
 
   it("retries when Pierre declines an initial render attempt", async () => {
@@ -158,7 +145,7 @@ describe("PierreFileDiff", () => {
     pierre.setRenderResults([false, true]);
 
     render(PierreFileDiff, {
-      props: { active: true, file: makeFile() },
+      props: { file: makeFile() },
     });
 
     await waitFor(() => {
@@ -166,51 +153,11 @@ describe("PierreFileDiff", () => {
     });
   });
 
-  it("renders an inactive expanded file after a fallback viewport probe", async () => {
-    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
-    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
-    const diffArea = document.createElement("div");
-    diffArea.className = "diff-area";
-    document.body.appendChild(diffArea);
-    let fileNearViewport = false;
-    Element.prototype.getBoundingClientRect = function () {
-      if (this instanceof HTMLElement && this.classList.contains("diff-area")) {
-        return rect({ top: 0, bottom: 400, height: 400 });
-      }
-      if (this instanceof HTMLElement && this.tagName === "DIFFS-CONTAINER") {
-        return fileNearViewport
-          ? rect({ top: 80, bottom: 180, height: 100 })
-          : rect({ top: 1_200, bottom: 1_300, height: 100 });
-      }
-      return originalGetBoundingClientRect.call(this);
-    };
-
-    try {
-      render(PierreFileDiff, {
-        target: diffArea,
-        props: { active: false, file: makeFile() },
-      });
-
-      await Promise.resolve();
-      expect(pierre.renderCount()).toBe(0);
-
-      fileNearViewport = true;
-      await fireEvent.scroll(diffArea);
-
-      await waitFor(() => {
-        expect(pierre.renderCount()).toBe(1);
-      });
-    } finally {
-      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
-      diffArea.remove();
-    }
-  });
-
   it("passes split diff style to Pierre when side-by-side mode is enabled", async () => {
     const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
 
     render(PierreFileDiff, {
-      props: { active: true, file: makeFile(), viewMode: "split" },
+      props: { file: makeFile(), viewMode: "split" },
     });
 
     await waitFor(() => {
@@ -235,14 +182,14 @@ describe("PierreFileDiff", () => {
     }];
 
     const { rerender } = render(PierreFileDiff, {
-      props: { active: true, file, lineAnnotations: firstAnnotations },
+      props: { file, lineAnnotations: firstAnnotations },
     });
 
     await waitFor(() => {
       expect(pierre.renderCount()).toBe(1);
     });
 
-    await rerender({ active: true, file, lineAnnotations: nextAnnotations });
+    await rerender({ file, lineAnnotations: nextAnnotations });
 
     await waitFor(() => {
       expect(pierre.renderCount()).toBe(2);
@@ -254,7 +201,7 @@ describe("PierreFileDiff", () => {
     const file = makeFile();
 
     const { rerender } = render(PierreFileDiff, {
-      props: { active: true, file },
+      props: { file },
     });
 
     await waitFor(() => {
@@ -262,7 +209,6 @@ describe("PierreFileDiff", () => {
     });
 
     await rerender({
-      active: true,
       file,
       selectedRange: { start: 2, end: 2, side: "additions" },
       transientLineAnnotation: {
@@ -276,25 +222,3 @@ describe("PierreFileDiff", () => {
     expect(pierre.renderCount()).toBe(1);
   });
 });
-
-function rect({
-  top,
-  bottom,
-  height,
-}: {
-  top: number;
-  bottom: number;
-  height: number;
-}): DOMRect {
-  return {
-    top,
-    bottom,
-    height,
-    left: 0,
-    right: 500,
-    width: 500,
-    x: 0,
-    y: top,
-    toJSON: () => ({}),
-  } as DOMRect;
-}

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -1,5 +1,6 @@
 import {
   cleanup,
+  fireEvent,
   render,
   waitFor,
 } from "@testing-library/svelte";
@@ -10,18 +11,35 @@ import type { DiffFile } from "../../api/types.js";
 const pierre = (() => {
   const counts = {
     cleanUp: 0,
+    expand: 0,
     render: 0,
     virtualized: 0,
   };
   let renderResults: boolean[] = [];
+  let events: string[] = [];
+  let lastExpansion:
+    | { direction: unknown; expansionLineCount: number | undefined; hunkIndex: number }
+    | undefined;
   let lastOptions: FileDiffOptions<unknown> | undefined;
   let lastVirtualizer: unknown;
   const cleanUp = () => {
     counts.cleanUp += 1;
   };
-  const renderDiff = () => {
+  const renderDiff = (props?: { fileContainer?: HTMLElement }) => {
     counts.render += 1;
-    return renderResults.shift() ?? true;
+    const didRender = renderResults.shift() ?? true;
+    events.push(`render:${String(didRender)}`);
+    if (didRender && props?.fileContainer) {
+      const root = props.fileContainer.shadowRoot ?? props.fileContainer.attachShadow({ mode: "open" });
+      root.innerHTML = `
+        <pre data-diff-type="unified">
+          <div data-separator data-expand-index="0">
+            <button type="button" data-expand-button data-expand-down>expand</button>
+          </div>
+        </pre>
+      `;
+    }
+    return didRender;
   };
   const metadata = {
     additionLines: ["new line\n"],
@@ -36,7 +54,15 @@ const pierre = (() => {
       lastOptions = options;
     }
     cleanUp = cleanUp;
-    expandHunk = () => {};
+    expandHunk = (
+      hunkIndex: number,
+      direction: unknown,
+      expansionLineCount?: number,
+    ) => {
+      counts.expand += 1;
+      events.push("expand");
+      lastExpansion = { direction, expansionLineCount, hunkIndex };
+    };
     getLineIndex = (lineNumber: number): [number, number] => [lineNumber, lineNumber];
     render = renderDiff;
     setOptions = (options?: FileDiffOptions<unknown>) => {
@@ -55,7 +81,10 @@ const pierre = (() => {
   return {
     cleanUp,
     cleanUpCount: () => counts.cleanUp,
+    expandCount: () => counts.expand,
+    events: () => [...events],
     FileDiff,
+    lastExpansion: () => lastExpansion,
     lastOptions: () => lastOptions,
     lastVirtualizer: () => lastVirtualizer,
     metadata,
@@ -65,8 +94,11 @@ const pierre = (() => {
     renderCount: () => counts.render,
     reset: () => {
       counts.cleanUp = 0;
+      counts.expand = 0;
       counts.render = 0;
       counts.virtualized = 0;
+      lastExpansion = undefined;
+      events = [];
       renderResults = [];
       lastOptions = undefined;
       lastVirtualizer = undefined;
@@ -151,6 +183,75 @@ describe("PierreFileDiff", () => {
     await waitFor(() => {
       expect(pierre.renderCount()).toBe(2);
     });
+  });
+
+  it("replays context expansion after a deferred full-context render", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const loadFileText = vi.fn(async (side: "old" | "new") =>
+      side === "old" ? "line 1\nold line\n" : "line 1\nnew line\n"
+    );
+    const hadCancelAnimationFrame = "cancelAnimationFrame" in globalThis;
+    const hadRequestAnimationFrame = "requestAnimationFrame" in globalThis;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const frameCallbacks: FrameRequestCallback[] = [];
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+    pierre.setRenderResults([true, false, true, true]);
+
+    try {
+      render(PierreFileDiff, {
+        props: { file: makeFile(), loadFileText },
+      });
+
+      const expandButton = await waitFor(() => {
+        const button = document
+          .querySelector(".pierre-diff")
+          ?.shadowRoot
+          ?.querySelector<HTMLElement>("[data-expand-button]");
+        expect(button).toBeTruthy();
+        return button!;
+      });
+
+      await fireEvent.click(expandButton);
+
+      for (const callback of frameCallbacks.splice(0)) {
+        callback(performance.now());
+      }
+
+      await waitFor(() => {
+        expect(pierre.expandCount()).toBe(1);
+      });
+      const events = pierre.events();
+      const failedRenderIndex = events.indexOf("render:false");
+      const replayRenderIndex = events.findIndex((event, index) =>
+        index > failedRenderIndex && event === "render:true"
+      );
+      const expandIndex = events.indexOf("expand");
+      expect(failedRenderIndex).toBeGreaterThan(-1);
+      expect(replayRenderIndex).toBeGreaterThan(failedRenderIndex);
+      expect(expandIndex).toBeGreaterThan(replayRenderIndex);
+      expect(pierre.lastExpansion()).toEqual({
+        direction: "down",
+        expansionLineCount: undefined,
+        hunkIndex: 0,
+      });
+      expect(loadFileText).toHaveBeenCalledTimes(2);
+    } finally {
+      if (hadRequestAnimationFrame) {
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      } else {
+        delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+      }
+      if (hadCancelAnimationFrame) {
+        globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+      } else {
+        delete (globalThis as { cancelAnimationFrame?: unknown }).cancelAnimationFrame;
+      }
+    }
   });
 
   it("passes split diff style to Pierre when side-by-side mode is enabled", async () => {

--- a/packages/ui/src/components/diff/PierreFileTree.svelte
+++ b/packages/ui/src/components/diff/PierreFileTree.svelte
@@ -24,6 +24,7 @@
   let tree: FileTree | undefined;
   let renderedTreeKey = "";
   let syncingSelection = false;
+  let selectedPathScrollFrame = 0;
 
   const safeFiles = $derived(files ?? []);
   const treePaths = $derived(safeFiles.map((file) => file.path));
@@ -81,6 +82,7 @@
 
   onMount(() => {
     return () => {
+      cancelAnimationFrame(selectedPathScrollFrame);
       tree?.cleanUp();
       tree = undefined;
     };
@@ -122,8 +124,29 @@
     if (selectedPath && tree.getItem(selectedPath)) {
       tree.getItem(selectedPath)?.select();
       tree.focusNearestPath(selectedPath);
+      scheduleSelectedPathIntoView(selectedPath);
     }
     syncingSelection = false;
+  }
+
+  function scheduleSelectedPathIntoView(path: string): void {
+    scrollPathIntoView(path);
+    cancelAnimationFrame(selectedPathScrollFrame);
+    selectedPathScrollFrame = requestAnimationFrame(() => {
+      selectedPathScrollFrame = 0;
+      scrollPathIntoView(path);
+    });
+  }
+
+  function scrollPathIntoView(path: string): void {
+    const root = host?.shadowRoot;
+    if (!root) return;
+    for (const item of root.querySelectorAll<HTMLElement>("[data-item-path]")) {
+      if (item.dataset.itemPath !== path) continue;
+      if (typeof item.scrollIntoView !== "function") return;
+      item.scrollIntoView({ block: "nearest" });
+      return;
+    }
   }
 </script>
 

--- a/packages/ui/src/components/diff/pierre-diff.test.ts
+++ b/packages/ui/src/components/diff/pierre-diff.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { DiffFile } from "../../api/types.js";
-import { diffFileWithPatch, parsePierreFileDiff, patchPath } from "./pierre-diff.js";
+import {
+  diffFileWithPatch,
+  parsePierreFileDiff,
+  parsePierreFileDiffWithContents,
+  patchPath,
+  pierreFileContents,
+} from "./pierre-diff.js";
 
 function makeFile(path: string, patchBody: string): DiffFile {
   const patch = `diff --git a/${path} b/${path}
@@ -119,13 +125,23 @@ describe("Pierre diff parsing", () => {
     expect((second as { cacheKey?: string } | undefined)?.cacheKey).toBeUndefined();
   });
 
-  it("omits cache keys when sparse context files are supplied for expansion", () => {
-    const parsed = parsePierreFileDiff(makeFile("src/foo.ts", "-old line\n+new line"), {
+  it("uses distinct cache keys for sparse and full context contents", () => {
+    const file = makeFile("src/foo.ts", "-old line\n+new line");
+    const parsed = parsePierreFileDiff(file, {
       enableDemandContextExpansion: true,
+    });
+    const sparseOld = pierreFileContents("src/foo.ts", "line 1\nold line\n", "sparse-old");
+    const fullOld = pierreFileContents("src/foo.ts", "line 1\nold line\n", "full-old");
+    const full = parsePierreFileDiffWithContents(file, {
+      oldFile: fullOld,
+      newFile: pierreFileContents("src/foo.ts", "line 1\nnew line\n", "full-new"),
     });
 
     expect(parsed).toBeDefined();
-    expect((parsed as { cacheKey?: string } | undefined)?.cacheKey).toBeUndefined();
+    expect(full).toBeDefined();
+    expect(sparseOld.cacheKey).toBeDefined();
+    expect(fullOld.cacheKey).toBeDefined();
+    expect(fullOld.cacheKey).not.toBe(sparseOld.cacheKey);
   });
 
   it("falls back to patch-only parsing for huge sparse line ranges", () => {

--- a/packages/ui/src/components/diff/pierre-diff.ts
+++ b/packages/ui/src/components/diff/pierre-diff.ts
@@ -26,6 +26,25 @@ export function parsePierreFileDiff(
   return parsePatchOnly(patchedFile);
 }
 
+export function parsePierreFileDiffWithContents(
+  file: DiffFile,
+  contents: { oldFile: FileContents; newFile: FileContents },
+): FileDiffMetadata | undefined {
+  return processPatchWithContext(diffFileWithPatch(file), contents);
+}
+
+export function pierreFileContents(
+  name: string,
+  contents: string,
+  cacheIdentity: string,
+): FileContents {
+  return {
+    name,
+    contents,
+    cacheKey: fileContentsCacheKey(name, contents, cacheIdentity),
+  };
+}
+
 export function diffFileWithPatch(file: DiffFile): DiffFile {
   const patch = file.patch || synthesizePatch(file);
   return patch === file.patch ? file : { ...file, patch };
@@ -41,8 +60,8 @@ function processPatchWithContext(
   const safePatch = safePierrePatch(file);
   if (safePatch === file.patch) return parsePatchOnly(file);
   return tryProcessPatch(safePatch, {
-    oldFile: { ...contents.oldFile, name: safePierreFileName(file, "old") },
-    newFile: { ...contents.newFile, name: safePierreFileName(file, "new") },
+    oldFile: fileContentsWithName(contents.oldFile, safePierreFileName(file, "old"), "safe-old"),
+    newFile: fileContentsWithName(contents.newFile, safePierreFileName(file, "new"), "safe-new"),
   }) ?? parsePatchOnly({ ...file, patch: safePatch });
 }
 
@@ -207,18 +226,34 @@ function sparsePatchContents(file: DiffFile): { oldFile: FileContents; newFile: 
   const newContents = joinSparseLines(newLines);
 
   return {
-    oldFile: {
-      name: file.old_path || file.path,
-      contents: oldContents,
-    },
-    newFile: {
-      name: file.path,
-      contents: newContents,
-    },
+    oldFile: pierreFileContents(file.old_path || file.path, oldContents, "sparse-old"),
+    newFile: pierreFileContents(file.path, newContents, "sparse-new"),
   };
 }
 
 function joinSparseLines(lines: string[]): string {
   while (lines.length > 0 && lines[lines.length - 1] == null) lines.pop();
   return lines.map((line) => line ?? "").join("\n");
+}
+
+function fileContentsWithName(
+  file: FileContents,
+  name: string,
+  cacheIdentity: string,
+): FileContents {
+  return {
+    ...file,
+    name,
+    cacheKey: fileContentsCacheKey(name, file.contents, `${cacheIdentity}:${file.cacheKey ?? ""}`),
+  };
+}
+
+function fileContentsCacheKey(name: string, contents: string, cacheIdentity: string): string {
+  let hash = 0x811c9dc5;
+  const seed = `${cacheIdentity}\0${name}\0${contents.length}\0${contents}`;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${cacheIdentity}:${contents.length}:${(hash >>> 0).toString(36)}`;
 }

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -98,6 +98,7 @@
         number={itemNumber}
         loadOnMount={false}
         keyboardActive={false}
+        pageKeyboardActive={active}
         richPreviewEnabled={false}
         contextExpansionEnabled={false}
         reviewMode="disabled"


### PR DESCRIPTION
- Keeps Pierre-rendered diff jumps and context expansion stable in large virtualized diffs.
- Restores focused PageDown paging in workspace diff panels without enabling broader diff shortcuts.
- Adds regression coverage for deferred context expansion and workspace diff keyboard scrolling.