### PR TITLE
Run frontend tooling through bun-latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
 DEV_LOG_DIR ?= tmp/logs
 DEV_BACKEND_LOG ?= $(DEV_LOG_DIR)/backend-dev.log
 VITE_PLUS_VERSION := 0.1.24
-VITE_PLUS_BIN := node ./node_modules/vite-plus/bin/vp
-VITE_PLUS_FRONTEND_BIN := node ../node_modules/vite-plus/bin/vp
-VITE_PLUS_PACKAGE_BIN := node ../../node_modules/vite-plus/bin/vp
+VITE_PLUS_BIN := bun-latest ./node_modules/vite-plus/bin/vp
+VITE_PLUS_FRONTEND_BIN := bun-latest ../node_modules/vite-plus/bin/vp
+VITE_PLUS_PACKAGE_BIN := bun-latest ../../node_modules/vite-plus/bin/vp
 
 .PHONY: ensure-embed-dir ensure-tmp-dir check-air air-install build build-release install \
         rust-pty-manager rust-test vite-plus-install frontend-deps check-vite-plus-bin frontend githubapp-frontend frontend-dev frontend-dev-bun frontend-check api-generate roborev-api-generate \
@@ -87,7 +87,7 @@ install: build-release
 
 # Install Bun workspace dependencies for frontend and packages/ui
 frontend-deps:
-	bun install
+	bun-latest install --no-save
 
 check-vite-plus-bin:
 	@test -f node_modules/vite-plus/bin/vp || { echo "vite-plus is not installed; run make frontend-deps" >&2; exit 1; }
@@ -97,8 +97,8 @@ vite-plus-install:
 	@if command -v vp >/dev/null 2>&1; then \
 		vp --version | head -n 1; \
 	else \
-		echo "vp not found; installing vite-plus@$(VITE_PLUS_VERSION) with Bun"; \
-		bun install -g vite-plus@$(VITE_PLUS_VERSION); \
+		echo "vp not found; installing vite-plus@$(VITE_PLUS_VERSION) with bun-latest"; \
+		bun-latest install -g vite-plus@$(VITE_PLUS_VERSION); \
 	fi
 
 # Build frontend SPA and copy into embed directory
@@ -120,7 +120,7 @@ githubapp-frontend: frontend-deps
 frontend-dev:
 	./scripts/frontend-dev.sh $(ARGS)
 
