### PR TITLE
fix: render markdown tables with GitHub's table layout model

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -322,8 +322,11 @@ a:hover {
   font-weight: 600;
   white-space: nowrap;
 }
-.markdown-body th:not(:last-child),
-.markdown-body td:not(:last-child) {
+/* Compact leading columns only apply to text-only tables. A table holding
+   images (e.g. side-by-side screenshots) must keep auto layout so each
+   column shares the width evenly, matching GitHub's rendering. */
+.markdown-body table:not(:has(img)) th:not(:last-child),
+.markdown-body table:not(:has(img)) td:not(:last-child) {
   width: 1%;
   white-space: nowrap;
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -300,9 +300,18 @@ a:hover {
   height: auto;
   border-radius: var(--radius-sm);
 }
+/* GitHub's (Primer) table layout model: shrink-wrap to content, cap at
+   the container, scroll on overflow. Auto table layout then gives compact
+   columns their content width and wraps or scrolls wide ones, so text
+   tables and side-by-side image tables both render the way github.com
+   renders them. No width hacks or nowrap overrides on cells. */
 .markdown-body table {
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
   border-collapse: collapse;
+  font-variant: tabular-nums;
   margin: 10px 0 12px;
   font-size: 0.9em;
   line-height: 1.45;
@@ -313,26 +322,11 @@ a:hover {
   border: 1px solid var(--border-muted);
   text-align: left;
   vertical-align: top;
-  word-break: normal;
-  overflow-wrap: normal;
 }
 .markdown-body th {
   background: var(--bg-surface-hover);
   color: var(--text-secondary);
   font-weight: 600;
-  white-space: nowrap;
-}
-/* Compact leading columns only apply to text-only tables. A table holding
-   images (e.g. side-by-side screenshots) must keep auto layout so each
-   column shares the width evenly, matching GitHub's rendering. */
-.markdown-body table:not(:has(img)) th:not(:last-child),
-.markdown-body table:not(:has(img)) td:not(:last-child) {
-  width: 1%;
-  white-space: nowrap;
-}
-.markdown-body th:last-child,
-.markdown-body td:last-child {
-  overflow-wrap: anywhere;
 }
 .markdown-body tr:nth-child(even) td {
   background: color-mix(in srgb, var(--bg-surface-hover) 42%, transparent);

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -322,6 +322,12 @@ a:hover {
   border: 1px solid var(--border-muted);
   text-align: left;
   vertical-align: top;
+  /* Reset the word-break: break-word inherited from PR/issue body
+     containers: it feeds soft-wrap opportunities into auto table layout's
+     min-content sizing, splitting long tokens instead of letting the
+     column grow and the table scroll the way github.com renders it. */
+  word-break: normal;
+  overflow-wrap: normal;
 }
 .markdown-body th {
   background: var(--bg-surface-hover);

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -163,6 +163,100 @@ test("markdown tables keep compact columns readable", async ({ page }) => {
   await expect(page.locator(".markdown-body table")).toHaveCSS("border-collapse", "collapse");
 });
 
+test("markdown tables with images share width evenly like GitHub", async ({ page }) => {
+  // Serve a fixed-size image for every screenshot cell so auto table layout
+  // has real intrinsic widths to distribute.
+  await page.route("https://images.test/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300"><rect width="600" height="300" fill="#7a7"/></svg>',
+    });
+  });
+
+  await page.route("**/api/v1/pulls/github/acme/widgets/42", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        merge_request: {
+          ID: 1,
+          RepoID: 1,
+          GitHubID: 101,
+          Number: 42,
+          URL: "https://github.com/acme/widgets/pull/42",
+          Title: "Add browser regression coverage",
+          Author: "marius",
+          State: "open",
+          IsDraft: false,
+          Body: [
+            "| Default | Sort dropdown | Activity sort |",
+            "| --- | --- | --- |",
+            "| ![default](https://images.test/shot-1.svg) | ![dropdown](https://images.test/shot-2.svg) | ![activity](https://images.test/shot-3.svg) |",
+          ].join("\n"),
+          HeadBranch: "feature/playwright",
+          BaseBranch: "main",
+          Additions: 120,
+          Deletions: 12,
+          CommentCount: 3,
+          ReviewDecision: "APPROVED",
+          CIStatus: "success",
+          CIChecksJSON: "[]",
+          CreatedAt: "2026-03-29T14:00:00Z",
+          UpdatedAt: "2026-03-30T14:00:00Z",
+          LastActivityAt: "2026-03-30T14:00:00Z",
+          MergedAt: null,
+          ClosedAt: null,
+          KanbanStatus: "reviewing",
+          Starred: false,
+          repo_owner: "acme",
+          repo_name: "widgets",
+          platform_host: "github.com",
+          repo: mockRepo,
+          worktree_links: [],
+        },
+        repo_owner: "acme",
+        repo_name: "widgets",
+        platform_host: "github.com",
+        repo: mockRepo,
+        detail_loaded: true,
+        detail_fetched_at: "2026-03-30T14:00:00Z",
+        worktree_links: [],
+      }),
+    });
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42");
+
+  const images = page.locator(".markdown-body table img");
+  await expect(images).toHaveCount(3);
+
+  const widths: number[] = [];
+  for (let i = 0; i < 3; i++) {
+    const box = await images.nth(i).boundingBox();
+    expect(box).not.toBeNull();
+    widths.push(box!.width);
+  }
+
+  // Every screenshot gets a real share of the row instead of the first
+  // columns collapsing to slivers while the last column takes everything.
+  for (const width of widths) {
+    expect(width).toBeGreaterThan(100);
+  }
+  expect(Math.max(...widths) / Math.min(...widths)).toBeLessThan(1.25);
+
+  // The table stays within the description container instead of overflowing.
+  const tableBox = await page.locator(".markdown-body table").boundingBox();
+  const bodyBox = await page.locator(".markdown-body").first().boundingBox();
+  expect(tableBox).not.toBeNull();
+  expect(bodyBox).not.toBeNull();
+  expect(tableBox!.width).toBeLessThanOrEqual(bodyBox!.width + 1);
+});
+
 test("add description to empty-body PR shows add-description-btn", async ({ page }) => {
   // Override the GET route to return a PR with empty body.
   await page.route("**/api/v1/pulls/github/acme/widgets/42", async (route) => {

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -182,6 +182,80 @@ test("markdown tables keep compact columns readable", async ({ page }) => {
   await expect(page.locator(".markdown-body table")).toHaveCSS("border-collapse", "collapse");
 });
 
+test("markdown tables keep long unbroken values on one line and scroll", async ({ page }) => {
+  const longToken = "deadbeef".repeat(30);
+  await page.route("**/api/v1/pulls/github/acme/widgets/42", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        merge_request: {
+          ID: 1,
+          RepoID: 1,
+          GitHubID: 101,
+          Number: 42,
+          URL: "https://github.com/acme/widgets/pull/42",
+          Title: "Add browser regression coverage",
+          Author: "marius",
+          State: "open",
+          IsDraft: false,
+          Body: ["| Name | Digest |", "| --- | --- |", `| image | ${longToken} |`].join("\n"),
+          HeadBranch: "feature/playwright",
+          BaseBranch: "main",
+          Additions: 120,
+          Deletions: 12,
+          CommentCount: 3,
+          ReviewDecision: "APPROVED",
+          CIStatus: "success",
+          CIChecksJSON: "[]",
+          CreatedAt: "2026-03-29T14:00:00Z",
+          UpdatedAt: "2026-03-30T14:00:00Z",
+          LastActivityAt: "2026-03-30T14:00:00Z",
+          MergedAt: null,
+          ClosedAt: null,
+          KanbanStatus: "reviewing",
+          Starred: false,
+          repo_owner: "acme",
+          repo_name: "widgets",
+          platform_host: "github.com",
+          repo: mockRepo,
+          worktree_links: [],
+        },
+        repo_owner: "acme",
+        repo_name: "widgets",
+        platform_host: "github.com",
+        repo: mockRepo,
+        detail_loaded: true,
+        detail_fetched_at: "2026-03-30T14:00:00Z",
+        worktree_links: [],
+      }),
+    });
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42");
+
+  // The PR body container sets word-break: break-word; cells must reset it
+  // so an unbroken token keeps its intrinsic width instead of splitting.
+  const digestCell = page.locator(".markdown-body td").filter({ hasText: longToken.slice(0, 24) });
+  await expect(digestCell).toBeVisible();
+  const digestLines = await digestCell.evaluate((el) => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    return Array.from(range.getClientRects()).filter((rect) => rect.width > 0).length;
+  });
+  expect(digestLines).toBe(1);
+
+  // The too-wide table scrolls horizontally within itself like GitHub.
+  const overflow = await page
+    .locator(".markdown-body table")
+    .evaluate((el) => ({ scrollWidth: el.scrollWidth, clientWidth: el.clientWidth }));
+  expect(overflow.scrollWidth).toBeGreaterThan(overflow.clientWidth);
+});
+
 test("markdown tables with images share width evenly like GitHub", async ({ page }) => {
   // Serve a fixed-size image for every screenshot cell so auto table layout
   // has real intrinsic widths to distribute.

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -158,8 +158,27 @@ test("markdown tables keep compact columns readable", async ({ page }) => {
   const commitCell = page.locator(".markdown-body td").filter({ hasText: "b2af4711" });
   await expect(taskHeader).toBeVisible();
   await expect(commitCell).toBeVisible();
-  await expect(taskHeader).toHaveCSS("white-space", "nowrap");
-  await expect(commitCell).toHaveCSS("white-space", "nowrap");
+
+  // Auto table layout gives the compact columns their content width, so
+  // the commit hash renders on a single line without nowrap overrides.
+  const commitLines = await commitCell.evaluate((el) => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    return Array.from(range.getClientRects()).filter((rect) => rect.width > 0).length;
+  });
+  expect(commitLines).toBe(1);
+
+  // The long description column absorbs the remaining width; the compact
+  // columns stay narrow instead of splitting the table evenly.
+  const taskBox = await taskHeader.boundingBox();
+  const tableBox = await page.locator(".markdown-body table").boundingBox();
+  const bodyBox = await page.locator(".markdown-body").first().boundingBox();
+  expect(taskBox).not.toBeNull();
+  expect(tableBox).not.toBeNull();
+  expect(bodyBox).not.toBeNull();
+  expect(taskBox!.width).toBeLessThan(tableBox!.width * 0.2);
+  expect(tableBox!.width).toBeLessThanOrEqual(bodyBox!.width + 1);
+
   await expect(page.locator(".markdown-body table")).toHaveCSS("border-collapse", "collapse");
 });
 


### PR DESCRIPTION
Markdown tables holding images — the common side-by-side screenshot pattern in PR descriptions — rendered nothing like GitHub: a compact-column rule (`width: 1%` + `nowrap`, added in #220 for key/value tables) collapsed every leading column to a sliver and handed all the width to the last one. Text tables also stretched to the full container, where GitHub shrink-wraps them.

Rather than keep patching a homegrown layout model, this adopts the table layout GitHub's own pages serve (Primer): `display: block; width: max-content; max-width: 100%; overflow: auto`, with no per-column width or nowrap overrides. Auto table layout keeps #220's compact key/value columns on one line for free, so descriptions render in middleman the way their authors previewed them on GitHub.

- Screenshot tables split the width across columns proportionally instead of collapsing
- Text tables shrink-wrap to their content like GitHub instead of stretching full width
- Overly wide tables scroll horizontally within the table

### Before
![markdown-table-before.png](https://github.com/user-attachments/assets/cdbd8b16-0d02-4226-9b8a-25cc5866c63a)

### After
![markdown-table-after.png](https://github.com/user-attachments/assets/57b6635b-385a-418d-9864-6e6fcadc28aa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
