### PR TITLE
fix: dismiss assignee/reviewer pickers on outside click

### DIFF
--- a/frontend/src/lib/components/detail/UserListEditor.test.ts
+++ b/frontend/src/lib/components/detail/UserListEditor.test.ts
@@ -100,6 +100,28 @@ describe("UserListEditor", () => {
     expect(screen.queryByRole("dialog", { name: "Edit assignees" })).toBeNull();
   });
 
+  it("closes an open picker when another editor's chip is activated by keyboard", async () => {
+    const props = {
+      users: [],
+      canEdit: true,
+      loadCandidates: vi.fn().mockResolvedValue(["alice"]),
+      onchange: vi.fn(),
+    };
+    render(UserListEditor, { props: { ...props, label: "Assignees" } });
+    render(UserListEditor, { props: { ...props, label: "Reviewers" } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Edit assignees" }));
+    await waitFor(() => expect(screen.getByRole("dialog", { name: "Edit assignees" })).toBeTruthy());
+
+    // Enter/Space on a button dispatches only a click — no mousedown —
+    // so this must be handled by the shared open-picker slot, not the
+    // document-mousedown dismissal.
+    await fireEvent.click(screen.getByRole("button", { name: "Edit reviewers" }));
+
+    await waitFor(() => expect(screen.getByRole("dialog", { name: "Edit reviewers" })).toBeTruthy());
+    expect(screen.queryByRole("dialog", { name: "Edit assignees" })).toBeNull();
+  });
+
   it("clears a candidate-load error once a later fetch succeeds", async () => {
     const loadCandidates = vi
       .fn()

--- a/frontend/src/lib/components/detail/UserListEditor.test.ts
+++ b/frontend/src/lib/components/detail/UserListEditor.test.ts
@@ -55,6 +55,51 @@ describe("UserListEditor", () => {
     expect(onchange).not.toHaveBeenCalled();
   });
 
+  it("dismisses the picker on a press outside the chip and panel", async () => {
+    render(UserListEditor, {
+      props: {
+        label: "Assignees",
+        users: [],
+        canEdit: true,
+        loadCandidates: vi.fn().mockResolvedValue(["alice"]),
+        onchange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Edit assignees" }));
+    await waitFor(() => expect(screen.getByRole("dialog", { name: "Edit assignees" })).toBeTruthy());
+
+    // A press inside the panel must not dismiss it.
+    await fireEvent.mouseDown(screen.getByLabelText("Filter users"));
+    expect(screen.getByRole("dialog", { name: "Edit assignees" })).toBeTruthy();
+
+    await fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Edit assignees" })).toBeNull());
+  });
+
+  it("closes an open picker when another editor's chip is pressed", async () => {
+    const props = {
+      users: [],
+      canEdit: true,
+      loadCandidates: vi.fn().mockResolvedValue(["alice"]),
+      onchange: vi.fn(),
+    };
+    render(UserListEditor, { props: { ...props, label: "Assignees" } });
+    render(UserListEditor, { props: { ...props, label: "Reviewers" } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Edit assignees" }));
+    await waitFor(() => expect(screen.getByRole("dialog", { name: "Edit assignees" })).toBeTruthy());
+
+    // A real pointer press fires mousedown before click; both pickers
+    // must never be on screen together.
+    const reviewersChip = screen.getByRole("button", { name: "Edit reviewers" });
+    await fireEvent.mouseDown(reviewersChip);
+    await fireEvent.click(reviewersChip);
+
+    await waitFor(() => expect(screen.getByRole("dialog", { name: "Edit reviewers" })).toBeTruthy());
+    expect(screen.queryByRole("dialog", { name: "Edit assignees" })).toBeNull();
+  });
+
   it("clears a candidate-load error once a later fetch succeeds", async () => {
     const loadCandidates = vi
       .fn()

--- a/frontend/tests/e2e-full/assignees-reviewers.spec.ts
+++ b/frontend/tests/e2e-full/assignees-reviewers.spec.ts
@@ -234,6 +234,12 @@ test.describe("assignee and reviewer editing", () => {
       await page.getByRole("button", { name: "Edit reviewers" }).click();
       await expect(page.getByRole("dialog", { name: "Edit reviewers" })).toBeVisible();
       await expect(page.getByRole("dialog", { name: "Edit assignees" })).toBeHidden();
+
+      // Keyboard activation fires no mousedown, so the swap must not
+      // depend on the document-mousedown dismissal path.
+      await page.getByRole("button", { name: "Edit assignees" }).press("Enter");
+      await expect(page.getByRole("dialog", { name: "Edit assignees" })).toBeVisible();
+      await expect(page.getByRole("dialog", { name: "Edit reviewers" })).toBeHidden();
     } finally {
       await isolatedServer?.stop();
     }

--- a/frontend/tests/e2e-full/assignees-reviewers.spec.ts
+++ b/frontend/tests/e2e-full/assignees-reviewers.spec.ts
@@ -211,6 +211,34 @@ test.describe("assignee and reviewer editing", () => {
     }
   });
 
+  test("an outside press dismisses the picker and pickers never stack", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    try {
+      isolatedServer = await startIsolatedE2EServer();
+      const baseURL = isolatedServer.info.base_url;
+
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+
+      await page.getByRole("button", { name: "Edit assignees" }).click();
+      await expect(page.getByRole("dialog", { name: "Edit assignees" })).toBeVisible();
+
+      // Clicking anywhere outside the chip and panel dismisses it.
+      await page.locator(".pull-detail .detail-title").click();
+      await expect(page.getByRole("dialog", { name: "Edit assignees" })).toBeHidden();
+
+      // Opening the reviewers picker while assignees is open swaps
+      // them; the two panels must never be on screen together.
+      await page.getByRole("button", { name: "Edit assignees" }).click();
+      await expect(page.getByRole("dialog", { name: "Edit assignees" })).toBeVisible();
+      await page.getByRole("button", { name: "Edit reviewers" }).click();
+      await expect(page.getByRole("dialog", { name: "Edit reviewers" })).toBeVisible();
+      await expect(page.getByRole("dialog", { name: "Edit assignees" })).toBeHidden();
+    } finally {
+      await isolatedServer?.stop();
+    }
+  });
+
   test("issue detail edits assignees", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     try {

--- a/packages/ui/src/components/detail/UserListEditor.svelte
+++ b/packages/ui/src/components/detail/UserListEditor.svelte
@@ -118,6 +118,16 @@
     });
   }
 
+  function onDocumentMousedown(event: MouseEvent): void {
+    // Dismiss on any press outside the chip and panel. Pressing
+    // another editor's chip lands here too, so opening one picker
+    // closes any other before its own toggle runs.
+    if (!open) return;
+    const target = event.target as Node;
+    if (anchorEl?.contains(target) || popoverEl?.contains(target)) return;
+    closePicker();
+  }
+
   async function togglePicker(event?: MouseEvent): Promise<void> {
     if (open) {
       closePicker();
@@ -190,6 +200,8 @@
     };
   });
 </script>
+
+<svelte:document onmousedown={onDocumentMousedown} />
 
 {#if users.length > 0 || canEdit}
   <span class="user-list-editor" bind:this={anchorEl} data-user-list-editor={editorId}>

--- a/packages/ui/src/components/detail/UserListEditor.svelte
+++ b/packages/ui/src/components/detail/UserListEditor.svelte
@@ -1,3 +1,12 @@
+<script module lang="ts">
+  // All editor instances share one open-picker slot so at most one
+  // picker exists across the app. The document-mousedown dismissal
+  // below only sees pointer presses; keyboard or assistive-tech
+  // activation of another chip reaches togglePicker without any
+  // mousedown, and this slot is what closes the previous picker then.
+  let closeOpenEditor: (() => void) | null = null;
+</script>
+
 <script lang="ts">
   import { tick, type Snippet } from "svelte";
   import PlusIcon from "@lucide/svelte/icons/plus";
@@ -56,6 +65,7 @@
   let queryDebounce: ReturnType<typeof setTimeout> | null = null;
 
   function closePicker(): void {
+    if (closeOpenEditor === closePicker) closeOpenEditor = null;
     open = false;
     pendingUser = null;
     candidatesError = null;
@@ -134,6 +144,8 @@
       return;
     }
     autofocusFilter = event !== undefined && !(window.matchMedia?.("(pointer: coarse)").matches ?? false);
+    closeOpenEditor?.();
+    closeOpenEditor = closePicker;
     open = true;
     candidatesError = null;
     mutationError = null;


### PR DESCRIPTION
The assignee and reviewer chip popovers only closed via their X button or re-clicking their own chip, so a click elsewhere on the page left the panel floating, and pressing one chip while the other picker was open stacked both panels on screen.

UserListEditor now uses the same document-mousedown dismissal pattern the label picker already follows: any press outside the chip and panel closes the picker. That one mechanism also makes the pickers mutually exclusive, since pressing another editor's chip counts as an outside press for the open one.

- Clicking outside an open assignees/reviewers picker now dismisses it
- The assignees and reviewers pickers can no longer be open at the same time (also mutually exclusive with the label picker)

Demo:

https://github.com/user-attachments/assets/67bab759-3087-4712-9e2d-9c126e662bd8

🤖 Generated with [Claude Code](https://claude.com/claude-code)