### PR TITLE
fix: serve startup UI before backend warmup

### DIFF
--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -415,23 +415,52 @@ func run(opts serve.Options) error {
 	var database *db.DB
 	var srv *server.Server
 	var syncer *ghclient.Syncer
+	var telemetryReporter *telemetry.Reporter
+	var profilerSrv *profiler.Server
 	defer func() {
 		shutdownCtx, cancel := context.WithTimeout(
 			context.Background(), 10*time.Second,
 		)
 		defer cancel()
-		if srv != nil {
-			if err := srv.Shutdown(shutdownCtx); err != nil {
-				slog.Warn("server shutdown", "err", err)
-			}
-		} else if err := httpSrv.Shutdown(shutdownCtx); err != nil {
-			slog.Warn("startup server shutdown", "err", err)
-		}
-		if syncer != nil {
-			syncer.Stop()
-		}
-		if database != nil {
-			database.Close()
+		for _, shutdownErr := range runMainShutdown(
+			shutdownCtx,
+			mainShutdownCallbacks{
+				ShutdownPrimaryHTTP: func(ctx context.Context) error {
+					if srv != nil {
+						return srv.Shutdown(ctx)
+					}
+					return httpSrv.Shutdown(ctx)
+				},
+				StopSyncer: func() {
+					if syncer != nil {
+						syncer.Stop()
+					}
+				},
+				ShutdownProfiler: func(context.Context) error {
+					if profilerSrv != nil {
+						profilerCtx, profilerCancel := context.WithTimeout(
+							context.Background(), 5*time.Second,
+						)
+						defer profilerCancel()
+						return profilerSrv.Shutdown(profilerCtx)
+					}
+					return nil
+				},
+				CloseTelemetry: func() error {
+					if telemetryReporter != nil {
+						return telemetryReporter.Close()
+					}
+					return nil
+				},
+				CloseDatabase: func() error {
+					if database != nil {
+						return database.Close()
+					}
+					return nil
+				},
+			},
+		) {
+			slog.Warn(shutdownErr.message, "err", shutdownErr.err)
 		}
 	}()
 
@@ -484,16 +513,11 @@ func run(opts serve.Options) error {
 	)
 	syncer.SetFetchers(startup.fetchers)
 
-	telemetryReporter := telemetry.NewReporterOrDisabled(telemetry.Options{
+	telemetryReporter = telemetry.NewReporterOrDisabled(telemetry.Options{
 		Database: database,
 		Version:  version,
 		Commit:   commit,
 	})
-	defer func() {
-		if err := telemetryReporter.Close(); err != nil {
-			slog.Warn("close telemetry", "err", err)
-		}
-	}()
 	if telemetryReporter.Enabled() {
 		if err := telemetryReporter.Capture("daemon_active", map[string]any{
 			"repo_count": len(repos),
@@ -539,7 +563,7 @@ func run(opts serve.Options) error {
 	syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(ctx, database, nil))
 	syncer.Start(ctx)
 
-	profilerSrv, err := profiler.Start(opts.ProfilerAddr)
+	profilerSrv, err = profiler.Start(opts.ProfilerAddr)
 	if err != nil {
 		return err
 	}
@@ -552,15 +576,6 @@ func run(opts serve.Options) error {
 			"starting profiler listener",
 			"addr", profilerAddr,
 		)
-		defer func() {
-			shutdownCtx, cancel := context.WithTimeout(
-				context.Background(), 5*time.Second,
-			)
-			defer cancel()
-			if err := profilerSrv.Shutdown(shutdownCtx); err != nil {
-				slog.Warn("profiler shutdown", "err", err)
-			}
-		}()
 	}
 
 	displayVersion := version
@@ -580,6 +595,62 @@ func run(opts serve.Options) error {
 	case err := <-errCh:
 		return fmt.Errorf("server: %w", err)
 	}
+}
+
+type mainShutdownCallbacks struct {
+	ShutdownPrimaryHTTP func(context.Context) error
+	StopSyncer          func()
+	ShutdownProfiler    func(context.Context) error
+	CloseTelemetry      func() error
+	CloseDatabase       func() error
+}
+
+type mainShutdownError struct {
+	message string
+	err     error
+}
+
+func runMainShutdown(
+	ctx context.Context,
+	callbacks mainShutdownCallbacks,
+) []mainShutdownError {
+	var errs []mainShutdownError
+	if callbacks.ShutdownPrimaryHTTP != nil {
+		if err := callbacks.ShutdownPrimaryHTTP(ctx); err != nil {
+			errs = append(errs, mainShutdownError{
+				message: "server shutdown",
+				err:     err,
+			})
+		}
+	}
+	if callbacks.StopSyncer != nil {
+		callbacks.StopSyncer()
+	}
+	if callbacks.ShutdownProfiler != nil {
+		if err := callbacks.ShutdownProfiler(ctx); err != nil {
+			errs = append(errs, mainShutdownError{
+				message: "profiler shutdown",
+				err:     err,
+			})
+		}
+	}
+	if callbacks.CloseTelemetry != nil {
+		if err := callbacks.CloseTelemetry(); err != nil {
+			errs = append(errs, mainShutdownError{
+				message: "close telemetry",
+				err:     err,
+			})
+		}
+	}
+	if callbacks.CloseDatabase != nil {
+		if err := callbacks.CloseDatabase(); err != nil {
+			errs = append(errs, mainShutdownError{
+				message: "close database",
+				err:     err,
+			})
+		}
+	}
+	return errs
 }
 
 func profilerSrvDone(srv *profiler.Server) <-chan error {

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -370,16 +370,85 @@ func run(opts serve.Options) error {
 		}
 	}()
 
-	database, err := db.Open(cfg.DBPath())
+	ctx, stopSignals := signal.NotifyContext(
+		context.Background(),
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer stopSignals()
+
+	assets, err := web.Assets()
+	if err != nil {
+		return fmt.Errorf("load frontend assets: %w", err)
+	}
+
+	addr := cfg.ListenAddr()
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", addr, err)
+	}
+
+	if err := writeRuntimeMetadata(lockHandle, ln); err != nil {
+		slog.Warn("write runtime metadata", "err", err)
+	}
+
+	startupHandler := server.NewStartupHandler(
+		assets, cfg, server.ServerOptions{}, ln,
+	)
+	switcher := server.NewSwitchHandler(startupHandler)
+	httpSrv := &http.Server{
+		Handler:     switcher,
+		ReadTimeout: 15 * time.Second,
+		// WriteTimeout is 0 (disabled) because SSE and proxy
+		// responses are long-lived by design.
+		IdleTimeout: 60 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		if serveErr := httpSrv.Serve(ln); !errors.Is(serveErr, http.ErrServerClosed) {
+			errCh <- serveErr
+		}
+	}()
+
+	slog.Info(fmt.Sprintf("starting server at http://%s", ln.Addr().String()))
+
+	var database *db.DB
+	var srv *server.Server
+	var syncer *ghclient.Syncer
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 10*time.Second,
+		)
+		defer cancel()
+		if srv != nil {
+			if err := srv.Shutdown(shutdownCtx); err != nil {
+				slog.Warn("server shutdown", "err", err)
+			}
+		} else if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("startup server shutdown", "err", err)
+		}
+		if syncer != nil {
+			syncer.Stop()
+		}
+		if database != nil {
+			database.Close()
+		}
+	}()
+
+	if ctx.Err() != nil {
+		slog.Info("shutting down")
+		return nil
+	}
+
+	database, err = db.Open(cfg.DBPath())
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
-	defer database.Close()
 
 	tokenSources := tokenauth.NewSourceSet(tokenauth.Options{
 		GitHubCLI: config.GitHubCLITokenForHost,
 	})
-	providerSources, err := collectProviderTokenSources(context.Background(), cfg, tokenSources)
+	providerSources, err := collectProviderTokenSources(ctx, cfg, tokenSources)
 	if err != nil {
 		return err
 	}
@@ -392,15 +461,20 @@ func run(opts serve.Options) error {
 	}
 
 	repos := resolveStartupRepos(
-		context.Background(), cfg, startup.registry, database,
+		ctx, cfg, startup.registry, database,
 	)
 	slog.Debug("startup repos resolved", "count", len(repos))
+
+	if ctx.Err() != nil {
+		slog.Info("shutting down")
+		return nil
+	}
 
 	cloneMgr := gitclone.New(
 		filepath.Join(cfg.DataDir, "clones"), startup.cloneAuth,
 	)
 
-	syncer := ghclient.NewSyncerWithRegistry(
+	syncer = ghclient.NewSyncerWithRegistry(
 		startup.registry, database, cloneMgr, repos,
 		cfg.SyncDuration(), startup.rateTrackers, startup.budgets,
 	)
@@ -428,12 +502,7 @@ func run(opts serve.Options) error {
 		}
 	}
 
-	assets, err := web.Assets()
-	if err != nil {
-		return fmt.Errorf("load frontend assets: %w", err)
-	}
-
-	srv := server.NewWithConfig(
+	srv = server.NewWithConfig(
 		database, syncer, cloneMgr, assets,
 		cfg, configPath, server.ServerOptions{
 			WorktreeDir:         filepath.Join(cfg.DataDir, "worktrees"),
@@ -467,15 +536,8 @@ func run(opts serve.Options) error {
 		Data: syncer.Status(),
 	})
 
-	ctx, stop := signal.NotifyContext(
-		context.Background(),
-		syscall.SIGINT,
-		syscall.SIGTERM,
-	)
 	syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(ctx, database, nil))
 	syncer.Start(ctx)
-	defer syncer.Stop()
-	defer stop()
 
 	profilerSrv, err := profiler.Start(opts.ProfilerAddr)
 	if err != nil {
@@ -501,45 +563,13 @@ func run(opts serve.Options) error {
 		}()
 	}
 
-	// srv.Shutdown MUST be the last-registered defer so LIFO runs
-	// it FIRST on return: close the HTTP listener (and SSE hub)
-	// before syncer.Stop blocks for up to 30 s, otherwise the
-	// process keeps serving requests against a syncer that is
-	// already winding down.
-	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(
-			context.Background(), 10*time.Second,
-		)
-		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			slog.Warn("server shutdown", "err", err)
-		}
-	}()
-
 	displayVersion := version
 	if version == "dev" && commit != "unknown" {
 		displayVersion = "dev-" + commit
 	}
 	srv.SetVersion(displayVersion)
-
-	addr := cfg.ListenAddr()
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("listen on %s: %w", addr, err)
-	}
-
-	if err := writeRuntimeMetadata(lockHandle, ln); err != nil {
-		slog.Warn("write runtime metadata", "err", err)
-	}
-
-	slog.Info(fmt.Sprintf("starting server at http://%s", ln.Addr().String()))
-
-	errCh := make(chan error, 1)
-	go func() {
-		if serveErr := srv.Serve(ln); !errors.Is(serveErr, http.ErrServerClosed) {
-			errCh <- serveErr
-		}
-	}()
+	srv.AttachHTTPServer(httpSrv, ln)
+	switcher.Swap(srv)
 
 	select {
 	case <-ctx.Done():

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -375,7 +376,8 @@ func run(opts serve.Options) error {
 		syscall.SIGINT,
 		syscall.SIGTERM,
 	)
-	defer stopSignals()
+	stopSignalsOnce := sync.OnceFunc(stopSignals)
+	defer stopSignalsOnce()
 
 	assets, err := web.Assets()
 	if err != nil {
@@ -425,6 +427,7 @@ func run(opts serve.Options) error {
 		for _, shutdownErr := range runMainShutdown(
 			shutdownCtx,
 			mainShutdownCallbacks{
+				StopSignals: stopSignalsOnce,
 				ShutdownPrimaryHTTP: func(ctx context.Context) error {
 					if srv != nil {
 						return srv.Shutdown(ctx)
@@ -598,6 +601,7 @@ func run(opts serve.Options) error {
 }
 
 type mainShutdownCallbacks struct {
+	StopSignals         func()
 	ShutdownPrimaryHTTP func(context.Context) error
 	StopSyncer          func()
 	ShutdownProfiler    func(context.Context) error
@@ -615,6 +619,9 @@ func runMainShutdown(
 	callbacks mainShutdownCallbacks,
 ) []mainShutdownError {
 	var errs []mainShutdownError
+	if callbacks.StopSignals != nil {
+		callbacks.StopSignals()
+	}
 	if callbacks.ShutdownPrimaryHTTP != nil {
 		if err := callbacks.ShutdownPrimaryHTTP(ctx); err != nil {
 			errs = append(errs, mainShutdownError{

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -535,6 +535,7 @@ func run(opts serve.Options) error {
 			TokenSources:        tokenSources,
 		},
 	)
+	srv.AttachHTTPServer(httpSrv, ln)
 	slog.Debug(
 		"server initialized",
 		"base_path", cfg.BasePath,
@@ -583,7 +584,6 @@ func run(opts serve.Options) error {
 		displayVersion = "dev-" + commit
 	}
 	srv.SetVersion(displayVersion)
-	srv.AttachHTTPServer(httpSrv, ln)
 	switcher.Swap(srv)
 
 	select {

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -11,7 +11,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	gh "github.com/google/go-github/v84/github"
 	Assert "github.com/stretchr/testify/assert"
@@ -193,6 +195,35 @@ func TestRunMainShutdownClosesPrimaryHTTPBeforeAncillaryServices(t *testing.T) {
 		"telemetry",
 		"database",
 	}, order)
+}
+
+func TestRunClosesPrimaryListenerWhenProfilerStartFails(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	require.NoError(os.MkdirAll(dataDir, 0o700))
+	cfgPath := filepath.Join(root, "config.toml")
+	appPort := reserveFreePort(t)
+	writeMinimalConfig(t, cfgPath, dataDir, appPort)
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_LOCK_E2E", "")
+
+	err := run(serve.Options{
+		ConfigPath:   cfgPath,
+		ProfilerAddr: "0.0.0.0:0",
+	})
+	require.Error(err)
+	assert.Contains(err.Error(), "profiler address")
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(appPort))
+	assert.Eventually(func() bool {
+		ln, listenErr := net.Listen("tcp", addr)
+		if listenErr != nil {
+			return false
+		}
+		return ln.Close() == nil
+	}, 2*time.Second, 25*time.Millisecond)
 }
 
 func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -159,13 +159,16 @@ func TestWriteRuntimeMetadataRejectsNonTCPListener(t *testing.T) {
 	Assert.Contains(t, err.Error(), "non-TCP")
 }
 
-func TestRunMainShutdownClosesPrimaryHTTPBeforeAncillaryServices(t *testing.T) {
+func TestRunMainShutdownStopsSignalsBeforeLongCleanup(t *testing.T) {
 	var order []string
 	record := func(name string) {
 		order = append(order, name)
 	}
 
 	errs := runMainShutdown(t.Context(), mainShutdownCallbacks{
+		StopSignals: func() {
+			record("signals")
+		},
 		ShutdownPrimaryHTTP: func(context.Context) error {
 			record("primary-http")
 			return nil
@@ -189,6 +192,7 @@ func TestRunMainShutdownClosesPrimaryHTTPBeforeAncillaryServices(t *testing.T) {
 
 	Assert.Empty(t, errs)
 	Assert.Equal(t, []string{
+		"signals",
 		"primary-http",
 		"syncer",
 		"profiler",

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -157,6 +157,44 @@ func TestWriteRuntimeMetadataRejectsNonTCPListener(t *testing.T) {
 	Assert.Contains(t, err.Error(), "non-TCP")
 }
 
+func TestRunMainShutdownClosesPrimaryHTTPBeforeAncillaryServices(t *testing.T) {
+	var order []string
+	record := func(name string) {
+		order = append(order, name)
+	}
+
+	errs := runMainShutdown(t.Context(), mainShutdownCallbacks{
+		ShutdownPrimaryHTTP: func(context.Context) error {
+			record("primary-http")
+			return nil
+		},
+		StopSyncer: func() {
+			record("syncer")
+		},
+		ShutdownProfiler: func(context.Context) error {
+			record("profiler")
+			return nil
+		},
+		CloseTelemetry: func() error {
+			record("telemetry")
+			return nil
+		},
+		CloseDatabase: func() error {
+			record("database")
+			return nil
+		},
+	})
+
+	Assert.Empty(t, errs)
+	Assert.Equal(t, []string{
+		"primary-http",
+		"syncer",
+		"profiler",
+		"telemetry",
+		"database",
+	}, order)
+}
+
 func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 	assert := Assert.New(t)
 	cfg := &config.Config{

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount, untrack } from "svelte";
+  import { onDestroy, untrack } from "svelte";
   import {
     Provider,
     PRListView,
@@ -43,6 +43,7 @@
   import { initItemRefHandler } from "./lib/utils/itemRefHandler.js";
   import { globalRepoForSelectedRoute } from "./lib/utils/repoSelectionSync.js";
   import { runAppStartup } from "./lib/utils/appStartup.js";
+  import { waitUntilBackendReady } from "./lib/utils/backendReadiness.js";
   import {
     initTheme,
     cleanupTheme,
@@ -325,6 +326,23 @@
     };
   }
 
+  function loadKataDaemonRosterAfterBackendReady(signal: AbortSignal): void {
+    void (async () => {
+      try {
+        const roster = await loadKataDaemonRoster();
+        if (signal.aborted) return;
+        setKataDaemonRoster(roster.ids, roster.defaultId);
+        kataDaemonInfos = roster.daemons;
+        kataDefaultDaemonId = roster.defaultId;
+      } catch {
+        if (signal.aborted) return;
+        kataDaemonInfos = [];
+        kataDefaultDaemonId = undefined;
+        setKataDaemonRoster([], undefined);
+      }
+    })();
+  }
+
   function isModeVisible(mode: keyof ModeVisibility): boolean {
     return stores?.settings.isModeVisible(mode) ?? true;
   }
@@ -362,6 +380,8 @@
     const cleanupContainer = initContainerObserver(appEl);
     const cleanupItemRefs = initItemRefHandler();
     const cancelStartup = runAppStartup({
+      waitUntilBackendReady,
+      afterBackendReady: loadKataDaemonRosterAfterBackendReady,
       getSettings,
       getStores: () => startupStores,
       beforeInitialLoad: () => syncGlobalRepoWithRoute(startupStores),
@@ -510,28 +530,6 @@
   onDestroy(() => {
     stopFullAppShell();
     stores?.events.disconnect();
-  });
-
-  onMount(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const roster = await loadKataDaemonRoster();
-        if (cancelled) return;
-        setKataDaemonRoster(roster.ids, roster.defaultId);
-        kataDaemonInfos = roster.daemons;
-        kataDefaultDaemonId = roster.defaultId;
-      } catch {
-        if (!cancelled) {
-          kataDaemonInfos = [];
-          kataDefaultDaemonId = undefined;
-          setKataDaemonRoster([], undefined);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
   });
 
   $effect(() => {

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -142,11 +142,22 @@ vi.mock("./lib/messages/kataMessageLinker.js", () => ({
   }),
 }));
 vi.mock("./lib/utils/appStartup.js", () => ({
-  runAppStartup: ({ onReady }: { onReady: () => void }) => {
+  runAppStartup: ({
+    afterBackendReady,
+    onReady,
+  }: {
+    afterBackendReady?: (signal: AbortSignal) => void;
+    onReady: () => void;
+  }) => {
+    const signal = new AbortController().signal;
+    const markReady = () => {
+      afterBackendReady?.(signal);
+      onReady();
+    };
     if (startup.autoReady) {
-      queueMicrotask(onReady);
+      queueMicrotask(markReady);
     } else {
-      startup.readyCallbacks.push(onReady);
+      startup.readyCallbacks.push(markReady);
     }
     return vi.fn();
   },
@@ -182,6 +193,7 @@ function createAppTarget() {
 
 describe("App feature routes", () => {
   beforeEach(async () => {
+    vi.clearAllMocks();
     featureImports.docs = 0;
     featureImports.messages = 0;
     featureImports.failDocsOnce = false;
@@ -222,6 +234,7 @@ describe("App feature routes", () => {
     startup.autoReady = false;
     const { replaceUrl } = await import("./lib/stores/router.svelte.ts");
     replaceUrl("/docs?folder=notes&doc=README.md");
+    const { fetchKataDaemons } = await import("./lib/api/kata/daemons.js");
     const { default: App } = await import("./App.svelte");
 
     render(App, { target: createAppTarget() });
@@ -229,11 +242,13 @@ describe("App feature routes", () => {
     await waitFor(() => expect(featureImports.docs).toBe(1));
 
     expect(screen.queryByTestId("docs-feature")).toBeNull();
+    expect(fetchKataDaemons).not.toHaveBeenCalled();
 
     for (const onReady of startup.readyCallbacks) {
       onReady();
     }
     await waitFor(() => expect(screen.getByTestId("docs-feature")).toBeTruthy());
+    await waitFor(() => expect(fetchKataDaemons).toHaveBeenCalledTimes(1));
   });
 
   it("keeps Docs and Messages mounted while hidden", async () => {

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -76,6 +76,16 @@ async function flushMicrotasks(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("runAppStartup", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -99,6 +109,39 @@ describe("runAppStartup", () => {
     expect(stores.settings.setModeVisibility).toHaveBeenCalledWith(settings.modes);
     expect(stores.settings.setTerminalSettings).toHaveBeenCalledWith(settings.terminal);
     expect(stores.activity.hydrateDefaults).toHaveBeenCalledWith(settings.activity);
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(stores.sync.startPolling).toHaveBeenCalledTimes(1);
+    expect(stores.pulls.loadPulls).toHaveBeenCalledTimes(1);
+    expect(stores.issues.loadIssues).toHaveBeenCalledTimes(1);
+    expect(stores.events.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for backend readiness before fetching settings or loading data", async () => {
+    const stores = makeStores();
+    const ready = deferred<void>();
+    const getSettings = vi.fn(() => Promise.resolve(makeSettings()));
+    const onReady = vi.fn();
+
+    runAppStartup({
+      waitUntilBackendReady: () => ready.promise,
+      getSettings,
+      getStores: () => stores,
+      onReady,
+    });
+
+    await flushMicrotasks();
+
+    expect(getSettings).not.toHaveBeenCalled();
+    expect(onReady).not.toHaveBeenCalled();
+    expect(stores.sync.startPolling).not.toHaveBeenCalled();
+    expect(stores.pulls.loadPulls).not.toHaveBeenCalled();
+    expect(stores.issues.loadIssues).not.toHaveBeenCalled();
+    expect(stores.events.connect).not.toHaveBeenCalled();
+
+    ready.resolve();
+    await flushMicrotasks();
+
+    expect(getSettings).toHaveBeenCalledTimes(1);
     expect(onReady).toHaveBeenCalledTimes(1);
     expect(stores.sync.startPolling).toHaveBeenCalledTimes(1);
     expect(stores.pulls.loadPulls).toHaveBeenCalledTimes(1);

--- a/frontend/src/lib/utils/appStartup.ts
+++ b/frontend/src/lib/utils/appStartup.ts
@@ -2,6 +2,8 @@ import type { StoreInstances } from "@middleman/ui";
 import type { Settings } from "@middleman/ui/api/types";
 
 export interface AppStartupDeps {
+  waitUntilBackendReady?: (signal: AbortSignal) => Promise<void>;
+  afterBackendReady?: (signal: AbortSignal) => void;
   getSettings: () => Promise<Settings>;
   getStores: () => StoreInstances | undefined;
   onReady: () => void;
@@ -40,7 +42,19 @@ async function loadSettingsWithTimeout(getSettings: () => Promise<Settings>): Pr
  */
 export function runAppStartup(deps: AppStartupDeps): () => void {
   let cancelled = false;
+  const abort = new AbortController();
   void (async () => {
+    try {
+      if (deps.waitUntilBackendReady) {
+        await deps.waitUntilBackendReady(abort.signal);
+      }
+    } catch (err) {
+      if (cancelled || abort.signal.aborted) return;
+      console.warn("Failed waiting for backend readiness:", err);
+      return;
+    }
+    if (cancelled) return;
+    deps.afterBackendReady?.(abort.signal);
     try {
       const settings = await loadSettingsWithTimeout(deps.getSettings);
       if (cancelled) return;
@@ -69,5 +83,6 @@ export function runAppStartup(deps: AppStartupDeps): () => void {
   })();
   return () => {
     cancelled = true;
+    abort.abort();
   };
 }

--- a/frontend/src/lib/utils/backendReadiness.test.ts
+++ b/frontend/src/lib/utils/backendReadiness.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+async function importReadiness(basePath = "/") {
+  vi.resetModules();
+  window.__BASE_PATH__ = basePath;
+  return import("./backendReadiness.js");
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+}
+
+describe("waitUntilBackendReady", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    window.__BASE_PATH__ = "/";
+  });
+
+  it("polls the base-path health endpoint until it is ready", async () => {
+    vi.useFakeTimers();
+    const fetch = vi.fn().mockResolvedValueOnce({ ok: false }).mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal("fetch", fetch);
+    const { waitUntilBackendReady } = await importReadiness("/middleman/");
+
+    const ready = waitUntilBackendReady(new AbortController().signal);
+    await flushMicrotasks();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "/middleman/healthz",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(750);
+    await ready;
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when the caller aborts while waiting between polls", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const { waitUntilBackendReady } = await importReadiness();
+    const controller = new AbortController();
+    const abortReason = new Error("cancelled");
+
+    const ready = waitUntilBackendReady(controller.signal);
+    await flushMicrotasks();
+    controller.abort(abortReason);
+
+    await expect(ready).rejects.toBe(abortReason);
+  });
+});

--- a/frontend/src/lib/utils/backendReadiness.ts
+++ b/frontend/src/lib/utils/backendReadiness.ts
@@ -1,0 +1,47 @@
+import { getBasePath } from "../stores/router.svelte.js";
+
+const BACKEND_READY_POLL_MS = 750;
+
+function readinessPath(): string {
+  const base = getBasePath().replace(/\/$/, "");
+  return `${base}/healthz`;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("Aborted", "AbortError");
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      window.clearTimeout(timeout);
+      reject(abortReason(signal));
+    };
+    const timeout = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function waitUntilBackendReady(signal: AbortSignal): Promise<void> {
+  const path = readinessPath();
+  while (!signal.aborted) {
+    try {
+      const response = await fetch(path, {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+        signal,
+      });
+      if (response.ok) return;
+    } catch (err) {
+      if (signal.aborted) throw err;
+    }
+    await sleep(BACKEND_READY_POLL_MS, signal);
+  }
+  throw abortReason(signal);
+}

--- a/frontend/tests/e2e-full/app-startup.spec.ts
+++ b/frontend/tests/e2e-full/app-startup.spec.ts
@@ -5,6 +5,46 @@ test.describe("app startup", () => {
   // path can complete and the app can finish booting.
   test.setTimeout(20_000);
 
+  test("shows app chrome while waiting for backend readiness", async ({ page }) => {
+    let healthRequests = 0;
+    let settingsRequests = 0;
+    let releaseBackendReadiness: () => void = () => {};
+    const backendReady = new Promise<void>((resolve) => {
+      releaseBackendReadiness = resolve;
+    });
+
+    await page.route("**/healthz", async (route) => {
+      healthRequests++;
+      if (healthRequests < 3) {
+        await route.fulfill({
+          status: 503,
+          contentType: "application/problem+json",
+          body: JSON.stringify({ status: 503, code: "serviceUnavailable" }),
+        });
+        return;
+      }
+      await backendReady;
+      await route.continue();
+    });
+
+    await page.route("**/api/v1/settings", async (route) => {
+      settingsRequests++;
+      await route.continue();
+    });
+
+    await page.goto("/");
+
+    await expect(page.locator(".app-header")).toBeVisible();
+    await expect(page.locator(".loading-state")).toBeVisible();
+    await expect.poll(() => healthRequests).toBeGreaterThanOrEqual(3);
+    expect(settingsRequests).toBe(0);
+
+    releaseBackendReadiness();
+    await expect.poll(() => settingsRequests).toBeGreaterThan(0);
+
+    await page.unrouteAll({ behavior: "ignoreErrors" });
+  });
+
   test("startup recovers and loads data when /api/v1/settings stalls past the timeout", async ({ page }) => {
     let settingsRequests = 0;
     let pullsRequested = false;

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -806,63 +806,7 @@ func newServer(
 	}
 
 	if frontend != nil {
-		indexBytes, err := fs.ReadFile(frontend, "index.html")
-		if err != nil {
-			indexBytes = []byte("<!DOCTYPE html><html><body>frontend not found</body></html>")
-		}
-		indexTemplate := string(indexBytes)
-		if basePath != "/" {
-			prefix := strings.TrimSuffix(basePath, "/")
-			indexTemplate = strings.ReplaceAll(indexTemplate, `src="/assets/`, `src="`+prefix+`/assets/`)
-			indexTemplate = strings.ReplaceAll(indexTemplate, `href="/assets/`, `href="`+prefix+`/assets/`)
-		}
-
-		serveIndex := func(w http.ResponseWriter) {
-			idx := strings.Replace(indexTemplate, "<head>",
-				`<head><script>`+s.bootstrapScript()+`</script>`, 1)
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			// index.html references content-hashed bundles. Browsers
-			// must always re-fetch it so a rebuild is picked up; the
-			// hashed assets it references can still be cached forever.
-			w.Header().Set("Cache-Control",
-				"no-store, no-cache, must-revalidate, max-age=0")
-			w.Header().Set("Pragma", "no-cache")
-			w.Header().Set("Expires", "0")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(idx))
-		}
-
-		fileServer := http.FileServerFS(frontend)
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/api/") {
-				http.NotFound(w, r)
-				return
-			}
-			name := strings.TrimPrefix(r.URL.Path, "/")
-			if name == "" || name == "index.html" {
-				serveIndex(w)
-				return
-			}
-			f, err := frontend.Open(name)
-			if err == nil {
-				f.Close()
-				if strings.HasPrefix(r.URL.Path, "/assets/") {
-					w.Header().Set("Cache-Control",
-						"public, max-age=31536000, immutable")
-				}
-				fileServer.ServeHTTP(w, r)
-				return
-			}
-			// A missing /assets/* request is a stale-bundle fetch from
-			// an old cached index.html. Returning the SPA HTML here
-			// would 200 with the wrong Content-Type and leave the page
-			// stuck on a failed module import.
-			if strings.HasPrefix(r.URL.Path, "/assets/") {
-				http.NotFound(w, r)
-				return
-			}
-			serveIndex(w)
-		})
+		mux.Handle("/", newSPAAssetHandler(frontend, basePath, s.bootstrapScript))
 	}
 
 	// When serving under a base path, use an outer mux with
@@ -1114,9 +1058,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) checkHost(w http.ResponseWriter, r *http.Request) bool {
 	s.allowedHostMu.RLock()
-	enabled := len(s.allowedHosts) > 0
+	allowedHosts := s.allowedHosts
 	s.allowedHostMu.RUnlock()
-	if !enabled {
+	return checkListenerHost(w, r, allowedHosts)
+}
+
+func checkListenerHost(
+	w http.ResponseWriter,
+	r *http.Request,
+	allowedHosts map[string]struct{},
+) bool {
+	if len(allowedHosts) == 0 {
 		return true
 	}
 	if !authorityIsLoopbackHost(r.Host) || isLoopbackRemoteAddr(r.RemoteAddr) {
@@ -1295,6 +1247,15 @@ func (s *Server) Serve(ln net.Listener) error {
 	s.bgMu.Unlock()
 
 	return srv.Serve(ln)
+}
+
+// AttachHTTPServer records an externally-started HTTP server so Shutdown can
+// close the listener after a startup handler has been swapped to this Server.
+func (s *Server) AttachHTTPServer(srv *http.Server, ln net.Listener) {
+	s.setAllowedHostsForListener(ln)
+	s.bgMu.Lock()
+	s.httpSrv = srv
+	s.bgMu.Unlock()
 }
 
 func (s *Server) setAllowedHostsForListener(ln net.Listener) {

--- a/internal/server/spa_handler.go
+++ b/internal/server/spa_handler.go
@@ -42,8 +42,7 @@ func newSPAAssetHandler(
 	}
 
 	fileServer := http.FileServerFS(frontend)
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/api/") {
 			http.NotFound(w, r)
 			return
@@ -73,5 +72,4 @@ func newSPAAssetHandler(
 		}
 		serveIndex(w)
 	})
-	return mux
 }

--- a/internal/server/spa_handler.go
+++ b/internal/server/spa_handler.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"io/fs"
+	"net/http"
+	"strings"
+)
+
+func newSPAAssetHandler(
+	frontend fs.FS,
+	basePath string,
+	bootstrapScript func() string,
+) http.Handler {
+	indexBytes, err := fs.ReadFile(frontend, "index.html")
+	if err != nil {
+		indexBytes = []byte("<!DOCTYPE html><html><body>frontend not found</body></html>")
+	}
+	indexTemplate := string(indexBytes)
+	if basePath != "/" {
+		prefix := strings.TrimSuffix(basePath, "/")
+		indexTemplate = strings.ReplaceAll(indexTemplate, `src="/assets/`, `src="`+prefix+`/assets/`)
+		indexTemplate = strings.ReplaceAll(indexTemplate, `href="/assets/`, `href="`+prefix+`/assets/`)
+	}
+
+	serveIndex := func(w http.ResponseWriter) {
+		script := ""
+		if bootstrapScript != nil {
+			script = bootstrapScript()
+		}
+		idx := strings.Replace(indexTemplate, "<head>",
+			`<head><script>`+script+`</script>`, 1)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		// index.html references content-hashed bundles. Browsers
+		// must always re-fetch it so a rebuild is picked up; the
+		// hashed assets it references can still be cached forever.
+		w.Header().Set("Cache-Control",
+			"no-store, no-cache, must-revalidate, max-age=0")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(idx))
+	}
+
+	fileServer := http.FileServerFS(frontend)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			http.NotFound(w, r)
+			return
+		}
+		name := strings.TrimPrefix(r.URL.Path, "/")
+		if name == "" || name == "index.html" {
+			serveIndex(w)
+			return
+		}
+		f, err := frontend.Open(name)
+		if err == nil {
+			_ = f.Close()
+			if strings.HasPrefix(r.URL.Path, "/assets/") {
+				w.Header().Set("Cache-Control",
+					"public, max-age=31536000, immutable")
+			}
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		// A missing /assets/* request is a stale-bundle fetch from
+		// an old cached index.html. Returning the SPA HTML here
+		// would 200 with the wrong Content-Type and leave the page
+		// stuck on a failed module import.
+		if strings.HasPrefix(r.URL.Path, "/assets/") {
+			http.NotFound(w, r)
+			return
+		}
+		serveIndex(w)
+	})
+	return mux
+}

--- a/internal/server/startup_handler.go
+++ b/internal/server/startup_handler.go
@@ -43,12 +43,15 @@ type startupHandler struct {
 	hostOpts     HostCheckOptions
 	allowedHosts map[string]struct{}
 	basePath     string
-	spa          http.Handler
+	frontend     fs.FS
+	fileServer   http.Handler
+	startupPage  []byte
 }
 
 // NewStartupHandler returns a minimal handler for the window between listener
-// bind and full backend readiness. It serves the embedded SPA and health/livez,
-// but reports API and websocket routes as service unavailable.
+// bind and full backend readiness. It serves a startup page that reloads when
+// the full server is ready, serves immutable frontend assets, and reports API
+// and websocket routes as service unavailable.
 func NewStartupHandler(
 	frontend fs.FS,
 	cfg *config.Config,
@@ -65,24 +68,39 @@ func NewStartupHandler(
 		options.HostCheckAllowLoopbackAnyPort,
 	)
 
-	var spa http.Handler
+	var fileServer http.Handler
 	if frontend != nil {
-		spa = newSPAAssetHandler(frontend, basePath, func() string {
-			return startupBootstrapScript(basePath)
-		})
+		fileServer = http.FileServerFS(frontend)
 	}
 
 	return &startupHandler{
 		hostOpts:     hostOpts,
 		allowedHosts: allowedHostsForListener(ln),
 		basePath:     basePath,
-		spa:          spa,
+		frontend:     frontend,
+		fileServer:   fileServer,
+		startupPage:  []byte(startupPageHTML()),
 	}
 }
 
-func startupBootstrapScript(basePath string) string {
-	safeBase, _ := json.Marshal(basePath)
-	return `window.__BASE_PATH__=` + scriptSafe(string(safeBase)) + `;`
+func startupPageHTML() string {
+	healthPath, _ := json.Marshal("/healthz")
+	return `<!DOCTYPE html><html><head><meta charset="utf-8">` +
+		`<meta name="viewport" content="width=device-width,initial-scale=1">` +
+		`<title>middleman is starting</title><style>` +
+		`:root{color-scheme:light dark;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}` +
+		`body{min-height:100vh;margin:0;display:grid;place-items:center;background:#f7f8fb;color:#20242c}` +
+		`main{max-width:34rem;padding:2rem;text-align:center}` +
+		`h1{margin:0 0 .75rem;font-size:1.35rem;font-weight:650}` +
+		`p{margin:0;color:#596273;line-height:1.5}` +
+		`@media (prefers-color-scheme:dark){body{background:#15171c;color:#eef1f6}p{color:#aab2c0}}` +
+		`</style></head><body><main><h1>middleman is starting</h1>` +
+		`<p>The interface will reload when the local server is ready.</p></main><script>` +
+		`const middlemanReadyPath=` + scriptSafe(string(healthPath)) + `;` +
+		`async function waitForMiddleman(){try{const response=await fetch(middlemanReadyPath,{cache:"no-store",headers:{Accept:"application/json"}});` +
+		`if(response.ok){window.location.reload();return;}}catch(error){}` +
+		`window.setTimeout(waitForMiddleman,750);}window.setTimeout(waitForMiddleman,250);` +
+		`</script></body></html>`
 }
 
 func writeStartupUnavailable(w http.ResponseWriter, _ *http.Request) {
@@ -144,9 +162,30 @@ func (h *startupHandler) serveInner(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path == "/ws",
 		strings.HasPrefix(r.URL.Path, "/ws/"):
 		writeStartupUnavailable(w, r)
-	case h.spa != nil:
-		h.spa.ServeHTTP(w, r)
+	case strings.HasPrefix(r.URL.Path, "/assets/") && h.fileServer != nil:
+		h.serveAsset(w, r)
 	default:
-		writeStartupUnavailable(w, r)
+		h.serveStartupPage(w)
 	}
+}
+
+func (h *startupHandler) serveAsset(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimPrefix(r.URL.Path, "/")
+	f, err := h.frontend.Open(name)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	_ = f.Close()
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	h.fileServer.ServeHTTP(w, r)
+}
+
+func (h *startupHandler) serveStartupPage(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(h.startupPage)
 }

--- a/internal/server/startup_handler.go
+++ b/internal/server/startup_handler.go
@@ -43,15 +43,13 @@ type startupHandler struct {
 	hostOpts     HostCheckOptions
 	allowedHosts map[string]struct{}
 	basePath     string
-	frontend     fs.FS
-	fileServer   http.Handler
-	startupPage  []byte
+	spa          http.Handler
 }
 
 // NewStartupHandler returns a minimal handler for the window between listener
-// bind and full backend readiness. It serves a startup page that reloads when
-// the full server is ready, serves immutable frontend assets, and reports API
-// and websocket routes as service unavailable.
+// bind and full backend readiness. It serves the real SPA shell and frontend
+// assets immediately, while API and websocket routes report service unavailable
+// until the full server is swapped in.
 func NewStartupHandler(
 	frontend fs.FS,
 	cfg *config.Config,
@@ -68,46 +66,20 @@ func NewStartupHandler(
 		options.HostCheckAllowLoopbackAnyPort,
 	)
 
-	var fileServer http.Handler
+	var spa http.Handler
 	if frontend != nil {
-		fileServer = http.FileServerFS(frontend)
+		spa = newSPAAssetHandler(frontend, basePath, func() string {
+			safeBase, _ := json.Marshal(basePath)
+			return `window.__BASE_PATH__=` + scriptSafe(string(safeBase)) + `;`
+		})
 	}
 
 	return &startupHandler{
 		hostOpts:     hostOpts,
 		allowedHosts: allowedHostsForListener(ln),
 		basePath:     basePath,
-		frontend:     frontend,
-		fileServer:   fileServer,
-		startupPage:  []byte(startupPageHTML(startupReadinessPath(basePath))),
+		spa:          spa,
 	}
-}
-
-func startupReadinessPath(basePath string) string {
-	if basePath == "/" {
-		return "/healthz"
-	}
-	return strings.TrimSuffix(basePath, "/") + "/healthz"
-}
-
-func startupPageHTML(readinessPath string) string {
-	healthPath, _ := json.Marshal(readinessPath)
-	return `<!DOCTYPE html><html><head><meta charset="utf-8">` +
-		`<meta name="viewport" content="width=device-width,initial-scale=1">` +
-		`<title>middleman is starting</title><style>` +
-		`:root{color-scheme:light dark;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}` +
-		`body{min-height:100vh;margin:0;display:grid;place-items:center;background:#f7f8fb;color:#20242c}` +
-		`main{max-width:34rem;padding:2rem;text-align:center}` +
-		`h1{margin:0 0 .75rem;font-size:1.35rem;font-weight:650}` +
-		`p{margin:0;color:#596273;line-height:1.5}` +
-		`@media (prefers-color-scheme:dark){body{background:#15171c;color:#eef1f6}p{color:#aab2c0}}` +
-		`</style></head><body><main><h1>middleman is starting</h1>` +
-		`<p>The interface will reload when the local server is ready.</p></main><script>` +
-		`const middlemanReadyPath=` + scriptSafe(string(healthPath)) + `;` +
-		`async function waitForMiddleman(){try{const response=await fetch(middlemanReadyPath,{cache:"no-store",headers:{Accept:"application/json"}});` +
-		`if(response.ok){window.location.reload();return;}}catch(error){}` +
-		`window.setTimeout(waitForMiddleman,750);}window.setTimeout(waitForMiddleman,250);` +
-		`</script></body></html>`
 }
 
 func writeStartupUnavailable(w http.ResponseWriter, _ *http.Request) {
@@ -169,30 +141,11 @@ func (h *startupHandler) serveInner(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path == "/ws",
 		strings.HasPrefix(r.URL.Path, "/ws/"):
 		writeStartupUnavailable(w, r)
-	case strings.HasPrefix(r.URL.Path, "/assets/") && h.fileServer != nil:
-		h.serveAsset(w, r)
 	default:
-		h.serveStartupPage(w)
+		if h.spa == nil {
+			http.NotFound(w, r)
+			return
+		}
+		h.spa.ServeHTTP(w, r)
 	}
-}
-
-func (h *startupHandler) serveAsset(w http.ResponseWriter, r *http.Request) {
-	name := strings.TrimPrefix(r.URL.Path, "/")
-	f, err := h.frontend.Open(name)
-	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-	_ = f.Close()
-	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-	h.fileServer.ServeHTTP(w, r)
-}
-
-func (h *startupHandler) serveStartupPage(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
-	w.Header().Set("Pragma", "no-cache")
-	w.Header().Set("Expires", "0")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(h.startupPage)
 }

--- a/internal/server/startup_handler.go
+++ b/internal/server/startup_handler.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"io/fs"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+
+	"go.kenn.io/middleman/internal/config"
+)
+
+// SwitchHandler delegates each request to the currently installed handler.
+// It lets startup bind and serve a small UI-ready handler, then swap to the
+// full server without closing the listener.
+type SwitchHandler struct {
+	current atomic.Value
+}
+
+type switchHandlerTarget struct {
+	handler http.Handler
+}
+
+// NewSwitchHandler creates a handler that initially delegates to initial.
+func NewSwitchHandler(initial http.Handler) *SwitchHandler {
+	h := &SwitchHandler{}
+	h.current.Store(switchHandlerTarget{handler: initial})
+	return h
+}
+
+// Swap replaces the delegate used for subsequent requests.
+func (h *SwitchHandler) Swap(next http.Handler) {
+	h.current.Store(switchHandlerTarget{handler: next})
+}
+
+// ServeHTTP implements http.Handler.
+func (h *SwitchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.current.Load().(switchHandlerTarget).handler.ServeHTTP(w, r)
+}
+
+type startupHandler struct {
+	hostOpts     HostCheckOptions
+	allowedHosts map[string]struct{}
+	handler      http.Handler
+}
+
+// NewStartupHandler returns a minimal handler for the window between listener
+// bind and full backend readiness. It serves the embedded SPA and health/livez,
+// but reports API and websocket routes as service unavailable.
+func NewStartupHandler(
+	frontend fs.FS,
+	cfg *config.Config,
+	options ServerOptions,
+	ln net.Listener,
+) http.Handler {
+	basePath := "/"
+	if cfg != nil && cfg.BasePath != "" {
+		basePath = cfg.BasePath
+	}
+	hostOpts := resolveHostCheckOptions(
+		cfg,
+		options.HostCheck,
+		options.HostCheckAllowLoopbackAnyPort,
+	)
+
+	inner := http.NewServeMux()
+	inner.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, healthResponse{Status: "ok"})
+	})
+	inner.HandleFunc("/healthz", writeStartupUnavailable)
+	inner.HandleFunc("/api/", writeStartupUnavailable)
+	inner.HandleFunc("/api", writeStartupUnavailable)
+	inner.HandleFunc("/ws/", writeStartupUnavailable)
+	inner.HandleFunc("/ws", writeStartupUnavailable)
+	if frontend != nil {
+		inner.Handle("/", newSPAAssetHandler(frontend, basePath, func() string {
+			return startupBootstrapScript(basePath)
+		}))
+	} else {
+		inner.HandleFunc("/", writeStartupUnavailable)
+	}
+
+	var handler http.Handler = inner
+	if basePath != "/" {
+		outer := http.NewServeMux()
+		prefix := strings.TrimSuffix(basePath, "/")
+		outer.Handle("/healthz", inner)
+		outer.Handle("/livez", inner)
+		outer.Handle(basePath, http.StripPrefix(prefix, inner))
+		handler = outer
+	}
+
+	return &startupHandler{
+		hostOpts:     hostOpts,
+		allowedHosts: allowedHostsForListener(ln),
+		handler:      handler,
+	}
+}
+
+func startupBootstrapScript(basePath string) string {
+	safeBase, _ := json.Marshal(basePath)
+	return `window.__BASE_PATH__=` + scriptSafe(string(safeBase)) + `;`
+}
+
+func writeStartupUnavailable(w http.ResponseWriter, _ *http.Request) {
+	writeProblemResponse(w, newProblem(
+		http.StatusServiceUnavailable,
+		CodeServiceUnavailable,
+		"middleman is still starting",
+		map[string]any{"reason": "starting"},
+	))
+}
+
+func (h *startupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !checkHost(w, r, h.hostOpts) {
+		return
+	}
+	if !checkListenerHost(w, r, h.allowedHosts) {
+		return
+	}
+	h.handler.ServeHTTP(w, r)
+}

--- a/internal/server/startup_handler.go
+++ b/internal/server/startup_handler.go
@@ -79,12 +79,19 @@ func NewStartupHandler(
 		basePath:     basePath,
 		frontend:     frontend,
 		fileServer:   fileServer,
-		startupPage:  []byte(startupPageHTML()),
+		startupPage:  []byte(startupPageHTML(startupReadinessPath(basePath))),
 	}
 }
 
-func startupPageHTML() string {
-	healthPath, _ := json.Marshal("/healthz")
+func startupReadinessPath(basePath string) string {
+	if basePath == "/" {
+		return "/healthz"
+	}
+	return strings.TrimSuffix(basePath, "/") + "/healthz"
+}
+
+func startupPageHTML(readinessPath string) string {
+	healthPath, _ := json.Marshal(readinessPath)
 	return `<!DOCTYPE html><html><head><meta charset="utf-8">` +
 		`<meta name="viewport" content="width=device-width,initial-scale=1">` +
 		`<title>middleman is starting</title><style>` +

--- a/internal/server/startup_handler.go
+++ b/internal/server/startup_handler.go
@@ -42,7 +42,8 @@ func (h *SwitchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type startupHandler struct {
 	hostOpts     HostCheckOptions
 	allowedHosts map[string]struct{}
-	handler      http.Handler
+	basePath     string
+	spa          http.Handler
 }
 
 // NewStartupHandler returns a minimal handler for the window between listener
@@ -64,37 +65,18 @@ func NewStartupHandler(
 		options.HostCheckAllowLoopbackAnyPort,
 	)
 
-	inner := http.NewServeMux()
-	inner.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
-		writeJSON(w, http.StatusOK, healthResponse{Status: "ok"})
-	})
-	inner.HandleFunc("/healthz", writeStartupUnavailable)
-	inner.HandleFunc("/api/", writeStartupUnavailable)
-	inner.HandleFunc("/api", writeStartupUnavailable)
-	inner.HandleFunc("/ws/", writeStartupUnavailable)
-	inner.HandleFunc("/ws", writeStartupUnavailable)
+	var spa http.Handler
 	if frontend != nil {
-		inner.Handle("/", newSPAAssetHandler(frontend, basePath, func() string {
+		spa = newSPAAssetHandler(frontend, basePath, func() string {
 			return startupBootstrapScript(basePath)
-		}))
-	} else {
-		inner.HandleFunc("/", writeStartupUnavailable)
-	}
-
-	var handler http.Handler = inner
-	if basePath != "/" {
-		outer := http.NewServeMux()
-		prefix := strings.TrimSuffix(basePath, "/")
-		outer.Handle("/healthz", inner)
-		outer.Handle("/livez", inner)
-		outer.Handle(basePath, http.StripPrefix(prefix, inner))
-		handler = outer
+		})
 	}
 
 	return &startupHandler{
 		hostOpts:     hostOpts,
 		allowedHosts: allowedHostsForListener(ln),
-		handler:      handler,
+		basePath:     basePath,
+		spa:          spa,
 	}
 }
 
@@ -119,5 +101,52 @@ func (h *startupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !checkListenerHost(w, r, h.allowedHosts) {
 		return
 	}
-	h.handler.ServeHTTP(w, r)
+	h.serve(w, r)
+}
+
+func (h *startupHandler) serve(w http.ResponseWriter, r *http.Request) {
+	if h.basePath == "/" {
+		h.serveInner(w, r)
+		return
+	}
+
+	switch r.URL.Path {
+	case "/healthz", "/livez":
+		h.serveInner(w, r)
+		return
+	}
+
+	prefix := strings.TrimSuffix(h.basePath, "/")
+	if r.URL.Path == prefix {
+		http.Redirect(w, r, prefix+"/", http.StatusMovedPermanently)
+		return
+	}
+	if !strings.HasPrefix(r.URL.Path, h.basePath) {
+		http.NotFound(w, r)
+		return
+	}
+
+	stripped := r.Clone(r.Context())
+	stripped.URL.Path = strings.TrimPrefix(r.URL.Path, prefix)
+	if r.URL.RawPath != "" {
+		stripped.URL.RawPath = strings.TrimPrefix(r.URL.RawPath, prefix)
+	}
+	h.serveInner(w, stripped)
+}
+
+func (h *startupHandler) serveInner(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/livez":
+		writeJSON(w, http.StatusOK, healthResponse{Status: "ok"})
+	case r.URL.Path == "/healthz",
+		r.URL.Path == "/api",
+		strings.HasPrefix(r.URL.Path, "/api/"),
+		r.URL.Path == "/ws",
+		strings.HasPrefix(r.URL.Path, "/ws/"):
+		writeStartupUnavailable(w, r)
+	case h.spa != nil:
+		h.spa.ServeHTTP(w, r)
+	default:
+		writeStartupUnavailable(w, r)
+	}
 }

--- a/internal/server/startup_handler_test.go
+++ b/internal/server/startup_handler_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/config"
+)
+
+func TestSwitchHandlerSwapsDifferentHandlerTypes(t *testing.T) {
+	switcher := NewSwitchHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	firstRR := httptest.NewRecorder()
+	switcher.ServeHTTP(firstRR, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.Equal(t, http.StatusAccepted, firstRR.Code)
+
+	next := http.NewServeMux()
+	next.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	switcher.Swap(next)
+
+	secondRR := httptest.NewRecorder()
+	switcher.ServeHTTP(secondRR, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.Equal(t, http.StatusNoContent, secondRR.Code)
+}
+
+func TestStartupHandlerServesSPAWhileAPIUnavailable(t *testing.T) {
+	frontend := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body>app</body></html>`),
+		},
+		"assets/index-DEADBEEF.js": &fstest.MapFile{
+			Data: []byte(`console.log("bundle");`),
+		},
+	}
+	cfg := &config.Config{
+		Host:     "127.0.0.1",
+		Port:     8091,
+		BasePath: "/",
+	}
+	handler := NewStartupHandler(
+		frontend,
+		cfg,
+		ServerOptions{},
+		staticListener{addr: staticListenerAddr("127.0.0.1:8091")},
+	)
+
+	rootReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	rootReq.Host = "127.0.0.1:8091"
+	rootReq.RemoteAddr = "127.0.0.1:1234"
+	rootRR := httptest.NewRecorder()
+	handler.ServeHTTP(rootRR, rootReq)
+
+	assert := Assert.New(t)
+	assert.Equal(http.StatusOK, rootRR.Code)
+	assert.Contains(rootRR.Body.String(), `window.__BASE_PATH__="/"`)
+	assert.Contains(rootRR.Body.String(), "app")
+
+	apiReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	apiReq.Host = "127.0.0.1:8091"
+	apiReq.RemoteAddr = "127.0.0.1:1234"
+	apiRR := httptest.NewRecorder()
+	handler.ServeHTTP(apiRR, apiReq)
+
+	assert.Equal(http.StatusServiceUnavailable, apiRR.Code)
+	assert.Equal("application/problem+json", apiRR.Header().Get("Content-Type"))
+	var problem ProblemError
+	require.NoError(t, json.Unmarshal(apiRR.Body.Bytes(), &problem))
+	assert.Equal(CodeServiceUnavailable, problem.Code)
+
+	assetReq := httptest.NewRequest(http.MethodGet, "/assets/index-DEADBEEF.js", nil)
+	assetReq.Host = "127.0.0.1:8091"
+	assetReq.RemoteAddr = "127.0.0.1:1234"
+	assetRR := httptest.NewRecorder()
+	handler.ServeHTTP(assetRR, assetReq)
+
+	assert.Equal(http.StatusOK, assetRR.Code)
+	assert.Equal("public, max-age=31536000, immutable", assetRR.Header().Get("Cache-Control"))
+}
+
+func TestStartupHandlerUsesHostValidation(t *testing.T) {
+	frontend := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body>app</body></html>`),
+		},
+	}
+	cfg := &config.Config{
+		Host:     "127.0.0.1",
+		Port:     8091,
+		BasePath: "/",
+	}
+	handler := NewStartupHandler(
+		frontend,
+		cfg,
+		ServerOptions{},
+		staticListener{addr: staticListenerAddr("127.0.0.1:8091")},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "attacker.example:8091"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	Assert.Equal(t, http.StatusForbidden, rr.Code, rr.Body.String())
+}

--- a/internal/server/startup_handler_test.go
+++ b/internal/server/startup_handler_test.go
@@ -40,7 +40,7 @@ func TestSwitchHandlerSwapsDifferentHandlerTypes(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, secondRR.Code)
 }
 
-func TestStartupHandlerServesStartupPageWhileAPIUnavailable(t *testing.T) {
+func TestStartupHandlerServesSPAWhileAPIUnavailable(t *testing.T) {
 	frontend := fstest.MapFS{
 		"index.html": &fstest.MapFile{
 			Data: []byte(`<!DOCTYPE html><html><head></head><body>app</body></html>`),
@@ -69,9 +69,9 @@ func TestStartupHandlerServesStartupPageWhileAPIUnavailable(t *testing.T) {
 
 	assert := Assert.New(t)
 	assert.Equal(http.StatusOK, rootRR.Code)
-	assert.Contains(rootRR.Body.String(), "middleman is starting")
-	assert.Contains(rootRR.Body.String(), `const middlemanReadyPath="/healthz";`)
-	assert.NotContains(rootRR.Body.String(), `<body>app</body>`)
+	assert.Contains(rootRR.Body.String(), `<body>app</body>`)
+	assert.Contains(rootRR.Body.String(), `window.__BASE_PATH__="/"`)
+	assert.NotContains(rootRR.Body.String(), "middleman is starting")
 
 	apiReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
 	apiReq.Host = "127.0.0.1:8091"
@@ -147,9 +147,10 @@ func TestStartupHandlerHonorsBasePath(t *testing.T) {
 
 	assert := Assert.New(t)
 	assert.Equal(http.StatusOK, rr.Code)
-	assert.Contains(rr.Body.String(), "middleman is starting")
-	assert.Contains(rr.Body.String(), `const middlemanReadyPath="/middleman/healthz";`)
-	assert.NotContains(rr.Body.String(), `src="/middleman/assets/index.js"`)
+	assert.Contains(rr.Body.String(), `<body>app</body>`)
+	assert.Contains(rr.Body.String(), `window.__BASE_PATH__="/middleman/"`)
+	assert.Contains(rr.Body.String(), `src="/middleman/assets/index.js"`)
+	assert.NotContains(rr.Body.String(), "middleman is starting")
 
 	healthReq := httptest.NewRequest(http.MethodGet, "/middleman/healthz", nil)
 	healthReq.Host = "127.0.0.1:8091"
@@ -234,8 +235,9 @@ func TestStartupHandlerSwapsToFullServerOverHTTP(t *testing.T) {
 	rootStatus, _, rootBody := getHTTPBody(t, client, baseURL+"/")
 	assert := Assert.New(t)
 	assert.Equal(http.StatusOK, rootStatus)
-	assert.Contains(rootBody, "middleman is starting")
-	assert.NotContains(rootBody, `<body>app</body>`)
+	assert.Contains(rootBody, `<body>app</body>`)
+	assert.Contains(rootBody, `window.__BASE_PATH__="/"`)
+	assert.NotContains(rootBody, "middleman is starting")
 
 	apiStatus, apiHeader, apiBody := getHTTPBody(
 		t, client, baseURL+"/api/v1/sync/status",

--- a/internal/server/startup_handler_test.go
+++ b/internal/server/startup_handler_test.go
@@ -148,8 +148,16 @@ func TestStartupHandlerHonorsBasePath(t *testing.T) {
 	assert := Assert.New(t)
 	assert.Equal(http.StatusOK, rr.Code)
 	assert.Contains(rr.Body.String(), "middleman is starting")
-	assert.Contains(rr.Body.String(), `const middlemanReadyPath="/healthz";`)
+	assert.Contains(rr.Body.String(), `const middlemanReadyPath="/middleman/healthz";`)
 	assert.NotContains(rr.Body.String(), `src="/middleman/assets/index.js"`)
+
+	healthReq := httptest.NewRequest(http.MethodGet, "/middleman/healthz", nil)
+	healthReq.Host = "127.0.0.1:8091"
+	healthReq.RemoteAddr = "127.0.0.1:1234"
+	healthRR := httptest.NewRecorder()
+	handler.ServeHTTP(healthRR, healthReq)
+
+	assert.Equal(http.StatusServiceUnavailable, healthRR.Code)
 
 	apiReq := httptest.NewRequest(http.MethodGet, "/middleman/api/v1/settings", nil)
 	apiReq.Host = "127.0.0.1:8091"

--- a/internal/server/startup_handler_test.go
+++ b/internal/server/startup_handler_test.go
@@ -111,3 +111,49 @@ func TestStartupHandlerUsesHostValidation(t *testing.T) {
 
 	Assert.Equal(t, http.StatusForbidden, rr.Code, rr.Body.String())
 }
+
+func TestStartupHandlerHonorsBasePath(t *testing.T) {
+	frontend := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head><script src="/assets/index.js"></script></head><body>app</body></html>`),
+		},
+	}
+	cfg := &config.Config{
+		Host:     "127.0.0.1",
+		Port:     8091,
+		BasePath: "/middleman/",
+	}
+	handler := NewStartupHandler(
+		frontend,
+		cfg,
+		ServerOptions{},
+		staticListener{addr: staticListenerAddr("127.0.0.1:8091")},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/middleman/", nil)
+	req.Host = "127.0.0.1:8091"
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert := Assert.New(t)
+	assert.Equal(http.StatusOK, rr.Code)
+	assert.Contains(rr.Body.String(), `window.__BASE_PATH__="/middleman/"`)
+	assert.Contains(rr.Body.String(), `src="/middleman/assets/index.js"`)
+
+	apiReq := httptest.NewRequest(http.MethodGet, "/middleman/api/v1/settings", nil)
+	apiReq.Host = "127.0.0.1:8091"
+	apiReq.RemoteAddr = "127.0.0.1:1234"
+	apiRR := httptest.NewRecorder()
+	handler.ServeHTTP(apiRR, apiReq)
+
+	assert.Equal(http.StatusServiceUnavailable, apiRR.Code)
+
+	bareReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	bareReq.Host = "127.0.0.1:8091"
+	bareReq.RemoteAddr = "127.0.0.1:1234"
+	bareRR := httptest.NewRecorder()
+	handler.ServeHTTP(bareRR, bareReq)
+
+	assert.Equal(http.StatusNotFound, bareRR.Code)
+}

--- a/internal/server/startup_handler_test.go
+++ b/internal/server/startup_handler_test.go
@@ -1,15 +1,23 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/middleman/internal/config"
+	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
 
 func TestSwitchHandlerSwapsDifferentHandlerTypes(t *testing.T) {
@@ -32,7 +40,7 @@ func TestSwitchHandlerSwapsDifferentHandlerTypes(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, secondRR.Code)
 }
 
-func TestStartupHandlerServesSPAWhileAPIUnavailable(t *testing.T) {
+func TestStartupHandlerServesStartupPageWhileAPIUnavailable(t *testing.T) {
 	frontend := fstest.MapFS{
 		"index.html": &fstest.MapFile{
 			Data: []byte(`<!DOCTYPE html><html><head></head><body>app</body></html>`),
@@ -61,8 +69,9 @@ func TestStartupHandlerServesSPAWhileAPIUnavailable(t *testing.T) {
 
 	assert := Assert.New(t)
 	assert.Equal(http.StatusOK, rootRR.Code)
-	assert.Contains(rootRR.Body.String(), `window.__BASE_PATH__="/"`)
-	assert.Contains(rootRR.Body.String(), "app")
+	assert.Contains(rootRR.Body.String(), "middleman is starting")
+	assert.Contains(rootRR.Body.String(), `const middlemanReadyPath="/healthz";`)
+	assert.NotContains(rootRR.Body.String(), `<body>app</body>`)
 
 	apiReq := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
 	apiReq.Host = "127.0.0.1:8091"
@@ -138,8 +147,9 @@ func TestStartupHandlerHonorsBasePath(t *testing.T) {
 
 	assert := Assert.New(t)
 	assert.Equal(http.StatusOK, rr.Code)
-	assert.Contains(rr.Body.String(), `window.__BASE_PATH__="/middleman/"`)
-	assert.Contains(rr.Body.String(), `src="/middleman/assets/index.js"`)
+	assert.Contains(rr.Body.String(), "middleman is starting")
+	assert.Contains(rr.Body.String(), `const middlemanReadyPath="/healthz";`)
+	assert.NotContains(rr.Body.String(), `src="/middleman/assets/index.js"`)
 
 	apiReq := httptest.NewRequest(http.MethodGet, "/middleman/api/v1/settings", nil)
 	apiReq.Host = "127.0.0.1:8091"
@@ -156,4 +166,116 @@ func TestStartupHandlerHonorsBasePath(t *testing.T) {
 	handler.ServeHTTP(bareRR, bareReq)
 
 	assert.Equal(http.StatusNotFound, bareRR.Code)
+}
+
+func TestStartupHandlerSwapsToFullServerOverHTTP(t *testing.T) {
+	frontend := fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: []byte(`<!DOCTYPE html><html><head></head><body>app</body></html>`),
+		},
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cfg := &config.Config{
+		Host:           "127.0.0.1",
+		Port:           port,
+		BasePath:       "/",
+		SyncInterval:   "5m",
+		GitHubTokenEnv: "MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_STARTUP_TEST",
+		Activity: config.Activity{
+			ViewMode:  "threaded",
+			TimeRange: "7d",
+		},
+	}
+
+	switcher := NewSwitchHandler(NewStartupHandler(
+		frontend,
+		cfg,
+		ServerOptions{},
+		ln,
+	))
+	httpSrv := &http.Server{Handler: switcher}
+	errCh := make(chan error, 1)
+	go func() {
+		if serveErr := httpSrv.Serve(ln); !errors.Is(serveErr, http.ErrServerClosed) {
+			errCh <- serveErr
+		}
+	}()
+
+	var fullServer *Server
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if fullServer != nil {
+			require.NoError(t, fullServer.Shutdown(shutdownCtx))
+		} else {
+			require.NoError(t, httpSrv.Shutdown(shutdownCtx))
+		}
+		select {
+		case serveErr := <-errCh:
+			require.NoError(t, serveErr)
+		default:
+		}
+	})
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	baseURL := "http://" + ln.Addr().String()
+
+	rootStatus, _, rootBody := getHTTPBody(t, client, baseURL+"/")
+	assert := Assert.New(t)
+	assert.Equal(http.StatusOK, rootStatus)
+	assert.Contains(rootBody, "middleman is starting")
+	assert.NotContains(rootBody, `<body>app</body>`)
+
+	apiStatus, apiHeader, apiBody := getHTTPBody(
+		t, client, baseURL+"/api/v1/sync/status",
+	)
+	assert.Equal(http.StatusServiceUnavailable, apiStatus)
+	assert.Equal("application/problem+json", apiHeader.Get("Content-Type"))
+	assert.Contains(apiBody, `"reason":"starting"`)
+
+	database := dbtest.Open(t)
+	mock := &mockGH{}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, nil, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	fullServer = New(
+		database, syncer, frontend, "/", cfg,
+		ServerOptions{HostCheckAllowLoopbackAnyPort: true},
+	)
+	fullServer.AttachHTTPServer(httpSrv, ln)
+	switcher.Swap(fullServer)
+
+	readyStatus, readyHeader, readyBody := getHTTPBody(
+		t, client, baseURL+"/api/v1/sync/status",
+	)
+	assert.Equal(http.StatusOK, readyStatus)
+	assert.True(
+		strings.HasPrefix(readyHeader.Get("Content-Type"), "application/json"),
+		readyHeader.Get("Content-Type"),
+	)
+	assert.Contains(readyBody, `"running":`)
+
+	readyRootStatus, _, readyRootBody := getHTTPBody(t, client, baseURL+"/")
+	assert.Equal(http.StatusOK, readyRootStatus)
+	assert.Contains(readyRootBody, "app")
+	assert.Contains(readyRootBody, `window.__BASE_PATH__="/"`)
+}
+
+func getHTTPBody(
+	t *testing.T,
+	client *http.Client,
+	url string,
+) (int, http.Header, string) {
+	t.Helper()
+	resp, err := client.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, resp.Header, string(body)
 }


### PR DESCRIPTION
## Summary

- Bind the HTTP listener before backend warmup so the browser gets an HTTP response instead of a connection-level 502 during slow startup.
- Serve the embedded SPA shell and static assets during warmup while API and websocket routes return a structured startup 503 until the full server is ready.
- Gate frontend startup API and data work on `/healthz`, so app chrome can render immediately while data panes stay in the normal loading state.
- Swap the existing listener to the full server after initialization and preserve normal shutdown and host-validation behavior across that handoff.

## Notes

This does not make backend data available earlier; it lets the UI mount while startup finishes.
