### PR TITLE
Classify textual diffs without language allowlists

### DIFF
--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2539,9 +2539,9 @@ test.describe("diff view (git-backed)", () => {
         name: "Filter changed files",
       });
       await expect(categoryFilter.getByRole("button", { name: "Plans/docs (2)" })).toBeVisible();
-      await expect(categoryFilter.getByRole("button", { name: "Code (2)" })).toBeVisible();
+      await expect(categoryFilter.getByRole("button", { name: "Code (3)" })).toBeVisible();
       await expect(categoryFilter.getByRole("button", { name: "Tests (1)" })).toBeVisible();
-      await expect(categoryFilter.getByRole("button", { name: "Other (1)" })).toBeVisible();
+      await expect(categoryFilter.getByRole("button", { name: "Other (0)" })).toBeVisible();
       await expect(categoryFilter.getByRole("button", { name: "All (6)" })).toHaveAttribute("aria-pressed", "true");
 
       await categoryFilter.getByRole("button", { name: "Tests (1)" }).click();

--- a/packages/ui/src/components/detail/DiffSummaryChip.test.ts
+++ b/packages/ui/src/components/detail/DiffSummaryChip.test.ts
@@ -64,16 +64,15 @@ describe("DiffSummaryChip", () => {
     const labels = Array.from(popover.querySelectorAll(".diff-summary-row > span:first-child")).map(
       (label) => label.textContent,
     );
-    expect(labels).toEqual(["Plans/docs", "Code", "Tests", "Other", "Generated"]);
+    expect(labels).toEqual(["Plans/docs", "Code", "Tests", "Generated"]);
     expect(screen.getByText("Plans/docs")).toBeTruthy();
     expect(screen.queryByText("Total")).toBeNull();
     expect(rowText(popover, "Plans/docs")).toBe("Plans/docs +10 −2");
     expect(screen.getByText("Code")).toBeTruthy();
-    expect(rowText(popover, "Code")).toBe("Code +40 −6");
+    expect(rowText(popover, "Code")).toBe("Code +41 −7");
     expect(screen.getByText("Tests")).toBeTruthy();
     expect(rowText(popover, "Tests")).toBe("Tests +20 −8");
-    expect(screen.getByText("Other")).toBeTruthy();
-    expect(rowText(popover, "Other")).toBe("Other +1 −1");
+    expect(screen.queryByText("Other")).toBeNull();
     expect(screen.getByText("Generated")).toBeTruthy();
     expect(rowText(popover, "Generated")).toBe("Generated +3 −3");
     expect(loadFiles).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/components/detail/diff-summary.test.ts
+++ b/packages/ui/src/components/detail/diff-summary.test.ts
@@ -34,7 +34,7 @@ describe("diff summary categorization", () => {
         ...file("bun.lock", 1, 1),
         is_generated: false,
       }),
-    ).toBe("other");
+    ).toBe("code");
   });
 
   it("puts documentation and planning paths into plans/docs", () => {
@@ -65,9 +65,9 @@ describe("diff summary categorization", () => {
 
     expect(summary.plansDocs).toEqual({ additions: 10, deletions: 2 });
     expect(summary.generated).toEqual({ additions: 5, deletions: 1 });
-    expect(summary.code).toEqual({ additions: 30, deletions: 4 });
+    expect(summary.code).toEqual({ additions: 31, deletions: 5 });
     expect(summary.tests).toEqual({ additions: 20, deletions: 8 });
-    expect(summary.other).toEqual({ additions: 1, deletions: 1 });
+    expect(summary.other).toEqual({ additions: 0, deletions: 0 });
     expect(summary.total).toEqual({ additions: 66, deletions: 16 });
   });
 });

--- a/packages/ui/src/utils/diff-categories.test.ts
+++ b/packages/ui/src/utils/diff-categories.test.ts
@@ -31,8 +31,18 @@ describe("diff file categorization", () => {
     expect(categorizeDiffFile(file("Makefile"))).toBe("code");
   });
 
-  it("keeps binary files outside the code bucket", () => {
+  it("treats lockfiles as generated", () => {
+    expect(categorizeDiffFile(file("flake.lock"))).toBe("generated");
+    expect(categorizeDiffFile(file("pixi.lock"))).toBe("generated");
+    expect(categorizeDiffFile(file("pnpm-lock.yaml"))).toBe("generated");
+    expect(categorizeDiffFile(file("package-lock.json"))).toBe("generated");
+    expect(categorizeDiffFile(binaryFile("flake.lock"))).toBe("generated");
+  });
+
+  it("keeps non-generated binary files outside the code bucket", () => {
     expect(categorizeDiffFile(binaryFile("assets/logo.png"))).toBe("other");
+    expect(categorizeDiffFile(binaryFile("docs/logo.png"))).toBe("other");
+    expect(categorizeDiffFile(binaryFile("tests/fixtures/screenshot.png"))).toBe("other");
     expect(categorizeDiffFile(binaryFile("release/middleman.tar.gz"))).toBe("other");
   });
 });

