### PR TITLE
Fix Firefox viewport overflow

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -7,6 +7,11 @@
   padding: 0;
 }
 
+* {
+  scrollbar-color: var(--border-default) transparent;
+  scrollbar-width: thin;
+}
+
 /* Light theme */
 :root {
   --bg-primary: #f5f6f8;
@@ -114,8 +119,6 @@
   --mermaid-note-border: #d4a72c;
 
   color-scheme: light;
-  scrollbar-color: var(--border-default) transparent;
-  scrollbar-width: thin;
 }
 
 /* Dark theme */

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -114,6 +114,8 @@
   --mermaid-note-border: #d4a72c;
 
   color-scheme: light;
+  scrollbar-color: var(--border-default) transparent;
+  scrollbar-width: thin;
 }
 
 /* Dark theme */

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -14,7 +14,8 @@ test("Firefox receives compact scrollbar styling for app scroll panes", async ({
   await expect(page.locator(".settings-page")).toBeVisible();
   await expect(
     page.evaluate(() => {
-      const rootRules = Array.from(document.styleSheets)
+      const settingsPane = document.querySelector(".settings-page");
+      const appRules = Array.from(document.styleSheets)
         .flatMap((sheet) => {
           try {
             return Array.from(sheet.cssRules);
@@ -22,10 +23,13 @@ test("Firefox receives compact scrollbar styling for app scroll panes", async ({
             return [];
           }
         })
-        .filter((rule): rule is CSSStyleRule => "selectorText" in rule && rule.selectorText === ":root");
+        .filter((rule): rule is CSSStyleRule => "selectorText" in rule);
 
-      return rootRules.some(
-        (rule) => rule.style.scrollbarWidth === "thin" && rule.style.scrollbarColor.includes("transparent"),
+      return appRules.some(
+        (rule) =>
+          settingsPane?.matches(rule.selectorText) === true &&
+          rule.style.scrollbarWidth === "thin" &&
+          rule.style.scrollbarColor.includes("transparent"),
       );
     }),
   ).resolves.toBe(true);

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -12,6 +12,9 @@ test("Firefox receives compact scrollbar styling for app scroll panes", async ({
   await page.goto("/settings");
 
   await expect(page.locator(".settings-page")).toBeVisible();
+  await expect(page.locator(".settings-page").evaluate((pane) => pane.scrollHeight > pane.clientHeight)).resolves.toBe(
+    true,
+  );
   await expect(
     page.evaluate(() => {
       const settingsPane = document.querySelector(".settings-page");

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "./support/mockApi";
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("Firefox receives compact scrollbar styling for app scroll panes", async ({ page, browserName }) => {
+  test.skip(browserName !== "firefox", "Firefox-specific scrollbar regression");
+
+  await page.goto("/settings");
+
+  await expect(page.locator(".settings-page")).toBeVisible();
+  await expect(
+    page.evaluate(() => {
+      const rootRules = Array.from(document.styleSheets)
+        .flatMap((sheet) => {
+          try {
+            return Array.from(sheet.cssRules);
+          } catch {
+            return [];
+          }
+        })
+        .filter((rule): rule is CSSStyleRule => "selectorText" in rule && rule.selectorText === ":root");
+
+      return rootRules.some(
+        (rule) => rule.style.scrollbarWidth === "thin" && rule.style.scrollbarColor.includes("transparent"),
+      );
+    }),
+  ).resolves.toBe(true);
+
+  await expect(
+    page.evaluate(() => {
+      const appRect = document.querySelector("#app")?.getBoundingClientRect();
+
+      return {
+        heightFits: appRect?.height === window.innerHeight,
+        widthFits: appRect?.width === window.innerWidth,
+      };
+    }),
+  ).resolves.toEqual({ heightFits: true, widthFits: true });
+});


### PR DESCRIPTION
- Add standards-based compact scrollbar styling for Firefox and Zen.
- Add a Firefox Playwright regression that checks app viewport fit.