### PR TITLE
feat: make the reviews Cost column sortable

### DIFF
--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -21,6 +21,51 @@ function makeJob(id: number, startedAt?: string, finishedAt?: string): ReviewJob
   };
 }
 
+describe("createJobsStore cost sorting", () => {
+  function makeCostJob(id: number, tokenUsage?: string): ReviewJob {
+    return {
+      ...makeJob(id),
+      ...(tokenUsage !== undefined ? { token_usage: tokenUsage } : {}),
+    };
+  }
+
+  it("sorts missing cost before zero-dollar jobs", async () => {
+    const jobs: ReviewJob[] = [
+      makeCostJob(8),
+      makeCostJob(2, JSON.stringify({ has_cost: true, cost_usd: 0.5 })),
+      makeCostJob(6, JSON.stringify({ has_cost: true, cost_usd: 0 })),
+      makeCostJob(5, "not json"),
+    ];
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: {
+          jobs,
+          has_more: false,
+          stats: { done: 1, closed: 0, open: 0 },
+        },
+        error: undefined,
+      }),
+    };
+
+    const store = createJobsStore({
+      client: client as never,
+      navigate: vi.fn(),
+    });
+
+    await store.loadJobs();
+    store.setSortColumn("cost");
+
+    expect(store.getSortColumn()).toBe("cost");
+    expect(store.getSortDirection()).toBe("asc");
+    expect(store.getJobs().map((job) => job.id)).toEqual([8, 5, 6, 2]);
+
+    store.setSortColumn("cost");
+
+    expect(store.getSortDirection()).toBe("desc");
+    expect(store.getJobs().map((job) => job.id)).toEqual([2, 6, 8, 5]);
+  });
+});
+
 describe("createJobsStore elapsed sorting", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -431,6 +431,29 @@ test.describe.serial("Roborev", () => {
       expect(lastDash).toBeLessThan(firstZero);
     });
 
+    test("click Cost header sorts by cost", async ({ page }) => {
+      await waitForReviewsReady(page);
+      await waitForJobRows(page, 10);
+
+      // Job 74 is the only costed job (~$0.42) on the first
+      // page; every other row renders "--". Ascending order
+      // puts missing costs first, so the costed row sinks to
+      // the bottom; descending brings it to the top.
+      const costHeader = page.locator("th.sortable").filter({ hasText: "Cost" });
+      await costHeader.click();
+      await page.waitForTimeout(300);
+
+      const costCells = page.locator(".col-cost");
+      await expect(costCells.last()).toHaveText("~$0.42");
+      await expect(costCells.first()).toHaveText("--");
+
+      await costHeader.click();
+      await page.waitForTimeout(300);
+
+      await expect(costCells.first()).toHaveText("~$0.42");
+      await expect(costCells.last()).toHaveText("--");
+    });
+
     test("sort persists across filter changes", async ({ page }) => {
       await waitForReviewsReady(page);
       await waitForJobRows(page, 10);

--- a/packages/ui/src/components/roborev/JobRow.svelte
+++ b/packages/ui/src/components/roborev/JobRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { components } from "../../api/roborev/generated/schema.js";
+  import { parseCostUsd } from "../../utils/roborev-cost.js";
   import { timeAgo } from "../../utils/time.js";
   import StatusBadge from "./StatusBadge.svelte";
   import VerdictBadge from "./VerdictBadge.svelte";
@@ -32,23 +33,9 @@
   }
 
   function formatCost(tokenUsage: string | undefined): string {
-    if (!tokenUsage) return "--";
-    try {
-      const usage: unknown = JSON.parse(tokenUsage);
-      if (
-        typeof usage !== "object" ||
-        usage === null ||
-        !("has_cost" in usage) ||
-        !("cost_usd" in usage) ||
-        usage.has_cost !== true ||
-        typeof usage.cost_usd !== "number"
-      ) {
-        return "--";
-      }
-      return `~$${usage.cost_usd.toFixed(2)}`;
-    } catch {
-      return "--";
-    }
+    const cost = parseCostUsd(tokenUsage);
+    if (cost === null) return "--";
+    return `~$${cost.toFixed(2)}`;
   }
 
   function shortRef(ref: string): string {

--- a/packages/ui/src/components/roborev/JobTable.svelte
+++ b/packages/ui/src/components/roborev/JobTable.svelte
@@ -11,6 +11,7 @@
     | "verdict"
     | "agent"
     | "elapsed"
+    | "cost"
     | "job_type"
     | "enqueued_at";
 
@@ -36,9 +37,9 @@
       sortable: true,
     },
     {
-      key: "id",
+      key: "cost",
       label: "Cost",
-      sortable: false,
+      sortable: true,
     },
     {
       key: "job_type",

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -1,5 +1,6 @@
 import type { RoborevClient } from "../../api/roborev/client.js";
 import type { components, operations } from "../../api/roborev/generated/schema.js";
+import { parseCostUsd } from "../../utils/roborev-cost.js";
 
 type ReviewJob = components["schemas"]["ReviewJob"];
 type JobStats = components["schemas"]["JobStats"];
@@ -11,7 +12,7 @@ export interface JobsStoreOptions {
   onError?: (msg: string) => void;
 }
 
-type SortColumn = "id" | "status" | "verdict" | "agent" | "elapsed" | "job_type" | "enqueued_at";
+type SortColumn = "id" | "status" | "verdict" | "agent" | "elapsed" | "cost" | "job_type" | "enqueued_at";
 type SortDirection = "asc" | "desc";
 
 export function createJobsStore(opts: JobsStoreOptions) {
@@ -75,6 +76,8 @@ export function createJobsStore(opts: JobsStoreOptions) {
         return job.agent;
       case "elapsed":
         return getElapsedSeconds(job);
+      case "cost":
+        return parseCostUsd(job.token_usage) ?? -1;
       case "job_type":
         return job.job_type;
       case "enqueued_at":

--- a/packages/ui/src/utils/roborev-cost.ts
+++ b/packages/ui/src/utils/roborev-cost.ts
@@ -1,0 +1,21 @@
+// Extracts the USD cost from a roborev job's token_usage JSON blob.
+// Returns null when the job has no reported cost.
+export function parseCostUsd(tokenUsage: string | undefined): number | null {
+  if (!tokenUsage) return null;
+  try {
+    const usage: unknown = JSON.parse(tokenUsage);
+    if (
+      typeof usage !== "object" ||
+      usage === null ||
+      !("has_cost" in usage) ||
+      !("cost_usd" in usage) ||
+      usage.has_cost !== true ||
+      typeof usage.cost_usd !== "number"
+    ) {
+      return null;
+    }
+    return usage.cost_usd;
+  } catch {
+    return null;
+  }
+}

--- a/tests/integration/roborev/Dockerfile
+++ b/tests/integration/roborev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG ROBOREV_REF=main
 COPY . /src
 WORKDIR /src


### PR DESCRIPTION
The reviews table allowed sorting by every populated column except Cost, so finding expensive review jobs meant scanning the column by eye.

- Clicking the Cost header now sorts by the parsed dollar amount, toggling ascending/descending like the other columns; jobs without a reported cost sort below zero-dollar jobs, matching how missing elapsed durations sort.
- Cost parsing is shared between the row display and the sort comparator so the two cannot drift.
- The roborev e2e builder image moves to golang:1.26 because roborev main now requires Go 1.26.3 and the suite could no longer build on golang:1.25.

![cost-sort-capture.png](https://github.com/user-attachments/assets/2fedfa5a-dcfd-401c-8c31-b934073f55fd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)