### PR TITLE
perf: stop GitLab diff review failure fakes from triggering SDK retries

### DIFF
--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -120,8 +120,9 @@ func TestAppStateRegistryWaitsForInFlightHandlersAfterSwap(t *testing.T) {
 	}()
 	<-started
 
+	require := require.New(t)
 	swapped := states.Swap(newState)
-	require.Same(t, oldState, swapped)
+	require.Same(oldState, swapped)
 
 	drained := make(chan struct{})
 	go func() {
@@ -131,24 +132,24 @@ func TestAppStateRegistryWaitsForInFlightHandlersAfterSwap(t *testing.T) {
 
 	select {
 	case <-drained:
-		require.Fail(t, "old state drained before its in-flight handler returned")
+		require.Fail("old state drained before its in-flight handler returned")
 	case <-time.After(100 * time.Millisecond):
 	}
 
 	newRecorder := httptest.NewRecorder()
 	states.ServeHTTP(newRecorder, httptest.NewRequest(http.MethodGet, "/", nil))
-	require.Equal(t, http.StatusAccepted, newRecorder.Code)
+	require.Equal(http.StatusAccepted, newRecorder.Code)
 
 	close(release)
 	select {
 	case <-oldDone:
 	case <-time.After(5 * time.Second):
-		require.Fail(t, "old handler did not return")
+		require.Fail("old handler did not return")
 	}
 	select {
 	case <-drained:
 	case <-time.After(5 * time.Second):
-		require.Fail(t, "old state did not drain after handler returned")
+		require.Fail("old state did not drain after handler returned")
 	}
 }
 

--- a/internal/github/rate_limit_live_test.go
+++ b/internal/github/rate_limit_live_test.go
@@ -15,6 +15,7 @@ import (
 func TestLiveGitHubRateLimitSnapshotUsesGoGitHub(t *testing.T) {
 	skipUnlessLiveGitHubTests(t)
 	assert := Assert.New(t)
+	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -25,10 +26,10 @@ func TestLiveGitHubRateLimitSnapshotUsesGoGitHub(t *testing.T) {
 	}
 
 	limits, resp, err := client.RateLimit.Get(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, limits)
-	require.NotNil(t, limits.Core)
+	require.NoError(err)
+	require.NotNil(resp)
+	require.NotNil(limits)
+	require.NotNil(limits.Core)
 
 	assert.Equal(http.StatusOK, resp.StatusCode)
 	assert.Positive(limits.Core.Limit)

--- a/internal/platform/gitlab/diff_review_test.go
+++ b/internal/platform/gitlab/diff_review_test.go
@@ -131,7 +131,8 @@ func TestGitLabPublishDiffReviewDraftReturnsPartialErrorWhenApproveFails(t *test
 			writeJSON(w, `{}`)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/approve":
 			assert.Equal(http.MethodPost, r.Method)
-			http.Error(w, `{"message": "approval failed"}`, http.StatusInternalServerError)
+			// 422 keeps the failure non-retryable; the SDK retries 5xx with backoff.
+			http.Error(w, `{"message": "approval failed"}`, http.StatusUnprocessableEntity)
 		default:
 			http.NotFound(w, r)
 		}
@@ -242,7 +243,8 @@ func TestGitLabPublishDiffReviewDraftDoesNotApproveWhenPublishFails(t *testing.T
 			writeJSON(w, `{"approved": true}`)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
 			assert.Equal(http.MethodPut, r.Method)
-			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+			// 422 keeps the failure non-retryable; the SDK retries 5xx with backoff.
+			http.Error(w, `{"message": "publish failed"}`, http.StatusUnprocessableEntity)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55":
 			assert.Equal(http.MethodDelete, r.Method)
 			deleted = true
@@ -286,7 +288,8 @@ func TestGitLabPublishDiffReviewDraftReturnsNormalErrorWhenFirstPublishCleanupFa
 			writeJSON(w, `{"id": 55, "note": "range note"}`)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55/publish":
 			assert.Equal(http.MethodPut, r.Method)
-			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+			// 422 keeps the failure non-retryable; the SDK retries 5xx with backoff.
+			http.Error(w, `{"message": "publish failed"}`, http.StatusUnprocessableEntity)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/55":
 			assert.Equal(http.MethodDelete, r.Method)
 			http.Error(w, `{"message": "delete failed"}`, http.StatusBadRequest)
@@ -337,7 +340,8 @@ func TestGitLabPublishDiffReviewDraftReturnsPartialErrorAfterSomeDraftsPublish(t
 			writeJSON(w, `{}`)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56/publish":
 			assert.Equal(http.MethodPut, r.Method)
-			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+			// 422 keeps the failure non-retryable; the SDK retries 5xx with backoff.
+			http.Error(w, `{"message": "publish failed"}`, http.StatusUnprocessableEntity)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56":
 			assert.Equal(http.MethodDelete, r.Method)
 			deleted = true
@@ -403,7 +407,8 @@ func TestGitLabPublishDiffReviewDraftKeepsPartialErrorWhenRemainingCleanupFails(
 			writeJSON(w, `{}`)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56/publish":
 			assert.Equal(http.MethodPut, r.Method)
-			http.Error(w, `{"message": "publish failed"}`, http.StatusInternalServerError)
+			// 422 keeps the failure non-retryable; the SDK retries 5xx with backoff.
+			http.Error(w, `{"message": "publish failed"}`, http.StatusUnprocessableEntity)
 		case "/api/v4/projects/group%2Fproject/merge_requests/7/draft_notes/56":
 			assert.Equal(http.MethodDelete, r.Method)
 			http.Error(w, `{"message": "delete failed"}`, http.StatusBadRequest)

--- a/middleman_test.go
+++ b/middleman_test.go
@@ -84,22 +84,23 @@ func TestNewEmbeddedBootstrapGlobals(t *testing.T) {
 }
 
 func TestNewWiresGraphQLTrackerIntoEmbeddedClient(t *testing.T) {
+	require := require.New(t)
 	inst, err := New(Options{
 		Token:   "test-token",
 		DataDir: t.TempDir(),
 		Repos:   []Repo{{Owner: "acme", Name: "widget"}},
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 	defer inst.Close()
 
 	client, err := inst.syncer.ClientForHost("github.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	value := reflect.ValueOf(client)
-	require.Equal(t, reflect.Pointer, value.Kind())
+	require.Equal(reflect.Pointer, value.Kind())
 	tracker := value.Elem().FieldByName("graphQLRateTracker")
-	require.True(t, tracker.IsValid())
-	require.False(t, tracker.IsNil())
+	require.True(tracker.IsValid())
+	require.False(tracker.IsNil())
 }
 
 func TestEmbedConfigFullFlow(t *testing.T) {


### PR DESCRIPTION
The five `TestGitLabPublishDiffReviewDraft*` failure-path tests returned 500 from their fake GitLab endpoints. The GitLab SDK retries 5xx with exponential backoff, so each test spent ~12s sleeping and `internal/platform/gitlab` took ~60s — almost all of it waiting on retries of calls the tests intend to fail exactly once.

The fakes now return 422, which the SDK does not retry. 422 was chosen over 403/404 because `mapGitLabError` maps those to `permission_denied`/`not_found`, while 422 falls through to the same default error code a 500 produced, keeping each test's asserted behavior unchanged.

- `go test ./internal/platform/gitlab -shuffle=on` drops from 61.6s to ~1.2s
- Also converts three tests to local `require := require.New(t)` helpers; these pre-existing violations failed the repo-wide `testify-helper-check` pre-commit hook and blocked any Go commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)