### PR TITLE
test: stop kata route-reset e2e test from racing the bootstrap placeholder heading

### DIFF
--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -1551,7 +1551,7 @@ test("kata route reset ignores a stale routed view response", async ({ page }) =
     short_id: "inbox-stale",
     qualified_id: "Inbox#inbox-stale",
     title: "Inbox response that should stay stale",
-    body: "This routed response should not replace the winning Today route.",
+    body: "This routed response should not replace the winning bare-route All Open view.",
     labels: ["triage"],
   });
   const backend = await startKataBackend({
@@ -1564,7 +1564,7 @@ test("kata route reset ignores a stale routed view response", async ({ page }) =
   try {
     await page.goto(`${server.info.base_url}/kata`);
 
-    await expect(page.getByRole("heading", { name: "Today", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "All Open", level: 2 })).toBeVisible();
     const issueReadsBefore = backend.state.seenPaths.filter((path) => path === "GET /api/v1/issues?status=open").length;
     backend.state.issuesBarrier = stalledIssues;
 
@@ -1576,7 +1576,7 @@ test("kata route reset ignores a stale routed view response", async ({ page }) =
     await page.goto(`${server.info.base_url}/kata`);
     releaseIssues();
 
-    await expect(page.getByRole("heading", { name: "Today", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "All Open", level: 2 })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Inbox", level: 2 })).toHaveCount(0);
     await expect(page.getByRole("button", { name: /Pay rent/ })).toBeVisible();
   } finally {


### PR DESCRIPTION
The Playwright e2e test "kata route reset ignores a stale routed view response" (added in #457) asserted a "Today" heading after each bare /kata navigation, but bare /kata intentionally lands on "All Open": the workspace bootstraps with view `all`, `applyRouteViewScope` falls back to `all` for bare routes, and the component tests from the same PR (including the unit-level twin of this scenario in KataWorkspaceRouting.test.ts) all encode All Open for bare mounts. "Today" only ever appeared because the store's pre-bootstrap placeholder view is `emptyView("today")`, so the assertion passed solely by catching that transient window before the bootstrap response landed. Under CI load (2 workers, --trace on) the bootstrap settles first and the test failed deterministically.

- The test now expects the "All Open" heading after both bare /kata navigations; the stale-inbox-response checks are unchanged.
- The sibling bootstrap-stall test asserts its headings only after the routed Inbox view renders, so it does not share the race (verified 10x under trace at 2 workers).

Validation: both tests pass with --trace on (previously a near-certain repro), and the full kata.spec.ts chromium suite passes (62 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)