### PR TITLE
fix: launch tmux panes without a shell handoff (fish/Nix-safe)

### DIFF
--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -34,6 +34,7 @@ import (
 	"go.kenn.io/middleman/internal/telemetry"
 	"go.kenn.io/middleman/internal/tokenauth"
 	"go.kenn.io/middleman/internal/web"
+	"go.kenn.io/middleman/internal/workspace/panebootstrap"
 )
 
 type splitLogHandler struct {
@@ -86,6 +87,11 @@ var (
 var runServer = run
 
 func main() {
+	// If tmux launched us as a pane bootstrap, exec the real command and
+	// never return. Must precede configureLogging (no log files in a pane)
+	// and any flag parsing.
+	panebootstrap.ExecIfRequested()
+
 	closeLog, err := configureLogging(os.Stderr)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "configure logging: %v\n", err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -58,6 +58,7 @@ import (
 	"go.kenn.io/middleman/internal/tokenauth"
 	"go.kenn.io/middleman/internal/workspace"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
+	"go.kenn.io/middleman/internal/workspace/panebootstrap"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -66,6 +67,10 @@ const serverRuntimeHelperMarker = "middleman-runtime-helper"
 var ptyE2ESemaphore = semaphore.NewWeighted(1)
 
 func TestMain(m *testing.M) {
+	// Real-tmux e2e tests launch panes that re-exec this test binary as
+	// the pane bootstrap; exec the handoff command and never return before
+	// the suite (or the helper-process check) runs.
+	panebootstrap.ExecIfRequested()
 	if isServerHelperProcess() {
 		os.Exit(m.Run())
 	}

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -23,9 +23,14 @@ import (
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/ptyowner"
 	ptyownerruntime "go.kenn.io/middleman/internal/ptyowner/runtime"
+	"go.kenn.io/middleman/internal/workspace/panebootstrap"
 )
 
 func TestMain(m *testing.M) {
+	// Real-tmux tests in this package launch panes that re-exec this test
+	// binary as the pane bootstrap; exec the handoff command and never
+	// return before the suite (or the helper check) runs.
+	panebootstrap.ExecIfRequested()
 	if os.Getenv("MIDDLEMAN_LOCALRUNTIME_HELPER") == "1" {
 		os.Exit(m.Run())
 	}
@@ -345,11 +350,21 @@ exit 0
 	assert.NotContains(newSession, "-e")
 	assert.Contains(newSession, "-c")
 	assert.Contains(newSession, "/tmp/work tree")
-	assert.Contains(newSessionText, "__middleman_env_file=")
-	assert.Contains(newSessionText, "exec env -i")
-	assert.Contains(newSessionText, `XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR-}"`)
-	assert.Contains(newSessionText, shellquote.Join(agent.Command[0]))
 	assert.NotContains(newSessionText, "argv-visible-value")
+
+	// The pane bootstrap reads env and argv from the 0600 handoff file;
+	// the tmux argv only carries the dialect-neutral launch token, so the
+	// preserved value never reaches tmux state.
+	paneToken := ""
+	for _, arg := range newSession {
+		if strings.Contains(arg, panebootstrap.Subcommand) {
+			paneToken = arg
+		}
+	}
+	require.NotEmpty(paneToken)
+	env, argv := readPaneHandoff(t, paneToken)
+	assert.Contains(argv, agent.Command[0])
+	assert.Contains(env, "XDG_RUNTIME_DIR=argv-visible-value")
 }
 
 func TestManagerLaunchCommandResolvesTmuxBeforeEmbeddingScript(t *testing.T) {
@@ -514,19 +529,8 @@ exit 0
 	newSessionText := strings.Join(newSession, "\n")
 	assert.Contains(newSession, "-c")
 	assert.Contains(newSession, "/tmp/work tree")
-	assert.Contains(newSessionText, "exec env -i")
-	assert.Contains(newSessionText, shellquote.Join(os.Args[0]))
-	assert.Contains(
-		newSessionText,
-		"XDG_RUNTIME_DIR=\"${XDG_RUNTIME_DIR-}\"",
-	)
-	assert.Contains(
-		newSessionText,
-		"MIDDLEMAN_TEST_CUSTOM_SHELL_ENV=\"${MIDDLEMAN_TEST_CUSTOM_SHELL_ENV-}\"",
-	)
 	assert.Contains(newSession, "-E")
 	assert.NotContains(newSession, "-e")
-	assert.Contains(newSessionText, "__middleman_env_file=")
 	assert.Contains(newSession, ";")
 	assert.Contains(newSession, "set-option")
 	assert.Contains(newSession, "-t")
@@ -535,6 +539,20 @@ exit 0
 	assert.Contains(newSession, "middleman:test-owner")
 	assert.NotContains(newSessionText, "argv-visible-value")
 	assert.NotContains(newSessionText, "custom-visible-value")
+
+	// The pane bootstrap reads env and argv from the 0600 handoff file;
+	// the tmux argv only carries the dialect-neutral launch token.
+	paneToken := ""
+	for _, arg := range newSession {
+		if strings.Contains(arg, panebootstrap.Subcommand) {
+			paneToken = arg
+		}
+	}
+	require.NotEmpty(paneToken)
+	env, argv := readPaneHandoff(t, paneToken)
+	assert.Contains(argv, os.Args[0])
+	assert.Contains(env, "XDG_RUNTIME_DIR=argv-visible-value")
+	assert.Contains(env, "MIDDLEMAN_TEST_CUSTOM_SHELL_ENV=custom-visible-value")
 	assert.Len(mgr.ListSessions("ws:alpha"), 1)
 }
 
@@ -933,20 +951,19 @@ func TestManagerLaunchCommandDoesNotEmbedEnvForWrappedAgent(t *testing.T) {
 	resolvedShell, err := resolveExecutable("sh")
 	require.NoError(t, err)
 
-	paneCommand := tmuxAgentEnvPolicy.paneEnvironment(
+	paneEnv := tmuxAgentEnvPolicy.paneEnvironment(
 		os.Environ(), []string{resolvedShell, "-c", "echo ok"}, nil,
-	).paneCommand
-	assert.Contains(paneCommand, "exec ")
-	assert.Contains(paneCommand, "env -i")
-	assert.Contains(paneCommand, shellquote.Join(resolvedShell))
-	assert.Contains(
-		paneCommand,
-		"XDG_RUNTIME_DIR=\"${XDG_RUNTIME_DIR-}\"",
 	)
-	assert.NotContains(paneCommand, "TERM=xterm-256color")
-	assert.NotContains(paneCommand, "secret-token")
-	assert.NotContains(paneCommand, "context7-secret")
-	assert.NotContains(paneCommand, "not-carried")
+
+	// The pane argv is exactly the command; no env is folded into it, so
+	// nothing reaches tmux state. Preserved keys live in the handoff env
+	// (the 0600 file the bootstrap reads), and secrets are stripped.
+	assert.Equal([]string{resolvedShell, "-c", "echo ok"}, paneEnv.command)
+	env := paneEnv.handoffEnv()
+	joined := strings.Join(env, "\n")
+	assert.Contains(env, "XDG_RUNTIME_DIR=not-carried")
+	assert.NotContains(joined, "secret-token")
+	assert.NotContains(joined, "context7-secret")
 }
 
 func TestTmuxLauncherCopiesClientEnvWithoutGlobalUpdateEnvironment(t *testing.T) {
@@ -1004,13 +1021,10 @@ func TestTmuxLauncherCopiesClientEnvWithoutGlobalUpdateEnvironment(t *testing.T)
 		[]string{"/bin/sh", "-c", printCommand},
 		[]string{"MIDDLEMAN_STRIPPED_ENV"},
 	)
-	paneCommand := paneEnv.paneCommand
-	require.NotContains(paneCommand, "client-visible-value")
-	require.NotContains(paneCommand, "client-secret")
-	require.NotContains(paneCommand, "client-stripped")
-	require.NotContains(paneCommand, "server-visible-value")
-	require.NotContains(paneCommand, "server-secret")
-	require.NotContains(paneCommand, "server-stripped")
+	// End-to-end through real tmux: the pane re-execs this test binary as
+	// the bootstrap (see TestMain), which applies the handoff env and execs
+	// printCommand. The output check below proves the pane saw the client
+	// env (not the seed/server env) with secrets stripped.
 
 	tmuxCommand := []string{tmuxPath, "-f", "/dev/null", "-S", socket}
 	_, err = tmuxLauncher{

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -11,6 +11,7 @@ import (
 
 	shellquote "github.com/kballard/go-shellquote"
 	"go.kenn.io/middleman/internal/procutil"
+	"go.kenn.io/middleman/internal/workspace/panebootstrap"
 )
 
 type tmuxEnvPolicy struct {
@@ -18,9 +19,9 @@ type tmuxEnvPolicy struct {
 }
 
 type tmuxPaneEnvironment struct {
-	keys        []string
-	paneCommand string
-	commandEnv  []string
+	keys       []string
+	command    []string
+	commandEnv []string
 }
 
 var (
@@ -35,18 +36,36 @@ func (p tmuxEnvPolicy) paneEnvironment(
 ) tmuxPaneEnvironment {
 	env := p.environment(baseEnv, extraStripVars)
 	envWithTerm := append(slices.Clone(env), "TERM=xterm-256color")
-	keys := tmuxEnvironmentKeys(envWithTerm)
-	parts := make([]string, 0, len(keys)+4)
-	parts = append(parts, "exec", "env", "-i")
-	for _, key := range keys {
-		parts = append(parts, key+"=\"${"+key+"-}\"")
-	}
-	parts = append(parts, shellCommand(command))
 	return tmuxPaneEnvironment{
-		keys:        keys,
-		paneCommand: strings.Join(parts, " "),
-		commandEnv:  envWithTerm,
+		keys:       tmuxEnvironmentKeys(envWithTerm),
+		command:    slices.Clone(command),
+		commandEnv: envWithTerm,
 	}
+}
+
+// handoffEnv returns the KEY=VALUE entries the pane runs under, reproducing
+// the old `exec env -i KEY="${KEY-}" ...` dance: only the policy's
+// preserved, shell-identifier keys, with last-wins values from commandEnv
+// (so the appended TERM=xterm-256color overrides any inherited TERM). The
+// pane bootstrap applies these as the process environment via env -i
+// semantics; commandEnv itself is left intact for tmux subprocess argv.
+func (e tmuxPaneEnvironment) handoffEnv() []string {
+	values := make(map[string]string, len(e.commandEnv))
+	for _, kv := range e.commandEnv {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		values[kv[:eq]] = kv[eq+1:]
+	}
+	out := make([]string, 0, len(e.keys))
+	for _, key := range e.keys {
+		if !isShellIdentifier(key) {
+			continue
+		}
+		out = append(out, key+"="+values[key])
+	}
+	return out
 }
 
 func (p tmuxEnvPolicy) keys(extraStripVars []string) []string {
@@ -220,73 +239,40 @@ func (e tmuxCommandError) Unwrap() error {
 	return e.err
 }
 
+// newSessionPaneCommand writes the pane's env and argv to a 0600 handoff
+// file and returns a single dialect-neutral launch token,
+// `exec '<exe>' __tmux-pane-bootstrap '<handoff>'`, plus a cleanup that
+// removes the file if the session is never created. tmux runs a lone
+// shell-command argument through the user's default shell, so the token
+// must parse identically under POSIX shells and fish; this one is just
+// three quoted words, and the leading exec keeps the pane a single process
+// so PTY EOF reaches attach clients the instant the command exits. The exe
+// re-execs middleman itself into panebootstrap, which applies the handoff
+// env (env -i semantics) and execs the real command with no shell in the
+// chain — see internal/workspace/panebootstrap for why any /bin/sh hop
+// breaks pane teardown on macOS.
+//
+// Caveat: tmux still interposes the user's default-shell to run this token,
+// so a host whose SHELL is /bin/sh re-enters the slow path. That is not
+// fixable while tmux runs window commands through default-shell; the common
+// case (zsh, bash 5, fish) is unaffected because the shell exec's away
+// before the bootstrap runs.
 func (l tmuxLauncher) newSessionPaneCommand() (string, func(), error) {
-	path, err := writeTmuxPaneEnvironment(l.Pane.commandEnv, l.Pane.keys)
+	exe, err := os.Executable()
 	if err != nil {
-		return "", nil, fmt.Errorf("write tmux pane environment: %w", err)
+		return "", nil, fmt.Errorf("resolve middleman executable: %w", err)
+	}
+	path, err := panebootstrap.WriteHandoff(
+		tmuxPaneEnvironmentTempDir(), l.Pane.handoffEnv(), l.Pane.command,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("write tmux pane handoff: %w", err)
 	}
 	cleanup := func() {
 		_ = os.Remove(path)
 	}
-	return strings.Join([]string{
-		"__middleman_env_file=" + shellCommand([]string{path}),
-		`__middleman_cleanup_env_file() { /bin/rm -f "$__middleman_env_file"; }`,
-		`trap __middleman_cleanup_env_file EXIT`,
-		`if [ ! -r "$__middleman_env_file" ]; then exit 127; fi`,
-		`. "$__middleman_env_file"`,
-		`__middleman_cleanup_env_file`,
-		`trap - EXIT`,
-		`unset -f __middleman_cleanup_env_file`,
-		`unset __middleman_env_file`,
-		l.Pane.paneCommand,
-	}, "\n"), cleanup, nil
-}
-
-func writeTmuxPaneEnvironment(env []string, keys []string) (string, error) {
-	values := make(map[string]string, len(env))
-	for _, kv := range env {
-		eq := strings.IndexByte(kv, '=')
-		if eq <= 0 {
-			continue
-		}
-		values[kv[:eq]] = kv[eq+1:]
-	}
-
-	var content strings.Builder
-	for _, key := range keys {
-		if !isShellIdentifier(key) {
-			continue
-		}
-		content.WriteString("export ")
-		content.WriteString(key)
-		content.WriteByte('=')
-		content.WriteString(shellCommand([]string{values[key]}))
-		content.WriteByte('\n')
-	}
-
-	// This short-lived handoff keeps preserved values out of tmux argv. The
-	// file is 0600 and cleaned on tmux launch failure and pane shell exit, but
-	// it is not intended to be a same-user sandbox boundary.
-	file, err := os.CreateTemp(tmuxPaneEnvironmentTempDir(), "middleman-tmux-env-*")
-	if err != nil {
-		return "", err
-	}
-	path := file.Name()
-	if err := file.Chmod(0o600); err != nil {
-		_ = file.Close()
-		_ = os.Remove(path)
-		return "", err
-	}
-	if _, err := file.WriteString(content.String()); err != nil {
-		_ = file.Close()
-		_ = os.Remove(path)
-		return "", err
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return "", err
-	}
-	return path, nil
+	token := "exec " + shellCommand([]string{exe, panebootstrap.Subcommand, path})
+	return token, cleanup, nil
 }
 
 func tmuxPaneEnvironmentTempDir() string {
@@ -310,6 +296,10 @@ func (l tmuxLauncher) newSessionCommand(paneCommand string) []string {
 	if l.CWD != "" {
 		command = append(command, "-c", l.CWD)
 	}
+	// paneCommand is a single dialect-neutral token (see
+	// newSessionPaneCommand); tmux hands a lone shell-command argument
+	// to the user's default shell, where `exec /bin/sh '<script>'`
+	// parses identically under POSIX shells and fish.
 	command = append(command, paneCommand)
 	if l.OwnerMarker != "" {
 		command = append(

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -8,12 +8,31 @@ import (
 	"strings"
 	"testing"
 
+	shellquote "github.com/kballard/go-shellquote"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/workspace/panebootstrap"
 )
+
+// readPaneHandoff parses the pane launch token,
+// `exec '<exe>' __tmux-pane-bootstrap '<handoff>'`, asserts its shape, and
+// returns the env and argv recorded in the handoff file.
+func readPaneHandoff(t *testing.T, token string) (env, argv []string) {
+	t.Helper()
+	rest, ok := strings.CutPrefix(token, "exec ")
+	require.True(t, ok, "pane token must start with exec: %q", token)
+	words, err := shellquote.Split(rest)
+	require.NoError(t, err)
+	require.Len(t, words, 3, "pane token: %q", token)
+	require.Equal(t, panebootstrap.Subcommand, words[1])
+	env, argv, err = panebootstrap.ReadHandoff(words[2])
+	require.NoError(t, err)
+	return env, argv
+}
 
 func TestTmuxLauncherAgentOperationsKeepEnvValuesOutOfArgv(t *testing.T) {
 	assert := Assert.New(t)
+	requireT := require.New(t)
 	t.Setenv("XDG_RUNTIME_DIR", "argv-visible-value")
 	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "secret-value")
 
@@ -28,10 +47,10 @@ func TestTmuxLauncherAgentOperationsKeepEnvValuesOutOfArgv(t *testing.T) {
 		OwnerMarker: "middleman:test-owner",
 	}
 
-	paneCommand, cleanup, err := launcher.newSessionPaneCommand()
-	require.NoError(t, err)
+	token, cleanup, err := launcher.newSessionPaneCommand()
+	requireT.NoError(err)
 	t.Cleanup(cleanup)
-	newSession := launcher.newSessionCommand(paneCommand)
+	newSession := launcher.newSessionCommand(token)
 	newSessionText := strings.Join(newSession, "\n")
 
 	assert.Equal("new-session", newSession[1])
@@ -39,21 +58,31 @@ func TestTmuxLauncherAgentOperationsKeepEnvValuesOutOfArgv(t *testing.T) {
 	assert.NotContains(newSession, "-e")
 	assert.Contains(newSession, "-c")
 	assert.Contains(newSession, "/tmp/work tree")
-	assert.Contains(newSessionText, "exec env -i")
 	assert.Contains(newSession, ";")
 	assert.Contains(newSession, "set-option")
 	assert.Contains(newSession, "@middleman_owner")
 	assert.Contains(newSession, "middleman:test-owner")
-	assert.Contains(newSessionText, `XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR-}"`)
-	assert.Contains(newSessionText, "__middleman_env_file=")
-	assert.Contains(newSessionText, "trap __middleman_cleanup_env_file EXIT")
-	assert.Contains(newSessionText, "trap - EXIT")
+
+	// Preserved env values live in the handoff file, never in tmux argv.
 	assert.NotContains(newSessionText, "argv-visible-value")
 	assert.NotContains(newSessionText, "secret-value")
+
+	// The pane command must be one dialect-neutral token: tmux hands a
+	// lone shell-command argument to the user's default shell, so anything
+	// but a single quoted-words token breaks on fish hosts.
+	assert.Contains(newSession, token)
+	assert.True(strings.HasPrefix(token, "exec "), token)
+
+	env, argv := readPaneHandoff(t, token)
+	assert.Equal([]string{"/bin/sh", "-lc", "sleep 10"}, argv)
+	// The agent policy preserves XDG_RUNTIME_DIR but strips the token.
+	assert.Contains(env, "XDG_RUNTIME_DIR=argv-visible-value")
+	assert.NotContains(strings.Join(env, "\n"), "secret-value")
 }
 
 func TestTmuxLauncherShellPolicyPreservesCustomEnvByKey(t *testing.T) {
 	assert := Assert.New(t)
+	requireT := require.New(t)
 	t.Setenv("MIDDLEMAN_TEST_CUSTOM_SHELL_ENV", "custom-visible-value")
 
 	shellKeys := tmuxShellEnvPolicy.keys(nil)
@@ -62,14 +91,23 @@ func TestTmuxLauncherShellPolicyPreservesCustomEnvByKey(t *testing.T) {
 	assert.Contains(shellKeys, "MIDDLEMAN_TEST_CUSTOM_SHELL_ENV")
 	assert.NotContains(agentKeys, "MIDDLEMAN_TEST_CUSTOM_SHELL_ENV")
 
-	paneCommand := tmuxShellEnvPolicy.paneEnvironment(
+	paneEnv := tmuxShellEnvPolicy.paneEnvironment(
 		os.Environ(), []string{"/bin/sh"}, nil,
-	).paneCommand
-	assert.Contains(
-		paneCommand,
-		`MIDDLEMAN_TEST_CUSTOM_SHELL_ENV="${MIDDLEMAN_TEST_CUSTOM_SHELL_ENV-}"`,
 	)
-	assert.NotContains(paneCommand, "custom-visible-value")
+	launcher := tmuxLauncher{
+		TmuxCommand: []string{"/usr/bin/tmux"},
+		Session:     "middleman-test",
+		Pane:        paneEnv,
+	}
+	token, cleanup, err := launcher.newSessionPaneCommand()
+	requireT.NoError(err)
+	t.Cleanup(cleanup)
+
+	// The shell policy carries the custom value in the handoff env; it
+	// never appears in the tmux launch token.
+	env, _ := readPaneHandoff(t, token)
+	assert.Contains(env, "MIDDLEMAN_TEST_CUSTOM_SHELL_ENV=custom-visible-value")
+	assert.NotContains(token, "custom-visible-value")
 }
 
 func TestTmuxLauncherRejectsUnownedExistingSession(t *testing.T) {
@@ -99,8 +137,8 @@ exit 0
 		TmuxCommand: []string{tmuxPath},
 		Session:     "middleman-test",
 		Pane: tmuxPaneEnvironment{
-			paneCommand: "exec /bin/sh",
-			keys:        []string{"PATH", "TERM"},
+			command: []string{"/bin/sh"},
+			keys:    []string{"PATH", "TERM"},
 			commandEnv: append(
 				os.Environ(),
 				"TMUX_RECORD="+record,
@@ -124,8 +162,7 @@ exit 0
 		"attach-session", "-t", "middleman-test",
 	})
 	assert.NotContains(records, []string{
-		"new-session", "-e", "PATH", "-e", "TERM",
-		"-d", "-s", "middleman-test", "exec /bin/sh",
+		"new-session", "-E", "-d", "-s", "middleman-test",
 	})
 }
 

--- a/internal/workspace/panebootstrap/exec_unix.go
+++ b/internal/workspace/panebootstrap/exec_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package panebootstrap
+
+import "syscall"
+
+// execProcess replaces the current process image with argv under env,
+// inheriting the tmux pane's fds and working directory. On success it does
+// not return.
+func execProcess(argv0 string, argv, env []string) error {
+	return syscall.Exec(argv0, argv, env)
+}

--- a/internal/workspace/panebootstrap/exec_windows.go
+++ b/internal/workspace/panebootstrap/exec_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package panebootstrap
+
+import "errors"
+
+// execProcess is unreachable on Windows: tmux panes are a unix-only
+// concept and the launcher never emits the bootstrap token there. The stub
+// exists so panebootstrap and its importers cross-compile; if the
+// subcommand is somehow requested, ExecIfRequested surfaces this error and
+// exits 127.
+func execProcess(argv0 string, argv, env []string) error {
+	return errors.New("pane bootstrap is not supported on windows")
+}

--- a/internal/workspace/panebootstrap/panebootstrap.go
+++ b/internal/workspace/panebootstrap/panebootstrap.go
@@ -1,0 +1,211 @@
+// Package panebootstrap provides a shell-free tmux pane launcher.
+//
+// tmux runs a window's command through the user's default shell. Routing
+// the real pane command through any /bin/sh hop breaks pane teardown on
+// macOS: tmux fails to destroy a pane on PTY fd-close while the process
+// is still alive once bash 3.2 (the system /bin/sh) has been anywhere in
+// the exec chain, even after it has exec'd away. That delays the websocket
+// exit frame from PTY EOF (~prompt) to cmd.Wait (~the command's lifetime).
+//
+// Instead the launcher emits a single dialect-neutral token,
+//
+//	exec '<exe>' __tmux-pane-bootstrap '<handoff>'
+//
+// that re-execs the middleman binary itself (resolved via os.Executable,
+// the same idiom internal/ptyowner uses for its pty-owner subcommand). The
+// token parses identically under POSIX shells and fish, needs no /bin/sh
+// or /bin/rm on PATH (Nix-safe), and keeps preserved env values out of
+// tmux argv. This package is that re-exec target: ExecIfRequested reads the
+// handoff file (env + argv) written by WriteHandoff, deletes it, and
+// replaces the process with the real command under a clean environment
+// (env -i semantics). The pane is then a single process, so PTY EOF
+// reaches attach clients the instant the command exits.
+package panebootstrap
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Subcommand is the hidden argv[1] that requests the pane bootstrap.
+const Subcommand = "__tmux-pane-bootstrap"
+
+// handoffHeader is the first NUL-delimited field of a handoff file; the
+// trailing version guards against format drift across binary upgrades.
+const handoffHeader = "middleman-pane-handoff/1"
+
+// WriteHandoff serializes env and argv into a 0600 file in dir and returns
+// its path. dir may be empty, in which case the OS default temp dir is
+// used. The format is NUL-framed because env and argv entries may contain
+// newlines, quotes, or invalid UTF-8 but — by the execve contract — never
+// a NUL byte:
+//
+//	middleman-pane-handoff/1\x00<envCount>\x00<argvCount>\x00
+//	<env-0>\x00 ... <env-N>\x00 <argv-0>\x00 ... <argv-M>\x00
+//
+// The explicit counts let ReadHandoff split env from argv unambiguously
+// even when trailing entries are empty strings.
+func WriteHandoff(dir string, env, argv []string) (string, error) {
+	var buf strings.Builder
+	buf.WriteString(handoffHeader)
+	buf.WriteByte(0)
+	buf.WriteString(strconv.Itoa(len(env)))
+	buf.WriteByte(0)
+	buf.WriteString(strconv.Itoa(len(argv)))
+	buf.WriteByte(0)
+	for _, entry := range env {
+		buf.WriteString(entry)
+		buf.WriteByte(0)
+	}
+	for _, entry := range argv {
+		buf.WriteString(entry)
+		buf.WriteByte(0)
+	}
+
+	file, err := os.CreateTemp(dir, "middleman-tmux-handoff-*")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if _, err := file.WriteString(buf.String()); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}
+
+// ReadHandoff parses a file written by WriteHandoff. It is exported so the
+// launcher's tests can assert handoff contents without re-deriving the
+// format.
+func ReadHandoff(path string) (env, argv []string, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	parts := strings.Split(string(data), "\x00")
+	if len(parts) < 3 {
+		return nil, nil, fmt.Errorf("pane handoff: malformed (need header and counts)")
+	}
+	if parts[0] != handoffHeader {
+		return nil, nil, fmt.Errorf("pane handoff: bad header %q", parts[0])
+	}
+	envCount, err := strconv.Atoi(parts[1])
+	if err != nil || envCount < 0 {
+		return nil, nil, fmt.Errorf("pane handoff: bad env count %q", parts[1])
+	}
+	argvCount, err := strconv.Atoi(parts[2])
+	if err != nil || argvCount < 0 {
+		return nil, nil, fmt.Errorf("pane handoff: bad argv count %q", parts[2])
+	}
+	// Every entry is NUL-terminated, so Split yields a trailing "" past
+	// the final NUL; require at least the declared entry count.
+	rest := parts[3:]
+	if len(rest) < envCount+argvCount {
+		return nil, nil, fmt.Errorf(
+			"pane handoff: truncated (want %d entries, have %d)",
+			envCount+argvCount, len(rest),
+		)
+	}
+	env = append([]string(nil), rest[:envCount]...)
+	argv = append([]string(nil), rest[envCount:envCount+argvCount]...)
+	return env, argv, nil
+}
+
+// ExecIfRequested checks whether this process was invoked as the tmux pane
+// bootstrap (os.Args is exactly [exe, Subcommand, handoffPath]). If so it
+// reads the handoff, removes it, and replaces the process image with the
+// real command under the handoff environment — it never returns in that
+// case (it execs or calls os.Exit(127)). Otherwise it returns immediately
+// so normal startup proceeds. Call it as the first statement of a binary's
+// main/TestMain, before any logging or flag parsing.
+func ExecIfRequested() {
+	if len(os.Args) != 3 || os.Args[1] != Subcommand {
+		return
+	}
+	path := os.Args[2]
+	env, argv, readErr := ReadHandoff(path)
+	// Remove before exec: exec never returns, and leaking a 0600 temp
+	// file is better than killing the user's pane, so a Remove failure is
+	// logged but must not abort the launch.
+	if rmErr := os.Remove(path); rmErr != nil {
+		fmt.Fprintf(os.Stderr, "pane bootstrap: remove handoff: %v\n", rmErr)
+	}
+	if readErr != nil {
+		bootstrapFail("read handoff", readErr)
+	}
+	if len(argv) == 0 {
+		bootstrapFail("handoff", errors.New("empty command"))
+	}
+	argv0, resolveErr := resolveArgv0(argv[0], env)
+	if resolveErr != nil {
+		bootstrapFail("resolve command", resolveErr)
+	}
+	bootstrapFail("exec", execProcess(argv0, argv, env))
+}
+
+// bootstrapFail reports a launch failure on stderr and exits 127, matching
+// the exit code the old POSIX handoff script used for an unreadable env
+// file. execProcess on success never returns, so reaching here always
+// means a real failure.
+func bootstrapFail(stage string, err error) {
+	if err == nil {
+		err = errors.New("unknown error")
+	}
+	fmt.Fprintf(os.Stderr, "pane bootstrap: %s: %v\n", stage, err)
+	os.Exit(127)
+}
+
+// resolveArgv0 returns the path to exec for argv[0]. Absolute paths are
+// used as-is (the launcher already resolves the command to an absolute
+// path before writing the handoff). A bare name is looked up against the
+// handoff's PATH — not the process environment, which env -i leaves bare.
+// A relative path containing a separator is rejected, mirroring
+// ptyowner/runtime.ResolveExecutable: it would resolve inside the pane's
+// working directory, which may be an untrusted worktree.
+func resolveArgv0(name string, env []string) (string, error) {
+	if name == "" {
+		return "", errors.New("empty argv[0]")
+	}
+	if filepath.IsAbs(name) {
+		return name, nil
+	}
+	if strings.ContainsRune(name, filepath.Separator) {
+		return "", fmt.Errorf(
+			"command %q must be an absolute path or a PATH-resolvable name",
+			name,
+		)
+	}
+	var pathEnv string
+	for _, kv := range env {
+		if rest, ok := strings.CutPrefix(kv, "PATH="); ok {
+			pathEnv = rest
+		}
+	}
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		if !filepath.IsAbs(candidate) {
+			continue
+		}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("command %q not found in handoff PATH", name)
+}

--- a/internal/workspace/panebootstrap/panebootstrap_test.go
+++ b/internal/workspace/panebootstrap/panebootstrap_test.go
@@ -1,0 +1,158 @@
+package panebootstrap
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/procutil"
+)
+
+const execHelperMarker = "panebootstrap-exec-helper"
+
+func TestMain(m *testing.M) {
+	// When this binary is invoked as the pane bootstrap, exec the handoff
+	// command and never return — this is what the exec e2e exercises. In a
+	// normal `go test` invocation os.Args[1] is a -test flag, so this is a
+	// no-op and the suite runs.
+	ExecIfRequested()
+	os.Exit(m.Run())
+}
+
+func TestWriteReadHandoffRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		env  []string
+		argv []string
+	}{
+		{"simple", []string{"PATH=/usr/bin", "TERM=xterm"}, []string{"/bin/sh", "-c", "echo hi"}},
+		{"empty env", nil, []string{"/bin/true"}},
+		{"value with newline", []string{"X=line1\nline2"}, []string{"/bin/echo", ""}},
+		{"value with quotes and equals", []string{`Q=a"b'c=d`}, []string{"/bin/echo", "a=b", ""}},
+		{"trailing empty argv args", []string{"A=1"}, []string{"/bin/echo", "", "x", ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := Assert.New(t)
+			path, err := WriteHandoff(dir, tc.env, tc.argv)
+			require.NoError(t, err)
+
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(os.FileMode(0o600), info.Mode().Perm())
+
+			gotEnv, gotArgv, err := ReadHandoff(path)
+			require.NoError(t, err)
+			// slices.Equal treats nil and empty as equal, sidestepping the
+			// nil-vs-[]string{} reflect.DeepEqual trap.
+			assert.True(slices.Equal(tc.env, gotEnv), "env: want %q got %q", tc.env, gotEnv)
+			assert.True(slices.Equal(tc.argv, gotArgv), "argv: want %q got %q", tc.argv, gotArgv)
+		})
+	}
+}
+
+func TestReadHandoffRejectsMalformed(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		require.NoError(os.WriteFile(p, []byte(content), 0o600))
+		return p
+	}
+
+	_, _, err := ReadHandoff(write("garbage", "not a handoff at all"))
+	require.Error(err)
+	_, _, err = ReadHandoff(write("badheader", "wrong/9\x002\x000\x00a\x00b\x00"))
+	require.Error(err)
+	_, _, err = ReadHandoff(write("badcount", handoffHeader+"\x00notnum\x000\x00"))
+	require.Error(err)
+	_, _, err = ReadHandoff(write("truncated", handoffHeader+"\x005\x000\x00only\x00"))
+	require.Error(err)
+	_, _, err = ReadHandoff(filepath.Join(dir, "does-not-exist"))
+	require.Error(err)
+}
+
+// TestExecIfRequestedExecsHandoffCommand drives the full bootstrap: spawn
+// this test binary as `<exe> __tmux-pane-bootstrap <handoff>`, which reads
+// the handoff, removes it, and execs the recorded argv (the test binary's
+// exec helper) under exactly the handoff env.
+func TestExecIfRequestedExecsHandoffCommand(t *testing.T) {
+	assert := Assert.New(t)
+	dir := t.TempDir()
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	handoffEnv := []string{
+		"BOOTSTRAP_TEST_KEY=bootstrap-test-value",
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + os.Getenv("HOME"),
+	}
+	helperArgv := []string{exe, "-test.run=TestExecHelper", "--", execHelperMarker, "extra-arg"}
+	path, err := WriteHandoff(dir, handoffEnv, helperArgv)
+	require.NoError(t, err)
+
+	cmd := procutil.Command(exe, Subcommand, path)
+	// Pollute the bootstrap process env to prove env -i wipes it before exec.
+	cmd.Env = append(os.Environ(), "SHOULD_NOT_LEAK=leaked")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	got := string(out)
+
+	// argv delivered to the exec'd command.
+	assert.Contains(got, "ARG:"+execHelperMarker)
+	assert.Contains(got, "ARG:extra-arg")
+	// The handoff env is present...
+	assert.Contains(got, "ENV:BOOTSTRAP_TEST_KEY=bootstrap-test-value")
+	// ...and the bootstrap process's own env did not leak through (env -i).
+	assert.NotContains(got, "SHOULD_NOT_LEAK")
+	// The handoff file is removed before exec.
+	_, statErr := os.Stat(path)
+	assert.True(os.IsNotExist(statErr), "handoff file must be removed, stat err: %v", statErr)
+}
+
+func TestExecIfRequestedExits127OnBadHandoff(t *testing.T) {
+	assert := Assert.New(t)
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "garbage")
+	require.NoError(t, os.WriteFile(bad, []byte("not a handoff"), 0o600))
+
+	for _, path := range []string{bad, filepath.Join(dir, "missing")} {
+		cmd := procutil.Command(exe, Subcommand, path)
+		runErr := cmd.Run()
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, runErr, &exitErr)
+		assert.Equal(127, exitErr.ExitCode(), "handoff %q", path)
+	}
+}
+
+// TestExecHelper is the exec target for TestExecIfRequestedExecsHandoffCommand.
+// It is a no-op unless invoked with the marker after a `--` separator.
+func TestExecHelper(t *testing.T) {
+	args := os.Args
+	i := slices.Index(args, "--")
+	if i < 0 {
+		return
+	}
+	args = args[i+1:]
+	if len(args) == 0 || args[0] != execHelperMarker {
+		return
+	}
+	var b strings.Builder
+	for _, e := range os.Environ() {
+		b.WriteString("ENV:" + e + "\n")
+	}
+	for _, a := range args {
+		b.WriteString("ARG:" + a + "\n")
+	}
+	fmt.Print(b.String())
+	os.Exit(0)
+}


### PR DESCRIPTION
main's tmux pane handoff builds a multi-line POSIX shell snippet (source an env file, `/bin/rm` cleanup, then `exec env -i KEY="${KEY-}" ... cmd`) and runs it through the user's default shell. That breaks two real setups:

- **fish users**: the POSIX snippet doesn't parse under fish, so pane launch fails.
- **NixOS users**: the hardcoded `/bin/rm` cleanup fails (no `/bin/rm`).

This replaces the shell snippet with a hidden `__tmux-pane-bootstrap` subcommand: the launcher writes the pane env and argv to a 0600 handoff file and emits a single dialect-neutral token, `exec '<exe>' __tmux-pane-bootstrap '<handoff>'`. The new `internal/workspace/panebootstrap` package re-execs the middleman binary, applies the handoff env (env -i semantics), and execs the command directly.

- Pane launch works under fish and on NixOS (no shell snippet, no `/bin/rm`)
- No shell in the pane exec chain; preserved env values still kept out of tmux argv
- Forecloses the macOS tmux pane-teardown regression a `/bin/sh` handoff reintroduces (PTY EOF, not process exit, must drive the terminal's exit frame)
- Reuses the `os.Executable()` self-re-exec idiom already used by `internal/ptyowner` for its pty-owner subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>
