### PR TITLE
Remove Mermaid viewer pan controls

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -384,11 +384,10 @@ a:hover {
 }
 .mermaid-viewer__controls--nav {
   top: 50%;
-  grid-template-columns: repeat(3, 34px);
+  grid-template-columns: 34px;
   transform: translateY(-50%);
 }
-.mermaid-viewer__button,
-.mermaid-viewer__spacer {
+.mermaid-viewer__button {
   width: 34px;
   height: 34px;
 }
@@ -508,13 +507,12 @@ a:hover {
   }
   .mermaid-viewer__controls--top,
   .mermaid-viewer__controls--nav {
-    grid-template-columns: repeat(3, 30px);
+    grid-template-columns: 30px;
   }
   .mermaid-viewer__controls--top {
     grid-template-columns: repeat(2, 30px);
   }
-  .mermaid-viewer__button,
-  .mermaid-viewer__spacer {
+  .mermaid-viewer__button {
     width: 30px;
     height: 30px;
   }

--- a/frontend/src/lib/utils/markdownMermaid.test.ts
+++ b/frontend/src/lib/utils/markdownMermaid.test.ts
@@ -76,6 +76,12 @@ function clearMermaidThemeVars(): void {
   }
 }
 
+function expectNoDirectionalPanButtons(root: ParentNode): void {
+  for (const label of ["Pan diagram up", "Pan diagram right", "Pan diagram down", "Pan diagram left"]) {
+    expect(root.querySelector(`button[aria-label="${label}"]`)).toBeNull();
+  }
+}
+
 async function flushQueuedRender(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -361,7 +367,10 @@ describe("renderMarkdownMermaidDiagrams", () => {
     const pan = root.querySelector<HTMLElement>(".mermaid-viewer__pan");
     expect(pre?.classList.contains("mermaid-viewer")).toBe(true);
     expect(root.querySelector(".mermaid-viewer__viewport svg")).not.toBeNull();
-    expect(root.querySelectorAll(".mermaid-viewer__button")).toHaveLength(7);
+    expect(root.querySelectorAll(".mermaid-viewer__button")).toHaveLength(3);
+    expect(root.querySelectorAll(".mermaid-viewer__controls--nav .mermaid-viewer__button")).toHaveLength(1);
+    expect(root.querySelector('button[aria-label="Reset diagram view"]')).not.toBeNull();
+    expectNoDirectionalPanButtons(root);
     expect(root.querySelector('button[aria-label="Zoom in diagram"]')).toBeNull();
     expect(root.querySelector('button[aria-label="Zoom out diagram"]')).toBeNull();
     const expandButton = root.querySelector<HTMLButtonElement>('button[aria-label="Open diagram in expanded view"]');
@@ -377,9 +386,6 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(viewport?.dispatchEvent(wheelZoomIn)).toBe(false);
     expect(wheelZoomIn.defaultPrevented).toBe(true);
     expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1.16)");
-
-    root.querySelector<HTMLButtonElement>('button[aria-label="Pan diagram right"]')?.click();
-    expect(pan?.style.transform).toBe("translate(80px, 0px) scale(1.16)");
 
     root.querySelector<HTMLButtonElement>('button[aria-label="Reset diagram view"]')?.click();
     expect(pan?.style.transform).toBe("translate(0px, 0px) scale(1)");
@@ -421,7 +427,9 @@ describe("renderMarkdownMermaidDiagrams", () => {
     expect(overlay?.getAttribute("role")).toBe("dialog");
     expect(overlay?.getAttribute("aria-modal")).toBe("true");
     expect(overlay?.querySelector("svg")).not.toBeNull();
-    expect(overlay?.querySelectorAll(".mermaid-viewer__controls--nav .mermaid-viewer__button")).toHaveLength(5);
+    expect(overlay?.querySelectorAll(".mermaid-viewer__controls--nav .mermaid-viewer__button")).toHaveLength(1);
+    expect(overlay?.querySelector('button[aria-label="Reset diagram view"]')).not.toBeNull();
+    if (overlay) expectNoDirectionalPanButtons(overlay);
     expect(overlay?.querySelector('button[aria-label="Copy Mermaid source"]')).toBeNull();
     expect(overlay?.querySelector('button[aria-label="Zoom in diagram"]')).toBeNull();
 

--- a/frontend/src/lib/utils/markdownMermaid.ts
+++ b/frontend/src/lib/utils/markdownMermaid.ts
@@ -39,7 +39,6 @@ const MERMAID_VIEWER_SELECTOR = ".markdown-body pre.mermaid.mermaid-viewer, .doc
 const MERMAID_VIEWER_ATTACHED = "true";
 const MIN_SCALE = 0.4;
 const MAX_SCALE = 3;
-const PAN_STEP = 80;
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
 const WHEEL_DELTA_LINE = 1;
 const WHEEL_DELTA_PAGE = 2;
@@ -349,16 +348,7 @@ function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivEleme
     updateTransform();
   };
 
-  const panBy = (deltaX: number, deltaY: number) => {
-    offsetX += deltaX;
-    offsetY += deltaY;
-    updateTransform();
-  };
-
-  const controls = createMermaidNavControls({
-    panBy,
-    resetView,
-  });
+  const controls = createMermaidResetControls(resetView);
 
   attachDragPanning(viewport, {
     onDrag(deltaX, deltaY) {
@@ -385,23 +375,10 @@ function createPannableDiagramView(svg: SVGSVGElement): { controls: HTMLDivEleme
   return { controls, viewport };
 }
 
-function createMermaidNavControls(actions: {
-  panBy: (deltaX: number, deltaY: number) => void;
-  resetView: () => void;
-}): HTMLDivElement {
+function createMermaidResetControls(resetView: () => void): HTMLDivElement {
   const navControls = document.createElement("div");
   navControls.className = "mermaid-viewer__controls mermaid-viewer__controls--nav";
-  navControls.append(
-    createMermaidSpacer(),
-    createMermaidButton("Pan diagram up", "↑", () => actions.panBy(0, -PAN_STEP)),
-    createMermaidSpacer(),
-    createMermaidButton("Pan diagram left", "←", () => actions.panBy(-PAN_STEP, 0)),
-    createMermaidButton("Reset diagram view", "⟳", actions.resetView),
-    createMermaidButton("Pan diagram right", "→", () => actions.panBy(PAN_STEP, 0)),
-    createMermaidSpacer(),
-    createMermaidButton("Pan diagram down", "↓", () => actions.panBy(0, PAN_STEP)),
-    createMermaidSpacer(),
-  );
+  navControls.append(createMermaidButton("Reset diagram view", "⟳", resetView));
   return navControls;
 }
 
@@ -470,13 +447,6 @@ function createMermaidButton(label: string, text: string, onClick: () => void | 
     void onClick();
   });
   return button;
-}
-
-function createMermaidSpacer(): HTMLSpanElement {
-  const spacer = document.createElement("span");
-  spacer.className = "mermaid-viewer__spacer";
-  spacer.setAttribute("aria-hidden", "true");
-  return spacer;
 }
 
 async function copyMermaidSource(source: string, button: HTMLButtonElement): Promise<void> {

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -139,6 +139,8 @@ test("markdown mermaid fences render as diagrams", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Zoom in diagram" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Zoom out diagram" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Copy Mermaid source" })).toBeVisible();
+  await expect(page.locator(".markdown-body").getByRole("button", { name: "Reset diagram view" })).toBeVisible();
+  await expect(page.locator(".markdown-body").getByRole("button", { name: /Pan diagram/ })).toHaveCount(0);
 
   const diagramViewport = page.locator(".markdown-body .mermaid-viewer__viewport");
   const diagramPan = page.locator(".markdown-body .mermaid-viewer__pan");
@@ -150,8 +152,11 @@ test("markdown mermaid fences render as diagrams", async ({ page }) => {
     .not.toBe(initialTransform);
 
   await page.getByRole("button", { name: "Open diagram in expanded view" }).click();
-  await expect(page.getByRole("dialog", { name: "Expanded Mermaid diagram" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Close expanded diagram" })).toBeVisible();
+  const expandedDiagram = page.getByRole("dialog", { name: "Expanded Mermaid diagram" });
+  await expect(expandedDiagram).toBeVisible();
+  await expect(expandedDiagram.getByRole("button", { name: "Close expanded diagram" })).toBeVisible();
+  await expect(expandedDiagram.getByRole("button", { name: "Reset diagram view" })).toBeVisible();
+  await expect(expandedDiagram.getByRole("button", { name: /Pan diagram/ })).toHaveCount(0);
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog", { name: "Expanded Mermaid diagram" })).toBeHidden();
 });


### PR DESCRIPTION
- Removes the directional Mermaid diagram pan buttons from inline and expanded viewers.
- Keeps the reset button available for restoring the diagram viewport after drag panning or wheel zooming.
- Updates browser coverage so the viewer exposes reset without pan controls.
