### PR TITLE
Fix Markdown rich diff rendering

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "check": "cd .. && node node_modules/vite-plus/bin/vp run frontend-package-check",
     "lint": "node ../node_modules/vite-plus/bin/vp lint . --no-error-on-unmatched-pattern",
     "lint:fix": "node ../node_modules/vite-plus/bin/vp lint . --fix --no-error-on-unmatched-pattern",
-    "typecheck": "cd .. && node node_modules/vite-plus/bin/vp lint frontend '!frontend/dist/**' '!frontend/test-results/**' --no-error-on-unmatched-pattern --threads=1 && cd frontend && node ../node_modules/vite-plus/bin/vp exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
+    "typecheck": "cd .. && node node_modules/vite-plus/bin/vp run frontend-package-typecheck",
     "test": "node ../node_modules/vite-plus/bin/vp test run",
     "test:e2e": "node ./scripts/run-e2e-to-file.ts",
     "test:e2e:mock": "node node_modules/.bin/playwright test --config=playwright.config.ts",

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -392,12 +392,12 @@ const previewDiff: DiffResult = withServerDiffData({
       status: "modified",
       is_binary: false,
       is_whitespace_only: false,
-      additions: 4,
-      deletions: 3,
+      additions: 5,
+      deletions: 4,
       hunks: [
         {
           old_start: 1,
-          old_count: 5,
+          old_count: 6,
           new_start: 1,
           new_count: 6,
           lines: [
@@ -425,6 +425,16 @@ const previewDiff: DiffResult = withServerDiffData({
               old_num: 5,
             },
             { type: "add", content: "- [x] Markdown task", new_num: 5 },
+            {
+              type: "delete",
+              content: "<em>alpha</em><strong>beta</strong><code>gamma</code>",
+              old_num: 6,
+            },
+            {
+              type: "add",
+              content: '<a href="/link">link</a><strong>two</strong><code>three</code>',
+              new_num: 6,
+            },
           ],
         },
       ],
@@ -919,7 +929,9 @@ async function mockFilePreviewApi(page: Page): Promise<void> {
           path,
           media_type: "text/markdown; charset=utf-8",
           encoding: "base64",
-          content: btoa("# Rendered preview\n\n- [x] Markdown task\n"),
+          content: btoa(
+            '# Rendered preview\n\nNew paragraph that should be highlighted.\n\n- [x] Markdown task\n<a href="/link">link</a><strong>two</strong><code>three</code>\n',
+          ),
         }),
       });
       return;
