### PR TITLE
fix: stop kata keyboard scrolling from fetching every row traversed

### DIFF
--- a/frontend/src/lib/api/kata/taskClient.test.ts
+++ b/frontend/src/lib/api/kata/taskClient.test.ts
@@ -659,6 +659,30 @@ describe("kata task HTTP client", () => {
     expect(calls[0]!.headers.get(KATA_DAEMON_HEADER)).toBe("work");
   });
 
+  test("threads abort signals through issue and events fetches", async () => {
+    const { fetchImpl } = createFetchStub({
+      "/api/v1/issues/issue-1": {
+        body: { issue: { ...issue("issue-1", "Shown issue"), body: "Body" }, comments: [], labels: [], links: [] },
+      },
+      "/api/v1/events?limit=100": {
+        body: { reset_required: false, events: [], next_after_id: 0 },
+      },
+    });
+    const signals: (AbortSignal | null | undefined)[] = [];
+    const recordingFetch: typeof fetch = (input, init) => {
+      signals.push(init?.signal);
+      return fetchImpl(input, init);
+    };
+    const api = createKataTaskAPI({ fetchImpl: recordingFetch });
+    const controller = new AbortController();
+
+    await api.issue("issue-1", { signal: controller.signal });
+    await api.events({ issue_uid: "issue-1", limit: 100 }, { signal: controller.signal });
+
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => signal === controller.signal)).toBe(true);
+  });
+
   test("fetches events with supported server params and filters issue_uid client-side", async () => {
     const { calls, fetchImpl } = createFetchStub({
       "/api/v1/events?project_id=2&after_id=4": {

--- a/frontend/src/lib/api/kata/taskClient.ts
+++ b/frontend/src/lib/api/kata/taskClient.ts
@@ -44,6 +44,16 @@ interface RequestResult<T> {
   headers: Headers;
 }
 
+// The explicit `| undefined` unions are required by
+// exactOptionalPropertyTypes: call sites pass values that may be
+// undefined (e.g. daemonHeaders() or an optional caller signal).
+interface KataRequestInit {
+  method?: string | undefined;
+  body?: unknown;
+  headers?: Record<string, string> | undefined;
+  signal?: AbortSignal | undefined;
+}
+
 interface ErrorEnvelope {
   code: string;
   message: string;
@@ -246,15 +256,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     return { [KATA_DAEMON_HEADER]: daemonId ?? "" };
   }
 
-  async function request<T>(
-    path: string,
-    init: {
-      method?: string | undefined;
-      body?: unknown;
-      headers?: Record<string, string> | undefined;
-      signal?: AbortSignal | undefined;
-    } = {},
-  ): Promise<RequestResult<T>> {
+  async function request<T>(path: string, init: KataRequestInit = {}): Promise<RequestResult<T>> {
     const headers = new Headers(init.headers);
     const requestInit: RequestInit = {
       method: init.method ?? "GET",

--- a/frontend/src/lib/api/kata/taskClient.ts
+++ b/frontend/src/lib/api/kata/taskClient.ts
@@ -248,13 +248,21 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
 
   async function request<T>(
     path: string,
-    init: { method?: string | undefined; body?: unknown; headers?: Record<string, string> | undefined } = {},
+    init: {
+      method?: string | undefined;
+      body?: unknown;
+      headers?: Record<string, string> | undefined;
+      signal?: AbortSignal | undefined;
+    } = {},
   ): Promise<RequestResult<T>> {
     const headers = new Headers(init.headers);
     const requestInit: RequestInit = {
       method: init.method ?? "GET",
       headers,
     };
+    if (init.signal) {
+      requestInit.signal = init.signal;
+    }
     if (init.body !== undefined) {
       headers.set("Content-Type", "application/json");
       requestInit.body = JSON.stringify(init.body);
@@ -334,9 +342,15 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     return normalizeKataTaskList(result.body).groups.flatMap((group) => group.issues);
   }
 
-  async function fetchIssue(uid: string, daemonId?: string, pinned = false): Promise<KataTaskDetail> {
+  async function fetchIssue(
+    uid: string,
+    daemonId?: string,
+    pinned = false,
+    signal?: AbortSignal,
+  ): Promise<KataTaskDetail> {
     const result = await request<unknown>(taskPath(`/issues/${encodeURIComponent(uid)}`), {
       headers: pinned ? pinnedDaemonHeaders(daemonId) : daemonHeaders(daemonId),
+      signal,
     });
     return { ...normalizeKataTaskDetail(result.body), etag: result.headers.get("etag") ?? undefined };
   }
@@ -531,17 +545,17 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     },
 
     async issue(uid, opts) {
-      return fetchIssue(uid, opts?.daemonId, opts?.pinned);
+      return fetchIssue(uid, opts?.daemonId, opts?.pinned, opts?.signal);
     },
 
-    async events(query = {}) {
+    async events(query = {}, opts) {
       async function fetchPage(afterID?: number): Promise<KataTaskEventsResponse> {
         const params = new URLSearchParams();
         if (query.project_id !== undefined) params.set("project_id", String(query.project_id));
         if (afterID !== undefined) params.set("after_id", String(afterID));
         if (query.limit !== undefined) params.set("limit", String(query.limit));
         const suffix = params.toString() ? `?${params.toString()}` : "";
-        const result = await request<unknown>(taskPath(`/events${suffix}`));
+        const result = await request<unknown>(taskPath(`/events${suffix}`), { signal: opts?.signal });
         return normalizeKataEvents(result.body);
       }
 
@@ -583,7 +597,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
       if (query.after_id !== undefined) params.set("after_id", String(query.after_id));
       if (query.limit !== undefined && query.issue_uid === undefined) params.set("limit", String(query.limit));
       const suffix = params.toString() ? `?${params.toString()}` : "";
-      const result = await request<unknown>(taskPath(`/events${suffix}`));
+      const result = await request<unknown>(taskPath(`/events${suffix}`), { signal: opts?.signal });
       const events = normalizeKataEvents(result.body);
       return {
         ...events,

--- a/frontend/src/lib/api/kata/taskTypes.ts
+++ b/frontend/src/lib/api/kata/taskTypes.ts
@@ -359,8 +359,8 @@ export interface KataTaskAPI {
   ): Promise<KataTaskMutationResponse>;
   issues(query: KataTaskIssuesQuery): Promise<KataTaskViewResponse>;
   search(filters: KataTaskSearchFilters, opts?: { daemonId?: string }): Promise<KataTaskSearchResponse>;
-  issue(uid: string, opts?: { daemonId?: string; pinned?: boolean }): Promise<KataTaskDetail>;
-  events(query?: KataTaskEventsQuery): Promise<KataTaskEventsResponse>;
+  issue(uid: string, opts?: { daemonId?: string; pinned?: boolean; signal?: AbortSignal }): Promise<KataTaskDetail>;
+  events(query?: KataTaskEventsQuery, opts?: { signal?: AbortSignal }): Promise<KataTaskEventsResponse>;
   addComment(target: KataTaskMutationTarget, actor: string, body: string): Promise<KataTaskMutationResponse>;
   addLabel(target: KataTaskMutationTarget, actor: string, label: string): Promise<KataTaskMutationResponse>;
   removeLabel(target: KataTaskMutationTarget, actor: string, label: string): Promise<KataTaskMutationResponse>;

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -213,13 +213,21 @@
   }
 
   // Keyboard navigation selects on every step, and each selection kicks
-  // off a detail + events fetch upstream. Debounce the notification so
-  // holding j/k doesn't fire a request per row traversed — focus still
-  // moves instantly, only the fetch waits for the cursor to settle.
+  // off a detail + events fetch upstream. Selection therefore only
+  // commits once the keyboard settles: 50ms after the last navigation
+  // keydown, and never while a navigation key is still physically held.
+  // The held-key gate matters because OS key-repeat intervals are often
+  // longer than any reasonable debounce — a timer alone would still
+  // commit one fetch per repeated row. Focus itself moves instantly;
+  // only the upstream notification waits for the cursor to settle.
   const KEYBOARD_SELECT_DEBOUNCE_MS = 50;
+  const KEYBOARD_NAV_KEYS = new Set(["ArrowDown", "ArrowUp", "j", "k", "Home", "End", "g", "G"]);
   let keyboardSelectTimer: ReturnType<typeof setTimeout> | undefined;
+  let pendingKeyboardSelectUID: string | null = null;
+  const heldNavKeys = new Set<string>();
 
   function cancelPendingKeyboardSelect() {
+    pendingKeyboardSelectUID = null;
     if (keyboardSelectTimer !== undefined) {
       clearTimeout(keyboardSelectTimer);
       keyboardSelectTimer = undefined;
@@ -233,20 +241,55 @@
     onSelect(issue);
   }
 
+  function restartKeyboardSelectTimer() {
+    if (keyboardSelectTimer !== undefined) clearTimeout(keyboardSelectTimer);
+    keyboardSelectTimer = setTimeout(() => {
+      keyboardSelectTimer = undefined;
+      // A navigation key is still held: stay pending. The matching keyup
+      // restarts the timer, so even a slow OS key-repeat never commits
+      // intermediate rows mid-hold.
+      if (heldNavKeys.size > 0) return;
+      commitKeyboardSelect();
+    }, KEYBOARD_SELECT_DEBOUNCE_MS);
+  }
+
+  function commitKeyboardSelect() {
+    const uid = pendingKeyboardSelectUID;
+    pendingKeyboardSelectUID = null;
+    if (!uid) return;
+    // Re-resolve at commit time: a live refresh inside the settle window
+    // can drop the row, and selecting a vanished issue would surface an
+    // error for something the user can no longer see.
+    const issue = findIssueByUID(uid);
+    if (issue) onSelect(issue);
+  }
+
   function focusRow(target: HTMLElement | null) {
     if (!target) return;
     target.focus();
     const uid = target.dataset.uid;
     if (!uid || !findIssueByUID(uid)) return;
-    cancelPendingKeyboardSelect();
-    keyboardSelectTimer = setTimeout(() => {
-      keyboardSelectTimer = undefined;
-      // Re-resolve at fire time: a live refresh inside the debounce
-      // window can drop the row, and selecting a vanished issue would
-      // surface an error for something the user can no longer see.
-      const issue = findIssueByUID(uid);
-      if (issue) onSelect(issue);
-    }, KEYBOARD_SELECT_DEBOUNCE_MS);
+    pendingKeyboardSelectUID = uid;
+    restartKeyboardSelectTimer();
+  }
+
+  // Window-level so a release outside the table (focus moved mid-hold)
+  // can't strand a key in the held set and block selection forever.
+  function handleWindowKeyup(event: KeyboardEvent) {
+    if (!KEYBOARD_NAV_KEYS.has(event.key)) return;
+    heldNavKeys.delete(event.key);
+    if (heldNavKeys.size === 0 && pendingKeyboardSelectUID !== null && keyboardSelectTimer === undefined) {
+      restartKeyboardSelectTimer();
+    }
+  }
+
+  // Keyups are lost entirely when the window loses focus mid-hold; treat
+  // blur as releasing everything so the pending selection still settles.
+  function handleWindowBlur() {
+    heldNavKeys.clear();
+    if (pendingKeyboardSelectUID !== null && keyboardSelectTimer === undefined) {
+      restartKeyboardSelectTimer();
+    }
   }
 
   function handleListKeydown(event: KeyboardEvent) {
@@ -303,6 +346,7 @@
         return;
     }
     event.preventDefault();
+    heldNavKeys.add(event.key);
     // Boundary keys (j on last, k on first, Home/End at the edge) can
     // resolve to the row already focused; skip the re-focus so we
     // don't double-fire the click handler and refetch the same issue.
@@ -335,6 +379,8 @@
     loadingChildren = {};
   });
 </script>
+
+<svelte:window onkeyup={handleWindowKeyup} onblur={handleWindowBlur} />
 
 <main class="issue-list" aria-label="Issues">
   <div class="pane-header">

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -21,6 +21,7 @@
     selectedIssueUID?: string | null;
     loading?: boolean;
     resetGeneration?: number;
+    navigationGeneration?: number;
     api?: KataTaskAPI;
     onSelect: (issue: KataTaskSummary) => void;
   }
@@ -32,6 +33,7 @@
     selectedIssueUID = null,
     loading = false,
     resetGeneration = 0,
+    navigationGeneration = 0,
     api = undefined,
     onSelect,
   }: Props = $props();
@@ -378,6 +380,19 @@
     expanded = {};
     childrenByUID = {};
     loadingChildren = {};
+  });
+
+  // A pending keyboard selection dies the moment the workspace starts
+  // any navigation (view/scope/route/daemon change). Waiting for the
+  // post-load list remount is too late: a held key released while the
+  // new view's data is still in flight would commit against the old
+  // view and its onSelect would supersede the in-progress navigation.
+  let lastNavigationGeneration: number | null = null;
+  $effect(() => {
+    if (lastNavigationGeneration !== null && navigationGeneration !== lastNavigationGeneration) {
+      cancelPendingKeyboardSelect();
+    }
+    lastNavigationGeneration = navigationGeneration;
   });
 </script>
 

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
   import ChevronUpIcon from "@lucide/svelte/icons/chevron-up";
@@ -211,14 +212,41 @@
     return `Sort by ${label}`;
   }
 
+  // Keyboard navigation selects on every step, and each selection kicks
+  // off a detail + events fetch upstream. Debounce the notification so
+  // holding j/k doesn't fire a request per row traversed — focus still
+  // moves instantly, only the fetch waits for the cursor to settle.
+  const KEYBOARD_SELECT_DEBOUNCE_MS = 50;
+  let keyboardSelectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function cancelPendingKeyboardSelect() {
+    if (keyboardSelectTimer !== undefined) {
+      clearTimeout(keyboardSelectTimer);
+      keyboardSelectTimer = undefined;
+    }
+  }
+
+  onDestroy(cancelPendingKeyboardSelect);
+
+  function selectNow(issue: KataTaskSummary) {
+    cancelPendingKeyboardSelect();
+    onSelect(issue);
+  }
+
   function focusRow(target: HTMLElement | null) {
     if (!target) return;
     target.focus();
     const uid = target.dataset.uid;
-    const issue = uid ? findIssueByUID(uid) : undefined;
-    if (issue) {
-      onSelect(issue);
-    }
+    if (!uid || !findIssueByUID(uid)) return;
+    cancelPendingKeyboardSelect();
+    keyboardSelectTimer = setTimeout(() => {
+      keyboardSelectTimer = undefined;
+      // Re-resolve at fire time: a live refresh inside the debounce
+      // window can drop the row, and selecting a vanished issue would
+      // surface an error for something the user can no longer see.
+      const issue = findIssueByUID(uid);
+      if (issue) onSelect(issue);
+    }, KEYBOARD_SELECT_DEBOUNCE_MS);
   }
 
   function handleListKeydown(event: KeyboardEvent) {
@@ -443,7 +471,7 @@
     aria-current={isSelected(issue) ? "true" : undefined}
     aria-expanded={expandable ? isExpanded : undefined}
     data-uid={issue.uid}
-    onclick={() => onSelect(issue)}
+    onclick={() => selectNow(issue)}
   >
     <span class="cell cell-id"><span class="id-badge">{displayId(issue)}</span></span>
     <span class="cell cell-title">
@@ -502,7 +530,7 @@
           class:selected={isSelected(child)}
           aria-current={isSelected(child) ? "true" : undefined}
           data-uid={child.uid}
-          onclick={() => onSelect(child)}
+          onclick={() => selectNow(child)}
         >
           <span class="cell cell-id"><span class="id-badge">{displayId(child)}</span></span>
           <span class="cell cell-title">

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -221,9 +221,11 @@
   // commit one fetch per repeated row. Focus itself moves instantly;
   // only the upstream notification waits for the cursor to settle.
   const KEYBOARD_SELECT_DEBOUNCE_MS = 50;
-  const KEYBOARD_NAV_KEYS = new Set(["ArrowDown", "ArrowUp", "j", "k", "Home", "End", "g", "G"]);
   let keyboardSelectTimer: ReturnType<typeof setTimeout> | undefined;
   let pendingKeyboardSelectUID: string | null = null;
+  // Tracked by event.code (physical key), not event.key: "G" is Shift+g,
+  // so releasing Shift before g would make keydown record "G" but keyup
+  // report "g", stranding the entry and blocking selection until blur.
   const heldNavKeys = new Set<string>();
 
   function cancelPendingKeyboardSelect() {
@@ -276,8 +278,7 @@
   // Window-level so a release outside the table (focus moved mid-hold)
   // can't strand a key in the held set and block selection forever.
   function handleWindowKeyup(event: KeyboardEvent) {
-    if (!KEYBOARD_NAV_KEYS.has(event.key)) return;
-    heldNavKeys.delete(event.key);
+    if (!heldNavKeys.delete(event.code)) return;
     if (heldNavKeys.size === 0 && pendingKeyboardSelectUID !== null && keyboardSelectTimer === undefined) {
       restartKeyboardSelectTimer();
     }
@@ -346,7 +347,7 @@
         return;
     }
     event.preventDefault();
-    heldNavKeys.add(event.key);
+    heldNavKeys.add(event.code);
     // Boundary keys (j on last, k on first, Home/End at the edge) can
     // resolve to the row already focused; skip the re-focus so we
     // don't double-fire the click handler and refetch the same issue.

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -247,6 +247,7 @@ describe("KataIssueList", () => {
 
     parentRow.focus();
     await fireEvent.keyDown(parentRow, { key: "j" });
+    await fireEvent.keyUp(childRow, { key: "j" });
     expect(document.activeElement).toBe(childRow);
     await waitFor(() => {
       expect(selected[selected.length - 1]).toBe("issue-child");
@@ -273,12 +274,14 @@ describe("KataIssueList", () => {
     const rows = visibleRows();
     rows[0]!.focus();
     await fireEvent.keyDown(rows[0]!, { key: "j" });
+    await fireEvent.keyUp(rows[1]!, { key: "j" });
     expect(document.activeElement).toBe(rows[1]);
     await waitFor(() => {
       expect(selected[selected.length - 1]).toBe(rows[1]!.dataset.uid);
     });
 
     await fireEvent.keyDown(rows[1]!, { key: "k" });
+    await fireEvent.keyUp(rows[0]!, { key: "k" });
     expect(document.activeElement).toBe(rows[0]);
     await waitFor(() => {
       expect(selected[selected.length - 1]).toBe(rows[0]!.dataset.uid);
@@ -287,18 +290,10 @@ describe("KataIssueList", () => {
 
   it("debounces keyboard navigation so only the final row is selected", async () => {
     vi.useFakeTimers();
-    const third = task({
-      id: 103,
-      uid: "issue-water-plants",
-      short_id: "water-plants",
-      qualified_id: "Home#water-plants",
-      title: "Water plants",
-      updated_at: "2026-05-13T08:00:00Z",
-    });
     const selected: string[] = [];
     render(KataIssueList, {
       props: {
-        currentView: viewWithIssues([...baseIssues, third]),
+        currentView: viewWithIssues([...baseIssues, thirdIssue()]),
         selectedIssueUID: null,
         loading: false,
         onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
@@ -308,10 +303,41 @@ describe("KataIssueList", () => {
     const rows = visibleRows();
     rows[0]!.focus();
     await fireEvent.keyDown(rows[0]!, { key: "j" });
-    await fireEvent.keyDown(rows[1]!, { key: "j" });
+    await fireEvent.keyDown(rows[1]!, { key: "j", repeat: true });
+    await fireEvent.keyUp(rows[2]!, { key: "j" });
     expect(document.activeElement).toBe(rows[2]);
     expect(selected).toEqual([]);
 
+    vi.advanceTimersByTime(50);
+    expect(selected).toEqual([rows[2]!.dataset.uid]);
+  });
+
+  it("holds selection while a navigation key repeats slower than the debounce", async () => {
+    vi.useFakeTimers();
+    const selected: string[] = [];
+    render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([...baseIssues, thirdIssue()]),
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
+      },
+    });
+
+    const rows = visibleRows();
+    rows[0]!.focus();
+    // OS key-repeat slower than the 50ms debounce: each repeat arrives
+    // after the timer has already expired. The held key must keep the
+    // selection pending so intermediate rows never commit.
+    await fireEvent.keyDown(rows[0]!, { key: "j" });
+    vi.advanceTimersByTime(100);
+    expect(selected).toEqual([]);
+
+    await fireEvent.keyDown(rows[1]!, { key: "j", repeat: true });
+    vi.advanceTimersByTime(100);
+    expect(selected).toEqual([]);
+
+    await fireEvent.keyUp(rows[2]!, { key: "j" });
     vi.advanceTimersByTime(50);
     expect(selected).toEqual([rows[2]!.dataset.uid]);
   });
@@ -336,6 +362,7 @@ describe("KataIssueList", () => {
     await fireEvent.click(rows[0]!);
     expect(selected).toEqual([rows[0]!.dataset.uid]);
 
+    await fireEvent.keyUp(rows[0]!, { key: "j" });
     vi.advanceTimersByTime(100);
     expect(selected).toEqual([rows[0]!.dataset.uid]);
   });
@@ -515,6 +542,17 @@ describe("KataIssueList", () => {
     expect(screen.queryByRole("button", { name: /Stale child/ })).toBeNull();
   });
 });
+
+function thirdIssue(): KataTaskSummary {
+  return task({
+    id: 103,
+    uid: "issue-water-plants",
+    short_id: "water-plants",
+    qualified_id: "Home#water-plants",
+    title: "Water plants",
+    updated_at: "2026-05-13T08:00:00Z",
+  });
+}
 
 function visibleRows(): HTMLElement[] {
   return screen

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -289,19 +289,7 @@ describe("KataIssueList", () => {
   });
 
   it("debounces keyboard navigation so only the final row is selected", async () => {
-    vi.useFakeTimers();
-    const selected: string[] = [];
-    render(KataIssueList, {
-      props: {
-        currentView: viewWithIssues([...baseIssues, thirdIssue()]),
-        selectedIssueUID: null,
-        loading: false,
-        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
-      },
-    });
-
-    const rows = visibleRows();
-    rows[0]!.focus();
+    const { selected, rows } = renderKeyboardList(viewWithIssues([...baseIssues, thirdIssue()]));
     await fireEvent.keyDown(rows[0]!, { key: "j" });
     await fireEvent.keyDown(rows[1]!, { key: "j", repeat: true });
     await fireEvent.keyUp(rows[2]!, { key: "j" });
@@ -313,19 +301,7 @@ describe("KataIssueList", () => {
   });
 
   it("holds selection while a navigation key repeats slower than the debounce", async () => {
-    vi.useFakeTimers();
-    const selected: string[] = [];
-    render(KataIssueList, {
-      props: {
-        currentView: viewWithIssues([...baseIssues, thirdIssue()]),
-        selectedIssueUID: null,
-        loading: false,
-        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
-      },
-    });
-
-    const rows = visibleRows();
-    rows[0]!.focus();
+    const { selected, rows } = renderKeyboardList(viewWithIssues([...baseIssues, thirdIssue()]));
     // OS key-repeat slower than the 50ms debounce: each repeat arrives
     // after the timer has already expired. The held key must keep the
     // selection pending so intermediate rows never commit.
@@ -343,19 +319,7 @@ describe("KataIssueList", () => {
   });
 
   it("commits the selection when Shift is released before the navigation key", async () => {
-    vi.useFakeTimers();
-    const selected: string[] = [];
-    render(KataIssueList, {
-      props: {
-        currentView,
-        selectedIssueUID: null,
-        loading: false,
-        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
-      },
-    });
-
-    const rows = visibleRows();
-    rows[0]!.focus();
+    const { selected, rows } = renderKeyboardList();
     // Shift+g jumps to the end; the keydown reports key "G" but releasing
     // Shift first makes the keyup report key "g". The physical code is
     // stable across both, so the held entry must still clear.
@@ -370,19 +334,7 @@ describe("KataIssueList", () => {
   });
 
   it("clicking a row selects immediately and cancels a pending keyboard selection", async () => {
-    vi.useFakeTimers();
-    const selected: string[] = [];
-    render(KataIssueList, {
-      props: {
-        currentView,
-        selectedIssueUID: null,
-        loading: false,
-        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
-      },
-    });
-
-    const rows = visibleRows();
-    rows[0]!.focus();
+    const { selected, rows } = renderKeyboardList();
     await fireEvent.keyDown(rows[0]!, { key: "j" });
     expect(selected).toEqual([]);
 
@@ -569,6 +521,24 @@ describe("KataIssueList", () => {
     expect(screen.queryByRole("button", { name: /Stale child/ })).toBeNull();
   });
 });
+
+// Shared setup for the fake-timer keyboard tests: renders the list,
+// records selections, and focuses the first row ready for key events.
+function renderKeyboardList(view: KataCurrentView = currentView) {
+  vi.useFakeTimers();
+  const selected: string[] = [];
+  render(KataIssueList, {
+    props: {
+      currentView: view,
+      selectedIssueUID: null,
+      loading: false,
+      onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
+    },
+  });
+  const rows = visibleRows();
+  rows[0]!.focus();
+  return { selected, rows };
+}
 
 function thirdIssue(): KataTaskSummary {
   return task({

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -342,6 +342,33 @@ describe("KataIssueList", () => {
     expect(selected).toEqual([rows[2]!.dataset.uid]);
   });
 
+  it("commits the selection when Shift is released before the navigation key", async () => {
+    vi.useFakeTimers();
+    const selected: string[] = [];
+    render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
+      },
+    });
+
+    const rows = visibleRows();
+    rows[0]!.focus();
+    // Shift+g jumps to the end; the keydown reports key "G" but releasing
+    // Shift first makes the keyup report key "g". The physical code is
+    // stable across both, so the held entry must still clear.
+    await fireEvent.keyDown(rows[0]!, { key: "G", code: "KeyG", shiftKey: true });
+    expect(document.activeElement).toBe(rows[rows.length - 1]);
+    vi.advanceTimersByTime(50);
+    expect(selected).toEqual([]);
+
+    await fireEvent.keyUp(rows[rows.length - 1]!, { key: "g", code: "KeyG" });
+    vi.advanceTimersByTime(50);
+    expect(selected).toEqual([rows[rows.length - 1]!.dataset.uid]);
+  });
+
   it("clicking a row selects immediately and cancels a pending keyboard selection", async () => {
     vi.useFakeTimers();
     const selected: string[] = [];

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -333,6 +333,31 @@ describe("KataIssueList", () => {
     expect(selected).toEqual([rows[rows.length - 1]!.dataset.uid]);
   });
 
+  it("drops a pending keyboard selection when workspace navigation begins", async () => {
+    vi.useFakeTimers();
+    const selected: string[] = [];
+    const props = {
+      currentView,
+      selectedIssueUID: null,
+      loading: false,
+      navigationGeneration: 0,
+      onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
+    };
+    const { rerender } = render(KataIssueList, { props });
+
+    const rows = visibleRows();
+    rows[0]!.focus();
+    await fireEvent.keyDown(rows[0]!, { key: "j" });
+
+    // Navigation starts while the key is still held: the view data has
+    // not arrived yet (same currentView, no remount), so only the
+    // generation bump can stop the release from committing stale.
+    await rerender({ ...props, navigationGeneration: 1 });
+    await fireEvent.keyUp(rows[1]!, { key: "j" });
+    vi.advanceTimersByTime(100);
+    expect(selected).toEqual([]);
+  });
+
   it("clicking a row selects immediately and cancels a pending keyboard selection", async () => {
     const { selected, rows } = renderKeyboardList();
     await fireEvent.keyDown(rows[0]!, { key: "j" });

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -68,6 +68,7 @@ describe("KataIssueList", () => {
     cleanup();
     window.localStorage.clear();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("renders the heading, table columns, and the selected row metadata", () => {
@@ -247,7 +248,9 @@ describe("KataIssueList", () => {
     parentRow.focus();
     await fireEvent.keyDown(parentRow, { key: "j" });
     expect(document.activeElement).toBe(childRow);
-    expect(selected[selected.length - 1]).toBe("issue-child");
+    await waitFor(() => {
+      expect(selected[selected.length - 1]).toBe("issue-child");
+    });
 
     await fireEvent.keyDown(parentRow, { key: "ArrowLeft" });
     await waitFor(() => {
@@ -271,11 +274,70 @@ describe("KataIssueList", () => {
     rows[0]!.focus();
     await fireEvent.keyDown(rows[0]!, { key: "j" });
     expect(document.activeElement).toBe(rows[1]);
-    expect(selected[selected.length - 1]).toBe(rows[1]!.dataset.uid);
+    await waitFor(() => {
+      expect(selected[selected.length - 1]).toBe(rows[1]!.dataset.uid);
+    });
 
     await fireEvent.keyDown(rows[1]!, { key: "k" });
     expect(document.activeElement).toBe(rows[0]);
-    expect(selected[selected.length - 1]).toBe(rows[0]!.dataset.uid);
+    await waitFor(() => {
+      expect(selected[selected.length - 1]).toBe(rows[0]!.dataset.uid);
+    });
+  });
+
+  it("debounces keyboard navigation so only the final row is selected", async () => {
+    vi.useFakeTimers();
+    const third = task({
+      id: 103,
+      uid: "issue-water-plants",
+      short_id: "water-plants",
+      qualified_id: "Home#water-plants",
+      title: "Water plants",
+      updated_at: "2026-05-13T08:00:00Z",
+    });
+    const selected: string[] = [];
+    render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([...baseIssues, third]),
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
+      },
+    });
+
+    const rows = visibleRows();
+    rows[0]!.focus();
+    await fireEvent.keyDown(rows[0]!, { key: "j" });
+    await fireEvent.keyDown(rows[1]!, { key: "j" });
+    expect(document.activeElement).toBe(rows[2]);
+    expect(selected).toEqual([]);
+
+    vi.advanceTimersByTime(50);
+    expect(selected).toEqual([rows[2]!.dataset.uid]);
+  });
+
+  it("clicking a row selects immediately and cancels a pending keyboard selection", async () => {
+    vi.useFakeTimers();
+    const selected: string[] = [];
+    render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: (issue: KataTaskSummary) => selected.push(issue.uid),
+      },
+    });
+
+    const rows = visibleRows();
+    rows[0]!.focus();
+    await fireEvent.keyDown(rows[0]!, { key: "j" });
+    expect(selected).toEqual([]);
+
+    await fireEvent.click(rows[0]!);
+    expect(selected).toEqual([rows[0]!.dataset.uid]);
+
+    vi.advanceTimersByTime(100);
+    expect(selected).toEqual([rows[0]!.dataset.uid]);
   });
 
   it("Home and End jump to first and last rows", async () => {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -560,6 +560,11 @@
     switchingDaemon = true;
     resetDetailDrafts();
     resetIssueExpansion();
+    // The switch abandons any in-flight detail load (only a completed
+    // selection is captured for restore above), so drop it before the
+    // daemon reload: its failure mid-switch would otherwise surface a
+    // stale error from the previous daemon.
+    store.invalidatePendingLoads();
     setActiveKataDaemon(id);
     stopEventStream();
     try {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -92,6 +92,11 @@
   let syncedRouteViewName: KataTaskViewName | null = null;
   let syncedRouteScopeUID: string | null = null;
   let navigationGeneration = 0;
+  // Reactive shadow of navigationGeneration so the issue list can drop
+  // a pending keyboard selection the moment any navigation starts —
+  // the list only remounts after the new view's data arrives, which is
+  // too late for a selection released mid-transition.
+  let navigationEpoch = $state(0);
   let observedRouteSignature = "";
   const layoutStorageKey = "middleman:kata:task-layout/v1";
   const defaultSplitSizes: Record<SplitOrientation, number> = {
@@ -235,6 +240,7 @@
 
   function beginNavigation(): number {
     navigationGeneration += 1;
+    navigationEpoch = navigationGeneration;
     return navigationGeneration;
   }
 
@@ -807,6 +813,7 @@
         selectedIssueUID={store.pendingSelectionUID ?? store.selectedIssue?.issue.uid ?? null}
         loading={viewLoading}
         resetGeneration={listResetGeneration}
+        navigationGeneration={navigationEpoch}
         api={store.api}
         onSelect={(issue) => {
           void selectIssue(issue.uid);

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -470,6 +470,9 @@
   async function updateSearchFilters(filters: Partial<KataTaskSearchFilters>): Promise<void> {
     const generation = beginNavigation();
     resetDetailDrafts();
+    // Same rationale as openRoutedProjectScope: a pending detail load is
+    // abandoned by the filter reload, so drop it before awaiting.
+    store.invalidatePendingLoads();
     await runViewTask(() => store.updateSearchFilters(filters));
     if (!isCurrentNavigation(generation)) return;
     const nextScopeUID = scopeUIDFromFilters(store.searchFilters);
@@ -509,6 +512,12 @@
   async function openRoutedProjectScope(projectUID: string): Promise<void> {
     const generation = beginNavigation();
     resetDetailDrafts();
+    // Scope changes keep a completed selection but abandon an in-flight
+    // one (the scoped reload re-selects from selectedIssue, which a
+    // pending load hasn't populated). Invalidate up front so the doomed
+    // detail request can't fail into a stale workspace error while the
+    // scoped list is still loading.
+    store.invalidatePendingLoads();
     const ok = await runViewTask(() => store.updateSearchFilters({ scope: { kind: "project", project_uid: projectUID } }));
     if (!ok || !isCurrentNavigation(generation)) return;
     syncedRouteViewName = null;

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -489,9 +489,13 @@
     const generation = beginNavigation();
     resetDetailDrafts();
     store.resetSearchFilters();
+    // Clear (and thereby abort) the abandoned selection before awaiting
+    // the new view: while that fetch is in flight, a still-running
+    // detail load could fail and surface a stale error for a selection
+    // this navigation has already discarded.
+    store.clearSelection();
     await runViewTask(() => store.openView(viewName, { selectFirst: false }));
     if (!isCurrentNavigation(generation)) return;
-    store.clearSelection();
     syncedRouteViewName = viewName;
     syncedRouteScopeUID = null;
     syncedRouteIssueUID = null;

--- a/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
@@ -144,7 +144,10 @@ describe("KataWorkspace", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(api.issue).not.toHaveBeenCalledWith("issue-email-susan");
+    // Match on the first argument only: issue() also receives a
+    // { signal } options argument, so a full-arguments matcher would
+    // pass vacuously even if the stale selection fired.
+    expect(vi.mocked(api.issue).mock.calls.map((call) => call[0])).not.toContain("issue-email-susan");
     expect(screen.queryByRole("heading", { name: "Email Susan re: Q3" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "Pay rent" })).toBeNull();
     const taskList = document.querySelector(".issue-list");

--- a/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
@@ -174,7 +174,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
     });
-    expect(api.issue).toHaveBeenCalledWith("issue-email-susan");
+    expect(api.issue).toHaveBeenCalledWith("issue-email-susan", { signal: expect.any(AbortSignal) });
   });
 
   it("selects the routed task after bootstrap when it is outside the initial view", async () => {
@@ -202,7 +202,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Later review" })).toBeTruthy();
     });
-    expect(issueMock).toHaveBeenCalledWith("issue-later-review");
+    expect(issueMock).toHaveBeenCalledWith("issue-later-review", { signal: expect.any(AbortSignal) });
   });
 
   it("updates the selection when the routed task changes", async () => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -805,6 +805,28 @@ describe("kata workspace store", () => {
     expect(store.pendingSelectionUID).toBeNull();
   });
 
+  test("invalidating pending loads aborts the in-flight detail load", async () => {
+    const api = createFakeKataTaskAPI();
+    const signals: (AbortSignal | undefined)[] = [];
+    api.mocks.issue.mockImplementationOnce(
+      (_uid: string, opts?: { signal?: AbortSignal }) =>
+        new Promise<KataTaskDetail>((_resolve, reject) => {
+          signals.push(opts?.signal);
+          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+            once: true,
+          });
+        }),
+    );
+    const store = createKataWorkspaceStore({ api });
+
+    const pending = store.selectIssue("issue-pay-rent");
+    store.invalidatePendingLoads();
+
+    await expect(pending).resolves.toBe(false);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(store.pendingSelectionUID).toBeNull();
+  });
+
   test("clearing the selection aborts the in-flight detail load", async () => {
     const api = createFakeKataTaskAPI();
     const signals: (AbortSignal | undefined)[] = [];

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -33,6 +33,24 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+// Fake API whose next issue-detail load hangs until its abort signal
+// fires, then rejects like a real aborted fetch. The captured signals
+// let tests assert which load was aborted.
+function apiWithHangingIssueDetail() {
+  const api = createFakeKataTaskAPI();
+  const signals: (AbortSignal | undefined)[] = [];
+  api.mocks.issue.mockImplementationOnce(
+    (_uid: string, opts?: { signal?: AbortSignal }) =>
+      new Promise<KataTaskDetail>((_resolve, reject) => {
+        signals.push(opts?.signal);
+        opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+          once: true,
+        });
+      }),
+  );
+  return { api, signals };
+}
+
 const fetchedAt = "2026-05-15T16:00:00.000Z";
 
 function project(
@@ -782,17 +800,7 @@ describe("kata workspace store", () => {
   });
 
   test("selecting a new issue aborts the in-flight detail load for the previous one", async () => {
-    const api = createFakeKataTaskAPI();
-    const firstSignals: (AbortSignal | undefined)[] = [];
-    api.mocks.issue.mockImplementationOnce(
-      (_uid: string, opts?: { signal?: AbortSignal }) =>
-        new Promise<KataTaskDetail>((_resolve, reject) => {
-          firstSignals.push(opts?.signal);
-          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
-            once: true,
-          });
-        }),
-    );
+    const { api, signals } = apiWithHangingIssueDetail();
     const store = createKataWorkspaceStore({ api });
 
     const first = store.selectIssue("issue-pay-rent");
@@ -800,23 +808,13 @@ describe("kata workspace store", () => {
 
     await expect(second).resolves.toBe(true);
     await expect(first).resolves.toBe(false);
-    expect(firstSignals[0]?.aborted).toBe(true);
+    expect(signals[0]?.aborted).toBe(true);
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
     expect(store.pendingSelectionUID).toBeNull();
   });
 
   test("invalidating pending loads aborts the in-flight detail load", async () => {
-    const api = createFakeKataTaskAPI();
-    const signals: (AbortSignal | undefined)[] = [];
-    api.mocks.issue.mockImplementationOnce(
-      (_uid: string, opts?: { signal?: AbortSignal }) =>
-        new Promise<KataTaskDetail>((_resolve, reject) => {
-          signals.push(opts?.signal);
-          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
-            once: true,
-          });
-        }),
-    );
+    const { api, signals } = apiWithHangingIssueDetail();
     const store = createKataWorkspaceStore({ api });
 
     const pending = store.selectIssue("issue-pay-rent");
@@ -828,17 +826,7 @@ describe("kata workspace store", () => {
   });
 
   test("clearing the selection aborts the in-flight detail load", async () => {
-    const api = createFakeKataTaskAPI();
-    const signals: (AbortSignal | undefined)[] = [];
-    api.mocks.issue.mockImplementationOnce(
-      (_uid: string, opts?: { signal?: AbortSignal }) =>
-        new Promise<KataTaskDetail>((_resolve, reject) => {
-          signals.push(opts?.signal);
-          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
-            once: true,
-          });
-        }),
-    );
+    const { api, signals } = apiWithHangingIssueDetail();
     const store = createKataWorkspaceStore({ api });
 
     const pending = store.selectIssue("issue-pay-rent");

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -781,6 +781,53 @@ describe("kata workspace store", () => {
     expect(store.pendingSelectionUID).toBeNull();
   });
 
+  test("selecting a new issue aborts the in-flight detail load for the previous one", async () => {
+    const api = createFakeKataTaskAPI();
+    const firstSignals: (AbortSignal | undefined)[] = [];
+    api.mocks.issue.mockImplementationOnce(
+      (_uid: string, opts?: { signal?: AbortSignal }) =>
+        new Promise<KataTaskDetail>((_resolve, reject) => {
+          firstSignals.push(opts?.signal);
+          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+            once: true,
+          });
+        }),
+    );
+    const store = createKataWorkspaceStore({ api });
+
+    const first = store.selectIssue("issue-pay-rent");
+    const second = store.selectIssue("issue-call-dentist");
+
+    await expect(second).resolves.toBe(true);
+    await expect(first).resolves.toBe(false);
+    expect(firstSignals[0]?.aborted).toBe(true);
+    expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
+    expect(store.pendingSelectionUID).toBeNull();
+  });
+
+  test("clearing the selection aborts the in-flight detail load", async () => {
+    const api = createFakeKataTaskAPI();
+    const signals: (AbortSignal | undefined)[] = [];
+    api.mocks.issue.mockImplementationOnce(
+      (_uid: string, opts?: { signal?: AbortSignal }) =>
+        new Promise<KataTaskDetail>((_resolve, reject) => {
+          signals.push(opts?.signal);
+          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+            once: true,
+          });
+        }),
+    );
+    const store = createKataWorkspaceStore({ api });
+
+    const pending = store.selectIssue("issue-pay-rent");
+    store.clearSelection();
+
+    await expect(pending).resolves.toBe(false);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(store.selectedIssue).toBeNull();
+    expect(store.pendingSelectionUID).toBeNull();
+  });
+
   test("opens a different view and selects its first issue", async () => {
     const store = createKataWorkspaceStore({ api: createFakeKataTaskAPI() });
     await store.bootstrap();
@@ -915,7 +962,7 @@ describe("kata workspace store", () => {
       '"rev-1"',
     );
     expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
-    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent");
+    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent", { signal: expect.any(AbortSignal) });
   });
 
   test("serializes metadata patches so rapid edits use the refreshed ETag", async () => {
@@ -1192,7 +1239,7 @@ describe("kata workspace store", () => {
     const mutation = store.addComment("issue-pay-rent", "fixture-user", "Payment is scheduled.");
     await Promise.resolve();
     await Promise.resolve();
-    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent");
+    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent", { signal: expect.any(AbortSignal) });
 
     await store.selectIssue("issue-call-dentist");
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
@@ -1346,7 +1393,7 @@ describe("kata workspace store", () => {
 
     expect(store.eventCursor).toBe(77);
     expect(api.mocks.issues).toHaveBeenCalledWith({ view: "today" });
-    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent");
+    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent", { signal: expect.any(AbortSignal) });
     expect(store.selectedIssue?.comments.map((comment) => comment.body)).toContain("Remote note.");
   });
 

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -554,6 +554,11 @@ export class KataWorkspaceStore {
   invalidatePendingLoads(): void {
     this.viewRequestID++;
     this.detailRequestID++;
+    // Abort like clearSelection() does: without it, a superseded detail
+    // load keeps running and a late rejection surfaces a stale error
+    // for a navigation the user already left.
+    this.detailAbort?.abort();
+    this.detailAbort = null;
     this.pendingSelectionUID = null;
   }
 

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -438,8 +438,7 @@ export class KataWorkspaceStore {
 
   clearSelection(): void {
     this.detailRequestID++;
-    this.detailAbort?.abort();
-    this.detailAbort = null;
+    this.abortPendingDetail();
     this.selectedIssue = null;
     this.selectedEvents = [];
     this.selectedRecurrences = [];
@@ -554,12 +553,17 @@ export class KataWorkspaceStore {
   invalidatePendingLoads(): void {
     this.viewRequestID++;
     this.detailRequestID++;
-    // Abort like clearSelection() does: without it, a superseded detail
-    // load keeps running and a late rejection surfaces a stale error
-    // for a navigation the user already left.
+    this.abortPendingDetail();
+    this.pendingSelectionUID = null;
+  }
+
+  // Whenever a detail load stops being wanted (newer selection, cleared
+  // selection, route invalidation), abort it: a superseded request left
+  // running ties up the daemon and its late rejection would surface a
+  // stale error for a navigation the user already left.
+  private abortPendingDetail(): void {
     this.detailAbort?.abort();
     this.detailAbort = null;
-    this.pendingSelectionUID = null;
   }
 
   resetEventCursor(): void {
@@ -801,11 +805,7 @@ export class KataWorkspaceStore {
     viewRequestID: number | undefined,
     detailRequestID: number,
   ): Promise<boolean> {
-    // A newer selection makes the previous detail load moot — abort it so
-    // the connection isn't tied up; the server cancels the proxied daemon
-    // request along with it.
-    this.detailAbort?.abort();
-    this.detailAbort = null;
+    this.abortPendingDetail();
 
     if (!uid) {
       if (viewRequestID === undefined || viewRequestID === this.viewRequestID) {

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -13,6 +13,7 @@ import type {
   KataTaskEditPatch,
   KataTaskEvent,
   KataTaskEventStreamMessage,
+  KataTaskEventsResponse,
   KataTaskIssuesQuery,
   KataTaskMetadataPatch,
   KataTaskMutationResponse,
@@ -223,6 +224,7 @@ export class KataWorkspaceStore {
 
   private viewRequestID = 0;
   private detailRequestID = 0;
+  private detailAbort: AbortController | null = null;
   private unscopedViewName: KataTaskViewName = "today";
   private issueETags = new Map<string, string>();
   private metadataQueues = new Map<string, Promise<void>>();
@@ -436,6 +438,8 @@ export class KataWorkspaceStore {
 
   clearSelection(): void {
     this.detailRequestID++;
+    this.detailAbort?.abort();
+    this.detailAbort = null;
     this.selectedIssue = null;
     this.selectedEvents = [];
     this.selectedRecurrences = [];
@@ -792,6 +796,12 @@ export class KataWorkspaceStore {
     viewRequestID: number | undefined,
     detailRequestID: number,
   ): Promise<boolean> {
+    // A newer selection makes the previous detail load moot — abort it so
+    // the connection isn't tied up; the server cancels the proxied daemon
+    // request along with it.
+    this.detailAbort?.abort();
+    this.detailAbort = null;
+
     if (!uid) {
       if (viewRequestID === undefined || viewRequestID === this.viewRequestID) {
         this.selectedIssue = null;
@@ -803,7 +813,23 @@ export class KataWorkspaceStore {
       return false;
     }
 
-    const [detail, events] = await Promise.all([this.api.issue(uid), this.api.events({ issue_uid: uid, limit: 100 })]);
+    const abort = new AbortController();
+    this.detailAbort = abort;
+    let detail: KataTaskDetail;
+    let events: KataTaskEventsResponse;
+    try {
+      [detail, events] = await Promise.all([
+        this.api.issue(uid, { signal: abort.signal }),
+        this.api.events({ issue_uid: uid, limit: 100 }, { signal: abort.signal }),
+      ]);
+    } catch (error) {
+      // Aborted means superseded: a newer selection owns the pane now, so
+      // this failure must not surface as a user-facing error.
+      if (abort.signal.aborted) return false;
+      throw error;
+    } finally {
+      if (this.detailAbort === abort) this.detailAbort = null;
+    }
     if (viewRequestID !== undefined && viewRequestID !== this.viewRequestID) return false;
     if (detailRequestID !== this.detailRequestID) return false;
     this.selectedIssue = detail;

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2290,6 +2290,52 @@ test("kata sidebar view click aborts a pending detail load before the new view a
   }
 });
 
+test("kata project scope click drops a pending detail load before the scoped list arrives", async ({ page }) => {
+  let releaseDetail = () => {};
+  const stalledDetail = new Promise<void>((resolve) => {
+    releaseDetail = resolve;
+  });
+  let releaseIssues = () => {};
+  const stalledIssues = new Promise<void>((resolve) => {
+    releaseIssues = resolve;
+  });
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=all`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
+    await expect(rentRow).toBeVisible();
+
+    // Select Pay rent with its detail stalled, then scope to a project
+    // whose backlog fetch is also stalled. The scoped reload abandons
+    // the in-flight selection, so its failing detail request must be
+    // dropped at click time rather than painting a stale error while
+    // the scoped list loads.
+    backend.state.issueDetailGates.set("issue-rent", { barrier: stalledDetail, status: 500 });
+    await rentRow.click();
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-rent");
+
+    backend.state.issuesBarrier = stalledIssues;
+    await page.getByRole("button", { name: "Finances 1", exact: true }).click();
+    releaseDetail();
+    await page.waitForTimeout(750);
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+
+    releaseIssues();
+    await expect(page.locator(".issue-list").getByRole("heading", { name: "Finances", level: 2 })).toBeVisible();
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+  } finally {
+    releaseDetail();
+    releaseIssues();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata key released during a stalled view transition does not commit a stale selection", async ({ page }) => {
   let releaseIssues = () => {};
   const stalledIssues = new Promise<void>((resolve) => {

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2138,6 +2138,84 @@ test("kata task list keyboard navigation moves focus and selection", async ({ pa
   }
 });
 
+test("kata task list keyboard scrolling only fetches the final settled task", async ({ page }) => {
+  const traversal = [
+    issueSummary({
+      id: 31,
+      uid: "issue-first",
+      project_id: 2,
+      project_uid: "project-kata",
+      project_name: "Kata",
+      short_id: "kat-31",
+      qualified_id: "Kata#kat-31",
+      title: "First task",
+      body: "First task body.",
+      labels: [],
+    }),
+    {
+      ...issueSummary({
+        id: 32,
+        uid: "issue-skipped",
+        project_id: 2,
+        project_uid: "project-kata",
+        project_name: "Kata",
+        short_id: "kat-32",
+        qualified_id: "Kata#kat-32",
+        title: "Skipped task",
+        body: "Skipped task body.",
+        labels: [],
+      }),
+      updated_at: "2026-05-15T09:00:00Z",
+    },
+    {
+      ...issueSummary({
+        id: 33,
+        uid: "issue-settled",
+        project_id: 2,
+        project_uid: "project-kata",
+        project_name: "Kata",
+        short_id: "kat-33",
+        qualified_id: "Kata#kat-33",
+        title: "Settled task",
+        body: "Settled task body.",
+        labels: [],
+      }),
+      updated_at: "2026-05-15T08:00:00Z",
+    },
+  ];
+  const backend = await startKataBackend({ issues: traversal });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await page.getByRole("button", { name: "All Open" }).click();
+    const rows = page.locator(".issue-list .issue-row");
+    await expect(rows.first()).toContainText("First task");
+    await expect(rows.nth(1)).toContainText("Skipped task");
+    await expect(rows.nth(2)).toContainText("Settled task");
+
+    // Hold j across the first two rows: keydowns move focus immediately,
+    // but the selection must not commit until the key is released, no
+    // matter how much wall-clock time the traversal takes.
+    await rows.first().focus();
+    await page.keyboard.down("j");
+    await page.keyboard.down("j");
+    await page.keyboard.up("j");
+
+    await expect(rows.nth(2)).toBeFocused();
+    await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Settled task body.");
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-settled");
+    const detailFetches = backend.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/issues/"));
+    expect(detailFetches).toEqual(["GET /api/v1/issues/issue-settled"]);
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata single configured daemon hides the daemon switcher", async ({ page }) => {
   const backend = await startKataBackend();
   const kataHome = await configureKataHome(backend.url);

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2197,18 +2197,62 @@ test("kata task list keyboard scrolling only fetches the final settled task", as
     await expect(rows.nth(2)).toContainText("Settled task");
 
     // Hold j across the first two rows: keydowns move focus immediately,
-    // but the selection must not commit until the key is released, no
-    // matter how much wall-clock time the traversal takes.
+    // but the selection must not commit until the key is released. The
+    // waits between steps deliberately exceed the 50ms debounce — a
+    // timer-only debounce (no held-key gate) commits each traversed row
+    // whenever the OS key-repeat interval outlasts the debounce window,
+    // which is the regression this test pins.
     await rows.first().focus();
     await page.keyboard.down("j");
-    await page.keyboard.down("j");
-    await page.keyboard.up("j");
+    await expect(rows.nth(1)).toBeFocused();
+    await page.waitForTimeout(150);
+    expect(backend.state.seenPaths).not.toContain("GET /api/v1/issues/issue-skipped");
 
+    await page.keyboard.down("j");
     await expect(rows.nth(2)).toBeFocused();
+    await page.waitForTimeout(150);
+    expect(backend.state.seenPaths).not.toContain("GET /api/v1/issues/issue-settled");
+
+    await page.keyboard.up("j");
     await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Settled task body.");
     await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-settled");
     const detailFetches = backend.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/issues/"));
     expect(detailFetches).toEqual(["GET /api/v1/issues/issue-settled"]);
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata task list selection settles when Shift is released before G", async ({ page }) => {
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await page.getByRole("button", { name: "All Open" }).click();
+    const rows = page.locator(".issue-list .issue-row");
+    await expect(rows.first()).toContainText("Email Susan re: Q3");
+    await expect(rows.nth(1)).toContainText("Pay rent");
+
+    // Shift+g jumps to the end. The keydown reports key "G", but
+    // releasing Shift first makes the keyup report "g" — held-key
+    // tracking must survive the modifier release order or the pending
+    // selection strands until the window blurs. The physical "KeyG"
+    // descriptor makes Playwright resolve the event key against the
+    // modifier state at each step, like a real keyboard.
+    await rows.first().focus();
+    await page.keyboard.down("Shift");
+    await page.keyboard.down("KeyG");
+    await page.keyboard.up("Shift");
+    await page.keyboard.up("KeyG");
+
+    await expect(rows.nth(1)).toBeFocused();
+    await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Send June rent from checking.");
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-rent");
   } finally {
     await server.stop();
     kataHome.restore();

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2244,6 +2244,48 @@ test("kata view change drops a held keyboard selection from the previous view", 
   }
 });
 
+test("kata key released during a stalled view transition does not commit a stale selection", async ({ page }) => {
+  let releaseIssues = () => {};
+  const stalledIssues = new Promise<void>((resolve) => {
+    releaseIssues = resolve;
+  });
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=all`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    const rows = page.locator(".issue-list .issue-row");
+    await expect(rows.first()).toContainText("Email Susan re: Q3");
+    await expect(rows.nth(1)).toContainText("Pay rent");
+
+    // Hold j (parking a pending selection of Pay rent), then start a
+    // view change whose issues fetch is stalled. The old list is still
+    // mounted while that fetch hangs, so releasing the key here would —
+    // without the navigation-epoch cancel — commit the stale selection,
+    // fetch Pay rent's detail, and supersede the in-flight navigation
+    // so the route never updates.
+    await rows.first().focus();
+    await page.keyboard.down("j");
+    backend.state.issuesBarrier = stalledIssues;
+    await page.getByRole("button", { name: /^Today/ }).click();
+    await page.keyboard.up("j");
+    await page.waitForTimeout(750);
+
+    releaseIssues();
+    await expect(page.locator(".issue-list").getByRole("heading", { name: "Today", level: 2 })).toBeVisible();
+    await expect(page).toHaveURL(/view=today/);
+    await expect(page.getByText("Select a task")).toBeVisible();
+    expect(backend.state.seenPaths).not.toContain("GET /api/v1/issues/issue-rent");
+  } finally {
+    releaseIssues();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata task list keyboard scrolling only fetches the final settled task", async ({ page }) => {
   const traversal = [
     issueSummary({

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2211,6 +2211,39 @@ test("kata route change aborts a pending detail load instead of surfacing its la
   }
 });
 
+test("kata view change drops a held keyboard selection from the previous view", async ({ page }) => {
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=all`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    const rows = page.locator(".issue-list .issue-row");
+    await expect(rows.first()).toContainText("Email Susan re: Q3");
+    await expect(rows.nth(1)).toContainText("Pay rent");
+
+    // Hold j so the pending selection of Pay rent stays parked, then
+    // switch views while it is still held. Pay rent also exists in the
+    // Today view, so a stale commit after the switch would still
+    // resolve and fetch it — the view change must drop the pending
+    // selection instead.
+    await rows.first().focus();
+    await page.keyboard.down("j");
+    await page.getByRole("button", { name: /^Today/ }).click();
+    await expect(page.locator(".issue-list").getByRole("heading", { name: "Today", level: 2 })).toBeVisible();
+    await page.keyboard.up("j");
+
+    await page.waitForTimeout(750);
+    expect(backend.state.seenPaths).not.toContain("GET /api/v1/issues/issue-rent");
+    await expect(page.getByText("Select a task")).toBeVisible();
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata task list keyboard scrolling only fetches the final settled task", async ({ page }) => {
   const traversal = [
     issueSummary({

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -40,7 +40,17 @@ type BackendState = {
   eventsBarrier?: Promise<void> | undefined;
   issuesBarrier?: Promise<void> | undefined;
   searchBarriers: Map<string, Promise<void>>;
+  issueDetailGates: Map<string, IssueDetailGate>;
   onEventsRequest?: ((state: BackendState, url: URL) => void) | undefined;
+};
+
+// Stalls one issue-detail response until `barrier` resolves; when
+// `status` is set the gated response is that error instead of the
+// normal detail body. Lets tests race navigation against an
+// in-flight detail load.
+type IssueDetailGate = {
+  barrier: Promise<void>;
+  status?: number | undefined;
 };
 
 type MsgvaultBackendState = {
@@ -155,6 +165,7 @@ type KataBackendOptions = {
   eventsBarrier?: Promise<void> | undefined;
   issuesBarrier?: Promise<void> | undefined;
   searchBarriers?: Map<string, Promise<void>> | undefined;
+  issueDetailGates?: Map<string, IssueDetailGate> | undefined;
   onEventsRequest?: ((state: BackendState, url: URL) => void) | undefined;
 };
 
@@ -345,6 +356,7 @@ async function startKataBackend(options: KataBackendOptions = {}): Promise<Backe
     eventsBarrier: options.eventsBarrier,
     issuesBarrier: options.issuesBarrier,
     searchBarriers: options.searchBarriers ?? new Map(),
+    issueDetailGates: options.issueDetailGates ?? new Map(),
     onEventsRequest: options.onEventsRequest,
   };
   const server = createServer((req, res) => {
@@ -506,7 +518,19 @@ async function handleKataRequest(state: BackendState, req: IncomingMessage, res:
 
   const issueDetailRoute = /^\/api\/v1\/issues\/([^/]+)$/.exec(url.pathname);
   if (issueDetailRoute) {
-    writeIssueDetail(state, res, decodeURIComponent(issueDetailRoute[1] ?? ""));
+    const uid = decodeURIComponent(issueDetailRoute[1] ?? "");
+    const gate = state.issueDetailGates.get(uid);
+    if (gate) {
+      state.issueDetailGates.delete(uid);
+      await gate.barrier;
+      if (gate.status !== undefined) {
+        writeJSON(res, gate.status, {
+          error: { code: "internal", message: "kata daemon exploded" },
+        });
+        return;
+      }
+    }
+    writeIssueDetail(state, res, uid);
     return;
   }
 
@@ -2132,6 +2156,55 @@ test("kata task list keyboard navigation moves focus and selection", async ({ pa
       "Confirm the Q3 project review agenda.",
     );
   } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata route change aborts a pending detail load instead of surfacing its late failure", async ({ page }) => {
+  let releaseDetail = () => {};
+  const stalledDetail = new Promise<void>((resolve) => {
+    releaseDetail = resolve;
+  });
+  let releaseIssues = () => {};
+  const stalledIssues = new Promise<void>((resolve) => {
+    releaseIssues = resolve;
+  });
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=all`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await page.getByRole("button", { name: /^Today/ }).click();
+    const rentRow = page.getByRole("button", { name: /Pay rent/ });
+    await expect(rentRow).toBeVisible();
+
+    // Stall Pay rent's detail response, then select it so the load hangs.
+    backend.state.issueDetailGates.set("issue-rent", { barrier: stalledDetail, status: 500 });
+    await rentRow.click();
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-rent");
+
+    // Navigate back to All Open while the detail load is in flight, and
+    // stall the new view's issues fetch so the route transition stays
+    // mid-flight when the superseded detail request finally fails.
+    backend.state.issuesBarrier = stalledIssues;
+    await page.goBack();
+
+    // The daemon now fails the superseded request. Route invalidation
+    // aborted it, so the failure must not surface as a workspace error.
+    releaseDetail();
+    await page.waitForTimeout(750);
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+
+    releaseIssues();
+    await expect(page.getByRole("heading", { name: "All Open", level: 2 })).toBeVisible();
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+  } finally {
+    releaseDetail();
+    releaseIssues();
     await server.stop();
     kataHome.restore();
     await backend.close();

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2244,6 +2244,52 @@ test("kata view change drops a held keyboard selection from the previous view", 
   }
 });
 
+test("kata sidebar view click aborts a pending detail load before the new view arrives", async ({ page }) => {
+  let releaseDetail = () => {};
+  const stalledDetail = new Promise<void>((resolve) => {
+    releaseDetail = resolve;
+  });
+  let releaseIssues = () => {};
+  const stalledIssues = new Promise<void>((resolve) => {
+    releaseIssues = resolve;
+  });
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=all`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
+    await expect(rentRow).toBeVisible();
+
+    // Select Pay rent with its detail response stalled, then click a
+    // sidebar view whose issues fetch is also stalled. The navigation
+    // abandons the selection, so the doomed detail request must be
+    // aborted at click time — not after the new view's data arrives —
+    // or its failure paints a stale error over the transition.
+    backend.state.issueDetailGates.set("issue-rent", { barrier: stalledDetail, status: 500 });
+    await rentRow.click();
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-rent");
+
+    backend.state.issuesBarrier = stalledIssues;
+    await page.getByRole("button", { name: /^Today/ }).click();
+    releaseDetail();
+    await page.waitForTimeout(750);
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+
+    releaseIssues();
+    await expect(page.locator(".issue-list").getByRole("heading", { name: "Today", level: 2 })).toBeVisible();
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+  } finally {
+    releaseDetail();
+    releaseIssues();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata key released during a stalled view transition does not commit a stale selection", async ({ page }) => {
   let releaseIssues = () => {};
   const stalledIssues = new Promise<void>((resolve) => {

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2336,6 +2336,106 @@ test("kata project scope click drops a pending detail load before the scoped lis
   }
 });
 
+test("kata search filter change drops a pending detail load before results arrive", async ({ page }) => {
+  let releaseDetail = () => {};
+  const stalledDetail = new Promise<void>((resolve) => {
+    releaseDetail = resolve;
+  });
+  let releaseIssues = () => {};
+  const stalledIssues = new Promise<void>((resolve) => {
+    releaseIssues = resolve;
+  });
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=all`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
+    await expect(rentRow).toBeVisible();
+
+    // Select Pay rent with its detail stalled, then type a search query
+    // whose results fetch is also stalled. The filter reload abandons
+    // the in-flight selection, so its failing detail request must be
+    // dropped when the filter changes — not after results arrive.
+    backend.state.issueDetailGates.set("issue-rent", { barrier: stalledDetail, status: 500 });
+    await rentRow.click();
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-rent");
+
+    backend.state.issuesBarrier = stalledIssues;
+    await page.getByLabel("Search tasks").fill("susan");
+    releaseDetail();
+    await page.waitForTimeout(750);
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+
+    releaseIssues();
+    await expect(page.locator(".issue-list").getByRole("button", { name: /Email Susan re: Q3/ })).toBeVisible();
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+  } finally {
+    releaseDetail();
+    releaseIssues();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata daemon switch drops a pending detail load from the previous daemon", async ({ page }) => {
+  let releaseDetail = () => {};
+  const stalledDetail = new Promise<void>((resolve) => {
+    releaseDetail = resolve;
+  });
+  let releaseIssues = () => {};
+  const stalledIssues = new Promise<void>((resolve) => {
+    releaseIssues = resolve;
+  });
+  const home = await startKataBackend();
+  const work = await startKataBackend();
+  const kataHome = await configureKataHomeDaemons(
+    [
+      { name: "home", url: home.url },
+      { name: "work", url: work.url },
+    ],
+    "home",
+  );
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=all`);
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
+    await expect(rentRow).toBeVisible();
+
+    // Select Pay rent on the home daemon with its detail stalled, then
+    // switch daemons while the new daemon's issue list is also stalled.
+    // The switch abandons the selection, so the old daemon's failing
+    // detail request must not paint an error over the switch.
+    home.state.issueDetailGates.set("issue-rent", { barrier: stalledDetail, status: 500 });
+    await rentRow.click();
+    await expect.poll(() => home.state.seenPaths).toContain("GET /api/v1/issues/issue-rent");
+
+    work.state.issuesBarrier = stalledIssues;
+    await page.getByTestId("daemon-chip").click();
+    await page.getByTestId("daemon-row-work").click();
+    releaseDetail();
+    await page.waitForTimeout(750);
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+
+    releaseIssues();
+    await expect(page.getByTestId("daemon-chip")).toContainText("work");
+    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
+  } finally {
+    releaseDetail();
+    releaseIssues();
+    await server.stop();
+    kataHome.restore();
+    await home.close();
+    await work.close();
+  }
+});
+
 test("kata key released during a stalled view transition does not commit a stale selection", async ({ page }) => {
   let releaseIssues = () => {};
   const stalledIssues = new Promise<void>((resolve) => {


### PR DESCRIPTION
Scrolling the kata task list with the keyboard fired a detail + events fetch for every row the cursor passed through. Nothing was debounced or cancelled, so holding j/k launched dozens of requests that all ran to completion against the kata daemon, and the browser's per-host connection limit let the abandoned requests delay the fetch for the row the user actually landed on.

- Keyboard selection now commits only when navigation settles: 50ms after the last navigation keydown, and never while a navigation key is still physically held. The held-key gate matters because OS key-repeat intervals are often slower than any reasonable debounce, which would otherwise still commit one fetch per repeated row. Focus continues to move instantly.
- Clicking a row selects immediately and cancels any pending keyboard selection, so selections cannot land out of order.
- The workspace store aborts the previous in-flight detail load when a new selection starts, threading an AbortSignal through the kata API client. The server's reverse proxy forwards the request context, so a browser-side abort also cancels the proxied daemon request. Superseded loads resolve quietly instead of surfacing an error.

Validation: kata component and store unit tests (including a key-repeat-slower-than-debounce case and abort/supersede cases), and a full-stack Playwright e2e that holds j across three rows and asserts exactly one detail fetch reaches the backend. Full kata e2e spec: 63 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)