### PR TITLE
fix: round rate-limit sync waits for readable status

### DIFF
--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -37,11 +37,24 @@ type SyncStatus struct {
 }
 
 func formatRateLimitWait(wait time.Duration) string {
-	rounded := wait.Round(time.Second)
-	if wait > 0 && rounded < time.Second {
-		rounded = time.Second
+	if wait <= 0 {
+		return "0s"
 	}
-	return rounded.String()
+	if wait < time.Minute {
+		seconds := int((wait + time.Second - time.Nanosecond) / time.Second)
+		return fmt.Sprintf("%ds", seconds)
+	}
+
+	minutes := int((wait + time.Minute - time.Nanosecond) / time.Minute)
+	hours := minutes / 60
+	remainingMinutes := minutes % 60
+	if hours == 0 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	if remainingMinutes == 0 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dh%dm", hours, remainingMinutes)
 }
 
 // DiffSyncErrorCode categorizes the reason a diff sync failed. The frontend

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -36,6 +36,14 @@ type SyncStatus struct {
 	LastError   string    `json:"last_error,omitempty"`
 }
 
+func formatRateLimitWait(wait time.Duration) string {
+	rounded := wait.Round(time.Second)
+	if wait > 0 && rounded < time.Second {
+		rounded = time.Second
+	}
+	return rounded.String()
+}
+
 // DiffSyncErrorCode categorizes the reason a diff sync failed. The frontend
 // uses this category to render a user-facing message that does not leak local
 // clone paths, refs, SHAs, or git stderr.
@@ -2454,7 +2462,7 @@ func (s *Syncer) runWorker(
 				s.publishStatus(&SyncStatus{
 					Running: true,
 					Progress: fmt.Sprintf(
-						"rate limited, waiting %s", wait,
+						"rate limited, waiting %s", formatRateLimitWait(wait),
 					),
 				})
 				select {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -6457,7 +6457,29 @@ func TestSyncer_OnStatusChangeCallback(t *testing.T) {
 		"last callback should be running=false")
 }
 
-func TestSyncerRateLimitProgressRoundsWaitToSeconds(t *testing.T) {
+func TestFormatRateLimitWaitUsesSecondsOnlyBelowOneMinute(t *testing.T) {
+	assert := Assert.New(t)
+
+	tests := []struct {
+		name string
+		wait time.Duration
+		want string
+	}{
+		{name: "sub-second waits round up to one second", wait: 364 * time.Millisecond, want: "1s"},
+		{name: "sub-minute waits show seconds", wait: 38*time.Second + 364*time.Millisecond, want: "39s"},
+		{name: "minute-scale waits hide seconds", wait: 25*time.Minute + 38*time.Second + 364*time.Millisecond, want: "26m"},
+		{name: "hour-scale waits hide seconds", wait: 2*time.Hour + time.Minute + time.Second, want: "2h2m"},
+		{name: "exact hours hide zero minutes", wait: 2 * time.Hour, want: "2h"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(tt.want, formatRateLimitWait(tt.wait))
+		})
+	}
+}
+
+func TestSyncerRateLimitProgressUsesMinuteScaleWaits(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	d := openTestDB(t)
@@ -6511,7 +6533,8 @@ func TestSyncerRateLimitProgressRoundsWaitToSeconds(t *testing.T) {
 
 	assert.Contains(got, "rate limited, waiting ")
 	assert.NotContains(got, ".")
-	assert.Regexp(`rate limited, waiting \d+m\d+s$`, got)
+	assert.NotContains(got, "s")
+	assert.Regexp(`rate limited, waiting \d+m$`, got)
 }
 
 // notModifiedErr returns the error shape go-github surfaces when the

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -6457,6 +6457,63 @@ func TestSyncer_OnStatusChangeCallback(t *testing.T) {
 		"last callback should be running=false")
 }
 
+func TestSyncerRateLimitProgressRoundsWaitToSeconds(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	rt := NewRateTracker(d, "github.com", "rest")
+	rt.UpdateFromRate(Rate{
+		Remaining: 0,
+		Reset:     time.Now().Add(25*time.Minute + 38*time.Second + 364*time.Millisecond),
+	})
+
+	s := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}},
+		d, nil,
+		[]RepoRef{{Owner: "o", Name: "n", PlatformHost: "github.com"}},
+		time.Hour,
+		map[string]*RateTracker{"github.com": rt},
+		nil,
+	)
+
+	progress := make(chan string, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	s.SetOnStatusChange(func(status *SyncStatus) {
+		if strings.Contains(status.Progress, "rate limited, waiting") {
+			select {
+			case progress <- status.Progress:
+			default:
+			}
+			cancel()
+		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		s.RunOnce(ctx)
+		close(done)
+	}()
+
+	var got string
+	select {
+	case got = <-progress:
+	case <-time.After(2 * time.Second):
+		require.FailNow("RunOnce did not publish rate-limit progress")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow("RunOnce did not return after cancel")
+	}
+
+	assert.Contains(got, "rate limited, waiting ")
+	assert.NotContains(got, ".")
+	assert.Regexp(`rate limited, waiting \d+m\d+s$`, got)
+}
+
 // notModifiedErr returns the error shape go-github surfaces when the
 // HTTP transport receives a 304 Not Modified response. The etag
 // transport intercepts list-endpoint requests and adds If-None-Match


### PR DESCRIPTION
The sync status bar now reports rate-limit backoff waits at human-scale precision instead of raw duration precision like `25m38.364362s`.

Because the status is not a live per-second countdown, waits at a minute or more render as compact minute/hour values like `26m`; sub-minute waits still show seconds.