-# Run Vite+ dev server after installing dependencies with Bun; Node launches Vite+ (use alongside `make dev`)
+# Run Vite+ dev server after installing dependencies with Bun (use alongside `make dev`)
 frontend-dev-bun: frontend-deps
 	cd frontend && $(VITE_PLUS_FRONTEND_BIN) dev
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,14 +5,14 @@
   "license": "Elastic-2.0",
   "type": "module",
   "scripts": {
-    "dev": "node ../node_modules/vite-plus/bin/vp dev",
-    "build": "node ../node_modules/vite-plus/bin/vp build --logLevel warn",
-    "preview": "node ../node_modules/vite-plus/bin/vp preview",
-    "check": "cd .. && node node_modules/vite-plus/bin/vp run frontend-package-check",
-    "lint": "node ../node_modules/vite-plus/bin/vp lint . --no-error-on-unmatched-pattern",
-    "lint:fix": "node ../node_modules/vite-plus/bin/vp lint . --fix --no-error-on-unmatched-pattern",
-    "typecheck": "cd .. && node node_modules/vite-plus/bin/vp run frontend-package-typecheck",
-    "test": "node ../node_modules/vite-plus/bin/vp test run",
+    "dev": "bun-latest ../node_modules/vite-plus/bin/vp dev",
+    "build": "bun-latest ../node_modules/vite-plus/bin/vp build --logLevel warn",
+    "preview": "bun-latest ../node_modules/vite-plus/bin/vp preview",
+    "check": "cd .. && bun-latest node_modules/vite-plus/bin/vp run frontend-package-check",
+    "lint": "bun-latest ../node_modules/vite-plus/bin/vp lint . --no-error-on-unmatched-pattern",
+    "lint:fix": "bun-latest ../node_modules/vite-plus/bin/vp lint . --fix --no-error-on-unmatched-pattern",
+    "typecheck": "cd .. && bun-latest node_modules/vite-plus/bin/vp run frontend-package-typecheck",
+    "test": "bun-latest ../node_modules/vite-plus/bin/vp test run",
     "test:e2e": "node ./scripts/run-e2e-to-file.ts",
     "test:e2e:mock": "node node_modules/.bin/playwright test --config=playwright.config.ts",
     "demo-workspace": "node node_modules/.bin/playwright test --config tests/demo/playwright-demo.config.ts"
@@ -54,13 +54,12 @@
   "devEngines": {
     "packageManager": {
       "name": "bun",
+      "version": "latest",
       "onFail": "download"
     },
     "runtime": {
-      "name": "node",
-      "version": ">=24.0.0",
+      "name": "bun-latest",
       "onFail": "download"
     }
-  },
-  "packageManager": "bun@1.3.11"
+  }
 }

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -118,7 +118,7 @@ async function tryBuildFrontend(frontendDir: string): Promise<BuildOutcome> {
   }
 
   return await new Promise<BuildOutcome>((resolve) => {
-    const build = spawn(process.execPath, [vitePlusBin, "build", "--logLevel", "warn"], {
+    const build = spawn("bun-latest", [vitePlusBin, "build", "--logLevel", "warn"], {
       cwd: frontendDir,
       stdio: "inherit",
       env: process.env,

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   ],
   "type": "module",
   "scripts": {
-    "check": "node node_modules/vite-plus/bin/vp run frontend-check",
-    "demo-workspace": "node node_modules/vite-plus/bin/vp run middleman-frontend#demo-workspace",
-    "fmt": "node node_modules/vite-plus/bin/vp fmt frontend packages/ui packages/github-app-ui '!frontend/dist/**' '!packages/github-app-ui/dist/**' '!frontend/test-results/**' '!packages/github-app-ui/test-results/**' '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1",
-    "fmt:check": "node node_modules/vite-plus/bin/vp fmt --check frontend packages/ui packages/github-app-ui '!frontend/dist/**' '!packages/github-app-ui/dist/**' '!frontend/test-results/**' '!packages/github-app-ui/test-results/**' '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1",
-    "test:e2e": "node node_modules/vite-plus/bin/vp run middleman-frontend#test:e2e && cd packages/github-app-ui && node ../../node_modules/vite-plus/bin/vp build --logLevel warn && node node_modules/.bin/playwright test"
+    "check": "bun-latest node_modules/vite-plus/bin/vp run frontend-check",
+    "demo-workspace": "bun-latest node_modules/vite-plus/bin/vp run middleman-frontend#demo-workspace",
+    "fmt": "bun-latest node_modules/vite-plus/bin/vp fmt frontend packages/ui packages/github-app-ui '!frontend/dist/**' '!packages/github-app-ui/dist/**' '!frontend/test-results/**' '!packages/github-app-ui/test-results/**' '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1",
+    "fmt:check": "bun-latest node_modules/vite-plus/bin/vp fmt --check frontend packages/ui packages/github-app-ui '!frontend/dist/**' '!packages/github-app-ui/dist/**' '!frontend/test-results/**' '!packages/github-app-ui/test-results/**' '!packages/ui/src/api/generated/**' '!packages/ui/src/api/roborev/generated/**' --no-error-on-unmatched-pattern --threads=1",
+    "test:e2e": "bun-latest node_modules/vite-plus/bin/vp run middleman-frontend#test:e2e && cd packages/github-app-ui && bun-latest ../../node_modules/vite-plus/bin/vp build --logLevel warn && node node_modules/.bin/playwright test"
   },
   "devDependencies": {
     "@sveltejs/mcp": "0.1.24",
@@ -21,11 +21,11 @@
   "devEngines": {
     "packageManager": {
       "name": "bun",
+      "version": "latest",
       "onFail": "download"
     },
     "runtime": {
-      "name": "node",
-      "version": ">=24.0.0",
+      "name": "bun-latest",
       "onFail": "download"
     }
   },

--- a/packages/github-app-ui/package.json
+++ b/packages/github-app-ui/package.json
@@ -5,11 +5,11 @@
   "license": "Elastic-2.0",
   "type": "module",
   "scripts": {
-    "dev": "node ../../node_modules/vite-plus/bin/vp dev",
-    "build": "node ../../node_modules/vite-plus/bin/vp build --logLevel warn",
-    "check": "cd ../.. && node node_modules/vite-plus/bin/vp run github-app-ui-package-check",
-    "test:e2e": "node ../../node_modules/vite-plus/bin/vp build --logLevel warn && node node_modules/.bin/playwright test",
-    "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp run github-app-ui-package-typecheck"
+    "dev": "bun-latest ../../node_modules/vite-plus/bin/vp dev",
+    "build": "bun-latest ../../node_modules/vite-plus/bin/vp build --logLevel warn",
+    "check": "cd ../.. && bun-latest node_modules/vite-plus/bin/vp run github-app-ui-package-check",
+    "test:e2e": "bun-latest ../../node_modules/vite-plus/bin/vp build --logLevel warn && node node_modules/.bin/playwright test",
+    "typecheck": "cd ../.. && bun-latest node_modules/vite-plus/bin/vp run github-app-ui-package-typecheck"
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -113,9 +113,9 @@
     }
   },
   "scripts": {
-    "check": "cd ../.. && node node_modules/vite-plus/bin/vp run ui-package-check",
-    "lint": "cd ../.. && node node_modules/vite-plus/bin/vp lint packages/ui --no-error-on-unmatched-pattern",
-    "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp run ui-package-typecheck"
+    "check": "cd ../.. && bun-latest node_modules/vite-plus/bin/vp run ui-package-check",
+    "lint": "cd ../.. && bun-latest node_modules/vite-plus/bin/vp lint packages/ui --no-error-on-unmatched-pattern",
+    "typecheck": "cd ../.. && bun-latest node_modules/vite-plus/bin/vp run ui-package-typecheck"
   },
   "dependencies": {
     "@lucide/svelte": "1.17.0",

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -11,9 +11,20 @@ processes:
     namespace: dev
     log_location: "tmp/logs/backend-process-compose.log"
     command: "sh ./scripts/dev-stack-backend.sh"
+    readiness_probe:
+      http_get:
+        host: 127.0.0.1
+        scheme: http
+        path: /healthz
+        port: 8091
+      initial_delay_seconds: 5
+      period_seconds: 5
+      timeout_seconds: 3
+      success_threshold: 1
+      failure_threshold: 10
 
   frontend:
     description: "Vite frontend dev server on 127.0.0.1:5174"
     namespace: dev
     log_location: "tmp/logs/frontend-process-compose.log"
-    command: "sh ./scripts/dev-stack-frontend.sh"
+    command: "bun install ${BUN_INSTALL_FLAGS:-} && cd frontend && exec vp dev -- ${FRONTEND_ARGS:-}"

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -27,4 +27,4 @@ processes:
     description: "Vite frontend dev server on 127.0.0.1:5174"
     namespace: dev
     log_location: "tmp/logs/frontend-process-compose.log"
-    command: "bun install ${BUN_INSTALL_FLAGS:-} && cd frontend && exec vp dev -- ${FRONTEND_ARGS:-}"
+    command: "sh ./scripts/dev-stack-frontend.sh"

--- a/scripts/dev-stack-frontend.sh
+++ b/scripts/dev-stack-frontend.sh
@@ -2,7 +2,29 @@
 
 set -eu
 
+if [ -d "$HOME/.local/share/mise/installs/bun/latest/bin" ]; then
+  PATH="$HOME/.local/share/mise/installs/bun/latest/bin:$PATH"
+fi
+if [ -d "$HOME/.local/share/mise/installs/node/24.16.0/bin" ]; then
+  PATH="$HOME/.local/share/mise/installs/node/24.16.0/bin:$PATH"
+fi
+export PATH
+
+if command -v bun-latest >/dev/null 2>&1; then
+  bun_latest="bun-latest"
+elif [ -x "$HOME/.local/share/mise/installs/bun/latest/bin/bun-latest" ]; then
+  bun_latest="$HOME/.local/share/mise/installs/bun/latest/bin/bun-latest"
+else
+  echo "bun-latest not found; install it with: bunx bun-pr main" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "node not found; Vite+ still requires node on PATH while running under bun-latest" >&2
+  exit 1
+fi
+
 mkdir -p tmp/logs
-bun install ${BUN_INSTALL_FLAGS:-}
+"$bun_latest" install --no-save ${BUN_INSTALL_FLAGS:-}
 cd frontend
-exec ../node_modules/.bin/vp dev -- ${FRONTEND_ARGS:-}
+exec "$bun_latest" ../node_modules/vite-plus/bin/vp dev -- ${FRONTEND_ARGS:-}

--- a/scripts/frontend-dev.sh
+++ b/scripts/frontend-dev.sh
@@ -8,7 +8,29 @@ log_file="$log_dir/frontend-dev.log"
 
 mkdir -p "$log_dir"
 
+if [ -d "$HOME/.local/share/mise/installs/bun/latest/bin" ]; then
+  PATH="$HOME/.local/share/mise/installs/bun/latest/bin:$PATH"
+fi
+if [ -d "$HOME/.local/share/mise/installs/node/24.16.0/bin" ]; then
+  PATH="$HOME/.local/share/mise/installs/node/24.16.0/bin:$PATH"
+fi
+export PATH
+
+if command -v bun-latest >/dev/null 2>&1; then
+  bun_latest="bun-latest"
+elif [ -x "$HOME/.local/share/mise/installs/bun/latest/bin/bun-latest" ]; then
+  bun_latest="$HOME/.local/share/mise/installs/bun/latest/bin/bun-latest"
+else
+  echo "bun-latest not found; install it with: bunx bun-pr main" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "node not found; Vite+ still requires node on PATH while running under bun-latest" >&2
+  exit 1
+fi
+
 cd "$repo_root"
-bun install ${BUN_INSTALL_FLAGS:-}
+"$bun_latest" install --no-save ${BUN_INSTALL_FLAGS:-}
 cd frontend
-../node_modules/.bin/vp dev -- ${@:+"$@"} 2>&1 | tee "$log_file"
+"$bun_latest" ../node_modules/vite-plus/bin/vp dev -- ${@:+"$@"} 2>&1 | tee "$log_file"

--- a/scripts/run-roborev-e2e.sh
+++ b/scripts/run-roborev-e2e.sh
@@ -37,8 +37,8 @@ trap 'FAILED=1' ERR
 # 1. Build frontend + e2e server (unless SKIP_BUILD=1)
 if [ "${SKIP_BUILD:-}" != "1" ]; then
   echo "--- build frontend ---"
-  cd "$REPO_ROOT" && bun install --frozen-lockfile
-  cd "$REPO_ROOT/frontend" && node ../node_modules/vite-plus/bin/vp build --logLevel warn
+  cd "$REPO_ROOT" && bun-latest install --no-save --frozen-lockfile
+  cd "$REPO_ROOT/frontend" && bun-latest ../node_modules/vite-plus/bin/vp build --logLevel warn
   rm -rf "$REPO_ROOT/internal/web/dist"
   cp -r "$REPO_ROOT/frontend/dist" "$REPO_ROOT/internal/web/dist"
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "vite-plus";
 
-const rootVP = "node node_modules/vite-plus/bin/vp";
-const frontendVP = "node ../node_modules/vite-plus/bin/vp";
-const uiVP = "node ../../node_modules/vite-plus/bin/vp";
-const packageVP = "node ../../node_modules/vite-plus/bin/vp";
+const rootVP = "bun-latest node_modules/vite-plus/bin/vp";
+const frontendVP = "bun-latest ../node_modules/vite-plus/bin/vp";
+const uiVP = "bun-latest ../../node_modules/vite-plus/bin/vp";
+const packageVP = "bun-latest ../../node_modules/vite-plus/bin/vp";
 
 export default defineConfig({
   run: {


### PR DESCRIPTION
The frontend Vite+ paths still depended on Node-launched Vite+ or the global vp shim, which made local installs and process-compose startup sensitive to whatever runtime happened to be first on PATH. That defeated the goal of using the bun-latest build installed with bun-pr and also let test commands resolve dependencies from the wrong Vite+ installation.

This switches the package scripts, Vite+ task commands, build helpers, and process-compose frontend entrypoint to run the repo-local Vite+ binary through bun-latest. The process-compose path now goes through the shared frontend script so sparse environments recover the mise-managed bun-latest path, while still exposing node because Vite+ internals require a node binary to be discoverable. Installs use --no-save so dependency setup does not mutate package.json during startup.

Validation run:
- make frontend
- sh -n scripts/dev-stack-frontend.sh
- bash -n scripts/frontend-dev.sh
- git diff --check
- stripped-PATH sh ./scripts/dev-stack-frontend.sh launched Vite+ successfully on a test port
- bun-latest run --cwd frontend test passed 237 files / 2362 tests with 2 skipped before the final script-path changes
- node node_modules/.bin/playwright test --config=playwright.config.ts was run and failed in existing UI specs unrelated to the runtime/install paths: inline-review still showed Publish review after submit_review flipped unavailable, and workspace sorting matched Activity against both Activity and Item activity in strict mode