### PR TITLE
chore: move dependency bumps to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "enabledManagers": ["github-actions", "gomod", "bun", "custom.regex"],
+  "osvVulnerabilityAlerts": true,
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": null,
+    "prCreation": "immediate"
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies",
+      "groupSlug": "go-dependencies",
+      "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"]
+    },
+    {
+      "matchManagers": ["bun", "custom.regex"],
+      "groupName": "JavaScript dependencies",
+      "groupSlug": "javascript-dependencies"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)\\.github/workflows/.+\\.ya?ml$/",
+        "/(^|/)Dockerfile\\.dev$/"
+      ],
+      "matchStrings": [
+        "bun-version:\\s*[\"']?(?<currentValue>\\d+\\.\\d+\\.\\d+)[\"']?",
+        "bun-v(?<currentValue>\\d+\\.\\d+\\.\\d+)/bun-linux"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "oven-sh/bun",
+      "versioningTemplate": "semver"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
-  "enabledManagers": ["github-actions", "gomod", "bun", "custom.regex"],
   "osvVulnerabilityAlerts": true,
   "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-required",
@@ -18,6 +17,11 @@
       "groupName": "Go dependencies",
       "groupSlug": "go-dependencies",
       "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "Rust dependencies",
+      "groupSlug": "rust-dependencies"
     },
     {
       "matchManagers": ["bun", "custom.regex"],
@@ -38,6 +42,7 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "oven-sh/bun",
+      "extractVersionTemplate": "^bun-v(?<version>\\d+\\.\\d+\\.\\d+)$",
       "versioningTemplate": "semver"
     }
   ]


### PR DESCRIPTION
Middleman should use the same Renovate-based dependency automation now used by roborev instead of Dependabot-style dependency update setup.

This adds Renovate coverage for the repo while letting Renovate discover supported dependency managers normally, so Docker and other existing dependency surfaces are not skipped by a narrow whitelist. Go module updates keep gomod tidy/import-path handling, Rust updates are batched together, and Bun/frontend JavaScript dependency updates are grouped into their own PR stream.

Pinned Bun runtime references in workflows and Dockerfile.dev are handled with a custom regex manager that extracts semver from `bun-v...` GitHub release tags.

Validated with `jq . renovate.json`, `bunx --bun renovate-config-validator renovate.json`, local Bun tag extraction checks, and the repository commit/push hooks.