### PR TITLE
fix: defer merges until pending CI passes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,11 @@ frontend-dev-bun: frontend-deps
 
 # Run TypeScript/Svelte lint and type checks
 frontend-check: frontend-deps
-	$(VITE_PLUS_BIN) run frontend-check
+	$(VITE_PLUS_BIN) fmt --check frontend packages/ui packages/github-app-ui --no-error-on-unmatched-pattern --threads=1
+	$(VITE_PLUS_BIN) lint frontend packages/ui packages/github-app-ui '!frontend/dist/**' '!packages/github-app-ui/dist/**' '!frontend/test-results/**' '!packages/github-app-ui/test-results/**' '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1
+	cd frontend && ../node_modules/.bin/svelte-check --tsconfig ./tsconfig.json --fail-on-warnings
+	cd packages/ui && ../../node_modules/.bin/svelte-check --tsconfig ./tsconfig.json --fail-on-warnings
+	cd packages/github-app-ui && ../../node_modules/.bin/svelte-check --tsconfig ./tsconfig.json --fail-on-warnings
 
 # Prevent production frontend code from bypassing generated API clients
 frontend-api-client-check: check-vite-plus-bin

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1520,6 +1520,21 @@ func buildAppState(
 			return
 		}
 		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/pr-ci-state/pending-status-only" {
+			// CIStatus is pending while CIChecksJSON is still empty.
+			// Keep the provider pinned to pending so the deferred-merge
+			// endpoint can refresh granular checks before queueing.
+			setPR1CIState(w, r, database, fc, "pending-status-only", ciFixtureOptions{
+				statusName: "pending",
+				checksJSON: "",
+				pinProviderTo: &struct {
+					Status     string
+					Conclusion string
+				}{Status: "in_progress", Conclusion: ""},
+			})
+			return
+		}
+		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-ci-state/dropdown-mixed" {
 			// 21-check payload spanning every bucket so the dropdown
 			// e2e can exercise the summary header, all five sections,

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -752,6 +752,25 @@ components:
         - score
         - hit_type
       type: object
+    DeferMergePRBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/DeferMergePRBody.json
+          format: uri
+          readOnly: true
+          type: string
+        pending_checks:
+          format: int64
+          type: integer
+        status:
+          type: string
+      required:
+        - status
+        - pending_checks
+      type: object
     DependencyCapabilities:
       additionalProperties: false
       properties:
@@ -2630,29 +2649,6 @@ components:
         - merged
         - sha
         - message
-      type: object
-    MergePRHostInputBody:
-      additionalProperties: false
-      properties:
-        $schema:
-          description: A URL to the JSON Schema for this object.
-          examples:
-            - /api/v1/schemas/MergePRHostInputBody.json
-          format: uri
-          readOnly: true
-          type: string
-        commit_message:
-          type: string
-        commit_title:
-          type: string
-        expected_head_sha:
-          type: string
-        method:
-          type: string
-      required:
-        - commit_title
-        - commit_message
-        - method
       type: object
     MergePRInputBody:
       additionalProperties: false
@@ -9709,7 +9705,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MergePRHostInputBody"
+              $ref: "#/components/schemas/MergePRInputBody"
         required: true
       responses:
         "200":
@@ -9725,6 +9721,58 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Merge pull request
+      tags:
+        - Pull Requests
+  /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/merge/deferred:
+    post:
+      operationId: defer-merge-pull-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MergePRInputBody"
+        required: true
+      responses:
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeferMergePRBody"
+          description: Accepted
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Defer pull request merge until pending CI passes
       tags:
         - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/ready-for-review:
@@ -13340,6 +13388,53 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Merge pull request
+      tags:
+        - Pull Requests
+  /pulls/{provider}/{owner}/{name}/{number}/merge/deferred:
+    post:
+      operationId: defer-merge-pull
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MergePRInputBody"
+        required: true
+      responses:
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeferMergePRBody"
+          description: Accepted
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Defer pull request merge until pending CI passes
       tags:
         - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/ready-for-review:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -885,6 +885,7 @@
     {client}
     roborevBaseUrl="/api/roborev"
     onError={showFlash}
+    onNotification={showFlash}
     onNavigate={(e) =>
       navigate(typeof e === "string" ? e : e.path)}
     onWorkspaceCommand={emitWorkspaceCommand}

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -455,6 +455,38 @@ test.describe("detail action buttons", () => {
     }
   });
 
