### PR TITLE
test: make pty owner title e2e test deterministic without a UTF-8 locale

### DIFF
--- a/internal/github/rate_limit_live_test.go
+++ b/internal/github/rate_limit_live_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestLiveGitHubRateLimitSnapshotUsesGoGitHub(t *testing.T) {
 	skipUnlessLiveGitHubTests(t)
+	require := require.New(t)
 	assert := Assert.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -25,10 +26,10 @@ func TestLiveGitHubRateLimitSnapshotUsesGoGitHub(t *testing.T) {
 	}
 
 	limits, resp, err := client.RateLimit.Get(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, limits)
-	require.NotNil(t, limits.Core)
+	require.NoError(err)
+	require.NotNil(resp)
+	require.NotNil(limits)
+	require.NotNil(limits.Core)
 
 	assert.Equal(http.StatusOK, resp.StatusCode)
 	assert.Positive(limits.Core.Limit)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18534,9 +18534,16 @@ func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 	workspaceTerminalConnWriteRead(
 		t, ctx, conn, "stty -echo\rprintf '%s\\n' $((40+2))\r", "42",
 	)
+	// The spinner glyph is sent as printf octal escapes (\342\240\264
+	// is "⠴") so the typed line stays pure ASCII. Raw multibyte bytes
+	// written to an interactive shell are interpreted by readline as
+	// meta editing commands when the host has no UTF-8 locale set,
+	// scrambling the command before it runs. The session still emits
+	// the real multibyte title for the pty owner to track.
 	workspaceTerminalConnWriteRead(
 		t, ctx, conn,
-		"printf 'title-sent\\n'; printf '\\033]0;⠴ t3code-b5014b03\\007'\r",
+		"printf 'title-sent\\n'; "+
+			"printf '\\033]0;\\342\\240\\264 t3code-b5014b03\\007'\r",
 		"t3code-b5014b03",
 	)
 

--- a/middleman_test.go
+++ b/middleman_test.go
@@ -84,22 +84,23 @@ func TestNewEmbeddedBootstrapGlobals(t *testing.T) {
 }
 
 func TestNewWiresGraphQLTrackerIntoEmbeddedClient(t *testing.T) {
+	require := require.New(t)
 	inst, err := New(Options{
 		Token:   "test-token",
 		DataDir: t.TempDir(),
 		Repos:   []Repo{{Owner: "acme", Name: "widget"}},
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 	defer inst.Close()
 
 	client, err := inst.syncer.ClientForHost("github.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	value := reflect.ValueOf(client)
-	require.Equal(t, reflect.Pointer, value.Kind())
+	require.Equal(reflect.Pointer, value.Kind())
 	tracker := value.Elem().FieldByName("graphQLRateTracker")
-	require.True(t, tracker.IsValid())
-	require.False(t, tracker.IsNil())
+	require.True(tracker.IsValid())
+	require.False(tracker.IsNil())
 }
 
 func TestEmbedConfigFullFlow(t *testing.T) {


### PR DESCRIPTION
TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E failed deterministically on dev machines whose test environment has no UTF-8 locale (LANG/LC_ALL unset, common under agent harnesses), while passing in CI. The test typed the spinner title escape into the interactive /bin/sh pty session as raw UTF-8; in a C locale, bash 3.2's readline interprets the spinner glyph's high-bit bytes as meta editing commands (the pty transcript shows `(arg: 1)`/`(arg: 4)` digit-argument prompts), scrambling the printf line before it executes — so the OSC title never reaches the pty owner's title parser and the poll times out.

- The test now sends the spinner glyph as printf octal escapes (`\342\240\264`), keeping the typed line pure ASCII in any locale while the session still emits the real multibyte title. The escape still flows through the pty owner's title tracking into `TmuxWorking`, and the asserted title is unchanged.
- Two pre-existing direct-testify tests (`middleman_test.go`, `internal/github/rate_limit_live_test.go`) now use local `require` helpers; the repo-wide testify-helper-check hook rejected every commit until they complied.

The e2e test now passes 5/5 with no locale set (previously 0/3) and with `LANG=en_US.UTF-8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)