### PR TITLE
Add context-sync Stop hook enforcement

### DIFF
--- a/.agents/skills/context-sync
+++ b/.agents/skills/context-sync
@@ -1,0 +1,1 @@
+../../skills/context-sync

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/hooks/context-sync-stop.sh\" stop",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/context-sync
+++ b/.claude/skills/context-sync
@@ -1,0 +1,1 @@
+../../skills/context-sync

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/hooks/context-sync-stop.sh\" stop",
+            "timeout": 30,
+            "statusMessage": "Checking context-sync state"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/hooks/context-sync-stop.sh
+++ b/scripts/hooks/context-sync-stop.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: context-sync-stop.sh stop|mark|status
+
+stop    Enforce that context-sync has checked the current worktree state.
+mark    Record the current worktree state after context-sync --check or sync.
+status  Print whether the current worktree state is marked.
+USAGE
+}
+
+find_root() {
+  git rev-parse --show-toplevel 2>/dev/null || return 1
+}
+
+state_file() {
+  local root="$1"
+  local git_dir
+
+  git_dir="$(git -C "$root" rev-parse --git-dir 2>/dev/null)" || return 1
+  case "$git_dir" in
+    /*) printf '%s\n' "$git_dir/middleman-context-sync-stop" ;;
+    *) printf '%s\n' "$root/$git_dir/middleman-context-sync-stop" ;;
+  esac
+}
+
+fingerprint() {
+  local root="$1"
+
+  {
+    git -C "$root" rev-parse HEAD
+    git -C "$root" status --porcelain=v1 -z
+    git -C "$root" diff --binary --no-ext-diff HEAD --
+    git -C "$root" ls-files --others --exclude-standard -z |
+      while IFS= read -r -d '' path; do
+        printf 'untracked %s\0' "$path"
+        if [ -f "$root/$path" ]; then
+          shasum -a 256 "$root/$path"
+        fi
+      done
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+mark_current() {
+  local root="$1"
+  local file
+  local fp
+
+  file="$(state_file "$root")" || return 1
+  fp="$(fingerprint "$root")" || return 1
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$fp" >"$file"
+}
+
+current_is_marked() {
+  local root="$1"
+  local file
+  local fp
+
+  file="$(state_file "$root")" || return 1
+  [ -f "$file" ] || return 1
+  fp="$(fingerprint "$root")" || return 1
+  [ "$(cat "$file")" = "$fp" ]
+}
+
+require_marked() {
+  local root="$1"
+
+  if current_is_marked "$root"; then
+    exit 0
+  fi
+
+  cat >&2 <<'MESSAGE'
+middleman context-sync is required before this turn can complete.
+
+Run:
+  context-sync --check
+  scripts/hooks/context-sync-stop.sh mark
+
+If context-sync reports drift, address it or report the findings before marking.
+MESSAGE
+  exit 2
+}
+
+main() {
+  local command="${1:-}"
+  local root
+
+  case "$command" in
+    stop|mark|status) ;;
+    *) usage; exit 64 ;;
+  esac
+
+  root="$(find_root)" || exit 0
+  [ -f "$root/skills/context-sync/SKILL.md" ] || exit 0
+
+  case "$command" in
+    stop) require_marked "$root" ;;
+    mark) mark_current "$root" ;;
+    status)
+      if current_is_marked "$root"; then
+        echo "context-sync-stop: current worktree state is marked"
+      else
+        echo "context-sync-stop: current worktree state is not marked"
+        exit 1
+      fi
+      ;;
+  esac
+}
+
+main "$@"

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -10,8 +10,7 @@ argument-hint: "[area] [--check | --audit-claims]"
 Keep middleman's context system honest: scan the context docs, compare them against
 the current code, detect drift and knowledge gaps, ask the maintainer to fill them,
 and draft updates for review. Adapted for this repo's Go + Svelte stack and its
-single-surface context layout (hub `CLAUDE.md` + flat `context/*.md` topic docs). There
-is no `.claude/rules/` WHY/HOW split and no Python tooling here — do not introduce either.
+single-surface context layout: root `CLAUDE.md` routes to flat `context/*.md` topic docs.
 
 **Arguments:**
 - No args: sync every area in the area map below.

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: context-sync
+description: Scan middleman's context docs for staleness against the current Go/Svelte code, verify anchored claims, surface knowledge gaps, and draft reviewed updates. Use on demand when context/ docs, the root CLAUDE.md, or docs/ specs may have drifted from the code, after large refactors, or when an agent hits a gotcha context should have prevented.
+disable-model-invocation: true
+argument-hint: "[area] [--check | --audit-claims]"
+---
+
+# Context Sync (middleman)
+
+Keep middleman's context system honest: scan the context docs, compare them against
+the current code, detect drift and knowledge gaps, ask the maintainer to fill them,
+and draft updates for review. Adapted for this repo's Go + Svelte stack and its
+single-surface context layout (hub `CLAUDE.md` + flat `context/*.md` topic docs). There
+is no `.claude/rules/` WHY/HOW split and no Python tooling here — do not introduce either.
+
+**Arguments:**
+- No args: sync every area in the area map below.
+- `$1 = area`: sync one area (see Area Map, e.g. `platform`, `github-sync`, `db`,
+  `server`, `frontend`, `errors`, `testing`, `mobile`, `kata`, `docs`, `messages`).
+- `--check`: report staleness only, propose nothing.
+- `--audit-claims`: run the four-tag claim verification (see `claim-verifier.md`) over
+  every anchored claim in the scanned docs.
+
+## Stop Hook Completion
+
+This repo installs Claude Code and Codex `Stop` hooks that require context-sync to check
+the current worktree state before a turn completes. When a Stop hook asks for context
+sync, run `context-sync --check` first. If it reports drift, address the drift or report
+the findings before marking the state as checked.
+
+After any successful `context-sync --check` or full context-sync run, mark the current
+worktree state:
+
+```bash
+scripts/hooks/context-sync-stop.sh mark
+```
+
+Do not mark first. The marker is only a loop guard proving the current git worktree
+fingerprint has already been checked.
+
+## Step 1: Load the Guide
+
+Read `context-guide.md` in this skill directory. It carries the full philosophy: the
+grep test, anchored-claim format, what belongs in the hub vs. a topic doc, size limits,
+and how invariant claims map to Go guard tests/analyzers rather than Python probes.
+Internalize it before proposing any change.
+
+## Step 2: Validate the Manifest
+
+middleman routes context from the root `CLAUDE.md` (Conventions, Provider Support, and
+Non-Provider Modes sections reference `context/*.md` and `docs/superpowers/specs/*`).
+Check that:
+
+- every `context/*.md` reference in `CLAUDE.md` points to a file that exists;
+- every `context/*.md` and `docs/**/*.md` that an agent would need is reachable from
+  `CLAUDE.md` or from another reachable doc (orphaned context is invisible);
+- `AGENTS.md` still resolves to `CLAUDE.md` (it is a symlink).
+
+Report broken links and orphaned docs. Unreachable context is a high-priority gap.
+
+## Step 3: Scan Areas
+
+For each area (or just `$1`):
+
+Dispatch a read-only subagent (Agent tool, `Explore` or `general-purpose`). Give it:
+
+- the relevant `context/*.md` topic doc(s) for the area, plus any section of the root
+  `CLAUDE.md` that governs it;
+- the code paths that area covers (see Area Map);
+- the anchored-claim and four-tag rules from `context-guide.md`.
+
+Collect from each subagent:
+
+- a proposed diff for the topic doc (and/or the relevant `CLAUDE.md` section);
+- a one-paragraph summary of what drifted and why;
+- knowledge-gap questions (things the code cannot answer on its own);
+- anchor verification results — per anchor: resolves / moved / gone;
+- any invariant claim that should be (but is not) backed by a Go guard test/analyzer.
+
+If `--check` was passed, report the summaries and stop here.
+
+If `--audit-claims` was passed, additionally dispatch a claim-verifier subagent per doc
+using `claim-verifier.md` as its instructions, and run the four-tag verification over
+every anchor.
+
+### Area Map
+
+| Area | Topic doc(s) | Code it must track |
+|------|--------------|--------------------|
+| `platform` | `context/provider-architecture.md`, `context/platform-sync-invariants.md` | `internal/platform/` (registry, types, metadata, persist), `internal/platform/<provider>/` |
+| `github-sync` | `context/github-sync-invariants.md` | `internal/github/` (sync, graphql, client, transports) |
+| `db` | `context/db-migrations.md`, `context/embeds.md` | `internal/db/`, `internal/db/migrations/` |
+| `server` | `context/workspace-apis.md`, `context/workspace-runtime-lifecycle.md` | `internal/server/`, `internal/apiclient/generated/` |
+| `errors` | `context/error-handling.md` | error envelopes across `internal/server/`, frontend error branching |
+| `retries` | `context/retries-and-backoffs.md` | retry/backoff/single-flight paths against upstreams |
+| `testing` | `context/testing.md` | `internal/server/apitest/`, `internal/server/e2etest/`, test helpers |
+| `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/` |
+| `mobile` | `context/mobile-ux.md` | `frontend/src/` `/m` routes and phone-first components |
+| `kata` | `docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md` | `internal/kata/` |
+| `docs` | same spec as `kata` | `internal/docs/` |
+| `messages` | same spec as `kata` | `internal/messages/msgvault/` |
+
+When `internal/docs/`, `internal/kata/`, or `internal/messages/msgvault/` graduate from
+the shared modes design spec to their own `context/*.md` docs, add rows here and a
+routing reference in `CLAUDE.md`.
+
+## Step 4: Check Design Decisions
+
+middleman records durable decisions in `docs/adr/` (for example
+`docs/adr/0001-utc-datetime-policy.md`). Scan recent conversation history and recent
+commits for design decisions or domain knowledge the maintainer stated that are not yet
+captured in an ADR or topic doc. Propose where each belongs (ADR vs. topic doc).
+
+## Step 5: Research, Suggest, Then Ask
+
+For each knowledge gap, do not ask a bare question. Follow the research-then-suggest
+pattern in `context-guide.md`:
+
+- general technical patterns: search for current best practice first, then propose;
+- middleman-specific domain knowledge: ask the maintainer directly.
+
+Present confidence-tagged suggestions the maintainer can confirm or correct.
+
+## Step 6: Check Invariant Guards
+
+middleman encodes hard invariants as Go tests and custom analyzers under `tools/` and
+`internal/server/{apitest,e2etest}/`, not as Python probes. For each invariant a context
+doc asserts (provider identity tuple, capability gating, UTC datetimes, stable error
+codes, no-`net/http`-mux, testify-only assertions), confirm a guard exists. If an
+invariant is documented but unguarded, flag it as a gap and propose the smallest guard
+(a Go test or an analyzer like `tools/nohttpmux` / `tools/migrationhistorycheck`).
+
+When a guard and a doc disagree, that is a high-priority finding for Step 7.
+
+## Step 7: Present Diffs
+
+Show all proposed changes. Flag DELETIONS and MODIFICATIONS separately from additions —
+deletions are higher risk (removing context that was actually needed is harder to
+recover from than adding noise). Wait for maintainer approval before applying anything.
+
+## Step 8: Apply, Route, Commit
+
+Apply approved changes. If a new area/topic doc was created, add its routing reference
+to the root `CLAUDE.md`, and add symlinks for any new skill under both `.claude/skills/`
+and `.agents/skills/` (each pointing to `../../skills/<name>`). Then commit following the
+repo's git workflow: a conventional-commit subject that states the user-visible reason
+(for example `docs: realign platform-sync context with capability registry`), a body
+explaining what drifted, and the project's standard hook-enforced commit path. Do not
+amend; do not bypass hooks.

--- a/skills/context-sync/claim-verifier.md
+++ b/skills/context-sync/claim-verifier.md
@@ -1,0 +1,69 @@
+# Claim Verifier — Subagent Instructions (middleman)
+
+You are a read-only subagent verifying the factual claims in a single context document
+against the current state of middleman's code. You MUST NOT modify any code or doc
+files. Return findings; the parent run presents them to the maintainer.
+
+## Inputs
+
+- Path to one context document (a `context/*.md` topic doc, a section of `CLAUDE.md`, or
+  a `docs/` spec).
+- The anchored-claim format and four-tag scheme from `context-guide.md`.
+- The worktree to verify against.
+
+## Task
+
+For each factual claim in the document:
+
+1. Identify its anchor (`` `file.go::Symbol` ``, `` `file.go:line` ``, or a directory).
+   If a factual claim has no anchor, note it as `MISSING-ANCHOR` and propose one.
+2. Resolve the anchor with `rg` / file reads. Confirm the symbol, type, route,
+   migration, or behavior still exists and matches what the claim asserts.
+3. Tag the claim:
+   - VERIFIED — found, accurate; if the symbol moved, give the refreshed anchor.
+   - OUTDATED — found, but the claim no longer matches; include a `delta:` line stating
+     what the code does now vs. what the doc says.
+   - GONE — the referenced symbol/route/migration no longer exists; set anchor to `N/A`.
+   - UNVERIFIABLE — behavioral/judgment claim that code cannot settle; include a
+     `question:` line for the maintainer.
+
+## Critical invariants — verify with extra care, tag CRITICAL
+
+These are middleman's load-bearing cross-cutting rules. When a document touches one,
+re-check it directly against code rather than trusting the prose:
+
+- **Provider identity tuple.** Claim that identity is `(platform, platform_host, owner,
+  name)` everywhere and routes are provider-aware (`/pulls/{provider}/{owner}/{name}/
+  {number}`, `/host/{platform_host}/...`). Re-check `internal/platform/` (registry,
+  types, persist) and representative `internal/server/` route registrations.
+- **Capability gating.** Claim that provider differences go through `Capabilities()` and
+  return typed `unsupported_capability` errors with no silent GitHub-only fallback.
+  Re-check `internal/platform/` capability declarations and their call sites before
+  mutations.
+- **GitHub-only isolation.** Claim that GraphQL bulk fetch / ETag recovery stay in
+  `internal/github/` and remain optional around the neutral persistence path. Re-check
+  `internal/github/` and confirm the neutral path still works without them.
+- **UTC datetime policy.** Claim that timestamps are stored and emitted in UTC (RFC3339)
+  with local conversion only in the Svelte layer. Cross-check against
+  `docs/adr/0001-utc-datetime-policy.md` and storage/API boundaries.
+- **Stable error envelopes.** Claim that clients branch on stable codes/details, not
+  prose. Re-check `context/error-handling.md` against actual error construction in
+  `internal/server/` and frontend error branching.
+- **Canonical provider list.** The supported-provider set is stated once in `CLAUDE.md`.
+  If any scanned doc restates the set, flag it as a poisoning/drift risk (OUTDATED).
+
+## Return
+
+Return a per-document summary, one line per claim:
+
+`{anchor or N/A} — {TAG} — {claim summary}{; delta/question/refreshed-anchor as needed}`
+
+End with a count line: `{doc}: V verified, O outdated, G gone, U unverifiable, M missing-anchor`.
+
+## Constraints
+
+- MUST NOT modify any code or documentation file.
+- MUST attempt to resolve every anchor before tagging.
+- MUST include a `delta:` line on every OUTDATED claim.
+- MUST include a `question:` line on every UNVERIFIABLE claim.
+- MUST propose an anchor for every MISSING-ANCHOR factual claim.

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -27,10 +27,9 @@ GOOD (not greppable): "GitHub GraphQL bulk fetch is an optimization layered *aro
 neutral persistence path, not through it — keep it optional so other providers keep
 working when the GraphQL path is skipped."
 
-## Single-Surface Layout (no WHY/HOW split)
+## Single-Surface Layout
 
-middleman does not use per-module `CLAUDE.md` files or a `.claude/rules/` directory. Its
-context lives in two places, and that is deliberate — do not introduce a dual surface:
+middleman's durable agent context lives in two places:
 
 - **Root `CLAUDE.md`** — the hub. Project overview, architecture, the single canonical
   provider list, non-provider modes, project structure, key files, dev/test commands,

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -1,0 +1,179 @@
+# Context Engineering Guide — middleman
+
+Loaded during a `context-sync` run. The complete philosophy and rules for keeping
+middleman's context system aligned with its code. This guide is adapted from a generic
+context-engineering system to middleman's actual stack (Go backend, Svelte 5 SPA, a
+small Rust pty-manager) and its single-surface context layout.
+
+## Core Principle: The Grep Test
+
+Every line in a context file must fail this test: "Could an agent discover this by
+reading the code or running `rg`?" If yes, delete it.
+
+**INCLUDE:** domain knowledge, design rationale, cross-cutting invariants, gotchas,
+non-obvious conventions, and routing between docs.
+**EXCLUDE:** file listings, function signatures, struct fields, import graphs, and code
+style that `golangci-lint` / `gofmt` / `oxfmt` already enforce.
+
+### Good vs Bad Context
+
+BAD (greppable): "`Registry` is defined in `internal/platform/registry.go`."
+GOOD (not greppable): "Provider identity is always the tuple `(platform, platform_host,
+owner, name)`; code that keys repos by `owner/name/number` alone will silently collide
+across hosts once a self-hosted Forgejo and github.com share an owner."
+
+BAD (greppable): "`internal/github/graphql.go` has a `BulkFetch` function."
+GOOD (not greppable): "GitHub GraphQL bulk fetch is an optimization layered *around* the
+neutral persistence path, not through it — keep it optional so other providers keep
+working when the GraphQL path is skipped."
+
+## Single-Surface Layout (no WHY/HOW split)
+
+middleman does not use per-module `CLAUDE.md` files or a `.claude/rules/` directory. Its
+context lives in two places, and that is deliberate — do not introduce a dual surface:
+
+- **Root `CLAUDE.md`** — the hub. Project overview, architecture, the single canonical
+  provider list, non-provider modes, project structure, key files, dev/test commands,
+  conventions, git/PR workflow, and routing references into `context/`.
+- **`context/*.md`** — topic docs. One concern each (provider sync invariants, error
+  handling, db migrations, retries, testing discipline, UI design system, mobile UX,
+  etc.). Deep enough to hold real rationale; narrow enough to load only when relevant.
+
+Specs and plans live under `docs/superpowers/specs/` and `docs/superpowers/plans/`;
+durable, dated decisions live under `docs/adr/`.
+
+### The Sorting Test
+
+When a new fact arrives, ask: does it describe the *whole project's* shape or workflow
+(→ root `CLAUDE.md`), one *concern in depth* (→ the matching `context/*.md`), a *dated
+decision* you chose between alternatives (→ `docs/adr/`), or a *feature still being
+designed* (→ `docs/superpowers/specs/`)? Put it in exactly one home and route to it.
+
+## Anchored Claims
+
+Every factual claim in `context/*.md` and in fact-bearing sections of `CLAUDE.md` should
+cite a code location so it can be verified and so drift is detectable.
+
+**Format:**
+- `` `path/to/file.go::SymbolName` `` — preferred; symbol anchors survive reformatting
+  and line shifts. Works for Go (`registry.go::Registry`), TypeScript, and Svelte.
+- `` `path/to/file.go:123` `` — only when the target is genuinely nameless (a specific
+  SQL string in a migration, an inline constant, a literal route string).
+- A directory anchor (`` `internal/platform/` ``) is acceptable for claims about a
+  package's role rather than a single symbol.
+
+**What needs an anchor:** factual claims — behavior, invariants, the identity of a
+function/type/route/migration/capability.
+**What doesn't:** rationale, opinions, design motivation, "why we avoid X".
+
+This repo already uses this anchor style informally throughout `context/`. The sync run
+verifies anchors by resolving each with `rg` against the worktree. A future
+`mise run check-anchors` task (a small Go tool under `tools/`, in the family of
+`tools/nohttpmux` and `tools/migrationhistorycheck`) can make this a pre-commit gate;
+until then, anchor resolution is part of the sync.
+
+## Four-Tag Verification (`--audit-claims`)
+
+Each anchored claim gets one tag:
+
+- VERIFIED — found in code, still accurate; anchor refreshed if the symbol moved.
+- OUTDATED — found, but the claim no longer matches behavior; write the delta.
+- GONE — the symbol/type/route/migration no longer exists; flag for removal.
+- UNVERIFIABLE — a behavioral or judgment claim ("fastest when…", "safe because…");
+  flag for maintainer review.
+
+Structural drift (renames, moves, deletions) is mechanical and the verifier resolves it.
+Behavioral drift is where `--audit-claims` flags UNVERIFIABLE rows, and where a Go guard
+test should exist if the invariant matters.
+
+## Invariant Guards (the Go analogue of probes)
+
+The most fragile invariants should be protected by runnable code, not prose. In
+middleman that means Go tests and custom analyzers, not Python probes. Examples of
+invariants that warrant a guard:
+
+- Provider identity is the full `(platform, platform_host, owner, name)` tuple
+  everywhere; routes carry `provider`/`platform_host`.
+- Provider capability differences go through the capability model and return typed
+  `unsupported_capability` errors — never a silent GitHub-only fallback.
+- Datetimes are UTC at storage and API boundaries, RFC3339 on the wire
+  (`docs/adr/0001-utc-datetime-policy.md`); local conversion only in the Svelte layer.
+- Error envelopes branch on stable codes/details, not prose (`context/error-handling.md`).
+- No `net/http` mux usage where the repo forbids it (`tools/nohttpmux`).
+- Tests use testify assertions, not `t.Fatal`/`t.Error` (`tools/testifyhelpercheck`).
+
+**When a guard fails, three deliberate choices:**
+
+1. Fix the code — the guard was right.
+2. Update the guard — the design changed on purpose; record it (ADR or topic-doc note)
+   in the same change.
+3. Delete the guard — the invariant no longer applies; document why.
+
+Silencing a failing guard without recording the decision is forbidden.
+
+## Where to Store Context
+
+| Content type | Store in | Why |
+|--------------|----------|-----|
+| Project shape, canonical provider list, modes, key files, workflow | root `CLAUDE.md` | The always-loaded hub |
+| Provider-neutral sync identity, tokens, freshness, route shape | `context/platform-sync-invariants.md` | Cross-provider invariants |
+| New-provider checklist, package layout | `context/provider-architecture.md` | Onboarding a provider |
+| GitHub-only sync behavior (GraphQL, ETag) | `context/github-sync-invariants.md` | Isolated optimization |
+| Schema evolution rules | `context/db-migrations.md` | Migrations are the source of truth |
+| API error envelopes + frontend branching | `context/error-handling.md` | Stable contract |
+| Retry/backoff/single-flight | `context/retries-and-backoffs.md` | Upstream flakiness |
+| HTTP test discipline (apitest vs e2etest) | `context/testing.md` | Wire-level testing |
+| UI/TS/Svelte conventions, interaction contracts | `context/ui-design-system.md`, `context/ui-interaction-contracts.md` | Frontend consistency |
+| Phone-first mobile workflow | `context/mobile-ux.md` | `/m` is its own UX |
+| Kata / Docs / Messages mode integration | `docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md` | Until dedicated docs exist |
+| A decision chosen over an alternative | `docs/adr/NNNN-title.md` | Dated, durable rationale |
+| A feature still being designed | `docs/superpowers/specs/YYYY-MM-DD-topic-design.md` | Loaded only when needed |
+
+Every new topic doc MUST get a routing reference from root `CLAUDE.md` (or from another
+reachable doc). Unreachable context is invisible to agents.
+
+## Size Guidance
+
+These are soft ceilings; when a doc outgrows one, split by sub-concern rather than
+deleting substance. They are not a mandate to shrink today's docs.
+
+| File | Soft max lines | Rationale |
+|------|----------------|-----------|
+| Each `context/*.md` topic doc | ~250 | One concern, deep but scannable |
+| `docs/adr/*` entry | ~80 | One decision |
+| `docs/superpowers/specs/*` | as needed | Design surface, archived after landing |
+
+The root `CLAUDE.md` is the hub and is allowed to be long, but it should stay a router
+and a conventions list — push any concern that grows rationale into a `context/` doc and
+reference it.
+
+## When to Update Context
+
+- A maintainer explains a design decision → capture it promptly (ADR or topic doc).
+- A new provider, mode, or cross-cutting invariant lands → add/extend the topic doc and
+  route to it from `CLAUDE.md`.
+- An agent makes a mistake context would have prevented → add the gotcha.
+- A convention changes → update the relevant doc and, if it is an invariant, its guard.
+- Code is deleted or restructured → remove the now-GONE context.
+
+## When NOT to Update Context
+
+- Code was reformatted (the formatters own this).
+- A function/type was added or renamed (greppable).
+- Tests were added (greppable).
+- Dependencies changed (`go.mod` / `bun.lock` are authoritative).
+
+## Staleness Signals
+
+- A doc references a file, type, route, or migration that no longer exists.
+- A doc describes a pattern the code no longer follows.
+- Two docs (or a doc and `CLAUDE.md`) contradict each other.
+- An anchor fails to resolve.
+- An invariant guard fails.
+- The canonical provider list in `CLAUDE.md` is restated (and thus can drift) elsewhere.
+
+## Context Poisoning Safeguard
+
+When proposing updates, present DELETIONS and MODIFICATIONS separately from additions and
+justify each removal. Removing context that turns out to be load-bearing is more costly
+than leaving a redundant line.


### PR DESCRIPTION
Context docs can drift when agents finish code changes without a deliberate sync pass. This adds a repo-local context-sync skill and Stop-hook enforcement for Claude Code and Codex so turn completion requires checking the current worktree fingerprint.

- Adds the middleman context-sync skill and agent symlinks
- Adds Claude Code and Codex Stop hooks
- Records checked state in git-local metadata so hooks do not loop after a sync check