### PR TITLE
fix: stop config reload from crashing servers built without a syncer

### DIFF
--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -291,8 +291,14 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 	// Resolve the new repo set against the boot-time registry. Repos
 	// whose (platform, host) the registry never learned about cannot
 	// reach a client without a restart; skip those for SetRepos but
-	// keep them in s.cfg so the UI mirrors the file.
-	previous := s.syncer.TrackedRepos()
+	// keep them in s.cfg so the UI mirrors the file. A server built
+	// without a syncer (embedded or test setups) still hot-reloads the
+	// non-sync surfaces below, so the syncer is nil-guarded rather than
+	// treated as a reload failure.
+	var previous []ghclient.RepoRef
+	if s.syncer != nil {
+		previous = s.syncer.TrackedRepos()
+	}
 	resolved, skipped := s.resolveReposForReload(ctx, newCfg.Repos, previous)
 	if len(skipped) > 0 {
 		slog.Info(
@@ -324,11 +330,13 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 		s.msgvault.applyConfig(newCfg)
 	}
 
-	s.syncer.SetRepos(resolved)
-	s.syncer.SetBranchActivityLimits(
-		newCfg.BranchActivityRetention(),
-		newCfg.Activity.DefaultBranchMaxCommits,
-	)
+	if s.syncer != nil {
+		s.syncer.SetRepos(resolved)
+		s.syncer.SetBranchActivityLimits(
+			newCfg.BranchActivityRetention(),
+			newCfg.Activity.DefaultBranchMaxCommits,
+		)
+	}
 
 	s.refreshRuntimeTargetsLocked()
 	if s.runtime != nil {

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -348,6 +348,41 @@ func TestConfigReload_WatcherFiresOnInPlaceEdit(t *testing.T) {
 	assert.Equal("30d", gotActivity.TimeRange)
 }
 
+// A server constructed without a syncer (Server.New permits nil; embedded
+// and docs/msgvault-only setups use it) must hot-reload non-sync surfaces
+// instead of panicking in the watcher goroutine. Regression test for a nil
+// TrackedRepos dereference that crashed the whole test binary in CI.
+func TestConfigReload_NilSyncerAppliesHotReloadWithoutPanic(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	writeConfigToml(t, cfgPath, validReloadConfig)
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+
+	srv := NewWithConfig(
+		openTestDB(t), nil, nil, nil, cfg, cfgPath, ServerOptions{},
+	)
+	waitForConfigWatcher(t, srv, 2*time.Second)
+	stream := streamConfigEvents(t, srv)
+	defer stream.Close()
+
+	writeConfigToml(t, cfgPath, validReloadConfigChangedActivity)
+
+	ev := waitForConfigEvent(t, stream, 2*time.Second)
+	require.True(ev.Valid, "expected valid reload on a syncer-less server")
+	assert.Empty(ev.Error)
+	assert.False(ev.RestartRequired)
+
+	srv.cfgMu.Lock()
+	gotActivity := srv.cfg.Activity
+	srv.cfgMu.Unlock()
+	assert.Equal("flat", gotActivity.ViewMode)
+	assert.Equal("30d", gotActivity.TimeRange)
+}
+
 func TestConfigReload_UpdatesBranchActivityLimits(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
A config-file change on a server built without a syncer panicked in the watcher goroutine: `applyConfigChange` called `s.syncer.TrackedRepos()` (and `SetRepos`/`SetBranchActivityLimits`) without a nil check, even though `Server.New` permits a nil syncer and the rest of the reload path already guards for it. Because the panic happens on a background goroutine, it takes down the whole process — on PR #475 it crashed the CI test binary and ~14 unrelated parallel workspace tests.

- Config reload on a syncer-less server now applies the hot-reloadable non-sync surfaces (activity, modes, docs, msgvault, runtime targets) and skips only the repo-set and branch-activity updates, instead of crashing.
- Adds a regression test that drives the real watcher → reload → SSE path against a nil-syncer server; it reproduces the exact CI SIGSEGV with the guard reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)