### PR TITLE
fix: keep tmux-backed workspaces alive under tmux 3.6 session listing

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18112,8 +18112,12 @@ func middlemanTmuxSessions(
 	tmuxPath string,
 	includePath func(string) bool,
 ) ([]string, error) {
+	// Colon-separated because tmux 3.6+ sanitizes control characters in
+	// -F output (a tab prints as "_"). Session names cannot contain ":"
+	// (tmux replaces it with "_"), so cutting at the first colon is
+	// unambiguous even when the session path contains colons.
 	cmd := procutil.CommandContext(
-		ctx, tmuxPath, "list-sessions", "-F", "#{session_name}\t#{session_path}",
+		ctx, tmuxPath, "list-sessions", "-F", "#{session_name}:#{session_path}",
 	)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -18129,7 +18133,7 @@ func middlemanTmuxSessions(
 
 	var sessions []string
 	for line := range strings.SplitSeq(stdout.String(), "\n") {
-		name, path, ok := strings.Cut(line, "\t")
+		name, path, ok := strings.Cut(line, ":")
 		if !ok || !strings.HasPrefix(name, "middleman-") {
 			continue
 		}
@@ -19828,8 +19832,8 @@ for a in "$@"; do
 done
 case "$1" in
   list-sessions)
-    printf 'middleman-0000000000000001\t%%s\n' "$MIDDLEMAN_TMUX_OWNER"
-    printf 'middleman-0000000000000001-0123456789abcdef\t%%s\n' "$MIDDLEMAN_TMUX_OWNER"
+    printf 'middleman-0000000000000001:%%s\n' "$MIDDLEMAN_TMUX_OWNER"
+    printf 'middleman-0000000000000001-0123456789abcdef:%%s\n' "$MIDDLEMAN_TMUX_OWNER"
     exit 0
     ;;
   kill-session)

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1320,12 +1320,20 @@ type tmuxSessionInfo struct {
 	owner string
 }
 
+// tmuxSessionListFormat joins the session name and owner marker with a
+// colon. tmux 3.6+ sanitizes control characters in -F output (a literal
+// tab prints as "_"), so the separator must be printable. A colon is
+// unambiguous because tmux replaces ":" in session names with "_", so no
+// live session name can contain one; the owner marker ("middleman:<hex>")
+// does, which is why parsing cuts at the first colon only.
+const tmuxSessionListFormat = "#{session_name}:#{@middleman_owner}"
+
 func (m *Manager) listTmuxSessionInfos(
 	ctx context.Context,
 ) ([]tmuxSessionInfo, error) {
 	cmd := m.tmuxExec(
 		ctx,
-		"list-sessions", "-F", "#{session_name}\t#{@middleman_owner}",
+		"list-sessions", "-F", tmuxSessionListFormat,
 	)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -1347,7 +1355,7 @@ func (m *Manager) listTmuxSessionInfos(
 		if line == "" {
 			continue
 		}
-		name, owner, _ := strings.Cut(line, "\t")
+		name, owner, _ := strings.Cut(line, ":")
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -20,6 +21,7 @@ import (
 	gitcmd "go.kenn.io/kit/git/cmd"
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/gitclone"
+	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/ptyowner"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
@@ -1259,10 +1261,10 @@ func TestManagerReapOrphanTmuxSessionsKillsUnknownManagedSessions(t *testing.T) 
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'middleman-0000000000000001\t%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
+		`    printf 'middleman-0000000000000001:%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
 		`    printf 'middleman-ffffffffffffffff\n'` + "\n" +
-		`    printf 'middleman-aaaaaaaaaaaaaaaa-0123456789abcdef\t%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
-		`    printf 'middleman-aaaaaaaaaaaaaaaa-claude\t%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
+		`    printf 'middleman-aaaaaaaaaaaaaaaa-0123456789abcdef:%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
+		`    printf 'middleman-aaaaaaaaaaaaaaaa-claude:%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
 		`    printf 'middleman-notes\nother-session\n'` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
@@ -1297,7 +1299,7 @@ func TestManagerReapOrphanTmuxSessionsKillsUnknownManagedSessions(t *testing.T) 
 	assert.Equal(
 		[]string{
 			"wrap", "list-sessions", "-F",
-			"#{session_name}\t#{@middleman_owner}",
+			"#{session_name}:#{@middleman_owner}",
 		},
 		argvs[0],
 	)
@@ -1331,9 +1333,9 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'middleman-0000000000000001\t%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
-		`    printf 'middleman-0000000000000001-57de4cf40144bdf7\t%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
-		`    printf 'middleman-aaaaaaaaaaaaaaaa-c857d09db23e6822\t%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
+		`    printf 'middleman-0000000000000001:%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
+		`    printf 'middleman-0000000000000001-57de4cf40144bdf7:%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
+		`    printf 'middleman-aaaaaaaaaaaaaaaa-c857d09db23e6822:%s\n' "$MIDDLEMAN_TMUX_OWNER"` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
 		"done\n" +
@@ -1488,6 +1490,139 @@ func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
 	require.NoError(err)
 	require.NotNil(legacyOwner)
 	assert.Equal("ready", legacyOwner.Status)
+}
+
+// TestManagerTmuxSessionListSurvivesTmux36Sanitization guards against
+// tmux 3.6+'s format sanitization: control characters in -F output print
+// as "_", so a literal tab separator corrupts every line into
+// "<name>_<owner>", making prune mark live workspaces as errored and reap
+// skip owned orphans. The fake tmux expands the requested format the way
+// tmux 3.6 does, including the tab-to-underscore substitution, so this
+// fails if the list format ever reverts to a control-character separator.
+func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record")
+	script := filepath.Join(dir, "fake-tmux")
+	body := "#!/bin/sh\n" +
+		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
+		`fmt=''` + "\n" +
+		`prev=''` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$prev" = "-F" ]; then fmt="$a"; fi` + "\n" +
+		`  prev="$a"` + "\n" +
+		`done` + "\n" +
+		`for a in "$@"; do` + "\n" +
+		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
+		`    for name in middleman-0000000000000001 middleman-aaaaaaaaaaaaaaaa; do` + "\n" +
+		`      printf '%s\n' "$fmt" \` + "\n" +
+		`        | sed -e "s|#{session_name}|$name|" \` + "\n" +
+		`              -e "s|#{@middleman_owner}|$MIDDLEMAN_TMUX_OWNER|" \` + "\n" +
+		`        | tr '\t' '_'` + "\n" +
+		`    done` + "\n" +
+		`    exit 0` + "\n" +
+		`  fi` + "\n" +
+		`done` + "\n" +
+		"exit 0\n"
+	require.NoError(os.WriteFile(script, []byte(body), 0o755))
+	t.Setenv("TMUX_RECORD", record)
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{script, "wrap"})
+	t.Setenv("MIDDLEMAN_TMUX_OWNER", mgr.tmuxOwnerMarker())
+	ctx := context.Background()
+
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "0000000000000001",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		GitHeadRef:   "feature/live",
+		WorktreePath: filepath.Join(t.TempDir(), "live"),
+		TmuxSession:  "middleman-0000000000000001",
+		Status:       "ready",
+	}))
+
+	require.NoError(mgr.PruneMissingTmuxSessions(ctx))
+	live, err := d.GetWorkspace(ctx, "0000000000000001")
+	require.NoError(err)
+	require.NotNil(live)
+	assert.Equal("ready", live.Status)
+
+	require.NoError(mgr.ReapOrphanTmuxSessions(ctx))
+	argvs := readRecorderArgv(t, record)
+	assert.Contains(argvs, []string{
+		"wrap", "kill-session", "-t", "middleman-aaaaaaaaaaaaaaaa",
+	})
+	assert.NotContains(argvs, []string{
+		"wrap", "kill-session", "-t", "middleman-0000000000000001",
+	})
+}
+
+// TestManagerListTmuxSessionInfosRealTmux lists sessions through an
+// actual tmux server on an isolated socket. tmux 3.6+ sanitizes control
+// characters in -F output, which silently broke a tab-separated list
+// format on real servers while fake-script tests kept passing; running
+// against the installed binary catches any future sanitization drift.
+func TestManagerListTmuxSessionInfosRealTmux(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("real tmux listing test uses Unix tmux")
+	}
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skipf("tmux unavailable in this test environment: %v", err)
+	}
+
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	dir, err := os.MkdirTemp("/tmp", "middleman-tmux-list-*")
+	require.NoError(err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	socket := filepath.Join(dir, "tmux.sock")
+	t.Cleanup(func() {
+		_ = procutil.Command(
+			tmuxPath, "-f", "/dev/null", "-S", socket, "kill-server",
+		).Run()
+	})
+	run := func(args ...string) {
+		t.Helper()
+		cmd := procutil.Command(
+			tmuxPath,
+			append([]string{"-f", "/dev/null", "-S", socket}, args...)...,
+		)
+		cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+		out, err := cmd.CombinedOutput()
+		require.NoError(err, string(out))
+	}
+
+	const owned = "middleman-0123456789abcdef"
+	const unowned = "middleman-fedcba9876543210"
+	run("new-session", "-d", "-s", owned, "sleep 30")
+	run("new-session", "-d", "-s", unowned, "sleep 30")
+
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{tmuxPath, "-f", "/dev/null", "-S", socket})
+	run("set-option", "-t", owned, "@middleman_owner", mgr.tmuxOwnerMarker())
+
+	infos, err := mgr.listTmuxSessionInfos(context.Background())
+	require.NoError(err)
+	owners := make(map[string]string, len(infos))
+	for _, info := range infos {
+		owners[info.name] = info.owner
+	}
+	require.Len(owners, 2)
+	assert.Equal(mgr.tmuxOwnerMarker(), owners[owned])
+	assert.Contains(owners, unowned)
+	assert.Empty(owners[unowned])
 }
 
 func TestManagerTmuxSessionsForWorkspaceReadsStoredRuntimeSessions(


### PR DESCRIPTION
tmux 3.6+ sanitizes control characters in `-F` format output: a literal tab prints as `_`. The tab-separated `#{session_name}\t#{@middleman_owner}` session-list format therefore parsed every session as `<name>_<owner>`, so on hosts with tmux 3.6 (e.g. homebrew tmux 3.6b) middleman treated every live session as missing: each workspaces list call marked ready tmux-backed workspaces as errored ("tmux session is no longer running"), and orphan reaping read empty owner markers and silently skipped cleanup. CI never caught this because its machines run older tmux or none.

The separator is now `:`, which tmux never sanitizes and which cannot appear in a session name (tmux rewrites `:` to `_` on creation), so cutting at the first colon stays unambiguous even though owner markers (`middleman:<hex>`) and session paths contain colons of their own. Since the real behavior only manifests against a real tmux 3.6 server, coverage comes from a fake tmux that emulates the tab-to-underscore substitution (fails if the format ever reverts to a control-character separator) plus a real-tmux listing test on an isolated socket to catch future sanitization drift.

- Ready tmux-backed workspaces no longer flip to error status on every list call under tmux 3.6+
- Orphaned middleman tmux sessions are reaped again on startup under tmux 3.6+
- `TestWorkspaceListReportsCommitsAheadBehindE2E` passes on tmux 3.6 machines; full `internal/server` suite green locally with `-shuffle=on` after rebasing onto main

🤖 Generated with [Claude Code](https://claude.com/claude-code)