### PR TITLE
Add Mermaid rendering to markdown

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "ghostty-web": "^0.4.0",
         "js-toml": "^1.0.3",
         "marked": "17.0.5",
+        "mermaid": "11.15.0",
         "openapi-fetch": "^0.17.0",
         "simple-icons": "^16.19.0",
       },
@@ -81,6 +82,8 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -90,6 +93,8 @@
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/runtime-corejs3": ["@babel/runtime-corejs3@7.29.2", "", { "dependencies": { "core-js-pure": "^3.48.0" } }, "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.2.0", "", { "dependencies": { "@chevrotain/gast": "11.2.0", "@chevrotain/types": "11.2.0", "lodash-es": "4.17.23" } }, "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ=="],
 
@@ -195,6 +200,10 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.3", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -222,6 +231,8 @@
     "@lucide/svelte": ["@lucide/svelte@1.3.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-ZRjfWKklbD9Sjhnb6d7v8A3zSGwVHNTM8kOiObSUIiF4B2rU4zskWV7ysp5tY0wOPl7ttj2bXGQvAd6qOCVhIA=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
     "@middleman/ui": ["@middleman/ui@workspace:packages/ui"],
 
@@ -477,9 +488,73 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -500,6 +575,8 @@
     "@typescript-eslint/types": ["@typescript-eslint/types@8.58.1", "", {}, "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -589,13 +666,91 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "core-js-pure": ["core-js-pure@3.49.0", "", {}, "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -604,6 +759,8 @@
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -622,6 +779,8 @@
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-toolkit": ["es-toolkit@1.47.0", "", {}, "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -649,6 +808,8 @@
 
     "ghostty-web": ["ghostty-web@0.4.0", "", {}, "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
@@ -663,7 +824,11 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -680,6 +845,12 @@
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -729,6 +900,8 @@
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
+    "mermaid": ["mermaid@11.15.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "es-toolkit": "^1.45.1", "katex": "^0.16.25", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw=="],
+
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
     "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
@@ -775,9 +948,13 @@
 
     "oxlint-tsgolint": ["oxlint-tsgolint@0.22.1", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.22.1", "@oxlint-tsgolint/darwin-x64": "0.22.1", "@oxlint-tsgolint/linux-arm64": "0.22.1", "@oxlint-tsgolint/linux-x64": "0.22.1", "@oxlint-tsgolint/win32-arm64": "0.22.1", "@oxlint-tsgolint/win32-x64": "0.22.1" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg=="],
 
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
     "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -796,6 +973,10 @@
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
@@ -865,13 +1046,19 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
     "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
@@ -902,6 +1089,8 @@
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
@@ -939,6 +1128,8 @@
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
@@ -960,6 +1151,8 @@
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
+
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1011,11 +1204,23 @@
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "@mermaid-js/parser/@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 
@@ -1034,6 +1239,10 @@
     "vitest/tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
 
     "vitest/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "vite-node/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "ghostty-web": "^0.4.0",
     "js-toml": "^1.0.3",
     "marked": "17.0.5",
+    "mermaid": "11.15.0",
     "openapi-fetch": "^0.17.0",
     "simple-icons": "^16.19.0"
   },

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -464,7 +464,7 @@ a:hover {
   border-color: transparent;
   box-shadow: none;
   color: var(--text-secondary);
-  font-size: 28px;
+  font-size: var(--font-size-xl);
 }
 .mermaid-viewer-lightbox__close:hover {
   background: color-mix(in srgb, var(--bg-surface-hover) 76%, transparent);

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -96,6 +96,23 @@
   --diff-stale-text: #9a6700;
   --diff-stale-border: #d4a72c;
 
+  /* Mermaid view — light theme */
+  --mermaid-bg: #ffffff;
+  --mermaid-viewer-bg: #f6f8fa;
+  --mermaid-node-bg: #ffffff;
+  --mermaid-node-text: #24292f;
+  --mermaid-node-border: #d0d7de;
+  --mermaid-cluster-bg: #f6f8fa;
+  --mermaid-cluster-text: #24292f;
+  --mermaid-cluster-border: #d0d7de;
+  --mermaid-line: #57606a;
+  --mermaid-text: #24292f;
+  --mermaid-label-bg: #ffffff;
+  --mermaid-label-text: #24292f;
+  --mermaid-note-bg: #fff8c5;
+  --mermaid-note-text: #24292f;
+  --mermaid-note-border: #d4a72c;
+
   color-scheme: light;
 }
 
@@ -158,6 +175,23 @@
   --diff-stale-bg: rgba(187, 128, 9, 0.15);
   --diff-stale-text: #d29922;
   --diff-stale-border: #9e6a03;
+
+  /* Mermaid view — dark theme */
+  --mermaid-bg: #0d1117;
+  --mermaid-viewer-bg: #4a4d4b;
+  --mermaid-node-bg: #f6f8fa;
+  --mermaid-node-text: #24292f;
+  --mermaid-node-border: #d0d7de;
+  --mermaid-cluster-bg: #4a4d4b;
+  --mermaid-cluster-text: #f0f6fc;
+  --mermaid-cluster-border: #4a4d4b;
+  --mermaid-line: #c9d1d9;
+  --mermaid-text: #c9d1d9;
+  --mermaid-label-bg: #30363d;
+  --mermaid-label-text: #f0f6fc;
+  --mermaid-note-bg: #30363d;
+  --mermaid-note-text: #f0f6fc;
+  --mermaid-note-border: #8b949e;
 
   color-scheme: dark;
 }
@@ -286,12 +320,10 @@ a:hover {
 }
 .markdown-body pre.mermaid.mermaid-viewer,
 .doc-markdown pre.mermaid.mermaid-viewer {
-  --mermaid-viewer-bg: #f6f8fa;
   --mermaid-viewer-control-bg: rgba(36, 41, 47, 0.92);
   --mermaid-viewer-control-hover: rgba(48, 54, 61, 0.96);
   --mermaid-viewer-control-border: rgba(139, 148, 158, 0.48);
   --mermaid-viewer-control-text: #f0f6fc;
-  --mermaid-viewer-edge-label-text: #24292f;
 
   position: relative;
   height: clamp(180px, 34vw, 420px);
@@ -302,11 +334,6 @@ a:hover {
   border-color: var(--border-default);
   border-radius: var(--radius-md);
   text-align: initial;
-}
-:root.dark .markdown-body pre.mermaid.mermaid-viewer,
-:root.dark .doc-markdown pre.mermaid.mermaid-viewer {
-  --mermaid-viewer-bg: #4a4d4b;
-  --mermaid-viewer-edge-label-text: #f0f6fc;
 }
 .mermaid-viewer__viewport {
   width: 100%;
@@ -392,12 +419,12 @@ a:hover {
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel,
 .doc-markdown pre.mermaid.mermaid-viewer .edgeLabel,
 .mermaid-viewer-lightbox .edgeLabel {
-  color: var(--mermaid-viewer-edge-label-text);
+  color: var(--mermaid-label-text);
 }
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel text,
 .doc-markdown pre.mermaid.mermaid-viewer .edgeLabel text,
 .mermaid-viewer-lightbox .edgeLabel text {
-  fill: var(--mermaid-viewer-edge-label-text) !important;
+  fill: var(--mermaid-label-text) !important;
 }
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel span,
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel p,
@@ -408,11 +435,9 @@ a:hover {
 .mermaid-viewer-lightbox .edgeLabel span,
 .mermaid-viewer-lightbox .edgeLabel p,
 .mermaid-viewer-lightbox .edgeLabel div {
-  color: var(--mermaid-viewer-edge-label-text) !important;
+  color: var(--mermaid-label-text) !important;
 }
 .mermaid-viewer-lightbox {
-  --mermaid-viewer-edge-label-text: #24292f;
-
   position: fixed;
   inset: 0;
   z-index: 80;
@@ -422,21 +447,15 @@ a:hover {
   padding: 28px;
   background: rgba(1, 4, 9, 0.72);
 }
-:root.dark .mermaid-viewer-lightbox {
-  --mermaid-viewer-edge-label-text: #f0f6fc;
-}
 .mermaid-viewer-lightbox__panel {
   position: relative;
   width: min(96vw, 1540px);
   height: min(84vh, 760px);
   overflow: hidden;
-  background: var(--bg-inset);
+  background: var(--mermaid-bg);
   border: 2px solid color-mix(in srgb, var(--text-secondary) 72%, var(--border-default));
   border-radius: var(--radius-lg);
   box-shadow: 0 8px 24px rgba(1, 4, 9, 0.38);
-}
-:root.dark .mermaid-viewer-lightbox__panel {
-  background: #0d1117;
 }
 .mermaid-viewer-lightbox .mermaid-viewer__viewport {
   background: transparent;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -387,11 +387,6 @@ a:hover {
   color: var(--accent-green);
   border-color: color-mix(in srgb, var(--accent-green) 70%, transparent);
 }
-.mermaid-viewer__button-icon {
-  width: 18px;
-  height: 18px;
-  flex: none;
-}
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel,
 .doc-markdown pre.mermaid.mermaid-viewer .edgeLabel,
 .mermaid-viewer-lightbox .edgeLabel {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -380,6 +380,32 @@ a:hover {
   color: var(--accent-green);
   border-color: color-mix(in srgb, var(--accent-green) 70%, transparent);
 }
+.mermaid-viewer__button-icon {
+  width: 18px;
+  height: 18px;
+  flex: none;
+}
+.markdown-body pre.mermaid.mermaid-viewer .edgeLabel,
+.doc-markdown pre.mermaid.mermaid-viewer .edgeLabel,
+.mermaid-viewer-lightbox .edgeLabel {
+  color: #f0f6fc;
+}
+.markdown-body pre.mermaid.mermaid-viewer .edgeLabel text,
+.doc-markdown pre.mermaid.mermaid-viewer .edgeLabel text,
+.mermaid-viewer-lightbox .edgeLabel text {
+  fill: #f0f6fc !important;
+}
+.markdown-body pre.mermaid.mermaid-viewer .edgeLabel span,
+.markdown-body pre.mermaid.mermaid-viewer .edgeLabel p,
+.markdown-body pre.mermaid.mermaid-viewer .edgeLabel div,
+.doc-markdown pre.mermaid.mermaid-viewer .edgeLabel span,
+.doc-markdown pre.mermaid.mermaid-viewer .edgeLabel p,
+.doc-markdown pre.mermaid.mermaid-viewer .edgeLabel div,
+.mermaid-viewer-lightbox .edgeLabel span,
+.mermaid-viewer-lightbox .edgeLabel p,
+.mermaid-viewer-lightbox .edgeLabel div {
+  color: #f0f6fc !important;
+}
 .mermaid-viewer-lightbox {
   position: fixed;
   inset: 0;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -274,21 +274,211 @@ a:hover {
   background: none;
   padding: 0;
 }
-.markdown-body pre.mermaid {
-  background: var(--bg-surface);
-  text-align: center;
-}
-.markdown-body pre.mermaid svg {
-  max-width: 100%;
-  height: auto;
-}
+.markdown-body pre.mermaid,
 .doc-markdown pre.mermaid {
   background: var(--bg-surface);
   text-align: center;
 }
+.markdown-body pre.mermaid svg,
 .doc-markdown pre.mermaid svg {
   max-width: 100%;
   height: auto;
+}
+.markdown-body pre.mermaid.mermaid-viewer,
+.doc-markdown pre.mermaid.mermaid-viewer {
+  --mermaid-viewer-bg: #f6f8fa;
+  --mermaid-viewer-control-bg: rgba(36, 41, 47, 0.92);
+  --mermaid-viewer-control-hover: rgba(48, 54, 61, 0.96);
+  --mermaid-viewer-control-border: rgba(139, 148, 158, 0.48);
+  --mermaid-viewer-control-text: #f0f6fc;
+
+  position: relative;
+  height: clamp(180px, 34vw, 420px);
+  min-height: 180px;
+  padding: 0;
+  overflow: hidden;
+  background: var(--mermaid-viewer-bg);
+  border-color: var(--border-default);
+  border-radius: var(--radius-md);
+  text-align: initial;
+}
+:root.dark .markdown-body pre.mermaid.mermaid-viewer,
+:root.dark .doc-markdown pre.mermaid.mermaid-viewer {
+  --mermaid-viewer-bg: #4a4d4b;
+}
+.mermaid-viewer__viewport {
+  width: 100%;
+  height: 100%;
+  min-height: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+}
+.mermaid-viewer__viewport--dragging {
+  cursor: grabbing;
+}
+.mermaid-viewer__pan {
+  max-width: calc(100% - 28px);
+  max-height: calc(100% - 28px);
+  transform-origin: center center;
+  transition: transform 120ms ease-out;
+  will-change: transform;
+}
+.markdown-body pre.mermaid.mermaid-viewer svg,
+.doc-markdown pre.mermaid.mermaid-viewer svg {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  background: transparent;
+}
+.mermaid-viewer__controls {
+  position: absolute;
+  right: 10px;
+  z-index: 2;
+  display: grid;
+  gap: 6px;
+  pointer-events: auto;
+}
+.mermaid-viewer__controls--top {
+  top: 10px;
+  grid-template-columns: repeat(2, 34px);
+}
+.mermaid-viewer__controls--nav {
+  top: 50%;
+  grid-template-columns: repeat(3, 34px);
+  transform: translateY(-50%);
+}
+.mermaid-viewer__button,
+.mermaid-viewer__spacer {
+  width: 34px;
+  height: 34px;
+}
+.mermaid-viewer__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--mermaid-viewer-control-border);
+  border-radius: var(--radius-md);
+  background: var(--mermaid-viewer-control-bg);
+  color: var(--mermaid-viewer-control-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-lg);
+  line-height: 1;
+  box-shadow: 0 1px 4px rgba(1, 4, 9, 0.24);
+}
+.mermaid-viewer__button:hover {
+  background: var(--mermaid-viewer-control-hover);
+}
+.mermaid-viewer__button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+.mermaid-viewer__button[data-copied="true"] {
+  color: var(--accent-green);
+  border-color: color-mix(in srgb, var(--accent-green) 70%, transparent);
+}
+.mermaid-viewer-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  background: rgba(1, 4, 9, 0.72);
+}
+.mermaid-viewer-lightbox__panel {
+  position: relative;
+  width: min(96vw, 1540px);
+  height: min(84vh, 760px);
+  overflow: hidden;
+  background: var(--bg-inset);
+  border: 2px solid color-mix(in srgb, var(--text-secondary) 72%, var(--border-default));
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 24px rgba(1, 4, 9, 0.38);
+}
+:root.dark .mermaid-viewer-lightbox__panel {
+  background: #0d1117;
+}
+.mermaid-viewer-lightbox .mermaid-viewer__viewport {
+  background: transparent;
+}
+.mermaid-viewer-lightbox .mermaid-viewer__pan {
+  width: calc(100% - 96px);
+  height: calc(100% - 96px);
+  max-width: none;
+  max-height: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mermaid-viewer-lightbox svg {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+}
+.mermaid-viewer-lightbox .mermaid-viewer__controls--nav {
+  right: 24px;
+  bottom: 24px;
+  top: auto;
+  transform: none;
+}
+.mermaid-viewer-lightbox__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 3;
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  color: var(--text-secondary);
+  font-size: 28px;
+}
+.mermaid-viewer-lightbox__close:hover {
+  background: color-mix(in srgb, var(--bg-surface-hover) 76%, transparent);
+  color: var(--text-primary);
+}
+@media (prefers-reduced-motion: reduce) {
+  .mermaid-viewer__pan {
+    transition: none;
+  }
+}
+@media (max-width: 640px) {
+  .markdown-body pre.mermaid.mermaid-viewer,
+  .doc-markdown pre.mermaid.mermaid-viewer {
+    height: 240px;
+  }
+  .mermaid-viewer__controls--top,
+  .mermaid-viewer__controls--nav {
+    grid-template-columns: repeat(3, 30px);
+  }
+  .mermaid-viewer__controls--top {
+    grid-template-columns: repeat(2, 30px);
+  }
+  .mermaid-viewer__button,
+  .mermaid-viewer__spacer {
+    width: 30px;
+    height: 30px;
+  }
+  .mermaid-viewer-lightbox {
+    padding: 10px;
+  }
+  .mermaid-viewer-lightbox__panel {
+    width: 100%;
+    height: 88vh;
+  }
+  .mermaid-viewer-lightbox .mermaid-viewer__pan {
+    width: calc(100% - 32px);
+    height: calc(100% - 72px);
+  }
+  .mermaid-viewer-lightbox .mermaid-viewer__controls--nav {
+    right: 12px;
+    bottom: 12px;
+  }
 }
 .markdown-body a {
   color: var(--accent-blue);

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -321,8 +321,13 @@ a:hover {
   cursor: grabbing;
 }
 .mermaid-viewer__pan {
+  width: calc(100% - 28px);
+  height: calc(100% - 28px);
   max-width: calc(100% - 28px);
   max-height: calc(100% - 28px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transform-origin: center center;
   transition: transform 120ms ease-out;
   will-change: transform;
@@ -330,6 +335,8 @@ a:hover {
 .markdown-body pre.mermaid.mermaid-viewer svg,
 .doc-markdown pre.mermaid.mermaid-viewer svg {
   display: block;
+  width: 100%;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
   background: transparent;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -291,6 +291,7 @@ a:hover {
   --mermaid-viewer-control-hover: rgba(48, 54, 61, 0.96);
   --mermaid-viewer-control-border: rgba(139, 148, 158, 0.48);
   --mermaid-viewer-control-text: #f0f6fc;
+  --mermaid-viewer-edge-label-text: #24292f;
 
   position: relative;
   height: clamp(180px, 34vw, 420px);
@@ -305,6 +306,7 @@ a:hover {
 :root.dark .markdown-body pre.mermaid.mermaid-viewer,
 :root.dark .doc-markdown pre.mermaid.mermaid-viewer {
   --mermaid-viewer-bg: #4a4d4b;
+  --mermaid-viewer-edge-label-text: #f0f6fc;
 }
 .mermaid-viewer__viewport {
   width: 100%;
@@ -390,12 +392,12 @@ a:hover {
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel,
 .doc-markdown pre.mermaid.mermaid-viewer .edgeLabel,
 .mermaid-viewer-lightbox .edgeLabel {
-  color: #f0f6fc;
+  color: var(--mermaid-viewer-edge-label-text);
 }
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel text,
 .doc-markdown pre.mermaid.mermaid-viewer .edgeLabel text,
 .mermaid-viewer-lightbox .edgeLabel text {
-  fill: #f0f6fc !important;
+  fill: var(--mermaid-viewer-edge-label-text) !important;
 }
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel span,
 .markdown-body pre.mermaid.mermaid-viewer .edgeLabel p,
@@ -406,9 +408,11 @@ a:hover {
 .mermaid-viewer-lightbox .edgeLabel span,
 .mermaid-viewer-lightbox .edgeLabel p,
 .mermaid-viewer-lightbox .edgeLabel div {
-  color: #f0f6fc !important;
+  color: var(--mermaid-viewer-edge-label-text) !important;
 }
 .mermaid-viewer-lightbox {
+  --mermaid-viewer-edge-label-text: #24292f;
+
   position: fixed;
   inset: 0;
   z-index: 80;
@@ -417,6 +421,9 @@ a:hover {
   justify-content: center;
   padding: 28px;
   background: rgba(1, 4, 9, 0.72);
+}
+:root.dark .mermaid-viewer-lightbox {
+  --mermaid-viewer-edge-label-text: #f0f6fc;
 }
 .mermaid-viewer-lightbox__panel {
   position: relative;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -274,6 +274,22 @@ a:hover {
   background: none;
   padding: 0;
 }
+.markdown-body pre.mermaid {
+  background: var(--bg-surface);
+  text-align: center;
+}
+.markdown-body pre.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+.doc-markdown pre.mermaid {
+  background: var(--bg-surface);
+  text-align: center;
+}
+.doc-markdown pre.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
 .markdown-body a {
   color: var(--accent-blue);
 }

--- a/frontend/src/lib/api/docs/markdown.test.ts
+++ b/frontend/src/lib/api/docs/markdown.test.ts
@@ -175,6 +175,13 @@ describe("hardened rendering", () => {
     expect(html).toMatch(/<td[^>]*>done<\/td>/);
   });
 
+  test("renders mermaid fences as mermaid diagram targets", () => {
+    const html = renderDocsMarkdown("```mermaid\ngraph TD\n  A --> B\n```", baseOptions);
+
+    expect(html).toContain('<pre class="mermaid">graph TD\n  A --&gt; B</pre>');
+    expect(html).not.toContain("language-mermaid");
+  });
+
   test("images get loading=lazy and decoding=async for perf", () => {
     const html = renderDocsMarkdown("![logo](./assets/logo.png)", baseOptions);
     expect(html).toMatch(/<img[^>]+loading="lazy"/);

--- a/frontend/src/lib/api/docs/markdown.ts
+++ b/frontend/src/lib/api/docs/markdown.ts
@@ -369,6 +369,10 @@ function wikilinkAnchor(
 
 function docsRenderer(options: DocsMarkdownOptions, imageToken: string) {
   return {
+    code(token: Tokens.Code): string | false {
+      if (!isMermaidFence(token.lang)) return false;
+      return `<pre class="mermaid">${escapeHtml(token.text)}</pre>`;
+    },
     link(this: { parser: { parseInline: (tokens: Tokens.Generic[]) => string } }, token: Tokens.Link) {
       const inner = this.parser.parseInline(token.tokens ?? []);
       const href = token.href ?? "";
@@ -446,6 +450,10 @@ function docsRenderer(options: DocsMarkdownOptions, imageToken: string) {
       return `<h${level} id="${escapeAttr(id)}">${inner}</h${level}>`;
     },
   };
+}
+
+function isMermaidFence(lang: string | undefined): boolean {
+  return (lang ?? "").trim().split(/\s+/, 1)[0]?.toLowerCase() === "mermaid";
 }
 
 function isExternal(href: string): boolean {

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
 import {
   initMarkdownMermaidRendering,
   renderMarkdownMermaidDiagrams,
@@ -19,6 +19,62 @@ function renderSvgInto(nodes: ArrayLike<HTMLElement>): void {
   }
 }
 
+const TEST_THEME_VARS = {
+  light: {
+    "--font-sans": "Inter, sans-serif",
+    "--font-size-md": "13px",
+    "--mermaid-bg": "#ffffff",
+    "--mermaid-viewer-bg": "#f6f8fa",
+    "--mermaid-node-bg": "#ffffff",
+    "--mermaid-node-text": "#24292f",
+    "--mermaid-node-border": "#d0d7de",
+    "--mermaid-cluster-bg": "#f6f8fa",
+    "--mermaid-cluster-text": "#24292f",
+    "--mermaid-cluster-border": "#d0d7de",
+    "--mermaid-line": "#57606a",
+    "--mermaid-text": "#24292f",
+    "--mermaid-label-bg": "#ffffff",
+    "--mermaid-label-text": "#24292f",
+    "--mermaid-note-bg": "#fff8c5",
+    "--mermaid-note-text": "#24292f",
+    "--mermaid-note-border": "#d4a72c",
+  },
+  dark: {
+    "--font-sans": "Inter, sans-serif",
+    "--font-size-md": "13px",
+    "--mermaid-bg": "#0d1117",
+    "--mermaid-viewer-bg": "#4a4d4b",
+    "--mermaid-node-bg": "#f6f8fa",
+    "--mermaid-node-text": "#24292f",
+    "--mermaid-node-border": "#d0d7de",
+    "--mermaid-cluster-bg": "#4a4d4b",
+    "--mermaid-cluster-text": "#f0f6fc",
+    "--mermaid-cluster-border": "#4a4d4b",
+    "--mermaid-line": "#c9d1d9",
+    "--mermaid-text": "#c9d1d9",
+    "--mermaid-label-bg": "#30363d",
+    "--mermaid-label-text": "#f0f6fc",
+    "--mermaid-note-bg": "#30363d",
+    "--mermaid-note-text": "#f0f6fc",
+    "--mermaid-note-border": "#8b949e",
+  },
+} as const;
+
+const TEST_THEME_VAR_NAMES = Object.keys(TEST_THEME_VARS.light);
+
+function installMermaidThemeVars(theme: keyof typeof TEST_THEME_VARS): void {
+  const style = document.documentElement.style;
+  for (const [name, value] of Object.entries(TEST_THEME_VARS[theme])) {
+    style.setProperty(name, value);
+  }
+}
+
+function clearMermaidThemeVars(): void {
+  for (const name of TEST_THEME_VAR_NAMES) {
+    document.documentElement.style.removeProperty(name);
+  }
+}
+
 async function flushQueuedRender(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -26,7 +82,12 @@ async function flushQueuedRender(): Promise<void> {
 }
 
 describe("renderMarkdownMermaidDiagrams", () => {
+  beforeEach(() => {
+    installMermaidThemeVars("light");
+  });
+
   afterEach(() => {
+    clearMermaidThemeVars();
     document.documentElement.classList.remove("dark");
     document.querySelectorAll(".mermaid-viewer-lightbox").forEach((node) => node.remove());
   });
@@ -75,6 +136,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
   });
 
   test("uses dark mermaid theme variables when the app is in dark mode", async () => {
+    installMermaidThemeVars("dark");
     document.documentElement.classList.add("dark");
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
@@ -302,6 +364,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
         }),
       );
 
+      installMermaidThemeVars("dark");
       document.documentElement.classList.add("dark");
       await flushQueuedRender();
 

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -207,6 +207,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
         rejectOnce = false;
         for (const node of Array.from(nodes)) {
           node.dataset.processed = "true";
+          node.textContent = "Syntax error";
         }
         throw renderError;
       }
@@ -218,6 +219,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
     await expect(renderMarkdownMermaidDiagrams(root, loader)).rejects.toThrow(renderError);
     expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.mermaidRendered).toBeUndefined();
     expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.processed).toBeUndefined();
+    expect(root.querySelector<HTMLElement>("pre.mermaid")?.textContent).toBe("graph TD\nA-->B");
 
     const rendered = await renderMarkdownMermaidDiagrams(root, loader);
 
@@ -234,6 +236,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
         suppressOnce = false;
         for (const node of Array.from(nodes)) {
           node.dataset.processed = "true";
+          node.textContent = "Syntax error";
         }
         return;
       }
@@ -247,12 +250,50 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(firstRender).toBe(0);
     expect(block?.dataset.mermaidRendered).toBeUndefined();
     expect(block?.dataset.processed).toBeUndefined();
+    expect(block?.textContent).toBe("graph TD\nA-->B");
 
     const secondRender = await renderMarkdownMermaidDiagrams(root, loader);
 
     expect(secondRender).toBe(1);
     expect(mermaid.run).toHaveBeenCalledTimes(2);
     expect(block?.classList.contains("mermaid-viewer")).toBe(true);
+  });
+
+  test("leaves Mermaid blocks beyond the per-document count limit unrendered", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = `<div class="markdown-body">${Array.from(
+      { length: 26 },
+      (_, index) => `<pre class="mermaid">graph TD\nA${index}-->B${index}</pre>`,
+    ).join("")}</div>`;
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      renderSvgInto(nodes);
+    });
+    const loader = vi.fn(async () => mermaid);
+
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(rendered).toBe(25);
+    expect(mermaid.run).toHaveBeenCalledWith({
+      nodes: Array.from(root.querySelectorAll("pre.mermaid")).slice(0, 25),
+      suppressErrors: true,
+    });
+    const skipped = Array.from(root.querySelectorAll<HTMLElement>("pre")).at(-1);
+    expect(skipped?.classList.contains("mermaid")).toBe(false);
+    expect(skipped?.textContent).toBe("graph TD\nA25-->B25");
+  });
+
+  test("leaves Mermaid blocks beyond the per-document source byte limit unrendered", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = `<div class="markdown-body"><pre class="mermaid">${"A".repeat(200_001)}</pre></div>`;
+    const loader = vi.fn(async () => mermaidLoader());
+
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(rendered).toBe(0);
+    expect(loader).not.toHaveBeenCalled();
+    const skipped = root.querySelector<HTMLElement>("pre");
+    expect(skipped?.classList.contains("mermaid")).toBe(false);
+    expect(skipped?.textContent).toBe("A".repeat(200_001));
   });
 
   test("wraps rendered diagrams in viewer controls", async () => {

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test, vi } from "vite-plus/test";
-import { renderMarkdownMermaidDiagrams } from "./markdownMermaid";
+import { renderMarkdownMermaidDiagrams, type MarkdownMermaidAPI } from "./markdownMermaid";
 
-function mermaidLoader() {
+function mermaidLoader(run?: MarkdownMermaidAPI["run"]): MarkdownMermaidAPI {
+  const defaultRun: MarkdownMermaidAPI["run"] = async () => undefined;
   return {
     initialize: vi.fn(),
-    run: vi.fn().mockResolvedValue(undefined),
+    run: vi.fn(run ?? defaultRun),
   };
 }
 
@@ -51,5 +52,93 @@ describe("renderMarkdownMermaidDiagrams", () => {
 
     expect(rendered).toBe(0);
     expect(mermaid.run).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not start another render for pending mermaid blocks", async () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<div class="markdown-body"><pre class="mermaid" data-mermaid-rendered="pending">graph TD\nA-->B</pre></div>';
+    const loader = vi.fn(async () => mermaidLoader());
+
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(rendered).toBe(0);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  test("wraps rendered diagrams in viewer controls", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      for (const node of Array.from(nodes)) {
+        node.innerHTML = '<svg viewBox="0 0 120 60"><text>diagram</text></svg>';
+      }
+    });
+    const loader = vi.fn(async () => mermaid);
+
+    await renderMarkdownMermaidDiagrams(root, loader);
+
+    const pre = root.querySelector("pre.mermaid");
+    const pan = root.querySelector<HTMLElement>(".mermaid-viewer__pan");
+    expect(pre?.classList.contains("mermaid-viewer")).toBe(true);
+    expect(root.querySelector(".mermaid-viewer__viewport svg")).not.toBeNull();
+    expect(root.querySelectorAll(".mermaid-viewer__button")).toHaveLength(9);
+    expect(root.querySelector('button[aria-label="Open diagram in expanded view"]')).not.toBeNull();
+    expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1)");
+
+    root.querySelector<HTMLButtonElement>('button[aria-label="Zoom in diagram"]')?.click();
+    expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1.2)");
+
+    root.querySelector<HTMLButtonElement>('button[aria-label="Reset diagram view"]')?.click();
+    expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1)");
+  });
+
+  test("copies the original mermaid source", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="doc-markdown"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      for (const node of Array.from(nodes)) {
+        node.innerHTML = '<svg viewBox="0 0 120 60"></svg>';
+      }
+    });
+    const loader = vi.fn(async () => mermaid);
+
+    await renderMarkdownMermaidDiagrams(root, loader);
+    root.querySelector<HTMLButtonElement>('button[aria-label="Copy Mermaid source"]')?.click();
+
+    expect(writeText).toHaveBeenCalledWith("graph TD\nA-->B");
+  });
+
+  test("opens an expanded diagram overlay from the top control", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      for (const node of Array.from(nodes)) {
+        node.innerHTML = '<svg viewBox="0 0 120 60"><text>diagram</text></svg>';
+      }
+    });
+    const loader = vi.fn(async () => mermaid);
+
+    await renderMarkdownMermaidDiagrams(root, loader);
+    root.querySelector<HTMLButtonElement>('button[aria-label="Open diagram in expanded view"]')?.click();
+
+    const overlay = document.querySelector<HTMLElement>(".mermaid-viewer-lightbox");
+    const overlayPan = document.querySelector<HTMLElement>(".mermaid-viewer-lightbox .mermaid-viewer__pan");
+    expect(overlay?.getAttribute("role")).toBe("dialog");
+    expect(overlay?.getAttribute("aria-modal")).toBe("true");
+    expect(overlay?.querySelector("svg")).not.toBeNull();
+    expect(overlay?.querySelectorAll(".mermaid-viewer__controls--nav .mermaid-viewer__button")).toHaveLength(7);
+    expect(overlay?.querySelector('button[aria-label="Copy Mermaid source"]')).toBeNull();
+
+    overlay?.querySelector<HTMLButtonElement>('button[aria-label="Zoom in diagram"]')?.click();
+    expect(overlayPan?.style.transform).toBe("translate(0px, 0px) scale(1.2)");
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(document.querySelector(".mermaid-viewer-lightbox")).toBeNull();
   });
 });

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -380,4 +380,49 @@ describe("renderMarkdownMermaidDiagrams", () => {
       root.remove();
     }
   });
+
+  test("rerenders if the app theme changes during an in-flight render", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    document.body.append(root);
+    let activeRenderTheme = "light";
+    let releaseFirstRender: (() => void) | undefined;
+    let runCount = 0;
+    const run = vi.fn<MarkdownMermaidAPI["run"]>(async ({ nodes }) => {
+      runCount += 1;
+      const renderTheme = activeRenderTheme;
+      if (runCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirstRender = resolve;
+        });
+      }
+      for (const node of Array.from(nodes)) {
+        node.innerHTML = `<svg data-theme="${renderTheme}" viewBox="0 0 120 60"><text>diagram</text></svg>`;
+      }
+    });
+    const mermaid = mermaidLoader(run);
+    vi.mocked(mermaid.initialize).mockImplementation((config) => {
+      activeRenderTheme = config.themeVariables.darkMode === true ? "dark" : "light";
+    });
+    const loader = vi.fn(async () => mermaid);
+    const controller = initMarkdownMermaidRendering(root, loader);
+
+    try {
+      await flushQueuedRender();
+      expect(mermaid.run).toHaveBeenCalledTimes(1);
+
+      installMermaidThemeVars("dark");
+      document.documentElement.classList.add("dark");
+      await flushQueuedRender();
+      releaseFirstRender?.();
+      await flushQueuedRender();
+      await flushQueuedRender();
+
+      expect(root.querySelector("svg")?.getAttribute("data-theme")).toBe("dark");
+      expect(mermaid.run).toHaveBeenCalledTimes(2);
+    } finally {
+      controller.disconnect();
+      root.remove();
+    }
+  });
 });

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test, vi } from "vite-plus/test";
-import { renderMarkdownMermaidDiagrams, type MarkdownMermaidAPI } from "./markdownMermaid";
+import { afterEach, describe, expect, test, vi } from "vite-plus/test";
+import {
+  initMarkdownMermaidRendering,
+  renderMarkdownMermaidDiagrams,
+  type MarkdownMermaidAPI,
+} from "./markdownMermaid";
 
 function mermaidLoader(run?: MarkdownMermaidAPI["run"]): MarkdownMermaidAPI {
   const defaultRun: MarkdownMermaidAPI["run"] = async () => undefined;
@@ -15,7 +19,18 @@ function renderSvgInto(nodes: ArrayLike<HTMLElement>): void {
   }
 }
 
