### PR TITLE
fix: keep provider sync optional for non-provider modes

### DIFF
--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -538,11 +538,6 @@ func TestListActivity(t *testing.T) {
 	_ = prID2
 }
 
-//go:fix inline
-func ptrInt64(v int64) *int64 {
-	return new(v)
-}
-
 func insertOversizedBranchCommitRow(
 	ctx context.Context,
 	d *DB,
@@ -820,7 +815,7 @@ func TestUpsertMREventsPreservesDirectURLWhenPartialRefreshOmitsIt(t *testing.T)
 
 	err := d.UpsertMREvents(ctx, []MREvent{{
 		MergeRequestID: prID,
-		PlatformID:     ptrInt64(101),
+		PlatformID:     new(int64(101)),
 		EventType:      "issue_comment",
 		Author:         "reviewer",
 		Body:           "first",
@@ -832,7 +827,7 @@ func TestUpsertMREventsPreservesDirectURLWhenPartialRefreshOmitsIt(t *testing.T)
 
 	err = d.UpsertMREvents(ctx, []MREvent{{
 		MergeRequestID: prID,
-		PlatformID:     ptrInt64(101),
+		PlatformID:     new(int64(101)),
 		EventType:      "issue_comment",
 		Author:         "reviewer",
 		Body:           "edited",
@@ -910,7 +905,7 @@ func TestUpsertIssueEventsPreservesDirectURLWhenPartialRefreshOmitsIt(t *testing
 
 	err := d.UpsertIssueEvents(ctx, []IssueEvent{{
 		IssueID:    issueID,
-		PlatformID: ptrInt64(202),
+		PlatformID: new(int64(202)),
 		EventType:  "issue_comment",
 		Author:     "reporter",
 		Body:       "first",
@@ -922,7 +917,7 @@ func TestUpsertIssueEventsPreservesDirectURLWhenPartialRefreshOmitsIt(t *testing
 
 	err = d.UpsertIssueEvents(ctx, []IssueEvent{{
 		IssueID:    issueID,
-		PlatformID: ptrInt64(202),
+		PlatformID: new(int64(202)),
 		EventType:  "issue_comment",
 		Author:     "reporter",
 		Body:       "edited",

--- a/internal/server/e2etest/sync_routes_test.go
+++ b/internal/server/e2etest/sync_routes_test.go
@@ -1,0 +1,59 @@
+package e2etest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/apiclient"
+	"go.kenn.io/middleman/internal/apiclient/generated"
+	"go.kenn.io/middleman/internal/server"
+	"go.kenn.io/middleman/internal/testutil/dbtest"
+)
+
+func TestSyncRoutesWithoutProviderSyncerE2E(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	database := dbtest.Open(t)
+	srv := server.New(database, nil, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	status, err := client.HTTP.GetSyncStatusWithResponse(t.Context())
+	require.NoError(err)
+	require.Equal(http.StatusOK, status.StatusCode(), string(status.Body))
+	require.NotNil(status.JSON200)
+	assert.False(status.JSON200.Running)
+	assert.Nil(status.JSON200.LastRunAt)
+	assert.Nil(status.JSON200.LastError)
+
+	rates, err := client.HTTP.GetRateLimitsWithResponse(t.Context())
+	require.NoError(err)
+	require.Equal(http.StatusOK, rates.StatusCode(), string(rates.Body))
+	require.NotNil(rates.JSON200)
+	assert.Empty(rates.JSON200.Hosts)
+
+	trigger, err := client.HTTP.TriggerSyncWithResponse(
+		t.Context(),
+		nil,
+		func(_ context.Context, req *http.Request) error {
+			req.Header.Set("Content-Type", "application/json")
+			return nil
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusServiceUnavailable, trigger.StatusCode(), string(trigger.Body))
+	require.NotNil(trigger.ApplicationproblemJSONDefault)
+	assert.Equal(generated.ServiceUnavailable, trigger.ApplicationproblemJSONDefault.Code)
+	require.NotNil(trigger.ApplicationproblemJSONDefault.Detail)
+	assert.Equal("syncer not configured", *trigger.ApplicationproblemJSONDefault.Detail)
+}

--- a/internal/server/e2etest/timeline_assignment_test.go
+++ b/internal/server/e2etest/timeline_assignment_test.go
@@ -79,7 +79,7 @@ func TestE2E_DetailTimelineReturnsCommentDirectURLs(t *testing.T) {
 
 	require.NoError(database.UpsertMREvents(t.Context(), []db.MREvent{{
 		MergeRequestID: mrID,
-		PlatformID:     ptrInt64(101),
+		PlatformID:     new(int64(101)),
 		EventType:      "issue_comment",
 		Author:         "wesm",
 		Body:           "PR comment",
@@ -89,7 +89,7 @@ func TestE2E_DetailTimelineReturnsCommentDirectURLs(t *testing.T) {
 	}}))
 	require.NoError(database.UpsertIssueEvents(t.Context(), []db.IssueEvent{{
 		IssueID:    issueID,
-		PlatformID: ptrInt64(202),
+		PlatformID: new(int64(202)),
 		EventType:  "issue_comment",
 		Author:     "alice",
 		Body:       "Issue comment",
@@ -196,11 +196,6 @@ func seedAssignmentTimelineItems(t *testing.T, database *db.DB) (int64, int64) {
 	require.NoError(t, err)
 
 	return mrID, issueID
-}
-
-//go:fix inline
-func ptrInt64(v int64) *int64 {
-	return new(v)
 }
 
 func getTimelineDetail(

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3204,6 +3204,9 @@ func (s *Server) triggerSync(
 	ctx context.Context,
 	input *triggerSyncInput,
 ) (*acceptedOutput, error) {
+	if s.syncer == nil {
+		return nil, problemServiceUnavailable("syncer not configured")
+	}
 	s.syncer.TriggerRunWithPriority(
 		context.WithoutCancel(ctx),
 		s.priorityReposFromFilter(input.PriorityRepos),
@@ -3308,12 +3311,18 @@ func repoPlatformForPriority(repo ghclient.RepoRef) platform.Kind {
 }
 
 func (s *Server) syncStatus(_ context.Context, _ *struct{}) (*syncStatusOutput, error) {
+	if s.syncer == nil {
+		return &syncStatusOutput{Body: &ghclient.SyncStatus{}}, nil
+	}
 	return &syncStatusOutput{Body: s.syncer.Status()}, nil
 }
 
 func (s *Server) getRateLimits(
 	_ context.Context, _ *struct{},
 ) (*rateLimitsOutput, error) {
+	if s.syncer == nil {
+		return &rateLimitsOutput{Body: rateLimitsResponse{Hosts: map[string]rateLimitHostStatus{}}}, nil
+	}
 	trackers := s.syncer.RateTrackers()
 	gqlTrackers := s.syncer.GQLRateTrackers()
 	budgets := s.syncer.Budgets()

--- a/internal/server/sync_routes_test.go
+++ b/internal/server/sync_routes_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/github"
+)
+
+func TestSyncRoutesWithoutSyncer(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	srv := New(openTestDB(t), nil, nil, "/", nil, ServerOptions{})
+
+	statusRR := doJSON(t, srv, http.MethodGet, "/api/v1/sync/status", nil)
+	require.Equal(http.StatusOK, statusRR.Code, statusRR.Body.String())
+
+	var status github.SyncStatus
+	require.NoError(json.NewDecoder(statusRR.Body).Decode(&status))
+	assert.False(status.Running)
+	assert.Empty(status.LastRunAt)
+	assert.Empty(status.LastError)
+
+	ratesRR := doJSON(t, srv, http.MethodGet, "/api/v1/rate-limits", nil)
+	require.Equal(http.StatusOK, ratesRR.Code, ratesRR.Body.String())
+
+	var rates rateLimitsResponse
+	require.NoError(json.NewDecoder(ratesRR.Body).Decode(&rates))
+	assert.Empty(rates.Hosts)
+
+	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
+	require.Equal(http.StatusServiceUnavailable, syncRR.Code, syncRR.Body.String())
+
+	var problem ProblemError
+	require.NoError(json.NewDecoder(syncRR.Body).Decode(&problem))
+	assert.Equal(CodeServiceUnavailable, problem.Code)
+	assert.Equal("syncer not configured", problem.Detail)
+}


### PR DESCRIPTION
- Keep provider sync status and rate-limit endpoints safe when middleman runs without a provider syncer.
- Return idle sync/read state for syncer-less reads and a typed 503 for manual provider sync.
- Add handler and e2e coverage for the nil-syncer path.

This started as a check for direct Kata/GitHub sync coupling, such as a shared function that sequentially loops through Kata and GitHub sync work. I did not find that kind of coupling; the issue found instead was that global provider sync routes assumed a provider syncer exists, which can still affect Kata and other non-provider surfaces through frontend polling.
