### PR TITLE
fix: restore provider approval reviews

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -784,9 +784,10 @@
     const workflowApprovalReady = Boolean(
       capabilities.workflow_approval && wfa?.checked && wfa.required,
     );
-    // Same rendered-head source as PullDetail: the detail envelope's
-    // verified reviewed_head_sha, not the mutable platform_head_sha.
+    // Merge remains tied to the verified reviewed_head_sha, but approval
+    // should include the latest synced provider head when one is known.
     const renderedHeadSha = detail.reviewed_head_sha ?? "";
+    const latestPlatformHeadSha = detail.platform_head_sha ?? "";
     // TS cannot carry the !stores narrowing into the closure below.
     const appStores = stores;
     return {
@@ -794,7 +795,7 @@
         State: pr.State,
         IsDraft: pr.IsDraft,
         MergeableState: pr.MergeableState,
-        platform_head_sha: renderedHeadSha,
+        platform_head_sha: latestPlatformHeadSha,
       },
       ref: {
         provider: sel.provider,

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -414,12 +414,12 @@ test.describe("detail action buttons", () => {
     const merge = page.locator(".btn--merge");
     const close = page.locator(".btn--close");
 
-    await expect(approve).toHaveCount(0);
+    await expect(approve).toBeVisible();
     await expect(merge).toBeVisible();
     await expect(close).toBeVisible();
 
     // All action buttons use the shared action-button base class
-    for (const btn of [merge, close]) {
+    for (const btn of [approve, merge, close]) {
       const classes = await btn.getAttribute("class");
       expect(classes).toContain("action-button");
     }
@@ -514,7 +514,7 @@ test.describe("detail action buttons", () => {
     await expect(page.locator(".primary-actions-wrap .action-error")).toBeVisible();
   });
 
-  test("narrow actions menu omits unsupported approve action", async ({ page }) => {
+  test("narrow actions menu includes supported approve action", async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 720 });
     await page.goto("/pulls/github/acme/widgets/1");
     await expect(page.locator(".pull-detail")).toBeVisible();
@@ -523,12 +523,12 @@ test.describe("detail action buttons", () => {
     const menu = page.locator(".actions-menu-popover");
     await expect(menu).toBeVisible();
 
-    await expect(menu.locator(".btn--approve")).toHaveCount(0);
+    await expect(menu.locator(".btn--approve")).toBeVisible();
     await expect(menu.locator(".btn--merge")).toBeVisible();
     await expect(menu.locator(".btn--close")).toBeVisible();
   });
 
-  test("GitHub approve action stays unavailable in UI and API", async ({ page }) => {
+  test("GitHub approve action is available in UI and API", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     try {
       isolatedServer = await startIsolatedE2EServer();
@@ -538,7 +538,7 @@ test.describe("detail action buttons", () => {
 
       await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
       await expect(page.locator(".pull-detail")).toBeVisible();
-      await expect(page.locator(".btn--approve")).toHaveCount(0);
+      await expect(page.locator(".btn--approve")).toBeVisible();
 
       const response = await page.request.post(`${detailURL}/approve`, {
         data: {
@@ -546,20 +546,9 @@ test.describe("detail action buttons", () => {
           expected_head_sha: "head-sha",
         },
       });
-      expect(response.status()).toBe(409);
-      const problem = (await response.json()) as {
-        code: string;
-        details?: {
-          capability?: string;
-          provider?: string;
-          platformHost?: string;
-        };
-      };
-      expect(problem.code).toBe("unsupportedCapability");
-      expect(problem.details).toMatchObject({
-        capability: "review_mutation",
-        provider: "github",
-        platformHost: "github.com",
+      expect(response.status()).toBe(200);
+      expect((await response.json()) as { status?: string }).toMatchObject({
+        status: "approved",
       });
     } finally {
       await isolatedServer?.stop();
@@ -602,13 +591,12 @@ test.describe("detail action buttons", () => {
     const merge = page.locator(".btn--merge");
     const close = page.locator(".btn--close");
 
-    await expect(approve).toHaveCount(0);
-    for (const btn of [ready, merge, close]) {
+    for (const btn of [ready, approve, merge, close]) {
       await expect(btn).toBeVisible();
     }
 
     const metrics = await page.evaluate(() => {
-      const selectors = [".btn--ready", ".btn--merge", ".btn--close"];
+      const selectors = [".btn--ready", ".btn--approve", ".btn--merge", ".btn--close"];
       return selectors.map((selector) => {
         const element = document.querySelector(selector);
         if (!(element instanceof HTMLElement)) {
@@ -662,7 +650,7 @@ test.describe("detail action buttons", () => {
       expect((await readyResponse.json()).status).toBe("ready_for_review");
 
       await expect(page.locator(".btn--ready")).toHaveCount(0);
-      await expect(page.locator(".btn--approve")).toHaveCount(0);
+      await expect(page.locator(".btn--approve")).toBeVisible();
       await expect(page.locator(".btn--merge")).toBeVisible();
       await expect(page.locator(".btn--close")).toBeVisible();
 

--- a/frontend/tests/e2e-full/focus-mode.spec.ts
+++ b/frontend/tests/e2e-full/focus-mode.spec.ts
@@ -34,7 +34,7 @@ test.describe("focus mode", () => {
     await page.locator(".actions-menu-trigger").click();
 
     await expect(page.locator(".actions-row--primary .btn--approve")).toBeHidden();
-    await expect(page.locator(".actions-menu-popover .btn--approve")).toHaveCount(0);
+    await expect(page.locator(".actions-menu-popover .btn--approve")).toBeVisible();
     await expect(page.locator(".actions-menu-popover .btn--merge")).toBeVisible();
     await expect(page.locator(".actions-menu-popover .btn--close")).toBeVisible();
     await expect(page.locator(".actions-menu-popover").getByRole("button", { name: "Labels" })).toBeVisible();

--- a/frontend/tests/e2e/head-pinned-actions.spec.ts
+++ b/frontend/tests/e2e/head-pinned-actions.spec.ts
@@ -117,6 +117,32 @@ function unboundDetailEnvelope(platformHeadSha: string, reviewedHeadSha = platfo
   };
 }
 
+async function mockPull77Detail(page: Page, platformHeadSha: string, reviewedHeadSha: string): Promise<void> {
+  await page.route("**/api/v1/pulls/github/acme/widgets/77", async (route: Route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(unboundDetailEnvelope(platformHeadSha, reviewedHeadSha)),
+    });
+  });
+
+  await page.route("**/api/v1/pulls/github/acme/widgets/77/sync", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(unboundDetailEnvelope(platformHeadSha, reviewedHeadSha)),
+    });
+  });
+
+  await page.route("**/api/v1/pulls/github/acme/widgets/77/sync/async", async (route: Route) => {
+    await route.fulfill({ status: 202, contentType: "application/json", body: "{}" });
+  });
+}
+
 async function gotoPull42(page: Page): Promise<void> {
   await page.goto("/pulls/github/acme/widgets/42");
   await expect(page.locator(".detail-title")).toContainText("Add browser regression coverage");
@@ -173,6 +199,38 @@ test.describe("head-pinned merge and approve", () => {
     await expect(page.locator(".approve-popover")).toHaveCount(0);
     expect(approveBody).not.toBeNull();
     expect(approveBody!["expected_head_sha"]).toBe(REVIEWED_SHA);
+  });
+
+  test("merge stays on reviewed head while toolbar approve uses synced head", async ({ page }) => {
+    const platformHead = SYNCED_SHA;
+    const reviewedHead = REVIEWED_SHA;
+    let mergeBody: Record<string, unknown> | null = null;
+    let approveBody: Record<string, unknown> | null = null;
+
+    await mockPull77Detail(page, platformHead, reviewedHead);
+    await page.route("**/api/v1/pulls/github/acme/widgets/77/merge", async (route: Route) => {
+      mergeBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    });
+    await page.route("**/api/v1/pulls/github/acme/widgets/77/approve", async (route: Route) => {
+      approveBody = JSON.parse(route.request().postData() ?? "{}");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "approved" }),
+      });
+    });
+
+    await page.goto("/pulls/github/acme/widgets/77");
+    await expect(page.locator(".detail-title")).toContainText("Unbound head PR");
+
+    await openMergeModalAndConfirm(page);
+    expect(mergeBody).not.toBeNull();
+    expect(mergeBody!["expected_head_sha"]).toBe(reviewedHead);
+
+    await submitApproval(page);
+    expect(approveBody).not.toBeNull();
+    expect(approveBody!["expected_head_sha"]).toBe(platformHead);
   });
 
   test("stale approval renders the provider side-effect context", async ({ page }) => {
@@ -237,6 +295,35 @@ test.describe("head-pinned merge and approve", () => {
 });
 
 test.describe("palette approve head conflict", () => {
+  test("uses the synced head when it differs from the reviewed head", async ({ page }) => {
+    await mockApi(page);
+
+    const platformHead = SYNCED_SHA;
+    const reviewedHead = REVIEWED_SHA;
+    await mockPull77Detail(page, platformHead, reviewedHead);
+    await page.route("**/api/v1/pulls/github/acme/widgets/77/approve", async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "approved" }),
+      });
+    });
+
+    const approveRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "POST" && /\/pulls\/github\/acme\/widgets\/77\/approve$/.test(new URL(req.url()).pathname),
+    );
+    await page.goto("/pulls/github/acme/widgets/77");
+    await expect(page.locator(".detail-title")).toContainText("Unbound head PR");
+    await page.keyboard.press("Meta+K");
+    await page.locator(".palette-input").fill("approve pr");
+    await page.keyboard.press("Enter");
+
+    const request = await approveRequest;
+    const body = request.postDataJSON() as { expected_head_sha?: string };
+    expect(body.expected_head_sha).toBe(platformHead);
+  });
+
   test("stale_state from a palette approval reloads the detail before retry", async ({ page }) => {
     await mockApi(page);
 

--- a/frontend/tests/e2e/head-pinned-actions.spec.ts
+++ b/frontend/tests/e2e/head-pinned-actions.spec.ts
@@ -3,8 +3,9 @@ import { mockApi } from "./support/mockApi";
 
 // Wire-level coverage for the head-pinning contract
 // (context/provider-architecture.md "Head binding"): the detail view
-// echoes the rendered reviewed_head_sha as expected_head_sha on merge
-// and approve when available, and branches on the 409 conflict reasons.
+// echoes the rendered reviewed_head_sha as expected_head_sha on merge,
+// sends the latest synced provider head on approve when available, and
+// branches on the 409 conflict reasons.
 
 // Matches the reviewed_head_sha mockApi serves for acme/widgets#42.
 const REVIEWED_SHA = "42aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa42";
@@ -155,7 +156,7 @@ test.describe("head-pinned merge and approve", () => {
     expect(mergeBody!["expected_head_sha"]).toBe(REVIEWED_SHA);
   });
 
-  test("approve echoes the rendered head as expected_head_sha", async ({ page }) => {
+  test("approve sends the latest synced head as expected_head_sha", async ({ page }) => {
     let approveBody: Record<string, unknown> | null = null;
     await page.route(APPROVE_PATH, async (route: Route) => {
       approveBody = JSON.parse(route.request().postData() ?? "{}");
@@ -270,8 +271,9 @@ test.describe("palette approve head conflict", () => {
     await page.locator(".palette-input").fill("approve pr");
     await page.keyboard.press("Enter");
 
-    // The pin must be the rendered head, and the conflict must trigger a
-    // detail reload so the user re-reviews current data before retrying.
+    // The approval pin must be the latest synced provider head; in this
+    // fixture it matches the rendered reviewed head. The conflict must
+    // trigger a detail reload so the user re-reviews current data before retrying.
     const request = await approveRequest;
     const body = request.postDataJSON() as { expected_head_sha?: string };
     expect(body.expected_head_sha).toBe(REVIEWED_SHA);
@@ -285,9 +287,10 @@ test.describe("head_unknown action gating", () => {
     await mockApi(page);
 
     // Approval is safe without a locally verified reviewed_head_sha: the
-    // server sends a head SHA when it has one, and providers may approve
-    // the current head otherwise. Merge remains blocked until
-    // reviewed_head_sha proves the rendered diff snapshot is current.
+    // client still sends the latest synced provider head when it has one,
+    // and providers may approve the current head otherwise. Merge remains
+    // blocked until reviewed_head_sha proves the rendered diff snapshot
+    // is current.
     const platformHead = SYNCED_SHA;
     let reviewedHead = "";
     let approveRequested = false;
@@ -335,7 +338,7 @@ test.describe("head_unknown action gating", () => {
     await submitApproval(page);
     expect(approveRequested).toBe(true);
     expect(approveBody).not.toBeNull();
-    expect(approveBody!["expected_head_sha"]).toBeUndefined();
+    expect(approveBody!["expected_head_sha"]).toBe(platformHead);
 
     // A diff sync verifies the reviewed head; the reloaded detail
     // re-enables merge, while approval remains available.

--- a/frontend/tests/e2e/head-pinned-actions.spec.ts
+++ b/frontend/tests/e2e/head-pinned-actions.spec.ts
@@ -7,7 +7,8 @@ import { mockApi } from "./support/mockApi";
 // sends the latest synced provider head on approve when available, and
 // branches on the 409 conflict reasons.
 
-// Matches the reviewed_head_sha mockApi serves for acme/widgets#42.
+// The default acme/widgets#42 fixture uses the same SHA for platform_head_sha
+// and reviewed_head_sha; the PR #77 cases below cover divergent heads.
 const REVIEWED_SHA = "42aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa42";
 const SYNCED_SHA = "0123456789abcdef0123456789abcdef01234567";
 

--- a/frontend/tests/e2e/head-pinned-actions.spec.ts
+++ b/frontend/tests/e2e/head-pinned-actions.spec.ts
@@ -4,7 +4,7 @@ import { mockApi } from "./support/mockApi";
 // Wire-level coverage for the head-pinning contract
 // (context/provider-architecture.md "Head binding"): the detail view
 // echoes the rendered reviewed_head_sha as expected_head_sha on merge
-// and approve, and branches on the 409 conflict reasons.
+// and approve when available, and branches on the 409 conflict reasons.
 
 // Matches the reviewed_head_sha mockApi serves for acme/widgets#42.
 const REVIEWED_SHA = "42aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa42";
@@ -58,9 +58,9 @@ const providerCapabilities = {
   supported_review_actions: [],
 };
 
-// A GitLab-shaped PR whose head has never been synced, for the
-// head_unknown flow. Local fixture so the shared mockApi pulls (which
-// now all carry a head SHA) stay untouched.
+// A PR whose reviewed head has never been synced, for the head_unknown
+// flow. Local fixture so the shared mockApi pulls (which now all carry a
+// reviewed head SHA) stay untouched.
 const unboundPR = {
   ID: 9,
   RepoID: 1,
@@ -280,17 +280,18 @@ test.describe("palette approve head conflict", () => {
   });
 });
 
-test.describe("head_unknown approve conflict", () => {
-  test("head-bound actions stay disabled until diff sync records the reviewed head", async ({ page }) => {
+test.describe("head_unknown action gating", () => {
+  test("approve can proceed without a reviewed head while merge waits for diff sync", async ({ page }) => {
     await mockApi(page);
 
-    // On a head-binding provider the UI never fires an unbound
-    // mutation: even with a raw platform head, approve and merge stay
-    // disabled until reviewed_head_sha proves the diff snapshot is
-    // current.
+    // Approval is safe without a locally verified reviewed_head_sha: the
+    // server sends a head SHA when it has one, and providers may approve
+    // the current head otherwise. Merge remains blocked until
+    // reviewed_head_sha proves the rendered diff snapshot is current.
     const platformHead = SYNCED_SHA;
     let reviewedHead = "";
     let approveRequested = false;
+    let approveBody: Record<string, unknown> | null = null;
 
     await page.route("**/api/v1/pulls/github/acme/widgets/77", async (route: Route) => {
       if (route.request().method() !== "GET") {
@@ -318,6 +319,7 @@ test.describe("head_unknown approve conflict", () => {
 
     await page.route("**/api/v1/pulls/github/acme/widgets/77/approve", async (route: Route) => {
       approveRequested = true;
+      approveBody = JSON.parse(route.request().postData() ?? "{}");
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -328,12 +330,15 @@ test.describe("head_unknown approve conflict", () => {
     await page.goto("/pulls/github/acme/widgets/77");
     await expect(page.locator(".detail-title")).toContainText("Unbound head PR");
 
-    await expect(page.locator(".btn--approve").first()).toBeDisabled();
+    await expect(page.locator(".btn--approve").first()).toBeEnabled();
     await expect(page.locator(".btn--merge").first()).toBeDisabled();
-    expect(approveRequested).toBe(false);
+    await submitApproval(page);
+    expect(approveRequested).toBe(true);
+    expect(approveBody).not.toBeNull();
+    expect(approveBody!["expected_head_sha"]).toBeUndefined();
 
     // A diff sync verifies the reviewed head; the reloaded detail
-    // re-enables the head-bound actions.
+    // re-enables merge, while approval remains available.
     reviewedHead = SYNCED_SHA;
     await page.reload();
     await expect(page.locator(".detail-title")).toContainText("Unbound head PR");

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -656,6 +656,7 @@ func (p gitHubClientProvider) Capabilities() platform.Capabilities {
 		CommentMutation:       true,
 		StateMutation:         true,
 		MergeMutation:         true,
+		ReviewMutation:        true,
 		MutationHeadBinding:   true,
 		WorkflowApproval:      true,
 		ReadyForReview:        true,
@@ -669,6 +670,7 @@ func (p gitHubClientProvider) Capabilities() platform.Capabilities {
 		NativeMultilineRanges: true,
 		SupportedReviewActions: []platform.ReviewAction{
 			platform.ReviewActionComment,
+			platform.ReviewActionApprove,
 			platform.ReviewActionRequestChanges,
 		},
 	}
@@ -1351,8 +1353,6 @@ func githubRequestedReviewerLogins(pr *gh.PullRequest) []string {
 	return logins
 }
 
-// ApproveMergeRequest is intentionally unsupported because GitHub approvals
-// cannot be submitted atomically against the expected pull request head.
 func (p gitHubClientProvider) ApproveMergeRequest(
 	ctx context.Context,
 	ref platform.RepoRef,
@@ -1360,8 +1360,23 @@ func (p gitHubClientProvider) ApproveMergeRequest(
 	body string,
 	expectedHeadSHA string,
 ) (platform.MergeRequestEvent, error) {
-	return platform.MergeRequestEvent{},
-		platform.UnsupportedCapability(platform.KindGitHub, p.host, "approve_merge_request")
+	review, err := p.client.CreateReviewWithComments(
+		ctx,
+		ref.Owner,
+		ref.Name,
+		number,
+		"APPROVE",
+		body,
+		expectedHeadSHA,
+		nil,
+	)
+	if err != nil {
+		return platform.MergeRequestEvent{}, err
+	}
+	if review == nil {
+		return platform.MergeRequestEvent{}, fmt.Errorf("provider returned no review")
+	}
+	return platformgithub.NormalizeReviewEvent(ref, number, review), nil
 }
 
 func (p gitHubClientProvider) ListMergeRequestReviewThreads(
@@ -1492,9 +1507,6 @@ func (p gitHubClientProvider) PublishDiffReviewDraft(
 	number int,
 	input platform.PublishDiffReviewDraftInput,
 ) (*platform.PublishedDiffReview, error) {
-	if input.Action == platform.ReviewActionApprove {
-		return nil, platform.UnsupportedCapability(platform.KindGitHub, p.host, "approve_merge_request")
-	}
 	event, err := githubReviewEvent(input.Action)
 	if err != nil {
 		return nil, err
@@ -1531,6 +1543,8 @@ func githubReviewEvent(action platform.ReviewAction) (string, error) {
 	switch action {
 	case platform.ReviewActionComment:
 		return "COMMENT", nil
+	case platform.ReviewActionApprove:
+		return "APPROVE", nil
 	case platform.ReviewActionRequestChanges:
 		return "REQUEST_CHANGES", nil
 	default:

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -1090,25 +1090,37 @@ func TestGitHubProviderPublishDiffReviewDraftMapsReviewComments(t *testing.T) {
 	assert.Equal(12, comment.GetLine())
 }
 
-func TestGitHubProviderPublishDiffReviewDraftApproveUnsupported(t *testing.T) {
+func TestGitHubProviderPublishDiffReviewDraftApproveSubmitsReview(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	mock := &mockClient{}
 	provider := gitHubClientProvider{client: mock, host: "github.com"}
+	line := 12
 
-	_, err := provider.PublishDiffReviewDraft(t.Context(), platform.RepoRef{
+	result, err := provider.PublishDiffReviewDraft(t.Context(), platform.RepoRef{
 		Owner: "acme",
 		Name:  "widget",
 	}, 7, platform.PublishDiffReviewDraftInput{
+		Body:    "ship it",
 		Action:  platform.ReviewActionApprove,
 		HeadSHA: "reviewed-head",
+		Comments: []platform.LocalDiffReviewDraftComment{{
+			Body: "inline note",
+			Range: platform.DiffReviewLineRange{
+				Path: "src/main.go",
+				Side: "right",
+				Line: line,
+			},
+		}},
 	})
 
-	var platformErr *platform.Error
-	require.ErrorAs(err, &platformErr)
-	assert.Equal(platform.ErrCodeUnsupportedCapability, platformErr.Code)
-	assert.Equal("approve_merge_request", platformErr.Capability)
-	assert.Empty(mock.createdReviewEvent, "unsupported approval must not reach the review API")
+	require.NoError(err)
+	require.NotNil(result)
+	assert.Equal("APPROVE", mock.createdReviewEvent)
+	assert.Equal("ship it", mock.createdReviewBody)
+	assert.Equal("reviewed-head", mock.createdReviewCommitID)
+	require.Len(mock.createdReviewComments, 1)
+	assert.Equal("inline note", mock.createdReviewComments[0].GetBody())
 }
 
 func TestGitHubProviderCapabilitiesExposeReviewThreadReads(t *testing.T) {
@@ -1120,8 +1132,8 @@ func TestGitHubProviderCapabilitiesExposeReviewThreadReads(t *testing.T) {
 	require.True(caps.ReadReviewThreads)
 	require.True(caps.ReviewDraftMutation)
 	require.False(caps.ReviewThreadResolution)
-	require.False(caps.ReviewMutation)
-	require.NotContains(caps.SupportedReviewActions, platform.ReviewActionApprove)
+	require.True(caps.ReviewMutation)
+	require.Contains(caps.SupportedReviewActions, platform.ReviewActionApprove)
 }
 
 func TestGitHubProviderListMergeRequestReviewThreadsMapsGraphQLThreads(t *testing.T) {
@@ -10435,21 +10447,21 @@ func TestResolveDisplayName_StaleWhileErrorBacksOff(t *testing.T) {
 	assert.Equal(4, callCount)
 }
 
-func TestGitHubProviderApproveUnsupported(t *testing.T) {
+func TestGitHubProviderApproveSubmitsReviewForReviewedHead(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	mock := &mockClient{}
 	provider := gitHubClientProvider{client: mock, host: "github.com"}
 
-	_, err := provider.ApproveMergeRequest(
+	event, err := provider.ApproveMergeRequest(
 		t.Context(), platform.RepoRef{Owner: "acme", Name: "widget"}, 7,
 		"ship it", "reviewed-head",
 	)
-	var platformErr *platform.Error
-	require.ErrorAs(err, &platformErr)
-	assert.Equal(platform.ErrCodeUnsupportedCapability, platformErr.Code)
-	assert.Equal("approve_merge_request", platformErr.Capability)
-	assert.Empty(mock.createdReviewEvent, "unsupported approval must not reach the review API")
+	require.NoError(err)
+	assert.Equal("review", event.EventType)
+	assert.Equal("APPROVE", mock.createdReviewEvent)
+	assert.Equal("ship it", mock.createdReviewBody)
+	assert.Equal("reviewed-head", mock.createdReviewCommitID)
 }
 
 func TestIsGitHubHeadModified(t *testing.T) {

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -133,11 +133,11 @@ type ReviewerMutator interface {
 }
 
 type ReviewMutator interface {
-	// ApproveMergeRequest approves the MR. expectedHeadSHA is the head
-	// commit the caller reviewed; providers that support head binding must
-	// reject the approval when the MR head has moved past it. An empty
-	// value skips the check. Providers whose API cannot bind the approval
-	// to a head commit treat it as advisory.
+	// ApproveMergeRequest approves the MR. expectedHeadSHA is the caller's
+	// target provider head for the approval; providers that support head
+	// binding must reject the approval when the MR head has moved past it.
+	// An empty value skips the check. Providers whose API cannot bind the
+	// approval to a head commit treat it as advisory.
 	ApproveMergeRequest(
 		ctx context.Context,
 		ref RepoRef,

--- a/internal/platform/forgejo/client.go
+++ b/internal/platform/forgejo/client.go
@@ -147,6 +147,7 @@ func (c *Client) Capabilities() platform.Capabilities {
 	caps.NativeMultilineRanges = false
 	caps.SupportedReviewActions = []platform.ReviewAction{
 		platform.ReviewActionComment,
+		platform.ReviewActionApprove,
 		platform.ReviewActionRequestChanges,
 	}
 	return caps

--- a/internal/platform/forgejo/client_test.go
+++ b/internal/platform/forgejo/client_test.go
@@ -256,6 +256,7 @@ func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 		CommentMutation:       true,
 		StateMutation:         true,
 		MergeMutation:         true,
+		ReviewMutation:        true,
 		IssueMutation:         true,
 		LabelMutation:         true,
 		AssigneeMutation:      true,
@@ -266,6 +267,7 @@ func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 		NativeMultilineRanges: false,
 		SupportedReviewActions: []platform.ReviewAction{
 			platform.ReviewActionComment,
+			platform.ReviewActionApprove,
 			platform.ReviewActionRequestChanges,
 		},
 	}, client.Capabilities())
@@ -457,31 +459,48 @@ func TestClientMutationCapabilityUsesForgejoEndpoints(t *testing.T) {
 	}, seen)
 }
 
-func TestClientApproveMergeRequestUnsupported(t *testing.T) {
+func TestClientApproveMergeRequestSubmitsReview(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
 	var sawRequest bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawRequest = true
-		http.NotFound(w, r)
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/api/v1/repos/owner/repo/pulls/7/reviews", r.URL.Path)
+		var body struct {
+			Event    string `json:"event"`
+			Body     string `json:"body"`
+			CommitID string `json:"commit_id"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		assert.Equal("APPROVED", body.Event)
+		assert.Equal("ship it", body.Body)
+		assert.Equal("reviewed-head", body.CommitID)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id": 40, "state": "APPROVED", "body": "ship it", "user": map[string]any{"login": "dana"},
+			"submitted_at": "2026-05-01T12:00:00Z",
+		}))
 	}))
 	defer server.Close()
 
 	client, err := NewClient("codeberg.test", testTokenSource("forgejo-token"), WithBaseURLForTesting(server.URL))
 	require.NoError(err)
 
-	_, err = client.ApproveMergeRequest(
+	event, err := client.ApproveMergeRequest(
 		context.Background(),
 		platform.RepoRef{Owner: "owner", Name: "repo"},
 		7,
 		"ship it",
 		"reviewed-head",
 	)
-	var platformErr *platform.Error
-	require.ErrorAs(err, &platformErr)
-	assert.Equal(platform.ErrCodeUnsupportedCapability, platformErr.Code)
-	assert.Equal("approve_merge_request", platformErr.Capability)
-	assert.False(sawRequest)
+	require.NoError(err)
+	assert.True(sawRequest)
+	assert.Equal("review", event.EventType)
+	assert.Equal("APPROVED", event.Summary)
 }
 
 func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {

--- a/internal/platform/forgejo/diff_review.go
+++ b/internal/platform/forgejo/diff_review.go
@@ -34,9 +34,6 @@ func (t *transport) PublishDiffReviewDraft(
 	number int,
 	input platform.PublishDiffReviewDraftInput,
 ) (*platform.PublishedDiffReview, error) {
-	if input.Action == platform.ReviewActionApprove {
-		return nil, platform.UnsupportedCapability(platform.KindForgejo, host, "approve_merge_request")
-	}
 	comments := make([]forgejosdk.CreatePullReviewComment, 0, len(input.Comments))
 	commitID := input.HeadSHA
 	for _, comment := range input.Comments {
@@ -146,6 +143,8 @@ func (t *transport) listPullReviewComments(
 
 func forgejoReviewState(action platform.ReviewAction) forgejosdk.ReviewStateType {
 	switch action {
+	case platform.ReviewActionApprove:
+		return forgejosdk.ReviewStateApproved
 	case platform.ReviewActionRequestChanges:
 		return forgejosdk.ReviewStateRequestChanges
 	default:

--- a/internal/platform/forgejo/diff_review_test.go
+++ b/internal/platform/forgejo/diff_review_test.go
@@ -79,19 +79,39 @@ func TestPublishDiffReviewDraftCreatesForgejoReview(t *testing.T) {
 	assert.Equal(submitted, result.SubmittedAt)
 }
 
-func TestPublishDiffReviewDraftApproveUnsupported(t *testing.T) {
+func TestPublishDiffReviewDraftApproveSubmitsReview(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
-	var sawRequest bool
+	submitted := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sawRequest = true
-		http.NotFound(w, r)
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/api/v1/repos/acme/widgets/pulls/42/reviews", r.URL.Path)
+		var body struct {
+			Event    string `json:"event"`
+			Body     string `json:"body"`
+			CommitID string `json:"commit_id"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		assert.Equal("APPROVED", body.Event)
+		assert.Equal("ship it", body.Body)
+		assert.Equal("reviewed-head", body.CommitID)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id":           100,
+			"state":        "APPROVED",
+			"body":         "ship it",
+			"submitted_at": submitted.Format(time.RFC3339),
+			"user":         map[string]any{"login": "reviewer"},
+		}))
 	}))
 	defer server.Close()
 
 	client, err := NewClient("codeberg.test", testTokenSource("token"), WithBaseURLForTesting(server.URL))
 	require.NoError(err)
-	_, err = client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
+	result, err := client.PublishDiffReviewDraft(context.Background(), platform.RepoRef{
 		Owner: "acme",
 		Name:  "widgets",
 	}, 42, platform.PublishDiffReviewDraftInput{
@@ -100,11 +120,10 @@ func TestPublishDiffReviewDraftApproveUnsupported(t *testing.T) {
 		HeadSHA: "reviewed-head",
 	})
 
-	var platformErr *platform.Error
-	require.ErrorAs(err, &platformErr)
-	assert.Equal(platform.ErrCodeUnsupportedCapability, platformErr.Code)
-	assert.Equal("approve_merge_request", platformErr.Capability)
-	assert.False(sawRequest)
+	require.NoError(err)
+	require.NotNil(result)
+	assert.Equal("100", result.ProviderReviewID)
+	assert.Equal(submitted, result.SubmittedAt)
 }
 
 func TestListMergeRequestReviewThreadsReadsForgejoReviewComments(t *testing.T) {

--- a/internal/platform/forgejo/mutation.go
+++ b/internal/platform/forgejo/mutation.go
@@ -95,6 +95,30 @@ func (c *Client) ApproveMergeRequest(
 	return c.provider.ApproveMergeRequest(ctx, ref, number, body, expectedHeadSHA)
 }
 
+func (t *transport) CreatePullReview(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.ReviewOptions,
+) (gitealike.ReviewDTO, error) {
+	t.spendSyncBudget(ctx)
+	var review *forgejosdk.PullReview
+	var resp *forgejosdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		review, resp, err = t.api.CreatePullReview(ref.Owner, ref.Name, int64(number), forgejosdk.CreatePullReviewOptions{
+			State:    forgejosdk.ReviewStateType(opts.State),
+			Body:     opts.Body,
+			CommitID: opts.CommitID,
+		})
+		return err
+	})
+	if err != nil {
+		return gitealike.ReviewDTO{}, forgejoHTTPError(resp, err)
+	}
+	return convertReview(review), nil
+}
+
 func (c *Client) EditMergeRequestContent(
 	ctx context.Context,
 	ref platform.RepoRef,

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -255,6 +255,7 @@ func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 		CommentMutation:     true,
 		StateMutation:       true,
 		MergeMutation:       true,
+		ReviewMutation:      true,
 		IssueMutation:       true,
 		LabelMutation:       true,
 		AssigneeMutation:    true,
@@ -512,31 +513,48 @@ func TestClientMutationCapabilityUsesGiteaEndpoints(t *testing.T) {
 	}, seen)
 }
 
-func TestClientApproveMergeRequestUnsupported(t *testing.T) {
+func TestClientApproveMergeRequestSubmitsReview(t *testing.T) {
 	assert := Assert.New(t)
 	require := Require.New(t)
 	var sawRequest bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawRequest = true
-		http.NotFound(w, r)
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/api/v1/repos/owner/repo/pulls/7/reviews", r.URL.Path)
+		var body struct {
+			Event    string `json:"event"`
+			Body     string `json:"body"`
+			CommitID string `json:"commit_id"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		assert.Equal("APPROVED", body.Event)
+		assert.Equal("ship it", body.Body)
+		assert.Equal("reviewed-head", body.CommitID)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id": 40, "state": "APPROVED", "body": "ship it", "user": map[string]any{"login": "dana"},
+			"submitted_at": "2026-05-01T12:00:00Z",
+		}))
 	}))
 	defer server.Close()
 
 	client, err := NewClient("gitea.test", testTokenSource("gitea-token"), WithBaseURLForTesting(server.URL))
 	require.NoError(err)
 
-	_, err = client.ApproveMergeRequest(
+	event, err := client.ApproveMergeRequest(
 		context.Background(),
 		platform.RepoRef{Owner: "owner", Name: "repo"},
 		7,
 		"ship it",
 		"reviewed-head",
 	)
-	var platformErr *platform.Error
-	require.ErrorAs(err, &platformErr)
-	assert.Equal(platform.ErrCodeUnsupportedCapability, platformErr.Code)
-	assert.Equal("approve_merge_request", platformErr.Capability)
-	assert.False(sawRequest)
+	require.NoError(err)
+	assert.True(sawRequest)
+	assert.Equal("review", event.EventType)
+	assert.Equal("APPROVED", event.Summary)
 }
 
 func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {

--- a/internal/platform/gitea/mutation.go
+++ b/internal/platform/gitea/mutation.go
@@ -95,6 +95,30 @@ func (c *Client) ApproveMergeRequest(
 	return c.provider.ApproveMergeRequest(ctx, ref, number, body, expectedHeadSHA)
 }
 
+func (t *transport) CreatePullReview(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	opts gitealike.ReviewOptions,
+) (gitealike.ReviewDTO, error) {
+	t.spendSyncBudget(ctx)
+	var review *giteasdk.PullReview
+	var resp *giteasdk.Response
+	err := t.withRequestContext(ctx, func() error {
+		var err error
+		review, resp, err = t.api.CreatePullReview(ref.Owner, ref.Name, int64(number), giteasdk.CreatePullReviewOptions{
+			State:    giteasdk.ReviewStateType(opts.State),
+			Body:     opts.Body,
+			CommitID: opts.CommitID,
+		})
+		return err
+	})
+	if err != nil {
+		return gitealike.ReviewDTO{}, giteaHTTPError(resp, err)
+	}
+	return convertReview(review), nil
+}
+
 func (c *Client) EditMergeRequestContent(
 	ctx context.Context,
 	ref platform.RepoRef,

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -82,6 +82,9 @@ func (p *Provider) Capabilities() platform.Capabilities {
 		caps.MutationHeadBinding = true
 		caps.LabelMutation = hasLabels
 		caps.AssigneeMutation = true
+		if _, ok := p.transport.(ReviewMutationTransport); ok {
+			caps.ReviewMutation = true
+		}
 		if _, ok := p.transport.(ReviewRequestTransport); ok {
 			caps.ReviewerMutation = true
 		}
@@ -561,9 +564,6 @@ func (p *Provider) MergeMergeRequest(
 	return platform.MergeResult{Merged: result.Merged, SHA: result.SHA, Message: result.Message}, nil
 }
 
-// ApproveMergeRequest is intentionally unsupported because Gitea-like
-// approvals cannot be submitted atomically against the expected pull request
-// head.
 func (p *Provider) ApproveMergeRequest(
 	ctx context.Context,
 	ref platform.RepoRef,
@@ -571,8 +571,24 @@ func (p *Provider) ApproveMergeRequest(
 	body string,
 	expectedHeadSHA string,
 ) (platform.MergeRequestEvent, error) {
-	return platform.MergeRequestEvent{},
-		platform.UnsupportedCapability(p.kind, p.host, "approve_merge_request")
+	transport, ok := p.transport.(ReviewMutationTransport)
+	if !ok || !p.options.Mutations {
+		return platform.MergeRequestEvent{},
+			platform.UnsupportedCapability(p.kind, p.host, "approve_merge_request")
+	}
+	review, err := transport.CreatePullReview(ctx, ref, number, ReviewOptions{
+		State:    "APPROVED",
+		Body:     body,
+		CommitID: expectedHeadSHA,
+	})
+	if err != nil {
+		return platform.MergeRequestEvent{}, p.mapError(err)
+	}
+	events := NormalizeMergeRequestEvents(p.kind, ref, number, nil, []ReviewDTO{review}, nil)
+	if len(events) == 0 {
+		return platform.MergeRequestEvent{}, fmt.Errorf("provider returned no review event")
+	}
+	return events[0], nil
 }
 
 func (p *Provider) EditMergeRequestContent(

--- a/internal/platform/gitealike/provider_test.go
+++ b/internal/platform/gitealike/provider_test.go
@@ -42,6 +42,7 @@ func TestProviderCapabilitiesEnableProvenMutations(t *testing.T) {
 		CommentMutation:     true,
 		StateMutation:       true,
 		MergeMutation:       true,
+		ReviewMutation:      true,
 		IssueMutation:       true,
 		AssigneeMutation:    true,
 		MutationHeadBinding: true,
@@ -364,6 +365,7 @@ type fakeTransport struct {
 	prErrSeq    []error
 	issue       IssueDTO
 	merge       MergeResultDTO
+	review      ReviewDTO
 
 	userRepoPages []int
 	orgRepoPages  []int
@@ -514,6 +516,11 @@ func (t *fakeTransport) MergePullRequest(_ context.Context, _ platform.RepoRef, 
 	return t.merge, nil
 }
 
+func (t *fakeTransport) CreatePullReview(_ context.Context, _ platform.RepoRef, _ int, opts ReviewOptions) (ReviewDTO, error) {
+	t.mutationCalls = append(t.mutationCalls, "review:"+opts.State+":"+opts.CommitID)
+	return t.review, nil
+}
+
 func pageFor[T any](pages [][]T, page int) ([]T, Page, error) {
 	if page < 1 || page > len(pages) {
 		return nil, Page{}, nil
@@ -560,19 +567,22 @@ func TestProviderMergePinsExpectedHeadAndClassifiesConflict(t *testing.T) {
 	assert.Equal(409, conflictErr.StatusCode)
 }
 
-func TestProviderApproveUnsupported(t *testing.T) {
+func TestProviderApproveSubmitsReview(t *testing.T) {
 	require := Require.New(t)
 	assert := Assert.New(t)
 	ref := platform.RepoRef{Owner: "acme", Name: "widget"}
 
-	transport := &fakeTransport{}
+	transport := &fakeTransport{
+		review: ReviewDTO{
+			ID: 22, User: UserDTO{UserName: "dana"}, State: "APPROVED",
+			Body: "ship it", Submitted: time.Date(2026, 5, 1, 2, 3, 4, 0, time.UTC),
+		},
+	}
 	provider := NewProvider(platform.KindGitea, "gitea.example.com", transport, WithMutations())
 
-	_, err := provider.ApproveMergeRequest(context.Background(), ref, 7, "ship it", "reviewed-head")
-	var platformErr *platform.Error
-	require.ErrorAs(err, &platformErr)
-	assert.Equal(platform.ErrCodeUnsupportedCapability, platformErr.Code)
-	assert.Equal("approve_merge_request", platformErr.Capability)
-	assert.NotContains(transport.mutationCalls, "review",
-		"unsupported approval must not reach the review API")
+	event, err := provider.ApproveMergeRequest(context.Background(), ref, 7, "ship it", "reviewed-head")
+	require.NoError(err)
+	assert.Equal("review", event.EventType)
+	assert.Equal("APPROVED", event.Summary)
+	assert.Equal("review:APPROVED:reviewed-head", transport.mutationCalls[len(transport.mutationCalls)-1])
 }

--- a/internal/platform/gitealike/types.go
+++ b/internal/platform/gitealike/types.go
@@ -59,6 +59,10 @@ type ReviewRequestTransport interface {
 	DeleteReviewRequests(ctx context.Context, ref platform.RepoRef, number int, reviewers []string) error
 }
 
+type ReviewMutationTransport interface {
+	CreatePullReview(ctx context.Context, ref platform.RepoRef, number int, opts ReviewOptions) (ReviewDTO, error)
+}
+
 type ActionsTransport interface {
 	ListActionRuns(ctx context.Context, ref platform.RepoRef, sha string, opts PageOptions) ([]ActionRunDTO, Page, error)
 }
@@ -245,6 +249,12 @@ type MergeOptions struct {
 	// provider rejects the merge if the PR head moved past the
 	// reviewed commit.
 	ExpectedHeadSHA string
+}
+
+type ReviewOptions struct {
+	State    string
+	Body     string
+	CommitID string
 }
 
 type MergeResultDTO struct {

--- a/internal/platform/gitlab/mutation.go
+++ b/internal/platform/gitlab/mutation.go
@@ -385,12 +385,12 @@ func (c *Client) EditIssueContent(
 }
 
 // ApproveMergeRequest approves an MR through the GitLab approvals API.
-// A non-empty expectedHeadSHA binds the approval to the reviewed commit:
-// GitLab rejects the approval when the MR head has moved. The approval
-// itself needs no client-side check, but when a body will be posted as a
-// note (notes are not sha-bound) the current head is verified first so a
-// stale review does not leave an orphaned comment (a small race window
-// remains between the check and the note).
+// A non-empty expectedHeadSHA binds the approval to the caller's target
+// provider head: GitLab rejects the approval when the MR head has moved.
+// The approval itself needs no client-side check, but when a body will be
+// posted as a note (notes are not sha-bound) the current head is verified
+// first so a stale approval comment does not leave an orphaned note (a small
+// race window remains between the check and the note).
 //
 // GitLab approvals carry no body, so a non-empty body is posted as a
 // regular MR note before approving; the synthesized approval event keeps

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -313,10 +313,11 @@ type Capabilities struct {
 	ReviewThreadResolution bool
 	ReadReviewThreads      bool
 	NativeMultilineRanges  bool
-	// MutationHeadBinding is true when merge and approve mutations are
-	// hard-bound to the reviewed head SHA: the provider rejects the
-	// mutation when the MR head moved past it. Providers without it treat
-	// the expected head SHA as advisory.
+	// MutationHeadBinding is true when mutations can be hard-bound to an
+	// expected head SHA and the provider rejects the mutation when the MR
+	// head moved past it. Merge uses the reviewed diff head as that pin;
+	// direct approval uses the caller's target provider head. Providers
+	// without it treat the expected head SHA as advisory.
 	MutationHeadBinding    bool
 	SupportedReviewActions []ReviewAction
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5573,15 +5573,32 @@ func TestAPIEditIssueCommentRejectsNilProviderPayload(t *testing.T) {
 	assert.Equal("original body", events[0].Body)
 }
 
-func TestAPIApprovePRUnsupportedBeforeProviderCall(t *testing.T) {
+func TestAPIApprovePRSubmitsGitHubReview(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
 
 	var providerCalled atomic.Bool
+	var reviewCommitID string
 	mock := &mockGH{
-		createReviewFn: func(context.Context, string, string, int, string, string) (*gh.PullRequestReview, error) {
+		createReviewWithCommentsFn: func(
+			_ context.Context,
+			_, _ string,
+			_ int,
+			event, body, commitID string,
+			_ []*gh.DraftReviewComment,
+		) (*gh.PullRequestReview, error) {
 			providerCalled.Store(true)
-			return nil, nil
+			reviewCommitID = commitID
+			id := int64(101)
+			state := event
+			now := gh.Timestamp{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}
+			return &gh.PullRequestReview{
+				ID:          &id,
+				State:       &state,
+				Body:        &body,
+				SubmittedAt: &now,
+				User:        &gh.User{Login: new("reviewer")},
+			}, nil
 		},
 	}
 	srv, database := setupTestServerWithMock(t, mock)
@@ -5597,15 +5614,15 @@ func TestAPIApprovePRUnsupportedBeforeProviderCall(t *testing.T) {
 		generated.ApprovePullJSONRequestBody{ExpectedHeadSha: &expectedHeadSHA},
 	)
 	require.NoError(err)
-	require.Equal(http.StatusConflict, resp.StatusCode(), string(resp.Body))
-	assertUnsupportedCapabilityProblem(
-		t, bytes.NewReader(resp.Body), "github", "github.com", "review_mutation",
-	)
-	assert.False(providerCalled.Load())
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+	assert.True(providerCalled.Load())
+	assert.Equal(expectedHeadSHA, reviewCommitID)
 
 	events, err := database.ListMREvents(t.Context(), mrID)
 	require.NoError(err)
-	require.Empty(events)
+	require.Len(events, 1)
+	assert.Equal("review", events[0].EventType)
+	assert.Equal("APPROVE", events[0].Summary)
 }
 
 func TestAPIMergePRRejectsNilProviderPayload(t *testing.T) {
@@ -13986,13 +14003,12 @@ func TestAPIGitealikeMutationsPersistThroughServer(t *testing.T) {
 		},
 	)
 	require.NoError(err)
-	require.Equal(http.StatusConflict, approveResp.StatusCode(), string(approveResp.Body))
-	assertUnsupportedCapabilityProblem(
-		t, bytes.NewReader(approveResp.Body), "gitea", "gitea.test", "review_mutation",
-	)
+	require.Equal(http.StatusOK, approveResp.StatusCode(), string(approveResp.Body))
 	mrEvents, err = database.ListMREvents(ctx, mrSeven.ID)
 	require.NoError(err)
-	assert.Len(mrEvents, 1)
+	require.Len(mrEvents, 2)
+	assert.Equal("review", mrEvents[1].EventType)
+	assert.Equal("APPROVED", mrEvents[1].Summary)
 
 	mergeResp, err := client.HTTP.MergePullOnHostWithResponse(
 		ctx, "gitea.test", "gitea", "tea", "kettle", 7,
@@ -14339,7 +14355,7 @@ func TestAPIGitealikePinnedMergeGenericConflictStaysConflict(t *testing.T) {
 		"an unrelated 409 must not present as a stale-head re-review flow")
 }
 
-func TestAPIGitealikeApproveUnsupportedBeforeProviderCall(t *testing.T) {
+func TestAPIGitealikeApproveSubmitsReview(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	transport := &apiTestGitealikeTransport{}
@@ -14354,15 +14370,11 @@ func TestAPIGitealikeApproveUnsupportedBeforeProviderCall(t *testing.T) {
 		},
 	)
 	require.NoError(err)
-	require.Equal(http.StatusConflict, resp.StatusCode())
-	assertUnsupportedCapabilityProblem(
-		t, bytes.NewReader(resp.Body), "gitea", "gitea.test", "review_mutation",
-	)
-	assert.NotContains(transport.mutationCalls, "review:7:lgtm")
-	assert.NotContains(transport.mutationCalls, "delete_review:7:980")
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+	assert.Contains(transport.mutationCalls, "review:7:lgtm:abc123")
 }
 
-func TestAPIGitealikeApproveUnsupportedDoesNotReadRacingHead(t *testing.T) {
+func TestAPIGitealikeApproveDoesNotReadRacingHead(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	transport := &apiTestGitealikeTransport{}
@@ -14378,12 +14390,9 @@ func TestAPIGitealikeApproveUnsupportedDoesNotReadRacingHead(t *testing.T) {
 		},
 	)
 	require.NoError(err)
-	require.Equal(http.StatusConflict, resp.StatusCode())
-	assertUnsupportedCapabilityProblem(
-		t, bytes.NewReader(resp.Body), "gitea", "gitea.test", "review_mutation",
-	)
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
 	assert.Equal(0, transport.headCalls)
-	assert.Empty(transport.mutationCalls)
+	assert.Contains(transport.mutationCalls, "review:7:lgtm:abc123")
 }
 
 func TestAPIGiteaActionsSyncPersistsThroughServer(t *testing.T) {
@@ -14802,7 +14811,7 @@ func TestAPIGitealikeMergeHeadMismatchMapsToStaleState(t *testing.T) {
 	assert.Equal([]string{"abc123"}, transport.mergeHeadPins)
 }
 
-func TestAPIGitealikeApproveUnsupportedBeforeHeadRace(t *testing.T) {
+func TestAPIGitealikeApproveBeforeHeadRace(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
 	ctx := t.Context()
@@ -14819,15 +14828,8 @@ func TestAPIGitealikeApproveUnsupportedBeforeHeadRace(t *testing.T) {
 	)
 
 	require.NoError(err)
-	require.Equal(http.StatusConflict, resp.StatusCode(), string(resp.Body))
-	require.NotNil(resp.ApplicationproblemJSONDefault)
-	assert.Equal("unsupportedCapability", string(resp.ApplicationproblemJSONDefault.Code))
-	require.NotNil(resp.ApplicationproblemJSONDefault.Details)
-	assert.Equal("review_mutation", (*resp.ApplicationproblemJSONDefault.Details)["capability"])
-	assert.Equal("gitea", (*resp.ApplicationproblemJSONDefault.Details)["provider"])
-	assert.Equal("gitea.test", (*resp.ApplicationproblemJSONDefault.Details)["platformHost"])
-	assert.NotContains(transport.mutationCalls, "review:7:approved")
-	assert.NotContains(transport.mutationCalls, "delete_review:7:980")
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+	assert.Contains(transport.mutationCalls, "review:7:approved:abc123")
 }
 
 type apiTestGitealikeTransport struct {
@@ -15156,6 +15158,25 @@ func (t *apiTestGitealikeTransport) MergePullRequest(
 	pr.MergedAt = &now
 	pr.Updated = now
 	return gitealike.MergeResultDTO{Merged: true, SHA: "merged-sha", Message: "merged"}, nil
+}
+
+func (t *apiTestGitealikeTransport) CreatePullReview(
+	_ context.Context,
+	_ platform.RepoRef,
+	number int,
+	opts gitealike.ReviewOptions,
+) (gitealike.ReviewDTO, error) {
+	if t.findPull(number) == nil {
+		return gitealike.ReviewDTO{}, platform.ErrNotFound
+	}
+	t.mutationCalls = append(t.mutationCalls, fmt.Sprintf("review:%d:%s:%s", number, opts.Body, opts.CommitID))
+	return gitealike.ReviewDTO{
+		ID:        980,
+		User:      gitealike.UserDTO{UserName: "mutation-bot"},
+		State:     opts.State,
+		Body:      opts.Body,
+		Submitted: time.Now().UTC().Truncate(time.Second),
+	}, nil
 }
 
 func (t *apiTestGitealikeTransport) findPull(number int) *gitealike.PullRequestDTO {
@@ -20517,6 +20538,10 @@ func TestServerStartupReapsUnrecordedRuntimeTmuxSessionE2E(t *testing.T) {
 
 	require := require.New(t)
 	assert := Assert.New(t)
+	previousStartupCleanupTimeout := startupTmuxCleanupTimeout
+	startupTmuxCleanupTimeout = 10 * time.Second
+	t.Cleanup(func() { startupTmuxCleanupTimeout = previousStartupCleanupTimeout })
+
 	dir := t.TempDir()
 	record := filepath.Join(dir, "record")
 	tmuxPath := filepath.Join(dir, "fake-tmux")

--- a/internal/server/diff_review_handlers.go
+++ b/internal/server/diff_review_handlers.go
@@ -196,12 +196,13 @@ func (s *Server) publishDiffReviewDraft(
 	if reviewHeadSHA == "" {
 		reviewHeadSHA = mr.PlatformHeadSHA
 	}
-	// Approve publishes are head-bound: on providers that enforce head
-	// binding they must clear the same reviewedHeadSHA gate as /approve
-	// and /merge, which fails closed on a missing or stale reviewed diff
-	// snapshot — including a moved base SHA with an unchanged head. The
-	// per-comment head check below only compares DiffHeadSHA, so a stale
-	// base would otherwise let an approval land on an out-of-date diff.
+	// Approve publishes include inline draft comments, so on providers
+	// that enforce head binding they use the reviewedHeadSHA gate shared
+	// with merge rather than direct /approve's provider-head target. This
+	// fails closed on a missing or stale reviewed diff snapshot, including
+	// a moved base SHA with an unchanged head. The per-comment head check
+	// below only compares DiffHeadSHA, so a stale base would otherwise let
+	// an approval land on an out-of-date diff.
 	if action == platform.ReviewActionApprove && caps.MutationHeadBinding {
 		gatedHead, gateErr := s.reviewedHeadSHA(repo, mr)
 		if gateErr != nil {

--- a/internal/server/e2etest/github_head_pin_test.go
+++ b/internal/server/e2etest/github_head_pin_test.go
@@ -2,8 +2,8 @@ package e2etest
 
 // Full-stack coverage for provider-enforced head pins on GitHub: the HTTP API
 // must hand the reviewed head to merge mutations, map the provider's moved-head
-// rejection to a 409 conflict with reason stale_state, and reject approval
-// paths before any non-atomic provider mutation runs.
+// rejection to a 409 conflict with reason stale_state, and send approval
+// reviews with the rendered commit id when one is available.
 
 import (
 	"context"
@@ -308,17 +308,28 @@ func TestGitHubMergeGenericConflictKeepsConflictReason(t *testing.T) {
 		"an unrelated provider conflict must not present as staleness")
 }
 
-func TestGitHubApproveUnsupportedBeforeProviderCall(t *testing.T) {
+func TestGitHubApproveSubmitsReview(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	var providerCalled atomic.Bool
+	var reviewCommitID string
 	mock := &mockGH{
 		createReviewWithCommentsFn: func(
-			_ context.Context, _, _ string, _ int, _, _, _ string,
+			_ context.Context, _, _ string, _ int, event, body, commitID string,
 			_ []*gh.DraftReviewComment,
 		) (*gh.PullRequestReview, error) {
 			providerCalled.Store(true)
-			return &gh.PullRequestReview{}, nil
+			reviewCommitID = commitID
+			id := int64(77)
+			state := event
+			now := gh.Timestamp{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}
+			return &gh.PullRequestReview{
+				ID:          &id,
+				State:       &state,
+				Body:        &body,
+				SubmittedAt: &now,
+				User:        &gh.User{Login: new("reviewer")},
+			}, nil
 		},
 	}
 	srv, _, _ := setupGitHubHeadPinServer(t, mock)
@@ -327,27 +338,36 @@ func TestGitHubApproveUnsupportedBeforeProviderCall(t *testing.T) {
 		"/api/v1/pulls/github/acme/widget/7/approve",
 		json.RawMessage(`{"body":"lgtm","expected_head_sha":"reviewed-sha"}`),
 	)
-	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
-	problem := decodeConflictProblemBody(t, json.NewDecoder(rr.Body))
-	assert.Equal("unsupportedCapability", problem.Code)
-	require.NotNil(problem.Details)
-	assert.Equal("review_mutation", problem.Details["capability"])
-	assert.Equal("github", problem.Details["provider"])
-	assert.Equal("github.com", problem.Details["platformHost"])
-	assert.False(providerCalled.Load())
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.True(providerCalled.Load())
+	assert.Equal("reviewed-sha", reviewCommitID)
 }
 
-func TestGitHubReviewDraftApproveUnsupportedBeforeProviderCall(t *testing.T) {
+func TestGitHubReviewDraftApprovePublishesReview(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	var providerCalled atomic.Bool
+	var reviewCommitID string
 	mock := &mockGH{
 		createReviewWithCommentsFn: func(
-			_ context.Context, _, _ string, _ int, _, _, _ string,
-			_ []*gh.DraftReviewComment,
+			_ context.Context, _, _ string, _ int, event, body, commitID string,
+			comments []*gh.DraftReviewComment,
 		) (*gh.PullRequestReview, error) {
 			providerCalled.Store(true)
-			return &gh.PullRequestReview{}, nil
+			reviewCommitID = commitID
+			assert.Equal("APPROVE", event)
+			assert.Equal("summary note", body)
+			assert.Len(comments, 1)
+			id := int64(78)
+			state := event
+			now := gh.Timestamp{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}
+			return &gh.PullRequestReview{
+				ID:          &id,
+				State:       &state,
+				Body:        &body,
+				SubmittedAt: &now,
+				User:        &gh.User{Login: new("reviewer")},
+			}, nil
 		},
 	}
 	srv, database, repoID := setupGitHubHeadPinServer(t, mock)
@@ -375,13 +395,10 @@ func TestGitHubReviewDraftApproveUnsupportedBeforeProviderCall(t *testing.T) {
 		"/api/v1/pulls/github/acme/widget/7/review-draft/publish",
 		json.RawMessage(`{"action":"approve","body":"summary note"}`),
 	)
-	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
-	problem := decodeConflictProblemBody(t, json.NewDecoder(rr.Body))
-	assert.Equal("unsupportedCapability", problem.Code)
-	require.NotNil(problem.Details)
-	assert.Equal("review_action_approve", problem.Details["capability"])
-	assert.False(providerCalled.Load())
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.True(providerCalled.Load())
+	assert.Equal("reviewed-sha", reviewCommitID)
 	storedDraft, err := database.GetMRReviewDraft(ctx, mr.ID)
 	require.NoError(err)
-	require.NotNil(storedDraft, "unsupported approve must preserve the local draft")
+	require.Nil(storedDraft)
 }

--- a/internal/server/e2etest/github_head_pin_test.go
+++ b/internal/server/e2etest/github_head_pin_test.go
@@ -3,7 +3,7 @@ package e2etest
 // Full-stack coverage for provider-enforced head pins on GitHub: the HTTP API
 // must hand the reviewed head to merge mutations, map the provider's moved-head
 // rejection to a 409 conflict with reason stale_state, and send approval
-// reviews with the rendered commit id when one is available.
+// reviews with the requested or stored provider head when one is available.
 
 import (
 	"context"
@@ -341,6 +341,42 @@ func TestGitHubApproveSubmitsReview(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	assert.True(providerCalled.Load())
 	assert.Equal("reviewed-sha", reviewCommitID)
+}
+
+func TestGitHubApproveOmittedHeadPinUsesStoredPlatformHead(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var providerCalled atomic.Bool
+	var reviewCommitID string
+	mock := &mockGH{
+		createReviewWithCommentsFn: func(
+			_ context.Context, _, _ string, _ int, event, body, commitID string,
+			_ []*gh.DraftReviewComment,
+		) (*gh.PullRequestReview, error) {
+			providerCalled.Store(true)
+			reviewCommitID = commitID
+			id := int64(79)
+			state := event
+			now := gh.Timestamp{Time: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}
+			return &gh.PullRequestReview{
+				ID:          &id,
+				State:       &state,
+				Body:        &body,
+				SubmittedAt: &now,
+				User:        &gh.User{Login: new("reviewer")},
+			}, nil
+		},
+	}
+	srv, database, repoID := setupGitHubHeadPinServerWithoutReviewedDiff(t, mock)
+	require.NoError(database.UpdatePlatformSHAs(t.Context(), repoID, 7, "platform-sha", "base-sha"))
+
+	rr := doJSONRequest(t, srv, http.MethodPost,
+		"/api/v1/pulls/github/acme/widget/7/approve",
+		json.RawMessage(`{"body":"lgtm"}`),
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.True(providerCalled.Load())
+	assert.Equal("platform-sha", reviewCommitID)
 }
 
 func TestGitHubReviewDraftApprovePublishesReview(t *testing.T) {

--- a/internal/server/e2etest/gitlab_mutations_test.go
+++ b/internal/server/e2etest/gitlab_mutations_test.go
@@ -673,6 +673,22 @@ func TestGitLabMutationApprove(t *testing.T) {
 	assert.True(commentSeen, "approval comment was not synced into local events")
 }
 
+func TestGitLabMutationApproveAllowsOmittedHeadPin(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, _, recorder, _ := setupGitLabMutationServer(t)
+
+	rr := doGitLabJSON(t, srv, http.MethodPost,
+		"/api/v1/pulls/gitlab/acme/widget/7/approve",
+		`{"body":"ship it"}`,
+	)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	approve, ok := recorder.find(http.MethodPost, "/api/v4/projects/4242/merge_requests/7/approve")
+	require.True(ok, "fake GitLab API did not receive approval")
+	assert.Contains(approve.Body, `"sha":"head-sha"`)
+}
+
 func TestGitLabMutationApproveStaleHeadReturnsConflict(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -1003,10 +1019,10 @@ func TestGitLabSquashAlwaysProjectDisallowsMergeCommitE2E(t *testing.T) {
 	assert.False(settings.AllowRebaseMerge)
 }
 
-// Head-binding providers reject merge and approve requests that omit the
-// client's head pin: an omitted pin would silently bind to whatever the
-// cache holds now, which may be newer than what the user reviewed.
-func TestGitLabMutationOmittedHeadPinRejected(t *testing.T) {
+// Head-binding providers reject merge requests that omit the client's head
+// pin: an omitted pin would silently bind to whatever the cache holds now,
+// which may be newer than what the user reviewed.
+func TestGitLabMergeOmittedHeadPinRejected(t *testing.T) {
 	tests := []struct {
 		name         string
 		path         string
@@ -1018,12 +1034,6 @@ func TestGitLabMutationOmittedHeadPinRejected(t *testing.T) {
 			path:         "/api/v1/pulls/gitlab/acme/widget/7/merge",
 			body:         `{"method":"squash","commit_title":"t","commit_message":"m"}`,
 			mutationPath: "/api/v4/projects/4242/merge_requests/7/merge",
-		},
-		{
-			name:         "approve",
-			path:         "/api/v1/pulls/gitlab/acme/widget/7/approve",
-			body:         `{"body":"ship it"}`,
-			mutationPath: "/api/v4/projects/4242/merge_requests/7/approve",
 		},
 	}
 	for _, tt := range tests {
@@ -1082,8 +1092,8 @@ func TestGitLabMutationResponsesExposeHeadSHA(t *testing.T) {
 
 // The stored head is only a cache: when a sync moves it between the
 // client's render and click, the client's expected_head_sha assertion
-// must reject the mutation before any provider call.
-func TestGitLabMutationClientExpectedHeadMismatchFailsClosed(t *testing.T) {
+// must reject merge before any provider call.
+func TestGitLabMergeClientExpectedHeadMismatchFailsClosed(t *testing.T) {
 	tests := []struct {
 		name         string
 		path         string
@@ -1095,12 +1105,6 @@ func TestGitLabMutationClientExpectedHeadMismatchFailsClosed(t *testing.T) {
 			path:         "/api/v1/pulls/gitlab/acme/widget/7/merge",
 			body:         `{"method":"squash","commit_title":"t","commit_message":"m","expected_head_sha":"reviewed-old-head"}`,
 			mutationPath: "/api/v4/projects/4242/merge_requests/7/merge",
-		},
-		{
-			name:         "approve",
-			path:         "/api/v1/pulls/gitlab/acme/widget/7/approve",
-			body:         `{"body":"ship it","expected_head_sha":"reviewed-old-head"}`,
-			mutationPath: "/api/v4/projects/4242/merge_requests/7/approve",
 		},
 	}
 	for _, tt := range tests {
@@ -1161,12 +1165,12 @@ func TestGitLabMutationGenericMergeConflictDoesNotResync(t *testing.T) {
 	assert.False(synced, "generic conflicts must not resync on head-binding providers")
 }
 
-// A legacy or partially synced row with no head SHA fails closed: the
-// user never reviewed any particular commit, so neither merge nor approve
-// may proceed. The path must not sync either — persisting a fresh head
-// would let an immediate retry from the same stale UI mutate a commit
-// nobody reviewed — so consecutive requests keep failing identically.
-func TestGitLabMutationMissingHeadSHAFailsClosed(t *testing.T) {
+// A legacy or partially synced row with no head SHA fails closed for merge:
+// the user never reviewed any particular commit, so merge may not proceed.
+// The path must not sync either — persisting a fresh head would let an
+// immediate retry from the same stale UI mutate a commit nobody reviewed —
+// so consecutive requests keep failing identically.
+func TestGitLabMergeMissingHeadSHAFailsClosed(t *testing.T) {
 	tests := []struct {
 		name         string
 		path         string
@@ -1178,12 +1182,6 @@ func TestGitLabMutationMissingHeadSHAFailsClosed(t *testing.T) {
 			path:         "/api/v1/pulls/gitlab/acme/widget/7/merge",
 			body:         `{"method":"squash","commit_title":"t","commit_message":"m"}`,
 			mutationPath: "/api/v4/projects/4242/merge_requests/7/merge",
-		},
-		{
-			name:         "approve",
-			path:         "/api/v1/pulls/gitlab/acme/widget/7/approve",
-			body:         `{"body":"ship it"}`,
-			mutationPath: "/api/v4/projects/4242/merge_requests/7/approve",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2392,28 +2392,7 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 
-	// Bind the approval to the head commit the user reviewed locally so a
-	// source-branch push between review and approval is rejected instead
-	// of approving unreviewed code.
-	expectedHeadSHA, err := s.reviewedHeadSHA(repo, mr)
-	if err != nil {
-		return nil, err
-	}
-	// Head-binding providers require the client to pin the head it
-	// rendered: an omitted pin would silently bind to whatever the cache
-	// holds now, which may be newer than what the user reviewed.
-	if strings.TrimSpace(input.Body.ExpectedHeadSHA) == "" &&
-		s.capabilitiesForRepo(*repo).MutationHeadBinding {
-		return nil, problemValidation(
-			"body.expected_head_sha",
-			"required for this provider: echo the platform_head_sha you rendered",
-		)
-	}
-	if err := s.verifyClientReviewedHead(
-		repo, input.Number, input.Body.ExpectedHeadSHA, expectedHeadSHA,
-	); err != nil {
-		return nil, err
-	}
+	expectedHeadSHA := approvalReviewHeadSHA(mr, input.Body.ExpectedHeadSHA)
 
 	platformEvent, err := mutator.ApproveMergeRequest(
 		ctx, platformRepoRefFromDB(*repo), input.Number, input.Body.Body,
@@ -2458,6 +2437,19 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	}
 
 	return &actionStatusOutput{Body: actionStatusBody{Status: "approved"}}, nil
+}
+
+func approvalReviewHeadSHA(mr *db.MergeRequest, clientSHA string) string {
+	if sha := strings.TrimSpace(clientSHA); sha != "" {
+		return sha
+	}
+	if mr == nil {
+		return ""
+	}
+	if mr.DiffHeadSHA != "" && !diffSnapshotStale(mr) {
+		return mr.DiffHeadSHA
+	}
+	return mr.PlatformHeadSHA
 }
 
 func (s *Server) approveWorkflows(ctx context.Context, input *repoNumberInput) (*actionStatusOutput, error) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2439,6 +2439,12 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	return &actionStatusOutput{Body: actionStatusBody{Status: "approved"}}, nil
 }
 
+// approvalReviewHeadSHA resolves the provider commit to attach a direct
+// approval to. Direct /approve is a provider-head mutation: clients should
+// send the head captured when the approval UI opened, normally
+// platform_head_sha. If older clients omit it, bind to the best stored
+// provider head. Merge and draft-review publish use reviewedHeadSHA instead
+// because those paths require a verified diff snapshot.
 func approvalReviewHeadSHA(mr *db.MergeRequest, clientSHA string) string {
 	if sha := strings.TrimSpace(clientSHA); sha != "" {
 		return sha

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -359,8 +359,9 @@ type mergePRInput struct {
 		CommitTitle   string `json:"commit_title"`
 		CommitMessage string `json:"commit_message"`
 		Method        string `json:"method"`
-		// ExpectedHeadSHA: see approvePRInput. Optional client assertion
-		// of the reviewed head commit.
+		// ExpectedHeadSHA is the reviewed diff head the client rendered.
+		// For head-binding providers, merge rejects missing, stale, or
+		// mismatched reviewed-head assertions before provider mutation.
 		ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
 	}
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -334,10 +334,10 @@ type approvePRInput struct {
 	Number       int    `path:"number"`
 	Body         struct {
 		Body string `json:"body"`
-		// ExpectedHeadSHA is the head commit the client rendered when the
-		// user reviewed. When set, the mutation is rejected if the locally
-		// synced head differs, so a sync between render and click cannot
-		// rebind the action to an unreviewed commit.
+		// ExpectedHeadSHA is the provider head the client intends to approve.
+		// Current clients capture platform_head_sha when the approval UI opens;
+		// if omitted, the server falls back to the best stored provider head
+		// for compatibility with older clients.
 		ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
 	}
 }
@@ -2400,8 +2400,8 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	)
 	if err != nil {
 		if errors.Is(err, platform.ErrStaleState) {
-			// The MR head moved past the reviewed commit; refresh local
-			// state so the user re-reviews against the current head.
+			// The MR head moved past the requested approval target; refresh
+			// local state so the user retries against the current head.
 			s.runBackground(func(bgCtx context.Context) {
 				if syncErr := s.syncer.SyncMROnProvider(
 					bgCtx,
@@ -2442,9 +2442,12 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 // approvalReviewHeadSHA resolves the provider commit to attach a direct
 // approval to. Direct /approve is a provider-head mutation: clients should
 // send the head captured when the approval UI opened, normally
-// platform_head_sha. If older clients omit it, bind to the best stored
-// provider head. Merge and draft-review publish use reviewedHeadSHA instead
-// because those paths require a verified diff snapshot.
+// platform_head_sha. Omitting the pin is a compatibility path for older
+// clients; in that case middleman binds the approval to the best stored
+// provider head rather than rejecting the request. Stale supplied pins are
+// delegated to provider head-binding where available and mapped through the
+// normal stale_state path. Merge and draft-review publish use reviewedHeadSHA
+// instead because those paths require a verified diff snapshot.
 func approvalReviewHeadSHA(mr *db.MergeRequest, clientSHA string) string {
 	if sha := strings.TrimSpace(clientSHA); sha != "" {
 		return sha

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -40,13 +40,9 @@
     oncompleted,
   }: Props = $props();
 
-  // A head-binding provider cannot approve without a pinned head; treat
-  // a missing synced head like a stale view.
-  const headPinMissing = $derived(requireHeadPin && !expectedHeadSha);
-
   // Captured when the approval form opens: a background detail refresh
   // must not silently rebind the pin while the form is on screen. A
-  // genuinely moved head is rejected by the server against this pin.
+  // provider with SHA guards can reject a moved head against this pin.
   let pinAtOpen = $state("");
 
   let expanded = $state(false);
@@ -111,7 +107,7 @@
   }
 
   async function handleApprove(): Promise<void> {
-    if (disabled || headPinMissing || submitting) return;
+    if (disabled || submitting) return;
     submitting = true;
     error = null;
     try {
@@ -137,13 +133,11 @@
       if (!expanded) pinAtOpen = (expectedHeadSha ?? "").trim();
       expanded = !expanded;
     }}
-    disabled={disabled || headPinMissing || submitting}
+    disabled={disabled || submitting}
     ariaExpanded={expanded}
     tone="success"
     surface="soft"
-    title={headPinMissing
-      ? "The reviewed head commit has not been synced yet; approving is disabled until the next sync records it"
-      : expanded
+    title={expanded
         ? "Close the approval form"
         : "Open the approval form to submit a code review on this pull request"}
     label="Approve"

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -17,8 +17,10 @@
     repoPath: string;
     size?: "sm" | "md";
     disabled?: boolean;
-    /** Head commit the rendered detail showed; pinned on approve. */
+    /** Head commit the rendered diff showed; fallback pin on approve. */
     expectedHeadSha?: string | undefined;
+    /** Latest synced PR head from the provider; preferred pin on approve. */
+    platformHeadSha?: string | undefined;
     /** capabilities.mutation_head_binding for this repo's provider. */
     requireHeadPin?: boolean;
     onheadconflict?: ((reason: "stale_state" | "head_unknown", context?: string) => void) | undefined;
@@ -35,6 +37,7 @@
     size = "md",
     disabled = false,
     expectedHeadSha,
+    platformHeadSha,
     requireHeadPin = false,
     onheadconflict,
     oncompleted,
@@ -130,7 +133,7 @@
     class="btn btn--approve"
     onclick={() => {
       if (disabled || submitting) return;
-      if (!expanded) pinAtOpen = (expectedHeadSha ?? "").trim();
+      if (!expanded) pinAtOpen = (platformHeadSha ?? expectedHeadSha ?? "").trim();
       expanded = !expanded;
     }}
     disabled={disabled || submitting}

--- a/packages/ui/src/components/detail/ApproveButton.svelte.test.ts
+++ b/packages/ui/src/components/detail/ApproveButton.svelte.test.ts
@@ -63,4 +63,47 @@ describe("ApproveButton head conflicts", () => {
     expect(screen.getByRole("dialog", { name: "Approve pull request" })).toBeTruthy();
     expect(screen.queryByText("target changed since it was reviewed; refresh and retry")).toBeNull();
   });
+
+  it("submits the latest synced platform head when it differs from reviewed head", async () => {
+    const post = vi.fn().mockResolvedValue({
+      data: { status: "approved" },
+      error: undefined,
+      response: new Response("{}"),
+    });
+    render(ApproveButton, {
+      props: {
+        owner: "acme",
+        name: "widget",
+        number: 7,
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/widget",
+        expectedHeadSha: "reviewed-sha",
+        platformHeadSha: "platform-head-sha",
+      },
+      context: new Map<symbol, unknown>([
+        [
+          API_CLIENT_KEY,
+          {
+            POST: post,
+          },
+        ],
+        [
+          STORES_KEY,
+          {
+            detail: { loadDetail: vi.fn().mockResolvedValue(undefined) },
+            pulls: { loadPulls: vi.fn().mockResolvedValue(undefined) },
+          },
+        ],
+      ]),
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    const dialog = screen.getByRole("dialog", { name: "Approve pull request" });
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+    const [, init] = post.mock.calls[0] as [string, { body: { expected_head_sha?: string } }];
+    expect(init.body.expected_head_sha).toBe("platform-head-sha");
+  });
 });

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -633,9 +633,9 @@
   let showMergeModal = $state(false);
 
   // Head-pinning conflict state (context/provider-architecture.md
-  // "Head binding"). Merge and approve echo the rendered head as
-  // expected_head_sha; a 409 conflict with reason stale_state or
-  // head_unknown lands here.
+  // "Head binding"). Merge echoes the rendered reviewed head, while
+  // approve sends the latest synced provider head when known. A 409
+  // conflict with reason stale_state or head_unknown lands here.
   let headConflict = $state<"stale_state" | "head_unknown" | null>(null);
   // Provider side-effect context from the conflict response (an
   // approval that could not be revoked, posted review text a retry
@@ -645,19 +645,22 @@
   const detailHeadSha = $derived(
     detailStore.getDetail()?.reviewed_head_sha ?? "",
   );
+  const latestPlatformHeadSha = $derived(
+    detailStore.getDetail()?.platform_head_sha ?? "",
+  );
   // After head_unknown the reviewed head stays unbound until diff sync
   // records a current snapshot,
-  // so head-bound actions (approve, merge) are disabled until the
-  // refreshed detail carries a reviewed head SHA again. Once the SHA arrives
-  // this clears on its own; the stale_state prompt instead stays until
-  // the user completes a head-bound action or navigates away.
+  // so merge is disabled until the refreshed detail carries a reviewed
+  // head SHA again. Once the SHA arrives this clears on its own; the
+  // stale_state prompt instead stays until the user completes a
+  // head-bound action or navigates away.
   const headActionsBlocked = $derived(
     headConflict === "head_unknown" && detailHeadSha === "",
   );
-  // Preflight guard: a head-binding provider must never fire an unbound
-  // mutation, so head-bound actions stay disabled until diff sync proves
-  // the rendered code matches the current head — no request, no 409
-  // round trip.
+  // Preflight guard for merge: a head-binding provider must never merge
+  // against an unbound reviewed diff, so merge stays disabled until diff
+  // sync proves the rendered code matches the current head — no request,
+  // no 409 round trip.
   const headPinMissing = $derived(
     (detailStore.getDetail()?.repo?.capabilities?.mutation_head_binding ?? false)
       && detailHeadSha === "",
@@ -1704,6 +1707,7 @@
               size="sm"
               disabled={stalePR || headActionsBlocked}
               expectedHeadSha={detailHeadSha}
+              platformHeadSha={latestPlatformHeadSha}
               requireHeadPin={capabilities.mutation_head_binding}
               onheadconflict={handleHeadConflict}
               oncompleted={() => { headConflict = null; headConflictContext = null; }}

--- a/packages/ui/src/components/detail/keyboard-actions.test.ts
+++ b/packages/ui/src/components/detail/keyboard-actions.test.ts
@@ -84,6 +84,7 @@ interface BuildOpts {
   approveCommentBody?: string;
   platformHost?: string;
   expectedHeadSha?: string;
+  requireHeadPin?: boolean;
   onHeadConflict?: (reason: "stale_state" | "head_unknown") => void;
 }
 
@@ -121,6 +122,7 @@ function buildInput(opts: BuildOpts = {}): PRDetailActionInput {
             viewerCanMerge: true,
           }),
     stale: opts.stale ?? false,
+    requireHeadPin: opts.requireHeadPin ?? false,
     stores: stores as unknown as PRDetailActionInput["stores"],
     client,
     ...(opts.approveCommentBody !== undefined && {
@@ -175,6 +177,10 @@ describe("canApprovePR", () => {
 
   it("returns true for open PR with approve capability", () => {
     expect(canApprovePR(buildInput())).toBe(true);
+  });
+
+  it("returns true when approval head pinning is unavailable", () => {
+    expect(canApprovePR(buildInput({ requireHeadPin: true }))).toBe(true);
   });
 });
 

--- a/packages/ui/src/components/detail/keyboard-actions.test.ts
+++ b/packages/ui/src/components/detail/keyboard-actions.test.ts
@@ -83,6 +83,7 @@ interface BuildOpts {
   onError?: (msg: string) => void;
   approveCommentBody?: string;
   platformHost?: string;
+  platformHeadSha?: string;
   expectedHeadSha?: string;
   requireHeadPin?: boolean;
   onHeadConflict?: (reason: "stale_state" | "head_unknown") => void;
@@ -96,6 +97,7 @@ function buildInput(opts: BuildOpts = {}): PRDetailActionInput {
       State: opts.state ?? "open",
       IsDraft: opts.isDraft ?? false,
       MergeableState: opts.mergeableState ?? "clean",
+      platform_head_sha: opts.platformHeadSha,
     },
     ref: {
       provider: "github",
@@ -257,7 +259,7 @@ describe("runApprovePR", () => {
     expect(client.POST).not.toHaveBeenCalled();
   });
 
-  it("echoes the reviewed head as expected_head_sha when provided", async () => {
+  it("echoes the reviewed head as expected_head_sha when only reviewed head is provided", async () => {
     const client = fakeClient();
     await runApprovePR(
       buildInput({
@@ -269,7 +271,20 @@ describe("runApprovePR", () => {
     expect(init.body).toEqual({ body: "", expected_head_sha: "abc123" });
   });
 
-  it("omits expected_head_sha when the rendered head is unknown", async () => {
+  it("prefers the latest synced platform head over the reviewed head", async () => {
+    const client = fakeClient();
+    await runApprovePR(
+      buildInput({
+        client,
+        platformHeadSha: " platform-head ",
+        expectedHeadSha: " reviewed-head ",
+      }),
+    );
+    const [, init] = client.POST.mock.calls[0];
+    expect(init.body).toEqual({ body: "", expected_head_sha: "platform-head" });
+  });
+
+  it("omits expected_head_sha when no synced or reviewed head is known", async () => {
     const client = fakeClient();
     await runApprovePR(buildInput({ client, expectedHeadSha: "" }));
     const [, init] = client.POST.mock.calls[0];
@@ -354,6 +369,22 @@ describe("canOpenMerge", () => {
 
   it("returns false when PR has merge conflicts (dirty)", () => {
     expect(canOpenMerge(buildInput({ mergeableState: "dirty" }))).toBe(false);
+  });
+
+  it("returns false when head binding requires a reviewed head and only the platform head is known", () => {
+    expect(
+      canOpenMerge(
+        buildInput({
+          requireHeadPin: true,
+          platformHeadSha: "synced-head",
+          expectedHeadSha: "",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when head binding requires and has a reviewed head", () => {
+    expect(canOpenMerge(buildInput({ requireHeadPin: true, expectedHeadSha: "reviewed-head" }))).toBe(true);
   });
 
   it("returns true for clean open PR with merge capability", () => {

--- a/packages/ui/src/components/detail/keyboard-actions.ts
+++ b/packages/ui/src/components/detail/keyboard-actions.ts
@@ -257,23 +257,16 @@ function describeError(err: { detail?: string; title?: string } | undefined, fal
 // Approve PR ----------------------------------------------------------
 
 export function canApprovePR(input: PRDetailActionInput): boolean {
-  return (
-    input.pr.State === "open" &&
-    input.viewerCan.approve &&
-    !input.stale &&
-    (!input.requireHeadPin || !!input.pr.platform_head_sha)
-  );
+  return input.pr.State === "open" && input.viewerCan.approve && !input.stale;
 }
 
 export async function runApprovePR(input: PRDetailActionInput): Promise<void> {
   if (!canApprovePR(input)) return;
   const { ref, number } = input;
   const body = (input.approveCommentBody ?? "").trim();
-  // Pin the approval to the head the user reviewed; the server rejects
-  // the request when the synced head has moved past it. Callers that
-  // build the input from the loaded detail pass expectedHeadSha; the
-  // pr row's platform_head_sha is the fallback for callers that already
-  // projected the reviewed head into the action input.
+  // Include the head the user reviewed when available. Providers that
+  // support SHA guards can reject stale approvals; others attach the
+  // review to the supplied commit or approve the current head.
   const expectedHeadSha = (input.expectedHeadSha ?? input.pr.platform_head_sha ?? "").trim();
   const { error } = await input.client.POST(providerItemPath("pulls", ref, "/approve"), {
     params: { path: { ...providerRouteParams(ref), number } },

--- a/packages/ui/src/components/detail/keyboard-actions.ts
+++ b/packages/ui/src/components/detail/keyboard-actions.ts
@@ -196,9 +196,10 @@ export interface PRDetailActionInput {
   stores: PRDetailActionStores;
   client: MiddlemanClient;
   /**
-   * True when the provider hard-binds mutations to the reviewed head
-   * (capabilities.mutation_head_binding). Head-bound actions are
-   * unavailable until the loaded detail carries reviewed_head_sha to pin.
+   * True when the provider supports mutation head binding
+   * (capabilities.mutation_head_binding). Merge is unavailable until the
+   * loaded detail carries reviewed_head_sha to pin; approve may still run
+   * and sends the latest synced provider head when known.
    */
   requireHeadPin?: boolean;
   /**
@@ -209,9 +210,10 @@ export interface PRDetailActionInput {
   approveCommentBody?: string;
   /**
    * Head commit the rendered detail was reviewed at
-   * (detail.reviewed_head_sha). When set, head-bound mutations echo it
-   * as expected_head_sha so the server rejects the action with a 409
-   * conflict if a sync rebound the head between render and click.
+   * (detail.reviewed_head_sha). Merge uses this as its strict pin.
+   * Approve prefers pr.platform_head_sha so the provider receives the
+   * latest synced PR head, then falls back here if the platform head is
+   * unknown.
    */
   expectedHeadSha?: string;
   /**
@@ -250,6 +252,10 @@ function hasMergeConflicts(pr: PRDetailActionPR): boolean {
   return pr.State === "open" && pr.MergeableState === "dirty";
 }
 
+function hasReviewedHeadPin(input: PRDetailActionInput): boolean {
+  return (input.expectedHeadSha ?? "").trim() !== "";
+}
+
 function describeError(err: { detail?: string; title?: string } | undefined, fallback: string): string {
   return err?.detail ?? err?.title ?? fallback;
 }
@@ -264,10 +270,11 @@ export async function runApprovePR(input: PRDetailActionInput): Promise<void> {
   if (!canApprovePR(input)) return;
   const { ref, number } = input;
   const body = (input.approveCommentBody ?? "").trim();
-  // Include the head the user reviewed when available. Providers that
+  // Include the latest synced PR head when available. Providers that
   // support SHA guards can reject stale approvals; others attach the
-  // review to the supplied commit or approve the current head.
-  const expectedHeadSha = (input.expectedHeadSha ?? input.pr.platform_head_sha ?? "").trim();
+  // review to the supplied commit or approve the current head. Fall back
+  // to reviewed_head_sha only when the provider head is unknown.
+  const expectedHeadSha = (input.pr.platform_head_sha ?? input.expectedHeadSha ?? "").trim();
   const { error } = await input.client.POST(providerItemPath("pulls", ref, "/approve"), {
     params: { path: { ...providerRouteParams(ref), number } },
     body: {
@@ -303,7 +310,7 @@ export function canOpenMerge(input: PRDetailActionInput): boolean {
     input.repoSettings.viewerCanMerge &&
     !input.stale &&
     !hasMergeConflicts(input.pr) &&
-    (!input.requireHeadPin || !!input.pr.platform_head_sha)
+    (!input.requireHeadPin || hasReviewedHeadPin(input))
   );
 }
 


### PR DESCRIPTION
The GitLab parity work made approval availability depend on providers proving an atomic head-bound approval path. That hid the APPROVE button for GitHub and under-advertised Gitea-like provider review APIs, even though approval is a safe review mutation when middleman sends a head SHA opportunistically instead of requiring one locally.

This restores approval as a normal provider review action while keeping merge on the stricter head-bound path. Reviewers should treat this as a regression fix for maintainer workflow parity across providers, with GitLab approval matching its API contract where `sha` is optional but checked when supplied.

Validation:
- `make test-short`
- `make frontend-check`
- `cd frontend && bun x playwright test --config=playwright.config.ts --project=chromium tests/e2e/head-pinned-actions.spec.ts`
- `cd frontend && bun x playwright test --config=playwright.config.ts --project=firefox tests/e2e/head-pinned-actions.spec.ts`
- `cd frontend && bun x playwright test --config=playwright-e2e.config.ts --project=chromium tests/e2e-full/detail-action-buttons.spec.ts`
- `cd frontend && bun x playwright test --config=playwright-e2e.config.ts --project=firefox tests/e2e-full/detail-action-buttons.spec.ts`
- focused provider/server approval tests
- frontend approval action tests