### PR TITLE
Fix Kata daemon switcher behavior

### DIFF
--- a/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
+++ b/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import CheckIcon from "@lucide/svelte/icons/check";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
+  import ServerIcon from "@lucide/svelte/icons/server";
 
   import type { KataDaemonInfo } from "../../api/kata/daemons.js";
 
   interface Props {
     daemons: KataDaemonInfo[];
     activeId: string | undefined;
+    activeStatusLabel?: string | undefined;
+    activeStatusTone?: "error" | undefined;
     onSelect: (id: string) => void;
   }
 
-  let { daemons, activeId, onSelect }: Props = $props();
+  let { daemons, activeId, activeStatusLabel = undefined, activeStatusTone = undefined, onSelect }: Props = $props();
 
   let open = $state(false);
   const active = $derived(
@@ -23,6 +26,18 @@
     open = false;
     if (id !== active?.id) onSelect(id);
   }
+
+  function daemonStatusLabel(daemon: KataDaemonInfo): string {
+    if (daemon.id === active?.id && activeStatusLabel) return activeStatusLabel;
+    if (daemon.health === "connected") return "connected";
+    if (daemon.health === "auth_required") return "needs auth";
+    return "unreachable";
+  }
+
+  function daemonStatusTone(daemon: KataDaemonInfo): string {
+    if (daemon.id === active?.id && activeStatusTone) return activeStatusTone;
+    return daemon.health;
+  }
 </script>
 
 <div class="daemon-switcher">
@@ -30,19 +45,19 @@
     type="button"
     class="daemon-chip"
     data-testid="daemon-chip"
-    aria-label={`Kata daemon: ${active?.id ?? "default"}`}
+    aria-label={`Switch Kata daemon: ${active?.id ?? "default"}`}
+    title="Switch Kata daemon"
     aria-haspopup="menu"
     aria-expanded={open}
     onclick={() => (open = !open)}
   >
