### PR TITLE
test: stop running webkit e2e suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
+        browser: [chromium, firefox]
     name: e2e (${{ matrix.browser }})
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -3,10 +3,10 @@ import { ensureE2EServer } from "./tests/e2e-full/support/e2eServer";
 
 const serverInfo = await ensureE2EServer();
 
-// Local worker count, tuned per engine: chromium and webkit scale to
-// 75% of cores, while firefox's heavier per-worker processes degrade
-// past ~50% (measured locally: 9 workers beat both 6 and 13). CI
-// runners are small; they keep Playwright's default.
+// Local worker count, tuned per engine: chromium scales to 75% of cores,
+// while firefox's heavier per-worker processes degrade past ~50% (measured
+// locally: 9 workers beat both 6 and 13). CI runners are small; they keep
+// Playwright's default.
 function localWorkers(): string {
   const args = process.argv.join(" ");
   return /--project[= ]firefox/.test(args) ? "50%" : "75%";
@@ -41,14 +41,6 @@ export default defineConfig({
       testIgnore: /roborev/,
       use: {
         ...devices["Desktop Firefox"],
-      },
-    },
-    {
-      name: "webkit",
-      testIgnore: /roborev/,
-      use: {
-        ...devices["Desktop Safari"],
-        deviceScaleFactor: 1,
       },
     },
     {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -37,12 +37,5 @@ export default defineConfig({
         ...devices["Desktop Firefox"],
       },
     },
-    {
-      name: "webkit",
-      use: {
-        ...devices["Desktop Safari"],
-        deviceScaleFactor: 1,
-      },
-    },
   ],
 });

--- a/frontend/scripts/e2e-run-plan.ts
+++ b/frontend/scripts/e2e-run-plan.ts
@@ -1,4 +1,4 @@
-const defaultProjectRuns = [["--project=chromium"], ["--project=firefox"], ["--project=webkit"]];
+const defaultProjectRuns = [["--project=chromium"], ["--project=firefox"]];
 
 function includesProjectArg(args: string[]): boolean {
   return args.some((arg) => arg === "--project" || arg.startsWith("--project="));

--- a/scripts/run-e2e-to-file.test.ts
+++ b/scripts/run-e2e-to-file.test.ts
@@ -4,18 +4,17 @@ import { test } from "node:test";
 import { planE2ERuns } from "../frontend/scripts/e2e-run-plan";
 
 test("plans isolated default browser project runs", () => {
-  assert.deepEqual(planE2ERuns([]), [["--project=chromium"], ["--project=firefox"], ["--project=webkit"]]);
+  assert.deepEqual(planE2ERuns([]), [["--project=chromium"], ["--project=firefox"]]);
 });
 
 test("appends non-project args to each isolated browser project run", () => {
   assert.deepEqual(planE2ERuns(["--headed", "tests/e2e-full/workspace-sidebar.spec.ts"]), [
     ["--project=chromium", "--headed", "tests/e2e-full/workspace-sidebar.spec.ts"],
     ["--project=firefox", "--headed", "tests/e2e-full/workspace-sidebar.spec.ts"],
-    ["--project=webkit", "--headed", "tests/e2e-full/workspace-sidebar.spec.ts"],
   ]);
 });
 
 test("respects explicit project args as a single requested run", () => {
   assert.deepEqual(planE2ERuns(["--project=firefox", "--headed"]), [["--project=firefox", "--headed"]]);
-  assert.deepEqual(planE2ERuns(["--project", "webkit", "--headed"]), [["--project", "webkit", "--headed"]]);
+  assert.deepEqual(planE2ERuns(["--project", "chromium", "--headed"]), [["--project", "chromium", "--headed"]]);
 });


### PR DESCRIPTION
WebKit is no longer part of the browser coverage this project needs, so keeping it in the default local and CI Playwright schedules adds runtime and maintenance cost without useful signal. This PR narrows the scheduled e2e browser set to Chromium and Firefox across CI, Playwright configs, and the local scripted run plan.

The run-plan regression test now pins the reduced default browser set, so hooks will catch accidental reintroduction of WebKit into the normal schedule. Explicit project arguments still pass through unchanged for targeted local use.

Validation:
- `./node_modules/.bin/playwright test --config=playwright.config.ts --list | awk '/\\[webkit\\]/{found=1; print} /^Total:/{print} END{exit found}'`\n- `./node_modules/.bin/playwright test --config=playwright-e2e.config.ts --list | awk '/\\[webkit\\]/{found=1; print} /^Total:/{print} END{exit found}'`\n- `bun -e 'import("./frontend/scripts/e2e-run-plan.ts").then((m) => console.log(JSON.stringify(m.planE2ERuns([]))))'`\n- `bun test scripts/*.test.mjs scripts/*.test.ts`\n- commit hooks