### PR TITLE
fix: unbreak the internal/github build after testify-helper collision on main

### DIFF
--- a/internal/github/rate_limit_live_test.go
+++ b/internal/github/rate_limit_live_test.go
@@ -16,7 +16,6 @@ func TestLiveGitHubRateLimitSnapshotUsesGoGitHub(t *testing.T) {
 	skipUnlessLiveGitHubTests(t)
 	require := require.New(t)
 	assert := Assert.New(t)
-	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()


### PR DESCRIPTION
#476 and #477 each independently added the same `require := require.New(t)` helper line to `TestLiveGitHubRateLimitSnapshotUsesGoGitHub` while unblocking the testify-helper-check hook. Each PR's CI passed on its own merge base, but after both merged the function declares the helper twice, so `internal/github` no longer compiles and the test, race, and lint jobs on main are red with `no new variables on left side of :=`.

- Removes the duplicate declaration, keeping the helper conversion both PRs intended

Validation: `go vet ./internal/github`, `go test ./internal/github -shuffle=on`, `golangci-lint run ./internal/github` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)