### PR TITLE
fix: hide sidebar shortcut hint without a target

### DIFF
--- a/frontend/src/lib/components/keyboard/Cheatsheet.svelte
+++ b/frontend/src/lib/components/keyboard/Cheatsheet.svelte
@@ -13,6 +13,7 @@
     getAllActions,
     getAllCheatsheetEntries,
   } from "../../stores/keyboard/registry.svelte.js";
+  import { isActionVisible } from "../../stores/keyboard/visibility.js";
   import type {
     Action,
     CheatsheetEntry,
@@ -46,7 +47,7 @@
   // unit tests drive grouping without standing up the full app context.
   const visibleActions = $derived<Action[]>(
     stores
-      ? getAllActions().filter((a) => a.when(buildContext(stores)))
+      ? getAllActions().filter((a) => isActionVisible(a, buildContext(stores)))
       : getAllActions(),
   );
 

--- a/frontend/src/lib/components/keyboard/Palette.svelte
+++ b/frontend/src/lib/components/keyboard/Palette.svelte
@@ -18,6 +18,7 @@
   import { buildContext } from "../../stores/keyboard/context.svelte.js";
   import { handleCommandResult } from "../../stores/keyboard/dispatch.svelte.js";
   import { getAllActions } from "../../stores/keyboard/registry.svelte.js";
+  import { isActionVisible } from "../../stores/keyboard/visibility.js";
   import {
     groupResults,
     parsePaletteQuery,
@@ -70,7 +71,7 @@
       return getAllActions();
     }
     const ctx = buildContext(stores);
-    return getAllActions().filter((a) => a.when(ctx));
+    return getAllActions().filter((a) => isActionVisible(a, ctx));
   });
   const grouped = $derived(
     groupResults({

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getStores, KbdBadge, SelectDropdown } from "@middleman/ui";
+  import { getStores, SelectDropdown } from "@middleman/ui";
   import {
     getBasePath,
     getPage,
@@ -161,7 +161,6 @@
           strokeWidth="1.5"
           aria-hidden="true"
         />
-        <KbdBadge binding={{ key: "[", ctrlOrMeta: true }} />
       </HeaderIconButton>
     {/if}
     <span class="brand">

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -258,6 +258,16 @@ describe("AppHeader", () => {
     expect(workspaceOptions[0]?.getAttribute("aria-selected")).toBe("true");
   });
 
+  it("does not show the collapsed sidebar shortcut hint on Activity", () => {
+    initTheme();
+    navigate("/");
+    setSidebarCollapsed(true);
+    const { container } = render(AppHeader);
+
+    expect(container.querySelector("button[title='Expand sidebar']")).toBeTruthy();
+    expect(container.querySelector("kbd[aria-label]")).toBeNull();
+  });
+
   it("opens selected Activity PR in PRs tab with files tab preserved", async () => {
     initTheme();
     navigate("/?selected=pr:1&provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&selected_tab=files");

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -156,4 +156,35 @@ describe("defaultActions", () => {
     expect(cheatsheet!.when(ctx("pulls"))).toBe(true);
     expect(cheatsheet!.when(ctx("issues"))).toBe(true);
   });
+
+  it("sidebar.toggle only fires on pages with a sidebar target", () => {
+    const action = defaultActions.find((a) => a.id === "sidebar.toggle");
+    expect(action).toBeDefined();
+
+    expect(action!.when(ctx("activity"))).toBe(false);
+    expect(action!.when(ctx("repos"))).toBe(false);
+    expect(
+      action!.when(
+        ctx("pulls", {
+          route: { page: "pulls", view: "list" } as never,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      action!.when(
+        ctx("pulls", {
+          route: { page: "pulls", view: "board" } as never,
+        }),
+      ),
+    ).toBe(false);
+    expect(action!.when(ctx("issues"))).toBe(true);
+    expect(action!.when(ctx("workspaces"))).toBe(true);
+    expect(
+      action!.when(
+        ctx("terminal", {
+          route: { page: "terminal", workspaceId: "1" } as never,
+        }),
+      ),
+    ).toBe(true);
+  });
 });

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -16,6 +16,7 @@ function ctx(page: Context["page"], overrides: Partial<Context> = {}): Context {
     selectedIssue: null,
     isDiffView: false,
     detailTab: "conversation",
+    sidebarTargetAvailable: true,
     ...overrides,
   };
 }
@@ -196,6 +197,15 @@ describe("defaultActions", () => {
       }),
     );
     expect(isSidebarCollapsed()).toBe(true);
+    setSidebarCollapsed(false);
+    const compactPulls = ctx("pulls", {
+      route: { page: "pulls", view: "list" } as never,
+      sidebarTargetAvailable: false,
+    });
+    expect(action!.when(compactPulls)).toBe(true);
+    expect(visible(compactPulls)).toBe(false);
+    action!.handler(compactPulls);
+    expect(isSidebarCollapsed()).toBe(false);
     expect(
       action!.when(
         ctx("pulls", {

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
 
 import { defaultActions, setStoreInstances } from "./actions.js";
+import { isSidebarCollapsed, setSidebarCollapsed } from "../sidebar.svelte.js";
 import {
   OPEN_LABEL_PICKER_EVENT,
   type OpenLabelPickerDetail,
@@ -38,6 +39,10 @@ const selected = {
 };
 
 describe("defaultActions", () => {
+  afterEach(() => {
+    setSidebarCollapsed(false);
+  });
+
   it("includes the migrated globals", () => {
     const ids = defaultActions.map((a) => a.id);
     expect(ids).toEqual(
@@ -157,12 +162,20 @@ describe("defaultActions", () => {
     expect(cheatsheet!.when(ctx("issues"))).toBe(true);
   });
 
-  it("sidebar.toggle only fires on pages with a sidebar target", () => {
+  it("sidebar.toggle reserves the chord everywhere but only toggles pages with a sidebar target", () => {
     const action = defaultActions.find((a) => a.id === "sidebar.toggle");
     expect(action).toBeDefined();
 
-    expect(action!.when(ctx("activity"))).toBe(false);
-    expect(action!.when(ctx("repos"))).toBe(false);
+    const visible = action!.visible ?? action!.when;
+
+    expect(action!.when(ctx("activity"))).toBe(true);
+    expect(visible(ctx("activity"))).toBe(false);
+    setSidebarCollapsed(false);
+    action!.handler(ctx("activity"));
+    expect(isSidebarCollapsed()).toBe(false);
+
+    expect(action!.when(ctx("repos"))).toBe(true);
+    expect(visible(ctx("repos"))).toBe(false);
     expect(
       action!.when(
         ctx("pulls", {
@@ -171,16 +184,45 @@ describe("defaultActions", () => {
       ),
     ).toBe(true);
     expect(
+      visible(
+        ctx("pulls", {
+          route: { page: "pulls", view: "list" } as never,
+        }),
+      ),
+    ).toBe(true);
+    action!.handler(
+      ctx("pulls", {
+        route: { page: "pulls", view: "list" } as never,
+      }),
+    );
+    expect(isSidebarCollapsed()).toBe(true);
+    expect(
       action!.when(
+        ctx("pulls", {
+          route: { page: "pulls", view: "board" } as never,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      visible(
         ctx("pulls", {
           route: { page: "pulls", view: "board" } as never,
         }),
       ),
     ).toBe(false);
     expect(action!.when(ctx("issues"))).toBe(true);
+    expect(visible(ctx("issues"))).toBe(true);
     expect(action!.when(ctx("workspaces"))).toBe(true);
+    expect(visible(ctx("workspaces"))).toBe(true);
     expect(
       action!.when(
+        ctx("terminal", {
+          route: { page: "terminal", workspaceId: "1" } as never,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      visible(
         ctx("terminal", {
           route: { page: "terminal", workspaceId: "1" } as never,
         }),

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -33,6 +33,19 @@ const onPullsListNotBoard = (ctx: Context): boolean => ctx.page === "pulls" && !
 
 const onIssuesList = (ctx: Context): boolean => ctx.page === "issues";
 
+function hasSidebarShortcutTarget(ctx: Context): boolean {
+  switch (ctx.route.page) {
+    case "pulls":
+      return ctx.route.view === "list";
+    case "issues":
+    case "workspaces":
+    case "terminal":
+      return true;
+    default:
+      return false;
+  }
+}
+
 type LabelEditableSelection = Omit<OpenLabelPickerDetail, "itemType">;
 
 type LabelEditableDetail = {
@@ -243,7 +256,7 @@ export const defaultActions: Action[] = [
     scope: "global",
     binding: { key: "[", ctrlOrMeta: true },
     priority: 0,
-    when: () => isSidebarToggleEnabled(),
+    when: (ctx) => isSidebarToggleEnabled() && hasSidebarShortcutTarget(ctx),
     handler: () => toggleSidebar(),
   },
   {

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -256,8 +256,11 @@ export const defaultActions: Action[] = [
     scope: "global",
     binding: { key: "[", ctrlOrMeta: true },
     priority: 0,
-    when: (ctx) => isSidebarToggleEnabled() && hasSidebarShortcutTarget(ctx),
-    handler: () => toggleSidebar(),
+    when: () => isSidebarToggleEnabled(),
+    visible: (ctx) => isSidebarToggleEnabled() && hasSidebarShortcutTarget(ctx),
+    handler: (ctx) => {
+      if (hasSidebarShortcutTarget(ctx)) toggleSidebar();
+    },
   },
   {
     id: "palette.open",

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -34,6 +34,7 @@ const onPullsListNotBoard = (ctx: Context): boolean => ctx.page === "pulls" && !
 const onIssuesList = (ctx: Context): boolean => ctx.page === "issues";
 
 function hasSidebarShortcutTarget(ctx: Context): boolean {
+  if (!ctx.sidebarTargetAvailable) return false;
   switch (ctx.route.page) {
     case "pulls":
       return ctx.route.view === "list";

--- a/frontend/src/lib/stores/keyboard/context.svelte.ts
+++ b/frontend/src/lib/stores/keyboard/context.svelte.ts
@@ -1,4 +1,4 @@
-import { getRoute, getPage, getDetailTab, isDiffView, getSelectedPRFromRoute } from "../router.svelte.js";
+import { getRoute, getPage, getDetailTab, isDiffView, getSelectedPRFromRoute, type Route } from "../router.svelte.js";
 import type { Context } from "./types.js";
 import type { PullSelection } from "@middleman/ui/stores/pulls";
 import type { IssueSelection } from "@middleman/ui/stores/issues";
@@ -8,10 +8,16 @@ interface SelectionSources {
   issues: { getSelectedIssue: () => IssueSelection | null };
 }
 
+function sidebarTargetAvailable(route: Route): boolean {
+  if (route.page !== "pulls" && route.page !== "issues") return true;
+  return document.querySelector(".sidebar") !== null;
+}
+
 export function buildContext(stores: SelectionSources): Context {
+  const route = getRoute();
   return {
     page: getPage(),
-    route: getRoute(),
+    route,
     // Mirror App.svelte's render path: route-derived selection wins so PR
     // detail navigation via deep-link or back/forward keeps actions enabled
     // before the pulls store has hydrated.
@@ -19,5 +25,6 @@ export function buildContext(stores: SelectionSources): Context {
     selectedIssue: stores.issues.getSelectedIssue(),
     isDiffView: isDiffView(),
     detailTab: getDetailTab(),
+    sidebarTargetAvailable: sidebarTargetAvailable(route),
   };
 }

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
@@ -16,6 +16,7 @@ const ctx: Context = {
   selectedIssue: null,
   isDiffView: false,
   detailTab: "conversation",
+  sidebarTargetAvailable: true,
 };
 
 const event = (init: Partial<KeyboardEvent>) =>

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { dispatchKeydown } from "./dispatch.svelte.js";
+import { defaultActions } from "./actions.js";
 import { registerScopedActions, resetRegistry } from "./registry.svelte.js";
+import { isSidebarCollapsed, setSidebarCollapsed } from "../sidebar.svelte.js";
 import { pushModalFrame, resetModalStack } from "@middleman/ui/stores/keyboard/modal-stack";
 import type { Action, Context } from "./types.js";
 
@@ -20,6 +22,10 @@ const event = (init: Partial<KeyboardEvent>) =>
   Object.assign(new KeyboardEvent("keydown", init), {
     preventDefault: vi.fn(),
   });
+
+afterEach(() => {
+  setSidebarCollapsed(false);
+});
 
 describe("dispatchKeydown — global registry", () => {
   beforeEach(() => {
@@ -59,6 +65,21 @@ describe("dispatchKeydown — global registry", () => {
     registerScopedActions("test", [a]);
     dispatchKeydown(event({ key: "j" }), () => ctx);
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("reserves Cmd+[ on pages where the sidebar command is hidden", () => {
+    registerScopedActions("defaults", defaultActions);
+    setSidebarCollapsed(false);
+    const e = event({ key: "[", metaKey: true });
+
+    dispatchKeydown(e, () => ({
+      ...ctx,
+      page: "activity",
+      route: { page: "activity" } as never,
+    }));
+
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(isSidebarCollapsed()).toBe(false);
   });
 });
 

--- a/frontend/src/lib/stores/keyboard/types.ts
+++ b/frontend/src/lib/stores/keyboard/types.ts
@@ -16,6 +16,7 @@ export interface Context {
   selectedIssue: IssueSelection | null;
   isDiffView: boolean;
   detailTab: DetailTab;
+  sidebarTargetAvailable: boolean;
 }
 
 export interface PreviewBlock {

--- a/frontend/src/lib/stores/keyboard/types.ts
+++ b/frontend/src/lib/stores/keyboard/types.ts
@@ -32,6 +32,7 @@ export interface Action {
   binding: KeySpec | KeySpec[] | null;
   priority: number;
   when: (ctx: Context) => boolean;
+  visible?: (ctx: Context) => boolean;
   handler: (ctx: Context) => void | Promise<void>;
   preview?: (ctx: Context) => PreviewBlock;
 }

--- a/frontend/src/lib/stores/keyboard/visibility.ts
+++ b/frontend/src/lib/stores/keyboard/visibility.ts
@@ -1,0 +1,5 @@
+import type { Action, Context } from "./types.js";
+
+export function isActionVisible(action: Action, ctx: Context): boolean {
+  return (action.visible ?? action.when)(ctx);
+}

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -277,6 +277,11 @@ test.describe("CI dropdown", () => {
       });
       await expect(showMore).toBeVisible();
       await showMore.evaluate((button: HTMLElement) => button.click());
+      await expect(
+        panel.getByRole("button", {
+          name: /Show fewer passed/i,
+        }),
+      ).toBeVisible();
 
       const passedRowsAfter = panel.locator(".ci-section-passed .ci-row");
       await expect(passedRowsAfter).toHaveCount(12);

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2628,14 +2628,16 @@ test.describe("diff view (git-backed)", () => {
       const cacheFile = page.locator('[data-file-path="internal/cache.go"]');
       await cacheFile.scrollIntoViewIfNeeded();
       await selectPierreReviewLine(cacheFile, 1, "right");
-      await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
+      const rightComposer = page.getByPlaceholder("Leave a comment");
+      await expect(rightComposer).toBeVisible();
+      await expect(rightComposer).toBeFocused();
       await expectPierreDiffFirstVisible(cacheFile, diffAdditionsSelector);
       const cacheContentBox = await cacheFile.locator(".file-content").boundingBox();
       const composerBox = await cacheFile.locator(".inline-composer").boundingBox();
       expect(cacheContentBox).not.toBeNull();
       expect(composerBox).not.toBeNull();
       expect(composerBox!.x + composerBox!.width).toBeLessThanOrEqual(cacheContentBox!.x + cacheContentBox!.width + 1);
-      await page.getByPlaceholder("Leave a comment").fill("Right-side cache note");
+      await rightComposer.fill("Right-side cache note");
       await page.getByRole("button", { name: "Add comment" }).click();
       await expect(
         page.locator(".inline-draft-comment", {
@@ -2646,8 +2648,10 @@ test.describe("diff view (git-backed)", () => {
       const configFile = page.locator('[data-file-path="config.yaml"]');
       await configFile.scrollIntoViewIfNeeded();
       await selectPierreReviewLine(configFile, 1, "left");
-      await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
-      await page.getByPlaceholder("Leave a comment").fill("Left-side config note");
+      const leftComposer = page.getByPlaceholder("Leave a comment");
+      await expect(leftComposer).toBeVisible();
+      await expect(leftComposer).toBeFocused();
+      await leftComposer.fill("Left-side config note");
       await page.getByRole("button", { name: "Add comment" }).click();
       await expect(
         page.locator(".inline-draft-comment", {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -437,13 +437,17 @@ function treeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: s
   return pageOrLocator.locator(`.diff-file-tree [data-item-path="${cssString(path)}"]`);
 }
 
+async function clickVisibleTarget(target: Locator): Promise<void> {
+  await expect(target).toBeVisible({ timeout: 10_000 });
+  await target.scrollIntoViewIfNeeded();
+  const box = await target.boundingBox();
+  expect(box).not.toBeNull();
+  await target.page().mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+}
+
 async function clickTreeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: string): Promise<void> {
   const item = treeFileItem(pageOrLocator, path);
-  await expect(item).toBeVisible();
-  await item.scrollIntoViewIfNeeded();
-  await item.click({ timeout: 2_000 }).catch(async () => {
-    await item.evaluate((node) => (node as HTMLElement).click());
-  });
+  await clickVisibleTarget(item);
   await expect(item).toHaveAttribute("aria-selected", "true");
 }
 
@@ -596,8 +600,7 @@ async function clickPierreContextExpander(
     .filter({ visible: true })
     .nth(separatorIndex);
   const expander = separator.locator(buttonSelector).filter({ visible: true }).first();
-  await expect(expander).toBeVisible();
-  await expander.evaluate((button: HTMLElement) => button.click());
+  await clickVisibleTarget(expander);
 }
 
 async function expectPierreDarkBackgroundMatchesAppSurface(file: ReturnType<Page["locator"]>) {
@@ -920,7 +923,7 @@ async function selectPierreReviewLine(file: Locator, line: number, side: "left" 
   ].join(",");
   const target = file.locator(`.pierre-diff ${selector}`).first();
   await expect(target).toBeVisible({ timeout: 10_000 });
-  await target.locator("[data-middleman-line-comment-button]").click();
+  await clickVisibleTarget(target.locator("[data-middleman-line-comment-button]"));
 }
 
 // --- Functional tests ---

--- a/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
+++ b/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
@@ -23,4 +23,21 @@ test.describe("migrated global shortcuts", () => {
     await page.keyboard.press("Meta+BracketLeft");
     await expect(sidebar).toHaveAttribute("data-collapsed", (!wasCollapsed).toString());
   });
+
+  test("Cmd+[ stays inactive on Activity where no sidebar target exists", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("middleman-sidebar", "collapsed");
+    });
+    await page.goto("/");
+
+    const expandButton = page.getByRole("button", {
+      name: "Expand sidebar",
+    });
+    await expect(expandButton).toBeVisible();
+    await expect(page.locator("header kbd[aria-label$='-[']")).toHaveCount(0);
+
+    await page.keyboard.press("Meta+BracketLeft");
+
+    await expect(expandButton).toBeVisible();
+  });
 });

--- a/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
+++ b/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
@@ -35,6 +35,23 @@ test.describe("migrated global shortcuts", () => {
     });
     await expect(expandButton).toBeVisible();
     await expect(page.locator("header kbd[aria-label$='-[']")).toHaveCount(0);
+
+    await page.locator("main.app-main").click();
+    await page.keyboard.press("Meta+K");
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible();
+    await expect(palette.getByText("Toggle sidebar", { exact: true })).toHaveCount(0);
+    await page.keyboard.press("Escape");
+    await expect(palette).toBeHidden();
+
+    await page.locator("main.app-main").click();
+    await page.keyboard.press("Shift+/");
+    const cheatsheet = page.getByRole("dialog", { name: "Keyboard shortcuts" });
+    await expect(cheatsheet).toBeVisible();
+    await expect(cheatsheet.getByText("Toggle sidebar", { exact: true })).toHaveCount(0);
+    await page.keyboard.press("Escape");
+    await expect(cheatsheet).toBeHidden();
+
     await page.evaluate(() => {
       const state = window as Window & {
         __middleman_last_bracket_default_prevented?: boolean | null;

--- a/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
+++ b/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
@@ -24,7 +24,7 @@ test.describe("migrated global shortcuts", () => {
     await expect(sidebar).toHaveAttribute("data-collapsed", (!wasCollapsed).toString());
   });
 
-  test("Cmd+[ stays inactive on Activity where no sidebar target exists", async ({ page }) => {
+  test("Cmd+[ is reserved on Activity without toggling the sidebar", async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem("middleman-sidebar", "collapsed");
     });
@@ -35,9 +35,32 @@ test.describe("migrated global shortcuts", () => {
     });
     await expect(expandButton).toBeVisible();
     await expect(page.locator("header kbd[aria-label$='-[']")).toHaveCount(0);
+    await page.evaluate(() => {
+      const state = window as Window & {
+        __middleman_last_bracket_default_prevented?: boolean | null;
+      };
+      state.__middleman_last_bracket_default_prevented = null;
+      window.addEventListener("keydown", (event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === "[") {
+          state.__middleman_last_bracket_default_prevented = event.defaultPrevented;
+        }
+      });
+    });
 
     await page.keyboard.press("Meta+BracketLeft");
 
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as Window & {
+                __middleman_last_bracket_default_prevented?: boolean | null;
+              }
+            ).__middleman_last_bracket_default_prevented,
+        ),
+      )
+      .toBe(true);
     await expect(expandButton).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
+++ b/frontend/tests/e2e/keyboard-shortcuts-migration.spec.ts
@@ -63,4 +63,39 @@ test.describe("migrated global shortcuts", () => {
       .toBe(true);
     await expect(expandButton).toBeVisible();
   });
+
+  test("Cmd+[ is reserved on compact PR list without toggling persisted sidebar state", async ({ page }) => {
+    await page.setViewportSize({ width: 480, height: 800 });
+    await page.goto("/pulls");
+
+    await expect(page.locator(".sidebar")).toHaveCount(0);
+    await page.evaluate(() => {
+      localStorage.removeItem("middleman-sidebar");
+      const state = window as Window & {
+        __middleman_last_bracket_default_prevented?: boolean | null;
+      };
+      state.__middleman_last_bracket_default_prevented = null;
+      window.addEventListener("keydown", (event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === "[") {
+          state.__middleman_last_bracket_default_prevented = event.defaultPrevented;
+        }
+      });
+    });
+
+    await page.keyboard.press("Meta+BracketLeft");
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as Window & {
+                __middleman_last_bracket_default_prevented?: boolean | null;
+              }
+            ).__middleman_last_bracket_default_prevented,
+        ),
+      )
+      .toBe(true);
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("middleman-sidebar"))).toBeNull();
+  });
 });

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -463,7 +463,11 @@ describe("DiffFile", () => {
     });
 
     await clickLineCommentButton(2, "right");
-    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+    const textarea = screen.getByPlaceholderText("Leave a comment");
+    expect(textarea).toBeTruthy();
+    await waitFor(() => {
+      expect(textarea).toBe(document.activeElement);
+    });
     await waitFor(() => {
       expect(selectedPierreLines()).toHaveLength(4);
     });

--- a/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
+++ b/packages/ui/src/components/diff/DiffInlineCommentComposer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import SendIcon from "@lucide/svelte/icons/send";
   import XIcon from "@lucide/svelte/icons/x";
-  import { onMount, tick } from "svelte";
+  import { tick } from "svelte";
   import type { DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
   import { getStores } from "../../context.js";
   import ActionButton from "../shared/ActionButton.svelte";
@@ -20,16 +20,42 @@
   const submitting = $derived(diffReviewDraft.isSubmitting());
   const error = $derived(diffReviewDraft.getError());
 
-  onMount(() => {
+  function setupTextarea(node: HTMLTextAreaElement) {
+    textareaEl = node;
+    let destroyed = false;
+    let focusFrame = 0;
+    let focusTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    function focusTextarea(): void {
+      if (destroyed || !node.isConnected || node.disabled) return;
+      node.focus({ preventScroll: true });
+    }
+
     void tick().then(() => {
-      textareaEl?.focus({ preventScroll: true });
+      focusTextarea();
       scheduleAutosizeTextarea();
+      focusFrame = requestAnimationFrame(() => {
+        focusFrame = requestAnimationFrame(() => {
+          focusFrame = 0;
+          focusTextarea();
+        });
+      });
+      focusTimeout = setTimeout(() => {
+        focusTimeout = undefined;
+        focusTextarea();
+      }, 50);
     });
 
-    return () => {
-      if (autosizeFrame) cancelAnimationFrame(autosizeFrame);
+    return {
+      destroy(): void {
+        destroyed = true;
+        if (textareaEl === node) textareaEl = undefined;
+        if (focusFrame) cancelAnimationFrame(focusFrame);
+        if (focusTimeout !== undefined) clearTimeout(focusTimeout);
+        if (autosizeFrame) cancelAnimationFrame(autosizeFrame);
+      },
     };
-  });
+  }
 
   function autosizeTextarea(): void {
     if (!textareaEl) return;
@@ -63,6 +89,7 @@
 
 <div class="inline-composer">
   <textarea
+    use:setupTextarea
     bind:this={textareaEl}
     bind:value={body}
     placeholder="Leave a comment"

--- a/packages/ui/src/components/diff/DiffReviewThreadInlineComment.svelte
+++ b/packages/ui/src/components/diff/DiffReviewThreadInlineComment.svelte
@@ -2,7 +2,7 @@
   import MessageSquareReplyIcon from "@lucide/svelte/icons/message-square-reply";
   import SendIcon from "@lucide/svelte/icons/send";
   import XIcon from "@lucide/svelte/icons/x";
-  import { onMount, tick } from "svelte";
+  import { tick } from "svelte";
   import type { ReviewThread } from "./review-thread-context.js";
   import { reviewThreadLineLabel } from "./review-thread-context.js";
   import ActionButton from "../shared/ActionButton.svelte";
@@ -25,20 +25,19 @@
   let replyBody = $state("");
   let submitting = $state(false);
   let error = $state<string | null>(null);
-  let threadEl: HTMLDivElement | undefined = $state();
   let textareaEl: HTMLTextAreaElement | undefined = $state();
   let panelWidth = $state<string | undefined>();
 
-  onMount(() => {
+  function setupThreadLayout(node: HTMLDivElement): { destroy: () => void } {
     let animationFrame = 0;
     const scheduleLayout = () => {
       if (animationFrame) cancelAnimationFrame(animationFrame);
       animationFrame = requestAnimationFrame(() => {
         animationFrame = 0;
-        updatePanelWidth();
+        updatePanelWidth(node);
       });
     };
-    const container = threadEl ? layoutContainer(threadEl) : null;
+    const container = layoutContainer(node);
     const resizeObserver = typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(scheduleLayout)
       : undefined;
@@ -46,17 +45,39 @@
       container.addEventListener("scroll", scheduleLayout, { passive: true });
       resizeObserver?.observe(container);
     }
-    if (threadEl) resizeObserver?.observe(threadEl);
+    resizeObserver?.observe(node);
     window.addEventListener("resize", scheduleLayout);
     scheduleLayout();
 
-    return () => {
-      if (animationFrame) cancelAnimationFrame(animationFrame);
-      container?.removeEventListener("scroll", scheduleLayout);
-      window.removeEventListener("resize", scheduleLayout);
-      resizeObserver?.disconnect();
+    return {
+      destroy: () => {
+        if (animationFrame) cancelAnimationFrame(animationFrame);
+        container?.removeEventListener("scroll", scheduleLayout);
+        window.removeEventListener("resize", scheduleLayout);
+        resizeObserver?.disconnect();
+      },
     };
-  });
+  }
+
+  function updatePanelWidth(element: HTMLElement): void {
+    const container = layoutContainer(element);
+    if (!container) {
+      panelWidth = undefined;
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    const threadRect = element.getBoundingClientRect();
+    const available = Math.floor(containerRect.right - threadRect.left - 12);
+    panelWidth = available > 0 ? `${available}px` : undefined;
+  }
+
+  function layoutContainer(element: HTMLElement): HTMLElement | null {
+    const root = element.getRootNode();
+    if (root instanceof ShadowRoot && root.host instanceof HTMLElement) {
+      return root.host.closest(".file-content") ?? root.host.closest(".diff-area");
+    }
+    return element.closest(".file-content") ?? element.closest(".diff-area");
+  }
 
   function startReply(): void {
     replying = true;
@@ -90,27 +111,6 @@
       submitting = false;
     }
   }
-
-  function updatePanelWidth(): void {
-    if (!threadEl) return;
-    const container = layoutContainer(threadEl);
-    if (!container) {
-      panelWidth = undefined;
-      return;
-    }
-    const containerRect = container.getBoundingClientRect();
-    const threadRect = threadEl.getBoundingClientRect();
-    const available = Math.floor(containerRect.right - threadRect.left - 12);
-    panelWidth = available > 0 ? `${available}px` : undefined;
-  }
-
-  function layoutContainer(element: HTMLElement): HTMLElement | null {
-    const root = element.getRootNode();
-    if (root instanceof ShadowRoot && root.host instanceof HTMLElement) {
-      return root.host.closest(".file-content") ?? root.host.closest(".diff-area");
-    }
-    return element.closest(".file-content") ?? element.closest(".diff-area");
-  }
 </script>
 
 <div
@@ -118,7 +118,7 @@
   class:inline-review-thread--file-level={fileLevel}
   class:inline-review-thread--idle-reply={canReply && !thread.resolved && !replying}
   data-review-thread-id={thread.id}
-  bind:this={threadEl}
+  use:setupThreadLayout
   style:--inline-review-thread-width={panelWidth}
   tabindex="-1"
 >


### PR DESCRIPTION
- Hide the Ctrl+[ keyboard hint and command listings when the active page or compact presentation has no sidebar target.
- Keep Ctrl/Cmd+[ reserved on those pages so browser Back does not fire, without toggling persisted sidebar state.
- Keep the sidebar toggle active on pages where it can collapse or expand the sidebar, with regression coverage for Activity and compact PR lists.
- Use real Playwright click interactions in diff e2e helpers so covered or disabled targets still fail tests.
