### PR TITLE
fix: record the ready setup event before flipping workspace status

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22972,6 +22972,51 @@ func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
 	assert.Len(afterEvents, len(beforeEvents))
 }
 
+// TestWorkspaceReadyStatusImpliesReadySetupEventE2E pins the write order
+// in Manager.Setup: the final "setup ready" event must be recorded before
+// status flips to "ready". When the order was reversed, pollers that
+// reacted to status=ready could read a setup-event list still missing its
+// last row, which made retry-conflict event-count assertions flake on CI.
+func TestWorkspaceReadyStatusImpliesReadySetupEventE2E(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	client, database, _, _ := setupTestServerWithWorkspaces(t)
+	ctx := context.Background()
+
+	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	wsID := createResp.JSON202.Id
+
+	// Read the event log immediately after the first observation of
+	// status=ready: the ready event must already be there.
+	waitForWorkspaceReady(t, ctx, client, wsID)
+	events, err := database.ListWorkspaceSetupEvents(ctx, wsID)
+	require.NoError(err)
+	sawReadyEvent := false
+	for _, event := range events {
+		if event.Stage == "setup" && event.Outcome == "ready" {
+			sawReadyEvent = true
+		}
+	}
+	require.True(
+		sawReadyEvent,
+		"workspace reported status=ready before the setup ready "+
+			"event was recorded; events: %d", len(events),
+	)
+}
+
 func TestWorkspaceCreateNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -457,6 +457,16 @@ func (m *Manager) Setup(
 		"terminal session started",
 	)
 
+	// Record the final setup event before flipping status: "ready" is
+	// the externally visible completion signal, so observers that poll
+	// status must never see "ready" while the event log is still
+	// missing its last row. failSetup keeps the same event-then-status
+	// order on the error path.
+	m.recordSetupEvent(
+		ctx,
+		ws.ID, workspaceSetupStageSetup, "ready",
+		"workspace ready",
+	)
 	if err := m.updateWorkspaceStatus(
 		ctx, ws.ID, "ready", nil,
 	); err != nil {
@@ -466,11 +476,6 @@ func (m *Manager) Setup(
 			fmt.Errorf("update status to ready: %w", err),
 		)
 	}
-	m.recordSetupEvent(
-		ctx,
-		ws.ID, workspaceSetupStageSetup, "ready",
-		"workspace ready",
-	)
 	return nil
 }
 


### PR DESCRIPTION
Fixes the CI flake in `TestWorkspaceRetryReadyWorkspaceConflictE2E` seen on #474 (run 27377060466).

`Manager.Setup` flipped workspace status to `ready` before inserting the final "workspace ready" setup event. Status is the externally visible completion signal, so anything polling it — including the test's `waitForWorkspaceReady` helper — could read the setup-event list before the last row landed, making a no-op retry appear to have added an event. Recording the event first makes `status=ready` imply a complete event log, and matches the failure path, which already records its event before setting status to `error`. Nothing relied on the old order: the tmux readiness probe treats status and events as alternative signals.

- Setup now records the "workspace ready" event before updating status to `ready`
- New e2e test pins the ordering by checking the event log at the first observation of `status=ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)