### PR TITLE
Fix split inline review composer placement

### DIFF
--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -38,6 +38,7 @@ function pullDetail(
   provider = "github",
   platformHost = "github.com",
   operations?: Record<string, unknown>,
+  events?: Array<Record<string, unknown>>,
 ) {
   return {
     merge_request: {
@@ -67,7 +68,7 @@ function pullDetail(
       KanbanStatus: "reviewing",
       Starred: false,
     },
-    events: [
+    events: events ?? [
       {
         ID: 51,
         MergeRequestID: 1,
@@ -207,6 +208,50 @@ const diffResponse = {
   ],
 };
 
+const splitComposerDiffResponse = {
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "src/main.ts",
+      old_path: "src/main.ts",
+      status: "modified",
+      additions: 2,
+      deletions: 0,
+      is_binary: false,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 1,
+          new_start: 1,
+          new_count: 3,
+          section: "",
+          lines: [
+            {
+              type: "context",
+              old_num: 1,
+              new_num: 1,
+              content: "const a = 1;",
+            },
+            {
+              type: "add",
+              old_num: null,
+              new_num: 2,
+              content: "const b = 2;",
+            },
+            {
+              type: "add",
+              old_num: null,
+              new_num: 3,
+              content: "const c = 3;",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 const multiHunkDiffResponse = {
   stale: false,
   whitespace_only_count: 0,
@@ -333,6 +378,7 @@ function scrollingDiffResponse() {
 }
 
 type MockInlineReviewOptions = {
+  detailEvents?: Array<Record<string, unknown>>;
   publishStatus?: "published" | "partially_published";
   detailBody?: string;
   detailFetchedAtSequence?: string[];
@@ -363,7 +409,14 @@ async function mockInlineReviewAPI(
       await route.fallback();
       return;
     }
-    const detail = pullDetail(reviewThreadResolved, capabilities, provider, platformHost, options.operations);
+    const detail = pullDetail(
+      reviewThreadResolved,
+      capabilities,
+      provider,
+      platformHost,
+      options.operations,
+      options.detailEvents,
+    );
     if (options.detailBody !== undefined) {
       detail.merge_request.Body = options.detailBody;
     }
@@ -582,6 +635,59 @@ test("adds and publishes an inline draft review comment", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Show full comment" })).toHaveCount(0);
   await page.getByRole("button", { name: "Publish review" }).click();
   await expect(page.getByText("1 draft comment")).toBeHidden();
+});
+
+test("keeps split-mode inline composers on trailing right-side hunk lines", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("diff-view-mode", "split");
+  });
+  await mockInlineReviewAPI(page, baseCapabilities, "github", "github.com", splitComposerDiffResponse, undefined, {
+    detailEvents: [],
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  async function assertRightSideComposer(line: number): Promise<void> {
+    const button = page.getByRole("button", { name: `Comment on new line ${line}` });
+    await expect(button).toBeVisible();
+    await expect(
+      button.evaluate((element) => {
+        const code = element.closest("code");
+        const pre = code?.parentElement;
+        if (!code || !pre) return null;
+        if (code.hasAttribute("data-additions")) return "additions";
+        if (code.hasAttribute("data-deletions")) return "deletions";
+        const index = Array.from(pre.children).indexOf(code);
+        if (index === 0) return "deletions";
+        if (index === 1) return "additions";
+        return null;
+      }),
+    ).resolves.toBe("additions");
+
+    await button.click();
+    await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
+    await expect(
+      page
+        .locator(".pierre-diff")
+        .first()
+        .evaluate((host, lineNumber) => {
+          const slot = host.shadowRoot?.querySelector(`slot[name="annotation-additions-${lineNumber}"]`);
+          const code = slot?.closest("code");
+          const pre = code?.parentElement;
+          if (!code || !pre) return null;
+          if (code.hasAttribute("data-additions")) return "additions";
+          if (code.hasAttribute("data-deletions")) return "deletions";
+          const index = Array.from(pre.children).indexOf(code);
+          if (index === 0) return "deletions";
+          if (index === 1) return "additions";
+          return null;
+        }, line),
+    ).resolves.toBe("additions");
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByPlaceholder("Leave a comment")).toHaveCount(0);
+  }
+
+  await assertRightSideComposer(2);
+  await assertRightSideComposer(3);
 });
 
 test("shows a visible composer focus indicator without focus flicker", async ({ page }) => {

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -656,7 +656,9 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
         if (!code || !pre) return null;
         if (code.hasAttribute("data-additions")) return "additions";
         if (code.hasAttribute("data-deletions")) return "deletions";
-        const index = Array.from(pre.children).indexOf(code);
+        const index = Array.from(pre.children)
+          .filter((child) => child.tagName.toLowerCase() === "code")
+          .indexOf(code);
         if (index === 0) return "deletions";
         if (index === 1) return "additions";
         return null;
@@ -676,7 +678,9 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
           if (!code || !pre) return null;
           if (code.hasAttribute("data-additions")) return "additions";
           if (code.hasAttribute("data-deletions")) return "deletions";
-          const index = Array.from(pre.children).indexOf(code);
+          const index = Array.from(pre.children)
+            .filter((child) => child.tagName.toLowerCase() === "code")
+            .indexOf(code);
           if (index === 0) return "deletions";
           if (index === 1) return "additions";
           return null;

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -134,6 +134,41 @@ function makeFile(overrides: Partial<DiffFileType> = {}): DiffFileType {
   };
 }
 
+function makeTwoAdditionFile(): DiffFileType {
+  return makeFile({
+    additions: 2,
+    deletions: 1,
+    patch: `diff --git a/src/foo.ts b/src/foo.ts
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,2 +1,3 @@
+ line 1
+-old line
++new line
++newer line
+`,
+    hunks: [
+      {
+        old_start: 1,
+        old_count: 2,
+        new_start: 1,
+        new_count: 3,
+        lines: [
+          {
+            type: "context",
+            content: "line 1",
+            old_num: 1,
+            new_num: 1,
+          },
+          { type: "delete", content: "old line", old_num: 2 },
+          { type: "add", content: "new line", new_num: 2 },
+          { type: "add", content: "newer line", new_num: 3 },
+        ],
+      },
+    ],
+  });
+}
+
 function makeReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
   return {
     id: "thread-1",
@@ -457,6 +492,18 @@ describe("DiffFile", () => {
     return document.querySelector(".pierre-diff")?.shadowRoot?.querySelectorAll("[data-selected-line]");
   }
 
+  function splitColumnSide(element: Element | null | undefined): "additions" | "deletions" | null {
+    const code = element?.closest("code");
+    const pre = code?.parentElement;
+    if (!code || !pre) return null;
+    if (code.hasAttribute("data-additions")) return "additions";
+    if (code.hasAttribute("data-deletions")) return "deletions";
+    const index = Array.from(pre.children).indexOf(code);
+    if (index === 0) return "deletions";
+    if (index === 1) return "additions";
+    return null;
+  }
+
   function expandedContextLineTexts(): string[] {
     return Array.from(
       document
@@ -510,6 +557,35 @@ describe("DiffFile", () => {
 
     expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
     expect(selectedPierreLines()).toHaveLength(0);
+  });
+
+  it("keeps right-side inline composers in the additions column in split mode", async () => {
+    renderDiffFile(makeTwoAdditionFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+      viewMode: "split",
+    });
+
+    async function assertRightSideComposer(line: number): Promise<void> {
+      const button = await findLineCommentButton(line, "right");
+      expect(splitColumnSide(button)).toBe("additions");
+
+      await clickLineCommentButton(line, "right");
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+        const slot = document
+          .querySelector(".pierre-diff")
+          ?.shadowRoot?.querySelector<HTMLSlotElement>(`slot[name="annotation-additions-${line}"]`);
+        expect(splitColumnSide(slot)).toBe("additions");
+      });
+
+      await fireEvent.click(screen.getByText("Cancel"));
+      await waitFor(() => expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull());
+    }
+
+    await assertRightSideComposer(2);
+    await assertRightSideComposer(3);
   });
 
   it("focuses the inline composer textarea exactly once after opening", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -93,6 +93,7 @@ import type { DiffFile as DiffFileType, FilePreview } from "../../api/types.js";
 import { STORES_KEY } from "../../context.js";
 import type { DiffReviewDraftComment, DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
 import { createDiffStore } from "../../stores/diff.svelte.js";
+import { renderedCodeSide } from "./pierre-dom.js";
 import type { ReviewThread } from "./review-thread-context.js";
 
 function makeFile(overrides: Partial<DiffFileType> = {}): DiffFileType {
@@ -494,14 +495,7 @@ describe("DiffFile", () => {
 
   function splitColumnSide(element: Element | null | undefined): "additions" | "deletions" | null {
     const code = element?.closest("code");
-    const pre = code?.parentElement;
-    if (!code || !pre) return null;
-    if (code.hasAttribute("data-additions")) return "additions";
-    if (code.hasAttribute("data-deletions")) return "deletions";
-    const index = Array.from(pre.children).indexOf(code);
-    if (index === 0) return "deletions";
-    if (index === 1) return "additions";
-    return null;
+    return code ? (renderedCodeSide(code) ?? null) : null;
   }
 
   function expandedContextLineTexts(): string[] {
@@ -586,6 +580,17 @@ describe("DiffFile", () => {
 
     await assertRightSideComposer(2);
     await assertRightSideComposer(3);
+  });
+
+  it("infers split column side from code-column order when non-code siblings are present", () => {
+    const pre = document.createElement("pre");
+    const deletions = document.createElement("code");
+    const separator = document.createElement("span");
+    const additions = document.createElement("code");
+    pre.append(deletions, separator, additions);
+
+    expect(renderedCodeSide(deletions)).toBe("deletions");
+    expect(renderedCodeSide(additions)).toBe("additions");
   });
 
   it("focuses the inline composer textarea exactly once after opening", async () => {

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -22,6 +22,10 @@
     pierreDiffDebugEnabled,
     pierreFileContents,
   } from "./pierre-diff.js";
+  import {
+    renderedCodeColumns,
+    renderedCodeSide as renderedPierreCodeSide,
+  } from "./pierre-dom.js";
   import { diffTokenizeMaxLineLength, getPierreDiffWorkerPool } from "./pierre-worker-pool.js";
 
   interface Props {
@@ -1323,8 +1327,8 @@
 
   function refreshRenderedLineRows(pre: HTMLPreElement, split: boolean): void {
     const next = new Map<number, RenderedLinePair[]>();
-    for (const [codeIndex, code] of Array.from(pre.children).entries()) {
-      const side = split ? renderedCodeSide(code, codeIndex) : undefined;
+    for (const code of renderedCodeColumns(pre)) {
+      const side = split ? renderedPierreCodeSide(code) : undefined;
       const [gutter, content] = Array.from(code.children);
       if (!gutter || !content) continue;
       const contentRows = Array.from(content.children);
@@ -1345,14 +1349,6 @@
     renderedLineRows = next;
   }
 
-  function renderedCodeSide(code: Element, codeIndex: number): PierreSide | undefined {
-    if (code.hasAttribute("data-deletions")) return "deletions";
-    if (code.hasAttribute("data-additions")) return "additions";
-    if (codeIndex === 0) return "deletions";
-    if (codeIndex === 1) return "additions";
-    return undefined;
-  }
-
   function linePairMatchesSide(
     pair: RenderedLinePair,
     split: boolean,
@@ -1371,8 +1367,8 @@
       linePairMatchesSide(pair, split, side)
     );
     if (cached) return cached;
-    for (const [codeIndex, code] of Array.from(pre.children).entries()) {
-      const codeSide = split ? renderedCodeSide(code, codeIndex) : undefined;
+    for (const code of renderedCodeColumns(pre)) {
+      const codeSide = split ? renderedPierreCodeSide(code) : undefined;
       if (split && side != null && codeSide !== side) continue;
       const [gutter, content] = Array.from(code.children);
       if (!gutter || !content) continue;

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -45,6 +45,7 @@
   type RenderedLinePair = {
     content: HTMLElement;
     gutter: HTMLElement;
+    side: PierreSide | undefined;
   };
   type TransientAnnotationRow = {
     content?: HTMLElement;
@@ -958,14 +959,26 @@
     for (const hunk of fileHunks) {
       for (const line of hunk.lines) {
         if (line.old_num != null) {
-          markLineTarget(pre, getLineIndex(line.old_num, "deletions"), split, {
-            "data-diff-old-line": String(line.old_num),
-          });
+          markLineTarget(
+            pre,
+            getLineIndex(line.old_num, "deletions"),
+            split,
+            "deletions",
+            {
+              "data-diff-old-line": String(line.old_num),
+            },
+          );
         }
         if (line.new_num != null) {
-          markLineTarget(pre, getLineIndex(line.new_num, "additions"), split, {
-            "data-diff-new-line": String(line.new_num),
-          });
+          markLineTarget(
+            pre,
+            getLineIndex(line.new_num, "additions"),
+            split,
+            "additions",
+            {
+              "data-diff-new-line": String(line.new_num),
+            },
+          );
         }
       }
     }
@@ -1217,7 +1230,7 @@
     if (!indexes) return undefined;
 
     const lineIndex = split ? indexes[1] : indexes[0];
-    const target = renderedLinePair(pre, lineIndex, split);
+    const target = renderedLinePair(pre, lineIndex, split, annotation.side as PierreSide);
     if (!target) return undefined;
 
     const gutter = document.createElement("div");
@@ -1247,12 +1260,13 @@
     pre: HTMLPreElement,
     indexes: [number, number] | undefined,
     split: boolean,
+    side: PierreSide,
     attributes: Record<string, string>,
   ): void {
     if (!indexes) return;
     const lineIndex = split ? indexes[1] : indexes[0];
     if (!Number.isFinite(lineIndex)) return;
-    const pair = renderedLinePair(pre, lineIndex, split);
+    const pair = renderedLinePair(pre, lineIndex, split, side);
     if (!pair) return;
     pair.content.tabIndex = -1;
     pair.gutter.tabIndex = -1;
@@ -1309,7 +1323,8 @@
 
   function refreshRenderedLineRows(pre: HTMLPreElement, split: boolean): void {
     const next = new Map<number, RenderedLinePair[]>();
-    for (const code of Array.from(pre.children)) {
+    for (const [codeIndex, code] of Array.from(pre.children).entries()) {
+      const side = split ? renderedCodeSide(code, codeIndex) : undefined;
       const [gutter, content] = Array.from(code.children);
       if (!gutter || !content) continue;
       const contentRows = Array.from(content.children);
@@ -1323,21 +1338,42 @@
         const lineIndex = parseRenderedLineIndex(contentElement, split);
         if (lineIndex == null) continue;
         const rows = next.get(lineIndex) ?? [];
-        rows.push({ content: contentElement, gutter: gutterElement });
+        rows.push({ content: contentElement, gutter: gutterElement, side });
         next.set(lineIndex, rows);
       }
     }
     renderedLineRows = next;
   }
 
+  function renderedCodeSide(code: Element, codeIndex: number): PierreSide | undefined {
+    if (code.hasAttribute("data-deletions")) return "deletions";
+    if (code.hasAttribute("data-additions")) return "additions";
+    if (codeIndex === 0) return "deletions";
+    if (codeIndex === 1) return "additions";
+    return undefined;
+  }
+
+  function linePairMatchesSide(
+    pair: RenderedLinePair,
+    split: boolean,
+    side: PierreSide | undefined,
+  ): boolean {
+    return !split || side == null || pair.side === side;
+  }
+
   function renderedLinePair(
     pre: HTMLPreElement,
     targetIndex: number,
     split: boolean,
+    side?: PierreSide,
   ): RenderedLinePair | undefined {
-    const cached = renderedLineRows.get(targetIndex)?.[0];
+    const cached = renderedLineRows.get(targetIndex)?.find((pair) =>
+      linePairMatchesSide(pair, split, side)
+    );
     if (cached) return cached;
-    for (const code of Array.from(pre.children)) {
+    for (const [codeIndex, code] of Array.from(pre.children).entries()) {
+      const codeSide = split ? renderedCodeSide(code, codeIndex) : undefined;
+      if (split && side != null && codeSide !== side) continue;
       const [gutter, content] = Array.from(code.children);
       if (!gutter || !content) continue;
       const gutterRows = Array.from(gutter.children);
@@ -1348,7 +1384,7 @@
           const index = Array.prototype.indexOf.call(content.children, contentElement);
           const gutterElement = gutterRows[index];
           if (gutterElement instanceof HTMLElement) {
-            return { content: contentElement, gutter: gutterElement };
+            return { content: contentElement, gutter: gutterElement, side: codeSide };
           }
         }
         if ((lineIndex ?? 0) > targetIndex) return undefined;

--- a/packages/ui/src/components/diff/pierre-dom.ts
+++ b/packages/ui/src/components/diff/pierre-dom.ts
@@ -1,0 +1,17 @@
+export type RenderedCodeSide = "deletions" | "additions";
+
+export function renderedCodeColumns(pre: Element): Element[] {
+  return Array.from(pre.children).filter((child) => child.tagName.toLowerCase() === "code");
+}
+
+export function renderedCodeSide(code: Element): RenderedCodeSide | undefined {
+  if (code.hasAttribute("data-deletions")) return "deletions";
+  if (code.hasAttribute("data-additions")) return "additions";
+
+  const pre = code.parentElement;
+  if (!pre) return undefined;
+  const codeIndex = renderedCodeColumns(pre).indexOf(code);
+  if (codeIndex === 0) return "deletions";
+  if (codeIndex === 1) return "additions";
+  return undefined;
+}


### PR DESCRIPTION
Fixes split diff inline review composer placement when adding a draft comment near the end of a hunk.

- Tracks the rendered split column side when marking line targets and inserting transient composer rows.
- Falls back to split column position when Pierre does not emit side marker attributes in the rendered DOM.
- Adds component and Playwright coverage for the second-to-last and last right-side hunk lines.

Screenshot:

![inline-review-last-line-split-composer-page.png](https://github.com/user-attachments/assets/0b33648c-4ac4-48e4-b36b-e3c0ce1716cb)
