### PR TITLE
feat: add creation and activity sort modes to the workspace list

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -312,31 +312,6 @@
   <div class="sidebar-header">
     <span class="sidebar-header-label">Workspaces</span>
     <span class="sidebar-header-count">{sidebarCountLabel}</span>
-    {#if isSidebarToggleEnabled && onCollapseSidebar}
-      <LeftSidebarToggle
-        state="expanded"
-        label="Workspaces sidebar"
-        onclick={onCollapseSidebar}
-        class="left-sidebar-toggle--push left-sidebar-toggle--compact"
-      />
-    {/if}
-  </div>
-  <div class="workspace-controls">
-    <label class="workspace-filter">
-      <SearchIcon
-        class="workspace-filter-icon"
-        size="13"
-        strokeWidth="2.25"
-        aria-hidden="true"
-      />
-      <input
-        type="search"
-        value={searchQuery}
-        placeholder="Filter workspaces"
-        aria-label="Filter workspaces"
-        oninput={updateSearch}
-      />
-    </label>
     <div class="workspace-sort">
       <FilterDropdown
         label={sortLabel}
@@ -348,7 +323,30 @@
         align="end"
       />
     </div>
+    {#if isSidebarToggleEnabled && onCollapseSidebar}
+      <LeftSidebarToggle
+        state="expanded"
+        label="Workspaces sidebar"
+        onclick={onCollapseSidebar}
+        class="left-sidebar-toggle--push left-sidebar-toggle--compact"
+      />
+    {/if}
   </div>
+  <label class="workspace-filter">
+    <SearchIcon
+      class="workspace-filter-icon"
+      size="13"
+      strokeWidth="2.25"
+      aria-hidden="true"
+    />
+    <input
+      type="search"
+      value={searchQuery}
+      placeholder="Filter workspaces"
+      aria-label="Filter workspaces"
+      oninput={updateSearch}
+    />
+  </label>
   <div class="sidebar-list">
     {#if sortMode === "repo"}
     {#each [...grouped] as [repoKey, items] (repoKey)}
@@ -562,34 +560,38 @@
     opacity: 0.7;
   }
 
-  .workspace-controls {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin: 6px 8px 4px;
-    flex-shrink: 0;
-  }
-
   .workspace-filter {
     display: flex;
     align-items: center;
     gap: 6px;
     height: 28px;
-    flex: 1 1 auto;
-    min-width: 0;
+    margin: 6px 8px 4px;
     padding: 0 8px;
     border: 1px solid var(--border-muted);
     border-radius: 6px;
     background: var(--bg-surface);
     color: var(--text-muted);
+    flex-shrink: 0;
   }
 
   .workspace-sort {
+    /* Claims the header's free space so the sort trigger (and the
+     * collapse toggle after it) sit flush right. */
+    margin-left: auto;
     flex-shrink: 0;
   }
 
   .workspace-sort :global(.filter-btn) {
-    min-height: 28px;
+    /* Borderless inside the 28px header rail; the dropdown trigger
+     * reads as header chrome rather than a standalone button. */
+    min-height: 22px;
+    padding: 2px 6px;
+    border-color: transparent;
+    background: transparent;
+  }
+
+  .workspace-sort :global(.filter-btn:hover:not(:disabled)) {
+    border-color: var(--border-muted);
   }
 
   :global(.workspace-filter-icon) {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -320,15 +320,17 @@
         title="Sort workspaces"
         minWidth="170px"
         icon="sort"
-        align="end"
       />
     </div>
     {#if isSidebarToggleEnabled && onCollapseSidebar}
+      <!-- No --push here: .workspace-sort's auto margin already
+           claims the free space, and a second auto margin would
+           split it and strand the sort trigger mid-header. -->
       <LeftSidebarToggle
         state="expanded"
         label="Workspaces sidebar"
         onclick={onCollapseSidebar}
-        class="left-sidebar-toggle--push left-sidebar-toggle--compact"
+        class="left-sidebar-toggle--compact"
       />
     {/if}
   </div>

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -9,9 +9,16 @@
   import { client } from "../../api/runtime.js";
   import {
     DiffStats,
+    FilterDropdown,
     LeftSidebarToggle,
   } from "@middleman/ui";
   import ProviderIcon from "../provider/ProviderIcon.svelte";
+  import {
+    loadWorkspaceListSort,
+    saveWorkspaceListSort,
+    workspaceListSortOptions,
+    type WorkspaceListSort,
+  } from "./workspaceListSort.ts";
 
   interface Workspace {
     id: string;
@@ -74,6 +81,7 @@
   let workspaces = $state.raw<Workspace[]>([]);
   let collapsedGroups = $state<Set<string>>(new Set());
   let searchQuery = $state("");
+  let sortMode = $state<WorkspaceListSort>(loadWorkspaceListSort());
 
   type GroupedWorkspaces = Map<string, Workspace[]>;
 
@@ -109,6 +117,47 @@
     }
     return map;
   });
+
+  const sortLabel = $derived(
+    workspaceListSortOptions.find(
+      (option) => option.value === sortMode,
+    )?.label ?? "Org / repo",
+  );
+
+  const sortSections = $derived.by(() => [
+    {
+      items: workspaceListSortOptions.map((option) => ({
+        id: option.value,
+        label: option.label,
+        active: sortMode === option.value,
+        closeOnSelect: true,
+        onSelect: () => setSort(option.value),
+      })),
+    },
+  ]);
+
+  // Flat ordering for the timestamp sorts. The org/repo mode keeps
+  // the API order (created_at DESC) inside each repo group instead.
+  const sortedFlat = $derived.by(() => {
+    const stamp = sortMode === "activity"
+      ? (ws: Workspace) =>
+        timeValue(ws.tmux_last_output_at) || timeValue(ws.created_at)
+      : (ws: Workspace) => timeValue(ws.created_at);
+    return [...visibleWorkspaces].sort(
+      (a, b) => stamp(b) - stamp(a) || a.id.localeCompare(b.id),
+    );
+  });
+
+  function setSort(sort: WorkspaceListSort): void {
+    sortMode = sort;
+    saveWorkspaceListSort(sort);
+  }
+
+  function timeValue(value: string | null | undefined): number {
+    if (!value) return 0;
+    const ms = Date.parse(value);
+    return Number.isNaN(ms) ? 0 : ms;
+  }
 
   const showProviderIcons = $derived.by(() => {
     const providers = new Set<string>();
@@ -272,22 +321,36 @@
       />
     {/if}
   </div>
-  <label class="workspace-filter">
-    <SearchIcon
-      class="workspace-filter-icon"
-      size="13"
-      strokeWidth="2.25"
-      aria-hidden="true"
-    />
-    <input
-      type="search"
-      value={searchQuery}
-      placeholder="Filter workspaces"
-      aria-label="Filter workspaces"
-      oninput={updateSearch}
-    />
-  </label>
+  <div class="workspace-controls">
+    <label class="workspace-filter">
+      <SearchIcon
+        class="workspace-filter-icon"
+        size="13"
+        strokeWidth="2.25"
+        aria-hidden="true"
+      />
+      <input
+        type="search"
+        value={searchQuery}
+        placeholder="Filter workspaces"
+        aria-label="Filter workspaces"
+        oninput={updateSearch}
+      />
+    </label>
+    <div class="workspace-sort">
+      <FilterDropdown
+        label={sortLabel}
+        showBadge={false}
+        sections={sortSections}
+        title="Sort workspaces"
+        minWidth="170px"
+        icon="sort"
+        align="end"
+      />
+    </div>
+  </div>
   <div class="sidebar-list">
+    {#if sortMode === "repo"}
     {#each [...grouped] as [repoKey, items] (repoKey)}
       {@const collapsed =
         !normalizedSearchQuery && collapsedGroups.has(repoKey)}
@@ -313,6 +376,17 @@
       </button>
       {#if !collapsed}
         {#each items as ws (ws.id)}
+          {@render workspaceRow(ws, false)}
+        {/each}
+      {/if}
+    {/each}
+    {:else}
+      {#each sortedFlat as ws (ws.id)}
+        {@render workspaceRow(ws, true)}
+      {/each}
+    {/if}
+
+    {#snippet workspaceRow(ws: Workspace, showRepo: boolean)}
           {@const adds = ws.mr_additions}
           {@const dels = ws.mr_deletions}
           {@const showDiff =
@@ -366,6 +440,14 @@
                 {/if}
               </div>
               <div class="ws-row-meta">
+                {#if showRepo}
+                  <span
+                    class="repo-context"
+                    title={`${ws.platform_host}/${ws.repo_owner}/${ws.repo_name}`}
+                  >
+                    {ws.repo_owner}/{ws.repo_name}
+                  </span>
+                {/if}
                 <span class="branch-chip" title={ws.git_head_ref}>
                   <GitBranchIcon
                     class="branch-icon"
@@ -429,9 +511,7 @@
               #{ws.item_number}
             </button>
           </div>
-        {/each}
-      {/if}
-    {/each}
+    {/snippet}
     {#if visibleWorkspaces.length === 0 && normalizedSearchQuery}
       <p class="filter-empty">No workspaces match.</p>
     {/if}
@@ -482,18 +562,34 @@
     opacity: 0.7;
   }
 
+  .workspace-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 6px 8px 4px;
+    flex-shrink: 0;
+  }
+
   .workspace-filter {
     display: flex;
     align-items: center;
     gap: 6px;
     height: 28px;
-    margin: 6px 8px 4px;
+    flex: 1 1 auto;
+    min-width: 0;
     padding: 0 8px;
     border: 1px solid var(--border-muted);
     border-radius: 6px;
     background: var(--bg-surface);
     color: var(--text-muted);
+  }
+
+  .workspace-sort {
     flex-shrink: 0;
+  }
+
+  .workspace-sort :global(.filter-btn) {
+    min-height: 28px;
   }
 
   :global(.workspace-filter-icon) {
@@ -738,6 +834,20 @@
     }
   }
 
+  .repo-context {
+    /* Flat sorts drop the per-repo group headers, so each row
+     * carries its own repo context on the meta line. Caps at half
+     * the line so the branch chip always keeps some room. */
+    flex: 0 1 auto;
+    max-width: 50%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+  }
+
   .branch-chip {
     /* Lives on the meta line; takes whatever width is left after
      * push state and diff stats and truncates with ellipsis. */
@@ -872,6 +982,14 @@
 
   @container workspace-rail (max-width: 220px) {
     .push-state {
+      display: none;
+    }
+  }
+
+  /* The sort trigger collapses to its icon before the filter input
+   * is squeezed into uselessness. */
+  @container workspace-rail (max-width: 240px) {
+    .workspace-sort :global(.filter-trigger-label) {
       display: none;
     }
   }

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -138,6 +138,10 @@
 
   // Flat ordering for the timestamp sorts. The org/repo mode keeps
   // the API order (created_at DESC) inside each repo group instead.
+  // "Activity" means terminal output only (tmux_last_output_at);
+  // pane-title or working-state changes do not count, and
+  // workspaces that have never produced output fall back to their
+  // creation time.
   const sortedFlat = $derived.by(() => {
     const stamp = sortMode === "activity"
       ? (ws: Workspace) =>
@@ -157,6 +161,32 @@
     if (!value) return 0;
     const ms = Date.parse(value);
     return Number.isNaN(ms) ? 0 : ms;
+  }
+
+  // Owner/name pairs that exist on more than one platform host.
+  // Flat rows prefix the host for these so identical repo names on
+  // different hosts stay distinguishable; repo identity is always
+  // (platform, host, owner, name), never owner/name alone.
+  const ambiguousFlatRepos = $derived.by(() => {
+    const hostByRepo = new Map<string, string>();
+    const ambiguous = new Set<string>();
+    for (const ws of workspaces) {
+      const key = `${ws.repo_owner}/${ws.repo_name}`;
+      const seen = hostByRepo.get(key);
+      if (seen === undefined) {
+        hostByRepo.set(key, ws.platform_host);
+      } else if (seen !== ws.platform_host) {
+        ambiguous.add(key);
+      }
+    }
+    return ambiguous;
+  });
+
+  function flatRepoLabel(ws: Workspace): string {
+    const key = `${ws.repo_owner}/${ws.repo_name}`;
+    return ambiguousFlatRepos.has(key)
+      ? `${ws.platform_host}/${key}`
+      : key;
   }
 
   const showProviderIcons = $derived.by(() => {
@@ -445,7 +475,14 @@
                     class="repo-context"
                     title={`${ws.platform_host}/${ws.repo_owner}/${ws.repo_name}`}
                   >
-                    {ws.repo_owner}/{ws.repo_name}
+                    {#if showProviderIcons && workspaceProvider(ws)}
+                      <ProviderIcon
+                        provider={workspaceProvider(ws)!}
+                        size={10}
+                        class="repo-context-icon"
+                      />
+                    {/if}
+                    <span class="repo-context-name">{flatRepoLabel(ws)}</span>
                   </span>
                 {/if}
                 <span class="branch-chip" title={ws.git_head_ref}>
@@ -842,14 +879,26 @@
     /* Flat sorts drop the per-repo group headers, so each row
      * carries its own repo context on the meta line. Caps at half
      * the line so the branch chip always keeps some room. */
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
     flex: 0 1 auto;
     max-width: 50%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    min-width: 0;
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
     color: var(--text-muted);
+  }
+
+  .repo-context-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.repo-context-icon) {
+    color: var(--text-muted);
+    flex-shrink: 0;
   }
 
   .branch-chip {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -314,12 +314,71 @@ describe("WorkspaceListSidebar", () => {
     expect(container.querySelectorAll(".repo-context")).toHaveLength(0);
 
     await fireEvent.click(screen.getByTitle("Sort workspaces"));
-    await fireEvent.click(screen.getByRole("button", { name: /Recently created/ }));
+    await fireEvent.click(screen.getByRole("button", { name: "Created" }));
 
     expect(rowTitles(container)).toEqual(["Newest created", "Most recently active", "Oldest without activity"]);
     expect(container.querySelectorAll(".group-header")).toHaveLength(0);
     // Flat rows carry their own repo context instead of a header.
     expect(container.querySelectorAll(".repo-context")).toHaveLength(3);
+  });
+
+  it("keeps provider and host identity visible in flat rows", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-github",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widgets",
+            number: 1,
+            title: "GitHub workspace",
+            createdAt: "2026-05-12T12:00:00Z",
+          }),
+          workspaceFixture({
+            id: "ws-gitlab",
+            provider: "gitlab",
+            platformHost: "gitlab.example.com",
+            owner: "acme",
+            name: "widgets",
+            number: 2,
+            title: "GitLab workspace",
+            createdAt: "2026-05-11T12:00:00Z",
+          }),
+          workspaceFixture({
+            id: "ws-other",
+            provider: "gitlab",
+            platformHost: "gitlab.example.com",
+            owner: "platform",
+            name: "api",
+            number: 3,
+            title: "Unambiguous workspace",
+            createdAt: "2026-05-10T12:00:00Z",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-github" },
+    });
+    await screen.findByText("GitHub workspace");
+
+    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByRole("button", { name: "Created" }));
+
+    // Provider icons survive the loss of group headers.
+    expect(container.querySelectorAll(".repo-context")).toHaveLength(3);
+    expect(screen.getByRole("img", { name: "GitHub" })).toBeTruthy();
+    expect(screen.getAllByRole("img", { name: "GitLab" })).toHaveLength(2);
+
+    // acme/widgets exists on two hosts, so its rows carry the host;
+    // platform/api is unique and stays short.
+    const contextNames = container.querySelectorAll(".repo-context-name");
+    expect(contextNames[0]?.textContent?.trim()).toBe("github.com/acme/widgets");
+    expect(contextNames[1]?.textContent?.trim()).toBe("gitlab.example.com/acme/widgets");
+    expect(contextNames[2]?.textContent?.trim()).toBe("platform/api");
   });
 
   it("sorts flat by last activity with creation time as fallback", async () => {
@@ -333,7 +392,7 @@ describe("WorkspaceListSidebar", () => {
     await screen.findByText("Newest created");
 
     await fireEvent.click(screen.getByTitle("Sort workspaces"));
-    await fireEvent.click(screen.getByRole("button", { name: /Recent activity/ }));
+    await fireEvent.click(screen.getByRole("button", { name: "Activity" }));
 
     // ws-old has no tmux output, so it sorts by its creation time.
     expect(rowTitles(container)).toEqual(["Most recently active", "Newest created", "Oldest without activity"]);
@@ -350,7 +409,7 @@ describe("WorkspaceListSidebar", () => {
     await screen.findByText("Newest created");
 
     await fireEvent.click(screen.getByTitle("Sort workspaces"));
-    await fireEvent.click(screen.getByRole("button", { name: /Recent activity/ }));
+    await fireEvent.click(screen.getByRole("button", { name: "Activity" }));
     first.unmount();
 
     const { container } = render(WorkspaceListSidebar, {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -33,6 +33,8 @@ interface WorkspaceFixtureOptions {
   title?: string;
   branch?: string;
   itemType?: "pull_request" | "issue";
+  createdAt?: string;
+  tmuxLastOutputAt?: string | null;
 }
 
 function workspaceFixture({
@@ -45,6 +47,8 @@ function workspaceFixture({
   title = `PR ${number}`,
   branch = `feature-${number}`,
   itemType = "pull_request",
+  createdAt = "2026-05-12T12:00:00Z",
+  tmuxLastOutputAt = null,
 }: WorkspaceFixtureOptions) {
   return {
     id,
@@ -64,16 +68,61 @@ function workspaceFixture({
     worktree_path: `/tmp/${id}`,
     tmux_session: id,
     status: "ready",
-    created_at: "2026-05-12T12:00:00Z",
+    created_at: createdAt,
+    tmux_last_output_at: tmuxLastOutputAt,
     mr_title: title,
     mr_state: "open",
   };
+}
+
+// Three workspaces across two repos with distinct creation and
+// activity timestamps, listed in API order (created_at DESC).
+function sortFixtures() {
+  return [
+    workspaceFixture({
+      id: "ws-new",
+      provider: "github",
+      platformHost: "github.com",
+      owner: "kenn-io",
+      name: "middleman",
+      number: 3,
+      title: "Newest created",
+      createdAt: "2026-05-12T12:00:00Z",
+      tmuxLastOutputAt: "2026-05-12T13:00:00Z",
+    }),
+    workspaceFixture({
+      id: "ws-mid",
+      provider: "github",
+      platformHost: "github.com",
+      owner: "kenn-io",
+      name: "agentsview",
+      number: 2,
+      title: "Most recently active",
+      createdAt: "2026-05-11T12:00:00Z",
+      tmuxLastOutputAt: "2026-05-14T09:00:00Z",
+    }),
+    workspaceFixture({
+      id: "ws-old",
+      provider: "github",
+      platformHost: "github.com",
+      owner: "kenn-io",
+      name: "middleman",
+      number: 1,
+      title: "Oldest without activity",
+      createdAt: "2026-05-10T12:00:00Z",
+    }),
+  ];
+}
+
+function rowTitles(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll(".ws-name")).map((el) => el.textContent?.trim() ?? "");
 }
 
 describe("WorkspaceListSidebar", () => {
   beforeEach(() => {
     mockGet.mockReset();
     mockNavigate.mockReset();
+    localStorage.clear();
     vi.stubGlobal("EventSource", MockEventSource);
   });
 
@@ -248,5 +297,68 @@ describe("WorkspaceListSidebar", () => {
       target: { value: "" },
     });
     expect(container.querySelectorAll(".ws-row")).toHaveLength(0);
+  });
+
+  it("sorts flat by creation time and drops group headers", async () => {
+    mockGet.mockResolvedValue({
+      data: { workspaces: sortFixtures() },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-new" },
+    });
+    await screen.findByText("Newest created");
+
+    // Default org/repo mode groups rows under repo headers.
+    expect(screen.getByText("kenn-io/middleman")).toBeTruthy();
+    expect(container.querySelectorAll(".repo-context")).toHaveLength(0);
+
+    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByRole("button", { name: /Recently created/ }));
+
+    expect(rowTitles(container)).toEqual(["Newest created", "Most recently active", "Oldest without activity"]);
+    expect(container.querySelectorAll(".group-header")).toHaveLength(0);
+    // Flat rows carry their own repo context instead of a header.
+    expect(container.querySelectorAll(".repo-context")).toHaveLength(3);
+  });
+
+  it("sorts flat by last activity with creation time as fallback", async () => {
+    mockGet.mockResolvedValue({
+      data: { workspaces: sortFixtures() },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-new" },
+    });
+    await screen.findByText("Newest created");
+
+    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByRole("button", { name: /Recent activity/ }));
+
+    // ws-old has no tmux output, so it sorts by its creation time.
+    expect(rowTitles(container)).toEqual(["Most recently active", "Newest created", "Oldest without activity"]);
+  });
+
+  it("persists the selected sort across mounts", async () => {
+    mockGet.mockResolvedValue({
+      data: { workspaces: sortFixtures() },
+    });
+
+    const first = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-new" },
+    });
+    await screen.findByText("Newest created");
+
+    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByRole("button", { name: /Recent activity/ }));
+    first.unmount();
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-new" },
+    });
+    await screen.findByText("Newest created");
+
+    expect(rowTitles(container)).toEqual(["Most recently active", "Newest created", "Oldest without activity"]);
+    expect(container.querySelectorAll(".group-header")).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/components/terminal/workspaceListSort.ts
+++ b/frontend/src/lib/components/terminal/workspaceListSort.ts
@@ -5,8 +5,8 @@ export const workspaceListSortOptions: {
   label: string;
 }[] = [
   { value: "repo", label: "Org / repo" },
-  { value: "created", label: "Recently created" },
-  { value: "activity", label: "Recent activity" },
+  { value: "created", label: "Created" },
+  { value: "activity", label: "Activity" },
 ];
 
 export const defaultWorkspaceListSort: WorkspaceListSort = "repo";

--- a/frontend/src/lib/components/terminal/workspaceListSort.ts
+++ b/frontend/src/lib/components/terminal/workspaceListSort.ts
@@ -1,0 +1,47 @@
+export type WorkspaceListSort = "repo" | "created" | "activity";
+
+export const workspaceListSortOptions: {
+  value: WorkspaceListSort;
+  label: string;
+}[] = [
+  { value: "repo", label: "Org / repo" },
+  { value: "created", label: "Recently created" },
+  { value: "activity", label: "Recent activity" },
+];
+
+export const defaultWorkspaceListSort: WorkspaceListSort = "repo";
+
+const storageKey = "middleman:workspaceListSort";
+
+const validSorts = new Set<WorkspaceListSort>(workspaceListSortOptions.map((option) => option.value));
+
+function getStorage(): Storage | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadWorkspaceListSort(): WorkspaceListSort {
+  const storage = getStorage();
+  if (!storage) return defaultWorkspaceListSort;
+
+  try {
+    const value = storage.getItem(storageKey) as WorkspaceListSort | null;
+    return value && validSorts.has(value) ? value : defaultWorkspaceListSort;
+  } catch {
+    return defaultWorkspaceListSort;
+  }
+}
+
+export function saveWorkspaceListSort(sort: WorkspaceListSort): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(storageKey, sort);
+  } catch {
+    // Storage blocked - the sort still applies for the current page instance.
+  }
+}

--- a/frontend/tests/e2e-full/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/workspace-sidebar.spec.ts
@@ -141,6 +141,69 @@ test.describe("workspace sidebar full-stack", () => {
     }
   });
 
+  test("flat sort modes order real workspaces by creation time and keep provider identity", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      // Created sequentially, so the gitlab workspace has the newer
+      // created_at in the real database. created_at is stored with
+      // second granularity (datetime('now')), so space the two
+      // creations far enough apart that they cannot tie.
+      const githubResponse = await api.post("/api/v1/issues/github/acme/widgets/10/workspace", {
+        data: {},
+      });
+      expect(githubResponse.status()).toBe(202);
+      const githubWorkspace = (await githubResponse.json()) as WorkspaceStatusResponse;
+      await waitForWorkspaceReady(api, githubWorkspace.id);
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+      const gitlabResponse = await api.post(
+        "/api/v1/host/gitlab.example.com/issues/gitlab/group/project/11/workspace",
+        {
+          data: {},
+        },
+      );
+      expect(gitlabResponse.status()).toBe(202);
+      const gitlabWorkspace = (await gitlabResponse.json()) as WorkspaceStatusResponse;
+      await waitForWorkspaceReady(api, gitlabWorkspace.id);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${githubWorkspace.id}`);
+
+      const rows = page.locator(".workspace-list-sidebar .ws-row");
+      const headers = page.locator(".workspace-list-sidebar .group-header");
+      await expect(rows).toHaveCount(2);
+      await expect(headers).toHaveCount(2);
+
+      await page.getByTitle("Sort workspaces").click();
+      await page.locator(".filter-dropdown .filter-item", { hasText: "Created" }).click();
+
+      // Flat list ordered by the real created_at column: the
+      // gitlab workspace was created last, so it sorts first.
+      await expect(headers).toHaveCount(0);
+      await expect(rows).toHaveCount(2);
+      await expect(rows.first().locator(".repo-context")).toContainText("group/project");
+      await expect(rows.last().locator(".repo-context")).toContainText("acme/widgets");
+
+      // Provider identity survives without group headers.
+      await expect(rows.first().getByRole("img", { name: "GitLab" })).toBeVisible();
+      await expect(rows.last().getByRole("img", { name: "GitHub" })).toBeVisible();
+
+      // The choice persists against the real backend across reloads.
+      await page.reload();
+      await expect(rows).toHaveCount(2);
+      await expect(headers).toHaveCount(0);
+      await expect(rows.first().locator(".repo-context")).toContainText("group/project");
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("filters real workspace API results and expands collapsed matches during search", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3168,7 +3168,7 @@ test.describe("workspace list sorting", () => {
 
     const sortTrigger = page.getByTitle("Sort workspaces");
     await sortTrigger.click();
-    await page.getByRole("button", { name: "Recently created" }).click();
+    await page.locator(".filter-dropdown").getByRole("button", { name: "Created" }).click();
 
     await expect(names).toHaveText(["Newest created", "Most recently active", "Oldest without activity"]);
     await expect(headers).toHaveCount(0);
@@ -3176,7 +3176,7 @@ test.describe("workspace list sorting", () => {
     await expect(page.locator(".workspace-list-sidebar .repo-context").first()).toContainText("acme/widgets");
 
     await sortTrigger.click();
-    await page.getByRole("button", { name: "Recent activity" }).click();
+    await page.locator(".filter-dropdown").getByRole("button", { name: "Activity" }).click();
 
     // ws-old has no tmux output and falls back to creation time.
     await expect(names).toHaveText(["Most recently active", "Newest created", "Oldest without activity"]);
@@ -3187,10 +3187,42 @@ test.describe("workspace list sorting", () => {
     await expect(headers).toHaveCount(0);
 
     await sortTrigger.click();
-    await page.getByRole("button", { name: "Org / repo" }).click();
+    await page.locator(".filter-dropdown").getByRole("button", { name: "Org / repo" }).click();
 
     await expect(headers).toHaveCount(2);
     await expect(names).toHaveText(["Newest created", "Oldest without activity", "Most recently active"]);
+  });
+
+  test("sort trigger hugs the collapse toggle and the dropdown opens left-aligned", async ({ page }) => {
+    await page.goto("/workspaces");
+
+    const trigger = page.getByTitle("Sort workspaces");
+    const toggle = page.getByRole("button", { name: "Collapse Workspaces sidebar" });
+    await expect(trigger).toBeVisible();
+    await expect(toggle).toBeVisible();
+
+    const triggerBox = await trigger.boundingBox();
+    const toggleBox = await toggle.boundingBox();
+    expect(triggerBox).not.toBeNull();
+    expect(toggleBox).not.toBeNull();
+
+    // Regression: two competing auto margins (sort wrapper + toggle
+    // push class) once split the header's free space and stranded
+    // the trigger mid-header. The trigger must sit directly beside
+    // the toggle at the right edge.
+    const gap = toggleBox!.x - (triggerBox!.x + triggerBox!.width);
+    expect(gap).toBeGreaterThanOrEqual(0);
+    expect(gap).toBeLessThanOrEqual(12);
+
+    await trigger.click();
+    const dropdown = page.locator(".filter-dropdown");
+    await expect(dropdown).toBeVisible();
+    const dropdownBox = await dropdown.boundingBox();
+    expect(dropdownBox).not.toBeNull();
+
+    // Regression: align="end" used to hang the panel out to the
+    // left over the filter input. Left edges must align instead.
+    expect(Math.abs(dropdownBox!.x - triggerBox!.x)).toBeLessThanOrEqual(1.5);
   });
 });
 

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3101,6 +3101,100 @@ test.describe("workspace list bubble opens right sidebar", () => {
 });
 
 // -------------------------------------------------------
+// Group 3.4: Workspace list sorting
+// -------------------------------------------------------
+
+test.describe("workspace list sorting", () => {
+  // Three workspaces across two repos, in API order
+  // (created_at DESC). The most recently active workspace is
+  // neither the newest nor in the first repo group, so each sort
+  // mode produces a distinct row order.
+  const wsNew = {
+    ...testWorkspace,
+    id: "ws-new",
+    item_number: 3,
+    mr_title: "Newest created",
+    created_at: "2026-05-12T12:00:00Z",
+    tmux_last_output_at: "2026-05-12T13:00:00Z",
+  };
+  const wsMid = {
+    ...testWorkspace,
+    id: "ws-mid",
+    repo_owner: "kenn-io",
+    repo_name: "agentsview",
+    repo: workspaceRepoRef("kenn-io", "agentsview"),
+    item_number: 2,
+    mr_title: "Most recently active",
+    created_at: "2026-05-11T12:00:00Z",
+    tmux_last_output_at: "2026-05-14T09:00:00Z",
+  };
+  const wsOld = {
+    ...testWorkspace,
+    id: "ws-old",
+    item_number: 1,
+    mr_title: "Oldest without activity",
+    created_at: "2026-05-10T12:00:00Z",
+  };
+
+  test.beforeEach(async ({ page }) => {
+    await mockApi(page);
+    await page.route("**/api/v1/events", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: "",
+      });
+    });
+    await page.route("**/api/v1/workspaces", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ workspaces: [wsNew, wsMid, wsOld] }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200 });
+    });
+  });
+
+  test("offers creation and activity sorts and persists the choice across reloads", async ({ page }) => {
+    await page.goto("/workspaces");
+
+    const names = page.locator(".workspace-list-sidebar .ws-name");
+    const headers = page.locator(".workspace-list-sidebar .group-header");
+    await expect(names).toHaveText(["Newest created", "Oldest without activity", "Most recently active"]);
+    await expect(headers).toHaveCount(2);
+
+    const sortTrigger = page.getByTitle("Sort workspaces");
+    await sortTrigger.click();
+    await page.getByRole("button", { name: "Recently created" }).click();
+
+    await expect(names).toHaveText(["Newest created", "Most recently active", "Oldest without activity"]);
+    await expect(headers).toHaveCount(0);
+    // Without group headers each row carries its own repo context.
+    await expect(page.locator(".workspace-list-sidebar .repo-context").first()).toContainText("acme/widgets");
+
+    await sortTrigger.click();
+    await page.getByRole("button", { name: "Recent activity" }).click();
+
+    // ws-old has no tmux output and falls back to creation time.
+    await expect(names).toHaveText(["Most recently active", "Newest created", "Oldest without activity"]);
+
+    await page.reload();
+
+    await expect(names).toHaveText(["Most recently active", "Newest created", "Oldest without activity"]);
+    await expect(headers).toHaveCount(0);
+
+    await sortTrigger.click();
+    await page.getByRole("button", { name: "Org / repo" }).click();
+
+    await expect(headers).toHaveCount(2);
+    await expect(names).toHaveText(["Newest created", "Oldest without activity", "Most recently active"]);
+  });
+});
+
+// -------------------------------------------------------
 // Group 3.5: Delayed-response navigation (no flash, no
 // stale-action targets)
 // -------------------------------------------------------


### PR DESCRIPTION
The workspace rail only offered one ordering — grouped by org/repo with newest-created first inside each group — so finding the workspace you most recently touched, or the one you just created in another repo, meant scanning every group by eye.

- Adds a sort selector to the workspace rail header with three modes: **Org / repo** (previous behavior, still the default), **Created**, and **Activity** (terminal output time, falling back to creation time for workspaces that have never produced output)
- The timestamp sorts render a flat list; each row then carries its own repo context — including the provider icon in multi-provider setups and the platform host when the same owner/name exists on more than one host
- The choice persists across reloads

| Default (Org / repo) | Sort dropdown | Activity sort |
|---|---|---|
| ![pr-sort-default.png](https://github.com/user-attachments/assets/4793488d-c7f0-4688-8f96-fb5fdd984f9f) | ![pr-sort-dropdown.png](https://github.com/user-attachments/assets/82a53ee8-39cc-4293-8dc5-92cc41410c10) | ![pr-sort-activity.png](https://github.com/user-attachments/assets/dc3e11bd-ff47-4844-a97d-17d63a9cd939) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
