### PR TITLE
Add markdown image zoom overlay

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -560,6 +560,195 @@ a:hover {
   height: auto;
   border-radius: var(--radius-sm);
 }
+.markdown-image-expander {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: top;
+  line-height: 0;
+}
+.markdown-image-expander > a {
+  display: inline-block;
+  max-width: 100%;
+  line-height: 0;
+}
+.markdown-image-expander img {
+  display: block;
+  min-width: 1px;
+  min-height: 1px;
+}
+.markdown-image-expander__button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(139, 148, 158, 0.5);
+  border-radius: var(--radius-md);
+  background: rgba(36, 41, 47, 0.84);
+  color: #f0f6fc;
+  box-shadow: 0 1px 4px rgba(1, 4, 9, 0.24);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    background-color 120ms ease-out,
+    opacity 120ms ease-out;
+}
+.markdown-image-expander:hover .markdown-image-expander__button,
+.markdown-image-expander:focus-within .markdown-image-expander__button {
+  opacity: 1;
+  pointer-events: auto;
+}
+.markdown-image-expander__button:hover {
+  background: rgba(48, 54, 61, 0.96);
+}
+.markdown-image-expander__button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+.markdown-image-expander__icon {
+  position: relative;
+  display: block;
+  width: 15px;
+  height: 15px;
+}
+.markdown-image-expander__icon::before,
+.markdown-image-expander__icon::after {
+  position: absolute;
+  display: block;
+  content: "";
+}
+.markdown-image-expander__icon::before {
+  top: 1px;
+  left: 1px;
+  width: 10px;
+  height: 10px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+}
+.markdown-image-expander__icon::after {
+  right: 1px;
+  bottom: 1px;
+  width: 6px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+  transform: rotate(45deg);
+  transform-origin: center;
+}
+.markdown-image-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 130;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  background: rgba(1, 4, 9, 0.72);
+}
+.markdown-image-lightbox__panel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  height: fit-content;
+  max-width: calc(100vw - 56px);
+  max-height: calc(100vh - 56px);
+  overflow: visible;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: 0 8px 24px rgba(1, 4, 9, 0.38);
+}
+.markdown-image-lightbox__panel img {
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: calc(100vw - 56px);
+  max-height: calc(100vh - 56px);
+  object-fit: contain;
+}
+.markdown-image-lightbox__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-xl);
+  line-height: 1;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    background-color 120ms ease-out,
+    border-color 120ms ease-out,
+    color 120ms ease-out,
+    opacity 120ms ease-out;
+}
+.markdown-image-lightbox__panel:hover .markdown-image-lightbox__close,
+.markdown-image-lightbox__panel:focus-within .markdown-image-lightbox__close {
+  background: rgba(36, 41, 47, 0.84);
+  border-color: rgba(139, 148, 158, 0.5);
+  color: #f0f6fc;
+  box-shadow: 0 1px 4px rgba(1, 4, 9, 0.24);
+  opacity: 1;
+  pointer-events: auto;
+}
+.markdown-image-lightbox__close:hover {
+  background: rgba(48, 54, 61, 0.96);
+  color: #f0f6fc;
+}
+.markdown-image-lightbox__close:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+@media (hover: none), (pointer: coarse) {
+  .markdown-image-expander__button,
+  .markdown-image-lightbox__close {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .markdown-image-expander__button {
+    transition: none;
+  }
+  .markdown-image-lightbox__close {
+    transition: none;
+  }
+}
+@media (max-width: 640px) {
+  .markdown-image-expander__button {
+    top: 6px;
+    right: 6px;
+    width: 32px;
+    height: 32px;
+  }
+  .markdown-image-lightbox {
+    padding: 10px;
+  }
+  .markdown-image-lightbox__panel {
+    max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 20px);
+  }
+  .markdown-image-lightbox__panel img {
+    max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 20px);
+  }
+}
 /* GitHub's (Primer) table layout model: shrink-wrap to content, cap at
    the container, scroll on overflow. Auto table layout then gives compact
    columns their content width and wraps or scrolls wide ones, so text

--- a/frontend/src/lib/utils/markdownImages.test.ts
+++ b/frontend/src/lib/utils/markdownImages.test.ts
@@ -1,0 +1,242 @@
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
+import { getStackDepth, getTopFrame, resetModalStack } from "@middleman/ui/stores/keyboard/modal-stack";
+import { expandMarkdownImages } from "./markdownImages";
+
+const appCss = readFileSync("src/app.css", "utf8");
+
+function declarationsFor(selector: string): Map<string, string> {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = appCss.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+  if (match?.[1]) {
+    return new Map(
+      match[1]
+        .split(";")
+        .map((declaration) => declaration.trim())
+        .filter(Boolean)
+        .map((declaration) => {
+          const separator = declaration.indexOf(":");
+          return [declaration.slice(0, separator).trim(), declaration.slice(separator + 1).trim()];
+        }),
+    );
+  }
+  throw new Error(`Missing CSS rule for ${selector}`);
+}
+
+describe("expandMarkdownImages", () => {
+  beforeEach(() => {
+    resetModalStack();
+  });
+
+  afterEach(() => {
+    resetModalStack();
+    document.querySelectorAll(".markdown-image-lightbox").forEach((node) => node.remove());
+  });
+
+  test("adds a top-right control that opens the markdown image in an overlay", () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><p><img src="/shots/dashboard.png" alt="Quality dashboard"></p></div>';
+
+    const enhanced = expandMarkdownImages(root);
+    const button = root.querySelector<HTMLButtonElement>('button[aria-label="Open image in expanded view"]');
+
+    expect(enhanced).toBe(1);
+    expect(button).not.toBeNull();
+    expect(button?.closest(".markdown-image-expander")?.querySelector("img")?.getAttribute("src")).toBe(
+      "/shots/dashboard.png",
+    );
+
+    button?.click();
+
+    const overlay = document.querySelector<HTMLElement>(".markdown-image-lightbox");
+    const expanded = overlay?.querySelector<HTMLImageElement>("img");
+    expect(overlay?.getAttribute("role")).toBe("dialog");
+    expect(overlay?.getAttribute("aria-modal")).toBe("true");
+    expect(expanded?.getAttribute("src")).toBe("/shots/dashboard.png");
+    expect(expanded?.getAttribute("alt")).toBe("Quality dashboard");
+    expect(document.activeElement).toBe(overlay);
+  });
+
+  test("keeps zoom controls outside linked markdown images", () => {
+    const root = document.createElement("div");
+    root.innerHTML = [
+      '<div class="markdown-body"><p>',
+      '<a href="/shots/dashboard-full.png"><img src="/shots/dashboard.png" alt="Quality dashboard"></a>',
+      "</p></div>",
+    ].join("");
+
+    const enhanced = expandMarkdownImages(root);
+    const link = root.querySelector<HTMLAnchorElement>("a");
+    const button = root.querySelector<HTMLButtonElement>('button[aria-label="Open image in expanded view"]');
+
+    expect(enhanced).toBe(1);
+    expect(link?.parentElement?.classList.contains("markdown-image-expander")).toBe(true);
+    expect(link?.querySelector("img")).not.toBeNull();
+    expect(button?.closest("a")).toBeNull();
+  });
+
+  test("skips images inside links that also contain text", () => {
+    const root = document.createElement("div");
+    root.innerHTML = [
+      '<div class="markdown-body"><p>',
+      '<a href="/shots/dashboard-full.png">Open <img src="/shots/dashboard.png" alt="Quality dashboard"> full size</a>',
+      "</p></div>",
+    ].join("");
+
+    const enhanced = expandMarkdownImages(root);
+
+    expect(enhanced).toBe(0);
+    expect(root.querySelector(".markdown-image-expander")).toBeNull();
+    expect(root.querySelector('button[aria-label="Open image in expanded view"]')).toBeNull();
+  });
+
+  test("blocks global shortcuts while the expanded image overlay is open", () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><p><img src="/shots/dashboard.png" alt="Quality dashboard"></p></div>';
+    const windowShortcut = vi.fn();
+    window.addEventListener("keydown", windowShortcut);
+
+    try {
+      expandMarkdownImages(root);
+      root.querySelector<HTMLButtonElement>('button[aria-label="Open image in expanded view"]')?.click();
+
+      const overlay = document.querySelector<HTMLElement>(".markdown-image-lightbox");
+      const closeButton = overlay?.querySelector<HTMLButtonElement>('button[aria-label="Close expanded image"]');
+      expect(getTopFrame()?.frameId).toBe("markdown-image-lightbox");
+      expect(getStackDepth()).toBe(1);
+
+      closeButton?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "1" }));
+      expect(windowShortcut).not.toHaveBeenCalled();
+
+      const escape = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Escape" });
+      closeButton?.dispatchEvent(escape);
+      expect(escape.defaultPrevented).toBe(true);
+      expect(document.querySelector(".markdown-image-lightbox")).toBeNull();
+      expect(getStackDepth()).toBe(0);
+    } finally {
+      window.removeEventListener("keydown", windowShortcut);
+    }
+  });
+
+  test("keeps keyboard focus inside the expanded image overlay", () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<div class="markdown-body"><p><img src="/shots/dashboard.png" alt="Quality dashboard"></p></div>';
+
+    expandMarkdownImages(root);
+    root.querySelector<HTMLButtonElement>('button[aria-label="Open image in expanded view"]')?.click();
+
+    const overlay = document.querySelector<HTMLElement>(".markdown-image-lightbox");
+    const closeButton = overlay?.querySelector<HTMLButtonElement>('button[aria-label="Close expanded image"]');
+    expect(document.activeElement).toBe(overlay);
+
+    const tabFromOverlay = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" });
+    overlay?.dispatchEvent(tabFromOverlay);
+    expect(tabFromOverlay.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(closeButton);
+
+    const tabFromClose = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" });
+    closeButton?.dispatchEvent(tabFromClose);
+    expect(tabFromClose.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(closeButton);
+
+    const shiftTabFromClose = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      shiftKey: true,
+    });
+    closeButton?.dispatchEvent(shiftTabFromClose);
+    expect(shiftTabFromClose.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(closeButton);
+  });
+
+  test("lets the expanded image use the viewport instead of a fixed-height canvas", () => {
+    const panelStyle = declarationsFor(".markdown-image-lightbox__panel");
+    const imageStyle = declarationsFor(".markdown-image-lightbox__panel img");
+
+    expect(panelStyle.get("width")).toBe("fit-content");
+    expect(panelStyle.get("height")).toBe("fit-content");
+    expect(panelStyle.get("max-width")).toBe("calc(100vw - 56px)");
+    expect(panelStyle.get("max-height")).toBe("calc(100vh - 56px)");
+    expect(panelStyle.get("overflow")).toBe("visible");
+    expect(imageStyle.get("max-width")).toBe("calc(100vw - 56px)");
+    expect(imageStyle.get("max-height")).toBe("calc(100vh - 56px)");
+  });
+
+  test("renders the expanded image without panel border chrome", () => {
+    const panelStyle = declarationsFor(".markdown-image-lightbox__panel");
+
+    expect(panelStyle.get("background")).toBe("transparent");
+    expect(panelStyle.get("border")).toBe("none");
+    expect(panelStyle.get("border-radius")).toBe("0");
+  });
+
+  test("places the expanded image overlay above shared modal layers", () => {
+    const overlayStyle = declarationsFor(".markdown-image-lightbox");
+
+    expect(Number(overlayStyle.get("z-index"))).toBeGreaterThan(120);
+  });
+
+  test("keeps the zoom affordance hidden until image hover or keyboard focus", () => {
+    const buttonStyle = declarationsFor(".markdown-image-expander__button");
+
+    expect(buttonStyle.get("opacity")).toBe("0");
+    expect(buttonStyle.get("pointer-events")).toBe("none");
+    expect(appCss).toContain(
+      [
+        ".markdown-image-expander:hover .markdown-image-expander__button,",
+        ".markdown-image-expander:focus-within .markdown-image-expander__button {",
+        "  opacity: 1;",
+        "  pointer-events: auto;",
+        "}",
+      ].join("\n"),
+    );
+  });
+
+  test("keeps image controls available on touch pointers", () => {
+    expect(appCss).toContain(
+      [
+        "@media (hover: none), (pointer: coarse) {",
+        "  .markdown-image-expander__button,",
+        "  .markdown-image-lightbox__close {",
+        "    opacity: 1;",
+        "    pointer-events: auto;",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+  });
+
+  test("keeps wrapped lazy images visible before browser image decode finishes", () => {
+    const imageStyle = declarationsFor(".markdown-image-expander img");
+
+    expect(imageStyle.get("display")).toBe("block");
+    expect(imageStyle.get("min-width")).toBe("1px");
+    expect(imageStyle.get("min-height")).toBe("1px");
+  });
+
+  test("keeps the overlay close control hidden until overlay hover or keyboard focus", () => {
+    const closeStyle = declarationsFor(".markdown-image-lightbox__close");
+    const visibleStyle = declarationsFor(
+      ".markdown-image-lightbox__panel:hover .markdown-image-lightbox__close,\n.markdown-image-lightbox__panel:focus-within .markdown-image-lightbox__close",
+    );
+
+    expect(closeStyle.get("opacity")).toBe("0");
+    expect(closeStyle.get("pointer-events")).toBe("none");
+    expect(visibleStyle.get("background")).toBe("rgba(36, 41, 47, 0.84)");
+    expect(visibleStyle.get("color")).toBe("#f0f6fc");
+    expect(appCss).toContain(
+      [
+        ".markdown-image-lightbox__panel:hover .markdown-image-lightbox__close,",
+        ".markdown-image-lightbox__panel:focus-within .markdown-image-lightbox__close {",
+        "  background: rgba(36, 41, 47, 0.84);",
+        "  border-color: rgba(139, 148, 158, 0.5);",
+        "  color: #f0f6fc;",
+        "  box-shadow: 0 1px 4px rgba(1, 4, 9, 0.24);",
+        "  opacity: 1;",
+        "  pointer-events: auto;",
+        "}",
+      ].join("\n"),
+    );
+  });
+});

--- a/frontend/src/lib/utils/markdownImages.ts
+++ b/frontend/src/lib/utils/markdownImages.ts
@@ -1,0 +1,208 @@
+import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
+
+export interface MarkdownImageExpansionController {
+  renderNow: () => void;
+  disconnect: () => void;
+}
+
+const IMAGE_SELECTOR = ".markdown-body img, .doc-markdown img, .diff-image-preview img";
+const EXPANDER_CLASS = "markdown-image-expander";
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+let closeActiveMarkdownImageLightbox: (() => void) | null = null;
+
+export function expandMarkdownImages(root: ParentNode): number {
+  let enhanced = 0;
+
+  for (const image of Array.from(root.querySelectorAll<HTMLImageElement>(IMAGE_SELECTOR))) {
+    if (attachImageExpander(image)) {
+      enhanced += 1;
+    }
+  }
+
+  return enhanced;
+}
+
+function attachImageExpander(image: HTMLImageElement): boolean {
+  if (!image.getAttribute("src")) return false;
+  if (image.closest(`.${EXPANDER_CLASS}`) || image.closest(".markdown-image-lightbox")) return false;
+
+  const target = expandableTargetFor(image);
+  if (!target?.parentNode) return false;
+
+  const wrapper = image.ownerDocument.createElement("span");
+  wrapper.className = EXPANDER_CLASS;
+  target.before(wrapper);
+
+  const button = createImageExpanderButton(image.ownerDocument, () => openMarkdownImageLightbox(image));
+  wrapper.append(target, button);
+  return true;
+}
+
+function expandableTargetFor(image: HTMLImageElement): HTMLAnchorElement | HTMLImageElement | null {
+  const parent = image.parentElement;
+  const AnchorElement = image.ownerDocument.defaultView?.HTMLAnchorElement ?? HTMLAnchorElement;
+  if (
+    parent instanceof AnchorElement &&
+    parent.querySelectorAll("img").length === 1 &&
+    parent.textContent?.trim() === ""
+  ) {
+    return parent;
+  }
+  if (image.closest("a")) return null;
+  return image;
+}
+
+function createImageExpanderButton(doc: Document, onClick: () => void): HTMLButtonElement {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.className = "markdown-image-expander__button";
+  button.setAttribute("aria-label", "Open image in expanded view");
+  button.title = "Open image in expanded view";
+
+  const icon = doc.createElement("span");
+  icon.className = "markdown-image-expander__icon";
+  icon.setAttribute("aria-hidden", "true");
+  button.append(icon);
+
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onClick();
+  });
+
+  return button;
+}
+
+function openMarkdownImageLightbox(sourceImage: HTMLImageElement): void {
+  closeActiveMarkdownImageLightbox?.();
+
+  const doc = sourceImage.ownerDocument;
+  const HTMLElementCtor = doc.defaultView?.HTMLElement ?? HTMLElement;
+  const overlay = doc.createElement("div");
+  overlay.className = "markdown-image-lightbox";
+  overlay.setAttribute("aria-label", "Expanded image");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("role", "dialog");
+  overlay.tabIndex = -1;
+
+  const panel = doc.createElement("div");
+  panel.className = "markdown-image-lightbox__panel";
+
+  const expanded = doc.createElement("img");
+  const src = sourceImage.currentSrc || sourceImage.getAttribute("src") || sourceImage.src;
+  if (src) expanded.setAttribute("src", src);
+  expanded.setAttribute("alt", sourceImage.getAttribute("alt") ?? "");
+
+  const closeButton = doc.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "markdown-image-lightbox__close";
+  closeButton.setAttribute("aria-label", "Close expanded image");
+  closeButton.title = "Close expanded image";
+  closeButton.textContent = "x";
+  closeButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    closeLightbox();
+  });
+
+  panel.append(expanded, closeButton);
+  overlay.append(panel);
+
+  const restoreFocusTo = doc.activeElement instanceof HTMLElementCtor ? doc.activeElement : null;
+  const popModalFrame = pushModalFrame("markdown-image-lightbox", []);
+  const onKeyDown = (event: KeyboardEvent) => {
+    event.stopPropagation();
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeLightbox();
+      return;
+    }
+    if (event.key === "Tab") {
+      trapLightboxFocus(event);
+    }
+  };
+
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) closeLightbox();
+  });
+  overlay.addEventListener("keydown", onKeyDown);
+  doc.addEventListener("keydown", onKeyDown);
+  doc.body.append(overlay);
+  closeActiveMarkdownImageLightbox = closeLightbox;
+  overlay.focus({ preventScroll: true });
+
+  function closeLightbox(): void {
+    overlay.removeEventListener("keydown", onKeyDown);
+    doc.removeEventListener("keydown", onKeyDown);
+    popModalFrame();
+    overlay.remove();
+    if (closeActiveMarkdownImageLightbox === closeLightbox) {
+      closeActiveMarkdownImageLightbox = null;
+    }
+    restoreFocusTo?.focus({ preventScroll: true });
+  }
+
+  function trapLightboxFocus(event: KeyboardEvent): void {
+    const focusableElements = Array.from(overlay.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+      (element) => !element.hidden,
+    );
+    event.preventDefault();
+
+    if (focusableElements.length === 0) {
+      overlay.focus({ preventScroll: true });
+      return;
+    }
+
+    const activeElement = doc.activeElement instanceof HTMLElementCtor ? doc.activeElement : null;
+    const currentIndex = activeElement ? focusableElements.indexOf(activeElement) : -1;
+    const nextIndex = event.shiftKey
+      ? currentIndex <= 0
+        ? focusableElements.length - 1
+        : currentIndex - 1
+      : currentIndex >= focusableElements.length - 1
+        ? 0
+        : currentIndex + 1;
+    focusableElements[nextIndex]?.focus({ preventScroll: true });
+  }
+}
+
+export function initMarkdownImageExpansion(root: HTMLElement | Document = document): MarkdownImageExpansionController {
+  let disconnected = false;
+  let scheduled = false;
+
+  const render = () => {
+    if (disconnected || scheduled) return;
+    scheduled = true;
+    queueMicrotask(() => {
+      scheduled = false;
+      if (!disconnected) expandMarkdownImages(root);
+    });
+  };
+
+  const observer =
+    typeof MutationObserver === "undefined"
+      ? null
+      : new MutationObserver(() => {
+          render();
+        });
+  observer?.observe(root instanceof Document ? root.documentElement : root, {
+    childList: true,
+    subtree: true,
+  });
+  render();
+
+  return {
+    renderNow: render,
+    disconnect() {
+      disconnected = true;
+      observer?.disconnect();
+    },
+  };
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { mount } from "svelte";
 import App from "./App.svelte";
 import "./app.css";
+import { initMarkdownImageExpansion } from "./lib/utils/markdownImages.js";
 import { initMarkdownMermaidRendering } from "./lib/utils/markdownMermaid.js";
 
 const target = document.getElementById("app");
@@ -10,4 +11,5 @@ if (!target) {
 }
 
 mount(App, { target });
+initMarkdownImageExpansion(target);
 initMarkdownMermaidRendering(target);

--- a/frontend/tests/e2e-full/docs.spec.ts
+++ b/frontend/tests/e2e-full/docs.spec.ts
@@ -72,6 +72,27 @@ test.describe("docs workspace", () => {
       const logo = page.locator('img[alt="logo"]');
       await expect(logo).toBeVisible();
       await expect(logo).toHaveAttribute("src", /\/api\/v1\/docs\/folders\/notes\/blob\?path=assets%2Flogo\.png/);
+
+      const zoomButton = page.getByRole("button", { name: "Open image in expanded view" });
+      await expect(zoomButton).toHaveCount(1);
+      await expect(zoomButton).toHaveCSS("opacity", "0");
+      await logo.hover();
+      await expect(zoomButton).toHaveCSS("opacity", "1");
+      await zoomButton.click();
+
+      const dialog = page.getByRole("dialog", { name: "Expanded image" });
+      await expect(dialog).toBeVisible();
+      await expect(dialog.locator('img[alt="logo"]')).toHaveAttribute(
+        "src",
+        /\/api\/v1\/docs\/folders\/notes\/blob\?path=assets%2Flogo\.png/,
+      );
+      const closeImageButton = dialog.getByRole("button", { name: "Close expanded image" });
+      await page.keyboard.press("Tab");
+      await expect(closeImageButton).toBeFocused();
+      await page.keyboard.press("Tab");
+      await expect(closeImageButton).toBeFocused();
+      await closeImageButton.click();
+      await expect(dialog).toBeHidden();
     } finally {
       await server.stop();
     }

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import { mockApi } from "./support/mockApi";
 
@@ -35,6 +35,38 @@ const mockRepo = {
   name: "widgets",
   capabilities: mockCapabilities,
 };
+
+async function routeMockDashboardImage(page: Page): Promise<void> {
+  await page.route("**/mock-dashboard.svg", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/svg+xml",
+      body: [
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1400" viewBox="0 0 1600 1400">',
+        '<rect width="1600" height="1400" fill="#f6f8fa"/>',
+        '<rect x="120" y="120" width="1360" height="1160" rx="18" fill="#ffffff" stroke="#d0d7de" stroke-width="6"/>',
+        '<rect x="210" y="220" width="420" height="80" rx="10" fill="#2563eb"/>',
+        '<rect x="210" y="410" width="1180" height="48" rx="12" fill="#8fb0f4"/>',
+        '<rect x="210" y="540" width="890" height="48" rx="12" fill="#8fb0f4"/>',
+        '<rect x="210" y="780" width="1180" height="360" rx="18" fill="#e9eefc"/>',
+        "</svg>",
+      ].join(""),
+    });
+  });
+}
+
+async function renderMockDashboardMarkdownImage(page: Page) {
+  await page.goto("/pulls/github/acme/widgets/42");
+  await page.locator(".edit-body-btn").click();
+
+  await page.locator(".body-edit-textarea").fill("Screenshots\n\n![Quality dashboard](/mock-dashboard.svg)");
+  await page.locator(".body-edit .title-edit-save").click();
+
+  const image = page.getByRole("img", { name: "Quality dashboard" }).first();
+  const zoomButton = page.getByRole("button", { name: "Open image in expanded view" });
+  await expect(image).toBeVisible();
+  return { image, zoomButton };
+}
 
 test.beforeEach(async ({ page }) => {
   await mockApi(page);
@@ -122,6 +154,135 @@ test("markdown mermaid fences render as diagrams", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Close expanded diagram" })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog", { name: "Expanded Mermaid diagram" })).toBeHidden();
+});
+
+test("markdown images open in an expanded overlay", async ({ page }) => {
+  await page.setViewportSize({ width: 1000, height: 700 });
+  await routeMockDashboardImage(page);
+
+  const { image, zoomButton } = await renderMockDashboardMarkdownImage(page);
+
+  const imageBox = await image.boundingBox();
+  const buttonBox = await zoomButton.boundingBox();
+  expect(imageBox).not.toBeNull();
+  expect(buttonBox).not.toBeNull();
+  expect(buttonBox!.x).toBeGreaterThan(imageBox!.x + imageBox!.width - 44);
+  expect(buttonBox!.y).toBeLessThan(imageBox!.y + 16);
+  await expect(zoomButton).toHaveCSS("opacity", "0");
+  await expect(zoomButton).toHaveCSS("pointer-events", "none");
+
+  await image.hover();
+  await expect(zoomButton).toHaveCSS("opacity", "1");
+  await expect(zoomButton).toHaveCSS("pointer-events", "auto");
+
+  await zoomButton.click();
+  const dialog = page.getByRole("dialog", { name: "Expanded image" });
+  await expect(dialog).toBeVisible();
+  const panel = dialog.locator(".markdown-image-lightbox__panel");
+  const expandedImage = dialog.getByRole("img", { name: "Quality dashboard" });
+  const closeButton = dialog.getByRole("button", { name: "Close expanded image" });
+  await expect(expandedImage).toBeVisible();
+  await expect(dialog).toBeFocused();
+
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  const panelBox = await panel.boundingBox();
+  const expandedBox = await expandedImage.boundingBox();
+  expect(panelBox).not.toBeNull();
+  expect(expandedBox).not.toBeNull();
+  expect(panelBox!.width).toBeLessThanOrEqual(viewport!.width - 56 + 1);
+  expect(panelBox!.height).toBeLessThanOrEqual(viewport!.height - 56 + 1);
+  expect(expandedBox!.width).toBeLessThanOrEqual(viewport!.width - 56 + 1);
+  expect(expandedBox!.height).toBeLessThanOrEqual(viewport!.height - 56 + 1);
+
+  await expect(panel).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+  await expect(panel).toHaveCSS("border-top-width", "0px");
+  await expect(panel).toHaveCSS("border-right-width", "0px");
+  await expect(panel).toHaveCSS("border-bottom-width", "0px");
+  await expect(panel).toHaveCSS("border-left-width", "0px");
+  await expect(panel).toHaveCSS("border-radius", "0px");
+  await expect(closeButton).toHaveCSS("opacity", "0");
+  await expect(closeButton).toHaveCSS("pointer-events", "none");
+
+  await expandedImage.hover();
+  await expect(closeButton).toHaveCSS("opacity", "1");
+  await expect(closeButton).toHaveCSS("pointer-events", "auto");
+  await closeButton.click();
+  await expect(dialog).toBeHidden();
+
+  await image.hover();
+  await zoomButton.click();
+  await expect(dialog).toBeVisible();
+  await page.keyboard.press("Tab");
+  await expect(closeButton).toBeFocused();
+  await expect(closeButton).toHaveCSS("opacity", "1");
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});
+
+test("markdown image lightbox opens above drawer layers", async ({ page }) => {
+  await page.setViewportSize({ width: 1000, height: 700 });
+  await routeMockDashboardImage(page);
+
+  const { image, zoomButton } = await renderMockDashboardMarkdownImage(page);
+  await page.evaluate(() => {
+    const expander = document.querySelector(".markdown-image-expander");
+    if (!expander) throw new Error("missing markdown image expander");
+
+    const drawer = document.createElement("div");
+    drawer.className = "test-drawer-layer";
+    Object.assign(drawer.style, {
+      alignItems: "flex-start",
+      background: "rgba(0, 0, 0, 0.01)",
+      display: "flex",
+      inset: "0",
+      justifyContent: "center",
+      paddingTop: "80px",
+      position: "fixed",
+      zIndex: "100",
+    });
+
+    expander.replaceWith(drawer);
+    drawer.append(expander);
+    document.body.append(drawer);
+  });
+
+  await image.hover();
+  await zoomButton.click();
+
+  const dialog = page.getByRole("dialog", { name: "Expanded image" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toHaveCSS("z-index", "130");
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        Boolean(
+          document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2)?.closest(".markdown-image-lightbox"),
+        ),
+      ),
+    )
+    .toBe(true);
+});
+
+test.describe("touch markdown image zoom", () => {
+  test.skip(({ browserName }) => browserName === "firefox", "Firefox does not support Playwright mobile emulation");
+  test.use({
+    hasTouch: true,
+    isMobile: true,
+    viewport: { width: 390, height: 844 },
+  });
+
+  test("keeps the zoom affordance tappable without hover", async ({ page }) => {
+    await routeMockDashboardImage(page);
+
+    const { zoomButton } = await renderMockDashboardMarkdownImage(page);
+    await expect(zoomButton).toHaveCSS("opacity", "1");
+    await expect(zoomButton).toHaveCSS("pointer-events", "auto");
+
+    await zoomButton.tap();
+    await expect(page.getByRole("dialog", { name: "Expanded image" })).toBeVisible();
+  });
 });
 
 test("markdown tables keep compact columns readable", async ({ page }) => {


### PR DESCRIPTION
Adds a GitHub-style expanded image view for markdown-rendered images across PRs, issues, docs, and image previews.

- Shows a subtle magnifier on image hover or keyboard focus.
- Keeps image zoom controls usable on touch devices without relying on hover.
- Opens images in a viewport-sized overlay above drawers and popovers.
- Removes expanded-image panel chrome so screenshots are not framed by a border.
- Keeps tiny lazy-loaded images visible after enhancement.
- Keeps keyboard focus contained while the expanded overlay is open.
- Blocks global shortcuts while the image overlay is open.
