### PR TITLE
Fix force-push timeline commit ordering

### DIFF
--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -317,6 +317,14 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 			"allCommits":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
 			"lastCommit":{"nodes":[]},
 			"timelineItems":{"nodes":[{
+				"__typename":"HeadRefForcePushedEvent",
+				"id":"HFP_1",
+				"actor":{"login":"alice"},
+				"beforeCommit":{"oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+				"afterCommit":{"oid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+				"createdAt":"` + now + `",
+				"ref":{"name":"feature"}
+			},{
 				"__typename":"BaseRefChangedEvent",
 				"id":"BRC_1",
 				"actor":{"login":"bob"},
@@ -364,33 +372,40 @@ func TestGraphQLFetcherFetchRepoPRsIncludesTimelineEvents(t *testing.T) {
 	require.NotNil(result)
 	require.Len(result.PullRequests, 1)
 	require.True(sawTimelineItems)
-	require.Len(result.PullRequests[0].TimelineEvents, 6)
+	require.Len(result.PullRequests[0].TimelineEvents, 7)
 
 	event := result.PullRequests[0].TimelineEvents[0]
+	assert.Equal("force_push", event.EventType)
+	assert.Equal("HFP_1", event.NodeID)
+	assert.Equal("alice", event.Actor)
+	assert.Equal("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", event.BeforeSHA)
+	assert.Equal("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", event.AfterSHA)
+	assert.Equal("feature", event.Ref)
+	event = result.PullRequests[0].TimelineEvents[1]
 	assert.Equal("base_ref_changed", event.EventType)
 	assert.Equal("BRC_1", event.NodeID)
 	assert.Equal("bob", event.Actor)
 	assert.Equal("main", event.PreviousRefName)
 	assert.Equal("release", event.CurrentRefName)
-	deleted := result.PullRequests[0].TimelineEvents[1]
+	deleted := result.PullRequests[0].TimelineEvents[2]
 	assert.Equal("comment_deleted", deleted.EventType)
 	assert.Equal("CDE_1", deleted.NodeID)
 	assert.Equal("maintainer", deleted.Actor)
 	assert.Equal("reviewer", deleted.DeletedCommentAuthor)
-	assigned := result.PullRequests[0].TimelineEvents[2]
+	assigned := result.PullRequests[0].TimelineEvents[3]
 	assert.Equal("assigned", assigned.EventType)
 	assert.Equal("AE_1", assigned.NodeID)
 	assert.Equal("wesm", assigned.Actor)
 	assert.Equal("wesm", assigned.Assignee)
-	merged := result.PullRequests[0].TimelineEvents[3]
+	merged := result.PullRequests[0].TimelineEvents[4]
 	assert.Equal("merged", merged.EventType)
 	assert.Equal("ME_1", merged.NodeID)
 	assert.Equal("merger", merged.Actor)
-	closed := result.PullRequests[0].TimelineEvents[4]
+	closed := result.PullRequests[0].TimelineEvents[5]
 	assert.Equal("closed", closed.EventType)
 	assert.Equal("CE_1", closed.NodeID)
 	assert.Equal("closer", closed.Actor)
-	reopened := result.PullRequests[0].TimelineEvents[5]
+	reopened := result.PullRequests[0].TimelineEvents[6]
 	assert.Equal("reopened", reopened.EventType)
 	assert.Equal("RE_1", reopened.NodeID)
 	assert.Equal("opener", reopened.Actor)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -28,7 +28,7 @@ func parseInt64(raw string) (int64, error) {
 	return strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
 }
 
-func withCommitOrderMetadata(metadataJSON string, order int) string {
+func withCommitOrderMetadata(metadataJSON string, listOrder int, stableOrder int) string {
 	metadata := map[string]any{}
 	if metadataJSON != "" {
 		var existing map[string]any
@@ -36,12 +36,100 @@ func withCommitOrderMetadata(metadataJSON string, order int) string {
 			metadata = existing
 		}
 	}
-	metadata["commit_order"] = order
+	metadata["commit_order"] = listOrder
+	metadata["commit_order_key"] = stableOrder
 	encoded, err := json.Marshal(metadata)
 	if err != nil {
 		return metadataJSON
 	}
 	return string(encoded)
+}
+
+func commitMetadataOrder(metadataJSON string) int {
+	if metadataJSON == "" {
+		return 0
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		return 0
+	}
+	if order := metadataInt(metadata["commit_order_key"]); order > 0 {
+		return order
+	}
+	return metadataInt(metadata["commit_order"])
+}
+
+func metadataInt(value any) int {
+	switch v := value.(type) {
+	case float64:
+		if v > 0 && v == float64(int(v)) {
+			return int(v)
+		}
+	case int:
+		if v > 0 {
+			return v
+		}
+	case int64:
+		if v > 0 {
+			return int(v)
+		}
+	case json.Number:
+		if n, err := strconv.Atoi(v.String()); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+type commitOrderAssigner struct {
+	bySHA map[string]int
+	next  int
+}
+
+func newCommitOrderAssigner(events []db.MREvent) commitOrderAssigner {
+	assigner := commitOrderAssigner{bySHA: map[string]int{}}
+	for _, event := range events {
+		if event.EventType != "commit" {
+			continue
+		}
+		order := commitMetadataOrder(event.MetadataJSON)
+		if order == 0 && event.ID > 0 {
+			order = int(event.ID)
+		}
+		if order > assigner.next {
+			assigner.next = order
+		}
+		sha := commitOrderSHA(event.Summary)
+		if sha != "" && order > 0 {
+			assigner.bySHA[sha] = order
+		}
+	}
+	return assigner
+}
+
+func (a *commitOrderAssigner) apply(event *db.MREvent, listOrder int) {
+	sha := commitOrderSHA(event.Summary)
+	stableOrder := a.bySHA[sha]
+	if stableOrder == 0 {
+		a.next++
+		stableOrder = a.next
+		if sha != "" {
+			a.bySHA[sha] = stableOrder
+		}
+	}
+	event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, listOrder, stableOrder)
+}
+
+func (s *Syncer) commitOrderAssigner(ctx context.Context, mrID int64) (commitOrderAssigner, error) {
+	events, err := s.db.ListMREvents(ctx, mrID)
+	if err != nil {
+		return commitOrderAssigner{}, err
+	}
+	return newCommitOrderAssigner(events), nil
+}
+
+func commitOrderSHA(summary string) string {
+	return strings.ToLower(strings.TrimSpace(summary))
 }
 
 // SyncStatus holds the current state of the sync engine.
@@ -873,7 +961,7 @@ func (p gitHubClientProvider) ListMergeRequestEvents(
 	}
 	for i, commit := range commits {
 		event := platformgithub.NormalizeCommitEvent(ref, number, commit)
-		event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, i+1)
+		event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, i+1, i+1)
 		out = append(out, event)
 	}
 	for _, timelineEvent := range timelineEvents {
@@ -4871,6 +4959,10 @@ func (s *Syncer) syncOpenMRFromBulk(
 	// Timeline events — comments, reviews, commits, and system events.
 	// Events use ON CONFLICT DO NOTHING, so partial data is safe.
 	var events []db.MREvent
+	commitOrderer, err := s.commitOrderAssigner(ctx, mrID)
+	if err != nil {
+		return fmt.Errorf("load commit order for MR #%d: %w", number, err)
+	}
 	for _, c := range bulk.Comments {
 		events = append(events, NormalizeCommentEvent(mrID, c))
 	}
@@ -4879,7 +4971,7 @@ func (s *Syncer) syncOpenMRFromBulk(
 	}
 	for i, c := range bulk.Commits {
 		event := NormalizeCommitEvent(mrID, c)
-		event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, i+1)
+		commitOrderer.apply(&event, i+1)
 		events = append(events, event)
 	}
 	for _, timelineEvent := range bulk.TimelineEvents {
@@ -5417,8 +5509,17 @@ func (s *Syncer) syncProviderMRDetailExtras(
 	if err == nil {
 		dbEvents := make([]db.MREvent, 0, len(events))
 		commentDedupeKeys := make([]string, 0, len(events))
+		commitOrderer, orderErr := s.commitOrderAssigner(ctx, mrID)
+		if orderErr != nil {
+			return calls, false, fmt.Errorf("load commit order for MR #%d: %w", number, orderErr)
+		}
+		commitListOrder := 0
 		for _, event := range events {
 			dbEvent := platform.DBMREvent(mrID, event)
+			if dbEvent.EventType == "commit" {
+				commitListOrder++
+				commitOrderer.apply(&dbEvent, commitListOrder)
+			}
 			dbEvents = append(dbEvents, dbEvent)
 			if dbEvent.EventType == "issue_comment" {
 				commentDedupeKeys = append(commentDedupeKeys, dbEvent.DedupeKey)
@@ -5824,6 +5925,10 @@ func (s *Syncer) refreshTimeline(
 	}
 
 	var events []db.MREvent
+	commitOrderer, err := s.commitOrderAssigner(ctx, mrID)
+	if err != nil {
+		return fmt.Errorf("load commit order for MR #%d: %w", number, err)
+	}
 	for _, c := range comments {
 		events = append(events, NormalizeCommentEvent(mrID, c))
 	}
@@ -5832,7 +5937,7 @@ func (s *Syncer) refreshTimeline(
 	}
 	for i, c := range commits {
 		event := NormalizeCommitEvent(mrID, c)
-		event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, i+1)
+		commitOrderer.apply(&event, i+1)
 		events = append(events, event)
 	}
 	for _, timelineEvent := range timelineEvents {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -28,6 +28,22 @@ func parseInt64(raw string) (int64, error) {
 	return strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
 }
 
+func withCommitOrderMetadata(metadataJSON string, order int) string {
+	metadata := map[string]any{}
+	if metadataJSON != "" {
+		var existing map[string]any
+		if err := json.Unmarshal([]byte(metadataJSON), &existing); err == nil && existing != nil {
+			metadata = existing
+		}
+	}
+	metadata["commit_order"] = order
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return metadataJSON
+	}
+	return string(encoded)
+}
+
 // SyncStatus holds the current state of the sync engine.
 type SyncStatus struct {
 	Running     bool      `json:"running"`
@@ -855,8 +871,10 @@ func (p gitHubClientProvider) ListMergeRequestEvents(
 	for _, review := range reviews {
 		out = append(out, platformgithub.NormalizeReviewEvent(ref, number, review))
 	}
-	for _, commit := range commits {
-		out = append(out, platformgithub.NormalizeCommitEvent(ref, number, commit))
+	for i, commit := range commits {
+		event := platformgithub.NormalizeCommitEvent(ref, number, commit)
+		event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, i+1)
+		out = append(out, event)
 	}
 	for _, timelineEvent := range timelineEvents {
 		event := platformgithub.NormalizeTimelineEvent(ref, number, platformgithub.PullRequestTimelineEvent{
@@ -4859,8 +4877,10 @@ func (s *Syncer) syncOpenMRFromBulk(
 	for _, r := range bulk.Reviews {
 		events = append(events, NormalizeReviewEvent(mrID, r))
 	}
-	for _, c := range bulk.Commits {
-		events = append(events, NormalizeCommitEvent(mrID, c))
+	for i, c := range bulk.Commits {
+		event := NormalizeCommitEvent(mrID, c)
+		event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, i+1)
+		events = append(events, event)
 	}
 	for _, timelineEvent := range bulk.TimelineEvents {
 		if event := NormalizeTimelineEvent(mrID, timelineEvent); event != nil {
@@ -5810,8 +5830,10 @@ func (s *Syncer) refreshTimeline(
 	for _, r := range reviews {
 		events = append(events, NormalizeReviewEvent(mrID, r))
 	}
-	for _, c := range commits {
-		events = append(events, NormalizeCommitEvent(mrID, c))
+	for i, c := range commits {
+		event := NormalizeCommitEvent(mrID, c)
+		event.MetadataJSON = withCommitOrderMetadata(event.MetadataJSON, i+1)
+		events = append(events, event)
 	}
 	for _, timelineEvent := range timelineEvents {
 		event := NormalizeTimelineEvent(mrID, timelineEvent)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -1786,6 +1786,107 @@ func TestSyncStoresForcePushEvent(t *testing.T) {
 	assert.Contains(commit.MetadataJSON, `"commit_order":1`)
 }
 
+func TestSyncAssignsStableCommitOrderKeysAcrossForcePushReplacement(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	oldBaseSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldHeadSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	newBaseSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	newHeadSHA := "dddddddddddddddddddddddddddddddddddddddd"
+
+	commit := func(sha, msg string, committedAt time.Time) *gh.RepositoryCommit {
+		return &gh.RepositoryCommit{
+			SHA: &sha,
+			Commit: &gh.Commit{
+				Message: &msg,
+				Author:  &gh.CommitAuthor{Name: new("dev"), Date: makeTimestamp(committedAt)},
+			},
+		}
+	}
+
+	mc := &mockClient{
+		commits: []*gh.RepositoryCommit{
+			commit(newBaseSHA, "new base", now.Add(-30*time.Minute)),
+			commit(newHeadSHA, "new head", now.Add(-20*time.Minute)),
+		},
+		timelineEvents: []PullRequestTimelineEvent{{
+			EventType: "force_push",
+			Actor:     "alice",
+			BeforeSHA: oldHeadSHA,
+			AfterSHA:  newHeadSHA,
+			Ref:       "feature",
+			CreatedAt: now.Add(-10 * time.Minute),
+		}},
+		reviews:  []*gh.PullRequestReview{},
+		comments: []*gh.IssueComment{},
+	}
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     1,
+		Number:         1,
+		URL:            "https://github.com/owner/repo/pull/1",
+		Title:          "force push",
+		Author:         "dev",
+		State:          "open",
+		HeadBranch:     "feature",
+		BaseBranch:     "main",
+		CreatedAt:      now.Add(-3 * time.Hour),
+		UpdatedAt:      now,
+		LastActivityAt: now,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertMREvents(ctx, []db.MREvent{
+		{
+			MergeRequestID: mrID,
+			EventType:      "commit",
+			Summary:        oldBaseSHA,
+			Body:           "old base",
+			MetadataJSON:   `{"commit_order":1,"commit_order_key":1}`,
+			CreatedAt:      now.Add(-2 * time.Hour),
+			DedupeKey:      "commit-" + oldBaseSHA[:12],
+		},
+		{
+			MergeRequestID: mrID,
+			EventType:      "commit",
+			Summary:        oldHeadSHA,
+			Body:           "old head",
+			MetadataJSON:   `{"commit_order":2,"commit_order_key":2}`,
+			CreatedAt:      now.Add(-1 * time.Hour),
+			DedupeKey:      "commit-" + oldHeadSHA[:12],
+		},
+	}))
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{repo}, time.Minute, nil, testBudget(500))
+	require.NoError(syncer.refreshTimeline(ctx, repo, repoID, mrID, buildOpenPR(1, now)))
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+
+	findCommit := func(sha string) *db.MREvent {
+		for i := range events {
+			if events[i].EventType == "commit" && events[i].Summary == sha {
+				return &events[i]
+			}
+		}
+		return nil
+	}
+
+	oldHead := findCommit(oldHeadSHA)
+	newHead := findCommit(newHeadSHA)
+	require.NotNil(oldHead)
+	require.NotNil(newHead)
+	assert.Contains(oldHead.MetadataJSON, `"commit_order":2`)
+	assert.Contains(oldHead.MetadataJSON, `"commit_order_key":2`)
+	assert.Contains(newHead.MetadataJSON, `"commit_order":2`)
+	assert.Contains(newHead.MetadataJSON, `"commit_order_key":4`)
+}
+
 func TestSyncStoresPullRequestTimelineEvents(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -1769,16 +1769,21 @@ func TestSyncStoresForcePushEvent(t *testing.T) {
 	require.NotEmpty(events)
 
 	var forcePush *db.MREvent
+	var commit *db.MREvent
 	for i := range events {
 		if events[i].EventType == "force_push" {
 			forcePush = &events[i]
-			break
+		}
+		if events[i].EventType == "commit" {
+			commit = &events[i]
 		}
 	}
 	require.NotNil(forcePush)
+	require.NotNil(commit)
 	assert.Equal("alice", forcePush.Author)
 	assert.Equal("aaaaaaa -> bbbbbbb", forcePush.Summary)
 	assert.Contains(forcePush.MetadataJSON, `"ref":"feature"`)
+	assert.Contains(commit.MetadataJSON, `"commit_order":1`)
 }
 
 func TestSyncStoresPullRequestTimelineEvents(t *testing.T) {
@@ -8566,6 +8571,8 @@ func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
 
 	now := time.Date(2024, 6, 3, 14, 0, 0, 0, time.UTC)
 	timelineAt := now.Add(3 * time.Minute)
+	commitSHA := "abc123def456"
+	commitMsg := "fix: preserve timeline commit order"
 	syncer := NewSyncer(
 		map[string]Client{"github.com": &mockClient{}},
 		d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
@@ -8575,6 +8582,16 @@ func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
 
 	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
 		PR: buildOpenPR(1, now),
+		Commits: []*gh.RepositoryCommit{{
+			SHA: &commitSHA,
+			Commit: &gh.Commit{
+				Message: &commitMsg,
+				Author: &gh.CommitAuthor{
+					Name: new("dev"),
+					Date: makeTimestamp(now.Add(-time.Minute)),
+				},
+			},
+		}},
 		TimelineEvents: []PullRequestTimelineEvent{{
 			NodeID:          "BRC_1",
 			EventType:       "base_ref_changed",
@@ -8605,11 +8622,20 @@ func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
 
 	events, err := d.ListMREvents(ctx, mr.ID)
 	require.NoError(err)
-	require.Len(events, 2)
+	require.Len(events, 3)
 	assert.Equal("comment_deleted", events[0].EventType)
 	assert.Equal("deleted a comment from reviewer", events[0].Summary)
 	assert.Equal("base_ref_changed", events[1].EventType)
 	assert.Equal("main -> release", events[1].Summary)
+	var commit *db.MREvent
+	for i := range events {
+		if events[i].EventType == "commit" {
+			commit = &events[i]
+			break
+		}
+	}
+	require.NotNil(commit)
+	assert.Contains(commit.MetadataJSON, `"commit_order":1`)
 }
 
 // buildOpenPRWithSHA mirrors buildOpenPR but lets the caller set the

--- a/internal/server/e2etest/timeline_assignment_test.go
+++ b/internal/server/e2etest/timeline_assignment_test.go
@@ -107,6 +107,55 @@ func TestE2E_DetailTimelineReturnsCommentDirectURLs(t *testing.T) {
 	assert.Equal("https://github.com/acme/widget/issues/5#issuecomment-202", issueDetail.Events[0].DirectURL)
 }
 
+func TestE2E_DetailTimelineReturnsForcePushCommitOrderingMetadata(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv, database := setupTestServer(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	mrID, _ := seedAssignmentTimelineItems(t, database)
+	oldHead := "cccccccccccccccccccccccccccccccccccccccc"
+	newHead := "ffffffffffffffffffffffffffffffffffffffff"
+	require.NoError(database.UpsertMREvents(t.Context(), []db.MREvent{
+		{
+			MergeRequestID: mrID,
+			EventType:      "force_push",
+			Author:         "alice",
+			Summary:        "ccccccc -> fffffff",
+			MetadataJSON:   `{"before_sha":"` + oldHead + `","after_sha":"` + newHead + `"}`,
+			CreatedAt:      time.Now().UTC(),
+			DedupeKey:      "timeline-force-push",
+		},
+		{
+			MergeRequestID: mrID,
+			EventType:      "commit",
+			Summary:        newHead,
+			Body:           "new head after same-length rebase",
+			MetadataJSON:   `{"commit_order":2,"commit_order_key":4}`,
+			CreatedAt:      time.Now().UTC().Add(-time.Minute),
+			DedupeKey:      "timeline-commit-new-head",
+		},
+	}))
+
+	prDetail := getTimelineDetail(t, ts, "/api/v1/pulls/github/acme/widget/1")
+	var commitEvent *struct {
+		EventType    string `json:"EventType"`
+		Author       string `json:"Author"`
+		Summary      string `json:"Summary"`
+		MetadataJSON string `json:"MetadataJSON"`
+		DirectURL    string `json:"DirectURL"`
+	}
+	for i := range prDetail.Events {
+		if prDetail.Events[i].EventType == "commit" && prDetail.Events[i].Summary == newHead {
+			commitEvent = &prDetail.Events[i]
+		}
+	}
+	require.NotNil(commitEvent)
+	assert.JSONEq(`{"commit_order":2,"commit_order_key":4}`, commitEvent.MetadataJSON)
+}
+
 func seedAssignmentTimelineItems(t *testing.T, database *db.DB) (int64, int64) {
 	t.Helper()
 	ctx := t.Context()

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -269,6 +269,11 @@
     return event.EventType === "commit" ? normalizeSHA(event.Summary) : null;
   }
 
+  function commitOrder(event: PREvent | IssueEvent): number {
+    if (event.EventType !== "commit") return event.ID;
+    return metadataNumber(parseMetadata(event), "commit_order") ?? event.ID;
+  }
+
   function addUniquePrefix(
     prefixes: CommitSHAIndex["prefixes"],
     prefix: string,
@@ -336,11 +341,25 @@
       if (beforeCommit) {
         const afterSHA = forcePushAfterSHA(event);
         const afterCommit = afterSHA ? lookupCommitBySHA(commitIndex, afterSHA) : null;
+        const beforeOrder = commitOrder(beforeCommit);
+        const afterOrder = afterCommit ? commitOrder(afterCommit) : null;
+        if (afterCommit && afterOrder !== null && afterOrder < beforeOrder) {
+          boundaries.push({
+            eventID: event.ID,
+            orderCommitID: afterOrder,
+            startAfterCommitID: 0,
+            afterCommitID: afterOrder,
+            endAtCommitID: afterOrder,
+            pushedAt: eventSortValue(event),
+            usesAfterAnchor: true,
+          });
+          continue;
+        }
         boundaries.push({
           eventID: event.ID,
-          orderCommitID: beforeCommit.ID,
-          startAfterCommitID: beforeCommit.ID,
-          afterCommitID: afterCommit?.ID,
+          orderCommitID: beforeOrder,
+          startAfterCommitID: beforeOrder,
+          afterCommitID: afterCommit ? commitOrder(afterCommit) : undefined,
           pushedAt: eventSortValue(event),
           usesAfterAnchor: false,
         });
@@ -352,10 +371,10 @@
       if (!afterCommit) continue;
       boundaries.push({
         eventID: event.ID,
-        orderCommitID: afterCommit.ID,
+        orderCommitID: commitOrder(afterCommit),
         startAfterCommitID: 0,
-        afterCommitID: afterCommit.ID,
-        endAtCommitID: afterCommit.ID,
+        afterCommitID: commitOrder(afterCommit),
+        endAtCommitID: commitOrder(afterCommit),
         pushedAt: eventSortValue(event),
         usesAfterAnchor: true,
       });
@@ -407,7 +426,11 @@
 
     const commitEvents = sourceEvents
       .filter((event) => event.EventType === "commit")
-      .sort((a, b) => a.ID - b.ID);
+      .sort((a, b) => commitOrder(a) - commitOrder(b) || a.ID - b.ID);
+    const commitOrderAt = (index: number): number => {
+      const event = commitEvents[index];
+      return event ? commitOrder(event) : Number.POSITIVE_INFINITY;
+    };
     let commitIndex = 0;
 
     for (const [index, generation] of generations.entries()) {
@@ -420,13 +443,13 @@
       };
       while (
         commitIndex < commitEvents.length &&
-        (commitEvents[commitIndex]?.ID ?? 0) <= generation.effectiveStartAfterCommitID
+        commitOrderAt(commitIndex) <= generation.effectiveStartAfterCommitID
       ) {
         commitIndex += 1;
       }
       while (
         commitIndex < commitEvents.length &&
-        (commitEvents[commitIndex]?.ID ?? Number.POSITIVE_INFINITY) <= generation.effectiveEndAtCommitID
+        commitOrderAt(commitIndex) <= generation.effectiveEndAtCommitID
       ) {
         const event = commitEvents[commitIndex];
         if (!event) break;

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -271,7 +271,8 @@
 
   function commitOrder(event: PREvent | IssueEvent): number {
     if (event.EventType !== "commit") return event.ID;
-    return metadataNumber(parseMetadata(event), "commit_order") ?? event.ID;
+    const metadata = parseMetadata(event);
+    return metadataNumber(metadata, "commit_order_key") ?? metadataNumber(metadata, "commit_order") ?? event.ID;
   }
 
   function addUniquePrefix(

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -740,6 +740,57 @@ describe("EventTimeline", () => {
     );
   });
 
+  it("orders force-push generations by stable commit keys when list positions collide", () => {
+    const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
+    const newHead = "ffffffffffffffffffffffffffffffffffffffff";
+    const { container } = render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 70,
+            EventType: "force_push",
+            Author: "alice",
+            Summary: "ccccccc -> fffffff",
+            CreatedAt: "2024-06-01T12:00:00Z",
+            MetadataJSON: JSON.stringify({
+              before_sha: oldHead,
+              after_sha: newHead,
+            }),
+          }),
+          makeEvent({
+            ID: 20,
+            EventType: "commit",
+            Summary: newHead,
+            Body: "new head after same-length rebase",
+            CreatedAt: "2024-06-01T10:03:00Z",
+            MetadataJSON: JSON.stringify({ commit_order: 2, commit_order_key: 4 }),
+          }),
+          makeEvent({
+            ID: 30,
+            EventType: "commit",
+            Summary: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            Body: "new base after same-length rebase",
+            CreatedAt: "2024-06-01T10:02:00Z",
+            MetadataJSON: JSON.stringify({ commit_order: 1, commit_order_key: 3 }),
+          }),
+          makeEvent({
+            ID: 90,
+            EventType: "commit",
+            Summary: oldHead,
+            Body: "old head before same-length rebase",
+            CreatedAt: "2024-06-01T10:03:00Z",
+            MetadataJSON: JSON.stringify({ commit_order: 2, commit_order_key: 2 }),
+          }),
+        ],
+      },
+    });
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("new head after same-length rebase")).toBeLessThan(text.indexOf("ccccccc -> fffffff"));
+    expect(text.indexOf("new base after same-length rebase")).toBeLessThan(text.indexOf("ccccccc -> fffffff"));
+    expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(text.indexOf("old head before same-length rebase"));
+  });
+
   it("keeps later commits in chronological order after force-push generations", () => {
     const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
     const newHead = "ffffffffffffffffffffffffffffffffffffffff";

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -683,6 +683,63 @@ describe("EventTimeline", () => {
     expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(text.indexOf("old C2 before rebase"));
   });
 
+  it("orders force-push generations from commit ancestry even when database IDs are not generation order", () => {
+    const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
+    const newHead = "ffffffffffffffffffffffffffffffffffffffff";
+    const { container } = render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 70,
+            EventType: "force_push",
+            Author: "alice",
+            Summary: "ccccccc -> fffffff",
+            CreatedAt: "2024-06-01T12:00:00Z",
+            MetadataJSON: JSON.stringify({
+              before_sha: oldHead,
+              after_sha: newHead,
+            }),
+          }),
+          makeEvent({
+            ID: 20,
+            EventType: "commit",
+            Summary: newHead,
+            Body: "new head after rebase despite lower database id",
+            CreatedAt: "2024-06-01T10:03:00Z",
+            MetadataJSON: JSON.stringify({ commit_order: 3 }),
+          }),
+          makeEvent({
+            ID: 30,
+            EventType: "commit",
+            Summary: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            Body: "new base after rebase despite lower database id",
+            CreatedAt: "2024-06-01T10:02:00Z",
+            MetadataJSON: JSON.stringify({ commit_order: 2 }),
+          }),
+          makeEvent({
+            ID: 90,
+            EventType: "commit",
+            Summary: oldHead,
+            Body: "old head before rebase with higher database id",
+            CreatedAt: "2024-06-01T10:03:00Z",
+            MetadataJSON: JSON.stringify({ commit_order: 1 }),
+          }),
+        ],
+      },
+    });
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("new head after rebase despite lower database id")).toBeLessThan(
+      text.indexOf("ccccccc -> fffffff"),
+    );
+    expect(text.indexOf("new base after rebase despite lower database id")).toBeLessThan(
+      text.indexOf("ccccccc -> fffffff"),
+    );
+    expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(
+      text.indexOf("old head before rebase with higher database id"),
+    );
+  });
+
   it("keeps later commits in chronological order after force-push generations", () => {
     const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
     const newHead = "ffffffffffffffffffffffffffffffffffffffff";


### PR DESCRIPTION
- Persist GitHub PR commit list order so force-push boundaries do not depend on database insertion IDs.
- Render PR timeline force-push generations using commit order metadata with legacy fallback for existing rows.
- Add regression coverage for REST sync, bulk GraphQL sync, and timeline rendering.

![force-push-boundary.png](https://github.com/user-attachments/assets/f85b7565-ccf8-440a-ae92-0b3da0026c12)