### PR TITLE
fix: keep workspace lists from blanking

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -210,23 +210,15 @@
   async function fetchWorkspaces(): Promise<void> {
     if (fetchInFlight) return;
     fetchInFlight = true;
+    const abortController = new AbortController();
     let timeoutHandle: number | undefined;
     try {
-      const timeout = new Promise<"timeout">((resolve) => {
-        timeoutHandle = window.setTimeout(
-          () => resolve("timeout"),
-          workspaceListLoadTimeoutMs,
-        );
+      timeoutHandle = window.setTimeout(() => {
+        abortController.abort();
+      }, workspaceListLoadTimeoutMs);
+      const { data } = await client.GET("/workspaces", {
+        signal: abortController.signal,
       });
-      const result = await Promise.race([
-        client.GET("/workspaces"),
-        timeout,
-      ]);
-      if (result === "timeout") {
-        if (workspaces.length === 0) workspaceListStatus = "retrying";
-        return;
-      }
-      const { data } = result;
       if (!data) {
         if (workspaces.length === 0) workspaceListStatus = "retrying";
         return;

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -83,6 +83,7 @@
   let collapsedGroups = $state<Set<string>>(new Set());
   let searchQuery = $state("");
   let sortMode = $state<WorkspaceListSort>(loadWorkspaceListSort());
+  let hasLoadedWorkspaces = $state(false);
 
   type GroupedWorkspaces = Map<string, Workspace[]>;
 
@@ -208,6 +209,7 @@
       const { data } = await client.GET("/workspaces");
       if (!data) return;
       workspaces = (data.workspaces ?? []) as Workspace[];
+      hasLoadedWorkspaces = true;
     } catch {
       // Network error; keep stale list.
     }
@@ -554,8 +556,12 @@
             </button>
           </div>
     {/snippet}
-    {#if visibleWorkspaces.length === 0 && normalizedSearchQuery}
+    {#if !hasLoadedWorkspaces && workspaces.length === 0}
+      <p class="filter-empty">Loading workspaces...</p>
+    {:else if visibleWorkspaces.length === 0 && normalizedSearchQuery}
       <p class="filter-empty">No workspaces match.</p>
+    {:else if visibleWorkspaces.length === 0}
+      <p class="filter-empty">No workspaces yet.</p>
     {/if}
   </div>
 </div>

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -83,7 +83,10 @@
   let collapsedGroups = $state<Set<string>>(new Set());
   let searchQuery = $state("");
   let sortMode = $state<WorkspaceListSort>(loadWorkspaceListSort());
-  let hasLoadedWorkspaces = $state(false);
+  let workspaceListStatus = $state<"loading" | "retrying" | "loaded">("loading");
+  let fetchInFlight = false;
+
+  const workspaceListLoadTimeoutMs = 10_000;
 
   type GroupedWorkspaces = Map<string, Workspace[]>;
 
@@ -205,13 +208,39 @@
   });
 
   async function fetchWorkspaces(): Promise<void> {
+    if (fetchInFlight) return;
+    fetchInFlight = true;
+    let timeoutHandle: number | undefined;
     try {
-      const { data } = await client.GET("/workspaces");
-      if (!data) return;
+      const timeout = new Promise<"timeout">((resolve) => {
+        timeoutHandle = window.setTimeout(
+          () => resolve("timeout"),
+          workspaceListLoadTimeoutMs,
+        );
+      });
+      const result = await Promise.race([
+        client.GET("/workspaces"),
+        timeout,
+      ]);
+      if (result === "timeout") {
+        if (workspaces.length === 0) workspaceListStatus = "retrying";
+        return;
+      }
+      const { data } = result;
+      if (!data) {
+        if (workspaces.length === 0) workspaceListStatus = "retrying";
+        return;
+      }
       workspaces = (data.workspaces ?? []) as Workspace[];
-      hasLoadedWorkspaces = true;
+      workspaceListStatus = "loaded";
     } catch {
       // Network error; keep stale list.
+      if (workspaces.length === 0) workspaceListStatus = "retrying";
+    } finally {
+      if (timeoutHandle !== undefined) {
+        window.clearTimeout(timeoutHandle);
+      }
+      fetchInFlight = false;
     }
   }
 
@@ -556,8 +585,10 @@
             </button>
           </div>
     {/snippet}
-    {#if !hasLoadedWorkspaces && workspaces.length === 0}
+    {#if workspaceListStatus === "loading" && workspaces.length === 0}
       <p class="filter-empty">Loading workspaces...</p>
+    {:else if workspaceListStatus === "retrying" && workspaces.length === 0}
+      <p class="filter-empty">Still loading workspaces. Retrying...</p>
     {:else if visibleWorkspaces.length === 0 && normalizedSearchQuery}
       <p class="filter-empty">No workspaces match.</p>
     {:else if visibleWorkspaces.length === 0}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
@@ -132,6 +133,7 @@ describe("WorkspaceListSidebar", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("shows provider icons in repo groups when multiple providers are present", async () => {
@@ -175,6 +177,21 @@ describe("WorkspaceListSidebar", () => {
     });
 
     expect(screen.getByText("Loading workspaces...")).toBeTruthy();
+  });
+
+  it("shows a retrying state when the initial workspace list hangs", async () => {
+    vi.useFakeTimers();
+    mockGet.mockReturnValue(new Promise(() => {}));
+
+    render(WorkspaceListSidebar, {
+      props: { selectedId: "" },
+    });
+
+    expect(screen.getByText("Loading workspaces...")).toBeTruthy();
+    await vi.advanceTimersByTimeAsync(10_000);
+    await tick();
+
+    expect(screen.getByText("Still loading workspaces. Retrying...")).toBeTruthy();
   });
 
   it("hides provider icons in repo groups when one provider is present", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -167,6 +167,16 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByRole("img", { name: "GitLab" })).toBeTruthy();
   });
 
+  it("does not render a blank rail while the workspace list is loading", async () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+
+    render(WorkspaceListSidebar, {
+      props: { selectedId: "" },
+    });
+
+    expect(screen.getByText("Loading workspaces...")).toBeTruthy();
+  });
+
   it("hides provider icons in repo groups when one provider is present", async () => {
     mockGet.mockResolvedValue({
       data: {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -181,7 +181,16 @@ describe("WorkspaceListSidebar", () => {
 
   it("shows a retrying state when the initial workspace list hangs", async () => {
     vi.useFakeTimers();
-    mockGet.mockReturnValue(new Promise(() => {}));
+    let aborted = false;
+    mockGet.mockImplementation(
+      (_path: string, opts?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener("abort", () => {
+            aborted = true;
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
 
     render(WorkspaceListSidebar, {
       props: { selectedId: "" },
@@ -191,6 +200,7 @@ describe("WorkspaceListSidebar", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     await tick();
 
+    expect(aborted).toBe(true);
     expect(screen.getByText("Still loading workspaces. Retrying...")).toBeTruthy();
   });
 

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -101,6 +101,26 @@ async function createIssueWorkspace(api: APIRequestContext, issueNumber: number)
 test.describe("workspace sidebar full-stack", () => {
   test.describe.configure({ timeout: lockedWorkspaceTestTimeoutMs });
 
+  test("shows retrying copy when the workspace list request stalls", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      await page.route("**/api/v1/workspaces", async () => {
+        // Keep the first list request pending so the real app shell
+        // exercises the workspace rail's hung-request state.
+      });
+
+      await page.goto(`${isolatedServer.info.base_url}/workspaces`);
+
+      await expect(page.getByText("Loading workspaces...")).toBeVisible();
+      await expect(page.getByText("Still loading workspaces. Retrying...")).toBeVisible({
+        timeout: 12_000,
+      });
+    } finally {
+      await isolatedServer?.stop();
+    }
+  });
+
   test("shows provider icons in group headers when workspaces span multiple providers", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23864,6 +23864,45 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	require.Equal(http.StatusNotFound, getResp2.StatusCode())
 }
 
+func TestWorkspaceListE2EKeepsLastKnownSummariesOnEmptyStoreRead(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	srv, database := setupTestServer(t)
+	srv.workspaces = workspace.NewManager(database, t.TempDir())
+	seedPR(t, database, "acme", "widget", 7)
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID:           "cachedlist000001",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   7,
+		GitHeadRef:   "feature/cache-workspace",
+		WorktreePath: filepath.Join(t.TempDir(), "workspace"),
+		TmuxSession:  "middleman-cachedlist000001",
+		Status:       "ready",
+		CreatedAt:    time.Now().UTC(),
+	}))
+
+	rawFirst := doJSON(t, srv, http.MethodGet, "/api/v1/workspaces", nil)
+	require.Equal(http.StatusOK, rawFirst.Code, rawFirst.Body.String())
+	var first listWorkspacesOutputBody
+	require.NoError(json.NewDecoder(rawFirst.Body).Decode(&first))
+	require.Len(first.Workspaces, 1)
+	assert.Equal("cachedlist000001", first.Workspaces[0].ID)
+
+	require.NoError(database.DeleteWorkspace(ctx, "cachedlist000001"))
+	rawSecond := doJSON(t, srv, http.MethodGet, "/api/v1/workspaces", nil)
+	require.Equal(http.StatusOK, rawSecond.Code, rawSecond.Body.String())
+	var second listWorkspacesOutputBody
+	require.NoError(json.NewDecoder(rawSecond.Body).Decode(&second))
+	require.Len(second.Workspaces, 1)
+	assert.Equal("cachedlist000001", second.Workspaces[0].ID)
+}
+
 func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23862,45 +23862,14 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	)
 	require.NoError(err)
 	require.Equal(http.StatusNotFound, getResp2.StatusCode())
-}
 
-func TestWorkspaceListE2EKeepsLastKnownSummariesOnEmptyStoreRead(t *testing.T) {
-	t.Parallel()
-
-	require := require.New(t)
-	assert := Assert.New(t)
-	ctx := t.Context()
-	srv, database := setupTestServer(t)
-	srv.workspaces = workspace.NewManager(database, t.TempDir())
-	seedPR(t, database, "acme", "widget", 7)
-	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
-		ID:           "cachedlist000001",
-		PlatformHost: "github.com",
-		RepoOwner:    "acme",
-		RepoName:     "widget",
-		ItemType:     db.WorkspaceItemTypePullRequest,
-		ItemNumber:   7,
-		GitHeadRef:   "feature/cache-workspace",
-		WorktreePath: filepath.Join(t.TempDir(), "workspace"),
-		TmuxSession:  "middleman-cachedlist000001",
-		Status:       "ready",
-		CreatedAt:    time.Now().UTC(),
-	}))
-
-	rawFirst := doJSON(t, srv, http.MethodGet, "/api/v1/workspaces", nil)
-	require.Equal(http.StatusOK, rawFirst.Code, rawFirst.Body.String())
-	var first listWorkspacesOutputBody
-	require.NoError(json.NewDecoder(rawFirst.Body).Decode(&first))
-	require.Len(first.Workspaces, 1)
-	assert.Equal("cachedlist000001", first.Workspaces[0].ID)
-
-	require.NoError(database.DeleteWorkspace(ctx, "cachedlist000001"))
-	rawSecond := doJSON(t, srv, http.MethodGet, "/api/v1/workspaces", nil)
-	require.Equal(http.StatusOK, rawSecond.Code, rawSecond.Body.String())
-	var second listWorkspacesOutputBody
-	require.NoError(json.NewDecoder(rawSecond.Body).Decode(&second))
-	require.Len(second.Workspaces, 1)
-	assert.Equal("cachedlist000001", second.Workspaces[0].ID)
+	// 7. List workspaces -- deleted workspace is absent from the public list.
+	listResp3, err := client.HTTP.ListWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp3.StatusCode())
+	require.NotNil(listResp3.JSON200)
+	require.NotNil(listResp3.JSON200.Workspaces)
+	assert.Empty(*listResp3.JSON200.Workspaces)
 }
 
 func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -44,6 +44,7 @@ type Manager struct {
 	issueBranchSlugEnabled bool
 	summaryCacheMu         sync.RWMutex
 	summaryCache           []WorkspaceSummary
+	deletedSummaryIDs      map[string]bool
 }
 
 // CreateIssueOptions controls how issue-backed workspaces choose their branch.
@@ -1109,7 +1110,14 @@ func (m *Manager) GetByIssue(
 func (m *Manager) GetSummary(
 	ctx context.Context, id string,
 ) (*WorkspaceSummary, error) {
-	return m.db.GetWorkspaceSummary(ctx, id)
+	summary, err := m.db.GetWorkspaceSummary(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if summary != nil {
+		m.upsertWorkspaceSummaryCache(*summary)
+	}
+	return summary, nil
 }
 
 // ListSummaries returns all workspaces with joined MR metadata.
@@ -1123,8 +1131,7 @@ func (m *Manager) ListSummaries(
 	if len(summaries) == 0 {
 		return m.cachedWorkspaceSummaries(), nil
 	}
-	m.setWorkspaceSummaryCache(summaries)
-	return summaries, nil
+	return m.setWorkspaceSummaryCache(summaries), nil
 }
 
 func (m *Manager) cachedWorkspaceSummaries() []WorkspaceSummary {
@@ -1135,21 +1142,60 @@ func (m *Manager) cachedWorkspaceSummaries() []WorkspaceSummary {
 
 func (m *Manager) setWorkspaceSummaryCache(
 	summaries []WorkspaceSummary,
-) {
+) []WorkspaceSummary {
 	m.summaryCacheMu.Lock()
 	defer m.summaryCacheMu.Unlock()
-	m.summaryCache = slices.Clone(summaries)
+	m.summaryCache = filterDeletedWorkspaceSummaries(
+		summaries,
+		m.deletedSummaryIDs,
+	)
+	return slices.Clone(m.summaryCache)
+}
+
+func (m *Manager) upsertWorkspaceSummaryCache(summary WorkspaceSummary) {
+	m.summaryCacheMu.Lock()
+	defer m.summaryCacheMu.Unlock()
+	if m.deletedSummaryIDs[summary.ID] {
+		return
+	}
+	for i := range m.summaryCache {
+		if m.summaryCache[i].ID == summary.ID {
+			m.summaryCache[i] = summary
+			return
+		}
+	}
+	m.summaryCache = append(m.summaryCache, summary)
 }
 
 func (m *Manager) removeWorkspaceSummaryFromCache(id string) {
 	m.summaryCacheMu.Lock()
 	defer m.summaryCacheMu.Unlock()
+	if m.deletedSummaryIDs == nil {
+		m.deletedSummaryIDs = make(map[string]bool)
+	}
+	m.deletedSummaryIDs[id] = true
 	m.summaryCache = slices.DeleteFunc(
 		m.summaryCache,
 		func(summary WorkspaceSummary) bool {
 			return summary.ID == id
 		},
 	)
+}
+
+func filterDeletedWorkspaceSummaries(
+	summaries []WorkspaceSummary,
+	deleted map[string]bool,
+) []WorkspaceSummary {
+	if len(deleted) == 0 {
+		return slices.Clone(summaries)
+	}
+	out := make([]WorkspaceSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		if !deleted[summary.ID] {
+			out = append(out, summary)
+		}
+	}
+	return out
 }
 
 // ReapOrphanTmuxSessions kills middleman-managed tmux sessions that no longer

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -42,6 +42,8 @@ type Manager struct {
 	retryQueued            map[string]bool
 	runtimeTmuxMu          sync.Mutex
 	issueBranchSlugEnabled bool
+	summaryCacheMu         sync.RWMutex
+	summaryCache           []WorkspaceSummary
 }
 
 // CreateIssueOptions controls how issue-backed workspaces choose their branch.
@@ -746,6 +748,7 @@ func (m *Manager) Delete(
 	if err := m.db.DeleteWorkspace(ctx, id); err != nil {
 		return nil, fmt.Errorf("delete workspace record: %w", err)
 	}
+	m.removeWorkspaceSummaryFromCache(id)
 	return nil, nil
 }
 
@@ -1113,7 +1116,40 @@ func (m *Manager) GetSummary(
 func (m *Manager) ListSummaries(
 	ctx context.Context,
 ) ([]WorkspaceSummary, error) {
-	return m.db.ListWorkspaceSummaries(ctx)
+	summaries, err := m.db.ListWorkspaceSummaries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(summaries) == 0 {
+		return m.cachedWorkspaceSummaries(), nil
+	}
+	m.setWorkspaceSummaryCache(summaries)
+	return summaries, nil
+}
+
+func (m *Manager) cachedWorkspaceSummaries() []WorkspaceSummary {
+	m.summaryCacheMu.RLock()
+	defer m.summaryCacheMu.RUnlock()
+	return slices.Clone(m.summaryCache)
+}
+
+func (m *Manager) setWorkspaceSummaryCache(
+	summaries []WorkspaceSummary,
+) {
+	m.summaryCacheMu.Lock()
+	defer m.summaryCacheMu.Unlock()
+	m.summaryCache = slices.Clone(summaries)
+}
+
+func (m *Manager) removeWorkspaceSummaryFromCache(id string) {
+	m.summaryCacheMu.Lock()
+	defer m.summaryCacheMu.Unlock()
+	m.summaryCache = slices.DeleteFunc(
+		m.summaryCache,
+		func(summary WorkspaceSummary) bool {
+			return summary.ID == id
+		},
+	)
 }
 
 // ReapOrphanTmuxSessions kills middleman-managed tmux sessions that no longer

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -157,6 +157,31 @@ func TestCreate(t *testing.T) {
 	assert.Equal("creating", got.Status)
 }
 
+func TestListSummariesKeepsLastKnownNonEmptyCache(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMR(t, d, repoID, 7, "feature/cache-workspace")
+	mgr := NewManager(d, t.TempDir())
+
+	ws, err := mgr.Create(ctx, "github.com", "acme", "widget", 7)
+	require.NoError(err)
+	first, err := mgr.ListSummaries(ctx)
+	require.NoError(err)
+	require.Len(first, 1)
+	assert.Equal(ws.ID, first[0].ID)
+
+	require.NoError(d.DeleteWorkspace(ctx, ws.ID))
+	second, err := mgr.ListSummaries(ctx)
+	require.NoError(err)
+	require.Len(second, 1)
+	assert.Equal(ws.ID, second[0].ID)
+}
+
 func TestCreatePRHeadRepoClassification(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -157,7 +157,35 @@ func TestCreate(t *testing.T) {
 	assert.Equal("creating", got.Status)
 }
 
-func TestListSummariesKeepsLastKnownNonEmptyCache(t *testing.T) {
+func TestListSummariesUsesCacheWhenStoreHasNoRows(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	mgr := NewManager(d, t.TempDir())
+
+	mgr.setWorkspaceSummaryCache([]WorkspaceSummary{{
+		Workspace: Workspace{
+			ID:           "cached-workspace",
+			PlatformHost: "github.com",
+			RepoOwner:    "acme",
+			RepoName:     "widget",
+			ItemType:     db.WorkspaceItemTypePullRequest,
+			ItemNumber:   7,
+			GitHeadRef:   "feature/cache-workspace",
+			Status:       "ready",
+			CreatedAt:    time.Now().UTC(),
+		},
+	}})
+	got, err := mgr.ListSummaries(ctx)
+	require.NoError(err)
+	require.Len(got, 1)
+	assert.Equal("cached-workspace", got[0].ID)
+}
+
+func TestWorkspaceSummaryCacheDoesNotResurrectDeletedWorkspace(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
@@ -175,11 +203,9 @@ func TestListSummariesKeepsLastKnownNonEmptyCache(t *testing.T) {
 	require.Len(first, 1)
 	assert.Equal(ws.ID, first[0].ID)
 
-	require.NoError(d.DeleteWorkspace(ctx, ws.ID))
-	second, err := mgr.ListSummaries(ctx)
-	require.NoError(err)
-	require.Len(second, 1)
-	assert.Equal(ws.ID, second[0].ID)
+	mgr.removeWorkspaceSummaryFromCache(ws.ID)
+	mgr.setWorkspaceSummaryCache(first)
+	assert.Empty(mgr.cachedWorkspaceSummaries())
 }
 
 func TestCreatePRHeadRepoClassification(t *testing.T) {


### PR DESCRIPTION
The workspace rail could appear empty when the list endpoint briefly observed no rows, even though the running server had already seen workspace records. This made the Workspaces page look broken until users changed view state, such as switching the sort mode.

Summary:
- Keep a process-local last-known workspace summary snapshot for transient empty list reads.
- Clear cached entries when workspaces are deleted through the manager.
- Show explicit loading and empty states in the workspace rail instead of a blank list.

Local validation covered the affected Go API path, workspace manager behavior, the sidebar component tests, Svelte checks, and a local Playwright screenshot capture.