+async function flushQueuedRender(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+}
+
 describe("renderMarkdownMermaidDiagrams", () => {
+  afterEach(() => {
+    document.documentElement.classList.remove("dark");
+    document.querySelectorAll(".mermaid-viewer-lightbox").forEach((node) => node.remove());
+  });
+
   test("does not load mermaid when the rendered markdown has no mermaid diagrams", async () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre><code>plain code</code></pre></div>';
@@ -44,6 +59,38 @@ describe("renderMarkdownMermaidDiagrams", () => {
       secure: ["securityLevel", "startOnLoad"],
       theme: "base",
       themeVariables: expect.objectContaining({
+        background: "#ffffff",
+        clusterBkg: "#f6f8fa",
+        darkMode: false,
+        edgeLabelBackground: "#ffffff",
+        labelTextColor: "#24292f",
+        lineColor: "#57606a",
+        primaryColor: "#ffffff",
+      }),
+    });
+    expect(mermaid.run).toHaveBeenCalledWith({
+      nodes: [root.querySelector("pre.mermaid")],
+      suppressErrors: true,
+    });
+  });
+
+  test("uses dark mermaid theme variables when the app is in dark mode", async () => {
+    document.documentElement.classList.add("dark");
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      renderSvgInto(nodes);
+    });
+    const loader = vi.fn(async () => mermaid);
+
+    await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(mermaid.initialize).toHaveBeenCalledWith({
+      startOnLoad: false,
+      securityLevel: "strict",
+      secure: ["securityLevel", "startOnLoad"],
+      theme: "base",
+      themeVariables: expect.objectContaining({
         background: "#0d1117",
         clusterBkg: "#4a4d4b",
         darkMode: true,
@@ -52,10 +99,6 @@ describe("renderMarkdownMermaidDiagrams", () => {
         lineColor: "#c9d1d9",
         primaryColor: "#f6f8fa",
       }),
-    });
-    expect(mermaid.run).toHaveBeenCalledWith({
-      nodes: [root.querySelector("pre.mermaid")],
-      suppressErrors: true,
     });
   });
 
@@ -233,5 +276,45 @@ describe("renderMarkdownMermaidDiagrams", () => {
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(document.querySelector(".mermaid-viewer-lightbox")).toBeNull();
+  });
+
+  test("rerenders diagrams when the app theme changes", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    document.body.append(root);
+    let renderCount = 0;
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      renderCount += 1;
+      for (const node of Array.from(nodes)) {
+        node.innerHTML = `<svg data-render="${renderCount}" viewBox="0 0 120 60"><text>diagram</text></svg>`;
+      }
+    });
+    const loader = vi.fn(async () => mermaid);
+    const controller = initMarkdownMermaidRendering(root, loader);
+
+    try {
+      await flushQueuedRender();
+
+      expect(root.querySelector("svg")?.getAttribute("data-render")).toBe("1");
+      expect(mermaid.initialize).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          themeVariables: expect.objectContaining({ darkMode: false }),
+        }),
+      );
+
+      document.documentElement.classList.add("dark");
+      await flushQueuedRender();
+
+      expect(root.querySelector("svg")?.getAttribute("data-render")).toBe("2");
+      expect(mermaid.run).toHaveBeenCalledTimes(2);
+      expect(mermaid.initialize).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          themeVariables: expect.objectContaining({ darkMode: true }),
+        }),
+      );
+    } finally {
+      controller.disconnect();
+      root.remove();
+    }
   });
 });

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -89,17 +89,29 @@ describe("renderMarkdownMermaidDiagrams", () => {
     await renderMarkdownMermaidDiagrams(root, loader);
 
     const pre = root.querySelector("pre.mermaid");
+    const viewport = root.querySelector<HTMLElement>(".mermaid-viewer__viewport");
     const pan = root.querySelector<HTMLElement>(".mermaid-viewer__pan");
     expect(pre?.classList.contains("mermaid-viewer")).toBe(true);
     expect(root.querySelector(".mermaid-viewer__viewport svg")).not.toBeNull();
-    expect(root.querySelectorAll(".mermaid-viewer__button")).toHaveLength(9);
+    expect(root.querySelectorAll(".mermaid-viewer__button")).toHaveLength(7);
+    expect(root.querySelector('button[aria-label="Zoom in diagram"]')).toBeNull();
+    expect(root.querySelector('button[aria-label="Zoom out diagram"]')).toBeNull();
     const expandButton = root.querySelector<HTMLButtonElement>('button[aria-label="Open diagram in expanded view"]');
     expect(expandButton?.querySelector("svg")).not.toBeNull();
     expect(expandButton?.textContent?.trim()).toBe("");
     expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1)");
 
-    root.querySelector<HTMLButtonElement>('button[aria-label="Zoom in diagram"]')?.click();
-    expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1.2)");
+    Object.defineProperty(viewport, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ bottom: 60, height: 60, left: 0, right: 120, top: 0, width: 120, x: 0, y: 0 }),
+    });
+    const wheelZoomIn = new WheelEvent("wheel", { cancelable: true, clientX: 60, clientY: 30, deltaY: -100 });
+    expect(viewport?.dispatchEvent(wheelZoomIn)).toBe(false);
+    expect(wheelZoomIn.defaultPrevented).toBe(true);
+    expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1.16)");
+
+    root.querySelector<HTMLButtonElement>('button[aria-label="Pan diagram right"]')?.click();
+    expect(pan?.style.transform).toBe("translate(80px, 0px) scale(1.16)");
 
     root.querySelector<HTMLButtonElement>('button[aria-label="Reset diagram view"]')?.click();
     expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1)");
