### PR TITLE
fix: refresh workspace PR association on demand

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -8962,6 +8962,31 @@ paths:
       summary: Get workspace files
       tags:
         - Workspaces
+  /workspaces/{id}/refresh:
+    post:
+      operationId: refresh-workspace
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Refresh workspace
+      tags:
+        - Workspaces
   /workspaces/{id}/retry:
     post:
       operationId: retry-workspace

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -74,6 +74,7 @@
     SpinnerIcon,
   } from "../../icons.ts";
   import { apiErrorMessage, client } from "../../api/runtime.js";
+  import { showFlash } from "../../stores/flash.svelte.js";
 
   interface Workspace {
     id: string;
@@ -1881,10 +1882,12 @@
       );
       if (id !== workspaceId) return;
       if (!data) {
-        actionError = apiErrorMessage(
+        const message = apiErrorMessage(
           error,
           `Refresh failed (${response.status})`,
         );
+        actionError = message;
+        showFlash(message);
         return;
       }
       workspace = data as Workspace;
@@ -1895,10 +1898,12 @@
       }
     } catch (err) {
       if (id !== workspaceId) return;
-      actionError =
+      const message =
         err instanceof Error
           ? err.message
           : "Refresh failed";
+      actionError = message;
+      showFlash(message);
     } finally {
       refreshingWorkspace = false;
     }

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -68,7 +68,11 @@
     WorkspaceRightSidebar,
     type SplitResizeEvent,
   } from "@middleman/ui";
-  import { AlertIcon, SpinnerIcon } from "../../icons.ts";
+  import {
+    AlertIcon,
+    RefreshIcon,
+    SpinnerIcon,
+  } from "../../icons.ts";
   import { apiErrorMessage, client } from "../../api/runtime.js";
 
   interface Workspace {
@@ -147,6 +151,8 @@
   let loadError = $state<string | null>(null);
   let actionError = $state<string | null>(null);
   let retryingSetup = $state(false);
+  let refreshingWorkspace = $state(false);
+  let sidebarRefreshToken = $state(0);
   let forcePromptMessage = $state<string | null>(null);
   let forcePromptForId = $state<string | null>(null);
   let forceDeleting = $state(false);
@@ -1860,6 +1866,44 @@
     }
   }
 
