### PR TITLE
Fix PR checklist wrapping

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -799,30 +799,22 @@ a:hover {
   list-style: none;
   padding-left: 0;
 }
-/* The <li> is a flex row so the checkbox aligns with the first line of
-   the label, but `flex-wrap: wrap` plus `flex-basis: 100%` on nested
-   lists pushes them onto their own row — otherwise a nested `<ul>` or
-   `<ol>` would render as a flex row sibling of the checkbox and
-   collapse the visible hierarchy. */
+/* Keep the <li> in normal block/inline flow so long checklist labels
+   wrap like ordinary markdown text instead of moving to a new flex row. */
 .markdown-body .task-list-item {
   position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  column-gap: 6px;
-  row-gap: 0;
+  display: block;
   padding: 1px 4px 1px 22px;
   margin: 0;
   border-radius: var(--radius-sm);
 }
 .markdown-body .task-list-item > ul,
 .markdown-body .task-list-item > ol {
-  flex-basis: 100%;
   margin: 0;
 }
 .markdown-body .task-list-item input[type="checkbox"] {
-  margin: 0 4px 0 0;
-  flex-shrink: 0;
+  margin: 0 8px 0 0;
+  vertical-align: -0.1em;
   cursor: default;
 }
 .markdown-body .task-list-item--interactive input[type="checkbox"] {

--- a/frontend/src/lib/utils/markdownTaskListStyle.test.ts
+++ b/frontend/src/lib/utils/markdownTaskListStyle.test.ts
@@ -1,8 +1,8 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, test } from "vite-plus/test";
 
-const appCss = readFileSync(fileURLToPath(new URL("../../app.css", import.meta.url)), "utf8");
+const appCssPath = existsSync("src/app.css") ? "src/app.css" : "frontend/src/app.css";
+const appCss = readFileSync(appCssPath, "utf8");
 
 function declarationsFor(selector: string): Map<string, string> {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/frontend/src/lib/utils/markdownTaskListStyle.test.ts
+++ b/frontend/src/lib/utils/markdownTaskListStyle.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vite-plus/test";
+
+const appCss = readFileSync(fileURLToPath(new URL("../../app.css", import.meta.url)), "utf8");
+
+function declarationsFor(selector: string): Map<string, string> {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = appCss.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+  if (match?.[1]) {
+    return new Map(
+      match[1]
+        .split(";")
+        .map((declaration) => declaration.trim())
+        .filter(Boolean)
+        .map((declaration) => {
+          const separator = declaration.indexOf(":");
+          return [declaration.slice(0, separator).trim(), declaration.slice(separator + 1).trim()];
+        }),
+    );
+  }
+  throw new Error(`Missing CSS rule for ${selector}`);
+}
+
+describe("markdown task list styles", () => {
+  test("keeps checkbox labels in normal inline flow for long PR descriptions", () => {
+    const itemStyle = declarationsFor(".markdown-body .task-list-item");
+
+    expect(itemStyle.get("display")).toBe("block");
+    expect(itemStyle.has("flex-wrap")).toBe(false);
+  });
+});

--- a/frontend/tests/e2e-full/description-task-list.spec.ts
+++ b/frontend/tests/e2e-full/description-task-list.spec.ts
@@ -26,6 +26,51 @@ test.describe("PR description task list", () => {
     return server;
   }
 
+  test("keeps long checklist text on the checkbox line", async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 720 });
+    const server = await openPullDetail(page);
+    try {
+      const body = page.locator(".body-section .markdown-body");
+      const longItem = body.locator(".task-list-item--interactive").filter({ hasText: "Small, scoped PR" });
+      await expect(longItem).toBeVisible();
+
+      const metrics = await longItem.evaluate((li) => {
+        const checkbox = li.querySelector<HTMLInputElement>('input[type="checkbox"]');
+        if (!checkbox) throw new Error("missing task checkbox");
+
+        const walker = document.createTreeWalker(li, NodeFilter.SHOW_TEXT);
+        let textNode: Text | null = null;
+        let offset = -1;
+        while (walker.nextNode()) {
+          const node = walker.currentNode as Text;
+          offset = node.data.indexOf("Small");
+          if (offset >= 0) {
+            textNode = node;
+            break;
+          }
+        }
+        if (!textNode || offset < 0) throw new Error("missing checklist text");
+
+        const range = document.createRange();
+        range.setStart(textNode, offset);
+        range.setEnd(textNode, offset + "Small".length);
+        const textRect = range.getBoundingClientRect();
+        const checkboxRect = checkbox.getBoundingClientRect();
+
+        return {
+          checkboxBottom: checkboxRect.bottom,
+          checkboxTop: checkboxRect.top,
+          textTop: textRect.top,
+        };
+      });
+
+      expect(metrics.textTop).toBeLessThan(metrics.checkboxBottom);
+      expect(Math.abs(metrics.textTop - metrics.checkboxTop)).toBeLessThan(8);
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("checkbox clicks toggle locally and persist on reload", async ({ page }) => {
     const server = await openPullDetail(page);
     try {

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -95,7 +95,8 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		"- [ ] Cmd+K opens palette, focus lands in the search input\n" +
 		"- [ ] Tab/Shift+Tab cycles within the palette dialog only\n" +
 		"- [ ] `>settings` + Enter navigates to /settings\n" +
-		"- [x] Cache invalidates on widget update\n"
+		"- [x] Cache invalidates on widget update\n" +
+		"- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces\n"
 	w1ID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:            widgetsID,
 		PlatformID:        1001,


### PR DESCRIPTION
Fixes #513.

- Keeps long task-list labels in PR descriptions on the checkbox line.
- Preserves existing interactive checklist controls for toggling and drag reorder.

Screenshot:
![issue-513-pr-description.png](https://github.com/user-attachments/assets/225579dc-a8f7-4b25-9bc8-bce8e406e315)