### PR TITLE
fix: hide default-branch commits when Commits is deselected in the activity filter

### DIFF
--- a/frontend/tests/e2e/default-branch-activity.spec.ts
+++ b/frontend/tests/e2e/default-branch-activity.spec.ts
@@ -349,6 +349,22 @@ test.describe("default branch activity", () => {
     ).toBeVisible();
   });
 
+  test("legacy URL with stale default-branch commit types hides commit rows on load", async ({ page }) => {
+    await mockDefaultBranchActivity(page);
+    // URLs written before the fix kept default_branch_commit in the types
+    // param even with commit deselected; hydration must normalize it away.
+    await page.goto(
+      "/?view=flat&types=new_pr,new_issue,default_branch_commit,default_branch_force_push,comment,review,force_push",
+    );
+
+    await expect(page.locator(".activity-row", { hasText: "aaaaaaa -> bbbbbbb" })).toBeVisible();
+    await expect(
+      page.locator(".activity-row", {
+        hasText: "Ship direct main commit",
+      }),
+    ).toHaveCount(0);
+  });
+
   test("deselecting Force pushes hides default-branch force pushes", async ({ page }) => {
     await mockDefaultBranchActivity(page);
     await page.goto("/?view=flat");

--- a/frontend/tests/e2e/default-branch-activity.spec.ts
+++ b/frontend/tests/e2e/default-branch-activity.spec.ts
@@ -194,12 +194,20 @@ async function mockDefaultBranchActivity(page: Page): Promise<void> {
     });
   });
   await page.route("**/api/v1/activity**", async (route) => {
+    // Mirror the real API: when a types filter is present, only return
+    // matching activity_type rows (internal/db/queries_activity.go).
+    const url = new URL(route.request().url());
+    const types = url.searchParams.getAll("types").flatMap((value) => value.split(","));
+    const items =
+      types.length > 0
+        ? activityItems.filter((item) => types.includes((item as { activity_type: string }).activity_type))
+        : activityItems;
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
         capped: false,
-        items: activityItems,
+        items,
       }),
     });
   });
@@ -316,6 +324,46 @@ test.describe("default branch activity", () => {
     await expect(
       page.locator(".activity-row", {
         hasText: "Add browser regression coverage",
+      }),
+    ).toBeVisible();
+  });
+
+  test("deselecting Commits hides default-branch commit rows", async ({ page }) => {
+    await mockDefaultBranchActivity(page);
+    await page.goto("/?view=flat");
+
+    const commitRows = page.locator(".activity-row", {
+      hasText: "Ship direct main commit",
+    });
+    await expect(commitRows).toHaveCount(5);
+
+    await selectActivityFilterItem(page, "Commits");
+
+    await expect(commitRows).toHaveCount(0);
+    // Other activity is unaffected: the force push and the PR comment remain.
+    await expect(page.locator(".activity-row", { hasText: "aaaaaaa -> bbbbbbb" })).toBeVisible();
+    await expect(
+      page.locator(".activity-row", {
+        hasText: "Add browser regression coverage",
+      }),
+    ).toBeVisible();
+  });
+
+  test("deselecting Force pushes hides default-branch force pushes", async ({ page }) => {
+    await mockDefaultBranchActivity(page);
+    await page.goto("/?view=flat");
+
+    const forcePushRow = page.locator(".activity-row", {
+      hasText: "aaaaaaa -> bbbbbbb",
+    });
+    await expect(forcePushRow).toBeVisible();
+
+    await selectActivityFilterItem(page, "Force pushes");
+
+    await expect(forcePushRow).toHaveCount(0);
+    await expect(
+      page.locator(".activity-row", {
+        hasText: "Ship direct main commit 1",
       }),
     ).toBeVisible();
   });

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import type { ActivityItem } from "../api/types.js";
   import {
-    DEFAULT_BRANCH_ACTIVITY_TYPES,
+    buildActivityFilterTypes,
     DEFAULT_EVENT_TYPES,
     type TimeRange,
     type ViewMode,
@@ -121,21 +121,11 @@
   });
 
   function applyFilters(): void {
-    const types: string[] = [];
-    const filter = activity.getItemFilter();
-    if (filter === "prs") types.push("new_pr");
-    else if (filter === "issues") types.push("new_issue");
-    else {
-      types.push("new_pr", "new_issue");
-      if (!activity.getHideDefaultBranchActivity()) {
-        types.push(...DEFAULT_BRANCH_ACTIVITY_TYPES);
-      }
-    }
-    for (const evt of activity.getEnabledEvents()) types.push(evt);
-    const allSelected = filter === "all"
-      && activity.getEnabledEvents().size === EVENT_TYPES.length
-      && !activity.getHideDefaultBranchActivity();
-    activity.setActivityFilterTypes(allSelected ? [] : types);
+    activity.setActivityFilterTypes(buildActivityFilterTypes(
+      activity.getItemFilter(),
+      activity.getEnabledEvents(),
+      activity.getHideDefaultBranchActivity(),
+    ));
     activity.syncToURL();
     void activity.loadActivity();
   }

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -59,6 +59,9 @@ const expandAllThreads = vi.hoisted(() => vi.fn());
 const hideDefaultBranchActivity = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
 const setActivityFilterTypes = vi.hoisted(() => vi.fn());