--- a/packages/ui/src/utils/diff-categories.test.ts
+++ b/packages/ui/src/utils/diff-categories.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { DiffFile } from "../api/types.js";
+import { categorizeDiffFile } from "./diff-categories.js";
+
+function file(path: string): DiffFile {
+  return {
+    path,
+    old_path: path,
+    status: "modified",
+    is_binary: false,
+    is_whitespace_only: false,
+    additions: 1,
+    deletions: 1,
+    patch: "@@ -1 +1 @@\n-old\n+new\n",
+    hunks: [],
+  };
+}
+
+function binaryFile(path: string): DiffFile {
+  return {
+    ...file(path),
+    is_binary: true,
+    patch: "",
+  };
+}
+
+describe("diff file categorization", () => {
+  it("treats non-binary changed files as code without per-language allowlisting", () => {
+    expect(categorizeDiffFile(file("flake.nix"))).toBe("code");
+    expect(categorizeDiffFile(file("config/middleman.toml"))).toBe("code");
+    expect(categorizeDiffFile(file("Makefile"))).toBe("code");
+  });
+
+  it("keeps binary files outside the code bucket", () => {
+    expect(categorizeDiffFile(binaryFile("assets/logo.png"))).toBe("other");
+    expect(categorizeDiffFile(binaryFile("release/middleman.tar.gz"))).toBe("other");
+  });
+});

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -103,9 +103,9 @@ export function categorizeDiffFile(file: string | CategorizableDiffFile): DiffFi
 
   if (generatedMetadata === true) return "generated";
   if (generatedMetadata !== false && hasGeneratedSignal(base)) return "generated";
+  if (binaryMetadata === true) return "other";
   if (hasTestSignal(parts, base)) return "tests";
   if (hasDocsSignal(parts, base, ext)) return "plansDocs";
-  if (binaryMetadata === true) return "other";
   return "code";
 }
 

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -4,6 +4,7 @@ export type DiffFileCategory = "plansDocs" | "generated" | "code" | "tests" | "o
 export type DiffFileCategoryFilter = DiffFileCategory | "all";
 export type DiffFileCategoryCounts = Record<DiffFileCategoryFilter, number>;
 type CategorizableDiffFile = Pick<DiffFile, "path"> & {
+  is_binary?: boolean;
   is_generated?: boolean;
 };
 
@@ -18,41 +19,6 @@ export const diffFileCategoryOptions: {
   { value: "generated", label: "Generated" },
   { value: "all", label: "All" },
 ];
-
-const codeExtensions = new Set([
-  ".bash",
-  ".c",
-  ".cc",
-  ".cpp",
-  ".cs",
-  ".css",
-  ".go",
-  ".gql",
-  ".graphql",
-  ".h",
-  ".hpp",
-  ".html",
-  ".java",
-  ".js",
-  ".jsx",
-  ".kt",
-  ".kts",
-  ".less",
-  ".php",
-  ".py",
-  ".rb",
-  ".rs",
-  ".sass",
-  ".scss",
-  ".sh",
-  ".sql",
-  ".svelte",
-  ".swift",
-  ".ts",
-  ".tsx",
-  ".vue",
-  ".zsh",
-]);
 
 const docsExtensions = new Set([".adoc", ".md", ".mdx", ".rst", ".txt"]);
 
@@ -132,14 +98,15 @@ export function categorizeDiffFile(file: string | CategorizableDiffFile): DiffFi
   const parts = pathParts(path);
   const base = basename(path);
   const ext = extension(path);
+  const binaryMetadata = typeof file === "string" ? false : file.is_binary;
   const generatedMetadata = typeof file === "string" ? undefined : file.is_generated;
 
   if (generatedMetadata === true) return "generated";
   if (generatedMetadata !== false && hasGeneratedSignal(base)) return "generated";
   if (hasTestSignal(parts, base)) return "tests";
   if (hasDocsSignal(parts, base, ext)) return "plansDocs";
-  if (codeExtensions.has(ext)) return "code";
-  return "other";
+  if (binaryMetadata === true) return "other";
+  return "code";
 }
 
 export function filterDiffFilesByCategory(files: DiffFile[], filter: DiffFileCategoryFilter): DiffFile[] {


### PR DESCRIPTION
- Treat unknown non-binary changed files as Code after generated, test, and docs rules run, so Nix, config, Makefile, and future source-like files do not need extension allowlist entries.
- Keep generated lockfiles such as `flake.lock`, `pixi.lock`, and package-manager lockfiles in Generated.
- Keep remaining binary files in Other before docs/test path buckets so asset diffs do not inflate source categories.
- Update diff summary, popover, helper, and e2e coverage for the new category behavior.