+  test("aggregate pending CI merge action enqueues deferred merge when check rows are empty", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    try {
+      isolatedServer = await startIsolatedE2EServer();
+      const baseURL = isolatedServer.info.base_url;
+      const seedResponse = await page.request.post(`${baseURL}/__e2e/pr-ci-state/pending-status-only`);
+      expect(seedResponse.ok()).toBe(true);
+
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+
+      await page.locator(".btn--merge").first().click();
+      const modal = page.locator(".modal", { hasText: "Merge Pull Request" });
+      await expect(modal).toBeVisible();
+
+      const deferResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.request().method() === "POST" &&
+          url.pathname === "/api/v1/pulls/github/acme/widgets/1/merge/deferred"
+        );
+      });
+      await modal.getByRole("button", { name: "Merge after CI is complete" }).click();
+      expect((await deferResponse).status()).toBe(202);
+
+      await expect(modal).toHaveCount(0);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+    } finally {
+      await isolatedServer?.stop();
+    }
+  });
+
   test("repo merge permission disables merge action with reason end-to-end", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     try {

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -425,6 +425,36 @@ test.describe("detail action buttons", () => {
     }
   });
 
+  test("pending CI merge action enqueues deferred merge and closes the modal", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    try {
+      isolatedServer = await startIsolatedE2EServer();
+      const baseURL = isolatedServer.info.base_url;
+
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+
+      await page.locator(".btn--merge").first().click();
+      const modal = page.locator(".modal", { hasText: "Merge Pull Request" });
+      await expect(modal).toBeVisible();
+
+      const deferResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.request().method() === "POST" &&
+          url.pathname === "/api/v1/pulls/github/acme/widgets/1/merge/deferred"
+        );
+      });
+      await modal.getByRole("button", { name: "Merge after CI is complete" }).click();
+      expect((await deferResponse).status()).toBe(202);
+
+      await expect(modal).toHaveCount(0);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+    } finally {
+      await isolatedServer?.stop();
+    }
+  });
+
   test("repo merge permission disables merge action with reason end-to-end", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     try {

--- a/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
+++ b/frontend/tests/e2e-full/utc-maintainer-flows.spec.ts
@@ -60,7 +60,7 @@ function mergeTarget(browserName: string): PullRef {
     case "chromium":
       return widgetsPull(7);
     case "firefox":
-      return widgetsPull(1);
+      return toolsPull(1);
     case "webkit":
       return toolsPull(1);
     default:

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -722,6 +722,14 @@ type CrossFolderHit struct {
 	Snippet    *BodySnippet `json:"snippet,omitempty"`
 }
 
+// DeferMergePRBody defines model for DeferMergePRBody.
+type DeferMergePRBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema        *string `json:"$schema,omitempty"`
+	PendingChecks int64   `json:"pending_checks"`
+	Status        string  `json:"status"`
+}
+
 // DependencyCapabilities defines model for DependencyCapabilities.
 type DependencyCapabilities struct {
 	Gh   bool `json:"gh"`
@@ -1476,16 +1484,6 @@ type MergePRBody struct {
 	Merged  bool    `json:"merged"`
 	Message string  `json:"message"`
 	Sha     string  `json:"sha"`
-}
-
-// MergePRHostInputBody defines model for MergePRHostInputBody.
-type MergePRHostInputBody struct {
-	// Schema A URL to the JSON Schema for this object.
-	Schema          *string `json:"$schema,omitempty"`
-	CommitMessage   string  `json:"commit_message"`
-	CommitTitle     string  `json:"commit_title"`
-	ExpectedHeadSha *string `json:"expected_head_sha,omitempty"`
-	Method          string  `json:"method"`
 }
 
 // MergePRInputBody defines model for MergePRInputBody.
@@ -3435,7 +3433,10 @@ type SetPrGithubStateOnHostJSONRequestBody = GithubStateHostInputBody
 type SetPrLabelsOnHostJSONRequestBody = SetLabelsRequest
 
 // MergePullOnHostJSONRequestBody defines body for MergePullOnHost for application/json ContentType.
-type MergePullOnHostJSONRequestBody = MergePRHostInputBody
+type MergePullOnHostJSONRequestBody = MergePRInputBody
+
+// DeferMergePullOnHostJSONRequestBody defines body for DeferMergePullOnHost for application/json ContentType.
+type DeferMergePullOnHostJSONRequestBody = MergePRInputBody
 
 // CreatePrReviewDraftCommentOnHostJSONRequestBody defines body for CreatePrReviewDraftCommentOnHost for application/json ContentType.
 type CreatePrReviewDraftCommentOnHostJSONRequestBody = CreateDiffReviewDraftCommentHostInputBody
@@ -3541,6 +3542,9 @@ type SetPrLabelsJSONRequestBody = SetLabelsRequest
 
 // MergePullJSONRequestBody defines body for MergePull for application/json ContentType.
 type MergePullJSONRequestBody = MergePRInputBody
+
+// DeferMergePullJSONRequestBody defines body for DeferMergePull for application/json ContentType.
+type DeferMergePullJSONRequestBody = MergePRInputBody
 
 // CreatePrReviewDraftCommentJSONRequestBody defines body for CreatePrReviewDraftComment for application/json ContentType.
 type CreatePrReviewDraftCommentJSONRequestBody = CreateDiffReviewDraftCommentInputBody
@@ -4018,6 +4022,11 @@ type ClientInterface interface {
 
 	MergePullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body MergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// DeferMergePullOnHostWithBody request with any body
+	DeferMergePullOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	DeferMergePullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body DeferMergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// MarkPullReadyForReviewOnHost request
 	MarkPullReadyForReviewOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4348,6 +4357,11 @@ type ClientInterface interface {
 	MergePullWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	MergePull(ctx context.Context, provider string, owner string, name string, number int64, body MergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeferMergePullWithBody request with any body
+	DeferMergePullWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	DeferMergePull(ctx context.Context, provider string, owner string, name string, number int64, body DeferMergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// MarkPullReadyForReview request
 	MarkPullReadyForReview(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6105,6 +6119,30 @@ func (c *Client) MergePullOnHost(ctx context.Context, platformHost string, provi
 	return c.Client.Do(req)
 }
 
+func (c *Client) DeferMergePullOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeferMergePullOnHostRequestWithBody(c.Server, platformHost, provider, owner, name, number, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeferMergePullOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body DeferMergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeferMergePullOnHostRequest(c.Server, platformHost, provider, owner, name, number, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) MarkPullReadyForReviewOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewMarkPullReadyForReviewOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
@@ -7559,6 +7597,30 @@ func (c *Client) MergePullWithBody(ctx context.Context, provider string, owner s
 
 func (c *Client) MergePull(ctx context.Context, provider string, owner string, name string, number int64, body MergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewMergePullRequest(c.Server, provider, owner, name, number, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeferMergePullWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeferMergePullRequestWithBody(c.Server, provider, owner, name, number, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeferMergePull(ctx context.Context, provider string, owner string, name string, number int64, body DeferMergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeferMergePullRequest(c.Server, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -14080,6 +14142,81 @@ func NewMergePullOnHostRequestWithBody(server string, platformHost string, provi
 	return req, nil
 }
 
+// NewDeferMergePullOnHostRequest calls the generic DeferMergePullOnHost builder with application/json body
+func NewDeferMergePullOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64, body DeferMergePullOnHostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewDeferMergePullOnHostRequestWithBody(server, platformHost, provider, owner, name, number, "application/json", bodyReader)
+}
+
+// NewDeferMergePullOnHostRequestWithBody generates requests for DeferMergePullOnHost with any type of body
+func NewDeferMergePullOnHostRequestWithBody(server string, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam4 string
+
+	pathParam4, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/pulls/%s/%s/%s/%s/merge/deferred", pathParam0, pathParam1, pathParam2, pathParam3, pathParam4)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewMarkPullReadyForReviewOnHostRequest generates requests for MarkPullReadyForReviewOnHost
 func NewMarkPullReadyForReviewOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
@@ -19455,6 +19592,74 @@ func NewMergePullRequestWithBody(server string, provider string, owner string, n
 	return req, nil
 }
 
+// NewDeferMergePullRequest calls the generic DeferMergePull builder with application/json body
+func NewDeferMergePullRequest(server string, provider string, owner string, name string, number int64, body DeferMergePullJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewDeferMergePullRequestWithBody(server, provider, owner, name, number, "application/json", bodyReader)
+}
+
+// NewDeferMergePullRequestWithBody generates requests for DeferMergePull with any type of body
+func NewDeferMergePullRequestWithBody(server string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/pulls/%s/%s/%s/%s/merge/deferred", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewMarkPullReadyForReviewRequest generates requests for MarkPullReadyForReview
 func NewMarkPullReadyForReviewRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
@@ -23119,6 +23324,11 @@ type ClientWithResponsesInterface interface {
 
 	MergePullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body MergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*MergePullOnHostResponse, error)
 
+	// DeferMergePullOnHostWithBodyWithResponse request with any body
+	DeferMergePullOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeferMergePullOnHostResponse, error)
+
+	DeferMergePullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body DeferMergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*DeferMergePullOnHostResponse, error)
+
 	// MarkPullReadyForReviewOnHostWithResponse request
 	MarkPullReadyForReviewOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewOnHostResponse, error)
 
@@ -23449,6 +23659,11 @@ type ClientWithResponsesInterface interface {
 	MergePullWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MergePullResponse, error)
 
 	MergePullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body MergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*MergePullResponse, error)
+
+	// DeferMergePullWithBodyWithResponse request with any body
+	DeferMergePullWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeferMergePullResponse, error)
+
+	DeferMergePullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body DeferMergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*DeferMergePullResponse, error)
 
 	// MarkPullReadyForReviewWithResponse request
 	MarkPullReadyForReviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewResponse, error)
@@ -25690,6 +25905,29 @@ func (r MergePullOnHostResponse) StatusCode() int {
 	return 0
 }
 
+type DeferMergePullOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON202                       *DeferMergePRBody
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeferMergePullOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeferMergePullOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type MarkPullReadyForReviewOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -27670,6 +27908,29 @@ func (r MergePullResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r MergePullResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeferMergePullResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON202                       *DeferMergePRBody
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeferMergePullResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeferMergePullResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -30290,6 +30551,23 @@ func (c *ClientWithResponses) MergePullOnHostWithResponse(ctx context.Context, p
 	return ParseMergePullOnHostResponse(rsp)
 }
 
+// DeferMergePullOnHostWithBodyWithResponse request with arbitrary body returning *DeferMergePullOnHostResponse
+func (c *ClientWithResponses) DeferMergePullOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeferMergePullOnHostResponse, error) {
+	rsp, err := c.DeferMergePullOnHostWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeferMergePullOnHostResponse(rsp)
+}
+
+func (c *ClientWithResponses) DeferMergePullOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body DeferMergePullOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*DeferMergePullOnHostResponse, error) {
+	rsp, err := c.DeferMergePullOnHost(ctx, platformHost, provider, owner, name, number, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeferMergePullOnHostResponse(rsp)
+}
+
 // MarkPullReadyForReviewOnHostWithResponse request returning *MarkPullReadyForReviewOnHostResponse
 func (c *ClientWithResponses) MarkPullReadyForReviewOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewOnHostResponse, error) {
 	rsp, err := c.MarkPullReadyForReviewOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
@@ -31351,6 +31629,23 @@ func (c *ClientWithResponses) MergePullWithResponse(ctx context.Context, provide
 		return nil, err
 	}
 	return ParseMergePullResponse(rsp)
+}
+
+// DeferMergePullWithBodyWithResponse request with arbitrary body returning *DeferMergePullResponse
+func (c *ClientWithResponses) DeferMergePullWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeferMergePullResponse, error) {
+	rsp, err := c.DeferMergePullWithBody(ctx, provider, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeferMergePullResponse(rsp)
+}
+
+func (c *ClientWithResponses) DeferMergePullWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body DeferMergePullJSONRequestBody, reqEditors ...RequestEditorFn) (*DeferMergePullResponse, error) {
+	rsp, err := c.DeferMergePull(ctx, provider, owner, name, number, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeferMergePullResponse(rsp)
 }
 
 // MarkPullReadyForReviewWithResponse request returning *MarkPullReadyForReviewResponse
@@ -34960,6 +35255,39 @@ func ParseMergePullOnHostResponse(rsp *http.Response) (*MergePullOnHostResponse,
 	return response, nil
 }
 
+// ParseDeferMergePullOnHostResponse parses an HTTP response from a DeferMergePullOnHostWithResponse call
+func ParseDeferMergePullOnHostResponse(rsp *http.Response) (*DeferMergePullOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeferMergePullOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest DeferMergePRBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseMarkPullReadyForReviewOnHostResponse parses an HTTP response from a MarkPullReadyForReviewOnHostWithResponse call
 func ParseMarkPullReadyForReviewOnHostResponse(rsp *http.Response) (*MarkPullReadyForReviewOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -37713,6 +38041,39 @@ func ParseMergePullResponse(rsp *http.Response) (*MergePullResponse, error) {
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeferMergePullResponse parses an HTTP response from a DeferMergePullWithResponse call
+func ParseDeferMergePullResponse(rsp *http.Response) (*DeferMergePullResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeferMergePullResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest DeferMergePRBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ProblemError

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -1,0 +1,327 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/middleman/internal/db"
+	ghclient "go.kenn.io/middleman/internal/github"
+)
+
+const deferredMergePollInterval = time.Minute
+
+type deferredMergeCheckKey struct {
+	App  string
+	Name string
+}
+
+type deferredMergeCompletedPayload struct {
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	RepoPath     string `json:"repo_path"`
+	Owner        string `json:"owner"`
+	Name         string `json:"name"`
+	Number       int    `json:"number"`
+	HeadSHA      string `json:"head_sha"`
+	Status       string `json:"status"`
+	Merged       bool   `json:"merged,omitempty"`
+	SHA          string `json:"sha,omitempty"`
+	Message      string `json:"message,omitempty"`
+	Error        string `json:"error,omitempty"`
+	CompletedAt  string `json:"completed_at"`
+}
+
+func (s *Server) deferMergePR(
+	ctx context.Context,
+	input *deferMergePRInput,
+) (*deferMergePROutput, error) {
+	body, err := s.enqueueDeferredMerge(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Number, input.Body, deferredMergePollInterval)
+	if err != nil {
+		return nil, err
+	}
+	return &deferMergePROutput{Status: 202, Body: body}, nil
+}
+
+func (s *Server) enqueueDeferredMerge(
+	ctx context.Context,
+	provider string,
+	platformHost string,
+	owner string,
+	name string,
+	number int,
+	body mergePRInputBody,
+	pollInterval time.Duration,
+) (deferMergePRBody, error) {
+	if pollInterval <= 0 {
+		pollInterval = deferredMergePollInterval
+	}
+	repo, err := s.requireRepoRouteCapability(
+		ctx,
+		provider, platformHost, owner, name,
+		capabilityMergeMutation,
+	)
+	if err != nil {
+		return deferMergePRBody{}, err
+	}
+	if err := s.requireSyncerCapability(*repo, capabilityMergeMutation); err != nil {
+		return deferMergePRBody{}, err
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	if err != nil {
+		return deferMergePRBody{}, problemInternal("get pull request failed")
+	}
+	if mr == nil {
+		return deferMergePRBody{}, problemNotFound(CodePullNotFound, "pull request not found", nil)
+	}
+	pendingKeys, err := pendingDeferredMergeCheckKeys(mr.CIChecksJSON)
+	if err != nil {
+		return deferMergePRBody{}, problemValidation("ci_checks", err.Error())
+	}
+	key := deferredMergeKey(*repo, number)
+	if !s.markDeferredMergeInFlight(key) {
+		return deferMergePRBody{}, problemConflict(
+			CodeConflict,
+			"a deferred merge is already waiting for this pull request",
+			map[string]any{"reason": "already_pending"},
+		)
+	}
+	started := s.runBackground(func(bgCtx context.Context) {
+		defer s.clearDeferredMergeInFlight(key)
+		s.runDeferredMerge(bgCtx, *repo, number, body, pendingKeys, pollInterval)
+	})
+	if !started {
+		s.clearDeferredMergeInFlight(key)
+		return deferMergePRBody{}, problemServiceUnavailable("server is shutting down")
+	}
+	return deferMergePRBody{
+		Status:        "queued",
+		PendingChecks: len(pendingKeys),
+	}, nil
+}
+
+func (s *Server) runDeferredMerge(
+	ctx context.Context,
+	repo db.Repo,
+	number int,
+	body mergePRInputBody,
+	pendingKeys []deferredMergeCheckKey,
+	pollInterval time.Duration,
+) {
+	if len(pendingKeys) == 0 {
+		s.completeDeferredMerge(ctx, repo, number, body)
+		return
+	}
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		state, err := s.refreshDeferredMergeCI(ctx, repo, number, pendingKeys)
+		if err != nil {
+			s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, err.Error())
+			return
+		}
+		switch state {
+		case "passed":
+			s.completeDeferredMerge(ctx, repo, number, body)
+			return
+		case "failed":
+			s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, "a check that was pending failed; merge was not performed")
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Server) refreshDeferredMergeCI(
+	ctx context.Context,
+	repo db.Repo,
+	number int,
+	pendingKeys []deferredMergeCheckKey,
+) (string, error) {
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	if err != nil {
+		return "", err
+	}
+	if mr == nil {
+		return "", errors.New("pull request no longer exists")
+	}
+	if _, err := s.syncer.RefreshMRCIStatusOnProvider(
+		ctx,
+		ghclient.RepoRef{
+			Platform:           repoProviderKind(repo),
+			Owner:              repo.Owner,
+			Name:               repo.Name,
+			PlatformHost:       repoProviderHost(repo),
+			RepoPath:           repo.RepoPath,
+			PlatformExternalID: repo.PlatformRepoID,
+			WebURL:             repo.WebURL,
+			CloneURL:           repo.CloneURL,
+			DefaultBranch:      repo.DefaultBranch,
+		},
+		repo.ID,
+		number,
+		mr.PlatformHeadSHA,
+	); err != nil {
+		return "", err
+	}
+	refreshed, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	if err != nil {
+		return "", err
+	}
+	if refreshed == nil {
+		return "", errors.New("pull request no longer exists after CI refresh")
+	}
+	s.hub.Broadcast(Event{
+		Type: "pr_ci_refreshed",
+		Data: prCIRefreshedPayload{
+			Provider:     string(repoProviderKind(repo)),
+			PlatformHost: repoProviderHost(repo),
+			RepoPath:     repo.RepoPath,
+			Owner:        repo.Owner,
+			Name:         repo.Name,
+			Number:       number,
+			HeadSHA:      refreshed.PlatformHeadSHA,
+			RefreshedAt:  formatUTCRFC3339(s.now().UTC()),
+			Warnings:     []string{},
+		},
+	})
+	return deferredMergeCheckState(pendingKeys, refreshed.CIChecksJSON)
+}
+
+func (s *Server) completeDeferredMerge(
+	ctx context.Context,
+	repo db.Repo,
+	number int,
+	body mergePRInputBody,
+) {
+	result, err := s.mergePRWithBody(ctx, string(repoProviderKind(repo)), repoProviderHost(repo), repo.Owner, repo.Name, number, body)
+	if err != nil {
+		s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, err.Error())
+		return
+	}
+	s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
+	s.hub.Broadcast(Event{
+		Type: "deferred_merge_completed",
+		Data: deferredMergeCompletedPayload{
+			Provider:     string(repoProviderKind(repo)),
+			PlatformHost: repoProviderHost(repo),
+			RepoPath:     repo.RepoPath,
+			Owner:        repo.Owner,
+			Name:         repo.Name,
+			Number:       number,
+			HeadSHA:      body.ExpectedHeadSHA,
+			Status:       "merged",
+			Merged:       result.Merged,
+			SHA:          result.SHA,
+			Message:      result.Message,
+			CompletedAt:  formatUTCRFC3339(s.now().UTC()),
+		},
+	})
+}
+
+func (s *Server) broadcastDeferredMergeFailure(repo db.Repo, number int, headSHA string, message string) {
+	slog.Warn("deferred merge failed",
+		"provider", repoProviderKind(repo),
+		"platform_host", repoProviderHost(repo),
+		"repo_path", repo.RepoPath,
+		"number", number,
+		"err", message,
+	)
+	s.hub.Broadcast(Event{
+		Type: "deferred_merge_completed",
+		Data: deferredMergeCompletedPayload{
+			Provider:     string(repoProviderKind(repo)),
+			PlatformHost: repoProviderHost(repo),
+			RepoPath:     repo.RepoPath,
+			Owner:        repo.Owner,
+			Name:         repo.Name,
+			Number:       number,
+			HeadSHA:      headSHA,
+			Status:       "failed",
+			Error:        message,
+			CompletedAt:  formatUTCRFC3339(s.now().UTC()),
+		},
+	})
+}
+
+func pendingDeferredMergeCheckKeys(checksJSON string) ([]deferredMergeCheckKey, error) {
+	var checks []db.CICheck
+	if strings.TrimSpace(checksJSON) == "" {
+		return nil, nil
+	}
+	if err := json.Unmarshal([]byte(checksJSON), &checks); err != nil {
+		return nil, err
+	}
+	keys := make([]deferredMergeCheckKey, 0)
+	for _, check := range checks {
+		if check.Status != "completed" {
+			keys = append(keys, deferredMergeCheckKey{App: check.App, Name: check.Name})
+		}
+	}
+	return keys, nil
+}
+
+func deferredMergeCheckState(keys []deferredMergeCheckKey, checksJSON string) (string, error) {
+	var checks []db.CICheck
+	if strings.TrimSpace(checksJSON) != "" {
+		if err := json.Unmarshal([]byte(checksJSON), &checks); err != nil {
+			return "", err
+		}
+	}
+	byKey := make(map[deferredMergeCheckKey]db.CICheck, len(checks))
+	for _, check := range checks {
+		byKey[deferredMergeCheckKey{App: check.App, Name: check.Name}] = check
+	}
+	pending := false
+	for _, key := range keys {
+		check, ok := byKey[key]
+		if !ok {
+			pending = true
+			continue
+		}
+		if check.Status != "completed" {
+			pending = true
+			continue
+		}
+		switch check.Conclusion {
+		case "success", "neutral", "skipped":
+		default:
+			return "failed", nil
+		}
+	}
+	if pending {
+		return "pending", nil
+	}
+	return "passed", nil
+}
+
+func deferredMergeKey(repo db.Repo, number int) string {
+	return string(repoProviderKind(repo)) + ":" + repoProviderHost(repo) + ":" + repo.RepoPath + "#" + strconv.Itoa(number)
+}
+
+func (s *Server) markDeferredMergeInFlight(key string) bool {
+	s.deferredMergeMu.Lock()
+	defer s.deferredMergeMu.Unlock()
+	if s.deferredMergeInFlight == nil {
+		s.deferredMergeInFlight = make(map[string]struct{})
+	}
+	if _, ok := s.deferredMergeInFlight[key]; ok {
+		return false
+	}
+	s.deferredMergeInFlight[key] = struct{}{}
+	return true
+}
+
+func (s *Server) clearDeferredMergeInFlight(key string) {
+	s.deferredMergeMu.Lock()
+	defer s.deferredMergeMu.Unlock()
+	delete(s.deferredMergeInFlight, key)
+}

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -11,6 +11,7 @@ import (
 
 	"go.kenn.io/middleman/internal/db"
 	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/platform"
 )
 
 const (
@@ -21,6 +22,12 @@ const (
 type deferredMergeCheckKey struct {
 	App  string
 	Name string
+}
+
+type deferredMergeTargetSnapshot struct {
+	HeadSHA    string
+	BaseBranch string
+	BaseSHA    string
 }
 
 type deferredMergeCompletedPayload struct {
@@ -85,21 +92,35 @@ func (s *Server) enqueueDeferredMerge(
 	if mr == nil {
 		return deferMergePRBody{}, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
-	if _, err := s.preflightMergePR(repo, mr, number, body); err != nil {
+	expectedHeadSHA, err := s.preflightMergePR(repo, mr, number, body)
+	if err != nil {
 		return deferMergePRBody{}, err
 	}
-	queuedHeadSHA := mr.PlatformHeadSHA
+	queuedTarget := deferredMergeTargetSnapshotFromMR(mr)
+	if strings.TrimSpace(expectedHeadSHA) != "" {
+		queuedTarget.HeadSHA = expectedHeadSHA
+	}
 	pendingKeys, err := pendingDeferredMergeCheckKeys(mr.CIChecksJSON)
 	if err != nil {
 		return deferMergePRBody{}, problemValidation("ci_checks", err.Error())
 	}
+	aggregateState := deferredMergeAggregateState(mr.CIStatus)
 	if len(pendingKeys) == 0 {
-		pendingKeys, err = s.refreshPendingDeferredMergeCheckKeys(ctx, *repo, number, mr.PlatformHeadSHA)
+		refreshed, refreshedKeys, err := s.refreshPendingDeferredMergeCheckKeys(ctx, *repo, number, queuedTarget)
 		if err != nil {
 			return deferMergePRBody{}, err
 		}
+		pendingKeys = refreshedKeys
+		aggregateState = deferredMergeAggregateState(refreshed.CIStatus)
 	}
-	if len(pendingKeys) == 0 {
+	if aggregateState == "failed" {
+		return deferMergePRBody{}, problemConflict(
+			CodeConflict,
+			"CI checks have already failed",
+			map[string]any{"reason": "ci_failed"},
+		)
+	}
+	if len(pendingKeys) == 0 && aggregateState != "pending" {
 		return deferMergePRBody{}, problemConflict(
 			CodeConflict,
 			"no pending CI checks to wait for",
@@ -116,7 +137,7 @@ func (s *Server) enqueueDeferredMerge(
 	}
 	started := s.runBackground(func(bgCtx context.Context) {
 		defer s.clearDeferredMergeInFlight(key)
-		s.runDeferredMerge(bgCtx, *repo, number, body, pendingKeys, queuedHeadSHA, pollInterval, maxWait)
+		s.runDeferredMerge(bgCtx, *repo, number, body, pendingKeys, queuedTarget, pollInterval, maxWait)
 	})
 	if !started {
 		s.clearDeferredMergeInFlight(key)
@@ -134,14 +155,10 @@ func (s *Server) runDeferredMerge(
 	number int,
 	body mergePRInputBody,
 	pendingKeys []deferredMergeCheckKey,
-	queuedHeadSHA string,
+	queuedTarget deferredMergeTargetSnapshot,
 	pollInterval time.Duration,
 	maxWait time.Duration,
 ) {
-	if len(pendingKeys) == 0 {
-		s.completeDeferredMerge(ctx, repo, number, body, queuedHeadSHA)
-		return
-	}
 	if maxWait <= 0 {
 		maxWait = defaultDeferredMergeMaxWait
 	}
@@ -150,24 +167,24 @@ func (s *Server) runDeferredMerge(
 	timeout := time.NewTimer(maxWait)
 	defer timeout.Stop()
 	for {
-		state, err := s.refreshDeferredMergeCI(ctx, repo, number, pendingKeys, queuedHeadSHA)
+		state, err := s.refreshDeferredMergeCI(ctx, repo, number, pendingKeys, queuedTarget)
 		if err != nil {
-			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), err.Error())
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), err.Error())
 			return
 		}
 		switch state {
 		case "passed":
-			s.completeDeferredMerge(ctx, repo, number, body, queuedHeadSHA)
+			s.completeDeferredMerge(ctx, repo, number, body, queuedTarget)
 			return
 		case "failed":
-			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), "a current CI check failed; merge was not performed")
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), "a current CI check failed; merge was not performed")
 			return
 		}
 		select {
 		case <-ctx.Done():
 			return
 		case <-timeout.C:
-			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), "timed out waiting for pending CI checks to finish; merge was not performed")
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), "timed out waiting for pending CI checks to finish; merge was not performed")
 			return
 		case <-ticker.C:
 		}
@@ -179,7 +196,7 @@ func (s *Server) refreshDeferredMergeCI(
 	repo db.Repo,
 	number int,
 	pendingKeys []deferredMergeCheckKey,
-	queuedHeadSHA string,
+	queuedTarget deferredMergeTargetSnapshot,
 ) (string, error) {
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 	if err != nil {
@@ -188,15 +205,15 @@ func (s *Server) refreshDeferredMergeCI(
 	if mr == nil {
 		return "", errors.New("pull request no longer exists")
 	}
-	if strings.TrimSpace(queuedHeadSHA) != "" && mr.PlatformHeadSHA != queuedHeadSHA {
-		return "", errors.New("target changed since deferred merge was queued; refresh and retry")
+	if err := deferredMergeTargetMatchesDB(mr, queuedTarget); err != nil {
+		return "", err
 	}
 	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
 		deferredMergeRepoRef(repo),
 		repo.ID,
 		number,
-		mr.PlatformHeadSHA,
+		queuedTarget.HeadSHA,
 	)
 	if err != nil {
 		return "", err
@@ -211,8 +228,8 @@ func (s *Server) refreshDeferredMergeCI(
 	if refreshed == nil {
 		return "", errors.New("pull request no longer exists after CI refresh")
 	}
-	if strings.TrimSpace(queuedHeadSHA) != "" && refreshed.PlatformHeadSHA != queuedHeadSHA {
-		return "", errors.New("target changed since deferred merge was queued; refresh and retry")
+	if err := deferredMergeTargetMatchesDB(refreshed, queuedTarget); err != nil {
+		return "", err
 	}
 	s.hub.Broadcast(Event{
 		Type: "pr_ci_refreshed",
@@ -228,31 +245,31 @@ func (s *Server) refreshDeferredMergeCI(
 			Warnings:     []string{},
 		},
 	})
-	return deferredMergeCheckState(pendingKeys, refreshed.CIChecksJSON)
+	return deferredMergeCheckState(refreshed.CIStatus, pendingKeys, refreshed.CIChecksJSON)
 }
 
 func (s *Server) refreshPendingDeferredMergeCheckKeys(
 	ctx context.Context,
 	repo db.Repo,
 	number int,
-	headSHA string,
-) ([]deferredMergeCheckKey, error) {
+	queuedTarget deferredMergeTargetSnapshot,
+) (*db.MergeRequest, []deferredMergeCheckKey, error) {
 	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
 		deferredMergeRepoRef(repo),
 		repo.ID,
 		number,
-		headSHA,
+		queuedTarget.HeadSHA,
 	)
 	if err != nil {
-		return nil, providerCallProblemWithDetail(
+		return nil, nil, providerCallProblemWithDetail(
 			err,
 			string(repoProviderKind(repo)), repoProviderHost(repo),
 			"refresh PR CI before deferring merge: "+err.Error(),
 		)
 	}
 	if len(warnings) > 0 {
-		return nil, problemConflict(
+		return nil, nil, problemConflict(
 			CodeConflict,
 			"could not refresh CI checks before deferring merge",
 			map[string]any{"reason": "ci_refresh_unavailable", "warnings": warnings},
@@ -260,16 +277,23 @@ func (s *Server) refreshPendingDeferredMergeCheckKeys(
 	}
 	refreshed, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 	if err != nil {
-		return nil, problemInternal("get pull request after CI refresh failed")
+		return nil, nil, problemInternal("get pull request after CI refresh failed")
 	}
 	if refreshed == nil {
-		return nil, problemNotFound(CodePullNotFound, "pull request not found after CI refresh", nil)
+		return nil, nil, problemNotFound(CodePullNotFound, "pull request not found after CI refresh", nil)
+	}
+	if err := deferredMergeTargetMatchesDB(refreshed, queuedTarget); err != nil {
+		return nil, nil, problemConflict(
+			CodeConflict,
+			err.Error(),
+			map[string]any{"reason": "stale_state"},
+		)
 	}
 	keys, err := pendingDeferredMergeCheckKeys(refreshed.CIChecksJSON)
 	if err != nil {
-		return nil, problemValidation("ci_checks", err.Error())
+		return nil, nil, problemValidation("ci_checks", err.Error())
 	}
-	return keys, nil
+	return refreshed, keys, nil
 }
 
 func deferredMergeRepoRef(repo db.Repo) ghclient.RepoRef {
@@ -291,15 +315,15 @@ func (s *Server) completeDeferredMerge(
 	repo db.Repo,
 	number int,
 	body mergePRInputBody,
-	queuedHeadSHA string,
+	queuedTarget deferredMergeTargetSnapshot,
 ) {
-	if err := s.ensureDeferredMergeHeadUnchanged(ctx, repo, number, queuedHeadSHA); err != nil {
-		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), err.Error())
+	if err := s.ensureDeferredMergeTargetUnchanged(ctx, repo, number, queuedTarget); err != nil {
+		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), err.Error())
 		return
 	}
 	result, err := s.mergePRWithBody(ctx, string(repoProviderKind(repo)), repoProviderHost(repo), repo.Owner, repo.Name, number, body)
 	if err != nil {
-		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), err.Error())
+		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), err.Error())
 		return
 	}
 	s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
@@ -312,7 +336,7 @@ func (s *Server) completeDeferredMerge(
 			Owner:        repo.Owner,
 			Name:         repo.Name,
 			Number:       number,
-			HeadSHA:      deferredMergeHeadSHA(body, queuedHeadSHA),
+			HeadSHA:      deferredMergeHeadSHA(body, queuedTarget.HeadSHA),
 			Status:       "merged",
 			Merged:       result.Merged,
 			SHA:          result.SHA,
@@ -322,10 +346,7 @@ func (s *Server) completeDeferredMerge(
 	})
 }
 
-func (s *Server) ensureDeferredMergeHeadUnchanged(ctx context.Context, repo db.Repo, number int, queuedHeadSHA string) error {
-	if strings.TrimSpace(queuedHeadSHA) == "" {
-		return nil
-	}
+func (s *Server) ensureDeferredMergeTargetUnchanged(ctx context.Context, repo db.Repo, number int, queuedTarget deferredMergeTargetSnapshot) error {
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 	if err != nil {
 		return err
@@ -333,7 +354,63 @@ func (s *Server) ensureDeferredMergeHeadUnchanged(ctx context.Context, repo db.R
 	if mr == nil {
 		return errors.New("pull request no longer exists")
 	}
-	if mr.PlatformHeadSHA != queuedHeadSHA {
+	if err := deferredMergeTargetMatchesDB(mr, queuedTarget); err != nil {
+		return err
+	}
+	reader, err := s.syncer.Registry().MergeRequestReader(repoProviderKind(repo), repoProviderHost(repo))
+	if err != nil {
+		return err
+	}
+	current, err := reader.GetMergeRequest(ctx, platformRepoRefFromDB(repo), number)
+	if err != nil {
+		return err
+	}
+	if err := deferredMergeTargetMatchesProvider(current, queuedTarget); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deferredMergeTargetSnapshotFromMR(mr *db.MergeRequest) deferredMergeTargetSnapshot {
+	if mr == nil {
+		return deferredMergeTargetSnapshot{}
+	}
+	return deferredMergeTargetSnapshot{
+		HeadSHA:    strings.TrimSpace(mr.PlatformHeadSHA),
+		BaseBranch: strings.TrimSpace(mr.BaseBranch),
+		BaseSHA:    strings.TrimSpace(mr.PlatformBaseSHA),
+	}
+}
+
+func deferredMergeTargetMatchesDB(mr *db.MergeRequest, queued deferredMergeTargetSnapshot) error {
+	if mr == nil {
+		return errors.New("pull request no longer exists")
+	}
+	return deferredMergeTargetMatches(
+		queued,
+		strings.TrimSpace(mr.PlatformHeadSHA),
+		strings.TrimSpace(mr.BaseBranch),
+		strings.TrimSpace(mr.PlatformBaseSHA),
+	)
+}
+
+func deferredMergeTargetMatchesProvider(mr platform.MergeRequest, queued deferredMergeTargetSnapshot) error {
+	return deferredMergeTargetMatches(
+		queued,
+		strings.TrimSpace(mr.HeadSHA),
+		strings.TrimSpace(mr.BaseBranch),
+		strings.TrimSpace(mr.BaseSHA),
+	)
+}
+
+func deferredMergeTargetMatches(queued deferredMergeTargetSnapshot, headSHA, baseBranch, baseSHA string) error {
+	if strings.TrimSpace(queued.HeadSHA) != "" && headSHA != queued.HeadSHA {
+		return errors.New("target changed since deferred merge was queued; refresh and retry")
+	}
+	if strings.TrimSpace(queued.BaseBranch) != "" && baseBranch != queued.BaseBranch {
+		return errors.New("target changed since deferred merge was queued; refresh and retry")
+	}
+	if strings.TrimSpace(queued.BaseSHA) != "" && baseSHA != queued.BaseSHA {
 		return errors.New("target changed since deferred merge was queued; refresh and retry")
 	}
 	return nil
@@ -388,7 +465,11 @@ func pendingDeferredMergeCheckKeys(checksJSON string) ([]deferredMergeCheckKey, 
 	return keys, nil
 }
 
-func deferredMergeCheckState(keys []deferredMergeCheckKey, checksJSON string) (string, error) {
+func deferredMergeCheckState(aggregateStatus string, keys []deferredMergeCheckKey, checksJSON string) (string, error) {
+	aggregateState := deferredMergeAggregateState(aggregateStatus)
+	if aggregateState == "failed" {
+		return "failed", nil
+	}
 	var checks []db.CICheck
 	if strings.TrimSpace(checksJSON) != "" {
 		if err := json.Unmarshal([]byte(checksJSON), &checks); err != nil {
@@ -436,7 +517,25 @@ func deferredMergeCheckState(keys []deferredMergeCheckKey, checksJSON string) (s
 	if currentPending {
 		return "pending", nil
 	}
+	if aggregateState == "pending" {
+		return "pending", nil
+	}
 	return "passed", nil
+}
+
+func deferredMergeAggregateState(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "":
+		return ""
+	case "success", "passed":
+		return "passed"
+	case "failure", "failed", "error", "cancelled", "canceled", "timed_out":
+		return "failed"
+	case "pending", "in_progress", "queued", "running", "waiting":
+		return "pending"
+	default:
+		return "pending"
+	}
 }
 
 func deferredMergeKey(repo db.Repo, number int) string {

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -13,7 +13,10 @@ import (
 	ghclient "go.kenn.io/middleman/internal/github"
 )
 
-const deferredMergePollInterval = time.Minute
+const (
+	deferredMergePollInterval = time.Minute
+	deferredMergeMaxWait      = 24 * time.Hour
+)
 
 type deferredMergeCheckKey struct {
 	App  string
@@ -82,6 +85,13 @@ func (s *Server) enqueueDeferredMerge(
 	if err != nil {
 		return deferMergePRBody{}, problemValidation("ci_checks", err.Error())
 	}
+	if len(pendingKeys) == 0 {
+		return deferMergePRBody{}, problemConflict(
+			CodeConflict,
+			"no pending CI checks to wait for",
+			map[string]any{"reason": "no_pending_checks"},
+		)
+	}
 	key := deferredMergeKey(*repo, number)
 	if !s.markDeferredMergeInFlight(key) {
 		return deferMergePRBody{}, problemConflict(
@@ -118,6 +128,8 @@ func (s *Server) runDeferredMerge(
 	}
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
+	timeout := time.NewTimer(deferredMergeMaxWait)
+	defer timeout.Stop()
 	for {
 		state, err := s.refreshDeferredMergeCI(ctx, repo, number, pendingKeys)
 		if err != nil {
@@ -134,6 +146,9 @@ func (s *Server) runDeferredMerge(
 		}
 		select {
 		case <-ctx.Done():
+			return
+		case <-timeout.C:
+			s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, "timed out waiting for pending CI checks to finish; merge was not performed")
 			return
 		case <-ticker.C:
 		}
@@ -153,7 +168,7 @@ func (s *Server) refreshDeferredMergeCI(
 	if mr == nil {
 		return "", errors.New("pull request no longer exists")
 	}
-	if _, err := s.syncer.RefreshMRCIStatusOnProvider(
+	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
 		ghclient.RepoRef{
 			Platform:           repoProviderKind(repo),
@@ -169,8 +184,12 @@ func (s *Server) refreshDeferredMergeCI(
 		repo.ID,
 		number,
 		mr.PlatformHeadSHA,
-	); err != nil {
+	)
+	if err != nil {
 		return "", err
+	}
+	if len(warnings) > 0 {
+		return "", errors.New("could not refresh CI checks; deferred merge was not performed: " + strings.Join(warnings, "; "))
 	}
 	refreshed, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 	if err != nil {

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -193,6 +193,9 @@ func (s *Server) runDeferredMerge(
 		case "failed":
 			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), "a current CI check failed; merge was not performed")
 			return
+		case "unknown":
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), "aggregate CI status is unavailable after refresh; merge was not performed")
+			return
 		}
 		select {
 		case <-ctx.Done():
@@ -507,6 +510,9 @@ func deferredMergeCheckState(aggregateStatus string, keys []deferredMergeCheckKe
 		default:
 			return "failed", nil
 		}
+	}
+	if aggregateState == "unknown" {
+		return "unknown", nil
 	}
 	pending := false
 	for _, key := range keys {

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -160,7 +160,7 @@ func (s *Server) runDeferredMerge(
 			s.completeDeferredMerge(ctx, repo, number, body, queuedHeadSHA)
 			return
 		case "failed":
-			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), "a check failed; merge was not performed")
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), "a current CI check failed; merge was not performed")
 			return
 		}
 		select {
@@ -395,6 +395,10 @@ func deferredMergeCheckState(keys []deferredMergeCheckKey, checksJSON string) (s
 			return "", err
 		}
 	}
+	// Middleman does not have a provider-neutral required-check model. Deferred
+	// merge therefore fails closed: the checks that were pending when queued
+	// must pass, and the current refreshed snapshot must contain no failed or
+	// still-pending checks before the merge is attempted.
 	byKey := make(map[deferredMergeCheckKey]db.CICheck, len(checks))
 	currentPending := false
 	for _, check := range checks {

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -85,6 +85,10 @@ func (s *Server) enqueueDeferredMerge(
 	if mr == nil {
 		return deferMergePRBody{}, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
+	if _, err := s.preflightMergePR(repo, mr, number, body); err != nil {
+		return deferMergePRBody{}, err
+	}
+	queuedHeadSHA := mr.PlatformHeadSHA
 	pendingKeys, err := pendingDeferredMergeCheckKeys(mr.CIChecksJSON)
 	if err != nil {
 		return deferMergePRBody{}, problemValidation("ci_checks", err.Error())
@@ -112,7 +116,7 @@ func (s *Server) enqueueDeferredMerge(
 	}
 	started := s.runBackground(func(bgCtx context.Context) {
 		defer s.clearDeferredMergeInFlight(key)
-		s.runDeferredMerge(bgCtx, *repo, number, body, pendingKeys, pollInterval, maxWait)
+		s.runDeferredMerge(bgCtx, *repo, number, body, pendingKeys, queuedHeadSHA, pollInterval, maxWait)
 	})
 	if !started {
 		s.clearDeferredMergeInFlight(key)
@@ -130,11 +134,12 @@ func (s *Server) runDeferredMerge(
 	number int,
 	body mergePRInputBody,
 	pendingKeys []deferredMergeCheckKey,
+	queuedHeadSHA string,
 	pollInterval time.Duration,
 	maxWait time.Duration,
 ) {
 	if len(pendingKeys) == 0 {
-		s.completeDeferredMerge(ctx, repo, number, body)
+		s.completeDeferredMerge(ctx, repo, number, body, queuedHeadSHA)
 		return
 	}
 	if maxWait <= 0 {
@@ -145,24 +150,24 @@ func (s *Server) runDeferredMerge(
 	timeout := time.NewTimer(maxWait)
 	defer timeout.Stop()
 	for {
-		state, err := s.refreshDeferredMergeCI(ctx, repo, number, pendingKeys)
+		state, err := s.refreshDeferredMergeCI(ctx, repo, number, pendingKeys, queuedHeadSHA)
 		if err != nil {
-			s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, err.Error())
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), err.Error())
 			return
 		}
 		switch state {
 		case "passed":
-			s.completeDeferredMerge(ctx, repo, number, body)
+			s.completeDeferredMerge(ctx, repo, number, body, queuedHeadSHA)
 			return
 		case "failed":
-			s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, "a check that was pending failed; merge was not performed")
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), "a check failed; merge was not performed")
 			return
 		}
 		select {
 		case <-ctx.Done():
 			return
 		case <-timeout.C:
-			s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, "timed out waiting for pending CI checks to finish; merge was not performed")
+			s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), "timed out waiting for pending CI checks to finish; merge was not performed")
 			return
 		case <-ticker.C:
 		}
@@ -174,6 +179,7 @@ func (s *Server) refreshDeferredMergeCI(
 	repo db.Repo,
 	number int,
 	pendingKeys []deferredMergeCheckKey,
+	queuedHeadSHA string,
 ) (string, error) {
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 	if err != nil {
@@ -181,6 +187,9 @@ func (s *Server) refreshDeferredMergeCI(
 	}
 	if mr == nil {
 		return "", errors.New("pull request no longer exists")
+	}
+	if strings.TrimSpace(queuedHeadSHA) != "" && mr.PlatformHeadSHA != queuedHeadSHA {
+		return "", errors.New("target changed since deferred merge was queued; refresh and retry")
 	}
 	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
@@ -201,6 +210,9 @@ func (s *Server) refreshDeferredMergeCI(
 	}
 	if refreshed == nil {
 		return "", errors.New("pull request no longer exists after CI refresh")
+	}
+	if strings.TrimSpace(queuedHeadSHA) != "" && refreshed.PlatformHeadSHA != queuedHeadSHA {
+		return "", errors.New("target changed since deferred merge was queued; refresh and retry")
 	}
 	s.hub.Broadcast(Event{
 		Type: "pr_ci_refreshed",
@@ -279,10 +291,15 @@ func (s *Server) completeDeferredMerge(
 	repo db.Repo,
 	number int,
 	body mergePRInputBody,
+	queuedHeadSHA string,
 ) {
+	if err := s.ensureDeferredMergeHeadUnchanged(ctx, repo, number, queuedHeadSHA); err != nil {
+		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), err.Error())
+		return
+	}
 	result, err := s.mergePRWithBody(ctx, string(repoProviderKind(repo)), repoProviderHost(repo), repo.Owner, repo.Name, number, body)
 	if err != nil {
-		s.broadcastDeferredMergeFailure(repo, number, body.ExpectedHeadSHA, err.Error())
+		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedHeadSHA), err.Error())
 		return
 	}
 	s.hub.Broadcast(Event{Type: "data_changed", Data: struct{}{}})
@@ -295,7 +312,7 @@ func (s *Server) completeDeferredMerge(
 			Owner:        repo.Owner,
 			Name:         repo.Name,
 			Number:       number,
-			HeadSHA:      body.ExpectedHeadSHA,
+			HeadSHA:      deferredMergeHeadSHA(body, queuedHeadSHA),
 			Status:       "merged",
 			Merged:       result.Merged,
 			SHA:          result.SHA,
@@ -303,6 +320,30 @@ func (s *Server) completeDeferredMerge(
 			CompletedAt:  formatUTCRFC3339(s.now().UTC()),
 		},
 	})
+}
+
+func (s *Server) ensureDeferredMergeHeadUnchanged(ctx context.Context, repo db.Repo, number int, queuedHeadSHA string) error {
+	if strings.TrimSpace(queuedHeadSHA) == "" {
+		return nil
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	if err != nil {
+		return err
+	}
+	if mr == nil {
+		return errors.New("pull request no longer exists")
+	}
+	if mr.PlatformHeadSHA != queuedHeadSHA {
+		return errors.New("target changed since deferred merge was queued; refresh and retry")
+	}
+	return nil
+}
+
+func deferredMergeHeadSHA(body mergePRInputBody, queuedHeadSHA string) string {
+	if strings.TrimSpace(body.ExpectedHeadSHA) != "" {
+		return body.ExpectedHeadSHA
+	}
+	return queuedHeadSHA
 }
 
 func (s *Server) broadcastDeferredMergeFailure(repo db.Repo, number int, headSHA string, message string) {
@@ -355,8 +396,18 @@ func deferredMergeCheckState(keys []deferredMergeCheckKey, checksJSON string) (s
 		}
 	}
 	byKey := make(map[deferredMergeCheckKey]db.CICheck, len(checks))
+	currentPending := false
 	for _, check := range checks {
 		byKey[deferredMergeCheckKey{App: check.App, Name: check.Name}] = check
+		if check.Status != "completed" {
+			currentPending = true
+			continue
+		}
+		switch check.Conclusion {
+		case "success", "neutral", "skipped":
+		default:
+			return "failed", nil
+		}
 	}
 	pending := false
 	for _, key := range keys {
@@ -376,6 +427,9 @@ func deferredMergeCheckState(keys []deferredMergeCheckKey, checksJSON string) (s
 		}
 	}
 	if pending {
+		return "pending", nil
+	}
+	if currentPending {
 		return "pending", nil
 	}
 	return "passed", nil

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -92,6 +92,13 @@ func (s *Server) enqueueDeferredMerge(
 	if mr == nil {
 		return deferMergePRBody{}, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
+	if mr.State != db.MergeRequestStateOpen {
+		return deferMergePRBody{}, problemConflict(
+			CodeConflict,
+			"pull request is not open",
+			map[string]any{"reason": "not_open"},
+		)
+	}
 	expectedHeadSHA, err := s.preflightMergePR(repo, mr, number, body)
 	if err != nil {
 		return deferMergePRBody{}, err
@@ -225,6 +232,9 @@ func (s *Server) refreshDeferredMergeCI(
 	if err := deferredMergeTargetMatchesDB(mr, queuedTarget); err != nil {
 		return "", err
 	}
+	if err := deferredMergeRequireOpenDB(mr); err != nil {
+		return "", err
+	}
 	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
 		deferredMergeRepoRef(repo),
@@ -246,6 +256,9 @@ func (s *Server) refreshDeferredMergeCI(
 		return "", errors.New("pull request no longer exists after CI refresh")
 	}
 	if err := deferredMergeTargetMatchesDB(refreshed, queuedTarget); err != nil {
+		return "", err
+	}
+	if err := deferredMergeRequireOpenDB(refreshed); err != nil {
 		return "", err
 	}
 	s.hub.Broadcast(Event{
@@ -374,6 +387,9 @@ func (s *Server) ensureDeferredMergeTargetUnchanged(ctx context.Context, repo db
 	if err := deferredMergeTargetMatchesDB(mr, queuedTarget); err != nil {
 		return err
 	}
+	if err := deferredMergeRequireOpenDB(mr); err != nil {
+		return err
+	}
 	reader, err := s.syncer.Registry().MergeRequestReader(repoProviderKind(repo), repoProviderHost(repo))
 	if err != nil {
 		return err
@@ -383,6 +399,9 @@ func (s *Server) ensureDeferredMergeTargetUnchanged(ctx context.Context, repo db
 		return err
 	}
 	if err := deferredMergeTargetMatchesProvider(current, queuedTarget); err != nil {
+		return err
+	}
+	if err := deferredMergeRequireOpenProvider(current); err != nil {
 		return err
 	}
 	return nil
@@ -418,6 +437,31 @@ func deferredMergeTargetMatchesProvider(mr platform.MergeRequest, queued deferre
 		strings.TrimSpace(mr.BaseBranch),
 		strings.TrimSpace(mr.BaseSHA),
 	)
+}
+
+// deferredMergeRequireOpenDB fails a deferred merge whose target is no longer
+// open in the local snapshot. Closing a pull request is the only cancel a user
+// has for a queued deferred merge, so the background worker must abort once the
+// close has synced rather than merge a pull request the maintainer retracted.
+func deferredMergeRequireOpenDB(mr *db.MergeRequest) error {
+	if mr == nil {
+		return errors.New("pull request no longer exists")
+	}
+	if mr.State != db.MergeRequestStateOpen {
+		return errors.New("pull request is no longer open; deferred merge was not performed")
+	}
+	return nil
+}
+
+// deferredMergeRequireOpenProvider re-checks open state against the provider
+// immediately before merging. This is the authoritative gate: the local row can
+// lag a close until the next sync, and a closed pull request that is reopened
+// with the same head must not be silently merged by the queued worker.
+func deferredMergeRequireOpenProvider(mr platform.MergeRequest) error {
+	if !strings.EqualFold(strings.TrimSpace(mr.State), string(db.MergeRequestStateOpen)) {
+		return errors.New("pull request is no longer open; deferred merge was not performed")
+	}
+	return nil
 }
 
 func deferredMergeTargetMatches(queued deferredMergeTargetSnapshot, headSHA, baseBranch, baseSHA string) error {

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	deferredMergePollInterval = time.Minute
-	deferredMergeMaxWait      = 24 * time.Hour
+	deferredMergePollInterval   = time.Minute
+	defaultDeferredMergeMaxWait = 24 * time.Hour
 )
 
 type deferredMergeCheckKey struct {
@@ -43,7 +43,7 @@ func (s *Server) deferMergePR(
 	ctx context.Context,
 	input *deferMergePRInput,
 ) (*deferMergePROutput, error) {
-	body, err := s.enqueueDeferredMerge(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Number, input.Body, deferredMergePollInterval)
+	body, err := s.enqueueDeferredMerge(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Number, input.Body, deferredMergePollInterval, s.deferredMergeMaxWait)
 	if err != nil {
 		return nil, err
 	}
@@ -59,9 +59,13 @@ func (s *Server) enqueueDeferredMerge(
 	number int,
 	body mergePRInputBody,
 	pollInterval time.Duration,
+	maxWait time.Duration,
 ) (deferMergePRBody, error) {
 	if pollInterval <= 0 {
 		pollInterval = deferredMergePollInterval
+	}
+	if maxWait <= 0 {
+		maxWait = defaultDeferredMergeMaxWait
 	}
 	repo, err := s.requireRepoRouteCapability(
 		ctx,
@@ -86,6 +90,12 @@ func (s *Server) enqueueDeferredMerge(
 		return deferMergePRBody{}, problemValidation("ci_checks", err.Error())
 	}
 	if len(pendingKeys) == 0 {
+		pendingKeys, err = s.refreshPendingDeferredMergeCheckKeys(ctx, *repo, number, mr.PlatformHeadSHA)
+		if err != nil {
+			return deferMergePRBody{}, err
+		}
+	}
+	if len(pendingKeys) == 0 {
 		return deferMergePRBody{}, problemConflict(
 			CodeConflict,
 			"no pending CI checks to wait for",
@@ -102,7 +112,7 @@ func (s *Server) enqueueDeferredMerge(
 	}
 	started := s.runBackground(func(bgCtx context.Context) {
 		defer s.clearDeferredMergeInFlight(key)
-		s.runDeferredMerge(bgCtx, *repo, number, body, pendingKeys, pollInterval)
+		s.runDeferredMerge(bgCtx, *repo, number, body, pendingKeys, pollInterval, maxWait)
 	})
 	if !started {
 		s.clearDeferredMergeInFlight(key)
@@ -121,14 +131,18 @@ func (s *Server) runDeferredMerge(
 	body mergePRInputBody,
 	pendingKeys []deferredMergeCheckKey,
 	pollInterval time.Duration,
+	maxWait time.Duration,
 ) {
 	if len(pendingKeys) == 0 {
 		s.completeDeferredMerge(ctx, repo, number, body)
 		return
 	}
+	if maxWait <= 0 {
+		maxWait = defaultDeferredMergeMaxWait
+	}
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
-	timeout := time.NewTimer(deferredMergeMaxWait)
+	timeout := time.NewTimer(maxWait)
 	defer timeout.Stop()
 	for {
 		state, err := s.refreshDeferredMergeCI(ctx, repo, number, pendingKeys)
@@ -170,17 +184,7 @@ func (s *Server) refreshDeferredMergeCI(
 	}
 	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
 		ctx,
-		ghclient.RepoRef{
-			Platform:           repoProviderKind(repo),
-			Owner:              repo.Owner,
-			Name:               repo.Name,
-			PlatformHost:       repoProviderHost(repo),
-			RepoPath:           repo.RepoPath,
-			PlatformExternalID: repo.PlatformRepoID,
-			WebURL:             repo.WebURL,
-			CloneURL:           repo.CloneURL,
-			DefaultBranch:      repo.DefaultBranch,
-		},
+		deferredMergeRepoRef(repo),
 		repo.ID,
 		number,
 		mr.PlatformHeadSHA,
@@ -213,6 +217,61 @@ func (s *Server) refreshDeferredMergeCI(
 		},
 	})
 	return deferredMergeCheckState(pendingKeys, refreshed.CIChecksJSON)
+}
+
+func (s *Server) refreshPendingDeferredMergeCheckKeys(
+	ctx context.Context,
+	repo db.Repo,
+	number int,
+	headSHA string,
+) ([]deferredMergeCheckKey, error) {
+	warnings, err := s.syncer.RefreshMRCIStatusOnProvider(
+		ctx,
+		deferredMergeRepoRef(repo),
+		repo.ID,
+		number,
+		headSHA,
+	)
+	if err != nil {
+		return nil, providerCallProblemWithDetail(
+			err,
+			string(repoProviderKind(repo)), repoProviderHost(repo),
+			"refresh PR CI before deferring merge: "+err.Error(),
+		)
+	}
+	if len(warnings) > 0 {
+		return nil, problemConflict(
+			CodeConflict,
+			"could not refresh CI checks before deferring merge",
+			map[string]any{"reason": "ci_refresh_unavailable", "warnings": warnings},
+		)
+	}
+	refreshed, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
+	if err != nil {
+		return nil, problemInternal("get pull request after CI refresh failed")
+	}
+	if refreshed == nil {
+		return nil, problemNotFound(CodePullNotFound, "pull request not found after CI refresh", nil)
+	}
+	keys, err := pendingDeferredMergeCheckKeys(refreshed.CIChecksJSON)
+	if err != nil {
+		return nil, problemValidation("ci_checks", err.Error())
+	}
+	return keys, nil
+}
+
+func deferredMergeRepoRef(repo db.Repo) ghclient.RepoRef {
+	return ghclient.RepoRef{
+		Platform:           repoProviderKind(repo),
+		Owner:              repo.Owner,
+		Name:               repo.Name,
+		PlatformHost:       repoProviderHost(repo),
+		RepoPath:           repo.RepoPath,
+		PlatformExternalID: repo.PlatformRepoID,
+		WebURL:             repo.WebURL,
+		CloneURL:           repo.CloneURL,
+		DefaultBranch:      repo.DefaultBranch,
+	}
 }
 
 func (s *Server) completeDeferredMerge(

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -100,25 +100,39 @@ func (s *Server) enqueueDeferredMerge(
 	if strings.TrimSpace(expectedHeadSHA) != "" {
 		queuedTarget.HeadSHA = expectedHeadSHA
 	}
+	if strings.TrimSpace(queuedTarget.BaseSHA) == "" {
+		return deferMergePRBody{}, problemConflict(
+			CodeConflict,
+			"target base commit has not been synced; refresh and retry",
+			map[string]any{"reason": "base_unknown"},
+		)
+	}
 	pendingKeys, err := pendingDeferredMergeCheckKeys(mr.CIChecksJSON)
 	if err != nil {
 		return deferMergePRBody{}, problemValidation("ci_checks", err.Error())
 	}
 	aggregateState := deferredMergeAggregateState(mr.CIStatus)
-	if len(pendingKeys) == 0 {
-		refreshed, refreshedKeys, err := s.refreshPendingDeferredMergeCheckKeys(ctx, *repo, number, queuedTarget)
-		if err != nil {
-			return deferMergePRBody{}, err
-		}
-		pendingKeys = refreshedKeys
-		aggregateState = deferredMergeAggregateState(refreshed.CIStatus)
-	}
 	if aggregateState == "failed" {
 		return deferMergePRBody{}, problemConflict(
 			CodeConflict,
 			"CI checks have already failed",
 			map[string]any{"reason": "ci_failed"},
 		)
+	}
+	if len(pendingKeys) == 0 && aggregateState != "pending" {
+		refreshed, refreshedKeys, err := s.refreshPendingDeferredMergeCheckKeys(ctx, *repo, number, queuedTarget)
+		if err != nil {
+			return deferMergePRBody{}, err
+		}
+		pendingKeys = refreshedKeys
+		aggregateState = deferredMergeAggregateState(refreshed.CIStatus)
+		if aggregateState == "failed" {
+			return deferMergePRBody{}, problemConflict(
+				CodeConflict,
+				"CI checks have already failed",
+				map[string]any{"reason": "ci_failed"},
+			)
+		}
 	}
 	if len(pendingKeys) == 0 && aggregateState != "pending" {
 		return deferMergePRBody{}, problemConflict(
@@ -517,7 +531,7 @@ func deferredMergeCheckState(aggregateStatus string, keys []deferredMergeCheckKe
 	if currentPending {
 		return "pending", nil
 	}
-	if aggregateState == "pending" {
+	if aggregateState != "passed" {
 		return "pending", nil
 	}
 	return "passed", nil
@@ -526,7 +540,7 @@ func deferredMergeCheckState(aggregateStatus string, keys []deferredMergeCheckKe
 func deferredMergeAggregateState(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "":
-		return ""
+		return "unknown"
 	case "success", "passed":
 		return "passed"
 	case "failure", "failed", "error", "cancelled", "canceled", "timed_out":
@@ -534,7 +548,7 @@ func deferredMergeAggregateState(status string) string {
 	case "pending", "in_progress", "queued", "running", "waiting":
 		return "pending"
 	default:
-		return "pending"
+		return "unknown"
 	}
 }
 

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -174,14 +174,16 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 		want            string
 	}{
 		{
-			name: "missing captured check stays pending",
+			name:            "missing captured check stays pending",
+			aggregateStatus: "success",
 			checks: []db.CICheck{{
 				App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success",
 			}},
 			want: "pending",
 		},
 		{
-			name: "in progress captured check stays pending",
+			name:            "in progress captured check stays pending",
+			aggregateStatus: "pending",
 			checks: []db.CICheck{
 				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
 				{App: "Buildkite", Name: "integration", Status: "in_progress"},
@@ -215,7 +217,8 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 			want: "failed",
 		},
 		{
-			name: "non captured pending keeps waiting",
+			name:            "non captured pending keeps waiting",
+			aggregateStatus: "pending",
 			checks: []db.CICheck{
 				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
 				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
@@ -224,12 +227,12 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 			want: "pending",
 		},
 		{
-			name: "unknown aggregate keeps passing rows pending",
+			name: "unknown aggregate blocks passing rows",
 			checks: []db.CICheck{
 				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
 				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
 			},
-			want: "pending",
+			want: "unknown",
 		},
 		{
 			name:            "aggregate pending keeps passing rows pending",
@@ -626,7 +629,7 @@ func TestDeferMergeEndpointRejectsFailedAggregateCIWithPassingRows(t *testing.T)
 	}
 }
 
-func TestDeferMergeEndpointWaitsForAggregatePendingCIWithPassingRows(t *testing.T) {
+func TestDeferMergeEndpointFailsWhenAggregatePendingRefreshBecomesUnknown(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
@@ -692,14 +695,94 @@ func TestDeferMergeEndpointWaitsForAggregatePendingCIWithPassingRows(t *testing.
 			require.True(ok)
 			completed = payload
 		case <-time.After(time.Second):
-			require.FailNow("timed out waiting for aggregate-pending deferred merge timeout")
+			require.FailNow("timed out waiting for aggregate-unknown deferred merge failure")
 		}
 		if completed.Status != "" {
 			break
 		}
 	}
 	require.Equal("failed", completed.Status)
-	require.Contains(completed.Error, "timed out waiting for pending CI checks")
+	require.Contains(completed.Error, "aggregate CI status is unavailable")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointFailsWhenGranularPendingRefreshHasUnknownAggregate(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref:      ref,
+			ciChecks: map[string][]platform.CICheck{"head-sha": {}},
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	srv, database, repoID, client := newDeferredMergeRouteServer(
+		t,
+		provider,
+		ref,
+		now,
+		[]db.CICheck{{App: "GitLab", Name: "pipeline", Status: "in_progress"}},
+	)
+	require.NoError(database.UpdateMRCIStatus(
+		ctx,
+		repoID,
+		7,
+		"",
+		mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "in_progress",
+		}}),
+	))
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON202)
+	require.Equal(int64(1), resp.JSON202.PendingChecks)
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for aggregate-unknown deferred merge failure")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "aggregate CI status is unavailable")
 	select {
 	case call := <-provider.mergeCh:
 		require.Failf("unexpected merge", "merge call: %+v", call)

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -66,6 +66,7 @@ func newDeferredMergeRouteServer(
 	ref platform.RepoRef,
 	now time.Time,
 	initialChecks []db.CICheck,
+	options ...ServerOptions,
 ) (*Server, *db.DB, int64, *apiclient.Client) {
 	t.Helper()
 	ctx := t.Context()
@@ -113,7 +114,11 @@ func newDeferredMergeRouteServer(
 		},
 	)
 	t.Cleanup(syncer.Stop)
-	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	opts := ServerOptions{}
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	srv := New(database, syncer, nil, "/", nil, opts)
 	setTestServerNow(t, srv, now)
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	return srv, database, repoID, setupTestClient(t, srv)
@@ -385,6 +390,58 @@ func TestDeferMergeEndpointRejectsWithoutPendingChecks(t *testing.T) {
 	}
 }
 
+func TestDeferMergeEndpointRefreshesEmptyPendingSnapshotBeforeRejecting(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App:    "GitLab",
+					Name:   "pipeline",
+					Status: "in_progress",
+				}},
+			},
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	_, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, nil, ServerOptions{
+		deferredMergeMaxWait: 10 * time.Millisecond,
+	})
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON202)
+	require.Equal(int64(1), resp.JSON202.PendingChecks)
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestDeferMergeEndpointBroadcastsFailureWhenCIRefreshWarns(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
@@ -444,6 +501,87 @@ func TestDeferMergeEndpointBroadcastsFailureWhenCIRefreshWarns(t *testing.T) {
 	require.Equal("failed", completed.Status)
 	require.Contains(completed.Error, "could not refresh CI checks")
 	require.Equal("2026-06-15T12:00:00Z", completed.CompletedAt)
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointBroadcastsFailureWhenPendingChecksTimeOut(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App:    "GitLab",
+					Name:   "pipeline",
+					Status: "in_progress",
+				}},
+			},
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	srv, _, _, client := newDeferredMergeRouteServer(
+		t,
+		provider,
+		ref,
+		now,
+		[]db.CICheck{{App: "GitLab", Name: "pipeline", Status: "in_progress"}},
+		ServerOptions{deferredMergeMaxWait: 10 * time.Millisecond},
+	)
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge timeout event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "timed out waiting for pending CI checks")
+	require.Eventually(func() bool {
+		srv.deferredMergeMu.Lock()
+		defer srv.deferredMergeMu.Unlock()
+		return len(srv.deferredMergeInFlight) == 0
+	}, time.Second, 10*time.Millisecond)
 	select {
 	case call := <-provider.mergeCh:
 		require.Failf("unexpected merge", "merge call: %+v", call)

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -1,0 +1,290 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/apiclient/generated"
+	"go.kenn.io/middleman/internal/db"
+	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/platform"
+	"go.kenn.io/middleman/internal/testutil/dbtest"
+)
+
+type deferredMergeTestProvider struct {
+	apiTestGitLabProvider
+	mergeCh  chan deferredMergeTestMergeCall
+	mergeErr error
+}
+
+type deferredMergeTestMergeCall struct {
+	Number          int
+	CommitTitle     string
+	CommitMessage   string
+	Method          string
+	ExpectedHeadSHA string
+}
+
+func (p *deferredMergeTestProvider) Capabilities() platform.Capabilities {
+	caps := p.apiTestGitLabProvider.Capabilities()
+	caps.MergeMutation = true
+	return caps
+}
+
+func (p *deferredMergeTestProvider) MergeMergeRequest(
+	_ context.Context,
+	_ platform.RepoRef,
+	number int,
+	commitTitle string,
+	commitMessage string,
+	method string,
+	expectedHeadSHA string,
+) (platform.MergeResult, error) {
+	if p.mergeCh != nil {
+		p.mergeCh <- deferredMergeTestMergeCall{
+			Number:          number,
+			CommitTitle:     commitTitle,
+			CommitMessage:   commitMessage,
+			Method:          method,
+			ExpectedHeadSHA: expectedHeadSHA,
+		}
+	}
+	if p.mergeErr != nil {
+		return platform.MergeResult{}, p.mergeErr
+	}
+	return platform.MergeResult{Merged: true, SHA: "merge-sha", Message: "merged"}, nil
+}
+
+func TestPendingDeferredMergeCheckKeysCapturesOnlyPendingChecks(t *testing.T) {
+	checksJSON := mustDeferredMergeChecksJSON(t, []db.CICheck{
+		{App: "GitHub Actions", Name: "unit", Status: "in_progress"},
+		{App: "Buildkite", Name: "integration", Status: "queued"},
+		{App: "GitHub Actions", Name: "lint", Status: "completed", Conclusion: "success"},
+	})
+
+	keys, err := pendingDeferredMergeCheckKeys(checksJSON)
+	require.NoError(t, err)
+	require.Equal(t, []deferredMergeCheckKey{
+		{App: "GitHub Actions", Name: "unit"},
+		{App: "Buildkite", Name: "integration"},
+	}, keys)
+}
+
+func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
+	keys := []deferredMergeCheckKey{
+		{App: "GitHub Actions", Name: "unit"},
+		{App: "Buildkite", Name: "integration"},
+	}
+
+	tests := []struct {
+		name   string
+		checks []db.CICheck
+		want   string
+	}{
+		{
+			name: "missing captured check stays pending",
+			checks: []db.CICheck{{
+				App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success",
+			}},
+			want: "pending",
+		},
+		{
+			name: "in progress captured check stays pending",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "in_progress"},
+			},
+			want: "pending",
+		},
+		{
+			name: "captured checks pass",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "skipped"},
+			},
+			want: "passed",
+		},
+		{
+			name: "captured failure blocks merge",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "failure"},
+			},
+			want: "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deferredMergeCheckState(keys, mustDeferredMergeChecksJSON(t, tt.checks))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDeferMergeEndpointQueuesMergeAndBroadcastsCompletion(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           ref,
+				PlatformID:     7001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "Defer merge",
+				Author:         "ada",
+				State:          "open",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				HeadSHA:        "head-sha",
+				BaseSHA:        "base-sha",
+				CIStatus:       "pending",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App:        "GitLab",
+					Name:       "pipeline",
+					Status:     "completed",
+					Conclusion: "success",
+				}},
+			},
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Defer merge",
+		Author:          "ada",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "pending",
+		CIChecksJSON: mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "in_progress",
+		}}),
+		CIHadPending:   true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(err)
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindGitLab,
+			PlatformHost: ref.Host,
+			Owner:        ref.Owner,
+			Name:         ref.Name,
+			RepoPath:     ref.RepoPath,
+		}},
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{
+			ghclient.RateBucketKey("gitlab", ref.Host): ghclient.NewSyncBudget(100),
+		},
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	setTestServerNow(t, srv, now)
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+	events, _ := srv.Hub().Subscribe(ctx, false)
+	expectedHeadSHA := "head-sha"
+
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{
+			CommitTitle:     "Merge title",
+			CommitMessage:   "Merge body",
+			Method:          "squash",
+			ExpectedHeadSha: &expectedHeadSHA,
+		},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON202)
+	require.Equal("queued", resp.JSON202.Status)
+	require.Equal(int64(1), resp.JSON202.PendingChecks)
+
+	var mergeCall deferredMergeTestMergeCall
+	select {
+	case mergeCall = <-provider.mergeCh:
+	case <-time.After(time.Second):
+		require.FailNow("timed out waiting for deferred merge")
+	}
+	require.Equal(7, mergeCall.Number)
+	require.Equal("squash", mergeCall.Method)
+	require.Equal("head-sha", mergeCall.ExpectedHeadSHA)
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge completion event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("merged", completed.Status)
+	require.True(completed.Merged)
+	require.Equal("merge-sha", completed.SHA)
+	require.Equal("2026-06-15T12:00:00Z", completed.CompletedAt)
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Equal("merged", string(stored.State))
+}
+
+func mustDeferredMergeChecksJSON(t *testing.T, checks []db.CICheck) string {
+	t.Helper()
+	raw, err := json.Marshal(checks)
+	require.NoError(t, err)
+	return string(raw)
+}

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -189,7 +189,8 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 			want: "pending",
 		},
 		{
-			name: "captured checks pass",
+			name:            "captured checks pass with aggregate success",
+			aggregateStatus: "success",
 			checks: []db.CICheck{
 				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
 				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "skipped"},
@@ -219,6 +220,14 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
 				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
 				{App: "GitHub Actions", Name: "deploy", Status: "in_progress"},
+			},
+			want: "pending",
+		},
+		{
+			name: "unknown aggregate keeps passing rows pending",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
 			},
 			want: "pending",
 		},
@@ -469,9 +478,18 @@ func TestDeferMergeEndpointRejectsWithoutPendingChecks(t *testing.T) {
 		apiTestGitLabProvider: apiTestGitLabProvider{ref: ref},
 		mergeCh:               make(chan deferredMergeTestMergeCall, 1),
 	}
-	_, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+	_, database, repoID, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
 		App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success",
 	}})
+	require.NoError(database.UpdateMRCIStatus(
+		ctx,
+		repoID,
+		7,
+		"success",
+		mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success",
+		}}),
+	))
 
 	expectedHeadSHA := "head-sha"
 	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
@@ -486,6 +504,202 @@ func TestDeferMergeEndpointRejectsWithoutPendingChecks(t *testing.T) {
 	require.NoError(err)
 	require.Equal(409, resp.StatusCode(), string(resp.Body))
 	require.Contains(string(resp.Body), "no_pending_checks")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointRejectsMissingBaseSHA(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{ref: ref},
+		mergeCh:               make(chan deferredMergeTestMergeCall, 1),
+	}
+	_, database, repoID, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	_, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Defer merge",
+		Author:          "ada",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		PlatformBaseSHA: "",
+		CIStatus:        "pending",
+		CIChecksJSON: mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "in_progress",
+		}}),
+		CIHadPending:   true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(err)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(409, resp.StatusCode(), string(resp.Body))
+	require.Contains(string(resp.Body), "base_unknown")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointRejectsFailedAggregateCIWithPassingRows(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{ref: ref},
+		mergeCh:               make(chan deferredMergeTestMergeCall, 1),
+	}
+	_, database, repoID, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success",
+	}})
+	require.NoError(database.UpdateMRCIStatus(
+		ctx,
+		repoID,
+		7,
+		"failure",
+		mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success",
+		}}),
+	))
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(409, resp.StatusCode(), string(resp.Body))
+	require.Contains(string(resp.Body), "ci_failed")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointWaitsForAggregatePendingCIWithPassingRows(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref:      ref,
+			ciChecks: map[string][]platform.CICheck{"head-sha": {}},
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	srv, database, repoID, client := newDeferredMergeRouteServer(
+		t,
+		provider,
+		ref,
+		now,
+		[]db.CICheck{{App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success"}},
+		ServerOptions{deferredMergeMaxWait: 10 * time.Millisecond},
+	)
+	require.NoError(database.UpdateMRCIStatus(
+		ctx,
+		repoID,
+		7,
+		"pending",
+		mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success",
+		}}),
+	))
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON202)
+	require.Equal(int64(0), resp.JSON202.PendingChecks)
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for aggregate-pending deferred merge timeout")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "timed out waiting for pending CI checks")
 	select {
 	case call := <-provider.mergeCh:
 		require.Failf("unexpected merge", "merge call: %+v", call)
@@ -520,9 +734,10 @@ func TestDeferMergeEndpointRefreshesEmptyPendingSnapshotBeforeRejecting(t *testi
 		},
 		mergeCh: make(chan deferredMergeTestMergeCall, 1),
 	}
-	_, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, nil, ServerOptions{
+	_, database, repoID, client := newDeferredMergeRouteServer(t, provider, ref, now, nil, ServerOptions{
 		deferredMergeMaxWait: 10 * time.Millisecond,
 	})
+	require.NoError(database.UpdateMRCIStatus(ctx, repoID, 7, "", "[]"))
 
 	expectedHeadSHA := "head-sha"
 	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -168,9 +168,10 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		checks []db.CICheck
-		want   string
+		name            string
+		aggregateStatus string
+		checks          []db.CICheck
+		want            string
 	}{
 		{
 			name: "missing captured check stays pending",
@@ -221,11 +222,29 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 			},
 			want: "pending",
 		},
+		{
+			name:            "aggregate pending keeps passing rows pending",
+			aggregateStatus: "pending",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
+			},
+			want: "pending",
+		},
+		{
+			name:            "aggregate failure blocks passing rows",
+			aggregateStatus: "failure",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
+			},
+			want: "failed",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := deferredMergeCheckState(keys, mustDeferredMergeChecksJSON(t, tt.checks))
+			got, err := deferredMergeCheckState(tt.aggregateStatus, keys, mustDeferredMergeChecksJSON(t, tt.checks))
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
@@ -753,6 +772,107 @@ func TestDeferMergeEndpointBroadcastsFailureWhenHeadChangesWhileWaiting(t *testi
 			completed = payload
 		case <-time.After(time.Second):
 			require.FailNow("timed out waiting for deferred merge stale-head event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "target changed")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointBroadcastsFailureWhenProviderBaseChangesBeforeMerge(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	ciStarted := make(chan struct{})
+	ciRelease := make(chan struct{})
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           ref,
+				PlatformID:     7001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "Defer merge",
+				Author:         "ada",
+				State:          "open",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				HeadSHA:        "head-sha",
+				BaseSHA:        "base-sha",
+				CIStatus:       "pending",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App:        "GitLab",
+					Name:       "pipeline",
+					Status:     "completed",
+					Conclusion: "success",
+				}},
+			},
+		},
+		mergeCh:   make(chan deferredMergeTestMergeCall, 1),
+		ciStarted: ciStarted,
+		ciRelease: ciRelease,
+	}
+	srv, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+
+	select {
+	case <-ciStarted:
+	case <-time.After(time.Second):
+		require.FailNow("timed out waiting for deferred CI refresh to start")
+	}
+	provider.mergeRequests[0].BaseSHA = "new-base-sha"
+	close(ciRelease)
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge stale-base event")
 		}
 		if completed.Status != "" {
 			break

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,8 +19,11 @@ import (
 
 type deferredMergeTestProvider struct {
 	apiTestGitLabProvider
-	mergeCh  chan deferredMergeTestMergeCall
-	mergeErr error
+	mergeCh       chan deferredMergeTestMergeCall
+	mergeErr      error
+	ciStarted     chan struct{}
+	ciStartedOnce sync.Once
+	ciRelease     chan struct{}
 }
 
 type deferredMergeTestMergeCall struct {
@@ -34,6 +38,24 @@ func (p *deferredMergeTestProvider) Capabilities() platform.Capabilities {
 	caps := p.apiTestGitLabProvider.Capabilities()
 	caps.MergeMutation = true
 	return caps
+}
+
+func (p *deferredMergeTestProvider) ListCIChecks(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sha string,
+) ([]platform.CICheck, error) {
+	if p.ciStarted != nil {
+		p.ciStartedOnce.Do(func() { close(p.ciStarted) })
+	}
+	if p.ciRelease != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-p.ciRelease:
+		}
+	}
+	return p.apiTestGitLabProvider.ListCIChecks(ctx, ref, sha)
 }
 
 func (p *deferredMergeTestProvider) MergeMergeRequest(
@@ -633,6 +655,111 @@ func TestDeferMergeEndpointBroadcastsFailureWhenCurrentChecksFail(t *testing.T) 
 	}
 	require.Equal("failed", completed.Status)
 	require.Contains(completed.Error, "check failed")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointBroadcastsFailureWhenHeadChangesWhileWaiting(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	ciStarted := make(chan struct{})
+	ciRelease := make(chan struct{})
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App:        "GitLab",
+					Name:       "pipeline",
+					Status:     "completed",
+					Conclusion: "success",
+				}},
+			},
+		},
+		mergeCh:   make(chan deferredMergeTestMergeCall, 1),
+		ciStarted: ciStarted,
+		ciRelease: ciRelease,
+	}
+	srv, database, repoID, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+
+	select {
+	case <-ciStarted:
+	case <-time.After(time.Second):
+		require.FailNow("timed out waiting for deferred CI refresh to start")
+	}
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Defer merge",
+		Author:          "ada",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "new-head-sha",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "pending",
+		CIChecksJSON: mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "in_progress",
+		}}),
+		CIHadPending:   true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(err)
+	close(ciRelease)
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge stale-head event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "target changed")
 	select {
 	case call := <-provider.mergeCh:
 		require.Failf("unexpected merge", "merge call: %+v", call)

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -181,6 +181,24 @@ func TestDeferredMergeCheckStateRequiresCapturedChecksToPass(t *testing.T) {
 			},
 			want: "failed",
 		},