+const enabledEvents = vi.hoisted(() => ({
+  value: new Set(["comment", "review", "commit", "force_push"]),
+}));
 
 vi.mock("../context.js", () => ({
   getNavigate: () => vi.fn(),
@@ -70,7 +73,7 @@ vi.mock("../context.js", () => ({
       startActivityPolling: vi.fn(),
       stopActivityPolling: vi.fn(),
       getActivitySearch: () => "",
-      getEnabledEvents: () => new Set(["comment", "review", "commit", "force_push"]),
+      getEnabledEvents: () => enabledEvents.value,
       getHideClosedMerged: () => false,
       getHideBots: () => false,
       getHideDefaultBranchActivity: () => hideDefaultBranchActivity.value,
@@ -88,7 +91,9 @@ vi.mock("../context.js", () => ({
       toggleThreadItem: vi.fn(),
       setActivityFilterTypes,
       setItemFilter: vi.fn(),
-      setEnabledEvents: vi.fn(),
+      setEnabledEvents: vi.fn((events: Set<string>) => {
+        enabledEvents.value = events;
+      }),
       setHideClosedMerged: vi.fn(),
       setHideBots: vi.fn(),
       setHideDefaultBranchActivity: vi.fn((value: boolean) => {
@@ -123,6 +128,7 @@ describe("ActivityFeed compact mode", () => {
     collapseThreads.value = false;
     hideDefaultBranchActivity.value = false;
     hideOrgName.value = false;
+    enabledEvents.value = new Set(["comment", "review", "commit", "force_push"]);
     setActivityFilterTypes.mockClear();
     items.value = [
       activityItem("selected"),
@@ -327,6 +333,38 @@ describe("ActivityFeed compact mode", () => {
     expect(row?.textContent).not.toContain("#0");
     expect(row?.querySelector(".chip--kind-pr")).toBeNull();
     expect(row?.querySelector(".chip--kind-issue")).toBeNull();
+  });
+
+  it("deselecting Commits also hides default-branch commit activity", async () => {
+    render(ActivityFeed, { props: { compact: true } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "View" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Commits" }));
+
+    expect(setActivityFilterTypes).toHaveBeenCalledWith([
+      "new_pr",
+      "new_issue",
+      "default_branch_force_push",
+      "comment",
+      "review",
+      "force_push",
+    ]);
+  });
+
+  it("deselecting Force pushes also hides default-branch force pushes", async () => {
+    render(ActivityFeed, { props: { compact: true } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "View" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Force pushes" }));
+
+    expect(setActivityFilterTypes).toHaveBeenCalledWith([
+      "new_pr",
+      "new_issue",
+      "default_branch_commit",
+      "comment",
+      "review",
+      "commit",
+    ]);
   });
 
   it("can hide default-branch activity from the filter dropdown", async () => {

--- a/packages/ui/src/stores/activity.svelte.test.ts
+++ b/packages/ui/src/stores/activity.svelte.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 import type { ActivitySettings } from "../api/types.js";
-import { createActivityStore } from "./activity.svelte.js";
+import { buildActivityFilterTypes, createActivityStore, DEFAULT_EVENT_TYPES } from "./activity.svelte.js";
 
 const fakeClient = {
   GET: async () => ({
@@ -116,6 +116,66 @@ describe("activity store collapse state", () => {
 
     s.hydrateDefaults(settings(false));
     expect(s.getCollapseThreads()).toBe(false);
+  });
+});
+
+describe("buildActivityFilterTypes", () => {
+  const allEvents = new Set<string>(DEFAULT_EVENT_TYPES);
+
+  it("returns no filter when everything is selected", () => {
+    expect(buildActivityFilterTypes("all", allEvents, false)).toEqual([]);
+  });
+
+  it("drops default-branch commits when the commit event is deselected", () => {
+    const enabled = new Set(["comment", "review", "force_push"]);
+    expect(buildActivityFilterTypes("all", enabled, false)).toEqual([
+      "new_pr",
+      "new_issue",
+      "default_branch_force_push",
+      "comment",
+      "review",
+      "force_push",
+    ]);
+  });
+
+  it("drops default-branch force pushes when the force-push event is deselected", () => {
+    const enabled = new Set(["comment", "review", "commit"]);
+    expect(buildActivityFilterTypes("all", enabled, false)).toEqual([
+      "new_pr",
+      "new_issue",
+      "default_branch_commit",
+      "comment",
+      "review",
+      "commit",
+    ]);
+  });
+
+  it("excludes all default-branch activity when it is hidden", () => {
+    expect(buildActivityFilterTypes("all", allEvents, true)).toEqual([
+      "new_pr",
+      "new_issue",
+      "comment",
+      "review",
+      "commit",
+      "force_push",
+    ]);
+  });
+
+  it("never includes default-branch activity for PR or issue item filters", () => {
+    expect(buildActivityFilterTypes("prs", allEvents, false)).toEqual([
+      "new_pr",
+      "comment",
+      "review",
+      "commit",
+      "force_push",
+    ]);
+    expect(buildActivityFilterTypes("issues", allEvents, false)).toEqual([
+      "new_issue",
+      "comment",
+      "review",
+      "commit",
+      "force_push",
+    ]);
   });
 });
 

--- a/packages/ui/src/stores/activity.svelte.test.ts
+++ b/packages/ui/src/stores/activity.svelte.test.ts
@@ -179,6 +179,41 @@ describe("buildActivityFilterTypes", () => {
   });
 });
 
+describe("activity store URL hydration", () => {
+  it("normalizes legacy URLs that kept default-branch commits while commit was deselected", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?types=new_pr,new_issue,default_branch_commit,default_branch_force_push,comment,review,force_push",
+    );
+    const s = makeStore();
+    s.initializeFromMount();
+    expect(s.getActivityFilterTypes()).toEqual([
+      "new_pr",
+      "new_issue",
+      "default_branch_force_push",
+      "comment",
+      "review",
+      "force_push",
+    ]);
+    expect(new URLSearchParams(window.location.search).get("types")).toBe(
+      "new_pr,new_issue,default_branch_force_push,comment,review,force_push",
+    );
+  });
+
+  it("normalizes a legacy all-selected types list back to no filter", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?types=new_pr,new_issue,default_branch_commit,default_branch_force_push,comment,review,commit,force_push",
+    );
+    const s = makeStore();
+    s.initializeFromMount();
+    expect(s.getActivityFilterTypes()).toEqual([]);
+    expect(new URLSearchParams(window.location.search).has("types")).toBe(false);
+  });
+});
+
 describe("activity store default-branch visibility", () => {
   it("shows default-branch activity by default and persists the hide flag", () => {
     const s = makeStore();

--- a/packages/ui/src/stores/activity.svelte.ts
+++ b/packages/ui/src/stores/activity.svelte.ts
@@ -7,7 +7,39 @@ export type ItemFilter = "all" | "prs" | "issues";
 
 export const DEFAULT_EVENT_TYPES = ["comment", "review", "commit", "force_push"] as const;
 
-export const DEFAULT_BRANCH_ACTIVITY_TYPES = ["default_branch_commit", "default_branch_force_push"] as const;
+// Default-branch activity rows render as "Commit"/"Force-pushed" just like
+// their PR counterparts, so the event-type toggles must govern both kinds.
+const BRANCH_TYPE_FOR_EVENT: Partial<Record<string, string>> = {
+  commit: "default_branch_commit",
+  force_push: "default_branch_force_push",
+};
+
+export function buildActivityFilterTypes(
+  itemFilter: ItemFilter,
+  enabledEvents: ReadonlySet<string>,
+  hideDefaultBranchActivity: boolean,
+): string[] {
+  const allSelected =
+    itemFilter === "all" && enabledEvents.size === DEFAULT_EVENT_TYPES.length && !hideDefaultBranchActivity;
+  if (allSelected) return [];
+
+  const types: string[] = [];
+  if (itemFilter === "prs") types.push("new_pr");
+  else if (itemFilter === "issues") types.push("new_issue");
+  else {
+    types.push("new_pr", "new_issue");
+    if (!hideDefaultBranchActivity) {
+      for (const evt of DEFAULT_EVENT_TYPES) {
+        const branchType = BRANCH_TYPE_FOR_EVENT[evt];
+        if (branchType && enabledEvents.has(evt)) types.push(branchType);
+      }
+    }
+  }
+  for (const evt of DEFAULT_EVENT_TYPES) {
+    if (enabledEvents.has(evt)) types.push(evt);
+  }
+  return types;
+}
 
 const RANGE_MS: Record<TimeRange, number> = {
   "24h": 24 * 60 * 60 * 1000,

--- a/packages/ui/src/stores/activity.svelte.ts
+++ b/packages/ui/src/stores/activity.svelte.ts
@@ -354,6 +354,10 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     else if (hasIssue && !hasPR) itemFilter = "issues";
     else itemFilter = "all";
     enabledEvents = new Set(DEFAULT_EVENT_TYPES.filter((t) => filterTypes.includes(t)));
+    // URLs written before the event toggles governed default-branch types can
+    // list default_branch_commit while commit is deselected; rebuild so the
+    // request matches the filter state the dropdown shows.
+    filterTypes = buildActivityFilterTypes(itemFilter, enabledEvents, hideDefaultBranchActivity);
   }
 
   function applyCollapsedFromURL(): void {

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -3,8 +3,7 @@
   import type { ActivityItem } from "../api/types.js";
   import { getStores } from "../context.js";
   import {
-    DEFAULT_BRANCH_ACTIVITY_TYPES,
-    DEFAULT_EVENT_TYPES,
+    buildActivityFilterTypes,
     type ItemFilter,
     type TimeRange,
   } from "../stores/activity.svelte.js";
@@ -157,25 +156,11 @@
   const visibleGroups = $derived(groups.slice(0, 30));
 
   function applyFilters(): void {
-    const types: string[] = [];
-    const filter = activity.getItemFilter();
-    if (filter === "prs") types.push("new_pr");
-    else if (filter === "issues") types.push("new_issue");
-    else {
-      types.push("new_pr", "new_issue");
-      if (!activity.getHideDefaultBranchActivity()) {
-        types.push(...DEFAULT_BRANCH_ACTIVITY_TYPES);
-      }
-    }
-
-    for (const eventType of activity.getEnabledEvents()) {
-      types.push(eventType);
-    }
-
-    const allSelected = filter === "all"
-      && activity.getEnabledEvents().size === DEFAULT_EVENT_TYPES.length
-      && !activity.getHideDefaultBranchActivity();
-    activity.setActivityFilterTypes(allSelected ? [] : types);
+    activity.setActivityFilterTypes(buildActivityFilterTypes(
+      activity.getItemFilter(),
+      activity.getEnabledEvents(),
+      activity.getHideDefaultBranchActivity(),
+    ));
     activity.syncToURL();
     void activity.loadActivity();
   }


### PR DESCRIPTION
Closes #453

- Deselecting "Commits" in the activity filter dropdown now also hides default-branch commit rows; previously only PR-attached commit events were removed while default-branch commits (which render with the same "Commit" label) stayed visible.
- The "Force pushes" toggle likewise now governs default-branch force pushes.
- Desktop and mobile activity views share one filter-types helper instead of duplicating the logic.

All event types selected — default-branch commit rows visible:

![issue-453-before.png](https://github.com/user-attachments/assets/00d60aa4-8d8a-420c-861a-017e627aa2dc)

Commits deselected — default-branch commit rows now hidden:

![issue-453-after.png](https://github.com/user-attachments/assets/f744eded-3dff-42e3-9044-8d1c7d9067cf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)