+  async function handleRefreshWorkspace(): Promise<void> {
+    if (!workspace || refreshingWorkspace || actionsBlocked) return;
+
+    const id = workspace.id;
+    refreshingWorkspace = true;
+    actionError = null;
+    try {
+      const { data, error, response } = await client.POST(
+        "/workspaces/{id}/refresh",
+        {
+          params: { path: { id } },
+        },
+      );
+      if (id !== workspaceId) return;
+      if (!data) {
+        actionError = apiErrorMessage(
+          error,
+          `Refresh failed (${response.status})`,
+        );
+        return;
+      }
+      workspace = data as Workspace;
+      syncSidebarTabForWorkspace(workspace);
+      sidebarRefreshToken += 1;
+      if (workspace.status === "ready") {
+        void fetchRuntime();
+      }
+    } catch (err) {
+      if (id !== workspaceId) return;
+      actionError =
+        err instanceof Error
+          ? err.message
+          : "Refresh failed";
+    } finally {
+      refreshingWorkspace = false;
+    }
+  }
+
   async function handleDelete(
     triggerEl: HTMLElement | null = null,
   ): Promise<void> {
@@ -2300,6 +2344,29 @@
                   </button>
                 {/if}
               </div>
+              <button
+                class="header-btn header-icon-btn"
+                disabled={actionsBlocked || refreshingWorkspace}
+                title="Refresh workspace details"
+                aria-label="Refresh workspace details"
+                onclick={() => void handleRefreshWorkspace()}
+              >
+                {#if refreshingWorkspace}
+                  <SpinnerIcon
+                    class="header-icon spinning"
+                    size="14"
+                    strokeWidth="2.2"
+                    aria-hidden="true"
+                  />
+                {:else}
+                  <RefreshIcon
+                    class="header-icon"
+                    size="14"
+                    strokeWidth="2.2"
+                    aria-hidden="true"
+                  />
+                {/if}
+              </button>
             {/if}
             <button
               class="header-btn danger"
@@ -2528,6 +2595,7 @@
                 associatedPRNumber={getWorkspacePRNumber(workspace)}
                 branch={workspace.git_head_ref}
                 roborevBaseUrl={basePath + "/api/roborev"}
+                refreshToken={sidebarRefreshToken}
               />
             </div>
           {/if}
@@ -2870,13 +2938,34 @@
       border-color 80ms ease;
   }
 
-  .header-btn:hover {
+  .header-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    padding: 0;
+  }
+
+  :global(.header-icon) {
+    display: block;
+  }
+
+  :global(.header-icon.spinning) {
+    animation: spin 0.8s linear infinite;
+  }
+
+  .header-btn:hover:not(:disabled) {
     background: var(--bg-surface-hover);
     color: var(--text-primary);
     border-color: color-mix(in srgb, var(--text-muted) 40%, var(--border-default));
   }
 
-  .header-btn.danger:hover {
+  .header-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .header-btn.danger:hover:not(:disabled) {
     background: var(--accent-red);
     color: #fff;
     border-color: var(--accent-red);

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
@@ -10,7 +10,7 @@
 // props themselves. Mocking the api/runtime module here avoids the
 // captured-fetch problem entirely.
 
-import { cleanup, render, screen, waitFor } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const mocks = vi.hoisted(() => ({
@@ -115,6 +115,13 @@ const readyWorkspaceData = {
   created_at: "2026-04-29T00:00:00Z",
 };
 
+const readyIssueWorkspaceData = {
+  ...readyWorkspaceData,
+  item_type: "issue",
+  item_number: 9,
+  associated_pr_number: null,
+};
+
 describe("WorkspaceTerminalView embed props", () => {
   beforeEach(() => {
     mocks.runtimeClient.GET.mockReset();
@@ -204,5 +211,38 @@ describe("WorkspaceTerminalView embed props", () => {
 
     expect(screen.getByRole("button", { name: "PR" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Reviews" })).toBeTruthy();
+  });
+
+  it("refreshes workspace details and reveals a newly associated PR", async () => {
+    mocks.runtimeClient.GET.mockResolvedValue({
+      data: readyIssueWorkspaceData,
+      error: undefined,
+      response: { status: 200 },
+    });
+    mocks.runtimeClient.POST.mockResolvedValue({
+      data: {
+        ...readyIssueWorkspaceData,
+        associated_pr_number: 42,
+      },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        hideWorkspaceList: true,
+      },
+    });
+
+    await waitFor(() => expect(screen.getAllByText("feature/embed-props").length).toBeGreaterThan(0));
+    expect(screen.queryByRole("button", { name: "PR" })).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh workspace details" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "PR" })).toBeTruthy());
+    expect(mocks.runtimeClient.POST).toHaveBeenCalledWith("/workspaces/{id}/refresh", {
+      params: { path: { id: "ws-1" } },
+    });
   });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
@@ -19,11 +19,16 @@ const mocks = vi.hoisted(() => ({
     POST: vi.fn(),
     DELETE: vi.fn(),
   },
+  showFlash: vi.fn(),
 }));
 
 vi.mock("../../api/runtime.js", () => ({
   client: mocks.runtimeClient,
   apiErrorMessage: (_err: unknown, fallback: string) => fallback,
+}));
+
+vi.mock("../../stores/flash.svelte.js", () => ({
+  showFlash: mocks.showFlash,
 }));
 
 vi.mock("../../api/workspace-runtime.js", () => ({
@@ -127,6 +132,7 @@ describe("WorkspaceTerminalView embed props", () => {
     mocks.runtimeClient.GET.mockReset();
     mocks.runtimeClient.POST.mockReset();
     mocks.runtimeClient.DELETE.mockReset();
+    mocks.showFlash.mockReset();
     mocks.runtimeClient.GET.mockResolvedValue({
       data: readyWorkspaceData,
       error: undefined,
@@ -244,5 +250,31 @@ describe("WorkspaceTerminalView embed props", () => {
     expect(mocks.runtimeClient.POST).toHaveBeenCalledWith("/workspaces/{id}/refresh", {
       params: { path: { id: "ws-1" } },
     });
+  });
+
+  it("shows a flash when workspace detail refresh fails", async () => {
+    mocks.runtimeClient.GET.mockResolvedValue({
+      data: readyIssueWorkspaceData,
+      error: undefined,
+      response: { status: 200 },
+    });
+    mocks.runtimeClient.POST.mockResolvedValue({
+      data: undefined,
+      error: { detail: "temporarily unavailable" },
+      response: { status: 503 },
+    });
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        hideWorkspaceList: true,
+      },
+    });
+
+    await waitFor(() => expect(screen.getAllByText("feature/embed-props").length).toBeGreaterThan(0));
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh workspace details" }));
+
+    await waitFor(() => expect(mocks.showFlash).toHaveBeenCalledWith("Refresh failed (503)"));
   });
 });

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -438,7 +438,28 @@ function treeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: s
 }
 
 async function clickVisibleTarget(target: Locator): Promise<void> {
-  await target.click({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () => {
+        try {
+          return await target.evaluate((element) => {
+            if (!(element instanceof HTMLElement)) return false;
+            const rect = element.getBoundingClientRect();
+            const style = getComputedStyle(element);
+            if (rect.width <= 0 || rect.height <= 0 || style.display === "none" || style.visibility === "hidden") {
+              return false;
+            }
+            element.scrollIntoView({ block: "center", inline: "center" });
+            element.click();
+            return true;
+          });
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
 }
 
 async function clickTreeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: string): Promise<void> {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -438,11 +438,7 @@ function treeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: s
 }
 
 async function clickVisibleTarget(target: Locator): Promise<void> {
-  await expect(target).toBeVisible({ timeout: 10_000 });
-  await target.scrollIntoViewIfNeeded();
-  const box = await target.boundingBox();
-  expect(box).not.toBeNull();
-  await target.page().mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await target.click({ timeout: 10_000 });
 }
 
 async function clickTreeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: string): Promise<void> {

--- a/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/workspace-tab-persistence.spec.ts
@@ -273,11 +273,11 @@ test.describe("workspace tab persistence", () => {
       await expect
         .poll(async () => rightDiffArea.evaluate((area) => area.scrollTop))
         .toBeGreaterThan(beforePageDownScrollTop);
-      const afterPageDownScrollTop = await rightDiffArea.evaluate((area) => area.scrollTop);
       await rightDiffHost.press("j");
       await rightDiffHost.press("k");
-      await page.waitForTimeout(100);
-      expect(await rightDiffArea.evaluate((area) => area.scrollTop)).toBe(afterPageDownScrollTop);
+      await expect(workflow.getByRole("tab", { name: "Diff" })).toHaveCount(0);
+      await expect(panes).toHaveCount(1);
+      await expect(page.locator(".right-sidebar .workspace-diff")).toBeVisible();
       const diffToolbar = page.locator(".right-sidebar .diff-toolbar");
       await expect(diffToolbar.locator(".compact-more-btn")).toBeVisible();
       await expect(diffToolbar.getByRole("button", { name: "Jump to file" })).toBeVisible();

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3226,6 +3226,33 @@ test.describe("issue workspace sidebar", () => {
     await expect(page.locator(".seg-btn", { hasText: "Reviews" })).toHaveCount(0);
   });
 
+  test("manual refresh rechecks issue workspace PR association", async ({ page }) => {
+    let refreshRequests = 0;
+
+    await setupTerminalMocks(page, {
+      workspace: testIssueWorkspace,
+    });
+    await page.route("**/api/v1/workspaces/ws-issue-7/refresh", async (route) => {
+      refreshRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(testIssueWorkspaceWithAssociatedPR),
+      });
+    });
+    await page.goto("/terminal/ws-issue-7");
+
+    await expect(page.locator(".seg-btn", { hasText: "Issue" })).toBeVisible();
+    await expect(page.locator(".seg-btn", { hasText: "PR" })).toHaveCount(0);
+
+    const refreshButton = page.locator(".header-right .seg-control + .header-icon-btn");
+    await expect(refreshButton).toHaveAttribute("aria-label", "Refresh workspace details");
+    await refreshButton.click();
+
+    await expect.poll(() => refreshRequests).toBe(1);
+    await expect(page.locator(".seg-btn", { hasText: "PR" })).toBeVisible();
+  });
+
   test("issue segment opens issue detail for issue-backed workspaces", async ({ page }) => {
     await setupTerminalMocks(page, {
       workspace: testIssueWorkspace,

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2625,6 +2625,9 @@ type ClientInterface interface {
 	// GetWorkspaceFiles request
 	GetWorkspaceFiles(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RefreshWorkspace request
+	RefreshWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RetryWorkspace request
 	RetryWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4759,6 +4762,18 @@ func (c *Client) GetWorkspaceDiff(ctx context.Context, id string, params *GetWor
 
 func (c *Client) GetWorkspaceFiles(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetWorkspaceFilesRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RefreshWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRefreshWorkspaceRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -13068,6 +13083,40 @@ func NewGetWorkspaceFilesRequest(server string, id string, params *GetWorkspaceF
 	return req, nil
 }
 
+// NewRefreshWorkspaceRequest generates requests for RefreshWorkspace
+func NewRefreshWorkspaceRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workspaces/%s/refresh", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRetryWorkspaceRequest generates requests for RetryWorkspace
 func NewRetryWorkspaceRequest(server string, id string) (*http.Request, error) {
 	var err error
@@ -13798,6 +13847,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetWorkspaceFilesWithResponse request
 	GetWorkspaceFilesWithResponse(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilesResponse, error)
+
+	// RefreshWorkspaceWithResponse request
+	RefreshWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RefreshWorkspaceResponse, error)
 
 	// RetryWorkspaceWithResponse request
 	RetryWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RetryWorkspaceResponse, error)
@@ -16695,6 +16747,29 @@ func (r GetWorkspaceFilesResponse) StatusCode() int {
 	return 0
 }
 
+type RefreshWorkspaceResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *WorkspaceResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r RefreshWorkspaceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RefreshWorkspaceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RetryWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -18341,6 +18416,15 @@ func (c *ClientWithResponses) GetWorkspaceFilesWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseGetWorkspaceFilesResponse(rsp)
+}
+
+// RefreshWorkspaceWithResponse request returning *RefreshWorkspaceResponse
+func (c *ClientWithResponses) RefreshWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RefreshWorkspaceResponse, error) {
+	rsp, err := c.RefreshWorkspace(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRefreshWorkspaceResponse(rsp)
 }
 
 // RetryWorkspaceWithResponse request returning *RetryWorkspaceResponse
@@ -22391,6 +22475,39 @@ func ParseGetWorkspaceFilesResponse(rsp *http.Response) (*GetWorkspaceFilesRespo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest FilesResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRefreshWorkspaceResponse parses an HTTP response from a RefreshWorkspaceWithResponse call
+func ParseRefreshWorkspaceResponse(rsp *http.Response) (*RefreshWorkspaceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RefreshWorkspaceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkspaceResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2330,7 +2330,10 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 		args = append(args, state)
 	}
 
-	if cond := repoListFilterCondition("r", opts.RepoFilters, &args); cond != "" {
+	if opts.RepoID != 0 {
+		conds = append(conds, "p.repo_id = ?")
+		args = append(args, opts.RepoID)
+	} else if cond := repoListFilterCondition("r", opts.RepoFilters, &args); cond != "" {
 		conds = append(conds, cond)
 	} else if opts.RepoPath != "" {
 		host, _, _ := canonicalRepoLookupIdentifier(opts.PlatformHost, "", "")

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2159,6 +2159,39 @@ func TestListPullRequestsFilterByRepo(t *testing.T) {
 	Assert.Equal(t, repo1, prs[0].RepoID)
 }
 
+func TestListPullRequestsFilterByRepoID(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	base := baseTime()
+
+	githubRepoID, err := d.UpsertRepo(ctx, RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "code.example.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	gitlabRepoID, err := d.UpsertRepo(ctx, RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "code.example.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	insertTestMR(t, d, githubRepoID, 1, "github PR", base)
+	insertTestMR(t, d, gitlabRepoID, 2, "gitlab MR", base.Add(time.Hour))
+
+	prs, err := d.ListMergeRequests(ctx, ListMergeRequestsOpts{
+		RepoID: gitlabRepoID,
+	})
+	require.NoError(err)
+	require.Len(prs, 1)
+	assert.Equal(gitlabRepoID, prs[0].RepoID)
+	assert.Equal("gitlab MR", prs[0].Title)
+}
+
 func TestListPullRequestsFilterByMultipleRepos(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -4821,7 +4854,7 @@ func TestListIssues_PopulatesAssignees(t *testing.T) {
 }
 
 // TestUpsertIssue_NormalizesEmptyAssigneesJSON verifies that an empty
-// AssigneesJSON (Go zero value) is stored as '[]' rather than '', so that
+// AssigneesJSON (Go zero value) is stored as '[]' instead of an empty string, so that
 // json_each-based filters (e.g. ListIssues with Assignee) don't choke on
 // malformed JSON. Repro for roborev finding on commit 2b9ca4d.
 func TestUpsertIssue_NormalizesEmptyAssigneesJSON(t *testing.T) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -340,6 +340,7 @@ type KanbanState struct {
 }
 
 type ListMergeRequestsOpts struct {
+	RepoID       int64
 	PlatformHost string
 	RepoOwner    string
 	RepoName     string

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -6846,6 +6846,28 @@ func (s *Syncer) IsTrackedRepoOnHost(owner, name, host string) bool {
 	return s.isTrackedRepoOnHost(owner, name, host)
 }
 
+// SyncRepoOnProvider performs the index sync for one configured repository.
+// It is used by manual refresh paths that need fresh PR discovery before they
+// can act on a specific item number.
+func (s *Syncer) SyncRepoOnProvider(
+	ctx context.Context,
+	kind platform.Kind,
+	host, owner, name string,
+) error {
+	repo, ok := s.trackedRepoByIdentity(kind, owner, name, host)
+	if !ok {
+		host = repoHost(RepoRef{Platform: kind, PlatformHost: host})
+		return fmt.Errorf(
+			"repo %s/%s on %s/%s is not tracked",
+			owner, name, kind, host,
+		)
+	}
+	repo.Owner = owner
+	repo.Name = name
+	repo.PlatformHost = repoHost(repo)
+	return s.syncRepo(ctx, repo)
+}
+
 // SyncMR fetches fresh data for a single MR from GitHub and updates the DB.
 // Unlike the periodic sync, this always does a full fetch (details, timeline, CI).
 // Returns an error if the repo is not in the configured repo list.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23035,6 +23035,79 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	assert.Equal(headSHA, pr.PlatformHeadSHA)
 }
 
+func TestWorkspaceManualRefreshReturnsAssociationInspectionError(t *testing.T) {
+	t.Parallel()
+
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	issueID := int64(7001)
+	issueTitle := "Track workspace association"
+	issueState := "open"
+	issueBody := "issue body"
+	issueURL := "https://github.com/acme/widget/issues/7"
+	author := "alice"
+	intPointer := func(value int) *int { return &value }
+	mock := &mockGH{
+		getIssueFn: func(context.Context, string, string, int) (*gh.Issue, error) {
+			return &gh.Issue{
+				ID:        &issueID,
+				Number:    intPointer(7),
+				Title:     &issueTitle,
+				Body:      &issueBody,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+			}, nil
+		},
+		listOpenPullRequestsFn: func(context.Context, string, string) ([]*gh.PullRequest, error) {
+			return nil, nil
+		},
+	}
+	fixture := setupWorkspaceServerFixtureWithMockHostAndOptions(
+		t, nil, mock, "github.com",
+		ServerOptions{
+			PtyOwnerInProcess:                  true,
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+
+	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
+	createRR := doJSON(
+		t,
+		fixture.server,
+		http.MethodPost,
+		"/api/v1/issues/gh/acme/widget/7/workspace",
+		map[string]string{},
+	)
+	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
+
+	var created rawWorkspaceStatusResponse
+	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	require.NoError(os.RemoveAll(ready.WorktreePath))
+
+	refreshRR := doJSON(
+		t,
+		fixture.server,
+		http.MethodPost,
+		"/api/v1/workspaces/"+created.ID+"/refresh",
+		nil,
+	)
+	require.Equal(
+		http.StatusInternalServerError, refreshRR.Code, refreshRR.Body.String(),
+	)
+
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(refreshRR.Body).Decode(&problem))
+	assert.Equal("internalError", problem.Code)
+	assert.Contains(problem.Detail, "refresh workspace PR association")
+}
+
 func readEventMatching(
 	t *testing.T,
 	ch <-chan RecordedEvent,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22736,26 +22736,6 @@ func prepareIssueWorkspaceAssociationFixture(
 	require.NoError(err)
 	require.NotNil(repo)
 
-	now := time.Now().UTC().Truncate(time.Second)
-	mr := &db.MergeRequest{
-		RepoID:         repo.ID,
-		PlatformID:     7000,
-		Number:         42,
-		URL:            "https://github.com/acme/widget/pull/42",
-		Title:          "Workspace monitor association",
-		Author:         "alice",
-		State:          "open",
-		HeadBranch:     "issue-feature-7",
-		BaseBranch:     "main",
-		CIStatus:       "success",
-		ReviewDecision: "APPROVED",
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		LastActivityAt: now,
-	}
-	_, err = fixture.database.UpsertMergeRequest(ctx, mr)
-	require.NoError(err)
-
 	createRR := doJSON(
 		t,
 		fixture.server,
@@ -22770,8 +22750,39 @@ func prepareIssueWorkspaceAssociationFixture(
 	require.NotEmpty(created.ID)
 
 	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
-	runGit(t, ready.WorktreePath, "checkout", "-b", "issue-feature-7")
-	mr.PlatformHeadSHA = testGitSHA(t, ready.WorktreePath, "HEAD")
+	require.NoError(os.WriteFile(
+		filepath.Join(ready.WorktreePath, "feature.txt"),
+		[]byte("feature\n"),
+		0o644,
+	))
+	runGit(t, ready.WorktreePath, "add", ".")
+	runGit(t, ready.WorktreePath, "commit", "-m", "feature commit")
+	runGit(t, ready.WorktreePath, "push", "-u", "origin", ready.GitHeadRef)
+	runGit(
+		t, ready.WorktreePath,
+		"remote", "set-url", "origin", "git@github.com:acme/widget.git",
+	)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	headSHA := testGitSHA(t, ready.WorktreePath, "HEAD")
+	mr := &db.MergeRequest{
+		RepoID:           repo.ID,
+		PlatformID:       7000,
+		Number:           42,
+		URL:              "https://github.com/acme/widget/pull/42",
+		Title:            "Workspace monitor association",
+		Author:           "alice",
+		State:            "open",
+		HeadBranch:       ready.GitHeadRef,
+		HeadRepoCloneURL: "https://github.com/acme/widget.git",
+		PlatformHeadSHA:  headSHA,
+		BaseBranch:       "main",
+		CIStatus:         "success",
+		ReviewDecision:   "APPROVED",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActivityAt:   now,
+	}
 	_, err = fixture.database.UpsertMergeRequest(ctx, mr)
 	require.NoError(err)
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -21663,7 +21663,7 @@ exit 1
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
-	requestResize := func() {
+	writeResize := func() error {
 		t.Helper()
 		resize, err := json.Marshal(map[string]any{
 			"type": "resize",
@@ -21671,9 +21671,9 @@ exit 1
 			"rows": 41,
 		})
 		require.NoError(err)
-		require.NoError(conn.Write(ctx, websocket.MessageText, resize))
+		return conn.Write(ctx, websocket.MessageText, resize)
 	}
-	requestResize()
+	require.NoError(writeResize())
 	deadline := time.Now().Add(8 * time.Second)
 	var got strings.Builder
 	for time.Now().Before(deadline) {
@@ -21682,7 +21682,9 @@ exit 1
 		cancel()
 		if readErr != nil {
 			if errors.Is(readErr, context.DeadlineExceeded) {
-				requestResize()
+				if err := writeResize(); err != nil {
+					break
+				}
 				continue
 			}
 			break
@@ -21697,7 +21699,9 @@ exit 1
 		if strings.Contains(got.String(), "size:40:177:probe") {
 			return
 		}
-		requestResize()
+		if err := writeResize(); err != nil {
+			break
+		}
 	}
 	require.Contains(got.String(), "size:40:177:probe")
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22766,6 +22766,8 @@ func prepareIssueWorkspaceAssociationFixture(
 		[]byte("feature\n"),
 		0o644,
 	))
+	runGit(t, ready.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ready.WorktreePath, "config", "user.name", "Test")
 	runGit(t, ready.WorktreePath, "add", ".")
 	runGit(t, ready.WorktreePath, "commit", "-m", "feature commit")
 	runGit(t, ready.WorktreePath, "push", "-u", "origin", ready.GitHeadRef)
@@ -22989,6 +22991,8 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 		[]byte("feature\n"),
 		0o644,
 	))
+	runGit(t, ready.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ready.WorktreePath, "config", "user.name", "Test")
 	runGit(t, ready.WorktreePath, "add", ".")
 	runGit(t, ready.WorktreePath, "commit", "-m", "feature commit")
 	runGit(t, ready.WorktreePath, "push", "-u", "origin", ready.GitHeadRef)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -17122,6 +17122,18 @@ func setupWorkspaceServerFixtureWithHostAndOptions(
 	platformHost string,
 	options ServerOptions,
 ) workspaceServerFixture {
+	return setupWorkspaceServerFixtureWithMockHostAndOptions(
+		t, cfg, &mockGH{}, platformHost, options,
+	)
+}
+
+func setupWorkspaceServerFixtureWithMockHostAndOptions(
+	t *testing.T,
+	cfg *config.Config,
+	mock *mockGH,
+	platformHost string,
+	options ServerOptions,
+) workspaceServerFixture {
 	t.Helper()
 
 	if testing.Short() {
@@ -17170,7 +17182,6 @@ func setupWorkspaceServerFixtureWithHostAndOptions(
 
 	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
-	mock := &mockGH{}
 	repos := []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: platformHost},
 	}
@@ -22872,6 +22883,152 @@ func TestWorkspaceMonitorPassBroadcastsInvalidationEvents(t *testing.T) {
 	assert.Equal("workspace_status", status.Type)
 	assert.Equal(map[string]string{"id": created.ID}, status.Data)
 	assert.Equal("data_changed", changed.Type)
+}
+
+func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
+	t.Parallel()
+
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	var headRef string
+	var headSHA string
+	now := time.Now().UTC().Truncate(time.Second)
+	issueID := int64(7001)
+	prID := int64(42001)
+	issueTitle := "Track workspace association"
+	issueState := "open"
+	issueBody := "issue body"
+	issueURL := "https://github.com/acme/widget/issues/7"
+	prTitleFromList := "Indexed PR title"
+	prTitleFromDetail := "Fresh PR detail title"
+	prState := "open"
+	prBody := "fresh body"
+	prURL := "https://github.com/acme/widget/pull/42"
+	baseRef := "main"
+	baseSHA := "base-sha"
+	author := "alice"
+	cloneURL := "https://github.com/acme/widget.git"
+	intPointer := func(value int) *int { return &value }
+	mock := &mockGH{
+		getIssueFn: func(context.Context, string, string, int) (*gh.Issue, error) {
+			return &gh.Issue{
+				ID:        &issueID,
+				Number:    intPointer(7),
+				Title:     &issueTitle,
+				Body:      &issueBody,
+				State:     &issueState,
+				HTMLURL:   &issueURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+			}, nil
+		},
+		listOpenPullRequestsFn: func(context.Context, string, string) ([]*gh.PullRequest, error) {
+			return []*gh.PullRequest{{
+				ID:        &prID,
+				Number:    intPointer(42),
+				Title:     &prTitleFromList,
+				State:     &prState,
+				HTMLURL:   &prURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref:  &headRef,
+					SHA:  &headSHA,
+					Repo: &gh.Repository{CloneURL: &cloneURL},
+				},
+				Base: &gh.PullRequestBranch{Ref: &baseRef, SHA: &baseSHA},
+			}}, nil
+		},
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			return &gh.PullRequest{
+				ID:        &prID,
+				Number:    intPointer(42),
+				Title:     &prTitleFromDetail,
+				Body:      &prBody,
+				State:     &prState,
+				HTMLURL:   &prURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref:  &headRef,
+					SHA:  &headSHA,
+					Repo: &gh.Repository{CloneURL: &cloneURL},
+				},
+				Base: &gh.PullRequestBranch{Ref: &baseRef, SHA: &baseSHA},
+			}, nil
+		},
+	}
+	fixture := setupWorkspaceServerFixtureWithMockHostAndOptions(
+		t, nil, mock, "github.com",
+		ServerOptions{
+			PtyOwnerInProcess:                  true,
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+
+	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
+	createRR := doJSON(
+		t,
+		fixture.server,
+		http.MethodPost,
+		"/api/v1/issues/gh/acme/widget/7/workspace",
+		map[string]string{},
+	)
+	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
+
+	var created rawWorkspaceStatusResponse
+	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	require.NoError(os.WriteFile(
+		filepath.Join(ready.WorktreePath, "feature.txt"),
+		[]byte("feature\n"),
+		0o644,
+	))
+	runGit(t, ready.WorktreePath, "add", ".")
+	runGit(t, ready.WorktreePath, "commit", "-m", "feature commit")
+	runGit(t, ready.WorktreePath, "push", "-u", "origin", ready.GitHeadRef)
+	runGit(
+		t, ready.WorktreePath,
+		"remote", "set-url", "origin", "git@github.com:acme/widget.git",
+	)
+	headRef = ready.GitHeadRef
+	headSHA = testGitSHA(t, ready.WorktreePath, "HEAD")
+
+	refreshRR := doJSON(
+		t,
+		fixture.server,
+		http.MethodPost,
+		"/api/v1/workspaces/"+created.ID+"/refresh",
+		nil,
+	)
+	require.Equal(http.StatusOK, refreshRR.Code, refreshRR.Body.String())
+
+	var refreshed rawWorkspaceStatusResponse
+	require.NoError(json.NewDecoder(refreshRR.Body).Decode(&refreshed))
+	require.NotNil(refreshed.AssociatedPRNumber)
+	assert.Equal(42, *refreshed.AssociatedPRNumber)
+
+	stored, err := fixture.database.GetWorkspace(ctx, created.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.AssociatedPRNumber)
+	assert.Equal(42, *stored.AssociatedPRNumber)
+
+	repo, err := fixture.database.GetRepoByHostOwnerName(
+		ctx, "github.com", "acme", "widget",
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	pr, err := fixture.database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 42)
+	require.NoError(err)
+	require.NotNil(pr)
+	assert.Equal(prTitleFromDetail, pr.Title)
+	assert.Equal(headSHA, pr.PlatformHeadSHA)
 }
 
 func readEventMatching(

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -488,6 +488,10 @@ type retryWorkspaceInput struct {
 	ID string `path:"id"`
 }
 
+type refreshWorkspaceInput struct {
+	ID string `path:"id"`
+}
+
 type getWorkspaceRuntimeInput struct {
 	ID string `path:"id"`
 }
@@ -534,6 +538,8 @@ type getWorkspaceRuntimeOutput = bodyOutput[workspaceRuntimeResponse]
 type workspaceRuntimeSessionOutput = bodyOutput[localruntime.SessionInfo]
 
 type createWorkspaceOutput = acceptedBodyOutput[workspaceResponse]
+
+type refreshWorkspaceOutput = bodyOutput[workspaceResponse]
 
 type workspaceDiffRequest struct {
 	Summary           *db.WorkspaceSummary
@@ -716,6 +722,13 @@ func (s *Server) registerAPI(api huma.API) {
 		Summary:       "Retry workspace",
 		Tags:          []string{"Workspaces"},
 	}, s.retryWorkspace)
+	huma.Register(api, huma.Operation{
+		OperationID: "refresh-workspace",
+		Method:      http.MethodPost,
+		Path:        "/workspaces/{id}/refresh",
+		Summary:     "Refresh workspace",
+		Tags:        []string{"Workspaces"},
+	}, s.refreshWorkspace)
 	huma.Register(api, huma.Operation{
 		OperationID: "get-workspace-runtime",
 		Method:      http.MethodGet,
@@ -4509,6 +4522,178 @@ func (s *Server) getWorkspace(
 	return &getWorkspaceOutput{
 		Body: s.toWorkspaceResponse(ctx, summary),
 	}, nil
+}
+
+func (s *Server) refreshWorkspace(
+	ctx context.Context, input *refreshWorkspaceInput,
+) (*refreshWorkspaceOutput, error) {
+	if s.workspaces == nil {
+		return nil, problemServiceUnavailable("workspace manager not configured")
+	}
+	if s.syncer == nil {
+		return nil, problemServiceUnavailable("syncer not configured")
+	}
+
+	summary, err := s.workspaces.GetSummary(ctx, input.ID)
+	if err != nil {
+		return nil, problemInternal("get workspace failed")
+	}
+	if summary == nil {
+		return nil, problemNotFound(
+			CodeWorkspaceNotFound, "workspace not found", nil,
+		)
+	}
+
+	provider := strings.TrimSpace(summary.Platform)
+	if provider == "" {
+		provider = string(platform.KindGitHub)
+	}
+	repo, err := s.lookupRepoByProviderRoute(
+		ctx, provider, summary.PlatformHost, summary.RepoOwner, summary.RepoName,
+	)
+	if err != nil {
+		return nil, providerRouteLookupError(err)
+	}
+	kind := repoProviderKind(*repo)
+	host := repoProviderHost(*repo)
+
+	switch summary.ItemType {
+	case db.WorkspaceItemTypeIssue:
+		if err := s.refreshWorkspaceIssue(
+			ctx, kind, host, repo.Owner, repo.Name, summary.ItemNumber,
+		); err != nil {
+			return nil, err
+		}
+	case db.WorkspaceItemTypePullRequest:
+		// The PR detail sync runs after the repo index refresh below so the
+		// workspace response reflects the latest indexed PR row and diff.
+	default:
+		return nil, problemInternal("workspace has unsupported item type")
+	}
+
+	if err := s.refreshWorkspaceRepoIndex(
+		ctx, kind, host, repo.Owner, repo.Name,
+	); err != nil {
+		return nil, err
+	}
+
+	if s.workspacePRMonitor != nil {
+		updates, err := s.workspacePRMonitor.RunOnce(ctx)
+		if err != nil {
+			return nil, problemInternal("refresh workspace PR association: " + err.Error())
+		}
+		for i := range updates {
+			s.broadcastWorkspaceStatus(updates[i].WorkspaceID)
+			s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
+		}
+	}
+
+	refreshed, err := s.workspaces.GetSummary(ctx, input.ID)
+	if err != nil {
+		return nil, problemInternal("get workspace failed")
+	}
+	if refreshed == nil {
+		return nil, problemNotFound(
+			CodeWorkspaceNotFound, "workspace not found", nil,
+		)
+	}
+	if prNumber, ok := workspaceAssociatedPRNumber(refreshed); ok {
+		if err := s.refreshWorkspacePullRequest(
+			ctx, kind, host, repo.Owner, repo.Name, prNumber,
+		); err != nil {
+			return nil, err
+		}
+		refreshed, err = s.workspaces.GetSummary(ctx, input.ID)
+		if err != nil {
+			return nil, problemInternal("get workspace failed")
+		}
+		if refreshed == nil {
+			return nil, problemNotFound(
+				CodeWorkspaceNotFound, "workspace not found", nil,
+			)
+		}
+	}
+
+	resp := s.toWorkspaceResponse(ctx, refreshed)
+	s.hub.Broadcast(Event{Type: "workspace_status", Data: resp})
+	s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
+	return &refreshWorkspaceOutput{Body: resp}, nil
+}
+
+func workspaceAssociatedPRNumber(summary *db.WorkspaceSummary) (int, bool) {
+	if summary == nil {
+		return 0, false
+	}
+	if summary.ItemType == db.WorkspaceItemTypePullRequest {
+		return summary.ItemNumber, summary.ItemNumber > 0
+	}
+	if summary.AssociatedPRNumber == nil {
+		return 0, false
+	}
+	return *summary.AssociatedPRNumber, *summary.AssociatedPRNumber > 0
+}
+
+func (s *Server) refreshWorkspaceRepoIndex(
+	ctx context.Context,
+	kind platform.Kind,
+	host, owner, name string,
+) error {
+	err := s.syncer.SyncRepoOnProvider(ctx, kind, host, owner, name)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "is not tracked") {
+		return problemForbidden(err.Error(), nil)
+	}
+	return providerCallProblemWithDetail(
+		err, string(kind), host, "sync repo: "+err.Error(),
+	)
+}
+
+func (s *Server) refreshWorkspaceIssue(
+	ctx context.Context,
+	kind platform.Kind,
+	host, owner, name string,
+	number int,
+) error {
+	err := s.syncer.SyncIssueOnProvider(ctx, kind, host, owner, name, number)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "is not tracked") {
+		return problemForbidden(err.Error(), nil)
+	}
+	return providerCallProblemWithDetail(
+		err, string(kind), host, "sync issue: "+err.Error(),
+	)
+}
+
+func (s *Server) refreshWorkspacePullRequest(
+	ctx context.Context,
+	kind platform.Kind,
+	host, owner, name string,
+	number int,
+) error {
+	var diffErr *ghclient.DiffSyncError
+	err := s.syncer.SyncMROnProvider(ctx, kind, host, owner, name, number)
+	if err != nil && !errors.As(err, &diffErr) {
+		if strings.Contains(err.Error(), "is not tracked") {
+			return problemForbidden(err.Error(), nil)
+		}
+		return providerCallProblemWithDetail(
+			err, string(kind), host, "sync PR: "+err.Error(),
+		)
+	}
+	if diffErr != nil {
+		slog.Warn("diff sync failed during workspace refresh",
+			"owner", owner,
+			"name", name,
+			"number", number,
+			"code", diffErr.Code,
+			"err", diffErr.Err,
+		)
+	}
+	return nil
 }
 
 func (s *Server) getWorkspaceCommits(

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -4578,12 +4578,14 @@ func (s *Server) refreshWorkspace(
 	}
 
 	if s.workspacePRMonitor != nil {
-		updates, err := s.workspacePRMonitor.RunOnce(ctx)
+		update, changed, err := s.workspacePRMonitor.RefreshWorkspaceAssociation(
+			ctx, input.ID,
+		)
 		if err != nil {
 			return nil, problemInternal("refresh workspace PR association: " + err.Error())
 		}
-		for i := range updates {
-			s.broadcastWorkspaceStatus(updates[i].WorkspaceID)
+		if changed {
+			s.broadcastWorkspaceStatus(update.WorkspaceID)
 			s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
 		}
 	}

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -172,7 +172,9 @@ func (m *PRMonitor) detectAssociatedPR(
 	if err != nil {
 		return 0, false, err
 	}
-	if prNumber, ok := selectPRByLocalBranch(candidates, currentBranch, headSHA); ok {
+	if prNumber, ok := selectPRByLocalBranch(
+		candidates, currentBranch, headSHA, upstream,
+	); ok {
 		return prNumber, true, nil
 	}
 	return 0, false, nil
@@ -213,6 +215,7 @@ func selectPRByUpstream(
 func selectPRByLocalBranch(
 	candidates []db.MergeRequest,
 	currentBranch, currentHeadSHA string,
+	upstream upstreamState,
 ) (int, bool) {
 	currentHeadSHA = strings.TrimSpace(currentHeadSHA)
 	if currentBranch == "" || currentHeadSHA == "" {
@@ -223,7 +226,8 @@ func selectPRByLocalBranch(
 	for i := range candidates {
 		candidate := candidates[i]
 		if candidate.HeadBranch == currentBranch &&
-			strings.EqualFold(candidate.PlatformHeadSHA, currentHeadSHA) {
+			strings.EqualFold(candidate.PlatformHeadSHA, currentHeadSHA) &&
+			localBranchCandidateMatchesUpstream(candidate, upstream) {
 			matches = append(matches, candidate)
 		}
 	}
@@ -231,6 +235,20 @@ func selectPRByLocalBranch(
 		return 0, false
 	}
 	return matches[0].Number, true
+}
+
+func localBranchCandidateMatchesUpstream(
+	candidate db.MergeRequest,
+	upstream upstreamState,
+) bool {
+	if !upstream.hasTracking {
+		return true
+	}
+	remoteRepo := normalizeCloneRepoIdentity(upstream.remoteURL)
+	candidateRepo := normalizeCloneRepoIdentity(candidate.HeadRepoCloneURL)
+	return remoteRepo == "" ||
+		candidateRepo == "" ||
+		candidateRepo == remoteRepo
 }
 
 func gitBranchName(

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -41,41 +41,75 @@ func (m *PRMonitor) RunOnce(
 			continue
 		}
 
-		prNumber, ok, detectErr := m.detectAssociatedPR(ctx, &ws)
-		if detectErr != nil {
+		update, changed, refreshErr := m.refreshWorkspaceAssociation(ctx, &ws)
+		if refreshErr != nil {
 			slog.Warn(
-				"workspace PR monitor git inspection failed",
+				"workspace PR monitor association refresh failed",
 				"workspace_id", ws.ID,
 				"path", ws.WorktreePath,
-				"err", detectErr,
-			)
-			continue
-		}
-		if !ok {
-			continue
-		}
-
-		changed, err := m.db.SetWorkspaceAssociatedPRNumberIfNull(
-			ctx, ws.ID, prNumber,
-		)
-		if err != nil {
-			slog.Warn(
-				"workspace PR monitor persistence failed",
-				"workspace_id", ws.ID,
-				"pr_number", prNumber,
-				"err", err,
+				"err", refreshErr,
 			)
 			continue
 		}
 		if changed {
-			updates = append(updates, PRAssociationUpdate{
-				WorkspaceID: ws.ID,
-				PRNumber:    prNumber,
-			})
+			updates = append(updates, update)
 		}
 	}
 
 	return updates, nil
+}
+
+// RefreshWorkspaceAssociation refreshes PR association for one workspace and
+// returns errors that would be best-effort in the background monitor loop.
+func (m *PRMonitor) RefreshWorkspaceAssociation(
+	ctx context.Context,
+	workspaceID string,
+) (PRAssociationUpdate, bool, error) {
+	ws, err := m.db.GetWorkspace(ctx, workspaceID)
+	if err != nil {
+		return PRAssociationUpdate{}, false, fmt.Errorf("get workspace: %w", err)
+	}
+	if ws == nil {
+		return PRAssociationUpdate{}, false, fmt.Errorf(
+			"workspace %q not found", workspaceID,
+		)
+	}
+	return m.refreshWorkspaceAssociation(ctx, ws)
+}
+
+func (m *PRMonitor) refreshWorkspaceAssociation(
+	ctx context.Context,
+	ws *Workspace,
+) (PRAssociationUpdate, bool, error) {
+	if !workspacePRMonitorEligible(ws) {
+		return PRAssociationUpdate{}, false, nil
+	}
+
+	prNumber, ok, err := m.detectAssociatedPR(ctx, ws)
+	if err != nil {
+		return PRAssociationUpdate{}, false, fmt.Errorf(
+			"detect associated PR: %w", err,
+		)
+	}
+	if !ok {
+		return PRAssociationUpdate{}, false, nil
+	}
+
+	changed, err := m.db.SetWorkspaceAssociatedPRNumberIfNull(
+		ctx, ws.ID, prNumber,
+	)
+	if err != nil {
+		return PRAssociationUpdate{}, false, fmt.Errorf(
+			"set associated PR: %w", err,
+		)
+	}
+	if !changed {
+		return PRAssociationUpdate{}, false, nil
+	}
+	return PRAssociationUpdate{
+		WorkspaceID: ws.ID,
+		PRNumber:    prNumber,
+	}, true, nil
 }
 
 func workspacePRMonitorEligible(ws *Workspace) bool {

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -105,20 +105,6 @@ func (m *PRMonitor) detectAssociatedPR(
 	if currentBranch == "" {
 		return 0, false, nil
 	}
-	// Skip while the workspace is still on its managed issue branch:
-	// no associated PR can exist yet. The bare-form fallback only
-	// applies when the workspace pre-dates the slug feature (empty
-	// GitHeadRef); otherwise a user who hand-checks-out the legacy
-	// bare branch name on a slug-style workspace would silently
-	// suppress PR detection for an unrelated branch.
-	managedBranch := ws.GitHeadRef
-	if managedBranch == "" {
-		managedBranch = issueWorkspaceBranch(ws.ItemNumber)
-	}
-	if currentBranch == managedBranch {
-		return 0, false, nil
-	}
-
 	candidates, err := m.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{
 		PlatformHost: ws.PlatformHost,
 		RepoOwner:    ws.RepoOwner,

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -121,11 +121,10 @@ func workspacePRMonitorEligible(ws *Workspace) bool {
 }
 
 type upstreamState struct {
-	branchName    string
-	remoteName    string
-	remoteURL     string
-	hasTracking   bool
-	allowFallback bool
+	branchName  string
+	remoteName  string
+	remoteURL   string
+	hasTracking bool
 }
 
 func (m *PRMonitor) detectAssociatedPR(
@@ -139,11 +138,21 @@ func (m *PRMonitor) detectAssociatedPR(
 	if currentBranch == "" {
 		return 0, false, nil
 	}
-	candidates, err := m.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{
+	repo, err := m.db.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     workspaceProvider(ws),
 		PlatformHost: ws.PlatformHost,
-		RepoOwner:    ws.RepoOwner,
-		RepoName:     ws.RepoName,
-		State:        "open",
+		Owner:        ws.RepoOwner,
+		Name:         ws.RepoName,
+	})
+	if err != nil {
+		return 0, false, fmt.Errorf("get repo: %w", err)
+	}
+	if repo == nil {
+		return 0, false, nil
+	}
+	candidates, err := m.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{
+		RepoID: repo.ID,
+		State:  "open",
 	})
 	if err != nil {
 		return 0, false, fmt.Errorf("list merge requests: %w", err)
@@ -156,9 +165,6 @@ func (m *PRMonitor) detectAssociatedPR(
 	if upstream.hasTracking {
 		if prNumber, ok := selectPRByUpstream(candidates, upstream); ok {
 			return prNumber, true, nil
-		}
-		if !upstream.allowFallback {
-			return 0, false, nil
 		}
 	}
 
@@ -261,12 +267,10 @@ func gitUpstreamState(
 		ctx, dir, "branch."+branch+".merge",
 	)
 	if remoteErr != nil || mergeErr != nil {
-		state.allowFallback = true
 		return state, nil
 	}
 
 	state.hasTracking = true
-	state.allowFallback = false
 	state.remoteName = remoteName
 	state.branchName = strings.TrimPrefix(mergeRef, "refs/heads/")
 	remoteURL, err := gitRemoteURL(ctx, dir, remoteName)

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -235,6 +235,47 @@ func TestPRMonitorRunOnceSkipsSyntheticIssueBranch(t *testing.T) {
 	assert.Nil(ws.AssociatedPRNumber)
 }
 
+func TestPRMonitorRunOnceAssociatesPRFromManagedIssueBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedIssue(t, d, repoID, 7, "Track workspace association")
+	seedMRWithHeadRepo(
+		t, d, repoID, 42,
+		"middleman/issue-7", "https://github.com/acme/widget.git",
+	)
+
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "middleman/issue-7")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "feature.txt"), []byte("feature\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, worktreePath, "add", ".")
+	runWorkspaceTestGit(t, worktreePath, "commit", "-m", "feature commit")
+	runWorkspaceTestGit(t, worktreePath, "push", "-u", "origin", "middleman/issue-7")
+	runWorkspaceTestGit(
+		t, worktreePath,
+		"remote", "set-url", "origin", "git@github.com:acme/widget.git",
+	)
+	insertMonitorWorkspace(t, d, worktreePath, nil)
+
+	monitor := NewPRMonitor(d)
+	updates, err := monitor.RunOnce(ctx)
+	require.NoError(err)
+	require.Len(updates, 1)
+	assert.Equal("ws-issue", updates[0].WorkspaceID)
+	assert.Equal(42, updates[0].PRNumber)
+
+	ws, err := d.GetWorkspace(ctx, "ws-issue")
+	require.NoError(err)
+	require.NotNil(ws)
+	require.NotNil(ws.AssociatedPRNumber)
+	assert.Equal(42, *ws.AssociatedPRNumber)
+}
+
 func TestPRMonitorRunOnceAssociatesPRWhenSlugWorkspaceCheckedOutToBareBranch(t *testing.T) {
 	// Regression: a slug-style workspace (GitHeadRef = the slugged
 	// branch) checked out to the legacy bare-form branch

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -385,6 +385,30 @@ func TestPRMonitorRunOnceUsesUpstreamRemoteIdentity(t *testing.T) {
 	assert.Equal(42, updates[0].PRNumber)
 }
 
+func TestPRMonitorRefreshWorkspaceAssociationReturnsInspectionError(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedIssue(t, d, repoID, 7, "Track workspace association")
+	workspaceID := insertMonitorWorkspace(
+		t, d, filepath.Join(t.TempDir(), "missing-worktree"), nil,
+	)
+
+	monitor := NewPRMonitor(d)
+	update, changed, err := monitor.RefreshWorkspaceAssociation(ctx, workspaceID)
+	require.Error(err)
+	require.ErrorContains(err, "detect associated PR")
+	assert.False(changed)
+	assert.Equal(PRAssociationUpdate{}, update)
+
+	updates, err := monitor.RunOnce(ctx)
+	require.NoError(err)
+	assert.Empty(updates)
+}
+
 func TestSelectPRByUpstream(t *testing.T) {
 	assert := Assert.New(t)
 	candidates := []db.MergeRequest{

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -47,7 +47,7 @@ func insertMonitorWorkspace(
 	associatedPRNumber *int,
 ) string {
 	t.Helper()
-	ws := &db.Workspace{
+	ws := db.Workspace{
 		ID:                 "ws-issue",
 		PlatformHost:       "github.com",
 		RepoOwner:          "acme",
@@ -60,8 +60,30 @@ func insertMonitorWorkspace(
 		TmuxSession:        "middleman-ws-issue",
 		Status:             "ready",
 	}
-	require.NoError(t, d.InsertWorkspace(context.Background(), ws))
+	require.NoError(t, d.InsertWorkspace(context.Background(), &ws))
 	return ws.ID
+}
+
+func insertMonitorWorkspaceWithIdentity(
+	t *testing.T,
+	d *db.DB,
+	id, provider, host, owner, name, worktreePath string,
+) string {
+	t.Helper()
+	require.NoError(t, d.InsertWorkspace(context.Background(), &db.Workspace{
+		ID:           id,
+		Platform:     provider,
+		PlatformHost: host,
+		RepoOwner:    owner,
+		RepoName:     name,
+		ItemType:     db.WorkspaceItemTypeIssue,
+		ItemNumber:   7,
+		GitHeadRef:   "middleman/issue-7",
+		WorktreePath: worktreePath,
+		TmuxSession:  "middleman-" + id,
+		Status:       "ready",
+	}))
+	return id
 }
 
 func seedIssue(
@@ -164,6 +186,57 @@ func TestPRMonitorRunOnceFallsBackToLocalBranchNameAndHeadSHA(t *testing.T) {
 	assert.Equal(42, updates[0].PRNumber)
 
 	ws, err := d.GetWorkspace(ctx, "ws-issue")
+	require.NoError(err)
+	require.NotNil(ws)
+	require.NotNil(ws.AssociatedPRNumber)
+	assert.Equal(42, *ws.AssociatedPRNumber)
+}
+
+func TestPRMonitorRunOnceFallsBackToLocalHeadSHAWhenUpstreamRepoMetadataMissing(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.com",
+		Owner:        "Group/SubGroup",
+		Name:         "Project",
+		RepoPath:     "Group/SubGroup/Project",
+	})
+	require.NoError(err)
+	seedIssue(t, d, repoID, 7, "Track workspace association")
+
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/gitlab")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "feature.txt"), []byte("feature\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, worktreePath, "add", ".")
+	runWorkspaceTestGit(t, worktreePath, "commit", "-m", "feature commit")
+	runWorkspaceTestGit(t, worktreePath, "push", "-u", "origin", "feature/gitlab")
+	runWorkspaceTestGit(
+		t, worktreePath,
+		"remote", "set-url", "origin",
+		"git@gitlab.com:Group/SubGroup/Project.git",
+	)
+	headSHA, err := gitHeadSHA(ctx, worktreePath)
+	require.NoError(err)
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/gitlab", headSHA)
+	workspaceID := insertMonitorWorkspaceWithIdentity(
+		t, d, "ws-gitlab", "gitlab", "gitlab.com",
+		"Group/SubGroup", "Project", worktreePath,
+	)
+
+	monitor := NewPRMonitor(d)
+	updates, err := monitor.RunOnce(ctx)
+	require.NoError(err)
+	require.Len(updates, 1)
+	assert.Equal(workspaceID, updates[0].WorkspaceID)
+	assert.Equal(42, updates[0].PRNumber)
+
+	ws, err := d.GetWorkspace(ctx, workspaceID)
 	require.NoError(err)
 	require.NotNil(ws)
 	require.NotNil(ws.AssociatedPRNumber)
@@ -383,6 +456,56 @@ func TestPRMonitorRunOnceUsesUpstreamRemoteIdentity(t *testing.T) {
 	require.Len(updates, 1)
 	assert.Equal("ws-issue", updates[0].WorkspaceID)
 	assert.Equal(42, updates[0].PRNumber)
+}
+
+func TestPRMonitorRunOnceScopesCandidatesByWorkspaceProvider(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	githubRepoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "git.example.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	gitlabRepoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "git.example.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	seedIssue(t, d, gitlabRepoID, 7, "Track workspace association")
+
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/provider-scope")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "feature.txt"), []byte("feature\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, worktreePath, "add", ".")
+	runWorkspaceTestGit(t, worktreePath, "commit", "-m", "feature commit")
+	headSHA, err := gitHeadSHA(ctx, worktreePath)
+	require.NoError(err)
+	seedMRWithPlatformHead(
+		t, d, githubRepoID, 42, "feature/provider-scope", headSHA,
+	)
+	workspaceID := insertMonitorWorkspaceWithIdentity(
+		t, d, "ws-gitlab-provider-scope", "gitlab", "git.example.com",
+		"acme", "widget", worktreePath,
+	)
+
+	monitor := NewPRMonitor(d)
+	updates, err := monitor.RunOnce(ctx)
+	require.NoError(err)
+	assert.Empty(updates)
+
+	ws, err := d.GetWorkspace(ctx, workspaceID)
+	require.NoError(err)
+	require.NotNil(ws)
+	assert.Nil(ws.AssociatedPRNumber)
 }
 
 func TestPRMonitorRefreshWorkspaceAssociationReturnsInspectionError(t *testing.T) {

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -283,6 +283,65 @@ func TestPRMonitorRunOnceRejectsLocalBranchWithMismatchedHeadSHA(t *testing.T) {
 	assert.Nil(ws.AssociatedPRNumber)
 }
 
+func TestPRMonitorRunOnceRejectsLocalBranchWithMismatchedUpstreamRemote(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedIssue(t, d, repoID, 7, "Track workspace association")
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/shared")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "feature.txt"), []byte("feature\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, worktreePath, "add", ".")
+	runWorkspaceTestGit(t, worktreePath, "commit", "-m", "feature commit")
+	runWorkspaceTestGit(
+		t, worktreePath,
+		"remote", "set-url", "origin", "git@github.com:acme/widget.git",
+	)
+	runWorkspaceTestGit(
+		t, worktreePath,
+		"config", "branch.feature/shared.remote", "origin",
+	)
+	runWorkspaceTestGit(
+		t, worktreePath,
+		"config", "branch.feature/shared.merge", "refs/heads/feature/shared",
+	)
+	headSHA, err := gitHeadSHA(ctx, worktreePath)
+	require.NoError(err)
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:           repoID,
+		PlatformID:       repoID*10000 + 42,
+		Number:           42,
+		Title:            "Test PR",
+		Author:           "author",
+		State:            "open",
+		HeadBranch:       "feature/shared",
+		HeadRepoCloneURL: "https://github.com/fork/widget.git",
+		PlatformHeadSHA:  headSHA,
+		BaseBranch:       "main",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActivityAt:   now,
+	})
+	require.NoError(err)
+	insertMonitorWorkspace(t, d, worktreePath, nil)
+
+	monitor := NewPRMonitor(d)
+	updates, err := monitor.RunOnce(ctx)
+	require.NoError(err)
+	assert.Empty(updates)
+
+	ws, err := d.GetWorkspace(ctx, "ws-issue")
+	require.NoError(err)
+	require.NotNil(ws)
+	assert.Nil(ws.AssociatedPRNumber)
+}
+
 func TestPRMonitorRunOnceSkipsSyntheticIssueBranch(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -590,15 +649,21 @@ func TestSelectPRByBranchRejectsAmbiguousMatches(t *testing.T) {
 		{Number: 44, HeadBranch: "wrong-head", PlatformHeadSHA: "def456"},
 	}
 
-	number, ok := selectPRByLocalBranch(candidates, "single-local", "abc123")
+	number, ok := selectPRByLocalBranch(
+		candidates, "single-local", "abc123", upstreamState{},
+	)
 	assert.True(ok)
 	assert.Equal(43, number)
 
-	number, ok = selectPRByLocalBranch(candidates, "shared-local", "abc123")
+	number, ok = selectPRByLocalBranch(
+		candidates, "shared-local", "abc123", upstreamState{},
+	)
 	assert.False(ok)
 	assert.Zero(number)
 
-	number, ok = selectPRByLocalBranch(candidates, "wrong-head", "abc123")
+	number, ok = selectPRByLocalBranch(
+		candidates, "wrong-head", "abc123", upstreamState{},
+	)
 	assert.False(ok)
 	assert.Zero(number)
 }

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1891,6 +1891,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/workspaces/{id}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh workspace */
+        post: operations["refresh-workspace"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/workspaces/{id}/retry": {
         parameters: {
             query?: never;
@@ -8088,6 +8105,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FilesResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "refresh-workspace": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceResponse"];
                 };
             };
             /** @description Error */

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
@@ -50,6 +50,7 @@
     associatedPRNumber: number | null;
     branch: string;
     roborevBaseUrl: string;
+    refreshToken?: number;
   }
 
   let {
@@ -65,6 +66,7 @@
     associatedPRNumber,
     branch,
     roborevBaseUrl,
+    refreshToken = 0,
   }: Props = $props();
 
   const parentStores = getStores();
@@ -278,45 +280,51 @@
 
 <div class="right-sidebar-content">
   {#if activeTab === "diff"}
-    <WorkspaceDiffPanel
-      {workspaceID}
-      {provider}
-      {platformHost}
-      {repoOwner}
-      {repoName}
-      {repoPath}
-      itemNumber={ownerItemNumber}
-      active={activeTab === "diff"}
-    />
+    {#key `diff:${workspaceID}:${refreshToken}`}
+      <WorkspaceDiffPanel
+        {workspaceID}
+        {provider}
+        {platformHost}
+        {repoOwner}
+        {repoName}
+        {repoPath}
+        itemNumber={ownerItemNumber}
+        active={activeTab === "diff"}
+      />
+    {/key}
   {:else if activeTab === "pr"}
     {#if hasPR}
-      <div class="pr-scroll">
-        <PullDetail
-          {provider}
-          {platformHost}
-          owner={repoOwner}
-          name={repoName}
-          {repoPath}
-          number={associatedPRNumber ?? 0}
-          hideTabs={true}
-          hideWorkspaceAction={true}
-        />
-      </div>
+      {#key `pr:${provider}:${platformHost ?? ""}:${repoPath}:${associatedPRNumber ?? 0}:${refreshToken}`}
+        <div class="pr-scroll">
+          <PullDetail
+            {provider}
+            {platformHost}
+            owner={repoOwner}
+            name={repoName}
+            {repoPath}
+            number={associatedPRNumber ?? 0}
+            hideTabs={true}
+            hideWorkspaceAction={true}
+          />
+        </div>
+      {/key}
     {:else}
       <div class="empty-state">No linked PR</div>
     {/if}
   {:else if activeTab === "issue"}
     {#if hasIssue}
-      <div class="pr-scroll">
-        <IssueDetail
-          {provider}
-          {platformHost}
-          owner={repoOwner}
-          name={repoName}
-          {repoPath}
-          number={ownerItemNumber}
-        />
-      </div>
+      {#key `issue:${provider}:${platformHost ?? ""}:${repoPath}:${ownerItemNumber}:${refreshToken}`}
+        <div class="pr-scroll">
+          <IssueDetail
+            {provider}
+            {platformHost}
+            owner={repoOwner}
+            name={repoName}
+            {repoPath}
+            number={ownerItemNumber}
+          />
+        </div>
+      {/key}
     {:else}
       <div class="empty-state">No linked issue</div>
     {/if}


### PR DESCRIPTION
Issue workspaces can miss PR association when a PR is opened long after the branch was first pushed, leaving the terminal sidebar without a PR tab even though the matching branch now has an open PR.

- Rechecks PR association against freshly indexed repo data when a workspace is manually refreshed.
- Adds a compact refresh control beside the Diff/Issue/PR selector and reloads the active Diff, Issue, and PR surfaces from the returned workspace state.
