### PR TITLE
Use GitHub rate-limit snapshots during sync

### DIFF
--- a/cmd/middleman/provider_startup.go
+++ b/cmd/middleman/provider_startup.go
@@ -31,6 +31,10 @@ type providerFactoryOutput struct {
 	provider     platform.Provider
 }
 
+type graphQLRateTrackerSetter interface {
+	SetGraphQLRateTracker(*github.RateTracker)
+}
+
 type providerStartup struct {
 	registry     *platform.Registry
 	rateTrackers map[string]*github.RateTracker
@@ -222,6 +226,9 @@ func buildProviderStartup(
 	for host := range githubHosts {
 		rateKey := github.RateBucketKey(string(platform.KindGitHub), host)
 		gqlRT := github.NewPlatformRateTracker(database, string(platform.KindGitHub), host, "graphql")
+		if setter, ok := clients[host].(graphQLRateTrackerSetter); ok {
+			setter.SetGraphQLRateTracker(gqlRT)
+		}
 		source := startup.cloneSources[tokenauth.Key{
 			Platform: string(platform.KindGitHub),
 			Host:     host,

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -231,14 +231,21 @@ func restAPIOriginForHost(platformHost string) string {
 }
 
 type liveClient struct {
-	gh              *gh.Client
-	httpClient      *http.Client
-	rateTracker     *RateTracker
-	platformHost    string
-	graphQLEndpoint string
-	etag            *etagTransport
-	viewerMu        sync.Mutex
-	viewerLogin     string
+	gh                 *gh.Client
+	httpClient         *http.Client
+	rateTracker        *RateTracker
+	graphQLRateTracker *RateTracker
+	platformHost       string
+	graphQLEndpoint    string
+	etag               *etagTransport
+	viewerMu           sync.Mutex
+	viewerLogin        string
+}
+
+// SetGraphQLRateTracker attaches the tracker used by liveClient's direct
+// GraphQL HTTP helpers.
+func (c *liveClient) SetGraphQLRateTracker(rateTracker *RateTracker) {
+	c.graphQLRateTracker = rateTracker
 }
 
 // InvalidateListETagsForRepo evicts cached ETag entries for the repo's
@@ -739,12 +746,36 @@ func (c *liveClient) trackRate(resp *gh.Response) {
 	c.rateTracker.UpdateFromRate(rateFromGitHub(resp.Rate))
 }
 
-func (c *liveClient) trackRateHeaders(resp *http.Response) {
-	if resp == nil || c.rateTracker == nil {
+func (c *liveClient) GetRateLimitSnapshot(ctx context.Context) (*RateLimitSnapshot, error) {
+	limits, _, err := c.gh.RateLimit.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get GitHub rate limit snapshot: %w", err)
+	}
+	if limits == nil {
+		return &RateLimitSnapshot{}, nil
+	}
+	snapshot := &RateLimitSnapshot{}
+	if limits.Core != nil {
+		rate := rateFromGitHub(*limits.Core)
+		snapshot.Core = &rate
+	}
+	if limits.GraphQL != nil {
+		rate := rateFromGitHub(*limits.GraphQL)
+		snapshot.GraphQL = &rate
+	}
+	return snapshot, nil
+}
+
+func (c *liveClient) trackGraphQLRateHeaders(resp *http.Response) {
+	if resp == nil || c.graphQLRateTracker == nil {
 		return
 	}
-	c.rateTracker.RecordRequest()
-	remaining, err := strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining"))
+	c.graphQLRateTracker.RecordRequest()
+	remaining, err := parseRateHeaderInt(resp.Header, "X-RateLimit-Remaining")
+	if err != nil {
+		return
+	}
+	limit, err := parseRateHeaderInt(resp.Header, "X-RateLimit-Limit")
 	if err != nil {
 		return
 	}
@@ -752,9 +783,17 @@ func (c *liveClient) trackRateHeaders(resp *http.Response) {
 	if err != nil {
 		return
 	}
-	c.rateTracker.UpdateFromRate(rateFromGitHubHeaders(
-		0, remaining, time.Unix(resetUnix, 0).UTC(),
+	c.graphQLRateTracker.UpdateFromRate(rateFromGitHubHeaders(
+		limit, remaining, time.Unix(resetUnix, 0).UTC(),
 	))
+}
+
+func parseRateHeaderInt(header http.Header, name string) (int, error) {
+	value, err := strconv.ParseInt(header.Get(name), 10, strconv.IntSize)
+	if err != nil {
+		return 0, err
+	}
+	return int(value), nil
 }
 
 func (c *liveClient) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
@@ -1127,7 +1166,7 @@ func (c *liveClient) ListPullRequestReviewThreads(
 				owner, repo, number, err,
 			)
 		}
-		c.trackRateHeaders(resp)
+		c.trackGraphQLRateHeaders(resp)
 		if resp.StatusCode != http.StatusOK {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf(
@@ -1251,7 +1290,7 @@ func (c *liveClient) listPullRequestReviewThreadComments(
 				owner, repo, number, threadID, err,
 			)
 		}
-		c.trackRateHeaders(resp)
+		c.trackGraphQLRateHeaders(resp)
 		if resp.StatusCode != http.StatusOK {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf(
@@ -1444,7 +1483,7 @@ func (c *liveClient) ListPullRequestTimelineEvents(
 				owner, repo, number, err,
 			)
 		}
-		c.trackRateHeaders(resp)
+		c.trackGraphQLRateHeaders(resp)
 		if resp.StatusCode != http.StatusOK {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf(
@@ -1627,7 +1666,7 @@ func (c *liveClient) ListIssueTimelineEvents(
 				owner, repo, number, err,
 			)
 		}
-		c.trackRateHeaders(resp)
+		c.trackGraphQLRateHeaders(resp)
 		if resp.StatusCode != http.StatusOK {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf(
@@ -1944,7 +1983,7 @@ func (c *liveClient) MarkPullRequestReadyForReview(
 		if err != nil {
 			return nil, err
 		}
-		c.trackRateHeaders(resp)
+		c.trackGraphQLRateHeaders(resp)
 		if resp.StatusCode != http.StatusOK {
 			_ = resp.Body.Close()
 			return resp, newReadyForReviewError(

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -154,6 +154,30 @@ func TestListTagsTracksRate(t *testing.T) {
 	require.Equal(5000, rt.RateLimit())
 }
 
+func TestTrackGraphQLRateHeadersUsesGraphQLTracker(t *testing.T) {
+	assert := Assert.New(t)
+	database := openTestDB(t)
+	restRT := NewRateTracker(database, "github.example.com", "rest")
+	gqlRT := NewRateTracker(database, "github.example.com", "graphql")
+	resetAt := time.Now().Add(time.Hour).Unix()
+	c := &liveClient{rateTracker: restRT}
+	c.SetGraphQLRateTracker(gqlRT)
+	header := http.Header{}
+	header.Set("X-RateLimit-Limit", "5000")
+	header.Set("X-RateLimit-Remaining", "4996")
+	header.Set("X-RateLimit-Reset", strconv.FormatInt(resetAt, 10))
+	resp := &http.Response{Header: header}
+
+	c.trackGraphQLRateHeaders(resp)
+
+	assert.Equal(0, restRT.RequestsThisHour())
+	assert.False(restRT.Known())
+	assert.Equal(1, gqlRT.RequestsThisHour())
+	assert.Equal(4996, gqlRT.Remaining())
+	assert.Equal(5000, gqlRT.RateLimit())
+	assert.True(gqlRT.Known())
+}
+
 func TestListOpenIssuesLogsFetchProgressForLargeIssueSet(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/github/graphql_live_test.go
+++ b/internal/github/graphql_live_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -11,18 +10,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const liveGraphQLTestsEnv = "MIDDLEMAN_LIVE_GITHUB_TESTS"
-
 func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
-	if os.Getenv(liveGraphQLTestsEnv) != "1" {
-		t.Skipf("set %s=1 to validate GraphQL queries against GitHub", liveGraphQLTestsEnv)
-	}
-
-	token := os.Getenv("MIDDLEMAN_GITHUB_TOKEN")
-	if token == "" {
-		token = os.Getenv("GITHUB_TOKEN")
-	}
-	require.NotEmpty(t, token, "set MIDDLEMAN_GITHUB_TOKEN or GITHUB_TOKEN")
+	skipUnlessLiveGitHubTests(t)
+	token := requireLiveGitHubToken(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/internal/github/live_test.go
+++ b/internal/github/live_test.go
@@ -1,0 +1,31 @@
+package github
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const liveGitHubTestsEnv = "MIDDLEMAN_LIVE_GITHUB_TESTS"
+
+func skipUnlessLiveGitHubTests(t *testing.T) {
+	t.Helper()
+	if os.Getenv(liveGitHubTestsEnv) != "1" {
+		t.Skipf("set %s=1 to validate against GitHub", liveGitHubTestsEnv)
+	}
+}
+
+func liveGitHubToken() string {
+	if token := os.Getenv("MIDDLEMAN_GITHUB_TOKEN"); token != "" {
+		return token
+	}
+	return os.Getenv("GITHUB_TOKEN")
+}
+
+func requireLiveGitHubToken(t *testing.T) string {
+	t.Helper()
+	token := liveGitHubToken()
+	require.NotEmpty(t, token, "set MIDDLEMAN_GITHUB_TOKEN or GITHUB_TOKEN")
+	return token
+}

--- a/internal/github/rate.go
+++ b/internal/github/rate.go
@@ -13,6 +13,11 @@ const RateReserveBuffer = ratelimit.RateReserveBuffer
 type Rate = ratelimit.Rate
 type RateTracker = ratelimit.RateTracker
 
+type RateLimitSnapshot struct {
+	Core    *Rate
+	GraphQL *Rate
+}
+
 func NewRateTracker(
 	database *db.DB, platformHost string, apiType string,
 ) *RateTracker {

--- a/internal/github/rate_limit_live_test.go
+++ b/internal/github/rate_limit_live_test.go
@@ -1,0 +1,45 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v84/github"
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestLiveGitHubRateLimitSnapshotUsesGoGitHub(t *testing.T) {
+	skipUnlessLiveGitHubTests(t)
+	assert := Assert.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	client := gh.NewClient(nil)
+	if token := liveGitHubToken(); token != "" {
+		client = gh.NewClient(oauthHTTPClient(token))
+	}
+
+	limits, resp, err := client.RateLimit.Get(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, limits)
+	require.NotNil(t, limits.Core)
+
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	assert.Positive(limits.Core.Limit)
+	assert.GreaterOrEqual(limits.Core.Remaining, 0)
+	assert.LessOrEqual(limits.Core.Remaining, limits.Core.Limit)
+	assert.True(limits.Core.Reset.After(time.Now().Add(-time.Minute)))
+}
+
+func oauthHTTPClient(token string) *http.Client {
+	return oauth2.NewClient(
+		context.Background(),
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	)
+}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -134,6 +134,7 @@ type WatchedMR struct {
 // SetParallelism has not been called. Bounded so we don't burst the
 // per-host GitHub rate limit / abuse-detection thresholds.
 const defaultParallelism = 4
+const rateLimitSnapshotRefreshInterval = time.Minute
 
 // Display-name cache parameters. Display names rarely change,
 // so the success TTL is long enough to skip lookups across many
@@ -285,6 +286,8 @@ type Syncer struct {
 	rateTrackers             map[string]*RateTracker    // provider/host bucket -> tracker
 	budgets                  map[string]*SyncBudget     // provider/host bucket -> budget
 	fetchers                 map[string]*GraphQLFetcher // host -> GraphQL fetcher
+	rateLimitSnapshotMu      sync.Mutex
+	rateLimitSnapshotRefresh map[string]time.Time
 	repos                    []RepoRef
 	reposMu                  sync.Mutex
 	interval                 time.Duration
@@ -533,6 +536,7 @@ func NewSyncerWithRegistry(
 		budgets:                  budgets,
 		repos:                    repos,
 		interval:                 interval,
+		rateLimitSnapshotRefresh: make(map[string]time.Time),
 		branchActivityRetention:  defaultBranchActivityRetention,
 		branchActivityMaxCommits: defaultBranchActivityMaxCommits,
 		nextSyncAfter:            make(map[string]time.Time),
@@ -2281,6 +2285,114 @@ func (s *Syncer) GQLRateTrackers() map[string]*RateTracker {
 	return result
 }
 
+type rateLimitSnapshotter interface {
+	GetRateLimitSnapshot(ctx context.Context) (*RateLimitSnapshot, error)
+}
+
+// RefreshRateLimitSnapshots refreshes GitHub REST and GraphQL quota facts from
+// GitHub's /rate_limit endpoint. The snapshot call is intentionally not
+// recorded as a middleman request because GitHub does not charge it against the
+// primary REST budget.
+func (s *Syncer) RefreshRateLimitSnapshots(ctx context.Context) {
+	s.refreshRateLimitSnapshots(ctx)
+}
+
+func (s *Syncer) refreshRateLimitSnapshots(ctx context.Context) map[string]struct{} {
+	refreshed := make(map[string]struct{})
+	if s == nil || s.clients == nil {
+		return refreshed
+	}
+	for _, rt := range s.rateTrackers {
+		if rt == nil || rt.Provider() != string(platform.KindGitHub) || rt.APIType() != "rest" {
+			continue
+		}
+		key := rt.BucketKey()
+		if !s.claimRateLimitSnapshotRefresh(key, time.Now().UTC()) {
+			continue
+		}
+		client, err := s.clientFor(RepoRef{
+			Platform:     platform.KindGitHub,
+			PlatformHost: rt.PlatformHost(),
+		})
+		if err != nil {
+			continue
+		}
+		snapshotter, ok := client.(rateLimitSnapshotter)
+		if !ok {
+			continue
+		}
+		snapshot, err := snapshotter.GetRateLimitSnapshot(ctx)
+		if err != nil {
+			slog.Warn("refresh GitHub rate limit snapshot failed",
+				"host", rt.PlatformHost(), "err", err)
+			continue
+		}
+		if snapshot == nil {
+			continue
+		}
+		if snapshot.Core != nil {
+			rt.UpdateFromSnapshot(*snapshot.Core)
+			refreshed[key] = struct{}{}
+		}
+		if snapshot.GraphQL != nil {
+			if gqlRT := s.graphQLRateTrackerForHost(rt.PlatformHost()); gqlRT != nil {
+				gqlRT.UpdateFromSnapshot(*snapshot.GraphQL)
+			}
+		}
+	}
+	return refreshed
+}
+
+func (s *Syncer) claimRateLimitSnapshotRefresh(key string, now time.Time) bool {
+	s.rateLimitSnapshotMu.Lock()
+	defer s.rateLimitSnapshotMu.Unlock()
+	if s.rateLimitSnapshotRefresh == nil {
+		s.rateLimitSnapshotRefresh = make(map[string]time.Time)
+	}
+	last := s.rateLimitSnapshotRefresh[key]
+	if !last.IsZero() && now.Sub(last) < rateLimitSnapshotRefreshInterval {
+		return false
+	}
+	s.rateLimitSnapshotRefresh[key] = now
+	return true
+}
+
+func (s *Syncer) graphQLRateTrackerForHost(platformHost string) *RateTracker {
+	if s.fetchers == nil {
+		return nil
+	}
+	fetcher := s.fetchers[canonicalRepoHost(platformHost)]
+	if fetcher == nil {
+		return nil
+	}
+	return fetcher.RateTracker()
+}
+
+func (s *Syncer) clearRecoveredRateLimitGates(
+	refreshed map[string]struct{},
+	nextAfter map[string]time.Time,
+	interval time.Duration,
+) {
+	if len(refreshed) == 0 || nextAfter == nil || interval <= 0 {
+		return
+	}
+	now := time.Now().UTC()
+	for bucket := range refreshed {
+		after, ok := nextAfter[bucket]
+		if !ok || !now.Before(after) {
+			continue
+		}
+		rt := s.rateTrackers[bucket]
+		if rt == nil {
+			continue
+		}
+		refreshedDelay := interval * time.Duration(rt.ThrottleFactor())
+		if after.Sub(now) > refreshedDelay {
+			delete(nextAfter, bucket)
+		}
+	}
+}
+
 // runState holds the per-RunOnce mutable state shared by the
 // worker pool. Extracted into a struct so runWorker can be a
 // directly testable method instead of an inline closure.
@@ -2441,6 +2553,8 @@ func (s *Syncer) runOnce(
 	}
 	defer s.running.Store(false)
 
+	rateLimitSnapshotCtx := ctx
+
 	// Mark context so the budget transport counts HTTP calls
 	// made during background sync. User-initiated server
 	// handler paths do not carry this key and are not counted.
@@ -2483,6 +2597,10 @@ func (s *Syncer) runOnce(
 	nextAfter := s.nextSyncAfter
 	if bypassNextSyncAfter {
 		nextAfter = nil
+	}
+	if rateLimitSnapshotCtx.Err() == nil {
+		refreshed := s.refreshRateLimitSnapshots(rateLimitSnapshotCtx)
+		s.clearRecoveredRateLimitGates(refreshed, nextAfter, s.interval)
 	}
 	eligibleBuckets := s.hostEligibility(repoBuckets, nextAfter)
 
@@ -2540,10 +2658,6 @@ dispatch:
 	close(work)
 	wg.Wait()
 
-	s.advanceNextSync(
-		eligibleBuckets, s.nextSyncAfter, s.interval,
-	)
-
 	// Detail drain: fetch full details for highest-priority items
 	// within the per-host budget. Runs after index scan completes.
 	if !canceled.Load() && ctx.Err() == nil {
@@ -2586,6 +2700,13 @@ dispatch:
 		})
 		return
 	}
+
+	if rateLimitSnapshotCtx.Err() == nil {
+		s.RefreshRateLimitSnapshots(rateLimitSnapshotCtx)
+	}
+	s.advanceNextSync(
+		eligibleBuckets, s.nextSyncAfter, s.interval,
+	)
 
 	slog.Info("sync complete", "repos", total)
 

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -524,6 +524,21 @@ type mockClient struct {
 	createdReviewComments           []*gh.DraftReviewComment
 }
 
+type rateLimitSnapshotMockClient struct {
+	*mockClient
+	snapshot           *RateLimitSnapshot
+	snapshotCalls      atomic.Int32
+	syncBudgetContexts atomic.Int32
+}
+
+func (m *rateLimitSnapshotMockClient) GetRateLimitSnapshot(ctx context.Context) (*RateLimitSnapshot, error) {
+	m.snapshotCalls.Add(1)
+	if IsSyncBudgetContext(ctx) {
+		m.syncBudgetContexts.Add(1)
+	}
+	return m.snapshot, nil
+}
+
 type labelCatalogTestClient struct {
 	*mockClient
 	labels []*gh.Label
@@ -9943,6 +9958,160 @@ func TestSyncerGQLRateTrackers(t *testing.T) {
 	gqlTrackers := syncer.GQLRateTrackers()
 	assert.Len(gqlTrackers, 1)
 	assert.Same(gqlRT, gqlTrackers["github.com"])
+}
+
+func TestRunOnceRefreshesGitHubRateLimitSnapshotOutsideSyncBudget(t *testing.T) {
+	assert := Assert.New(t)
+	d := openTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	restReset := now.Add(time.Hour)
+	gqlReset := now.Add(90 * time.Minute)
+	restRT := NewRateTracker(d, "github.com", "rest")
+	gqlRT := NewRateTracker(d, "github.com", "graphql")
+	budget := NewSyncBudget(100)
+	client := &rateLimitSnapshotMockClient{
+		mockClient: &mockClient{},
+		snapshot: &RateLimitSnapshot{
+			Core: &Rate{
+				Limit:     5000,
+				Remaining: 4991,
+				Reset:     restReset,
+			},
+			GraphQL: &Rate{
+				Limit:     5000,
+				Remaining: 4988,
+				Reset:     gqlReset,
+			},
+		},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		d, nil,
+		nil,
+		time.Minute,
+		map[string]*RateTracker{"github.com": restRT},
+		map[string]*SyncBudget{"github.com": budget},
+	)
+	syncer.SetFetchers(map[string]*GraphQLFetcher{
+		"github.com": NewGraphQLFetcher(testTokenSource("token"), "github.com", gqlRT, nil),
+	})
+
+	syncer.RunOnce(t.Context())
+
+	assert.Equal(int32(1), client.snapshotCalls.Load())
+	assert.Equal(int32(0), client.syncBudgetContexts.Load())
+	assert.Equal(0, budget.Spent())
+	assert.Equal(0, restRT.RequestsThisHour())
+	assert.Equal(4991, restRT.Remaining())
+	assert.Equal(5000, restRT.RateLimit())
+	if assert.NotNil(restRT.ResetAt()) {
+		assert.Equal(restReset, *restRT.ResetAt())
+	}
+	assert.Equal(0, gqlRT.RequestsThisHour())
+	assert.Equal(4988, gqlRT.Remaining())
+	assert.Equal(5000, gqlRT.RateLimit())
+	if assert.NotNil(gqlRT.ResetAt()) {
+		assert.Equal(gqlReset, *gqlRT.ResetAt())
+	}
+}
+
+func TestRunOnceSnapshotWindowResetResetsSyncBudget(t *testing.T) {
+	assert := Assert.New(t)
+	d := openTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	oldReset := now.Add(time.Hour)
+	newReset := now.Add(2 * time.Hour)
+	restRT := NewRateTracker(d, "github.com", "rest")
+	restRT.UpdateFromRate(Rate{
+		Limit:     5000,
+		Remaining: 4999,
+		Reset:     oldReset,
+	})
+	for range 50 {
+		restRT.RecordRequest()
+	}
+	restRT.SetResetAtForTesting(now.Add(-time.Minute))
+	budget := NewSyncBudget(100)
+	budget.Spend(100)
+	client := &rateLimitSnapshotMockClient{
+		mockClient: &mockClient{},
+		snapshot: &RateLimitSnapshot{
+			Core: &Rate{
+				Limit:     5000,
+				Remaining: 4990,
+				Reset:     newReset,
+			},
+		},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		d, nil,
+		nil,
+		time.Minute,
+		map[string]*RateTracker{"github.com": restRT},
+		map[string]*SyncBudget{"github.com": budget},
+	)
+
+	syncer.RunOnce(t.Context())
+
+	assert.Equal(int32(1), client.snapshotCalls.Load())
+	assert.Equal(0, restRT.RequestsThisHour())
+	assert.Equal(0, budget.Spent())
+	assert.Equal(4990, restRT.Remaining())
+	if assert.NotNil(restRT.ResetAt()) {
+		assert.Equal(newReset, *restRT.ResetAt())
+	}
+}
+
+func TestRunOnceRecoveredRateLimitSnapshotClearsStaleThrottleGate(t *testing.T) {
+	assert := Assert.New(t)
+	d := openTestDB(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	resetAt := now.Add(time.Hour)
+	rt := NewRateTracker(d, "github.com", "rest")
+	rt.UpdateFromRate(Rate{
+		Limit:     5000,
+		Remaining: 400,
+		Reset:     resetAt,
+	})
+	client := &rateLimitSnapshotMockClient{
+		mockClient: &mockClient{},
+		snapshot: &RateLimitSnapshot{
+			Core: &Rate{
+				Limit:     5000,
+				Remaining: 4900,
+				Reset:     resetAt,
+			},
+		},
+	}
+	interval := time.Minute
+
+	mock := &mockClient{}
+	client.mockClient = mock
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		d, nil,
+		[]RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		interval,
+		map[string]*RateTracker{"github.com": rt},
+		nil,
+	)
+	syncer.nextSyncAfter["github.com"] = time.Now().UTC().Add(8 * interval)
+
+	beforeRun := time.Now().UTC()
+	syncer.RunOnce(t.Context())
+
+	assert.True(mock.listOpenPRsCalled)
+	nextSyncAfter, ok := syncer.nextSyncAfter["github.com"]
+	if assert.True(ok) {
+		assert.Less(nextSyncAfter.Sub(beforeRun), 2*interval)
+	}
+	assert.Equal(4900, rt.Remaining())
 }
 
 func TestSyncerGQLRateTrackersSkipsNil(t *testing.T) {

--- a/internal/ratelimit/rate.go
+++ b/internal/ratelimit/rate.go
@@ -144,17 +144,33 @@ func (rt *RateTracker) SetOnWindowReset(fn func()) {
 // the reset time moved forward, the provider started a new rate window and the
 // request counter resets to stay aligned with that window.
 func (rt *RateTracker) UpdateFromRate(rate Rate) {
+	rt.updateFromRate(rate, 1, false)
+}
+
+// UpdateFromSnapshot updates remaining/limit/reset from provider snapshot data
+// that does not itself represent a counted API request.
+func (rt *RateTracker) UpdateFromSnapshot(rate Rate) {
+	rt.updateFromRate(rate, 0, true)
+}
+
+func (rt *RateTracker) updateFromRate(
+	rate Rate,
+	resetWindowCount int,
+	resetExpiredWindow bool,
+) {
 	rt.mu.Lock()
+	now := time.Now().UTC()
 	resetTime := rate.Reset.UTC()
 	// Detect provider window reset: remaining increases AND the
 	// previous resetAt has passed (proving the old window ended).
 	// Both conditions are required to avoid false resets from
 	// out-of-order responses within the same window.
 	var windowReset bool
-	if rt.remaining >= 0 && rate.Remaining > rt.remaining &&
-		rt.resetAt != nil && !time.Now().Before(*rt.resetAt) {
-		rt.count = 1 // the current request is the first in the new window
-		rt.hourStart = time.Now().UTC()
+	expiredWindow := rt.resetAt != nil && !now.Before(*rt.resetAt)
+	if expiredWindow && (resetExpiredWindow ||
+		rt.remaining >= 0 && rate.Remaining > rt.remaining) {
+		rt.count = resetWindowCount
+		rt.hourStart = now
 		windowReset = true
 	}
 	fn := rt.onWindowReset

--- a/internal/ratelimit/rate_test.go
+++ b/internal/ratelimit/rate_test.go
@@ -353,6 +353,40 @@ func TestRateTrackerResetAtJitterDoesNotResetCounter(t *testing.T) {
 	assert.Equal(50, rt.RequestsThisHour())
 }
 
+func TestRateTrackerSnapshotResetDoesNotRequireRemainingIncrease(t *testing.T) {
+	assert := Assert.New(t)
+	d := openTestDB(t)
+	rt := newGitHubRateTracker(d, "github.com", "rest")
+	var resetCallbacks int
+	rt.SetOnWindowReset(func() {
+		resetCallbacks++
+	})
+
+	oldReset := time.Now().Add(30 * time.Minute)
+	rt.UpdateFromRate(Rate{
+		Limit:     5000,
+		Remaining: 4999,
+		Reset:     oldReset,
+	})
+	for range 50 {
+		rt.RecordRequest()
+	}
+
+	pastReset := time.Now().Add(-1 * time.Minute)
+	rt.SetResetAtForTesting(pastReset)
+	newReset := time.Now().Add(time.Hour)
+	rt.UpdateFromSnapshot(Rate{
+		Limit:     5000,
+		Remaining: 4990,
+		Reset:     newReset,
+	})
+
+	assert.Equal(0, rt.RequestsThisHour())
+	assert.Equal(4990, rt.Remaining())
+	assert.Equal(newReset.UTC(), *rt.ResetAt())
+	assert.Equal(1, resetCallbacks)
+}
+
 // TestRateTrackerProductionFlow simulates the exact production
 // pattern: every API call does RecordRequest + UpdateFromRate
 // (via trackRate), then the counter is read via RequestsThisHour

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -216,6 +216,8 @@ type mockGH struct {
 	listOpenIssuesFn           func(context.Context, string, string) ([]*gh.Issue, error)
 	listIssueCommentsFn        func(context.Context, string, string, int) ([]*gh.IssueComment, error)
 	listReviewThreadsFn        func(context.Context, string, string, int) ([]ghclient.PullRequestReviewThread, error)
+	rateLimitSnapshotFn        func(context.Context) (*ghclient.RateLimitSnapshot, error)
+	rateLimitSnapshotCalls     int
 	listIssueCommentsErr       error
 }
 
@@ -284,6 +286,14 @@ func (m *mockGH) GetUser(ctx context.Context, login string) (*gh.User, error) {
 		return m.getUserFn(ctx, login)
 	}
 	return &gh.User{Login: &login}, nil
+}
+
+func (m *mockGH) GetRateLimitSnapshot(ctx context.Context) (*ghclient.RateLimitSnapshot, error) {
+	m.rateLimitSnapshotCalls++
+	if m.rateLimitSnapshotFn != nil {
+		return m.rateLimitSnapshotFn(ctx)
+	}
+	return nil, nil
 }
 
 func (m *mockGH) ListRepositoriesByOwner(
@@ -15643,6 +15653,94 @@ func TestAPIRateLimitsWithGQL(t *testing.T) {
 	assert.Equal(5000, host.GQLLimit)
 	assert.True(host.GQLKnown)
 	assert.NotEmpty(host.GQLResetAt)
+}
+
+func TestAPIRateLimitsReadsLocalStateWithoutRefreshingGitHubRateLimit(t *testing.T) {
+	assert := Assert.New(t)
+
+	database := dbtest.Open(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	localRestReset := now.Add(30 * time.Minute)
+	localGQLReset := now.Add(45 * time.Minute)
+	gitHubRestReset := now.Add(time.Hour)
+	gitHubGQLReset := now.Add(90 * time.Minute)
+
+	restRT := ghclient.NewRateTracker(database, "github.com", "rest")
+	gqlRT := ghclient.NewRateTracker(database, "github.com", "graphql")
+	restRT.UpdateFromRate(ghclient.Rate{
+		Limit:     5000,
+		Remaining: 3000,
+		Reset:     localRestReset,
+	})
+	gqlRT.UpdateFromRate(ghclient.Rate{
+		Limit:     5000,
+		Remaining: 4000,
+		Reset:     localGQLReset,
+	})
+	mock := &mockGH{
+		rateLimitSnapshotFn: func(context.Context) (*ghclient.RateLimitSnapshot, error) {
+			return &ghclient.RateLimitSnapshot{
+				Core: &ghclient.Rate{
+					Limit:     5000,
+					Remaining: 4991,
+					Reset:     gitHubRestReset,
+				},
+				GraphQL: &ghclient.Rate{
+					Limit:     5000,
+					Remaining: 4988,
+					Reset:     gitHubGQLReset,
+				},
+			}, nil
+		},
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil,
+		[]ghclient.RepoRef{{
+			Owner: "acme", Name: "widget",
+			PlatformHost: "github.com",
+		}},
+		time.Minute,
+		map[string]*ghclient.RateTracker{"github.com": restRT},
+		nil,
+	)
+	syncer.SetFetchers(map[string]*ghclient.GraphQLFetcher{
+		"github.com": ghclient.NewGraphQLFetcher(testTokenSource("token"), "github.com", gqlRT, nil),
+	})
+	t.Cleanup(syncer.Stop)
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	fetch := func() rateLimitsResponse {
+		resp, err := http.Get(ts.URL + "/api/v1/rate-limits")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(200, resp.StatusCode)
+
+		var body rateLimitsResponse
+		err = json.NewDecoder(resp.Body).Decode(&body)
+		require.NoError(t, err)
+		return body
+	}
+
+	body := fetch()
+	host, ok := body.Hosts["github.com"]
+	assert.True(ok)
+	assert.Equal(0, mock.rateLimitSnapshotCalls)
+	assert.Equal(0, host.RequestsHour)
+	assert.Equal(3000, host.RateRemaining)
+	assert.Equal(5000, host.RateLimit)
+	assert.Equal(formatUTCRFC3339(localRestReset), host.RateResetAt)
+	assert.True(host.Known)
+	assert.Equal(4000, host.GQLRemaining)
+	assert.Equal(5000, host.GQLLimit)
+	assert.Equal(formatUTCRFC3339(localGQLReset), host.GQLResetAt)
+	assert.True(host.GQLKnown)
+
+	_ = fetch()
+	assert.Equal(0, mock.rateLimitSnapshotCalls)
 }
 
 func TestAPIRateLimitsGQLDefaultsUnknown(t *testing.T) {

--- a/internal/server/e2etest/fixtures_test.go
+++ b/internal/server/e2etest/fixtures_test.go
@@ -126,6 +126,7 @@ func gracefulShutdown(t *testing.T, srv *server.Server) {
 }
 
 type mockGH struct {
+	getRateLimitSnapshotFn func(context.Context) (*ghclient.RateLimitSnapshot, error)
 	getRepositoryFn        func(context.Context, string, string) (*gh.Repository, error)
 	listOpenPullRequestsFn func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listReposByOwnerFn     func(context.Context, string) ([]*gh.Repository, error)
@@ -134,6 +135,13 @@ type mockGH struct {
 func (m *mockGH) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
 	if m.listOpenPullRequestsFn != nil {
 		return m.listOpenPullRequestsFn(ctx, owner, repo)
+	}
+	return nil, nil
+}
+
+func (m *mockGH) GetRateLimitSnapshot(ctx context.Context) (*ghclient.RateLimitSnapshot, error) {
+	if m.getRateLimitSnapshotFn != nil {
+		return m.getRateLimitSnapshotFn(ctx)
 	}
 	return nil, nil
 }

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -71,6 +71,61 @@ name = "widget"
 	}
 }
 
+func TestTriggerSyncE2ERefreshesSnapshotBeforeRateBackoff(t *testing.T) {
+	require := require.New(t)
+
+	synced := make(chan struct{})
+	var syncedClosed atomic.Bool
+	mock := &mockGH{
+		getRateLimitSnapshotFn: func(context.Context) (*ghclient.RateLimitSnapshot, error) {
+			resetAt := time.Now().UTC().Add(time.Hour)
+			return &ghclient.RateLimitSnapshot{
+				Core: &ghclient.Rate{
+					Limit:     5000,
+					Remaining: 4800,
+					Reset:     resetAt,
+				},
+			}, nil
+		},
+		listOpenPullRequestsFn: func(
+			_ context.Context, _, _ string,
+		) ([]*gh.PullRequest, error) {
+			if syncedClosed.CompareAndSwap(false, true) {
+				close(synced)
+			}
+			return nil, nil
+		},
+	}
+	baseURL, client, _, syncer := startSyncCooldownE2EServerWithSyncer(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, mock)
+	rt := syncer.RateTrackers()["github.com"]
+	require.NotNil(rt)
+	rt.UpdateFromRate(ghclient.Rate{
+		Limit:     5000,
+		Remaining: 0,
+		Reset:     time.Now().UTC().Add(time.Hour),
+	})
+
+	status, body := postJSON(
+		t, client, baseURL+"/api/v1/sync", nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+
+	select {
+	case <-synced:
+	case <-time.After(2 * time.Second):
+		require.Fail("explicit sync did not refresh snapshot before rate backoff")
+	}
+}
+
 func TestTriggerSyncE2EPrioritizesFilteredRepos(t *testing.T) {
 	require := require.New(t)
 

--- a/middleman.go
+++ b/middleman.go
@@ -243,6 +243,10 @@ type Instance struct {
 	closed         bool
 }
 
+type graphQLRateTrackerSetter interface {
+	SetGraphQLRateTracker(*ghclient.RateTracker)
+}
+
 // New creates a middleman Instance from the given options. It
 // wraps NewWithContext with context.Background(); callers that
 // need to bound or cancel a slow ResolveToken callback should
@@ -387,6 +391,9 @@ func NewWithContext(
 		gqlRT := ghclient.NewPlatformRateTracker(
 			database, "github", host, "graphql",
 		)
+		if setter, ok := clients[host].(graphQLRateTrackerSetter); ok {
+			setter.SetGraphQLRateTracker(gqlRT)
+		}
 		fetchers[host] = ghclient.NewGraphQLFetcher(
 			hostSources[host], host, gqlRT, budgets[rateKey],
 		)

--- a/middleman_test.go
+++ b/middleman_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"testing/fstest"
@@ -80,6 +81,25 @@ func TestNewEmbeddedBootstrapGlobals(t *testing.T) {
 	assert := Assert.New(t)
 	assert.Contains(body, `window.__middleman_config=`)
 	assert.NotContains(body, `__MIDDLEMAN_EMBEDDED__`)
+}
+
+func TestNewWiresGraphQLTrackerIntoEmbeddedClient(t *testing.T) {
+	inst, err := New(Options{
+		Token:   "test-token",
+		DataDir: t.TempDir(),
+		Repos:   []Repo{{Owner: "acme", Name: "widget"}},
+	})
+	require.NoError(t, err)
+	defer inst.Close()
+
+	client, err := inst.syncer.ClientForHost("github.com")
+	require.NoError(t, err)
+
+	value := reflect.ValueOf(client)
+	require.Equal(t, reflect.Pointer, value.Kind())
+	tracker := value.Elem().FieldByName("graphQLRateTracker")
+	require.True(t, tracker.IsValid())
+	require.False(t, tracker.IsNil())
 }
 
 func TestEmbedConfigFullFlow(t *testing.T) {


### PR DESCRIPTION
This makes the budget/rate-limit display more trustworthy without making the UI read path do network work.

- Uses GitHub `/rate_limit` data for core and GraphQL `limit`, `remaining`, and `reset` times, so reset timing comes from GitHub accounting instead of whichever ordinary API response was last observed.
- Keeps `GET /api/v1/rate-limits` local-only; opening or polling the UI does not call GitHub or mutate tracker state.
- Keeps REST and GraphQL quota accounting separate, including direct GraphQL helper calls; `/rate_limit` refreshes do not increment `requests_hour` or spend `SyncBudget`.
- Refreshes quota facts before host eligibility and scheduling, so recovered quota restores normal cadence instead of waiting on stale throttling.
