### PR TITLE
fix: stop repo summary results count from shifting the toolbar

### DIFF
--- a/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
@@ -120,15 +120,20 @@
     },
   ]);
 
-  const filteredSummaries = $derived.by(() => {
+  const searchedSummaries = $derived.by(() => {
     const q = searchQuery.trim().toLowerCase();
-    const matches = summaries.filter((summary) => {
+    if (q === "") return summaries;
+    return summaries.filter((summary) =>
+      repoKey(summary).toLowerCase().includes(q)
+        || summary.platform_host.toLowerCase().includes(q));
+  });
+
+  const filteredSummaries = $derived.by(() => {
+    const matches = searchedSummaries.filter((summary) => {
       if (activeFilter === "prs" && summary.open_pr_count === 0) return false;
       if (activeFilter === "issues" && summary.open_issue_count === 0) return false;
       if (activeFilter === "stale" && !isStaleRelease(summary)) return false;
-      if (q === "") return true;
-      return repoKey(summary).toLowerCase().includes(q)
-        || summary.platform_host.toLowerCase().includes(q);
+      return true;
     });
 
     return [...matches].sort((a, b) => {
@@ -156,6 +161,10 @@
     );
     return providers.size > 1;
   });
+
+  function resultsLabel(count: number): string {
+    return `${count} ${count === 1 ? "result" : "results"}`;
+  }
 
   function dateValue(value: string | undefined): number {
     if (!value) return 0;
@@ -434,7 +443,12 @@
           />
         </div>
         <span class="repo-page__results">
-          {filteredSummaries.length} {filteredSummaries.length === 1 ? "result" : "results"}
+          <span class="repo-page__results-sizer" aria-hidden="true">
+            {searchedSummaries.length} results
+          </span>
+          <span class="repo-page__results-value">
+            {resultsLabel(filteredSummaries.length)}
+          </span>
         </span>
         <button
           type="button"
@@ -639,9 +653,24 @@
   }
 
   .repo-page__results {
+    display: inline-grid;
+    justify-items: end;
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Sizer and value stack in the same grid cell so the label is always as
+     wide as the unfiltered ("All") count, preventing layout shift when
+     switching filters changes the digit count. */
+  .repo-page__results-sizer,
+  .repo-page__results-value {
+    grid-area: 1 / 1;
     white-space: nowrap;
+  }
+
+  .repo-page__results-sizer {
+    visibility: hidden;
   }
 
   .repo-page__refresh {

--- a/frontend/tests/e2e/repo-summary-results-label.spec.ts
+++ b/frontend/tests/e2e/repo-summary-results-label.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("results label keeps its width when filters change the count", async ({ page }) => {
+  await page.goto("/repos");
+
+  const results = page.locator(".repo-page__results");
+  await expect(results).toContainText("12 results");
+
+  const allBox = await results.boundingBox();
+  expect(allBox).not.toBeNull();
+
+  const refresh = page.getByRole("button", { name: "Refresh repositories" });
+  const refreshBoxAll = await refresh.boundingBox();
+  expect(refreshBoxAll).not.toBeNull();
+
+  // "Has PRs" drops the count from two digits to one; the label and its
+  // neighbors must not move.
+  await page.getByRole("button", { name: "Has PRs", exact: true }).click();
+  await expect(results).toContainText("4 results");
+
+  const prsBox = await results.boundingBox();
+  expect(prsBox).not.toBeNull();
+  expect(prsBox!.width).toBeCloseTo(allBox!.width, 1);
+  expect(prsBox!.x).toBeCloseTo(allBox!.x, 1);
+
+  const refreshBoxPrs = await refresh.boundingBox();
+  expect(refreshBoxPrs!.x).toBeCloseTo(refreshBoxAll!.x, 1);
+});

--- a/frontend/tests/e2e/support/mockApi.ts
+++ b/frontend/tests/e2e/support/mockApi.ts
@@ -207,6 +207,36 @@ const repos = [
   },
 ];
 
+// Twelve repos with open PRs on only a few of them, so switching the summary
+// page filter between "All" (2-digit count) and "Has PRs" (1-digit count)
+// exercises the results-label digit change.
+const repoSummaries = Array.from({ length: 12 }, (_, i) => {
+  const name = `repo-${String(i + 1).padStart(2, "0")}`;
+  return {
+    owner: "acme",
+    name,
+    platform_host: "github.com",
+    repo: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name,
+      repo_path: `acme/${name}`,
+    },
+    cached_pr_count: i < 4 ? 3 : 0,
+    open_pr_count: i < 4 ? 3 : 0,
+    draft_pr_count: 0,
+    cached_issue_count: i < 3 ? 2 : 0,
+    open_issue_count: i < 3 ? 2 : 0,
+    most_recent_activity_at: "2026-03-30T12:00:00Z",
+    last_sync_completed_at: "2026-03-30T14:00:30Z",
+    last_sync_started_at: "2026-03-30T14:00:00Z",
+    last_sync_error: "",
+    active_authors: [],
+    recent_issues: [],
+  };
+});
+
 const syncStatus = {
   running: false,
   last_run_at: "2026-03-30T14:00:30Z",
@@ -553,6 +583,11 @@ export async function mockApi(page: Page): Promise<void> {
 
     if (method === "GET" && pathname === "/api/v1/repos") {
       await fulfillJson(route, repos);
+      return;
+    }
+
+    if (method === "GET" && pathname === "/api/v1/repos/summary") {
+      await fulfillJson(route, repoSummaries);
       return;
     }
 


### PR DESCRIPTION
Switching filters on the repositories page changed the digit width of the "N results" label, resizing it and nudging the sort dropdown and refresh button on every filter change.

- The results label now reserves the width of the largest count any filter can produce (the search-only match total), so the toolbar stays put when filters change.
- Tabular numerals keep digit widths constant; the visible count stays right-aligned next to the refresh button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)