### PR TITLE
fix: hide stale closed Kata tasks under open filter

### DIFF
--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -4,7 +4,7 @@
   import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
   import ChevronUpIcon from "@lucide/svelte/icons/chevron-up";
   import { relativeTime, shortDate } from "../../api/dates.js";
-  import type { KataTaskAPI, KataTaskSummary } from "../../api/kata/taskTypes.js";
+  import type { KataTaskAPI, KataTaskSearchFilters, KataTaskSummary } from "../../api/kata/taskTypes.js";
   import type { KataCurrentView } from "../../stores/kata-workspace.svelte.js";
   import {
     DEFAULT_KATA_TASK_SORT,
@@ -20,6 +20,7 @@
     scopedProjectName?: string | null;
     selectedIssueUID?: string | null;
     loading?: boolean;
+    statusFilter?: KataTaskSearchFilters["status"];
     resetGeneration?: number;
     navigationGeneration?: number;
     api?: KataTaskAPI;
@@ -32,6 +33,7 @@
     scopedProjectName = null,
     selectedIssueUID = null,
     loading = false,
+    statusFilter = "all",
     resetGeneration = 0,
     navigationGeneration = 0,
     api = undefined,
@@ -53,8 +55,9 @@
   // today-bucket detail that doesn't carry inside a project view.
   // Collapse to a flat list and let the sort drive the order.
   let isProjectScoped = $derived(Boolean(scopedProjectName));
+  let statusVisibleGroups = $derived(filterGroupsByStatus(currentView.groups, statusFilter));
   let flatIssues = $derived(
-    isProjectScoped ? topLevelIssues(currentView.groups.flatMap((group) => group.issues)) : [],
+    isProjectScoped ? topLevelIssues(statusVisibleGroups.flatMap((group) => group.issues)) : [],
   );
 
   // For the Today view, the kata daemon hands us a "This evening"
@@ -66,7 +69,7 @@
   // "evening" bucket in any other view passes through unchanged.
   let visibleGroups = $derived.by(() => {
     if (isProjectScoped) return [];
-    const groups = currentView.groups.map((group) => ({ ...group, issues: [...group.issues] }));
+    const groups = statusVisibleGroups.map((group) => ({ ...group, issues: [...group.issues] }));
     if (currentView.name === "today") {
       const todayIdx = groups.findIndex((group) => group.id === "today");
       const eveningIdx = groups.findIndex((group) => group.id === "evening");
@@ -90,11 +93,7 @@
   // per group. A single-group view (like Inbox) has nothing to collapse,
   // so keep its labeled region instead of dropping it to a bare list.
   let shouldFlatten = $derived(!isProjectScoped && sort.key === "updated" && visibleGroups.length > 1);
-  let globalSortedIssues = $derived(
-    shouldFlatten
-      ? sortKataTasks(topLevelIssues(currentView.groups.flatMap((group) => group.issues)), sort)
-      : [],
-  );
+  let globalSortedIssues = $derived(shouldFlatten ? sortKataTasks(visibleGroups.flatMap((group) => group.issues), sort) : []);
 
   function loadSort(): KataTaskSort {
     if (typeof window === "undefined") return DEFAULT_KATA_TASK_SORT;
@@ -170,6 +169,22 @@
 
   function parentHierarchyKey(issue: KataTaskSummary): string | null {
     return issue.parent_short_id ? `${issue.project_uid}:${issue.parent_short_id}` : null;
+  }
+
+  function issueMatchesStatusFilter(issue: KataTaskSummary): boolean {
+    return statusFilter === "all" || issue.status === statusFilter;
+  }
+
+  function filterGroupsByStatus(
+    groups: KataCurrentView["groups"],
+    status: KataTaskSearchFilters["status"],
+  ): KataCurrentView["groups"] {
+    return groups
+      .map((group) => ({
+        ...group,
+        issues: group.issues.filter((issue) => status === "all" || issue.status === status),
+      }))
+      .filter((group) => group.issues.length > 0);
   }
 
   function topLevelIssues(
@@ -358,15 +373,19 @@
   }
 
   function findIssueByUID(uid: string): KataTaskSummary | undefined {
-    for (const group of currentView.groups) {
+    for (const group of statusVisibleGroups) {
       const match = group.issues.find((issue) => issue.uid === uid);
       if (match) return match;
     }
     for (const children of Object.values(childrenByUID)) {
-      const match = children.find((issue) => issue.uid === uid);
+      const match = children.find((issue) => issue.uid === uid && issueMatchesStatusFilter(issue));
       if (match) return match;
     }
     return undefined;
+  }
+
+  function visibleChildren(issue: KataTaskSummary): KataTaskSummary[] {
+    return (childrenByUID[issue.uid] ?? []).filter(issueMatchesStatusFilter);
   }
 
   $effect(() => {
@@ -581,10 +600,10 @@
   {#if isExpanded}
     {#if loadingChildren[issue.uid]}
       <div class="children-status">Loading subtasks…</div>
-    {:else if (childrenByUID[issue.uid] ?? []).length === 0}
+    {:else if visibleChildren(issue).length === 0}
       <div class="children-status">No subtasks.</div>
     {:else}
-      {#each childrenByUID[issue.uid] ?? [] as child (child.uid)}
+      {#each visibleChildren(issue) as child (child.uid)}
         {@const childPriority = priorityLabel(child.priority)}
         {@const childLabels = child.labels?.join(" · ") ?? ""}
         <button

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -414,6 +414,11 @@
     return store.currentView.groups.flatMap((group) => group.issues);
   }
 
+  function selectedIssueMatchesStatusFilter(status: KataTaskSearchFilters["status"]): boolean {
+    const selected = store.selectedIssue?.issue;
+    return !selected || status === "all" || selected.status === status;
+  }
+
   function loadLayoutPrefs(): void {
     if (typeof window === "undefined") return;
     try {
@@ -472,10 +477,14 @@
 
   async function updateSearchFilters(filters: Partial<KataTaskSearchFilters>): Promise<void> {
     const generation = beginNavigation();
+    const nextStatus = filters.status ?? store.searchFilters.status;
     resetDetailDrafts();
     // Same rationale as openRoutedProjectScope: a pending detail load is
     // abandoned by the filter reload, so drop it before awaiting.
     store.invalidatePendingLoads();
+    if (!selectedIssueMatchesStatusFilter(nextStatus)) {
+      store.clearSelection();
+    }
     await runViewTask(() => store.updateSearchFilters(filters));
     if (!isCurrentNavigation(generation)) return;
     const nextScopeUID = scopeUIDFromFilters(store.searchFilters);
@@ -826,6 +835,7 @@
         scopedProjectName={selectedProjectName()}
         selectedIssueUID={store.pendingSelectionUID ?? store.selectedIssue?.issue.uid ?? null}
         loading={viewLoading}
+        statusFilter={store.searchFilters.status}
         resetGeneration={listResetGeneration}
         navigationGeneration={navigationEpoch}
         api={store.api}

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -114,6 +114,9 @@
       daemonInfos.find((daemon) => daemon.default)?.id ??
       daemonInfos[0]?.id,
   );
+  const listStatusFilter = $derived<KataTaskSearchFilters["status"]>(
+    store.currentView.name === "logbook" ? "all" : store.searchFilters.status,
+  );
   const eventStream = createKataEventStreamController({
     getDaemonId: () => activeKataDaemonId,
     getLastEventID: () => store.eventCursor,
@@ -835,7 +838,7 @@
         scopedProjectName={selectedProjectName()}
         selectedIssueUID={store.pendingSelectionUID ?? store.selectedIssue?.issue.uid ?? null}
         loading={viewLoading}
-        statusFilter={store.searchFilters.status}
+        statusFilter={listStatusFilter}
         resetGeneration={listResetGeneration}
         navigationGeneration={navigationEpoch}
         api={store.api}

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -144,6 +144,24 @@ describe("KataWorkspace", () => {
     expect(screen.getByRole("region", { name: /^Inbox\s+1$/ })).toBeTruthy();
   });
 
+  it("renders closed logbook tasks while the default status filter remains open", async () => {
+    const closedIssue = {
+      ...issue("issue-done-work", "Done work", "project-kata"),
+      status: "closed" as const,
+      closed_at: "2026-05-15T12:00:00.000Z",
+    };
+    const { api } = createWorkspaceAPI([closedIssue]);
+
+    render(KataWorkspace, { props: { api, routeViewName: "logbook" } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Logbook" })).toBeTruthy();
+      expect(screen.getByRole("combobox", { name: "Status: Open" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /Done work/ })).toBeTruthy();
+    });
+    expect(screen.queryByText("No tasks")).toBeNull();
+  });
+
   it("captures a new task into the inbox from the feature toolbar", async () => {
     const { api, createIssue } = createWorkspaceAPI();
 

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -405,6 +405,77 @@ describe("KataWorkspace", () => {
     });
   });
 
+  it("hides closed task rows immediately when the status filter changes to open", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const openIssue = issue("issue-open-work", "Open work", "project-kata");
+    const closedIssue = {
+      ...issue("issue-done-work", "Done work", "project-kata"),
+      status: "closed" as const,
+      closed_at: "2026-05-15T12:00:00.000Z",
+    };
+    const { api, search } = createWorkspaceAPI([openIssue, closedIssue]);
+    const delayedOpenSearch = deferred<KataTaskSearchResponse>();
+    let openSearches = 0;
+    search.mockImplementation(async (filters: KataTaskSearchFilters) => {
+      if (filters.scope.kind !== "project" || filters.scope.project_uid !== "project-kata") {
+        return { filters, issues: [], fetched_at: fetchedAt };
+      }
+      if (filters.status === "closed") {
+        return { filters, issues: [closedIssue], fetched_at: fetchedAt };
+      }
+      if (filters.status === "open") {
+        openSearches += 1;
+        if (openSearches > 1) return delayedOpenSearch.promise;
+        return { filters, issues: [openIssue], fetched_at: fetchedAt };
+      }
+      return { filters, issues: [openIssue, closedIssue], fetched_at: fetchedAt };
+    });
+
+    render(KataWorkspace, { props: { api, routeScopeUID: "project-kata" } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Open work/ })).toBeTruthy();
+    });
+    await fireEvent.click(screen.getByRole("combobox", { name: "Status: Open" }));
+    await fireEvent.click(screen.getByRole("option", { name: "Closed" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Done work/ })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Reopen" })).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByRole("combobox", { name: "Status: Closed" }));
+    await fireEvent.click(screen.getByRole("option", { name: "Open" }));
+
+    expect(screen.getByRole("combobox", { name: "Status: Open" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Done work/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reopen" })).toBeNull();
+
+    delayedOpenSearch.resolve({
+      filters: {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "open",
+        owner: "",
+        label: "",
+        query: "",
+      },
+      issues: [openIssue],
+      fetched_at: fetchedAt,
+    });
+  });
+
   it("keeps the loading announcement active until the newest overlapping search finishes", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -3385,6 +3385,64 @@ test("kata search filters tasks through the configured external daemon", async (
   }
 });
 
+test("kata status filter hides closed rows while the open reload is pending", async ({ page }) => {
+  const closedKataTask = issueSummary({
+    id: 33,
+    uid: "issue-closed-kata",
+    project_id: 2,
+    project_uid: "project-kata",
+    project_name: "Kata",
+    short_id: "kat-closed",
+    qualified_id: "Kata#kat-closed",
+    title: "Closed Kata task",
+    body: "This task should disappear when Open is selected.",
+    status: "closed",
+    closed_at: now,
+    owner: "Susan",
+    labels: ["work"],
+  });
+  let releaseOpenIssues!: () => void;
+  const openIssuesBarrier = new Promise<void>((resolve) => {
+    releaseOpenIssues = resolve;
+  });
+  const backend = await startKataBackend({ issues: [...issues, closedKataTask] });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata`);
+    const taskList = page.locator(".kata-list");
+
+    await page.getByRole("button", { name: /^Kata\s+1$/ }).click();
+    await expect(taskList.getByRole("button", { name: /Email Susan re: Q3/ })).toBeVisible();
+
+    await page.getByRole("combobox", { name: "Status: Open" }).click();
+    await page.getByRole("option", { name: "Closed" }).click();
+    await expect(taskList.getByRole("button", { name: /Closed Kata task/ })).toBeVisible();
+    await expect(
+      page.getByRole("region", { name: "Task detail" }).getByRole("button", { name: "Reopen" }),
+    ).toBeVisible();
+
+    backend.state.issuesBarrier = openIssuesBarrier;
+    await page.getByRole("combobox", { name: "Status: Closed" }).click();
+    await page.getByRole("option", { name: "Open" }).click();
+
+    await expect(page.getByRole("combobox", { name: "Status: Open" })).toBeVisible();
+    await expect(taskList.getByRole("button", { name: /Closed Kata task/ })).toHaveCount(0);
+    await expect(page.getByRole("region", { name: "Task detail" }).getByRole("button", { name: "Reopen" })).toHaveCount(
+      0,
+    );
+
+    releaseOpenIssues();
+    await expect(taskList.getByRole("button", { name: /Email Susan re: Q3/ })).toBeVisible();
+  } finally {
+    releaseOpenIssues();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata search clears loading after the newest overlapping daemon search finishes", async ({ page }) => {
   let releaseOldSearch!: () => void;
   const oldSearchBarrier = new Promise<void>((resolve) => {

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -3385,6 +3385,41 @@ test("kata search filters tasks through the configured external daemon", async (
   }
 });
 
+test("kata logbook shows closed tasks with the default open status filter", async ({ page }) => {
+  const closedKataTask = issueSummary({
+    id: 34,
+    uid: "issue-logbook-closed",
+    project_id: 2,
+    project_uid: "project-kata",
+    project_name: "Kata",
+    short_id: "kat-logbook",
+    qualified_id: "Kata#kat-logbook",
+    title: "Logbook closed Kata task",
+    body: "This closed task should stay visible in Logbook.",
+    status: "closed",
+    closed_at: now,
+    owner: "Susan",
+    labels: ["work"],
+  });
+  const backend = await startKataBackend({ issues: [...issues, closedKataTask] });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?view=logbook`);
+
+    const taskList = page.locator(".kata-list");
+    await expect(page.getByRole("heading", { name: "Logbook" })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Status: Open" })).toBeVisible();
+    await expect(taskList.getByRole("button", { name: /Logbook closed Kata task/ })).toBeVisible();
+    await expect(taskList.getByText("No tasks")).toHaveCount(0);
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata status filter hides closed rows while the open reload is pending", async ({ page }) => {
   const closedKataTask = issueSummary({
     id: 33,


### PR DESCRIPTION
Fixes stale Kata task visibility around status filtering.

- Applies the selected status filter to rendered Kata list groups immediately, including child rows and sorted/flattened views.
- Keeps Logbook rows visible when the routed view loads closed tasks while the dropdown remains at the default Open state.
- Clears the active task detail when switching to a status that excludes the selected task.
- Adds component and full-stack Kata regressions for the closed-to-open pending reload case and the Logbook default-filter route.

Local limitation: Firefox Playwright cannot launch on this host (`RenderCompositorSWGL failed mapping default framebuffer`); Chromium Kata e2e covers the browser regression locally and CI should cover Firefox.