+		{
+			name: "non captured failure blocks merge",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
+				{App: "GitHub Actions", Name: "security", Status: "completed", Conclusion: "failure"},
+			},
+			want: "failed",
+		},
+		{
+			name: "non captured pending keeps waiting",
+			checks: []db.CICheck{
+				{App: "GitHub Actions", Name: "unit", Status: "completed", Conclusion: "success"},
+				{App: "Buildkite", Name: "integration", Status: "completed", Conclusion: "success"},
+				{App: "GitHub Actions", Name: "deploy", Status: "in_progress"},
+			},
+			want: "pending",
+		},
 	}
 
 	for _, tt := range tests {
@@ -348,6 +366,50 @@ func TestDeferMergeEndpointQueuesMergeAndBroadcastsCompletion(t *testing.T) {
 	require.Equal("merged", string(stored.State))
 }
 
+func TestDeferMergeEndpointRejectsInvalidMergeMethodBeforeQueueing(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{ref: ref},
+		mergeCh:               make(chan deferredMergeTestMergeCall, 1),
+	}
+	srv, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "fast-forward"},
+	)
+	require.NoError(err)
+	require.Equal(400, resp.StatusCode(), string(resp.Body))
+	require.Contains(string(resp.Body), "invalid merge method")
+	srv.deferredMergeMu.Lock()
+	require.Empty(srv.deferredMergeInFlight)
+	srv.deferredMergeMu.Unlock()
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
 func TestDeferMergeEndpointRejectsWithoutPendingChecks(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
@@ -378,7 +440,7 @@ func TestDeferMergeEndpointRejectsWithoutPendingChecks(t *testing.T) {
 		ref.Owner,
 		ref.Name,
 		7,
-		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
 	)
 	require.NoError(err)
 	require.Equal(409, resp.StatusCode(), string(resp.Body))
@@ -429,7 +491,7 @@ func TestDeferMergeEndpointRefreshesEmptyPendingSnapshotBeforeRejecting(t *testi
 		ref.Owner,
 		ref.Name,
 		7,
-		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
 	)
 	require.NoError(err)
 	require.Equal(202, resp.StatusCode(), string(resp.Body))
@@ -476,7 +538,7 @@ func TestDeferMergeEndpointBroadcastsFailureWhenCIRefreshWarns(t *testing.T) {
 		ref.Owner,
 		ref.Name,
 		7,
-		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
 	)
 	require.NoError(err)
 	require.Equal(202, resp.StatusCode(), string(resp.Body))
@@ -501,6 +563,76 @@ func TestDeferMergeEndpointBroadcastsFailureWhenCIRefreshWarns(t *testing.T) {
 	require.Equal("failed", completed.Status)
 	require.Contains(completed.Error, "could not refresh CI checks")
 	require.Equal("2026-06-15T12:00:00Z", completed.CompletedAt)
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointBroadcastsFailureWhenCurrentChecksFail(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {
+					{App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success"},
+					{App: "GitLab", Name: "security", Status: "completed", Conclusion: "failure"},
+				},
+			},
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	srv, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge failure event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "check failed")
 	select {
 	case call := <-provider.mergeCh:
 		require.Failf("unexpected merge", "merge call: %+v", call)
@@ -553,7 +685,7 @@ func TestDeferMergeEndpointBroadcastsFailureWhenPendingChecksTimeOut(t *testing.
 		ref.Owner,
 		ref.Name,
 		7,
-		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
 	)
 	require.NoError(err)
 	require.Equal(202, resp.StatusCode(), string(resp.Body))

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -1266,6 +1266,284 @@ func TestDeferMergeEndpointBroadcastsFailureWhenPendingChecksTimeOut(t *testing.
 	}
 }
 
+func TestDeferMergeEndpointRejectsClosedPullRequest(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{ref: ref},
+		mergeCh:               make(chan deferredMergeTestMergeCall, 1),
+	}
+	_, database, repoID, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	// Closing a pull request is the only cancel a user has for a queued
+	// deferred merge, so queueing one on a closed pull request must be
+	// rejected outright rather than spawning a worker that waits on CI.
+	_, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Defer merge",
+		Author:          "ada",
+		State:           "closed",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "pending",
+		CIChecksJSON: mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "in_progress",
+		}}),
+		CIHadPending:   true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(err)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(409, resp.StatusCode(), string(resp.Body))
+	require.Contains(string(resp.Body), "not_open")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointBroadcastsFailureWhenTargetClosedWhileWaiting(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	ciStarted := make(chan struct{})
+	ciRelease := make(chan struct{})
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App:        "GitLab",
+					Name:       "pipeline",
+					Status:     "completed",
+					Conclusion: "success",
+				}},
+			},
+		},
+		mergeCh:   make(chan deferredMergeTestMergeCall, 1),
+		ciStarted: ciStarted,
+		ciRelease: ciRelease,
+	}
+	srv, database, repoID, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+
+	select {
+	case <-ciStarted:
+	case <-time.After(time.Second):
+		require.FailNow("timed out waiting for deferred CI refresh to start")
+	}
+	// The pull request is closed mid-wait, even though its head and base are
+	// unchanged. The worker must abort instead of merging a retracted target.
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Defer merge",
+		Author:          "ada",
+		State:           "closed",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "pending",
+		CIChecksJSON: mustDeferredMergeChecksJSON(t, []db.CICheck{{
+			App: "GitLab", Name: "pipeline", Status: "in_progress",
+		}}),
+		CIHadPending:   true,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(err)
+	close(ciRelease)
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge closed-target event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "no longer open")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointBroadcastsFailureWhenProviderClosedBeforeMerge(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	ciStarted := make(chan struct{})
+	ciRelease := make(chan struct{})
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref: ref,
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           ref,
+				PlatformID:     7001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "Defer merge",
+				Author:         "ada",
+				State:          "open",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				HeadSHA:        "head-sha",
+				BaseSHA:        "base-sha",
+				CIStatus:       "pending",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App:        "GitLab",
+					Name:       "pipeline",
+					Status:     "completed",
+					Conclusion: "success",
+				}},
+			},
+		},
+		mergeCh:   make(chan deferredMergeTestMergeCall, 1),
+		ciStarted: ciStarted,
+		ciRelease: ciRelease,
+	}
+	srv, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+
+	select {
+	case <-ciStarted:
+	case <-time.After(time.Second):
+		require.FailNow("timed out waiting for deferred CI refresh to start")
+	}
+	// The local row still says open, but the provider reports the pull request
+	// closed (e.g. closed-to-cancel before the next sync). The authoritative
+	// pre-merge provider check must block the merge.
+	provider.mergeRequests[0].State = "closed"
+	close(ciRelease)
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge provider-closed event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "no longer open")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
 func mustDeferredMergeChecksJSON(t *testing.T, checks []db.CICheck) string {
 	t.Helper()
 	raw, err := json.Marshal(checks)

--- a/internal/server/deferred_merge_test.go
+++ b/internal/server/deferred_merge_test.go
@@ -3,10 +3,12 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/apiclient"
 	"go.kenn.io/middleman/internal/apiclient/generated"
 	"go.kenn.io/middleman/internal/db"
 	ghclient "go.kenn.io/middleman/internal/github"
@@ -56,6 +58,65 @@ func (p *deferredMergeTestProvider) MergeMergeRequest(
 		return platform.MergeResult{}, p.mergeErr
 	}
 	return platform.MergeResult{Merged: true, SHA: "merge-sha", Message: "merged"}, nil
+}
+
+func newDeferredMergeRouteServer(
+	t *testing.T,
+	provider *deferredMergeTestProvider,
+	ref platform.RepoRef,
+	now time.Time,
+	initialChecks []db.CICheck,
+) (*Server, *db.DB, int64, *apiclient.Client) {
+	t.Helper()
+	ctx := t.Context()
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(t, err)
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(t, err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:           "Defer merge",
+		Author:          "ada",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "head-sha",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "pending",
+		CIChecksJSON:    mustDeferredMergeChecksJSON(t, initialChecks),
+		CIHadPending:    true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(t, err)
+
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:     platform.KindGitLab,
+			PlatformHost: ref.Host,
+			Owner:        ref.Owner,
+			Name:         ref.Name,
+			RepoPath:     ref.RepoPath,
+		}},
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{
+			ghclient.RateBucketKey("gitlab", ref.Host): ghclient.NewSyncBudget(100),
+		},
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	setTestServerNow(t, srv, now)
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	return srv, database, repoID, setupTestClient(t, srv)
 }
 
 func TestPendingDeferredMergeCheckKeysCapturesOnlyPendingChecks(t *testing.T) {
@@ -280,6 +341,114 @@ func TestDeferMergeEndpointQueuesMergeAndBroadcastsCompletion(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Equal("merged", string(stored.State))
+}
+
+func TestDeferMergeEndpointRejectsWithoutPendingChecks(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{ref: ref},
+		mergeCh:               make(chan deferredMergeTestMergeCall, 1),
+	}
+	_, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success",
+	}})
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(409, resp.StatusCode(), string(resp.Body))
+	require.Contains(string(resp.Body), "no_pending_checks")
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
+}
+
+func TestDeferMergeEndpointBroadcastsFailureWhenCIRefreshWarns(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	provider := &deferredMergeTestProvider{
+		apiTestGitLabProvider: apiTestGitLabProvider{
+			ref:   ref,
+			ciErr: errors.New("gitlab pipeline API unavailable"),
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	srv, _, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+
+	var completed deferredMergeCompletedPayload
+	for range 4 {
+		select {
+		case ev := <-events:
+			if ev.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := ev.Event.Data.(deferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-time.After(time.Second):
+			require.FailNow("timed out waiting for deferred merge failure event")
+		}
+		if completed.Status != "" {
+			break
+		}
+	}
+	require.Equal("failed", completed.Status)
+	require.Contains(completed.Error, "could not refresh CI checks")
+	require.Equal("2026-06-15T12:00:00Z", completed.CompletedAt)
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	default:
+	}
 }
 
 func mustDeferredMergeChecksJSON(t *testing.T, checks []db.CICheck) string {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -355,15 +355,26 @@ type mergePRInput struct {
 	Owner        string `path:"owner"`
 	Name         string `path:"name"`
 	Number       int    `path:"number"`
-	Body         struct {
-		CommitTitle   string `json:"commit_title"`
-		CommitMessage string `json:"commit_message"`
-		Method        string `json:"method"`
-		// ExpectedHeadSHA is the reviewed diff head the client rendered.
-		// For head-binding providers, merge rejects missing, stale, or
-		// mismatched reviewed-head assertions before provider mutation.
-		ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
-	}
+	Body         mergePRInputBody
+}
+
+type deferMergePRInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	Body         mergePRInputBody
+}
+
+type mergePRInputBody struct {
+	CommitTitle   string `json:"commit_title"`
+	CommitMessage string `json:"commit_message"`
+	Method        string `json:"method"`
+	// ExpectedHeadSHA is the reviewed diff head the client rendered.
+	// For head-binding providers, merge rejects missing, stale, or
+	// mismatched reviewed-head assertions before provider mutation.
+	ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
 }
 
 type mergePRBody struct {
@@ -373,6 +384,13 @@ type mergePRBody struct {
 }
 
 type mergePROutput = bodyOutput[mergePRBody]
+
+type deferMergePRBody struct {
+	Status        string `json:"status"`
+	PendingChecks int    `json:"pending_checks"`
+}
+
+type deferMergePROutput = acceptedBodyOutput[deferMergePRBody]
 
 type editPRContentInput struct {
 	Provider     string `path:"provider"`
@@ -1153,6 +1171,22 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 		documentOperation("merge-pull", "Merge pull request", "Pull Requests"))
 	huma.Post(api, hostPullPath+"/merge", s.mergePROnHost,
 		documentOperation("merge-pull-on-host", "Merge pull request", "Pull Requests"))
+	huma.Register(api, huma.Operation{
+		OperationID:   "defer-merge-pull",
+		Method:        http.MethodPost,
+		Path:          pullPath + "/merge/deferred",
+		DefaultStatus: http.StatusAccepted,
+		Summary:       "Defer pull request merge until pending CI passes",
+		Tags:          []string{"Pull Requests"},
+	}, s.deferMergePR)
+	huma.Register(api, huma.Operation{
+		OperationID:   "defer-merge-pull-on-host",
+		Method:        http.MethodPost,
+		Path:          hostPullPath + "/merge/deferred",
+		DefaultStatus: http.StatusAccepted,
+		Summary:       "Defer pull request merge until pending CI passes",
+		Tags:          []string{"Pull Requests"},
+	}, s.deferMergePROnHost)
 	huma.Post(api, pullPath+"/sync", s.syncPR,
 		documentOperation("sync-pull", "Sync pull request", "Pull Requests"))
 	huma.Post(api, hostPullPath+"/sync", s.syncPROnHost,
@@ -2873,9 +2907,25 @@ func (s *Server) readyForReview(ctx context.Context, input *repoNumberInput) (*a
 }
 
 func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutput, error) {
+	result, err := s.mergePRWithBody(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Number, input.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &mergePROutput{Body: result}, nil
+}
+
+func (s *Server) mergePRWithBody(
+	ctx context.Context,
+	provider string,
+	platformHost string,
+	owner string,
+	name string,
+	number int,
+	body mergePRInputBody,
+) (mergePRBody, error) {
 	validMethods := map[string]bool{"merge": true, "squash": true, "rebase": true}
-	if !validMethods[input.Body.Method] {
-		return nil, problemValidation(
+	if !validMethods[body.Method] {
+		return mergePRBody{}, problemValidation(
 			"body.method",
 			"invalid merge method: must be merge, squash, or rebase",
 			"merge", "squash", "rebase",
@@ -2884,29 +2934,29 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 
 	repo, err := s.requireRepoRouteCapability(
 		ctx,
-		input.Provider, input.PlatformHost, input.Owner, input.Name,
+		provider, platformHost, owner, name,
 		capabilityMergeMutation,
 	)
 	if err != nil {
-		return nil, err
+		return mergePRBody{}, err
 	}
 	if err := s.requireSyncerCapability(*repo, capabilityMergeMutation); err != nil {
-		return nil, err
+		return mergePRBody{}, err
 	}
 
 	mutator, err := s.syncer.MergeMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, unsupportedCapabilityProblem(*repo, capabilityMergeMutation)
+		return mergePRBody{}, unsupportedCapabilityProblem(*repo, capabilityMergeMutation)
 	}
 
-	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 	if err != nil {
-		return nil, problemInternal("get pull request failed")
+		return mergePRBody{}, problemInternal("get pull request failed")
 	}
 	if mr == nil {
-		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
+		return mergePRBody{}, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
 
 	// Bind the merge to the head commit the user reviewed locally so a
@@ -2914,38 +2964,38 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 	// instead of merging unreviewed code.
 	expectedHeadSHA, err := s.reviewedHeadSHA(repo, mr)
 	if err != nil {
-		return nil, err
+		return mergePRBody{}, err
 	}
 	// Head-binding providers require the client to pin the head it
 	// rendered: an omitted pin would silently bind to whatever the cache
 	// holds now, which may be newer than what the user reviewed.
-	if strings.TrimSpace(input.Body.ExpectedHeadSHA) == "" &&
+	if strings.TrimSpace(body.ExpectedHeadSHA) == "" &&
 		s.capabilitiesForRepo(*repo).MutationHeadBinding {
-		return nil, problemValidation(
+		return mergePRBody{}, problemValidation(
 			"body.expected_head_sha",
 			"required for this provider: echo the platform_head_sha you rendered",
 		)
 	}
 	if err := s.verifyClientReviewedHead(
-		repo, input.Number, input.Body.ExpectedHeadSHA, expectedHeadSHA,
+		repo, number, body.ExpectedHeadSHA, expectedHeadSHA,
 	); err != nil {
-		return nil, err
+		return mergePRBody{}, err
 	}
 
 	result, err := mutator.MergeMergeRequest(
 		ctx,
 		platformRepoRefFromDB(*repo),
-		input.Number,
-		input.Body.CommitTitle,
-		input.Body.CommitMessage,
-		input.Body.Method,
+		number,
+		body.CommitTitle,
+		body.CommitMessage,
+		body.Method,
 		expectedHeadSHA,
 	)
 	if err != nil {
 		if status, message, ok := mergeHTTPErrorStatus(err); ok {
 			slog.Error("provider merge failed",
-				"owner", input.Owner, "repo", input.Name,
-				"number", input.Number, "method", input.Body.Method,
+				"owner", owner, "repo", name,
+				"number", number, "method", body.Method,
 				"status", status,
 				"message", message,
 				"err", err)
@@ -2966,30 +3016,30 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 						if syncErr := s.syncer.SyncMROnProvider(
 							bgCtx,
 							repoProviderKind(*repo), repoProviderHost(*repo),
-							repo.Owner, repo.Name, input.Number,
+							repo.Owner, repo.Name, number,
 						); syncErr != nil {
 							slog.Warn("background sync after merge failure", "err", syncErr)
 						}
 					})
 				}
-				return nil, problemConflict(CodeConflict, message, map[string]any{"reason": reason})
+				return mergePRBody{}, problemConflict(CodeConflict, message, map[string]any{"reason": reason})
 			}
 
 			// Forward 4xx provider errors as-is so the user sees the real cause
 			// (e.g. 422 validation, 403 forbidden). 5xx becomes 502.
 			if status >= 400 && status < 500 {
-				return nil, newProblem(status, codeForStatus(status), message, nil)
+				return mergePRBody{}, newProblem(status, codeForStatus(status), message, nil)
 			}
-			return nil, problemUpstream(
+			return mergePRBody{}, problemUpstream(
 				"provider merge error: "+message,
 				string(repoProviderKind(*repo)), repoProviderHost(*repo),
 			)
 		}
 		slog.Error("provider merge transport error",
-			"owner", input.Owner, "repo", input.Name,
-			"number", input.Number, "method", input.Body.Method,
+			"owner", owner, "repo", name,
+			"number", number, "method", body.Method,
 			"err", err)
-		return nil, providerCallProblemWithDetail(
+		return mergePRBody{}, providerCallProblemWithDetail(
 			err,
 			string(repoProviderKind(*repo)), repoProviderHost(*repo),
 			"provider merge error: "+err.Error(),
@@ -2997,14 +3047,12 @@ func (s *Server) mergePR(ctx context.Context, input *mergePRInput) (*mergePROutp
 	}
 
 	now := s.now().UTC()
-	_ = s.db.UpdateMRState(ctx, repo.ID, input.Number, "merged", &now, &now)
+	_ = s.db.UpdateMRState(ctx, repo.ID, number, "merged", &now, &now)
 
-	return &mergePROutput{
-		Body: mergePRBody{
-			Merged:  result.Merged,
-			SHA:     result.SHA,
-			Message: result.Message,
-		},
+	return mergePRBody{
+		Merged:  result.Merged,
+		SHA:     result.SHA,
+		Message: result.Message,
 	}, nil
 }
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2923,15 +2923,6 @@ func (s *Server) mergePRWithBody(
 	number int,
 	body mergePRInputBody,
 ) (mergePRBody, error) {
-	validMethods := map[string]bool{"merge": true, "squash": true, "rebase": true}
-	if !validMethods[body.Method] {
-		return mergePRBody{}, problemValidation(
-			"body.method",
-			"invalid merge method: must be merge, squash, or rebase",
-			"merge", "squash", "rebase",
-		)
-	}
-
 	repo, err := s.requireRepoRouteCapability(
 		ctx,
 		provider, platformHost, owner, name,
@@ -2958,27 +2949,8 @@ func (s *Server) mergePRWithBody(
 	if mr == nil {
 		return mergePRBody{}, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
-
-	// Bind the merge to the head commit the user reviewed locally so a
-	// source-branch push between review and merge is rejected upstream
-	// instead of merging unreviewed code.
-	expectedHeadSHA, err := s.reviewedHeadSHA(repo, mr)
+	expectedHeadSHA, err := s.preflightMergePR(repo, mr, number, body)
 	if err != nil {
-		return mergePRBody{}, err
-	}
-	// Head-binding providers require the client to pin the head it
-	// rendered: an omitted pin would silently bind to whatever the cache
-	// holds now, which may be newer than what the user reviewed.
-	if strings.TrimSpace(body.ExpectedHeadSHA) == "" &&
-		s.capabilitiesForRepo(*repo).MutationHeadBinding {
-		return mergePRBody{}, problemValidation(
-			"body.expected_head_sha",
-			"required for this provider: echo the platform_head_sha you rendered",
-		)
-	}
-	if err := s.verifyClientReviewedHead(
-		repo, number, body.ExpectedHeadSHA, expectedHeadSHA,
-	); err != nil {
 		return mergePRBody{}, err
 	}
 
@@ -3054,6 +3026,46 @@ func (s *Server) mergePRWithBody(
 		SHA:     result.SHA,
 		Message: result.Message,
 	}, nil
+}
+
+func (s *Server) preflightMergePR(
+	repo *db.Repo,
+	mr *db.MergeRequest,
+	number int,
+	body mergePRInputBody,
+) (string, error) {
+	validMethods := map[string]bool{"merge": true, "squash": true, "rebase": true}
+	if !validMethods[body.Method] {
+		return "", problemValidation(
+			"body.method",
+			"invalid merge method: must be merge, squash, or rebase",
+			"merge", "squash", "rebase",
+		)
+	}
+
+	// Bind the merge to the head commit the user reviewed locally so a
+	// source-branch push between review and merge is rejected upstream
+	// instead of merging unreviewed code.
+	expectedHeadSHA, err := s.reviewedHeadSHA(repo, mr)
+	if err != nil {
+		return "", err
+	}
+	// Head-binding providers require the client to pin the head it
+	// rendered: an omitted pin would silently bind to whatever the cache
+	// holds now, which may be newer than what the user reviewed.
+	if strings.TrimSpace(body.ExpectedHeadSHA) == "" &&
+		s.capabilitiesForRepo(*repo).MutationHeadBinding {
+		return "", problemValidation(
+			"body.expected_head_sha",
+			"required for this provider: echo the platform_head_sha you rendered",
+		)
+	}
+	if err := s.verifyClientReviewedHead(
+		repo, number, body.ExpectedHeadSHA, expectedHeadSHA,
+	); err != nil {
+		return "", err
+	}
+	return expectedHeadSHA, nil
 }
 
 // reviewedHeadSHA resolves the head commit a mutation should be pinned

--- a/internal/server/provider_route_wrappers.go
+++ b/internal/server/provider_route_wrappers.go
@@ -248,13 +248,16 @@ type mergePRHostInput struct {
 	Owner        string `path:"owner"`
 	Name         string `path:"name"`
 	Number       int    `path:"number"`
-	Body         struct {
-		CommitTitle   string `json:"commit_title"`
-		CommitMessage string `json:"commit_message"`
-		Method        string `json:"method"`
-		// ExpectedHeadSHA: see mergePRInput.
-		ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
-	}
+	Body         mergePRInputBody
+}
+
+type deferMergePRHostInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	Body         mergePRInputBody
 }
 
 type editPRContentHostInput struct {
@@ -721,6 +724,18 @@ func (s *Server) mergePROnHost(ctx context.Context, input *mergePRHostInput) (*m
 		Body:         input.Body,
 	}
 	return s.mergePR(ctx, &next)
+}
+
+func (s *Server) deferMergePROnHost(ctx context.Context, input *deferMergePRHostInput) (*deferMergePROutput, error) {
+	next := deferMergePRInput{
+		Provider:     input.Provider,
+		PlatformHost: input.PlatformHost,
+		Owner:        input.Owner,
+		Name:         input.Name,
+		Number:       input.Number,
+		Body:         input.Body,
+	}
+	return s.deferMergePR(ctx, &next)
 }
 
 func (s *Server) syncPROnHost(ctx context.Context, input *repoNumberHostInput) (*syncPROutput, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,6 +71,7 @@ type ServerOptions struct {
 	// Use this for httptest-style listeners on ephemeral ports.
 	HostCheckAllowLoopbackAnyPort bool
 	msgvaultRemoteImageDeps       *msgvaultRemoteImageDeps
+	deferredMergeMaxWait          time.Duration
 }
 
 type shutdownDeadline struct {
@@ -177,6 +178,7 @@ type Server struct {
 	detailSyncInFlight     map[string]struct{}
 	deferredMergeMu        sync.Mutex
 	deferredMergeInFlight  map[string]struct{}
+	deferredMergeMaxWait   time.Duration
 	writeCredProbeMu       sync.Mutex
 	writeCredProbes        map[string]writeCredentialProbe
 	writeCredProbeInFlight map[string]chan struct{}
@@ -667,6 +669,10 @@ func newServer(
 		options.HostCheck,
 		options.HostCheckAllowLoopbackAnyPort,
 	)
+	deferredMergeMaxWait := options.deferredMergeMaxWait
+	if deferredMergeMaxWait <= 0 {
+		deferredMergeMaxWait = defaultDeferredMergeMaxWait
+	}
 
 	s := &Server{
 		db:                     database,
@@ -685,6 +691,7 @@ func newServer(
 		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
 		tmuxActivity:           newTmuxActivityTracker(nil),
 		labelCatalogRefreshIDs: make(map[int64]struct{}),
+		deferredMergeMaxWait:   deferredMergeMaxWait,
 		docsPublishLocks:       newDocsPublishLockSet(),
 		msgvault:               newMsgvaultHandler(cfg, basePath, options.msgvaultRemoteImageDeps),
 		bgCtx: shutdownAwareContext{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -175,6 +175,8 @@ type Server struct {
 	labelCatalogRefreshIDs map[int64]struct{}
 	detailSyncMu           sync.Mutex
 	detailSyncInFlight     map[string]struct{}
+	deferredMergeMu        sync.Mutex
+	deferredMergeInFlight  map[string]struct{}
 	writeCredProbeMu       sync.Mutex
 	writeCredProbes        map[string]writeCredentialProbe
 	writeCredProbeInFlight map[string]chan struct{}

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -96,6 +96,7 @@
     getPage?: () => string;
     roborevBaseUrl?: string;
     onError?: (msg: string) => void;
+    onNotification?: (msg: string) => void;
     stores?: StoreInstances | undefined;
     children?: import("svelte").Snippet;
   }
@@ -117,6 +118,7 @@
     getPage = () => "",
     roborevBaseUrl = undefined,
     onError = undefined,
+    onNotification = undefined,
     stores = $bindable(),
     children,
   }: Props = $props();
@@ -137,6 +139,7 @@
     gp: () => string,
     roborevBase: string | undefined,
     errorCb: ((msg: string) => void) | undefined,
+    notificationCb: ((msg: string) => void) | undefined,
   ): StoreInstances {
     const grouping = createGroupingStore();
     const detailActivityView = createDetailActivityViewStore();
@@ -319,6 +322,37 @@
           );
         }
       },
+      onDeferredMergeCompleted: (event) => {
+        void pullsStore.loadPulls();
+        void activityStore.loadActivity();
+        const detail = detailStore.getDetail();
+        if (
+          detail?.repo?.provider === event.provider &&
+          detail.repo.platform_host === event.platform_host &&
+          detail.repo.repo_path === event.repo_path &&
+          detail.repo_owner === event.owner &&
+          detail.repo_name === event.name &&
+          detail.merge_request?.Number === event.number
+        ) {
+          void detailStore.refreshDetailOnly(
+            event.owner,
+            event.name,
+            event.number,
+            {
+              provider: event.provider,
+              platformHost: event.platform_host,
+              repoPath: event.repo_path,
+            },
+          );
+        }
+        if (event.status === "merged") {
+          notificationCb?.(`${event.owner}/${event.name}#${event.number} merged after CI passed.`);
+        } else {
+          (notificationCb ?? errorCb)?.(
+            `Deferred merge for ${event.owner}/${event.name}#${event.number} failed: ${event.error ?? "checks did not pass"}`,
+          );
+        }
+      },
       onReconnectStale: () => {
         // The replay ring rolled past the client's cursor while it
         // was disconnected (long sleep, extended network outage).
@@ -411,7 +445,7 @@
     client, hostState, config, actions,
     onNavigate, onEvent, prepareRoute,
     onWorkspaceCommand,
-    sidebar, getPage, roborevBaseUrl, onError,
+    sidebar, getPage, roborevBaseUrl, onError, onNotification,
   );
 
   onDestroy(() => {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1340,6 +1340,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/merge/deferred": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Defer pull request merge until pending CI passes */
+        post: operations["defer-merge-pull-on-host"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/ready-for-review": {
         parameters: {
             query?: never;
@@ -2675,6 +2692,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/pulls/{provider}/{owner}/{name}/{number}/merge/deferred": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Defer pull request merge until pending CI passes */
+        post: operations["defer-merge-pull"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/pulls/{provider}/{owner}/{name}/{number}/ready-for-review": {
         parameters: {
             query?: never;
@@ -3984,6 +4018,17 @@ export interface components {
             score: number;
             snippet?: components["schemas"]["BodySnippet"];
         };
+        DeferMergePRBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/DeferMergePRBody.json
+             */
+            readonly $schema?: string;
+            /** Format: int64 */
+            pending_checks: number;
+            status: string;
+        };
         DependencyCapabilities: {
             gh: boolean;
             git: boolean;
@@ -4865,18 +4910,6 @@ export interface components {
             merged: boolean;
             message: string;
             sha: string;
-        };
-        MergePRHostInputBody: {
-            /**
-             * Format: uri
-             * @description A URL to the JSON Schema for this object.
-             * @example /api/v1/schemas/MergePRHostInputBody.json
-             */
-            readonly $schema?: string;
-            commit_message: string;
-            commit_title: string;
-            expected_head_sha?: string;
-            method: string;
         };
         MergePRInputBody: {
             /**
@@ -9377,7 +9410,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["MergePRHostInputBody"];
+                "application/json": components["schemas"]["MergePRInputBody"];
             };
         };
         responses: {
@@ -9388,6 +9421,45 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MergePRBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "defer-merge-pull-on-host": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MergePRInputBody"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeferMergePRBody"];
                 };
             };
             /** @description Error */
@@ -12454,6 +12526,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MergePRBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "defer-merge-pull": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MergePRInputBody"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeferMergePRBody"];
                 };
             };
             /** @description Error */

--- a/packages/ui/src/api/provider-routes.ts
+++ b/packages/ui/src/api/provider-routes.ts
@@ -71,6 +71,7 @@ type PullSuffix =
   | "/import-metadata"
   | "/labels"
   | "/merge"
+  | "/merge/deferred"
   | "/ready-for-review"
   | "/reviewers"
   | "/discussions/{discussion_id}/reply"

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -5,8 +5,6 @@
   import { providerItemPath, providerRouteParams } from "../../api/provider-routes.js";
   import { getClient } from "../../context.js";
   import { pushModalFrame } from "../../stores/keyboard/modal-stack.svelte.js";
-  import { bucketForCheck, parseCIChecks } from "../../utils/ci-buckets.js";
-  import type { CICheck } from "../../api/types.js";
   import ActionButton from "../shared/ActionButton.svelte";
 
   const client = getClient();
@@ -33,8 +31,6 @@
     requireHeadPin?: boolean;
     /** When true, the primary action waits for currently pending CI before merging. */
     deferUntilChecksPass?: boolean;
-    /** Current provider CI snapshot for the loaded pull request. */
-    checksJSON?: string;
     onclose: () => void;
     onmerged: () => void;
     onheadconflict?: ((reason: "stale_state" | "head_unknown", context?: string) => void) | undefined;
@@ -46,7 +42,6 @@
     allowSquash, allowMerge, allowRebase,
     expectedHeadSha, requireHeadPin = false,
     deferUntilChecksPass = false,
-    checksJSON = "",
     onclose, onmerged, onheadconflict,
   }: Props = $props();
 
@@ -111,14 +106,6 @@
   let merging = $state(false);
   let error = $state<string | null>(null);
 
-  const parsedChecks = $derived(parseCIChecks(checksJSON));
-
-  function pendingCheckKeys(checks: CICheck[]): string[] {
-    return checks
-      .filter((check) => bucketForCheck(check) === "pending")
-      .map((check) => `${check.app}\0${check.name}`);
-  }
-
   function mergeParams(): MergeParams {
     return {
       commit_title: commitTitle,
@@ -171,7 +158,7 @@
   }
 
   function handleMerge(): void {
-    if (deferUntilChecksPass && pendingCheckKeys(parsedChecks.checks).length > 0) {
+    if (deferUntilChecksPass) {
       void submitMerge(true);
       return;
     }

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -5,7 +5,11 @@
   import { providerItemPath, providerRouteParams } from "../../api/provider-routes.js";
   import { getClient } from "../../context.js";
   import { pushModalFrame } from "../../stores/keyboard/modal-stack.svelte.js";
+  import { bucketForCheck, parseCIChecks } from "../../utils/ci-buckets.js";
+  import type { CICheck } from "../../api/types.js";
   import ActionButton from "../shared/ActionButton.svelte";
+
+  const DEFAULT_CI_POLL_INTERVAL_MS = 60_000;
 
   const client = getClient();
 
@@ -29,6 +33,14 @@
     expectedHeadSha?: string | undefined;
     /** capabilities.mutation_head_binding for this repo's provider. */
     requireHeadPin?: boolean;
+    /** When true, the primary action waits for currently pending CI before merging. */
+    deferUntilChecksPass?: boolean;
+    /** Current provider CI snapshot for the loaded pull request. */
+    checksJSON?: string;
+    /** Refreshes the loaded CI snapshot while a deferred merge is armed. */
+    onrefreshci?: (() => Promise<void>) | undefined;
+    /** Test hook for shortening the default one-minute polling interval. */
+    ciPollIntervalMs?: number;
     onclose: () => void;
     onmerged: () => void;
     onheadconflict?: ((reason: "stale_state" | "head_unknown", context?: string) => void) | undefined;
@@ -39,6 +51,10 @@
     prAuthor, prAuthorDisplayName,
     allowSquash, allowMerge, allowRebase,
     expectedHeadSha, requireHeadPin = false,
+    deferUntilChecksPass = false,
+    checksJSON = "",
+    onrefreshci,
+    ciPollIntervalMs = DEFAULT_CI_POLL_INTERVAL_MS,
     onclose, onmerged, onheadconflict,
   }: Props = $props();
 
@@ -102,8 +118,55 @@
 
   let merging = $state(false);
   let error = $state<string | null>(null);
+  let waitingForCI = $state(false);
+  let deferredPendingCheckKeys = $state<string[] | null>(null);
+  let deferredMergeStarted = $state(false);
+  let deferredCIError = $state<string | null>(null);
 
-  async function handleMerge(): Promise<void> {
+  const parsedChecks = $derived(parseCIChecks(checksJSON));
+  const deferredCIState = $derived.by(() =>
+    deferredPendingCheckKeys === null
+      ? "idle"
+      : pendingCheckState(deferredPendingCheckKeys, parsedChecks.checks),
+  );
+  const pendingAtConfirmationCount = $derived(deferredPendingCheckKeys?.length ?? 0);
+
+  function checkKey(check: CICheck): string {
+    return `${check.app}\0${check.name}`;
+  }
+
+  function pendingCheckKeys(checks: CICheck[]): string[] {
+    return checks
+      .filter((check) => bucketForCheck(check) === "pending")
+      .map(checkKey);
+  }
+
+  function pendingCheckState(keys: readonly string[], checks: readonly CICheck[]): "pending" | "passed" | "failed" {
+    if (keys.length === 0) return "passed";
+    const checksByKey = new Map(checks.map((check) => [checkKey(check), check]));
+    let hasPending = false;
+    for (const key of keys) {
+      const check = checksByKey.get(key);
+      if (check === undefined) {
+        hasPending = true;
+        continue;
+      }
+      switch (bucketForCheck(check)) {
+        case "passed":
+        case "skipped":
+          break;
+        case "failed":
+        case "unknown":
+          return "failed";
+        case "pending":
+          hasPending = true;
+          break;
+      }
+    }
+    return hasPending ? "pending" : "passed";
+  }
+
+  async function submitMerge(): Promise<void> {
     if (headPinMissing) return;
     merging = true;
     error = null;
@@ -141,6 +204,44 @@
     }
   }
 
+  function handleMerge(): void {
+    if (deferUntilChecksPass && !waitingForCI) {
+      const keys = pendingCheckKeys(parsedChecks.checks);
+      if (keys.length > 0) {
+        deferredPendingCheckKeys = keys;
+        waitingForCI = true;
+        deferredMergeStarted = false;
+        deferredCIError = null;
+        error = null;
+        return;
+      }
+    }
+    void submitMerge();
+  }
+
+  $effect(() => {
+    if (!waitingForCI || deferredPendingCheckKeys === null) return;
+    if (deferredCIState === "failed") {
+      waitingForCI = false;
+      deferredCIError = "A check that was pending failed; merge was not performed.";
+      return;
+    }
+    if (deferredCIState === "passed") {
+      if (deferredMergeStarted) return;
+      deferredMergeStarted = true;
+      void submitMerge();
+      return;
+    }
+    if (onrefreshci === undefined) return;
+    const refresh = () => {
+      void onrefreshci().catch((err) => {
+        deferredCIError = err instanceof Error ? err.message : String(err);
+      });
+    };
+    const interval = setInterval(refresh, ciPollIntervalMs);
+    return () => clearInterval(interval);
+  });
+
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === "Escape") {
       e.preventDefault();
@@ -153,6 +254,17 @@
       methods.find(m => m.value === selectedMethod)?.label
       ?? "Merge"
     );
+  }
+
+  function deferredStatusText(): string {
+    const suffix = pendingAtConfirmationCount === 1 ? "check" : "checks";
+    return `Waiting for ${pendingAtConfirmationCount} pending ${suffix} to pass.`;
+  }
+
+  function primaryButtonLabel(): string {
+    if (merging) return "Merging...";
+    if (waitingForCI) return "Waiting for CI...";
+    return deferUntilChecksPass ? "Merge after CI is complete" : methodLabel();
   }
 </script>
 
@@ -233,6 +345,18 @@
       {#if error}
         <p class="merge-error">{error}</p>
       {/if}
+      {#if deferUntilChecksPass}
+        <div class="ci-defer-note" role={waitingForCI ? "status" : undefined}>
+          {#if waitingForCI}
+            {deferredStatusText()}
+          {:else}
+            CI is still running. This will merge only if the checks that are pending now pass.
+          {/if}
+        </div>
+      {/if}
+      {#if deferredCIError}
+        <p class="merge-error">{deferredCIError}</p>
+      {/if}
     </div>
 
     {#if headPinMissing}
@@ -254,18 +378,28 @@
       </ActionButton>
       <ActionButton
         class="btn btn--primary btn--green"
-        onclick={() => void handleMerge()}
-        disabled={merging || headPinMissing}
+        onclick={handleMerge}
+        disabled={merging || headPinMissing || waitingForCI}
         tone="success"
         surface="solid"
       >
-        {merging ? "Merging\u2026" : methodLabel()}
+        {primaryButtonLabel()}
       </ActionButton>
     </div>
   </div>
 </div>
 
 <style>
+  .ci-defer-note {
+    padding: 8px 10px;
+    border: 1px solid var(--accent-amber-soft, rgba(217, 119, 6, 0.35));
+    border-radius: var(--radius-sm);
+    background: var(--accent-amber-soft, rgba(217, 119, 6, 0.12));
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.35;
+  }
+
   .head-pin-note {
     margin: 0 0 var(--space-3, 12px);
     color: var(--text-secondary, #888);

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -9,8 +9,6 @@
   import type { CICheck } from "../../api/types.js";
   import ActionButton from "../shared/ActionButton.svelte";
 
-  const DEFAULT_CI_POLL_INTERVAL_MS = 60_000;
-
   const client = getClient();
 
   onMount(() => pushModalFrame("merge-modal", []));
@@ -37,10 +35,6 @@
     deferUntilChecksPass?: boolean;
     /** Current provider CI snapshot for the loaded pull request. */
     checksJSON?: string;
-    /** Refreshes the loaded CI snapshot while a deferred merge is armed. */
-    onrefreshci?: (() => Promise<void>) | undefined;
-    /** Test hook for shortening the default one-minute polling interval. */
-    ciPollIntervalMs?: number;
     onclose: () => void;
     onmerged: () => void;
     onheadconflict?: ((reason: "stale_state" | "head_unknown", context?: string) => void) | undefined;
@@ -53,8 +47,6 @@
     expectedHeadSha, requireHeadPin = false,
     deferUntilChecksPass = false,
     checksJSON = "",
-    onrefreshci,
-    ciPollIntervalMs = DEFAULT_CI_POLL_INTERVAL_MS,
     onclose, onmerged, onheadconflict,
   }: Props = $props();
 
@@ -118,69 +110,45 @@
 
   let merging = $state(false);
   let error = $state<string | null>(null);
-  let waitingForCI = $state(false);
-  let deferredPendingCheckKeys = $state<string[] | null>(null);
-  let deferredMergeStarted = $state(false);
-  let deferredCIError = $state<string | null>(null);
 
   const parsedChecks = $derived(parseCIChecks(checksJSON));
-  const deferredCIState = $derived.by(() =>
-    deferredPendingCheckKeys === null
-      ? "idle"
-      : pendingCheckState(deferredPendingCheckKeys, parsedChecks.checks),
-  );
-  const pendingAtConfirmationCount = $derived(deferredPendingCheckKeys?.length ?? 0);
-
-  function checkKey(check: CICheck): string {
-    return `${check.app}\0${check.name}`;
-  }
 
   function pendingCheckKeys(checks: CICheck[]): string[] {
     return checks
       .filter((check) => bucketForCheck(check) === "pending")
-      .map(checkKey);
+      .map((check) => `${check.app}\0${check.name}`);
   }
 
-  function pendingCheckState(keys: readonly string[], checks: readonly CICheck[]): "pending" | "passed" | "failed" {
-    if (keys.length === 0) return "passed";
-    const checksByKey = new Map(checks.map((check) => [checkKey(check), check]));
-    let hasPending = false;
-    for (const key of keys) {
-      const check = checksByKey.get(key);
-      if (check === undefined) {
-        hasPending = true;
-        continue;
-      }
-      switch (bucketForCheck(check)) {
-        case "passed":
-        case "skipped":
-          break;
-        case "failed":
-        case "unknown":
-          return "failed";
-        case "pending":
-          hasPending = true;
-          break;
-      }
+  function mergeParams(): MergeParams {
+    return {
+      commit_title: commitTitle,
+      commit_message: commitMessage,
+      method: selectedMethod,
+      ...(pinnedHeadShaAtOpen !== "" && { expected_head_sha: pinnedHeadShaAtOpen }),
+    };
+  }
+
+  function handleMergeError(requestError: { detail?: string; title?: string; details?: unknown } | undefined): boolean {
+    if (!requestError) return false;
+    const reason = isProblem(requestError) ? problemConflictReason(requestError) : undefined;
+    if (reason === "stale_state" || reason === "head_unknown") {
+      onheadconflict?.(reason, isProblem(requestError) ? problemConflictContext(requestError) : undefined);
+      onclose();
+      return true;
     }
-    return hasPending ? "pending" : "passed";
+    throw new Error(requestError.detail ?? requestError.title ?? "failed to merge pull request");
   }
 
-  async function submitMerge(): Promise<void> {
+  async function submitMerge(deferred: boolean): Promise<void> {
     if (headPinMissing) return;
     merging = true;
     error = null;
     try {
       // Pin the merge to the head the user reviewed; the server rejects
       // the request when the synced head has moved past it.
-      const params: MergeParams = {
-        commit_title: commitTitle,
-        commit_message: commitMessage,
-        method: selectedMethod,
-        ...(pinnedHeadShaAtOpen !== "" && { expected_head_sha: pinnedHeadShaAtOpen }),
-      };
+      const params = mergeParams();
       const ref = { provider, platformHost, owner, name, repoPath };
-      const { error } = await client.POST(providerItemPath("pulls", ref, "/merge"), {
+      const { error } = await client.POST(providerItemPath("pulls", ref, deferred ? "/merge/deferred" : "/merge"), {
         params: { path: { ...providerRouteParams(ref), number } },
         body: params,
       });
@@ -188,13 +156,11 @@
         // Head-pinning conflicts close the modal: the user must
         // re-review the refreshed detail before retrying, so an
         // inline retry from this stale form would be wrong.
-        const reason = isProblem(error) ? problemConflictReason(error) : undefined;
-        if (reason === "stale_state" || reason === "head_unknown") {
-          onheadconflict?.(reason, isProblem(error) ? problemConflictContext(error) : undefined);
-          onclose();
-          return;
-        }
-        throw new Error(error.detail ?? error.title ?? "failed to merge pull request");
+        if (handleMergeError(error)) return;
+      }
+      if (deferred) {
+        onclose();
+        return;
       }
       onmerged();
     } catch (err) {
@@ -205,42 +171,12 @@
   }
 
   function handleMerge(): void {
-    if (deferUntilChecksPass && !waitingForCI) {
-      const keys = pendingCheckKeys(parsedChecks.checks);
-      if (keys.length > 0) {
-        deferredPendingCheckKeys = keys;
-        waitingForCI = true;
-        deferredMergeStarted = false;
-        deferredCIError = null;
-        error = null;
-        return;
-      }
+    if (deferUntilChecksPass && pendingCheckKeys(parsedChecks.checks).length > 0) {
+      void submitMerge(true);
+      return;
     }
-    void submitMerge();
+    void submitMerge(false);
   }
-
-  $effect(() => {
-    if (!waitingForCI || deferredPendingCheckKeys === null) return;
-    if (deferredCIState === "failed") {
-      waitingForCI = false;
-      deferredCIError = "A check that was pending failed; merge was not performed.";
-      return;
-    }
-    if (deferredCIState === "passed") {
-      if (deferredMergeStarted) return;
-      deferredMergeStarted = true;
-      void submitMerge();
-      return;
-    }
-    if (onrefreshci === undefined) return;
-    const refresh = () => {
-      void onrefreshci().catch((err) => {
-        deferredCIError = err instanceof Error ? err.message : String(err);
-      });
-    };
-    const interval = setInterval(refresh, ciPollIntervalMs);
-    return () => clearInterval(interval);
-  });
 
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === "Escape") {
@@ -256,14 +192,8 @@
     );
   }
 
-  function deferredStatusText(): string {
-    const suffix = pendingAtConfirmationCount === 1 ? "check" : "checks";
-    return `Waiting for ${pendingAtConfirmationCount} pending ${suffix} to pass.`;
-  }
-
   function primaryButtonLabel(): string {
     if (merging) return "Merging...";
-    if (waitingForCI) return "Waiting for CI...";
     return deferUntilChecksPass ? "Merge after CI is complete" : methodLabel();
   }
 </script>
@@ -346,16 +276,9 @@
         <p class="merge-error">{error}</p>
       {/if}
       {#if deferUntilChecksPass}
-        <div class="ci-defer-note" role={waitingForCI ? "status" : undefined}>
-          {#if waitingForCI}
-            {deferredStatusText()}
-          {:else}
-            CI is still running. This will merge only if the checks that are pending now pass.
-          {/if}
+        <div class="ci-defer-note">
+          CI is still running. This will merge only if the checks that are pending now pass.
         </div>
-      {/if}
-      {#if deferredCIError}
-        <p class="merge-error">{deferredCIError}</p>
       {/if}
     </div>
 
@@ -379,7 +302,7 @@
       <ActionButton
         class="btn btn--primary btn--green"
         onclick={handleMerge}
-        disabled={merging || headPinMissing || waitingForCI}
+        disabled={merging || headPinMissing}
         tone="success"
         surface="solid"
       >

--- a/packages/ui/src/components/detail/MergeModal.svelte.test.ts
+++ b/packages/ui/src/components/detail/MergeModal.svelte.test.ts
@@ -149,4 +149,53 @@ describe("MergeModal head pinning", () => {
     expect(onheadconflict).not.toHaveBeenCalled();
     expect(onclose).not.toHaveBeenCalled();
   });
+
+  it("waits for checks that were pending at confirmation before merging", async () => {
+    vi.useFakeTimers();
+    const post = vi.fn().mockResolvedValue({ data: {}, error: undefined, response: new Response("{}") });
+    const onrefreshci = vi.fn(async () => undefined);
+    const pendingChecks = JSON.stringify([
+      {
+        name: "build",
+        status: "in_progress",
+        conclusion: "",
+        url: "https://example.com/build",
+        app: "GitHub Actions",
+      },
+    ]);
+    const passingChecks = JSON.stringify([
+      {
+        name: "build",
+        status: "completed",
+        conclusion: "success",
+        url: "https://example.com/build",
+        app: "GitHub Actions",
+      },
+    ]);
+    const { rerender } = renderModal(post, {
+      deferUntilChecksPass: true,
+      checksJSON: pendingChecks,
+      onrefreshci,
+      ciPollIntervalMs: 1_000,
+    });
+
+    await fireEvent.click(screen.getByText("Merge after CI is complete", { selector: ".modal-footer button" }));
+
+    expect(post).not.toHaveBeenCalled();
+    expect(screen.getByText("Waiting for 1 pending check to pass.")).toBeTruthy();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await waitFor(() => expect(onrefreshci).toHaveBeenCalledTimes(1));
+    await rerender({
+      ...baseProps,
+      deferUntilChecksPass: true,
+      checksJSON: passingChecks,
+      onrefreshci,
+      ciPollIntervalMs: 1_000,
+    });
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+    const [, init] = post.mock.calls[0];
+    expect(init.body.method).toBe("squash");
+  });
 });

--- a/packages/ui/src/components/detail/MergeModal.svelte.test.ts
+++ b/packages/ui/src/components/detail/MergeModal.svelte.test.ts
@@ -153,18 +153,8 @@ describe("MergeModal head pinning", () => {
   it("enqueues a deferred merge and closes when CI is still pending", async () => {
     const post = vi.fn().mockResolvedValue({ data: {}, error: undefined, response: new Response("{}") });
     const onclose = vi.fn();
-    const pendingChecks = JSON.stringify([
-      {
-        name: "build",
-        status: "in_progress",
-        conclusion: "",
-        url: "https://example.com/build",
-        app: "GitHub Actions",
-      },
-    ]);
     renderModal(post, {
       deferUntilChecksPass: true,
-      checksJSON: pendingChecks,
       onclose,
     });
 
@@ -174,6 +164,22 @@ describe("MergeModal head pinning", () => {
     const [path, init] = post.mock.calls[0];
     expect(path).toBe("/pulls/{provider}/{owner}/{name}/{number}/merge/deferred");
     expect(init.body.method).toBe("squash");
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("enqueues a deferred merge when requested without granular pending checks", async () => {
+    const post = vi.fn().mockResolvedValue({ data: {}, error: undefined, response: new Response("{}") });
+    const onclose = vi.fn();
+    renderModal(post, {
+      deferUntilChecksPass: true,
+      onclose,
+    });
+
+    await fireEvent.click(screen.getByText("Merge after CI is complete", { selector: ".modal-footer button" }));
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+    const [path] = post.mock.calls[0];
+    expect(path).toBe("/pulls/{provider}/{owner}/{name}/{number}/merge/deferred");
     expect(onclose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/components/detail/MergeModal.svelte.test.ts
+++ b/packages/ui/src/components/detail/MergeModal.svelte.test.ts
@@ -150,10 +150,9 @@ describe("MergeModal head pinning", () => {
     expect(onclose).not.toHaveBeenCalled();
   });
 
-  it("waits for checks that were pending at confirmation before merging", async () => {
-    vi.useFakeTimers();
+  it("enqueues a deferred merge and closes when CI is still pending", async () => {
     const post = vi.fn().mockResolvedValue({ data: {}, error: undefined, response: new Response("{}") });
-    const onrefreshci = vi.fn(async () => undefined);
+    const onclose = vi.fn();
     const pendingChecks = JSON.stringify([
       {
         name: "build",
@@ -163,39 +162,18 @@ describe("MergeModal head pinning", () => {
         app: "GitHub Actions",
       },
     ]);
-    const passingChecks = JSON.stringify([
-      {
-        name: "build",
-        status: "completed",
-        conclusion: "success",
-        url: "https://example.com/build",
-        app: "GitHub Actions",
-      },
-    ]);
-    const { rerender } = renderModal(post, {
+    renderModal(post, {
       deferUntilChecksPass: true,
       checksJSON: pendingChecks,
-      onrefreshci,
-      ciPollIntervalMs: 1_000,
+      onclose,
     });
 
     await fireEvent.click(screen.getByText("Merge after CI is complete", { selector: ".modal-footer button" }));
 
-    expect(post).not.toHaveBeenCalled();
-    expect(screen.getByText("Waiting for 1 pending check to pass.")).toBeTruthy();
-
-    await vi.advanceTimersByTimeAsync(1_000);
-    await waitFor(() => expect(onrefreshci).toHaveBeenCalledTimes(1));
-    await rerender({
-      ...baseProps,
-      deferUntilChecksPass: true,
-      checksJSON: passingChecks,
-      onrefreshci,
-      ciPollIntervalMs: 1_000,
-    });
-
     await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
-    const [, init] = post.mock.calls[0];
+    const [path, init] = post.mock.calls[0];
+    expect(path).toBe("/pulls/{provider}/{owner}/{name}/{number}/merge/deferred");
     expect(init.body.method).toBe("squash");
+    expect(onclose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -2036,6 +2036,14 @@
           allowRebase={repoSettings.allowRebase}
           expectedHeadSha={detailHeadSha}
           requireHeadPin={capabilities.mutation_head_binding}
+          deferUntilChecksPass={ciChecksHavePending(p.CIChecksJSON)}
+          checksJSON={p.CIChecksJSON}
+          onrefreshci={() => detailStore.refreshPendingCI(owner, name, number, {
+            provider,
+            platformHost,
+            repoPath,
+            workflowApprovalSync,
+          })}
           onheadconflict={handleHeadConflict}
           onclose={() => { showMergeModal = false; }}
           onmerged={() => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -2038,12 +2038,6 @@
           requireHeadPin={capabilities.mutation_head_binding}
           deferUntilChecksPass={ciChecksHavePending(p.CIChecksJSON)}
           checksJSON={p.CIChecksJSON}
-          onrefreshci={() => detailStore.refreshPendingCI(owner, name, number, {
-            provider,
-            platformHost,
-            repoPath,
-            workflowApprovalSync,
-          })}
           onheadconflict={handleHeadConflict}
           onclose={() => { showMergeModal = false; }}
           onmerged={() => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -202,6 +202,14 @@
     }
   }
 
+  function ciStatusIsPending(status: string): boolean {
+    return ["pending", "in_progress", "queued"].includes(status.toLowerCase());
+  }
+
+  function shouldDeferMergeForCI(status: string, checksJSON: string): boolean {
+    return ciStatusIsPending(status) || ciChecksHavePending(checksJSON);
+  }
+
   function requiredStatusChecksHaveNotPassed(checksJSON: string): boolean {
     if (!checksJSON) return false;
     try {
@@ -2036,8 +2044,7 @@
           allowRebase={repoSettings.allowRebase}
           expectedHeadSha={detailHeadSha}
           requireHeadPin={capabilities.mutation_head_binding}
-          deferUntilChecksPass={ciChecksHavePending(p.CIChecksJSON)}
-          checksJSON={p.CIChecksJSON}
+          deferUntilChecksPass={shouldDeferMergeForCI(p.CIStatus, p.CIChecksJSON)}
           onheadconflict={handleHeadConflict}
           onclose={() => { showMergeModal = false; }}
           onmerged={() => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -206,7 +206,22 @@
     return ["pending", "in_progress", "queued"].includes(status.toLowerCase());
   }
 
+  function ciStatusHasFailed(status: string): boolean {
+    return [
+      "failure",
+      "failed",
+      "error",
+      "cancelled",
+      "canceled",
+      "timed_out",
+    ].includes(status.toLowerCase());
+  }
+
   function shouldDeferMergeForCI(status: string, checksJSON: string): boolean {
+    // The backend rejects a deferred merge once aggregate CI has failed, so a
+    // failed pipeline with a check still running must use the normal merge path
+    // rather than route to the deferred endpoint that would 409.
+    if (ciStatusHasFailed(status)) return false;
     return ciStatusIsPending(status) || ciChecksHavePending(checksJSON);
   }
 

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -713,4 +713,23 @@ describe("PullDetail approvals", () => {
     expect(screen.getByRole("heading", { name: "Merge Pull Request" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Merge after CI is complete" })).toBeTruthy();
   });
+
+  it("opens the merge modal in deferred mode when aggregate CI is pending without check rows", async () => {
+    const detail = pullDetail();
+    detail.repo.capabilities.merge_mutation = true;
+    detail.merge_request.CIStatus = "pending";
+    detail.merge_request.CIChecksJSON = "";
+
+    renderPullDetail(detail, {
+      AllowSquashMerge: true,
+      AllowMergeCommit: false,
+      AllowRebaseMerge: false,
+      ViewerCanMerge: true,
+    });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Squash and merge" }));
+
+    expect(screen.getByRole("heading", { name: "Merge Pull Request" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Merge after CI is complete" })).toBeTruthy();
+  });
 });

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -686,4 +686,31 @@ describe("PullDetail approvals", () => {
     expect(button.disabled).toBe(true);
     expect(button.title).toBe("No user credential for writes on github.com");
   });
+
+  it("opens the merge modal in deferred mode when CI is still pending", async () => {
+    const detail = pullDetail();
+    detail.repo.capabilities.merge_mutation = true;
+    detail.merge_request.CIStatus = "pending";
+    detail.merge_request.CIChecksJSON = JSON.stringify([
+      {
+        name: "build",
+        status: "in_progress",
+        conclusion: "",
+        url: "https://example.com/build",
+        app: "GitHub Actions",
+      },
+    ]);
+
+    renderPullDetail(detail, {
+      AllowSquashMerge: true,
+      AllowMergeCommit: false,
+      AllowRebaseMerge: false,
+      ViewerCanMerge: true,
+    });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Squash and merge" }));
+
+    expect(screen.getByRole("heading", { name: "Merge Pull Request" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Merge after CI is complete" })).toBeTruthy();
+  });
 });

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -732,4 +732,40 @@ describe("PullDetail approvals", () => {
     expect(screen.getByRole("heading", { name: "Merge Pull Request" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Merge after CI is complete" })).toBeTruthy();
   });
+
+  it("opens the merge modal in normal mode when aggregate CI has already failed", async () => {
+    const detail = pullDetail();
+    detail.repo.capabilities.merge_mutation = true;
+    detail.merge_request.CIStatus = "failure";
+    detail.merge_request.CIChecksJSON = JSON.stringify([
+      {
+        name: "build",
+        status: "completed",
+        conclusion: "failure",
+        url: "https://example.com/build",
+        app: "GitHub Actions",
+      },
+      {
+        name: "integration",
+        status: "in_progress",
+        conclusion: "",
+        url: "https://example.com/integration",
+        app: "GitHub Actions",
+      },
+    ]);
+
+    renderPullDetail(detail, {
+      AllowSquashMerge: true,
+      AllowMergeCommit: false,
+      AllowRebaseMerge: false,
+      ViewerCanMerge: true,
+    });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Squash and merge" }));
+
+    expect(screen.getByRole("heading", { name: "Merge Pull Request" })).toBeTruthy();
+    // A failed aggregate with a still-running check must not route to deferred
+    // merge, since the backend would reject that with a 409.
+    expect(screen.queryByRole("button", { name: "Merge after CI is complete" })).toBeNull();
+  });
 });

--- a/packages/ui/src/stores/events.svelte.ts
+++ b/packages/ui/src/stores/events.svelte.ts
@@ -83,6 +83,22 @@ export interface PRCIRefreshedEvent {
   warnings: string[];
 }
 
+export interface DeferredMergeCompletedEvent {
+  provider: string;
+  platform_host: string;
+  repo_path: string;
+  owner: string;
+  name: string;
+  number: number;
+  head_sha: string;
+  status: "merged" | "failed";
+  merged?: boolean;
+  sha?: string;
+  message?: string;
+  error?: string;
+  completed_at: string;
+}
+
 export interface EventsStoreOptions {
   /**
    * Base URL path (typically from config.basePath). Trailing
@@ -110,6 +126,7 @@ export interface EventsStoreOptions {
   onPRDetailRefreshed?: (event: PRDetailRefreshedEvent) => void;
   onPRCIRefreshQueued?: (event: PRCIRefreshQueuedEvent) => void;
   onPRCIRefreshed?: (event: PRCIRefreshedEvent) => void;
+  onDeferredMergeCompleted?: (event: DeferredMergeCompletedEvent) => void;
 }
 
 /**
@@ -171,6 +188,7 @@ export function createEventsStore(opts: EventsStoreOptions = {}) {
     addJSONListener<PRDetailRefreshedEvent>(source, "pr_detail_refreshed", opts.onPRDetailRefreshed);
     addJSONListener<PRCIRefreshQueuedEvent>(source, "pr_ci_refresh_queued", opts.onPRCIRefreshQueued);
     addJSONListener<PRCIRefreshedEvent>(source, "pr_ci_refreshed", opts.onPRCIRefreshed);
+    addJSONListener<DeferredMergeCompletedEvent>(source, "deferred_merge_completed", opts.onDeferredMergeCompleted);
   }
 
   function disconnect(): void {


### PR DESCRIPTION
## Summary
- Move merge-after-CI into a backend deferred merge API endpoint instead of keeping the modal open.
- Close the modal immediately, store an in-process deferred intent, poll CI server-side, and merge only if the queued pending checks and current refreshed checks pass.
- Emit an SSE completion event when the deferred merge succeeds or fails so the app can notify the user after they navigate elsewhere.

## Note
Deferred merge intents are backend-owned but in-process only; they are not persisted across a middleman restart.
