### PR TITLE
Let activity users choose commit roll-up

### DIFF
--- a/frontend/tests/e2e/default-branch-activity.spec.ts
+++ b/frontend/tests/e2e/default-branch-activity.spec.ts
@@ -350,6 +350,35 @@ test.describe("default branch activity", () => {
     ).toBeVisible();
   });
 
+  test("roll-up toggle collapses commit runs in the flat feed", async ({ page }) => {
+    await mockDefaultBranchActivity(page);
+    await page.goto("/?view=flat");
+
+    const commitRows = page.locator(".activity-row", {
+      hasText: "Ship direct main commit",
+    });
+    await expect(commitRows).toHaveCount(5);
+
+    await selectActivityFilterItem(page, "Roll up commits");
+    await expect(page).toHaveURL(/rollup_commits=1/);
+
+    await expect(
+      page.locator(".activity-row.collapsed-row", {
+        hasText: "3 commits",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".activity-row", {
+        hasText: "Ship direct main commit 5",
+      }),
+    ).toHaveCount(0);
+    await expect(
+      page.locator(".activity-row", {
+        hasText: "Ship direct main commit 2",
+      }),
+    ).toBeVisible();
+  });
+
   test("legacy URL with stale default-branch commit types hides commit rows on load", async ({ page }) => {
     await mockDefaultBranchActivity(page);
     // URLs written before the fix kept default_branch_commit in the types

--- a/frontend/tests/e2e/default-branch-activity.spec.ts
+++ b/frontend/tests/e2e/default-branch-activity.spec.ts
@@ -295,10 +295,11 @@ async function pierreDiffCount(file: ReturnType<Page["locator"]>, selector: stri
 
 async function selectActivityFilterItem(page: Page, label: string): Promise<void> {
   await page.locator(".activity-feed .filter-btn", { hasText: "View" }).click();
-  await page.locator(".activity-feed .filter-dropdown").waitFor({
+  const dropdown = page.locator(".activity-feed .filter-dropdown");
+  await dropdown.waitFor({
     state: "visible",
   });
-  await page.locator(".activity-feed .filter-item", { hasText: label }).click();
+  await dropdown.getByRole("button", { name: label, exact: true }).click();
 }
 
 test.describe("default branch activity", () => {
@@ -394,10 +395,25 @@ test.describe("default branch activity", () => {
       }),
     ).toHaveCount(0);
     await expect(
-      page.locator(".item-row", {
-        hasText: "3 commits",
+      page.locator(".branch-activity-row", {
+        hasText: "Ship direct main commit 5",
       }),
     ).toBeVisible();
+    await expect(
+      page.locator(".branch-activity-row", {
+        hasText: "Ship direct main commit 4",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".branch-activity-row", {
+        hasText: "Ship direct main commit 3",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".branch-activity-row", {
+        hasText: "3 commits",
+      }),
+    ).toHaveCount(0);
     await expect(
       page.locator(".item-row", {
         hasText: "Add browser regression coverage",
@@ -414,6 +430,24 @@ test.describe("default branch activity", () => {
         hasText: "3 commits",
       }),
     ).toHaveCount(0);
+
+    await selectActivityFilterItem(page, "Roll up commits");
+    await expect(page).toHaveURL(/rollup_commits=1/);
+    await expect(
+      page.locator(".branch-activity-row", {
+        hasText: "Ship direct main commit 5",
+      }),
+    ).toHaveCount(0);
+    await expect(
+      page.locator(".branch-activity-row", {
+        hasText: "3 commits",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".branch-activity-row", {
+        hasText: "Ship direct main commit 2",
+      }),
+    ).toBeVisible();
 
     const forcePushRow = page.locator(".branch-activity-row", {
       hasText: "Force-pushed",

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -155,6 +155,11 @@
     activity.syncToURL();
   }
 
+  function handleRollUpCommitsChange(value: boolean): void {
+    activity.setRollUpCommits(value);
+    activity.syncToURL();
+  }
+
   const TIME_RANGES: { value: TimeRange; label: string }[] = [
     { value: "24h", label: "24h" },
     { value: "7d", label: "7d" },
@@ -322,7 +327,8 @@
 
   const currentViewDetail = $derived.by(() => {
     const mode = activity.getViewMode() === "flat" ? "Flat" : "Threaded";
-    return `${mode} · ${activity.getTimeRange()}`;
+    const commitMode = activity.getRollUpCommits() ? "Rolled commits" : "Individual commits";
+    return `${mode} · ${activity.getTimeRange()} · ${commitMode}`;
   });
 
   const collapseThreads = $derived(activity.getCollapseThreads());
@@ -360,6 +366,17 @@
         closeOnSelect: true,
         onSelect: () => handleTimeRangeChange(range.value),
       })),
+    },
+    {
+      title: "Commits",
+      items: [
+        {
+          id: "roll-up-commits",
+          label: "Roll up commits",
+          active: activity.getRollUpCommits(),
+          onSelect: () => handleRollUpCommitsChange(!activity.getRollUpCommits()),
+        },
+      ],
     },
     ...(activity.getViewMode() === "threaded"
       ? [

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -258,6 +258,7 @@
 
   const flatRows = $derived.by(() => collapseActivityRuns(displayItems, {
     rollUpCommits: activity.getRollUpCommits(),
+    rollUpNonCommitActivity: false,
   }));
 
   function resetFilters(): void {
@@ -330,8 +331,7 @@
 
   const currentViewDetail = $derived.by(() => {
     const mode = activity.getViewMode() === "flat" ? "Flat" : "Threaded";
-    const commitMode = activity.getRollUpCommits() ? "Rolled commits" : "Individual commits";
-    return `${mode} · ${activity.getTimeRange()} · ${commitMode}`;
+    return `${mode} · ${activity.getTimeRange()}`;
   });
 
   const collapseThreads = $derived(activity.getCollapseThreads());

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -15,6 +15,7 @@
     isDefaultBranchCommitActivity,
     isDefaultBranchForcePushActivity,
     isCollapsedActivityRow,
+    collapseActivityRuns,
     shortSha,
   } from "./activityRows.js";
   import {
@@ -255,7 +256,9 @@
     return result;
   });
 
-  const flatRows = $derived(displayItems);
+  const flatRows = $derived.by(() => collapseActivityRuns(displayItems, {
+    rollUpCommits: activity.getRollUpCommits(),
+  }));
 
   function resetFilters(): void {
     activity.setEnabledEvents(new Set(EVENT_TYPES));

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -56,6 +56,7 @@ const viewMode = vi.hoisted(() => ({
 const collapseThreads = vi.hoisted(() => ({ value: false }));
 const collapseAllThreads = vi.hoisted(() => vi.fn());
 const expandAllThreads = vi.hoisted(() => vi.fn());
+const rollUpCommits = vi.hoisted(() => ({ value: false }));
 const hideDefaultBranchActivity = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
 const setActivityFilterTypes = vi.hoisted(() => vi.fn());
@@ -87,6 +88,10 @@ vi.mock("../context.js", () => ({
       getCollapseThreads: () => collapseThreads.value,
       collapseAllThreads,
       expandAllThreads,
+      getRollUpCommits: () => rollUpCommits.value,
+      setRollUpCommits: vi.fn((value: boolean) => {
+        rollUpCommits.value = value;
+      }),
       isThreadItemExpanded: () => true,
       toggleThreadItem: vi.fn(),
       setActivityFilterTypes,
@@ -126,6 +131,7 @@ describe("ActivityFeed compact mode", () => {
   beforeEach(() => {
     viewMode.value = "flat";
     collapseThreads.value = false;
+    rollUpCommits.value = false;
     hideDefaultBranchActivity.value = false;
     hideOrgName.value = false;
     enabledEvents.value = new Set(["comment", "review", "commit", "force_push"]);
@@ -386,6 +392,15 @@ describe("ActivityFeed compact mode", () => {
       "commit",
       "force_push",
     ]);
+  });
+
+  it("can enable commit roll-up from the view dropdown", async () => {
+    render(ActivityFeed, { props: { compact: true } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "View" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Roll up commits" }));
+
+    expect(rollUpCommits.value).toBe(true);
   });
 });
 

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -314,6 +314,36 @@ describe("ActivityFeed compact mode", () => {
     expect(container.textContent).not.toContain("3 commits");
   });
 
+  it("rolls up default-branch commits in the flat table when enabled", () => {
+    rollUpCommits.value = true;
+    items.value = [
+      branchActivityItem("branch-commit-1", {
+        body_preview: "Ship direct main commit 1",
+        commit_sha: "1111111111111111111111111111111111111111",
+      }),
+      branchActivityItem("branch-commit-2", {
+        body_preview: "Ship direct main commit 2",
+        commit_sha: "2222222222222222222222222222222222222222",
+      }),
+      branchActivityItem("branch-commit-3", {
+        body_preview: "Ship direct main commit 3",
+        commit_sha: "3333333333333333333333333333333333333333",
+      }),
+    ];
+
+    const { container } = render(ActivityFeed, {
+      props: { compact: false },
+    });
+
+    const rows = container.querySelectorAll(".activity-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.classList.contains("collapsed-row")).toBe(true);
+    expect(rows[0]?.textContent).toContain("3 commits");
+    expect(container.textContent).not.toContain("Ship direct main commit 1");
+    expect(container.textContent).not.toContain("Ship direct main commit 2");
+    expect(container.textContent).not.toContain("Ship direct main commit 3");
+  });
+
   it("renders default-branch force-pushes in table rows", () => {
     items.value = [
       branchActivityItem("force-push", {

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -344,6 +344,32 @@ describe("ActivityFeed compact mode", () => {
     expect(container.textContent).not.toContain("Ship direct main commit 3");
   });
 
+  it("keeps consecutive comments expanded in the flat table", () => {
+    items.value = [
+      activityItem("comment-1", {
+        body_preview: "First comment",
+        created_at: "2026-04-27T12:03:00Z",
+      }),
+      activityItem("comment-2", {
+        body_preview: "Second comment",
+        created_at: "2026-04-27T12:02:00Z",
+      }),
+      activityItem("comment-3", {
+        body_preview: "Third comment",
+        created_at: "2026-04-27T12:01:00Z",
+      }),
+    ];
+
+    const { container } = render(ActivityFeed, {
+      props: { compact: false },
+    });
+
+    const rows = container.querySelectorAll(".activity-row");
+    expect(rows).toHaveLength(3);
+    expect(container.querySelectorAll(".activity-row.collapsed-row")).toHaveLength(0);
+    expect(container.textContent).not.toContain("3 commits");
+  });
+
   it("renders default-branch force-pushes in table rows", () => {
     items.value = [
       branchActivityItem("force-push", {

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -176,7 +176,9 @@
           itemAuthor: itemAuthor(first),
           workspace: first.workspace,
           events,
-          displayEvents: collapseActivityRuns(events),
+          displayEvents: collapseActivityRuns(events, {
+            rollUpCommits: activity.getRollUpCommits(),
+          }),
         },
       });
     }
@@ -188,7 +190,9 @@
     threadedEntries.sort((a, b) =>
       parseAPITimestamp(entryLatestTime(b)).getTime() - parseAPITimestamp(entryLatestTime(a)).getTime());
 
-    const allEntries = collapseTopLevelBranchRuns(threadedEntries);
+    const allEntries = activity.getRollUpCommits()
+      ? collapseTopLevelBranchRuns(threadedEntries)
+      : threadedEntries;
 
     if (!byRepo) {
       if (allEntries.length === 0) return [];
@@ -278,7 +282,9 @@
         branchItems.push(branchRowRepresentative(branchEntry.row));
         j++;
       }
-      for (const row of collapseActivityRuns(branchItems)) {
+      for (const row of collapseActivityRuns(branchItems, {
+        rollUpCommits: activity.getRollUpCommits(),
+      })) {
         result.push(branchEntryFromRow(row));
       }
       i = j;

--- a/packages/ui/src/components/ActivityThreaded.test.ts
+++ b/packages/ui/src/components/ActivityThreaded.test.ts
@@ -53,6 +53,7 @@ function branchActivityItem(id: string, overrides: Partial<ActivityItem> = {}): 
 const expanded = vi.hoisted(() => ({ value: true }));
 const groupByRepo = vi.hoisted(() => ({ value: false }));
 const hideOrgName = vi.hoisted(() => ({ value: false }));
+const rollUpCommits = vi.hoisted(() => ({ value: false }));
 const toggleThreadItem = vi.hoisted(() => vi.fn());
 
 vi.mock("../context.js", () => ({
@@ -64,6 +65,7 @@ vi.mock("../context.js", () => ({
     activity: {
       isThreadItemExpanded: () => expanded.value,
       toggleThreadItem,
+      getRollUpCommits: () => rollUpCommits.value,
     },
   }),
 }));
@@ -74,6 +76,7 @@ describe("ActivityThreaded collapse", () => {
     expanded.value = true;
     groupByRepo.value = false;
     hideOrgName.value = false;
+    rollUpCommits.value = false;
     toggleThreadItem.mockClear();
   });
 
@@ -115,6 +118,8 @@ describe("ActivityThreaded collapse", () => {
   });
 
   it("renders branch activity as top-level rows interleaved with item threads", async () => {
+    rollUpCommits.value = true;
+
     const { container } = render(ActivityThreaded, {
       props: {
         items: [
@@ -149,6 +154,38 @@ describe("ActivityThreaded collapse", () => {
     expect(container.textContent).not.toContain("main updates on acme/widgets");
     expect(container.textContent).not.toContain("#0");
     expect(container.querySelector(".branch-activity-row .thread-caret")).toBeNull();
+  });
+
+  it("shows default-branch commits as individual rows when commit roll-up is off", () => {
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [
+          branchActivityItem("c3", {
+            created_at: "2026-04-27T12:03:00Z",
+            body_preview: "Ship direct main commit 3",
+            commit_sha: "3333333333333333333333333333333333333333",
+          }),
+          branchActivityItem("c2", {
+            created_at: "2026-04-27T12:02:00Z",
+            body_preview: "Ship direct main commit 2",
+            commit_sha: "2222222222222222222222222222222222222222",
+          }),
+          branchActivityItem("c1", {
+            created_at: "2026-04-27T12:01:00Z",
+            body_preview: "Ship direct main commit 1",
+            commit_sha: "1111111111111111111111111111111111111111",
+          }),
+        ],
+        onSelectItem: undefined,
+      },
+    });
+
+    const rows = Array.from(container.querySelectorAll(".branch-activity-row"));
+    expect(rows).toHaveLength(3);
+    expect(rows[0]?.textContent).toContain("Ship direct main commit 3");
+    expect(rows[1]?.textContent).toContain("Ship direct main commit 2");
+    expect(rows[2]?.textContent).toContain("Ship direct main commit 1");
+    expect(container.textContent).not.toContain("3 commits");
   });
 
   it("labels commit rows without the branch type or duplicated commit text", () => {

--- a/packages/ui/src/components/activityRows.test.ts
+++ b/packages/ui/src/components/activityRows.test.ts
@@ -76,6 +76,23 @@ describe("collapseActivityRuns", () => {
     expect(isCollapsedActivityRow(rows[0]!) ? rows[0].representative.activity_type : undefined).toBe("review");
   });
 
+  it("can keep consecutive comments and reviews expanded", () => {
+    const rows = collapseActivityRuns(
+      [
+        item("9", "comment", "alice"),
+        item("8", "comment", "alice"),
+        item("7", "comment", "alice"),
+        item("6", "review", "alice"),
+        item("5", "review", "alice"),
+        item("4", "review", "alice"),
+      ],
+      { rollUpNonCommitActivity: false },
+    );
+
+    expect(rows).toHaveLength(6);
+    expect(rows.every((row) => !isCollapsedActivityRow(row))).toBe(true);
+  });
+
   it("does not merge runs of different event types", () => {
     const rows = collapseActivityRuns([
       item("9", "review", "alice"),

--- a/packages/ui/src/components/activityRows.test.ts
+++ b/packages/ui/src/components/activityRows.test.ts
@@ -43,11 +43,10 @@ function branchItem(id: string, activity_type: string, author: string, branchNam
 
 describe("collapseActivityRuns", () => {
   it("collapses three consecutive commits from the same author", () => {
-    const rows = collapseActivityRuns([
-      item("7", "commit", "alice"),
-      item("6", "commit", "alice"),
-      item("5", "commit", "alice"),
-    ]);
+    const rows = collapseActivityRuns(
+      [item("7", "commit", "alice"), item("6", "commit", "alice"), item("5", "commit", "alice")],
+      { rollUpCommits: true },
+    );
 
     expect(rows).toHaveLength(1);
     expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
@@ -106,15 +105,18 @@ describe("collapseActivityRuns", () => {
   });
 
   it("does not collapse across a force-push boundary", () => {
-    const rows = collapseActivityRuns([
-      item("9", "commit", "alice"),
-      item("8", "commit", "alice"),
-      item("7", "commit", "alice"),
-      item("6", "force_push", "alice"),
-      item("5", "commit", "alice"),
-      item("4", "commit", "alice"),
-      item("3", "commit", "alice"),
-    ]);
+    const rows = collapseActivityRuns(
+      [
+        item("9", "commit", "alice"),
+        item("8", "commit", "alice"),
+        item("7", "commit", "alice"),
+        item("6", "force_push", "alice"),
+        item("5", "commit", "alice"),
+        item("4", "commit", "alice"),
+        item("3", "commit", "alice"),
+      ],
+      { rollUpCommits: true },
+    );
 
     expect(rows).toHaveLength(3);
     expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
@@ -123,26 +125,58 @@ describe("collapseActivityRuns", () => {
   });
 
   it("rolls up branch commit runs by repo branch and author", () => {
-    const rows = collapseActivityRuns([
-      branchItem("9", "default_branch_commit", "alice"),
-      branchItem("8", "default_branch_commit", "alice"),
-      branchItem("7", "default_branch_commit", "alice"),
-    ]);
+    const rows = collapseActivityRuns(
+      [
+        branchItem("9", "default_branch_commit", "alice"),
+        branchItem("8", "default_branch_commit", "alice"),
+        branchItem("7", "default_branch_commit", "alice"),
+      ],
+      { rollUpCommits: true },
+    );
 
     expect(rows).toHaveLength(1);
     expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
     expect(isCollapsedActivityRow(rows[0]!) ? rows[0].representative.branch_name : undefined).toBe("main");
   });
 
+  it("keeps commit runs expanded when commit roll-up is disabled", () => {
+    const rows = collapseActivityRuns(
+      [
+        item("9", "commit", "alice"),
+        item("8", "commit", "alice"),
+        item("7", "commit", "alice"),
+        item("6", "comment", "alice"),
+        item("5", "comment", "alice"),
+        item("4", "comment", "alice"),
+        branchItem("3", "default_branch_commit", "alice"),
+        branchItem("2", "default_branch_commit", "alice"),
+        branchItem("1", "default_branch_commit", "alice"),
+      ],
+      { rollUpCommits: false },
+    );
+
+    expect(rows).toHaveLength(7);
+    expect(isCollapsedActivityRow(rows[0]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[1]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[2]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[3]!)).toBe(true);
+    expect(isCollapsedActivityRow(rows[4]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[5]!)).toBe(false);
+    expect(isCollapsedActivityRow(rows[6]!)).toBe(false);
+  });
+
   it("does not collapse branch commits across branches", () => {
-    const rows = collapseActivityRuns([
-      branchItem("9", "default_branch_commit", "alice", "main"),
-      branchItem("8", "default_branch_commit", "alice", "main"),
-      branchItem("7", "default_branch_commit", "alice", "main"),
-      branchItem("6", "default_branch_commit", "alice", "release"),
-      branchItem("5", "default_branch_commit", "alice", "release"),
-      branchItem("4", "default_branch_commit", "alice", "release"),
-    ]);
+    const rows = collapseActivityRuns(
+      [
+        branchItem("9", "default_branch_commit", "alice", "main"),
+        branchItem("8", "default_branch_commit", "alice", "main"),
+        branchItem("7", "default_branch_commit", "alice", "main"),
+        branchItem("6", "default_branch_commit", "alice", "release"),
+        branchItem("5", "default_branch_commit", "alice", "release"),
+        branchItem("4", "default_branch_commit", "alice", "release"),
+      ],
+      { rollUpCommits: true },
+    );
 
     expect(rows).toHaveLength(2);
     expect(isCollapsedActivityRow(rows[0]!)).toBe(true);

--- a/packages/ui/src/components/activityRows.ts
+++ b/packages/ui/src/components/activityRows.ts
@@ -12,6 +12,10 @@ export interface CollapsedActivityRun {
 
 export type ActivityRow = ActivityItem | CollapsedActivityRun;
 
+export interface CollapseActivityRunsOptions {
+  rollUpCommits?: boolean;
+}
+
 export function isCollapsedActivityRow(row: ActivityRow): row is CollapsedActivityRun {
   return "kind" in row && row.kind === "collapsed";
 }
@@ -45,26 +49,33 @@ function activityRunAuthor(item: ActivityItem): string {
   return item.author_name || item.author;
 }
 
-function activityRunGroupKey(item: ActivityItem): string | null {
+function activityRunGroupKey(item: ActivityItem, options: Required<CollapseActivityRunsOptions>): string | null {
   const author = activityRunAuthor(item);
-  if (item.activity_type === "commit" || item.activity_type === "comment" || item.activity_type === "review") {
+  if (item.activity_type === "commit") {
+    if (!options.rollUpCommits) return null;
+    return ["item", item.activity_type, repoKeyForItem(item), item.item_type, item.item_number, author].join("|");
+  }
+
+  if (item.activity_type === "comment" || item.activity_type === "review") {
     return ["item", item.activity_type, repoKeyForItem(item), item.item_type, item.item_number, author].join("|");
   }
 
   if (isDefaultBranchCommitActivity(item)) {
+    if (!options.rollUpCommits) return null;
     return ["branch", repoKeyForItem(item), item.branch_name ?? "", author].join("|");
   }
 
   return null;
 }
 
-export function collapseActivityRuns(items: ActivityItem[]): ActivityRow[] {
+export function collapseActivityRuns(items: ActivityItem[], options: CollapseActivityRunsOptions = {}): ActivityRow[] {
+  const resolvedOptions = { rollUpCommits: options.rollUpCommits ?? false };
   const result: ActivityRow[] = [];
   let i = 0;
 
   while (i < items.length) {
     const item = items[i]!;
-    const groupKey = activityRunGroupKey(item);
+    const groupKey = activityRunGroupKey(item, resolvedOptions);
     if (groupKey === null) {
       result.push(item);
       i++;
@@ -74,7 +85,7 @@ export function collapseActivityRuns(items: ActivityItem[]): ActivityRow[] {
     let j = i + 1;
     while (j < items.length) {
       const next = items[j]!;
-      if (activityRunGroupKey(next) !== groupKey) break;
+      if (activityRunGroupKey(next, resolvedOptions) !== groupKey) break;
       j++;
     }
 

--- a/packages/ui/src/components/activityRows.ts
+++ b/packages/ui/src/components/activityRows.ts
@@ -14,6 +14,7 @@ export type ActivityRow = ActivityItem | CollapsedActivityRun;
 
 export interface CollapseActivityRunsOptions {
   rollUpCommits?: boolean;
+  rollUpNonCommitActivity?: boolean;
 }
 
 export function isCollapsedActivityRow(row: ActivityRow): row is CollapsedActivityRun {
@@ -57,6 +58,7 @@ function activityRunGroupKey(item: ActivityItem, options: Required<CollapseActiv
   }
 
   if (item.activity_type === "comment" || item.activity_type === "review") {
+    if (!options.rollUpNonCommitActivity) return null;
     return ["item", item.activity_type, repoKeyForItem(item), item.item_type, item.item_number, author].join("|");
   }
 
@@ -69,7 +71,10 @@ function activityRunGroupKey(item: ActivityItem, options: Required<CollapseActiv
 }
 
 export function collapseActivityRuns(items: ActivityItem[], options: CollapseActivityRunsOptions = {}): ActivityRow[] {
-  const resolvedOptions = { rollUpCommits: options.rollUpCommits ?? false };
+  const resolvedOptions = {
+    rollUpCommits: options.rollUpCommits ?? false,
+    rollUpNonCommitActivity: options.rollUpNonCommitActivity ?? true,
+  };
   const result: ActivityRow[] = [];
   let i = 0;
 

--- a/packages/ui/src/stores/activity.svelte.test.ts
+++ b/packages/ui/src/stores/activity.svelte.test.ts
@@ -233,3 +233,23 @@ describe("activity store default-branch visibility", () => {
     expect(new URLSearchParams(window.location.search).has("hide_branch")).toBe(false);
   });
 });
+
+describe("activity store commit roll-up", () => {
+  it("shows individual commits by default and persists the URL override for rolled-up commits", () => {
+    const s = makeStore();
+    s.initializeFromMount();
+    expect(s.getRollUpCommits()).toBe(false);
+
+    s.setRollUpCommits(true);
+    s.syncToURL();
+    expect(new URLSearchParams(window.location.search).get("rollup_commits")).toBe("1");
+
+    const next = makeStore();
+    next.initializeFromMount();
+    expect(next.getRollUpCommits()).toBe(true);
+
+    next.setRollUpCommits(false);
+    next.syncToURL();
+    expect(new URLSearchParams(window.location.search).has("rollup_commits")).toBe(false);
+  });
+});

--- a/packages/ui/src/stores/activity.svelte.ts
+++ b/packages/ui/src/stores/activity.svelte.ts
@@ -74,6 +74,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   let timeRange = $state<TimeRange>("7d");
   let viewMode = $state<ViewMode>("flat");
   let collapseThreads = $state(false);
+  let rollUpCommits = $state(false);
   let collapseThreadsDefault = false;
   let expandOverrides = $state<Set<string>>(new Set());
   let pollHandle: ReturnType<typeof setInterval> | null = null;
@@ -118,6 +119,9 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   function getCollapseThreads(): boolean {
     return collapseThreads;
   }
+  function getRollUpCommits(): boolean {
+    return rollUpCommits;
+  }
   function isThreadItemExpanded(key: string): boolean {
     return expandOverrides.has(key) ? collapseThreads : !collapseThreads;
   }
@@ -153,6 +157,9 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   }
   function setViewMode(mode: ViewMode): void {
     viewMode = mode;
+  }
+  function setRollUpCommits(value: boolean): void {
+    rollUpCommits = value;
   }
   function collapseAllThreads(): void {
     collapseThreads = true;
@@ -392,6 +399,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       const viewParam = sp.get("view");
       if (viewParam === "flat" || viewParam === "threaded") viewMode = viewParam;
     }
+    rollUpCommits = sp.get("rollup_commits") === "1";
     hideDefaultBranchActivity = sp.get("hide_branch") === "1";
     applyCollapsedFromURL();
     deriveFiltersFromTypes();
@@ -407,6 +415,8 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     else sp.delete("range");
     if (viewMode !== "flat") sp.set("view", viewMode);
     else sp.delete("view");
+    if (rollUpCommits) sp.set("rollup_commits", "1");
+    else sp.delete("rollup_commits");
     if (hideDefaultBranchActivity) sp.set("hide_branch", "1");
     else sp.delete("hide_branch");
     if (collapseThreads !== collapseThreadsDefault) {
@@ -430,6 +440,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     getTimeRange,
     getViewMode,
     getCollapseThreads,
+    getRollUpCommits,
     isThreadItemExpanded,
     getHideClosedMerged,
     getHideBots,
@@ -441,6 +452,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     setActivitySearch,
     setTimeRange,
     setViewMode,
+    setRollUpCommits,
     collapseAllThreads,
     expandAllThreads,
     toggleThreadItem,


### PR DESCRIPTION
- Show individual activity commit rows by default.
- Add a View dropdown toggle to opt into rolling commit runs up.
- Preserve rolled-up commit view in shared URLs with `rollup_commits=1`.