### PR TITLE
Fix workspace diff rendering and context expansion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@lucide/svelte": "1.17.0",
-        "@pierre/diffs": "1.2.7",
+        "@pierre/diffs": "1.2.10",
         "@pierre/trees": "1.0.0-beta.4",
         "@tiptap/core": "3.26.0",
         "@tiptap/extension-document": "3.26.0",
@@ -279,9 +279,11 @@
 
     "@oxlint/plugins": ["@oxlint/plugins@1.61.0", "", {}, "sha512-nkOyZEF1vH527CkdQtOp1HMrVFEM4ResURvI2JFeGoup+h+43J/k/FgdOR9b9Isxg+Yae7qVDa7y3nssE8b3TQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.7", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-YrHmFZLDtiLZ4DkiVqMDUFqTFIct3ML3t20nMp0UeuiUtqrmRcenYVxPb4IafiNkhZZURhCiwcs89tVb/HrSDA=="],
+    "@pierre/diffs": ["@pierre/diffs@1.2.10", "", { "dependencies": { "@pierre/theme": "1.0.3", "@pierre/theming": "0.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-rPeAmDWarxFVTQpaf4y6wTxjZxU44xKJKoJti2zU21P06DVd9nRHZX+xSIObLB307Qjpaesyb1x/j0z94t7vLw=="],
 
     "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
+
+    "@pierre/theming": ["@pierre/theming@0.0.1", "", { "peerDependencies": { "@pierre/theme": "^1.0.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-1thlEtJbqdyLzc1ZS2KQa1q7FzDGHT4dTEdKHoyQjOMeWWOmbVG5/ndEfOKfAb5Fzkz8cNJrOjFLiZoDH/A03A=="],
 
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -11196,6 +11196,80 @@ paths:
       summary: Get workspace diff
       tags:
         - Workspaces
+  /workspaces/{id}/file-preview:
+    get:
+      operationId: get-workspace-file-preview
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: "Diff base: head, pushed, or merge-target"
+          explode: false
+          in: query
+          name: base
+          schema:
+            description: "Diff base: head, pushed, or merge-target"
+            type: string
+        - description: Set to hide to ignore whitespace-only changes
+          explode: false
+          in: query
+          name: whitespace
+          schema:
+            description: Set to hide to ignore whitespace-only changes
+            type: string
+        - description: Changed file path to preview
+          explode: false
+          in: query
+          name: path
+          schema:
+            description: Changed file path to preview
+            type: string
+        - description: Optional diff side to read for context expansion
+          explode: false
+          in: query
+          name: side
+          schema:
+            description: Optional diff side to read for context expansion
+            type: string
+        - description: Scope to a single commit SHA
+          explode: false
+          in: query
+          name: commit
+          schema:
+            description: Scope to a single commit SHA
+            type: string
+        - description: Start SHA for range diff (inclusive)
+          explode: false
+          in: query
+          name: from
+          schema:
+            description: Start SHA for range diff (inclusive)
+            type: string
+        - description: End SHA for range diff (inclusive)
+          explode: false
+          in: query
+          name: to
+          schema:
+            description: End SHA for range diff (inclusive)
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FilePreviewResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get workspace file preview
+      tags:
+        - Workspaces
   /workspaces/{id}/files:
     get:
       operationId: get-workspace-files

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -11211,6 +11211,10 @@ paths:
           name: base
           schema:
             description: "Diff base: head, pushed, or merge-target"
+            enum:
+              - head
+              - pushed
+              - merge-target
             type: string
         - description: Set to hide to ignore whitespace-only changes
           explode: false
@@ -11218,6 +11222,8 @@ paths:
           name: whitespace
           schema:
             description: Set to hide to ignore whitespace-only changes
+            enum:
+              - hide
             type: string
         - description: Changed file path to preview
           explode: false
@@ -11232,6 +11238,9 @@ paths:
           name: side
           schema:
             description: Optional diff side to read for context expansion
+            enum:
+              - old
+              - new
             type: string
         - description: Scope to a single commit SHA
           explode: false

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1959,9 +1959,12 @@
     // the user is still looking at it. Navigate away even after
     // an A→B→A round trip — otherwise they'd be staring at a
     // workspace that no longer exists.
-    if (!window.location.pathname.endsWith(`/terminal/${targetId}`))
-      return;
+    if (!isCurrentTerminalRoute(targetId)) return;
     navigate("/workspaces");
+  }
+
+  function isCurrentTerminalRoute(targetId: string): boolean {
+    return window.location.pathname.endsWith(`/terminal/${targetId}`);
   }
 
   async function confirmForceDelete(): Promise<void> {
@@ -2002,6 +2005,7 @@
       // destroyed.
       forcePromptMessage = null;
       forcePromptForId = null;
+      if (!isCurrentTerminalRoute(targetId)) return;
       navigate("/workspaces");
     } finally {
       forceDeleting = false;

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1959,6 +1959,8 @@
     // the user is still looking at it. Navigate away even after
     // an A→B→A round trip — otherwise they'd be staring at a
     // workspace that no longer exists.
+    if (!window.location.pathname.endsWith(`/terminal/${targetId}`))
+      return;
     navigate("/workspaces");
   }
 

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -197,10 +197,18 @@
     terminal.refresh(0, Math.max(0, terminal.rows - 1));
   }
 
+  function isFirefox(): boolean {
+    return navigator.userAgent.toLowerCase().includes("firefox/");
+  }
+
   function recreateWebglAddon(): void {
     if (!terminal) return;
     webglAddon?.dispose();
     webglAddon = null;
+    if (isFirefox()) {
+      scheduleTerminalResize();
+      return;
+    }
     try {
       const wgl = new WebglAddon();
       wgl.onContextLoss(() => {

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -406,6 +406,80 @@ describe("createDiffStore loadDiff", () => {
     expect(store.getScope()).toEqual({ kind: "commit", sha: "sha2" });
   });
 
+  it("keeps workspace preview generation stable until refreshed diff load starts", async () => {
+    const calls: string[] = [];
+    let resolveRefreshCommits: () => void = () => {};
+    let refreshCommitsStarted: () => void = () => {};
+    const refreshCommitsStartedPromise = new Promise<void>((resolve) => {
+      refreshCommitsStarted = resolve;
+    });
+    const refreshCommitsGate = new Promise<void>((resolve) => {
+      resolveRefreshCommits = resolve;
+    });
+    const commitResponses = [
+      [
+        {
+          sha: "sha2",
+          message: "second",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      [
+        {
+          sha: "sha2",
+          message: "second",
+          author_name: "Alice",
+          authored_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    ];
+    const files = makeFilesResult(["src/app.go"]);
+    const diff = makeDiffResult(["src/app.go"]);
+    let store: ReturnType<typeof createDiffStore>;
+    let generationAtRefreshedFilesRequest = -1;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+      if (url.includes("/workspaces/ws-1/commits")) {
+        if (commitResponses.length === 1) {
+          refreshCommitsStarted();
+          await refreshCommitsGate;
+        }
+        return Response.json({
+          commits: commitResponses.shift() ?? [],
+        });
+      }
+      if (url.includes("/workspaces/ws-1/files")) {
+        if (calls.includes("/api/v1/workspaces/ws-1/commits")) {
+          generationAtRefreshedFilesRequest = store.getFilePreviewGeneration();
+        }
+        return Response.json(files);
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json(diff);
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "merge-target");
+    await store.loadCommits();
+    const generationBeforeRefresh = store.getFilePreviewGeneration();
+
+    const refresh = store.loadWorkspaceDiff("ws-1", "merge-target", false, { refreshCommits: true });
+    await refreshCommitsStartedPromise;
+
+    expect(store.getFilePreviewGeneration()).toBe(generationBeforeRefresh);
+
+    resolveRefreshCommits();
+    await refresh;
+
+    expect(generationAtRefreshedFilesRequest).toBe(generationBeforeRefresh + 1);
+    expect(store.getFilePreviewGeneration()).toBe(generationBeforeRefresh + 1);
+  });
+
   it("resets workspace commit scope when refresh removes the selected commit", async () => {
     const calls: string[] = [];
     const commitResponses = [

--- a/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
@@ -5,7 +5,7 @@
 import { execFileSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
+import { expect, request as playwrightRequest, test, type APIRequestContext, type Locator } from "@playwright/test";
 import { startIsolatedWorkspaceE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
 
 type WorkspaceStatusResponse = {
@@ -24,6 +24,10 @@ function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   } catch {
     return false;
   }
+}
+
+function runGit(worktreePath: string, args: string[]): void {
+  execFileSync("git", args, { cwd: worktreePath, stdio: "ignore" });
 }
 
 async function waitForWorkspaceReady(api: APIRequestContext, workspaceId: string): Promise<void> {
@@ -51,6 +55,39 @@ async function createIssueWorkspace(api: APIRequestContext, issueNumber: number)
   const createdWorkspace = (await createResponse.json()) as WorkspaceStatusResponse;
   await waitForWorkspaceReady(api, createdWorkspace.id);
   return createdWorkspace;
+}
+
+async function clickPierreExpander(file: Locator, separatorIndex: number): Promise<void> {
+  const expander = file
+    .locator(".pierre-diff [data-separator][data-expand-index]")
+    .filter({ visible: true })
+    .nth(separatorIndex)
+    .locator("[data-expand-button]")
+    .filter({ visible: true })
+    .first();
+  await expect(expander).toBeVisible();
+  await expander.evaluate((button: HTMLElement) => {
+    button.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        shiftKey: true,
+      }),
+    );
+  });
+}
+
+async function expandedContextStats(file: Locator): Promise<{ blank: number; texts: string[] }> {
+  return await file.locator(".pierre-diff").evaluate((host) => {
+    const rows = Array.from(
+      host.shadowRoot?.querySelectorAll("[data-content] [data-line-type='context-expanded']") ?? [],
+    ).map((element) => element.textContent?.trim() ?? "");
+    return {
+      blank: rows.filter((text) => text.length === 0).length,
+      texts: rows.filter((text) => text.length > 0),
+    };
+  });
 }
 
 test.describe("workspace tab persistence", () => {
@@ -348,6 +385,93 @@ test.describe("workspace tab persistence", () => {
       await expect(page).toHaveURL(new RegExp(`/terminal/${workspace.id}$`));
       await expect(workflow.getByRole("tab", { name: "Shell" })).toHaveAttribute("aria-selected", "true");
       await expect(alphaDiffFile).toBeVisible();
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("workspace diff context expansion renders text from the real preview API", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+    await page.setViewportSize({ width: 1400, height: 860 });
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const workspace = await createIssueWorkspace(api, 12);
+      const workspaceResponse = await api.get(`/api/v1/workspaces/${workspace.id}`);
+      expect(workspaceResponse.ok()).toBe(true);
+      const workspaceDetail = (await workspaceResponse.json()) as WorkspaceStatusResponse;
+      expect(workspaceDetail.worktree_path).toBeTruthy();
+      const worktreePath = workspaceDetail.worktree_path!;
+
+      runGit(worktreePath, ["config", "user.email", "test@test.com"]);
+      runGit(worktreePath, ["config", "user.name", "Test"]);
+      const baseLines = Array.from({ length: 120 }, (_, index) => `workspace hidden line ${index + 1}`);
+      await writeFile(join(worktreePath, "expand-context.ts"), `${baseLines.join("\n")}\n`);
+      runGit(worktreePath, ["add", "expand-context.ts"]);
+      runGit(worktreePath, ["commit", "-m", "add expandable context fixture"]);
+      const changedLines = [...baseLines];
+      changedLines[9] = "workspace changed line 10";
+      changedLines[89] = "workspace changed line 90";
+      await writeFile(join(worktreePath, "expand-context.ts"), `${changedLines.join("\n")}\n`);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+      await page.locator(".seg-control .seg-btn", { hasText: "Diff" }).click();
+      const previewResponses = Promise.all([
+        page.waitForResponse((response) => {
+          const url = response.url();
+          return (
+            response.request().method() === "GET" &&
+            url.includes(`/api/v1/workspaces/${workspace.id}/file-preview`) &&
+            url.includes("path=expand-context.ts") &&
+            url.includes("side=old")
+          );
+        }),
+        page.waitForResponse((response) => {
+          const url = response.url();
+          return (
+            response.request().method() === "GET" &&
+            url.includes(`/api/v1/workspaces/${workspace.id}/file-preview`) &&
+            url.includes("path=expand-context.ts") &&
+            url.includes("side=new")
+          );
+        }),
+      ]);
+
+      const file = page.locator('.right-sidebar .diff-file[data-file-path="expand-context.ts"]');
+      await expect(file).toBeVisible();
+      await expect
+        .poll(async () => {
+          return await file.locator(".pierre-diff").evaluate((host) => {
+            return host.shadowRoot?.querySelectorAll("[data-separator][data-expand-index]").length ?? 0;
+          });
+        })
+        .toBeGreaterThanOrEqual(2);
+      await clickPierreExpander(file, 1);
+      const responses = await previewResponses;
+      expect(responses.every((response) => response.ok())).toBe(true);
+
+      await expect
+        .poll(async () => {
+          const stats = await expandedContextStats(file);
+          return {
+            blank: stats.blank,
+            hasMiddleLine: stats.texts.some((text) => text.includes("workspace hidden line 50")),
+          };
+        })
+        .toEqual({
+          blank: 0,
+          hasMiddleLine: true,
+        });
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
@@ -90,6 +90,10 @@ async function expandedContextStats(file: Locator): Promise<{ blank: number; tex
   });
 }
 
+async function pierreDiffText(file: Locator): Promise<string> {
+  return await file.locator(".pierre-diff").evaluate((host) => host.shadowRoot?.textContent ?? "");
+}
+
 test.describe("workspace tab persistence", () => {
   test.describe.configure({
     mode: "serial",
@@ -471,6 +475,67 @@ test.describe("workspace tab persistence", () => {
         .toEqual({
           blank: 0,
           hasMiddleLine: true,
+        });
+
+      const refreshedLines = [...changedLines];
+      refreshedLines[49] = "workspace refreshed hidden line 50";
+      await writeFile(join(worktreePath, "expand-context.ts"), `${refreshedLines.join("\n")}\n`);
+
+      const refreshResponse = page.waitForResponse((response) => {
+        return (
+          response.request().method() === "POST" &&
+          response.url().includes(`/api/v1/workspaces/${workspace.id}/refresh`)
+        );
+      });
+      await page.getByRole("button", { name: "Refresh workspace details" }).click();
+      expect((await refreshResponse).ok()).toBe(true);
+      await expect
+        .poll(async () => (await pierreDiffText(file)).includes("workspace refreshed hidden line 50"))
+        .toBe(true);
+
+      const refreshedPreviewResponses = Promise.all([
+        page.waitForResponse((response) => {
+          const url = response.url();
+          return (
+            response.request().method() === "GET" &&
+            url.includes(`/api/v1/workspaces/${workspace.id}/file-preview`) &&
+            url.includes("path=expand-context.ts") &&
+            url.includes("side=old")
+          );
+        }),
+        page.waitForResponse((response) => {
+          const url = response.url();
+          return (
+            response.request().method() === "GET" &&
+            url.includes(`/api/v1/workspaces/${workspace.id}/file-preview`) &&
+            url.includes("path=expand-context.ts") &&
+            url.includes("side=new")
+          );
+        }),
+      ]);
+      await expect
+        .poll(async () => {
+          return await file.locator(".pierre-diff").evaluate((host) => {
+            return host.shadowRoot?.querySelectorAll("[data-separator][data-expand-index]").length ?? 0;
+          });
+        })
+        .toBeGreaterThanOrEqual(3);
+      await clickPierreExpander(file, 1);
+      const refreshedResponses = await refreshedPreviewResponses;
+      expect(refreshedResponses.every((response) => response.ok())).toBe(true);
+      await expect
+        .poll(async () => {
+          const stats = await expandedContextStats(file);
+          return {
+            blank: stats.blank,
+            hasStaleHiddenLine: stats.texts.some((text) => text.includes("workspace hidden line 50")),
+            hasUnchangedContext: stats.texts.some((text) => text.includes("workspace hidden line 40")),
+          };
+        })
+        .toEqual({
+          blank: 0,
+          hasStaleHiddenLine: false,
+          hasUnchangedContext: true,
         });
     } finally {
       await api?.dispose();

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -616,6 +616,43 @@ async function expectRenderedNonBlankRows(file: ReturnType<Page["locator"]>, tex
     });
 }
 
+async function expectRenderedPierreContainmentDisabled(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        return await page.locator(".diff-file .pierre-diff").evaluateAll((hosts) => {
+          for (const host of hosts) {
+            const root = host.shadowRoot;
+            const code = root?.querySelector("code");
+            if (!(root instanceof ShadowRoot) || !(code instanceof HTMLElement)) continue;
+
+            const visibleTextRows = Array.from(root.querySelectorAll("[data-content] [data-line-type]")).filter(
+              (element): element is HTMLElement => {
+                if (!(element instanceof HTMLElement)) return false;
+                const rect = element.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0 && (element.textContent?.trim().length ?? 0) > 0;
+              },
+            ).length;
+            if (visibleTextRows === 0) continue;
+
+            const placeholderProbe = document.createElement("div");
+            placeholderProbe.dataset.placeholder = "";
+            root.append(placeholderProbe);
+            const containment = {
+              code: getComputedStyle(code).contain,
+              placeholder: getComputedStyle(placeholderProbe).contain,
+            };
+            placeholderProbe.remove();
+            return containment;
+          }
+          return null;
+        });
+      },
+      { timeout: 10_000 },
+    )
+    .toEqual({ code: "none", placeholder: "none" });
+}
+
 async function scrollDiffAreaUntilPierreText(
   page: Page,
   diffArea: Locator,
@@ -1598,6 +1635,7 @@ test.describe("diff view", () => {
         timeout: 10_000,
       })
       .toBe(0);
+    await expectRenderedPierreContainmentDisabled(page);
   });
 
   test("rich preview toggle renders markdown and browser images", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -616,6 +616,57 @@ async function expectRenderedNonBlankRows(file: ReturnType<Page["locator"]>, tex
     });
 }
 
+async function expectVisibleExpandedRowContent(file: ReturnType<Page["locator"]>, expectedText: string) {
+  await expect
+    .poll(async () => {
+      return await file.locator(".pierre-diff").evaluate((host, expectedText) => {
+        const root = host.shadowRoot;
+        const gutters = Array.from(root?.querySelectorAll("[data-gutter] > [data-line-index]") ?? []);
+        const contents = Array.from(root?.querySelectorAll("[data-content] > [data-line-index]") ?? []);
+        const visibleExpanded = gutters.filter((gutter): gutter is HTMLElement => {
+          if (!(gutter instanceof HTMLElement)) return false;
+          if (gutter.getAttribute("data-line-type") !== "context-expanded") return false;
+          const rect = gutter.getBoundingClientRect();
+          return rect.bottom > 0 && rect.top < window.innerHeight;
+        });
+
+        let matched = false;
+        let missing = 0;
+        let blank = 0;
+        for (const gutter of visibleExpanded) {
+          const gutterRect = gutter.getBoundingClientRect();
+          const index = gutter.getAttribute("data-line-index");
+          const content = contents.find((candidate): candidate is HTMLElement => {
+            if (!(candidate instanceof HTMLElement)) return false;
+            if (candidate.getAttribute("data-line-index") !== index) return false;
+            const contentRect = candidate.getBoundingClientRect();
+            return Math.abs(contentRect.top - gutterRect.top) <= 1;
+          });
+          if (!content) {
+            missing += 1;
+            continue;
+          }
+          const text = content.textContent?.trim() ?? "";
+          if (text.length === 0) blank += 1;
+          if (text.includes(expectedText)) matched = true;
+        }
+
+        return {
+          blank,
+          matched,
+          missing,
+          visibleExpandedPositive: visibleExpanded.length > 0,
+        };
+      }, expectedText);
+    })
+    .toEqual({
+      blank: 0,
+      matched: true,
+      missing: 0,
+      visibleExpandedPositive: true,
+    });
+}
+
 async function expectRenderedPierreContainmentDisabled(page: Page): Promise<void> {
   await expect
     .poll(
@@ -2196,6 +2247,7 @@ test.describe("diff view", () => {
     await clickPierreContextExpander(page, detailFile, 0, "[data-expand-down]");
     await expect.poll(() => [...new Set(previewSides)].sort()).toEqual(["new", "old"]);
     await expectRenderedNonBlankRows(schemaFile, "schema response row");
+    await expectVisibleExpandedRowContent(detailFile, "function onActionMenuKeydown(e: KeyboardEvent): void {");
     await scrollDiffAreaUntilPierreText(
       page,
       diffArea,

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2,7 +2,10 @@ import { expect, test, type Locator, type Page, type Request } from "@playwright
 import type { DiffFile, DiffLine, DiffResult, FilesResult } from "@middleman/ui/api/types";
 import { startIsolatedE2EServer } from "./support/e2eServer";
 
-type DiffFixtureFile = Omit<DiffFile, "patch"> & { patch?: string };
+type DiffFixtureFile = Omit<DiffFile, "patch"> & {
+  patch?: string;
+  preserveHunkCounts?: boolean;
+};
 type DiffFixture = Omit<DiffResult, "files"> & {
   files: DiffFixtureFile[];
 };
@@ -909,6 +912,7 @@ function patchForFile(file: DiffFixtureFile): string {
 }
 
 function normalizeFixtureFile(file: DiffFixtureFile): DiffFixtureFile {
+  if (file.preserveHunkCounts) return file;
   return {
     ...file,
     hunks: file.hunks.map((hunk) => ({
@@ -2135,6 +2139,7 @@ test.describe("diff view", () => {
         {
           path: "src/components/detail/PullDetail.svelte",
           old_path: "src/components/detail/PullDetail.svelte",
+          preserveHunkCounts: true,
           status: "modified",
           is_binary: false,
           is_whitespace_only: false,
@@ -2143,9 +2148,9 @@ test.describe("diff view", () => {
           hunks: [
             {
               old_start: 949,
-              old_count: 6,
+              old_count: 48,
               new_start: 949,
-              new_count: 7,
+              new_count: 49,
               lines: [
                 {
                   type: "context",

--- a/frontend/tests/e2e/comment-editing.spec.ts
+++ b/frontend/tests/e2e/comment-editing.spec.ts
@@ -193,7 +193,8 @@ test("edits a pull request timeline comment", async ({ page }) => {
   await expect(page.getByText("Edited PR comment")).toBeVisible();
 });
 
-test("copies a direct provider link from a pull request timeline comment", async ({ page, context }) => {
+test("copies a direct provider link from a pull request timeline comment", async ({ page, context, browserName }) => {
+  test.skip(browserName === "firefox", "Playwright Firefox does not support granting clipboard-read permission");
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   const directURL = "https://github.com/acme/widgets/pull/42#issuecomment-9101";
   const event: TimelineEvent = {

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -174,6 +174,7 @@ test("markdown images open in an expanded overlay", async ({ page }) => {
   expect(buttonBox).not.toBeNull();
   expect(buttonBox!.x).toBeGreaterThan(imageBox!.x + imageBox!.width - 44);
   expect(buttonBox!.y).toBeLessThan(imageBox!.y + 16);
+  await page.mouse.move(1, 1);
   await expect(zoomButton).toHaveCSS("opacity", "0");
   await expect(zoomButton).toHaveCSS("pointer-events", "none");
 

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1931,6 +1931,90 @@ test.describe("workspace launch home", () => {
       .toBe(true);
   });
 
+  test("xterm uses stable rendering for colored terminal diff output in Firefox", async ({ page, browserName }) => {
+    test.skip(browserName !== "firefox", "Firefox-specific xterm rendering regression coverage");
+    await page.addInitScript(() => {
+      Object.defineProperty(window, "__middlemanOpenedTerminalSockets", {
+        value: [] as string[],
+      });
+      const NativeWebSocket = window.WebSocket;
+      const diffOutput = [
+        "\x1b[31m--- a/internal/db/queries.go\x1b[0m\r\n",
+        "\x1b[41m\x1b[37m-        Number: 701,\x1b[0m\r\n",
+        '\x1b[41m\x1b[37m-        URL: "https://github.com/acme/widget/pull/701",\x1b[0m\r\n',
+        '\x1b[41m\x1b[37m-        Title: "Sort PR workspace",\x1b[0m\r\n',
+      ].join("");
+
+      class MockTerminalWebSocket extends EventTarget {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSING = 2;
+        static CLOSED = 3;
+
+        binaryType = "arraybuffer";
+        extensions = "";
+        onclose: ((event: CloseEvent) => void) | null = null;
+        onerror: ((event: Event) => void) | null = null;
+        onmessage: ((event: MessageEvent) => void) | null = null;
+        onopen: ((event: Event) => void) | null = null;
+        protocol = "";
+        readyState = MockTerminalWebSocket.OPEN;
+        readonly url: string;
+
+        constructor(url: string | URL, protocols?: string | string[]) {
+          super();
+          this.url = String(url);
+          if (!this.url.includes("/ws/v1/workspaces/")) {
+            return new NativeWebSocket(url, protocols);
+          }
+          queueMicrotask(() => {
+            (window as unknown as { __middlemanOpenedTerminalSockets: string[] }).__middlemanOpenedTerminalSockets.push(
+              this.url,
+            );
+            const event = new Event("open");
+            this.dispatchEvent(event);
+            this.onopen?.(event);
+            const message = new MessageEvent("message", {
+              data: new TextEncoder().encode(diffOutput).buffer,
+            });
+            this.dispatchEvent(message);
+            this.onmessage?.(message);
+          });
+        }
+
+        close(): void {
+          this.readyState = MockTerminalWebSocket.CLOSED;
+          const event = new CloseEvent("close");
+          this.dispatchEvent(event);
+          this.onclose?.(event);
+        }
+
+        send(): void {
+          // The rendering assertion only needs inbound terminal output.
+        }
+      }
+
+      window.WebSocket = MockTerminalWebSocket as unknown as typeof WebSocket;
+    });
+
+    await page.goto("/terminal/ws-123", {
+      waitUntil: "domcontentloaded",
+    });
+    await page.getByRole("button", { name: "Codex" }).click();
+
+    await expect(page.locator(".terminal-container .xterm")).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as unknown as { __middlemanOpenedTerminalSockets: string[] }).__middlemanOpenedTerminalSockets.some(
+            (url) => url.includes("/runtime/sessions/ws-123%3Acodex/terminal"),
+          ),
+        ),
+      )
+      .toBe(true);
+    await expect(page.locator(".terminal-container .xterm-screen canvas")).toHaveCount(0);
+  });
+
   test("xterm workspace terminal sends multiline browser paste as one payload", async ({ page }) => {
     await page.addInitScript(() => {
       type RecordedSocket = {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1059,6 +1059,53 @@ test.describe("terminal state icons", () => {
     expect(deleteRequests[1]).toContain("force=true");
   });
 
+  test("in-flight successful force DELETE does not yank the user off the route they chose", async ({ page }) => {
+    await setupTerminalMocks(page);
+
+    let deleteCount = 0;
+    await page.route(
+      (url) => url.pathname === "/api/v1/workspaces/ws-123",
+      async (route) => {
+        if (route.request().method() !== "DELETE") {
+          await route.fallback();
+          return;
+        }
+        deleteCount += 1;
+        if (deleteCount === 1) {
+          await route.fulfill({
+            status: 409,
+            contentType: "application/json",
+            body: JSON.stringify({
+              detail: "Worktree has uncommitted changes.",
+            }),
+          });
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        await route.fulfill({ status: 204 });
+      },
+    );
+
+    await page.goto("/terminal/ws-123");
+
+    await page.locator(".header-bar").getByRole("button", { name: "Delete" }).click();
+
+    const dialog = page.getByRole("dialog", {
+      name: "Force delete workspace?",
+    });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Force delete" }).click();
+
+    await page.evaluate(() => {
+      history.pushState(null, "", "/pulls");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    await page.waitForTimeout(700);
+
+    await expect(page).toHaveURL(/\/pulls$/);
+  });
+
   test("force-delete prompt cancel keeps the workspace and the modal closes", async ({ page }) => {
     const deleteRequests: string[] = [];
     page.on("request", (req) => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -311,6 +311,60 @@ func (e ResolveRepoItemParamsItemType) Valid() bool {
 	}
 }
 
+// Defines values for GetWorkspaceFilePreviewParamsBase.
+const (
+	Head        GetWorkspaceFilePreviewParamsBase = "head"
+	MergeTarget GetWorkspaceFilePreviewParamsBase = "merge-target"
+	Pushed      GetWorkspaceFilePreviewParamsBase = "pushed"
+)
+
+// Valid indicates whether the value is a known member of the GetWorkspaceFilePreviewParamsBase enum.
+func (e GetWorkspaceFilePreviewParamsBase) Valid() bool {
+	switch e {
+	case Head:
+		return true
+	case MergeTarget:
+		return true
+	case Pushed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetWorkspaceFilePreviewParamsWhitespace.
+const (
+	Hide GetWorkspaceFilePreviewParamsWhitespace = "hide"
+)
+
+// Valid indicates whether the value is a known member of the GetWorkspaceFilePreviewParamsWhitespace enum.
+func (e GetWorkspaceFilePreviewParamsWhitespace) Valid() bool {
+	switch e {
+	case Hide:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetWorkspaceFilePreviewParamsSide.
+const (
+	New GetWorkspaceFilePreviewParamsSide = "new"
+	Old GetWorkspaceFilePreviewParamsSide = "old"
+)
+
+// Valid indicates whether the value is a known member of the GetWorkspaceFilePreviewParamsSide enum.
+func (e GetWorkspaceFilePreviewParamsSide) Valid() bool {
+	switch e {
+	case New:
+		return true
+	case Old:
+		return true
+	default:
+		return false
+	}
+}
+
 // ActionStatusBody defines model for ActionStatusBody.
 type ActionStatusBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -2405,16 +2459,16 @@ type GetWorkspaceDiffParams struct {
 // GetWorkspaceFilePreviewParams defines parameters for GetWorkspaceFilePreview.
 type GetWorkspaceFilePreviewParams struct {
 	// Base Diff base: head, pushed, or merge-target
-	Base *string `form:"base,omitempty" json:"base,omitempty"`
+	Base *GetWorkspaceFilePreviewParamsBase `form:"base,omitempty" json:"base,omitempty"`
 
 	// Whitespace Set to hide to ignore whitespace-only changes
-	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
+	Whitespace *GetWorkspaceFilePreviewParamsWhitespace `form:"whitespace,omitempty" json:"whitespace,omitempty"`
 
 	// Path Changed file path to preview
 	Path *string `form:"path,omitempty" json:"path,omitempty"`
 
 	// Side Optional diff side to read for context expansion
-	Side *string `form:"side,omitempty" json:"side,omitempty"`
+	Side *GetWorkspaceFilePreviewParamsSide `form:"side,omitempty" json:"side,omitempty"`
 
 	// Commit Scope to a single commit SHA
 	Commit *string `form:"commit,omitempty" json:"commit,omitempty"`
@@ -2425,6 +2479,15 @@ type GetWorkspaceFilePreviewParams struct {
 	// To End SHA for range diff (inclusive)
 	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
+
+// GetWorkspaceFilePreviewParamsBase defines parameters for GetWorkspaceFilePreview.
+type GetWorkspaceFilePreviewParamsBase string
+
+// GetWorkspaceFilePreviewParamsWhitespace defines parameters for GetWorkspaceFilePreview.
+type GetWorkspaceFilePreviewParamsWhitespace string
+
+// GetWorkspaceFilePreviewParamsSide defines parameters for GetWorkspaceFilePreview.
+type GetWorkspaceFilePreviewParamsSide string
 
 // GetWorkspaceFilesParams defines parameters for GetWorkspaceFiles.
 type GetWorkspaceFilesParams struct {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2402,6 +2402,30 @@ type GetWorkspaceDiffParams struct {
 	To *string `form:"to,omitempty" json:"to,omitempty"`
 }
 
+// GetWorkspaceFilePreviewParams defines parameters for GetWorkspaceFilePreview.
+type GetWorkspaceFilePreviewParams struct {
+	// Base Diff base: head, pushed, or merge-target
+	Base *string `form:"base,omitempty" json:"base,omitempty"`
+
+	// Whitespace Set to hide to ignore whitespace-only changes
+	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
+
+	// Path Changed file path to preview
+	Path *string `form:"path,omitempty" json:"path,omitempty"`
+
+	// Side Optional diff side to read for context expansion
+	Side *string `form:"side,omitempty" json:"side,omitempty"`
+
+	// Commit Scope to a single commit SHA
+	Commit *string `form:"commit,omitempty" json:"commit,omitempty"`
+
+	// From Start SHA for range diff (inclusive)
+	From *string `form:"from,omitempty" json:"from,omitempty"`
+
+	// To End SHA for range diff (inclusive)
+	To *string `form:"to,omitempty" json:"to,omitempty"`
+}
+
 // GetWorkspaceFilesParams defines parameters for GetWorkspaceFiles.
 type GetWorkspaceFilesParams struct {
 	// Base Diff base: head, pushed, or merge-target
@@ -3298,6 +3322,9 @@ type ClientInterface interface {
 
 	// GetWorkspaceDiff request
 	GetWorkspaceDiff(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetWorkspaceFilePreview request
+	GetWorkspaceFilePreview(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetWorkspaceFiles request
 	GetWorkspaceFiles(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6003,6 +6030,18 @@ func (c *Client) GetWorkspaceCommits(ctx context.Context, id string, reqEditors 
 
 func (c *Client) GetWorkspaceDiff(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetWorkspaceDiffRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetWorkspaceFilePreview(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetWorkspaceFilePreviewRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -16024,6 +16063,139 @@ func NewGetWorkspaceDiffRequest(server string, id string, params *GetWorkspaceDi
 	return req, nil
 }
 
+// NewGetWorkspaceFilePreviewRequest generates requests for GetWorkspaceFilePreview
+func NewGetWorkspaceFilePreviewRequest(server string, id string, params *GetWorkspaceFilePreviewParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workspaces/%s/file-preview", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Base != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "base", *params.Base, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Whitespace != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "whitespace", *params.Whitespace, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Side != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "side", *params.Side, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Commit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "commit", *params.Commit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "from", *params.From, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.To != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "to", *params.To, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetWorkspaceFilesRequest generates requests for GetWorkspaceFiles
 func NewGetWorkspaceFilesRequest(server string, id string, params *GetWorkspaceFilesParams) (*http.Request, error) {
 	var err error
@@ -17024,6 +17196,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetWorkspaceDiffWithResponse request
 	GetWorkspaceDiffWithResponse(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*GetWorkspaceDiffResponse, error)
+
+	// GetWorkspaceFilePreviewWithResponse request
+	GetWorkspaceFilePreviewWithResponse(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilePreviewResponse, error)
 
 	// GetWorkspaceFilesWithResponse request
 	GetWorkspaceFilesWithResponse(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilesResponse, error)
@@ -20681,6 +20856,29 @@ func (r GetWorkspaceDiffResponse) StatusCode() int {
 	return 0
 }
 
+type GetWorkspaceFilePreviewResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *FilePreviewResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetWorkspaceFilePreviewResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetWorkspaceFilePreviewResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetWorkspaceFilesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -22782,6 +22980,15 @@ func (c *ClientWithResponses) GetWorkspaceDiffWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseGetWorkspaceDiffResponse(rsp)
+}
+
+// GetWorkspaceFilePreviewWithResponse request returning *GetWorkspaceFilePreviewResponse
+func (c *ClientWithResponses) GetWorkspaceFilePreviewWithResponse(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilePreviewResponse, error) {
+	rsp, err := c.GetWorkspaceFilePreview(ctx, id, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetWorkspaceFilePreviewResponse(rsp)
 }
 
 // GetWorkspaceFilesWithResponse request returning *GetWorkspaceFilesResponse
@@ -27904,6 +28111,39 @@ func ParseGetWorkspaceDiffResponse(rsp *http.Response) (*GetWorkspaceDiffRespons
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DiffResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetWorkspaceFilePreviewResponse parses an HTTP response from a GetWorkspaceFilePreviewWithResponse call
+func ParseGetWorkspaceFilePreviewResponse(rsp *http.Response) (*GetWorkspaceFilePreviewResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetWorkspaceFilePreviewResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest FilePreviewResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -21422,6 +21422,48 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assert.Equal(int64(1), pushedDiff.WhitespaceOnlyCount)
 }
 
+func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+
+	path := "preview.go"
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, path),
+		[]byte("package preview\n\nfunc value() string {\n\treturn \"base\"\n}\n"),
+		0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "add preview fixture")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, path),
+		[]byte("package preview\n\nfunc value() string {\n\treturn \"worktree\"\n}\n"),
+		0o644,
+	))
+
+	oldPreview := requestWorkspaceFilePreview(t, srv, ws.Id, "head", path, "old")
+	oldDecoded, err := base64.StdEncoding.DecodeString(oldPreview.Content)
+	require.NoError(err)
+	newPreview := requestWorkspaceFilePreview(t, srv, ws.Id, "head", path, "new")
+	newDecoded, err := base64.StdEncoding.DecodeString(newPreview.Content)
+	require.NoError(err)
+
+	assert.Equal(path, oldPreview.Path)
+	assert.Equal(path, newPreview.Path)
+	assert.Contains(string(oldDecoded), `return "base"`)
+	assert.NotContains(string(oldDecoded), `return "worktree"`)
+	assert.Contains(string(newDecoded), `return "worktree"`)
+	assert.NotContains(string(newDecoded), `return "base"`)
+}
+
 func TestWorkspaceDiffEndpointsReturnPierreTreeOrderE2E(t *testing.T) {
 	t.Parallel()
 
@@ -22003,6 +22045,34 @@ func requestWorkspaceDiffPath(
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var body generated.DiffResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return body
+}
+
+func requestWorkspaceFilePreview(
+	t *testing.T,
+	srv *Server,
+	workspaceID string,
+	base string,
+	path string,
+	side string,
+) filePreviewResponse {
+	t.Helper()
+
+	query := "/api/v1/workspaces/" + workspaceID +
+		"/file-preview?base=" + url.QueryEscape(base) +
+		"&path=" + url.QueryEscape(path)
+	if side != "" {
+		query += "&side=" + url.QueryEscape(side)
+	}
+	req := newWorkspaceFixtureRequest(http.MethodGet, query, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body filePreviewResponse
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 	return body
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -493,10 +493,10 @@ type getWorkspaceDiffInput struct {
 
 type getWorkspaceFilePreviewInput struct {
 	ID         string `path:"id"`
-	Base       string `query:"base"       doc:"Diff base: head, pushed, or merge-target"`
-	Whitespace string `query:"whitespace" doc:"Set to hide to ignore whitespace-only changes"`
+	Base       string `query:"base"       enum:"head,pushed,merge-target" doc:"Diff base: head, pushed, or merge-target"`
+	Whitespace string `query:"whitespace" enum:"hide"                     doc:"Set to hide to ignore whitespace-only changes"`
 	Path       string `query:"path"       doc:"Changed file path to preview"`
-	Side       string `query:"side" doc:"Optional diff side to read for context expansion"`
+	Side       string `query:"side"       enum:"old,new"                  doc:"Optional diff side to read for context expansion"`
 	Commit     string `query:"commit" doc:"Scope to a single commit SHA"`
 	From       string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
 	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -491,6 +491,17 @@ type getWorkspaceDiffInput struct {
 	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
 }
 
+type getWorkspaceFilePreviewInput struct {
+	ID         string `path:"id"`
+	Base       string `query:"base"       doc:"Diff base: head, pushed, or merge-target"`
+	Whitespace string `query:"whitespace" doc:"Set to hide to ignore whitespace-only changes"`
+	Path       string `query:"path"       doc:"Changed file path to preview"`
+	Side       string `query:"side" doc:"Optional diff side to read for context expansion"`
+	Commit     string `query:"commit" doc:"Scope to a single commit SHA"`
+	From       string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
+	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
+}
+
 type getWorkspaceCommitsInput struct {
 	ID string `path:"id"`
 }
@@ -541,6 +552,7 @@ type listWorkspacesOutput = bodyOutput[listWorkspacesOutputBody]
 type getWorkspaceOutput = bodyOutput[workspaceResponse]
 
 type getWorkspaceDiffOutput = bodyOutput[diffResponse]
+type getWorkspaceFilePreviewOutput = bodyOutput[filePreviewResponse]
 type getWorkspaceFilesOutput = bodyOutput[filesResponse]
 type getWorkspaceCommitsOutput = bodyOutput[commitsResponse]
 
@@ -727,6 +739,8 @@ func (s *Server) registerAPI(api huma.API) {
 		documentOperation("get-workspace-commits", "Get workspace commits", "Workspaces"))
 	huma.Get(api, "/workspaces/{id}/diff", s.getWorkspaceDiff,
 		documentOperation("get-workspace-diff", "Get workspace diff", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/file-preview", s.getWorkspaceFilePreview,
+		documentOperation("get-workspace-file-preview", "Get workspace file preview", "Workspaces"))
 	huma.Get(api, "/workspaces/{id}/files", s.getWorkspaceFiles,
 		documentOperation("get-workspace-files", "Get workspace files", "Workspaces"))
 	huma.Register(api, huma.Operation{
@@ -5037,6 +5051,61 @@ func (s *Server) getWorkspaceDiff(
 	}}, nil
 }
 
+func (s *Server) getWorkspaceFilePreview(
+	ctx context.Context,
+	input *getWorkspaceFilePreviewInput,
+) (*getWorkspaceFilePreviewOutput, error) {
+	if strings.TrimSpace(input.Path) == "" {
+		return nil, problemValidation("query.path", "path is required")
+	}
+	side := strings.TrimSpace(input.Side)
+	if side != "" && side != "old" && side != "new" {
+		return nil, problemValidation("query.side", "side must be old or new")
+	}
+
+	req, err := s.workspaceDiffRequest(ctx, input.ID, input.Base)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.applyWorkspaceDiffScope(
+		ctx, &req, input.Commit, input.From, input.To,
+	); err != nil {
+		return nil, err
+	}
+
+	hideWhitespace := input.Whitespace == "hide"
+	content, ok, err := s.workspaceFilePreview(
+		ctx, req, hideWhitespace, input.Path, side,
+	)
+	if err != nil {
+		if errors.Is(err, gitclone.ErrNotFound) {
+			return nil, problemNotFound(CodeNotFound, "workspace file preview not available: file is not changed in this diff", nil)
+		}
+		if errors.Is(err, gitclone.ErrTooLarge) {
+			return nil, problemPayloadTooLarge("file preview is too large", maxFilePreviewBytes)
+		}
+		slog.Error(
+			"failed to read workspace file preview",
+			"workspace_id", input.ID,
+			"base", req.Base,
+			"path", input.Path,
+			"err", err,
+		)
+		return nil, problemUpstream("failed to read workspace file preview", "", "")
+	}
+	if !ok {
+		return nil, workspaceDiffBaseUnavailable(req.Base)
+	}
+
+	return &getWorkspaceFilePreviewOutput{Body: filePreviewResponse{
+		Path:      content.Path,
+		MediaType: previewMediaType(content.Path, content.Data),
+		Encoding:  "base64",
+		Content:   base64.StdEncoding.EncodeToString(content.Data),
+		Size:      content.Size,
+	}}, nil
+}
+
 func (s *Server) workspaceDiffRequest(
 	ctx context.Context,
 	id string,
@@ -5268,6 +5337,47 @@ func (s *Server) workspaceDiff(
 	}
 	return workspace.WorktreeDiff(
 		ctx, req.Summary.WorktreePath, req.Base, hideWhitespace,
+	)
+}
+
+func (s *Server) workspaceFilePreview(
+	ctx context.Context,
+	req workspaceDiffRequest,
+	hideWhitespace bool,
+	path string,
+	side string,
+) (*gitclone.FileContent, bool, error) {
+	if req.FromSHA != "" && req.ToSHA != "" {
+		return workspace.WorktreeFileContentBetween(
+			ctx,
+			req.Summary.WorktreePath,
+			req.FromSHA,
+			req.ToSHA,
+			hideWhitespace,
+			path,
+			side,
+			maxFilePreviewBytes,
+		)
+	}
+	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
+		return workspace.WorktreeFileContentAgainstMergeTarget(
+			ctx,
+			req.Summary.WorktreePath,
+			req.MergeTargetBranch,
+			hideWhitespace,
+			path,
+			side,
+			maxFilePreviewBytes,
+		)
+	}
+	return workspace.WorktreeFileContent(
+		ctx,
+		req.Summary.WorktreePath,
+		req.Base,
+		hideWhitespace,
+		path,
+		side,
+		maxFilePreviewBytes,
 	)
 }
 

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -195,6 +195,26 @@ func WorktreeFileDiff(
 	return worktreeDiffFromRefPath(ctx, dir, baseRef, hideWhitespace, path)
 }
 
+func WorktreeFileContent(
+	ctx context.Context,
+	dir string,
+	base WorktreeDiffBase,
+	hideWhitespace bool,
+	path string,
+	side string,
+	maxBytes int64,
+) (*gitclone.FileContent, bool, error) {
+	baseRef, ok, err := worktreeDiffBaseRef(ctx, dir, base)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	content, err := worktreeFileContentFromRefs(
+		ctx, dir, baseRef, "", hideWhitespace, path, side, true, maxBytes,
+	)
+	return content, err == nil, err
+}
+
 func WorktreeDiffAgainstMergeTarget(
 	ctx context.Context,
 	dir string,
@@ -224,6 +244,26 @@ func WorktreeFileDiffAgainstMergeTarget(
 	return worktreeDiffFromRefPath(ctx, dir, baseRef, hideWhitespace, path)
 }
 
+func WorktreeFileContentAgainstMergeTarget(
+	ctx context.Context,
+	dir string,
+	targetBranch string,
+	hideWhitespace bool,
+	path string,
+	side string,
+	maxBytes int64,
+) (*gitclone.FileContent, bool, error) {
+	baseRef, ok, err := worktreeMergeTargetBaseRef(ctx, dir, targetBranch)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+
+	content, err := worktreeFileContentFromRefs(
+		ctx, dir, baseRef, "", hideWhitespace, path, side, true, maxBytes,
+	)
+	return content, err == nil, err
+}
+
 func worktreeDiffFromRef(
 	ctx context.Context,
 	dir string,
@@ -246,6 +286,22 @@ func WorktreeDiffBetween(
 	return result, err == nil, err
 }
 
+func WorktreeFileContentBetween(
+	ctx context.Context,
+	dir string,
+	fromRef string,
+	toRef string,
+	hideWhitespace bool,
+	path string,
+	side string,
+	maxBytes int64,
+) (*gitclone.FileContent, bool, error) {
+	content, err := worktreeFileContentFromRefs(
+		ctx, dir, fromRef, toRef, hideWhitespace, path, side, false, maxBytes,
+	)
+	return content, err == nil, err
+}
+
 func WorktreeFileDiffBetween(
 	ctx context.Context,
 	dir string,
@@ -258,6 +314,84 @@ func WorktreeFileDiffBetween(
 		ctx, dir, fromRef, toRef, hideWhitespace, path, false,
 	)
 	return result, err == nil, err
+}
+
+func worktreeFileContentFromRefs(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	headRef string,
+	hideWhitespace bool,
+	path string,
+	side string,
+	includeUntracked bool,
+	maxBytes int64,
+) (*gitclone.FileContent, error) {
+	path, err := cleanWorktreeDiffPath(path)
+	if err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, errors.New("diff path is required")
+	}
+
+	diff, err := worktreeDiffFromRefsPath(
+		ctx, dir, baseRef, headRef, hideWhitespace, path, includeUntracked,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var file *gitclone.DiffFile
+	for i := range diff.Files {
+		if diff.Files[i].Path == path {
+			file = &diff.Files[i]
+			break
+		}
+	}
+	if file == nil {
+		return nil, gitclone.ErrNotFound
+	}
+
+	ref := headRef
+	previewPath := file.Path
+	useWorktree := headRef == ""
+	switch side {
+	case "old":
+		if file.Status == "added" {
+			return nil, gitclone.ErrNotFound
+		}
+		ref = baseRef
+		previewPath = file.OldPath
+		if previewPath == "" {
+			previewPath = file.Path
+		}
+		useWorktree = false
+	case "new":
+		if file.Status == "deleted" {
+			return nil, gitclone.ErrNotFound
+		}
+	case "":
+		if file.Status == "deleted" {
+			ref = baseRef
+			previewPath = file.OldPath
+			if previewPath == "" {
+				previewPath = file.Path
+			}
+			useWorktree = false
+		}
+	default:
+		return nil, errors.New("side must be old or new")
+	}
+
+	previewPath, err = cleanWorktreeDiffPath(previewPath)
+	if err != nil {
+		return nil, err
+	}
+	if useWorktree {
+		return readWorktreeFileContent(dir, previewPath, maxBytes)
+	}
+	return worktreeBlobContent(ctx, dir, ref, previewPath, maxBytes)
 }
 
 func worktreeDiffFromRefPath(
@@ -355,6 +489,79 @@ func worktreeDiffFromRefsPath(
 		WhitespaceOnlyCount: wsCount,
 		Files:               files,
 	}, nil
+}
+
+func worktreeBlobContent(
+	ctx context.Context,
+	dir string,
+	ref string,
+	path string,
+	maxBytes int64,
+) (*gitclone.FileContent, error) {
+	object := ref + ":" + path
+	sizeOut, err := worktreeGitOutput(ctx, dir, "cat-file", "-s", object)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
+	}
+	size, err := strconv.ParseInt(strings.TrimSpace(string(sizeOut)), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse blob size: %w", err)
+	}
+	if maxBytes > 0 && size > maxBytes {
+		return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, size)
+	}
+	data, err := worktreeGitOutput(ctx, dir, "cat-file", "blob", object)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
+	}
+	return &gitclone.FileContent{Path: path, Data: data, Size: size}, nil
+}
+
+func readWorktreeFileContent(
+	dir string,
+	path string,
+	maxBytes int64,
+) (*gitclone.FileContent, error) {
+	fullPath := filepath.Join(dir, path)
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
+		}
+		data := []byte(target)
+		if maxBytes > 0 && int64(len(data)) > maxBytes {
+			return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, len(data))
+		}
+		return &gitclone.FileContent{Path: path, Data: data, Size: int64(len(data))}, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nil, gitclone.ErrNotFound
+	}
+
+	file, info, err := openRegularUntrackedFile(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
+	}
+	defer file.Close()
+	if maxBytes > 0 && info.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, info.Size())
+	}
+	limit := info.Size()
+	if maxBytes > 0 {
+		limit = maxBytes + 1
+	}
+	data, err := io.ReadAll(io.LimitReader(file, limit))
+	if err != nil {
+		return nil, err
+	}
+	if maxBytes > 0 && int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, len(data))
+	}
+	return &gitclone.FileContent{Path: path, Data: data, Size: info.Size()}, nil
 }
 
 func markWorktreeGeneratedFiles(

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -119,7 +119,7 @@
   },
   "dependencies": {
     "@lucide/svelte": "1.17.0",
-    "@pierre/diffs": "1.2.7",
+    "@pierre/diffs": "1.2.10",
     "@pierre/trees": "1.0.0-beta.4",
     "@tiptap/core": "3.26.0",
     "@tiptap/extension-document": "3.26.0",

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -10228,13 +10228,13 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description Diff base: head, pushed, or merge-target */
-                base?: string;
+                base?: "head" | "pushed" | "merge-target";
                 /** @description Set to hide to ignore whitespace-only changes */
-                whitespace?: string;
+                whitespace?: "hide";
                 /** @description Changed file path to preview */
                 path?: string;
                 /** @description Optional diff side to read for context expansion */
-                side?: string;
+                side?: "old" | "new";
                 /** @description Scope to a single commit SHA */
                 commit?: string;
                 /** @description Start SHA for range diff (inclusive) */
@@ -10519,6 +10519,9 @@ export const pathsHostPlatform_hostPullsProviderOwnerNameNumberFilePreviewGetPar
 export const pathsHostPlatform_hostRepoProviderOwnerNameResolveNumberPostParametersQueryItem_typeValues: ReadonlyArray<FlattenedDeepRequired<paths>["/host/{platform_host}/repo/{provider}/{owner}/{name}/resolve/{number}"]["post"]["parameters"]["query"]["item_type"]> = ["pr", "issue"];
 export const pathsPullsProviderOwnerNameNumberFilePreviewGetParametersQuerySideValues: ReadonlyArray<FlattenedDeepRequired<paths>["/pulls/{provider}/{owner}/{name}/{number}/file-preview"]["get"]["parameters"]["query"]["side"]> = ["old", "new"];
 export const pathsRepoProviderOwnerNameResolveNumberPostParametersQueryItem_typeValues: ReadonlyArray<FlattenedDeepRequired<paths>["/repo/{provider}/{owner}/{name}/resolve/{number}"]["post"]["parameters"]["query"]["item_type"]> = ["pr", "issue"];
+export const pathsWorkspacesIdFilePreviewGetParametersQueryBaseValues: ReadonlyArray<FlattenedDeepRequired<paths>["/workspaces/{id}/file-preview"]["get"]["parameters"]["query"]["base"]> = ["head", "pushed", "merge-target"];
+export const pathsWorkspacesIdFilePreviewGetParametersQueryWhitespaceValues: ReadonlyArray<FlattenedDeepRequired<paths>["/workspaces/{id}/file-preview"]["get"]["parameters"]["query"]["whitespace"]> = ["hide"];
+export const pathsWorkspacesIdFilePreviewGetParametersQuerySideValues: ReadonlyArray<FlattenedDeepRequired<paths>["/workspaces/{id}/file-preview"]["get"]["parameters"]["query"]["side"]> = ["old", "new"];
 export const activityTime_rangeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["Activity"]["time_range"]> = ["24h", "7d", "30d", "90d"];
 export const activityView_modeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["Activity"]["view_mode"]> = ["flat", "threaded"];
 export const mergeRequestKanbanStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["MergeRequest"]["KanbanStatus"]> = ["new", "reviewing", "waiting", "awaiting_merge"];

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2356,6 +2356,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/workspaces/{id}/file-preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get workspace file preview */
+        get: operations["get-workspace-file-preview"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/workspaces/{id}/files": {
         parameters: {
             query?: never;
@@ -10194,6 +10211,52 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DiffResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-workspace-file-preview": {
+        parameters: {
+            query?: {
+                /** @description Diff base: head, pushed, or merge-target */
+                base?: string;
+                /** @description Set to hide to ignore whitespace-only changes */
+                whitespace?: string;
+                /** @description Changed file path to preview */
+                path?: string;
+                /** @description Optional diff side to read for context expansion */
+                side?: string;
+                /** @description Scope to a single commit SHA */
+                commit?: string;
+                /** @description Start SHA for range diff (inclusive) */
+                from?: string;
+                /** @description End SHA for range diff (inclusive) */
+                to?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FilePreviewResponse"];
                 };
             };
             /** @description Error */

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -19,6 +19,7 @@
     diffFileWithPatch,
     parsePierreFileDiff,
     parsePierreFileDiffWithContents,
+    pierreDiffDebugEnabled,
     pierreFileContents,
   } from "./pierre-diff.js";
   import { diffTokenizeMaxLineLength, getPierreDiffWorkerPool } from "./pierre-worker-pool.js";
@@ -746,7 +747,7 @@
     debugPierreDiff("expand complete", {
       path: renderFile.path,
       hunkIndex,
-      rows: expandedContextDebugRows(),
+      rows: pierreDiffDebugEnabled() ? expandedContextDebugRows() : [],
     });
   }
 
@@ -764,7 +765,7 @@
         hunkIndex,
         didRender,
         fullCacheKey: fullContextFileDiff.cacheKey,
-        rows: expandedContextDebugRows(),
+        rows: pierreDiffDebugEnabled() ? expandedContextDebugRows() : [],
       });
       if (!didRender) scheduleRenderRetry();
     }

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -15,6 +15,7 @@
   import type { DiffFile } from "../../api/types.js";
   import {
     appThemeType,
+    debugPierreDiff,
     diffFileWithPatch,
     parsePierreFileDiff,
     parsePierreFileDiffWithContents,
@@ -661,9 +662,23 @@
     const expandAll = isExpandAllClick(target, event);
     const direction = expandAll ? "both" : expansionDirection(target);
     const expansionLineCount = expandAll ? Number.POSITIVE_INFINITY : undefined;
+    debugPierreDiff("expand click intercepted", {
+      path: renderFile.path,
+      hunkIndex,
+      direction,
+      expansionLineCount: expansionLineCount ?? "default",
+      fullContextLoaded: Boolean(fullContext),
+      fullContextRendered,
+      sparseCacheKey: pierreFile?.cacheKey,
+    });
     void loadFullContextAndExpand(hunkIndex, direction, expansionLineCount)
       .catch((err: unknown) => {
         contextError = err instanceof Error ? err.message : String(err);
+        debugPierreDiff("expand failed", {
+          path: renderFile.path,
+          hunkIndex,
+          error: contextError,
+        });
       });
   }
 
@@ -695,12 +710,25 @@
   ): Promise<void> {
     const requestFileKey = fileKey;
     const alreadyRendered = fullContextRendered;
+    debugPierreDiff("expand loading full context", {
+      path: renderFile.path,
+      hunkIndex,
+      direction,
+      alreadyRendered,
+    });
     const context = await loadFullContext(requestFileKey);
     if (!context || fileKey !== requestFileKey) return;
     await tick();
     if (fileKey !== requestFileKey) return;
     if (!alreadyRendered && !fullContextRendered) {
       const didRender = renderFullContext(context);
+      debugPierreDiff("expand full context render result", {
+        path: renderFile.path,
+        hunkIndex,
+        didRender,
+        fullCacheKey: fullContextFileDiff?.cacheKey,
+        sparseCacheKey: pierreFile?.cacheKey,
+      });
       if (fileKey !== requestFileKey) return;
       if (!didRender) {
         if (!fullContextFileDiff) return;
@@ -715,6 +743,11 @@
       }
     }
     expandRenderedHunk(hunkIndex, direction, expansionLineCount);
+    debugPierreDiff("expand complete", {
+      path: renderFile.path,
+      hunkIndex,
+      rows: expandedContextDebugRows(),
+    });
   }
 
   function expandRenderedHunk(
@@ -726,6 +759,13 @@
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
     if (fullContext && fullContextFileDiff) {
       const didRender = renderFullContextRange(fullContext, fullContextFileDiff);
+      debugPierreDiff("expand rerendered full context range", {
+        path: renderFile.path,
+        hunkIndex,
+        didRender,
+        fullCacheKey: fullContextFileDiff.cacheKey,
+        rows: expandedContextDebugRows(),
+      });
       if (!didRender) scheduleRenderRetry();
     }
     removeStalePlaceholderPres();
@@ -744,6 +784,15 @@
     rendered = false;
     clearRenderedDomState();
     fullContextFileDiff = parsePierreFileDiffWithContents(renderFile, context) ?? pierreFile;
+    debugPierreDiff("render full context prepared", {
+      path: renderFile.path,
+      sparseCacheKey: pierreFile?.cacheKey,
+      fullCacheKey: fullContextFileDiff?.cacheKey,
+      oldCacheKey: context.oldFile.cacheKey,
+      newCacheKey: context.newFile.cacheKey,
+      oldLength: context.oldFile.contents.length,
+      newLength: context.newFile.contents.length,
+    });
     if (!fullContextFileDiff) return false;
     const didRender = renderFullContextRange(context, fullContextFileDiff);
     pierreDiff.setSelectedLines(selectedRange);
@@ -832,14 +881,26 @@
       throw new Error("Context loading is unavailable");
     }
     contextError = null;
+    debugPierreDiff("fetch full context start", {
+      path: renderFile.path,
+      status: renderFile.status,
+    });
     const [oldContents, newContents] = await Promise.all([
       renderFile.status === "added" ? Promise.resolve("") : loadFileText("old"),
       renderFile.status === "deleted" ? Promise.resolve("") : loadFileText("new"),
     ]);
-    return {
+    const context = {
       oldFile: pierreFileContents(renderFile.old_path || renderFile.path, oldContents, "full-old"),
       newFile: pierreFileContents(renderFile.path, newContents, "full-new"),
     };
+    debugPierreDiff("fetch full context complete", {
+      path: renderFile.path,
+      oldLength: oldContents.length,
+      newLength: newContents.length,
+      oldCacheKey: context.oldFile.cacheKey,
+      newCacheKey: context.newFile.cacheKey,
+    });
+    return context;
   }
 
   function annotationKey(annotations: DiffLineAnnotation<unknown>[]): string {
@@ -1215,6 +1276,24 @@
 
   function renderedDiffPre(root = host?.shadowRoot): HTMLPreElement | null {
     return root?.querySelector<HTMLPreElement>("pre[data-diff]") ?? null;
+  }
+
+  function expandedContextDebugRows(): Array<{
+    altLine: string | null;
+    line: string | null;
+    text: string;
+    type: string | null;
+  }> {
+    const root = host?.shadowRoot;
+    if (!root) return [];
+    return Array.from(root.querySelectorAll<HTMLElement>("[data-line-type='context-expanded'][data-line]"))
+      .slice(0, 12)
+      .map((row) => ({
+        altLine: row.getAttribute("data-alt-line"),
+        line: row.getAttribute("data-line"),
+        text: (row.textContent ?? "").trim().slice(0, 120),
+        type: row.getAttribute("data-line-type"),
+      }));
   }
 
   function removeStalePlaceholderPres(): void {

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -199,6 +199,10 @@
         margin: 0;
         border-radius: 0;
       }
+      code,
+      [data-placeholder] {
+        contain: none;
+      }
       [data-separator='line-info'] {
         color: var(--diff-text-muted);
       }

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -724,9 +724,7 @@
   ): void {
     clearRenderedDomState();
     pierreDiff?.expandHunk(hunkIndex, direction, expansionLineCount);
-    if (pierreDiff instanceof VirtualizedFileDiff && fullContext && fullContextFileDiff) {
-      pierreDiff.rerender();
-    } else if (fullContext && fullContextFileDiff) {
+    if (fullContext && fullContextFileDiff) {
       const didRender = renderFullContextRange(fullContext, fullContextFileDiff);
       if (!didRender) scheduleRenderRetry();
     }

--- a/packages/ui/src/components/diff/pierre-diff.test.ts
+++ b/packages/ui/src/components/diff/pierre-diff.test.ts
@@ -161,6 +161,25 @@ describe("Pierre diff parsing", () => {
     expect(fullOld.cacheKey).not.toBe(sparseOld.cacheKey);
   });
 
+  it("renders partial hunk payloads whose headers keep provider line counts", () => {
+    const file = makeFile("src/foo.ts", "-old line\n+new line");
+    file.patch = file.patch.replace("@@ -1,2 +1,2 @@", "@@ -1,3 +1,5 @@");
+    file.hunks[0]!.old_count = 3;
+    file.hunks[0]!.new_count = 5;
+
+    const parsed = parsePierreFileDiff(file);
+    const full = parsePierreFileDiffWithContents(file, {
+      oldFile: pierreFileContents("src/foo.ts", "line 1\nold line\n", "full-old"),
+      newFile: pierreFileContents("src/foo.ts", "line 1\nnew line\n", "full-new"),
+    });
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.deletionLines).toContain("old line\n");
+    expect(parsed?.additionLines).toContain("new line\n");
+    expect(full).toBeDefined();
+    expect(full?.isPartial).toBe(false);
+  });
+
   it("falls back to patch-only parsing for huge sparse line ranges", () => {
     const parsed = parsePierreFileDiff(makeLargeLineFile(), {
       enableDemandContextExpansion: true,

--- a/packages/ui/src/components/diff/pierre-diff.test.ts
+++ b/packages/ui/src/components/diff/pierre-diff.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import type { DiffFile } from "../../api/types.js";
 import {
   diffFileWithPatch,
@@ -162,6 +162,42 @@ describe("Pierre diff parsing", () => {
     expect(parsed?.cacheKey).toBeDefined();
     expect(full?.cacheKey).toBeDefined();
     expect(full?.cacheKey).not.toBe(parsed?.cacheKey);
+  });
+
+  it("keeps Pierre diff debug logging disabled by default", () => {
+    window.localStorage.removeItem("middleman:debug:diff");
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    try {
+      parsePierreFileDiff(makeFile("src/foo.ts", "-old line\n+new line"), {
+        enableDemandContextExpansion: true,
+      });
+
+      expect(debug).not.toHaveBeenCalled();
+    } finally {
+      debug.mockRestore();
+    }
+  });
+
+  it("emits Pierre diff debug logging when explicitly enabled", () => {
+    window.localStorage.setItem("middleman:debug:diff", "1");
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    try {
+      parsePierreFileDiff(makeFile("src/foo.ts", "-old line\n+new line"), {
+        enableDemandContextExpansion: true,
+      });
+
+      expect(debug).toHaveBeenCalledWith(
+        "[middleman:diff]",
+        "parse sparse context diff",
+        expect.objectContaining({
+          kind: "sparse",
+          path: "src/foo.ts",
+        }),
+      );
+    } finally {
+      window.localStorage.removeItem("middleman:debug:diff");
+      debug.mockRestore();
+    }
   });
 
   it("renders partial hunk payloads whose headers keep provider line counts", () => {

--- a/packages/ui/src/components/diff/pierre-diff.test.ts
+++ b/packages/ui/src/components/diff/pierre-diff.test.ts
@@ -159,6 +159,9 @@ describe("Pierre diff parsing", () => {
     expect(sparseOld.cacheKey).toBeDefined();
     expect(fullOld.cacheKey).toBeDefined();
     expect(fullOld.cacheKey).not.toBe(sparseOld.cacheKey);
+    expect(parsed?.cacheKey).toBeDefined();
+    expect(full?.cacheKey).toBeDefined();
+    expect(full?.cacheKey).not.toBe(parsed?.cacheKey);
   });
 
   it("renders partial hunk payloads whose headers keep provider line counts", () => {

--- a/packages/ui/src/components/diff/pierre-diff.ts
+++ b/packages/ui/src/components/diff/pierre-diff.ts
@@ -36,6 +36,7 @@ export function parsePierreFileDiff(
       withRenderMetadata(
         patchedFile,
         withSyntheticPatchCacheKey(patchedFile, processPatchWithContext(patchedFile, contents)),
+        contextRenderCacheIdentity(patchedFile, "sparse", contents),
       ),
     );
   }
@@ -53,6 +54,7 @@ export function parsePierreFileDiffWithContents(
     withRenderMetadata(
       patchedFile,
       withSyntheticPatchCacheKey(patchedFile, processPatchWithContext(patchedFile, contents)),
+      contextRenderCacheIdentity(patchedFile, "full", contents),
     ),
   );
 }
@@ -134,19 +136,39 @@ function withSyntheticPatchCacheKey(file: DiffFile, meta: FileDiffMetadata | und
   };
 }
 
-function withRenderMetadata(file: DiffFile, meta: FileDiffMetadata | undefined): FileDiffMetadata | undefined {
+function withRenderMetadata(
+  file: DiffFile,
+  meta: FileDiffMetadata | undefined,
+  cacheIdentity?: string,
+): FileDiffMetadata | undefined {
   if (!meta) return meta;
   return {
     ...meta,
     cacheKey:
-      meta.cacheKey ??
-      fileContentsCacheKey(
-        file.path,
-        file.patch,
-        `${syntheticPatchFiles.has(file) ? "synthetic" : "provider"}-diff:${file.status}:${file.old_path || ""}`,
-      ),
+      cacheIdentity != null
+        ? fileContentsCacheKey(file.path, file.patch, cacheIdentity)
+        : (meta.cacheKey ??
+          fileContentsCacheKey(
+            file.path,
+            file.patch,
+            `${syntheticPatchFiles.has(file) ? "synthetic" : "provider"}-diff:${file.status}:${file.old_path || ""}`,
+          )),
     lang: meta.lang ?? getFiletypeFromFileName(file.path),
   };
+}
+
+function contextRenderCacheIdentity(
+  file: DiffFile,
+  kind: "full" | "sparse",
+  contents: { oldFile: FileContents; newFile: FileContents },
+): string {
+  return [
+    `${kind}-diff`,
+    file.status,
+    file.old_path || "",
+    contents.oldFile.cacheKey ?? "",
+    contents.newFile.cacheKey ?? "",
+  ].join(":");
 }
 
 function safePierrePatch(file: DiffFile): string {

--- a/packages/ui/src/components/diff/pierre-diff.ts
+++ b/packages/ui/src/components/diff/pierre-diff.ts
@@ -98,7 +98,7 @@ function tryProcessPatch(
     return processFile(patch, {
       oldFile: contents.oldFile,
       newFile: contents.newFile,
-      throwOnError: true,
+      throwOnError: false,
     });
   } catch {
     return undefined;
@@ -116,7 +116,7 @@ function parsePatchOnly(file: DiffFile): FileDiffMetadata | undefined {
 
 function tryParsePatch(patch: string): FileDiffMetadata | undefined {
   try {
-    return parsePatchFiles(patch, undefined, true)[0]?.files[0];
+    return parsePatchFiles(patch, undefined, false)[0]?.files[0];
   } catch {
     return undefined;
   }

--- a/packages/ui/src/components/diff/pierre-diff.ts
+++ b/packages/ui/src/components/diff/pierre-diff.ts
@@ -7,6 +7,9 @@ interface ParsePierreFileDiffOptions {
   enableDemandContextExpansion?: boolean;
 }
 
+type PierreDiffDebugDetails = Record<string, unknown>;
+
+const debugDiffStorageKey = "middleman:debug:diff";
 const maxSparseContextLine = 50_000;
 const syntheticPatchFiles = new WeakSet<DiffFile>();
 
@@ -32,17 +35,26 @@ export function parsePierreFileDiff(
   if (!patchedFile.patch) return undefined;
   if (options.enableDemandContextExpansion && canBuildSparsePatchContents(patchedFile)) {
     const contents = sparsePatchContents(patchedFile);
-    return withAutomationLanguage(
+    const meta = withAutomationLanguage(
       withRenderMetadata(
         patchedFile,
         withSyntheticPatchCacheKey(patchedFile, processPatchWithContext(patchedFile, contents)),
         contextRenderCacheIdentity(patchedFile, "sparse", contents),
       ),
     );
+    debugPierreDiff("parse sparse context diff", contextDebugDetails(patchedFile, "sparse", contents, meta));
+    return meta;
   }
-  return withAutomationLanguage(
+  const meta = withAutomationLanguage(
     withRenderMetadata(patchedFile, withSyntheticPatchCacheKey(patchedFile, parsePatchOnly(patchedFile))),
   );
+  debugPierreDiff("parse patch diff", {
+    path: patchedFile.path,
+    status: patchedFile.status,
+    cacheKey: meta?.cacheKey,
+    hunkCount: meta?.hunks.length,
+  });
+  return meta;
 }
 
 export function parsePierreFileDiffWithContents(
@@ -50,13 +62,15 @@ export function parsePierreFileDiffWithContents(
   contents: { oldFile: FileContents; newFile: FileContents },
 ): FileDiffMetadata | undefined {
   const patchedFile = diffFileWithPatch(file);
-  return withAutomationLanguage(
+  const meta = withAutomationLanguage(
     withRenderMetadata(
       patchedFile,
       withSyntheticPatchCacheKey(patchedFile, processPatchWithContext(patchedFile, contents)),
       contextRenderCacheIdentity(patchedFile, "full", contents),
     ),
   );
+  debugPierreDiff("parse full context diff", contextDebugDetails(patchedFile, "full", contents, meta));
+  return meta;
 }
 
 export function pierreFileContents(name: string, contents: string, cacheIdentity: string): FileContents {
@@ -65,6 +79,21 @@ export function pierreFileContents(name: string, contents: string, cacheIdentity
     contents,
     cacheKey: fileContentsCacheKey(name, contents, cacheIdentity),
   };
+}
+
+export function debugPierreDiff(message: string, details?: PierreDiffDebugDetails): void {
+  if (!pierreDiffDebugEnabled()) return;
+  console.debug("[middleman:diff]", message, details ?? {});
+}
+
+export function pierreDiffDebugEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (new URLSearchParams(window.location.search).get("debugDiff") === "1") return true;
+    return window.localStorage?.getItem(debugDiffStorageKey) === "1";
+  } catch {
+    return false;
+  }
 }
 
 export function diffFileWithPatch(file: DiffFile): DiffFile {
@@ -169,6 +198,25 @@ function contextRenderCacheIdentity(
     contents.oldFile.cacheKey ?? "",
     contents.newFile.cacheKey ?? "",
   ].join(":");
+}
+
+function contextDebugDetails(
+  file: DiffFile,
+  kind: "full" | "sparse",
+  contents: { oldFile: FileContents; newFile: FileContents },
+  meta: FileDiffMetadata | undefined,
+): PierreDiffDebugDetails {
+  return {
+    path: file.path,
+    status: file.status,
+    kind,
+    cacheKey: meta?.cacheKey,
+    hunkCount: meta?.hunks.length,
+    oldCacheKey: contents.oldFile.cacheKey,
+    newCacheKey: contents.newFile.cacheKey,
+    oldLength: contents.oldFile.contents.length,
+    newLength: contents.newFile.contents.length,
+  };
 }
 
 function safePierrePatch(file: DiffFile): string {

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -102,7 +102,7 @@
         keyboardActive={false}
         pageKeyboardActive={active}
         richPreviewEnabled={false}
-        contextExpansionEnabled={false}
+        contextExpansionEnabled
         reviewMode="disabled"
       />
     </div>

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -464,13 +464,13 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
 
   function diffQuery(): {
-    whitespace?: string;
+    whitespace?: "hide";
     commit?: string;
     from?: string;
     to?: string;
   } {
     return {
-      ...(hideWhitespace && { whitespace: "hide" }),
+      ...(hideWhitespace && { whitespace: "hide" as const }),
       ...(scope.kind === "commit" && { commit: scope.sha }),
       ...(scope.kind === "range" && {
         from: scope.fromSha,
@@ -569,7 +569,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
   function workspaceDiffQuery(base: WorkspaceDiffBase): {
     base: WorkspaceDiffBase;
-    whitespace?: string;
+    whitespace?: "hide";
     commit?: string;
     from?: string;
     to?: string;
@@ -744,6 +744,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentName = "";
     currentNumber = 0;
     currentCommitSHA = "";
+    clearFilePreviewCache();
     if (workspaceScopeChanged) {
       resetDiffScopeState();
     }

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -497,6 +497,10 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     path: string,
     side?: "old" | "new",
   ): Promise<FilePreview> {
+    if (currentWorkspaceID) {
+      return loadWorkspaceFilePreview(path, side);
+    }
+
     const ref = currentRouteRef();
     const key = `${ref.provider}:${ref.platformHost ?? ""}:${ref.repoPath}#${number}:${scopeCacheKey()}:${path}:${side ?? "preview"}`;
     const cached = filePreviewCache.get(key);
@@ -514,6 +518,37 @@ export function createDiffStore(opts?: DiffStoreOptions) {
               from: scope.fromSha,
               to: scope.toSha,
             }),
+          },
+        },
+      });
+      if (!data) {
+        throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+      }
+      return data as FilePreview;
+    })();
+
+    filePreviewCache.set(key, request);
+    try {
+      return await request;
+    } catch (err) {
+      filePreviewCache.delete(key);
+      throw err;
+    }
+  }
+
+  async function loadWorkspaceFilePreview(path: string, side?: "old" | "new"): Promise<FilePreview> {
+    const key = `workspace:${currentWorkspaceID}:${currentWorkspaceBase}:${scopeCacheKey()}:${path}:${side ?? "preview"}`;
+    const cached = filePreviewCache.get(key);
+    if (cached) return cached;
+
+    const request = (async () => {
+      const { data, error, response } = await apiClient.GET("/workspaces/{id}/file-preview", {
+        params: {
+          path: { id: currentWorkspaceID },
+          query: {
+            ...workspaceDiffQuery(currentWorkspaceBase),
+            path,
+            ...(side && { side }),
           },
         },
       });

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -601,7 +601,6 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       scope.kind === "commit" ? hasCommit(scope.sha) : hasCommit(scope.fromSha) && hasCommit(scope.toSha);
     if (scopeStillExists) return;
     scope = { kind: "head" };
-    clearFilePreviewCache();
   }
 
   function startDiffLoad(): {
@@ -744,7 +743,6 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentName = "";
     currentNumber = 0;
     currentCommitSHA = "";
-    clearFilePreviewCache();
     if (workspaceScopeChanged) {
       resetDiffScopeState();
     }
@@ -754,6 +752,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       resetScopeIfMissingFromLoadedCommits();
     }
 
+    clearFilePreviewCache();
     const { diffAc, filesAc } = startDiffLoad();
 
     try {


### PR DESCRIPTION
This fixes the workspace diff sidebar as a whole, including the original Firefox/Zen paint failure and the later context-expansion bugs that showed up with real workspace diffs.

- Restore visible virtualized Pierre diff rendering in Firefox/Zen without disabling virtualization.
- Update `@pierre/diffs` to v1.2.10 while keeping the local containment override still needed for the paint issue.
- Add API-backed workspace file previews so expanded workspace diff context renders real old/new file content instead of placeholder or stale rows.
- Keep workspace preview cache identity tied to accepted diff loads so refreshes, commit scope changes, and full-context rendering stay aligned.
- Add gated diff diagnostics for future Pierre reconciliation work and cover the workspace delete navigation races found during local validation.