-    <span class={`dot dot--${active?.health ?? "down"}`} aria-hidden="true"></span>
+    <ServerIcon class="chip-icon" size={13} strokeWidth={1.9} aria-hidden="true" />
     <span class="chip-label">{active?.id ?? "kata"}</span>
     <ChevronDownIcon size={12} strokeWidth={2} aria-hidden="true" />
   </button>
 
   {#if open}
     <div class="daemon-menu" data-align="start" role="menu" aria-label="Configured Kata daemons">
-      <p class="menu-head">Kata daemon</p>
       {#each daemons as daemon (daemon.id)}
         <button
           type="button"
@@ -53,21 +68,17 @@
           aria-checked={daemon.id === active?.id}
           onclick={() => choose(daemon.id)}
         >
-          <span class={`dot dot--${daemon.health}`} aria-hidden="true"></span>
+          <span class={`dot dot--${daemonStatusTone(daemon)}`} aria-hidden="true"></span>
           <span class="row-name">{daemon.id}</span>
+          <span class="row-meta" title={daemonStatusLabel(daemon)}>{daemonStatusLabel(daemon)}</span>
           {#if daemon.id === active?.id}
             <CheckIcon class="check" size={13} strokeWidth={2} aria-hidden="true" />
-          {:else if daemon.health === "auth_required"}
-            <span class="row-meta">needs auth</span>
-          {:else if daemon.health === "down"}
-            <span class="row-meta">unreachable</span>
           {/if}
           {#if daemon.hint}
             <span class="row-hint">{daemon.hint}</span>
           {/if}
         </button>
       {/each}
-      <p class="menu-foot">Configured Kata daemons</p>
     </div>
   {/if}
 </div>
@@ -105,6 +116,11 @@
     white-space: nowrap;
   }
 
+  .chip-icon {
+    color: var(--text-muted);
+    flex: none;
+  }
+
   .dot {
     width: 8px;
     height: 8px;
@@ -124,6 +140,10 @@
     background: var(--text-faint);
   }
 
+  .dot--error {
+    background: var(--accent-red);
+  }
+
   .daemon-menu {
     position: absolute;
     top: calc(100% + 6px);
@@ -138,19 +158,6 @@
     padding: 5px;
   }
 
-  .menu-head,
-  .menu-foot {
-    margin: 0;
-    padding: 5px 8px;
-    color: var(--text-faint);
-    font-size: var(--font-size-3xs);
-  }
-
-  .menu-foot {
-    border-top: 1px solid var(--border-muted);
-    margin-top: 3px;
-  }
-
   .daemon-row {
     width: 100%;
     border: 0;
@@ -158,7 +165,7 @@
     background: transparent;
     color: var(--text-primary);
     display: grid;
-    grid-template-columns: 14px minmax(0, 1fr) auto;
+    grid-template-columns: 14px minmax(0, 1fr) auto auto;
     align-items: center;
     gap: 9px;
     padding: 7px 8px;
@@ -185,6 +192,10 @@
   .row-meta {
     color: var(--text-muted);
     font-size: var(--font-size-xs);
+    max-width: 132px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .row-hint {

--- a/frontend/src/lib/features/kata/KataDaemonSwitcher.test.ts
+++ b/frontend/src/lib/features/kata/KataDaemonSwitcher.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { KataDaemonInfo } from "../../api/kata/daemons.js";
@@ -29,7 +29,26 @@ describe("KataDaemonSwitcher", () => {
   it("shows the active daemon id on the chip", () => {
     render(KataDaemonSwitcher, { props: { daemons, activeId: "home", onSelect: () => {} } });
 
-    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
+    const chip = screen.getByRole("button", { name: "Switch Kata daemon: home" });
+    expect(chip.textContent).toContain("home");
+    expect(chip.querySelector(".chip-icon")).toBeTruthy();
+    expect(screen.queryByText("Daemon")).toBeNull();
+  });
+
+  it("keeps daemon health indicators inside the menu", async () => {
+    const { container } = render(KataDaemonSwitcher, {
+      props: { daemons, activeId: "home", onSelect: () => {} },
+    });
+
+    expect(screen.getByTestId("daemon-chip").querySelector(".dot")).toBeNull();
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+
+    expect(screen.queryByText("Switch daemon")).toBeNull();
+    expect(screen.queryByText("Configured Kata daemons")).toBeNull();
+    expect(within(screen.getByTestId("daemon-row-home")).getByText("connected")).toBeTruthy();
+    expect(within(screen.getByTestId("daemon-row-work")).getByText("needs auth")).toBeTruthy();
+    expect(container.querySelector(".daemon-menu .dot")).toBeTruthy();
   });
 
   it("clicking a daemon row calls onSelect with its id", async () => {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -62,6 +62,7 @@
   }
 
   type SplitOrientation = "vertical" | "horizontal";
+  type FailureSurface = "request" | "daemon" | "none";
 
   let {
     api = undefined,
@@ -77,6 +78,8 @@
   let viewLoading = $state(false);
   let viewLoadingGeneration = 0;
   let error = $state<string | null>(null);
+  let requestError = $state<string | null>(null);
+  let lastTaskError: string | null = null;
   let unlinkBusyIds = $state<ReadonlySet<number>>(new Set());
   let unlinkError = $state<string | null>(null);
   let daemonInfos = $state.raw<KataDaemonInfo[]>([]);
@@ -151,9 +154,31 @@
     viewLoading = false;
   }
 
-  async function runViewTask(task: () => Promise<void | boolean>): Promise<boolean> {
-    const loadingGeneration = beginViewLoading();
+  function kataRequestErrorMessage(err: unknown): string {
+    return err instanceof Error ? err.message : "Kata request failed.";
+  }
+
+  function clearTaskErrors(): void {
     error = null;
+    requestError = null;
+    lastTaskError = null;
+  }
+
+  function surfaceTaskError(message: string, surface: FailureSurface): void {
+    lastTaskError = message;
+    if (surface === "request") {
+      requestError = message;
+    } else if (surface === "daemon") {
+      error = message;
+    }
+  }
+
+  async function runViewTask(
+    task: () => Promise<void | boolean>,
+    failureSurface: FailureSurface = "request",
+  ): Promise<boolean> {
+    const loadingGeneration = beginViewLoading();
+    clearTaskErrors();
     const expansionSignature = currentExpansionSignature();
     try {
       const ok = (await task()) ?? true;
@@ -162,20 +187,23 @@
       }
       return ok;
     } catch (err) {
-      error = err instanceof Error ? err.message : "Kata request failed.";
+      surfaceTaskError(kataRequestErrorMessage(err), failureSurface);
       return false;
     } finally {
       endViewLoading(loadingGeneration);
     }
   }
 
-  async function runViewTaskOrThrow(task: () => Promise<void>): Promise<void> {
+  async function runViewTaskOrThrow(
+    task: () => Promise<void>,
+    failureSurface: FailureSurface = "request",
+  ): Promise<void> {
     const loadingGeneration = beginViewLoading();
-    error = null;
+    clearTaskErrors();
     try {
       await task();
     } catch (err) {
-      error = err instanceof Error ? err.message : "Kata request failed.";
+      surfaceTaskError(kataRequestErrorMessage(err), failureSurface);
       throw err;
     } finally {
       endViewLoading(loadingGeneration);
@@ -547,7 +575,7 @@
       const ok = await runViewTask(async () => {
         await store.bootstrap(previousView);
         store.resetSearchFilters();
-      });
+      }, "daemon");
       if (!ok) {
         setActiveKataDaemon(previousExplicitDaemon);
         const restored = await runViewTask(async () => {
@@ -560,7 +588,7 @@
           if (previousIssueUID && store.selectedIssue?.issue.uid !== previousIssueUID) {
             await store.selectIssue(previousIssueUID);
           }
-        });
+        }, "daemon");
         if (restored) {
           await store.syncEventCursor();
         }
@@ -647,13 +675,13 @@
   async function createRecurrence(projectID: number, input: KataCreateRecurrenceInput): Promise<void> {
     await runViewTaskOrThrow(async () => {
       await store.createRecurrence(projectID, input);
-    });
+    }, "none");
   }
 
   async function patchRecurrence(id: number, input: KataPatchRecurrenceInput, etag: string): Promise<void> {
     await runViewTaskOrThrow(async () => {
       await store.patchRecurrence(id, input, etag);
-    });
+    }, "none");
   }
 
   async function deleteRecurrence(recurrence: KataRecurrence): Promise<boolean> {
@@ -697,9 +725,9 @@
     unlinkBusyIds = new Set(links.map((item) => item.message_id));
     unlinkError = null;
     try {
-      const ok = await runViewTask(() => store.patchMetadata(uid, actor, metadataPatch));
+      const ok = await runViewTask(() => store.patchMetadata(uid, actor, metadataPatch), "none");
       if (!ok) {
-        unlinkError = error || "Could not unlink message.";
+        unlinkError = lastTaskError || "Could not unlink message.";
       }
     } finally {
       unlinkBusyIds = new Set();
@@ -747,6 +775,10 @@
       </button>
     </div>
   </header>
+
+  {#if requestError}
+    <p class="kata-request-error" role="alert">{requestError}</p>
+  {/if}
 
   <div class="kata-layout">
     <KataSidebar
@@ -922,6 +954,17 @@
     align-items: center;
     gap: 10px;
     flex: 0 0 auto;
+  }
+
+  .kata-request-error {
+    margin: 10px 20px 0;
+    padding: 8px 10px;
+    border: 1px solid color-mix(in srgb, var(--accent-red) 42%, var(--border-default));
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--accent-red) 9%, var(--bg-primary));
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+    line-height: 1.35;
   }
 
   .header-action {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -62,7 +62,6 @@
   }
 
   type SplitOrientation = "vertical" | "horizontal";
-  type KataConnectionTone = "offline" | "connecting" | "online" | "error";
 
   let {
     api = undefined,
@@ -363,34 +362,10 @@
     return selectedProjectName() ?? systemViews.find((view) => view.name === store.currentView.name)?.label ?? "Kata";
   }
 
-  function activeDaemonLabel(): string {
-    return activeKataDaemonId ?? "Kata daemon";
-  }
-
-  function connectionLabel(): string {
+  function activeDaemonStatusLabel(): string | undefined {
     if (error) return error;
-    if (store.connection.status === "error") return store.connection.message ?? "Connection failed";
-    if (loading || store.connection.status === "connecting") return `Connecting - ${activeDaemonLabel()}`;
-    return "Connected";
-  }
-
-  function connectionTitle(): string {
-    if (error) return error;
-    if (store.connection.status === "error") return store.connection.message ?? "Connection failed";
-    if (store.connection.status === "online") return `Connected - ${activeDaemonLabel()}`;
-    if (loading || store.connection.status === "connecting") return `Connecting - ${activeDaemonLabel()}`;
-    return activeDaemonLabel();
-  }
-
-  function showVisibleConnectionStatus(): boolean {
-    const tone = connectionTone();
-    return tone === "connecting" || tone === "error";
-  }
-
-  function connectionTone(): KataConnectionTone {
-    if (error) return "error";
-    if (loading && store.connection.status !== "error") return "connecting";
-    return store.connection.status;
+    if (store.connection.status !== "error") return undefined;
+    return store.connection.message ?? "Connection failed";
   }
 
   function resetIssueExpansion(): void {
@@ -736,29 +711,16 @@
   <header class="kata-header">
     <div class="kata-header-title">
       <h1 id="kata-title">Kata</h1>
-      {#if daemonInfos.length > 1}
+      {#if daemonInfos.length > 0}
         <KataDaemonSwitcher
           daemons={daemonInfos}
           activeId={activeKataDaemonId}
+          activeStatusLabel={activeDaemonStatusLabel()}
+          activeStatusTone={activeDaemonStatusLabel() ? "error" : undefined}
           onSelect={(id) => {
             void switchKataDaemon(id);
           }}
         />
-      {/if}
-      {#if showVisibleConnectionStatus()}
-        <span
-          class="daemon-status"
-          role="status"
-          title={connectionTitle()}
-          aria-label={`Connection: ${connectionTone()}`}
-        >
-          <span class={`daemon-status-dot daemon-status-dot--${connectionTone()}`} aria-hidden="true"></span>
-          <span class="daemon-status-label">{connectionLabel()}</span>
-        </span>
-      {:else}
-        <span class="daemon-status-sr" role="status" aria-label={`Connection: ${connectionTone()}`}>
-          {connectionLabel()}
-        </span>
       {/if}
     </div>
     <div class="kata-header-actions">
@@ -975,59 +937,6 @@
     background: var(--bg-surface-hover);
     color: var(--text-primary);
     outline: none;
-  }
-
-  .daemon-status {
-    min-width: 0;
-    max-width: min(42vw, 460px);
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--text-muted);
-    font-size: var(--font-size-sm);
-  }
-
-  .daemon-status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: var(--radius-pill);
-    background: var(--text-faint);
-    flex: 0 0 auto;
-  }
-
-  .daemon-status-dot--online {
-    background: var(--accent-green);
-  }
-
-  .daemon-status-dot--connecting {
-    background: var(--accent-amber);
-  }
-
-  .daemon-status-dot--error {
-    background: var(--accent-red);
-  }
-
-  .daemon-status-label {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .daemon-status-dot--error + .daemon-status-label {
-    color: var(--accent-red);
-  }
-
-  .daemon-status-sr {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
   }
 
   .kata-layout {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -721,6 +721,8 @@
             void switchKataDaemon(id);
           }}
         />
+      {:else if activeDaemonStatusLabel()}
+        <span class="daemon-fallback-status" role="alert">{activeDaemonStatusLabel()}</span>
       {/if}
     </div>
     <div class="kata-header-actions">
@@ -902,6 +904,17 @@
     font-size: var(--font-size-lg);
     font-weight: 650;
     line-height: 1.2;
+  }
+
+  .daemon-fallback-status {
+    min-width: 0;
+    max-width: min(420px, 48vw);
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+    line-height: 1.3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .kata-header-actions {

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -258,7 +258,8 @@ describe("KataWorkspace", () => {
     );
     const { api } = createWorkspaceAPI();
     const instance = deferred<Awaited<ReturnType<typeof api.instance>>>();
-    vi.mocked(api.instance).mockReturnValue(instance.promise);
+    const instanceMock = api.instance as ReturnType<typeof vi.fn>;
+    instanceMock.mockReturnValue(instance.promise);
     const { container } = render(KataWorkspace, { props: { api } });
 
     await waitFor(() => {

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -573,6 +573,40 @@ describe("KataWorkspace", () => {
     expect(screen.queryByTestId("daemon-chip")).toBeNull();
   });
 
+  it("surfaces task request failures outside the daemon switcher", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const { api, assignOwner } = createWorkspaceAPI();
+    assignOwner.mockRejectedValueOnce(new Error("owner unavailable"));
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    });
+    const detailRegion = within(screen.getByRole("region", { name: "Task detail" }));
+    await fireEvent.click(detailRegion.getByRole("button", { name: "Owner: fixture-user" }));
+    const ownerInput = detailRegion.getByRole("combobox", { name: "Owner" }) as HTMLInputElement;
+    await fireEvent.input(ownerInput, { target: { value: "agent:new" } });
+    await fireEvent.keyDown(ownerInput, { key: "Enter" });
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("owner unavailable");
+    expect(ownerInput.value).toBe("agent:new");
+    expect(screen.getByTestId("daemon-chip").textContent).not.toContain("owner unavailable");
+  });
+
   it("rehydrates linked task titles when switching daemons with matching peer uids", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -217,6 +217,62 @@ describe("KataWorkspace", () => {
     expect(api.issues).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps the daemon switcher visible for a single daemon after connecting", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "local",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const { api } = createWorkspaceAPI();
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+      expect(screen.getByTestId("daemon-chip").textContent).toContain("local");
+    });
+  });
+
+  it("does not render a separate header connection status while a connected daemon is bootstrapping", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "kenn",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const { api } = createWorkspaceAPI();
+    const instance = deferred<Awaited<ReturnType<typeof api.instance>>>();
+    vi.mocked(api.instance).mockReturnValue(instance.promise);
+    const { container } = render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("daemon-chip").textContent).toContain("kenn");
+    });
+
+    expect(container.querySelector(".daemon-status")).toBeNull();
+    instance.resolve({
+      instance_uid: "instance-1",
+      version: "dev",
+      schema_version: 1,
+    });
+  });
+
   it("clears the routed task when daemon selection leaves no selected task", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({
@@ -494,8 +550,10 @@ describe("KataWorkspace", () => {
     render(KataWorkspace, { props: { api } });
 
     await waitFor(() => {
-      expect(screen.getByRole("status").textContent).toContain("Authentication required");
+      expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
     });
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    expect(within(screen.getByTestId("daemon-row-home")).getByText("Authentication required")).toBeTruthy();
     expect(screen.queryByText("daemon token missing")).toBeNull();
   });
 

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -256,9 +256,8 @@ describe("KataWorkspace", () => {
         ],
       }),
     );
-    const { api } = createWorkspaceAPI();
+    const { api, instance: instanceMock } = createWorkspaceAPI();
     const instance = deferred<Awaited<ReturnType<typeof api.instance>>>();
-    const instanceMock = api.instance as ReturnType<typeof vi.fn>;
     instanceMock.mockReturnValue(instance.promise);
     const { container } = render(KataWorkspace, { props: { api } });
 

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -557,6 +557,22 @@ describe("KataWorkspace", () => {
     expect(screen.queryByText("daemon token missing")).toBeNull();
   });
 
+  it("shows a header error when bootstrap fails without a daemon switcher", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [],
+      }),
+    );
+    const { api, instance } = createWorkspaceAPI();
+    instance.mockRejectedValueOnce(new Error("Kata daemon catalog is empty"));
+
+    render(KataWorkspace, { props: { api } });
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Kata daemon catalog is empty");
+    expect(screen.queryByTestId("daemon-chip")).toBeNull();
+  });
+
   it("rehydrates linked task titles when switching daemons with matching peer uids", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({

--- a/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
@@ -141,9 +141,10 @@ describe("KataWorkspace", () => {
     streamController?.close();
 
     await waitFor(() => {
-      expect(screen.getByText("Live updates disconnected")).toBeTruthy();
-      expect(screen.queryByText("Connected")).toBeNull();
+      expect(screen.queryByRole("status")).toBeNull();
     });
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    expect(within(screen.getByTestId("daemon-row-home")).getByText("Live updates disconnected")).toBeTruthy();
   });
 
   it("does not reconnect after a permanent live Kata stream failure", async () => {
@@ -174,8 +175,10 @@ describe("KataWorkspace", () => {
     render(KataWorkspace, { props: { api } });
 
     await waitFor(() => {
-      expect(screen.getByText("Kata event stream failed: HTTP 401")).toBeTruthy();
+      expect(streamRequests).toBe(1);
     });
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    expect(within(screen.getByTestId("daemon-row-home")).getByText("Kata event stream failed: HTTP 401")).toBeTruthy();
     await new Promise((resolve) => setTimeout(resolve, 150));
     expect(streamRequests).toBe(1);
   });
@@ -219,13 +222,11 @@ describe("KataWorkspace", () => {
     render(KataWorkspace, { props: { api } });
 
     await waitFor(() => {
-      expect(screen.getByText("Kata event stream failed: HTTP 503")).toBeTruthy();
-    });
-    await waitFor(() => {
       expect(streamRequests).toBe(2);
       expect(streamController).toBeTruthy();
-      expect(screen.getByRole("status", { name: "Connection: online" })).toBeTruthy();
     });
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    expect(within(screen.getByTestId("daemon-row-home")).getByText("connected")).toBeTruthy();
   });
 
   it("reconnects the live Kata event stream after a transient close", async () => {
@@ -278,9 +279,9 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(streamControllers).toHaveLength(2);
     });
-    await waitFor(() => {
-      expect(screen.getByRole("status", { name: "Connection: online" })).toBeTruthy();
-    });
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    expect(within(screen.getByTestId("daemon-row-home")).getByText("connected")).toBeTruthy();
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
     expect(streamHeaders[1]?.get("X-Middleman-Kata-Daemon")).toBe("home");
     expect(streamHeaders[1]?.get("Last-Event-ID")).toBe("5");
 

--- a/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
@@ -118,8 +118,8 @@ describe("KataWorkspace", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Today" })).toBeTruthy();
+      expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
     });
-    await screen.findByText("Live updates disconnected");
     await waitFor(() => expect(api.issues).toHaveBeenCalledTimes(2));
     await Promise.resolve();
     await Promise.resolve();

--- a/frontend/src/lib/features/kata/KataWorkspaceTestSupport.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceTestSupport.ts
@@ -272,6 +272,7 @@ function createWorkspaceAPI(
   options: { recurrences?: KataRecurrence[] | undefined; events?: KataTaskEvent[] | undefined } = {},
 ): {
   api: KataTaskAPI;
+  instance: ReturnType<typeof vi.fn>;
   search: ReturnType<typeof vi.fn>;
   addComment: ReturnType<typeof vi.fn>;
   addLabel: ReturnType<typeof vi.fn>;
@@ -356,15 +357,16 @@ function createWorkspaceAPI(
     rows = [created, ...rows];
     return { changed: true, issue: created, etag: '"rev-1"' };
   });
+  const instance = vi.fn(
+    async (): Promise<KataInstanceResponse> => ({
+      instance_uid: "instance-1",
+      version: "dev",
+      schema_version: 1,
+    }),
+  );
   return {
     api: {
-      instance: vi.fn(
-        async (): Promise<KataInstanceResponse> => ({
-          instance_uid: "instance-1",
-          version: "dev",
-          schema_version: 1,
-        }),
-      ),
+      instance,
       projects: vi.fn(async () => ({ projects, fetched_at: fetchedAt })),
       createProject: vi.fn(async (name: string) => ({
         id: 90,
@@ -427,6 +429,7 @@ function createWorkspaceAPI(
       patchRecurrence,
       deleteRecurrence: vi.fn(async () => undefined),
     },
+    instance,
     search,
     addComment,
     addLabel,

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -20,6 +20,28 @@ async function startDefaultIsolatedE2EServer() {
   return startIsolatedE2EServerWithOptions({ freshProcess: true });
 }
 
+async function expectKataDaemonSwitcherReady(page: Page): Promise<void> {
+  const chip = page.getByTestId("daemon-chip");
+  await expect(chip).toBeVisible();
+  await expect(chip.locator(".dot")).toHaveCount(0);
+
+  const kataHeader = page.locator(".kata-header");
+  await expect(kataHeader.getByText("Daemon", { exact: true })).toHaveCount(0);
+  await expect(kataHeader.getByText(/Connecting|Connection|authentication required/i)).toHaveCount(0);
+  await expect(page.getByRole("status").filter({ hasText: /Connecting|Connection/i })).toHaveCount(0);
+
+  await chip.click();
+  const menu = page.getByRole("menu", { name: "Configured Kata daemons" });
+  await expect(menu).toBeVisible();
+  await expect(menu.getByText("Switch daemon", { exact: true })).toHaveCount(0);
+  await expect(menu.getByText("Configured Kata daemons", { exact: true })).toHaveCount(0);
+  await expect(menu.locator(".daemon-row .row-meta").first()).toContainText(
+    /connected|needs auth|unreachable|Connection|Live updates disconnected/,
+  );
+  await chip.click();
+  await expect(menu).toBeHidden();
+}
+
 type BackendState = {
   commentsByUID: Map<string, CommentRow[]>;
   duplicateIssueListResponses: DuplicateIssueListResponse[];
@@ -1228,7 +1250,7 @@ test("kata workspace reads tasks through the configured external daemon", async 
     await page.goto(`${server.info.base_url}/kata`);
 
     await expect(page.getByRole("heading", { name: "Kata" })).toBeVisible();
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const payRentRow = page.getByRole("button", {
       name: /(?=.*Pay rent)(?=.*Finances#FIN-1)(?=.*project: Finances)(?=.*owner: Wes)(?=.*priority: 0)(?=.*home)/,
     });
@@ -1260,7 +1282,7 @@ test("kata workspace initial load does not mutate the configured external daemon
   try {
     await page.goto(`${server.info.base_url}/kata`);
 
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await expect(page.getByRole("button", { name: /Pay rent/ })).toBeVisible();
     await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events/stream");
     expect(backend.state.seenPaths.filter((path) => !path.startsWith("GET "))).toEqual([]);
@@ -1390,7 +1412,7 @@ test("kata workspace reloads from reset frames on the configured daemon stream",
   try {
     await page.goto(`${server.info.base_url}/kata`);
 
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await expect(page.getByRole("button", { name: /Pay rent/ })).toBeVisible();
     await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events/stream");
 
@@ -1419,7 +1441,7 @@ test("kata workspace applies a final reset frame when the configured daemon stre
   try {
     await page.goto(`${server.info.base_url}/kata`);
 
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await expect(page.getByRole("button", { name: /Pay rent/ })).toBeVisible();
     await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events/stream");
 
@@ -1455,7 +1477,7 @@ test("kata workspace ignores stale metadata update frames from the configured da
   try {
     await page.goto(`${server.info.base_url}/kata`);
 
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const payRentRow = page.locator(".kata-list").getByRole("button", { name: /Pay rent/ });
     await expect(payRentRow).toBeVisible();
     await payRentRow.click();
@@ -1823,7 +1845,7 @@ test("kata workspace applies cursor catch-up events before opening the configure
     await expect
       .poll(() => backend.state.seenPaths.some((path) => path.startsWith("GET /api/v1/events/stream")))
       .toBe(true);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
   } finally {
     await server.stop();
     kataHome.restore();
@@ -1839,7 +1861,7 @@ test("kata workspace reconnects after a closed configured daemon stream", async 
   try {
     await page.goto(`${server.info.base_url}/kata`);
 
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await expect
       .poll(() => backend.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream")).length)
       .toBe(1);
@@ -1850,7 +1872,7 @@ test("kata workspace reconnects after a closed configured daemon stream", async 
     await expect
       .poll(() => backend.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream")).length)
       .toBeGreaterThanOrEqual(2);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
   } finally {
     await server.stop();
     kataHome.restore();
@@ -1866,7 +1888,7 @@ test("kata workspace reconnects a closed configured daemon stream", async ({ pag
   try {
     await page.goto(`${server.info.base_url}/kata`);
 
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await expect(page.getByRole("button", { name: /Pay rent/ })).toBeVisible();
     await expect
       .poll(() => backend.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream")).length)
@@ -1878,7 +1900,7 @@ test("kata workspace reconnects a closed configured daemon stream", async ({ pag
     await expect
       .poll(() => backend.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream")).length)
       .toBeGreaterThanOrEqual(2);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     backend.state.issues = [
       {
@@ -1975,7 +1997,7 @@ test("kata task list sorts by priority when requested", async ({ page }) => {
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rows = page.locator(".issue-list .issue-row");
     await expect(rows.first()).toContainText("Alpha low priority");
     await expect(rows.nth(1)).toContainText("Zulu high priority");
@@ -2032,7 +2054,7 @@ test("kata task list defaults to newest first and sort controls switch priority"
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rows = page.locator(".issue-list .issue-row");
     await expect(rows.first()).toContainText("Routine newer task");
     await expect(rows.nth(1)).toContainText("Urgent older task");
@@ -2096,7 +2118,7 @@ test("kata task list sorting preserves visible groups", async ({ page }) => {
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=today`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const issueList = page.locator(".issue-list");
     const overdueGroup = issueList.getByRole("region", { name: "Overdue" });
     const todayGroup = issueList.getByRole("region", { name: "Today" });
@@ -2124,7 +2146,7 @@ test("kata task list keyboard navigation moves focus and selection", async ({ pa
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await page.getByRole("button", { name: "All Open" }).click();
     const rows = page.locator(".issue-list .issue-row");
     await expect(rows.first()).toContainText("Email Susan re: Q3");
@@ -2600,15 +2622,15 @@ test("kata task list selection settles when Shift is released before G", async (
   }
 });
 
-test("kata single configured daemon hides the daemon switcher", async ({ page }) => {
+test("kata single configured daemon keeps the daemon switcher visible", async ({ page }) => {
   const backend = await startKataBackend();
   const kataHome = await configureKataHome(backend.url);
   const server = await startIsolatedE2EServer();
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
-    await expect(page.getByTestId("daemon-chip")).toHaveCount(0);
+    await expectKataDaemonSwitcherReady(page);
+    await expect(page.getByTestId("daemon-chip")).toContainText("e2e");
   } finally {
     await server.stop();
     kataHome.restore();
@@ -2647,7 +2669,7 @@ test("kata sidebar hides task inbox projects", async ({ page }) => {
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Capture Inbox\s+1$/ })).toHaveCount(0);
@@ -2669,7 +2691,7 @@ test("kata sidebar switches system views and renders project areas", async ({ pa
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     await expect(page.getByRole("button", { name: "Inbox" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Today" })).toBeVisible();
@@ -2716,7 +2738,7 @@ test("kata project create submits inline input and switches scope", async ({ pag
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     await page.getByRole("button", { name: "New project" }).click();
     const input = page.getByRole("textbox", { name: "New project name" });
@@ -2741,7 +2763,7 @@ test("kata project create input cancels on Escape", async ({ page }) => {
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     await page.getByRole("button", { name: "New project" }).click();
     const input = page.getByRole("textbox", { name: "New project name" });
@@ -2766,7 +2788,7 @@ test("kata project rename submits inline input", async ({ page }) => {
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const listTitle = page.locator(".kata-list h2");
     const titleBeforeRename = await listTitle.innerText();
 
@@ -2794,7 +2816,7 @@ test("kata project rows can be renamed by double-clicking", async ({ page }) => 
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     await page.getByRole("button", { name: /^Finances\s+1$/ }).dblclick();
     const input = page.getByRole("textbox", { name: "Rename project" });
@@ -2819,7 +2841,7 @@ test("kata project row double-click enters rename", async ({ page }) => {
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     await page.getByRole("button", { name: /^Finances\s+1$/ }).dblclick({ delay: 300 });
 
@@ -2838,7 +2860,7 @@ test("kata project rename input cancels on Escape", async ({ page }) => {
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     await page.getByRole("button", { name: "Rename Finances" }).click();
     const input = page.getByRole("textbox", { name: "Rename project" });
@@ -2892,7 +2914,7 @@ test("kata parent row expands children loaded from detail", async ({ page }) => 
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const parentRow = page.getByRole("button", { name: /Parent task/ });
     await expect(parentRow).toBeVisible();
     await expect(page.getByRole("button", { name: /Child task/ })).toHaveCount(0);
@@ -2963,7 +2985,7 @@ test("kata task list selects visible parent when child sorts first", async ({ pa
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
 
     const parentRow = page.getByRole("button", { name: /Parent task/ });
     await expect(parentRow).toBeVisible();
@@ -4320,7 +4342,9 @@ test("kata owner assignment failure keeps the custom owner editor open", async (
     await ownerInput.fill("agent:new");
     await ownerInput.press("Enter");
 
-    await expect(page.getByRole("status", { name: "Connection: error" })).toContainText("owner unavailable");
+    await page.getByTestId("daemon-chip").click();
+    await expect(page.getByTestId("daemon-row-e2e")).toContainText("owner unavailable");
+    await page.getByTestId("daemon-chip").click();
     await expect(detail.getByLabel("Owner", { exact: true })).toHaveValue("agent:new");
     await expect(detail.getByRole("button", { name: "Owner: Wes" })).toHaveCount(0);
     expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")?.owner).toBe("Wes");

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2199,7 +2199,7 @@ test("kata route change aborts a pending detail load instead of surfacing its la
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await page.getByRole("button", { name: /^Today/ }).click();
     const rentRow = page.getByRole("button", { name: /Pay rent/ });
     await expect(rentRow).toBeVisible();
@@ -2240,7 +2240,7 @@ test("kata view change drops a held keyboard selection from the previous view", 
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rows = page.locator(".issue-list .issue-row");
     await expect(rows.first()).toContainText("Email Susan re: Q3");
     await expect(rows.nth(1)).toContainText("Pay rent");
@@ -2281,7 +2281,7 @@ test("kata sidebar view click aborts a pending detail load before the new view a
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
     await expect(rentRow).toBeVisible();
 
@@ -2327,7 +2327,7 @@ test("kata project scope click drops a pending detail load before the scoped lis
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
     await expect(rentRow).toBeVisible();
 
@@ -2373,7 +2373,7 @@ test("kata search filter change drops a pending detail load before results arriv
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
     await expect(rentRow).toBeVisible();
 
@@ -2425,7 +2425,7 @@ test("kata daemon switch drops a pending detail load from the previous daemon", 
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rentRow = page.locator(".issue-list .issue-row", { hasText: "Pay rent" });
     await expect(rentRow).toBeVisible();
 
@@ -2446,7 +2446,7 @@ test("kata daemon switch drops a pending detail load from the previous daemon", 
 
     releaseIssues();
     await expect(page.getByTestId("daemon-chip")).toContainText("work");
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await expect(page.getByRole("status", { name: "Connection: error" })).toHaveCount(0);
   } finally {
     releaseDetail();
@@ -2469,7 +2469,7 @@ test("kata key released during a stalled view transition does not commit a stale
 
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     const rows = page.locator(".issue-list .issue-row");
     await expect(rows.first()).toContainText("Email Susan re: Q3");
     await expect(rows.nth(1)).toContainText("Pay rent");
@@ -2551,7 +2551,7 @@ test("kata task list keyboard scrolling only fetches the final settled task", as
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await page.getByRole("button", { name: "All Open" }).click();
     const rows = page.locator(".issue-list .issue-row");
     await expect(rows.first()).toContainText("First task");
@@ -2594,7 +2594,7 @@ test("kata task list selection settles when Shift is released before G", async (
 
   try {
     await page.goto(`${server.info.base_url}/kata`);
-    await expect(page.getByRole("status", { name: "Connection: online" })).toBeVisible();
+    await expectKataDaemonSwitcherReady(page);
     await page.getByRole("button", { name: "All Open" }).click();
     const rows = page.locator(".issue-list .issue-row");
     await expect(rows.first()).toContainText("Email Susan re: Q3");
@@ -4342,9 +4342,9 @@ test("kata owner assignment failure keeps the custom owner editor open", async (
     await ownerInput.fill("agent:new");
     await ownerInput.press("Enter");
 
-    await page.getByTestId("daemon-chip").click();
-    await expect(page.getByTestId("daemon-row-e2e")).toContainText("owner unavailable");
-    await page.getByTestId("daemon-chip").click();
+    await expect
+      .poll(() => backend.state.seenPaths)
+      .toContain("POST /api/v1/projects/1/issues/issue-rent/actions/assign");
     await expect(detail.getByLabel("Owner", { exact: true })).toHaveValue("agent:new");
     await expect(detail.getByRole("button", { name: "Owner: Wes" })).toHaveCount(0);
     expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")?.owner).toBe("Wes");

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -4345,6 +4345,7 @@ test("kata owner assignment failure keeps the custom owner editor open", async (
     await expect
       .poll(() => backend.state.seenPaths)
       .toContain("POST /api/v1/projects/1/issues/issue-rent/actions/assign");
+    await expect(page.getByRole("alert")).toContainText("owner unavailable");
     await expect(detail.getByLabel("Owner", { exact: true })).toHaveValue("agent:new");
     await expect(detail.getByRole("button", { name: "Owner: Wes" })).toHaveCount(0);
     expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")?.owner).toBe("Wes");

--- a/internal/kata/catalog.go
+++ b/internal/kata/catalog.go
@@ -27,9 +27,8 @@ type catalogEntry struct {
 	AllowInsecure bool   `toml:"allow_insecure"`
 }
 
-// LoadCatalog reads Kata's shared daemon catalog. token_env is intentionally
-// not resolved here; ResolveDaemon applies that uniformly across daemon
-// sources.
+// LoadCatalog reads Kata's shared daemon catalog. Auth fields are retained
+// only for remote daemons; local entries are tokenless at the catalog boundary.
 func LoadCatalog() (Catalog, error) {
 	path, err := CatalogPath()
 	if err != nil {
@@ -61,19 +60,22 @@ func LoadCatalog() (Catalog, error) {
 			return Catalog{}, fmt.Errorf(
 				"kata catalog daemon %q: exactly one of local or url is required", e.Name)
 		}
-		if e.Token != "" && e.TokenEnv != "" {
-			return Catalog{}, fmt.Errorf(
-				"kata catalog daemon %q: token and token_env are mutually exclusive", e.Name)
-		}
-		out = append(out, Daemon{
+		daemon := Daemon{
 			ID:            e.Name,
 			URL:           e.URL,
-			Token:         e.Token,
-			TokenEnv:      e.TokenEnv,
 			AllowInsecure: e.AllowInsecure,
 			Local:         e.Local,
 			Default:       cat.ActiveDaemon != "" && e.Name == cat.ActiveDaemon,
-		})
+		}
+		if !e.Local {
+			if e.Token != "" && e.TokenEnv != "" {
+				return Catalog{}, fmt.Errorf(
+					"kata catalog daemon %q: token and token_env are mutually exclusive", e.Name)
+			}
+			daemon.Token = e.Token
+			daemon.TokenEnv = e.TokenEnv
+		}
+		out = append(out, daemon)
 	}
 	if cat.ActiveDaemon != "" {
 		if _, ok := seen[cat.ActiveDaemon]; !ok {

--- a/internal/kata/catalog_test.go
+++ b/internal/kata/catalog_test.go
@@ -151,6 +151,29 @@ token_env = "  KATA_WORK_TOKEN  "
 	assert.Equal("KATA_WORK_TOKEN", catalog.Daemons[0].TokenEnv)
 }
 
+func TestLoadCatalogLocalEntryIsTokenless(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeCatalog(t, home, `
+[[daemon]]
+name = "local"
+local = true
+token = "ignored"
+token_env = "IGNORED"
+`)
+
+	catalog, err := LoadCatalog()
+	require.NoError(err)
+	require.Len(catalog.Daemons, 1)
+
+	assert.True(catalog.Daemons[0].Local)
+	assert.Empty(catalog.Daemons[0].Token)
+	assert.Empty(catalog.Daemons[0].TokenEnv)
+}
+
 func TestLoadCatalogRejectsNeitherLocalNorURL(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/kata/validation.go
+++ b/internal/kata/validation.go
@@ -77,8 +77,13 @@ func ValidateLocalTarget(d Daemon) error {
 	return nil
 }
 
-// ResolveDaemon resolves TokenEnv and validates the daemon target.
+// ResolveDaemon resolves TokenEnv for remote daemons and validates the daemon target.
 func ResolveDaemon(d Daemon) (Daemon, error) {
+	if d.Local {
+		d.Token = ""
+		d.TokenEnv = ""
+		return d, ValidateLocalTarget(d)
+	}
 	if d.TokenEnv != "" {
 		v := strings.TrimSpace(os.Getenv(d.TokenEnv))
 		if v == "" {
@@ -86,13 +91,7 @@ func ResolveDaemon(d Daemon) (Daemon, error) {
 		}
 		d.Token = v
 	}
-	var err error
-	if d.Local {
-		err = ValidateLocalTarget(d)
-	} else {
-		err = ValidateTarget(d)
-	}
-	if err != nil {
+	if err := ValidateTarget(d); err != nil {
 		return d, err
 	}
 	return d, nil

--- a/internal/kata/validation_test.go
+++ b/internal/kata/validation_test.go
@@ -104,6 +104,25 @@ func TestResolveDaemonRejectsUnsetTokenEnv(t *testing.T) {
 	assert.Contains(err.Error(), "KATA_TEST_TOKEN")
 }
 
+func TestResolveDaemonLocalIgnoresTokenFields(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	t.Setenv("KATA_TEST_TOKEN", "")
+
+	daemon, err := ResolveDaemon(Daemon{
+		ID:       "local",
+		Local:    true,
+		Token:    "inline-secret",
+		TokenEnv: "KATA_TEST_TOKEN",
+	})
+
+	require.NoError(err)
+	assert.True(daemon.Local)
+	assert.Empty(daemon.Token)
+	assert.Empty(daemon.TokenEnv)
+}
+
 func TestResolveDaemonAppliesSecurityGuard(t *testing.T) {
 	require := require.New(t)
 

--- a/internal/server/e2etest/kata_daemon_test.go
+++ b/internal/server/e2etest/kata_daemon_test.go
@@ -79,9 +79,9 @@ local = true
 	require.NoError(err)
 
 	assert.Equal(http.StatusBadGateway, resp.StatusCode)
-	assert.Equal("", resp.Header.Get("Content-Encoding"))
-	assert.Equal("", resp.Header.Get("ETag"))
-	assert.Equal("", resp.Header.Get("WWW-Authenticate"))
+	assert.Empty(resp.Header.Get("Content-Encoding"))
+	assert.Empty(resp.Header.Get("ETag"))
+	assert.Empty(resp.Header.Get("WWW-Authenticate"))
 	assert.Contains(string(body), `"code":"upstreamError"`)
 	assert.NotContains(string(body), "Authentication required")
 
@@ -90,7 +90,7 @@ local = true
 	assert.Equal([]string{"", ""}, authorizations)
 }
 
-func TestKataLocalDaemonTokenIsNotUsedForRosterOrProxyE2E(t *testing.T) {
+func TestKataLocalDaemonTokenEnvIsNotUsedForRosterOrProxyE2E(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -108,13 +108,14 @@ func TestKataLocalDaemonTokenIsNotUsedForRosterOrProxyE2E(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
 	t.Setenv("KATA_DB", "")
+	t.Setenv("MIDDLEMAN_KATA_MISSING_TOKEN", "")
 	writeKataE2ECatalog(t, home, `
 active_daemon = "local"
 
 [[daemon]]
 name = "local"
 local = true
-token = "local-secret"
+token_env = "MIDDLEMAN_KATA_MISSING_TOKEN"
 `)
 	writeKataE2ERuntimeRecord(t, daemon.URL)
 	srv, _ := setupTestServer(t)

--- a/internal/server/e2etest/kata_daemon_test.go
+++ b/internal/server/e2etest/kata_daemon_test.go
@@ -1,0 +1,180 @@
+package e2etest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/apiclient"
+	"go.kenn.io/middleman/internal/kata"
+)
+
+func TestKataLocalDaemonChallengeIsDownAndProxyUpstreamErrorE2E(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	authorizations := []string{}
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		authorizations = append(authorizations, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("ETag", `"upstream"`)
+		w.Header().Set("WWW-Authenticate", `Bearer realm="kata"`)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"Authentication required"}`))
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataE2ECatalog(t, home, `
+active_daemon = "local"
+
+[[daemon]]
+name = "local"
+local = true
+`)
+	writeKataE2ERuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+	middleman := httptest.NewServer(srv)
+	defer middleman.Close()
+
+	client, err := apiclient.New(middleman.URL)
+	require.NoError(err)
+	roster, err := client.HTTP.ListKataDaemonsWithResponse(t.Context())
+	require.NoError(err)
+	require.Equal(http.StatusOK, roster.StatusCode(), string(roster.Body))
+	require.NotNil(roster.JSON200)
+	require.NotNil(roster.JSON200.Daemons)
+	require.Len(*roster.JSON200.Daemons, 1)
+	localDaemon := (*roster.JSON200.Daemons)[0]
+	assert.Equal("local", localDaemon.Id)
+	assert.Equal("none", localDaemon.Auth)
+	assert.Equal("down", localDaemon.Health)
+
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		middleman.URL+"/api/v1/kata/proxy/api/v1/instance",
+		http.NoBody,
+	)
+	require.NoError(err)
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp, err := middleman.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+
+	assert.Equal(http.StatusBadGateway, resp.StatusCode)
+	assert.Equal("", resp.Header.Get("Content-Encoding"))
+	assert.Equal("", resp.Header.Get("ETag"))
+	assert.Equal("", resp.Header.Get("WWW-Authenticate"))
+	assert.Contains(string(body), `"code":"upstreamError"`)
+	assert.NotContains(string(body), "Authentication required")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal([]string{"", ""}, authorizations)
+}
+
+func TestKataLocalDaemonTokenIsNotUsedForRosterOrProxyE2E(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	authorizations := []string{}
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		authorizations = append(authorizations, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"instance":"local"}`))
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataE2ECatalog(t, home, `
+active_daemon = "local"
+
+[[daemon]]
+name = "local"
+local = true
+token = "local-secret"
+`)
+	writeKataE2ERuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+	middleman := httptest.NewServer(srv)
+	defer middleman.Close()
+
+	client, err := apiclient.New(middleman.URL)
+	require.NoError(err)
+	roster, err := client.HTTP.ListKataDaemonsWithResponse(t.Context())
+	require.NoError(err)
+	require.Equal(http.StatusOK, roster.StatusCode(), string(roster.Body))
+	require.NotNil(roster.JSON200)
+	require.NotNil(roster.JSON200.Daemons)
+	require.Len(*roster.JSON200.Daemons, 1)
+	localDaemon := (*roster.JSON200.Daemons)[0]
+	assert.Equal("local", localDaemon.Id)
+	assert.Equal("none", localDaemon.Auth)
+	assert.Equal("connected", localDaemon.Health)
+
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		middleman.URL+"/api/v1/kata/proxy/api/v1/instance",
+		http.NoBody,
+	)
+	require.NoError(err)
+	req.Header.Set("Authorization", "Bearer caller-secret")
+	resp, err := middleman.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+
+	assert.Equal(http.StatusOK, resp.StatusCode, string(body))
+	assert.JSONEq(`{"instance":"local"}`, string(body))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal([]string{"", ""}, authorizations)
+}
+
+func writeKataE2ECatalog(t *testing.T, home string, body string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(body), 0o600))
+}
+
+func writeKataE2ERuntimeRecord(t *testing.T, address string) {
+	t.Helper()
+
+	runtimeDir, err := kata.RuntimeDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(runtimeDir, 0o700))
+	rec := kata.RuntimeRecord{
+		PID:       os.Getpid(),
+		Address:   address,
+		StartedAt: time.Now().UTC(),
+	}
+	body, err := json.Marshal(rec)
+	require.NoError(t, err)
+	path := filepath.Join(runtimeDir, "daemon."+strconv.Itoa(rec.PID)+".json")
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+}

--- a/internal/server/kata_proxy.go
+++ b/internal/server/kata_proxy.go
@@ -27,6 +27,7 @@ type kataProxyCacheKey struct {
 	id    string
 	url   string
 	token string
+	local bool
 }
 
 type kataProxyCacheEntry struct {
@@ -60,7 +61,7 @@ func (s *Server) kataProxy() http.Handler {
 }
 
 func (s *Server) kataProxyForDaemon(d kata.Daemon) (kataProxyCacheEntry, error) {
-	key := kataProxyCacheKey{id: d.ID, url: d.URL, token: kataDaemonForwardToken(d)}
+	key := kataProxyCacheKey{id: d.ID, url: d.URL, token: kataDaemonForwardToken(d), local: d.Local}
 	s.kataProxyMu.Lock()
 	if entry, ok := s.kataProxyCache[key]; ok {
 		s.kataProxyMu.Unlock()

--- a/internal/server/kata_proxy.go
+++ b/internal/server/kata_proxy.go
@@ -1,14 +1,17 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -57,7 +60,7 @@ func (s *Server) kataProxy() http.Handler {
 }
 
 func (s *Server) kataProxyForDaemon(d kata.Daemon) (kataProxyCacheEntry, error) {
-	key := kataProxyCacheKey{id: d.ID, url: d.URL, token: d.Token}
+	key := kataProxyCacheKey{id: d.ID, url: d.URL, token: kataDaemonForwardToken(d)}
 	s.kataProxyMu.Lock()
 	if entry, ok := s.kataProxyCache[key]; ok {
 		s.kataProxyMu.Unlock()
@@ -193,9 +196,44 @@ func newKataDaemonProxyEntry(d kata.Daemon) (kataProxyCacheEntry, error) {
 			pr.Out.Host = target.Host
 			pr.Out.Header.Del("Origin")
 			pr.Out.Header.Del(kataDaemonHeaderName)
-			if d.Token != "" && pr.Out.Header.Get("Authorization") == "" {
-				pr.Out.Header.Set("Authorization", "Bearer "+d.Token)
+			if d.Local {
+				pr.Out.Header.Del("Authorization")
+				return
 			}
+			if token := kataDaemonForwardToken(d); token != "" && pr.Out.Header.Get("Authorization") == "" {
+				pr.Out.Header.Set("Authorization", "Bearer "+token)
+			}
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			if !isKataLocalDaemonChallenge(d, resp.StatusCode) {
+				return nil
+			}
+			problem := newProblem(
+				http.StatusBadGateway,
+				CodeUpstreamError,
+				"Kata daemon is unreachable",
+				map[string]any{"daemon": d.ID},
+			)
+			body, err := json.Marshal(problem)
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			resp.StatusCode = problem.Status
+			resp.Status = "502 Bad Gateway"
+			resp.Header.Del("Content-Encoding")
+			resp.Header.Del("Content-Language")
+			resp.Header.Del("Content-Location")
+			resp.Header.Del("ETag")
+			resp.Header.Del("Last-Modified")
+			resp.Header.Del("Trailer")
+			resp.Header.Del("WWW-Authenticate")
+			resp.Header.Set("Content-Type", "application/problem+json")
+			resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+			resp.Trailer = nil
+			resp.ContentLength = int64(len(body))
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+			return nil
 		},
 		Transport: transport,
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {

--- a/internal/server/kata_proxy_test.go
+++ b/internal/server/kata_proxy_test.go
@@ -517,6 +517,83 @@ local = true
 	assert.Equal("late-local", strings.TrimSpace(rr.Body.String()))
 }
 
+func TestKataProxyLocalNoAuthDoesNotForwardAuthChallenge(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeProblemResponse(w, newProblem(
+			http.StatusUnauthorized,
+			CodeUnauthorized,
+			"Authentication required",
+			nil,
+		))
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataProxyCatalog(t, home, `
+active_daemon = "local"
+
+[[daemon]]
+name = "local"
+local = true
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/proxy/api/v1/instance", nil)
+
+	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
+	problem := decodeMsgvaultProblem(t, rr)
+	assert.Equal(CodeUpstreamError, problem.Code)
+	assert.NotContains(rr.Body.String(), "Authentication required")
+}
+
+func TestKataProxyLocalDaemonStripsAuthorization(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	authorizations := []string{}
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		authorizations = append(authorizations, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataProxyCatalog(t, home, `
+active_daemon = "local"
+
+[[daemon]]
+name = "local"
+local = true
+token = "local-secret"
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/proxy/api/v1/instance", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kata/proxy/api/v1/instance", nil)
+	req.Header.Set("Authorization", "Bearer caller-secret")
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal([]string{"", ""}, authorizations)
+}
+
 func TestKataProxyLocalDaemonRejectsNonLocalRuntimeTargets(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata_proxy_test.go
+++ b/internal/server/kata_proxy_test.go
@@ -594,6 +594,90 @@ token = "local-secret"
 	assert.Equal([]string{"", ""}, authorizations)
 }
 
+func TestKataProxyCacheSeparatesLocalAndRemoteDaemonMode(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	authorizations := []string{}
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		authorizations = append(authorizations, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataProxyCatalog(t, home, `
+active_daemon = "home"
+
+[[daemon]]
+name = "home"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kata/proxy/api/v1/instance", nil)
+	req.Header.Set("Authorization", "Bearer caller-secret")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	writeKataProxyCatalog(t, home, `
+active_daemon = "home"
+
+[[daemon]]
+name = "home"
+local = true
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/kata/proxy/api/v1/instance", nil)
+	req.Header.Set("Authorization", "Bearer caller-secret")
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal([]string{"Bearer caller-secret", ""}, authorizations)
+}
+
+func TestKataProxyLocalDaemonIgnoresTokenEnv(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	t.Setenv("MIDDLEMAN_KATA_MISSING_TOKEN", "")
+	writeKataProxyCatalog(t, home, `
+active_daemon = "local"
+
+[[daemon]]
+name = "local"
+local = true
+token_env = "MIDDLEMAN_KATA_MISSING_TOKEN"
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kata/proxy/api/v1/instance", nil)
+	req.Header.Set("Authorization", "Bearer caller-secret")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+}
+
 func TestKataProxyLocalDaemonRejectsNonLocalRuntimeTargets(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata_routes.go
+++ b/internal/server/kata_routes.go
@@ -91,7 +91,7 @@ func (s *Server) listKataDaemons(context.Context, *struct{}) (*listKataDaemonsOu
 	for i, configured := range catalog.Daemons {
 		d := resolved[i]
 		auth := "none"
-		if kataDaemonForwardToken(d) != "" {
+		if !d.Local && kataDaemonForwardToken(d) != "" {
 			auth = "token"
 		}
 		hint := ""
@@ -128,7 +128,7 @@ func (s *Server) kataDaemonHealth(id string, d kata.Daemon) string {
 	if d.URL == "" {
 		return "down"
 	}
-	cacheKey := id + kataDaemonCacheKeyDelim + d.URL
+	cacheKey := kataDaemonHealthCacheKey(id, d)
 
 	s.kataHealthMu.Lock()
 	if s.kataHealthCache == nil {
@@ -167,6 +167,13 @@ func (s *Server) kataDaemonHealth(id string, d kata.Daemon) string {
 	return state
 }
 
+func kataDaemonHealthCacheKey(id string, d kata.Daemon) string {
+	if d.Local {
+		return strings.Join([]string{id, d.URL, "local", ""}, kataDaemonCacheKeyDelim)
+	}
+	return strings.Join([]string{id, d.URL, "remote", kataDaemonForwardToken(d)}, kataDaemonCacheKeyDelim)
+}
+
 func probeKataDaemon(id string, d kata.Daemon) string {
 	probeURL, transport, err := kataDaemonProbeTarget(d.URL)
 	if err != nil {
@@ -185,8 +192,10 @@ func probeKataDaemon(id string, d kata.Daemon) string {
 	if err != nil {
 		return "down"
 	}
-	if token := kataDaemonForwardToken(d); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+	if !d.Local {
+		if token := kataDaemonForwardToken(d); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
 	}
 
 	client := &http.Client{

--- a/internal/server/kata_routes.go
+++ b/internal/server/kata_routes.go
@@ -91,7 +91,7 @@ func (s *Server) listKataDaemons(context.Context, *struct{}) (*listKataDaemonsOu
 	for i, configured := range catalog.Daemons {
 		d := resolved[i]
 		auth := "none"
-		if d.Token != "" {
+		if kataDaemonForwardToken(d) != "" {
 			auth = "token"
 		}
 		hint := ""
@@ -185,8 +185,8 @@ func probeKataDaemon(id string, d kata.Daemon) string {
 	if err != nil {
 		return "down"
 	}
-	if d.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+d.Token)
+	if token := kataDaemonForwardToken(d); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	client := &http.Client{
@@ -212,10 +212,24 @@ func probeKataDaemon(id string, d kata.Daemon) string {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return "connected"
 	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		if isKataLocalDaemonChallenge(d, resp.StatusCode) {
+			return "down"
+		}
 		return "auth_required"
 	default:
 		return "down"
 	}
+}
+
+func isKataLocalDaemonChallenge(d kata.Daemon, statusCode int) bool {
+	return d.Local && (statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden)
+}
+
+func kataDaemonForwardToken(d kata.Daemon) string {
+	if d.Local {
+		return ""
+	}
+	return d.Token
 }
 
 func kataDaemonProbeTarget(target string) (*url.URL, http.RoundTripper, error) {

--- a/internal/server/kata_routes_test.go
+++ b/internal/server/kata_routes_test.go
@@ -442,6 +442,84 @@ url = "`+upstream.URL+`"
 	assert.Equal(int32(1), probes.Load())
 }
 
+func TestKataDaemonsEndpointHealthCacheSeparatesLocalAndRemoteMode(t *testing.T) {
+	assert := Assert.New(t)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "home"
+url = "`+upstream.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	got := requestKataDaemonsByID(t, srv)
+	assert.Equal("auth_required", got["home"].Health)
+
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "home"
+local = true
+`)
+	writeKataProxyRuntimeRecord(t, upstream.URL)
+
+	got = requestKataDaemonsByID(t, srv)
+	assert.Equal("down", got["home"].Health)
+}
+
+func TestKataDaemonsEndpointHealthCacheSeparatesRemoteTokens(t *testing.T) {
+	assert := Assert.New(t)
+
+	var mu sync.Mutex
+	authorizations := []string{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		mu.Lock()
+		authorizations = append(authorizations, auth)
+		mu.Unlock()
+		if auth == "Bearer first-secret" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "home"
+url = "`+upstream.URL+`"
+token = "first-secret"
+`)
+	srv, _ := setupTestServer(t)
+
+	got := requestKataDaemonsByID(t, srv)
+	assert.Equal("connected", got["home"].Health)
+
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "home"
+url = "`+upstream.URL+`"
+token = "second-secret"
+`)
+
+	got = requestKataDaemonsByID(t, srv)
+	assert.Equal("auth_required", got["home"].Health)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal([]string{"Bearer first-secret", "Bearer second-secret"}, authorizations)
+}
+
 func TestKataDaemonsEndpointHealthOverTrailingSlashURL(t *testing.T) {
 	assert := Assert.New(t)
 

--- a/internal/server/kata_routes_test.go
+++ b/internal/server/kata_routes_test.go
@@ -221,6 +221,58 @@ local = true
 	assert.Contains(body.Daemons[0].Hint, "kata daemon start")
 }
 
+func TestKataDaemonsEndpointDoesNotReportAuthRequiredForLocalNoAuthDaemon(t *testing.T) {
+	assert := Assert.New(t)
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "local"
+local = true
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	got := requestKataDaemonsByID(t, srv)
+
+	assert.Equal("none", got["local"].Auth)
+	assert.Equal("down", got["local"].Health)
+}
+
+func TestKataDaemonsEndpointLocalDaemonDoesNotUseTokenAuth(t *testing.T) {
+	assert := Assert.New(t)
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "local"
+local = true
+token = "local-secret"
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	got := requestKataDaemonsByID(t, srv)
+
+	assert.Equal("none", got["local"].Auth)
+	assert.Equal("connected", got["local"].Health)
+}
+
 func TestKataDaemonsEndpointRedactsMalformedTargetErrors(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata_routes_test.go
+++ b/internal/server/kata_routes_test.go
@@ -273,6 +273,34 @@ token = "local-secret"
 	assert.Equal("connected", got["local"].Health)
 }
 
+func TestKataDaemonsEndpointLocalDaemonIgnoresTokenEnv(t *testing.T) {
+	assert := Assert.New(t)
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DB", "")
+	t.Setenv("MIDDLEMAN_KATA_MISSING_TOKEN", "")
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "local"
+local = true
+token_env = "MIDDLEMAN_KATA_MISSING_TOKEN"
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	got := requestKataDaemonsByID(t, srv)
+
+	assert.Equal("none", got["local"].Auth)
+	assert.Equal("connected", got["local"].Health)
+}
+
 func TestKataDaemonsEndpointRedactsMalformedTargetErrors(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
- Keeps the Kata daemon selector visible in the header even when the roster has one daemon.
- Keeps daemon connection and health details inside dropdown rows instead of showing stale header text like `Connecting - kenn`.
- Treats local Kata daemons as tokenless loopback targets across catalog loading, health checks, and proxying.
- Shows real Kata request failures as a visible workspace alert instead of hiding them in the daemon menu.