### PR TITLE
fix: preserve Activity view when returning via the top bar

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -141,6 +141,10 @@
     messages: "/messages",
   };
   const lastStickyModeRoutes = new SvelteMap<StickyMode, string>();
+  // Activity's selected item, detail tab, and filters all live in the URL
+  // query string. Remember the full activity path when leaving so the top-bar
+  // Activity tab restores the previous view instead of resetting to "/".
+  let lastActivityRoute = "/";
 
   function stickyModeForPage(page: ReturnType<typeof getPage>): StickyMode | null {
     return page === "kata" || page === "docs" || page === "messages" ? page : null;
@@ -150,6 +154,10 @@
     const currentMode = stickyModeForPage(getPage());
     if (!currentMode) return;
     lastStickyModeRoutes.set(currentMode, currentAppPath());
+  }
+
+  function rememberCurrentActivityRoute(): void {
+    if (getPage() === "activity") lastActivityRoute = currentAppPath();
   }
 
   function routeForTab(
@@ -179,7 +187,8 @@
   ): void {
     const currentMode = stickyModeForPage(getPage());
     rememberCurrentStickyModeRoute();
-    if (destination === "activity") navigate("/");
+    rememberCurrentActivityRoute();
+    if (destination === "activity") navigate(lastActivityRoute);
     else if (destination === "repos") navigate("/repos");
     else if (destination === "kata" || destination === "docs" || destination === "messages") {
       if (currentMode === destination) {

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -4,6 +4,7 @@
   import { SvelteMap } from "svelte/reactivity";
   import {
     getBasePath,
+    getLastActivityRoute,
     getPage,
     getView,
     navigate,
@@ -141,10 +142,6 @@
     messages: "/messages",
   };
   const lastStickyModeRoutes = new SvelteMap<StickyMode, string>();
-  // Activity's selected item, detail tab, and filters all live in the URL
-  // query string. Remember the full activity path when leaving so the top-bar
-  // Activity tab restores the previous view instead of resetting to "/".
-  let lastActivityRoute = "/";
 
   function stickyModeForPage(page: ReturnType<typeof getPage>): StickyMode | null {
     return page === "kata" || page === "docs" || page === "messages" ? page : null;
@@ -154,10 +151,6 @@
     const currentMode = stickyModeForPage(getPage());
     if (!currentMode) return;
     lastStickyModeRoutes.set(currentMode, currentAppPath());
-  }
-
-  function rememberCurrentActivityRoute(): void {
-    if (getPage() === "activity") lastActivityRoute = currentAppPath();
   }
 
   function routeForTab(
@@ -187,8 +180,7 @@
   ): void {
     const currentMode = stickyModeForPage(getPage());
     rememberCurrentStickyModeRoute();
-    rememberCurrentActivityRoute();
-    if (destination === "activity") navigate(lastActivityRoute);
+    if (destination === "activity") navigate(getLastActivityRoute());
     else if (destination === "repos") navigate("/repos");
     else if (destination === "kata" || destination === "docs" || destination === "messages") {
       if (currentMode === destination) {

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -519,6 +519,34 @@ describe("AppHeader", () => {
     );
   });
 
+  it("restores the previous Activity view when returning from PRs", async () => {
+    initTheme();
+    navigate("/?selected=pr:1&provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&range=30d");
+    render(AppHeader);
+
+    await fireEvent.click(screen.getByRole("button", { name: "PRs" }));
+    expect(window.location.pathname).toBe("/pulls/github/acme/widgets/1");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Activity" }));
+
+    expect(window.location.pathname + window.location.search).toBe(
+      "/?selected=pr:1&provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&range=30d",
+    );
+  });
+
+  it("restores the previous Activity view when returning from Repos", async () => {
+    initTheme();
+    navigate("/?range=90d&view=threaded");
+    render(AppHeader);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Repos" }));
+    expect(window.location.pathname).toBe("/repos");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Activity" }));
+
+    expect(window.location.pathname + window.location.search).toBe("/?range=90d&view=threaded");
+  });
+
   it("opens Issues list when Activity selection is a PR", async () => {
     initTheme();
     navigate("/?selected=pr:1&provider=github&platform_host=github.com&repo_path=acme%2Fwidgets&selected_tab=files");

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -534,6 +534,22 @@ describe("AppHeader", () => {
     );
   });
 
+  it("restores the previous Activity view when returning from the settings gear", async () => {
+    initTheme();
+    navigate("/?selected=pr:1&provider=github&platform_host=github.com&repo_path=acme%2Fwidgets");
+    render(AppHeader);
+
+    // The settings gear leaves Activity without going through navigateTab.
+    await fireEvent.click(screen.getByTitle("Settings"));
+    expect(window.location.pathname).toBe("/settings");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Activity" }));
+
+    expect(window.location.pathname + window.location.search).toBe(
+      "/?selected=pr:1&provider=github&platform_host=github.com&repo_path=acme%2Fwidgets",
+    );
+  });
+
   it("restores the previous Activity view when returning from Repos", async () => {
     initTheme();
     navigate("/?range=90d&view=threaded");

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -465,15 +465,27 @@ if (typeof window !== "undefined") {
 }
 
 // The Activity selection, detail tab, and feed filters all live in the URL
-// query string. Remember the full Activity path on every navigation away so
-// the top-bar Activity tab can restore the previous view instead of resetting
-// to a bare "/". Capturing here covers all exit paths (tabs, settings gear,
-// command palette) since every page transition flows through navigate().
+// query string. Remember the full Activity path so the top-bar Activity tab
+// can restore the previous view instead of resetting to a bare "/". The cache
+// is refreshed at every point the router observes the URL — navigate() (which
+// reads the live location before leaving, so a tab/settings/palette exit keeps
+// even filter-only writes), replaceUrl() (drawer selection changes), popstate
+// (browser Back/Forward), and initial load — so it stays current regardless of
+// how Activity is entered or left.
 let lastActivityRoute = "/";
 
 export function getLastActivityRoute(): string {
   return lastActivityRoute;
 }
+
+function rememberActivityRoute(): void {
+  if (route.page === "activity") {
+    lastActivityRoute = stripBase(currentLocationPath());
+  }
+}
+
+// Seed the cache when the app loads directly on an Activity URL.
+rememberActivityRoute();
 
 export function getRoute(): Route {
   return route;
@@ -492,9 +504,8 @@ export function buildItemRoute(ref: RoutableItemRef): string {
 }
 
 export function navigate(path: string, state?: Record<string, unknown>): void {
-  if (route.page === "activity") {
-    lastActivityRoute = stripBase(currentLocationPath());
-  }
+  // route still reflects the page being left; capture its live URL first.
+  rememberActivityRoute();
   const fullPath = basePrefix + path;
   history.pushState(state ?? null, "", fullPath);
   route = parseRoute(fullPath);
@@ -624,6 +635,7 @@ export function replaceUrl(path: string): void {
   const fullPath = basePrefix + path;
   history.replaceState(null, "", fullPath);
   route = parseRoute(fullPath);
+  rememberActivityRoute();
   fireRouteChange(route);
 }
 
@@ -631,6 +643,7 @@ export function replaceUrl(path: string): void {
 if (typeof window !== "undefined") {
   window.addEventListener("popstate", () => {
     route = parseRoute(currentLocationPath());
+    rememberActivityRoute();
     fireRouteChange(route);
   });
 }

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -469,9 +469,10 @@ if (typeof window !== "undefined") {
 // can restore the previous view instead of resetting to a bare "/". The cache
 // is refreshed at every point the router observes the URL — navigate() (which
 // reads the live location before leaving, so a tab/settings/palette exit keeps
-// even filter-only writes), replaceUrl() (drawer selection changes), popstate
-// (browser Back/Forward), and initial load — so it stays current regardless of
-// how Activity is entered or left.
+// even filter-only writes), replaceUrl() (drawer selection changes), direct
+// history.replaceState() writes from the Activity store, popstate (browser
+// Back/Forward), and initial load — so it stays current regardless of how
+// Activity is entered or left.
 let lastActivityRoute = "/";
 
 export function getLastActivityRoute(): string {
@@ -479,13 +480,22 @@ export function getLastActivityRoute(): string {
 }
 
 function rememberActivityRoute(): void {
-  if (route.page === "activity") {
-    lastActivityRoute = stripBase(currentLocationPath());
+  const currentPath = currentLocationPath();
+  if (route.page === "activity" && parseRoute(currentPath).page === "activity") {
+    lastActivityRoute = stripBase(currentPath);
   }
 }
 
 // Seed the cache when the app loads directly on an Activity URL.
 rememberActivityRoute();
+
+if (typeof window !== "undefined") {
+  const originalReplaceState = history.replaceState.bind(history);
+  history.replaceState = ((data: unknown, unused: string, url?: string | URL | null) => {
+    originalReplaceState(data, unused, url);
+    rememberActivityRoute();
+  }) as History["replaceState"];
+}
 
 export function getRoute(): Route {
   return route;

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -464,6 +464,17 @@ if (typeof window !== "undefined") {
   queueMicrotask(() => fireRouteChange(route));
 }
 
+// The Activity selection, detail tab, and feed filters all live in the URL
+// query string. Remember the full Activity path on every navigation away so
+// the top-bar Activity tab can restore the previous view instead of resetting
+// to a bare "/". Capturing here covers all exit paths (tabs, settings gear,
+// command palette) since every page transition flows through navigate().
+let lastActivityRoute = "/";
+
+export function getLastActivityRoute(): string {
+  return lastActivityRoute;
+}
+
 export function getRoute(): Route {
   return route;
 }
@@ -481,6 +492,9 @@ export function buildItemRoute(ref: RoutableItemRef): string {
 }
 
 export function navigate(path: string, state?: Record<string, unknown>): void {
+  if (route.page === "activity") {
+    lastActivityRoute = stripBase(currentLocationPath());
+  }
   const fullPath = basePrefix + path;
   history.pushState(state ?? null, "", fullPath);
   route = parseRoute(fullPath);

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -684,6 +684,15 @@ describe("router last activity route", () => {
     expect(getLastActivityRoute()).toBe("/?range=90d&view=threaded");
   });
 
+  it("captures direct Activity filter writes before leaving via Back/Forward", () => {
+    navigate("/?range=7d");
+    history.replaceState(null, "", "/?range=90d&view=threaded");
+    history.replaceState(null, "", "/pulls");
+    window.dispatchEvent(new Event("popstate"));
+    expect(getPage()).toBe("pulls");
+    expect(getLastActivityRoute()).toBe("/?range=90d&view=threaded");
+  });
+
   it("refreshes the cache when a drawer selection is written via replaceUrl", () => {
     replaceUrl("/?selected=pr:2&provider=github&repo_path=acme%2Fwidgets");
     expect(getLastActivityRoute()).toBe("/?selected=pr:2&provider=github&repo_path=acme%2Fwidgets");

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vite-plus/test";
-import { navigate, getRoute, getDetailTab, isDiffView, getSelectedPRFromRoute, getPage } from "./router.svelte.js";
+import {
+  navigate,
+  getRoute,
+  getDetailTab,
+  isDiffView,
+  getSelectedPRFromRoute,
+  getPage,
+  getLastActivityRoute,
+} from "./router.svelte.js";
 
 const prRoute = "/pulls/github/acme/widgets/42";
 const prFilesRoute = "/pulls/github/acme/widgets/42/files";
@@ -638,5 +646,40 @@ describe("router window bridges", () => {
       page: "embed-workspace-project",
       projectId: "prj_xyz",
     });
+  });
+});
+
+describe("router last activity route", () => {
+  beforeEach(() => {
+    navigate("/");
+  });
+
+  it("captures the Activity URL when leaving for another page", () => {
+    navigate("/?selected=pr:1&provider=github&repo_path=acme%2Fwidgets");
+    navigate("/pulls");
+    expect(getLastActivityRoute()).toBe("/?selected=pr:1&provider=github&repo_path=acme%2Fwidgets");
+  });
+
+  it("captures the Activity URL on a non-tab exit such as the settings route", () => {
+    navigate("/?selected=issue:10&provider=github&repo_path=acme%2Fwidgets");
+    navigate("/settings");
+    expect(getLastActivityRoute()).toBe("/?selected=issue:10&provider=github&repo_path=acme%2Fwidgets");
+  });
+
+  it("does not overwrite the cached route while navigating between non-Activity pages", () => {
+    navigate("/?range=30d");
+    navigate("/pulls");
+    navigate("/issues");
+    navigate("/settings");
+    expect(getLastActivityRoute()).toBe("/?range=30d");
+  });
+
+  it("captures filter-only query changes written without a route update", () => {
+    // Activity feed filters call history.replaceState directly, which does
+    // not update the reactive route. Capturing at navigate() time reads the
+    // live location, so those changes are still preserved on exit.
+    history.replaceState(null, "", "/?range=90d&view=threaded");
+    navigate("/pulls");
+    expect(getLastActivityRoute()).toBe("/?range=90d&view=threaded");
   });
 });

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vite-plus/test";
 import {
   navigate,
+  replaceUrl,
   getRoute,
   getDetailTab,
   isDiffView,
@@ -681,5 +682,30 @@ describe("router last activity route", () => {
     history.replaceState(null, "", "/?range=90d&view=threaded");
     navigate("/pulls");
     expect(getLastActivityRoute()).toBe("/?range=90d&view=threaded");
+  });
+
+  it("refreshes the cache when a drawer selection is written via replaceUrl", () => {
+    replaceUrl("/?selected=pr:2&provider=github&repo_path=acme%2Fwidgets");
+    expect(getLastActivityRoute()).toBe("/?selected=pr:2&provider=github&repo_path=acme%2Fwidgets");
+  });
+
+  it("captures the Activity URL when browser Back/Forward lands on Activity", () => {
+    navigate("/pulls");
+    // Simulate the browser restoring an Activity history entry: the URL
+    // changes underneath the app and a popstate fires without navigate().
+    history.replaceState(null, "", "/?selected=pr:7&provider=github&repo_path=acme%2Fwidgets");
+    window.dispatchEvent(new Event("popstate"));
+    expect(getLastActivityRoute()).toBe("/?selected=pr:7&provider=github&repo_path=acme%2Fwidgets");
+  });
+
+  it("preserves a drawer change made before leaving Activity via Back/Forward", () => {
+    // Reviewer scenario: change the drawer selection on Activity, then use
+    // Back to leave without navigate(). The cache must hold the latest
+    // Activity selection, not a stale one.
+    replaceUrl("/?selected=pr:2&provider=github&repo_path=acme%2Fwidgets");
+    history.replaceState(null, "", "/pulls");
+    window.dispatchEvent(new Event("popstate"));
+    expect(getPage()).toBe("pulls");
+    expect(getLastActivityRoute()).toBe("/?selected=pr:2&provider=github&repo_path=acme%2Fwidgets");
   });
 });

--- a/frontend/tests/e2e-full/navigation.spec.ts
+++ b/frontend/tests/e2e-full/navigation.spec.ts
@@ -76,6 +76,29 @@ test.describe("view navigation", () => {
     await expect(page.locator(".activity-shell.activity-shell--split")).toBeVisible();
   });
 
+  test("returning to Activity from the settings gear restores the selected item", async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".activity-feed").waitFor({ state: "visible", timeout: 10_000 });
+    await page.locator(".activity-table .activity-row").first().waitFor({ state: "visible", timeout: 10_000 });
+
+    const prRow = page
+      .locator(".activity-row")
+      .filter({ has: page.locator(".badge", { hasText: "PR" }) })
+      .first();
+    await prRow.click();
+    await expect(page.locator(".activity-shell.activity-shell--split")).toBeVisible();
+    await expect(page).toHaveURL(/\/\?.*selected=pr%3A/);
+
+    // The settings gear leaves Activity without going through the tab bar.
+    await page.getByTitle("Settings").click();
+    await expect(page).toHaveURL(/\/settings$/);
+
+    await page.locator(".view-tab", { hasText: "Activity" }).click();
+
+    await expect(page).toHaveURL(/\/\?.*selected=pr%3A/);
+    await expect(page.locator(".activity-shell.activity-shell--split")).toBeVisible();
+  });
+
   test("Kata shell does not expose repo selector or respond to PR number shortcuts", async ({ page }) => {
     await page.goto("/kata");
 

--- a/frontend/tests/e2e-full/navigation.spec.ts
+++ b/frontend/tests/e2e-full/navigation.spec.ts
@@ -49,6 +49,33 @@ test.describe("view navigation", () => {
     await page.locator(".activity-feed").waitFor({ state: "visible", timeout: 5_000 });
   });
 
+  test("returning to Activity from PRs restores the selected item", async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".activity-feed").waitFor({ state: "visible", timeout: 10_000 });
+    await page.locator(".activity-table .activity-row").first().waitFor({ state: "visible", timeout: 10_000 });
+
+    // Select a PR in the feed: the split view opens and the selection is
+    // written to the URL query string.
+    const prRow = page
+      .locator(".activity-row")
+      .filter({ has: page.locator(".badge", { hasText: "PR" }) })
+      .first();
+    await prRow.click();
+    await expect(page.locator(".activity-shell.activity-shell--split")).toBeVisible();
+    await expect(page).toHaveURL(/\/\?.*selected=pr%3A/);
+
+    // Leave for the PRs tab, then return to Activity via the top bar.
+    await page.locator(".view-tab", { hasText: "PRs" }).click();
+    await expect(page).toHaveURL(/\/pulls\//);
+
+    await page.locator(".view-tab", { hasText: "Activity" }).click();
+
+    // The previous Activity view comes back: the selection survives in the
+    // URL and the split view reopens, instead of resetting to a bare "/".
+    await expect(page).toHaveURL(/\/\?.*selected=pr%3A/);
+    await expect(page.locator(".activity-shell.activity-shell--split")).toBeVisible();
+  });
+
   test("Kata shell does not expose repo selector or respond to PR number shortcuts", async ({ page }) => {
     await page.goto("/kata");
 


### PR DESCRIPTION
Switching from Activity to PRs (or any other tab) and back via the top bar reset Activity to a bare \`/\`, discarding the selected item, detail tab, and feed filters. The transition felt jarring because the previous view was gone.

The top-bar Activity tab now remembers the full Activity path (selection plus filters, which all live in the URL query string) when you leave, mirroring the existing route memory for the Kata/Docs/Messages tabs, and navigates back to it on return.

- Returning to Activity restores the previously selected PR/issue and its split detail view
- Active filters (time range, view mode, event types, etc.) are preserved across the round-trip

Tests: `AppHeader` component tests for the restore behavior and a full-stack Playwright e2e covering the Activity → PRs → Activity round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)