@@ -140,15 +152,22 @@ describe("renderMarkdownMermaidDiagrams", () => {
     root.querySelector<HTMLButtonElement>('button[aria-label="Open diagram in expanded view"]')?.click();
 
     const overlay = document.querySelector<HTMLElement>(".mermaid-viewer-lightbox");
+    const overlayViewport = document.querySelector<HTMLElement>(".mermaid-viewer-lightbox .mermaid-viewer__viewport");
     const overlayPan = document.querySelector<HTMLElement>(".mermaid-viewer-lightbox .mermaid-viewer__pan");
     expect(overlay?.getAttribute("role")).toBe("dialog");
     expect(overlay?.getAttribute("aria-modal")).toBe("true");
     expect(overlay?.querySelector("svg")).not.toBeNull();
-    expect(overlay?.querySelectorAll(".mermaid-viewer__controls--nav .mermaid-viewer__button")).toHaveLength(7);
+    expect(overlay?.querySelectorAll(".mermaid-viewer__controls--nav .mermaid-viewer__button")).toHaveLength(5);
     expect(overlay?.querySelector('button[aria-label="Copy Mermaid source"]')).toBeNull();
+    expect(overlay?.querySelector('button[aria-label="Zoom in diagram"]')).toBeNull();
 
-    overlay?.querySelector<HTMLButtonElement>('button[aria-label="Zoom in diagram"]')?.click();
-    expect(overlayPan?.style.transform).toBe("translate(0px, 0px) scale(1.2)");
+    Object.defineProperty(overlayViewport, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ bottom: 60, height: 60, left: 0, right: 120, top: 0, width: 120, x: 0, y: 0 }),
+    });
+    const wheelZoomIn = new WheelEvent("wheel", { cancelable: true, clientX: 60, clientY: 30, deltaY: -100 });
+    expect(overlayViewport?.dispatchEvent(wheelZoomIn)).toBe(false);
+    expect(overlayPan?.style.transform).toBe("translate(0px, 0px) scale(1.16)");
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(document.querySelector(".mermaid-viewer-lightbox")).toBeNull();

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -39,6 +39,8 @@ describe("renderMarkdownMermaidDiagrams", () => {
         background: "#0d1117",
         clusterBkg: "#4a4d4b",
         darkMode: true,
+        edgeLabelBackground: "#30363d",
+        labelTextColor: "#f0f6fc",
         lineColor: "#c9d1d9",
         primaryColor: "#f6f8fa",
       }),
@@ -91,7 +93,9 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(pre?.classList.contains("mermaid-viewer")).toBe(true);
     expect(root.querySelector(".mermaid-viewer__viewport svg")).not.toBeNull();
     expect(root.querySelectorAll(".mermaid-viewer__button")).toHaveLength(9);
