### PR TITLE
fix: preserve workspace diff selection on refresh

### DIFF
--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -406,6 +406,66 @@ describe("createDiffStore loadDiff", () => {
     expect(store.getScope()).toEqual({ kind: "commit", sha: "sha2" });
   });
 
+  it("resets workspace commit scope when refresh removes the selected commit", async () => {
+    const calls: string[] = [];
+    const commitResponses = [
+      [
+        {
+          sha: "sha2",
+          message: "second",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      [
+        {
+          sha: "sha3",
+          message: "third",
+          author_name: "Alice",
+          authored_at: "2026-01-02T00:00:00Z",
+        },
+      ],
+    ];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+      if (url.includes("/workspaces/ws-1/commits")) {
+        return Response.json({
+          commits: commitResponses.shift() ?? [],
+        });
+      }
+      if (url.includes("/workspaces/ws-1/files")) {
+        return Response.json(files);
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json(diff);
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "merge-target");
+    await store.loadCommits();
+    store.selectCommit("sha2");
+
+    await vi.waitFor(() => {
+      expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2");
+    });
+
+    calls.length = 0;
+    await store.loadWorkspaceDiff("ws-1", "merge-target", false, { refreshCommits: true });
+
+    expect(calls).toContain("/api/v1/workspaces/ws-1/commits");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/files?base=merge-target");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=merge-target");
+    expect(calls.some((url) => url.includes("commit=sha2"))).toBe(false);
+    expect(store.getCommits()?.map((commit) => commit.sha)).toEqual(["sha3"]);
+    expect(store.getScope()).toEqual({ kind: "head" });
+  });
+
   it("applies selected range scope to workspace files and patch requests", async () => {
     const calls: string[] = [];
     const files = makeFilesResult(["src/app.go"]);

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -335,6 +335,77 @@ describe("createDiffStore loadDiff", () => {
     });
   });
 
+  it("refreshes workspace commits without resetting the selected scope", async () => {
+    const calls: string[] = [];
+    const commitResponses = [
+      [
+        {
+          sha: "sha2",
+          message: "second",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+        {
+          sha: "sha1",
+          message: "first",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      [
+        {
+          sha: "sha3",
+          message: "third",
+          author_name: "Alice",
+          authored_at: "2026-01-02T00:00:00Z",
+        },
+        {
+          sha: "sha2",
+          message: "second",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    ];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+      if (url.includes("/workspaces/ws-1/commits")) {
+        return Response.json({
+          commits: commitResponses.shift() ?? [],
+        });
+      }
+      if (url.includes("/workspaces/ws-1/files")) {
+        return Response.json(files);
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json(diff);
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "merge-target");
+    await store.loadCommits();
+    store.selectCommit("sha2");
+
+    await vi.waitFor(() => {
+      expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2");
+    });
+
+    calls.length = 0;
+    await store.loadWorkspaceDiff("ws-1", "merge-target", false, { refreshCommits: true });
+
+    expect(calls).toContain("/api/v1/workspaces/ws-1/commits");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/files?base=merge-target&commit=sha2");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2");
+    expect(store.getCommits()?.map((commit) => commit.sha)).toEqual(["sha3", "sha2"]);
+    expect(store.getScope()).toEqual({ kind: "commit", sha: "sha2" });
+  });
+
   it("applies selected range scope to workspace files and patch requests", async () => {
     const calls: string[] = [];
     const files = makeFilesResult(["src/app.go"]);

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -179,6 +179,7 @@ async function setupTerminalMocks(
       status: number;
       body?: unknown;
     };
+    diffRequests?: string[];
     runtime?: WorkspaceRuntime;
     runtimeEvents?: RuntimeEvents;
   },
@@ -227,6 +228,91 @@ async function setupTerminalMocks(
       status: response.status,
       contentType: "application/json",
       body: JSON.stringify(response.body ?? {}),
+    });
+  });
+
+  await page.route(`**/api/v1/workspaces/${ws.id}/refresh`, async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fulfill({ status: 405 });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ws),
+    });
+  });
+
+  await page.route(`**/api/v1/workspaces/${ws.id}/files*`, async (route) => {
+    opts?.diffRequests?.push(route.request().url());
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        stale: false,
+        whitespace_only_count: 0,
+        files: [
+          {
+            path: "src/auth.go",
+            old_path: "src/auth.go",
+            status: "modified",
+            is_binary: false,
+            is_whitespace_only: false,
+            additions: 1,
+            deletions: 1,
+            hunks: [],
+            patch: "",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route(`**/api/v1/workspaces/${ws.id}/diff*`, async (route) => {
+    opts?.diffRequests?.push(route.request().url());
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        stale: false,
+        whitespace_only_count: 0,
+        files: [
+          {
+            path: "src/auth.go",
+            old_path: "src/auth.go",
+            status: "modified",
+            is_binary: false,
+            is_whitespace_only: false,
+            additions: 1,
+            deletions: 1,
+            hunks: [],
+            patch: "",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route(`**/api/v1/workspaces/${ws.id}/commits`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        commits: [
+          {
+            sha: "sha2",
+            message: "second commit",
+            author_name: "Alice",
+            authored_at: "2026-01-01T00:00:00Z",
+          },
+          {
+            sha: "sha1",
+            message: "first commit",
+            author_name: "Alice",
+            authored_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
     });
   });
 
@@ -615,6 +701,23 @@ function closedTopDockedTerminalWorkflowLayout() {
   };
 }
 
+function hasWorkspaceDiffRequest(
+  requests: string[],
+  expected: {
+    base: string;
+    commit?: string;
+  },
+): boolean {
+  return requests.some((requestURL) => {
+    const url = new URL(requestURL);
+    return (
+      url.pathname === "/api/v1/workspaces/ws-123/diff" &&
+      url.searchParams.get("base") === expected.base &&
+      (expected.commit === undefined || url.searchParams.get("commit") === expected.commit)
+    );
+  });
+}
+
 function shellWorkflowPreset() {
   return {
     id: "preset-shell",
@@ -721,6 +824,32 @@ test.describe("terminal state icons", () => {
     const stateMessage = page.locator(".state-message");
     await expect(stateMessage).toContainText("Setting up workspace...");
     await expect(stateMessage.locator(".spinner")).toBeVisible();
+  });
+
+  test("refresh preserves workspace diff target and commit selection", async ({ page }) => {
+    const diffRequests: string[] = [];
+    await setupTerminalMocks(page, { diffRequests });
+
+    await page.goto("/terminal/ws-123");
+    await page.locator(".seg-btn", { hasText: "Diff" }).click();
+
+    await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "head" })).toBe(true);
+
+    await page.getByRole("button", { name: "Compare with merge target" }).click();
+    await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target" })).toBe(true);
+
+    await page.getByRole("button", { name: /Select commit range/ }).click();
+    await page.getByRole("button", { name: /second commit/ }).click();
+    await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target", commit: "sha2" })).toBe(true);
+
+    diffRequests.length = 0;
+    await page.getByRole("button", { name: "Refresh workspace details" }).click();
+
+    await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target", commit: "sha2" })).toBe(true);
+    await expect(page.getByRole("button", { name: "Compare with merge target" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   test("workspace load failure shows alert icon and retry recovers", async ({ page }) => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -159,6 +159,12 @@ type RuntimeEvents = {
  * priority (Playwright uses LIFO route matching).
  */
 type WorkspaceFixture = typeof testWorkspace | typeof testIssueWorkspace | typeof testIssueWorkspaceWithAssociatedPR;
+type WorkspaceCommitFixture = {
+  sha: string;
+  message: string;
+  author_name: string;
+  authored_at: string;
+};
 
 async function setupTerminalMocks(
   page: import("@playwright/test").Page,
@@ -181,6 +187,7 @@ async function setupTerminalMocks(
     };
     diffRequests?: string[];
     commitRequests?: string[];
+    workspaceCommitResponses?: WorkspaceCommitFixture[][];
     runtime?: WorkspaceRuntime;
     runtimeEvents?: RuntimeEvents;
   },
@@ -191,6 +198,25 @@ async function setupTerminalMocks(
   const rrStatus = opts?.roborevStatus ?? roborevStatus;
   const detailResponses = [...(opts?.workspaceDetailResponses ?? [])];
   const deleteResponses = [...(opts?.workspaceDeleteResponses ?? [])];
+  const commitResponses = [
+    ...(opts?.workspaceCommitResponses ?? [
+      [
+        {
+          sha: "sha2",
+          message: "second commit",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+        {
+          sha: "sha1",
+          message: "first commit",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    ]),
+  ];
+  let commitResponseIndex = 0;
   const runtime = JSON.parse(JSON.stringify(opts?.runtime ?? workspaceRuntime)) as WorkspaceRuntime;
 
   // Register catch-all first — later routes override.
@@ -296,24 +322,13 @@ async function setupTerminalMocks(
 
   await page.route(`**/api/v1/workspaces/${ws.id}/commits`, async (route) => {
     opts?.commitRequests?.push(route.request().url());
+    const commits = commitResponses[Math.min(commitResponseIndex, commitResponses.length - 1)] ?? [];
+    commitResponseIndex += 1;
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        commits: [
-          {
-            sha: "sha2",
-            message: "second commit",
-            author_name: "Alice",
-            authored_at: "2026-01-01T00:00:00Z",
-          },
-          {
-            sha: "sha1",
-            message: "first commit",
-            author_name: "Alice",
-            authored_at: "2026-01-01T00:00:00Z",
-          },
-        ],
+        commits,
       }),
     });
   });
@@ -707,7 +722,7 @@ function hasWorkspaceDiffRequest(
   requests: string[],
   expected: {
     base: string;
-    commit?: string;
+    commit?: string | null;
   },
 ): boolean {
   return requests.some((requestURL) => {
@@ -715,7 +730,10 @@ function hasWorkspaceDiffRequest(
     return (
       url.pathname === "/api/v1/workspaces/ws-123/diff" &&
       url.searchParams.get("base") === expected.base &&
-      (expected.commit === undefined || url.searchParams.get("commit") === expected.commit)
+      (expected.commit === undefined ||
+        (expected.commit === null
+          ? !url.searchParams.has("commit") && !url.searchParams.has("from") && !url.searchParams.has("to")
+          : url.searchParams.get("commit") === expected.commit))
     );
   });
 }
@@ -851,6 +869,58 @@ test.describe("terminal state icons", () => {
 
     await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target", commit: "sha2" })).toBe(true);
     await expect.poll(() => commitRequests.length).toBeGreaterThan(0);
+    await expect(page.getByRole("button", { name: "Compare with merge target" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  test("refresh clears workspace diff commit selection when the commit disappears", async ({ page }) => {
+    const diffRequests: string[] = [];
+    const commitRequests: string[] = [];
+    await setupTerminalMocks(page, {
+      diffRequests,
+      commitRequests,
+      workspaceCommitResponses: [
+        [
+          {
+            sha: "sha2",
+            message: "second commit",
+            author_name: "Alice",
+            authored_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        [
+          {
+            sha: "sha3",
+            message: "third commit",
+            author_name: "Alice",
+            authored_at: "2026-01-02T00:00:00Z",
+          },
+        ],
+      ],
+    });
+
+    await page.goto("/terminal/ws-123");
+    await page.locator(".seg-btn", { hasText: "Diff" }).click();
+
+    await page.getByRole("button", { name: "Compare with merge target" }).click();
+    await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target" })).toBe(true);
+
+    const scopeTrigger = page.getByRole("button", { name: /Select commit range/ });
+    await scopeTrigger.click();
+    await page.getByRole("button", { name: /second commit/ }).click();
+    await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target", commit: "sha2" })).toBe(true);
+    await expect(scopeTrigger).toHaveAccessibleName(/Select commit range: sha2/);
+
+    diffRequests.length = 0;
+    commitRequests.length = 0;
+    await page.getByRole("button", { name: "Refresh workspace details" }).click();
+
+    await expect.poll(() => commitRequests.length).toBeGreaterThan(0);
+    await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target", commit: null })).toBe(true);
+    expect(diffRequests.some((requestURL) => new URL(requestURL).searchParams.get("commit") === "sha2")).toBe(false);
+    await expect(scopeTrigger).toHaveAccessibleName(/Select commit range: HEAD/);
     await expect(page.getByRole("button", { name: "Compare with merge target" })).toHaveAttribute(
       "aria-pressed",
       "true",

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -180,6 +180,7 @@ async function setupTerminalMocks(
       body?: unknown;
     };
     diffRequests?: string[];
+    commitRequests?: string[];
     runtime?: WorkspaceRuntime;
     runtimeEvents?: RuntimeEvents;
   },
@@ -294,6 +295,7 @@ async function setupTerminalMocks(
   });
 
   await page.route(`**/api/v1/workspaces/${ws.id}/commits`, async (route) => {
+    opts?.commitRequests?.push(route.request().url());
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -828,7 +830,8 @@ test.describe("terminal state icons", () => {
 
   test("refresh preserves workspace diff target and commit selection", async ({ page }) => {
     const diffRequests: string[] = [];
-    await setupTerminalMocks(page, { diffRequests });
+    const commitRequests: string[] = [];
+    await setupTerminalMocks(page, { diffRequests, commitRequests });
 
     await page.goto("/terminal/ws-123");
     await page.locator(".seg-btn", { hasText: "Diff" }).click();
@@ -843,9 +846,11 @@ test.describe("terminal state icons", () => {
     await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target", commit: "sha2" })).toBe(true);
 
     diffRequests.length = 0;
+    commitRequests.length = 0;
     await page.getByRole("button", { name: "Refresh workspace details" }).click();
 
     await expect.poll(() => hasWorkspaceDiffRequest(diffRequests, { base: "merge-target", commit: "sha2" })).toBe(true);
+    await expect.poll(() => commitRequests.length).toBeGreaterThan(0);
     await expect(page.getByRole("button", { name: "Compare with merge target" })).toHaveAttribute(
       "aria-pressed",
       "true",

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -14,6 +14,7 @@
     repoPath: string;
     itemNumber: number;
     active?: boolean;
+    refreshToken?: number;
   }
 
   const {
@@ -25,6 +26,7 @@
     repoPath,
     itemNumber,
     active = false,
+    refreshToken = 0,
   }: Props = $props();
   const { diff } = getStores();
 
@@ -33,7 +35,7 @@
 
   $effect(() => {
     if (!active) return;
-    const key = `${workspaceID}:${base}`;
+    const key = `${workspaceID}:${base}:${refreshToken}`;
     if (loadedKey === key) return;
     loadedKey = key;
     void diff.loadWorkspaceDiff(workspaceID, base);

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -38,7 +38,7 @@
     const key = `${workspaceID}:${base}:${refreshToken}`;
     if (loadedKey === key) return;
     loadedKey = key;
-    void diff.loadWorkspaceDiff(workspaceID, base);
+    void diff.loadWorkspaceDiff(workspaceID, base, false, { refreshCommits: refreshToken > 0 });
   });
 
   function selectBase(nextBase: WorkspaceDiffBase): void {

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
@@ -280,7 +280,7 @@
 
 <div class="right-sidebar-content">
   {#if activeTab === "diff"}
-    {#key `diff:${workspaceID}:${refreshToken}`}
+    {#key `diff:${workspaceID}`}
       <WorkspaceDiffPanel
         {workspaceID}
         {provider}
@@ -290,6 +290,7 @@
         {repoPath}
         itemNumber={ownerItemNumber}
         active={activeTab === "diff"}
+        {refreshToken}
       />
     {/key}
   {:else if activeTab === "pr"}

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
@@ -1,0 +1,118 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { STORES_KEY } from "../../context.js";
+import { createDiffStore } from "../../stores/diff.svelte.js";
+import type { StoreInstances } from "../../types.js";
+import WorkspaceRightSidebar from "./WorkspaceRightSidebar.svelte";
+
+function makeStores(): Pick<StoreInstances, "diff"> & Partial<StoreInstances> {
+  return {
+    diff: createDiffStore(),
+    roborevDaemon: {
+      isAvailable: () => false,
+    } as StoreInstances["roborevDaemon"],
+  };
+}
+
+function renderSidebar(refreshToken = 0) {
+  return render(WorkspaceRightSidebar, {
+    props: {
+      activeTab: "diff",
+      workspaceID: "ws-1",
+      provider: "github",
+      platformHost: "github.com",
+      repoOwner: "acme",
+      repoName: "widgets",
+      repoPath: "acme/widgets",
+      ownerItemType: "pull_request",
+      ownerItemNumber: 7,
+      associatedPRNumber: 7,
+      branch: "feature/widgets",
+      roborevBaseUrl: "http://localhost/api/roborev",
+      refreshToken,
+    },
+    context: new Map([[STORES_KEY, makeStores()]]),
+  });
+}
+
+describe("WorkspaceRightSidebar", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves the workspace diff base and selected commit across refreshes", async () => {
+    const calls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+
+      if (url.includes("/api/roborev/api/repos")) {
+        return Response.json({ repos: [] });
+      }
+      if (url.includes("/api/v1/workspaces/ws-1/commits")) {
+        return Response.json({
+          commits: [
+            {
+              sha: "sha2",
+              message: "second commit",
+              author_name: "Alice",
+              authored_at: "2026-01-01T00:00:00Z",
+            },
+            {
+              sha: "sha1",
+              message: "first commit",
+              author_name: "Alice",
+              authored_at: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }
+      if (url.includes("/api/v1/workspaces/ws-1/files")) {
+        return Response.json({
+          stale: false,
+          whitespace_only_count: 0,
+          files: [],
+        });
+      }
+      if (url.includes("/api/v1/workspaces/ws-1/diff")) {
+        return Response.json({
+          stale: false,
+          whitespace_only_count: 0,
+          files: [],
+        });
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const { rerender } = renderSidebar();
+
+    await waitFor(() => {
+      expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=head"))).toBe(true);
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Compare with merge target" }));
+    await waitFor(() => {
+      expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=merge-target"))).toBe(true);
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /Select commit range/ }));
+    await fireEvent.click(await screen.findByRole("button", { name: /second commit/ }));
+    await waitFor(() => {
+      expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2"))).toBe(
+        true,
+      );
+    });
+
+    calls.length = 0;
+    await rerender({ refreshToken: 1 });
+
+    await waitFor(() => {
+      expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2"))).toBe(
+        true,
+      );
+    });
+    expect(screen.getByRole("button", { name: "Compare with merge target" }).getAttribute("aria-pressed")).toBe("true");
+    expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=head"))).toBe(false);
+  });
+});

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
@@ -112,6 +112,7 @@ describe("WorkspaceRightSidebar", () => {
         true,
       );
     });
+    expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/commits"))).toBe(true);
     expect(screen.getByRole("button", { name: "Compare with merge target" }).getAttribute("aria-pressed")).toBe("true");
     expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=head"))).toBe(false);
   });

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -23,6 +23,14 @@ export type DiffScope =
 export type WorkspaceDiffBase = "head" | "pushed" | "merge-target";
 export type DiffViewMode = "unified" | "split";
 
+export interface LoadWorkspaceDiffOptions {
+  refreshCommits?: boolean;
+}
+
+interface LoadCommitsOptions {
+  force?: boolean;
+}
+
 export type DiffScrollTarget = {
   path: string;
   line?: number | undefined;
@@ -151,6 +159,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let commits = $state<CommitInfo[] | null>(null);
   let commitsLoading = $state(false);
   let commitsError = $state<string | null>(null);
+  let commitsGeneration = 0;
   let scope = $state<DiffScope>({ kind: "head" });
   let filePreviewGeneration = $state(0);
   const filePreviewCache = new Map<string, Promise<FilePreview>>();
@@ -672,8 +681,17 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     await Promise.allSettled([filesPromise, diffPromise]);
   }
 
-  async function loadWorkspaceDiff(workspaceID: string, base: WorkspaceDiffBase, stacked = false): Promise<void> {
+  async function loadWorkspaceDiff(
+    workspaceID: string,
+    base: WorkspaceDiffBase,
+    stacked = false,
+    options: LoadWorkspaceDiffOptions = {},
+  ): Promise<void> {
     const workspaceScopeChanged = workspaceID !== currentWorkspaceID || base !== currentWorkspaceBase;
+    const shouldRefreshCommits =
+      options.refreshCommits === true &&
+      !workspaceScopeChanged &&
+      (commits !== null || commitsLoading || commitsError !== null);
     currentWorkspaceID = workspaceID;
     currentWorkspaceBase = base;
     currentWorkspaceStacked = stacked;
@@ -684,6 +702,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     if (workspaceScopeChanged) {
       resetDiffScopeState();
     }
+    const commitsPromise = shouldRefreshCommits ? loadCommits({ force: true }) : undefined;
 
     const { diffAc, filesAc } = startDiffLoad();
 
@@ -726,6 +745,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     } finally {
       finishDiffLoad(diffAc);
     }
+    await commitsPromise;
   }
 
   async function loadCommitDiff(identity: ProviderRouteRef, sha: string): Promise<void> {
@@ -814,14 +834,22 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentRepoPath = "";
   }
 
-  async function loadCommits(): Promise<void> {
-    if (commits || commitsLoading) return;
+  async function loadCommits(options: LoadCommitsOptions = {}): Promise<void> {
+    if (options.force) {
+      commitsGeneration += 1;
+      commits = null;
+      commitsLoading = false;
+      commitsError = null;
+    } else if (commits || commitsLoading) {
+      return;
+    }
     if (!currentWorkspaceID && (!currentOwner || !currentName || !currentNumber)) {
       return;
     }
 
     commitsLoading = true;
     commitsError = null;
+    const generation = commitsGeneration;
     const owner = currentOwner;
     const name = currentName;
     const number = currentNumber;
@@ -839,7 +867,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         currentWorkspaceID !== workspaceID ||
         currentOwner !== owner ||
         currentName !== name ||
-        currentNumber !== number
+        currentNumber !== number ||
+        generation !== commitsGeneration
       )
         return;
       if (!data) {
@@ -849,7 +878,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         currentWorkspaceID !== workspaceID ||
         currentOwner !== owner ||
         currentName !== name ||
-        currentNumber !== number
+        currentNumber !== number ||
+        generation !== commitsGeneration
       )
         return;
       commits = data.commits ?? [];
@@ -858,7 +888,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         currentWorkspaceID !== workspaceID ||
         currentOwner !== owner ||
         currentName !== name ||
-        currentNumber !== number
+        currentNumber !== number ||
+        generation !== commitsGeneration
       )
         return;
       commitsError = err instanceof Error ? err.message : String(err);
@@ -867,7 +898,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         currentWorkspaceID === workspaceID &&
         currentOwner === owner &&
         currentName === name &&
-        currentNumber === number
+        currentNumber === number &&
+        generation === commitsGeneration
       ) {
         commitsLoading = false;
       }

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -559,6 +559,16 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     commitsError = null;
   }
 
+  function resetScopeIfMissingFromLoadedCommits(): void {
+    if (!commits || scope.kind === "head") return;
+    const hasCommit = (sha: string) => commits?.some((commit) => commit.sha === sha) ?? false;
+    const scopeStillExists =
+      scope.kind === "commit" ? hasCommit(scope.sha) : hasCommit(scope.fromSha) && hasCommit(scope.toSha);
+    if (scopeStillExists) return;
+    scope = { kind: "head" };
+    clearFilePreviewCache();
+  }
+
   function startDiffLoad(): {
     diffAc: AbortController;
     filesAc: AbortController;
@@ -702,7 +712,11 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     if (workspaceScopeChanged) {
       resetDiffScopeState();
     }
-    const commitsPromise = shouldRefreshCommits ? loadCommits({ force: true }) : undefined;
+    if (shouldRefreshCommits) {
+      await loadCommits({ force: true });
+      if (currentWorkspaceID !== workspaceID || currentWorkspaceBase !== base) return;
+      resetScopeIfMissingFromLoadedCommits();
+    }
 
     const { diffAc, filesAc } = startDiffLoad();
 
@@ -745,7 +759,6 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     } finally {
       finishDiffLoad(diffAc);
     }
-    await commitsPromise;
   }
 
   async function loadCommitDiff(identity: ProviderRouteRef, sha: string): Promise<void> {


### PR DESCRIPTION
Refreshing workspace details remounted the diff panel, which discarded the selected compare base and commit/range scope. That sent reviewers back to HEAD even when they were checking Target, Branch, or a specific commit.

- Preserve the workspace diff panel instance across refreshes.
- Treat the refresh token as a reload signal for the existing panel.
- Add component and browser regression coverage for refreshing with Target plus a selected commit.
