### PR TITLE
fix: keep visible modes out of terminal options

### DIFF
--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import SettingsIcon from "@lucide/svelte/icons/settings";
   import { getStores } from "@middleman/ui";
-  import type { ModeVisibility } from "@middleman/ui/api/types";
   import type { TerminalSettings as TerminalSettingsType } from "@middleman/ui/api/types";
-  import ModeVisibilitySettings from "../settings/ModeVisibilitySettings.svelte";
   import TerminalSettings from "../settings/TerminalSettings.svelte";
 
   const { settings: settingsStore } = getStores();
@@ -13,14 +11,12 @@
   let terminal = $state<TerminalSettingsType>(
     settingsStore.getTerminalSettings(),
   );
-  let modes = $state<ModeVisibility>(settingsStore.getModeVisibility());
   let childSaving = $state(false);
 
   function toggleOpen(): void {
     if (childSaving) return;
     if (!open) {
       terminal = settingsStore.getTerminalSettings();
-      modes = settingsStore.getModeVisibility();
       childSaving = false;
     }
     open = !open;
@@ -81,20 +77,6 @@
           childSaving = saving;
         }}
       />
-      <div class="popover-section">
-        <div class="section-heading">Visible modes</div>
-        <ModeVisibilitySettings
-          {modes}
-          compact={true}
-          saveLabel="Save visible modes"
-          onUpdate={(updated) => {
-            modes = updated;
-          }}
-          onSavingChange={(saving) => {
-            childSaving = saving;
-          }}
-        />
-      </div>
     </div>
   {/if}
 </div>
@@ -150,21 +132,6 @@
     letter-spacing: 0.06em;
     border-bottom: 1px solid var(--border-muted);
     margin-bottom: 8px;
-  }
-
-  .popover-section {
-    border-top: 1px solid var(--border-muted);
-    margin-top: 10px;
-    padding-top: 10px;
-  }
-
-  .section-heading {
-    margin-bottom: 8px;
-    color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
   }
 
   @media (max-width: 620px) {

--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.test.ts
@@ -165,31 +165,13 @@ describe("TerminalOptionsMenu", () => {
     expect(currentTerminal.value.font_size).toBe(19);
   });
 
-  it("persists mode visibility from the options popover", async () => {
-    const updatedModes = {
-      ...defaultModes,
-      kata: true,
-      docs: true,
-      messages: true,
-    };
-    mockUpdateSettings.mockResolvedValue({ modes: updatedModes });
-
+  it("omits global mode visibility from the options popover", async () => {
     render(TerminalOptionsMenu);
 
     await fireEvent.click(screen.getByRole("button", { name: "Terminal options" }));
 
-    expect((screen.getByLabelText("Kata") as HTMLInputElement).checked).toBe(false);
-    expect((screen.getByLabelText("Docs") as HTMLInputElement).checked).toBe(false);
-    expect((screen.getByLabelText("Messages") as HTMLInputElement).checked).toBe(false);
-
-    await fireEvent.click(screen.getByLabelText("Kata"));
-    await fireEvent.click(screen.getByLabelText("Docs"));
-    await fireEvent.click(screen.getByLabelText("Messages"));
-    await fireEvent.click(screen.getByRole("button", { name: "Save visible modes" }));
-
-    await waitFor(() => {
-      expect(mockUpdateSettings).toHaveBeenCalledWith({ modes: updatedModes });
-    });
-    expect(mockSetModeVisibility).toHaveBeenCalledWith(updatedModes);
+    expect(screen.queryByText("Visible modes")).toBeNull();
+    expect(screen.queryByLabelText("Kata")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save visible modes" })).toBeNull();
   });
 });

--- a/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
@@ -226,7 +226,10 @@ test.describe("terminal options popover", () => {
       const initialScreenSize = await terminalScreenSizeKey(page);
 
       await page.getByRole("button", { name: "Terminal options" }).click();
-      await expect(page.getByRole("dialog", { name: "Terminal options" })).toBeVisible();
+      const terminalOptionsDialog = page.getByRole("dialog", { name: "Terminal options" });
+      await expect(terminalOptionsDialog).toBeVisible();
+      await expect(terminalOptionsDialog.getByText("Visible modes")).toHaveCount(0);
+      await expect(terminalOptionsDialog.getByRole("button", { name: "Save visible modes" })).toHaveCount(0);
       await page.getByLabel("Font size").fill("20");
       await expect.poll(() => terminalScreenSizeKey(page)).not.toBe(initialScreenSize);
 


### PR DESCRIPTION
Visible mode preferences are global app navigation settings, so exposing them in the workspace terminal options popover made a workspace-scoped menu mutate unrelated main navigation. This keeps the terminal popover focused on terminal behavior while leaving mode visibility in the main Settings view.

Validated locally with focused terminal options coverage and the affected full-stack settings/terminal browser spec.