### PR TITLE
test: close mandated e2e gaps for SSE replay and pushed-head observer

### DIFF
--- a/internal/server/e2etest/sse_replay_test.go
+++ b/internal/server/e2etest/sse_replay_test.go
@@ -151,6 +151,47 @@ func TestE2E_SSESinceQueryWorks(t *testing.T) {
 	assert.Equal("data_changed", f.Event)
 }
 
+func TestE2E_SSEBufferWraparoundReplaysRetainedEvents(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, _, _ := setupTestServerWithSSEBufferSize(t, 4)
+	defer gracefulShutdown(t, srv)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Six broadcasts into a 4-slot ring: ids 1 and 2 are overwritten,
+	// ids 3..6 remain. A cursor inside the retained window must replay
+	// the tail in order even though the ring has wrapped.
+	for i := 1; i <= 6; i++ {
+		srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: i})
+	}
+
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, ts.URL+"/api/v1/events", nil,
+	)
+	require.NoError(err)
+	req.Header.Set("Last-Event-ID", "4")
+	resp, err := ts.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	var replayed []string
+	for range 2 {
+		f := readSSEFrame(t, scanner)
+		assert.Equal("data_changed", f.Event)
+		replayed = append(replayed, f.ID)
+	}
+	assert.Equal([]string{"5", "6"}, replayed)
+
+	// Live delivery resumes after the replay with the next id.
+	waitForSubscribe(t, srv, 1)
+	srv.Hub().Broadcast(server.Event{Type: "data_changed", Data: "post-wrap"})
+	live := readSSEFrame(t, scanner)
+	assert.Equal("7", live.ID)
+}
+
 func TestE2E_SSEStaleCursorEmitsReconnectStale(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/workspace_pushed_head_e2e_test.go
+++ b/internal/server/workspace_pushed_head_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -106,6 +107,72 @@ func TestWorkspacePushedHeadObserverE2ERefreshesPRDetailAndSSE(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal(newHead, stored.PlatformHeadSHA)
+}
+
+func TestWorkspacePushedHeadObserverE2ELocalOnlyCommitTriggersNothing(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	var detailSyncCalls atomic.Int64
+	mock := &mockGH{
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			detailSyncCalls.Add(1)
+			return nil, nil
+		},
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		[]ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{WorktreeDir: t.TempDir()})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	worktreePath, pushedHead := setupPushedHeadE2EWorktree(t)
+	repoID := seedPushedHeadE2ERepoAndPR(t, database, pushedHead)
+	insertPushedHeadE2EWorkspace(t, database, worktreePath)
+
+	// Commit locally without pushing: the remote-tracking ref must not
+	// move, so the observer must treat the workspace as unchanged.
+	require.NoError(os.WriteFile(filepath.Join(worktreePath, "feature.txt"), []byte("local only\n"), 0o644))
+	runGit(t, worktreePath, "add", ".")
+	runGit(t, worktreePath, "commit", "-m", "local-only commit")
+	assert.Equal(pushedHead, testGitSHA(t, worktreePath, "refs/remotes/origin/feature"),
+		"local commit must not move the remote-tracking ref")
+
+	httpServer := httptest.NewServer(srv)
+	defer httpServer.Close()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL+"/api/v1/events", nil)
+	require.NoError(err)
+	resp, err := httpServer.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.Eventually(func() bool {
+		return srv.SubscriberCount() == 1
+	}, 2*time.Second, 5*time.Millisecond)
+	scanner := bufio.NewScanner(resp.Body)
+
+	srv.runWorkspacePushedHeadObserverPass(ctx)
+
+	// The pass enqueues nothing, so the sentinel broadcast after it must
+	// be the first frame the subscriber sees.
+	srv.Hub().Broadcast(Event{Type: "sentinel_after_pass", Data: map[string]any{}})
+	frame := readSSEFrameWithin(t, scanner, 5*time.Second, nil)
+	assert.Equal("sentinel_after_pass", frame.Event)
+
+	assert.Equal(int64(0), detailSyncCalls.Load(), "no PR detail sync may run for a local-only commit")
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 1)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("Old title", stored.Title)
+	assert.Equal(pushedHead, stored.PlatformHeadSHA)
 }
 
 func seedPushedHeadE2ERepoAndPR(t *testing.T, database *db.DB, oldHead string) int64 {


### PR DESCRIPTION
The SSE replay (2026-05-19 spec) and remote-head-refresh (2026-05-20 spec) features shipped with broad coverage, but two behaviors the specs treat as load-bearing had no wire-level test: replay from a cursor inside a ring that has already wrapped (the existing wraparound e2e only proved the stale path), and the negative guarantee that a local-only commit — no remote-tracking ref move — produces no refresh at all. The local-only case is asserted deterministically with a sentinel broadcast after the observer pass rather than a sleep, so the absence of events, provider sync calls, and DB writes is pinned without flakiness.

- e2e: SSE reconnect inside a wrapped ring replays the retained tail in order, then resumes live delivery
- e2e: a local-only commit in a PR workspace triggers no SSE events, no detail sync, and no DB mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)