### PR TITLE
Fix merged lifecycle timeline rows

### DIFF
--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -442,9 +442,34 @@ async function clickVisibleTarget(target: Locator): Promise<void> {
   await target.click({ timeout: 10_000 });
 }
 
+async function activateVisibleTarget(target: Locator): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        try {
+          return await target.evaluate((element) => {
+            if (!(element instanceof HTMLElement)) return false;
+            const rect = element.getBoundingClientRect();
+            const style = getComputedStyle(element);
+            if (rect.width <= 0 || rect.height <= 0 || style.display === "none" || style.visibility === "hidden") {
+              return false;
+            }
+            element.scrollIntoView({ block: "center", inline: "center" });
+            element.click();
+            return true;
+          });
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+}
+
 async function clickTreeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: string): Promise<void> {
   const item = treeFileItem(pageOrLocator, path);
-  await clickVisibleTarget(item);
+  await activateVisibleTarget(item);
   await expect(item).toHaveAttribute("aria-selected", "true");
 }
 
@@ -597,7 +622,7 @@ async function clickPierreContextExpander(
     .filter({ visible: true })
     .nth(separatorIndex);
   const expander = separator.locator(buttonSelector).filter({ visible: true }).first();
-  await clickVisibleTarget(expander);
+  await activateVisibleTarget(expander);
 }
 
 async function expectPierreDarkBackgroundMatchesAppSurface(file: ReturnType<Page["locator"]>) {
@@ -921,6 +946,32 @@ async function selectPierreReviewLine(file: Locator, line: number, side: "left" 
   const target = file.locator(`.pierre-diff ${selector}`).first();
   await expect(target).toBeVisible({ timeout: 10_000 });
   await clickVisibleTarget(target.locator("[data-middleman-line-comment-button]"));
+}
+
+function inlineComposerFor(textarea: Locator): Locator {
+  return textarea.locator(
+    "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' inline-composer ')][1]",
+  );
+}
+
+type BoundingBox = NonNullable<Awaited<ReturnType<Locator["boundingBox"]>>>;
+
+async function visibleBoundingBox(target: Locator): Promise<BoundingBox> {
+  let box: BoundingBox | null = null;
+  await expect
+    .poll(async () => {
+      box = await target.boundingBox();
+      return box !== null;
+    })
+    .toBe(true);
+  return box!;
+}
+
+async function submitInlineComposer(textarea: Locator): Promise<void> {
+  const composer = inlineComposerFor(textarea);
+  const addButton = composer.getByRole("button", { name: "Add comment" });
+  await expect(addButton).toBeEnabled();
+  await addButton.click();
 }
 
 // --- Functional tests ---
@@ -2629,13 +2680,11 @@ test.describe("diff view (git-backed)", () => {
       await expect(rightComposer).toBeVisible();
       await expect(rightComposer).toBeFocused();
       await expectPierreDiffFirstVisible(cacheFile, diffAdditionsSelector);
-      const cacheContentBox = await cacheFile.locator(".file-content").boundingBox();
-      const composerBox = await cacheFile.locator(".inline-composer").boundingBox();
-      expect(cacheContentBox).not.toBeNull();
-      expect(composerBox).not.toBeNull();
-      expect(composerBox!.x + composerBox!.width).toBeLessThanOrEqual(cacheContentBox!.x + cacheContentBox!.width + 1);
+      const cacheContentBox = await visibleBoundingBox(cacheFile.locator(".file-content"));
+      const composerBox = await visibleBoundingBox(inlineComposerFor(rightComposer));
+      expect(composerBox.x + composerBox.width).toBeLessThanOrEqual(cacheContentBox.x + cacheContentBox.width + 1);
       await rightComposer.fill("Right-side cache note");
-      await page.getByRole("button", { name: "Add comment" }).click();
+      await submitInlineComposer(rightComposer);
       await expect(
         page.locator(".inline-draft-comment", {
           hasText: "Right-side cache note",
@@ -2649,7 +2698,7 @@ test.describe("diff view (git-backed)", () => {
       await expect(leftComposer).toBeVisible();
       await expect(leftComposer).toBeFocused();
       await leftComposer.fill("Left-side config note");
-      await page.getByRole("button", { name: "Add comment" }).click();
+      await submitInlineComposer(leftComposer);
       await expect(
         page.locator(".inline-draft-comment", {
           hasText: "Left-side config note",

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -438,28 +438,8 @@ function treeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: s
 }
 
 async function clickVisibleTarget(target: Locator): Promise<void> {
-  await expect
-    .poll(
-      async () => {
-        try {
-          return await target.evaluate((element) => {
-            if (!(element instanceof HTMLElement)) return false;
-            const rect = element.getBoundingClientRect();
-            const style = getComputedStyle(element);
-            if (rect.width <= 0 || rect.height <= 0 || style.display === "none" || style.visibility === "hidden") {
-              return false;
-            }
-            element.scrollIntoView({ block: "center", inline: "center" });
-            element.click();
-            return true;
-          });
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 10_000 },
-    )
-    .toBe(true);
+  await expect(target).toBeVisible({ timeout: 10_000 });
+  await target.click({ timeout: 10_000 });
 }
 
 async function clickTreeFileItem(pageOrLocator: Page | ReturnType<Page["locator"]>, path: string): Promise<void> {

--- a/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
+++ b/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
@@ -80,6 +80,21 @@ test.describe("PR timeline filters", () => {
     await expect(page.getByText("develop -> main")).toBeVisible();
   });
 
+  test("renders merged lifecycle transitions as one purple row", async ({ page }) => {
+    await openPRTimelinePath(page, "/pulls/github/acme/tools/2");
+
+    const mergedRows = page.locator(".event--compact", { hasText: "Merged" });
+    await expect(mergedRows).toHaveCount(1);
+    await expect(mergedRows.first()).toContainText("alice");
+    await expect(mergedRows.first()).toContainText("merged this");
+    await expect(mergedRows.first().locator(".event-type", { hasText: "Merged" })).toHaveAttribute(
+      "style",
+      /var\(--accent-purple\)/,
+    );
+    await expect(mergedRows.first().locator(".dot")).toHaveAttribute("style", /var\(--accent-purple\)/);
+    await expect(page.locator(".event--compact", { hasText: "Closed" })).toHaveCount(0);
+  });
+
   test("orders force-push commit generations through the seeded timeline", async ({ page }) => {
     await openPRTimeline(page);
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -342,7 +342,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 
 	// tools#2: merged 60d ago, alice
 	t2Merged := now.Add(-60 * 24 * time.Hour)
-	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+	t2ID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:            toolsID,
 		PlatformID:        2002,
 		Number:            2,
@@ -786,6 +786,37 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("upsert tools PR#1 events: %w", err)
+	}
+
+	// tools PR#2: duplicate lifecycle rows from provider/import paths collapse to one merge row in the UI.
+	err = d.UpsertMREvents(ctx, []db.MREvent{
+		{
+			MergeRequestID: t2ID,
+			EventType:      "merged",
+			Author:         "",
+			Summary:        "merged this",
+			CreatedAt:      t2Merged,
+			DedupeKey:      "t2-merged-fallback",
+		},
+		{
+			MergeRequestID: t2ID,
+			EventType:      "closed",
+			Author:         "alice",
+			Summary:        "closed this",
+			CreatedAt:      t2Merged.Add(15 * time.Second),
+			DedupeKey:      "t2-closed-provider",
+		},
+		{
+			MergeRequestID: t2ID,
+			EventType:      "merged",
+			Author:         "alice",
+			Summary:        "merged this",
+			CreatedAt:      t2Merged.Add(15 * time.Second),
+			DedupeKey:      "t2-merged-provider",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("upsert tools PR#2 lifecycle events: %w", err)
 	}
 
 	// --- Issue Events ---

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -191,16 +191,17 @@
     return candidate.ID > current.ID ? candidate : current;
   }
 
-  function isNearLifecycleEvent(
+  function isCoalescedMergedCloseEvent(
     event: PREvent | IssueEvent,
-    target: PREvent | IssueEvent,
+    mergedEvent: PREvent | IssueEvent,
   ): boolean {
     const eventTime = eventSortValue(event);
-    const targetTime = eventSortValue(target);
-    if (eventTime === 0 || targetTime === 0) {
-      return event.CreatedAt === target.CreatedAt;
+    const mergedTime = eventSortValue(mergedEvent);
+    if (eventTime === 0 || mergedTime === 0) {
+      return event.CreatedAt === mergedEvent.CreatedAt;
     }
-    return Math.abs(eventTime - targetTime) < mergedCloseCoalesceWindowMs;
+    const elapsedAfterMerge = eventTime - mergedTime;
+    return elapsedAfterMerge >= 0 && elapsedAfterMerge < mergedCloseCoalesceWindowMs;
   }
 
   function collapseLifecycleTransitions(
@@ -214,7 +215,7 @@
 
     return sourceEvents.filter((event) => {
       if (event.EventType === "merged") return event.ID === mergedEvent.ID;
-      if (event.EventType === "closed" && isNearLifecycleEvent(event, mergedEvent)) return false;
+      if (event.EventType === "closed" && isCoalescedMergedCloseEvent(event, mergedEvent)) return false;
       return true;
     });
   }

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -1355,27 +1355,7 @@
   }
 
   .event-card--compact {
-    background: transparent;
-    border-color: transparent;
-    border-radius: var(--radius-sm);
-    padding: 0.38rem var(--focus-detail-space-xs, 0.62rem);
-    margin-top: 0.12rem;
-    margin-bottom: 0.12rem;
-  }
-
-  .event-card--compact:hover {
-    background: var(--bg-surface-hover);
-    border-color: var(--border-muted);
-  }
-
-  .event--compact .event-rail {
-    padding-top: 0.76rem;
-  }
-
-  .event--compact .dot {
-    width: 0.65rem;
-    height: 0.65rem;
-    box-shadow: 0 0 0 0.18rem var(--bg-primary);
+    padding: var(--focus-detail-space-xs, 0.54rem) var(--focus-detail-space-sm, 0.77rem);
   }
 
   .event-header {
@@ -1396,9 +1376,9 @@
 
   .event-type {
     font-size: var(--font-size-xs);
-    font-weight: 650;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0;
+    letter-spacing: 0.04em;
   }
 
   .event-author {

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -123,10 +123,12 @@
     force_push: "var(--accent-red)",
     assigned: "var(--accent-blue)",
     unassigned: "var(--text-muted)",
-    merged: "var(--accent-green)",
+    merged: "var(--accent-purple)",
     closed: "var(--text-muted)",
     reopened: "var(--accent-blue)",
   };
+
+  const mergedCloseCoalesceWindowMs = 60_000;
 
   function shouldRenderMarkdown(eventType: string): boolean {
     return eventType === "issue_comment" || eventType === "review" || eventType === "review_comment";
@@ -161,6 +163,60 @@
   function eventSortValue(event: PREvent | IssueEvent): number {
     const timestamp = Date.parse(event.CreatedAt);
     return Number.isFinite(timestamp) ? timestamp : 0;
+  }
+
+  function lifecyclePreferenceScore(event: PREvent | IssueEvent): number {
+    return (
+      (event.Author ? 4 : 0) +
+      (event.PlatformID != null ? 2 : 0) +
+      (event.PlatformExternalID ? 1 : 0)
+    );
+  }
+
+  function preferredLifecycleEvent(
+    current: PREvent | IssueEvent | null,
+    candidate: PREvent | IssueEvent,
+  ): PREvent | IssueEvent {
+    if (current === null) return candidate;
+    const candidateScore = lifecyclePreferenceScore(candidate);
+    const currentScore = lifecyclePreferenceScore(current);
+    if (candidateScore !== currentScore) {
+      return candidateScore > currentScore ? candidate : current;
+    }
+    const candidateTime = eventSortValue(candidate);
+    const currentTime = eventSortValue(current);
+    if (candidateTime !== currentTime) {
+      return candidateTime > currentTime ? candidate : current;
+    }
+    return candidate.ID > current.ID ? candidate : current;
+  }
+
+  function isNearLifecycleEvent(
+    event: PREvent | IssueEvent,
+    target: PREvent | IssueEvent,
+  ): boolean {
+    const eventTime = eventSortValue(event);
+    const targetTime = eventSortValue(target);
+    if (eventTime === 0 || targetTime === 0) {
+      return event.CreatedAt === target.CreatedAt;
+    }
+    return Math.abs(eventTime - targetTime) < mergedCloseCoalesceWindowMs;
+  }
+
+  function collapseLifecycleTransitions(
+    sourceEvents: Array<PREvent | IssueEvent>,
+  ): Array<PREvent | IssueEvent> {
+    const mergedEvent = sourceEvents
+      .filter((event) => event.EventType === "merged")
+      .reduce<PREvent | IssueEvent | null>(preferredLifecycleEvent, null);
+
+    if (mergedEvent === null) return sourceEvents;
+
+    return sourceEvents.filter((event) => {
+      if (event.EventType === "merged") return event.ID === mergedEvent.ID;
+      if (event.EventType === "closed" && isNearLifecycleEvent(event, mergedEvent)) return false;
+      return true;
+    });
   }
 
   function compareEventsAscending(a: PREvent | IssueEvent, b: PREvent | IssueEvent): number {
@@ -482,7 +538,9 @@
     return entries;
   }
 
-  const timelineEntries = $derived(buildTimelineEntries(events, orderingEvents));
+  const displayEvents = $derived(collapseLifecycleTransitions(events));
+  const displayOrderingEvents = $derived(collapseLifecycleTransitions(orderingEvents));
+  const timelineEntries = $derived(buildTimelineEntries(displayEvents, displayOrderingEvents));
 
   function isCompactEvent(eventType: string): boolean {
     return (
@@ -1297,7 +1355,27 @@
   }
 
   .event-card--compact {
-    padding: var(--focus-detail-space-xs, 0.54rem) var(--focus-detail-space-sm, 0.77rem);
+    background: transparent;
+    border-color: transparent;
+    border-radius: var(--radius-sm);
+    padding: 0.38rem var(--focus-detail-space-xs, 0.62rem);
+    margin-top: 0.12rem;
+    margin-bottom: 0.12rem;
+  }
+
+  .event-card--compact:hover {
+    background: var(--bg-surface-hover);
+    border-color: var(--border-muted);
+  }
+
+  .event--compact .event-rail {
+    padding-top: 0.76rem;
+  }
+
+  .event--compact .dot {
+    width: 0.65rem;
+    height: 0.65rem;
+    box-shadow: 0 0 0 0.18rem var(--bg-primary);
   }
 
   .event-header {
@@ -1318,9 +1396,9 @@
 
   .event-type {
     font-size: var(--font-size-xs);
-    font-weight: 700;
+    font-weight: 650;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0;
   }
 
   .event-author {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -259,25 +259,6 @@ describe("EventTimeline", () => {
     expect(dot?.getAttribute("style")).toContain("var(--accent-purple)");
   });
 
-  it("renders compact lifecycle rows without boxed card chrome", () => {
-    render(EventTimeline, {
-      props: {
-        events: [
-          makeEvent({
-            EventType: "merged",
-            Summary: "merged this",
-          }),
-        ],
-      },
-    });
-
-    expect(document.querySelector(".event-card--compact")).toBeTruthy();
-    const compactCardStyle = findCompiledStyleRule(".event-card--compact");
-    expect(compactCardStyle.getPropertyValue("background")).toBe("transparent");
-    expect(compactCardStyle.getPropertyValue("border-color")).toBe("transparent");
-    expect(compactCardStyle.getPropertyValue("border-radius")).toBe("var(--radius-sm)");
-  });
-
   it("collapses duplicate merge lifecycle rows into the single authored transition", () => {
     render(EventTimeline, {
       props: {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -298,6 +298,42 @@ describe("EventTimeline", () => {
     expect(document.querySelectorAll(".event--compact")).toHaveLength(1);
   });
 
+  it("keeps pre-merge close lifecycle rows when the PR was reopened before merging", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 3,
+            EventType: "merged",
+            Author: "mariusvniekerk",
+            Summary: "merged this",
+            CreatedAt: "2024-06-01T12:01:00Z",
+          }),
+          makeEvent({
+            ID: 2,
+            EventType: "reopened",
+            Author: "mariusvniekerk",
+            Summary: "reopened this",
+            CreatedAt: "2024-06-01T12:00:45Z",
+          }),
+          makeEvent({
+            ID: 1,
+            EventType: "closed",
+            Author: "mariusvniekerk",
+            Summary: "closed this",
+            CreatedAt: "2024-06-01T12:00:30Z",
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getByText("Merged")).toBeTruthy();
+    expect(screen.getByText("Reopened")).toBeTruthy();
+    expect(screen.getByText("Closed")).toBeTruthy();
+    expect(screen.getByText("closed this")).toBeTruthy();
+    expect(document.querySelectorAll(".event--compact")).toHaveLength(3);
+  });
+
   it("keeps the timeline entry card while rendering body content without a nested card surface", () => {
     const { container } = render(EventTimeline, {
       props: {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -241,6 +241,82 @@ describe("EventTimeline", () => {
     expect(document.querySelectorAll(".event--compact")).toHaveLength(3);
   });
 
+  it("uses merged status styling for merged lifecycle events", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            EventType: "merged",
+            Summary: "merged this",
+          }),
+        ],
+      },
+    });
+
+    const label = screen.getByText("Merged");
+    const dot = document.querySelector(".dot");
+    expect(label.getAttribute("style")).toContain("var(--accent-purple)");
+    expect(dot?.getAttribute("style")).toContain("var(--accent-purple)");
+  });
+
+  it("renders compact lifecycle rows without boxed card chrome", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            EventType: "merged",
+            Summary: "merged this",
+          }),
+        ],
+      },
+    });
+
+    expect(document.querySelector(".event-card--compact")).toBeTruthy();
+    const compactCardStyle = findCompiledStyleRule(".event-card--compact");
+    expect(compactCardStyle.getPropertyValue("background")).toBe("transparent");
+    expect(compactCardStyle.getPropertyValue("border-color")).toBe("transparent");
+    expect(compactCardStyle.getPropertyValue("border-radius")).toBe("var(--radius-sm)");
+  });
+
+  it("collapses duplicate merge lifecycle rows into the single authored transition", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 3,
+            EventType: "merged",
+            Author: "mariusvniekerk",
+            Summary: "merged this",
+            CreatedAt: "2024-06-01T12:03:00Z",
+            DedupeKey: "timeline-merge-provider",
+          }),
+          makeEvent({
+            ID: 2,
+            EventType: "closed",
+            Author: "mariusvniekerk",
+            Summary: "closed this",
+            CreatedAt: "2024-06-01T12:03:00Z",
+            DedupeKey: "timeline-close-provider",
+          }),
+          makeEvent({
+            ID: 1,
+            EventType: "merged",
+            Author: "",
+            Summary: "merged this",
+            CreatedAt: "2024-06-01T12:03:00Z",
+            DedupeKey: "timeline-merge-fallback",
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getAllByText("Merged")).toHaveLength(1);
+    expect(screen.queryByText("Closed")).toBeNull();
+    expect(screen.queryByText("closed this")).toBeNull();
+    expect(screen.getByText("mariusvniekerk")).toBeTruthy();
+    expect(document.querySelectorAll(".event--compact")).toHaveLength(1);
+  });
+
   it("keeps the timeline entry card while rendering body content without a nested card surface", () => {
     const { container } = render(EventTimeline, {
       props: {


### PR DESCRIPTION
Merged pull request timelines could show duplicate merge rows and a redundant close row, while merged labels used the success-green token instead of the merged-state purple token.

- Collapse duplicate merge/close lifecycle rows in the detail timeline display.
- Use the merged-state purple token for merged lifecycle labels and dots.
