### PR TITLE
Resize wide PR split view panes

### DIFF
--- a/frontend/tests/e2e/pr-split-view.spec.ts
+++ b/frontend/tests/e2e/pr-split-view.spec.ts
@@ -152,12 +152,13 @@ test("lets wide PR detail panes opt into split conversation and files", async ({
   await page.setViewportSize({ width: 2200, height: 1000 });
   await page.goto("/pulls/github/acme/widgets/42");
 
-  await expect(page.locator(".detail-title")).toContainText(
-    "Add browser regression coverage",
-  );
+  await expect(page.locator(".detail-title")).toContainText("Add browser regression coverage");
   await expect(page.locator(".detail-split-layout")).toHaveCount(0);
 
-  const splitToggle = page.getByRole("button", { name: "Split view" });
+  const splitToggle = page.getByRole("button", {
+    name: "Split view",
+    exact: true,
+  });
   await expect(splitToggle).toBeVisible();
   await expect(splitToggle).toHaveAttribute("aria-pressed", "false");
 
@@ -165,9 +166,39 @@ test("lets wide PR detail panes opt into split conversation and files", async ({
 
   await expect(splitToggle).toHaveAttribute("aria-pressed", "true");
   await expect(page.locator(".detail-split-layout")).toBeVisible();
-  await expect(page.locator(".detail-title")).toContainText(
-    "Add browser regression coverage",
-  );
+  await expect(page.locator(".detail-title")).toContainText("Add browser regression coverage");
   await expect(page.locator(".files-view")).toBeVisible();
   await expect(page.getByText("src/split-view.ts")).toBeVisible();
+
+  const conversationPane = page.locator(".detail-split-pane--conversation");
+  const resizeHandle = page.getByRole("button", { name: "Resize PR split view" });
+  await expect(conversationPane).toBeVisible();
+  await expect(resizeHandle).toBeVisible();
+  await expect(resizeHandle).toHaveCSS("cursor", "col-resize");
+
+  const before = await conversationPane.boundingBox();
+  const handleBox = await resizeHandle.boundingBox();
+  expect(before).not.toBeNull();
+  expect(handleBox).not.toBeNull();
+  if (!before || !handleBox) {
+    throw new Error("Expected split pane and resize handle to be measurable");
+  }
+
+  await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2 + 240,
+    handleBox.y + handleBox.height / 2,
+  );
+  await page.mouse.up();
+
+  await expect
+    .poll(async () => {
+      const box = await conversationPane.boundingBox();
+      return box?.width ?? 0;
+    })
+    .toBeGreaterThan(before.width + 150);
+  await expect
+    .poll(async () => await page.evaluate(() => localStorage.getItem("pr-detail-split-ratio")))
+    .not.toBeNull();
 });

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -1,18 +1,20 @@
 <script module lang="ts">
   type DetailTab = "conversation" | "files";
 
-  const filesScrollPositions: Record<string, number> = Object.create(null) as Record<string, number>;
+  const filesScrollPositions: Record<string, number> = Object.create(null) as Record<
+    string,
+    number
+  >;
 </script>
 
 <script lang="ts">
   import { untrack } from "svelte";
-  import {
-    getNavigate, getSidebar, getStores,
-  } from "../context.js";
+  import { getNavigate, getSidebar, getStores } from "../context.js";
   import CollapsibleResizableSidebar from "../components/shared/CollapsibleResizableSidebar.svelte";
+  import SplitResizeHandle from "../components/shared/SplitResizeHandle.svelte";
+  import type { SplitResizeEvent } from "../components/shared/split-resize.js";
   import PullList from "../components/sidebar/PullList.svelte";
-  import PullDetail
-    from "../components/detail/PullDetail.svelte";
+  import PullDetail from "../components/detail/PullDetail.svelte";
   import DiffFilesLayout from "../components/diff/DiffFilesLayout.svelte";
   import type { ProviderCapabilities, PullDetail as PullDetailResponse } from "../api/types.js";
   import type { DetailSyncMode } from "../stores/detail.svelte.js";
@@ -31,8 +33,11 @@
   const navigate = getNavigate();
   const { detail: detailStore } = getStores();
   const splitViewStorageKey = "pr-detail-split-view";
+  const splitViewRatioStorageKey = "pr-detail-split-ratio";
   const regularConversationPanelWidth = 800 + 24 + 24;
   const minSplitViewWidth = regularConversationPanelWidth * 2;
+  const minSplitPaneWidth = 480;
+  const splitResizeHandleWidth = 4;
 
   const defaultProviderCapabilities: ProviderCapabilities = {
     read_repositories: true,
@@ -92,9 +97,17 @@
   let detailHost: HTMLDivElement | undefined = $state();
   let detailHostWidth = $state(0);
   let splitViewEnabled = $state(loadSplitViewPreference());
+  let committedSplitRatio = $state(loadSplitViewRatio());
+  let dragSplitWidth: number | null = $state(null);
+  let splitResizeStartWidth = 0;
 
   const splitViewAvailable = $derived(selectedPR !== null && detailHostWidth >= minSplitViewWidth);
   const splitViewActive = $derived(splitViewAvailable && splitViewEnabled);
+  const splitContentWidth = $derived(Math.max(0, detailHostWidth - splitResizeHandleWidth));
+  const splitConversationWidth = $derived.by(() => {
+    if (splitContentWidth <= 0) return 0;
+    return clampSplitPaneWidth(dragSplitWidth ?? splitContentWidth * committedSplitRatio);
+  });
 
   function safeGetItem(key: string): string | null {
     try {
@@ -116,9 +129,55 @@
     return safeGetItem(splitViewStorageKey) === "1";
   }
 
+  function loadSplitViewRatio(): number {
+    const stored = safeGetItem(splitViewRatioStorageKey);
+    if (stored === null || stored.trim() === "") return 0.5;
+    const value = Number(stored);
+    return Number.isFinite(value) ? clampSplitRatio(value) : 0.5;
+  }
+
   function setSplitViewEnabled(enabled: boolean): void {
     splitViewEnabled = enabled;
     safeSetItem(splitViewStorageKey, enabled ? "1" : "0");
+  }
+
+  function clampSplitRatio(ratio: number): number {
+    if (!Number.isFinite(ratio)) return 0.5;
+    return Math.max(0.2, Math.min(0.8, ratio));
+  }
+
+  function splitPaneBounds(): { min: number; max: number } {
+    const min = Math.min(minSplitPaneWidth, Math.max(0, splitContentWidth / 2));
+    return {
+      min,
+      max: Math.max(min, splitContentWidth - min),
+    };
+  }
+
+  function clampSplitPaneWidth(width: number): number {
+    const bounds = splitPaneBounds();
+    return Math.max(bounds.min, Math.min(bounds.max, width));
+  }
+
+  function handleSplitResizeStart(): void {
+    splitResizeStartWidth = splitConversationWidth;
+  }
+
+  function splitWidthFromResize(event: SplitResizeEvent): number {
+    return clampSplitPaneWidth(splitResizeStartWidth + event.deltaX);
+  }
+
+  function handleSplitResize(event: SplitResizeEvent): void {
+    dragSplitWidth = splitWidthFromResize(event);
+  }
+
+  function handleSplitResizeEnd(event: SplitResizeEvent): void {
+    const finalWidth = splitWidthFromResize(event);
+    const finalRatio =
+      splitContentWidth > 0 ? clampSplitRatio(finalWidth / splitContentWidth) : 0.5;
+    committedSplitRatio = finalRatio;
+    dragSplitWidth = null;
+    safeSetItem(splitViewRatioStorageKey, finalRatio.toFixed(4));
   }
 
   function filesScrollKey(): string | null {
@@ -149,9 +208,7 @@
     }
     if (selectedPR === null) return;
     navigate(
-      tab === "files"
-        ? buildPullRequestFilesRoute(selectedPR)
-        : buildPullRequestRoute(selectedPR),
+      tab === "files" ? buildPullRequestFilesRoute(selectedPR) : buildPullRequestRoute(selectedPR),
     );
   }
 
@@ -166,13 +223,16 @@
     detail: PullDetailResponse | null,
     ref: PullRequestRouteRef | null,
   ): boolean {
-    return !!detail && !!ref
-      && detail.repo_owner === ref.owner
-      && detail.repo_name === ref.name
-      && detail.merge_request.Number === ref.number
-      && canonicalProvider(detail.repo?.provider ?? "") === canonicalProvider(ref.provider)
-      && detail.repo?.platform_host === ref.platformHost
-      && detail.repo?.repo_path === ref.repoPath;
+    return (
+      !!detail &&
+      !!ref &&
+      detail.repo_owner === ref.owner &&
+      detail.repo_name === ref.name &&
+      detail.merge_request.Number === ref.number &&
+      canonicalProvider(detail.repo?.provider ?? "") === canonicalProvider(ref.provider) &&
+      detail.repo?.platform_host === ref.platformHost &&
+      detail.repo?.repo_path === ref.repoPath
+    );
   }
 
   const selectedDetail = $derived.by(() => {
@@ -185,17 +245,12 @@
     const ref = selectedPR;
     untrack(() => {
       if (detailMatchesSelected(detailStore.getDetail(), ref)) return;
-      void detailStore.loadDetail(
-        ref.owner,
-        ref.name,
-        ref.number,
-        {
-          sync: false,
-          provider: ref.provider,
-          platformHost: ref.platformHost,
-          repoPath: ref.repoPath,
-        },
-      );
+      void detailStore.loadDetail(ref.owner, ref.name, ref.number, {
+        sync: false,
+        provider: ref.provider,
+        platformHost: ref.platformHost,
+        repoPath: ref.repoPath,
+      });
     });
   });
 
@@ -232,11 +287,7 @@
   mainEmpty={selectedPR === null}
 >
   {#snippet sidebar()}
-    <PullList
-      getDetailTab={() => detailTab}
-      showSelectedDiffSidebar={false}
-      {sidebarWidth}
-    />
+    <PullList getDetailTab={() => detailTab} showSelectedDiffSidebar={false} {sidebarWidth} />
   {/snippet}
 
   {#if selectedPR !== null}
@@ -271,7 +322,11 @@
 
       {#if splitViewActive}
         <div class="detail-split-layout">
-          <section class="detail-split-pane" aria-label="Conversation">
+          <section
+            class="detail-split-pane detail-split-pane--conversation"
+            aria-label="Conversation"
+            style:flex-basis={`${Math.round(splitConversationWidth)}px`}
+          >
             <PullDetail
               owner={selectedPR.owner}
               name={selectedPR.name}
@@ -286,6 +341,13 @@
               onStackMemberNavigate={handleStackMemberNavigate}
             />
           </section>
+          <SplitResizeHandle
+            class="detail-split-resize-handle"
+            ariaLabel="Resize PR split view"
+            onResizeStart={handleSplitResizeStart}
+            onResize={handleSplitResize}
+            onResizeEnd={handleSplitResizeEnd}
+          />
           <section class="detail-split-pane detail-split-pane--files" aria-label="Files changed">
             {#key `${selectedPR.provider}/${selectedPR.platformHost ?? ""}/${selectedPR.repoPath}/${selectedPR.number}`}
               <DiffFilesLayout
@@ -339,9 +401,7 @@
   {:else}
     <div class="placeholder-content">
       <p class="placeholder-text">Select a PR</p>
-      <p class="placeholder-hint">
-        j/k to navigate &middot; 1/2 to switch views
-      </p>
+      <p class="placeholder-hint">j/k to navigate &middot; 1/2 to switch views</p>
     </div>
   {/if}
 </CollapsibleResizableSidebar>
@@ -387,7 +447,9 @@
     padding: 8px 16px;
     color: var(--text-secondary);
     border-bottom: 2px solid transparent;
-    transition: color 0.1s, border-color 0.1s;
+    transition:
+      color 0.1s,
+      border-color 0.1s;
   }
 
   .detail-tab:hover {
@@ -430,8 +492,7 @@
   }
 
   .detail-split-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    display: flex;
     flex: 1;
     min-height: 0;
     min-width: 0;
@@ -445,8 +506,16 @@
     overflow: hidden;
   }
 
+  .detail-split-pane--conversation {
+    flex: 0 0 auto;
+  }
+
   .detail-split-pane--files {
-    border-left: 1px solid var(--border-default);
+    flex: 1 1 0;
+  }
+
+  :global(.detail-split-resize-handle) {
+    background: var(--border-default);
   }
 
   .detail-split-pane :global(.pull-detail-content) {

--- a/packages/ui/src/views/PRListView.test.ts
+++ b/packages/ui/src/views/PRListView.test.ts
@@ -44,6 +44,20 @@ class ResizeObserverMock {
   disconnect(): void {}
 }
 
+function mockElementRect(): DOMRect {
+  return {
+    width: observedWidth.value,
+    height: 1000,
+    x: 0,
+    y: 0,
+    top: 0,
+    right: observedWidth.value,
+    bottom: 1000,
+    left: 0,
+    toJSON: () => ({}),
+  };
+}
+
 function renderPRListView(detailTab: "conversation" | "files" = "conversation") {
   const detailStore = {
     getDetail: () => null,
@@ -78,10 +92,12 @@ describe("PRListView split view", () => {
     localStorage.clear();
     observedWidth.value = minSplitViewWidth;
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(mockElementRect);
   });
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -111,5 +127,36 @@ describe("PRListView split view", () => {
     expect(screen.getByTestId("pull-detail")).toBeTruthy();
     expect(screen.getByTestId("diff-files")).toBeTruthy();
     expect(localStorage.getItem("pr-detail-split-view")).toBe("1");
+  });
+
+  it("lets users resize wide split view panes", async () => {
+    observedWidth.value = 2200;
+
+    const { container } = renderPRListView();
+    await tick();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Split view" }));
+    await tick();
+
+    const conversationPane = container.querySelector<HTMLElement>(
+      ".detail-split-pane--conversation",
+    );
+    expect(conversationPane).not.toBeNull();
+    expect(conversationPane!.style.flexBasis).toBe("1098px");
+
+    const resizeHandle = screen.getByRole("button", {
+      name: "Resize PR split view",
+    });
+    await fireEvent.mouseDown(resizeHandle, { clientX: 100 });
+    await fireEvent.mouseMove(window, { clientX: 340 });
+    await tick();
+
+    expect(conversationPane!.style.flexBasis).toBe("1338px");
+
+    await fireEvent.mouseUp(window, { clientX: 340 });
+    await tick();
+
+    expect(conversationPane!.style.flexBasis).toBe("1338px");
+    expect(localStorage.getItem("pr-detail-split-ratio")).toBe("0.6093");
   });
 });


### PR DESCRIPTION
- Add a draggable center handle between Conversation and Files changed in wide PR split view.
- Persist the browser-local split ratio and clamp panes so both sides remain usable.
- Extend split-view coverage for component state and browser drag behavior.