### PR TITLE
fix: clarify workspace sort choices

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -130,6 +130,7 @@
       items: workspaceListSortOptions.map((option) => ({
         id: option.value,
         label: option.label,
+        description: option.description,
         active: sortMode === option.value,
         closeOnSelect: true,
         onSelect: () => setSort(option.value),

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -448,7 +448,11 @@ describe("WorkspaceListSidebar", () => {
     await screen.findByText("Newest created fallback");
 
     await fireEvent.click(screen.getByTitle("Sort workspaces"));
-    await fireEvent.click(screen.getByRole("button", { name: "Item activity" }));
+    const itemActivitySort = screen.getByRole("button", { name: "Item activity" });
+    expect(itemActivitySort.getAttribute("title")).toBe(
+      "Sort by latest linked PR or issue activity, falling back to workspace creation.",
+    );
+    await fireEvent.click(itemActivitySort);
 
     expect(rowTitles(container)).toEqual(["Issue recently changed", "PR recently changed", "Newest created fallback"]);
     expect(container.querySelectorAll(".group-header")).toHaveLength(0);

--- a/frontend/src/lib/components/terminal/workspaceListSort.ts
+++ b/frontend/src/lib/components/terminal/workspaceListSort.ts
@@ -3,11 +3,28 @@ export type WorkspaceListSort = "repo" | "created" | "activity" | "item-activity
 export const workspaceListSortOptions: {
   value: WorkspaceListSort;
   label: string;
+  description: string;
 }[] = [
-  { value: "repo", label: "Org / repo" },
-  { value: "created", label: "Created" },
-  { value: "activity", label: "Activity" },
-  { value: "item-activity", label: "Item activity" },
+  {
+    value: "repo",
+    label: "Org / repo",
+    description: "Group by repository, with newest workspaces first inside each repo.",
+  },
+  {
+    value: "created",
+    label: "Created",
+    description: "Sort all workspaces by when the workspace was created.",
+  },
+  {
+    value: "activity",
+    label: "Activity",
+    description: "Sort by latest terminal output, falling back to workspace creation.",
+  },
+  {
+    value: "item-activity",
+    label: "Item activity",
+    description: "Sort by latest linked PR or issue activity, falling back to workspace creation.",
+  },
 ];
 
 export const defaultWorkspaceListSort: WorkspaceListSort = "repo";

--- a/packages/ui/src/components/shared/FilterDropdown.svelte
+++ b/packages/ui/src/components/shared/FilterDropdown.svelte
@@ -8,6 +8,7 @@
   interface FilterDropdownItem {
     id: string;
     label: string;
+    description?: string;
     active: boolean;
     color?: string;
     disabled?: boolean;
@@ -144,6 +145,10 @@
     if (disabled) return;
     onReset?.();
   }
+
+  function itemDescriptionId(item: FilterDropdownItem): string {
+    return `filter-item-description-${item.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  }
 </script>
 
 <div class="filter-wrap">
@@ -194,6 +199,10 @@
             class:active={item.active}
             onclick={() => handleSelect(item)}
             disabled={disabled || item.disabled}
+            title={item.description}
+            aria-describedby={item.description
+              ? itemDescriptionId(item)
+              : undefined}
             type="button"
           >
             <span
@@ -211,6 +220,11 @@
               {/if}
             </span>
           </button>
+          {#if item.description}
+            <span id={itemDescriptionId(item)} class="sr-only">
+              {item.description}
+            </span>
+          {/if}
         {/each}
       {/each}
       {#if hasReset}
@@ -356,6 +370,18 @@
     justify-content: center;
     color: var(--accent-green);
     flex-shrink: 0;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .filter-reset {

--- a/packages/ui/src/components/shared/FilterDropdown.test.ts
+++ b/packages/ui/src/components/shared/FilterDropdown.test.ts
@@ -121,6 +121,35 @@ describe("FilterDropdown", () => {
     expect(document.querySelector(".filter-dropdown")).toBeNull();
   });
 
+  it("adds optional hover descriptions to menu items without changing their names", async () => {
+    render(FilterDropdown, {
+      props: {
+        label: "Sort",
+        sections: [
+          {
+            items: [
+              {
+                id: "updated",
+                label: "Updated",
+                description: "Sort by latest item activity.",
+                active: false,
+                onSelect: vi.fn(),
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /sort/i }));
+
+    const item = screen.getByRole("button", { name: "Updated" });
+    expect(item.getAttribute("title")).toBe("Sort by latest item activity.");
+    const descriptionId = item.getAttribute("aria-describedby");
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId!)?.textContent?.trim()).toBe("Sort by latest item activity.");
+  });
+
   it("supports end-aligned dropdown placement", async () => {
     render(FilterDropdown, {
       props: {


### PR DESCRIPTION
Workspace sort labels like Activity and Item activity are too terse to distinguish terminal output recency from linked PR or issue activity. This adds compact hover descriptions so maintainers can understand each sort mode without leaving the workspace sidebar flow.

- Adds descriptions for each workspace sort option
- Keeps the sort menu visually compact while exposing the same descriptions to assistive technology