### PR TITLE
chore: remove obsolete DOMPurify type package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,6 @@
         "@sveltejs/vite-plugin-svelte": "7.0.0",
         "@testing-library/svelte": "5.2.8",
         "@tsconfig/svelte": "5.0.8",
-        "@types/dompurify": "3.2.0",
         "@types/node": "^24.9.2",
         "jsdom": "26.1.0",
         "openapi-typescript": "^7.13.0",
@@ -70,7 +69,6 @@
       "devDependencies": {
         "@testing-library/svelte": "5.2.8",
         "@tsconfig/svelte": "^5.0.0",
-        "@types/dompurify": "3.2.0",
         "@types/node": "^24.9.2",
         "openapi-fetch": "^0.17.0",
         "svelte": "^5.55.7",
@@ -480,8 +478,6 @@
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
-
-    "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -1016,8 +1012,6 @@
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
-
-    "@types/dompurify/dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
     "@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,6 @@
     "@sveltejs/vite-plugin-svelte": "7.0.0",
     "@testing-library/svelte": "5.2.8",
     "@tsconfig/svelte": "5.0.8",
-    "@types/dompurify": "3.2.0",
     "@types/node": "^24.9.2",
     "jsdom": "26.1.0",
     "openapi-typescript": "^7.13.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -138,7 +138,6 @@
   "devDependencies": {
     "@testing-library/svelte": "5.2.8",
     "@tsconfig/svelte": "^5.0.0",
-    "@types/dompurify": "3.2.0",
     "@types/node": "^24.9.2",
     "openapi-fetch": "^0.17.0",
     "svelte": "^5.55.7",


### PR DESCRIPTION
DOMPurify now ships its own TypeScript declarations, so keeping `@types/dompurify` only adds deprecated dependency noise. This removes the stale type package from both frontend workspaces and refreshes the Bun lockfile while keeping the runtime DOMPurify dependency.