@@ -1620,6 +1632,12 @@ test.describe("diff view", () => {
     await expect(markdownPreview).toContainText("paragraph that should be highlighted.");
     await expect(markdownPreview.locator("del", { hasText: "Old" })).toBeVisible();
     await expect(markdownPreview.locator("ins", { hasText: "New" })).toBeVisible();
+    await expect(markdownPreview.locator("del em", { hasText: "alpha" })).toBeVisible();
+    await expect(markdownPreview.locator("ins a", { hasText: "link" })).toBeVisible();
+    await expect(markdownPreview.locator("strong del", { hasText: "beta" })).toBeVisible();
+    await expect(markdownPreview.locator("strong ins", { hasText: "two" })).toBeVisible();
+    await expect(markdownPreview.locator("code del", { hasText: "gamma" })).toBeVisible();
+    await expect(markdownPreview.locator("code ins", { hasText: "three" })).toBeVisible();
 
     const handlerFile = page.locator('[data-file-path="internal/server/handler.go"]');
     await handlerFile.scrollIntoViewIfNeeded();

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1614,20 +1614,12 @@ test.describe("diff view", () => {
 
     await previewToggle.click();
     await expect(previewToggle).toHaveAttribute("aria-checked", "true");
-    await expect(
-      page.getByLabel("After markdown preview").getByRole("heading", { name: "Rendered preview" }),
-    ).toBeVisible();
-    await expect(page.locator(".markdown-rich-diff")).toContainText("Markdown task");
-    await expect(
-      page.locator(".markdown-rich-diff__block--delete", {
-        hasText: "Old paragraph that should be highlighted.",
-      }),
-    ).toContainText("Old paragraph that should be highlighted.");
-    await expect(
-      page.locator(".markdown-rich-diff__block--add", {
-        hasText: "New paragraph that should be highlighted.",
-      }),
-    ).toContainText("New paragraph that should be highlighted.");
+    const markdownPreview = page.locator(".markdown-rich-diff--unified");
+    await expect(markdownPreview.getByRole("heading", { name: "Rendered preview" })).toBeVisible();
+    await expect(markdownPreview).toContainText("Markdown task");
+    await expect(markdownPreview).toContainText("paragraph that should be highlighted.");
+    await expect(markdownPreview.locator("del", { hasText: "Old" })).toBeVisible();
+    await expect(markdownPreview.locator("ins", { hasText: "New" })).toBeVisible();
 
     const handlerFile = page.locator('[data-file-path="internal/server/handler.go"]');
     await handlerFile.scrollIntoViewIfNeeded();
@@ -2843,10 +2835,9 @@ test.describe("diff view (git-backed)", () => {
       await categoryFilter.getByRole("button", { name: "Plans/docs (2)" }).click();
 
       const planFile = page.locator('[data-file-path="docs/cache-plan.md"]');
-      await expect(planFile.locator(".markdown-rich-diff__block--add")).toContainText("Cache refresh plan");
-      await expect(planFile.locator(".markdown-rich-diff__block--add")).toContainText(
-        "Verify changed-file summaries refresh",
-      );
+      const planPreview = planFile.locator(".markdown-rich-diff--unified");
+      await expect(planPreview.locator("ins", { hasText: "Cache refresh plan" })).toBeVisible();
+      await expect(planPreview.locator("ins", { hasText: "Verify changed-file summaries refresh" })).toBeVisible();
 
       const previewResponse = await page.request.get(
         `${server.info.base_url}/api/v1/pulls/github/acme/widgets/1/file-preview?path=internal/cache.go`,

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -392,14 +392,14 @@ const previewDiff: DiffResult = withServerDiffData({
       status: "modified",
       is_binary: false,
       is_whitespace_only: false,
-      additions: 5,
-      deletions: 4,
+      additions: 6,
+      deletions: 5,
       hunks: [
         {
           old_start: 1,
-          old_count: 6,
+          old_count: 7,
           new_start: 1,
-          new_count: 6,
+          new_count: 7,
           lines: [
             {
               type: "context",
@@ -434,6 +434,16 @@ const previewDiff: DiffResult = withServerDiffData({
               type: "add",
               content: '<a href="/link">link</a><strong>two</strong><code>three</code>',
               new_num: 6,
+            },
+            {
+              type: "delete",
+              content: "<table><tbody><tr><td>Keep</td></tr></tbody></table>",
+              old_num: 7,
+            },
+            {
+              type: "add",
+              content: "<table><tbody><tr><td>Keep</td><td>Added cell</td></tr></tbody></table>",
+              new_num: 7,
             },
           ],
         },
@@ -930,7 +940,7 @@ async function mockFilePreviewApi(page: Page): Promise<void> {
           media_type: "text/markdown; charset=utf-8",
           encoding: "base64",
           content: btoa(
-            '# Rendered preview\n\nNew paragraph that should be highlighted.\n\n- [x] Markdown task\n<a href="/link">link</a><strong>two</strong><code>three</code>\n',
+            '# Rendered preview\n\nNew paragraph that should be highlighted.\n\n- [x] Markdown task\n<a href="/link">link</a><strong>two</strong><code>three</code>\n<table><tbody><tr><td>Keep</td><td>Added cell</td></tr></tbody></table>\n',
           ),
         }),
       });
@@ -1638,6 +1648,8 @@ test.describe("diff view", () => {
     await expect(markdownPreview.locator("strong ins", { hasText: "two" })).toBeVisible();
     await expect(markdownPreview.locator("code del", { hasText: "gamma" })).toBeVisible();
     await expect(markdownPreview.locator("code ins", { hasText: "three" })).toBeVisible();
+    await expect(markdownPreview.locator("tr > ins")).toHaveCount(0);
+    await expect(markdownPreview.locator('td[data-diff-kind="insert"] ins', { hasText: "Added cell" })).toBeVisible();
 
     const handlerFile = page.locator('[data-file-path="internal/server/handler.go"]');
     await handlerFile.scrollIntoViewIfNeeded();

--- a/packages/github-app-ui/package.json
+++ b/packages/github-app-ui/package.json
@@ -9,7 +9,7 @@
     "build": "node ../../node_modules/vite-plus/bin/vp build --logLevel warn",
     "check": "cd ../.. && node node_modules/vite-plus/bin/vp run github-app-ui-package-check",
     "test:e2e": "node ../../node_modules/vite-plus/bin/vp build --logLevel warn && node node_modules/.bin/playwright test",
-    "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp check packages/github-app-ui --no-fmt --no-lint --no-error-on-unmatched-pattern --threads=1 && node node_modules/vite-plus/bin/vp run svelte-check:github-app-ui"
+    "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp run github-app-ui-package-typecheck"
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -115,7 +115,7 @@
   "scripts": {
     "check": "cd ../.. && node node_modules/vite-plus/bin/vp run ui-package-check",
     "lint": "cd ../.. && node node_modules/vite-plus/bin/vp lint packages/ui --no-error-on-unmatched-pattern",
-    "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp lint packages/ui '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1 && cd packages/ui && node ../../node_modules/vite-plus/bin/vp exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings"
+    "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp run ui-package-typecheck"
   },
   "dependencies": {
     "@lucide/svelte": "1.17.0",

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -539,6 +539,7 @@
             {repoPath}
             {number}
             active={inViewport}
+            {viewMode}
           />
         {/key}
       {:else if file.is_binary}

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -173,6 +173,7 @@ function renderDiffFile(
     reviewThreads?: ReviewThread[];
     createComment?: (body: string, range: DiffReviewLineRange) => Promise<boolean>;
     canReplyToThreads?: boolean;
+    viewMode?: "unified" | "split";
     replyToDiscussion?: (
       owner: string,
       name: string,
@@ -184,6 +185,7 @@ function renderDiffFile(
 ) {
   const diff = createDiffStore();
   if (options.richPreview) diff.setRichPreview(true);
+  if (options.viewMode) diff.setViewMode(options.viewMode);
   const diffReviewDraft = {
     getComments: () => options.draftComments ?? [],
     isSubmitting: () => false,
@@ -252,6 +254,8 @@ function textPreview(path: string, text: string): FilePreview {
 describe("DiffFile", () => {
   afterEach(() => {
     cleanup();
+    localStorage.removeItem("diff-rich-preview");
+    localStorage.removeItem("diff-view-mode");
   });
 
   async function expectPierreDiffText(pattern: RegExp): Promise<void> {
@@ -343,6 +347,31 @@ describe("DiffFile", () => {
 
     expect(screen.queryByLabelText("Before markdown preview")).toBeNull();
     await expectPierreDiffText(/old linenew line/);
+  });
+
+  it("renders markdown rich preview as a unified annotated document by default", async () => {
+    renderDiffFile(makeFile({ path: "README.md", old_path: "README.md" }), {
+      richPreview: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Before markdown preview")).toBeNull();
+      expect(screen.queryByLabelText("After markdown preview")).toBeNull();
+      expect(document.querySelector(".markdown-rich-diff--unified del")?.textContent).toBe("old");
+      expect(document.querySelector(".markdown-rich-diff--unified ins")?.textContent).toBe("new");
+    });
+  });
+
+  it("keeps markdown rich preview side by side when split diff mode is enabled", async () => {
+    renderDiffFile(makeFile({ path: "README.md", old_path: "README.md" }), {
+      richPreview: true,
+      viewMode: "split",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Before markdown preview")).toBeTruthy();
+      expect(screen.getByLabelText("After markdown preview")).toBeTruthy();
+    });
   });
 
   it("hides content after clicking the header to collapse", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -369,8 +369,13 @@ describe("DiffFile", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Before markdown preview")).toBeTruthy();
-      expect(screen.getByLabelText("After markdown preview")).toBeTruthy();
+      const beforePreview = screen.getByLabelText("Before markdown preview");
+      const afterPreview = screen.getByLabelText("After markdown preview");
+
+      expect(beforePreview.querySelector("del")?.textContent).toBe("old");
+      expect(beforePreview.querySelector("ins")).toBeNull();
+      expect(afterPreview.querySelector("del")).toBeNull();
+      expect(afterPreview.querySelector("ins")?.textContent).toBe("new");
     });
   });
 

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -21,7 +21,7 @@
   const { diff: diffStore } = getStores();
 
   interface MarkdownComparison {
-    diffHtml: string;
+    diffHtml?: string;
     oldHtml: string;
     newHtml: string;
   }
@@ -33,7 +33,7 @@
 
   const isMarkdownFile = $derived(isMarkdownPath(file.path));
   const markdownComparison = $derived.by(() =>
-    active && isMarkdownFile ? buildMarkdownComparison(file) : null,
+    active && isMarkdownFile ? buildMarkdownComparison(file, viewMode) : null,
   );
   const text = $derived(preview ? decodeText(preview.content) : "");
   const dataURL = $derived(preview ? `data:${preview.media_type};base64,${preview.content}` : "");
@@ -109,7 +109,7 @@
     }
   }
 
-  function buildMarkdownComparison(source: DiffFile): MarkdownComparison {
+  function buildMarkdownComparison(source: DiffFile, mode: DiffViewMode): MarkdownComparison {
     const oldLines: string[] = [];
     const newLines: string[] = [];
     for (const hunk of source.hunks) {
@@ -126,7 +126,7 @@
     const oldHtml = renderMarkdown(`${oldLines.join("\n")}\n`, repo);
     const newHtml = renderMarkdown(`${newLines.join("\n")}\n`, repo);
     return {
-      diffHtml: renderMarkdownDiff(oldHtml, newHtml),
+      ...(mode === "split" ? {} : { diffHtml: renderMarkdownDiff(oldHtml, newHtml) }),
       oldHtml,
       newHtml,
     };
@@ -159,7 +159,7 @@
         </div>
       {:else}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--unified markdown-body">
-          {@html markdownComparison.diffHtml}
+          {@html markdownComparison.diffHtml ?? markdownComparison.newHtml}
         </div>
       {/if}
     {:else}

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -2,7 +2,7 @@
   import type { DiffFile, FilePreview } from "../../api/types.js";
   import { getStores } from "../../context.js";
   import type { DiffViewMode } from "../../stores/diff.svelte.js";
-  import { renderMarkdownDiff } from "../../utils/markdown-diff.js";
+  import { renderMarkdownDiff, renderMarkdownSplitDiff } from "../../utils/markdown-diff.js";
   import { renderMarkdown } from "../../utils/markdown.js";
 
   interface Props {
@@ -125,10 +125,11 @@
     const repo = { provider, platformHost, owner, name, repoPath };
     const oldHtml = renderMarkdown(`${oldLines.join("\n")}\n`, repo);
     const newHtml = renderMarkdown(`${newLines.join("\n")}\n`, repo);
+    const splitHtml = mode === "split" ? renderMarkdownSplitDiff(oldHtml, newHtml) : null;
     return {
       ...(mode === "split" ? {} : { diffHtml: renderMarkdownDiff(oldHtml, newHtml) }),
-      oldHtml,
-      newHtml,
+      oldHtml: splitHtml?.beforeHtml ?? oldHtml,
+      newHtml: splitHtml?.afterHtml ?? newHtml,
     };
   }
 </script>
@@ -259,6 +260,11 @@
 
   .markdown-rich-diff__block--delete :global(*) {
     color: var(--text-primary);
+  }
+
+  .markdown-rich-diff--split :global(.markdown-diff__placeholder) {
+    visibility: hidden;
+    pointer-events: none;
   }
 
   .markdown-rich-diff__block--delete :global(p),

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -301,7 +301,15 @@
     display: block;
     margin: 0.55rem 0;
     padding: 0.45rem 0.6rem;
-    border: 1px solid currentColor;
+    border: 1px solid transparent;
+  }
+
+  .markdown-rich-diff--unified :global(ins.markdown-diff__block) {
+    border-color: color-mix(in srgb, var(--diff-add-text) 32%, transparent);
+  }
+
+  .markdown-rich-diff--unified :global(del.markdown-diff__block) {
+    border-color: color-mix(in srgb, var(--diff-del-text) 36%, transparent);
   }
 
   @media (max-width: 760px) {

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { DiffFile, FilePreview } from "../../api/types.js";
   import { getStores } from "../../context.js";
+  import type { DiffViewMode } from "../../stores/diff.svelte.js";
+  import { renderMarkdownDiff } from "../../utils/markdown-diff.js";
   import { renderMarkdown } from "../../utils/markdown.js";
 
   interface Props {
@@ -12,12 +14,14 @@
     repoPath: string;
     number: number;
     active: boolean;
+    viewMode?: DiffViewMode;
   }
 
-  const { file, provider, platformHost, owner, name, repoPath, number, active }: Props = $props();
+  const { file, provider, platformHost, owner, name, repoPath, number, active, viewMode = "unified" }: Props = $props();
   const { diff: diffStore } = getStores();
 
   interface MarkdownComparison {
+    diffHtml: string;
     oldHtml: string;
     newHtml: string;
   }
@@ -118,9 +122,13 @@
         if (line.type !== "delete") newLines.push(line.content);
       }
     }
+    const repo = { provider, platformHost, owner, name, repoPath };
+    const oldHtml = renderMarkdown(`${oldLines.join("\n")}\n`, repo);
+    const newHtml = renderMarkdown(`${newLines.join("\n")}\n`, repo);
     return {
-      oldHtml: renderMarkdown(`${oldLines.join("\n")}\n`, { provider, platformHost, owner, name, repoPath }),
-      newHtml: renderMarkdown(`${newLines.join("\n")}\n`, { provider, platformHost, owner, name, repoPath }),
+      diffHtml: renderMarkdownDiff(oldHtml, newHtml),
+      oldHtml,
+      newHtml,
     };
   }
 </script>
@@ -128,26 +136,32 @@
 <div class="preview-shell">
   {#if isMarkdownFile}
     {#if markdownComparison}
-      <div class="diff-rich-preview markdown-rich-diff">
-        <div
-          class="markdown-rich-diff__pane markdown-rich-diff__block--delete"
-          aria-label="Before markdown preview"
-        >
-          <div class="markdown-rich-diff__label">Before</div>
-          <div class="markdown-body">
-            {@html markdownComparison.oldHtml}
+      {#if viewMode === "split"}
+        <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--split">
+          <div
+            class="markdown-rich-diff__pane markdown-rich-diff__block--delete"
+            aria-label="Before markdown preview"
+          >
+            <div class="markdown-rich-diff__label">Before</div>
+            <div class="markdown-body">
+              {@html markdownComparison.oldHtml}
+            </div>
+          </div>
+          <div
+            class="markdown-rich-diff__pane markdown-rich-diff__block--add"
+            aria-label="After markdown preview"
+          >
+            <div class="markdown-rich-diff__label">After</div>
+            <div class="markdown-body">
+              {@html markdownComparison.newHtml}
+            </div>
           </div>
         </div>
-        <div
-          class="markdown-rich-diff__pane markdown-rich-diff__block--add"
-          aria-label="After markdown preview"
-        >
-          <div class="markdown-rich-diff__label">After</div>
-          <div class="markdown-body">
-            {@html markdownComparison.newHtml}
-          </div>
+      {:else}
+        <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--unified markdown-body">
+          {@html markdownComparison.diffHtml}
         </div>
-      </div>
+      {/if}
     {:else}
       <div class="preview-state">Loading preview</div>
     {/if}
@@ -207,7 +221,7 @@
     color: var(--text-primary);
   }
 
-  .markdown-rich-diff {
+  .markdown-rich-diff--split {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 12px;
@@ -259,8 +273,39 @@
     text-decoration-color: color-mix(in srgb, var(--diff-del-text) 70%, transparent);
   }
 
+  .markdown-rich-diff--unified {
+    max-width: 920px;
+  }
+
+  .markdown-rich-diff--unified :global(ins),
+  .markdown-rich-diff--unified :global(del) {
+    padding: 0 0.16em;
+    border-radius: 3px;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.12em;
+  }
+
+  .markdown-rich-diff--unified :global(ins) {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--diff-add-bg) 80%, transparent);
+    text-decoration-color: color-mix(in srgb, var(--diff-add-text) 65%, transparent);
+  }
+
+  .markdown-rich-diff--unified :global(del) {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--diff-del-bg) 82%, transparent);
+    text-decoration-color: color-mix(in srgb, var(--diff-del-text) 70%, transparent);
+  }
+
+  .markdown-rich-diff--unified :global(.markdown-diff__block) {
+    display: block;
+    margin: 0.55rem 0;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid currentColor;
+  }
+
   @media (max-width: 760px) {
-    .markdown-rich-diff {
+    .markdown-rich-diff--split {
       grid-template-columns: minmax(0, 1fr);
     }
   }

--- a/packages/ui/src/utils/markdown-diff.test.ts
+++ b/packages/ui/src/utils/markdown-diff.test.ts
@@ -83,6 +83,19 @@ describe("renderMarkdownDiff", () => {
     expect(fragment.querySelector('tbody > tr[data-diff-kind="insert"] > td > ins')?.textContent).toBe("Added");
   });
 
+  it("preserves table cell structure for inserted and deleted cells", () => {
+    const html = renderMarkdownDiff(
+      "<table><tbody><tr><td>Removed</td><td>Keep</td></tr></tbody></table>",
+      "<table><tbody><tr><td>Keep</td><td>Added</td></tr></tbody></table>",
+    );
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("tr > del")).toBeNull();
+    expect(fragment.querySelector("tr > ins")).toBeNull();
+    expect(fragment.querySelector('tr > td[data-diff-kind="delete"] > del')?.textContent).toBe("Removed");
+    expect(fragment.querySelector('tr > td[data-diff-kind="insert"] > ins')?.textContent).toBe("Added");
+  });
+
   it("renders heading level changes visibly", () => {
     const html = renderMarkdownDiff("<h2>Release notes</h2>", "<h3>Release notes</h3>");
 

--- a/packages/ui/src/utils/markdown-diff.test.ts
+++ b/packages/ui/src/utils/markdown-diff.test.ts
@@ -3,6 +3,12 @@
 import { describe, expect, it } from "vite-plus/test";
 import { renderMarkdownDiff, renderMarkdownSplitDiff } from "./markdown-diff.js";
 
+function htmlFragment(html: string): DocumentFragment {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  return template.content;
+}
+
 describe("renderMarkdownDiff", () => {
   it("renders changed prose as one annotated HTML document", () => {
     const html = renderMarkdownDiff("<p>Hello old world</p>", "<p>Hello new world</p>");
@@ -40,6 +46,43 @@ describe("renderMarkdownDiff", () => {
     expect(html).not.toContain("<ins><em>one</em></ins>");
   });
 
+  it("continues pairing compatible element changes after an incompatible sibling", () => {
+    const html = renderMarkdownDiff(
+      "<p><em>alpha</em><strong>beta</strong><code>gamma</code></p>",
+      '<p><a href="/link">link</a><strong>two</strong><code>three</code></p>',
+    );
+
+    expect(html).toContain("<del><em>alpha</em></del>");
+    expect(html).toContain('<ins><a href="/link">link</a></ins>');
+    expect(html).toContain("<strong><del>beta</del><ins>two</ins></strong>");
+    expect(html).toContain("<code><del>gamma</del><ins>three</ins></code>");
+    expect(html).not.toContain("<del><strong>beta</strong></del>");
+    expect(html).not.toContain("<ins><strong>two</strong></ins>");
+  });
+
+  it("preserves list item structure for inserted and deleted items", () => {
+    const html = renderMarkdownDiff("<ul><li>Removed</li><li>Keep</li></ul>", "<ul><li>Keep</li><li>Added</li></ul>");
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("ul > del")).toBeNull();
+    expect(fragment.querySelector("ul > ins")).toBeNull();
+    expect(fragment.querySelector('ul > li[data-diff-kind="delete"] > del')?.textContent).toBe("Removed");
+    expect(fragment.querySelector('ul > li[data-diff-kind="insert"] > ins')?.textContent).toBe("Added");
+  });
+
+  it("preserves table row structure for inserted and deleted rows", () => {
+    const html = renderMarkdownDiff(
+      "<table><tbody><tr><td>Removed</td></tr><tr><td>Keep</td></tr></tbody></table>",
+      "<table><tbody><tr><td>Keep</td></tr><tr><td>Added</td></tr></tbody></table>",
+    );
+    const fragment = htmlFragment(html);
+
+    expect(fragment.querySelector("tbody > del")).toBeNull();
+    expect(fragment.querySelector("tbody > ins")).toBeNull();
+    expect(fragment.querySelector('tbody > tr[data-diff-kind="delete"] > td > del')?.textContent).toBe("Removed");
+    expect(fragment.querySelector('tbody > tr[data-diff-kind="insert"] > td > ins')?.textContent).toBe("Added");
+  });
+
   it("renders heading level changes visibly", () => {
     const html = renderMarkdownDiff("<h2>Release notes</h2>", "<h3>Release notes</h3>");
 
@@ -74,5 +117,17 @@ describe("renderMarkdownDiff", () => {
       '<ins class="markdown-diff__block markdown-diff__placeholder" aria-hidden="true"><p>Added note</p></ins>',
     );
     expect(split.afterHtml).toContain('<ins class="markdown-diff__block"><p>Added note</p></ins>');
+  });
+
+  it("projects split structural additions with same-structure placeholders", () => {
+    const split = renderMarkdownSplitDiff("<ul><li>Keep</li></ul>", "<ul><li>Keep</li><li>Added</li></ul>");
+    const beforeFragment = htmlFragment(split.beforeHtml);
+    const afterFragment = htmlFragment(split.afterHtml);
+
+    expect(beforeFragment.querySelector("ul > ins")).toBeNull();
+    expect(
+      beforeFragment.querySelector('ul > li.markdown-diff__placeholder[data-diff-kind="insert"] > ins')?.textContent,
+    ).toBe("Added");
+    expect(afterFragment.querySelector('ul > li[data-diff-kind="insert"] > ins')?.textContent).toBe("Added");
   });
 });

--- a/packages/ui/src/utils/markdown-diff.test.ts
+++ b/packages/ui/src/utils/markdown-diff.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vite-plus/test";
+import { renderMarkdownDiff } from "./markdown-diff.js";
+
+describe("renderMarkdownDiff", () => {
+  it("renders changed prose as one annotated HTML document", () => {
+    const html = renderMarkdownDiff("<p>Hello old world</p>", "<p>Hello new world</p>");
+
+    expect(html).toContain("<p>");
+    expect(html).toContain("<del>old</del>");
+    expect(html).toContain("<ins>new</ins>");
+    expect(html).toContain("Hello");
+    expect(html).toContain("world");
+  });
+
+  it("marks inserted block nodes inline with the rendered document", () => {
+    const html = renderMarkdownDiff("<h2>Intro</h2>", "<h2>Intro</h2><p>Added note</p>");
+
+    expect(html).toContain("<h2>Intro</h2>");
+    expect(html).toContain('<ins class="markdown-diff__block"><p>Added note</p></ins>');
+  });
+});

--- a/packages/ui/src/utils/markdown-diff.test.ts
+++ b/packages/ui/src/utils/markdown-diff.test.ts
@@ -20,4 +20,28 @@ describe("renderMarkdownDiff", () => {
     expect(html).toContain("<h2>Intro</h2>");
     expect(html).toContain('<ins class="markdown-diff__block"><p>Added note</p></ins>');
   });
+
+  it("renders link target-only changes visibly", () => {
+    const html = renderMarkdownDiff('<p><a href="/old">docs</a></p>', '<p><a href="/new">docs</a></p>');
+
+    expect(html).toMatch(/<del><a href="\/old">docs<\/a><\/del>/);
+    expect(html).toMatch(/<ins><a href="\/new">docs<\/a><\/ins>/);
+  });
+
+  it("renders heading level changes visibly", () => {
+    const html = renderMarkdownDiff("<h2>Release notes</h2>", "<h3>Release notes</h3>");
+
+    expect(html).toContain('<del class="markdown-diff__block"><h2>Release notes</h2></del>');
+    expect(html).toContain('<ins class="markdown-diff__block"><h3>Release notes</h3></ins>');
+  });
+
+  it("falls back to a coarse visible diff for large comparisons", () => {
+    const before = `<p>${Array.from({ length: 150 }, (_, index) => `old-${index}`).join(" ")}</p>`;
+    const after = `<p>${Array.from({ length: 150 }, (_, index) => `new-${index}`).join(" ")}</p>`;
+
+    const html = renderMarkdownDiff(before, after);
+
+    expect(html).toContain("<del>old-0");
+    expect(html).toContain("<ins>new-0");
+  });
 });

--- a/packages/ui/src/utils/markdown-diff.test.ts
+++ b/packages/ui/src/utils/markdown-diff.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it } from "vite-plus/test";
-import { renderMarkdownDiff } from "./markdown-diff.js";
+import { renderMarkdownDiff, renderMarkdownSplitDiff } from "./markdown-diff.js";
 
 describe("renderMarkdownDiff", () => {
   it("renders changed prose as one annotated HTML document", () => {
@@ -43,5 +43,24 @@ describe("renderMarkdownDiff", () => {
 
     expect(html).toContain("<del>old-0");
     expect(html).toContain("<ins>new-0");
+  });
+
+  it("projects split diffs with placeholders to keep changed prose aligned", () => {
+    const split = renderMarkdownSplitDiff("<p>Hello old world</p>", "<p>Hello new world</p>");
+
+    expect(split.beforeHtml).toContain("<del>old</del>");
+    expect(split.beforeHtml).not.toContain("new");
+    expect(split.afterHtml).not.toContain("old");
+    expect(split.afterHtml).toContain("<ins>new</ins>");
+  });
+
+  it("projects split block additions with opposite-side placeholders", () => {
+    const split = renderMarkdownSplitDiff("<h2>Intro</h2>", "<h2>Intro</h2><p>Added note</p>");
+
+    expect(split.beforeHtml).toContain("<h2>Intro</h2>");
+    expect(split.beforeHtml).toContain(
+      '<ins class="markdown-diff__block markdown-diff__placeholder" aria-hidden="true"><p>Added note</p></ins>',
+    );
+    expect(split.afterHtml).toContain('<ins class="markdown-diff__block"><p>Added note</p></ins>');
   });
 });

--- a/packages/ui/src/utils/markdown-diff.test.ts
+++ b/packages/ui/src/utils/markdown-diff.test.ts
@@ -28,6 +28,18 @@ describe("renderMarkdownDiff", () => {
     expect(html).toMatch(/<ins><a href="\/new">docs<\/a><\/ins>/);
   });
 
+  it("pairs adjacent compatible element changes in order", () => {
+    const html = renderMarkdownDiff(
+      "<p><em>alpha</em><strong>beta</strong></p>",
+      "<p><em>one</em><strong>two</strong></p>",
+    );
+
+    expect(html).toContain("<em><del>alpha</del><ins>one</ins></em>");
+    expect(html).toContain("<strong><del>beta</del><ins>two</ins></strong>");
+    expect(html).not.toContain("<del><em>alpha</em></del>");
+    expect(html).not.toContain("<ins><em>one</em></ins>");
+  });
+
   it("renders heading level changes visibly", () => {
     const html = renderMarkdownDiff("<h2>Release notes</h2>", "<h3>Release notes</h3>");
 

--- a/packages/ui/src/utils/markdown-diff.ts
+++ b/packages/ui/src/utils/markdown-diff.ts
@@ -20,18 +20,12 @@ function nodesEqual(left: Node, right: Node): boolean {
 function nodesCompatible(left: Node, right: Node): boolean {
   if (left.nodeType === Node.TEXT_NODE && right.nodeType === Node.TEXT_NODE) return true;
   if (!(left instanceof Element) || !(right instanceof Element)) return false;
-  if (left.tagName === right.tagName) return compatibleAttributes(left, right);
-  return headingLevel(left) !== null && headingLevel(right) !== null && left.textContent === right.textContent;
-}
-
-function headingLevel(node: Element): number | null {
-  const match = node.tagName.match(/^H([1-6])$/);
-  return match ? Number(match[1]) : null;
+  return left.tagName === right.tagName && compatibleAttributes(left, right);
 }
 
 function compatibleAttributes(left: Element, right: Element): boolean {
-  const leftAttrs = attributesWithoutHref(left);
-  const rightAttrs = attributesWithoutHref(right);
+  const leftAttrs = attributesMap(left);
+  const rightAttrs = attributesMap(right);
   if (leftAttrs.size !== rightAttrs.size) return false;
   for (const [name, value] of leftAttrs) {
     if (rightAttrs.get(name) !== value) return false;
@@ -39,10 +33,9 @@ function compatibleAttributes(left: Element, right: Element): boolean {
   return true;
 }
 
-function attributesWithoutHref(element: Element): Map<string, string> {
+function attributesMap(element: Element): Map<string, string> {
   const attrs = new Map<string, string>();
   for (const attr of Array.from(element.attributes)) {
-    if (attr.name === "href") continue;
     attrs.set(attr.name, attr.value);
   }
   return attrs;
@@ -53,6 +46,13 @@ function diffSequence<T>(
   newItems: readonly T[],
   equal: (left: T, right: T) => boolean,
 ): DiffOp<T>[] {
+  if (oldItems.length * newItems.length > 20_000) {
+    return [
+      ...oldItems.map((oldItem): DiffOp<T> => ({ kind: "delete", oldItem })),
+      ...newItems.map((newItem): DiffOp<T> => ({ kind: "insert", newItem })),
+    ];
+  }
+
   const rows = oldItems.length + 1;
   const cols = newItems.length + 1;
   const lengths = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
@@ -133,36 +133,14 @@ function diffNode(oldNode: Node, newNode: Node): Node[] {
     return diffText(oldNode.textContent ?? "", newNode.textContent ?? "");
   }
   if (oldNode instanceof Element && newNode instanceof Element) {
-    if (headingLevel(oldNode) !== null && headingLevel(newNode) !== null && oldNode.tagName !== newNode.tagName) {
-      return [nodeWithUpdatedTag(oldNode, newNode)];
-    }
     if (oldNode.tagName === newNode.tagName && compatibleAttributes(oldNode, newNode)) {
       const clone = oldNode.cloneNode(false) as Element;
-      if (
-        oldNode instanceof HTMLAnchorElement &&
-        newNode instanceof HTMLAnchorElement &&
-        oldNode.href !== newNode.href
-      ) {
-        clone.setAttribute("data-before-href", oldNode.getAttribute("href") ?? "");
-        clone.setAttribute("href", newNode.getAttribute("href") ?? "");
-      }
       clone.append(...diffChildNodes(oldNode, newNode));
       markChangedContainer(clone);
       return [clone];
     }
   }
   return [wrapChangedNode("del", oldNode), wrapChangedNode("ins", newNode)];
-}
-
-function nodeWithUpdatedTag(oldNode: Element, newNode: Element): Element {
-  const replacement = document.createElement(newNode.tagName.toLowerCase());
-  for (const attr of Array.from(newNode.attributes)) {
-    replacement.setAttribute(attr.name, attr.value);
-  }
-  replacement.setAttribute("data-before-tag-name", oldNode.tagName.toLowerCase());
-  replacement.append(...diffChildNodes(oldNode, newNode));
-  markChangedContainer(replacement);
-  return replacement;
 }
 
 function markChangedContainer(element: Element): void {
@@ -237,6 +215,6 @@ export function renderMarkdownDiff(beforeHtml: string, afterHtml: string): strin
   const host = document.createElement("div");
   host.append(...diffChildNodes(before.content, after.content));
   return DOMPurify.sanitize(host.innerHTML, {
-    ADD_ATTR: ["class", "data-before-href", "data-before-tag-name"],
+    ADD_ATTR: ["class"],
   });
 }

--- a/packages/ui/src/utils/markdown-diff.ts
+++ b/packages/ui/src/utils/markdown-diff.ts
@@ -1,0 +1,242 @@
+import DOMPurify from "dompurify";
+
+type DiffOp<T> =
+  | { kind: "equal"; oldItem: T; newItem: T }
+  | { kind: "delete"; oldItem: T }
+  | { kind: "insert"; newItem: T };
+
+function parseHTMLFragment(html: string): HTMLTemplateElement {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  return template;
+}
+
+function nodesEqual(left: Node, right: Node): boolean {
+  if (left.nodeType !== right.nodeType) return false;
+  if (left.nodeType === Node.TEXT_NODE) return left.textContent === right.textContent;
+  return left instanceof Element && right instanceof Element && left.outerHTML === right.outerHTML;
+}
+
+function nodesCompatible(left: Node, right: Node): boolean {
+  if (left.nodeType === Node.TEXT_NODE && right.nodeType === Node.TEXT_NODE) return true;
+  if (!(left instanceof Element) || !(right instanceof Element)) return false;
+  if (left.tagName === right.tagName) return compatibleAttributes(left, right);
+  return headingLevel(left) !== null && headingLevel(right) !== null && left.textContent === right.textContent;
+}
+
+function headingLevel(node: Element): number | null {
+  const match = node.tagName.match(/^H([1-6])$/);
+  return match ? Number(match[1]) : null;
+}
+
+function compatibleAttributes(left: Element, right: Element): boolean {
+  const leftAttrs = attributesWithoutHref(left);
+  const rightAttrs = attributesWithoutHref(right);
+  if (leftAttrs.size !== rightAttrs.size) return false;
+  for (const [name, value] of leftAttrs) {
+    if (rightAttrs.get(name) !== value) return false;
+  }
+  return true;
+}
+
+function attributesWithoutHref(element: Element): Map<string, string> {
+  const attrs = new Map<string, string>();
+  for (const attr of Array.from(element.attributes)) {
+    if (attr.name === "href") continue;
+    attrs.set(attr.name, attr.value);
+  }
+  return attrs;
+}
+
+function diffSequence<T>(
+  oldItems: readonly T[],
+  newItems: readonly T[],
+  equal: (left: T, right: T) => boolean,
+): DiffOp<T>[] {
+  const rows = oldItems.length + 1;
+  const cols = newItems.length + 1;
+  const lengths = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+  for (let i = oldItems.length - 1; i >= 0; i--) {
+    for (let j = newItems.length - 1; j >= 0; j--) {
+      lengths[i]![j] = equal(oldItems[i]!, newItems[j]!)
+        ? lengths[i + 1]![j + 1]! + 1
+        : Math.max(lengths[i + 1]![j]!, lengths[i]![j + 1]!);
+    }
+  }
+
+  const ops: DiffOp<T>[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < oldItems.length && j < newItems.length) {
+    if (equal(oldItems[i]!, newItems[j]!)) {
+      ops.push({ kind: "equal", oldItem: oldItems[i]!, newItem: newItems[j]! });
+      i++;
+      j++;
+    } else if (lengths[i + 1]![j]! >= lengths[i]![j + 1]!) {
+      ops.push({ kind: "delete", oldItem: oldItems[i]! });
+      i++;
+    } else {
+      ops.push({ kind: "insert", newItem: newItems[j]! });
+      j++;
+    }
+  }
+  while (i < oldItems.length) {
+    ops.push({ kind: "delete", oldItem: oldItems[i]! });
+    i++;
+  }
+  while (j < newItems.length) {
+    ops.push({ kind: "insert", newItem: newItems[j]! });
+    j++;
+  }
+  return ops;
+}
+
+function diffChildNodes(oldParent: ParentNode, newParent: ParentNode): Node[] {
+  const oldChildren = Array.from(oldParent.childNodes);
+  const newChildren = Array.from(newParent.childNodes);
+  const ops = pairCompatibleNodes(diffSequence(oldChildren, newChildren, nodesEqual));
+  const output: Node[] = [];
+  for (const op of ops) {
+    if (op.kind === "equal") {
+      output.push(op.oldItem.cloneNode(true));
+    } else if (op.kind === "replace") {
+      output.push(...diffNode(op.oldItem, op.newItem));
+    } else if (op.kind === "delete") {
+      output.push(wrapChangedNode("del", op.oldItem));
+    } else {
+      output.push(wrapChangedNode("ins", op.newItem));
+    }
+  }
+  return output;
+}
+
+type PairedNodeOp = DiffOp<Node> | { kind: "replace"; oldItem: Node; newItem: Node };
+
+function pairCompatibleNodes(ops: DiffOp<Node>[]): PairedNodeOp[] {
+  const paired: PairedNodeOp[] = [];
+  for (let i = 0; i < ops.length; i++) {
+    const current = ops[i]!;
+    const next = ops[i + 1];
+    if (current.kind === "delete" && next?.kind === "insert" && nodesCompatible(current.oldItem, next.newItem)) {
+      paired.push({ kind: "replace", oldItem: current.oldItem, newItem: next.newItem });
+      i++;
+    } else {
+      paired.push(current);
+    }
+  }
+  return paired;
+}
+
+function diffNode(oldNode: Node, newNode: Node): Node[] {
+  if (nodesEqual(oldNode, newNode)) return [oldNode.cloneNode(true)];
+  if (oldNode.nodeType === Node.TEXT_NODE && newNode.nodeType === Node.TEXT_NODE) {
+    return diffText(oldNode.textContent ?? "", newNode.textContent ?? "");
+  }
+  if (oldNode instanceof Element && newNode instanceof Element) {
+    if (headingLevel(oldNode) !== null && headingLevel(newNode) !== null && oldNode.tagName !== newNode.tagName) {
+      return [nodeWithUpdatedTag(oldNode, newNode)];
+    }
+    if (oldNode.tagName === newNode.tagName && compatibleAttributes(oldNode, newNode)) {
+      const clone = oldNode.cloneNode(false) as Element;
+      if (
+        oldNode instanceof HTMLAnchorElement &&
+        newNode instanceof HTMLAnchorElement &&
+        oldNode.href !== newNode.href
+      ) {
+        clone.setAttribute("data-before-href", oldNode.getAttribute("href") ?? "");
+        clone.setAttribute("href", newNode.getAttribute("href") ?? "");
+      }
+      clone.append(...diffChildNodes(oldNode, newNode));
+      markChangedContainer(clone);
+      return [clone];
+    }
+  }
+  return [wrapChangedNode("del", oldNode), wrapChangedNode("ins", newNode)];
+}
+
+function nodeWithUpdatedTag(oldNode: Element, newNode: Element): Element {
+  const replacement = document.createElement(newNode.tagName.toLowerCase());
+  for (const attr of Array.from(newNode.attributes)) {
+    replacement.setAttribute(attr.name, attr.value);
+  }
+  replacement.setAttribute("data-before-tag-name", oldNode.tagName.toLowerCase());
+  replacement.append(...diffChildNodes(oldNode, newNode));
+  markChangedContainer(replacement);
+  return replacement;
+}
+
+function markChangedContainer(element: Element): void {
+  if (element.matches("li,tr")) element.classList.add("changed");
+}
+
+function wrapChangedNode(tagName: "del" | "ins", node: Node): HTMLElement {
+  const wrapper = document.createElement(tagName);
+  if (node instanceof Element && isBlockElement(node)) {
+    wrapper.classList.add("markdown-diff__block");
+  }
+  wrapper.append(node.cloneNode(true));
+  return wrapper;
+}
+
+function isBlockElement(node: Element): boolean {
+  return /^(ADDRESS|ARTICLE|ASIDE|BLOCKQUOTE|DIV|DL|FIELDSET|FIGCAPTION|FIGURE|FOOTER|FORM|H[1-6]|HEADER|HR|LI|MAIN|NAV|OL|P|PRE|SECTION|TABLE|UL)$/.test(
+    node.tagName,
+  );
+}
+
+function diffText(oldText: string, newText: string): Node[] {
+  const oldTokens = tokenizeText(oldText);
+  const newTokens = tokenizeText(newText);
+  const ops = coalesceTextOps(diffSequence(oldTokens, newTokens, (left, right) => left === right));
+  const output: Node[] = [];
+  for (const op of ops) {
+    if (op.kind === "equal") {
+      output.push(document.createTextNode(op.text));
+    } else {
+      const text = op.tokens.join("");
+      if (/^\s*$/.test(text)) {
+        output.push(document.createTextNode(text));
+        continue;
+      }
+      const wrapper = document.createElement(op.kind);
+      wrapper.textContent = text;
+      output.push(wrapper);
+    }
+  }
+  return output;
+}
+
+type TextOp = { kind: "equal"; text: string } | { kind: "del" | "ins"; tokens: string[] };
+
+function coalesceTextOps(ops: DiffOp<string>[]): TextOp[] {
+  const output: TextOp[] = [];
+  for (const op of ops) {
+    if (op.kind === "equal") {
+      const previous = output[output.length - 1];
+      if (previous?.kind === "equal") previous.text += op.oldItem;
+      else output.push({ kind: "equal", text: op.oldItem });
+    } else {
+      const kind = op.kind === "delete" ? "del" : "ins";
+      const token = op.kind === "delete" ? op.oldItem : op.newItem;
+      const previous = output[output.length - 1];
+      if (previous?.kind === kind) previous.tokens.push(token);
+      else output.push({ kind, tokens: [token] });
+    }
+  }
+  return output;
+}
+
+function tokenizeText(text: string): string[] {
+  return text.match(/\s+|[^\s]+/g) ?? [];
+}
+
+export function renderMarkdownDiff(beforeHtml: string, afterHtml: string): string {
+  if (beforeHtml === afterHtml) return beforeHtml;
+  const before = parseHTMLFragment(beforeHtml);
+  const after = parseHTMLFragment(afterHtml);
+  const host = document.createElement("div");
+  host.append(...diffChildNodes(before.content, after.content));
+  return DOMPurify.sanitize(host.innerHTML, {
+    ADD_ATTR: ["class", "data-before-href", "data-before-tag-name"],
+  });
+}

--- a/packages/ui/src/utils/markdown-diff.ts
+++ b/packages/ui/src/utils/markdown-diff.ts
@@ -208,13 +208,68 @@ function tokenizeText(text: string): string[] {
   return text.match(/\s+|[^\s]+/g) ?? [];
 }
 
-export function renderMarkdownDiff(beforeHtml: string, afterHtml: string): string {
-  if (beforeHtml === afterHtml) return beforeHtml;
+function diffHTMLFragment(beforeHtml: string, afterHtml: string): HTMLElement {
   const before = parseHTMLFragment(beforeHtml);
   const after = parseHTMLFragment(afterHtml);
   const host = document.createElement("div");
   host.append(...diffChildNodes(before.content, after.content));
-  return DOMPurify.sanitize(host.innerHTML, {
-    ADD_ATTR: ["class"],
+  return host;
+}
+
+function sanitizeMarkdownDiff(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ADD_ATTR: ["class", "aria-hidden"],
   });
+}
+
+function placeholderFor(node: Element): Element {
+  const placeholder = node.cloneNode(true) as Element;
+  placeholder.classList.add("markdown-diff__placeholder");
+  placeholder.setAttribute("aria-hidden", "true");
+  return placeholder;
+}
+
+function projectDiffForSide(node: Node, side: "before" | "after"): Node | null {
+  if (node instanceof Element) {
+    const tagName = node.tagName.toLowerCase();
+    if (tagName === "del" && side === "after") {
+      return node.classList.contains("markdown-diff__block") ? placeholderFor(node) : null;
+    }
+    if (tagName === "ins" && side === "before") {
+      return node.classList.contains("markdown-diff__block") ? placeholderFor(node) : null;
+    }
+    const clone = node.cloneNode(false) as Element;
+    for (const child of Array.from(node.childNodes)) {
+      const projected = projectDiffForSide(child, side);
+      if (projected) clone.append(projected);
+    }
+    return clone;
+  }
+  return node.cloneNode(true);
+}
+
+function projectDiffHTML(host: ParentNode, side: "before" | "after"): string {
+  const projection = document.createElement("div");
+  for (const child of Array.from(host.childNodes)) {
+    const projected = projectDiffForSide(child, side);
+    if (projected) projection.append(projected);
+  }
+  return sanitizeMarkdownDiff(projection.innerHTML);
+}
+
+export function renderMarkdownDiff(beforeHtml: string, afterHtml: string): string {
+  if (beforeHtml === afterHtml) return beforeHtml;
+  return sanitizeMarkdownDiff(diffHTMLFragment(beforeHtml, afterHtml).innerHTML);
+}
+
+export function renderMarkdownSplitDiff(
+  beforeHtml: string,
+  afterHtml: string,
+): { beforeHtml: string; afterHtml: string } {
+  if (beforeHtml === afterHtml) return { beforeHtml, afterHtml };
+  const host = diffHTMLFragment(beforeHtml, afterHtml);
+  return {
+    beforeHtml: projectDiffHTML(host, "before"),
+    afterHtml: projectDiffHTML(host, "after"),
+  };
 }

--- a/packages/ui/src/utils/markdown-diff.ts
+++ b/packages/ui/src/utils/markdown-diff.ts
@@ -116,13 +116,43 @@ function pairCompatibleNodes(ops: DiffOp<Node>[]): PairedNodeOp[] {
   const paired: PairedNodeOp[] = [];
   for (let i = 0; i < ops.length; i++) {
     const current = ops[i]!;
-    const next = ops[i + 1];
-    if (current.kind === "delete" && next?.kind === "insert" && nodesCompatible(current.oldItem, next.newItem)) {
-      paired.push({ kind: "replace", oldItem: current.oldItem, newItem: next.newItem });
-      i++;
-    } else {
+    if (current.kind !== "delete") {
       paired.push(current);
+      continue;
     }
+
+    const deleteRun: Extract<DiffOp<Node>, { kind: "delete" }>[] = [];
+    while (ops[i]?.kind === "delete") {
+      deleteRun.push(ops[i] as Extract<DiffOp<Node>, { kind: "delete" }>);
+      i++;
+    }
+
+    const insertRun: Extract<DiffOp<Node>, { kind: "insert" }>[] = [];
+    while (ops[i]?.kind === "insert") {
+      insertRun.push(ops[i] as Extract<DiffOp<Node>, { kind: "insert" }>);
+      i++;
+    }
+    i--;
+
+    if (insertRun.length === 0) {
+      paired.push(...deleteRun);
+      continue;
+    }
+
+    const pairCount = Math.min(deleteRun.length, insertRun.length);
+    let pairedCount = 0;
+    while (
+      pairedCount < pairCount &&
+      nodesCompatible(deleteRun[pairedCount]!.oldItem, insertRun[pairedCount]!.newItem)
+    ) {
+      paired.push({
+        kind: "replace",
+        oldItem: deleteRun[pairedCount]!.oldItem,
+        newItem: insertRun[pairedCount]!.newItem,
+      });
+      pairedCount++;
+    }
+    paired.push(...deleteRun.slice(pairedCount), ...insertRun.slice(pairedCount));
   }
   return paired;
 }

--- a/packages/ui/src/utils/markdown-diff.ts
+++ b/packages/ui/src/utils/markdown-diff.ts
@@ -111,6 +111,8 @@ function diffChildNodes(oldParent: ParentNode, newParent: ParentNode): Node[] {
 }
 
 type PairedNodeOp = DiffOp<Node> | { kind: "replace"; oldItem: Node; newItem: Node };
+type DeleteNodeOp = Extract<DiffOp<Node>, { kind: "delete" }>;
+type InsertNodeOp = Extract<DiffOp<Node>, { kind: "insert" }>;
 
 function pairCompatibleNodes(ops: DiffOp<Node>[]): PairedNodeOp[] {
   const paired: PairedNodeOp[] = [];
@@ -121,15 +123,15 @@ function pairCompatibleNodes(ops: DiffOp<Node>[]): PairedNodeOp[] {
       continue;
     }
 
-    const deleteRun: Extract<DiffOp<Node>, { kind: "delete" }>[] = [];
+    const deleteRun: DeleteNodeOp[] = [];
     while (ops[i]?.kind === "delete") {
-      deleteRun.push(ops[i] as Extract<DiffOp<Node>, { kind: "delete" }>);
+      deleteRun.push(ops[i] as DeleteNodeOp);
       i++;
     }
 
-    const insertRun: Extract<DiffOp<Node>, { kind: "insert" }>[] = [];
+    const insertRun: InsertNodeOp[] = [];
     while (ops[i]?.kind === "insert") {
-      insertRun.push(ops[i] as Extract<DiffOp<Node>, { kind: "insert" }>);
+      insertRun.push(ops[i] as InsertNodeOp);
       i++;
     }
     i--;
@@ -139,23 +141,29 @@ function pairCompatibleNodes(ops: DiffOp<Node>[]): PairedNodeOp[] {
       continue;
     }
 
-    const pairCount = Math.min(deleteRun.length, insertRun.length);
-    let pairedCount = 0;
-    while (
-      pairedCount < pairCount &&
-      nodesCompatible(deleteRun[pairedCount]!.oldItem, insertRun[pairedCount]!.newItem)
-    ) {
-      paired.push({
-        kind: "replace",
-        oldItem: deleteRun[pairedCount]!.oldItem,
-        newItem: insertRun[pairedCount]!.newItem,
-      });
-      pairedCount++;
-    }
-    paired.push(...deleteRun.slice(pairedCount), ...insertRun.slice(pairedCount));
+    paired.push(...pairChangedNodeRun(deleteRun, insertRun));
   }
   return paired;
 }
+
+function pairChangedNodeRun(deleteRun: DeleteNodeOp[], insertRun: InsertNodeOp[]): PairedNodeOp[] {
+  const deleteItems = deleteRun.map((op): ChangedNodeRunItem => ({ node: op.oldItem }));
+  const insertItems = insertRun.map((op): ChangedNodeRunItem => ({ node: op.newItem }));
+  const aligned = diffSequence(deleteItems, insertItems, (left, right) => nodesCompatible(left.node, right.node));
+  return aligned.map((op): PairedNodeOp => {
+    if (op.kind === "equal") {
+      return {
+        kind: "replace",
+        oldItem: op.oldItem.node,
+        newItem: op.newItem.node,
+      };
+    }
+    if (op.kind === "delete") return { kind: "delete", oldItem: op.oldItem.node };
+    return { kind: "insert", newItem: op.newItem.node };
+  });
+}
+
+type ChangedNodeRunItem = { node: Node };
 
 function diffNode(oldNode: Node, newNode: Node): Node[] {
   if (nodesEqual(oldNode, newNode)) return [oldNode.cloneNode(true)];
@@ -177,13 +185,52 @@ function markChangedContainer(element: Element): void {
   if (element.matches("li,tr")) element.classList.add("changed");
 }
 
-function wrapChangedNode(tagName: "del" | "ins", node: Node): HTMLElement {
+function wrapChangedNode(tagName: "del" | "ins", node: Node): Element {
+  if (node instanceof Element && isStructuralChildElement(node)) {
+    return wrapChangedStructuralElement(tagName, node);
+  }
+
   const wrapper = document.createElement(tagName);
   if (node instanceof Element && isBlockElement(node)) {
     wrapper.classList.add("markdown-diff__block");
   }
   wrapper.append(node.cloneNode(true));
   return wrapper;
+}
+
+function wrapChangedStructuralElement(tagName: "del" | "ins", element: Element): Element {
+  const clone = element.cloneNode(false) as Element;
+  clone.classList.add("changed", "markdown-diff__structural");
+  clone.setAttribute("data-diff-kind", tagName === "del" ? "delete" : "insert");
+
+  if (element.tagName === "TR") {
+    appendChangedTableRowChildren(clone, element, tagName);
+  } else {
+    clone.append(wrapChangedChildren(tagName, element));
+  }
+  return clone;
+}
+
+function appendChangedTableRowChildren(row: Element, source: Element, tagName: "del" | "ins"): void {
+  for (const child of Array.from(source.childNodes)) {
+    if (child instanceof Element && /^(TD|TH)$/.test(child.tagName)) {
+      const cell = child.cloneNode(false) as Element;
+      cell.append(wrapChangedChildren(tagName, child));
+      row.append(cell);
+    } else if (!(child.nodeType === Node.TEXT_NODE && /^\s*$/.test(child.textContent ?? ""))) {
+      row.append(child.cloneNode(true));
+    }
+  }
+}
+
+function wrapChangedChildren(tagName: "del" | "ins", source: ParentNode): HTMLElement {
+  const wrapper = document.createElement(tagName);
+  wrapper.append(...Array.from(source.childNodes).map((child) => child.cloneNode(true)));
+  return wrapper;
+}
+
+function isStructuralChildElement(node: Element): boolean {
+  return /^(LI|TR)$/.test(node.tagName);
 }
 
 function isBlockElement(node: Element): boolean {
@@ -248,7 +295,7 @@ function diffHTMLFragment(beforeHtml: string, afterHtml: string): HTMLElement {
 
 function sanitizeMarkdownDiff(html: string): string {
   return DOMPurify.sanitize(html, {
-    ADD_ATTR: ["class", "aria-hidden"],
+    ADD_ATTR: ["class", "aria-hidden", "data-diff-kind"],
   });
 }
 
@@ -261,6 +308,11 @@ function placeholderFor(node: Element): Element {
 
 function projectDiffForSide(node: Node, side: "before" | "after"): Node | null {
   if (node instanceof Element) {
+    const structuralKind = changedStructuralKind(node);
+    if ((structuralKind === "delete" && side === "after") || (structuralKind === "insert" && side === "before")) {
+      return placeholderFor(node);
+    }
+
     const tagName = node.tagName.toLowerCase();
     if (tagName === "del" && side === "after") {
       return node.classList.contains("markdown-diff__block") ? placeholderFor(node) : null;
@@ -276,6 +328,12 @@ function projectDiffForSide(node: Node, side: "before" | "after"): Node | null {
     return clone;
   }
   return node.cloneNode(true);
+}
+
+function changedStructuralKind(node: Element): "delete" | "insert" | null {
+  if (!node.classList.contains("markdown-diff__structural")) return null;
+  const kind = node.getAttribute("data-diff-kind");
+  return kind === "delete" || kind === "insert" ? kind : null;
 }
 
 function projectDiffHTML(host: ParentNode, side: "before" | "after"): string {

--- a/packages/ui/src/utils/markdown-diff.ts
+++ b/packages/ui/src/utils/markdown-diff.ts
@@ -230,7 +230,7 @@ function wrapChangedChildren(tagName: "del" | "ins", source: ParentNode): HTMLEl
 }
 
 function isStructuralChildElement(node: Element): boolean {
-  return /^(LI|TR)$/.test(node.tagName);
+  return /^(LI|TR|TD|TH)$/.test(node.tagName);
 }
 
 function isBlockElement(node: Element): boolean {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
         ],
         cache: false,
       },
+      // svelte-check behaves poorly with concurrent processes. Keep one task
+      // name and route package wrappers through it; cache hits keep repeated
+      // package-local typechecks cheap without exposing per-package tasks.
       "svelte-check": {
         command: [
           `(cd frontend && ${frontendVP} exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings)`,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   run: {
     tasks: {
       "frontend-check": {
-        command: `${rootVP} run frontend-fmt && ${rootVP} run frontend-lint && ${rootVP} run svelte-check:frontend && ${rootVP} run svelte-check:ui && ${rootVP} run svelte-check:github-app-ui`,
+        command: [`${rootVP} run frontend-fmt`, `${rootVP} run frontend-lint`, `${rootVP} run frontend-svelte-check`],
         cache: false,
       },
       "frontend-fmt": {
@@ -21,7 +21,22 @@ export default defineConfig({
         cache: false,
       },
       "frontend-package-check": {
-        command: `${rootVP} fmt --check frontend --no-error-on-unmatched-pattern --threads=1 && ${rootVP} lint frontend '!frontend/dist/**' '!frontend/test-results/**' --no-error-on-unmatched-pattern --threads=1 && ${rootVP} run svelte-check:frontend`,
+        command: [`${rootVP} fmt --check frontend --no-error-on-unmatched-pattern --threads=1`, `${rootVP} run frontend-package-typecheck`],
+        cache: false,
+      },
+      "frontend-package-typecheck": {
+        command: [
+          `${rootVP} lint frontend '!frontend/dist/**' '!frontend/test-results/**' --no-error-on-unmatched-pattern --threads=1`,
+          `${rootVP} run svelte-check:frontend`,
+        ],
+        cache: false,
+      },
+      "frontend-svelte-check": {
+        command: [
+          `${rootVP} run svelte-check:frontend`,
+          `${rootVP} run svelte-check:ui`,
+          `${rootVP} run svelte-check:github-app-ui`,
+        ],
         cache: false,
       },
       "svelte-check:frontend": {
@@ -40,11 +55,28 @@ export default defineConfig({
         cwd: "packages/github-app-ui",
       },
       "ui-package-check": {
-        command: `${rootVP} fmt --check packages/ui --no-error-on-unmatched-pattern --threads=1 && ${rootVP} lint packages/ui '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1 && ${rootVP} run svelte-check:ui`,
+        command: [`${rootVP} fmt --check packages/ui --no-error-on-unmatched-pattern --threads=1`, `${rootVP} run ui-package-typecheck`],
+        cache: false,
+      },
+      "ui-package-typecheck": {
+        command: [
+          `${rootVP} lint packages/ui '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1`,
+          `${rootVP} run svelte-check:ui`,
+        ],
         cache: false,
       },
       "github-app-ui-package-check": {
-        command: `${rootVP} fmt --check packages/github-app-ui --no-error-on-unmatched-pattern --threads=1 && ${rootVP} lint packages/github-app-ui '!packages/github-app-ui/dist/**' --no-error-on-unmatched-pattern --threads=1 && ${rootVP} run svelte-check:github-app-ui`,
+        command: [
+          `${rootVP} fmt --check packages/github-app-ui --no-error-on-unmatched-pattern --threads=1`,
+          `${rootVP} run github-app-ui-package-typecheck`,
+        ],
+        cache: false,
+      },
+      "github-app-ui-package-typecheck": {
+        command: [
+          `${rootVP} lint packages/github-app-ui '!packages/github-app-ui/dist/**' --no-error-on-unmatched-pattern --threads=1`,
+          `${rootVP} run svelte-check:github-app-ui`,
+        ],
         cache: false,
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   run: {
     tasks: {
       "frontend-check": {
-        command: [`${rootVP} run frontend-fmt`, `${rootVP} run frontend-lint`, `${rootVP} run frontend-svelte-check`],
+        command: [`${rootVP} run frontend-fmt`, `${rootVP} run frontend-lint`, `${rootVP} run svelte-check`],
         cache: false,
       },
       "frontend-fmt": {
@@ -27,32 +27,27 @@ export default defineConfig({
       "frontend-package-typecheck": {
         command: [
           `${rootVP} lint frontend '!frontend/dist/**' '!frontend/test-results/**' --no-error-on-unmatched-pattern --threads=1`,
-          `${rootVP} run svelte-check:frontend`,
+          `${rootVP} run svelte-check`,
         ],
         cache: false,
       },
-      "frontend-svelte-check": {
+      "svelte-check": {
         command: [
-          `${rootVP} run svelte-check:frontend`,
-          `${rootVP} run svelte-check:ui`,
-          `${rootVP} run svelte-check:github-app-ui`,
+          `(cd frontend && ${frontendVP} exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings)`,
+          `(cd packages/ui && ${uiVP} exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings)`,
+          `(cd packages/github-app-ui && ${packageVP} exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings)`,
         ],
-        cache: false,
-      },
-      "svelte-check:frontend": {
-        command: `${frontendVP} exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings`,
-        cache: false,
-        cwd: "frontend",
-      },
-      "svelte-check:ui": {
-        command: `${uiVP} exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings`,
-        cache: false,
-        cwd: "packages/ui",
-      },
-      "svelte-check:github-app-ui": {
-        command: `${packageVP} exec -- svelte-check --tsconfig ./tsconfig.json --fail-on-warnings`,
-        cache: false,
-        cwd: "packages/github-app-ui",
+        input: [
+          { auto: true },
+          "!node_modules/.vite-temp/**",
+          "!frontend/node_modules/.vite-temp/**",
+          "!packages/ui/node_modules/.vite-temp/**",
+          "!packages/github-app-ui/node_modules/.vite-temp/**",
+          "!node_modules/.vite/task-cache/**",
+          "!frontend/node_modules/.vite/task-cache/**",
+          "!packages/ui/node_modules/.vite/task-cache/**",
+          "!packages/github-app-ui/node_modules/.vite/task-cache/**",
+        ],
       },
       "ui-package-check": {
         command: [`${rootVP} fmt --check packages/ui --no-error-on-unmatched-pattern --threads=1`, `${rootVP} run ui-package-typecheck`],
@@ -61,7 +56,7 @@ export default defineConfig({
       "ui-package-typecheck": {
         command: [
           `${rootVP} lint packages/ui '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1`,
-          `${rootVP} run svelte-check:ui`,
+          `${rootVP} run svelte-check`,
         ],
         cache: false,
       },
@@ -75,7 +70,7 @@ export default defineConfig({
       "github-app-ui-package-typecheck": {
         command: [
           `${rootVP} lint packages/github-app-ui '!packages/github-app-ui/dist/**' --no-error-on-unmatched-pattern --threads=1`,
-          `${rootVP} run svelte-check:github-app-ui`,
+          `${rootVP} run svelte-check`,
         ],
         cache: false,
       },


### PR DESCRIPTION
## Summary
- Render Markdown rich preview as an annotated unified document instead of forcing before/after panes.
- Use the same rendered diff tree for split mode, with block placeholders so paragraphs stay aligned.
- Serialize frontend/UI Svelte checks through a single Vite+ Svelte-check task to avoid overlapping diagnostics.

## Screenshots
Unified:
![rich-markdown-unified.png](https://github.com/user-attachments/assets/870f7f2e-c954-476a-82b2-8772f8c7fede)

Split:
![rich-markdown-split-aligned.png](https://github.com/user-attachments/assets/03a2ee4d-3801-4d6f-ac76-7abc77945706)