-    expect(root.querySelector('button[aria-label="Open diagram in expanded view"]')).not.toBeNull();
+    const expandButton = root.querySelector<HTMLButtonElement>('button[aria-label="Open diagram in expanded view"]');
+    expect(expandButton?.querySelector("svg")).not.toBeNull();
+    expect(expandButton?.textContent?.trim()).toBe("");
     expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1)");
 
     root.querySelector<HTMLButtonElement>('button[aria-label="Zoom in diagram"]')?.click();

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, vi } from "vite-plus/test";
+import { renderMarkdownMermaidDiagrams } from "./markdownMermaid";
+
+function mermaidLoader() {
+  return {
+    initialize: vi.fn(),
+    run: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("renderMarkdownMermaidDiagrams", () => {
+  test("does not load mermaid when the rendered markdown has no mermaid diagrams", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre><code>plain code</code></pre></div>';
+    const loader = vi.fn(async () => mermaidLoader());
+
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(rendered).toBe(0);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  test("runs mermaid against unrendered markdown diagram blocks", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const mermaid = mermaidLoader();
+    const loader = vi.fn(async () => mermaid);
+
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(rendered).toBe(1);
+    expect(mermaid.initialize).toHaveBeenCalledWith({
+      startOnLoad: false,
+      securityLevel: "strict",
+      secure: ["securityLevel", "startOnLoad"],
+    });
+    expect(mermaid.run).toHaveBeenCalledWith({
+      nodes: [root.querySelector("pre.mermaid")],
+      suppressErrors: true,
+    });
+  });
+
+  test("does not render the same mermaid block twice", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="doc-markdown"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const mermaid = mermaidLoader();
+    const loader = vi.fn(async () => mermaid);
+
+    await renderMarkdownMermaidDiagrams(root, loader);
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(rendered).toBe(0);
+    expect(mermaid.run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -9,6 +9,12 @@ function mermaidLoader(run?: MarkdownMermaidAPI["run"]): MarkdownMermaidAPI {
   };
 }
 
+function renderSvgInto(nodes: ArrayLike<HTMLElement>): void {
+  for (const node of Array.from(nodes)) {
+    node.innerHTML = '<svg viewBox="0 0 120 60"><text>diagram</text></svg>';
+  }
+}
+
 describe("renderMarkdownMermaidDiagrams", () => {
   test("does not load mermaid when the rendered markdown has no mermaid diagrams", async () => {
     const root = document.createElement("div");
@@ -24,7 +30,9 @@ describe("renderMarkdownMermaidDiagrams", () => {
   test("runs mermaid against unrendered markdown diagram blocks", async () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
-    const mermaid = mermaidLoader();
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      renderSvgInto(nodes);
+    });
     const loader = vi.fn(async () => mermaid);
 
     const rendered = await renderMarkdownMermaidDiagrams(root, loader);
@@ -54,7 +62,9 @@ describe("renderMarkdownMermaidDiagrams", () => {
   test("does not render the same mermaid block twice", async () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="doc-markdown"><pre class="mermaid">graph TD\nA-->B</pre></div>';
-    const mermaid = mermaidLoader();
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      renderSvgInto(nodes);
+    });
     const loader = vi.fn(async () => mermaid);
 
     await renderMarkdownMermaidDiagrams(root, loader);
@@ -80,12 +90,23 @@ describe("renderMarkdownMermaidDiagrams", () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
     const renderError = new Error("render failed");
-    const run = vi.fn<MarkdownMermaidAPI["run"]>().mockRejectedValueOnce(renderError).mockResolvedValueOnce(undefined);
+    let rejectOnce = true;
+    const run = vi.fn<MarkdownMermaidAPI["run"]>(async ({ nodes }) => {
+      if (rejectOnce) {
+        rejectOnce = false;
+        for (const node of Array.from(nodes)) {
+          node.dataset.processed = "true";
+        }
+        throw renderError;
+      }
+      renderSvgInto(nodes);
+    });
     const mermaid = mermaidLoader(run);
     const loader = vi.fn(async () => mermaid);
 
     await expect(renderMarkdownMermaidDiagrams(root, loader)).rejects.toThrow(renderError);
     expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.mermaidRendered).toBeUndefined();
+    expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.processed).toBeUndefined();
 
     const rendered = await renderMarkdownMermaidDiagrams(root, loader);
 
@@ -93,13 +114,41 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(mermaid.run).toHaveBeenCalledTimes(2);
   });
 
+  test("allows suppressed mermaid render failures to be retried", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    let suppressOnce = true;
+    const run = vi.fn<MarkdownMermaidAPI["run"]>(async ({ nodes }) => {
+      if (suppressOnce) {
+        suppressOnce = false;
+        for (const node of Array.from(nodes)) {
+          node.dataset.processed = "true";
+        }
+        return;
+      }
+      renderSvgInto(nodes);
+    });
+    const mermaid = mermaidLoader(run);
+    const loader = vi.fn(async () => mermaid);
+
+    const firstRender = await renderMarkdownMermaidDiagrams(root, loader);
+    const block = root.querySelector<HTMLElement>("pre.mermaid");
+    expect(firstRender).toBe(0);
+    expect(block?.dataset.mermaidRendered).toBeUndefined();
+    expect(block?.dataset.processed).toBeUndefined();
+
+    const secondRender = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(secondRender).toBe(1);
+    expect(mermaid.run).toHaveBeenCalledTimes(2);
+    expect(block?.classList.contains("mermaid-viewer")).toBe(true);
+  });
+
   test("wraps rendered diagrams in viewer controls", async () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
     const mermaid = mermaidLoader(async ({ nodes }) => {
-      for (const node of Array.from(nodes)) {
-        node.innerHTML = '<svg viewBox="0 0 120 60"><text>diagram</text></svg>';
-      }
+      renderSvgInto(nodes);
     });
     const loader = vi.fn(async () => mermaid);
 
@@ -143,9 +192,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
       value: { writeText },
     });
     const mermaid = mermaidLoader(async ({ nodes }) => {
-      for (const node of Array.from(nodes)) {
-        node.innerHTML = '<svg viewBox="0 0 120 60"></svg>';
-      }
+      renderSvgInto(nodes);
     });
     const loader = vi.fn(async () => mermaid);
 
@@ -159,9 +206,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
     const mermaid = mermaidLoader(async ({ nodes }) => {
-      for (const node of Array.from(nodes)) {
-        node.innerHTML = '<svg viewBox="0 0 120 60"><text>diagram</text></svg>';
-      }
+      renderSvgInto(nodes);
     });
     const loader = vi.fn(async () => mermaid);
 

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -117,7 +117,10 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(mermaid.initialize).toHaveBeenCalledWith({
       startOnLoad: false,
       securityLevel: "strict",
-      secure: ["securityLevel", "startOnLoad"],
+      secure: ["secure", "securityLevel", "startOnLoad", "maxTextSize", "suppressErrorRendering", "maxEdges"],
+      maxTextSize: 50_000,
+      maxEdges: 500,
+      suppressErrorRendering: true,
       theme: "base",
       themeVariables: expect.objectContaining({
         background: "#ffffff",
@@ -150,7 +153,10 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(mermaid.initialize).toHaveBeenCalledWith({
       startOnLoad: false,
       securityLevel: "strict",
-      secure: ["securityLevel", "startOnLoad"],
+      secure: ["secure", "securityLevel", "startOnLoad", "maxTextSize", "suppressErrorRendering", "maxEdges"],
+      maxTextSize: 50_000,
+      maxEdges: 500,
+      suppressErrorRendering: true,
       theme: "base",
       themeVariables: expect.objectContaining({
         background: "#0d1117",

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -117,10 +117,30 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(mermaid.initialize).toHaveBeenCalledWith({
       startOnLoad: false,
       securityLevel: "strict",
-      secure: ["secure", "securityLevel", "startOnLoad", "maxTextSize", "suppressErrorRendering", "maxEdges"],
+      secure: [
+        "secure",
+        "securityLevel",
+        "startOnLoad",
+        "maxTextSize",
+        "suppressErrorRendering",
+        "maxEdges",
+        "dompurifyConfig",
+        "htmlLabels",
+        "themeCSS",
+        "fontFamily",
+        "altFontFamily",
+      ],
       maxTextSize: 50_000,
       maxEdges: 500,
       suppressErrorRendering: true,
+      dompurifyConfig: {
+        FORBID_ATTR: ["style"],
+        FORBID_TAGS: ["style"],
+      },
+      htmlLabels: false,
+      themeCSS: "",
+      fontFamily: "Inter, sans-serif",
+      altFontFamily: "Inter, sans-serif",
       theme: "base",
       themeVariables: expect.objectContaining({
         background: "#ffffff",
@@ -153,10 +173,30 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(mermaid.initialize).toHaveBeenCalledWith({
       startOnLoad: false,
       securityLevel: "strict",
-      secure: ["secure", "securityLevel", "startOnLoad", "maxTextSize", "suppressErrorRendering", "maxEdges"],
+      secure: [
+        "secure",
+        "securityLevel",
+        "startOnLoad",
+        "maxTextSize",
+        "suppressErrorRendering",
+        "maxEdges",
+        "dompurifyConfig",
+        "htmlLabels",
+        "themeCSS",
+        "fontFamily",
+        "altFontFamily",
+      ],
       maxTextSize: 50_000,
       maxEdges: 500,
       suppressErrorRendering: true,
+      dompurifyConfig: {
+        FORBID_ATTR: ["style"],
+        FORBID_TAGS: ["style"],
+      },
+      htmlLabels: false,
+      themeCSS: "",
+      fontFamily: "Inter, sans-serif",
+      altFontFamily: "Inter, sans-serif",
       theme: "base",
       themeVariables: expect.objectContaining({
         background: "#0d1117",
@@ -197,7 +237,7 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(loader).not.toHaveBeenCalled();
   });
 
-  test("allows failed mermaid renders to be retried", async () => {
+  test("restores the source and holds failed mermaid renders until the source changes", async () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
     const renderError = new Error("render failed");
@@ -217,17 +257,21 @@ describe("renderMarkdownMermaidDiagrams", () => {
     const loader = vi.fn(async () => mermaid);
 
     await expect(renderMarkdownMermaidDiagrams(root, loader)).rejects.toThrow(renderError);
-    expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.mermaidRendered).toBeUndefined();
+    expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.mermaidRendered).toBe("failed");
     expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.processed).toBeUndefined();
     expect(root.querySelector<HTMLElement>("pre.mermaid")?.textContent).toBe("graph TD\nA-->B");
 
-    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+    const unchangedRender = await renderMarkdownMermaidDiagrams(root, loader);
+    expect(unchangedRender).toBe(0);
 
+    const block = root.querySelector<HTMLElement>("pre.mermaid");
+    if (block) block.textContent = "graph TD\nA-->C";
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
     expect(rendered).toBe(1);
     expect(mermaid.run).toHaveBeenCalledTimes(2);
   });
 
-  test("allows suppressed mermaid render failures to be retried", async () => {
+  test("restores the source and holds suppressed mermaid render failures until the source changes", async () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
     let suppressOnce = true;
@@ -248,12 +292,15 @@ describe("renderMarkdownMermaidDiagrams", () => {
     const firstRender = await renderMarkdownMermaidDiagrams(root, loader);
     const block = root.querySelector<HTMLElement>("pre.mermaid");
     expect(firstRender).toBe(0);
-    expect(block?.dataset.mermaidRendered).toBeUndefined();
+    expect(block?.dataset.mermaidRendered).toBe("failed");
     expect(block?.dataset.processed).toBeUndefined();
     expect(block?.textContent).toBe("graph TD\nA-->B");
 
-    const secondRender = await renderMarkdownMermaidDiagrams(root, loader);
+    const unchangedRender = await renderMarkdownMermaidDiagrams(root, loader);
+    expect(unchangedRender).toBe(0);
 
+    if (block) block.textContent = "graph TD\nA-->C";
+    const secondRender = await renderMarkdownMermaidDiagrams(root, loader);
     expect(secondRender).toBe(1);
     expect(mermaid.run).toHaveBeenCalledTimes(2);
     expect(block?.classList.contains("mermaid-viewer")).toBe(true);

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -34,6 +34,14 @@ describe("renderMarkdownMermaidDiagrams", () => {
       startOnLoad: false,
       securityLevel: "strict",
       secure: ["securityLevel", "startOnLoad"],
+      theme: "base",
+      themeVariables: expect.objectContaining({
+        background: "#0d1117",
+        clusterBkg: "#4a4d4b",
+        darkMode: true,
+        lineColor: "#c9d1d9",
+        primaryColor: "#f6f8fa",
+      }),
     });
     expect(mermaid.run).toHaveBeenCalledWith({
       nodes: [root.querySelector("pre.mermaid")],

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { getStackDepth, getTopFrame, resetModalStack } from "@middleman/ui/stores/keyboard/modal-stack";
 import {
   initMarkdownMermaidRendering,
   renderMarkdownMermaidDiagrams,
@@ -83,10 +84,12 @@ async function flushQueuedRender(): Promise<void> {
 
 describe("renderMarkdownMermaidDiagrams", () => {
   beforeEach(() => {
+    resetModalStack();
     installMermaidThemeVars("light");
   });
 
   afterEach(() => {
+    resetModalStack();
     clearMermaidThemeVars();
     document.documentElement.classList.remove("dark");
     document.querySelectorAll(".mermaid-viewer-lightbox").forEach((node) => node.remove());
@@ -432,6 +435,38 @@ describe("renderMarkdownMermaidDiagrams", () => {
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     expect(document.querySelector(".mermaid-viewer-lightbox")).toBeNull();
+  });
+
+  test("blocks global shortcuts while the expanded diagram overlay is open", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const mermaid = mermaidLoader(async ({ nodes }) => {
+      renderSvgInto(nodes);
+    });
+    const loader = vi.fn(async () => mermaid);
+    const windowShortcut = vi.fn();
+    window.addEventListener("keydown", windowShortcut);
+
+    try {
+      await renderMarkdownMermaidDiagrams(root, loader);
+      root.querySelector<HTMLButtonElement>('button[aria-label="Open diagram in expanded view"]')?.click();
+
+      const overlay = document.querySelector<HTMLElement>(".mermaid-viewer-lightbox");
+      const closeButton = overlay?.querySelector<HTMLButtonElement>('button[aria-label="Close expanded diagram"]');
+      expect(getTopFrame()?.frameId).toBe("mermaid-lightbox");
+      expect(getStackDepth()).toBe(1);
+
+      closeButton?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "1" }));
+      expect(windowShortcut).not.toHaveBeenCalled();
+
+      const escape = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Escape" });
+      closeButton?.dispatchEvent(escape);
+      expect(escape.defaultPrevented).toBe(true);
+      expect(document.querySelector(".mermaid-viewer-lightbox")).toBeNull();
+      expect(getStackDepth()).toBe(0);
+    } finally {
+      window.removeEventListener("keydown", windowShortcut);
+    }
   });
 
   test("rerenders diagrams when the app theme changes", async () => {

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -76,6 +76,23 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(loader).not.toHaveBeenCalled();
   });
 
+  test("allows failed mermaid renders to be retried", async () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
+    const renderError = new Error("render failed");
+    const run = vi.fn<MarkdownMermaidAPI["run"]>().mockRejectedValueOnce(renderError).mockResolvedValueOnce(undefined);
+    const mermaid = mermaidLoader(run);
+    const loader = vi.fn(async () => mermaid);
+
+    await expect(renderMarkdownMermaidDiagrams(root, loader)).rejects.toThrow(renderError);
+    expect(root.querySelector<HTMLElement>("pre.mermaid")?.dataset.mermaidRendered).toBeUndefined();
+
+    const rendered = await renderMarkdownMermaidDiagrams(root, loader);
+
+    expect(rendered).toBe(1);
+    expect(mermaid.run).toHaveBeenCalledTimes(2);
+  });
+
   test("wraps rendered diagrams in viewer controls", async () => {
     const root = document.createElement("div");
     root.innerHTML = '<div class="markdown-body"><pre class="mermaid">graph TD\nA-->B</pre></div>';
@@ -97,8 +114,8 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(root.querySelector('button[aria-label="Zoom in diagram"]')).toBeNull();
     expect(root.querySelector('button[aria-label="Zoom out diagram"]')).toBeNull();
     const expandButton = root.querySelector<HTMLButtonElement>('button[aria-label="Open diagram in expanded view"]');
-    expect(expandButton?.querySelector("svg")).not.toBeNull();
-    expect(expandButton?.textContent?.trim()).toBe("");
+    expect(expandButton?.querySelector("svg")).toBeNull();
+    expect(expandButton?.textContent?.trim()).toBe("⟷");
     expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1)");
 
     Object.defineProperty(viewport, "getBoundingClientRect", {

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -24,8 +24,10 @@ const MERMAID_SELECTOR = ".markdown-body pre.mermaid, .doc-markdown pre.mermaid"
 const MERMAID_VIEWER_ATTACHED = "true";
 const MIN_SCALE = 0.4;
 const MAX_SCALE = 3;
-const ZOOM_STEP = 0.2;
 const PAN_STEP = 80;
+const WHEEL_ZOOM_SENSITIVITY = 0.0015;
+const WHEEL_DELTA_LINE = 1;
+const WHEEL_DELTA_PAGE = 2;
 const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
   darkMode: true,
   background: "#0d1117",
@@ -161,8 +163,13 @@ function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivEleme
     updateTransform();
   };
 
-  const zoomBy = (delta: number) => {
-    scale = clampScale(scale + delta);
+  const zoomTo = (nextScale: number, originX: number, originY: number) => {
+    nextScale = clampScale(nextScale);
+    if (nextScale === scale) return;
+    const scaleRatio = nextScale / scale;
+    offsetX = originX - (originX - offsetX) * scaleRatio;
+    offsetY = originY - (originY - offsetY) * scaleRatio;
+    scale = nextScale;
     updateTransform();
   };
 
@@ -175,7 +182,6 @@ function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivEleme
   const controls = createMermaidNavControls({
     panBy,
     resetView,
-    zoomBy,
   });
 
   attachDragPanning(viewport, {
@@ -183,6 +189,16 @@ function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivEleme
       offsetX += deltaX;
       offsetY += deltaY;
       updateTransform();
+    },
+  });
+  attachWheelZoom(viewport, {
+    onZoom(event) {
+      const rect = viewport.getBoundingClientRect();
+      zoomTo(
+        scale * Math.exp(-normalizeWheelDelta(event, viewport) * WHEEL_ZOOM_SENSITIVITY),
+        event.clientX - rect.left - rect.width / 2,
+        event.clientY - rect.top - rect.height / 2,
+      );
     },
   });
 
@@ -196,20 +212,19 @@ function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivEleme
 function createMermaidNavControls(actions: {
   panBy: (deltaX: number, deltaY: number) => void;
   resetView: () => void;
-  zoomBy: (delta: number) => void;
 }): HTMLDivElement {
   const navControls = document.createElement("div");
   navControls.className = "mermaid-viewer__controls mermaid-viewer__controls--nav";
   navControls.append(
     createMermaidSpacer(),
     createMermaidButton("Pan diagram up", "↑", () => actions.panBy(0, -PAN_STEP)),
-    createMermaidButton("Zoom in diagram", "+", () => actions.zoomBy(ZOOM_STEP)),
+    createMermaidSpacer(),
     createMermaidButton("Pan diagram left", "←", () => actions.panBy(-PAN_STEP, 0)),
     createMermaidButton("Reset diagram view", "⟳", actions.resetView),
     createMermaidButton("Pan diagram right", "→", () => actions.panBy(PAN_STEP, 0)),
     createMermaidSpacer(),
     createMermaidButton("Pan diagram down", "↓", () => actions.panBy(0, PAN_STEP)),
-    createMermaidButton("Zoom out diagram", "-", () => actions.zoomBy(-ZOOM_STEP)),
+    createMermaidSpacer(),
   );
   return navControls;
 }
@@ -363,6 +378,24 @@ function attachDragPanning(viewport: HTMLElement, drag: { onDrag: (deltaX: numbe
 
   viewport.addEventListener("pointerup", endDrag);
   viewport.addEventListener("pointercancel", endDrag);
+}
+
+function attachWheelZoom(viewport: HTMLElement, zoom: { onZoom: (event: WheelEvent) => void }): void {
+  viewport.addEventListener(
+    "wheel",
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      zoom.onZoom(event);
+    },
+    { passive: false },
+  );
+}
+
+function normalizeWheelDelta(event: WheelEvent, viewport: HTMLElement): number {
+  if (event.deltaMode === WHEEL_DELTA_LINE) return event.deltaY * 16;
+  if (event.deltaMode === WHEEL_DELTA_PAGE) return event.deltaY * (viewport.clientHeight || window.innerHeight || 800);
+  return event.deltaY;
 }
 
 function clampScale(value: number): number {

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -11,8 +11,15 @@ export interface MarkdownMermaidController {
 }
 
 const MERMAID_SELECTOR = ".markdown-body pre.mermaid, .doc-markdown pre.mermaid";
+const MERMAID_VIEWER_ATTACHED = "true";
+const MIN_SCALE = 0.4;
+const MAX_SCALE = 3;
+const ZOOM_STEP = 0.2;
+const PAN_STEP = 80;
 let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
 const initializedMermaid = new WeakSet<MarkdownMermaidAPI>();
+const diagramSources = new WeakMap<HTMLElement, string>();
+let closeActiveMermaidLightbox: (() => void) | null = null;
 
 async function loadMermaid(): Promise<MarkdownMermaidAPI> {
   if (!mermaidPromise) {
@@ -26,12 +33,13 @@ export async function renderMarkdownMermaidDiagrams(
   load: MarkdownMermaidLoader = loadMermaid,
 ): Promise<number> {
   const nodes = Array.from(root.querySelectorAll<HTMLElement>(MERMAID_SELECTOR)).filter(
-    (node) => node.dataset.mermaidRendered !== "true" && node.dataset.processed !== "true",
+    (node) => !node.dataset.mermaidRendered && node.dataset.processed !== "true",
   );
   if (nodes.length === 0) return 0;
 
   for (const node of nodes) {
     node.dataset.mermaidRendered = "pending";
+    diagramSources.set(node, node.textContent ?? "");
   }
 
   try {
@@ -45,6 +53,9 @@ export async function renderMarkdownMermaidDiagrams(
       initializedMermaid.add(mermaid);
     }
     await mermaid.run({ nodes, suppressErrors: true });
+    for (const node of nodes) {
+      attachMermaidViewer(node, diagramSources.get(node) ?? "");
+    }
   } finally {
     for (const node of nodes) {
       node.dataset.mermaidRendered = "true";
@@ -52,6 +63,227 @@ export async function renderMarkdownMermaidDiagrams(
   }
 
   return nodes.length;
+}
+
+function attachMermaidViewer(node: HTMLElement, source: string): void {
+  if (node.dataset.mermaidViewer === MERMAID_VIEWER_ATTACHED) return;
+
+  const svg = node.querySelector("svg");
+  if (!svg) return;
+
+  svg.remove();
+  const diagramView = createPannableDiagramView(svg);
+  const expandButton = createMermaidButton("Open diagram in expanded view", "↔", () => openMermaidLightbox(svg));
+  const copyButton = createMermaidButton("Copy Mermaid source", "⧉", () => copyMermaidSource(source, copyButton));
+  const topControls = document.createElement("div");
+  topControls.className = "mermaid-viewer__controls mermaid-viewer__controls--top";
+  topControls.append(expandButton, copyButton);
+
+  node.textContent = "";
+  node.classList.add("mermaid-viewer");
+  node.dataset.mermaidViewer = MERMAID_VIEWER_ATTACHED;
+  node.append(diagramView.viewport, topControls, diagramView.controls);
+}
+
+function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivElement; viewport: HTMLDivElement } {
+  let scale = 1;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  const viewport = document.createElement("div");
+  viewport.className = "mermaid-viewer__viewport";
+
+  const pan = document.createElement("div");
+  pan.className = "mermaid-viewer__pan";
+
+  const updateTransform = () => {
+    pan.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${formatScale(scale)})`;
+  };
+
+  const resetView = () => {
+    scale = 1;
+    offsetX = 0;
+    offsetY = 0;
+    updateTransform();
+  };
+
+  const zoomBy = (delta: number) => {
+    scale = clampScale(scale + delta);
+    updateTransform();
+  };
+
+  const panBy = (deltaX: number, deltaY: number) => {
+    offsetX += deltaX;
+    offsetY += deltaY;
+    updateTransform();
+  };
+
+  const controls = createMermaidNavControls({
+    panBy,
+    resetView,
+    zoomBy,
+  });
+
+  attachDragPanning(viewport, {
+    onDrag(deltaX, deltaY) {
+      offsetX += deltaX;
+      offsetY += deltaY;
+      updateTransform();
+    },
+  });
+
+  pan.append(svg);
+  viewport.append(pan);
+  updateTransform();
+
+  return { controls, viewport };
+}
+
+function createMermaidNavControls(actions: {
+  panBy: (deltaX: number, deltaY: number) => void;
+  resetView: () => void;
+  zoomBy: (delta: number) => void;
+}): HTMLDivElement {
+  const navControls = document.createElement("div");
+  navControls.className = "mermaid-viewer__controls mermaid-viewer__controls--nav";
+  navControls.append(
+    createMermaidSpacer(),
+    createMermaidButton("Pan diagram up", "↑", () => actions.panBy(0, -PAN_STEP)),
+    createMermaidButton("Zoom in diagram", "+", () => actions.zoomBy(ZOOM_STEP)),
+    createMermaidButton("Pan diagram left", "←", () => actions.panBy(-PAN_STEP, 0)),
+    createMermaidButton("Reset diagram view", "⟳", actions.resetView),
+    createMermaidButton("Pan diagram right", "→", () => actions.panBy(PAN_STEP, 0)),
+    createMermaidSpacer(),
+    createMermaidButton("Pan diagram down", "↓", () => actions.panBy(0, PAN_STEP)),
+    createMermaidButton("Zoom out diagram", "-", () => actions.zoomBy(-ZOOM_STEP)),
+  );
+  return navControls;
+}
+
+function openMermaidLightbox(svg: SVGSVGElement): void {
+  closeActiveMermaidLightbox?.();
+
+  const overlay = document.createElement("div");
+  overlay.className = "mermaid-viewer-lightbox";
+  overlay.setAttribute("aria-label", "Expanded Mermaid diagram");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("role", "dialog");
+
+  const panel = document.createElement("div");
+  panel.className = "mermaid-viewer-lightbox__panel";
+
+  const closeButton = createMermaidButton("Close expanded diagram", "×", closeLightbox);
+  closeButton.classList.add("mermaid-viewer-lightbox__close");
+
+  const expandedSvg = svg.cloneNode(true) as SVGSVGElement;
+  const diagramView = createPannableDiagramView(expandedSvg);
+  panel.append(diagramView.viewport, closeButton, diagramView.controls);
+  overlay.append(panel);
+
+  const restoreFocusTo = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeLightbox();
+    }
+  };
+
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) closeLightbox();
+  });
+
+  document.addEventListener("keydown", onKeyDown);
+  document.body.append(overlay);
+  closeActiveMermaidLightbox = closeLightbox;
+  closeButton.focus({ preventScroll: true });
+
+  function closeLightbox(): void {
+    document.removeEventListener("keydown", onKeyDown);
+    overlay.remove();
+    if (closeActiveMermaidLightbox === closeLightbox) {
+      closeActiveMermaidLightbox = null;
+    }
+    restoreFocusTo?.focus({ preventScroll: true });
+  }
+}
+
+function createMermaidButton(label: string, text: string, onClick: () => void | Promise<void>): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "mermaid-viewer__button";
+  button.setAttribute("aria-label", label);
+  button.title = label;
+  button.textContent = text;
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    void onClick();
+  });
+  return button;
+}
+
+function createMermaidSpacer(): HTMLSpanElement {
+  const spacer = document.createElement("span");
+  spacer.className = "mermaid-viewer__spacer";
+  spacer.setAttribute("aria-hidden", "true");
+  return spacer;
+}
+
+async function copyMermaidSource(source: string, button: HTMLButtonElement): Promise<void> {
+  if (!source || typeof navigator === "undefined" || !navigator.clipboard?.writeText) return;
+
+  try {
+    await navigator.clipboard.writeText(source);
+    button.dataset.copied = "true";
+    button.setAttribute("aria-label", "Copied Mermaid source");
+    button.title = "Copied Mermaid source";
+    window.setTimeout(() => {
+      button.dataset.copied = "false";
+      button.setAttribute("aria-label", "Copy Mermaid source");
+      button.title = "Copy Mermaid source";
+    }, 1200);
+  } catch (error: unknown) {
+    console.error("Failed to copy Mermaid source", error);
+  }
+}
+
+function attachDragPanning(viewport: HTMLElement, drag: { onDrag: (deltaX: number, deltaY: number) => void }): void {
+  let activeDrag: { pointerId: number; x: number; y: number } | null = null;
+
+  viewport.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
+    activeDrag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+    viewport.classList.add("mermaid-viewer__viewport--dragging");
+    if ("setPointerCapture" in viewport) {
+      viewport.setPointerCapture(event.pointerId);
+    }
+  });
+
+  viewport.addEventListener("pointermove", (event) => {
+    if (!activeDrag || activeDrag.pointerId !== event.pointerId) return;
+    drag.onDrag(event.clientX - activeDrag.x, event.clientY - activeDrag.y);
+    activeDrag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+  });
+
+  const endDrag = (event: PointerEvent) => {
+    if (!activeDrag || activeDrag.pointerId !== event.pointerId) return;
+    activeDrag = null;
+    viewport.classList.remove("mermaid-viewer__viewport--dragging");
+    if ("releasePointerCapture" in viewport) {
+      viewport.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  viewport.addEventListener("pointerup", endDrag);
+  viewport.addEventListener("pointercancel", endDrag);
+}
+
+function clampScale(value: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, Number(value.toFixed(2))));
+}
+
+function formatScale(value: number): string {
+  return Number(value.toFixed(2)).toString();
 }
 
 export function initMarkdownMermaidRendering(

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -433,17 +433,48 @@ export function initMarkdownMermaidRendering(
 ): MarkdownMermaidController {
   let disconnected = false;
   let scheduled = false;
+  let rendering = false;
+  let renderAfterCurrent = false;
+  let themeResetAfterCurrent = false;
   let renderedTheme = currentMermaidTheme();
 
   const render = () => {
-    if (disconnected || scheduled) return;
+    if (disconnected) return;
+    if (rendering) {
+      renderAfterCurrent = true;
+      return;
+    }
+    if (scheduled) return;
     scheduled = true;
-    queueMicrotask(() => {
+    queueMicrotask(async () => {
       scheduled = false;
       if (disconnected) return;
-      void renderMarkdownMermaidDiagrams(root, load).catch((error: unknown) => {
+      rendering = true;
+      const themeAtStart = currentMermaidTheme();
+      try {
+        await renderMarkdownMermaidDiagrams(root, load);
+      } catch (error: unknown) {
         console.error("Failed to render Mermaid diagrams in markdown", error);
-      });
+      } finally {
+        rendering = false;
+      }
+      if (disconnected) return;
+
+      const themeAtEnd = currentMermaidTheme();
+      if (themeResetAfterCurrent || themeAtEnd !== themeAtStart) {
+        themeResetAfterCurrent = false;
+        renderAfterCurrent = false;
+        renderedTheme = themeAtEnd;
+        resetRenderedMermaidViewers(root);
+        render();
+        return;
+      }
+
+      renderedTheme = themeAtEnd;
+      if (renderAfterCurrent) {
+        renderAfterCurrent = false;
+        render();
+      }
     });
   };
 
@@ -465,6 +496,10 @@ export function initMarkdownMermaidRendering(
           const nextTheme = currentMermaidTheme();
           if (nextTheme === renderedTheme) return;
           renderedTheme = nextTheme;
+          if (rendering) {
+            themeResetAfterCurrent = true;
+            return;
+          }
           resetRenderedMermaidViewers(root);
           render();
         });

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -6,6 +6,7 @@ export interface MarkdownMermaidAPI {
 export type MarkdownMermaidLoader = () => Promise<MarkdownMermaidAPI>;
 
 type MermaidThemeVariables = Record<string, boolean | string>;
+type MermaidThemeName = "light" | "dark";
 
 interface MarkdownMermaidConfig {
   startOnLoad: false;
@@ -21,6 +22,7 @@ export interface MarkdownMermaidController {
 }
 
 const MERMAID_SELECTOR = ".markdown-body pre.mermaid, .doc-markdown pre.mermaid";
+const MERMAID_VIEWER_SELECTOR = ".markdown-body pre.mermaid.mermaid-viewer, .doc-markdown pre.mermaid.mermaid-viewer";
 const MERMAID_VIEWER_ATTACHED = "true";
 const MIN_SCALE = 0.4;
 const MAX_SCALE = 3;
@@ -28,6 +30,45 @@ const PAN_STEP = 80;
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
 const WHEEL_DELTA_LINE = 1;
 const WHEEL_DELTA_PAGE = 2;
+const GITHUB_LIGHT_MERMAID_THEME: MermaidThemeVariables = {
+  darkMode: false,
+  background: "#ffffff",
+  fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif",
+  fontSize: "13px",
+  primaryColor: "#ffffff",
+  primaryTextColor: "#24292f",
+  primaryBorderColor: "#d0d7de",
+  secondaryColor: "#f6f8fa",
+  secondaryTextColor: "#24292f",
+  secondaryBorderColor: "#d0d7de",
+  tertiaryColor: "#f6f8fa",
+  tertiaryTextColor: "#24292f",
+  tertiaryBorderColor: "#d0d7de",
+  mainBkg: "#ffffff",
+  nodeTextColor: "#24292f",
+  nodeBorder: "#d0d7de",
+  clusterBkg: "#f6f8fa",
+  clusterBorder: "#d0d7de",
+  lineColor: "#57606a",
+  defaultLinkColor: "#57606a",
+  textColor: "#24292f",
+  titleColor: "#24292f",
+  edgeLabelBackground: "#ffffff",
+  labelColor: "#24292f",
+  labelTextColor: "#24292f",
+  loopTextColor: "#24292f",
+  noteBkgColor: "#fff8c5",
+  noteTextColor: "#24292f",
+  noteBorderColor: "#d4a72c",
+  actorBkg: "#ffffff",
+  actorBorder: "#d0d7de",
+  actorTextColor: "#24292f",
+  actorLineColor: "#57606a",
+  signalColor: "#57606a",
+  signalTextColor: "#24292f",
+  labelBoxBkgColor: "#ffffff",
+  labelBoxBorderColor: "#d0d7de",
+};
 const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
   darkMode: true,
   background: "#0d1117",
@@ -68,7 +109,7 @@ const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
   labelBoxBorderColor: "#8b949e",
 };
 let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
-const initializedMermaid = new WeakSet<MarkdownMermaidAPI>();
+const initializedMermaidTheme = new WeakMap<MarkdownMermaidAPI, MermaidThemeName>();
 const diagramSources = new WeakMap<HTMLElement, string>();
 let closeActiveMermaidLightbox: (() => void) | null = null;
 
@@ -95,16 +136,7 @@ export async function renderMarkdownMermaidDiagrams(
 
   try {
     const mermaid = await load();
-    if (!initializedMermaid.has(mermaid)) {
-      mermaid.initialize({
-        startOnLoad: false,
-        securityLevel: "strict",
-        secure: ["securityLevel", "startOnLoad"],
-        theme: "base",
-        themeVariables: GITHUB_DARK_MERMAID_THEME,
-      });
-      initializedMermaid.add(mermaid);
-    }
+    initializeMermaidForCurrentTheme(mermaid);
     await mermaid.run({ nodes, suppressErrors: true });
     let renderedCount = 0;
     for (const node of nodes) {
@@ -148,6 +180,42 @@ function attachMermaidViewer(node: HTMLElement, source: string): boolean {
 function clearMermaidRenderState(node: HTMLElement): void {
   delete node.dataset.mermaidRendered;
   delete node.dataset.processed;
+}
+
+function initializeMermaidForCurrentTheme(mermaid: MarkdownMermaidAPI): void {
+  const theme = currentMermaidTheme();
+  if (initializedMermaidTheme.get(mermaid) === theme) return;
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "strict",
+    secure: ["securityLevel", "startOnLoad"],
+    theme: "base",
+    themeVariables: mermaidThemeVariables(theme),
+  });
+  initializedMermaidTheme.set(mermaid, theme);
+}
+
+function currentMermaidTheme(): MermaidThemeName {
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function mermaidThemeVariables(theme: MermaidThemeName): MermaidThemeVariables {
+  return theme === "dark" ? GITHUB_DARK_MERMAID_THEME : GITHUB_LIGHT_MERMAID_THEME;
+}
+
+function resetRenderedMermaidViewers(root: ParentNode): void {
+  closeActiveMermaidLightbox?.();
+
+  for (const node of Array.from(root.querySelectorAll<HTMLElement>(MERMAID_VIEWER_SELECTOR))) {
+    const source = diagramSources.get(node);
+    if (source === undefined) continue;
+
+    node.textContent = source;
+    node.classList.remove("mermaid-viewer");
+    delete node.dataset.mermaidViewer;
+    clearMermaidRenderState(node);
+  }
 }
 
 function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivElement; viewport: HTMLDivElement } {
@@ -388,6 +456,7 @@ export function initMarkdownMermaidRendering(
 ): MarkdownMermaidController {
   let disconnected = false;
   let scheduled = false;
+  let renderedTheme = currentMermaidTheme();
 
   const render = () => {
     if (disconnected || scheduled) return;
@@ -411,6 +480,21 @@ export function initMarkdownMermaidRendering(
     childList: true,
     subtree: true,
   });
+
+  const themeObserver =
+    typeof MutationObserver === "undefined"
+      ? null
+      : new MutationObserver(() => {
+          const nextTheme = currentMermaidTheme();
+          if (nextTheme === renderedTheme) return;
+          renderedTheme = nextTheme;
+          resetRenderedMermaidViewers(root);
+          render();
+        });
+  themeObserver?.observe(document.documentElement, {
+    attributeFilter: ["class"],
+    attributes: true,
+  });
   render();
 
   return {
@@ -418,6 +502,7 @@ export function initMarkdownMermaidRendering(
     disconnect() {
       disconnected = true;
       observer?.disconnect();
+      themeObserver?.disconnect();
     },
   };
 }

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -106,27 +106,29 @@ export async function renderMarkdownMermaidDiagrams(
       initializedMermaid.add(mermaid);
     }
     await mermaid.run({ nodes, suppressErrors: true });
+    let renderedCount = 0;
     for (const node of nodes) {
-      attachMermaidViewer(node, diagramSources.get(node) ?? "");
+      if (attachMermaidViewer(node, diagramSources.get(node) ?? "")) {
+        node.dataset.mermaidRendered = "true";
+        renderedCount += 1;
+      } else {
+        clearMermaidRenderState(node);
+      }
     }
-    for (const node of nodes) {
-      node.dataset.mermaidRendered = "true";
-    }
+    return renderedCount;
   } catch (error: unknown) {
     for (const node of nodes) {
-      delete node.dataset.mermaidRendered;
+      clearMermaidRenderState(node);
     }
     throw error;
   }
-
-  return nodes.length;
 }
 
-function attachMermaidViewer(node: HTMLElement, source: string): void {
-  if (node.dataset.mermaidViewer === MERMAID_VIEWER_ATTACHED) return;
+function attachMermaidViewer(node: HTMLElement, source: string): boolean {
+  if (node.dataset.mermaidViewer === MERMAID_VIEWER_ATTACHED) return true;
 
   const svg = node.querySelector("svg");
-  if (!svg) return;
+  if (!svg) return false;
 
   svg.remove();
   const diagramView = createPannableDiagramView(svg);
@@ -140,6 +142,12 @@ function attachMermaidViewer(node: HTMLElement, source: string): void {
   node.classList.add("mermaid-viewer");
   node.dataset.mermaidViewer = MERMAID_VIEWER_ATTACHED;
   node.append(diagramView.viewport, topControls, diagramView.controls);
+  return true;
+}
+
+function clearMermaidRenderState(node: HTMLElement): void {
+  delete node.dataset.mermaidRendered;
+  delete node.dataset.processed;
 }
 
 function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivElement; viewport: HTMLDivElement } {

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -33,6 +33,8 @@ const PAN_STEP = 80;
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
 const WHEEL_DELTA_LINE = 1;
 const WHEEL_DELTA_PAGE = 2;
+const MAX_MERMAID_DIAGRAMS_PER_DOCUMENT = 25;
+const MAX_MERMAID_SOURCE_BYTES_PER_DOCUMENT = 200_000;
 const MERMAID_MAX_TEXT_SIZE = 50_000;
 const MERMAID_MAX_EDGES = 500;
 const MERMAID_SECURE_CONFIG = [
@@ -101,9 +103,7 @@ export async function renderMarkdownMermaidDiagrams(
   root: ParentNode,
   load: MarkdownMermaidLoader = loadMermaid,
 ): Promise<number> {
-  const nodes = Array.from(root.querySelectorAll<HTMLElement>(MERMAID_SELECTOR)).filter(
-    (node) => !node.dataset.mermaidRendered && node.dataset.processed !== "true",
-  );
+  const nodes = collectRenderableMermaidNodes(root);
   if (nodes.length === 0) return 0;
 
   for (const node of nodes) {
@@ -121,16 +121,62 @@ export async function renderMarkdownMermaidDiagrams(
         node.dataset.mermaidRendered = "true";
         renderedCount += 1;
       } else {
+        restoreMermaidSource(node);
         clearMermaidRenderState(node);
       }
     }
     return renderedCount;
   } catch (error: unknown) {
     for (const node of nodes) {
+      restoreMermaidSource(node);
       clearMermaidRenderState(node);
     }
     throw error;
   }
+}
+
+function collectRenderableMermaidNodes(root: ParentNode): HTMLElement[] {
+  const nodes: HTMLElement[] = [];
+  let diagramCount = 0;
+  let sourceBytes = 0;
+
+  for (const node of Array.from(root.querySelectorAll<HTMLElement>(MERMAID_SELECTOR))) {
+    const source = mermaidNodeSource(node);
+    const nextSourceBytes = mermaidSourceByteLength(source);
+    if (node.dataset.mermaidRendered || node.dataset.processed === "true") {
+      diagramCount += 1;
+      sourceBytes += nextSourceBytes;
+      continue;
+    }
+
+    if (
+      diagramCount >= MAX_MERMAID_DIAGRAMS_PER_DOCUMENT ||
+      sourceBytes + nextSourceBytes > MAX_MERMAID_SOURCE_BYTES_PER_DOCUMENT
+    ) {
+      skipMermaidRender(node);
+      continue;
+    }
+
+    diagramCount += 1;
+    sourceBytes += nextSourceBytes;
+    nodes.push(node);
+  }
+
+  return nodes;
+}
+
+function mermaidNodeSource(node: HTMLElement): string {
+  return diagramSources.get(node) ?? node.textContent ?? "";
+}
+
+function mermaidSourceByteLength(source: string): number {
+  return new TextEncoder().encode(source).byteLength;
+}
+
+function skipMermaidRender(node: HTMLElement): void {
+  node.classList.remove("mermaid");
+  node.dataset.mermaidRendered = "skipped";
+  delete node.dataset.processed;
 }
 
 function attachMermaidViewer(node: HTMLElement, source: string): boolean {
@@ -157,6 +203,13 @@ function attachMermaidViewer(node: HTMLElement, source: string): boolean {
 function clearMermaidRenderState(node: HTMLElement): void {
   delete node.dataset.mermaidRendered;
   delete node.dataset.processed;
+}
+
+function restoreMermaidSource(node: HTMLElement): void {
+  const source = diagramSources.get(node);
+  if (source !== undefined) {
+    node.textContent = source;
+  }
 }
 
 function initializeMermaidForCurrentTheme(mermaid: MarkdownMermaidAPI): void {

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -30,84 +30,43 @@ const PAN_STEP = 80;
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
 const WHEEL_DELTA_LINE = 1;
 const WHEEL_DELTA_PAGE = 2;
-const GITHUB_LIGHT_MERMAID_THEME: MermaidThemeVariables = {
-  darkMode: false,
-  background: "#ffffff",
-  fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif",
-  fontSize: "13px",
-  primaryColor: "#ffffff",
-  primaryTextColor: "#24292f",
-  primaryBorderColor: "#d0d7de",
-  secondaryColor: "#f6f8fa",
-  secondaryTextColor: "#24292f",
-  secondaryBorderColor: "#d0d7de",
-  tertiaryColor: "#f6f8fa",
-  tertiaryTextColor: "#24292f",
-  tertiaryBorderColor: "#d0d7de",
-  mainBkg: "#ffffff",
-  nodeTextColor: "#24292f",
-  nodeBorder: "#d0d7de",
-  clusterBkg: "#f6f8fa",
-  clusterBorder: "#d0d7de",
-  lineColor: "#57606a",
-  defaultLinkColor: "#57606a",
-  textColor: "#24292f",
-  titleColor: "#24292f",
-  edgeLabelBackground: "#ffffff",
-  labelColor: "#24292f",
-  labelTextColor: "#24292f",
-  loopTextColor: "#24292f",
-  noteBkgColor: "#fff8c5",
-  noteTextColor: "#24292f",
-  noteBorderColor: "#d4a72c",
-  actorBkg: "#ffffff",
-  actorBorder: "#d0d7de",
-  actorTextColor: "#24292f",
-  actorLineColor: "#57606a",
-  signalColor: "#57606a",
-  signalTextColor: "#24292f",
-  labelBoxBkgColor: "#ffffff",
-  labelBoxBorderColor: "#d0d7de",
-};
-const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
-  darkMode: true,
-  background: "#0d1117",
-  fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif",
-  fontSize: "13px",
-  primaryColor: "#f6f8fa",
-  primaryTextColor: "#24292f",
-  primaryBorderColor: "#d0d7de",
-  secondaryColor: "#f6f8fa",
-  secondaryTextColor: "#24292f",
-  secondaryBorderColor: "#d0d7de",
-  tertiaryColor: "#4a4d4b",
-  tertiaryTextColor: "#f0f6fc",
-  tertiaryBorderColor: "#4a4d4b",
-  mainBkg: "#f6f8fa",
-  nodeTextColor: "#24292f",
-  nodeBorder: "#d0d7de",
-  clusterBkg: "#4a4d4b",
-  clusterBorder: "#4a4d4b",
-  lineColor: "#c9d1d9",
-  defaultLinkColor: "#c9d1d9",
-  textColor: "#c9d1d9",
-  titleColor: "#c9d1d9",
-  edgeLabelBackground: "#30363d",
-  labelColor: "#c9d1d9",
-  labelTextColor: "#f0f6fc",
-  loopTextColor: "#f0f6fc",
-  noteBkgColor: "#30363d",
-  noteTextColor: "#f0f6fc",
-  noteBorderColor: "#8b949e",
-  actorBkg: "#f6f8fa",
-  actorBorder: "#d0d7de",
-  actorTextColor: "#24292f",
-  actorLineColor: "#8b949e",
-  signalColor: "#c9d1d9",
-  signalTextColor: "#c9d1d9",
-  labelBoxBkgColor: "#30363d",
-  labelBoxBorderColor: "#8b949e",
-};
+const MERMAID_THEME_TOKENS = {
+  background: "--mermaid-bg",
+  fontFamily: "--font-sans",
+  primaryColor: "--mermaid-node-bg",
+  primaryTextColor: "--mermaid-node-text",
+  primaryBorderColor: "--mermaid-node-border",
+  secondaryColor: "--mermaid-node-bg",
+  secondaryTextColor: "--mermaid-node-text",
+  secondaryBorderColor: "--mermaid-node-border",
+  tertiaryColor: "--mermaid-cluster-bg",
+  tertiaryTextColor: "--mermaid-cluster-text",
+  tertiaryBorderColor: "--mermaid-cluster-border",
+  mainBkg: "--mermaid-node-bg",
+  nodeTextColor: "--mermaid-node-text",
+  nodeBorder: "--mermaid-node-border",
+  clusterBkg: "--mermaid-cluster-bg",
+  clusterBorder: "--mermaid-cluster-border",
+  lineColor: "--mermaid-line",
+  defaultLinkColor: "--mermaid-line",
+  textColor: "--mermaid-text",
+  titleColor: "--mermaid-text",
+  edgeLabelBackground: "--mermaid-label-bg",
+  labelColor: "--mermaid-text",
+  labelTextColor: "--mermaid-label-text",
+  loopTextColor: "--mermaid-text",
+  noteBkgColor: "--mermaid-note-bg",
+  noteTextColor: "--mermaid-note-text",
+  noteBorderColor: "--mermaid-note-border",
+  actorBkg: "--mermaid-node-bg",
+  actorBorder: "--mermaid-node-border",
+  actorTextColor: "--mermaid-node-text",
+  actorLineColor: "--mermaid-line",
+  signalColor: "--mermaid-line",
+  signalTextColor: "--mermaid-text",
+  labelBoxBkgColor: "--mermaid-label-bg",
+  labelBoxBorderColor: "--mermaid-node-border",
+} satisfies Record<string, string>;
 let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
 const initializedMermaidTheme = new WeakMap<MarkdownMermaidAPI, MermaidThemeName>();
 const diagramSources = new WeakMap<HTMLElement, string>();
@@ -201,7 +160,25 @@ function currentMermaidTheme(): MermaidThemeName {
 }
 
 function mermaidThemeVariables(theme: MermaidThemeName): MermaidThemeVariables {
-  return theme === "dark" ? GITHUB_DARK_MERMAID_THEME : GITHUB_LIGHT_MERMAID_THEME;
+  const styles = getComputedStyle(document.documentElement);
+  const variables: MermaidThemeVariables = {
+    darkMode: theme === "dark",
+    fontSize: cssThemeToken(styles, "--font-size-md"),
+  };
+
+  for (const [mermaidName, cssName] of Object.entries(MERMAID_THEME_TOKENS)) {
+    variables[mermaidName] = cssThemeToken(styles, cssName);
+  }
+
+  return variables;
+}
+
+function cssThemeToken(styles: CSSStyleDeclaration, name: string): string {
+  const value = styles.getPropertyValue(name).trim();
+  if (!value) {
+    throw new Error(`Missing Mermaid theme CSS variable ${name}`);
+  }
+  return value;
 }
 
 function resetRenderedMermaidViewers(root: ParentNode): void {

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -1,0 +1,95 @@
+export interface MarkdownMermaidAPI {
+  initialize: (config: { startOnLoad: false; securityLevel: "strict"; secure: string[] }) => void;
+  run: (config: { nodes: ArrayLike<HTMLElement>; suppressErrors: true }) => Promise<unknown>;
+}
+
+export type MarkdownMermaidLoader = () => Promise<MarkdownMermaidAPI>;
+
+export interface MarkdownMermaidController {
+  renderNow: () => void;
+  disconnect: () => void;
+}
+
+const MERMAID_SELECTOR = ".markdown-body pre.mermaid, .doc-markdown pre.mermaid";
+let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
+const initializedMermaid = new WeakSet<MarkdownMermaidAPI>();
+
+async function loadMermaid(): Promise<MarkdownMermaidAPI> {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((module): MarkdownMermaidAPI => module.default);
+  }
+  return mermaidPromise;
+}
+
+export async function renderMarkdownMermaidDiagrams(
+  root: ParentNode,
+  load: MarkdownMermaidLoader = loadMermaid,
+): Promise<number> {
+  const nodes = Array.from(root.querySelectorAll<HTMLElement>(MERMAID_SELECTOR)).filter(
+    (node) => node.dataset.mermaidRendered !== "true" && node.dataset.processed !== "true",
+  );
+  if (nodes.length === 0) return 0;
+
+  for (const node of nodes) {
+    node.dataset.mermaidRendered = "pending";
+  }
+
+  try {
+    const mermaid = await load();
+    if (!initializedMermaid.has(mermaid)) {
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: "strict",
+        secure: ["securityLevel", "startOnLoad"],
+      });
+      initializedMermaid.add(mermaid);
+    }
+    await mermaid.run({ nodes, suppressErrors: true });
+  } finally {
+    for (const node of nodes) {
+      node.dataset.mermaidRendered = "true";
+    }
+  }
+
+  return nodes.length;
+}
+
+export function initMarkdownMermaidRendering(
+  root: HTMLElement | Document = document,
+  load: MarkdownMermaidLoader = loadMermaid,
+): MarkdownMermaidController {
+  let disconnected = false;
+  let scheduled = false;
+
+  const render = () => {
+    if (disconnected || scheduled) return;
+    scheduled = true;
+    queueMicrotask(() => {
+      scheduled = false;
+      if (disconnected) return;
+      void renderMarkdownMermaidDiagrams(root, load).catch((error: unknown) => {
+        console.error("Failed to render Mermaid diagrams in markdown", error);
+      });
+    });
+  };
+
+  const observer =
+    typeof MutationObserver === "undefined"
+      ? null
+      : new MutationObserver(() => {
+          render();
+        });
+  observer?.observe(root instanceof Document ? root.documentElement : root, {
+    childList: true,
+    subtree: true,
+  });
+  render();
+
+  return {
+    renderNow: render,
+    disconnect() {
+      disconnected = true;
+      observer?.disconnect();
+    },
+  };
+}

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -1,3 +1,5 @@
+import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
+
 export interface MarkdownMermaidAPI {
   initialize: (config: MarkdownMermaidConfig) => void;
   run: (config: { nodes: ArrayLike<HTMLElement>; suppressErrors: true }) => Promise<unknown>;
@@ -424,7 +426,9 @@ function openMermaidLightbox(svg: SVGSVGElement): void {
   overlay.append(panel);
 
   const restoreFocusTo = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const popModalFrame = pushModalFrame("mermaid-lightbox", []);
   const onKeyDown = (event: KeyboardEvent) => {
+    event.stopPropagation();
     if (event.key === "Escape") {
       event.preventDefault();
       closeLightbox();
@@ -434,6 +438,7 @@ function openMermaidLightbox(svg: SVGSVGElement): void {
   overlay.addEventListener("click", (event) => {
     if (event.target === overlay) closeLightbox();
   });
+  overlay.addEventListener("keydown", onKeyDown);
 
   document.addEventListener("keydown", onKeyDown);
   document.body.append(overlay);
@@ -441,7 +446,9 @@ function openMermaidLightbox(svg: SVGSVGElement): void {
   closeButton.focus({ preventScroll: true });
 
   function closeLightbox(): void {
+    overlay.removeEventListener("keydown", onKeyDown);
     document.removeEventListener("keydown", onKeyDown);
+    popModalFrame();
     overlay.remove();
     if (closeActiveMermaidLightbox === closeLightbox) {
       closeActiveMermaidLightbox = null;

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -51,7 +51,8 @@ const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
   titleColor: "#c9d1d9",
   edgeLabelBackground: "#30363d",
   labelColor: "#c9d1d9",
-  labelTextColor: "#24292f",
+  labelTextColor: "#f0f6fc",
+  loopTextColor: "#f0f6fc",
   noteBkgColor: "#30363d",
   noteTextColor: "#f0f6fc",
   noteBorderColor: "#8b949e",
@@ -64,6 +65,7 @@ const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
   labelBoxBkgColor: "#30363d",
   labelBoxBorderColor: "#8b949e",
 };
+type MermaidButtonContent = string | SVGSVGElement;
 let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
 const initializedMermaid = new WeakSet<MarkdownMermaidAPI>();
 const diagramSources = new WeakMap<HTMLElement, string>();
@@ -123,7 +125,9 @@ function attachMermaidViewer(node: HTMLElement, source: string): void {
 
   svg.remove();
   const diagramView = createPannableDiagramView(svg);
-  const expandButton = createMermaidButton("Open diagram in expanded view", "↔", () => openMermaidLightbox(svg));
+  const expandButton = createMermaidButton("Open diagram in expanded view", createExpandIcon(), () =>
+    openMermaidLightbox(svg),
+  );
   const copyButton = createMermaidButton("Copy Mermaid source", "⧉", () => copyMermaidSource(source, copyButton));
   const topControls = document.createElement("div");
   topControls.className = "mermaid-viewer__controls mermaid-viewer__controls--top";
@@ -257,19 +261,52 @@ function openMermaidLightbox(svg: SVGSVGElement): void {
   }
 }
 
-function createMermaidButton(label: string, text: string, onClick: () => void | Promise<void>): HTMLButtonElement {
+function createMermaidButton(
+  label: string,
+  content: MermaidButtonContent,
+  onClick: () => void | Promise<void>,
+): HTMLButtonElement {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "mermaid-viewer__button";
   button.setAttribute("aria-label", label);
   button.title = label;
-  button.textContent = text;
+  if (typeof content === "string") {
+    button.textContent = content;
+  } else {
+    button.append(content);
+  }
   button.addEventListener("click", (event) => {
     event.preventDefault();
     event.stopPropagation();
     void onClick();
   });
   return button;
+}
+
+function createExpandIcon(): SVGSVGElement {
+  return createSvgIcon(["M15 3h6v6", "M9 21H3v-6", "M21 3l-7 7", "M3 21l7-7"]);
+}
+
+function createSvgIcon(paths: string[]): SVGSVGElement {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.classList.add("mermaid-viewer__button-icon");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("focusable", "false");
+
+  for (const pathData of paths) {
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", pathData);
+    svg.append(path);
+  }
+
+  return svg;
 }
 
 function createMermaidSpacer(): HTMLSpanElement {

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -12,6 +12,9 @@ interface MarkdownMermaidConfig {
   startOnLoad: false;
   securityLevel: "strict";
   secure: string[];
+  maxTextSize: number;
+  maxEdges: number;
+  suppressErrorRendering: true;
   theme: "base";
   themeVariables: MermaidThemeVariables;
 }
@@ -30,6 +33,16 @@ const PAN_STEP = 80;
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
 const WHEEL_DELTA_LINE = 1;
 const WHEEL_DELTA_PAGE = 2;
+const MERMAID_MAX_TEXT_SIZE = 50_000;
+const MERMAID_MAX_EDGES = 500;
+const MERMAID_SECURE_CONFIG = [
+  "secure",
+  "securityLevel",
+  "startOnLoad",
+  "maxTextSize",
+  "suppressErrorRendering",
+  "maxEdges",
+];
 const MERMAID_THEME_TOKENS = {
   background: "--mermaid-bg",
   fontFamily: "--font-sans",
@@ -74,7 +87,12 @@ let closeActiveMermaidLightbox: (() => void) | null = null;
 
 async function loadMermaid(): Promise<MarkdownMermaidAPI> {
   if (!mermaidPromise) {
-    mermaidPromise = import("mermaid").then((module): MarkdownMermaidAPI => module.default);
+    mermaidPromise = import("mermaid")
+      .then((module): MarkdownMermaidAPI => module.default)
+      .catch((error: unknown) => {
+        mermaidPromise = null;
+        throw error;
+      });
   }
   return mermaidPromise;
 }
@@ -148,7 +166,10 @@ function initializeMermaidForCurrentTheme(mermaid: MarkdownMermaidAPI): void {
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: "strict",
-    secure: ["securityLevel", "startOnLoad"],
+    secure: [...MERMAID_SECURE_CONFIG],
+    maxTextSize: MERMAID_MAX_TEXT_SIZE,
+    maxEdges: MERMAID_MAX_EDGES,
+    suppressErrorRendering: true,
     theme: "base",
     themeVariables: mermaidThemeVariables(theme),
   });

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -15,6 +15,14 @@ interface MarkdownMermaidConfig {
   maxTextSize: number;
   maxEdges: number;
   suppressErrorRendering: true;
+  dompurifyConfig: {
+    FORBID_ATTR: string[];
+    FORBID_TAGS: string[];
+  };
+  htmlLabels: false;
+  themeCSS: "";
+  fontFamily: string;
+  altFontFamily: string;
   theme: "base";
   themeVariables: MermaidThemeVariables;
 }
@@ -44,6 +52,11 @@ const MERMAID_SECURE_CONFIG = [
   "maxTextSize",
   "suppressErrorRendering",
   "maxEdges",
+  "dompurifyConfig",
+  "htmlLabels",
+  "themeCSS",
+  "fontFamily",
+  "altFontFamily",
 ];
 const MERMAID_THEME_TOKENS = {
   background: "--mermaid-bg",
@@ -85,6 +98,7 @@ const MERMAID_THEME_TOKENS = {
 let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
 const initializedMermaidTheme = new WeakMap<MarkdownMermaidAPI, MermaidThemeName>();
 const diagramSources = new WeakMap<HTMLElement, string>();
+const failedDiagramSources = new WeakMap<HTMLElement, string>();
 let closeActiveMermaidLightbox: (() => void) | null = null;
 
 async function loadMermaid(): Promise<MarkdownMermaidAPI> {
@@ -118,18 +132,19 @@ export async function renderMarkdownMermaidDiagrams(
     let renderedCount = 0;
     for (const node of nodes) {
       if (attachMermaidViewer(node, diagramSources.get(node) ?? "")) {
+        failedDiagramSources.delete(node);
         node.dataset.mermaidRendered = "true";
         renderedCount += 1;
       } else {
         restoreMermaidSource(node);
-        clearMermaidRenderState(node);
+        markMermaidRenderFailed(node);
       }
     }
     return renderedCount;
   } catch (error: unknown) {
     for (const node of nodes) {
       restoreMermaidSource(node);
-      clearMermaidRenderState(node);
+      markMermaidRenderFailed(node);
     }
     throw error;
   }
@@ -143,6 +158,17 @@ function collectRenderableMermaidNodes(root: ParentNode): HTMLElement[] {
   for (const node of Array.from(root.querySelectorAll<HTMLElement>(MERMAID_SELECTOR))) {
     const source = mermaidNodeSource(node);
     const nextSourceBytes = mermaidSourceByteLength(source);
+    if (node.dataset.mermaidRendered === "failed") {
+      const failedSource = failedDiagramSources.get(node);
+      if (failedSource === undefined || failedSource === source) {
+        diagramCount += 1;
+        sourceBytes += nextSourceBytes;
+        continue;
+      }
+      failedDiagramSources.delete(node);
+      clearMermaidRenderState(node);
+    }
+
     if (node.dataset.mermaidRendered || node.dataset.processed === "true") {
       diagramCount += 1;
       sourceBytes += nextSourceBytes;
@@ -166,6 +192,9 @@ function collectRenderableMermaidNodes(root: ParentNode): HTMLElement[] {
 }
 
 function mermaidNodeSource(node: HTMLElement): string {
+  if (node.dataset.mermaidRendered === "failed") {
+    return node.textContent ?? "";
+  }
   return diagramSources.get(node) ?? node.textContent ?? "";
 }
 
@@ -205,6 +234,13 @@ function clearMermaidRenderState(node: HTMLElement): void {
   delete node.dataset.processed;
 }
 
+function markMermaidRenderFailed(node: HTMLElement): void {
+  const source = diagramSources.get(node) ?? node.textContent ?? "";
+  failedDiagramSources.set(node, source);
+  node.dataset.mermaidRendered = "failed";
+  delete node.dataset.processed;
+}
+
 function restoreMermaidSource(node: HTMLElement): void {
   const source = diagramSources.get(node);
   if (source !== undefined) {
@@ -215,6 +251,8 @@ function restoreMermaidSource(node: HTMLElement): void {
 function initializeMermaidForCurrentTheme(mermaid: MarkdownMermaidAPI): void {
   const theme = currentMermaidTheme();
   if (initializedMermaidTheme.get(mermaid) === theme) return;
+  const themeVariables = mermaidThemeVariables(theme);
+  const fontFamily = String(themeVariables.fontFamily);
 
   mermaid.initialize({
     startOnLoad: false,
@@ -223,8 +261,16 @@ function initializeMermaidForCurrentTheme(mermaid: MarkdownMermaidAPI): void {
     maxTextSize: MERMAID_MAX_TEXT_SIZE,
     maxEdges: MERMAID_MAX_EDGES,
     suppressErrorRendering: true,
+    dompurifyConfig: {
+      FORBID_ATTR: ["style"],
+      FORBID_TAGS: ["style"],
+    },
+    htmlLabels: false,
+    themeCSS: "",
+    fontFamily,
+    altFontFamily: fontFamily,
     theme: "base",
-    themeVariables: mermaidThemeVariables(theme),
+    themeVariables,
   });
   initializedMermaidTheme.set(mermaid, theme);
 }

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -67,7 +67,6 @@ const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
   labelBoxBkgColor: "#30363d",
   labelBoxBorderColor: "#8b949e",
 };
-type MermaidButtonContent = string | SVGSVGElement;
 let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
 const initializedMermaid = new WeakSet<MarkdownMermaidAPI>();
 const diagramSources = new WeakMap<HTMLElement, string>();
@@ -110,10 +109,14 @@ export async function renderMarkdownMermaidDiagrams(
     for (const node of nodes) {
       attachMermaidViewer(node, diagramSources.get(node) ?? "");
     }
-  } finally {
     for (const node of nodes) {
       node.dataset.mermaidRendered = "true";
     }
+  } catch (error: unknown) {
+    for (const node of nodes) {
+      delete node.dataset.mermaidRendered;
+    }
+    throw error;
   }
 
   return nodes.length;
@@ -127,9 +130,7 @@ function attachMermaidViewer(node: HTMLElement, source: string): void {
 
   svg.remove();
   const diagramView = createPannableDiagramView(svg);
-  const expandButton = createMermaidButton("Open diagram in expanded view", createExpandIcon(), () =>
-    openMermaidLightbox(svg),
-  );
+  const expandButton = createMermaidButton("Open diagram in expanded view", "⟷", () => openMermaidLightbox(svg));
   const copyButton = createMermaidButton("Copy Mermaid source", "⧉", () => copyMermaidSource(source, copyButton));
   const topControls = document.createElement("div");
   topControls.className = "mermaid-viewer__controls mermaid-viewer__controls--top";
@@ -276,52 +277,19 @@ function openMermaidLightbox(svg: SVGSVGElement): void {
   }
 }
 
-function createMermaidButton(
-  label: string,
-  content: MermaidButtonContent,
-  onClick: () => void | Promise<void>,
-): HTMLButtonElement {
+function createMermaidButton(label: string, text: string, onClick: () => void | Promise<void>): HTMLButtonElement {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "mermaid-viewer__button";
   button.setAttribute("aria-label", label);
   button.title = label;
-  if (typeof content === "string") {
-    button.textContent = content;
-  } else {
-    button.append(content);
-  }
+  button.textContent = text;
   button.addEventListener("click", (event) => {
     event.preventDefault();
     event.stopPropagation();
     void onClick();
   });
   return button;
-}
-
-function createExpandIcon(): SVGSVGElement {
-  return createSvgIcon(["M15 3h6v6", "M9 21H3v-6", "M21 3l-7 7", "M3 21l7-7"]);
-}
-
-function createSvgIcon(paths: string[]): SVGSVGElement {
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.classList.add("mermaid-viewer__button-icon");
-  svg.setAttribute("viewBox", "0 0 24 24");
-  svg.setAttribute("fill", "none");
-  svg.setAttribute("stroke", "currentColor");
-  svg.setAttribute("stroke-width", "2");
-  svg.setAttribute("stroke-linecap", "round");
-  svg.setAttribute("stroke-linejoin", "round");
-  svg.setAttribute("aria-hidden", "true");
-  svg.setAttribute("focusable", "false");
-
-  for (const pathData of paths) {
-    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    path.setAttribute("d", pathData);
-    svg.append(path);
-  }
-
-  return svg;
 }
 
 function createMermaidSpacer(): HTMLSpanElement {

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -1,9 +1,19 @@
 export interface MarkdownMermaidAPI {
-  initialize: (config: { startOnLoad: false; securityLevel: "strict"; secure: string[] }) => void;
+  initialize: (config: MarkdownMermaidConfig) => void;
   run: (config: { nodes: ArrayLike<HTMLElement>; suppressErrors: true }) => Promise<unknown>;
 }
 
 export type MarkdownMermaidLoader = () => Promise<MarkdownMermaidAPI>;
+
+type MermaidThemeVariables = Record<string, boolean | string>;
+
+interface MarkdownMermaidConfig {
+  startOnLoad: false;
+  securityLevel: "strict";
+  secure: string[];
+  theme: "base";
+  themeVariables: MermaidThemeVariables;
+}
 
 export interface MarkdownMermaidController {
   renderNow: () => void;
@@ -16,6 +26,44 @@ const MIN_SCALE = 0.4;
 const MAX_SCALE = 3;
 const ZOOM_STEP = 0.2;
 const PAN_STEP = 80;
+const GITHUB_DARK_MERMAID_THEME: MermaidThemeVariables = {
+  darkMode: true,
+  background: "#0d1117",
+  fontFamily: "Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif",
+  fontSize: "13px",
+  primaryColor: "#f6f8fa",
+  primaryTextColor: "#24292f",
+  primaryBorderColor: "#d0d7de",
+  secondaryColor: "#f6f8fa",
+  secondaryTextColor: "#24292f",
+  secondaryBorderColor: "#d0d7de",
+  tertiaryColor: "#4a4d4b",
+  tertiaryTextColor: "#f0f6fc",
+  tertiaryBorderColor: "#4a4d4b",
+  mainBkg: "#f6f8fa",
+  nodeTextColor: "#24292f",
+  nodeBorder: "#d0d7de",
+  clusterBkg: "#4a4d4b",
+  clusterBorder: "#4a4d4b",
+  lineColor: "#c9d1d9",
+  defaultLinkColor: "#c9d1d9",
+  textColor: "#c9d1d9",
+  titleColor: "#c9d1d9",
+  edgeLabelBackground: "#30363d",
+  labelColor: "#c9d1d9",
+  labelTextColor: "#24292f",
+  noteBkgColor: "#30363d",
+  noteTextColor: "#f0f6fc",
+  noteBorderColor: "#8b949e",
+  actorBkg: "#f6f8fa",
+  actorBorder: "#d0d7de",
+  actorTextColor: "#24292f",
+  actorLineColor: "#8b949e",
+  signalColor: "#c9d1d9",
+  signalTextColor: "#c9d1d9",
+  labelBoxBkgColor: "#30363d",
+  labelBoxBorderColor: "#8b949e",
+};
 let mermaidPromise: Promise<MarkdownMermaidAPI> | null = null;
 const initializedMermaid = new WeakSet<MarkdownMermaidAPI>();
 const diagramSources = new WeakMap<HTMLElement, string>();
@@ -49,6 +97,8 @@ export async function renderMarkdownMermaidDiagrams(
         startOnLoad: false,
         securityLevel: "strict",
         secure: ["securityLevel", "startOnLoad"],
+        theme: "base",
+        themeVariables: GITHUB_DARK_MERMAID_THEME,
       });
       initializedMermaid.add(mermaid);
     }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { mount } from "svelte";
 import App from "./App.svelte";
 import "./app.css";
+import { initMarkdownMermaidRendering } from "./lib/utils/markdownMermaid.js";
 
 const target = document.getElementById("app");
 
@@ -9,3 +10,4 @@ if (!target) {
 }
 
 mount(App, { target });
+initMarkdownMermaidRendering(target);

--- a/frontend/tests/e2e-full/docs.spec.ts
+++ b/frontend/tests/e2e-full/docs.spec.ts
@@ -346,6 +346,36 @@ test.describe("docs workspace", () => {
     }
   });
 
+  test("renders Mermaid fences from real markdown files", async ({ page }) => {
+    const docsRoot = await createDocsFixture();
+    await writeFile(
+      path.join(docsRoot, "diagram.md"),
+      ["# Diagram Fixture", "", "```mermaid", "graph TD", "  A --> B", "```", ""].join("\n"),
+    );
+    const server = await startIsolatedE2EServer();
+    try {
+      const folder = await page.request.post(`${server.info.base_url}/api/v1/docs/folders`, {
+        data: {
+          id: "notes",
+          name: "Notes",
+          path: docsRoot,
+        },
+      });
+      expect(folder.status()).toBe(201);
+
+      await page.goto(`${server.info.base_url}/docs?folder=notes&doc=diagram.md`);
+      await expect(page.getByRole("heading", { name: "Diagram Fixture", level: 1 })).toBeVisible();
+
+      const rendered = page.locator(".doc-markdown");
+      await expect(rendered.locator("code.language-mermaid")).toHaveCount(0);
+      await expect(rendered.locator("pre.mermaid.mermaid-viewer svg")).toBeVisible();
+      await expect(rendered.getByRole("button", { name: "Copy Mermaid source" })).toBeVisible();
+      await expect(rendered.getByRole("button", { name: "Open diagram in expanded view" })).toBeVisible();
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("strips protocol-relative links and images from real markdown files", async ({ page }) => {
     const docsRoot = await createDocsFixture();
     await writeFile(

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -104,8 +104,18 @@ test("markdown mermaid fences render as diagrams", async ({ page }) => {
 
   await expect(page.locator(".markdown-body code.language-mermaid")).toHaveCount(0);
   await expect(page.locator(".markdown-body pre.mermaid.mermaid-viewer svg")).toBeVisible();
-  await expect(page.getByRole("button", { name: "Zoom in diagram" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Zoom in diagram" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Zoom out diagram" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Copy Mermaid source" })).toBeVisible();
+
+  const diagramViewport = page.locator(".markdown-body .mermaid-viewer__viewport");
+  const diagramPan = page.locator(".markdown-body .mermaid-viewer__pan");
+  const initialTransform = await diagramPan.evaluate((element) => getComputedStyle(element).transform);
+  await diagramViewport.hover();
+  await page.mouse.wheel(0, -240);
+  await expect
+    .poll(async () => diagramPan.evaluate((element) => getComputedStyle(element).transform))
+    .not.toBe(initialTransform);
 
   await page.getByRole("button", { name: "Open diagram in expanded view" }).click();
   await expect(page.getByRole("dialog", { name: "Expanded Mermaid diagram" })).toBeVisible();

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -95,6 +95,17 @@ test("edit body: cancel preserves original", async ({ page }) => {
   await expect(page.locator(".markdown-body")).toContainText("Adds Playwright smoke tests");
 });
 
+test("markdown mermaid fences render as diagrams", async ({ page }) => {
+  await page.goto("/pulls/github/acme/widgets/42");
+  await page.locator(".edit-body-btn").click();
+
+  await page.locator(".body-edit-textarea").fill("```mermaid\ngraph TD\n  A --> B\n```");
+  await page.locator(".body-edit .title-edit-save").click();
+
+  await expect(page.locator(".markdown-body code.language-mermaid")).toHaveCount(0);
+  await expect(page.locator(".markdown-body pre.mermaid svg")).toBeVisible();
+});
+
 test("markdown tables keep compact columns readable", async ({ page }) => {
   await page.route("**/api/v1/pulls/github/acme/widgets/42", async (route) => {
     if (route.request().method() !== "GET") {

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -103,7 +103,15 @@ test("markdown mermaid fences render as diagrams", async ({ page }) => {
   await page.locator(".body-edit .title-edit-save").click();
 
   await expect(page.locator(".markdown-body code.language-mermaid")).toHaveCount(0);
-  await expect(page.locator(".markdown-body pre.mermaid svg")).toBeVisible();
+  await expect(page.locator(".markdown-body pre.mermaid.mermaid-viewer svg")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Zoom in diagram" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Copy Mermaid source" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Open diagram in expanded view" }).click();
+  await expect(page.getByRole("dialog", { name: "Expanded Mermaid diagram" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close expanded diagram" })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog", { name: "Expanded Mermaid diagram" })).toBeHidden();
 });
 
 test("markdown tables keep compact columns readable", async ({ page }) => {

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -202,3 +202,12 @@ describe("renderMarkdown task lists", () => {
     expect(outerOpen).toBeGreaterThanOrEqual(0);
   });
 });
+
+describe("renderMarkdown mermaid diagrams", () => {
+  it("renders mermaid fences as mermaid diagram targets", () => {
+    const html = renderMarkdown("```mermaid\ngraph TD\n  A --> B\n```");
+
+    expect(html).toContain('<pre class="mermaid">graph TD\n  A --&gt; B</pre>');
+    expect(html).not.toContain("language-mermaid");
+  });
+});

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -180,12 +180,24 @@ const DRAG_HANDLE_SVG =
   `<circle cx="9" cy="13" r="1.2"/>` +
   `</svg>`;
 
+function isMermaidFence(lang: string | undefined): boolean {
+  return (lang ?? "").trim().split(/\s+/, 1)[0]?.toLowerCase() === "mermaid";
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 const taskListRenderer: RendererObject = {
   blockquote(token): string {
     renderState.blockquoteDepth++;
     const inner = this.parser.parse(token.tokens);
     renderState.blockquoteDepth--;
     return `<blockquote>\n${inner}</blockquote>\n`;
+  },
+  code(token: Tokens.Code): string | false {
+    if (!isMermaidFence(token.lang)) return false;
+    return `<pre class="mermaid">${escapeHtml(token.text)}</pre>`;
   },
   // The checkbox renderer is called during the recursive parse
   // of a listitem's inner tokens. It allocates the next task


### PR DESCRIPTION
Adds Mermaid rendering for GFM markdown across the app by turning explicit `mermaid` fences into sanitized Mermaid targets and lazily rendering them in the browser.

- Mermaid diagrams now render in shared and docs markdown instead of appearing as `language-mermaid` code blocks.
- The viewer supports copy source, expanded overlay, drag and arrow panning, wheel zoom, reset, and theme-aware label colors.
- Mermaid is initialized with strict security settings protected from in-diagram overrides, bounded per-document rendering, source-preserving failure handling, and light/dark theme tokens.
