### PR TITLE
fix: stop background kata refreshes from swallowing row clicks

### DIFF
--- a/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
@@ -101,6 +101,89 @@ describe("KataWorkspace", () => {
     });
   });
 
+  it("keeps a row selection made while a stream-triggered reload is in flight", async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            {
+              id: "home",
+              url: "http://127.0.0.1:7777",
+              default: true,
+              auth: "none",
+              health: "connected",
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamController = controller;
+            },
+            cancel() {
+              streamController = undefined;
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const { api } = createWorkspaceAPI();
+    const onSelectedIssueChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, onSelectedIssueChange } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+      expect(streamController).toBeTruthy();
+    });
+
+    // Stall the view reload the reset event triggers so the click below
+    // lands while that refetch is still in flight.
+    const stalledView = deferred<Awaited<ReturnType<KataTaskAPI["issues"]>>>();
+    let reloadStarted = false;
+    vi.mocked(api.issues).mockImplementationOnce(async () => {
+      reloadStarted = true;
+      return stalledView.promise;
+    });
+    streamController?.enqueue(
+      new TextEncoder().encode(
+        `id: 6\nevent: sync.reset_required\ndata: ${JSON.stringify({ event_id: 6, reset_after_id: 6 })}\n\n`,
+      ),
+    );
+    await waitFor(() => {
+      expect(reloadStarted).toBe(true);
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /Email Susan re: Q3/ }));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    });
+
+    stalledView.resolve(
+      buildKataTaskView({
+        view: "all",
+        issues: initialIssues,
+        projects,
+        today: "2026-05-15",
+        fetched_at: fetchedAt,
+      }),
+    );
+
+    // The reload must not displace the selection the user just made.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+      expect(screen.queryByText("Select a task")).toBeNull();
+    });
+    expect(onSelectedIssueChange).toHaveBeenCalledWith("issue-email-susan");
+  });
+
   it("surfaces a disconnected live Kata event stream", async () => {
     let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -1298,6 +1298,53 @@ describe("kata workspace store", () => {
     expect(store.eventCursor).toBe(99);
   });
 
+  test("a mutation refresh supersedes a stale detail reload from an older event refresh", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap();
+    await store.selectIssue("issue-pay-rent");
+
+    // The remote event's own detail reload stalls; it was issued before
+    // the mutation below, so its payload predates the mutation.
+    const staleDetail = deferred<KataTaskDetail>();
+    api.mocks.issue.mockImplementationOnce(
+      (_uid: string, opts?: { signal?: AbortSignal }) =>
+        new Promise<KataTaskDetail>((resolve, reject) => {
+          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+            once: true,
+          });
+          void staleDetail.promise.then(resolve);
+        }),
+    );
+    const remote = store.applyRemoteEvent({ ...events[0]!, event_id: 99 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The post-mutation refresh must fetch this fresh detail; the stale
+    // reload above must not be allowed to overwrite it afterwards.
+    api.mocks.issue.mockImplementation(async (uid: string) => ({
+      ...detailFor(uid),
+      comments: [
+        {
+          id: 1,
+          issue_id: issues[0]!.id,
+          body: "Payment is scheduled.",
+          author: "fixture-user",
+          created_at: fetchedAt,
+        },
+      ],
+      etag: '"rev-2"',
+    }));
+    await store.addComment("issue-pay-rent", "fixture-user", "Payment is scheduled.");
+
+    staleDetail.resolve(detailFor("issue-pay-rent"));
+    await remote;
+
+    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+    expect(store.selectedIssue?.comments.map((comment) => comment.body)).toEqual(["Payment is scheduled."]);
+    expect(store.selectedIssue?.etag).toBe('"rev-2"');
+  });
+
   test("a selection completed during a remote-event view refresh is not reverted", async () => {
     const api = createFakeKataTaskAPI();
     const store = createKataWorkspaceStore({ api });

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -1261,6 +1261,66 @@ describe("kata workspace store", () => {
     expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
   });
 
+  test("a selection made while a remote-event view refresh is in flight is not discarded", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap();
+    store.clearSelection();
+
+    // The remote event's view refetch stalls so the user's selection
+    // lands while it is still in flight.
+    const stalledView = deferred<KataTaskViewResponse>();
+    api.mocks.issues.mockImplementationOnce(async () => stalledView.promise);
+    const remote = store.applyRemoteEvent({ ...events[0]!, event_id: 99 });
+
+    const slowDetail = deferred<KataTaskDetail>();
+    api.mocks.issue.mockImplementationOnce(
+      (_uid: string, opts?: { signal?: AbortSignal }) =>
+        new Promise<KataTaskDetail>((resolve, reject) => {
+          opts?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+            once: true,
+          });
+          void slowDetail.promise.then(resolve);
+        }),
+    );
+    const selection = store.selectIssue("issue-call-dentist");
+
+    stalledView.resolve(
+      buildKataTaskView({ view: "today", issues, projects, today: "2026-05-15", fetched_at: fetchedAt }),
+    );
+    await remote;
+
+    slowDetail.resolve(detailFor("issue-call-dentist"));
+    const applied = await selection;
+
+    expect(applied).toBe(true);
+    expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
+    expect(store.eventCursor).toBe(99);
+  });
+
+  test("a selection completed during a remote-event view refresh is not reverted", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap();
+
+    const stalledView = deferred<KataTaskViewResponse>();
+    api.mocks.issues.mockImplementationOnce(async () => stalledView.promise);
+    const remote = store.applyRemoteEvent({ ...events[0]!, event_id: 99 });
+
+    // The refresh captured the bootstrap selection as preferred; the
+    // user picks a different task before the view fetch resolves.
+    const applied = await store.selectIssue("issue-call-dentist");
+    expect(applied).toBe(true);
+
+    stalledView.resolve(
+      buildKataTaskView({ view: "today", issues, projects, today: "2026-05-15", fetched_at: fetchedAt }),
+    );
+    await remote;
+
+    expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
+    expect(store.eventCursor).toBe(99);
+  });
+
   test("syncs event cursor through paged event reads", async () => {
     const api = createFakeKataTaskAPI();
     api.mocks.events.mockImplementation(async (query: KataTaskEventsQuery = {}) => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -800,18 +800,21 @@ export class KataWorkspaceStore {
       issues = selectableViewIssues(view.groups);
     }
     this.currentView = nextView;
-    // An in-flight detail load belongs to a selection newer than this
-    // refresh. Reloading the detail here would abort that load and bump
-    // detailRequestID, silently discarding a row the user just clicked.
-    // Leave the pane to the pending load; the next refresh picks up any
-    // remote detail changes once the selection settles.
-    if (this.detailAbort !== null) {
-      return true;
-    }
     let resolvedUID = preferredUID;
     if (this.detailRequestID !== selectionEpoch) {
-      // A newer selection (or clear) completed during the view fetch;
-      // re-resolve so the stale preferredUID cannot revert it.
+      // The selection changed while the view fetch was in flight, so the
+      // preferredUID the caller captured is stale. If the newer selection
+      // is still loading, leave the pane to it: reloading here would
+      // abort that load and silently discard a row the user just clicked.
+      // The epoch gate matters — an in-flight load from before this
+      // refresh (e.g. an older refresh's own detail reload) must instead
+      // be superseded below, or its pre-refresh payload would later
+      // overwrite the refreshed detail and ETag state.
+      if (this.detailAbort !== null) {
+        return true;
+      }
+      // The newer selection (or clear) already completed; re-resolve so
+      // the stale preferredUID cannot revert it.
       resolvedUID = this.pendingSelectionUID ?? this.selectedIssue?.issue.uid ?? null;
     }
     const nextSelectedUID = resolvedUID === undefined ? (issues[0]?.uid ?? null) : resolvedUID;

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -755,6 +755,10 @@ export class KataWorkspaceStore {
 
   private async refreshCurrentView(preferredUID?: string | null): Promise<boolean> {
     const requestID = ++this.viewRequestID;
+    // Selection epoch at refresh start: any selection or clear that lands
+    // while the view fetch below is in flight bumps detailRequestID,
+    // which makes the preferredUID captured by the caller stale.
+    const selectionEpoch = this.detailRequestID;
     let nextView: KataCurrentView;
     let issues: KataTaskSummary[];
     if (shouldRefreshViaSearch(this.searchFilters, this.currentView.name)) {
@@ -796,7 +800,21 @@ export class KataWorkspaceStore {
       issues = selectableViewIssues(view.groups);
     }
     this.currentView = nextView;
-    const nextSelectedUID = preferredUID === undefined ? (issues[0]?.uid ?? null) : preferredUID;
+    // An in-flight detail load belongs to a selection newer than this
+    // refresh. Reloading the detail here would abort that load and bump
+    // detailRequestID, silently discarding a row the user just clicked.
+    // Leave the pane to the pending load; the next refresh picks up any
+    // remote detail changes once the selection settles.
+    if (this.detailAbort !== null) {
+      return true;
+    }
+    let resolvedUID = preferredUID;
+    if (this.detailRequestID !== selectionEpoch) {
+      // A newer selection (or clear) completed during the view fetch;
+      // re-resolve so the stale preferredUID cannot revert it.
+      resolvedUID = this.pendingSelectionUID ?? this.selectedIssue?.issue.uid ?? null;
+    }
+    const nextSelectedUID = resolvedUID === undefined ? (issues[0]?.uid ?? null) : resolvedUID;
     return await this.loadSelectedIssue(nextSelectedUID, requestID, ++this.detailRequestID);
   }
 


### PR DESCRIPTION
Clicking a task row in Kata mode while a background view refresh was in flight (a live SSE event, the bootstrap event-cursor sync, or a mutation reload) left the detail pane stuck on "Select a task". The refresh captured its preferred selection before its view fetch started, so on completion it reloaded the detail with that stale UID — aborting the click's in-flight detail fetch, marking it superseded, and clearing the pending selection. On daemons with busy agents there is almost always a refresh mid-flight, so clicks looked dead. (The list's keyboard-select debounce was a red herring; clicks bypass it.)

`refreshCurrentView` now treats user selection intent as newer than itself: an in-flight detail load keeps ownership of the pane, and a selection that completed during the view fetch is re-resolved instead of reverted. Explicit navigations (view/scope/route/daemon changes) still supersede pending selections.

- Clicking (or keyboard-selecting) a task now reliably opens it, even while live updates are streaming in

🤖 Generated with [Claude Code](https://claude.com/claude-code)